### PR TITLE
Proof of concept: login a user via default browser

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2111,6 +2111,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
+name = "open"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2078c0039e6a54a0c42c28faa984e115fb4c2d5bf2208f77d1961002df8576f8"
+dependencies = [
+ "pathdiff",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2214,6 +2224,12 @@ name = "paste"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"
@@ -3327,9 +3343,11 @@ dependencies = [
  "ignore",
  "objc",
  "once_cell",
+ "open",
  "percent-encoding",
  "rand 0.8.5",
  "raw-window-handle",
+ "regex",
  "rfd",
  "semver 1.0.16",
  "serde",
@@ -3382,6 +3400,7 @@ dependencies = [
  "png",
  "proc-macro2",
  "quote",
+ "regex",
  "semver 1.0.16",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ tauri-build = { version = "1.2", features = [] }
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.2", features = ["dialog-open", "fs-create-dir", "fs-exists", "fs-read-file", "fs-write-file", "path-all", "system-tray", "window-start-dragging"] }
+tauri = { version = "1.2", features = ["dialog-open", "fs-create-dir", "fs-exists", "fs-read-file", "fs-write-file", "path-all", "shell-open", "system-tray", "window-start-dragging"] }
 tauri-plugin-window-state = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "dev" }
 tauri-plugin-log = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "dev", features = ["colored"]  }
 log = "0.4.17"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -315,6 +315,9 @@ fn main() {
                         projects_storage,
                     });
 
+                    let window = app.get_window("main").unwrap();
+                    window.open_devtools();
+
                     Ok(())
                 })
                 .plugin(sentry_plugin)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,6 +21,9 @@
         "all": false,
         "startDragging": true
       },
+      "shell": {
+        "open": true
+      },
       "path": {
         "all": true
       },

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -65,7 +65,9 @@
     >
       <div class="center">Search GitButler</div>
     </div>
-    <div class="mr-4 font-bold cursor-default">User</div>
+    <div class="mr-4 font-bold cursor-default">
+      <a href="/user">User</a>
+    </div>
   </header>
 
   <main class="text-zinc-400 flex flex-row flex-grow h-screen">

--- a/src/routes/user/+page.svelte
+++ b/src/routes/user/+page.svelte
@@ -1,0 +1,64 @@
+<script>
+  let response = null;
+  let interval = null;
+  let token = null;
+
+  let login;
+  let user;
+
+  async function postData(url = "", data = {}) {
+    const response = await fetch(url, {
+      method: "POST", // *GET, POST, PUT, DELETE, etc.
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data), // body data type must match "Content-Type" header
+    });
+    return response.json(); // parses JSON response into native JavaScript objects
+  }
+
+  const fetchData = async (token) => {
+    try {
+      const res = await fetch(
+        "https://chacons.eu.ngrok.io/api/login/user/" + token
+      );
+      response = res.status;
+      console.log(response);
+      if (response === 200) {
+        console.log(res);
+        user = await res.json();
+        console.log(user);
+        clearInterval(interval);
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const logIn = () => {
+    postData("https://chacons.eu.ngrok.io/api/login/token")
+      .then((response) => {
+        console.log(response);
+        token = response.token;
+        console.log(token);
+        let url = "https://chacons.eu.ngrok.io/login/" + token;
+        login.href = url;
+        interval = setInterval(() => {
+          fetchData(token);
+        }, 5000);
+      })
+      .then((data) => console.log(data));
+  };
+
+  logIn();
+</script>
+
+<h1>Your User Account</h1>
+<hr />
+
+Temp Token: {token}
+
+<hr />
+
+<a bind:this={login} target="_blank" href="#"> Log In </a><br />
+{#if user}
+  User Data: {JSON.stringify(user)}
+{/if}


### PR DESCRIPTION
This is a somewhat working example of how to use the API to log in via a default OS browser. It requests a temp login token on page load (we should probably do this just before redirecting to the login screen, but that's a little difficult because `window.open()` doesn't work in <script> in Tauri), replaces the href in a log in link, then starts polling to see if you've logged in. When it sees you have, it stops polling and shows you the response, which eventually we should store to disk and then you're *logged in*.

Currently it is hardcoded to my local box via ngrok, but we can change that to a variable or the staging server or something.

Don't actually merge this, I just wanted a place to put the more or less working code so we could discuss the approach.