### PR TITLE
Make the whole directory before writing the delta file

### DIFF
--- a/src-tauri/src/deltas.rs
+++ b/src-tauri/src/deltas.rs
@@ -241,8 +241,10 @@ pub fn save_current_file_deltas(
     deltas: &Vec<Delta>,
 ) -> Result<(), std::io::Error> {
     let project_deltas_path = repo.path().join(butler::dir()).join("session/deltas");
-    std::fs::create_dir_all(&project_deltas_path)?;
     let delta_path = project_deltas_path.join(file_path);
+    let delta_dir = delta_path.parent().unwrap();
+    std::fs::create_dir_all(&delta_dir)?;
+    log::info!("mkdir {}", delta_path.to_str().unwrap());
     log::info!("Writing deltas to {}", delta_path.to_str().unwrap());
     let raw_deltas = serde_json::to_string(&deltas)?;
     std::fs::write(delta_path, raw_deltas)?;


### PR DESCRIPTION
I had to do this to get the client to start writing files, otherwise everything was:

<img width="2061" alt="CleanShot 2023-02-14 at 10 54 40@2x" src="https://user-images.githubusercontent.com/70/218704004-41abcd3f-fad0-4b0a-8586-f7a333978648.png">

Does this look right?