### PR TITLE
POC: Push to Git server after a flush

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ tauri-build = { version = "1.2", features = [] }
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.2", features = ["dialog-open", "fs-create-dir", "fs-exists", "fs-read-file", "fs-write-file", "path-all", "shell-open", "system-tray", "window-start-dragging"] }
+tauri = { version = "1.2", features = ["dialog-open", "fs-create-dir", "fs-exists", "fs-read-file", "fs-remove-file", "fs-write-file", "path-all", "shell-open", "system-tray", "window-start-dragging"] }
 tauri-plugin-window-state = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "dev" }
 tauri-plugin-log = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "dev", features = ["colored"]  }
 log = "0.4.17"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -119,6 +119,44 @@ fn add_project<R: Runtime>(
 }
 
 #[tauri::command]
+fn add_git_url(state: State<'_, AppState>, url: &str, path: &str) -> Result<(), Error> {
+    log::info!("ADD GIT URL: {} {}", url, path);
+
+    // add '.git/gb-url' to the path
+    let mut path = std::path::PathBuf::from(path);
+    path.push(".git");
+    path.push("gb-url");
+
+    // write contents to a file under the path
+    std::fs::write(path, url).map_err(|e| {
+        log::error!("{}", e);
+        Error {
+            message: "Failed to write git url".to_string(),
+        }
+    })?;
+
+    Ok(())
+}
+
+#[tauri::command]
+fn remove_git_url(state: State<'_, AppState>, path: &str) -> Result<(), Error> {
+    log::info!("REMOVE GIT URL: {}", path);
+    let mut path = std::path::PathBuf::from(path);
+    path.push(".git");
+    path.push("gb-url");
+
+    // remove file at path
+    std::fs::remove_file(path).map_err(|e| {
+        log::error!("{}", e);
+        Error {
+            message: "Failed to remove git url".to_string(),
+        }
+    })?;
+
+    Ok(())
+}
+
+#[tauri::command]
 fn list_projects(state: State<'_, AppState>) -> Result<Vec<projects::project::Project>, Error> {
     state.projects_storage.list_projects().map_err(|e| {
         log::error!("{}", e);
@@ -353,6 +391,8 @@ fn main() {
                     add_project,
                     list_projects,
                     delete_project,
+                    add_git_url,
+                    remove_git_url,
                     list_deltas,
                     list_sessions,
                     list_session_files,

--- a/src-tauri/src/projects/project.rs
+++ b/src-tauri/src/projects/project.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
-
+use tauri::PathResolver;
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Project {
     pub id: String,

--- a/src-tauri/src/projects/storage.rs
+++ b/src-tauri/src/projects/storage.rs
@@ -2,6 +2,7 @@ use crate::projects::project;
 use crate::storage;
 use anyhow::Result;
 
+// this is a comment
 const PROJECTS_FILE: &str = "projects.json";
 
 pub struct Storage {

--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -526,6 +526,7 @@ fn push_to_remote(repo: &Repository, user: &Option<User>) -> Result<(), git2::Er
         }
     }
 
+    // TODO: get the remote url from the config
     let remote_url = "https://test.app.gitbutler.com/git/287bff35-7827-4fc1-aab9-e9732da2b5ec";
 
     println!("Pushing to remote: {}", remote_url);

--- a/src-tauri/src/users/mod.rs
+++ b/src-tauri/src/users/mod.rs
@@ -1,0 +1,2 @@
+pub mod storage;
+pub mod user;

--- a/src-tauri/src/users/storage.rs
+++ b/src-tauri/src/users/storage.rs
@@ -1,0 +1,41 @@
+use crate::storage;
+use crate::users::user;
+use anyhow::Result;
+use serde_json::Value;
+const USER_FILE: &str = "user.json";
+
+pub struct Storage {
+    storage: storage::Storage,
+}
+
+impl Storage {
+    pub fn new(storage: storage::Storage) -> Self {
+        Self { storage }
+    }
+
+    pub fn get_user(&self) -> Result<Option<user::User>> {
+        match self.storage.read(USER_FILE) {
+            Ok(content) => match content {
+                Some(content) => {
+                    match serde_json::from_str::<Value>(content.as_str()) {
+                        Ok(v) => {
+                            let u = user::User {
+                                id: v["id"].to_string(),
+                                name: v["name"].as_str().unwrap().to_string(),
+                                email: v["email"].as_str().unwrap().to_string(),
+                                access_token: v["access_token"].as_str().unwrap().to_string(),
+                            };
+                            return Ok(Some(u));
+                        }
+                        Err(e) => {
+                            println!("Error: {:#?}", e);
+                            return Err(anyhow::anyhow!("Error: {:?}", e));
+                        }
+                    };
+                }
+                None => return Ok(None),
+            },
+            Err(_) => return Ok(None),
+        }
+    }
+}

--- a/src-tauri/src/users/user.rs
+++ b/src-tauri/src/users/user.rs
@@ -1,0 +1,18 @@
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct User {
+    pub id: String,
+    pub name: String,
+    pub email: String,
+    pub access_token: String,
+}
+
+impl AsRef<User> for User {
+    fn as_ref(&self) -> &User {
+        self
+    }
+}
+
+impl User {}

--- a/src-tauri/src/users/user.rs
+++ b/src-tauri/src/users/user.rs
@@ -9,10 +9,4 @@ pub struct User {
     pub access_token: String,
 }
 
-impl AsRef<User> for User {
-    fn as_ref(&self) -> &User {
-        self
-    }
-}
-
 impl User {}

--- a/src-tauri/src/watchers/git.rs
+++ b/src-tauri/src/watchers/git.rs
@@ -53,7 +53,7 @@ pub fn watch<R: tauri::Runtime>(
                         repo.workdir().unwrap().display()
                     );
                 }
-                if sessions::flush_current_session(&repo, &user).is_err() {
+                if sessions::flush_current_session(&repo, &user, &project).is_err() {
                     log::error!(
                         "Error while flushing current session for {}",
                         repo.workdir().unwrap().display()
@@ -62,7 +62,7 @@ pub fn watch<R: tauri::Runtime>(
             }
         }
 
-        match check_for_changes(&repo, &user) {
+        match check_for_changes(&repo, &user, &project) {
             Ok(Some(session)) => {
                 events::session(&window, &project, &session);
             }
@@ -92,9 +92,10 @@ pub fn watch<R: tauri::Runtime>(
 fn check_for_changes(
     repo: &Repository,
     user: &Option<User>,
+    project: &Project,
 ) -> Result<Option<sessions::Session>, Box<dyn std::error::Error>> {
     if ready_to_commit(repo)? {
-        Ok(Some(sessions::flush_current_session(repo, user)?))
+        Ok(Some(sessions::flush_current_session(repo, user, project)?))
     } else {
         Ok(None)
     }

--- a/src-tauri/src/watchers/git.rs
+++ b/src-tauri/src/watchers/git.rs
@@ -32,8 +32,7 @@ impl From<std::io::Error> for WatchError {
     }
 }
 
-//const FIVE_MINUTES: u64 = Duration::new(5 * 60, 0).as_secs();
-const FIVE_MINUTES: u64 = Duration::new(5, 0).as_secs();
+const FIVE_MINUTES: u64 = Duration::new(5 * 60, 0).as_secs();
 const ONE_HOUR: u64 = Duration::new(60 * 60, 0).as_secs();
 
 pub fn watch<R: tauri::Runtime>(

--- a/src-tauri/src/watchers/mod.rs
+++ b/src-tauri/src/watchers/mod.rs
@@ -3,6 +3,7 @@ mod git;
 
 pub use self::delta::WatcherCollection;
 use crate::projects::project::Project;
+use crate::users::user::User;
 use serde::Serialize;
 use tauri::{Runtime, Window};
 
@@ -46,9 +47,10 @@ pub fn watch<R: Runtime>(
     window: Window<R>,
     watchers: &WatcherCollection,
     project: &Project,
+    user: &Option<User>,
 ) -> Result<(), WatchError> {
     self::delta::watch(window.clone(), watchers, project.clone())?;
-    self::git::watch(window.clone(), project.clone())?;
+    self::git::watch(window.clone(), project.clone(), user.clone())?;
     Ok(())
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,10 +31,11 @@
         "all": false,
         "readFile": true,
         "writeFile": true,
+        "removeFile": true,
         "exists": true,
         "createDir": true,
         "scope": [
-            "$APPLOCALDATA/user.json"
+            "$APPLOCALDATA/*.json"
         ]
       }
     },

--- a/src/lib/authentication.ts
+++ b/src/lib/authentication.ts
@@ -21,14 +21,6 @@ export type User = {
     access_token: string,
 }
 
-export type Project = {
-    id: number,
-    name: string,
-    description: string,
-    created_at: string,
-    updated_at: string,
-    git_url: string,
-}
 
 const parseJSON = async (response: Response) => {
     if (response.status === 204 || response.status === 205) {

--- a/src/lib/authentication.ts
+++ b/src/lib/authentication.ts
@@ -22,7 +22,6 @@ export type User = {
     access_token: string,
 }
 
-
 const parseJSON = async (response: Response) => {
     if (response.status === 204 || response.status === 205) {
         return null;
@@ -56,18 +55,19 @@ export default ({ fetch }: { fetch: typeof window.fetch } = { fetch: window.fetc
             get: (token: string): Promise<User> => fetch(getUrl(`login/user/${token}.json`), {
                 method: 'GET',
             }).then(parseJSON),
-        },
-        project: {
-            get: (repoId: string): Promise<Project> => fetch(getUrl(`projects/${repoId}.json`), {
-                method: 'GET',
-            }).then(parseJSON),
-            create: (params: {} = {}): Promise<Project> => fetch(getUrl(`projects.json`), {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify(params),
-            }).then(parseJSON),
         }
+    },
+    project: {
+        get: (repoId: string): Promise<Project> => fetch(getUrl(`projects/${repoId}.json`), {
+            method: 'GET',
+        }).then(parseJSON),
+        create: (token: string, params: {} = {}): Promise<Project> => fetch(getUrl(`projects.json`), {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Auth-Token': token
+            },
+            body: JSON.stringify(params),
+        }).then(parseJSON),
     }
 })

--- a/src/lib/authentication.ts
+++ b/src/lib/authentication.ts
@@ -21,6 +21,15 @@ export type User = {
     access_token: string,
 }
 
+export type Project = {
+    id: number,
+    name: string,
+    description: string,
+    created_at: string,
+    updated_at: string,
+    git_url: string,
+}
+
 const parseJSON = async (response: Response) => {
     if (response.status === 204 || response.status === 205) {
         return null;
@@ -53,6 +62,18 @@ export default ({ fetch }: { fetch: typeof window.fetch } = { fetch: window.fetc
         user: {
             get: (token: string): Promise<User> => fetch(getUrl(`login/user/${token}.json`), {
                 method: 'GET',
+            }).then(parseJSON),
+        },
+        project: {
+            get: (repoId: string): Promise<Project> => fetch(getUrl(`projects/${repoId}.json`), {
+                method: 'GET',
+            }).then(parseJSON),
+            create: (params: {} = {}): Promise<Project> => fetch(getUrl(`projects.json`), {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(params),
             }).then(parseJSON),
         }
     }

--- a/src/lib/authentication.ts
+++ b/src/lib/authentication.ts
@@ -12,7 +12,6 @@ export type LoginToken = {
     url: string
 }
 
-
 const parseJSON = async (response: Response) => {
     if (response.status === 204 || response.status === 205) {
         return null;

--- a/src/lib/authentication.ts
+++ b/src/lib/authentication.ts
@@ -1,4 +1,5 @@
 import { dev } from '$app/environment'
+import type { Project } from '$lib/projects';
 
 const apiUrl = dev ? new URL('https://test.app.gitbutler.com/api/') : new URL('https://app.gitbutler.com/api/');
 

--- a/src/lib/authentication.ts
+++ b/src/lib/authentication.ts
@@ -1,5 +1,6 @@
 import { dev } from '$app/environment'
 import type { Project } from '$lib/projects';
+import type { User } from '$lib/user';
 
 const apiUrl = dev ? new URL('https://test.app.gitbutler.com/api/') : new URL('https://app.gitbutler.com/api/');
 
@@ -11,16 +12,6 @@ export type LoginToken = {
     url: string
 }
 
-export type User = {
-    id: number,
-    name: string,
-    email: string,
-    picture: string,
-    locale: string,
-    created_at: string,
-    updated_at: string,
-    access_token: string,
-}
 
 const parseJSON = async (response: Response) => {
     if (response.status === 204 || response.status === 205) {

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api";
-import { writable } from "svelte/store";
+import { writable, get } from "svelte/store";
 
 export type Project = {
     id: number,
@@ -17,6 +17,7 @@ export type Project = {
     sync: boolean,
 }
 
+
 const list = () => invoke<Project[]>("list_projects");
 
 const add = (params: { path: string }) =>
@@ -25,6 +26,7 @@ const add = (params: { path: string }) =>
 export default async () => {
     const init = await list();
     const store = writable<Project[]>(init);
+  
     return {
         subscribe: store.subscribe,
         add: (params: { path: string }) =>

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -2,10 +2,17 @@ import { invoke } from "@tauri-apps/api";
 import { writable } from "svelte/store";
 
 export type Project = {
-    id: string;
-    title: string;
-    path: string;
-};
+    id: number,
+    title: string,
+    path: string,
+
+    /* server things */
+    name: string,
+    description: string,
+    created_at: string,
+    updated_at: string,
+    git_url: string,
+}
 
 const list = () => invoke<Project[]>("list_projects");
 

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -12,6 +12,9 @@ export type Project = {
     created_at: string,
     updated_at: string,
     git_url: string,
+
+    /* settings */
+    sync: boolean,
 }
 
 const list = () => invoke<Project[]>("list_projects");
@@ -28,6 +31,6 @@ export default async () => {
             add(params).then((project) => {
                 store.update((projects) => [...projects, project]);
                 return project;
-            }),
+            })
     };
 };

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -1,0 +1,10 @@
+export type User = {
+    id: number,
+    name: string,
+    email: string,
+    picture: string,
+    locale: string,
+    created_at: string,
+    updated_at: string,
+    access_token: string,
+}

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -1,5 +1,5 @@
 import { BaseDirectory, exists, readTextFile, writeTextFile } from '@tauri-apps/api/fs';
-import type { User } from '$lib/authentication';
+import type { User } from '$lib/user';
 import { writable } from 'svelte/store';
 
 const userFile = 'user.json';

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -20,7 +20,7 @@ export default async () => {
 
     store.subscribe(async (user) => {
         if (user) {
-            console.log({ user });
+            console.log("User", user);
             await writeTextFile(userFile, JSON.stringify(user), {
                 dir: BaseDirectory.AppLocalData
             });

--- a/src/routes/projects/[projectId]/+layout.svelte
+++ b/src/routes/projects/[projectId]/+layout.svelte
@@ -5,18 +5,26 @@
     $: project = data.project;
     $: sessions = data.sessions;
     $: lastSessionId = $sessions[$sessions.length - 1]?.id;
+    console.log(project)
 </script>
 
-<div class="p-3 flex flex-row space-x-3 text-zinc-500 text-lg select-none">
-    <div>Week</div>
-    <a href="/projects/{$project?.id}" class="hover:text-zinc-300">Day</a>
-    {#if lastSessionId}
-        <a
-            href="/projects/{$project?.id}/sessions/{lastSessionId}"
-            class="hover:text-zinc-300"
-            title="go to current session">Session</a
-        >
-    {/if}
+<div class="flex flex-row justify-between">
+    <div class="p-3 flex flex-row space-x-3 text-zinc-500 text-lg select-none">
+        <div>Week</div>
+        <a href="/projects/{$project?.id}" class="hover:text-zinc-300">Day</a>
+        {#if lastSessionId}
+            <a
+                href="/projects/{$project?.id}/sessions/{lastSessionId}"
+                class="hover:text-zinc-300"
+                title="go to current session">Session</a
+            >
+        {/if}
+
+    </div>
+    <div class="flex flex-row p-4 space-x-4">
+        <div>{$project?.title}</div>
+        <div><a href="/projects/{$project?.id}/settings">settings</a></div>
+    </div>
 </div>
 
 <slot />

--- a/src/routes/projects/[projectId]/settings/+page.svelte
+++ b/src/routes/projects/[projectId]/settings/+page.svelte
@@ -1,29 +1,62 @@
 <script lang="ts">
     import type { PageData } from "./$types";
+    import type { Project } from "$lib/projects";
     import Authentication from "$lib/authentication";
+    import { BaseDirectory, writeTextFile } from '@tauri-apps/api/fs';
+    import Projects from '$lib/projects';
 
     const authApi = Authentication();
+    const projectsFile = 'projects.json';
 
     export let data: PageData;
     $: project = data.project;
     $: projects = data.projects;
     $: user = data.user;
 
+    Projects().then((projectStore) => {
+      projectStore.subscribe((newProjects) => {
+        // write to the disk
+        console.log("Projects Store Updated");
+        console.log(newProjects);
+      })
+    });
+
+    function updateProject(project: Project) {
+        console.log("Update Project", project);
+        const items = $projects;
+        const newProjects = items.map(item => item.id === project.id ? project : item);
+
+        console.log(newProjects);
+        // omg
+
+        writeTextFile(projectsFile, JSON.stringify(newProjects), {
+            dir: BaseDirectory.AppLocalData
+        });
+        $projects = newProjects;
+    };
+
     function enableSync() {
       const apiProject = authApi.project.create($user.access_token, {name: $project?.title})
         .then((res) => {
+            console.log("Git response");
             console.log(res);
             if($project) {
+              console.log("Updating Project");
               $project.git_url = res.git_url;
+              console.log("Set git url");
               $project.sync = true;
+              console.log("Set sync");
+              console.log($project);
+              updateProject($project);
             }
         })
-        .catch(() => null);
+        .catch((e) => console.log("error", e));
     }
 
     function disableSync() {
       if($project) {
         console.log($project);
+        $project.git_url = null;
         $project.sync = false;
       }
     }

--- a/src/routes/projects/[projectId]/settings/+page.svelte
+++ b/src/routes/projects/[projectId]/settings/+page.svelte
@@ -53,7 +53,7 @@
     };
 
     function enableSync() {
-      const apiProject = authApi.project.create($user.access_token, {name: $project?.title})
+      const apiProject = authApi.project.create($user.access_token, {name: $project?.title, uid: $project?.id})
         .then((res) => {
             console.log("Git response");
             console.log(res);

--- a/src/routes/projects/[projectId]/settings/+page.svelte
+++ b/src/routes/projects/[projectId]/settings/+page.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+    import type { PageData } from "./$types";
+    import Authentication from "$lib/authentication";
+
+    const authApi = Authentication();
+
+    export let data: PageData;
+    $: project = data.project;
+    $: projects = data.projects;
+    $: user = data.user;
+
+    function enableSync() {
+      const apiProject = authApi.project.create($user.access_token, {name: $project?.title})
+        .then((res) => {
+            console.log(res);
+            if($project) {
+              $project.git_url = res.git_url;
+              $project.sync = true;
+            }
+        })
+        .catch(() => null);
+    }
+
+    function disableSync() {
+      if($project) {
+        console.log($project);
+        $project.sync = false;
+      }
+    }
+</script>
+
+<div class="flex flex-col justify-between p-4">
+  <div>
+    ID: {$project?.id}
+  </div>
+  <div>
+    Title: {$project?.title}
+  </div>
+  <div>
+    {#if $project?.git_url}
+      Syncing to URL: {$project?.git_url}
+      <button on:click={disableSync}>Disable Sync</button>
+    {:else}
+      {#if $user}
+        <button on:click={enableSync}>Enable Sync</button>
+      {:else}
+        Log in to Sync
+      {/if}
+    {/if}
+  </div>
+</div>
+
+<slot />

--- a/src/routes/projects/[projectId]/settings/+page.svelte
+++ b/src/routes/projects/[projectId]/settings/+page.svelte
@@ -4,6 +4,7 @@
     import Authentication from "$lib/authentication";
     import { BaseDirectory, writeTextFile, removeFile, exists } from '@tauri-apps/api/fs';
   	import { beforeUpdate, afterUpdate } from 'svelte';
+    import { invoke } from "@tauri-apps/api";
 
     const authApi = Authentication();
 
@@ -17,6 +18,7 @@
     afterUpdate(() => {
       projectPath = "project-" + $project?.id.toString() + ".json"
       checkExists();
+
     })
 
     function checkExists() {
@@ -31,11 +33,18 @@
     }
 
     function updateProject(project: Project, url) {
-        writeTextFile(projectPath, url, {
+        writeTextFile(projectPath, JSON.stringify({url: url}), {
             dir: BaseDirectory.AppLocalData
         }).then(() => {
             console.log("Wrote URL");
             projectPath = "project-" + $project?.id.toString() + ".json"
+            invoke("add_git_url", { url: url, path: $project?.path }).then((res) => {
+              console.log("Added git url");
+              console.log(res);
+            }).catch((e) => {
+              console.log("Error adding git url");
+              console.log(e);
+            })
             checkExists();
         }).catch((e) => {
             console.log("Error writing URL");
@@ -64,6 +73,13 @@
             dir: BaseDirectory.AppLocalData
         }).then(() => {
             console.log("Removed URL");
+            invoke("remove_git_url", { path: $project?.path }).then((res) => {
+              console.log("Removed git url");
+              console.log(res);
+            }).catch((e) => {
+              console.log("Error removing git url");
+              console.log(e);
+            })
             checkExists();
         }).catch((e) => {
             console.log("Error removing URL");

--- a/src/routes/projects/[projectId]/settings/+page.ts
+++ b/src/routes/projects/[projectId]/settings/+page.ts
@@ -1,0 +1,17 @@
+import { derived } from "svelte/store";
+import type { PageLoad } from "./$types";
+import { building } from "$app/environment";
+
+export const prerender = false;
+
+export const load: PageLoad = async ({ parent, params }) => {
+  const { projects } = await parent();
+  const user = building ? writable<undefined>(undefined) : await (await import("$lib/users")).default();
+  return {
+    project: derived(projects, (projects) =>
+      projects.find((project) => project.id === params.projectId)
+    ),
+    projects: projects,
+    user: user
+  };
+};


### PR DESCRIPTION
This PR implements the concept of having the client try to push the gitbutler data to a server after a GB flush activity. 

In this PR, it pushes every time it flushes and the server and auth token are hard coded, since I'm not sure what the best way to get them out of the projects.json and user.json file is. I assume it's not too difficult as that's in Rust anyways, right?

We should probably make the function return immediately and no-op if the project is not registered with the server, or if the user is not logged in.

Before this is working, we would need to have a way to have the client create a project on the server and store the git url that is produced. You can do this with the user's auth token by doing a POST to `/api/projects` with a `name` parameter. The JSON returned should have a `git_url`. If we store this in `projects.json`, we should be able to pull it out easily here.

The user auth token should already exist in `user.json` if they are logged in.
