### PR TITLE
GB-40 Show footer indicating if a project is syncing

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,7 @@
             "all": false,
             "shell": {
                 "all": false,
-                "open": "^https://test.app.gitbutler.com/"
+                "open": true
             },
             "dialog": {
                 "all": false,

--- a/src-tauri/tauri.conf.release.json
+++ b/src-tauri/tauri.conf.release.json
@@ -8,7 +8,7 @@
         },
         "allowlist": {
             "shell": {
-                "open": "^https://test.app.gitbutler.com/"
+                "open": true
             }
         },
         "updater": {

--- a/src/routes/projects/[projectId]/+layout.svelte
+++ b/src/routes/projects/[projectId]/+layout.svelte
@@ -11,6 +11,16 @@
     $: sessions = data.sessions;
     $: lastSessionId = $sessions[$sessions.length - 1]?.id;
 
+    function projectUrl(project: Project) {
+        const gitUrl = project.api?.git_url;
+        // get host from git url
+        const url = new URL(gitUrl);
+        const host = url.origin;
+        const projectId = gitUrl.split("/").pop();
+
+        return `${host}/projects/${projectId}`;
+    }
+
     const contextProjectStore: Writable<Project | null | undefined> =
         getContext("project");
     $: contextProjectStore.set($project);
@@ -78,3 +88,38 @@
 </nav>
 
 <slot />
+
+<div class="absolute bottom-0 left-0 w-full">
+    <div
+        class="flex items-center flex-shrink-0 h-6 border-t select-none border-zinc-700 bg-zinc-900 "
+    >
+        <div
+            class="flex flex-row mx-4 items-center space-x-2 text-xs justify-between w-full"
+        >
+            {#if $project?.api?.sync}
+                <a
+                    href="/projects/{$project?.id}/settings"
+                    class="text-zinc-400 hover:text-zinc-300"
+                >
+                    <div class="flex flex-row items-center space-x-2 text-xs">
+                        <div class="w-2 h-2 bg-green-700 rounded-full" />
+                        <div class="text-zinc-200">Up to date</div>
+                    </div>
+                </a>
+                <a target="_blank" href={projectUrl($project)}
+                    >Open in GitButler Cloud</a
+                >
+            {:else}
+                <a
+                    href="/projects/{$project?.id}/settings"
+                    class="text-zinc-400 hover:text-zinc-300"
+                >
+                    <div class="flex flex-row items-center space-x-2 text-xs">
+                        <div class="w-2 h-2 bg-red-700 rounded-full" />
+                        <div class="text-zinc-200">Offline</div>
+                    </div>
+                </a>
+            {/if}
+        </div>
+    </div>
+</div>

--- a/src/routes/projects/[projectId]/+layout.svelte
+++ b/src/routes/projects/[projectId]/+layout.svelte
@@ -103,7 +103,7 @@
                 >
                     <div class="flex flex-row items-center space-x-2 text-xs">
                         <div class="w-2 h-2 bg-green-700 rounded-full" />
-                        <div class="text-zinc-200">Up to date</div>
+                        <div class="text-zinc-200">Syncing</div>
                     </div>
                 </a>
                 <a target="_blank" href={projectUrl($project)}


### PR DESCRIPTION
This adds the footer back, but only if you're in a project. If the project is not syncing to a server, it shows an 'offline' status:

<img width="912" alt="CleanShot 2023-02-22 at 19 12 24@2x" src="https://user-images.githubusercontent.com/70/220718649-0be1bf2b-5c50-42c5-817c-0149394b180d.png">

If you are syncing, it shows "Online":

<img width="912" alt="CleanShot 2023-02-22 at 19 12 18@2x" src="https://user-images.githubusercontent.com/70/220718656-e903f0ce-8188-4bf3-b5f3-72d30ddd030e.png">

I also added an 'Open in Cloud' link just to make that a little easier for now, but we'll want to do something different later.