### PR TITLE
Improve commit message parsing

### DIFF
--- a/src/routes/projects/[projectId]/commit/+page.svelte
+++ b/src/routes/projects/[projectId]/commit/+page.svelte
@@ -70,8 +70,8 @@
 			})
 			.then(({ message }) => {
 				const firstNewLine = message.indexOf('\n');
-				summary = firstNewLine > -1 ? message.slice(0, firstNewLine) : message;
-				description = firstNewLine > -1 ? message.slice(firstNewLine + 1) : '';
+				summary = firstNewLine > -1 ? message.slice(0, firstNewLine).trim() : message;
+				description = firstNewLine > -1 ? message.slice(firstNewLine + 1).trim() : '';
 			})
 			.catch(() => {
 				error('Failed to generate commit message');


### PR DESCRIPTION
Refactor the parsing of commit messages in the `+page.svelte` file to trim unnecessary whitespace from the summary and description fields. This change makes sure the processed commit message is more readable and concise.

Changes:
- Trim the summary and description lines after slicing the message