### PR TITLE
🔨 Refactor: Keyboard Shortcuts & Navigation

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,7 +10,6 @@
 	import CommandPalette from '$lib/components/CommandPalette/CommandPalette.svelte';
 	import { derived } from 'svelte/store';
 	import { onMount } from 'svelte';
-	import { goto } from '$app/navigation';
 
 	export let data: LayoutData;
 	const { user, posthog, projects } = data;
@@ -23,10 +22,7 @@
 
 	onMount(() =>
 		tinykeys(window, {
-			'Meta+k': () => commandPalette.show(),
-			'Shift+c': () => $project && goto(`/projects/${$project.id}/commit/`),
-			'Shift+t': () => $project && goto(`/projects/${$project.id}/terminal/`),
-			'a i p': () => $project && goto(`/projects/${$project.id}/aiplayground/`)
+			'Meta+k': () => commandPalette.show()
 		})
 	);
 

--- a/src/routes/projects/[projectId]/+layout.svelte
+++ b/src/routes/projects/[projectId]/+layout.svelte
@@ -5,9 +5,13 @@
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
 	import { IconTerminal } from '$lib/components/icons';
+	import { onMount } from 'svelte';
+	import tinykeys from 'tinykeys';
+	import { derived } from 'svelte/store';
 
 	export let data: LayoutData;
 	const { project } = data;
+	$: statuses = derived(data.statuses, (statuses) => statuses);
 
 	let query: string;
 
@@ -22,6 +26,23 @@
 
 		return `${host}/projects/${projectId}`;
 	}
+
+	onMount(() =>
+		tinykeys(window, {
+			'Shift+c': (event: KeyboardEvent) => {
+				const target = event.target as HTMLElement;
+				if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') return;
+				if ($statuses.length === 0) return;
+				$project && goto(`/projects/${$project.id}/commit/`);
+			},
+			'Shift+t': (event: KeyboardEvent) => {
+				const target = event.target as HTMLElement;
+				if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') return;
+				$project && goto(`/projects/${$project.id}/terminal/`);
+			},
+			'a i p': () => $project && goto(`/projects/${$project.id}/aiplayground/`)
+		})
+	);
 
 	$: selection = $page?.route?.id?.split('/')?.[3];
 </script>


### PR DESCRIPTION
- Improve keyboard shortcuts navigation in the project layout
- Add `onMount` for keyboard shortcuts
- Add `tinykeys` for keyboard shortcuts
- Add `statuses` derived store
- Add `Shift+c` and `Shift+t` keyboard shortcuts
- Add `a i p` keyboard shortcut

[src/routes/+layout.svelte]
- Remove the `goto` import
- Remove 3 key bindings
- Add an `a i p` key binding
[src/routes/projects/[projectId]/+layout.svelte]
- Add `onMount` for keyboard shortcuts
- Add `tinykeys` for keyboard shortcuts
- Add `statuses` derived store
- Add `Shift+c` keyboard shortcut to navigate to commit page
- Add `Shift+t` keyboard shortcut to navigate to terminal page
- Add `a i p` keyboard shortcut to navigate to AI Playground page
