### PR TITLE
🔨 Refactor command hotkeys

### DIFF
--- a/src/lib/components/CommandPalette/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette/CommandPalette.svelte
@@ -194,7 +194,9 @@
 											<svelte:component this={command.icon} class="icon h-5 w-5 text-zinc-500 " />
 											<span class="quick-command flex-1 text-left">{command.title}</span>
 											{#if command.hotkey}
-												<span class="quick-command-key">{command.hotkey}</span>
+												{#each command.hotkey.split(' ') as key}
+													<span class="quick-command-key">{key}</span>
+												{/each}
 											{/if}
 										</button>
 									</li>

--- a/src/lib/components/CommandPalette/commands.ts
+++ b/src/lib/components/CommandPalette/commands.ts
@@ -64,7 +64,7 @@ const actionsGroup = ({ project, input }: { project: Project; input: string }): 
 	commands: [
 		{
 			title: 'Quick commit',
-			hotkey: 'c',
+			hotkey: 'C',
 			action: {
 				title: 'Quick commit',
 				component: QuickCommit,
@@ -74,7 +74,7 @@ const actionsGroup = ({ project, input }: { project: Project; input: string }): 
 		},
 		{
 			title: 'Commit',
-			hotkey: 'Shift+c',
+			hotkey: 'Shift C',
 			action: {
 				href: `/projects/${project.id}/commit/`
 			},
@@ -82,7 +82,7 @@ const actionsGroup = ({ project, input }: { project: Project; input: string }): 
 		},
 		{
 			title: 'Terminal',
-			hotkey: 'Shift+t',
+			hotkey: 'Shift T',
 			action: {
 				href: `/projects/${project?.id}/terminal/`
 			},
@@ -90,7 +90,7 @@ const actionsGroup = ({ project, input }: { project: Project; input: string }): 
 		},
 		{
 			title: 'Replay History',
-			hotkey: 'r',
+			hotkey: 'R',
 			action: {
 				title: 'Replay working history',
 				commands: [


### PR DESCRIPTION
- Update hotkeys for Command Palette commands
- Update 'Quick commit' hotkey from `c` to `C`
- Update 'Commit' hotkey from `Shift+c` to `Shift C`
- Update 'Terminal' hotkey from `Shift+t` to `Shift T`
- Update 'Replay History' hotkey from `r` to `R`

[src/lib/components/CommandPalette/CommandPalette.svelte]
- Split the command.hotkey into separate keys and display them
[src/lib/components/CommandPalette/commands.ts]
- Change the hotkey for 'Quick commit' from `c` to `C`
- Change the hotkey for 'Commit' from `Shift+c` to `Shift C`
- Change the hotkey for 'Terminal' from `Shift+t` to `Shift T`
- Change the hotkey for 'Replay History' from `r` to `R`
