### PR TITLE
🔨 Refactor CommandPalette hotkeys

### DIFF
--- a/src/lib/components/CommandPalette/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette/CommandPalette.svelte
@@ -194,7 +194,7 @@
 											<svelte:component this={command.icon} class="icon h-5 w-5 text-zinc-500 " />
 											<span class="quick-command flex-1 text-left">{command.title}</span>
 											{#if command.hotkey}
-												{#each command.hotkey.split(' ') as key}
+												{#each command.hotkey.split('+') as key}
 													<span class="quick-command-key">{key}</span>
 												{/each}
 											{/if}

--- a/src/lib/components/CommandPalette/commands.ts
+++ b/src/lib/components/CommandPalette/commands.ts
@@ -1,4 +1,4 @@
-import QuickCommit from './QuickCommit.svelte';
+import type QuickCommit from './QuickCommit.svelte';
 import type { Project } from '$lib/projects';
 import { GitCommitIcon, IconFile, IconProject, IconTerminal, RewindIcon } from '../icons';
 import { matchFiles } from '$lib/git';
@@ -63,18 +63,8 @@ const actionsGroup = ({ project, input }: { project: Project; input: string }): 
 	title: 'Actions',
 	commands: [
 		{
-			title: 'Quick commit',
-			hotkey: 'C',
-			action: {
-				title: 'Quick commit',
-				component: QuickCommit,
-				props: { project }
-			},
-			icon: GitCommitIcon
-		},
-		{
 			title: 'Commit',
-			hotkey: 'Shift C',
+			hotkey: 'Shift+C',
 			action: {
 				href: `/projects/${project.id}/commit/`
 			},
@@ -82,7 +72,7 @@ const actionsGroup = ({ project, input }: { project: Project; input: string }): 
 		},
 		{
 			title: 'Terminal',
-			hotkey: 'Shift T',
+			hotkey: 'Shift+T',
 			action: {
 				href: `/projects/${project?.id}/terminal/`
 			},
@@ -90,7 +80,6 @@ const actionsGroup = ({ project, input }: { project: Project; input: string }): 
 		},
 		{
 			title: 'Replay History',
-			hotkey: 'R',
 			action: {
 				title: 'Replay working history',
 				commands: [


### PR DESCRIPTION
- Update hotkeys for `Commit` and `Terminal` commands
- Remove `Quick commit` command
- Add `Replay History` command
- Update hotkey split from ` ` to `+`

[src/lib/components/CommandPalette/commands.ts]
- Change the hotkey for `Commit` from `Shift C` to `Shift+C`
- Change the hotkey for `Terminal` from `Shift T` to `Shift+T`
- Remove the `Quick commit` command
- Add a `Replay History` command with no hotkey
[src/lib/components/CommandPalette/CommandPalette.svelte]
- Change the hotkey split from ` ` to `+`
