### PR TITLE
🔨 Refactor terminal route and connection logic

### DIFF
--- a/src-tauri/src/pty/connection.rs
+++ b/src-tauri/src/pty/connection.rs
@@ -115,6 +115,16 @@ pub async fn accept_connection(
                     Ok(0) => {
                         // EOF
                         log::info!("0 bytes read from pty. EOF.");
+                        if let Err(e) = ws_sender
+                            .send(tokio_tungstenite::tungstenite::Message::Close(None))
+                            .await
+                        {
+                            log::error!(
+                                "{}: error sending data to websocket: {:#}",
+                                shared_project_id,
+                                e
+                            );
+                        }
                         break;
                     }
                     Ok(n) => {

--- a/src/routes/projects/[projectId]/terminal/+page.svelte
+++ b/src/routes/projects/[projectId]/terminal/+page.svelte
@@ -17,7 +17,7 @@
 	const handleTerminalResize = debounce(() => term?.resize(), 5);
 	const runCommand = (command: string) => term?.run(command);
 
-	const terminal = (target: HTMLElement, params: { project: Project }) => {
+	$: terminal = (target: HTMLElement, params: { project: Project }) => {
 		let setupPromise = setupTerminal(params);
 		setupPromise.then((terminal) => (term = terminal));
 		setupPromise.then((terminal) => terminal.bind(target));

--- a/src/routes/projects/[projectId]/terminal/terminal.ts
+++ b/src/routes/projects/[projectId]/terminal/terminal.ts
@@ -81,7 +81,10 @@ const newSession = async (params: { project: Project }) => {
 		});
 
 		conn.addListener((message) => {
-			message.type === 'Close' && term.dispose();
+			if (message.type === 'Close') {
+				term.dispose();
+				location.reload();
+			}
 		});
 
 		return {


### PR DESCRIPTION
- Improved terminal experience by handling 'Close' messages and reloading the page
- Added logic to send a Close message to the websocket when EOF is reached
- Changed the `terminal` function to a reactive declaration and added a `setupTerminal` function call
