### PR TITLE
Optimize line numbering in Differ component

### DIFF
--- a/src/lib/components/Differ/Differ.svelte
+++ b/src/lib/components/Differ/Differ.svelte
@@ -146,8 +146,6 @@
 	};
 
 	$: rows = highlight.length > 0 ? padHighlighted(renderedRows) : renderedRows;
-	$: originalLineNumberDigits = String(rows.at(-1)?.originalLineNumber || '0').length;
-	$: currentLineNumberDigits = String(rows.at(-1)?.currentLineNumber || '0').length;
 
 	const scrollToChangedLine = () => {
 		const changedLines = document.getElementsByClassName('line-changed');
@@ -159,7 +157,11 @@
 </script>
 
 <div class="flex h-full w-full select-text whitespace-pre font-mono">
-	<div id="content" class="flex max-w-full flex-auto flex-col border-b border-zinc-800">
+	<div
+		id="content"
+		class="grid max-w-full flex-auto border-b border-zinc-800"
+		style:grid-template-columns="minmax(auto, max-content) minmax(auto, max-content) 1fr"
+	>
 		{#each rows as row}
 			{@const baseNumber =
 				row.type === RowType.Equal || row.type === RowType.Deletion
@@ -169,28 +171,23 @@
 				row.type === RowType.Equal || row.type === RowType.Addition
 					? String(row.currentLineNumber)
 					: ''}
-			<div
-				class="grid max-w-full grid-cols-3"
-				style:grid-template-columns="min-content min-content 1fr"
-			>
-				<span class="select-none border-r  border-zinc-800 bg-zinc-900 text-zinc-500/70">
-					<div class="mx-1.5 w-[{originalLineNumberDigits}ch] text-right">
-						{baseNumber}
-					</div>
-				</span>
+			<span class="select-none border-r  border-zinc-800 bg-zinc-900 text-zinc-500/70">
+				<div class="mx-1.5 text-right">
+					{baseNumber}
+				</div>
+			</span>
 
-				<span class="mr-1 select-none border-r border-zinc-800 bg-zinc-900 text-zinc-500/70">
-					<div class="mx-1.5 w-[{currentLineNumberDigits}ch] text-right">
-						{curNumber}
-					</div>
-				</span>
+			<span class="mr-1 select-none border-r border-zinc-800 bg-zinc-900 text-zinc-500/70">
+				<div class="mx-1.5 text-right">
+					{curNumber}
+				</div>
+			</span>
 
-				<span class="diff-line-{row.type} overflow-hidden whitespace-pre-wrap">
-					{#each row.render.html as content}
-						{@html content}
-					{/each}
-				</span>
-			</div>
+			<span class="diff-line-{row.type} overflow-hidden whitespace-pre-wrap">
+				{#each row.render.html as content}
+					{@html content}
+				{/each}
+			</span>
 		{/each}
 	</div>
 </div>


### PR DESCRIPTION
This commit improves the Differ component by removing unnecessary lines of code for determining the line number digits for both the original and current files. The general logic remains unchanged, but there's a cleaner approach for handling line numbering operations, resulting in a more concise and efficient implementation.

Removed lines:
- Original and current line number digit calculation