### PR TITLE
Add event_sender to App and update function signatures

### DIFF
--- a/src-tauri/src/app/watcher/watcher.rs
+++ b/src-tauri/src/app/watcher/watcher.rs
@@ -1,9 +1,7 @@
-use std::sync;
-
 use anyhow::Result;
 use crossbeam_channel::{select, unbounded};
 
-use crate::{app::gb_repository, events as app_events, projects, search};
+use crate::{app::gb_repository, events, projects, search};
 
 use super::{dispatchers, handlers};
 
@@ -20,8 +18,8 @@ impl<'watcher> Watcher<'watcher> {
         project_store: projects::Storage,
         gb_repository: &'watcher gb_repository::Repository,
         deltas_searcher: search::Deltas,
-        events: sync::mpsc::Sender<app_events::Event>,
         stop: crossbeam_channel::Receiver<()>,
+        events_sender: events::Sender,
     ) -> Result<Self> {
         Ok(Self {
             project_id: project.id.clone(),
@@ -31,7 +29,7 @@ impl<'watcher> Watcher<'watcher> {
                 project_store,
                 gb_repository,
                 deltas_searcher,
-                events,
+                events_sender,
             ),
             stop,
         })

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -1,7 +1,27 @@
+use anyhow::{Context, Result};
+use tauri::Manager;
+
 use crate::{
     app::{deltas, sessions},
     projects,
 };
+
+#[derive(Clone)]
+pub struct Sender {
+    app_handle: tauri::AppHandle,
+}
+
+impl Sender {
+    pub fn new(app_handle: tauri::AppHandle) -> Self {
+        Self { app_handle }
+    }
+
+    pub fn send(&self, event: Event) -> Result<()> {
+        self.app_handle
+            .emit_all(&event.name, Some(event.payload))
+            .context("emit event")
+    }
+}
 
 #[derive(Debug)]
 pub struct Event {


### PR DESCRIPTION
Implemented the addition of an event_sender property to the App struct which is used by the start_watcher and init functions. Updated the new, init, and start_watcher functions to work with the new event_sender, and removed the now unnecessary events argument.

Changes:
- Added event_sender property to App struct.
- Added event_sender argument to new function.
- Removed events argument from init_project, init, and start_watcher functions.
- Updated start_watcher and init functions to use the new event_sender.