### PR TITLE
Refactor Checkbox component and update ShareIssueModal defaults

### DIFF
--- a/src/lib/components/Checkbox/Checkbox.svelte
+++ b/src/lib/components/Checkbox/Checkbox.svelte
@@ -96,8 +96,8 @@
 
 	/* sizes */
 	input {
-		width: 18px;
-		height: 18px;
+		width: 16px;
+		height: 16px;
 	}
 	input.large {
 		width: 20px;

--- a/src/routes/ShareIssueModal.svelte
+++ b/src/routes/ShareIssueModal.svelte
@@ -79,7 +79,8 @@
 <Modal bind:this={modal} title="Share with GitButler team for review" on:close={onClose}>
 	<div class="flex flex-col gap-4">
 		<p>
-			If you are having trouble, please share your project and logs with the Gitbutler team. We will review it for you and help identify how we can help resolve the issue. 
+			If you are having trouble, please share your project and logs with the Gitbutler team. We will
+			review it for you and help identify how we can help resolve the issue.
 		</p>
 
 		{#if !user}
@@ -113,7 +114,8 @@
 		<div class="flex flex-col gap-1">
 			<span class="text-xl font-semibold"> Share logs </span>
 			<span class="text-sm text-text-subdued">
-				We personally ensure all information you share with us will be reviewed internally only and discarded post-resolution
+				We personally ensure all information you share with us will be reviewed internally only and
+				discarded post-resolution
 			</span>
 		</div>
 

--- a/src/routes/ShareIssueModal.svelte
+++ b/src/routes/ShareIssueModal.svelte
@@ -12,9 +12,9 @@
 	let modal: Modal;
 
 	let comments = '';
-	let sendLogs = true;
-	let sendProjectData = true;
-	let sendProjectRepository = true;
+	let sendLogs = false;
+	let sendProjectData = false;
+	let sendProjectRepository = false;
 	let email = '';
 
 	let isSending = false;
@@ -79,8 +79,7 @@
 <Modal bind:this={modal} title="Share with GitButler team for review" on:close={onClose}>
 	<div class="flex flex-col gap-4">
 		<p>
-			Submit an issue to be review by the GitButler team. This information will only be used
-			internally and will deleted after resolution is found.
+			If you are having trouble, please share your project and logs with the Gitbutler team. We will review it for you and help identify how we can help resolve the issue. 
 		</p>
 
 		{#if !user}
@@ -99,7 +98,7 @@
 			<label for="comments">Comments</label>
 
 			<textarea
-				placeholder="Provide any steps nessesary to reproduce the problem."
+				placeholder="Provide any steps necessary to reproduce the problem."
 				autocomplete="off"
 				autocorrect="off"
 				spellcheck="true"
@@ -114,12 +113,11 @@
 		<div class="flex flex-col gap-1">
 			<span class="text-xl font-semibold"> Share logs </span>
 			<span class="text-sm text-text-subdued">
-				Sharing will upload corresponding files with GitButler team. All share files will be deleted
-				after problem is removed.
+				We personally ensure all information you share with us will be reviewed internally only and discarded post-resolution
 			</span>
 		</div>
 
-		<div class="flex flex-col gap-3 text-lg">
+		<div class="flex flex-col gap-3">
 			<div class="flex items-center gap-2">
 				<Checkbox name="logs" bind:checked={sendLogs} disabled={isSending} />
 				<label for="logs">Share logs</label>


### PR DESCRIPTION
- Changed some of the language in the share modal
- In the Checkbox component, the default width and height have been reduced from 18px to 16px.
- In the ShareIssueModal component, the default values for `sendLogs`, `sendProjectData`, and `sendProjectRepository` are set to `false` instead of `true`.