### PR TITLE
Input and Textareas now leverage a global CSS styling and not tailwind

### DIFF
--- a/src/app.postcss
+++ b/src/app.postcss
@@ -13,11 +13,9 @@ button {
 	cursor: default;
 }
 
-textarea {
-	@apply rounded border border-zinc-600 bg-zinc-700 p-2 text-zinc-100;
-}
-textarea:focus {
+input, textarea, textarea:focus {
 	outline: none;
+	@apply rounded border border-zinc-600 bg-zinc-700 p-2 text-zinc-300;
 	@apply hover:border-zinc-500/80;
 	@apply focus:ring-2 focus:ring-blue-600/30;
 	@apply focus:border-[1px] focus:focus:border-blue-600;

--- a/src/app.postcss
+++ b/src/app.postcss
@@ -13,7 +13,9 @@ button {
 	cursor: default;
 }
 
-input, textarea, textarea:focus {
+input,
+textarea,
+textarea:focus {
 	outline: none;
 	@apply rounded border border-zinc-600 bg-zinc-700 p-2 text-zinc-300;
 	@apply hover:border-zinc-500/80;

--- a/src/routes/ShareIssueModal.svelte
+++ b/src/routes/ShareIssueModal.svelte
@@ -96,7 +96,7 @@
 		{/if}
 
 		<div class="flex flex-col gap-1">
-			<label for="comments">Comments</label>
+			<label for="comments" class="text-xl font-semibold">Comments</label>
 
 			<textarea
 				placeholder="Provide any steps necessary to reproduce the problem."
@@ -106,7 +106,7 @@
 				name="comments"
 				disabled={isSending}
 				rows="6"
-				class="h-full w-full resize-none rounded border border-zinc-600 bg-zinc-700 p-2 text-zinc-100  hover:border-zinc-500/80 focus:border-[] focus:focus:border-blue-600 focus:ring-2 focus:ring-blue-600/30"
+				class="h-full w-full resize-none"
 				bind:value={comments}
 			/>
 		</div>

--- a/src/routes/projects/[projectId]/commit/+page.svelte
+++ b/src/routes/projects/[projectId]/commit/+page.svelte
@@ -329,12 +329,7 @@
 					autocorrect="off"
 					spellcheck="true"
 					name="summary"
-					class="
-						w-full rounded border border-zinc-600 bg-zinc-700 p-2 text-zinc-100 
-						hover:border-zinc-500/80
-						focus:border-[1px] focus:focus:border-blue-600 
-						focus:ring-2 focus:ring-blue-600/30
-					"
+					class="w-full"
 					disabled={isGeneratingCommitMessage || isCommitting}
 					type="text"
 					placeholder="Summary (required)"
@@ -367,12 +362,7 @@
 						spellcheck="true"
 						name="description"
 						disabled={isGeneratingCommitMessage || isCommitting}
-						class="
-							h-full w-full resize-none rounded border border-zinc-600 bg-zinc-700 p-2 text-zinc-100 
-							hover:border-zinc-500/80
-							focus:border-[1px] focus:focus:border-blue-600 
-							focus:ring-2 focus:ring-blue-600/30
-						"
+						class="h-full w-full resize-none"
 						rows="10"
 						placeholder="Description (optional)"
 						bind:value={description}

--- a/src/routes/projects/[projectId]/player/[date]/BookmarkModal.svelte
+++ b/src/routes/projects/[projectId]/player/[date]/BookmarkModal.svelte
@@ -59,12 +59,7 @@
 			spellcheck="true"
 			name="description"
 			disabled={isCreating}
-			class="
-                h-full w-full resize-none rounded border border-zinc-600 bg-zinc-700 p-2 text-zinc-100 
-                hover:border-zinc-500/80
-                focus:border-[1px] focus:focus:border-blue-600 
-                focus:ring-2 focus:ring-blue-600/30
-            "
+			class="h-full w-full resize-none"
 			rows="6"
 			bind:value={note}
 		/>

--- a/src/routes/projects/[projectId]/settings/DetailsForm.svelte
+++ b/src/routes/projects/[projectId]/settings/DetailsForm.svelte
@@ -32,7 +32,7 @@
 				id="path"
 				name="path"
 				type="text"
-				class="w-full rounded border border-zinc-600 bg-zinc-700 p-2 text-zinc-300"
+				class="w-full"
 				value={project?.path}
 			/>
 		</div>
@@ -42,7 +42,7 @@
 				id="name"
 				name="name"
 				type="text"
-				class="w-full rounded border border-zinc-600 bg-zinc-700 p-2 text-zinc-300"
+				class="w-full"
 				placeholder="Project name can't be empty"
 				bind:value={title}
 				required
@@ -58,7 +58,7 @@
 				id="description"
 				name="description"
 				rows="3"
-				class="w-full rounded border border-zinc-600 bg-zinc-700 p-2 text-zinc-300"
+				class="w-full"
 				value={description}
 				on:input={onDescriptionInput}
 			/>

--- a/src/routes/projects/[projectId]/settings/DetailsForm.svelte
+++ b/src/routes/projects/[projectId]/settings/DetailsForm.svelte
@@ -27,14 +27,7 @@
 	<fieldset class="flex flex-col gap-3">
 		<div class="flex flex-col gap-1">
 			<label for="path">Path</label>
-			<input
-				disabled
-				id="path"
-				name="path"
-				type="text"
-				class="w-full"
-				value={project?.path}
-			/>
+			<input disabled id="path" name="path" type="text" class="w-full" value={project?.path} />
 		</div>
 		<div class="flex flex-col gap-1">
 			<label for="name">Project Name</label>

--- a/src/routes/users/+page.svelte
+++ b/src/routes/users/+page.svelte
@@ -137,7 +137,7 @@
 							name="name"
 							bind:value={userNameInput}
 							type="text"
-							class="w-full rounded border border-zinc-600 bg-zinc-700 px-4 py-2 text-zinc-300"
+							class="w-full"
 							placeholder="Name can't be empty"
 							required
 						/>
@@ -154,7 +154,7 @@
 							name="email"
 							bind:value={$user.email}
 							type="text"
-							class="w-full rounded border border-zinc-600 bg-zinc-700 px-4 py-2 text-zinc-300"
+							class="w-full"
 						/>
 					</div>
 


### PR DESCRIPTION
This commit introduces styling for input elements and performs some code clean-up by removing redundant lines of tailwind. The input now shares the same appearance and hover/focus effects as the textarea. Additionally, this diff removes commented-out code and ensures consistency in the CSS file across elements.

Changes include:
- Add input styling with border, background, padding, and text color
- Apply hover and focus effects to the input element
- Remove commented-out background-image lines in "CARD STYLING" section