### PR TITLE
Rename a couple of components and types

### DIFF
--- a/src/routes/projects_new/[projectId]/+page.svelte
+++ b/src/routes/projects_new/[projectId]/+page.svelte
@@ -4,10 +4,10 @@
 	import type { PageData } from './$types';
 
 	export let data: PageData;
-	let columnsData = data.columnsData;
+	let branchData = data.branchData;
 </script>
 
 <div class="flex h-full">
-	<Tray bind:columns={columnsData} />
-	<Board bind:columns={columnsData} />
+	<Tray bind:columns={branchData} />
+	<Board bind:columns={branchData} />
 </div>

--- a/src/routes/projects_new/[projectId]/+page.ts
+++ b/src/routes/projects_new/[projectId]/+page.ts
@@ -1,10 +1,10 @@
 import type { PageLoad } from './$types';
 import { wrapLoadWithSentry } from '@sentry/sveltekit';
-import type { BranchLane } from './board';
+import type { Branch } from './types';
 import { subSeconds, subMinutes, subHours } from 'date-fns';
 
-export const load: PageLoad = wrapLoadWithSentry(async () => {
-	const columnsData: BranchLane[] = [
+export const load: PageLoad = async () => {
+	const branches: Branch[] = [
 		{
 			id: 'c1',
 			name: 'feature-1',
@@ -101,6 +101,6 @@ export const load: PageLoad = wrapLoadWithSentry(async () => {
 	}));
 
 	return {
-		columnsData: columnsData
+		branchData: branches
 	};
-});
+};

--- a/src/routes/projects_new/[projectId]/Board.svelte
+++ b/src/routes/projects_new/[projectId]/Board.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
 	import { flip } from 'svelte/animate';
 	import { dndzone } from 'svelte-dnd-action';
-	import Lane from './Lane.svelte';
-	import type { BranchLane, File, Hunk } from './board';
+	import Lane from './BranchLane.svelte';
+	import type { Branch, File, Hunk } from './types';
 	import type { DndEvent } from 'svelte-dnd-action/typings';
 
-	export let columns: BranchLane[];
+	export let columns: Branch[];
 
 	const flipDurationMs = 300;
 
 	function handleDndEvent(
-		e: CustomEvent<DndEvent<BranchLane | File | Hunk>> & { target: HTMLElement }
+		e: CustomEvent<DndEvent<Branch | File | Hunk>> & { target: HTMLElement }
 	) {
-		columns = e.detail.items.filter((item) => item.kind == 'lane') as BranchLane[];
+		columns = e.detail.items.filter((item) => item.kind == 'lane') as Branch[];
 		// TODO: Create lanes out of dropped files/hunks
 	}
 </script>

--- a/src/routes/projects_new/[projectId]/BranchLane.svelte
+++ b/src/routes/projects_new/[projectId]/BranchLane.svelte
@@ -2,7 +2,7 @@
 	import { flip } from 'svelte/animate';
 	import { dndzone } from 'svelte-dnd-action';
 	import type { DndEvent } from 'svelte-dnd-action/typings';
-	import type { File, Hunk } from './board';
+	import type { File, Hunk } from './types';
 	import FileCard from './FileCard.svelte';
 
 	export let name: string;

--- a/src/routes/projects_new/[projectId]/FileCard.svelte
+++ b/src/routes/projects_new/[projectId]/FileCard.svelte
@@ -5,7 +5,7 @@
 	import { formatDistanceToNow, compareDesc } from 'date-fns';
 	import animateHeight from './animation';
 	import type { DndEvent } from 'svelte-dnd-action/typings';
-	import type { File, Hunk } from './board';
+	import type { File, Hunk } from './types';
 
 	export let file: File;
 

--- a/src/routes/projects_new/[projectId]/Tray.svelte
+++ b/src/routes/projects_new/[projectId]/Tray.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { flip } from 'svelte/animate';
 	import { Checkbox } from '$lib/components';
-	import type { BranchLane } from './board';
+	import type { Branch } from './types';
 
-	export let columns: BranchLane[];
+	export let columns: Branch[];
 </script>
 
 <section class="flex h-full w-64 flex-col gap-y-4 border-r border-zinc-700 bg-[#2F2F33] p-4">

--- a/src/routes/projects_new/[projectId]/types.ts
+++ b/src/routes/projects_new/[projectId]/types.ts
@@ -15,7 +15,7 @@ export type File = {
 	isDndShadowItem?: boolean;
 };
 
-export type BranchLane = {
+export type Branch = {
 	id: string;
 	name: string;
 	active: boolean;


### PR DESCRIPTION
When a type and a component name collide we've decided to alter the component name, typically by concatenating the type name and a noun for the intended visualisation. For example, Branch -> BranchLane.