### PR TITLE
Lint only changed files in CI

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -22,7 +22,7 @@ jobs:
 
             - name: Lint frontend
               run: |
-                pnpm lint
+                pnpm lint-ci
 
     check-frontend:
         runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "pnpm check --watch",
 		"lint": "prettier --plugin-search-dir . --check . && eslint .",
+		"lint-ci": "prettier --check $(git diff --name-only HEAD^..HEAD) && eslint $(git diff --name-only HEAD^..HEAD)",
 		"format": "prettier --plugin-search-dir . --write .",
 		"tauri": "tauri",
 		"story:dev": "histoire dev --open",


### PR DESCRIPTION
We can use `git diff --names-only` to get a list of files changed
between two revisions. The purpose is to stop lint errors from
untouched files showing up in code review.
