### PR TITLE
Remove animations from drag & drop actions

### DIFF
--- a/src/routes/projects_new/[projectId]/Board.svelte
+++ b/src/routes/projects_new/[projectId]/Board.svelte
@@ -45,18 +45,14 @@
 	class="swimlane-container flex h-full w-full snap-x gap-x-4 overflow-x-scroll bg-zinc-900 p-4"
 	use:dndzone={{
 		items: branches,
-		flipDurationMs,
 		types: ['branch'],
-		receives: ['branch', 'commit', 'file', 'hunk']
+		receives: ['branch']
 	}}
 	on:consider={handleDndEvent}
 	on:finalize={handleDndEvent}
 >
 	{#each branches.filter((c) => c.active) as { id, name, files, description } (id)}
-		<div
-			class="swimlane flex h-full w-96 snap-start scroll-ml-4 rounded-lg bg-zinc-900"
-			animate:flip={{ duration: flipDurationMs }}
-		>
+		<div class="swimlane flex h-full w-96 snap-start scroll-ml-4 rounded-lg bg-zinc-900">
 			<Lane {name} {description} bind:files on:empty={handleEmpty} />
 		</div>
 	{/each}

--- a/src/routes/projects_new/[projectId]/BranchLane.svelte
+++ b/src/routes/projects_new/[projectId]/BranchLane.svelte
@@ -55,7 +55,6 @@
 		class="flex flex-grow flex-col gap-y-2 overflow-x-hidden overflow-y-scroll "
 		use:dndzone={{
 			items: files,
-			flipDurationMs,
 			zoneTabIndex: -1,
 			types: ['file'],
 			receives: ['file', 'hunk']
@@ -64,7 +63,7 @@
 		on:finalize={handleDndEvent}
 	>
 		{#each files.filter((x) => x.hunks) as file, idx (file.id)}
-			<div class=" w-full" animate:flip={{ duration: flipDurationMs }}>
+			<div class=" w-full">
 				<FileCard bind:file on:empty={handleEmpty} />
 			</div>
 		{/each}

--- a/src/routes/projects_new/[projectId]/FileCard.svelte
+++ b/src/routes/projects_new/[projectId]/FileCard.svelte
@@ -44,7 +44,6 @@
 		class="hunk-change-container flex flex-col gap-2 rounded"
 		use:dndzone={{
 			items: file.hunks,
-			flipDurationMs,
 			zoneTabIndex: -1,
 			autoAriaDisabled: true,
 			types: ['hunk', file.path],
@@ -55,10 +54,7 @@
 	>
 		{#if expanded}
 			{#each file.hunks || [] as hunk (hunk.id)}
-				<div
-					animate:flip={{ duration: flipDurationMs }}
-					class="changed-hunk flex w-full flex-col gap-1 rounded bg-[#212121] p-2"
-				>
+				<div class="changed-hunk flex w-full flex-col gap-1 rounded bg-[#212121] p-2">
 					<div class="w-full text-ellipsis">
 						{hunk.name}
 					</div>


### PR DESCRIPTION
They severely affect performance of the UI by blocking the main
thread with calls to getClientBoundingRect. It feels more important
for the user experience to to get shadow/placeholder elements
displayed correctly.
