### PR TITLE
Fix weird container overflow

### DIFF
--- a/src/routes/projects_new/[projectId]/FileCard.svelte
+++ b/src/routes/projects_new/[projectId]/FileCard.svelte
@@ -77,7 +77,7 @@
 				<div
 					class="changed-hunk flex w-full flex-col gap-1 rounded-lg border border-light-200 dark:border-dark-400"
 				>
-					<div class="w-full text-ellipsis p-2">
+					<div class="overflow-hidden p-2">
 						{#await summarizeHunk(hunk.diff) then description}
 							{description}
 						{/await}


### PR DESCRIPTION
Without overflow-hidden the branch lane becomes scrollable horizontally.
This feels buggy, but it's unclear what's causing it atm.
