### PR TITLE
Remember expansion per file

### DIFF
--- a/src/routes/projects_new/[projectId]/FileCard.svelte
+++ b/src/routes/projects_new/[projectId]/FileCard.svelte
@@ -13,7 +13,7 @@
 	let zoneEl: HTMLElement;
 
 	const dispatch = createEventDispatcher();
-	export let expanded = true;
+	export let expanded: boolean | undefined;
 
 	function handleDndEvent(e: CustomEvent<DndEvent<Hunk>>) {
 		hunks = e.detail.items;
@@ -43,11 +43,14 @@
 	class="changed-file flex w-full flex-col justify-center gap-2 rounded-lg bg-white text-dark-600 shadow dark:bg-dark-800 dark:text-light-300"
 >
 	<div class="flex items-center gap-2">
-		<div class="flex-grow overflow-hidden text-ellipsis whitespace-nowrap" title={filepath}>
+		<div class="flex-grow overflow-hidden text-ellipsis whitespace-nowrap px-2" title={filepath}>
 			{@html boldenFilename(filepath)}
 		</div>
 		<div
-			on:click={() => (expanded = !expanded)}
+			on:click={() => {
+				expanded = !expanded;
+				dispatch('expanded', expanded);
+			}}
 			on:keypress={() => (expanded = !expanded)}
 			class="cursor-pointer p-2 text-light-600 dark:text-dark-200"
 		>

--- a/src/routes/projects_new/[projectId]/cache.ts
+++ b/src/routes/projects_new/[projectId]/cache.ts
@@ -1,0 +1,30 @@
+import type { File } from './types';
+
+const TRUE_KEY = '1';
+const FALSE_KEY = '0';
+
+function getKey(path: string): string {
+	return `expanded:${path}`;
+}
+
+export function getExpandedWithCacheFallback(file: File) {
+	if (file.expanded != undefined) {
+		return file.expanded; // No need to check after initial load
+	}
+	const value = localStorage.getItem(`expanded:${file.path}`);
+	if (value == TRUE_KEY) {
+		file.expanded = true;
+	} else if (value == FALSE_KEY) {
+		file.expanded = false;
+	}
+	return file.expanded;
+}
+
+export function setExpandedWithCache(file: File, value: boolean | undefined): void {
+	file.expanded = value;
+	if (file.expanded != undefined) {
+		localStorage.setItem(getKey(file.path), value ? TRUE_KEY : FALSE_KEY);
+	} else {
+		localStorage.removeItem(getKey(file.path));
+	}
+}

--- a/src/routes/projects_new/[projectId]/types.ts
+++ b/src/routes/projects_new/[projectId]/types.ts
@@ -17,6 +17,7 @@ export class File extends DndItem {
 	path!: string;
 	@Type(() => Hunk)
 	hunks!: Hunk[];
+	expanded?: boolean;
 }
 
 export class Branch extends DndItem {


### PR DESCRIPTION
Uses localStorage to store whether or not a file is toggled open. This
implementation behaves well wrt to "expand all", but the is never
flushed so this isn't a shippable solution.
