### PR TITLE
Update Target Branch

### DIFF
--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -324,6 +324,15 @@ impl App {
         Ok(Some(target))
     }
 
+    pub fn update_branch_target(&self, project_id: &str) -> Result<()> {
+        let gb_repository = self.gb_repository(project_id)?;
+        let project = self.gb_project(project_id)?;
+        let project_repository = project_repository::Repository::open(&project)
+            .context("failed to open project repository")?;
+        virtual_branches::update_branch_target(&gb_repository, &project_repository)?;
+        Ok(())
+    }
+
     pub fn list_virtual_branches(
         &self,
         project_id: &str,

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -376,7 +376,7 @@ impl App {
         let project = self.gb_project(project_id)?;
         let project_repository = project_repository::Repository::open(&project)
             .context("failed to open project repository")?;
-        virtual_branches::commit(&gb_repository, &project_repository, branch, message)?;
+        virtual_branches::commit(&gb_repository, &project_repository, branch, message, None)?;
         Ok(())
     }
 

--- a/src-tauri/src/bin/butler.rs
+++ b/src-tauri/src/bin/butler.rs
@@ -89,18 +89,18 @@ fn main() {
 fn run_reset(butler: ButlerCli) {
     // get the branch to commit
     let current_session = butler
-       .gb_repository
-       .get_or_create_current_session()
-       .expect("failed to get or create currnt session");
-   let current_session_reader = sessions::Reader::open(&butler.gb_repository, &current_session)
-       .expect("failed to open current session reader");
+        .gb_repository
+        .get_or_create_current_session()
+        .expect("failed to get or create currnt session");
+    let current_session_reader = sessions::Reader::open(&butler.gb_repository, &current_session)
+        .expect("failed to open current session reader");
 
-   let virtual_branches = virtual_branches::Iterator::new(&current_session_reader)
-       .expect("failed to read virtual branches")
-       .collect::<Result<Vec<virtual_branches::branch::Branch>, reader::Error>>()
-       .expect("failed to read virtual branches")
-       .into_iter()
-       .collect::<Vec<_>>(); 
+    let virtual_branches = virtual_branches::Iterator::new(&current_session_reader)
+        .expect("failed to read virtual branches")
+        .collect::<Result<Vec<virtual_branches::branch::Branch>, reader::Error>>()
+        .expect("failed to read virtual branches")
+        .into_iter()
+        .collect::<Vec<_>>();
 
     let writer = virtual_branches::branch::Writer::new(&butler.gb_repository);
     for mut branch in virtual_branches {

--- a/src-tauri/src/bin/butler.rs
+++ b/src-tauri/src/bin/butler.rs
@@ -156,6 +156,7 @@ fn run_commit(butler: ButlerCli) {
         &butler.project_repository(),
         &commit_branch,
         &message,
+        None,
     )
     .expect("failed to commit");
 }

--- a/src-tauri/src/bin/butler.rs
+++ b/src-tauri/src/bin/butler.rs
@@ -81,7 +81,32 @@ fn main() {
         "branches" => run_branches(butler),
         "remotes" => run_remotes(butler),
         "flush" => run_flush(butler), // artificially forces a session flush
+        "reset" => run_reset(butler), // sets all vbranches to unapplied
         _ => println!("Unknown command: {}", args.command),
+    }
+}
+
+fn run_reset(butler: ButlerCli) {
+    // get the branch to commit
+    let current_session = butler
+       .gb_repository
+       .get_or_create_current_session()
+       .expect("failed to get or create currnt session");
+   let current_session_reader = sessions::Reader::open(&butler.gb_repository, &current_session)
+       .expect("failed to open current session reader");
+
+   let virtual_branches = virtual_branches::Iterator::new(&current_session_reader)
+       .expect("failed to read virtual branches")
+       .collect::<Result<Vec<virtual_branches::branch::Branch>, reader::Error>>()
+       .expect("failed to read virtual branches")
+       .into_iter()
+       .collect::<Vec<_>>(); 
+
+    let writer = virtual_branches::branch::Writer::new(&butler.gb_repository);
+    for mut branch in virtual_branches {
+        println!("resetting {:?}", branch);
+        branch.applied = false;
+        writer.write(&branch).unwrap();
     }
 }
 
@@ -316,16 +341,22 @@ fn run_status(butler: ButlerCli) {
         virtual_branches::get_status_by_branch(&butler.gb_repository, &butler.project_repository())
             .expect("failed to get status by branch");
     for (branch, files) in statuses {
-        println!("branch: {}", branch.name.blue());
-        println!("  head: {}", branch.head.to_string().green());
-        println!("  tree: {}", branch.tree.to_string().green());
-        println!("    id: {}", branch.id.green());
-        println!(" files:");
-        for file in files {
-            println!("        {}", file.path);
-            for hunk in file.hunks {
-                println!("          {}", hunk.id);
+        if branch.applied {
+            println!(" branch: {}", branch.name.blue());
+            println!("   head: {}", branch.head.to_string().green());
+            println!("   tree: {}", branch.tree.to_string().green());
+            println!("     id: {}", branch.id.green());
+            println!("applied: {}", branch.applied.to_string().green());
+            println!(" files:");
+            for file in files {
+                println!("        {}", file.path.yellow());
+                for hunk in file.hunks {
+                    println!("          {}", hunk.id);
+                }
             }
+        } else {
+            println!(" branch: {}", branch.name.blue());
+            println!("applied: {}", branch.applied.to_string().green());
         }
         println!();
     }

--- a/src-tauri/src/gb_repository/repository.rs
+++ b/src-tauri/src/gb_repository/repository.rs
@@ -559,6 +559,7 @@ impl Repository {
             name: branch.name().unwrap().unwrap().to_string(),
             remote: remote_url_str.to_string(),
             sha: commit.id(),
+            behind: 0,
         };
 
         let target_writer = virtual_branches::target::Writer::new(self);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -645,6 +645,14 @@ async fn set_target_branch(
     Ok(target)
 }
 
+#[timed(duration(printer = "debug!"))]
+#[tauri::command(async)]
+async fn update_branch_target(handle: tauri::AppHandle, project_id: &str) -> Result<(), Error> {
+    let app = handle.state::<app::App>();
+    let target = app.update_branch_target(project_id)?;
+    Ok(target)
+}
+
 fn main() {
     let tauri_context = generate_context!();
 
@@ -790,6 +798,7 @@ fn main() {
             commit_virtual_branch,
             get_target_data,
             set_target_branch,
+            update_branch_target,
         ])
         .build(tauri_context)
         .expect("Failed to build tauri app")

--- a/src-tauri/src/project_repository/repository.rs
+++ b/src-tauri/src/project_repository/repository.rs
@@ -289,6 +289,13 @@ impl<'repository> Repository<'repository> {
         Ok(branches)
     }
 
+    pub fn behind(&self, sha1: git2::Oid, sha2: git2::Oid) -> Result<u32> {
+        let mut revwalk = self.git_repository.revwalk()?;
+        revwalk.push(sha1)?;
+        revwalk.hide(sha2)?;
+        Ok(revwalk.count().try_into()?)
+    }
+
     pub fn git_switch_branch(&self, branch: &str) -> Result<()> {
         let branch = self
             .git_repository

--- a/src-tauri/src/virtual_branches/branch/mod.rs
+++ b/src-tauri/src/virtual_branches/branch/mod.rs
@@ -8,8 +8,6 @@ use std::{fmt, ops, path, vec};
 
 use anyhow::{anyhow, Context, Result};
 
-use super::VirtualBranchCommit;
-
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct Ownership {
     pub file_path: path::PathBuf,

--- a/src-tauri/src/virtual_branches/iterator.rs
+++ b/src-tauri/src/virtual_branches/iterator.rs
@@ -110,6 +110,7 @@ mod tests {
                 unsafe { TEST_TARGET_INDEX }
             ))
             .unwrap(),
+            behind: 0,
         }
     }
 

--- a/src-tauri/src/virtual_branches/mod.rs
+++ b/src-tauri/src/virtual_branches/mod.rs
@@ -786,6 +786,45 @@ pub fn update_branch_target(
     // get tree object from our current working directory state
     let wd_tree = repo.find_tree(tree_id).unwrap();
 
+    let current_session = gb_repository
+        .get_or_create_current_session()
+        .context("failed to get or create currnt session")?;
+    let current_session_reader = sessions::Reader::open(gb_repository, &current_session)
+        .context("failed to open current session")?;
+
+    // get all virtual branches that are applied
+    let mut virtual_branches = Iterator::new(&current_session_reader)
+        .context("failed to create branch iterator")?
+        .collect::<Result<Vec<branch::Branch>, reader::Error>>()
+        .context("failed to read virtual branches")?
+        .into_iter()
+        .filter(|branch| branch.applied)
+        .collect::<Vec<_>>();
+
+    let mut merge_options = git2::MergeOptions::new();
+
+    // get tree from new target
+    let new_target_commit = repo.find_commit(new_target_oid)?;
+    let new_target_tree = new_target_commit.tree()?;
+    // get tree from target.sha
+    let target_commit = repo.find_commit(target.sha)?;
+    let target_tree = target_commit.tree()?;
+
+    // check index for conflicts
+    let merge_index = repo
+        .merge_trees(
+            &wd_tree,
+            &new_target_tree,
+            &target_tree,
+            Some(&merge_options),
+        )
+        .unwrap();
+
+    if merge_index.has_conflicts() {
+        // TODO: upstream won't merge, so unapply all the vbranches and reset the wd
+        bail!("merge conflict");
+    }
+
     // write the currrent target sha to a temp branch as a parent
     let my_ref = "refs/heads/gitbutler/temp";
     repo.reference(my_ref, target.sha, true, "update target")?;
@@ -810,29 +849,6 @@ pub fn update_branch_target(
         &[&target_commit],
     )?;
 
-    let mut merge_options = git2::MergeOptions::new();
-
-    // get tree from new target
-    let new_target_commit = repo.find_commit(new_target_oid)?;
-    let new_target_tree = new_target_commit.tree()?;
-    // get tree from target.sha
-    let target_commit = repo.find_commit(target.sha)?;
-    let target_tree = target_commit.tree()?;
-
-    // check index for conflicts
-    let merge_index = repo
-        .merge_trees(
-            &wd_tree,
-            &new_target_tree,
-            &target_tree,
-            Some(&merge_options),
-        )
-        .unwrap();
-
-    if merge_index.has_conflicts() {
-        bail!("merge conflict");
-    }
-
     // now we can try to merge the upstream branch into our current working directory
     let annotated_commit = repo.find_annotated_commit(new_target_oid)?;
     let mut checkout_options = git2::build::CheckoutBuilder::new();
@@ -846,20 +862,6 @@ pub fn update_branch_target(
     repo.cleanup_state()?;
 
     // ok, if that worked, then we can try to update all our virtual branches and write out our new target
-    let current_session = gb_repository
-        .get_or_create_current_session()
-        .context("failed to get or create currnt session")?;
-    let current_session_reader = sessions::Reader::open(gb_repository, &current_session)
-        .context("failed to open current session")?;
-
-    // get all virtual branches that are applied
-    let mut virtual_branches = Iterator::new(&current_session_reader)
-        .context("failed to create branch iterator")?
-        .collect::<Result<Vec<branch::Branch>, reader::Error>>()
-        .context("failed to read virtual branches")?
-        .into_iter()
-        .filter(|branch| branch.applied)
-        .collect::<Vec<_>>();
     let writer = branch::Writer::new(gb_repository);
 
     // update the heads of all our virtual branches

--- a/src-tauri/src/virtual_branches/mod.rs
+++ b/src-tauri/src/virtual_branches/mod.rs
@@ -95,7 +95,7 @@ pub fn remote_branches(
     let main_oid = default_target.sha;
 
     let current_time = time::SystemTime::now();
-    let too_old = time::Duration::from_secs(86_400 * 180); // 180 days (6 months) is too old
+    let too_old = time::Duration::from_secs(86_400 * 90); // 90 days (3 months) is too old
 
     let repo = &project_repository.git_repository;
     let mut branches: Vec<RemoteBranch> = Vec::new();

--- a/src-tauri/src/virtual_branches/mod.rs
+++ b/src-tauri/src/virtual_branches/mod.rs
@@ -768,9 +768,8 @@ pub fn update_branch_target(
     let oid = commit.id();
     println!("update target from {:?} to {:?}", target.sha, oid);
 
-    let mut index = git2::Index::new()?;
+    let mut index = repo.index()?;
     index.add_all(["*"], git2::IndexAddOption::DEFAULT, None)?;
-    repo.set_index(&mut index)?;
 
     let annotated_commit = repo.find_annotated_commit(oid)?;
 

--- a/src-tauri/src/virtual_branches/mod.rs
+++ b/src-tauri/src/virtual_branches/mod.rs
@@ -735,6 +735,19 @@ fn get_default_target(gb_repository: &gb_repository::Repository) -> Result<targe
     Ok(default_target)
 }
 
+// try to update the target branch
+// this means that we need to:
+// determine if what the target branch is now pointing to is mergeable with our current working directory
+// merge the target branch into our current working directory
+// update the target sha
+pub fn update_branch_target(
+    gb_repository: &gb_repository::Repository,
+    project_repository: &project_repository::Repository,
+) -> Result<()> {
+    println!("updating branch target");
+    Ok(())
+}
+
 fn write_tree(
     gb_repository: &gb_repository::Repository,
     project_repository: &project_repository::Repository,

--- a/src-tauri/src/virtual_branches/target/mod.rs
+++ b/src-tauri/src/virtual_branches/target/mod.rs
@@ -11,6 +11,7 @@ pub struct Target {
     pub name: String,
     pub remote: String,
     pub sha: git2::Oid,
+    pub behind: u32,
 }
 
 impl Serialize for Target {
@@ -21,6 +22,7 @@ impl Serialize for Target {
         let mut state = serializer.serialize_struct("Target", 3)?;
         state.serialize_field("name", &self.name)?;
         state.serialize_field("remote", &self.remote)?;
+        state.serialize_field("behind", &self.behind)?;
         state.serialize_field("sha", &self.sha.to_string())?;
         state.end()
     }
@@ -58,6 +60,11 @@ impl TryFrom<&dyn crate::reader::Reader> for Target {
                 ))
             })?;
 
-        Ok(Self { name, remote, sha })
+        Ok(Self {
+            name,
+            remote,
+            sha,
+            behind: 0,
+        })
     }
 }

--- a/src-tauri/src/virtual_branches/target/reader.rs
+++ b/src-tauri/src/virtual_branches/target/reader.rs
@@ -122,6 +122,7 @@ mod tests {
                 unsafe { TEST_TARGET_INDEX }
             ))
             .unwrap(),
+            behind: 0,
         }
     }
 
@@ -166,12 +167,14 @@ mod tests {
             name: "target".to_string(),
             remote: "remote".to_string(),
             sha: git2::Oid::from_str("fedcba9876543210fedcba9876543210fedcba98").unwrap(),
+            behind: 0,
         };
 
         let default_target = Target {
             name: "default_target".to_string(),
             remote: "default_remote".to_string(),
             sha: git2::Oid::from_str("0123456789abcdef0123456789abcdef01234567").unwrap(),
+            behind: 0,
         };
 
         let branch_writer = branch::Writer::new(&gb_repo);

--- a/src-tauri/src/virtual_branches/target/reader.rs
+++ b/src-tauri/src/virtual_branches/target/reader.rs
@@ -44,23 +44,7 @@ impl<'reader> TargetReader<'reader> {
             .unwrap();
         let commit = branch.get().peel_to_commit().unwrap();
         let oid = commit.id();
-        target.behind = project_repository.behind(target.sha, oid).unwrap();
-        Ok(target)
-    }
-
-    pub fn read_with_behind(
-        &self,
-        id: &str,
-        project_repository: &project_repository::Repository,
-    ) -> Result<Target, reader::Error> {
-        let mut target = self.read(id)?;
-        let repo = &project_repository.git_repository;
-        let branch = repo
-            .find_branch(&target.name, git2::BranchType::Remote)
-            .unwrap();
-        let commit = branch.get().peel_to_commit().unwrap();
-        let oid = commit.id();
-        target.behind = project_repository.behind(target.sha, oid).unwrap();
+        target.behind = project_repository.behind(oid, target.sha).unwrap();
         Ok(target)
     }
 }

--- a/src-tauri/src/virtual_branches/target/reader.rs
+++ b/src-tauri/src/virtual_branches/target/reader.rs
@@ -1,4 +1,7 @@
-use crate::reader::{self, SubReader};
+use crate::{
+    project_repository,
+    reader::{self, SubReader},
+};
 
 use super::Target;
 
@@ -28,6 +31,37 @@ impl<'reader> TargetReader<'reader> {
         let reader: &dyn crate::reader::Reader =
             &SubReader::new(self.reader, &format!("branches/{}/target", id));
         Target::try_from(reader)
+    }
+
+    pub fn read_default_with_behind(
+        &self,
+        project_repository: &project_repository::Repository,
+    ) -> Result<Target, reader::Error> {
+        let mut target = self.read_default()?;
+        let repo = &project_repository.git_repository;
+        let branch = repo
+            .find_branch(&target.name, git2::BranchType::Remote)
+            .unwrap();
+        let commit = branch.get().peel_to_commit().unwrap();
+        let oid = commit.id();
+        target.behind = project_repository.behind(target.sha, oid).unwrap();
+        Ok(target)
+    }
+
+    pub fn read_with_behind(
+        &self,
+        id: &str,
+        project_repository: &project_repository::Repository,
+    ) -> Result<Target, reader::Error> {
+        let mut target = self.read(id)?;
+        let repo = &project_repository.git_repository;
+        let branch = repo
+            .find_branch(&target.name, git2::BranchType::Remote)
+            .unwrap();
+        let commit = branch.get().peel_to_commit().unwrap();
+        let oid = commit.id();
+        target.behind = project_repository.behind(target.sha, oid).unwrap();
+        Ok(target)
     }
 }
 

--- a/src-tauri/src/virtual_branches/target/writer.rs
+++ b/src-tauri/src/virtual_branches/target/writer.rs
@@ -143,6 +143,7 @@ mod tests {
             name: "target_name".to_string(),
             remote: "target_remote".to_string(),
             sha: git2::Oid::from_str("0123456789abcdef0123456789abcdef01234567").unwrap(),
+            behind: 0,
         };
 
         let branch_writer = branch::Writer::new(&gb_repo);
@@ -229,6 +230,7 @@ mod tests {
             name: "target_name".to_string(),
             remote: "target_remote".to_string(),
             sha: git2::Oid::from_str("0123456789abcdef0123456789abcdef01234567").unwrap(),
+            behind: 0,
         };
 
         let branch_writer = branch::Writer::new(&gb_repo);
@@ -240,6 +242,7 @@ mod tests {
             name: "updated_target_name".to_string(),
             remote: "updated_target_remote".to_string(),
             sha: git2::Oid::from_str("fedcba9876543210fedcba9876543210fedcba98").unwrap(),
+            behind: 0,
         };
 
         target_writer.write(&branch.id, &updated_target)?;

--- a/src-tauri/src/watcher/handlers/project_file_change_tests.rs
+++ b/src-tauri/src/watcher/handlers/project_file_change_tests.rs
@@ -19,6 +19,7 @@ fn test_target() -> virtual_branches::target::Target {
             unsafe { TEST_TARGET_INDEX }
         ))
         .unwrap(),
+        behind: 0,
     }
 }
 

--- a/src/routes/projects_new/[projectId]/+page.svelte
+++ b/src/routes/projects_new/[projectId]/+page.svelte
@@ -30,7 +30,7 @@
 
 {#if target}
 	<div class="flex w-full max-w-full">
-		<Tray bind:branches {target} remoteBranches={remoteBranchesData} />
+		<Tray bind:branches {target} {projectId} remoteBranches={remoteBranchesData} />
 		<Board {projectId} bind:branches on:newBranch={handleNewBranch} />
 	</div>
 {:else}

--- a/src/routes/projects_new/[projectId]/+page.svelte
+++ b/src/routes/projects_new/[projectId]/+page.svelte
@@ -30,7 +30,7 @@
 
 {#if target}
 	<div class="flex w-full max-w-full">
-		<Tray bind:branches remoteBranches={remoteBranchesData} />
+		<Tray bind:branches {target} remoteBranches={remoteBranchesData} />
 		<Board {projectId} bind:branches on:newBranch={handleNewBranch} />
 	</div>
 {:else}

--- a/src/routes/projects_new/[projectId]/+page.ts
+++ b/src/routes/projects_new/[projectId]/+page.ts
@@ -1,5 +1,5 @@
 import { plainToInstance } from 'class-transformer';
-import { Branch, type BranchData } from './types';
+import { Target, Branch, type BranchData } from './types';
 import { invoke } from '$lib/ipc';
 import type { PageLoadEvent } from './$types';
 
@@ -12,7 +12,7 @@ async function getRemoteBranches(params: { projectId: string }) {
 }
 
 async function getTargetData(params: { projectId: string }) {
-	return invoke<object>('get_target_data', params);
+	return invoke<Target>('get_target_data', params);
 }
 
 async function getRemoteBranchesData(params: { projectId: string }) {

--- a/src/routes/projects_new/[projectId]/Board.svelte
+++ b/src/routes/projects_new/[projectId]/Board.svelte
@@ -4,7 +4,7 @@
 	import type { DndEvent } from 'svelte-dnd-action/typings';
 	import { createEventDispatcher } from 'svelte';
 	import NewBranchDropZone from './NewBranchDropZone.svelte';
-	import { type Branch, Target } from './types';
+	import type { Branch } from './types';
 
 	export let branches: Branch[];
 	export let projectId: string;

--- a/src/routes/projects_new/[projectId]/Board.svelte
+++ b/src/routes/projects_new/[projectId]/Board.svelte
@@ -4,8 +4,7 @@
 	import type { DndEvent } from 'svelte-dnd-action/typings';
 	import { createEventDispatcher } from 'svelte';
 	import NewBranchDropZone from './NewBranchDropZone.svelte';
-	import { Commit, type Branch } from './types';
-	import { plainToInstance } from 'class-transformer';
+	import { type Branch, Target } from './types';
 
 	export let branches: Branch[];
 	export let projectId: string;
@@ -27,49 +26,6 @@
 		}
 		branches = branches;
 	}
-
-	const testCommits = plainToInstance(Commit, [
-		{
-			id: '1',
-			authorEmail: 'mtsgrd@gmail.com',
-			authorName: 'Mattias Granlund',
-			description: 'Testing something out',
-			createdAt: 1687538314,
-			isRemote: true
-		},
-		{
-			id: '2',
-			authorEmail: 'kiril@videlov.com',
-			authorName: 'Kiril Videlov',
-			description: 'Testing something else out',
-			createdAt: 1687538315,
-			isRemote: true
-		},
-		{
-			id: '3',
-			authorEmail: 'nikita@galaiko.rocks',
-			authorName: 'Nikita Galaiko',
-			description: 'Rust rust rust',
-			createdAt: 1687538316,
-			isRemote: false
-		},
-		{
-			id: '4',
-			authorEmail: 'donahue.ian@gmail.com',
-			authorName: 'Ian Donahue',
-			description: 'Updated designs',
-			createdAt: 1687538317,
-			isRemote: false
-		},
-		{
-			id: '5',
-			authorEmail: 'schacon@gmail.com',
-			authorName: 'Scott Chacon',
-			description: 'Fixing that thing',
-			createdAt: 1687538317,
-			isRemote: false
-		}
-	]);
 </script>
 
 <div

--- a/src/routes/projects_new/[projectId]/Tray.svelte
+++ b/src/routes/projects_new/[projectId]/Tray.svelte
@@ -14,10 +14,16 @@
 	<div class="py-4 text-lg font-bold">Your Target</div>
 	<div class="flex flex-col gap-y-2">
 		<div>{target.name}</div>
-		<div>{target.remote}</div>
+		{#if target.behind > 0}
 		<div class="flex flex-row justify-between">
 			<div>behind {target.behind}</div>
+			<div>update target</div>
 		</div>
+		{:else}
+		<div class="flex flex-row justify-between">
+			<div>up to date</div>
+		</div>
+		{/if}
 	</div>
 
 	<div class="py-4 text-lg font-bold">Your Branches</div>

--- a/src/routes/projects_new/[projectId]/Tray.svelte
+++ b/src/routes/projects_new/[projectId]/Tray.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import { Checkbox } from '$lib/components';
-	import type { Branch, BranchData } from './types';
+	import type { Branch, BranchData, Target } from './types';
 	import { formatDistanceToNow } from 'date-fns';
 
+	export let target: Target;
 	export let branches: Branch[];
 	export let remoteBranches: BranchData[];
 </script>
@@ -10,6 +11,15 @@
 <div
 	class="w-80 shrink-0 overflow-y-auto bg-light-100 px-2 text-light-800 dark:bg-dark-800 dark:text-dark-100"
 >
+	<div class="py-4 text-lg font-bold">Your Target</div>
+	<div class="flex flex-col gap-y-2">
+		<div>{target.name}</div>
+		<div>{target.remote}</div>
+		<div class="flex flex-row justify-between">
+			<div>behind {target.behind}</div>
+		</div>
+	</div>
+
 	<div class="py-4 text-lg font-bold">Your Branches</div>
 	<div class="flex flex-col gap-y-2">
 		{#each branches as branch (branch.id)}

--- a/src/routes/projects_new/[projectId]/Tray.svelte
+++ b/src/routes/projects_new/[projectId]/Tray.svelte
@@ -1,11 +1,22 @@
 <script lang="ts">
-	import { Checkbox } from '$lib/components';
+	import { Button, Checkbox } from '$lib/components';
+	import { invoke } from '@tauri-apps/api';
 	import type { Branch, BranchData, Target } from './types';
 	import { formatDistanceToNow } from 'date-fns';
 
 	export let target: Target;
+	export let projectId: string;
 	export let branches: Branch[];
 	export let remoteBranches: BranchData[];
+
+	async function updateBranchTarget(params: { projectId: string }) {
+		return invoke('update_branch_target', params);
+	}
+
+	function updateTarget() {
+		console.log('update');
+		updateBranchTarget({ projectId: projectId });
+	}
 </script>
 
 <div
@@ -15,14 +26,14 @@
 	<div class="flex flex-col gap-y-2">
 		<div>{target.name}</div>
 		{#if target.behind > 0}
-		<div class="flex flex-row justify-between">
-			<div>behind {target.behind}</div>
-			<div>update target</div>
-		</div>
+			<div class="flex flex-row justify-between">
+				<div>behind {target.behind}</div>
+				<Button on:click={updateTarget}>Update Target</Button>
+			</div>
 		{:else}
-		<div class="flex flex-row justify-between">
-			<div>up to date</div>
-		</div>
+			<div class="flex flex-row justify-between">
+				<div>up to date</div>
+			</div>
 		{/if}
 	</div>
 

--- a/src/routes/projects_new/[projectId]/types.ts
+++ b/src/routes/projects_new/[projectId]/types.ts
@@ -52,3 +52,10 @@ export class Commit {
 	createdAt!: Date;
 	isRemote!: boolean;
 }
+
+export class Target {
+	sha!: string;
+	name!: string;
+	remote!: string;
+	behind!: number;
+}


### PR DESCRIPTION
This PR implements a way to update an out of date target branch.

This adds logic to see if the target branch is out of date (if say, origin/master has commits that are not on target.sha) and will show in the UI that the frozen target branch is behind. If this happens, it adds a button to update, which will call an `update_branch_target` function in Rust.

This function will:
* Check that there is in fact a new commit on the target branch
* Try to merge that new head commit into your current working directory, bailing if it cannot
* If that succeeds (the new upstream can merge cleanly with all your vbranch content), it will then update all your virtual branches
* If the vbranch has no commits, it simply updates the head so the diffs work properly again
* If the vbranch has commits, it will merge the new head into the virtual branch head and write the new merge commit to the vbranch commit list. omg.