### PR TITLE
Delete (unapply) branch when it's integrated upstream

### DIFF
--- a/src-tauri/src/virtual_branches/mod.rs
+++ b/src-tauri/src/virtual_branches/mod.rs
@@ -940,7 +940,6 @@ pub fn update_branch_target(
     // ok, if that worked, then we can try to update all our virtual branches and write out our new target
     let writer = branch::Writer::new(gb_repository);
 
-
     // update the heads of all our virtual branches
     for virtual_branch in &mut virtual_branches {
         let mut virtual_branch = virtual_branch.clone();

--- a/src/routes/projects_new/[projectId]/vbranches.ts
+++ b/src/routes/projects_new/[projectId]/vbranches.ts
@@ -27,7 +27,7 @@ export function getVirtualBranches(
 	const writeable = createWriteable(projectId);
 	const store: VirtualBranchOperations & Readable<Loadable<Branch[]>> = {
 		subscribe: writeable.subscribe,
-		setTarget: (branch) => setTarget(branch, projectId),
+		setTarget: (branch) => setTarget(projectId, branch),
 		createBranch: (name, path) => createBranch(writeable, projectId, name, path),
 		commitBranch: (branch, message) => commitBranch(writeable, projectId, branch, message),
 		updateBranchTarget: () => updateBranchTarget(writeable, projectId),


### PR DESCRIPTION
This PR adds the ability to delete a vbranch when updating the target by detecting when a vbranch is integrated upstream.