### PR TITLE
Allow resizing of tray from bottom right corner

### DIFF
--- a/src/routes/repo/[projectId]/Tray.svelte
+++ b/src/routes/repo/[projectId]/Tray.svelte
@@ -8,12 +8,33 @@
 	export let branches: Branch[];
 	export let remoteBranches: BranchData[];
 	export let virtualBranches: VirtualBranchOperations;
+
+	// store left tray width preference in localStorage
+	const cacheKey = 'config:tray-width';
+
+	function rememberWidth(node: HTMLElement) {
+		const cachedWidth = localStorage.getItem(cacheKey);
+		if (cachedWidth) node.style.width = cachedWidth;
+
+		const resizeObserver = new ResizeObserver((entries) => {
+			const width = entries.at(0)?.borderBoxSize[0].inlineSize.toString();
+			if (width) localStorage.setItem(cacheKey, width + 'px');
+		});
+		resizeObserver.observe(node);
+
+		return {
+			destroy: () => {
+				resizeObserver.unobserve(node);
+			}
+		};
+	}
 </script>
 
 <div
-	class="w-80 shrink-0 overflow-y-auto bg-light-100 px-2 text-light-800 dark:bg-dark-800 dark:text-dark-100"
+	use:rememberWidth
+	class="w-80 shrink-0 resize-x overflow-x-auto overflow-y-auto bg-light-100 px-2 text-light-800 dark:bg-dark-800 dark:text-dark-100"
 >
-	<div class="py-4 text-lg font-bold">Your Target</div>
+	<div class="py-4 text-lg font-bold">Your target</div>
 	<div class="flex flex-col gap-y-2">
 		<div>{target.name}</div>
 		{#if target.behind > 0}


### PR DESCRIPTION
The size is store in localStorage under `config:tray-width`.

<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#7iW1sKGgy`](https://gitbutler.com/schacon/web/reviews/7iW1sKGgy)

**return PatchStackSimple list**


this doesn't load all the patch data, which is slow

1 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [return PatchStackSimple list](https://gitbutler.com/schacon/web/reviews/7iW1sKGgy/commit/4ecee7dc-62cf-4467-a5e2-af08b242060b) | ⚠️ | <img width="20" height="20" src="https://app.gitbutler.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MTc5OSwicHVyIjoiYmxvYl9pZCJ9fQ==--687bcccbc32853fc081271e42902a4f2fe2d0554/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJwbmciLCJyZXNpemVfdG9fbGltaXQiOlsyNTAsMjUwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--7ee67cd2edc36c03e1be048e50e661945f3999b0/96BE8547-FD64-407D-9769-7AB30DB85615.png"> <img width="20" height="20" src="https://gitbutler-public.s3.us-east-1.amazonaws.com/images/gb-logo.png"> |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/schacon/web/reviews/7iW1sKGgy)_
<!-- GitButler Review Footer Boundary Bottom -->
