### PR TITLE
Small visual formatting of swimlane elements and side tray

### DIFF
--- a/src/routes/repo/[projectId]/BranchLane.svelte
+++ b/src/routes/repo/[projectId]/BranchLane.svelte
@@ -116,9 +116,11 @@
 	}
 </script>
 
-<div class="flex max-h-full w-[22.5rem] shrink-0 flex-col overflow-y-auto  p-4  dark:text-dark-100">
+<div
+	class="flex max-h-full w-[22.5rem] shrink-0 flex-col overflow-y-auto border-r border-zinc-800 px-4 dark:text-dark-100"
+>
 	<div
-		class="mb-2 flex w-full shrink-0 items-center rounded-lg bg-light-200 px-3 py-2 text-lg font-bold text-light-900 dark:bg-dark-1000 dark:font-normal dark:text-dark-100"
+		class="flex w-full shrink-0 items-center rounded-lg bg-light-200 px-3 py-2 text-lg font-bold text-light-900 dark:bg-dark-1000 dark:font-normal dark:text-dark-100"
 	>
 		<div class="mr-3 flex-grow-0 text-light-600 dark:text-dark-200">
 			<IconBranch />
@@ -128,7 +130,7 @@
 				type="text"
 				bind:value={name}
 				on:change={handleBranchNameChange}
-				class="border-0 bg-light-200 text-light-900 dark:bg-dark-1000 dark:font-normal dark:text-dark-100"
+				class="border-0 bg-light-200 text-base text-light-900 dark:bg-dark-1000 dark:font-normal dark:text-dark-100"
 			/>
 		</div>
 		<div class="ml-3 flex-grow-0 text-light-600 dark:text-dark-200">

--- a/src/routes/repo/[projectId]/FileCard.svelte
+++ b/src/routes/repo/[projectId]/FileCard.svelte
@@ -40,7 +40,7 @@
 </script>
 
 <div
-	class="changed-file flex w-full flex-col justify-center gap-2 rounded-lg bg-white text-dark-600 shadow dark:bg-dark-800 dark:text-light-300"
+	class="changed-file flex w-full flex-col justify-center rounded-lg bg-white py-2 text-dark-600 shadow dark:bg-dark-800 dark:text-light-300"
 >
 	<div class="flex items-center gap-2">
 		<div class="flex-grow overflow-hidden text-ellipsis whitespace-nowrap px-2" title={filepath}>
@@ -63,7 +63,7 @@
 	</div>
 
 	<div
-		class="hunk-change-container flex flex-col gap-2 rounded"
+		class="hunk-change-container flex flex-col gap-2 rounded px-2"
 		bind:this={zoneEl}
 		use:dndzone={{
 			items: hunks,
@@ -78,7 +78,7 @@
 		{#if expanded}
 			{#each hunks || [] as hunk (hunk.id)}
 				<div
-					class="changed-hunk flex w-full flex-col gap-1 rounded-lg border border-light-200 dark:border-dark-400"
+					class="changed-hunk flex w-full flex-col rounded border border-light-200 dark:border-dark-400"
 				>
 					<div class="truncate whitespace-normal p-2">
 						{#await summarizeHunk(hunk.diff) then description}
@@ -86,7 +86,7 @@
 						{/await}
 					</div>
 					<div
-						class="mx-2 cursor-pointer overflow-clip rounded border-t border-b border-light-200 text-sm dark:border-dark-700"
+						class="cursor-pointer overflow-clip rounded border-t border-b border-light-200 text-sm dark:border-dark-700"
 					>
 						<!-- Disabling syntax highlighting for performance reasons -->
 						<HunkDiffViewer diff={hunk.diff} filePath="foo" linesShown={2} />

--- a/src/routes/repo/[projectId]/Tray.svelte
+++ b/src/routes/repo/[projectId]/Tray.svelte
@@ -32,7 +32,7 @@
 
 <div
 	use:rememberWidth
-	class="w-80 shrink-0 resize-x overflow-x-auto overflow-y-auto bg-light-100 px-2 text-light-800 dark:bg-dark-800 dark:text-dark-100"
+	class="w-80 min-w-[200px] max-w-[400px] shrink-0 resize-x overflow-x-auto overflow-y-auto bg-light-100 px-2 text-light-800 dark:bg-dark-800 dark:text-dark-100"
 >
 	<div class="py-4 text-lg font-bold">Your target</div>
 	<div class="flex flex-col gap-y-2">
@@ -64,8 +64,8 @@
 		<div class="py-4 text-lg font-bold">Remote Branches</div>
 		{#each remoteBranches as branch}
 			<div class="flex flex-col justify-between rounded-lg p-2" title={branch.branch}>
-				<div class="flex flex-row justify-between">
-					<div class="cursor-pointer">
+				<div class="flex flex-row justify-between gap-4">
+					<div class="cursor-pointer truncate">
 						{branch.branch.replace('refs/remotes/', '')}
 					</div>
 					<div>{branch.ahead}/{branch.behind}</div>


### PR DESCRIPTION
I've done some small formatting and visual alignment of the interface with the design. 

- spacing of elements in swimlane
- min/max of tray
<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#6h3x7aG6U`](https://gitbutler.com/cto/gitbutler-web/reviews/6h3x7aG6U)

**share-my-seed**


2 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 2/2 | [Seed some basic users](https://gitbutler.com/cto/gitbutler-web/reviews/6h3x7aG6U/commit/71df0cbb-9b12-42d0-a815-3280bc30bb2c) | ⏳ |  |
| 1/2 | [Fix git_servers.rake, and call it from seeds.rb](https://gitbutler.com/cto/gitbutler-web/reviews/6h3x7aG6U/commit/03e04400-8c3f-4e30-a62f-518518b45cc9) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/cto/gitbutler-web/reviews/6h3x7aG6U)_
<!-- GitButler Review Footer Boundary Bottom -->
