### PR TITLE
Remove two-way bindings for board

### DIFF
--- a/src/routes/repo/[projectId]/+page.svelte
+++ b/src/routes/repo/[projectId]/+page.svelte
@@ -17,7 +17,7 @@
 
 {#if target}
 	<div class="flex w-full max-w-full">
-		<Tray bind:branches {target} remoteBranches={remoteBranchesData} {virtualBranches} />
+		<Tray {branches} {target} remoteBranches={remoteBranchesData} {virtualBranches} />
 		<Board {branches} {projectId} {virtualBranches} />
 	</div>
 {:else}

--- a/src/routes/repo/[projectId]/Board.svelte
+++ b/src/routes/repo/[projectId]/Board.svelte
@@ -53,9 +53,9 @@
 >
 	{#each branches.filter((c) => c.active) as { id, name, files, commits, description } (id)}
 		<Lane
-			bind:name
-			bind:commitMessage={description}
-			bind:files
+			{name}
+			commitMessage={description}
+			{files}
 			{commits}
 			on:empty={handleEmpty}
 			{projectId}

--- a/src/routes/repo/[projectId]/BranchLane.svelte
+++ b/src/routes/repo/[projectId]/BranchLane.svelte
@@ -192,8 +192,8 @@
 			{#each files.filter((x) => x.hunks) as file (file.id)}
 				<FileCard
 					filepath={file.path}
-					bind:expanded={file.expanded}
-					bind:hunks={file.hunks}
+					expanded={file.expanded}
+					hunks={file.hunks}
 					on:update={(e) => {
 						handleFileUpdate(file.id, e.detail);
 					}}


### PR DESCRIPTION
Updates are now pushed from the backend so we are ok with a one
directional data flow.
