### PR TITLE
Fix bug causing settings page to not load theme

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -13,7 +13,9 @@
 	import LinkProjectModal from './LinkProjectModal.svelte';
 	import Breadcrumbs from './Breadcrumbs.svelte';
 	import ShareIssueModal from './ShareIssueModal.svelte';
-	import ThemeSelector from './ThemeSelector.svelte';
+	import { initTheme } from '$lib/theme';
+
+	initTheme();
 
 	export let data: LayoutData;
 	const { posthog, projects, sentry, cloud } = data;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,13 +1,11 @@
 <script lang="ts">
 	import type { LayoutData } from './$types';
-	import { Button, Tooltip } from '$lib/components';
+	import { Button } from '$lib/components';
 	import { events } from '$lib';
-	import { initTheme } from '$lib/theme';
 
 	export let data: LayoutData;
 
 	const { projects } = data;
-	initTheme();
 </script>
 
 <div class="h-full w-full bg-light-200 p-8 text-light-900 dark:bg-dark-1000">


### PR DESCRIPTION
Initializing the theme in the page.svelte file meant it was not run when
accessing sub-routes.
