### PR TITLE
Tree writing fixes

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -996,6 +996,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "diffy"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e616e59155c92257e84970156f506287853355f58cd4a6eb167385722c32b790"
+dependencies = [
+ "nu-ansi-term",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,6 +1642,7 @@ dependencies = [
  "clap",
  "colored 2.0.0",
  "dialoguer",
+ "diffy",
  "dirs 5.0.1",
  "filetime",
  "fslock",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -57,6 +57,7 @@ tokio-util = "0.7.8"
 colored = "2.0.0"
 dirs = "5.0.1"
 dialoguer = "0.10.4"
+diffy = "0.3.0"
 
 [features]
 # by default Tauri runs in production mode


### PR DESCRIPTION
Tree writing (for commits and unapply vbranch stashing) now is tested and works properly for new and removed files as well as hunk level modifications per branch.