### PR TITLE
Fix the fetching issue

### DIFF
--- a/src-tauri/src/project_repository/repository.rs
+++ b/src-tauri/src/project_repository/repository.rs
@@ -390,8 +390,9 @@ impl<'repository> Repository<'repository> {
 
         output.status.success().then(|| ()).ok_or_else(|| {
             anyhow::anyhow!(
-                "failed to fetch: {}",
-                String::from_utf8(output.stderr).unwrap()
+                "failed to fetch from repository: {}: {}",
+                &self.project.title,
+                String::from_utf8(output.stderr).unwrap(),
             )
         })?;
 

--- a/src-tauri/src/virtual_branches/mod.rs
+++ b/src-tauri/src/virtual_branches/mod.rs
@@ -1763,7 +1763,7 @@ pub fn push(
 
     project_repository
         .push(&vbranch.head, &upstream)
-        .context("failed to fetch before push")?;
+        .context("failed to push")?;
 
     vbranch.upstream = upstream;
     branch_writer
@@ -1772,7 +1772,7 @@ pub fn push(
 
     project_repository
         .fetch()
-        .context("failed to fetch before push")
+        .context("failed to fetch after push")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Where there is no 'origin', the fetch fails, which never updates the last_fetched_at timestamp, but since it's set on init, it means it tries every 10 seconds rather then every 10 minutes. This change just updates the timestamp when the Event fires before it tries to fetch.