### PR TITLE
fix tray icon size when truncating

### DIFF
--- a/src/routes/repo/[projectId]/Tray.svelte
+++ b/src/routes/repo/[projectId]/Tray.svelte
@@ -158,11 +158,13 @@
 					class="flex flex-col justify-between border-b border-light-400 p-2 pl-2 pr-4 dark:border-dark-600"
 				>
 					<div class="flex flex-row items-center gap-x-2">
-						{#if branch.branch.match('refs/remotes')}
-							<IconRemote class="h-4 w-4" />
-						{:else}
-							<IconGitBranch class="h-4 w-4" />
-						{/if}
+						<div>
+							{#if branch.branch.match('refs/remotes')}
+								<IconRemote class="h-4 w-4" />
+							{:else}
+								<IconGitBranch class="h-4 w-4" />
+							{/if}
+						</div>
 						<div
 							class="flex-grow cursor-pointer truncate text-black dark:text-white"
 							title={branch.branch}


### PR DESCRIPTION
<img width="269" alt="image" src="https://github.com/gitbutlerapp/gitbutler-client/assets/4030927/b995f77f-aa1b-41b8-87ad-369083017e0b">
<img width="268" alt="image" src="https://github.com/gitbutlerapp/gitbutler-client/assets/4030927/e80e680e-01cc-4afd-b721-d9041d914266">
