### PR TITLE
Fetch button

### DIFF
--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -472,6 +472,16 @@ impl App {
         Ok(())
     }
 
+    pub fn fetch_from_target(&self, project_id: &str) -> Result<()> {
+        let project = self.gb_project(project_id)?;
+        let project_repository = project_repository::Repository::open(&project)?;
+        project_repository
+            .fetch()
+            .context("failed to fetch from target")?;
+
+        Ok(())
+    }
+
     pub fn upsert_bookmark(&self, bookmark: &bookmarks::Bookmark) -> Result<()> {
         let gb_repository = self.gb_repository(&bookmark.project_id)?;
         let writer = bookmarks::Writer::new(&gb_repository).context("failed to open writer")?;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -678,6 +678,14 @@ async fn push_virtual_branch(
 
 #[timed(duration(printer = "debug!"))]
 #[tauri::command(async)]
+async fn fetch_from_target(handle: tauri::AppHandle, project_id: &str) -> Result<(), Error> {
+    let app = handle.state::<app::App>();
+    app.fetch_from_target(project_id)?;
+    Ok(())
+}
+
+#[timed(duration(printer = "debug!"))]
+#[tauri::command(async)]
 async fn get_target_data(
     handle: tauri::AppHandle,
     project_id: &str,
@@ -883,6 +891,7 @@ fn main() {
             unapply_branch,
             push_virtual_branch,
             create_virtual_branch_from_branch,
+            fetch_from_target,
         ])
         .build(tauri_context)
         .expect("Failed to build tauri app")

--- a/src/routes/repo/[projectId]/Tray.svelte
+++ b/src/routes/repo/[projectId]/Tray.svelte
@@ -79,14 +79,28 @@
 		<div class="flex-grow text-lg font-bold" title={behindMessage}>{target.name}</div>
 		<div>{target.behind > 0 ? `behind ${target.behind}` : 'up-to-date'}</div>
 		<div class="flex-shrink-0 text-light-700 dark:text-dark-100" title={behindMessage}>
-			<button
-				class="p-1 disabled:text-light-300 disabled:dark:text-dark-300"
-				on:click={updateTargetModal.show}
-				disabled={target.behind == 0}
-				title={target.behind > 0 ? 'click to update target' : 'already up-to-date'}
-			>
-				<IconRefresh />
-			</button>
+			{#if target.behind == 0}
+				<button
+					class="p-1 disabled:text-light-300 disabled:dark:text-dark-300"
+					on:click={() => {
+						remoteBranchOperations.fetchFromTarget().then(() => {
+							virtualBranches.refresh();
+						});
+					}}
+					title="click to fetch"
+				>
+					<IconRefresh />
+				</button>
+			{:else}
+				<button
+					class="p-1 disabled:text-light-300 disabled:dark:text-dark-300"
+					on:click={updateTargetModal.show}
+					disabled={target.behind == 0}
+					title={target.behind > 0 ? 'click to update target' : 'already up-to-date'}
+				>
+					<IconRefresh />
+				</button>
+			{/if}
 		</div>
 	</div>
 

--- a/src/routes/repo/[projectId]/Tray.svelte
+++ b/src/routes/repo/[projectId]/Tray.svelte
@@ -11,6 +11,8 @@
 	import PopupMenuItem from '$lib/components/PopupMenu/PopupMenuItem.svelte';
 	import { getRemoteBranches } from './remoteBranches';
 	import { Value } from 'svelte-loadable-store';
+	import { get } from 'lscache';
+	import { invoke } from '@tauri-apps/api';
 
 	export let target: Target;
 	export let branches: Branch[];
@@ -49,6 +51,17 @@
 		});
 	}
 
+	async function getTargetData(params: { projectId: string }) {
+		target = await invoke<Target>('get_target_data', params);
+	}
+
+	function fetchTarget() {
+		remoteBranchOperations.fetchFromTarget().then(() => {
+			virtualBranches.refresh();
+		});
+		getTargetData({ projectId });
+	}
+
 	function rememberWidth(node: HTMLElement) {
 		const cachedWidth = localStorage.getItem(cacheKey);
 		if (cachedWidth) node.style.width = cachedWidth;
@@ -82,11 +95,7 @@
 			{#if target.behind == 0}
 				<button
 					class="p-1 disabled:text-light-300 disabled:dark:text-dark-300"
-					on:click={() => {
-						remoteBranchOperations.fetchFromTarget().then(() => {
-							virtualBranches.refresh();
-						});
-					}}
+					on:click={fetchTarget}
 					title="click to fetch"
 				>
 					<IconRefresh />

--- a/src/routes/repo/[projectId]/remoteBranches.ts
+++ b/src/routes/repo/[projectId]/remoteBranches.ts
@@ -12,6 +12,7 @@ export interface RemoteBranchOperations {
 	refresh(): Promise<void | object>;
 	updateBranchTarget(): Promise<void | object>;
 	createvBranchFromBranch(branch: string): Promise<void | string>;
+	fetchFromTarget(): Promise<void | object>;
 }
 
 export function getRemoteBranches(
@@ -26,7 +27,8 @@ export function getRemoteBranches(
 		refresh: () => refresh(projectId, writeable),
 		subscribe: writeable.subscribe,
 		updateBranchTarget: () => updateBranchTarget(writeable, projectId),
-		createvBranchFromBranch: (branch) => createvBranchFromBranch(writeable, projectId, branch)
+		createvBranchFromBranch: (branch) => createvBranchFromBranch(writeable, projectId, branch),
+		fetchFromTarget: () => fetchFromTarget(writeable, projectId)
 	};
 
 	cache.set(projectId, store);
@@ -50,6 +52,16 @@ function updateBranchTarget(writable: Writable<Loadable<BranchData[]>>, projectI
 		})
 		.catch(() => {
 			error('Unable to update target!');
+		});
+}
+
+function fetchFromTarget(writable: Writable<Loadable<BranchData[]>>, projectId: string) {
+	return invoke<void>('fetch_from_target', { projectId: projectId })
+		.then(() => {
+			refresh(projectId, writable);
+		})
+		.catch(() => {
+			error('Unable to fetch from upstream!');
 		});
 }
 


### PR DESCRIPTION
For the demo, or until we figure out how to fetch in the client as soon as a merge happens on the server, we need to rely on polling for upstream updates. Since we have a little disabled refresh button there anyhow, I figured for now we could make that button fetch from upstream manually.