### PR TITLE
Revert breadcrumb

### DIFF
--- a/src/routes/Breadcrumbs.svelte
+++ b/src/routes/Breadcrumbs.svelte
@@ -13,7 +13,7 @@
 		<a
 			class="button flex items-center px-3"
 			class:active={window.location.pathname.includes(`/projects/${project.id}`)}
-			href="/repo/{project.id}"
+			href="/projects/{project.id}"
 			title="{project.title} home"
 		>
 			{project.title}


### PR DESCRIPTION
I know the styles for these older pages aren't done, but I need access to the settings in order to delete projects in order to setup a good demo, so I'm reverting this for now.