### PR TITLE
One more fix for drop marker css

### DIFF
--- a/src/app.postcss
+++ b/src/app.postcss
@@ -350,9 +350,16 @@ input[type='checkbox'].large {
 	@apply block;
 }
 
-.drag-zone-hover.#new-branch-dz .call-to-action {
+.drag-zone-hover + #new-branch-dz .call-to-action {
 	@apply hidden;
 }
-.drag-zone-hover.#new-branch-dz .drag-zone-marker {
+.drag-zone-hover + #new-branch-dz .drag-zone-marker {
 	@apply block;
+}
+
+#new-branch-dz.drag-zone-hover .call-to-action {
+	@apply hidden;
+}
+#new-branch-dz.drag-zone-hover .drag-zone-marker {
+	@apply block bg-green-300 dark:bg-green-460;
 }


### PR DESCRIPTION
I will need to redo how the new branch dz changes styling when
drop is active. There are gaps in doing with sibling css that make it
flicker and sometimes stick to a state.
