### PR TITLE
Disable Sentry for dev mode

### DIFF
--- a/src/lib/vbranches/BranchStoresCache.ts
+++ b/src/lib/vbranches/BranchStoresCache.ts
@@ -14,10 +14,6 @@ export class BranchStoresCache {
 	remoteBranchStores: Map<string, Refreshable & Readable<Loadable<BranchData[]>>> = new Map();
 	targetBranchStores: Map<string, Refreshable & Readable<Loadable<Target>>> = new Map();
 
-	constructor() {
-		console.log('WHY IS THIS CALLED ALL THE TIME');
-	}
-
 	getVirtualBranchStore(projectId: string) {
 		const cachedStore = this.virtualBranchStores.get(projectId);
 		if (cachedStore) {

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -10,14 +10,21 @@ export const ssr = false;
 export const prerender = true;
 export const csr = true;
 
-export const load: LayoutLoad = wrapLoadWithSentry(({ fetch }) => {
+import { dev } from '$app/environment';
+
+// It turns out that this function gets called on every navigation when wrapped with Sentry. We
+// don't know why it happens, but we should investigate if it happens in prod as well as dev.
+// I examined the call stack and found a section suggesting it might not happen in prod.
+// TODO(mattias): Investigate and decide what to do
+function loadFn({ fetch: realFetch }: { fetch: typeof fetch }) {
 	log.setup();
 	return {
 		projects: api.projects.Projects(),
-		cloud: api.CloudApi({ fetch }),
+		cloud: api.CloudApi({ fetch: realFetch }),
 		branchStoresCache: new BranchStoresCache(),
 		posthog: Posthog(),
 		sentry: Sentry(),
 		userSettings: loadUserSettings()
 	};
-});
+}
+export const load: LayoutLoad = dev ? loadFn : wrapLoadWithSentry(loadFn);


### PR DESCRIPTION
The load function ends up getting called multiple times when wrapping it
with Sentry. Turning it off for now, but should be investigated.
