### PR TITLE
Stable sort hunks by lines then time

### DIFF
--- a/src/lib/diff/utils.ts
+++ b/src/lib/diff/utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Helper function to extract line numbers from the chunk header in a diff.
+ *
+ * @param diff A diff containing a chunk header
+ * @returns The original and modified file line numbers
+ */
+export function getLinesFromChunkHeader(diff: string): {
+	originalLineNumber: number;
+	currentLineNumber: number;
+} {
+	try {
+		const diffLines = diff.split('\n');
+		const header = diffLines[0];
+		const lr = header.split('@@')[1].trim().split(' ');
+		return {
+			originalLineNumber: parseInt(lr[0].split(',')[0].slice(1)),
+			currentLineNumber: parseInt(lr[1].split(',')[0].slice(1))
+		};
+	} catch {
+		return {
+			originalLineNumber: -1,
+			currentLineNumber: -1
+		};
+	}
+}

--- a/src/lib/vbranches/ipc.ts
+++ b/src/lib/vbranches/ipc.ts
@@ -1,6 +1,7 @@
 import { invoke } from '$lib/ipc';
 import { plainToInstance } from 'class-transformer';
 import { Branch, BranchData, Target } from './types';
+import { getLinesFromChunkHeader } from '$lib/diff/utils';
 
 export async function listVirtualBranches(params: { projectId: string }): Promise<Branch[]> {
 	const result = await invoke<any[]>('list_virtual_branches', params);
@@ -77,5 +78,20 @@ export async function fetchFromTarget(params: { projectId: string }) {
 
 function sortBranches(branches: Branch[]): Branch[] {
 	branches.sort((a, b) => a.order - b.order);
+	branches.forEach((branch) => {
+		const files = branch.files;
+		files.sort((a, b) => b.modifiedAt.getTime() - a.modifiedAt.getTime());
+		files.forEach((file) => {
+			const hunks = file.hunks;
+			// Sort by line before sorting by to prevent random order for hunks
+			// with the same timestamp.
+			hunks.sort((a, b) => {
+				const aln = getLinesFromChunkHeader(a.diff);
+				const bln = getLinesFromChunkHeader(b.diff);
+				return aln.currentLineNumber - bln.currentLineNumber;
+			});
+			hunks.sort((a, b) => b.modifiedAt.getTime() - a.modifiedAt.getTime());
+		});
+	});
 	return branches;
 }

--- a/src/routes/repo/[projectId]/HunkDiffViewer.svelte
+++ b/src/routes/repo/[projectId]/HunkDiffViewer.svelte
@@ -2,6 +2,7 @@
 	import { buildDiffRows, documentMap, RowType, type Row } from '$lib/components/Differ/renderer';
 	import { line, type DiffArray } from '$lib/diff';
 	import { create } from '$lib/components/Differ/CodeHighlighter';
+	import { getLinesFromChunkHeader } from '$lib/diff/utils';
 
 	export let diff: string;
 	export let filePath: string;
@@ -16,11 +17,7 @@
 		currentLineNumber: number;
 	} {
 		const diffLines = diff.split('\n');
-		const header = diffLines[0];
-
-		const lr = header.split('@@')[1].trim().split(' ');
-		const originalLineNumber = parseInt(lr[0].split(',')[0].slice(1));
-		const currentLineNumber = parseInt(lr[1].split(',')[0].slice(1));
+		const { originalLineNumber, currentLineNumber } = getLinesFromChunkHeader(diff);
 
 		const before = diffLines
 			.filter((line) => line.startsWith('-'))


### PR DESCRIPTION
When hunks have the same timestamp they get sorted randomly and
often skip places within a file card.
