### PR TITLE
Just default to patch bump

### DIFF
--- a/scripts/next.sh
+++ b/scripts/next.sh
@@ -45,13 +45,10 @@ minor)
 	PATCH="0"
 	echo "$MAJOR.$MINOR.$PATCH"
 	;;
-patch)
+*)
 	MAJOR="$(echo "$VERSION" | cut -d. -f1)"
 	MINOR="$(echo "$VERSION" | cut -d. -f2)"
 	PATCH="$(($(echo "$VERSION" | cut -d. -f3) + 1))"
 	echo "$MAJOR.$MINOR.$PATCH"
-	;;
-*)
-	error "invalid bump type: $BUMP"
 	;;
 esac


### PR DESCRIPTION
The nightly script is failing because we don't have an bump type input for `next.sh`. This just defaults to a patch bump if it's not major or minor.