### PR TITLE
new way of file rendering

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "tauri-apps.tauri-vscode",
     "rust-lang.rust-analyzer",
     "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode"
+    "esbenp.prettier-vscode",
+    "ZixuanChen.vitest-explorer"
   ]
 }

--- a/src/routes/repo/[projectId]/+page.ts
+++ b/src/routes/repo/[projectId]/+page.ts
@@ -1,15 +1,9 @@
-import type { BranchData } from '$lib/vbranches';
 import type { PageLoadEvent } from './$types';
 import { invoke } from '$lib/ipc';
 import { api } from '$lib';
 
 async function getRemoteBranches(params: { projectId: string }) {
 	return invoke<Array<string>>('git_remote_branches', params);
-}
-
-function sortBranchData(branchData: BranchData[]): BranchData[] {
-	// sort remote_branches_data by date
-	return branchData.sort((a, b) => b.lastCommitTs - a.lastCommitTs);
 }
 
 export async function load({ parent, params }: PageLoadEvent) {
@@ -30,21 +24,4 @@ export async function load({ parent, params }: PageLoadEvent) {
 		remoteBranchStore,
 		targetBranchStore
 	};
-}
-
-if (import.meta.vitest) {
-	const { it, expect } = import.meta.vitest;
-	it('sorts by last commit timestamp', () => {
-		const bd: BranchData[] = [
-			{
-				sha: 'a',
-				lastCommitTs: 1
-			} as BranchData,
-			{
-				sha: 'b',
-				lastCommitTs: 2
-			} as BranchData
-		];
-		expect(sortBranchData(bd)[0].sha).toBe('b');
-	});
 }

--- a/src/routes/repo/[projectId]/FileCardNext.svelte
+++ b/src/routes/repo/[projectId]/FileCardNext.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import { parseFileSections } from './fileSections';
+	import type { File } from '$lib/vbranches';
+	import RenderedLine from './RenderedLine.svelte';
+	export let file: File;
+
+	$: sections = parseFileSections(file);
+</script>
+
+<div>
+	{#each sections as section}
+		{#if 'hunk' in section}
+			<div class="border border-dark-100">
+				{#each section.subSections as subsection}
+					<div
+						class="grid h-full w-full flex-auto whitespace-pre font-mono text-sm"
+						style:grid-template-columns="minmax(auto, max-content) minmax(auto, max-content) 1fr"
+					>
+						{#each subsection.lines.slice(0, subsection.linesShown) as line}
+							<RenderedLine {line} sectionType={subsection.sectionType} />
+						{/each}
+					</div>
+					{#if subsection.linesShown < subsection.lines.length}
+						<button
+							class="text-sm"
+							on:click={() => {
+								subsection.linesShown = subsection.lines.length;
+							}}
+						>
+							Expand {subsection.lines.length} lines
+						</button>
+					{/if}
+				{/each}
+			</div>
+		{:else}
+			<div class="border-l border-transparent">
+				<div
+					class="grid h-full w-full flex-auto whitespace-pre font-mono text-sm"
+					style:grid-template-columns="minmax(auto, max-content) minmax(auto, max-content) 1fr"
+				>
+					{#each section.lines.slice(0, section.linesShown) as line}
+						<RenderedLine {line} sectionType={section.sectionType} />
+					{/each}
+				</div>
+			</div>
+			{#if section.linesShown < section.lines.length}
+				<button
+					class="text-sm"
+					on:click={() => {
+						if ('linesShown' in section) {
+							section.linesShown = section.lines.length;
+						}
+					}}
+				>
+					Expand {section.lines.length} lines
+				</button>
+			{/if}
+		{/if}
+	{/each}
+</div>

--- a/src/routes/repo/[projectId]/FileCardNext.svelte
+++ b/src/routes/repo/[projectId]/FileCardNext.svelte
@@ -17,7 +17,7 @@
 						style:grid-template-columns="minmax(auto, max-content) minmax(auto, max-content) 1fr"
 					>
 						{#each subsection.lines.slice(0, subsection.linesShown) as line}
-							<RenderedLine {line} sectionType={subsection.sectionType} />
+							<RenderedLine {line} sectionType={subsection.sectionType} filePath={file.path} />
 						{/each}
 					</div>
 					{#if subsection.linesShown < subsection.lines.length}
@@ -39,7 +39,7 @@
 					style:grid-template-columns="minmax(auto, max-content) minmax(auto, max-content) 1fr"
 				>
 					{#each section.lines.slice(0, section.linesShown) as line}
-						<RenderedLine {line} sectionType={section.sectionType} />
+						<RenderedLine {line} sectionType={section.sectionType} filePath={file.path} />
 					{/each}
 				</div>
 			</div>

--- a/src/routes/repo/[projectId]/RenderedLine.svelte
+++ b/src/routes/repo/[projectId]/RenderedLine.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import { SectionType } from './fileSections';
+	import type { Line } from './fileSections';
+	export let line: Line;
+	export let sectionType: SectionType;
+</script>
+
+<span
+	class="w-[1.5rem] select-none border-r border-light-400 bg-light-100 px-1 text-right text-light-600 dark:border-dark-400 dark:bg-dark-800 dark:text-light-300"
+>
+	{line.beforeLineNumber || ''}
+</span>
+<span
+	class="w-[1.5rem] select-none border-r border-light-400 bg-light-100 px-1 text-right text-light-600 dark:border-dark-400 dark:bg-dark-800 dark:text-light-300"
+>
+	{line.afterLineNumber || ''}
+</span>
+<span
+	class="pl-1 overflow-hidden whitespace-nowrap"
+	class:diff-line-deletion={sectionType === SectionType.RemovedLines}
+	class:diff-line-addition={sectionType === SectionType.AddedLines}
+>
+	{line.content}
+</span>

--- a/src/routes/repo/[projectId]/RenderedLine.svelte
+++ b/src/routes/repo/[projectId]/RenderedLine.svelte
@@ -1,8 +1,29 @@
 <script lang="ts">
 	import { SectionType } from './fileSections';
 	import type { Line } from './fileSections';
+	import { create } from '$lib/components/Differ/CodeHighlighter';
 	export let line: Line;
 	export let sectionType: SectionType;
+	export let filePath: string;
+
+	function toTokens(codeString: string): string[] {
+		function sanitize(text: string) {
+			var element = document.createElement('div');
+			element.innerText = text;
+			return element.innerHTML;
+		}
+
+		let highlighter = create(codeString, filePath);
+		let tokens: string[] = [];
+		highlighter.highlight((text, classNames) => {
+			const token = classNames
+				? `<span class=${classNames}>${sanitize(text)}</span>`
+				: sanitize(text);
+
+			tokens.push(token);
+		});
+		return tokens;
+	}
 </script>
 
 <span
@@ -20,5 +41,5 @@
 	class:diff-line-deletion={sectionType === SectionType.RemovedLines}
 	class:diff-line-addition={sectionType === SectionType.AddedLines}
 >
-	{line.content}
+	{@html toTokens(line.content).join('')}
 </span>

--- a/src/routes/repo/[projectId]/fileSections.test.ts
+++ b/src/routes/repo/[projectId]/fileSections.test.ts
@@ -1,0 +1,611 @@
+import { expect, test } from 'vitest';
+import type { File, Hunk } from '$lib/vbranches';
+import { parseHunkSection, parseFileSections, SectionType } from './fileSections';
+import type { Section, HunkSection } from './fileSections';
+
+const fileContent = `<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
+		<meta name="viewport" content="width=device-width" />
+		%sveltekit.head%
+	</head>
+	<body data-sveltekit-preload-data="hover" class="bg-[#212124] text-zinc-400">
+		<div style="display: contents">%sveltekit.body%</div>
+	</body>
+</html>`;
+const balancedHunkDiff = `@@ -3,7 +3,7 @@
+        <head>
+                <meta charset="utf-8" />
+                <link rel="icon" href="%sveltekit.assets%/favicon.png" />
+-               <meta name="viewport" content="width=device-width" />
++               <meta name="viewporttt" content="width=device-width" />
+                %sveltekit.head%
+        </head>
+        <body data-sveltekit-preload-data="hover" class="bg-[#212124] text-zinc-400">`;
+const moreAddedHunkDiff = `@@ -3,7 +3,8 @@
+        <head>
+                <meta charset="utf-8" />
+                <link rel="icon" href="%sveltekit.assets%/favicon.png" />
+-               <meta name="viewport" content="width=device-width" />
++               <meta name="viewport"
++                       content="width=device-width" />
+                %sveltekit.head%
+        </head>
+        <body data-sveltekit-preload-data="hover" class="bg-[#212124] text-zinc-400">`;
+const topOfFileHunk = `@@ -1,5 +1,5 @@
+ <!DOCTYPE html>
+-<html lang="en">
++<html lang="de">
+        <head>
+                <meta charset="utf-8" />
+                <link rel="icon" href="%sveltekit.assets%/favicon.png" />`;
+const bottomOfFileHunk = `@@ -8,5 +8,6 @@
+        </head>
+        <body data-sveltekit-preload-data="hover" class="bg-[#212124] text-zinc-400">
+                <div style="display: contents">%sveltekit.body%</div>
++               <p>wtf</p>
+        </body>
+ </html>`;
+const delteWholeFile = `@@ -1,12 +0,0 @@
+-<!DOCTYPE html>
+-<html lang="en">
+-       <head>
+-               <meta charset="utf-8" />
+-               <link rel="icon" href="%sveltekit.assets%/favicon.png" />
+-               <meta name="viewport" content="width=device-width" />
+-               %sveltekit.head%
+-       </head>
+-       <body data-sveltekit-preload-data="hover" class="bg-[#212124] text-zinc-400">
+-               <div style="display: contents">%sveltekit.body%</div>
+-       </body>
+-</html>`;
+const addWholeFile = `@@ -0,0 +1,12 @@
++<!DOCTYPE html>
++<html lang="en">
++       <head>
++               <meta charset="utf-8" />
++               <link rel="icon" href="%sveltekit.assets%/favicon.png" />
++               <meta name="viewport" content="width=device-width" />
++               %sveltekit.head%
++       </head>
++       <body data-sveltekit-preload-data="hover" class="bg-[#212124] text-zinc-400">
++               <div style="display: contents">%sveltekit.body%</div>
++       </body>
++</html>`;
+const multiChangeHunk = `@@ -1,12 +1,11 @@
+ <!DOCTYPE html>
+ <html lang="en">
+        <head>
+-               <meta charset="utf-8" />
+                <link rel="icon" href="%sveltekit.assets%/favicon.png" />
+                <meta name="viewport" content="width=device-width" />
+                %sveltekit.head%
+        </head>
+-       <body data-sveltekit-preload-data="hover" class="bg-[#212124] text-zinc-400">
++       <body data-sveltekit-preload-data="Hover" class="bg-[#212124] text-zinc-400">
+                <div style="display: contents">%sveltekit.body%</div>
+        </body>
+ </html>`;
+
+test('parses a balanced hunk section', () => {
+	const balancedHunk: Hunk = {
+		id: '1',
+		name: 'test',
+		diff: balancedHunkDiff,
+		modifiedAt: new Date(2021, 1, 1),
+		filePath: 'foo.py'
+	};
+	const hunkSection = parseHunkSection(balancedHunk);
+	expect(hunkSection).toBeDefined();
+	expect(hunkSection?.hunk).toBe(balancedHunk);
+	expect(hunkSection?.header.beforeStart).toBe(3);
+	expect(hunkSection?.header.beforeLength).toBe(7);
+	expect(hunkSection?.header.afterStart).toBe(3);
+	expect(hunkSection?.header.afterLength).toBe(7);
+	expect(hunkSection.subSections.length).toBe(4);
+	const firstContext = hunkSection.subSections[0];
+	expect(firstContext.sectionType).toBe(SectionType.Context);
+	expect(firstContext.linesShown).toBe(0);
+	expect(firstContext.lines).toEqual([
+		{
+			beforeLineNumber: 3,
+			afterLineNumber: 3,
+			content: `       <head>`
+		},
+		{
+			beforeLineNumber: 4,
+			afterLineNumber: 4,
+			content: `               <meta charset="utf-8" />`
+		},
+		{
+			beforeLineNumber: 5,
+			afterLineNumber: 5,
+			content: `               <link rel="icon" href="%sveltekit.assets%/favicon.png" />`
+		}
+	]);
+	const removedLines = hunkSection.subSections[1];
+	expect(removedLines.sectionType).toBe(SectionType.RemovedLines);
+	expect(removedLines.linesShown).toBe(1);
+	expect(removedLines.lines).toEqual([
+		{
+			beforeLineNumber: 6,
+			afterLineNumber: undefined,
+			content: `               <meta name="viewport" content="width=device-width" />`
+		}
+	]);
+	const addedLines = hunkSection.subSections[2];
+	expect(addedLines.sectionType).toBe(SectionType.AddedLines);
+	expect(addedLines.linesShown).toBe(1);
+	expect(addedLines.lines).toEqual([
+		{
+			beforeLineNumber: undefined,
+			afterLineNumber: 6,
+			content: `               <meta name="viewporttt" content="width=device-width" />`
+		}
+	]);
+	const secondContext = hunkSection.subSections[3];
+	expect(secondContext.sectionType).toBe(SectionType.Context);
+	expect(secondContext.linesShown).toBe(0);
+	expect(secondContext.lines).toEqual([
+		{
+			beforeLineNumber: 7,
+			afterLineNumber: 7,
+			content: `               %sveltekit.head%`
+		},
+		{
+			beforeLineNumber: 8,
+			afterLineNumber: 8,
+			content: `       </head>`
+		},
+		{
+			beforeLineNumber: 9,
+			afterLineNumber: 9,
+			content: `       <body data-sveltekit-preload-data="hover" class="bg-[#212124] text-zinc-400">`
+		}
+	]);
+});
+
+test('parses hunk sections with more added', () => {
+	const balancedHunk: Hunk = {
+		id: '1',
+		name: 'test',
+		diff: moreAddedHunkDiff,
+		modifiedAt: new Date(2021, 1, 1),
+		filePath: 'foo.py'
+	};
+	const hunkSection = parseHunkSection(balancedHunk);
+	expect(hunkSection).toBeDefined();
+	expect(hunkSection?.hunk).toBe(balancedHunk);
+	expect(hunkSection?.header.beforeStart).toBe(3);
+	expect(hunkSection?.header.beforeLength).toBe(7);
+	expect(hunkSection?.header.afterStart).toBe(3);
+	expect(hunkSection?.header.afterLength).toBe(8);
+	expect(hunkSection.subSections.length).toBe(4);
+	const firstContext = hunkSection.subSections[0];
+	expect(firstContext.sectionType).toBe(SectionType.Context);
+	expect(firstContext.linesShown).toBe(0);
+	expect(firstContext.lines).toEqual([
+		{
+			beforeLineNumber: 3,
+			afterLineNumber: 3,
+			content: `       <head>`
+		},
+		{
+			beforeLineNumber: 4,
+			afterLineNumber: 4,
+			content: `               <meta charset="utf-8" />`
+		},
+		{
+			beforeLineNumber: 5,
+			afterLineNumber: 5,
+			content: `               <link rel="icon" href="%sveltekit.assets%/favicon.png" />`
+		}
+	]);
+
+	const removedLines = hunkSection.subSections[1];
+	expect(removedLines.sectionType).toBe(SectionType.RemovedLines);
+	expect(removedLines.linesShown).toBe(1);
+	expect(removedLines.lines).toEqual([
+		{
+			beforeLineNumber: 6,
+			afterLineNumber: undefined,
+			content: `               <meta name="viewport" content="width=device-width" />`
+		}
+	]);
+
+	const addedLines = hunkSection.subSections[2];
+	expect(addedLines.sectionType).toBe(SectionType.AddedLines);
+	expect(addedLines.linesShown).toBe(1);
+	expect(addedLines.lines).toEqual([
+		{
+			beforeLineNumber: undefined,
+			afterLineNumber: 6,
+			content: `               <meta name="viewport"`
+		},
+		{
+			beforeLineNumber: undefined,
+			afterLineNumber: 7,
+			content: `                       content="width=device-width" />`
+		}
+	]);
+
+	const secondContext = hunkSection.subSections[3];
+	expect(secondContext.sectionType).toBe(SectionType.Context);
+	expect(secondContext.linesShown).toBe(0);
+	expect(secondContext.lines).toEqual([
+		{
+			beforeLineNumber: 7,
+			afterLineNumber: 8,
+			content: `               %sveltekit.head%`
+		},
+		{
+			beforeLineNumber: 8,
+			afterLineNumber: 9,
+			content: `       </head>`
+		},
+		{
+			beforeLineNumber: 9,
+			afterLineNumber: 10,
+			content: `       <body data-sveltekit-preload-data="hover" class="bg-[#212124] text-zinc-400">`
+		}
+	]);
+});
+
+test('parses a hunk with two changed places', () => {
+	const balancedHunk: Hunk = {
+		id: '1',
+		name: 'test',
+		diff: multiChangeHunk,
+		modifiedAt: new Date(2021, 1, 1),
+		filePath: 'foo.py'
+	};
+	const hunkSection = parseHunkSection(balancedHunk);
+	expect(hunkSection).toBeDefined();
+	expect(hunkSection?.hunk).toBe(balancedHunk);
+	expect(hunkSection?.header.beforeStart).toBe(1);
+	expect(hunkSection?.header.beforeLength).toBe(12);
+	expect(hunkSection?.header.afterStart).toBe(1);
+	expect(hunkSection?.header.afterLength).toBe(11);
+	expect(hunkSection.subSections.length).toBe(6);
+
+	const firstContext = hunkSection.subSections[0];
+	expect(firstContext.sectionType).toBe(SectionType.Context);
+	expect(firstContext.linesShown).toBe(0);
+	expect(firstContext.lines).toEqual([
+		{
+			beforeLineNumber: 1,
+			afterLineNumber: 1,
+			content: `<!DOCTYPE html>`
+		},
+		{
+			beforeLineNumber: 2,
+			afterLineNumber: 2,
+			content: `<html lang="en">`
+		},
+		{
+			beforeLineNumber: 3,
+			afterLineNumber: 3,
+			content: `       <head>`
+		}
+	]);
+	const firstHunkSubsection = hunkSection.subSections[1];
+	expect(firstHunkSubsection.sectionType).toBe(SectionType.RemovedLines);
+	expect(firstHunkSubsection.linesShown).toBe(1);
+	expect(firstHunkSubsection.lines).toEqual([
+		{
+			beforeLineNumber: 4,
+			afterLineNumber: undefined,
+			content: `               <meta charset="utf-8" />`
+		}
+	]);
+	const secondContext = hunkSection.subSections[2];
+	expect(secondContext.sectionType).toBe(SectionType.Context);
+	expect(secondContext.linesShown).toBe(0);
+	expect(secondContext.lines).toEqual([
+		{
+			beforeLineNumber: 5,
+			afterLineNumber: 4,
+			content: `               <link rel="icon" href="%sveltekit.assets%/favicon.png" />`
+		},
+		{
+			beforeLineNumber: 6,
+			afterLineNumber: 5,
+			content: `               <meta name="viewport" content="width=device-width" />`
+		},
+		{
+			beforeLineNumber: 7,
+			afterLineNumber: 6,
+			content: `               %sveltekit.head%`
+		},
+		{
+			beforeLineNumber: 8,
+			afterLineNumber: 7,
+			content: `       </head>`
+		}
+	]);
+	const secondHunkSubsection = hunkSection.subSections[3];
+	expect(secondHunkSubsection.sectionType).toBe(SectionType.RemovedLines);
+	expect(secondHunkSubsection.linesShown).toBe(1);
+	expect(secondHunkSubsection.lines).toEqual([
+		{
+			beforeLineNumber: 9,
+			afterLineNumber: undefined,
+			content: `       <body data-sveltekit-preload-data="hover" class="bg-[#212124] text-zinc-400">`
+		}
+	]);
+	const thirdHunkScubsection = hunkSection.subSections[4];
+	expect(thirdHunkScubsection.sectionType).toBe(SectionType.AddedLines);
+	expect(thirdHunkScubsection.linesShown).toBe(1);
+	expect(thirdHunkScubsection.lines).toEqual([
+		{
+			beforeLineNumber: undefined,
+			afterLineNumber: 8,
+			content: `       <body data-sveltekit-preload-data="Hover" class="bg-[#212124] text-zinc-400">`
+		}
+	]);
+	const thirdContext = hunkSection.subSections[5];
+	expect(thirdContext.sectionType).toBe(SectionType.Context);
+	expect(thirdContext.linesShown).toBe(0);
+	expect(thirdContext.lines).toEqual([
+		{
+			beforeLineNumber: 10,
+			afterLineNumber: 9,
+			content: `               <div style="display: contents">%sveltekit.body%</div>`
+		},
+		{
+			beforeLineNumber: 11,
+			afterLineNumber: 10,
+			content: `       </body>`
+		},
+		{
+			beforeLineNumber: 12,
+			afterLineNumber: 11,
+			content: `</html>`
+		}
+	]);
+});
+
+test('parses file with one hunk and balanced add-remove', () => {
+	const hunk: Hunk = {
+		id: '1',
+		name: 'test',
+		diff: balancedHunkDiff,
+		modifiedAt: new Date(2021, 1, 1),
+		filePath: 'foo.py'
+	};
+	const file: File = {
+		id: '1',
+		path: 'foo.py',
+		hunks: [hunk],
+		expanded: true,
+		modifiedAt: new Date(2021, 1, 1),
+		conflicted: false,
+		content: fileContent
+	};
+	const sections = parseFileSections(file);
+	expect(sections.length).toBe(3);
+	const beforeSection = sections[0] as Section;
+	expect(beforeSection.sectionType).toBe(SectionType.Context);
+	expect(beforeSection.linesShown).toBe(0);
+	expect(beforeSection.lines.length).toBe(2);
+	expect(beforeSection.lines[0]).toEqual({
+		beforeLineNumber: 1,
+		afterLineNumber: 1,
+		content: '<!DOCTYPE html>'
+	});
+	expect(beforeSection.lines[1]).toEqual({
+		beforeLineNumber: 2,
+		afterLineNumber: 2,
+		content: '<html lang="en">'
+	});
+
+	const hunkSection = sections[1] as HunkSection;
+	expect(hunkSection.hunk).toBe(hunk);
+
+	const afterSection = sections[2] as Section;
+	expect(afterSection.sectionType).toBe(SectionType.Context);
+	expect(afterSection.linesShown).toBe(0);
+	expect(afterSection.lines.length).toBe(3);
+	expect(afterSection.lines[0]).toEqual({
+		beforeLineNumber: 10,
+		afterLineNumber: 10,
+		content: '		<div style="display: contents">%sveltekit.body%</div>'
+	});
+	expect(afterSection.lines[1]).toEqual({
+		beforeLineNumber: 11,
+		afterLineNumber: 11,
+		content: '	</body>'
+	});
+	expect(afterSection.lines[2]).toEqual({
+		beforeLineNumber: 12,
+		afterLineNumber: 12,
+		content: '</html>'
+	});
+});
+
+test('parses file with one hunk with more added than removed', () => {
+	const hunk: Hunk = {
+		id: '1',
+		name: 'test',
+		diff: moreAddedHunkDiff,
+		modifiedAt: new Date(2021, 1, 1),
+		filePath: 'foo.py'
+	};
+	const file: File = {
+		id: '1',
+		path: 'foo.py',
+		hunks: [hunk],
+		expanded: true,
+		modifiedAt: new Date(2021, 1, 1),
+		conflicted: false,
+		content: fileContent
+	};
+	const sections = parseFileSections(file);
+	expect(sections.length).toBe(3);
+	const beforeSection = sections[0] as Section;
+	expect(beforeSection.lines.length).toBe(2);
+	expect(beforeSection.lines[0]).toEqual({
+		beforeLineNumber: 1,
+		afterLineNumber: 1,
+		content: '<!DOCTYPE html>'
+	});
+	expect(beforeSection.lines[1]).toEqual({
+		beforeLineNumber: 2,
+		afterLineNumber: 2,
+		content: '<html lang="en">'
+	});
+
+	const hunkSection = sections[1] as HunkSection;
+	expect(hunkSection.hunk).toBe(hunk);
+
+	const afterSection = sections[2] as Section;
+	expect(afterSection.lines.length).toBe(3);
+	expect(afterSection.lines[0]).toEqual({
+		beforeLineNumber: 10,
+		afterLineNumber: 11,
+		content: '		<div style="display: contents">%sveltekit.body%</div>'
+	});
+	expect(afterSection.lines[1]).toEqual({
+		beforeLineNumber: 11,
+		afterLineNumber: 12,
+		content: '	</body>'
+	});
+	expect(afterSection.lines[2]).toEqual({
+		beforeLineNumber: 12,
+		afterLineNumber: 13,
+		content: '</html>'
+	});
+});
+
+test('parses file with two hunks and context in the middle only', () => {
+	const topHunk: Hunk = {
+		id: '1',
+		name: 'top',
+		diff: topOfFileHunk,
+		modifiedAt: new Date(2021, 1, 1),
+		filePath: 'foo.py'
+	};
+	const bottomHunk: Hunk = {
+		id: '1',
+		name: 'bottom',
+		diff: bottomOfFileHunk,
+		modifiedAt: new Date(2021, 1, 1),
+		filePath: 'foo.py'
+	};
+	const file: File = {
+		id: '1',
+		path: 'foo.py',
+		hunks: [topHunk, bottomHunk],
+		expanded: true,
+		modifiedAt: new Date(2021, 1, 1),
+		conflicted: false,
+		content: fileContent
+	};
+	const sections = parseFileSections(file);
+	expect(sections.length).toBe(3);
+	const topHunkSection = sections[0] as HunkSection;
+	expect(topHunkSection.hunk).toBe(topHunk);
+	const middleSection = sections[1] as Section;
+	expect(middleSection.lines.length).toBe(2);
+	expect(middleSection.lines[0]).toEqual({
+		beforeLineNumber: 6,
+		afterLineNumber: 6,
+		content: '		<meta name="viewport" content="width=device-width" />'
+	});
+	expect(middleSection.lines[1]).toEqual({
+		beforeLineNumber: 7,
+		afterLineNumber: 7,
+		content: '		%sveltekit.head%'
+	});
+	const bottomHunkSection = sections[2] as HunkSection;
+	expect(bottomHunkSection.hunk).toBe(bottomHunk);
+	expect(bottomHunkSection.subSections[0].sectionType).toBe(SectionType.Context);
+	expect(bottomHunkSection.subSections[0].lines[0]).toEqual({
+		beforeLineNumber: 8,
+		afterLineNumber: 8,
+		content: '       </head>'
+	});
+	expect(bottomHunkSection.subSections[0].lines[1]).toEqual({
+		beforeLineNumber: 9,
+		afterLineNumber: 9,
+		content: '       <body data-sveltekit-preload-data="hover" class="bg-[#212124] text-zinc-400">'
+	});
+	expect(bottomHunkSection.subSections[0].lines[2]).toEqual({
+		beforeLineNumber: 10,
+		afterLineNumber: 10,
+		content: '               <div style="display: contents">%sveltekit.body%</div>'
+	});
+	expect(bottomHunkSection.subSections[1].sectionType).toBe(SectionType.AddedLines);
+	expect(bottomHunkSection.subSections[1].lines.length).toBe(1);
+	expect(bottomHunkSection.subSections[1].lines[0]).toEqual({
+		beforeLineNumber: undefined,
+		afterLineNumber: 11,
+		content: '               <p>wtf</p>'
+	});
+	expect(bottomHunkSection.subSections[2].sectionType).toBe(SectionType.Context);
+	expect(bottomHunkSection.subSections[2].lines.length).toBe(2);
+	expect(bottomHunkSection.subSections[2].lines[0]).toEqual({
+		beforeLineNumber: 11,
+		afterLineNumber: 12,
+		content: '       </body>'
+	});
+	expect(bottomHunkSection.subSections[2].lines[1]).toEqual({
+		beforeLineNumber: 12,
+		afterLineNumber: 13,
+		content: '</html>'
+	});
+});
+
+test('parses whole file deleted', () => {
+	const deleteHunk: Hunk = {
+		id: '1',
+		name: 'delete',
+		diff: delteWholeFile,
+		modifiedAt: new Date(2021, 1, 1),
+		filePath: 'foo.py'
+	};
+	const file: File = {
+		id: '1',
+		path: 'foo.py',
+		hunks: [deleteHunk],
+		expanded: true,
+		modifiedAt: new Date(2021, 1, 1),
+		conflicted: false,
+		content: fileContent
+	};
+	const sections = parseFileSections(file);
+	expect(sections.length).toBe(1);
+	const deleteHunkSection = sections[0] as HunkSection;
+	expect(deleteHunkSection.hunk).toBe(deleteHunk);
+	expect(deleteHunkSection.subSections.length).toBe(1);
+	expect(deleteHunkSection.subSections[0].sectionType).toBe(SectionType.RemovedLines);
+	expect(deleteHunkSection.subSections[0].lines.length).toBe(12);
+});
+
+test('parses new file created', () => {
+	const newFileHunk: Hunk = {
+		id: '1',
+		name: 'new',
+		diff: addWholeFile,
+		modifiedAt: new Date(2021, 1, 1),
+		filePath: 'foo.py'
+	};
+	const file: File = {
+		id: '1',
+		path: 'foo.py',
+		hunks: [newFileHunk],
+		expanded: true,
+		modifiedAt: new Date(2021, 1, 1),
+		conflicted: false,
+		content: fileContent
+	};
+	const sections = parseFileSections(file);
+	expect(sections.length).toBe(1);
+	const deleteHunkSection = sections[0] as HunkSection;
+	expect(deleteHunkSection.hunk).toBe(newFileHunk);
+	expect(deleteHunkSection.subSections.length).toBe(1);
+	expect(deleteHunkSection.subSections[0].sectionType).toBe(SectionType.AddedLines);
+	expect(deleteHunkSection.subSections[0].lines.length).toBe(12);
+});

--- a/src/routes/repo/[projectId]/fileSections.test.ts
+++ b/src/routes/repo/[projectId]/fileSections.test.ts
@@ -479,7 +479,7 @@ test('parses file with one hunk with more added than removed', () => {
 	});
 });
 
-test('parses file with two hunks and context in the middle only', () => {
+test('parses file with two hunks ordered by position in file', () => {
 	const topHunk: Hunk = {
 		id: '1',
 		name: 'top',
@@ -497,7 +497,7 @@ test('parses file with two hunks and context in the middle only', () => {
 	const file: File = {
 		id: '1',
 		path: 'foo.py',
-		hunks: [topHunk, bottomHunk],
+		hunks: [bottomHunk, topHunk],
 		expanded: true,
 		modifiedAt: new Date(2021, 1, 1),
 		conflicted: false,

--- a/src/routes/repo/[projectId]/fileSections.ts
+++ b/src/routes/repo/[projectId]/fileSections.ts
@@ -1,0 +1,159 @@
+import type { File, Hunk } from '$lib/vbranches';
+
+export type Line = {
+	beforeLineNumber: number | undefined;
+	afterLineNumber: number | undefined;
+	content: string;
+};
+
+export type HunkHeader = {
+	beforeStart: number;
+	beforeLength: number;
+	afterStart: number;
+	afterLength: number;
+};
+
+export type HunkSection = {
+	hunk: Hunk;
+	header: HunkHeader;
+	subSections: Section[];
+};
+
+export enum SectionType {
+	AddedLines,
+	RemovedLines,
+	Context
+}
+
+export type Section = {
+	linesShown: number;
+	lines: Line[];
+	sectionType: SectionType;
+};
+
+export function parseHunkHeader(header: string | undefined): HunkHeader {
+	if (!header) {
+		return { beforeStart: 0, beforeLength: 0, afterStart: 0, afterLength: 0 };
+	}
+	const [before, after] = header.split('@@')[1].trim().split(' ');
+	const [beforeStart, beforeLength] = before.split(',').map((n) => Math.abs(parseInt(n, 10)));
+	const [afterStart, afterLength] = after.split(',').map((n) => Math.abs(parseInt(n, 10)));
+	return { beforeStart, beforeLength, afterStart, afterLength };
+}
+
+export function parseHunkSection(hunk: Hunk): HunkSection {
+	const lines = hunk.diff.split('\n');
+	const header = parseHunkHeader(lines.shift());
+	const hunkSection: HunkSection = {
+		hunk: hunk,
+		header: header,
+		subSections: []
+	};
+
+	let currentBeforeLineNumber = header.beforeStart;
+	let currentAfterLineNumber = header.afterStart;
+
+	let currentSection: Section | undefined;
+	while (lines.length > 0) {
+		const line = lines.shift();
+		if (!line) break;
+		if (line.startsWith('-')) {
+			if (!currentSection || currentSection.sectionType != SectionType.RemovedLines) {
+				if (currentSection) hunkSection.subSections.push(currentSection);
+				currentSection = { linesShown: 1, lines: [], sectionType: SectionType.RemovedLines };
+			}
+			currentSection.lines.push({
+				beforeLineNumber: currentBeforeLineNumber,
+				afterLineNumber: undefined,
+				content: line.slice(1)
+			});
+			currentBeforeLineNumber++;
+		} else if (line.startsWith('+')) {
+			if (!currentSection || currentSection.sectionType != SectionType.AddedLines) {
+				if (currentSection) hunkSection.subSections.push(currentSection);
+				currentSection = { linesShown: 1, lines: [], sectionType: SectionType.AddedLines };
+			}
+			currentSection.lines.push({
+				beforeLineNumber: undefined,
+				afterLineNumber: currentAfterLineNumber,
+				content: line.slice(1)
+			});
+			currentAfterLineNumber++;
+		} else {
+			if (!currentSection || currentSection.sectionType != SectionType.Context) {
+				if (currentSection) hunkSection.subSections.push(currentSection);
+				currentSection = { linesShown: 0, lines: [], sectionType: SectionType.Context };
+			}
+			currentSection.lines.push({
+				beforeLineNumber: currentBeforeLineNumber,
+				afterLineNumber: currentAfterLineNumber,
+				content: line.slice(1)
+			});
+			currentBeforeLineNumber++;
+			currentAfterLineNumber++;
+		}
+	}
+	if (currentSection && currentSection.lines.length > 0) {
+		hunkSection.subSections.push(currentSection);
+	}
+	return hunkSection;
+}
+
+export function parseFileSections(file: File): (Section | HunkSection)[] {
+	const hunkSections = file.hunks
+		.map(parseHunkSection)
+		.filter((hunkSection) => hunkSection !== undefined);
+
+	const lines = file.content.split('\n');
+	const sections: (Section | HunkSection)[] = [];
+
+	let currentBeforeLineNumber = 1;
+	let currentAfterLineNumber = 1;
+	let currentContext: Section | undefined = undefined;
+
+	let i = 0;
+	while (i < lines.length) {
+		if (currentContext === undefined) {
+			currentContext = { linesShown: 0, lines: [], sectionType: SectionType.Context };
+		}
+		const nextHunk = hunkSections.at(0);
+		if (
+			!nextHunk ||
+			(currentBeforeLineNumber < nextHunk.header.beforeStart &&
+				currentAfterLineNumber < nextHunk.header.afterStart)
+		) {
+			// add line to current context
+			currentContext.lines.push({
+				beforeLineNumber: currentBeforeLineNumber,
+				afterLineNumber: currentAfterLineNumber,
+				content: lines[i]
+			});
+			currentBeforeLineNumber++;
+			currentAfterLineNumber++;
+			i++;
+			continue;
+		} else {
+			// flush current context
+			if (currentContext.lines.length > 0) {
+				sections.push(currentContext);
+				currentContext = undefined;
+			}
+			// add next hunk section and skip over to context after hunk
+			hunkSections.shift();
+			sections.push(nextHunk);
+			currentBeforeLineNumber = nextHunk.header.beforeStart + nextHunk.header.beforeLength;
+			currentAfterLineNumber = nextHunk.header.afterStart + nextHunk.header.afterLength;
+			// Jump over to the context after the hunk
+			i =
+				nextHunk.header.beforeLength > 0
+					? (i = currentBeforeLineNumber - 1)
+					: (i = currentAfterLineNumber - 1);
+			continue;
+		}
+	}
+	if (currentContext !== undefined && currentContext.lines.length > 0) {
+		sections.push(currentContext);
+	}
+
+	return sections;
+}

--- a/src/routes/repo/[projectId]/fileSections.ts
+++ b/src/routes/repo/[projectId]/fileSections.ts
@@ -13,11 +13,11 @@ export type HunkHeader = {
 	afterLength: number;
 };
 
-export type HunkSection = {
-	hunk: Hunk;
-	header: HunkHeader;
-	subSections: Section[];
-};
+export class HunkSection {
+	hunk!: Hunk;
+	header!: HunkHeader;
+	subSections!: Section[];
+}
 
 export enum SectionType {
 	AddedLines,
@@ -25,11 +25,11 @@ export enum SectionType {
 	Context
 }
 
-export type Section = {
-	linesShown: number;
-	lines: Line[];
-	sectionType: SectionType;
-};
+export class Section {
+	linesShown!: number;
+	lines!: Line[];
+	sectionType!: SectionType;
+}
 
 export function parseHunkHeader(header: string | undefined): HunkHeader {
 	if (!header) {
@@ -100,9 +100,12 @@ export function parseHunkSection(hunk: Hunk): HunkSection {
 }
 
 export function parseFileSections(file: File): (Section | HunkSection)[] {
+	if (!file.content) return [];
+
 	const hunkSections = file.hunks
 		.map(parseHunkSection)
-		.filter((hunkSection) => hunkSection !== undefined);
+		.filter((hunkSection) => hunkSection !== undefined)
+		.sort((a, b) => a.header.beforeStart - b.header.beforeStart);
 
 	const lines = file.content.split('\n');
 	const sections: (Section | HunkSection)[] = [];


### PR DESCRIPTION
the idea is similar to what github has when it renders code diffs - you can expand for additional context. 

so this should be a pretty flexible interface for expanding and collapsing context around hunks, because all of the complicated work is done first, outside of the components in `fileSections.ts`.

Made a new component `FileCardNext.svelte` while this is still work in progress (its not hooked up to drag and drop and its not styled yet)
