### PR TITLE
Butler committer settings

### DIFF
--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -610,6 +610,38 @@ impl App {
         Ok(head.name().unwrap().to_string())
     }
 
+    pub fn git_set_config(&self, project_id: &str, key: &str, value: &str) -> Result<String> {
+        let project = self.gb_project(project_id)?;
+        let project_repository = project_repository::Repository::open(&project)
+            .context("failed to open project repository")?;
+        let repo = &project_repository.git_repository;
+        let mut config = repo.config()?;
+        config.open_level(git2::ConfigLevel::Local)?;
+        config.set_str(key, value)?;
+        Ok(value.to_string())
+    }
+
+    pub fn git_get_config(&self, project_id: &str, key: &str) -> Result<Option<String>> {
+        let project = self.gb_project(project_id)?;
+        let project_repository = project_repository::Repository::open(&project)?;
+        let repo = &project_repository.git_repository;
+        let config = repo.config()?;
+        let value = config.get_string(key)?;
+        Ok(Some(value))
+    }
+
+    pub fn git_set_global_config(&self, key: &str, value: &str) -> Result<String> {
+        let mut config = git2::Config::open_default()?;
+        config.set_str(key, value)?;
+        Ok(value.to_string())
+    }
+
+    pub fn git_get_global_config(&self, key: &str) -> Result<Option<String>> {
+        let config = git2::Config::open_default()?;
+        let value = config.get_string(key)?;
+        Ok(Some(value))
+    }
+
     pub fn git_switch_branch(&self, project_id: &str, branch: &str) -> Result<()> {
         let project = self.gb_project(project_id)?;
         let project_repository = project_repository::Repository::open(&project)

--- a/src-tauri/src/gb_repository/repository.rs
+++ b/src-tauri/src/gb_repository/repository.rs
@@ -641,7 +641,7 @@ impl Repository {
 
     pub fn git_signatures(&self) -> Result<(git2::Signature<'_>, git2::Signature<'_>)> {
         let user = self.users_store.get().context("failed to get user")?;
-        let committer = git2::Signature::now("GitButler", "gitbutler@gitbutler.com")?;
+        let mut committer = git2::Signature::now("GitButler", "gitbutler@gitbutler.com")?;
 
         let mut author = match user {
             None => committer.clone(),
@@ -660,6 +660,11 @@ impl Repository {
             author = git2::Signature::now(&name?, &email?)?;
         }
 
+        let no_commiter_mark = config.get_string("gitbutler.utmostDiscretion");
+        dbg!(&no_commiter_mark);
+        if no_commiter_mark.is_ok() && no_commiter_mark? == "1" {
+            committer = author.clone();
+        }
         Ok((author, committer))
     }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -747,6 +747,54 @@ async fn mark_resolved(
     Ok(())
 }
 
+#[timed(duration(printer = "debug!"))]
+#[tauri::command(async)]
+async fn git_set_config(
+    handle: tauri::AppHandle,
+    project_id: &str,
+    key: &str,
+    value: &str,
+) -> Result<String, Error> {
+    let app = handle.state::<app::App>();
+    let result = app.git_set_config(project_id, key, value)?;
+    Ok(result)
+}
+
+#[timed(duration(printer = "debug!"))]
+#[tauri::command(async)]
+async fn git_get_config(
+    handle: tauri::AppHandle,
+    project_id: &str,
+    key: &str,
+) -> Result<Option<String>, Error> {
+    let app = handle.state::<app::App>();
+    let result = app.git_get_config(project_id, key)?;
+    Ok(result)
+}
+
+#[timed(duration(printer = "debug!"))]
+#[tauri::command(async)]
+async fn git_set_global_config(
+    handle: tauri::AppHandle,
+    key: &str,
+    value: &str,
+) -> Result<String, Error> {
+    let app = handle.state::<app::App>();
+    let result = app.git_set_global_config(key, value)?;
+    Ok(result)
+}
+
+#[timed(duration(printer = "debug!"))]
+#[tauri::command(async)]
+async fn git_get_global_config(
+    handle: tauri::AppHandle,
+    key: &str,
+) -> Result<Option<String>, Error> {
+    let app = handle.state::<app::App>();
+    let result = app.git_get_global_config(key)?;
+    Ok(result)
+}
+
 fn main() {
     let tauri_context = generate_context!();
 
@@ -905,6 +953,10 @@ fn main() {
             create_virtual_branch_from_branch,
             fetch_from_target,
             mark_resolved,
+            git_set_config,
+            git_get_config,
+            git_set_global_config,
+            git_get_global_config,
         ])
         .build(tauri_context)
         .expect("Failed to build tauri app")

--- a/src-tauri/src/virtual_branches/mod.rs
+++ b/src-tauri/src/virtual_branches/mod.rs
@@ -1834,6 +1834,12 @@ pub fn update_gitbutler_integration(
         message.push_str(" - ");
         message.push_str(branch.name.as_str());
         message.push('\n');
+
+        if branch.head != target.sha {
+            message.push_str("   branch head: ");
+            message.push_str(&branch.head.to_string());
+            message.push('\n');
+        }
         for file in &branch.ownership.files {
             message.push_str("   - ");
             message.push_str(&file.file_path.display().to_string());

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,7 +19,7 @@
             },
             "shell": {
                 "all": false,
-                "open": "^((https://)|(mailto:)|(vscode://)).+"
+                "open": "^((https://)|(http://)|(mailto:)|(vscode://)).+"
             },
             "dialog": {
                 "all": false,

--- a/src/lib/api/cloud/api.ts
+++ b/src/lib/api/cloud/api.ts
@@ -34,6 +34,7 @@ export type User = {
 	created_at: string;
 	updated_at: string;
 	access_token: string;
+	supporter: boolean;
 };
 
 export type Project = {

--- a/src/routes/user/+page.svelte
+++ b/src/routes/user/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Button, Modal, Login } from '$lib/components';
+	import { Button, Modal, Login, Link } from '$lib/components';
 	import type { PageData } from './$types';
 	import { stores, toasts } from '$lib';
 	import { deleteAllData } from '$lib/api';
@@ -7,6 +7,7 @@
 	import ThemeSelector from '../ThemeSelector.svelte';
 	import { getContext } from 'svelte';
 	import { SETTINGS_CONTEXT, type SettingsStore } from '$lib/userSettings';
+	import { invoke } from '@tauri-apps/api/tauri';
 
 	export let data: PageData;
 	const { cloud } = data;
@@ -72,6 +73,28 @@
 
 	let isDeleting = false;
 	let deleteConfirmationModal: Modal;
+
+	export function git_get_config(params: { key: string }) {
+		return invoke<string>('git_get_global_config', params);
+	}
+
+	export function git_set_config(params: { key: string; value: string }) {
+		return invoke<string>('git_set_global_config', params);
+	}
+
+	const setCommitterSetting = (value: boolean) => {
+		annotateCommits = value;
+		git_set_config({
+			key: 'gitbutler.utmostDiscretion',
+			value: value ? '1' : '0'
+		});
+	};
+
+	$: annotateCommits = false;
+
+	git_get_config({ key: 'gitbutler.utmostDiscretion' }).then((value) => {
+		annotateCommits = value === '1';
+	});
 
 	const onDeleteClicked = () =>
 		Promise.resolve()
@@ -192,6 +215,44 @@
 		{:else}
 			<Login />
 		{/if}
+		<div class="h-[0.0625rem] bg-light-400 dark:bg-dark-700" />
+		<div>
+			<h2 class="mb-2 text-lg font-medium">Git Stuff</h2>
+		</div>
+		<div class="flex items-center">
+			<div class="flex-grow">
+				<p>Credit GitButler as the Committer</p>
+				<div class="space-y-2 pr-8 text-sm text-light-700 dark:text-dark-200">
+					<div>
+						By default, everything in the GitButler client is free to use, but we credit ourselves
+						as the committer in your virtual branch commits. Community members and supporters of
+						GitButler can turn this off.
+					</div>
+					<Link
+						target="_blank"
+						rel="noreferrer"
+						href="https://docs.gitbutler.com/overview/why-gitbutler"
+					>
+						Learn more
+					</Link>
+				</div>
+			</div>
+			<div>
+				<label class="relative inline-flex cursor-pointer items-center">
+					<input
+						type="checkbox"
+						disabled={!$user?.supporter}
+						checked={annotateCommits}
+						on:change={(e) => setCommitterSetting(!!e.currentTarget?.checked)}
+						class="peer sr-only"
+					/>
+					<div
+						class="peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 dark:bg-gray-700 dark:border-gray-600 peer h-6 w-11 rounded-full bg-gray-400 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:bg-white after:transition-all after:content-[''] peer-checked:bg-purple-600 peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4"
+					/>
+				</label>
+			</div>
+		</div>
+
 		<div class="h-[0.0625rem] bg-light-400 dark:bg-dark-700" />
 		<div>
 			<h2 class="mb-2 text-lg font-medium">Appearance</h2>

--- a/src/routes/user/+page.svelte
+++ b/src/routes/user/+page.svelte
@@ -231,7 +231,7 @@
 					<Link
 						target="_blank"
 						rel="noreferrer"
-						href="https://docs.gitbutler.com/overview/why-gitbutler"
+						href="https://docs.gitbutler.com/features/virtual-branches/committer-mark"
 					>
 						Learn more
 					</Link>

--- a/src/routes/user/+page.svelte
+++ b/src/routes/user/+page.svelte
@@ -86,14 +86,14 @@
 		annotateCommits = value;
 		git_set_config({
 			key: 'gitbutler.utmostDiscretion',
-			value: value ? '1' : '0'
+			value: value ? '0' : '1'
 		});
 	};
 
-	$: annotateCommits = false;
+	$: annotateCommits = true;
 
 	git_get_config({ key: 'gitbutler.utmostDiscretion' }).then((value) => {
-		annotateCommits = value === '1';
+		annotateCommits = value ? value === '0' : true;
 	});
 
 	const onDeleteClicked = () =>


### PR DESCRIPTION
This PR introduces a setting that you can toggle if you are a supporter that sets a global git config setting `gitbutler.utmostDiscretion` that will stop the client from crediting itself in vbranch commits.

This _should_ pull the `supporter` setting from the server API for a user (if they are a paying user or we just toggled it for them) and if that's true then they can toggle the setting off:

![CleanShot 2023-07-20 at 10 16 18@2x](https://github.com/gitbutlerapp/gitbutler-client/assets/70/19f87258-fa32-4ad3-92d1-7328efeaad99)

If that's not true, they have to toggle the setting from the command line. The UI should read the setting from git properly, but they just can't toggle it in the UI. This way they can just ask us in Discord and we can tell them how to do it if they really don't want to pay us.