### PR TITLE
Make the vbranch test code a bit more dry

### DIFF
--- a/src-tauri/src/virtual_branches/tests.rs
+++ b/src-tauri/src/virtual_branches/tests.rs
@@ -4,14 +4,13 @@ use std::{thread, time::Duration};
 
 use tempfile::tempdir;
 
-use crate::projects::Project;
 use crate::{projects, storage, users};
 
 use super::*;
 
 pub struct TestDeps {
     repository: git2::Repository,
-    project: Project,
+    project: projects::Project,
     gb_repo: gb_repository::Repository,
     gb_repo_path: String,
     user_store: users::Storage,

--- a/src-tauri/src/virtual_branches/tests.rs
+++ b/src-tauri/src/virtual_branches/tests.rs
@@ -4,9 +4,43 @@ use std::{thread, time::Duration};
 
 use tempfile::tempdir;
 
+use crate::projects::Project;
 use crate::{projects, storage, users};
 
 use super::*;
+
+pub struct TestDeps {
+    repository: git2::Repository,
+    project: Project,
+    gb_repo: gb_repository::Repository,
+    gb_repo_path: String,
+    user_store: users::Storage,
+    project_store: projects::Storage,
+}
+
+fn get_test_deps() -> Result<TestDeps> {
+    let repository = test_repository()?;
+    let project = projects::Project::try_from(&repository)?;
+    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
+    let storage = storage::Storage::from_path(tempdir()?.path());
+    let user_store = users::Storage::new(storage.clone());
+    let project_store = projects::Storage::new(storage);
+    project_store.add_project(&project)?;
+    let gb_repo = gb_repository::Repository::open(
+        gb_repo_path.clone(),
+        project.id.clone(),
+        project_store.clone(),
+        user_store.clone(),
+    )?;
+    Ok(TestDeps {
+        repository,
+        project,
+        gb_repo,
+        gb_repo_path,
+        user_store,
+        project_store,
+    })
+}
 
 fn commit_all(repository: &git2::Repository) -> Result<git2::Oid> {
     let mut index = repository.index()?;
@@ -46,13 +80,14 @@ fn test_repository() -> Result<git2::Repository> {
 
 #[test]
 fn test_commit_on_branch_then_change_file_then_get_status() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo_path,
+        user_store,
+        project_store,
+        ..
+    } = get_test_deps()?;
 
     let file_path = std::path::Path::new("test.txt");
     std::fs::write(
@@ -121,19 +156,12 @@ fn test_commit_on_branch_then_change_file_then_get_status() -> Result<()> {
 
 #[test]
 fn test_track_binary_files() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
-    let gb_repo = gb_repository::Repository::open(
-        gb_repo_path,
-        project.id.clone(),
-        project_store,
-        user_store,
-    )?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo,
+        ..
+    } = get_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     let file_path = std::path::Path::new("test.txt");
@@ -238,19 +266,12 @@ fn test_track_binary_files() -> Result<()> {
 
 #[test]
 fn test_create_branch_with_ownership() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
-    let gb_repo = gb_repository::Repository::open(
-        gb_repo_path,
-        project.id.clone(),
-        project_store,
-        user_store,
-    )?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo,
+        ..
+    } = get_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     target::Writer::new(&gb_repo).write_default(&target::Target {
@@ -304,19 +325,12 @@ fn test_create_branch_with_ownership() -> Result<()> {
 
 #[test]
 fn test_create_branch_in_the_middle() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
-    let gb_repo = gb_repository::Repository::open(
-        gb_repo_path,
-        project.id.clone(),
-        project_store,
-        user_store,
-    )?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo,
+        ..
+    } = get_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     target::Writer::new(&gb_repo).write_default(&target::Target {
@@ -357,19 +371,12 @@ fn test_create_branch_in_the_middle() -> Result<()> {
 
 #[test]
 fn test_create_branch_no_arguments() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
-    let gb_repo = gb_repository::Repository::open(
-        gb_repo_path,
-        project.id.clone(),
-        project_store,
-        user_store,
-    )?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo,
+        ..
+    } = get_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     target::Writer::new(&gb_repo).write_default(&target::Target {
@@ -400,19 +407,12 @@ fn test_create_branch_no_arguments() -> Result<()> {
 
 #[test]
 fn test_hunk_expantion() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
-    let gb_repo = gb_repository::Repository::open(
-        gb_repo_path,
-        project.id.clone(),
-        project_store,
-        user_store,
-    )?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo,
+        ..
+    } = get_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     target::Writer::new(&gb_repo).write_default(&target::Target {
@@ -488,19 +488,12 @@ fn test_hunk_expantion() -> Result<()> {
 
 #[test]
 fn test_get_status_files_by_branch_no_hunks_no_branches() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
-    let gb_repo = gb_repository::Repository::open(
-        gb_repo_path,
-        project.id.clone(),
-        project_store,
-        user_store,
-    )?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo,
+        ..
+    } = get_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     target::Writer::new(&gb_repo).write_default(&target::Target {
@@ -521,19 +514,12 @@ fn test_get_status_files_by_branch_no_hunks_no_branches() -> Result<()> {
 
 #[test]
 fn test_get_status_files_by_branch() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
-    let gb_repo = gb_repository::Repository::open(
-        gb_repo_path,
-        project.id.clone(),
-        project_store,
-        user_store,
-    )?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo,
+        ..
+    } = get_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     target::Writer::new(&gb_repo).write_default(&target::Target {
@@ -573,13 +559,14 @@ fn test_get_status_files_by_branch() -> Result<()> {
 
 #[test]
 fn test_updated_ownership_should_bubble_up() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo_path,
+        user_store,
+        project_store,
+        ..
+    } = get_test_deps()?;
 
     let file_path = std::path::Path::new("test.txt");
     std::fs::write(
@@ -695,13 +682,14 @@ fn test_updated_ownership_should_bubble_up() -> Result<()> {
 
 #[test]
 fn test_move_hunks_multiple_sources() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo_path,
+        user_store,
+        project_store,
+        ..
+    } = get_test_deps()?;
 
     let file_path = std::path::Path::new("test.txt");
     std::fs::write(
@@ -810,13 +798,14 @@ fn test_move_hunks_multiple_sources() -> Result<()> {
 
 #[test]
 fn test_move_hunks_partial_explicitly() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo_path,
+        user_store,
+        project_store,
+        ..
+    } = get_test_deps()?;
 
     let file_path = std::path::Path::new("test.txt");
     std::fs::write(
@@ -906,13 +895,14 @@ fn test_move_hunks_partial_explicitly() -> Result<()> {
 
 #[test]
 fn test_add_new_hunk_to_the_end() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo_path,
+        user_store,
+        project_store,
+        ..
+    } = get_test_deps()?;
 
     let file_path = std::path::Path::new("test.txt");
     std::fs::write(
@@ -967,13 +957,14 @@ fn test_add_new_hunk_to_the_end() -> Result<()> {
 
 #[test]
 fn test_update_base_branch_base() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo_path,
+        user_store,
+        project_store,
+        ..
+    } = get_test_deps()?;
 
     // create a commit and set the target
     let file_path = std::path::Path::new("test.txt");
@@ -1078,13 +1069,14 @@ fn test_update_base_branch_base() -> Result<()> {
 
 #[test]
 fn test_update_base_branch_detect_integrated_branches() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo_path,
+        user_store,
+        project_store,
+        ..
+    } = get_test_deps()?;
 
     // create a commit and set the target
     let file_path = std::path::Path::new("test.txt");
@@ -1163,13 +1155,14 @@ fn test_update_base_branch_detect_integrated_branches() -> Result<()> {
 
 #[test]
 fn test_update_base_branch_detect_integrated_branches_with_more_work() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo_path,
+        user_store,
+        project_store,
+        ..
+    } = get_test_deps()?;
 
     // create a commit and set the target
     let file_path = std::path::Path::new("test.txt");
@@ -1244,20 +1237,13 @@ fn test_update_base_branch_detect_integrated_branches_with_more_work() -> Result
 
 #[test]
 fn test_update_target_with_conflicts_in_vbranches() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo,
+        ..
+    } = get_test_deps()?;
 
-    let gb_repo = gb_repository::Repository::open(
-        gb_repo_path,
-        project.id.clone(),
-        project_store,
-        user_store,
-    )?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     let current_session = gb_repo.get_or_create_current_session()?;
@@ -1579,19 +1565,12 @@ fn test_update_target_with_conflicts_in_vbranches() -> Result<()> {
 
 #[test]
 fn test_apply_unapply_branch() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
-    let gb_repo = gb_repository::Repository::open(
-        gb_repo_path,
-        project.id.clone(),
-        project_store,
-        user_store,
-    )?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo,
+        ..
+    } = get_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     // create a commit and set the target
@@ -1680,19 +1659,12 @@ fn test_apply_unapply_branch() -> Result<()> {
 
 #[test]
 fn test_apply_unapply_added_deleted_files() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
-    let gb_repo = gb_repository::Repository::open(
-        gb_repo_path,
-        project.id.clone(),
-        project_store,
-        user_store,
-    )?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo,
+        ..
+    } = get_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     // create a commit and set the target
@@ -1775,19 +1747,12 @@ fn test_apply_unapply_added_deleted_files() -> Result<()> {
 
 #[test]
 fn test_detect_mergeable_branch() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
-    let gb_repo = gb_repository::Repository::open(
-        gb_repo_path,
-        project.id.clone(),
-        project_store,
-        user_store,
-    )?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo,
+        ..
+    } = get_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     // create a commit and set the target
@@ -1949,19 +1914,12 @@ fn test_detect_mergeable_branch() -> Result<()> {
 
 #[test]
 fn test_detect_remote_commits() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
-    let gb_repo = gb_repository::Repository::open(
-        gb_repo_path,
-        project.id.clone(),
-        project_store,
-        user_store,
-    )?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo,
+        ..
+    } = get_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
     let current_session = gb_repo.get_or_create_current_session()?;
     let current_session_reader = sessions::Reader::open(&gb_repo, &current_session)?;
@@ -2053,19 +2011,12 @@ fn test_detect_remote_commits() -> Result<()> {
 
 #[test]
 fn test_create_vbranch_from_remote_branch() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
-    let gb_repo = gb_repository::Repository::open(
-        gb_repo_path,
-        project.id.clone(),
-        project_store,
-        user_store,
-    )?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo,
+        ..
+    } = get_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     // create a commit and set the target
@@ -2187,19 +2138,12 @@ fn test_create_vbranch_from_remote_branch() -> Result<()> {
 
 #[test]
 fn test_create_vbranch_from_behind_remote_branch() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
-    let gb_repo = gb_repository::Repository::open(
-        gb_repo_path,
-        project.id.clone(),
-        project_store,
-        user_store,
-    )?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo,
+        ..
+    } = get_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     // create a commit and set the target
@@ -2314,19 +2258,12 @@ fn test_create_vbranch_from_behind_remote_branch() -> Result<()> {
 
 #[test]
 fn test_partial_commit() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
-    let gb_repo = gb_repository::Repository::open(
-        gb_repo_path,
-        project.id.clone(),
-        project_store,
-        user_store,
-    )?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo,
+        ..
+    } = get_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     let file_path = std::path::Path::new("test.txt");
@@ -2449,19 +2386,12 @@ fn commit_sha_to_contents(repository: &git2::Repository, commit: &str, path: &st
 
 #[test]
 fn test_commit_add_and_delete_files() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
-    let gb_repo = gb_repository::Repository::open(
-        gb_repo_path,
-        project.id.clone(),
-        project_store,
-        user_store,
-    )?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo,
+        ..
+    } = get_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     let file_path = std::path::Path::new("test.txt");
@@ -2526,19 +2456,12 @@ fn test_commit_add_and_delete_files() -> Result<()> {
 
 #[test]
 fn test_commit_executable_and_symlinks() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
-    let gb_repo = gb_repository::Repository::open(
-        gb_repo_path,
-        project.id.clone(),
-        project_store,
-        user_store,
-    )?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo,
+        ..
+    } = get_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     let file_path = std::path::Path::new("test.txt");
@@ -2641,9 +2564,7 @@ fn tree_to_entry_list(
         let blob = object.as_blob().context("failed to get blob")?;
         // convert content to string
         let octal_mode = format!("{:o}", entry.filemode());
-        if let Ok(content) =
-            std::str::from_utf8(blob.content()).context("failed to convert content to string")
-        {
+        if let Ok(content) = std::str::from_utf8(blob.content()) {
             file_list.push((
                 path.to_string(),
                 octal_mode,
@@ -2664,19 +2585,12 @@ fn tree_to_entry_list(
 
 #[test]
 fn test_apply_out_of_date_vbranch() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
-    let gb_repo = gb_repository::Repository::open(
-        gb_repo_path,
-        project.id.clone(),
-        project_store,
-        user_store,
-    )?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo,
+        ..
+    } = get_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     // create a commit and set the target
@@ -2806,19 +2720,12 @@ fn test_apply_out_of_date_vbranch() -> Result<()> {
 
 #[test]
 fn test_apply_out_of_date_conflicting_vbranch() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
-    let gb_repo = gb_repository::Repository::open(
-        gb_repo_path,
-        project.id.clone(),
-        project_store,
-        user_store,
-    )?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo,
+        ..
+    } = get_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     // create a commit and set the target
@@ -2983,19 +2890,12 @@ fn test_apply_out_of_date_conflicting_vbranch() -> Result<()> {
 
 #[test]
 fn test_apply_conflicting_vbranch() -> Result<()> {
-    let repository = test_repository()?;
-    let project = projects::Project::try_from(&repository)?;
-    let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
-    let storage = storage::Storage::from_path(tempdir()?.path());
-    let user_store = users::Storage::new(storage.clone());
-    let project_store = projects::Storage::new(storage);
-    project_store.add_project(&project)?;
-    let gb_repo = gb_repository::Repository::open(
-        gb_repo_path,
-        project.id.clone(),
-        project_store,
-        user_store,
-    )?;
+    let TestDeps {
+        repository,
+        project,
+        gb_repo,
+        ..
+    } = get_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     // create a commit and set the target

--- a/src-tauri/src/virtual_branches/tests.rs
+++ b/src-tauri/src/virtual_branches/tests.rs
@@ -17,7 +17,7 @@ pub struct TestDeps {
     project_store: projects::Storage,
 }
 
-fn get_test_deps() -> Result<TestDeps> {
+fn new_test_deps() -> Result<TestDeps> {
     let repository = test_repository()?;
     let project = projects::Project::try_from(&repository)?;
     let gb_repo_path = tempdir()?.path().to_str().unwrap().to_string();
@@ -86,7 +86,7 @@ fn test_commit_on_branch_then_change_file_then_get_status() -> Result<()> {
         user_store,
         project_store,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
 
     let file_path = std::path::Path::new("test.txt");
     std::fs::write(
@@ -160,7 +160,7 @@ fn test_track_binary_files() -> Result<()> {
         project,
         gb_repo,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     let file_path = std::path::Path::new("test.txt");
@@ -270,7 +270,7 @@ fn test_create_branch_with_ownership() -> Result<()> {
         project,
         gb_repo,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     target::Writer::new(&gb_repo).write_default(&target::Target {
@@ -329,7 +329,7 @@ fn test_create_branch_in_the_middle() -> Result<()> {
         project,
         gb_repo,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     target::Writer::new(&gb_repo).write_default(&target::Target {
@@ -375,7 +375,7 @@ fn test_create_branch_no_arguments() -> Result<()> {
         project,
         gb_repo,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     target::Writer::new(&gb_repo).write_default(&target::Target {
@@ -411,7 +411,7 @@ fn test_hunk_expantion() -> Result<()> {
         project,
         gb_repo,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     target::Writer::new(&gb_repo).write_default(&target::Target {
@@ -492,7 +492,7 @@ fn test_get_status_files_by_branch_no_hunks_no_branches() -> Result<()> {
         project,
         gb_repo,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     target::Writer::new(&gb_repo).write_default(&target::Target {
@@ -518,7 +518,7 @@ fn test_get_status_files_by_branch() -> Result<()> {
         project,
         gb_repo,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     target::Writer::new(&gb_repo).write_default(&target::Target {
@@ -565,7 +565,7 @@ fn test_updated_ownership_should_bubble_up() -> Result<()> {
         user_store,
         project_store,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
 
     let file_path = std::path::Path::new("test.txt");
     std::fs::write(
@@ -688,7 +688,7 @@ fn test_move_hunks_multiple_sources() -> Result<()> {
         user_store,
         project_store,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
 
     let file_path = std::path::Path::new("test.txt");
     std::fs::write(
@@ -804,7 +804,7 @@ fn test_move_hunks_partial_explicitly() -> Result<()> {
         user_store,
         project_store,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
 
     let file_path = std::path::Path::new("test.txt");
     std::fs::write(
@@ -901,7 +901,7 @@ fn test_add_new_hunk_to_the_end() -> Result<()> {
         user_store,
         project_store,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
 
     let file_path = std::path::Path::new("test.txt");
     std::fs::write(
@@ -963,7 +963,7 @@ fn test_update_base_branch_base() -> Result<()> {
         user_store,
         project_store,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
 
     // create a commit and set the target
     let file_path = std::path::Path::new("test.txt");
@@ -1075,7 +1075,7 @@ fn test_update_base_branch_detect_integrated_branches() -> Result<()> {
         user_store,
         project_store,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
 
     // create a commit and set the target
     let file_path = std::path::Path::new("test.txt");
@@ -1161,7 +1161,7 @@ fn test_update_base_branch_detect_integrated_branches_with_more_work() -> Result
         user_store,
         project_store,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
 
     // create a commit and set the target
     let file_path = std::path::Path::new("test.txt");
@@ -1241,7 +1241,7 @@ fn test_update_target_with_conflicts_in_vbranches() -> Result<()> {
         project,
         gb_repo,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
 
     let project_repository = project_repository::Repository::open(&project)?;
 
@@ -1569,7 +1569,7 @@ fn test_apply_unapply_branch() -> Result<()> {
         project,
         gb_repo,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     // create a commit and set the target
@@ -1663,7 +1663,7 @@ fn test_apply_unapply_added_deleted_files() -> Result<()> {
         project,
         gb_repo,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     // create a commit and set the target
@@ -1751,7 +1751,7 @@ fn test_detect_mergeable_branch() -> Result<()> {
         project,
         gb_repo,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     // create a commit and set the target
@@ -1918,7 +1918,7 @@ fn test_detect_remote_commits() -> Result<()> {
         project,
         gb_repo,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
     let current_session = gb_repo.get_or_create_current_session()?;
     let current_session_reader = sessions::Reader::open(&gb_repo, &current_session)?;
@@ -2015,7 +2015,7 @@ fn test_create_vbranch_from_remote_branch() -> Result<()> {
         project,
         gb_repo,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     // create a commit and set the target
@@ -2142,7 +2142,7 @@ fn test_create_vbranch_from_behind_remote_branch() -> Result<()> {
         project,
         gb_repo,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     // create a commit and set the target
@@ -2262,7 +2262,7 @@ fn test_partial_commit() -> Result<()> {
         project,
         gb_repo,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     let file_path = std::path::Path::new("test.txt");
@@ -2390,7 +2390,7 @@ fn test_commit_add_and_delete_files() -> Result<()> {
         project,
         gb_repo,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     let file_path = std::path::Path::new("test.txt");
@@ -2460,7 +2460,7 @@ fn test_commit_executable_and_symlinks() -> Result<()> {
         project,
         gb_repo,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     let file_path = std::path::Path::new("test.txt");
@@ -2589,7 +2589,7 @@ fn test_apply_out_of_date_vbranch() -> Result<()> {
         project,
         gb_repo,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     // create a commit and set the target
@@ -2724,7 +2724,7 @@ fn test_apply_out_of_date_conflicting_vbranch() -> Result<()> {
         project,
         gb_repo,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     // create a commit and set the target
@@ -2894,7 +2894,7 @@ fn test_apply_conflicting_vbranch() -> Result<()> {
         project,
         gb_repo,
         ..
-    } = get_test_deps()?;
+    } = new_test_deps()?;
     let project_repository = project_repository::Repository::open(&project)?;
 
     // create a commit and set the target


### PR DESCRIPTION
I was trying to figure out how we can leverage the rust code for boostrapping new repos during development. It would be great if I only needed one command to spawn a repo with an active merge conflict.

While figuring things out I spotted this opportunity to make the code a bit more dry.