### PR TITLE
Refactor & enhance URL rendering logic for branches

### DIFF
--- a/src/routes/repo/[projectId]/Board.svelte
+++ b/src/routes/repo/[projectId]/Board.svelte
@@ -7,6 +7,7 @@
 	import { getContext } from 'svelte';
 	import { BRANCH_CONTROLLER_KEY } from '$lib/vbranches/branchController';
 	import type { CloudApi } from '$lib/api';
+	import { helpers } from 'mm-jsr';
 
 	export let projectId: string;
 	export let projectPath: string;
@@ -70,7 +71,7 @@
 		}
 	}}
 >
-	{#each branches.filter((c) => c.active) as { id, name, files, commits, description, order, conflicted } (id)}
+	{#each branches.filter((c) => c.active) as { id, name, files, commits, description, order, conflicted, upstream } (id)}
 		<Lane
 			on:dragstart={(e) => {
 				if (!e.dataTransfer) return;
@@ -91,6 +92,7 @@
 			{target}
 			{cloudEnabled}
 			{cloud}
+			{upstream}
 		/>
 	{/each}
 	<NewBranchDropZone />

--- a/src/routes/repo/[projectId]/BranchLane.svelte
+++ b/src/routes/repo/[projectId]/BranchLane.svelte
@@ -51,6 +51,7 @@
 	export let target: BaseBranch | undefined;
 	export let cloudEnabled: boolean;
 	export let cloud: ReturnType<typeof CloudApi>;
+	export let upstream: string | undefined;
 
 	const branchController = getContext<BranchController>(BRANCH_CONTROLLER_KEY);
 	const user = stores.user;
@@ -128,17 +129,11 @@
 		branchController.updateBranchName(branchId, name);
 	}
 
-	function nameToBranch(name: string): string {
-		const isAsciiAlphanumeric = (c: string): boolean => /^[A-Za-z0-9]$/.test(c);
-		return name
-			.split('')
-			.map((c) => (isAsciiAlphanumeric(c) ? c : '-'))
-			.join('');
-	}
-
-	function url(target: BaseBranch | undefined, branchName: string) {
+	function url(target: BaseBranch | undefined, upstreamBranchName: string) {
 		if (!target) return undefined;
 		const baseBranchName = target.branchName.split('/')[1];
+		const parts = upstreamBranchName.split('/');
+		const branchName = parts[parts.length - 1];
 		return `${target.repoBaseUrl}/compare/${baseBranchName}...${branchName}`;
 	}
 
@@ -481,11 +476,13 @@
 						/>
 
 						<div class="ml-12 flex items-center py-2 font-mono text-sm">
-							<Link target="_blank" rel="noreferrer" href={url(target, nameToBranch(name))}>
-								<span class="text-sm font-bold">
-									{target?.remoteName}/{nameToBranch(name)}
-								</span>
-							</Link>
+							{#if upstream}
+								<Link target="_blank" rel="noreferrer" href={url(target, upstream)}>
+									<span class="text-sm font-bold">
+										{upstream.split('refs/remotes/')[1]}
+									</span>
+								</Link>
+							{/if}
 						</div>
 
 						{#each remoteCommits as commit (commit.id)}


### PR DESCRIPTION
The changes refactor and enhance the logic for rendering URLs of a Git branch within the system. Prior to this, the logic created a url function based on the branch name, and used a nameToBranch function to call it, transforming the name string by replacing non-letter/numeric characters. This led to potential issues. 

- Added an 'upstream' object to 'branches' which is then passed on to further components using it. 
- The URL function now directly uses this 'upstream' object instead of deriving it from the branch name, leading to more consistency with remote branches.
- The nameToBranch function became obsolete and was removed.
- The URL now splits the upstream branch name and uses the last part for the branchName, maintaining the old structure while improving the accuracy.
- A condition was added to make sure the URL is only created if the 'upstream' exists.