### PR TITLE
Split user name into given and family names

### DIFF
--- a/src-tauri/src/users/user.rs
+++ b/src-tauri/src/users/user.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 pub struct User {
     pub id: u64,
     pub name: String,
+    pub given_name: Option<String>, 
+    pub family_name: Option<String>, 
     pub email: String,
     pub picture: String,
     pub locale: Option<String>,

--- a/src-tauri/src/users/user.rs
+++ b/src-tauri/src/users/user.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 pub struct User {
     pub id: u64,
     pub name: String,
-    pub given_name: Option<String>, 
-    pub family_name: Option<String>, 
+    pub given_name: Option<String>,
+    pub family_name: Option<String>,
     pub email: String,
     pub picture: String,
     pub locale: Option<String>,

--- a/src/lib/api/cloud/api.ts
+++ b/src/lib/api/cloud/api.ts
@@ -28,6 +28,8 @@ export type LoginToken = {
 export type User = {
 	id: number;
 	name: string;
+	given_name: string | undefined;
+	family_name: string | undefined;
 	email: string;
 	picture: string;
 	locale: string;
@@ -151,10 +153,16 @@ export default (
 						'X-Auth-Token': token
 					}
 				}).then(parseResponseJSON),
-			update: async (token: string, params: { name?: string; picture?: File }) => {
+			update: async (
+				token: string,
+				params: { given_name?: string; family_name?: string; picture?: File }
+			) => {
 				const formData = new FormData();
-				if (params.name) {
-					formData.append('name', params.name);
+				if (params.given_name) {
+					formData.append('given_name', params.given_name);
+				}
+				if (params.family_name) {
+					formData.append('family_name', params.family_name);
 				}
 				if (params.picture) {
 					formData.append('avatar', params.picture);


### PR DESCRIPTION
Refactored user name field into two separate fields: "given_name" and "family_name". Added functionality to retrieve, update, and validate these new fields. Also streamlined the code related to updating the user's picture.

Changes include:
- Splitting the single "name" field into "given_name" and "family_name" in the User structure and updating the associated functions.
- Modified the user updating function to handle these two new fields separately.
- Added new variables "newGivenName" and "newFamilyName" that store the user's input for these fields and are used to update the user's profile.
- Removed "userNameInput" variable and "pictureChanged" flag that were used to track changes in the previous implementation.
- Ensured that the new input fields are bound to the correct variables in the form markup.
- Included code to load the user's full name (both "given_name" and "family_name") when the page is loaded.
- Removed name-related code from the "user subscribe" block since this is now handled by the new fields.