### PR TITLE
Add gravatar to content security policy.

### DIFF
--- a/src-tauri/tauri.conf.nightly.json
+++ b/src-tauri/tauri.conf.nightly.json
@@ -16,7 +16,7 @@
         "security": {
             "csp": {
                 "default-src": "'self'",
-                "img-src": "'self' asset: https://asset.localhost 'self' data:",
+                "img-src": "'self' asset: https://asset.localhost data: https://www.gravatar.com",
                 "connect-src": "'self' https://eu.posthog.com https://app.gitbutler.com https://o4504644069687296.ingest.sentry.io ws://localhost:7703",
                 "script-src": "'self' https://eu.posthog.com",
                 "style-src": "'self' 'unsafe-inline'"


### PR DESCRIPTION
It's weird, I see an error in the console about gravatar not being in the CSP. At the same time gravatar icons in other components load fine.