### PR TITLE
Ensure changes are returned even if file content is absent

### DIFF
--- a/src/routes/repo/[projectId]/fileSections.ts
+++ b/src/routes/repo/[projectId]/fileSections.ts
@@ -139,12 +139,12 @@ export function parseHunkSection(hunk: Hunk): HunkSection {
 }
 
 export function parseFileSections(file: File): (ContentSection | HunkSection)[] {
-	if (!file.content) return [];
-
 	const hunkSections = file.hunks
 		.map(parseHunkSection)
 		.filter((hunkSection) => hunkSection !== undefined)
 		.sort((a, b) => a.header.beforeStart - b.header.beforeStart);
+
+	if (!file.content) return hunkSections;
 
 	const lines = file.content.split('\n');
 	const sections: (ContentSection | HunkSection)[] = [];


### PR DESCRIPTION
The revised code now allows the function parseFileSections to return hunkSections even if there is no file content. This appears to have resolved an issue where the function would return an empty array if the content was missing, hence potentially ignoring changes that have been stored in hunkSections.

Changes include:
- An early return statement has been moved further down in the code in the parseFileSections function.
- Now, even if file content does not exist, hunkSections are returned to the caller, ensuring that the changes are not missed.