### PR TITLE
Fixed context menu triggering for null line numbers

### DIFF
--- a/src/routes/repo/[projectId]/FileCardNext.svelte
+++ b/src/routes/repo/[projectId]/FileCardNext.svelte
@@ -187,7 +187,7 @@
 												on:contextmenu={(e) =>
 													popupMenu.openByMouse(e, {
 														section: subsection,
-														lineNumber: line.afterLineNumber
+														lineNumber: line.afterLineNumber ? line.afterLineNumber : line.beforeLineNumber
 													})}
 											/>
 										{/each}


### PR DESCRIPTION
This commit ensures the context menu triggers even when 'line.afterLineNumber' is null. It does this by checking if 'line.afterLineNumber' is not null, and if it is, it uses 'line.beforeLineNumber' instead.

Details:
- Replaced direct usage of 'line.afterLineNumber' with a conditional operator checking the value.
- If 'line.afterLineNumber' is not null, it will be used.
- If 'line.afterLineNumber' is null, 'line.beforeLineNumber' will be used instead.