### PR TITLE
Refined tooltip message for summary generation feature

### DIFF
--- a/src/routes/repo/[projectId]/BranchLane.svelte
+++ b/src/routes/repo/[projectId]/BranchLane.svelte
@@ -293,7 +293,7 @@
 							</Button>
 						{:else}
 							<Tooltip
-								label="Summary generation requres that you are logged in and have cloud sync enabled"
+								label="Summary generation requres that you are logged in and have cloud sync enabled for the project"
 							>
 								<Button
 									disabled={true}


### PR DESCRIPTION
The tooltip message for the summary generation feature has been enhanced. It now clearly mentions the need for the user to be logged in and have cloud sync enabled specifically for the project.

Changes:
- Tooltip message for the summary generation feature now reads "Summary generation requres that you are logged in and have cloud sync enabled for the project", making it context-specific and more informative.