### PR TITLE
Limit modal height so it can't touch the nav bar

### DIFF
--- a/src/lib/components/Overlay/Overlay.svelte
+++ b/src/lib/components/Overlay/Overlay.svelte
@@ -24,7 +24,7 @@
 
 <dialog
 	class="rounded-lg border-[0.5px] border-light-200 bg-white p-0 backdrop:bg-white/50 dark:border-dark-500 dark:bg-dark-1000 backdrop:dark:bg-black/50"
-	in:scale={{ duration: 150 }}
+	style="max-height: calc(100vh - 5rem)"
 	bind:this={dialog}
 	on:close={close}
 	on:close


### PR DESCRIPTION
I saw in posthog that the modal can be squished and become too big.

Locally I was not fully able to reproduce, but this commit at least limits the height so it can't overlay the nav bar.

The transition that I drop is not (and has not been) working, let's add this back later.