### PR TITLE
Add line change summary to each branch

### DIFF
--- a/src/routes/repo/[projectId]/Tray.svelte
+++ b/src/routes/repo/[projectId]/Tray.svelte
@@ -86,6 +86,7 @@
 					<div class="px-2 py-1">There are currently no branches</div>
 				{:else}
 					{#each branches as branch (branch.id)}
+						{@const { added, removed } = sumBranchLinesAddedRemoved(branch)}
 						{@const latestModifiedAt = branch.files.at(0)?.hunks.at(0)?.modifiedAt}
 						<div
 							role="listitem"
@@ -125,6 +126,14 @@
 							<div class="flex items-center text-sm text-light-700 dark:text-dark-300">
 								<div class="flex-grow">
 									{latestModifiedAt ? formatDistanceToNow(latestModifiedAt) : ''}
+								</div>
+								<div class="flex gap-1 font-mono text-sm font-bold">
+									<span class="text-green-500">
+										+{added}
+									</span>
+									<span class="text-red-500">
+										-{removed}
+									</span>
 								</div>
 							</div>
 						</div>


### PR DESCRIPTION
Added a new feature that summarizes the number of lines added and removed in each branch. This update will provide coders with a quicker and concise overview of the branch's changes.

Detailed changes:
- Added a "sumBranchLinesAddedRemoved" method to count the number of added and removed lines for each branch.
- The result of the method is displayed in monospace font, with green for added lines and red for removed lines