### PR TITLE
After linking a project, go directly to it

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -51,6 +51,7 @@
 						if (!project) return;
 						toasts.success(`Project ${project.title} created`);
 						linkProjectModal?.show(project.id);
+						goto(`/repo/${project.id}/`);
 					})
 					.catch((e: any) => toasts.error(e.message))
 			),

--- a/src/routes/LinkProjectModal.svelte
+++ b/src/routes/LinkProjectModal.svelte
@@ -6,6 +6,7 @@
 	import { IconFolder, IconLoading } from '$lib/icons';
 	import { toasts, api, stores } from '$lib';
 	import IconFolderPlus from '$lib/icons/IconFolderPlus.svelte';
+	import { goto } from '$app/navigation';
 
 	export let projects: ReturnType<typeof api.projects.Projects>;
 	export let cloud: ReturnType<typeof api.CloudApi>;
@@ -50,6 +51,7 @@
 					await project
 						.update({ api: { ...cloudProject, sync: true } })
 						.then(() => toasts.success(`Project linked`));
+					goto(`/repo/${$project.id}/`);
 				}
 				modal.close();
 			})


### PR DESCRIPTION
It is a little confusing to just land on the projects page again, we should redirect to the newly added project's page. Not sure if this is the best way to do it, but it seems to work.