### PR TITLE
Clear commit message after commit action

### DIFF
--- a/src/routes/repo/[projectId]/BranchLane.svelte
+++ b/src/routes/repo/[projectId]/BranchLane.svelte
@@ -323,6 +323,7 @@
 							color="purple"
 							on:click={() => {
 								if (commitMessage) commit();
+								commitMessage = '';
 								commitDialogShown = false;
 							}}
 						>


### PR DESCRIPTION
This commit introduces the feature to clear the commit message input field after the commit action is performed. Previously, the message input field retained the previous commit message, which was not ideal for future commits.

Detailing changes:
- A line of code is added that sets `commitMessage` variable to an empty string. This ensures that the message input field is cleared and ready for next commit message