### PR TITLE
Use square/svelte-store for virtual branches

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -35,7 +35,6 @@ module.exports = {
 		'@typescript-eslint/no-namespace': 'off',
 		'@typescript-eslint/no-empty-function': 'off',
 		'@typescript-eslint/no-explicit-any': 'off',
-		'square-svelte-store/use-square-svelte-stores': 'error',
 		'@typescript-eslint/no-unused-vars': [
 			'warn', // or "error"
 			{

--- a/src/lib/stores/fetches.ts
+++ b/src/lib/stores/fetches.ts
@@ -1,0 +1,11 @@
+import { subscribe } from '$lib/api/git/fetches';
+import { writable } from '@square/svelte-store';
+
+export function getFetchesStore(projectId: string) {
+	const store = writable<any>([]);
+	// TODO: We need to unsubscribe this!
+	subscribe({ projectId }, (result) => {
+		store.set(result);
+	});
+	return store;
+}

--- a/src/lib/stores/sessions.ts
+++ b/src/lib/stores/sessions.ts
@@ -1,37 +1,31 @@
-import { derived, writable, type Loadable, Loaded } from 'svelte-loadable-store';
-import * as sessions from '$lib/api/ipc/sessions';
-import { get, type Readable } from '@square/svelte-store';
+import { Session, list, subscribe } from '$lib/api/ipc/sessions';
+import { asyncWritable, get, type WritableLoadable } from '@square/svelte-store';
 
-const stores: Record<string, Readable<Loadable<sessions.Session[]>>> = {};
+const stores: Record<string, WritableLoadable<Session[]>> = {};
 
 export function getSessionStore(params: { projectId: string }) {
 	if (params.projectId in stores) return stores[params.projectId];
-
-	const store = derived(
-		writable(sessions.list(params), (set) => {
-			const unsubscribe = sessions.subscribe(params, ({ session }) => {
-				const oldValue = get(store);
-				if (oldValue.isLoading) {
-					sessions.list(params).then((x) => set(x));
-				} else if (Loaded.isError(oldValue)) {
-					sessions.list(params).then(set);
-				} else {
-					set(
-						oldValue.value
-							.filter((b) => b.id !== session.id)
-							.concat({
-								projectId: params.projectId,
-								...session
-							})
-					);
-				}
-			});
-			return () => {
-				Promise.resolve(unsubscribe).then((unsubscribe) => unsubscribe());
-			};
-		}),
-		(sessions) => sessions.sort((a, b) => a.meta.startTimestampMs - b.meta.startTimestampMs)
+	const store = asyncWritable(
+		[],
+		async () => {
+			const sessions = await list(params);
+			sessions.sort((a, b) => a.meta.startTimestampMs - b.meta.startTimestampMs);
+			return sessions;
+		},
+		async (data) => data
 	);
+	// TODO: Where do we unsubscribe this?
+	const unsubscribe = subscribe(params, ({ session }) => {
+		const oldValue = get(store);
+		store.set(
+			oldValue
+				.filter((b) => b.id !== session.id)
+				.concat({
+					projectId: params.projectId,
+					...session
+				})
+		);
+	});
 	stores[params.projectId] = store;
 	return store;
 }

--- a/src/lib/vbranches/branchController.ts
+++ b/src/lib/vbranches/branchController.ts
@@ -1,4 +1,4 @@
-import type { Branch, BranchData, BaseBranch, Reloadable } from './types';
+import type { Branch, BranchData, BaseBranch, WritableReloadable } from './types';
 import { toasts } from '$lib';
 import { invoke } from '$lib/ipc';
 
@@ -7,9 +7,9 @@ export const BRANCH_CONTROLLER_KEY = Symbol();
 export class BranchController {
 	constructor(
 		readonly projectId: string,
-		readonly virtualBranchStore: Reloadable<Branch[]>,
-		readonly remoteBranchStore: Reloadable<BranchData[]>,
-		readonly targetBranchStore: Reloadable<BaseBranch | undefined>
+		readonly virtualBranchStore: WritableReloadable<Branch[]>,
+		readonly remoteBranchStore: WritableReloadable<BranchData[]>,
+		readonly targetBranchStore: WritableReloadable<BaseBranch | undefined>
 	) {}
 
 	async setTarget(branch: string) {

--- a/src/lib/vbranches/types.ts
+++ b/src/lib/vbranches/types.ts
@@ -1,5 +1,7 @@
 import 'reflect-metadata';
 import { Type, Transform } from 'class-transformer';
+import type { Readable, WritableLoadable } from '@square/svelte-store';
+import type { LoadState, VisitedMap } from '@square/svelte-store/lib/async-stores/types';
 
 export class Hunk {
 	id!: string;
@@ -89,4 +91,9 @@ export class BaseBranch {
 	commitUrl(commitId: string): string | undefined {
 		return `${this.repoBaseUrl}/commit/${commitId}`;
 	}
+}
+
+export interface Reloadable<T> extends WritableLoadable<T> {
+	state: Readable<LoadState>;
+	reload(visitedMap?: VisitedMap): Promise<T>;
 }

--- a/src/lib/vbranches/types.ts
+++ b/src/lib/vbranches/types.ts
@@ -93,7 +93,7 @@ export class BaseBranch {
 	}
 }
 
-export interface Reloadable<T> extends WritableLoadable<T> {
+export interface WritableReloadable<T> extends WritableLoadable<T> {
 	state: Readable<LoadState>;
 	reload(visitedMap?: VisitedMap): Promise<T>;
 }

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -3,7 +3,6 @@ import { getCloudApiClient } from '$lib/api/cloud/api';
 import { projectsStore } from '$lib/api/ipc/projects';
 import Posthog from '$lib/posthog';
 import Sentry from '$lib/sentry';
-import { BranchStoresCache } from '$lib/vbranches/branchStoresCache';
 
 export const ssr = false;
 export const prerender = false;
@@ -12,7 +11,6 @@ export const csr = true;
 export const load: LayoutLoad = ({ fetch: realFetch }: { fetch: typeof fetch }) => ({
 	projects: projectsStore,
 	cloud: getCloudApiClient({ fetch: realFetch }),
-	branchStoresCache: new BranchStoresCache(),
 	posthog: Posthog(),
 	sentry: Sentry()
 });

--- a/src/routes/projects/[projectId]/player/+page.ts
+++ b/src/routes/projects/[projectId]/player/+page.ts
@@ -2,11 +2,10 @@ import { error, redirect } from '@sveltejs/kit';
 import { format, compareDesc } from 'date-fns';
 import type { PageLoad } from './$types';
 import { getSessionStore } from '$lib/stores/sessions';
-import { promisify } from 'svelte-loadable-store';
 
 export const load: PageLoad = async ({ url, params }) => {
-	const sessions = await promisify(getSessionStore({ projectId: params.projectId }));
-	const latestDate = sessions
+	const sessions = getSessionStore({ projectId: params.projectId });
+	const latestDate = (await sessions.load())
 		.map((session) => session.meta.startTimestampMs)
 		.sort(compareDesc)
 		.shift();

--- a/src/routes/projects/[projectId]/player/[date]/+page.ts
+++ b/src/routes/projects/[projectId]/player/[date]/+page.ts
@@ -2,11 +2,11 @@ import { redirect, error } from '@sveltejs/kit';
 import { format } from 'date-fns';
 import type { PageLoad } from './$types';
 import { getSessionStore } from '$lib/stores/sessions';
-import { promisify } from 'svelte-loadable-store';
+import { get } from '@square/svelte-store';
 
 export const load: PageLoad = async ({ params, url }) => {
-	const sessions = await promisify(getSessionStore({ projectId: params.projectId }));
-	const dateSessions = sessions.filter(
+	const sessions = getSessionStore({ projectId: params.projectId });
+	const dateSessions = (await sessions.load()).filter(
 		(session) => format(session.meta.startTimestampMs, 'yyyy-MM-dd') === params.date
 	);
 	if (!dateSessions.length) throw error(404, 'No sessions found');

--- a/src/routes/repo/[projectId]/+page.svelte
+++ b/src/routes/repo/[projectId]/+page.svelte
@@ -9,21 +9,30 @@
 	import BottomPanel from './BottomPanel.svelte';
 	import UpstreamBranchLane from './UpstreamBranchLane.svelte';
 	import { IconExternalLink } from '$lib/icons';
+	import {
+		getBaseBranchStore,
+		getRemoteBranchStore,
+		getVirtualBranchStore
+	} from '$lib/vbranches/branchStoresCache';
+	import { getSessionStore } from '$lib/stores/sessions';
+	import { getDeltasStore } from '$lib/stores/deltas';
+	import { getFetchesStore } from '$lib/stores/fetches';
 
 	export let data: PageData;
-	let {
-		projectId,
-		vbranchStore,
-		remoteBranchStore,
-		baseBranchStore,
-		remoteBranchNames,
-		project,
-		cloud
-	} = data;
+	let { projectId, remoteBranchNames, project, cloud } = data;
 
-	const branchesState = vbranchStore.state;
-	const remoteBranchesState = remoteBranchStore.state;
+	const fetchStore = getFetchesStore(projectId);
+	const sessionStore = getSessionStore({ projectId });
+	const baseBranchStore = getBaseBranchStore(projectId, [fetchStore]);
+	const remoteBranchStore = getRemoteBranchStore(projectId, [fetchStore]);
+
 	const baseBranchesState = baseBranchStore.state;
+	const remoteBranchesState = remoteBranchStore.state;
+
+	$: sessionId = $sessionStore?.at(-1)?.id ?? '';
+	$: deltasStore = getDeltasStore({ projectId, sessionId });
+	$: vbranchStore = getVirtualBranchStore(projectId, sessionId, [sessionStore, deltasStore]);
+	$: branchesState = vbranchStore?.state;
 
 	const userSettings = getContext<SettingsStore>(SETTINGS_CONTEXT);
 

--- a/src/routes/repo/[projectId]/+page.ts
+++ b/src/routes/repo/[projectId]/+page.ts
@@ -7,22 +7,14 @@ async function getRemoteBranches(params: { projectId: string }) {
 	return invoke<Array<string>>('git_remote_branches', params);
 }
 
-export async function load({ parent, params }: PageLoadEvent) {
+export async function load({ params }: PageLoadEvent) {
 	const projectId = params.projectId;
 	const remoteBranchNames = await getRemoteBranches({ projectId });
 	const project = getProjectStore({ id: params.projectId });
 
-	const { branchStoresCache } = await parent();
-	const vbranchStore = branchStoresCache.getVirtualBranchStore(projectId);
-	const remoteBranchStore = branchStoresCache.getRemoteBranchStore(projectId);
-	const baseBranchStore = branchStoresCache.getBaseBranchStore(projectId);
-
 	return {
 		projectId,
 		remoteBranchNames,
-		vbranchStore,
-		remoteBranchStore,
-		baseBranchStore,
 		project: project as Loadable<Project> & Pick<typeof project, 'update' | 'delete'>
 	};
 }

--- a/src/routes/repo/[projectId]/+page.ts
+++ b/src/routes/repo/[projectId]/+page.ts
@@ -15,14 +15,14 @@ export async function load({ parent, params }: PageLoadEvent) {
 	const { branchStoresCache } = await parent();
 	const vbranchStore = branchStoresCache.getVirtualBranchStore(projectId);
 	const remoteBranchStore = branchStoresCache.getRemoteBranchStore(projectId);
-	const targetBranchStore = branchStoresCache.getBaseBranchStore(projectId);
+	const baseBranchStore = branchStoresCache.getBaseBranchStore(projectId);
 
 	return {
 		projectId,
 		remoteBranchNames,
 		vbranchStore,
 		remoteBranchStore,
-		targetBranchStore,
+		baseBranchStore,
 		project: project as Loadable<Project> & Pick<typeof project, 'update' | 'delete'>
 	};
 }

--- a/src/routes/repo/[projectId]/Board.svelte
+++ b/src/routes/repo/[projectId]/Board.svelte
@@ -7,10 +7,17 @@
 	import { getContext } from 'svelte';
 	import type { getCloudApiClient } from '$lib/api/cloud/api';
 	import { Link } from '$lib/components';
+	import type { LoadState } from '@square/svelte-store';
+
 	export let projectId: string;
 	export let projectPath: string;
-	export let branches: Branch[];
+
+	export let branches: Branch[] | undefined;
+	export let branchesState: LoadState;
+
 	export let base: BaseBranch | undefined;
+	export let baseBranchState: LoadState;
+
 	export let cloudEnabled: boolean;
 	export let cloud: ReturnType<typeof getCloudApiClient>;
 
@@ -24,99 +31,106 @@
 	const dzType = 'text/branch';
 
 	function handleEmpty() {
-		const emptyIndex = branches.findIndex((item) => !item.files || item.files.length == 0);
-		if (emptyIndex != -1) {
-			branches.splice(emptyIndex, 1);
+		const emptyIndex = branches?.findIndex((item) => !item.files || item.files.length == 0);
+		if (emptyIndex && emptyIndex != -1) {
+			branches?.splice(emptyIndex, 1);
 		}
 		branches = branches;
 	}
 </script>
 
-<div
-	bind:this={dropZone}
-	id="branch-lanes"
-	class="flex flex-shrink flex-grow items-start gap-1 bg-light-300 dark:bg-dark-1100"
-	role="group"
-	use:dzHighlight={{ type: dzType }}
-	on:dragover={(e) => {
-		const children = [...e.currentTarget.children];
-		dropPosition = 0;
-		// We account for the NewBranchDropZone by subtracting 2
-		for (let i = 0; i < children.length - 2; i++) {
-			const pos = children[i].getBoundingClientRect();
-			if (e.clientX > pos.left + pos.width) {
-				dropPosition = i + 1; // Note that this is declared in the <script>
-			} else {
-				break;
-			}
-		}
-		const idx = children.indexOf(dragged);
-		if (idx != dropPosition) {
-			idx >= dropPosition
-				? children[dropPosition].before(dragged)
-				: children[dropPosition].after(dragged);
-		}
-	}}
-	on:drop={() => {
-		if (priorPosition != dropPosition) {
-			const el = branches.splice(priorPosition, 1);
-			branches.splice(dropPosition, 0, ...el);
-			branches.forEach((branch, i) => {
-				if (branch.order !== i) {
-					branchController.updateBranchOrder(branch.id, i);
+{#if branchesState.isLoading || baseBranchState.isLoading}
+	<div class="p-4">Loading...</div>
+{:else if branchesState.isError || baseBranchState.isError}
+	<div class="p-4">Something went wrong...</div>
+{:else if branches}
+	<div
+		bind:this={dropZone}
+		id="branch-lanes"
+		class="flex flex-shrink flex-grow items-start gap-1 bg-light-300 dark:bg-dark-1100"
+		role="group"
+		use:dzHighlight={{ type: dzType }}
+		on:dragover={(e) => {
+			const children = [...e.currentTarget.children];
+			dropPosition = 0;
+			// We account for the NewBranchDropZone by subtracting 2
+			for (let i = 0; i < children.length - 2; i++) {
+				const pos = children[i].getBoundingClientRect();
+				if (e.clientX > pos.left + pos.width) {
+					dropPosition = i + 1; // Note that this is declared in the <script>
+				} else {
+					break;
 				}
-			});
-		}
-	}}
->
-	{#each branches.filter((c) => c.active) as { id, name, files, commits, order, conflicted, upstream } (id)}
-		<Lane
-			on:dragstart={(e) => {
-				if (!e.dataTransfer) return;
-				e.dataTransfer.setData(dzType, id);
-				dragged = e.currentTarget;
-				priorPosition = Array.from(dropZone.children).indexOf(dragged);
-			}}
-			{name}
-			{files}
-			{commits}
-			{conflicted}
-			on:empty={handleEmpty}
-			{order}
-			{projectId}
-			branchId={id}
-			{projectPath}
-			{base}
-			{cloudEnabled}
-			{cloud}
-			{upstream}
-		/>
-	{/each}
+			}
+			const idx = children.indexOf(dragged);
+			if (idx != dropPosition) {
+				idx >= dropPosition
+					? children[dropPosition].before(dragged)
+					: children[dropPosition].after(dragged);
+			}
+		}}
+		on:drop={() => {
+			if (!branches) return;
+			if (priorPosition != dropPosition) {
+				const el = branches.splice(priorPosition, 1);
+				branches.splice(dropPosition, 0, ...el);
+				branches.forEach((branch, i) => {
+					if (branch.order !== i) {
+						branchController.updateBranchOrder(branch.id, i);
+					}
+				});
+			}
+		}}
+	>
+		{#each branches.filter((c) => c.active) as { id, name, files, commits, order, conflicted, upstream } (id)}
+			<Lane
+				on:dragstart={(e) => {
+					if (!e.dataTransfer) return;
+					e.dataTransfer.setData(dzType, id);
+					dragged = e.currentTarget;
+					priorPosition = Array.from(dropZone.children).indexOf(dragged);
+				}}
+				{name}
+				{files}
+				{commits}
+				{conflicted}
+				on:empty={handleEmpty}
+				{order}
+				{projectId}
+				branchId={id}
+				{projectPath}
+				{base}
+				{cloudEnabled}
+				{cloud}
+				{upstream}
+			/>
+		{/each}
 
-	{#if branches.filter((c) => c.active).length == 0}
-		<div
-			class="m-auto mx-20 flex w-full flex-grow items-center justify-center rounded border border-light-400 bg-light-200 p-8 dark:border-dark-500 dark:bg-dark-1000"
-		>
-			<div class="inline-flex w-96 flex-col items-center gap-y-4">
-				<h3 class="text-xl font-medium">You are up to date</h3>
-				<p class="text-light-700 dark:text-dark-200">
-					This means that your working directory looks exactly like your base branch. There isn't
-					anything locally that is not in your production code.
-				</p>
-				<p class="text-light-700 dark:text-dark-200">
-					If you start editing files in your working directory, a new virtual branch will
-					automatically be created and you can manage it here.
-				</p>
-				<Link
-					target="_blank"
-					rel="noreferrer"
-					href="https://docs.gitbutler.com/features/virtual-branches/branch-lanes"
-				>
-					Learn more
-				</Link>
+		{#if branches.length == 0}
+			<div
+				class="m-auto mx-20 flex w-full flex-grow items-center justify-center rounded border border-light-400 bg-light-200 p-8 dark:border-dark-500 dark:bg-dark-1000"
+			>
+				<div class="inline-flex w-96 flex-col items-center gap-y-4">
+					<h3 class="text-xl font-medium">You are up to date</h3>
+					<p class="text-light-700 dark:text-dark-200">
+						This means that your working directory looks exactly like your base branch. There isn't
+						anything locally that is not in your production code.
+					</p>
+					<p class="text-light-700 dark:text-dark-200">
+						If you start editing files in your working directory, a new virtual branch will
+						automatically be created and you can manage it here.
+					</p>
+					<Link
+						target="_blank"
+						rel="noreferrer"
+						href="https://docs.gitbutler.com/features/virtual-branches/branch-lanes"
+					>
+						Learn more
+					</Link>
+				</div>
 			</div>
-		</div>
-	{:else}
-		<NewBranchDropZone />
-	{/if}
-</div>
+		{:else}
+			<NewBranchDropZone />
+		{/if}
+	</div>
+{/if}

--- a/src/routes/repo/[projectId]/BottomPanel.svelte
+++ b/src/routes/repo/[projectId]/BottomPanel.svelte
@@ -5,7 +5,7 @@
 	import { formatDistanceToNow } from 'date-fns';
 	import type { SettingsStore } from '$lib/userSettings';
 
-	export let base: BaseBranch;
+	export let base: BaseBranch | undefined;
 	export let userSettings: SettingsStore;
 
 	export function createCommitUrl(id: string): string | undefined {
@@ -32,7 +32,7 @@
 				on:keypress={toggleExpanded}
 			>
 				<div class="text-sm font-bold uppercase">Common base</div>
-				{#if base.behind == 0}
+				{#if base?.behind == 0}
 					<div class="text-sm">{base.branchName}</div>
 				{/if}
 				{#if $userSettings.bottomPanelExpanded}
@@ -41,7 +41,7 @@
 					<IconTriangleUp />
 				{/if}
 			</div>
-			{#if !$userSettings.bottomPanelExpanded}
+			{#if !$userSettings.bottomPanelExpanded && base}
 				<div class="pr-4 font-mono text-xs text-light-600">
 					<a
 						class="underline hover:text-blue-500"
@@ -61,40 +61,42 @@
 			>
 				Recent commits
 			</h1>
-			<div
-				class="lane-scroll flex w-full flex-col gap-y-1 overflow-y-auto bg-white dark:bg-dark-1100"
-			>
-				{#each base.recentCommits as commit}
-					<div
-						class="flex flex-row items-center gap-x-1 border-b border-light-300 px-2 text-light-700 dark:border-dark-700 dark:text-dark-200"
-					>
-						<div class="w-24 shrink-0 truncate">{formatDistanceToNow(commit.createdAt)} ago</div>
-						<div class="flex w-32 shrink-0 flex-row items-center gap-x-1 truncate">
-							<img
-								class="relative z-30 inline h-3 w-3 rounded-full ring-1 ring-white dark:ring-black"
-								title="Gravatar for {commit.author.email}"
-								alt="Gravatar for {commit.author.email}"
-								srcset="{commit.author.gravatarUrl} 2x"
-								width="100"
-								height="100"
-								on:error
-							/>
-							<div>{commit.author.name}</div>
+			{#if base}
+				<div
+					class="lane-scroll flex w-full flex-col gap-y-1 overflow-y-auto bg-white dark:bg-dark-1100"
+				>
+					{#each base.recentCommits as commit}
+						<div
+							class="flex flex-row items-center gap-x-1 border-b border-light-300 px-2 text-light-700 dark:border-dark-700 dark:text-dark-200"
+						>
+							<div class="w-24 shrink-0 truncate">{formatDistanceToNow(commit.createdAt)} ago</div>
+							<div class="flex w-32 shrink-0 flex-row items-center gap-x-1 truncate">
+								<img
+									class="relative z-30 inline h-3 w-3 rounded-full ring-1 ring-white dark:ring-black"
+									title="Gravatar for {commit.author.email}"
+									alt="Gravatar for {commit.author.email}"
+									srcset="{commit.author.gravatarUrl} 2x"
+									width="100"
+									height="100"
+									on:error
+								/>
+								<div>{commit.author.name}</div>
+							</div>
+							<div class="grow truncate">{commit.description.substring(0, 100)}</div>
+							<div class="flex-shrink pr-4 font-mono text-sm text-light-600">
+								<a
+									href={createCommitUrl(commit.id)}
+									rel="noreferrer"
+									target="_blank"
+									class="hover:text-blue-500 hover:underline"
+								>
+									{commit.id.substring(0, 8)}
+								</a>
+							</div>
 						</div>
-						<div class="grow truncate">{commit.description.substring(0, 100)}</div>
-						<div class="flex-shrink pr-4 font-mono text-sm text-light-600">
-							<a
-								href={createCommitUrl(commit.id)}
-								rel="noreferrer"
-								target="_blank"
-								class="hover:text-blue-500 hover:underline"
-							>
-								{commit.id.substring(0, 8)}
-							</a>
-						</div>
-					</div>
-				{/each}
-			</div>
+					{/each}
+				</div>
+			{/if}
 		</div>
 	{/if}
 </div>

--- a/src/routes/repo/[projectId]/Tray.svelte
+++ b/src/routes/repo/[projectId]/Tray.svelte
@@ -15,9 +15,12 @@
 	import Scrollbar from '$lib/components/Scrollbar.svelte';
 	import IconMeatballMenu from '$lib/icons/IconMeatballMenu.svelte';
 	import IconHelp from '$lib/icons/IconHelp.svelte';
+	import type { LoadState } from '@square/svelte-store';
 
-	export let branches: Branch[];
-	export let remoteBranches: BranchData[];
+	export let branches: Branch[] | undefined;
+	export let branchesState: LoadState;
+	export let remoteBranches: BranchData[] | undefined;
+	export let remoteBranchesState: LoadState;
 
 	const userSettings = getContext<SettingsStore>(SETTINGS_CONTEXT);
 	const branchController = getContext<BranchController>(BRANCH_CONTROLLER_KEY);
@@ -107,7 +110,11 @@
 			class="hide-native-scrollbar relative flex max-h-full flex-grow flex-col overflow-y-scroll dark:bg-dark-900"
 		>
 			<div bind:this={vbContents}>
-				{#if !branches || branches.length == 0}
+				{#if branchesState.isLoading}
+					<div class="px-2 py-1">Loading...</div>
+				{:else if branchesState.isError}
+					<div class="px-2 py-1">Something went wrong!</div>
+				{:else if !branches || branches.length == 0}
 					<div class="p-4 text-light-700">You currently have no virtual branches.</div>
 				{:else}
 					{#each branches as branch (branch.id)}
@@ -206,7 +213,11 @@
 			class="hide-native-scrollbar relative flex max-h-full flex-grow flex-col overflow-y-scroll dark:bg-dark-900"
 		>
 			<div bind:this={rbContents}>
-				{#if !remoteBranches || remoteBranches.length == 0}
+				{#if remoteBranchesState.isLoading}
+					<div class="px-2 py-1">loading...</div>
+				{:else if remoteBranchesState.isError}
+					<div class="px-2 py-1">Something went wrong</div>
+				{:else if !remoteBranches || remoteBranches.length == 0}
 					<div class="p-4">
 						<p class="mb-2 text-light-700">
 							There are no local or remote Git branches that can be imported as virtual branches
@@ -219,8 +230,8 @@
 							Learn more
 						</Link>
 					</div>
-				{:else}
-					{#each remoteBranches ?? [] as branch}
+				{:else if remoteBranches}
+					{#each remoteBranches as branch}
 						<div
 							role="listitem"
 							on:contextmenu|preventDefault={(e) => remoteBranchContextMenu.openByMouse(e, branch)}
@@ -295,7 +306,7 @@
 
 	<!-- Your branches context menu -->
 	<PopupMenu bind:this={yourBranchContextMenu} let:item>
-		{@const disabled = branches.some((b) => b.id == item.id && b.active)}
+		{@const disabled = branches?.some((b) => b.id == item.id && b.active)}
 		<PopupMenuItem
 			{disabled}
 			title={disabled ? 'Unapply before delete' : 'Delete branch'}

--- a/src/routes/repo/[projectId]/UpstreamBranchLane.svelte
+++ b/src/routes/repo/[projectId]/UpstreamBranchLane.svelte
@@ -18,8 +18,8 @@
 
 	const branchController = getContext<BranchController>(BRANCH_CONTROLLER_KEY);
 
-	$: expanded = base.behind > 0;
-	$: multiple = base.upstreamCommits.length > 1;
+	$: expanded = base ? base.behind > 0 : false;
+	$: multiple = base ? base.upstreamCommits.length > 1 : false;
 </script>
 
 <div
@@ -42,7 +42,7 @@
 		>
 			<Tooltip
 				label={'Your upstream branch (' +
-					base.branchName +
+					base?.branchName +
 					') is up to date. Click to fetch again and check for new work.'}
 			>
 				<!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -57,21 +57,25 @@
 					<div
 						class="flex h-6 w-6 items-center justify-center rounded hover:bg-light-200 dark:hover:bg-dark-700"
 					>
-						{#if buttonHovered || fetching}
-							<div class:animate-spin={fetching}>
-								<IconRefresh class="h-4 w-4" />
-							</div>
-						{:else if base.remoteUrl.includes('github.com')}
-							<IconGithub class="h-4 w-4" />
-						{:else}
-							<IconBranch class="h-4 w-4" />
-						{/if}
-					</div>
-				</button>
+						<div
+							class="flex h-6 w-6 items-center justify-center rounded hover:bg-light-200 dark:hover:bg-dark-700"
+						>
+							{#if buttonHovered || fetching}
+								<div class:animate-spin={fetching}>
+									<IconRefresh class="h-4 w-4" />
+								</div>
+							{:else if base?.remoteUrl.includes('github.com')}
+								<IconGithub class="h-4 w-4" />
+							{:else}
+								<IconBranch class="h-4 w-4" />
+							{/if}
+						</div>
+					</div></button
+				>
 			</Tooltip>
 			{#if expanded}
 				<div class="flex-grow pl-2 font-mono font-bold">
-					{base.branchName}
+					{base?.branchName}
 				</div>
 			{/if}
 		</div>
@@ -84,8 +88,7 @@
 				class="relative flex h-full w-60 shrink-0 flex-grow cursor-default snap-center flex-col overflow-y-hidden overscroll-y-none border-light-300 bg-light-200 pr-1.5 dark:border-l dark:border-dark-600 dark:border-r-light-800 dark:bg-dark-700 dark:text-dark-100"
 			>
 				<div
-					bind:this={viewport}
-					class="hide-native-scrollbar flex max-h-full flex-grow flex-col overflow-y-scroll pb-8 pt-2"
+					class="relative flex h-full w-60 shrink-0 flex-grow cursor-default snap-center flex-col overflow-y-hidden overscroll-y-none border-light-300 bg-light-200 pr-2 dark:border-l dark:border-dark-600 dark:border-r-light-800 dark:bg-dark-700 dark:text-dark-100"
 				>
 					<div
 						class="mb-2 ml-8 rounded-sm bg-light-300 p-1 text-center text-xs text-light-700 dark:bg-dark-500"

--- a/src/routes/repo/[projectId]/settings/+page.ts
+++ b/src/routes/repo/[projectId]/settings/+page.ts
@@ -1,28 +1,10 @@
 import type { PageLoadEvent } from './$types';
-import { invoke } from '$lib/ipc';
 import { getProjectStore, type Project } from '$lib/api/ipc/projects';
 import type { Loadable } from '@square/svelte-store';
 
-async function getRemoteBranches(params: { projectId: string }) {
-	return invoke<Array<string>>('git_remote_branches', params);
-}
-
-export async function load({ parent, params }: PageLoadEvent) {
-	const projectId = params.projectId;
-	const remoteBranchNames = await getRemoteBranches({ projectId });
+export async function load({ params }: PageLoadEvent) {
 	const project = getProjectStore({ id: params.projectId });
-
-	const { branchStoresCache } = await parent();
-	const vbranchStore = branchStoresCache.getVirtualBranchStore(projectId);
-	const remoteBranchStore = branchStoresCache.getRemoteBranchStore(projectId);
-	const targetBranchStore = branchStoresCache.getBaseBranchStore(projectId);
-
 	return {
-		projectId,
-		remoteBranchNames,
-		vbranchStore,
-		remoteBranchStore,
-		targetBranchStore,
 		project: project as Loadable<Project> & Pick<typeof project, 'update' | 'delete'>
 	};
 }


### PR DESCRIPTION
Left todo's where subscriptions are never unsubscribed.

Simplify vbranch stores
- deltas, sessions, and fetches are now used to derive vbranch stores
- instantiated in page.svelte rather than layout.ts
- lifecycle hooks need to be added, e.g. onDestroy() to unsubscribe