### PR TITLE
Added commit data to Remote Branches

### DIFF
--- a/src-tauri/src/virtual_branches/tests.rs
+++ b/src-tauri/src/virtual_branches/tests.rs
@@ -2029,6 +2029,7 @@ fn test_detect_mergeable_branch() -> Result<()> {
     assert_eq!(remote1.ahead, 1);
     assert_eq!(remote1.merge_conflicts.len(), 1);
     assert_eq!(remote1.merge_conflicts.first().unwrap(), "test.txt");
+    assert_eq!(remote1.commits.len(), 1);
 
     let remote2 = &remotes
         .iter()
@@ -2037,6 +2038,7 @@ fn test_detect_mergeable_branch() -> Result<()> {
     assert!(remote2.mergeable);
     assert_eq!(remote2.ahead, 2);
     assert_eq!(remote2.merge_conflicts.len(), 0);
+    assert_eq!(remote2.commits.len(), 2);
 
     Ok(())
 }

--- a/src-tauri/src/virtual_branches/vbranch.rs
+++ b/src-tauri/src/virtual_branches/vbranch.rs
@@ -132,6 +132,7 @@ pub struct RemoteBranch {
     pub authors: Vec<Author>,
     pub mergeable: bool,
     pub merge_conflicts: Vec<String>,
+    pub commits: Vec<VirtualBranchCommit>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Clone)]
@@ -654,6 +655,13 @@ pub fn list_remote_branches(
                             authors: authors.into_iter().collect(),
                             mergeable,
                             merge_conflicts,
+                            commits: ahead
+                                .into_iter()
+                                .map(|commit| {
+                                    commit_to_vbranch_commit(project_repository, &commit, None)
+                                        .unwrap()
+                                })
+                                .collect(),
                         });
                     };
                 }
@@ -671,6 +679,7 @@ pub fn list_remote_branches(
                     authors: vec![],
                     mergeable: false,
                     merge_conflicts: vec![],
+                    commits: vec![],
                 });
             }
         }

--- a/src/lib/vbranches/types.ts
+++ b/src/lib/vbranches/types.ts
@@ -73,6 +73,7 @@ export class BranchData {
 	authors!: Author[];
 	mergeable!: boolean;
 	mergeConflicts!: string[];
+	commits!: Commit[];
 }
 
 export class BaseBranch {


### PR DESCRIPTION
In this commit, a new field, "commits", of type Vec<VirtualBranchCommit>, was added to the RemoteBranch struct. This field is populated in the list_remote_branches function as part of the RemoteBranch creation process. Additionally, two assertions have been inserted into the test_detect_mergeable_branch function ensuring the "commits" collection is populated correctly.

Changes included:
- Append new "commits" field to RemoteBranch struct
- Updated the list_remote_branches function to populate commits
- Updated tests to include checks on the size of the "commits" array