### PR TITLE
Reduce the length of "committer" sentence/explanation

### DIFF
--- a/src/routes/repo/[projectId]/Board.svelte
+++ b/src/routes/repo/[projectId]/Board.svelte
@@ -45,7 +45,7 @@
 	<div
 		bind:this={dropZone}
 		id="branch-lanes"
-		class="flex flex-shrink flex-grow items-start gap-1 bg-light-300 px-1 dark:bg-dark-1100"
+		class="flex flex-shrink flex-grow items-start gap-1 bg-light-300 dark:bg-dark-1100"
 		role="group"
 		use:dzHighlight={{ type: dzType }}
 		on:dragover={(e) => {

--- a/src/routes/repo/[projectId]/BranchLane.svelte
+++ b/src/routes/repo/[projectId]/BranchLane.svelte
@@ -277,7 +277,7 @@
 				>
 					{#if annotateCommits}
 						<div class="bg-blue-400 p-2 text-sm text-white">
-							GitButler will be the "committer" of this commit.
+							GitButler will be the committer of this commit.
 							<a
 								target="_blank"
 								rel="noreferrer"


### PR DESCRIPTION
Dropping the quotes shortens the string, and avoids the UI overflow.