### PR TITLE
Remove drop-shadow from purple buttons

### DIFF
--- a/src/styles/main.postcss
+++ b/src/styles/main.postcss
@@ -255,7 +255,7 @@ button:focus {
 	@apply bg-[#524C93]/20;
 }
 .purple.filled {
-	@apply border-b border-t border-b-[#3C386D] border-t-[#7570B1] bg-gradient-to-b from-[#5852A0] to-[#474281] text-light-50 no-underline drop-shadow;
+	@apply border-b border-t border-b-[#3C386D] border-t-[#7570B1] bg-gradient-to-b from-[#5852A0] to-[#474281] text-light-50 no-underline;
 }
 .purple.filled:hover {
 	@apply bg-[#423E7A];


### PR DESCRIPTION
It looks better without it, and the shadow was introducing a weird UI bug in the peek tray where a parent container inherited the shadow.