### PR TITLE
Fix rendering of compact indentation

### DIFF
--- a/src/routes/repo/[projectId]/RenderedLine.svelte
+++ b/src/routes/repo/[projectId]/RenderedLine.svelte
@@ -11,7 +11,7 @@
 	function toTokens(codeString: string): string[] {
 		function sanitize(text: string) {
 			var element = document.createElement('div');
-			element.innerText = text.replace(/\t/g, ' ').replace('   ', ' ');
+			element.innerText = text.replace('   ', ' ').replace(/\t/g, ' ');
 			return element.innerHTML;
 		}
 


### PR DESCRIPTION
Four tabs converted to spaces is  reduced to a single space by the second call to replace().