### PR TITLE
Fixes the dependabot PRs for typescript

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+auto-install-peers=true


### PR DESCRIPTION
CI currently fails with a mention about the lockfile setting settings.autoInstallPeers

Read more here: https://github.com/pnpm/pnpm/issues/6649