### PR TITLE
Add dismissable warning for merging upstream work

### DIFF
--- a/src/lib/config/config.ts
+++ b/src/lib/config/config.ts
@@ -4,3 +4,8 @@ export function projectHttpsWarningBannerDismissed(projectId: string): Persisted
 	const key = 'projectHttpsWarningBannerDismissed_';
 	return persisted(false, key + projectId);
 }
+
+export function projectMergeUpstreamWarningDismissed(projectId: string): Persisted<boolean> {
+	const key = 'projectMergeUpstreamWarningDismissed_';
+	return persisted(false, key + projectId);
+}

--- a/src/routes/repo/[projectId]/BaseBranchPeek.svelte
+++ b/src/routes/repo/[projectId]/BaseBranchPeek.svelte
@@ -4,13 +4,18 @@
 	import CommitCard from './CommitCard.svelte';
 	import type { BranchController } from '$lib/vbranches/branchController';
 	import Scrollbar from '$lib/components/Scrollbar.svelte';
+	import { projectMergeUpstreamWarningDismissed } from '$lib/config/config';
 
 	export let base: BaseBranch;
 	export let branchController: BranchController;
+	const mergeUpstreamWarningDismissed = projectMergeUpstreamWarningDismissed(
+		branchController.projectId
+	);
 
 	let updateTargetModal: Modal;
 	let viewport: HTMLElement;
 	let contents: HTMLElement;
+	let mergeUpstreamWarningDismissedCheckbox = false;
 
 	$: multiple = base ? base.upstreamCommits.length > 1 || base.upstreamCommits.length == 0 : false;
 </script>
@@ -71,7 +76,7 @@
 
 <Modal width="small" bind:this={updateTargetModal}>
 	<svelte:fragment slot="title">Merge Upstream Work</svelte:fragment>
-	<div class="flex flex-col space-y-2">
+	<div class="flex flex-col space-y-4">
 		<p class="text-blue-600">You are about to merge upstream work from your base branch.</p>
 		<p class="font-bold">What will this do?</p>
 		<p>
@@ -83,6 +88,10 @@
 			You can merge these manually later.
 		</p>
 		<p>Any virtual branches that are fully integrated upstream will be automatically removed.</p>
+		<label>
+			<input type="checkbox" bind:checked={mergeUpstreamWarningDismissedCheckbox} />
+			Don't show this again
+		</label>
 	</div>
 	<svelte:fragment slot="controls" let:close>
 		<Button height="small" kind="outlined" on:click={close}>Cancel</Button>
@@ -91,6 +100,9 @@
 			color="purple"
 			on:click={() => {
 				branchController.updateBaseBranch();
+				if (mergeUpstreamWarningDismissedCheckbox) {
+					mergeUpstreamWarningDismissed.set(true);
+				}
 				close();
 			}}
 		>


### PR DESCRIPTION
This update introduces a dismissable warning for merging upstream work from the base branch. The user can now choose not to show this warning again, and this choice is remembered by the system. This is achieved by adding a checkbox that triggers a new function, `projectMergeUpstreamWarningDismissed`, altering the interface's vertical space, and tweaking the execution of the `branchController.updateBaseBranch` method.

Detailed changes:
- Introduced a checkbox to the warning modal, binded to `mergeUpstreamWarningDismissedCheckbox`.
- Adjusted the vertical spacing between elements in the warning modal, from `space-y-2` to `space-y-4`.
- Modified the onclick method of the merge button to call `mergeUpstreamWarningDismissed.set(true)`, if `mergeUpstreamWarningDismissedCheckbox` is checked.
- Added `mergeUpstreamWarningDismissed` and `mergeUpstreamWarningDismissedCheckbox` variables to control the checkbox state, using the new `projectMergeUpstreamWarningDismissed` method.
- New `projectMergeUpstreamWarningDismissed` method added to handle persistent dismissal of the warning across sessions