### PR TITLE
Hide "offline" from the status bar

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -152,10 +152,7 @@
 							<div class="flex flex-row items-center space-x-2">
 								{#if $project?.api?.sync}
 									<div class="h-2 w-2 rounded-full bg-green-700" />
-									<span>online</span>
-								{:else}
-									<div class="h-2 w-2 rounded-full bg-red-700" />
-									<span class="text-light-600 dark:text-dark-200">offline</span>
+									<span>synced</span>
 								{/if}
 							</div>
 						</Link>


### PR DESCRIPTION
It draws unnecessary attention to a feature that does not yet add much value.

Came up during live debugging session with my friend Christian.