### PR TITLE
Add unread update count display

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -166,6 +166,11 @@
 					{#if $update?.enabled && $update?.shouldUpdate}
 						<div class="flex items-center gap-1">
 							{#if !updateStatus}
+								<div
+									class="mr-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-xs font-bold text-white"
+								>
+									1
+								</div>
 								<Link on:click={() => installUpdate()}>
 									version {$update.version} available
 								</Link>


### PR DESCRIPTION
This commit introduces an indication of unread updates. When there new updates available, a red circle with the number '1' will now be displayed. This visual cue gives users a quick way to see if there are updates that need their attention.

Changes:
- Added a div with a class containing several formatting properties.
- Inside this div, the number '1' is hard-coded, representing the number of updates