### PR TITLE
Signing commits

### DIFF
--- a/packages/butler/src/commands/commit.rs
+++ b/packages/butler/src/commands/commit.rs
@@ -56,6 +56,7 @@ impl super::RunCommand for Commit {
             .context("failed to get commit message")?;
 
         virtual_branches::commit(
+            None,
             app.gb_repository(),
             &app.project_repository(),
             &commit_branch,

--- a/packages/tauri/src/git/commit.rs
+++ b/packages/tauri/src/git/commit.rs
@@ -60,6 +60,10 @@ impl<'repo> Commit<'repo> {
     pub fn committer(&self) -> git2::Signature<'_> {
         self.commit.committer()
     }
+
+    pub fn raw_header(&self) -> Option<&str> {
+        self.commit.raw_header()
+    }
 }
 
 pub struct AnnotatedCommit<'repo> {

--- a/packages/tauri/src/git/repository.rs
+++ b/packages/tauri/src/git/repository.rs
@@ -215,6 +215,31 @@ impl Repository {
             .map_err(Into::into)
     }
 
+    pub fn commit_create_buffer(
+        &self,
+        author: &git2::Signature<'_>,
+        committer: &git2::Signature<'_>,
+        message: &str,
+        tree: &Tree<'_>,
+        parents: &[&Commit<'_>],
+    ) -> Result<git2::Buf> {
+        let parents: Vec<&git2::Commit> = parents
+            .iter()
+            .map(|c| c.to_owned().into())
+            .collect::<Vec<_>>();
+        let buf = self
+            .0
+            .commit_create_buffer(author, committer, message, tree.into(), &parents)?;
+        Ok(buf)
+    }
+
+    pub fn commit_signed(&self, commit_content: &str, signature: &str) -> Result<Oid> {
+        self.0
+            .commit_signed(commit_content, signature, None)
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
     pub fn config(&self) -> Result<git2::Config> {
         self.0.config().map_err(Into::into)
     }

--- a/packages/tauri/src/keys/key.rs
+++ b/packages/tauri/src/keys/key.rs
@@ -20,6 +20,10 @@ impl PrivateKey {
         Self::default()
     }
 
+    pub fn private_ssh_key(&self) -> ssh_key::PrivateKey {
+        self.0.clone()
+    }
+
     pub fn public_key(&self) -> PublicKey {
         PublicKey::from(self)
     }

--- a/packages/tauri/src/virtual_branches/controller.rs
+++ b/packages/tauri/src/virtual_branches/controller.rs
@@ -73,6 +73,7 @@ impl Controller {
         self.with_lock(project_id, || {
             self.with_verify_branch(project_id, |gb_repository, project_repository| {
                 super::commit(
+                    Some(&self.keys_storage.clone()),
                     gb_repository,
                     project_repository,
                     branch,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 importers:
 


### PR DESCRIPTION
Almost got commit signing working with the ed25519 key we write out, but we can't quite do it this way, because we don't specify an email address in the key when we write the key out, which I believe GitHub needs in order to verify. So the code signing part may well work correctly, but the key is possibly not formatted correctly for this.

I looked into this a bit more and I don't think this is easily possible. I can't even figure out how the email address is written into these keys. It will probably just be easier to be able to select a personal key the way that we do in the project settings for the push key. We might want to allow them to select different keys for each. But signing with the `id_ed25519` key that I generated by hand vs the random one we generate and uploading them both as signing keys to github results in one being verified and the other not, so I'm pretty sure that's the difference.

We may have to make the `keys` part a little more generic, to be able to use our keys_controller for more than populating the git credential thing.