### PR TITLE
chore: update language parser usage and add support for Ruby language

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -32,6 +32,7 @@
 		"@codemirror/lang-wast": "^6.0.1",
 		"@codemirror/lang-xml": "^6.0.2",
 		"@codemirror/language": "^6.9.0",
+		"@codemirror/legacy-modes": "^6.3.3",
 		"@codemirror/state": "^6.2.1",
 		"@codemirror/view": "^6.18.0",
 		"@histoire/plugin-svelte": "^0.17.0",

--- a/packages/ui/src/lib/components/Differ/CodeHighlighter.ts
+++ b/packages/ui/src/lib/components/Differ/CodeHighlighter.ts
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import { HighlightStyle, type LanguageSupport } from '@codemirror/language';
+import { HighlightStyle, StreamLanguage } from '@codemirror/language';
 import { tags, highlightTree } from '@lezer/highlight';
-import { NodeType, Tree } from '@lezer/common';
+import { NodeType, Tree, Parser } from '@lezer/common';
 import { javascript } from '@codemirror/lang-javascript';
 import { css } from '@codemirror/lang-css';
 import { html } from '@codemirror/lang-html';
@@ -19,6 +19,7 @@ import { wast } from '@codemirror/lang-wast';
 // import { svelte } from '@replit/codemirror-lang-svelte';
 import { vue } from '@codemirror/lang-vue';
 import { rust } from '@codemirror/lang-rust';
+import { ruby } from '@codemirror/legacy-modes/mode/ruby';
 
 const t = tags;
 
@@ -54,10 +55,10 @@ export const highlightStyle: HighlightStyle = HighlightStyle.define([
 ]);
 
 export function create(code: string, filepath: string): CodeHighlighter {
-	const language = languageFromFilename(filepath);
+	const parser = parserFromFilename(filepath);
 	let tree: Tree;
-	if (language) {
-		tree = language.language.parser.parse(code);
+	if (parser) {
+		tree = parser.parse(code);
 	} else {
 		tree = new Tree(NodeType.none, [], [], code.length);
 	}
@@ -82,7 +83,7 @@ export function highlightNode(node: Element, mimeType: string): void {
 	});
 }
 
-export function languageFromFilename(filename: string): LanguageSupport | null {
+export function parserFromFilename(filename: string): Parser | null {
 	const ext = filename.split('.').pop();
 	switch (ext) {
 		case 'jsx':
@@ -91,50 +92,50 @@ export function languageFromFilename(filename: string): LanguageSupport | null {
 			// because there are simply too many existing applications and
 			// examples out there that use JSX within .js files, and we don't
 			// want to break them.
-			return javascript({ jsx: true });
+			return javascript({ jsx: true }).language.parser;
 		case 'ts':
-			return javascript({ typescript: true });
+			return javascript({ typescript: true }).language.parser;
 		case 'tsx':
-			return javascript({ typescript: true, jsx: true });
+			return javascript({ typescript: true, jsx: true }).language.parser;
 
 		case 'css':
-			return css();
+			return css().language.parser;
 
 		case 'html':
-			return html({ selfClosingTags: true });
+			return html({ selfClosingTags: true }).language.parser;
 
 		case 'xml':
-			return xml();
+			return xml().language.parser;
 
 		case 'wasm':
-			return wast();
+			return wast().language.parser;
 
 		case 'cpp':
 		case 'c++':
 		case 'hpp':
 		case 'h++':
-			return cpp();
+			return cpp().language.parser;
 
 		// case 'text/x-go':
 		//     return new LanguageSupport(await CodeMirror.go());
 
 		case 'java':
-			return java();
+			return java().language.parser;
 
 		// case 'text/x-kotlin':
 		//     return new LanguageSupport(await CodeMirror.kotlin());
 
 		case 'json':
-			return json();
+			return json().language.parser;
 
 		case 'php':
-			return php();
+			return php().language.parser;
 
 		case 'python':
-			return python();
+			return python().language.parser;
 
 		case 'md':
-			return markdown();
+			return markdown().language.parser;
 
 		// case 'text/x-sh':
 		//     return new LanguageSupport(await CodeMirror.shell());
@@ -168,13 +169,16 @@ export function languageFromFilename(filename: string): LanguageSupport | null {
 			// return svelte();
 
 			// highlighting svelte with js + jsx works much better than the above
-			return javascript({ typescript: true, jsx: true });
+			return javascript({ typescript: true, jsx: true }).language.parser;
 
 		case 'vue':
-			return vue();
+			return vue().language.parser;
 
 		case 'rs':
-			return rust();
+			return rust().language.parser;
+
+		case 'rb':
+			return StreamLanguage.define(ruby).parser;
 
 		default:
 			return null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@codemirror/language':
         specifier: ^6.9.0
         version: 6.9.0
+      '@codemirror/legacy-modes':
+        specifier: ^6.3.3
+        version: 6.3.3
       '@codemirror/state':
         specifier: ^6.2.1
         version: 6.2.1
@@ -79,7 +82,7 @@ importers:
         version: 7.64.0(@sveltejs/kit@1.24.1)(svelte@4.2.0)
       '@square/svelte-store':
         specifier: git+https://git@github.com/gitbutlerapp/svelte-store.git
-        version: git@github.com+gitbutlerapp/svelte-store/4cf861db334188389186a6f41ddfc1ba157b4ffd(svelte@4.2.0)
+        version: github.com/gitbutlerapp/svelte-store/4cf861db334188389186a6f41ddfc1ba157b4ffd(svelte@4.2.0)
       '@sveltejs/adapter-static':
         specifier: ^2.0.3
         version: 2.0.3(@sveltejs/kit@1.24.1)
@@ -450,6 +453,12 @@ packages:
       '@lezer/highlight': 1.1.6
       '@lezer/lr': 1.3.10
       style-mod: 4.1.0
+    dev: true
+
+  /@codemirror/legacy-modes@6.3.3:
+    resolution: {integrity: sha512-X0Z48odJ0KIoh/HY8Ltz75/4tDYc9msQf1E/2trlxFaFFhgjpVHjZ/BCXe1Lk7s4Gd67LL/CeEEHNI+xHOiESg==}
+    dependencies:
+      '@codemirror/language': 6.9.0
     dev: true
 
   /@codemirror/lint@6.4.1:
@@ -5489,9 +5498,9 @@ packages:
     engines: {node: '>=12.20'}
     dev: true
 
-  git@github.com+gitbutlerapp/svelte-store/4cf861db334188389186a6f41ddfc1ba157b4ffd(svelte@4.2.0):
-    resolution: {commit: 4cf861db334188389186a6f41ddfc1ba157b4ffd, repo: git@github.com:gitbutlerapp/svelte-store.git, type: git}
-    id: git@github.com+gitbutlerapp/svelte-store/4cf861db334188389186a6f41ddfc1ba157b4ffd
+  github.com/gitbutlerapp/svelte-store/4cf861db334188389186a6f41ddfc1ba157b4ffd(svelte@4.2.0):
+    resolution: {tarball: https://codeload.github.com/gitbutlerapp/svelte-store/tar.gz/4cf861db334188389186a6f41ddfc1ba157b4ffd}
+    id: github.com/gitbutlerapp/svelte-store/4cf861db334188389186a6f41ddfc1ba157b4ffd
     name: '@square/svelte-store'
     version: 1.0.17
     peerDependencies:


### PR DESCRIPTION
The code changes in this commit update the usage of language parsers in the codebase. Instead of using the `LanguageSupport` interface from `@codemirror/language`, the code now directly uses the `Parser` interface from `@lezer/common`. Additionally, support for the Ruby language has been added by importing the `ruby` mode from `@codemirror/legacy-modes/mode/ruby` and defining a parser for it using `StreamLanguage.define(ruby