### PR TITLE
chore: update context menu in code editor component

### DIFF
--- a/packages/ui/src/routes/repo/[projectId]/FileCard.svelte
+++ b/packages/ui/src/routes/repo/[projectId]/FileCard.svelte
@@ -222,11 +222,17 @@
 										{/each}
 										{#if !subsection.expanded}
 											<div
+												role="group"
 												class="border-color-3 flex w-full"
 												class:border-t={sidx == section.subSections.length - 1 ||
 													(sidx > 0 && sidx < section.subSections.length - 1)}
 												class:border-b={sidx == 0 ||
 													(sidx > 0 && sidx < section.subSections.length - 1)}
+												on:contextmenu|preventDefault={(e) =>
+													popupMenu.openByMouse(e, {
+														section: section,
+														hunk
+													})}
 											>
 												<div
 													class="bg-color-4 text-color-4 hover:text-color-2 border-color-3 border-r text-center"

--- a/packages/ui/src/routes/repo/[projectId]/HunkContextMenu.svelte
+++ b/packages/ui/src/routes/repo/[projectId]/HunkContextMenu.svelte
@@ -16,21 +16,23 @@
 </script>
 
 <PopupMenu bind:this={popupMenu} let:item>
-	<PopupMenuItem
-		on:click={() => {
-			if ('expanded' in item.section) {
+	{#if 'expanded' in item.section}
+		<PopupMenuItem
+			on:click={() => {
 				item.section.expanded = false;
-			}
-		}}
-	>
-		Collapse
-	</PopupMenuItem>
+			}}
+		>
+			Collapse
+		</PopupMenuItem>
+	{/if}
 	{#if item.hunk !== undefined && !item.hunk.locked}
 		<PopupMenuItem on:click={() => branchController.unapplyHunk(item.hunk)}>Discard</PopupMenuItem>
 	{/if}
-	<PopupMenuItem
-		on:click={() => open(`vscode://file${projectPath}/${file.path}:${item.lineNumber}`)}
-	>
-		Open in Visual Studio Code
-	</PopupMenuItem>
+	{#if item.lineNumber}
+		<PopupMenuItem
+			on:click={() => open(`vscode://file${projectPath}/${file.path}:${item.lineNumber}`)}
+		>
+			Open in Visual Studio Code
+		</PopupMenuItem>
+	{/if}
 </PopupMenu>


### PR DESCRIPTION
The context menu in the code editor component has been updated to include a new option to collapse sections. Additionally, the "Open in Visual Studio Code" option will now only be displayed if there is a specific line number associated with the item.