### PR TITLE
fix: remove unnecessary steps in creating symlink content

### DIFF
--- a/packages/tauri/src/virtual_branches/virtual.rs
+++ b/packages/tauri/src/virtual_branches/virtual.rs
@@ -1708,10 +1708,7 @@ fn write_tree_onto_commit(
             if filemode == git::FileMode::Link {
                 // it's a symlink, make the content the path of the link
                 let link_target = std::fs::read_link(&full_path)?;
-                // make link_target into a relative path
-                let link_target = link_target.strip_prefix(project_repository.path()).unwrap();
-                // create a blob where the content is that target path string
-                // make a [u8] out of the PathBuf
+
                 let path_str = link_target.to_str().unwrap();
                 let bytes: &[u8] = path_str.as_bytes();
 

--- a/packages/tauri/src/virtual_branches/virtual.rs
+++ b/packages/tauri/src/virtual_branches/virtual.rs
@@ -1709,6 +1709,12 @@ fn write_tree_onto_commit(
                 // it's a symlink, make the content the path of the link
                 let link_target = std::fs::read_link(&full_path)?;
 
+                // if the link target is inside the project repository, make it relative
+                let link_target = link_target
+                    .strip_prefix(project_repository.path())
+                    .unwrap_or(&link_target);
+
+                // bytes dance
                 let path_str = link_target.to_str().unwrap();
                 let bytes: &[u8] = path_str.as_bytes();
 


### PR DESCRIPTION
The code previously included unnecessary steps to make the symlink target path relative and convert it to a byte array. These steps have been removed as they are not needed for creating the symlink content.