### PR TITLE
Destroy popup menues on component destruction

### DIFF
--- a/packages/ui/src/routes/repo/[projectId]/BranchLane.svelte
+++ b/packages/ui/src/routes/repo/[projectId]/BranchLane.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { userStore } from '$lib/stores/user';
 	import type { BaseBranch, Branch } from '$lib/vbranches/types';
-	import { getContext, onMount } from 'svelte';
+	import { getContext, onDestroy, onMount } from 'svelte';
 	import { Ownership } from '$lib/vbranches/ownership';
 	import { Button, Link, Modal, Tooltip } from '$lib/components';
 	import IconKebabMenu from '$lib/icons/IconKebabMenu.svelte';
@@ -207,6 +207,10 @@
 				generateBranchName();
 			}
 		});
+	});
+
+	onDestroy(() => {
+		popupMenu.$destroy();
 	});
 
 	const selectedOwnership = writable(Ownership.fromBranch(branch));

--- a/packages/ui/src/routes/repo/[projectId]/FileCard.svelte
+++ b/packages/ui/src/routes/repo/[projectId]/FileCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { ContentSection, HunkSection, parseFileSections } from './fileSections';
-	import { createEventDispatcher } from 'svelte';
+	import { createEventDispatcher, onDestroy } from 'svelte';
 	import type { File, Hunk } from '$lib/vbranches/types';
 	import type { Ownership } from '$lib/vbranches/ownership';
 	import type { Writable } from 'svelte/store';
@@ -91,6 +91,10 @@
 			selectedOwnership.update((ownership) => ownership.removeHunk(hunk.filePath, hunk.id));
 		}
 	}
+
+	onDestroy(() => {
+		popupMenu.$destroy();
+	});
 </script>
 
 <div


### PR DESCRIPTION
- because menus are rendered manually targeting the document body