### PR TITLE
Set files in data dir to user only (0o600)

### DIFF
--- a/packages/tauri/src/keys/storage.rs
+++ b/packages/tauri/src/keys/storage.rs
@@ -71,14 +71,24 @@ impl Storage {
 
 #[cfg(test)]
 mod tests {
+    use std::{fs, os::unix::prelude::PermissionsExt};
+
     use super::*;
 
     #[test]
     fn test_get_or_create() {
         let dir = tempfile::tempdir().unwrap();
         let controller = Storage::from(&dir.path().to_path_buf());
+
         let once = controller.get_or_create().unwrap();
         let twice = controller.get_or_create().unwrap();
         assert_eq!(once, twice);
+
+        // check permissions of the private key
+        let permissions = fs::metadata(dir.path().join("keys/ed25519"))
+            .unwrap()
+            .permissions();
+        let perms = format!("{:o}", permissions.mode());
+        assert_eq!(perms, "100600");
     }
 }

--- a/packages/tauri/src/storage.rs
+++ b/packages/tauri/src/storage.rs
@@ -1,5 +1,6 @@
 use std::{
     fs,
+    os::unix::prelude::PermissionsExt,
     path::{self, Path, PathBuf},
     sync::{Arc, RwLock},
 };
@@ -65,6 +66,13 @@ impl Storage {
             fs::create_dir_all(dir).map_err(Error::IO)?;
         }
         fs::write(file_path.clone(), content).map_err(Error::IO)?;
+
+        // Set the permissions to be user-only.
+        let metadata = fs::metadata(file_path.clone())?;
+        let mut permissions = metadata.permissions();
+        permissions.set_mode(0o600); // User read/write
+        fs::set_permissions(file_path.clone(), permissions)?;
+
         Ok(())
     }
 


### PR DESCRIPTION
This addresses the issue encountered in https://linear.app/gitbutler/issue/GB-580/ssh-key-perms-too-open

It also basically writes _all_files in the data dir this way, so I'm not sure if that's an issue?