### PR TITLE
chore: refactor projects_storage methods to use consistent naming and…

### DIFF
--- a/packages/butler/src/app.rs
+++ b/packages/butler/src/app.rs
@@ -23,9 +23,7 @@ impl App {
         let users_storage = users::Storage::from(&storage);
 
         let projects_storage = projects::Storage::try_from(&storage)?;
-        let projects = projects_storage
-            .list()
-            .context("failed to list projects")?;
+        let projects = projects_storage.list().context("failed to list projects")?;
 
         let project = projects
             .into_iter()

--- a/packages/butler/src/app.rs
+++ b/packages/butler/src/app.rs
@@ -24,7 +24,7 @@ impl App {
 
         let projects_storage = projects::Storage::try_from(&storage)?;
         let projects = projects_storage
-            .list_projects()
+            .list()
             .context("failed to list projects")?;
 
         let project = projects

--- a/packages/tauri/src/app.rs
+++ b/packages/tauri/src/app.rs
@@ -70,7 +70,7 @@ impl App {
     pub async fn init(&self) -> Result<()> {
         for project in self
             .projects_storage
-            .list_projects()
+            .list()
             .with_context(|| "failed to list projects")?
         {
             if let Err(error) = self.init_project(&project).await {
@@ -78,13 +78,6 @@ impl App {
             }
         }
         Ok(())
-    }
-
-    fn gb_project(&self, project_id: &str) -> Result<projects::Project> {
-        self.projects_storage
-            .get_project(project_id)
-            .context("failed to get project")?
-            .ok_or_else(|| anyhow::anyhow!("project {} not found", project_id))
     }
 
     pub fn get_user(&self) -> Result<Option<users::User>> {
@@ -100,10 +93,7 @@ impl App {
     }
 
     pub async fn add_project(&self, path: &path::Path) -> Result<projects::Project, Error> {
-        let all_projects = self
-            .projects_storage
-            .list_projects()
-            .map_err(Error::Other)?;
+        let all_projects = self.projects_storage.list().map_err(Error::Other)?;
 
         if all_projects.iter().any(|project| project.path == path) {
             return Err(Error::CreateProjectError(format!(
@@ -116,7 +106,7 @@ impl App {
             .map_err(|err| Error::CreateProjectError(err.to_string()))?;
 
         self.projects_storage
-            .add_project(&project)
+            .add(&project)
             .context("failed to add project")
             .map_err(Error::Other)?;
 
@@ -132,7 +122,7 @@ impl App {
         &self,
         project: &projects::UpdateRequest,
     ) -> Result<projects::Project> {
-        let updated = self.projects_storage.update_project(project)?;
+        let updated = self.projects_storage.update(project)?;
 
         if let Err(error) = self
             .watchers
@@ -148,50 +138,46 @@ impl App {
         Ok(updated)
     }
 
-    pub fn get_project(&self, id: &str) -> Result<Option<projects::Project>> {
-        self.projects_storage.get_project(id)
+    pub fn get_project(&self, id: &str) -> Result<projects::Project> {
+        self.projects_storage.get(id)
     }
 
     pub fn list_projects(&self) -> Result<Vec<projects::Project>> {
-        self.projects_storage.list_projects()
+        self.projects_storage.list()
     }
 
     pub async fn delete_project(&self, id: &str) -> Result<()> {
-        match self.projects_storage.get_project(id)? {
-            Some(project) => {
-                let gb_repository = match gb_repository::Repository::open(
-                    self.local_data_dir.clone(),
-                    &project,
-                    self.users_storage.get()?.as_ref(),
-                ) {
-                    Ok(repo) => Ok(Some(repo)),
-                    Err(gb_repository::Error::ProjectPathNotFound(_)) => Ok(None),
-                    Err(e) => Err(anyhow::anyhow!("failed to open repository: {:#}", e)),
-                }?;
+        let project = self.projects_storage.get(id)?;
+        let gb_repository = match gb_repository::Repository::open(
+            self.local_data_dir.clone(),
+            &project,
+            self.users_storage.get()?.as_ref(),
+        ) {
+            Ok(repo) => Ok(Some(repo)),
+            Err(gb_repository::Error::ProjectPathNotFound(_)) => Ok(None),
+            Err(e) => Err(anyhow::anyhow!("failed to open repository: {:#}", e)),
+        }?;
 
-                let project_id = project.id.clone();
-                if let Err(error) = self.watchers.stop(&project_id).await {
-                    tracing::error!(project_id, ?error, "failed to stop watcher for project",);
-                }
-
-                if let Some(gb_repository) = gb_repository {
-                    if let Err(error) = gb_repository.purge() {
-                        tracing::error!(
-                            project_id = project.id,
-                            ?error,
-                            "failed to remove project dir"
-                        );
-                    }
-                }
-
-                self.projects_storage
-                    .purge(&project.id)
-                    .context("failed to purge project")?;
-
-                Ok(())
-            }
-            None => Ok(()),
+        let project_id = project.id.clone();
+        if let Err(error) = self.watchers.stop(&project_id).await {
+            tracing::error!(project_id, ?error, "failed to stop watcher for project",);
         }
+
+        if let Some(gb_repository) = gb_repository {
+            if let Err(error) = gb_repository.purge() {
+                tracing::error!(
+                    project_id = project.id,
+                    ?error,
+                    "failed to remove project dir"
+                );
+            }
+        }
+
+        self.projects_storage
+            .purge(&project.id)
+            .context("failed to purge project")?;
+
+        Ok(())
     }
 
     pub fn list_sessions(
@@ -217,9 +203,8 @@ impl App {
         let user = self.users_storage.get()?;
         let project = self
             .projects_storage
-            .get_project(project_id)
-            .context("failed to get project")?
-            .ok_or_else(|| anyhow::anyhow!("project {} not found", project_id))?;
+            .get(project_id)
+            .context("failed to get project")?;
 
         let gb_repo =
             gb_repository::Repository::open(&self.local_data_dir, &project, user.as_ref())
@@ -232,7 +217,7 @@ impl App {
     }
 
     pub fn mark_resolved(&self, project_id: &str, path: &str) -> Result<()> {
-        let project = self.gb_project(project_id)?;
+        let project = self.projects_storage.get(project_id)?;
         let project_repository = project_repository::Repository::open(&project)
             .context("failed to open project repository")?;
         // mark file as resolved
@@ -241,7 +226,7 @@ impl App {
     }
 
     pub fn fetch_from_target(&self, project_id: &str) -> Result<(), Error> {
-        let project = self.gb_project(project_id)?;
+        let project = self.projects_storage.get(project_id)?;
         let project_repository = project_repository::Repository::open(&project)
             .context("failed to open project repository")?;
         let user = self.users_storage.get()?;
@@ -282,7 +267,7 @@ impl App {
     pub async fn upsert_bookmark(&self, bookmark: &bookmarks::Bookmark) -> Result<()> {
         {
             let user = self.users_storage.get()?;
-            let project = self.gb_project(&bookmark.project_id)?;
+            let project = self.projects_storage.get(&bookmark.project_id)?;
             let gb_repository =
                 gb_repository::Repository::open(&self.local_data_dir, &project, user.as_ref())?;
             let writer = bookmarks::Writer::new(&gb_repository).context("failed to open writer")?;
@@ -324,7 +309,7 @@ impl App {
         project_id: &str,
         context_lines: u32,
     ) -> Result<HashMap<path::PathBuf, String>> {
-        let project = self.gb_project(project_id)?;
+        let project = self.projects_storage.get(project_id)?;
         let project_repository = project_repository::Repository::open(&project)
             .context("failed to open project repository")?;
 
@@ -353,7 +338,7 @@ impl App {
     }
 
     pub fn git_remote_branches(&self, project_id: &str) -> Result<Vec<git::RemoteBranchName>> {
-        let project = self.gb_project(project_id)?;
+        let project = self.projects_storage.get(project_id)?;
         let project_repository = project_repository::Repository::open(&project)
             .context("failed to open project repository")?;
         project_repository.git_remote_branches()
@@ -364,7 +349,7 @@ impl App {
         project_id: &str,
     ) -> Result<Vec<virtual_branches::RemoteBranch>> {
         let user = self.users_storage.get()?;
-        let project = self.gb_project(project_id)?;
+        let project = self.projects_storage.get(project_id)?;
         let gb_repository =
             gb_repository::Repository::open(&self.local_data_dir, &project, user.as_ref())
                 .context("failed to open gb repo")?;
@@ -374,7 +359,7 @@ impl App {
     }
 
     pub fn git_head(&self, project_id: &str) -> Result<String> {
-        let project = self.gb_project(project_id)?;
+        let project = self.projects_storage.get(project_id)?;
         let project_repository = project_repository::Repository::open(&project)
             .context("failed to open project repository")?;
         let head = project_repository.get_head()?;
@@ -404,7 +389,7 @@ impl App {
 
     pub fn git_gb_push(&self, project_id: &str) -> Result<()> {
         let user = self.users_storage.get()?;
-        let project = self.gb_project(project_id)?;
+        let project = self.projects_storage.get(project_id)?;
         let gb_repository =
             gb_repository::Repository::open(&self.local_data_dir, &project, user.as_ref())
                 .context("failed to open gb repo")?;

--- a/packages/tauri/src/commands.rs
+++ b/packages/tauri/src/commands.rs
@@ -17,9 +17,7 @@ pub async fn get_project_archive_path(
     project_id: &str,
 ) -> Result<String, Error> {
     let app = handle.state::<app::App>();
-    let project = app
-        .get_project(project_id)?
-        .context("failed to get project")?;
+    let project = app.get_project(project_id)?;
 
     let zipper = handle.state::<zip::Zipper>();
     let zipped_logs = zipper.zip(project.path)?;
@@ -178,10 +176,7 @@ pub async fn add_project(
 
 #[tauri::command(async)]
 #[instrument(skip(handle))]
-pub async fn get_project(
-    handle: tauri::AppHandle,
-    id: &str,
-) -> Result<Option<projects::Project>, Error> {
+pub async fn get_project(handle: tauri::AppHandle, id: &str) -> Result<projects::Project, Error> {
     let app = handle.state::<app::App>();
     let project = app.get_project(id)?;
     Ok(project)

--- a/packages/tauri/src/gb_repository/repository_tests.rs
+++ b/packages/tauri/src/gb_repository/repository_tests.rs
@@ -205,13 +205,11 @@ fn test_remote_syncronization() -> Result<()> {
         path::PathBuf::from("test.txt"),
         "Hello World",
     )]));
-    suite
-        .projects_storage
-        .update_project(&projects::UpdateRequest {
-            id: case_one.project.id.clone(),
-            api: Some(api_project.clone()),
-            ..Default::default()
-        })?;
+    suite.projects_storage.update(&projects::UpdateRequest {
+        id: case_one.project.id.clone(),
+        api: Some(api_project.clone()),
+        ..Default::default()
+    })?;
     case_one.refresh();
 
     let writer = deltas::Writer::new(&case_one.gb_repository);
@@ -227,13 +225,11 @@ fn test_remote_syncronization() -> Result<()> {
 
     // create second local project, fetch it and make sure session is there
     let mut case_two = suite.new_case();
-    suite
-        .projects_storage
-        .update_project(&projects::UpdateRequest {
-            id: case_two.project.id.clone(),
-            api: Some(api_project.clone()),
-            ..Default::default()
-        })?;
+    suite.projects_storage.update(&projects::UpdateRequest {
+        id: case_two.project.id.clone(),
+        api: Some(api_project.clone()),
+        ..Default::default()
+    })?;
     case_two.refresh();
 
     case_two.gb_repository.fetch(Some(&user))?;
@@ -285,23 +281,19 @@ fn test_remote_sync_order() -> Result<()> {
     let suite = Suite::default();
 
     let mut case_one = suite.new_case();
-    suite
-        .projects_storage
-        .update_project(&projects::UpdateRequest {
-            id: case_one.project.id.clone(),
-            api: Some(api_project.clone()),
-            ..Default::default()
-        })?;
+    suite.projects_storage.update(&projects::UpdateRequest {
+        id: case_one.project.id.clone(),
+        api: Some(api_project.clone()),
+        ..Default::default()
+    })?;
     case_one.refresh();
 
     let mut case_two = suite.new_case();
-    suite
-        .projects_storage
-        .update_project(&projects::UpdateRequest {
-            id: case_two.project.id.clone(),
-            api: Some(api_project.clone()),
-            ..Default::default()
-        })?;
+    suite.projects_storage.update(&projects::UpdateRequest {
+        id: case_two.project.id.clone(),
+        api: Some(api_project.clone()),
+        ..Default::default()
+    })?;
     case_two.refresh();
 
     let user = suite.sign_in();

--- a/packages/tauri/src/test_utils.rs
+++ b/packages/tauri/src/test_utils.rs
@@ -62,7 +62,7 @@ impl Suite {
     fn case_from_repository(&self, repository: git::Repository) -> Case {
         let project = projects::Project::try_from(&repository).expect("failed to create project");
         self.projects_storage
-            .add_project(&project)
+            .add(&project)
             .expect("failed to add project");
         let project_repository = project_repository::Repository::open(&project)
             .expect("failed to create project repository");
@@ -89,9 +89,8 @@ impl Case<'_> {
         self.project = self
             .suite
             .projects_storage
-            .get_project(&self.project.id)
-            .expect("failed to get project")
-            .expect("project not found");
+            .get(&self.project.id)
+            .expect("failed to get project");
         self.project_repository = project_repository::Repository::open(&self.project)
             .expect("failed to create project repository");
         self.gb_repository =

--- a/packages/tauri/src/virtual_branches/controller.rs
+++ b/packages/tauri/src/virtual_branches/controller.rs
@@ -107,9 +107,8 @@ impl Controller {
     ) -> Result<bool, Error> {
         let project = self
             .projects_storage
-            .get_project(project_id)
-            .context("failed to get project")?
-            .context("project not found")?;
+            .get(project_id)
+            .context("failed to get project")?;
         let project_repository = project_repository::Repository::open(&project)
             .context("failed to open project repository")?;
         let user = self.users_storage.get().context("failed to get user")?;
@@ -128,9 +127,8 @@ impl Controller {
     ) -> Result<bool, Error> {
         let project = self
             .projects_storage
-            .get_project(project_id)
-            .context("failed to get project")?
-            .context("project not found")?;
+            .get(project_id)
+            .context("failed to get project")?;
         let project_repository = project_repository::Repository::open(&project)
             .context("failed to open project repository")?;
         let user = self.users_storage.get().context("failed to get user")?;
@@ -223,9 +221,8 @@ impl Controller {
     ) -> Result<Option<super::BaseBranch>, Error> {
         let project = self
             .projects_storage
-            .get_project(project_id)
-            .context("failed to get project")?
-            .context("project not found")?;
+            .get(project_id)
+            .context("failed to get project")?;
         let project_repository = project_repository::Repository::open(&project)
             .context("failed to open project repository")?;
         let user = self.users_storage.get().context("failed to get user")?;
@@ -248,9 +245,8 @@ impl Controller {
     ) -> Result<Vec<RemoteBranchFile>, Error> {
         let project = self
             .projects_storage
-            .get_project(project_id)
-            .context("failed to get project")?
-            .context("project not found")?;
+            .get(project_id)
+            .context("failed to get project")?;
         let project_repository = project_repository::Repository::open(&project)
             .context("failed to open project repository")?;
         let commit = project_repository
@@ -268,9 +264,8 @@ impl Controller {
     ) -> Result<super::BaseBranch, Error> {
         let project = self
             .projects_storage
-            .get_project(project_id)
-            .context("failed to get project")?
-            .context("project not found")?;
+            .get(project_id)
+            .context("failed to get project")?;
 
         let user = self.users_storage.get().context("failed to get user")?;
 
@@ -479,9 +474,8 @@ impl Controller {
     ) -> Result<T, Error> {
         let project = self
             .projects_storage
-            .get_project(project_id)
-            .context("failed to get project")?
-            .context("project not found")?;
+            .get(project_id)
+            .context("failed to get project")?;
         let project_repository = project_repository::Repository::open(&project)
             .context("failed to open project repository")?;
         let user = self.users_storage.get().context("failed to get user")?;

--- a/packages/tauri/src/watcher/handlers/fetch_gitbutler_data.rs
+++ b/packages/tauri/src/watcher/handlers/fetch_gitbutler_data.rs
@@ -70,7 +70,7 @@ impl HandlerInner {
 
         // mark fetching
         self.project_storage
-            .update_project(&projects::UpdateRequest {
+            .update(&projects::UpdateRequest {
                 id: project_id.to_string(),
                 gitbutler_data_last_fetched: Some(projects::FetchResult::Fetching {
                     timestamp_ms: now.duration_since(time::UNIX_EPOCH)?.as_millis(),
@@ -81,9 +81,8 @@ impl HandlerInner {
 
         let project = self
             .project_storage
-            .get_project(project_id)
-            .context("failed to get project")?
-            .ok_or_else(|| anyhow::anyhow!("project not found"))?;
+            .get(project_id)
+            .context("failed to get project")?;
 
         let gb_repo =
             gb_repository::Repository::open(self.local_data_dir.clone(), &project, user.as_ref())
@@ -115,7 +114,7 @@ impl HandlerInner {
         };
 
         self.project_storage
-            .update_project(&projects::UpdateRequest {
+            .update(&projects::UpdateRequest {
                 id: project_id.to_string(),
                 gitbutler_data_last_fetched: Some(fetch_result),
                 ..Default::default()

--- a/packages/tauri/src/watcher/handlers/fetch_project_data.rs
+++ b/packages/tauri/src/watcher/handlers/fetch_project_data.rs
@@ -75,7 +75,7 @@ impl HandlerInner {
 
         // mark fetching
         self.project_storage
-            .update_project(&projects::UpdateRequest {
+            .update(&projects::UpdateRequest {
                 id: project_id.to_string(),
                 project_data_last_fetched: Some(projects::FetchResult::Fetching {
                     timestamp_ms: now.duration_since(time::UNIX_EPOCH)?.as_millis(),
@@ -86,9 +86,8 @@ impl HandlerInner {
 
         let project = self
             .project_storage
-            .get_project(project_id)
-            .context("failed to get project")?
-            .ok_or_else(|| anyhow::anyhow!("project not found"))?;
+            .get(project_id)
+            .context("failed to get project")?;
 
         let gb_repo =
             gb_repository::Repository::open(self.local_data_dir.clone(), &project, user.as_ref())
@@ -132,7 +131,7 @@ impl HandlerInner {
             };
 
         self.project_storage
-            .update_project(&projects::UpdateRequest {
+            .update(&projects::UpdateRequest {
                 id: project_id.to_string(),
                 project_data_last_fetched: Some(fetch_result),
                 ..Default::default()

--- a/packages/tauri/src/watcher/handlers/flush_session.rs
+++ b/packages/tauri/src/watcher/handlers/flush_session.rs
@@ -1,6 +1,6 @@
 use std::path;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use tauri::AppHandle;
 
 use crate::{gb_repository, project_repository, projects, sessions, users};
@@ -38,9 +38,8 @@ impl Handler {
     ) -> Result<Vec<events::Event>> {
         let project = self
             .project_store
-            .get_project(project_id)
-            .context("failed to get project")?
-            .ok_or_else(|| anyhow!("project not found"))?;
+            .get(project_id)
+            .context("failed to get project")?;
 
         let user = self.user_store.get()?;
 

--- a/packages/tauri/src/watcher/handlers/git_file_change.rs
+++ b/packages/tauri/src/watcher/handlers/git_file_change.rs
@@ -27,13 +27,8 @@ impl Handler {
     ) -> Result<Vec<events::Event>> {
         let project = self
             .project_store
-            .get_project(project_id)
+            .get(project_id)
             .context("failed to get project")?;
-
-        if project.is_none() {
-            return Err(anyhow::anyhow!("project not found"));
-        }
-        let project = project.unwrap();
 
         let project_repository = project_repository::Repository::open(&project)
             .with_context(|| "failed to open project repository for project")?;

--- a/packages/tauri/src/watcher/handlers/index_handler.rs
+++ b/packages/tauri/src/watcher/handlers/index_handler.rs
@@ -72,10 +72,7 @@ impl Handler {
 
     pub fn reindex(&self, project_id: &str) -> Result<Vec<events::Event>> {
         let user = self.user_store.get()?;
-        let project = self
-            .project_store
-            .get_project(project_id)?
-            .context(format!("failed to get project with id {}", project_id))?;
+        let project = self.project_store.get(project_id)?;
 
         let gb_repository =
             gb_repository::Repository::open(self.local_data_dir.clone(), &project, user.as_ref())
@@ -95,10 +92,7 @@ impl Handler {
         session: &sessions::Session,
     ) -> Result<Vec<events::Event>> {
         let user = self.user_store.get()?;
-        let project = self
-            .project_store
-            .get_project(project_id)?
-            .context(format!("failed to get project with id {}", project_id))?;
+        let project = self.project_store.get(project_id)?;
 
         let gb_repository =
             gb_repository::Repository::open(self.local_data_dir.clone(), &project, user.as_ref())

--- a/packages/tauri/src/watcher/handlers/project_file_change.rs
+++ b/packages/tauri/src/watcher/handlers/project_file_change.rs
@@ -89,9 +89,8 @@ impl Handler {
     ) -> Result<Vec<events::Event>> {
         let project = self
             .project_store
-            .get_project(project_id)
-            .context("failed to get project")?
-            .ok_or_else(|| anyhow::anyhow!("project not found"))?;
+            .get(project_id)
+            .context("failed to get project")?;
 
         let project_repository = project_repository::Repository::open(&project)
             .with_context(|| "failed to open project repository for project")?;

--- a/packages/tauri/src/watcher/handlers/push_gitbutler_data.rs
+++ b/packages/tauri/src/watcher/handlers/push_gitbutler_data.rs
@@ -78,10 +78,7 @@ impl HandlerInner {
         };
 
         let user = self.user_storage.get()?;
-        let project = self
-            .project_storage
-            .get_project(project_id)?
-            .context("project not found")?;
+        let project = self.project_storage.get(project_id)?;
 
         let gb_repo =
             gb_repository::Repository::open(&self.local_data_dir, &project, user.as_ref())

--- a/packages/tauri/src/watcher/handlers/tick_handler.rs
+++ b/packages/tauri/src/watcher/handlers/tick_handler.rs
@@ -36,10 +36,7 @@ impl Handler {
     pub fn handle(&self, project_id: &str, now: &time::SystemTime) -> Result<Vec<events::Event>> {
         let user = self.user_store.get()?;
 
-        let project = match self.project_store.get_project(project_id)? {
-            None => return Ok(vec![]),
-            Some(project) => project,
-        };
+        let project = self.project_store.get(project_id)?;
 
         let gb_repo =
             gb_repository::Repository::open(&self.local_data_dir, &project, user.as_ref())


### PR DESCRIPTION
… simplify code

The changes in this commit refactor the methods in the `projects_storage` module to use consistent naming and simplify the code. The following changes were made:

- Renamed the `update_project` method to `update` in the `projects_storage` module.
- Renamed the `add_project` method to `add` in the `projects_storage` module.
- Renamed the `get_project` method to `get` in the `projects_storage` module.
- Renamed the `list_projects` method to `list` in the `projects_storage` module.

These changes improve code readability and maintainability by using consistent naming conventions and simplifying the method signatures.