### PR TITLE
fix: update svelte-store dependency to version 4cf861db334188389186a6…

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -42,7 +42,7 @@
 		"@lezer/highlight": "^1.1.6",
 		"@replit/codemirror-lang-svelte": "^6.0.0",
 		"@sentry/sveltekit": "^7.73.0",
-		"@square/svelte-store": "git+https://git@github.com/gitbutlerapp/svelte-store.git#5f54d113be638e5383965907333d50213dd4e05e",
+		"@square/svelte-store": "git+https://git@github.com/gitbutlerapp/svelte-store.git#4cf861db334188389186a6f41ddfc1ba157b4ffd",
 		"@sveltejs/adapter-static": "^2.0.3",
 		"@sveltejs/kit": "^1.24.1",
 		"@tauri-apps/api": "^1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: ^7.73.0
         version: 7.73.0(@sveltejs/kit@1.24.1)(svelte@4.2.1)
       '@square/svelte-store':
-        specifier: git+https://git@github.com/gitbutlerapp/svelte-store.git#5f54d113be638e5383965907333d50213dd4e05e
-        version: git@github.com+gitbutlerapp/svelte-store/5f54d113be638e5383965907333d50213dd4e05e(svelte@4.2.1)
+        specifier: git+https://git@github.com/gitbutlerapp/svelte-store.git#4cf861db334188389186a6f41ddfc1ba157b4ffd
+        version: github.com/gitbutlerapp/svelte-store/4cf861db334188389186a6f41ddfc1ba157b4ffd(svelte@4.2.1)
       '@sveltejs/adapter-static':
         specifier: ^2.0.3
         version: 2.0.3(@sveltejs/kit@1.24.1)
@@ -5452,13 +5452,13 @@ packages:
     engines: {node: '>=12.20'}
     dev: true
 
-  git@github.com+gitbutlerapp/svelte-store/5f54d113be638e5383965907333d50213dd4e05e(svelte@4.2.1):
-    resolution: {commit: 5f54d113be638e5383965907333d50213dd4e05e, repo: git@github.com:gitbutlerapp/svelte-store.git, type: git}
-    id: git@github.com+gitbutlerapp/svelte-store/5f54d113be638e5383965907333d50213dd4e05e
+  github.com/gitbutlerapp/svelte-store/4cf861db334188389186a6f41ddfc1ba157b4ffd(svelte@4.2.1):
+    resolution: {tarball: https://codeload.github.com/gitbutlerapp/svelte-store/tar.gz/4cf861db334188389186a6f41ddfc1ba157b4ffd}
+    id: github.com/gitbutlerapp/svelte-store/4cf861db334188389186a6f41ddfc1ba157b4ffd
     name: '@square/svelte-store'
     version: 1.0.17
     peerDependencies:
-      svelte: ^4.0.0
+      svelte: ^3.0.0
     dependencies:
       cookie-storage: 6.1.0
       svelte: 4.2.1


### PR DESCRIPTION
…f41ddfc1ba157 — something was broken with the new one

Getting this issue otherwise:
![Screenshot 2023-10-07 at 00 06 46](https://github.com/gitbutlerapp/gitbutler-client/assets/4030927/7479a3d0-4203-479f-aa5a-99e35c4e5b2e)
