### PR TITLE
feat: update set_user function to return the updated user object

### DIFF
--- a/packages/ui/src/lib/api/ipc/users.ts
+++ b/packages/ui/src/lib/api/ipc/users.ts
@@ -6,7 +6,7 @@ export async function get() {
 }
 
 export async function set(params: { user: User }) {
-	invoke<void>('set_user', params);
+	return invoke<User>('set_user', params);
 }
 
 const del = () => invoke<void>('delete_user');

--- a/packages/ui/src/lib/stores/user.ts
+++ b/packages/ui/src/lib/stores/user.ts
@@ -4,8 +4,8 @@ import { asyncWritable } from '@square/svelte-store';
 export const userStore = asyncWritable([], users.get, async (user) => {
 	if (user === null) {
 		await users.delete();
+		return null;
 	} else {
-		await users.set({ user });
+		return await users.set({ user });
 	}
-	return user;
 });


### PR DESCRIPTION
The `set_user` function in the client code has been updated to return the updated user object after setting it in the app. This change allows for better handling of the user object and enables further operations on it if needed. The updated function now returns a `Result<User, Error>` instead of `Result<(), Error>`.