### PR TITLE
use backoff while fetching data in background

### DIFF
--- a/packages/butler/src/commands/info.rs
+++ b/packages/butler/src/commands/info.rs
@@ -38,11 +38,11 @@ impl super::RunCommand for Info {
         );
         println!(
             "  project_data_last_fetched: {:?}",
-            app.project().project_data_last_fetched
+            app.project().project_data_last_fetch
         );
         println!(
             "  project_gitbutler_data_last_fetched: {:?}",
-            app.project().gitbutler_data_last_fetched
+            app.project().gitbutler_data_last_fetch
         );
         println!(
             "  path: {}",

--- a/packages/tauri/src/projects/storage.rs
+++ b/packages/tauri/src/projects/storage.rs
@@ -110,13 +110,13 @@ impl Storage {
         }
 
         if let Some(project_data_last_fetched) = update_request.project_data_last_fetched.as_ref() {
-            project.project_data_last_fetched = Some(project_data_last_fetched.clone());
+            project.project_data_last_fetch = Some(project_data_last_fetched.clone());
         }
 
         if let Some(gitbutler_data_last_fetched) =
             update_request.gitbutler_data_last_fetched.as_ref()
         {
-            project.gitbutler_data_last_fetched = Some(gitbutler_data_last_fetched.clone());
+            project.gitbutler_data_last_fetch = Some(gitbutler_data_last_fetched.clone());
         }
 
         self.storage

--- a/packages/tauri/src/watcher/handlers/fetch_gitbutler_data.rs
+++ b/packages/tauri/src/watcher/handlers/fetch_gitbutler_data.rs
@@ -86,17 +86,6 @@ impl HandlerInner {
             anyhow::bail!("sync disabled");
         }
 
-        // mark fetching
-        self.projects
-            .update(&projects::UpdateRequest {
-                id: *project_id,
-                gitbutler_data_last_fetched: Some(projects::FetchResult::Fetching {
-                    timestamp_ms: now.duration_since(time::UNIX_EPOCH)?.as_millis(),
-                }),
-                ..Default::default()
-            })
-            .context("failed to mark project as fetching")?;
-
         let project_repository = project_repository::Repository::try_from(&project)
             .context("failed to open repository")?;
         let gb_repo = gb_repository::Repository::open(
@@ -111,24 +100,23 @@ impl HandlerInner {
             .filter_map(Result::ok)
             .collect::<Vec<_>>();
 
-        let fetch_result = if let Err(error) = gb_repo.fetch(user.as_ref()) {
-            tracing::error!(%project_id, ?error, "failed to fetch gitbutler data");
+        let policy = backoff::ExponentialBackoffBuilder::new()
+            .with_max_elapsed_time(Some(time::Duration::from_secs(10 * 60)))
+            .build();
+
+        let fetch_result = if let Err(error) = backoff::retry(policy, || {
+            gb_repo.fetch(user.as_ref()).map_err(|err| {
+                tracing::warn!(%project_id, ?err, will_retry=true, "failed to fetch gitbutler data" );
+                backoff::Error::transient(err)
+            })
+        }) {
+            tracing::error!(%project_id, ?error, will_retry=false, "failed to fetch gitbutler data");
             projects::FetchResult::Error {
-                attempt: project
-                    .gitbutler_data_last_fetched
-                    .as_ref()
-                    .map_or(0, |r| match r {
-                        projects::FetchResult::Error { attempt, .. } => *attempt + 1,
-                        projects::FetchResult::Fetched { .. } => 0,
-                        projects::FetchResult::Fetching { .. } => 0,
-                    }),
-                timestamp_ms: now.duration_since(time::UNIX_EPOCH)?.as_millis(),
+                timestamp: *now,
                 error: error.to_string(),
             }
         } else {
-            projects::FetchResult::Fetched {
-                timestamp_ms: now.duration_since(time::UNIX_EPOCH)?.as_millis(),
-            }
+            projects::FetchResult::Fetched { timestamp: *now }
         };
 
         self.projects


### PR DESCRIPTION
instead of tracking intervals via saving sate to disk, have one thread to fetch using backoff policy, and restart the thread every 30 min