### PR TITLE
cleanup PostHog dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,7 +1968,6 @@ dependencies = [
  "notify",
  "num_cpus",
  "once_cell",
- "posthog-rs",
  "pretty_assertions",
  "r2d2",
  "r2d2_sqlite",
@@ -3874,18 +3873,6 @@ dependencies = [
  "log",
  "pin-project-lite",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "posthog-rs"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad1b35ffe50419992615288c40ee90fbf30da4c6faf251414675ea64e1cdfa3"
-dependencies = [
- "chrono",
- "reqwest",
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/packages/tauri/Cargo.toml
+++ b/packages/tauri/Cargo.toml
@@ -18,7 +18,7 @@ async-trait = "0.1.73"
 backoff = "0.4.0"
 bstr = "1.6.2"
 byteorder = "1.4.3"
-chrono = "0.4.29"
+chrono = { version = "0.4.29", features = ["serde"] }
 console-subscriber = "0.2.0"
 diffy = "0.3.0"
 filetime = "0.2.22"
@@ -27,7 +27,6 @@ git2 = { version = "0.18.1", features = ["vendored-openssl", "vendored-libgit2"]
 md5 = "0.7.0"
 notify = { version = "6.0.1" }
 num_cpus = "1.16.0"
-posthog-rs = "0.2.2"
 r2d2 = "0.8.10"
 r2d2_sqlite = "0.22.0"
 rand = "0.8.5"


### PR DESCRIPTION
cleanup since we have a handcrafted posthog implementation and this cargo dep only made sure chrono has the feature `serde` enabled