### PR TITLE
check unused dependencies in ci

### DIFF
--- a/.github/actions/init-env-rust/action.yaml
+++ b/.github/actions/init-env-rust/action.yaml
@@ -1,13 +1,17 @@
 name: init-rust
 description: prepare runner for rust related tasks
+inputs:
+  rust:
+    description: 'rust version'
+    required: false
+    default: 'stable'
 runs:
   using: "composite"
   steps:
-    - name: Install latest stable rust
-      uses: actions-rs/toolchain@v1
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
       with:
-        override: true
-        toolchain: stable
+        toolchain: ${{ inputs.rust }}
         components: rustfmt, clippy
 
     - name: Cache rust dependencies

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -92,6 +92,7 @@ jobs:
       - uses: ./.github/actions/init-env-rust
         with:
           rust: "nightly"
-      - run: cargo install cargo-udeps --locked
+      - name: install cargo udeps
+        run: cargo install cargo-udeps --locked
       - run: pnpm build
       - run: cargo +nightly udeps --all-targets

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -92,7 +92,7 @@ jobs:
       - uses: ./.github/actions/init-env-rust
         with:
           rust: "nightly"
-      - name: install cargo udeps
+      - name: Install cargo udeps
         run: cargo install cargo-udeps --locked
       - run: pnpm build
       - run: cargo +nightly udeps --all-targets

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -88,8 +88,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust Nightly
-        uses: dtolnay/rust-toolchain@nightly
+      - uses: ./.github/actions/init-env-rust
+        with:
+          rust: "nightly"
       - name: Install cargo-udeps
         env:
           UDEPS_VERSION: v0.1.42

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -101,4 +101,5 @@ jobs:
           mv cargo-udeps ~/.cargo/bin/
           cargo-udeps help
           cargo udeps -V
+      - run: mkdir -p packages/ui/build
       - run: cargo +nightly udeps --all-targets

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -101,5 +101,5 @@ jobs:
           mv cargo-udeps ~/.cargo/bin/
           cargo-udeps help
           cargo udeps -V
-      - run: mkdir -p packages/ui/build
+      - run: pnpm build
       - run: cargo +nightly udeps --all-targets

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -81,3 +81,22 @@ jobs:
       - run: pnpm build
       - run: cargo clippy --all-features --tests
       - run: cargo test --locked
+
+  udeps:
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust Nightly
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Install cargo-udeps
+        env:
+          UDEPS_VERSION: v0.1.42
+        run: |
+          wget -qO- https://github.com/est31/cargo-udeps/releases/download/${UDEPS_VERSION}/cargo-udeps-${UDEPS_VERSION}-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
+          cd cargo-udeps-${UDEPS_VERSION}-x86_64-unknown-linux-gnu
+          mv cargo-udeps ~/.cargo/bin/
+          cargo-udeps help
+          cargo udeps -V
+      - run: cargo +nightly udeps --all-targets

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -92,14 +92,6 @@ jobs:
       - uses: ./.github/actions/init-env-rust
         with:
           rust: "nightly"
-      - name: Install cargo-udeps
-        env:
-          UDEPS_VERSION: v0.1.42
-        run: |
-          wget -qO- https://github.com/est31/cargo-udeps/releases/download/${UDEPS_VERSION}/cargo-udeps-${UDEPS_VERSION}-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
-          cd cargo-udeps-${UDEPS_VERSION}-x86_64-unknown-linux-gnu
-          mv cargo-udeps ~/.cargo/bin/
-          cargo-udeps help
-          cargo udeps -V
+      - run: cargo install cargo-udeps --locked
       - run: pnpm build
       - run: cargo +nightly udeps --all-targets

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -88,6 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/init-env-node
       - uses: ./.github/actions/init-env-rust
         with:
           rust: "nightly"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,30 +933,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crash-context"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b85cef661eeca0c6675116310936972c520ebb0a33ddef16fd7efc957f4c1288"
-dependencies = [
- "cfg-if",
- "libc",
- "mach2",
-]
-
-[[package]]
-name = "crash-handler"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ddb8d457c6c6c6d0ebeeadb3b3f4b246c39ed83b0d3393f91bf06a5b79b05"
-dependencies = [
- "cfg-if",
- "crash-context",
- "libc",
- "mach2",
- "parking_lot",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1414,17 +1390,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "enum-primitive-derive"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c375b9c5eadb68d0a6efee2999fef292f45854c3444c86f09d8ab086ba942b0e"
-dependencies = [
- "num-traits",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1978,7 +1943,6 @@ dependencies = [
  "rusqlite",
  "rustix 0.38.13",
  "sentry",
- "sentry-rust-minidump",
  "sentry-tracing",
  "serde",
  "serde-jsonlines",
@@ -2079,17 +2043,6 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps 6.1.1",
-]
-
-[[package]]
-name = "goblin"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27c1b4369c2cd341b5de549380158b105a04c331be5db9110eef7b6d2742134"
-dependencies = [
- "log",
- "plain",
- "scroll",
 ]
 
 [[package]]
@@ -2914,15 +2867,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
-name = "mach2"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3010,15 +2954,6 @@ checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "memmap2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "memmap2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d28bba84adfe6646737845bc5ebbfa2c08424eb1c37e94a1fd2a82adb56a872"
@@ -3049,74 +2984,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "minidump-common"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9114b15d86ee5e5c3e3b4d05821d17237adbf98c11dd07fc8f5a9b037a010ee5"
-dependencies = [
- "bitflags 1.3.2",
- "debugid",
- "enum-primitive-derive",
- "num-traits",
- "range-map",
- "scroll",
- "smart-default",
-]
-
-[[package]]
-name = "minidump-writer"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9301e0f1b08ad0b310f40f92bffb40834461542a472a98814bc6cbb7f43f567"
-dependencies = [
- "bitflags 2.4.0",
- "byteorder",
- "cfg-if",
- "crash-context",
- "goblin",
- "libc",
- "mach2",
- "memmap2 0.5.10",
- "memoffset 0.9.0",
- "minidump-common",
- "nix",
- "procfs-core",
- "scroll",
- "tempfile",
- "thiserror",
-]
-
-[[package]]
-name = "minidumper"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261916bd44ec98562f8573f5e882ca08b1fea717b20bee95b6b39ad024869f97"
-dependencies = [
- "cfg-if",
- "crash-context",
- "libc",
- "log",
- "minidump-writer",
- "parking_lot",
- "polling",
- "scroll",
- "thiserror",
- "uds",
-]
-
-[[package]]
-name = "minidumper-child"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "409df6a030ca1b1f3e64a08eb16282566621db3b9839db2fe323e67ddda7e54b"
-dependencies = [
- "crash-handler",
- "minidumper",
- "thiserror",
- "uuid",
-]
 
 [[package]]
 name = "minimal-lexical"
@@ -3821,12 +3688,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
 name = "platforms"
 version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3953,17 +3814,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "procfs-core"
-version = "0.16.0-RC1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee00a90a41543fce203e6a8771bad043bfd6d88de8fd4e3118435a233d0c3c4"
-dependencies = [
- "bitflags 2.4.0",
- "chrono",
- "hex",
 ]
 
 [[package]]
@@ -4117,15 +3967,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "range-map"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a5a2d6c7039059af621472a4389be1215a816df61aa4d531cfe85264aee95f"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -4507,26 +4348,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scroll"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
-dependencies = [
- "scroll_derive",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.31",
-]
-
-[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4681,17 +4502,6 @@ checksum = "875b69f506da75bd664029eafb05f8934297d2990192896d17325f066bd665b7"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
-]
-
-[[package]]
-name = "sentry-rust-minidump"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac50b382465f5c6f26e7088e811ad791e835bacee951a0ea831a1cacd0a5cc15"
-dependencies = [
- "minidumper-child",
- "sentry",
- "thiserror",
 ]
 
 [[package]]
@@ -4976,17 +4786,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
-name = "smart-default"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "socket2"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5251,7 +5050,7 @@ dependencies = [
  "lru",
  "lz4_flex",
  "measure_time",
- "memmap2 0.6.2",
+ "memmap2",
  "murmurhash32",
  "num_cpus",
  "once_cell",
@@ -6046,15 +5845,6 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
-
-[[package]]
-name = "uds"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26095fa6d0208163cb66162d4b016c8f273226af3191ce651d6482ca760c31e7"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "uds_windows"

--- a/packages/tauri/Cargo.toml
+++ b/packages/tauri/Cargo.toml
@@ -36,7 +36,6 @@ resolve-path = "0.1.0"
 rusqlite = { version = "0.29.0", features = [ "bundled", "blob" ] }
 rustix = "0.38"
 sentry = { version = "0.31", features = ["backtrace", "contexts", "panic", "transport", "anyhow", "debug-images", "reqwest", "native-tls" ] }
-sentry-rust-minidump = "0.6.4"
 sentry-tracing = "0.31.7"
 serde = { version = "1.0", features = ["derive"] }
 serde-jsonlines = "0.4.0"


### PR DESCRIPTION
* also fixes the ci warnings about `set-output` usage due to using a maintained action to install the rust toolchain