### PR TITLE
fix GB wildcard ref pushing

### DIFF
--- a/packages/tauri/src/git/repository.rs
+++ b/packages/tauri/src/git/repository.rs
@@ -397,6 +397,13 @@ impl Repository {
             .map(|iter| iter.map(|reference| reference.map(Into::into).map_err(Into::into)))
             .map_err(Into::into)
     }
+
+    pub fn references_glob(&self, glob: &str) -> Result<impl Iterator<Item = Result<Reference>>> {
+        self.0
+            .references_glob(glob)
+            .map(|iter| iter.map(|reference| reference.map(Into::into).map_err(Into::into)))
+            .map_err(Into::into)
+    }
 }
 
 pub struct CheckoutTreeBuidler<'a> {

--- a/packages/tauri/src/project_repository/repository.rs
+++ b/packages/tauri/src/project_repository/repository.rs
@@ -345,7 +345,7 @@ impl Repository {
     pub fn push_to_gitbutler_server(
         &self,
         user: Option<&users::User>,
-        ref_spec: &str,
+        ref_specs: &[&str],
     ) -> Result<(), RemoteError> {
         let url = self
             .project
@@ -390,12 +390,12 @@ impl Repository {
             .map_err(|e| RemoteError::Other(e.into()))?;
 
         remote
-            .push(&[ref_spec], Some(&mut push_options))
+            .push(ref_specs, Some(&mut push_options))
             .map_err(|e| RemoteError::Other(e.into()))?;
 
         tracing::debug!(
             project_id = %self.project.id,
-            %ref_spec,
+            ref_spec = ref_specs.join(" "),
             bytes = bytes_pushed.load(std::sync::atomic::Ordering::Relaxed),
             "pushed to gb repo tmp ref",
         );


### PR DESCRIPTION
workaround libgit2 limitation of not pushing wildcards: explicitly pushing all `ref/gitbutler/..` refs

see: https://github.com/libgit2/libgit2/issues/6404