### PR TITLE
not not try to push code to gb every tick

### DIFF
--- a/packages/tauri/src/projects/controller.rs
+++ b/packages/tauri/src/projects/controller.rs
@@ -1,4 +1,4 @@
-use std::{path, time};
+use std::path;
 
 use anyhow::Context;
 use futures::executor::block_on;
@@ -95,10 +95,9 @@ impl Controller {
         if let Some(watchers) = &self.watchers {
             if let Some(api) = &project.api {
                 if api.sync {
-                    if let Err(error) = block_on(watchers.post(watcher::Event::FetchGitbutlerData(
-                        project.id,
-                        time::SystemTime::now(),
-                    ))) {
+                    if let Err(error) =
+                        block_on(watchers.post(watcher::Event::FetchGitbutlerData(project.id)))
+                    {
                         tracing::error!(
                             project_id = %project.id,
                             ?error,

--- a/packages/tauri/src/projects/mod.rs
+++ b/packages/tauri/src/projects/mod.rs
@@ -4,5 +4,5 @@ mod project;
 mod storage;
 
 pub use controller::*;
-pub use project::{ApiProject, AuthKey, FetchResult, Project, ProjectId};
+pub use project::{ApiProject, AuthKey, CodePushState, FetchResult, Project, ProjectId};
 pub use storage::UpdateRequest;

--- a/packages/tauri/src/projects/project.rs
+++ b/packages/tauri/src/projects/project.rs
@@ -47,6 +47,12 @@ impl FetchResult {
     }
 }
 
+#[derive(Debug, Deserialize, Serialize, Copy, Clone)]
+pub struct CodePushState {
+    pub id: git::Oid,
+    pub timestamp: time::SystemTime,
+}
+
 pub type ProjectId = Id<Project>;
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
@@ -63,7 +69,7 @@ pub struct Project {
     #[serde(default)]
     pub gitbutler_data_last_fetch: Option<FetchResult>,
     #[serde(default)]
-    pub gitbutler_code_push: Option<git::Oid>,
+    pub gitbutler_code_push_state: Option<CodePushState>,
 }
 
 impl AsRef<Project> for Project {

--- a/packages/tauri/src/projects/storage.rs
+++ b/packages/tauri/src/projects/storage.rs
@@ -2,7 +2,6 @@ use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager};
 
 use crate::{
-    git,
     paths::DataDir,
     projects::{project, ProjectId},
     storage,
@@ -44,7 +43,7 @@ pub struct UpdateRequest {
     pub project_data_last_fetched: Option<project::FetchResult>,
     pub gitbutler_data_last_fetched: Option<project::FetchResult>,
     pub preferred_key: Option<project::AuthKey>,
-    pub gitbutler_code_push: Option<git::Oid>,
+    pub gitbutler_code_push_state: Option<project::CodePushState>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -121,8 +120,8 @@ impl Storage {
             project.gitbutler_data_last_fetch = Some(gitbutler_data_last_fetched.clone());
         }
 
-        if let Some(oid) = update_request.gitbutler_code_push {
-            project.gitbutler_code_push = Some(oid);
+        if let Some(state) = update_request.gitbutler_code_push_state {
+            project.gitbutler_code_push_state = Some(state);
         }
 
         self.storage

--- a/packages/tauri/src/watcher/dispatchers/tick.rs
+++ b/packages/tauri/src/watcher/dispatchers/tick.rs
@@ -44,10 +44,7 @@ impl Dispatcher {
                         if self.cancellation_token.is_cancelled() {
                             break;
                         }
-                        if let Err(error) = tx
-                            .send(events::Event::Tick(project_id, time::SystemTime::now()))
-                            .await
-                        {
+                        if let Err(error) = tx.send(events::Event::Tick(project_id)).await {
                             tracing::error!(%project_id, ?error, "failed to send tick");
                         }
                     }
@@ -80,7 +77,7 @@ mod tests {
 
         let mut count = 0_i32;
         while let Some(event) = rx.recv().await {
-            if let events::Event::Tick(_, _) = event {
+            if let events::Event::Tick(_) = event {
                 count += 1_i32;
             }
         }

--- a/packages/tauri/src/watcher/events.rs
+++ b/packages/tauri/src/watcher/events.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, path, time};
+use std::{fmt::Display, path};
 
 use crate::{
     analytics, bookmarks, deltas, events,
@@ -9,13 +9,13 @@ use crate::{
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Event {
-    Tick(ProjectId, time::SystemTime),
+    Tick(ProjectId),
     Flush(ProjectId, sessions::Session),
 
-    FetchGitbutlerData(ProjectId, time::SystemTime),
+    FetchGitbutlerData(ProjectId),
     PushGitbutlerData(ProjectId),
     PushProjectToGitbutler(ProjectId),
-    FetchProjectData(ProjectId, time::SystemTime),
+    FetchProjectData(ProjectId),
 
     GitFileChange(ProjectId, path::PathBuf),
 
@@ -38,10 +38,10 @@ impl Event {
             Event::Analytics(event) => event.project_id(),
             Event::Emit(event) => event.project_id(),
             Event::Bookmark(bookmark) => &bookmark.project_id,
-            Event::Tick(project_id, _)
+            Event::Tick(project_id)
             | Event::IndexAll(project_id)
-            | Event::FetchGitbutlerData(project_id, _)
-            | Event::FetchProjectData(project_id, _)
+            | Event::FetchGitbutlerData(project_id)
+            | Event::FetchProjectData(project_id)
             | Event::Flush(project_id, _)
             | Event::GitFileChange(project_id, _)
             | Event::ProjectFileChange(project_id, _)
@@ -59,27 +59,12 @@ impl Display for Event {
         match self {
             Event::Analytics(event) => write!(f, "Analytics({})", event),
             Event::Emit(event) => write!(f, "Emit({})", event.name()),
-            Event::Tick(project_id, ts) => write!(
-                f,
-                "Tick({}, {})",
-                project_id,
-                ts.duration_since(time::UNIX_EPOCH).unwrap().as_millis()
-            ),
-            Event::FetchGitbutlerData(pid, ts) => {
-                write!(
-                    f,
-                    "FetchGitbutlerData({}, {})",
-                    pid,
-                    ts.duration_since(time::UNIX_EPOCH).unwrap().as_millis()
-                )
+            Event::Tick(project_id) => write!(f, "Tick({})", project_id,),
+            Event::FetchGitbutlerData(pid) => {
+                write!(f, "FetchGitbutlerData({})", pid,)
             }
-            Event::FetchProjectData(pid, ts) => {
-                write!(
-                    f,
-                    "FetchProjectData({}, {})",
-                    pid,
-                    ts.duration_since(time::UNIX_EPOCH).unwrap().as_millis()
-                )
+            Event::FetchProjectData(pid) => {
+                write!(f, "FetchProjectData({})", pid,)
             }
             Event::Flush(project_id, session) => write!(f, "Flush({}, {})", project_id, session.id),
             Event::GitFileChange(project_id, path) => {

--- a/packages/tauri/src/watcher/mod.rs
+++ b/packages/tauri/src/watcher/mod.rs
@@ -2,7 +2,7 @@ mod dispatchers;
 mod events;
 mod handlers;
 
-use std::{collections::HashMap, path, sync::Arc};
+use std::{collections::HashMap, path, sync::Arc, time};
 
 pub use events::Event;
 
@@ -170,7 +170,7 @@ impl WatcherInner {
                     let handler = self.handler.clone();
                     let tx = proxy_tx.clone();
                     let event = event.clone();
-                    move || match handler.handle(&event) {
+                    move || match handler.handle(&event, time::SystemTime::now()) {
                         Err(error) => tracing::error!(
                             project_id,
                             %event,


### PR DESCRIPTION
* use same tick interval as for fetch: 15min
* flush leading to push is unaffected by this
* all events using tick timestamp use it now at the time of execution instead of time of scheduling