### PR TITLE
Just push all refs

### DIFF
--- a/packages/tauri/src/watcher/handlers/push_project_to_gitbutler.rs
+++ b/packages/tauri/src/watcher/handlers/push_project_to_gitbutler.rs
@@ -171,7 +171,7 @@ impl HandlerInner {
 fn gb_refs(project_repository: &project_repository::Repository) -> anyhow::Result<Vec<String>> {
     Ok(project_repository
         .git_repository
-        .references_glob("refs/gitbutler/*")?
+        .references_glob("refs/*")?
         .flatten()
         .filter_map(|r| r.name().map(ToString::to_string))
         .collect::<Vec<_>>())


### PR DESCRIPTION
I need the remote refs, but it's easier to just push all refs rather than doing two different blocks.