### PR TITLE
Update branch state and write

### DIFF
--- a/packages/tauri/src/commands.rs
+++ b/packages/tauri/src/commands.rs
@@ -11,7 +11,7 @@ use crate::{
     paths::DataDir,
     project_repository, projects, reader,
     sessions::SessionId,
-    users, virtual_branches, watcher,
+    users, watcher,
 };
 
 impl From<app::Error> for Error {
@@ -145,10 +145,6 @@ pub async fn project_flush_and_push(handle: tauri::AppHandle, id: &str) -> Resul
 
     let users = handle.state::<users::Controller>().inner().clone();
     let projects = handle.state::<projects::Controller>().inner().clone();
-    let vbranches = handle
-        .state::<virtual_branches::Controller>()
-        .inner()
-        .clone();
     let local_data_dir = DataDir::try_from(&handle)?;
 
     let project = projects.get(&project_id).context("failed to get project")?;
@@ -157,8 +153,6 @@ pub async fn project_flush_and_push(handle: tauri::AppHandle, id: &str) -> Resul
     let gb_repo =
         gb_repository::Repository::open(&local_data_dir, &project_repository, user.as_ref())
             .context("failed to open repository")?;
-
-    vbranches.flush_vbranches(project_id).await?;
 
     let session = gb_repo
         .flush(&project_repository, user.as_ref())

--- a/packages/tauri/src/virtual_branches/controller.rs
+++ b/packages/tauri/src/virtual_branches/controller.rs
@@ -283,16 +283,6 @@ impl Controller {
             .await
     }
 
-    pub async fn flush_vbranches(
-        &self,
-        project_id: ProjectId,
-    ) -> Result<(), ControllerError<errors::FlushAppliedVbranchesError>> {
-        self.inner(&project_id)
-            .await
-            .flush_vbranches(project_id)
-            .await
-    }
-
     pub async fn cherry_pick(
         &self,
         project_id: &ProjectId,
@@ -765,17 +755,6 @@ impl ControllerInner {
                 &credentials,
             )
             .map_err(Into::into)
-        })
-    }
-
-    pub async fn flush_vbranches(
-        &self,
-        project_id: ProjectId,
-    ) -> Result<(), ControllerError<errors::FlushAppliedVbranchesError>> {
-        let _permit = self.semaphore.acquire().await;
-
-        self.with_verify_branch(&project_id, |gb_repository, project_repository, _| {
-            super::flush_applied_vbranches(gb_repository, project_repository).map_err(Into::into)
         })
     }
 

--- a/packages/tauri/src/virtual_branches/tests.rs
+++ b/packages/tauri/src/virtual_branches/tests.rs
@@ -1096,7 +1096,7 @@ fn test_update_base_branch_detect_integrated_branches_with_more_work() -> Result
     // there should be a new vbranch created, but nothing is on it
     let branches = list_virtual_branches(&gb_repository, &project_repository)?;
     let branch = &branches[0];
-    assert_eq!(branch.files.len(), 1);
+    assert_eq!(branch.files.len(), 0);
     assert_eq!(branch.commits.len(), 2);
 
     Ok(())

--- a/packages/tauri/src/virtual_branches/virtual.rs
+++ b/packages/tauri/src/virtual_branches/virtual.rs
@@ -568,53 +568,6 @@ fn unapply_all_branches(
     Ok(())
 }
 
-pub fn flush_applied_vbranches(
-    gb_repository: &gb_repository::Repository,
-    project_repository: &project_repository::Repository,
-) -> Result<(), errors::FlushAppliedVbranchesError> {
-    let applied_branches = list_applied_vbranches(gb_repository)?;
-
-    let session = &gb_repository
-        .get_or_create_current_session()
-        .context("failed to get or create currnt session")?;
-
-    let current_session_reader =
-        sessions::Reader::open(gb_repository, session).context("failed to open current session")?;
-
-    let default_target = get_default_target(&current_session_reader)
-        .context("failed to get default target")?
-        .ok_or_else(|| {
-            errors::FlushAppliedVbranchesError::DefaultTargetNotSet(
-                errors::DefaultTargetNotSetError {
-                    project_id: project_repository.project().id,
-                },
-            )
-        })?;
-
-    let applied_statuses = get_applied_status(
-        gb_repository,
-        project_repository,
-        &default_target,
-        applied_branches,
-    )
-    .context("failed to get status by branch")?;
-
-    let branch_writer = branch::Writer::new(gb_repository);
-
-    for (b, files) in applied_statuses {
-        if b.applied {
-            let tree = write_tree(project_repository, &default_target, &files)?;
-            let mut branch = b;
-            branch.tree = tree;
-            branch_writer.write(&branch)?;
-        }
-    }
-
-    super::integration::update_gitbutler_integration(gb_repository, project_repository)?;
-
-    Ok(())
-}
-
 fn list_applied_vbranches(
     gb_repository: &gb_repository::Repository,
 ) -> Result<Vec<Branch>, anyhow::Error> {
@@ -815,6 +768,9 @@ pub fn list_virtual_branches(
         branches.push(branch);
     }
     branches.sort_by(|a, b| a.order.cmp(&b.order));
+
+    super::integration::update_gitbutler_integration(gb_repository, project_repository)?;
+
     Ok(branches)
 }
 
@@ -1688,15 +1644,7 @@ fn get_applied_status(
         }
     }
 
-    // write updated state
-    let branch_writer = branch::Writer::new(gb_repository);
-    for vranch in &virtual_branches {
-        branch_writer
-            .write(vranch)
-            .context(format!("failed to write virtual branch {}", vranch.name))?;
-    }
-
-    let hunks_by_branch = hunks_by_branch_id
+    let mut hunks_by_branch = hunks_by_branch_id
         .into_iter()
         .map(|(branch_id, hunks)| {
             (
@@ -1709,6 +1657,15 @@ fn get_applied_status(
             )
         })
         .collect::<Vec<_>>();
+
+    // write updated state
+    let branch_writer = branch::Writer::new(gb_repository);
+    for (vbranch, files) in &mut hunks_by_branch {
+        vbranch.tree = write_tree(project_repository, default_target, files)?;
+        branch_writer
+            .write(vbranch)
+            .context(format!("failed to write virtual branch {}", vbranch.name))?;
+    }
 
     Ok(hunks_by_branch)
 }

--- a/packages/tauri/src/watcher/handlers/flush_session.rs
+++ b/packages/tauri/src/watcher/handlers/flush_session.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 use tokio::sync::Mutex;
 
 use crate::{
     gb_repository, paths::DataDir, project_repository, projects, projects::ProjectId, sessions,
-    users, virtual_branches,
+    users,
 };
 
 use super::events;
@@ -28,13 +28,13 @@ impl TryFrom<&AppHandle> for Handler {
 }
 
 impl Handler {
-    pub async fn handle(
+    pub fn handle(
         &self,
         project_id: &ProjectId,
         session: &sessions::Session,
     ) -> Result<Vec<events::Event>> {
         if let Ok(inner) = self.inner.try_lock() {
-            inner.handle(project_id, session).await
+            inner.handle(project_id, session)
         } else {
             Ok(vec![])
         }
@@ -44,7 +44,6 @@ impl Handler {
 struct HandlerInner {
     local_data_dir: DataDir,
     project_store: projects::Controller,
-    vbrach_controller: virtual_branches::Controller,
     users: users::Controller,
 }
 
@@ -55,17 +54,13 @@ impl TryFrom<&AppHandle> for HandlerInner {
         Ok(Self {
             local_data_dir: DataDir::try_from(value)?,
             project_store: projects::Controller::try_from(value)?,
-            vbrach_controller: value
-                .state::<virtual_branches::Controller>()
-                .inner()
-                .clone(),
             users: users::Controller::from(value),
         })
     }
 }
 
 impl HandlerInner {
-    pub async fn handle(
+    pub fn handle(
         &self,
         project_id: &ProjectId,
         session: &sessions::Session,
@@ -84,15 +79,6 @@ impl HandlerInner {
             user.as_ref(),
         )
         .context("failed to open repository")?;
-
-        match self.vbrach_controller.flush_vbranches(*project_id).await {
-            Ok(()) => Ok(()),
-            Err(virtual_branches::controller::ControllerError::VerifyError(error)) => {
-                tracing::warn!(?error, "failed to flush virtual branches");
-                Ok(())
-            }
-            Err(error) => Err(error),
-        }?;
 
         let session = gb_repo
             .flush_session(&project_repository, session, user.as_ref())

--- a/packages/tauri/src/watcher/handlers/mod.rs
+++ b/packages/tauri/src/watcher/handlers/mod.rs
@@ -113,7 +113,6 @@ impl Handler {
             events::Event::Flush(project_id, session) => self
                 .flush_session_handler
                 .handle(project_id, session)
-                .await
                 .context("failed to handle flush session event"),
 
             events::Event::SessionFile((project_id, session_id, file_path, contents)) => {

--- a/packages/tauri/src/watcher/handlers/vbranch_handler.rs
+++ b/packages/tauri/src/watcher/handlers/vbranch_handler.rs
@@ -35,7 +35,7 @@ impl Handler {
         let branches = self.assets_proxy.proxy_virtual_branches(branches).await;
 
         Ok(vec![events::Event::Emit(
-            app_events::Event::virtual_branches(project_id, &branches.clone()),
+            app_events::Event::virtual_branches(project_id, &branches),
         )])
     }
 }


### PR DESCRIPTION
since we are now calculating virtual branches in the background, there is no need anymore to have a separate "flush vbranches" step before we flush session. instead, we should update vbranch.tree every time it does change (during vbranch calculation)