### PR TITLE
fix pushing gitbutler refs even if target is not changed

### DIFF
--- a/packages/tauri/src/watcher/handlers/push_project_to_gitbutler.rs
+++ b/packages/tauri/src/watcher/handlers/push_project_to_gitbutler.rs
@@ -141,17 +141,19 @@ impl HandlerInner {
                     "project batch pushed",
                 );
             }
-        }
 
-        // push refs/{project_id}
-        match project_repository.push_to_gitbutler_server(
-            user.as_ref(),
-            &[&format!("+{}:refs/{}", default_target.sha, project_id)],
-        ) {
-            Ok(()) => {}
-            Err(project_repository::RemoteError::Network) => return Ok(vec![]),
-            Err(err) => return Err(err).context("failed to push"),
-        };
+            // push refs/{project_id}
+            match project_repository.push_to_gitbutler_server(
+                user.as_ref(),
+                &[&format!("+{}:refs/{}", default_target.sha, project_id)],
+            ) {
+                Ok(()) => {}
+                Err(project_repository::RemoteError::Network) => return Ok(vec![]),
+                Err(err) => return Err(err).context("failed to push"),
+            };
+
+            //TODO: remove push-tmp ref
+        }
 
         let refnames = gb_refs(&project_repository)?;
 
@@ -172,8 +174,6 @@ impl HandlerInner {
         project_repository
             .push_to_gitbutler_server(user.as_ref(), all_refs.as_slice())
             .context("failed to push project (all refs) to gitbutler")?;
-
-        //TODO: remove push-tmp ref
 
         tracing::info!(
             %project_id,


### PR DESCRIPTION
keep pushing gitbutler refs even if target did not change.
this will make sure we still batch up the target branch pushing on the first push (in case its big) and always make sure the gitbutler-refs are pushed (after that).

also:
* now also respects the tick interval of 15min to push without changes
* push will only log that it pushed if it actually pushed objects

this would be great to have in the next nightly. 