### PR TITLE
pushing all remotes

### DIFF
--- a/packages/tauri/src/git/repository.rs
+++ b/packages/tauri/src/git/repository.rs
@@ -18,6 +18,12 @@ impl<'a> From<&'a Repository> for &'a git2::Repository {
     }
 }
 
+impl From<git2::Repository> for Repository {
+    fn from(repo: git2::Repository) -> Self {
+        Self(repo)
+    }
+}
+
 impl Repository {
     #[cfg(test)]
     pub fn init_bare<P: AsRef<path::Path>>(path: P) -> Result<Self> {

--- a/packages/tauri/src/watcher/handlers/push_project_to_gitbutler.rs
+++ b/packages/tauri/src/watcher/handlers/push_project_to_gitbutler.rs
@@ -201,11 +201,11 @@ impl HandlerInner {
 }
 
 fn push_all_refs(
-    project_repository: project_repository::Repository,
-    user: Option<users::User>,
+    project_repository: &project_repository::Repository,
+    user: &Option<users::User>,
     project_id: &crate::id::Id<projects::Project>,
 ) -> Result<(), project_repository::RemoteError> {
-    let gb_references = collect_refs(&project_repository)?;
+    let gb_references = collect_refs(project_repository)?;
 
     let all_refs = gb_references
         .iter()

--- a/packages/tauri/src/watcher/handlers/push_project_to_gitbutler.rs
+++ b/packages/tauri/src/watcher/handlers/push_project_to_gitbutler.rs
@@ -108,14 +108,14 @@ impl HandlerInner {
                 )
                 .await
             {
-                Ok(_) => {}
+                Ok(()) => {}
                 Err(project_repository::RemoteError::Network) => return Ok(vec![]),
                 Err(err) => return Err(err).context("failed to push"),
             };
         }
 
-        match push_all_refs(project_repository, user, project_id) {
-            Ok(_) => {}
+        match push_all_refs(&project_repository, &user, project_id) {
+            Ok(()) => {}
             Err(project_repository::RemoteError::Network) => return Ok(vec![]),
             Err(err) => return Err(err).context("failed to push"),
         };


### PR DESCRIPTION
* handle network error gracefully
* clearify error handling
* cleanup code
* unittest for pushing fetched remotes that are on refs that were never checkedout