### PR TITLE
Data sync setting feature flag

### DIFF
--- a/packages/tauri/src/users/user.rs
+++ b/packages/tauri/src/users/user.rs
@@ -14,6 +14,7 @@ pub struct User {
     pub created_at: String,
     pub updated_at: String,
     pub access_token: String,
+    pub role: Option<String>,
     pub github_access_token: Option<String>,
     #[serde(default)]
     pub github_username: Option<String>,

--- a/packages/ui/src/lib/backend/cloud.ts
+++ b/packages/ui/src/lib/backend/cloud.ts
@@ -38,6 +38,7 @@ export type User = {
 	created_at: string;
 	updated_at: string;
 	access_token: string;
+	role: string | undefined;
 	supporter: boolean;
 	github_access_token: string | undefined;
 	github_username: string | undefined;

--- a/packages/ui/src/routes/[projectId]/settings/CloudForm.svelte
+++ b/packages/ui/src/routes/[projectId]/settings/CloudForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import * as toasts from '$lib/utils/toasts';
 	import { getCloudApiClient, type User } from '$lib/backend/cloud';
 	import type { Project } from '$lib/backend/projects';
 	import { createEventDispatcher, onMount } from 'svelte';
@@ -28,34 +29,36 @@
 		dispatch('updated', { ...project, api: { ...cloudProject, sync: project.api.sync } });
 	});
 
-	// const onSyncChange = async (event: Event) => {
-	// 	if (!user) return;
+	const onSyncChange = async (event: Event) => {
+		if (!user) return;
 
-	// 	const target = event.target as HTMLInputElement;
-	// 	const sync = target.checked;
+		const target = event.target as HTMLInputElement;
+		const sync = target.checked;
 
-	// 	try {
-	// 		const cloudProject =
-	// 			project.api ??
-	// 			(await cloud.projects.create(user.access_token, {
-	// 				name: project.title,
-	// 				description: project.description,
-	// 				uid: project.id
-	// 			}));
-	// 		dispatch('updated', { ...project, api: { ...cloudProject, sync } });
-	// 	} catch (error) {
-	// 		console.error(`Failed to update project sync status: ${error}`);
-	// 		toasts.error('Failed to update project sync status');
-	// 	}
-	// };
+		try {
+			const cloudProject =
+				project.api ??
+				(await cloud.projects.create(user.access_token, {
+					name: project.title,
+					description: project.description,
+					uid: project.id
+				}));
+			dispatch('updated', { ...project, api: { ...cloudProject, sync } });
+		} catch (error) {
+			console.error(`Failed to update project sync status: ${error}`);
+			toasts.error('Failed to update project sync status');
+		}
+	};
 </script>
 
 <section class="space-y-2">
-	<header>
-		<span class="text-text-subdued"> Summary generation </span>
-	</header>
-
 	{#if user}
+		<h2 class="text-xl">GitButler Cloud</h2>
+
+		<header>
+			<span class="text-text-subdued"> Summary generation </span>
+		</header>
+
 		<div
 			class="flex flex-row items-center justify-between rounded-lg border border-light-400 p-2 dark:border-dark-500"
 		>
@@ -75,17 +78,42 @@
 				</div>
 			</div>
 		</div>
-		{#if project.api}
-			<div class="flex flex-row justify-end space-x-2">
-				<div class="p-1">
-					<Link
-						target="_blank"
-						rel="noreferrer"
-						href="{PUBLIC_API_BASE_URL}projects/{project.api?.repository_id}"
-						>Go to GitButler Cloud Project</Link
-					>
+		{#if user.role === 'admin'}
+			<header>
+				<span class="text-text-subdued"> Full data synchronization </span>
+			</header>
+			<div
+				class="flex flex-row items-center justify-between rounded-lg border border-light-400 p-2 dark:border-dark-500"
+			>
+				<div class="flex flex-row space-x-3">
+					<div class="flex flex-row">
+						<form class="flex items-center gap-1">
+							<Checkbox
+								name="sync"
+								disabled={user === undefined}
+								checked={project.api?.sync || false}
+								on:change={onSyncChange}
+							/>
+							<label class="ml-2" for="sync">
+								Sync my history, repository and branch data for backup, sharing and team features.
+							</label>
+						</form>
+					</div>
 				</div>
 			</div>
+
+			{#if project.api}
+				<div class="flex flex-row justify-end space-x-2">
+					<div class="p-1">
+						<Link
+							target="_blank"
+							rel="noreferrer"
+							href="{PUBLIC_API_BASE_URL}projects/{project.api?.repository_id}"
+							>Go to GitButler Cloud Project</Link
+						>
+					</div>
+				</div>
+			{/if}
 		{/if}
 	{:else}
 		<Login {userService} />


### PR DESCRIPTION
This takes the new `role` field in the API and feature flags the data sync setting. Without the role or without the correct role, the screen looks like this:

<img width="692" alt="CleanShot 2023-12-01 at 15 36 15@2x" src="https://github.com/gitbutlerapp/gitbutler-client/assets/70/51429bdd-9408-4414-be86-3b3784ebb143">


With the admin role, the setting looks like this:

<img width="702" alt="CleanShot 2023-12-01 at 15 31 20@2x" src="https://github.com/gitbutlerapp/gitbutler-client/assets/70/70357daf-9e43-48b2-bb7f-a73754b489cc">

It appears to work and set both settings independently.

