### PR TITLE
add rust toolchain file

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -18,6 +18,7 @@ jobs:
               - 'packages/butler/**'
               - 'Cargo.lock'
               - 'Cargo.toml'
+              - 'rust-toolchain.toml'
             node:
               - 'packages/ui/**'
               - 'package.json'

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2023-12-08"
+components = [ "rustfmt", "rustc-dev", "clippy", "rust-src", "llvm-tools-preview" ]
+profile = "minimal"


### PR DESCRIPTION
Adds a `rust-toolchain.toml` file, which pins our toolchain to a specific nightly version for better build reproducability (both CI as well as individual developer machines).