### PR TITLE
Errors v2 WIP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1771,6 +1771,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "backoff",
+ "backtrace",
  "bstr 1.8.0",
  "byteorder",
  "chrono",

--- a/packages/tauri/Cargo.toml
+++ b/packages/tauri/Cargo.toml
@@ -24,6 +24,7 @@ tempfile = "3.8"
 anyhow = "1.0.72"
 async-trait = "0.1.74"
 backoff = "0.4.0"
+backtrace = { version = "0.3.69", optional = true }
 bstr = "1.8.0"
 byteorder = "1.5.0"
 chrono = { version = "0.4.31", features = ["serde"] }
@@ -50,7 +51,7 @@ reqwest = "0.11.22"
 resolve-path = "0.1.0"
 rusqlite = { version = "0.29.0", features = [ "bundled", "blob" ] }
 rustix = "0.38"
-sentry = { version = "0.32", features = ["backtrace", "contexts", "panic", "transport", "anyhow", "debug-images", "reqwest", "native-tls" ] }
+sentry = { version = "0.32", optional = true, features = ["backtrace", "contexts", "panic", "transport", "anyhow", "debug-images", "reqwest", "native-tls" ] }
 sentry-tracing = "0.32.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = [ "std", "arbitrary_precision" ] }
@@ -79,12 +80,15 @@ zip = "0.6.5"
 [features]
 # by default Tauri runs in production mode
 # when `tauri dev` runs it is executed with `cargo run --no-default-features` if `devPath` is an URL
-default = ["custom-protocol"]
+default = ["custom-protocol", "sentry", "error-context"]
 # this feature enables devtools
 devtools = ["tauri/devtools"]
 # this feature is used used for production builds where `devPath` points to the filesystem
 # DO NOT remove this
 custom-protocol = ["tauri/custom-protocol"]
+
+sentry = ["dep:sentry", "error-context"]
+error-context = ["dep:backtrace", "sentry/backtrace"]
 
 [lints]
 workspace = true

--- a/packages/tauri/src/error.rs
+++ b/packages/tauri/src/error.rs
@@ -1,69 +1,395 @@
-use core::fmt;
+#[cfg(feature = "sentry")]
+mod sentry;
 
-use serde::{ser::SerializeMap, Serialize};
+pub use legacy::*;
 
-#[derive(Debug)]
-pub enum Code {
-    Unknown,
-    Validation,
-    Projects,
-    Branches,
-    ProjectGitAuth,
-    ProjectGitRemote,
-    ProjectConflict,
-    ProjectHead,
-    Menu,
-    Hook,
-}
+pub mod gb {
+    #[cfg(feature = "error-context")]
+    pub use error_context::*;
 
-impl fmt::Display for Code {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Code::Menu => write!(f, "errors.menu"),
-            Code::Unknown => write!(f, "errors.unknown"),
-            Code::Validation => write!(f, "errors.validation"),
-            Code::Projects => write!(f, "errors.projects"),
-            Code::Branches => write!(f, "errors.branches"),
-            Code::ProjectGitAuth => write!(f, "errors.projects.git.auth"),
-            Code::ProjectGitRemote => write!(f, "errors.projects.git.remote"),
-            Code::ProjectHead => write!(f, "errors.projects.head"),
-            Code::ProjectConflict => write!(f, "errors.projects.conflict"),
-            Code::Hook => write!(f, "errors.hook"),
+    #[cfg(feature = "sentry")]
+    pub use super::sentry::*;
+
+    #[cfg(feature = "error-context")]
+    mod error_context {
+        use super::{ErrorKind, Result, WithContext};
+        use backtrace::Backtrace;
+        use std::collections::BTreeMap;
+
+        #[derive(Debug)]
+        pub struct Context {
+            pub backtrace: Backtrace,
+            pub caused_by: Option<Box<ErrorContext>>,
+            pub vars: BTreeMap<String, String>,
+        }
+
+        impl Default for Context {
+            fn default() -> Self {
+                Self {
+                    backtrace: Backtrace::new_unresolved(),
+                    caused_by: None,
+                    vars: BTreeMap::default(),
+                }
+            }
+        }
+
+        #[derive(Debug)]
+        pub struct ErrorContext {
+            error: ErrorKind,
+            context: Context,
+        }
+
+        impl core::fmt::Display for ErrorContext {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                self.error.fmt(f)
+            }
+        }
+
+        impl std::error::Error for ErrorContext {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                self.context
+                    .caused_by
+                    .as_ref()
+                    .map(|e| e as &dyn std::error::Error)
+            }
+
+            fn provide<'a>(&'a self, request: &mut std::error::Request<'a>) {
+                if request.would_be_satisfied_by_ref_of::<Backtrace>() {
+                    request.provide_ref(&self.context.backtrace);
+                }
+            }
+        }
+
+        impl ErrorContext {
+            #[inline]
+            pub fn error(&self) -> &ErrorKind {
+                &self.error
+            }
+
+            #[inline]
+            pub fn context(&self) -> Option<&Context> {
+                Some(&self.context)
+            }
+
+            pub(crate) fn into_owned(self) -> (ErrorKind, Context) {
+                (self.error, self.context)
+            }
+        }
+
+        impl<E: Into<ErrorContext>> WithContext<ErrorContext> for E {
+            fn add_err_context<K: Into<String>, V: Into<String>>(
+                self,
+                name: K,
+                value: V,
+            ) -> ErrorContext {
+                let mut e = self.into();
+                e.context.vars.insert(name.into(), value.into());
+                e
+            }
+
+            fn wrap_err<K: Into<ErrorKind>>(self, error: K) -> ErrorContext {
+                let mut new_err = ErrorContext {
+                    error: error.into(),
+                    context: Context::default(),
+                };
+
+                new_err.context.caused_by = Some(Box::new(self.into()));
+                new_err
+            }
+        }
+
+        impl<T, E> WithContext<Result<T>> for std::result::Result<T, E>
+        where
+            E: Into<ErrorKind>,
+        {
+            #[inline]
+            fn add_err_context<K: Into<String>, V: Into<String>>(
+                self,
+                name: K,
+                value: V,
+            ) -> Result<T> {
+                self.map_err(|e| {
+                    ErrorContext {
+                        error: e.into(),
+                        context: Context::default(),
+                    }
+                    .add_err_context(name, value)
+                })
+            }
+
+            #[inline]
+            fn wrap_err<K: Into<ErrorKind>>(self, error: K) -> Result<T> {
+                self.map_err(|e| {
+                    ErrorContext {
+                        error: e.into(),
+                        context: Context::default(),
+                    }
+                    .wrap_err(error)
+                })
+            }
+        }
+
+        #[cfg(feature = "error-context")]
+        impl serde::Serialize for ErrorContext {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                use serde::ser::SerializeSeq;
+                let mut seq = serializer.serialize_seq(None)?;
+                let mut current = Some(self);
+                while let Some(err) = current {
+                    seq.serialize_element(&err.error)?;
+                    current = err.context.caused_by.as_deref();
+                }
+                seq.end()
+            }
+        }
+
+        impl From<ErrorKind> for ErrorContext {
+            fn from(error: ErrorKind) -> Self {
+                Self {
+                    error,
+                    context: Context::default(),
+                }
+            }
+        }
+
+        #[cfg(test)]
+        mod tests {
+            use super::*;
+
+            #[test]
+            fn test_error_context() {
+                fn low_level_io() -> std::result::Result<(), std::io::Error> {
+                    Err(std::io::Error::new(std::io::ErrorKind::Other, "oh no!"))
+                }
+
+                fn app_level_io() -> Result<()> {
+                    low_level_io().add_err_context("foo", "bar")?;
+                    unreachable!();
+                }
+
+                use std::error::Error;
+
+                let r = app_level_io();
+                assert!(r.is_err());
+                let e = r.unwrap_err();
+                assert_eq!(
+                    e.context().unwrap().vars.get("foo"),
+                    Some(&"bar".to_string())
+                );
+                assert!(e.source().is_none());
+                assert!(e.to_string().starts_with("io.other-error:"));
+            }
+        }
+    }
+
+    pub trait WithContext<R> {
+        fn add_err_context<K: Into<String>, V: Into<String>>(self, name: K, value: V) -> R;
+        fn wrap_err<E: Into<ErrorKind>>(self, error: E) -> R;
+    }
+
+    #[cfg(not(feature = "error-context"))]
+    pub struct Context;
+
+    pub trait ErrorCode {
+        fn code(&self) -> String;
+        fn message(&self) -> String;
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum ErrorKind {
+        Io(#[from] ::std::io::Error),
+        Git(#[from] ::git2::Error),
+        CommonDirNotAvailable(String),
+    }
+
+    impl ErrorCode for std::io::Error {
+        fn code(&self) -> String {
+            slug::slugify(self.kind().to_string())
+        }
+
+        fn message(&self) -> String {
+            self.to_string()
+        }
+    }
+
+    impl ErrorCode for git2::Error {
+        fn code(&self) -> String {
+            slug::slugify(format!("{:?}", self.class()))
+        }
+
+        fn message(&self) -> String {
+            self.to_string()
+        }
+    }
+
+    impl ErrorCode for ErrorKind {
+        fn code(&self) -> String {
+            match self {
+                ErrorKind::Io(e) => format!("io.{}", <std::io::Error as ErrorCode>::code(e)),
+                ErrorKind::Git(e) => format!("git.{}", <git2::Error as ErrorCode>::code(e)),
+                ErrorKind::CommonDirNotAvailable(_) => "no-common-dir".to_string(),
+            }
+        }
+
+        fn message(&self) -> String {
+            match self {
+                ErrorKind::Io(e) => <std::io::Error as ErrorCode>::message(e),
+                ErrorKind::Git(e) => <git2::Error as ErrorCode>::message(e),
+                ErrorKind::CommonDirNotAvailable(s) => format!("{s} is not available"),
+            }
+        }
+    }
+
+    impl core::fmt::Display for ErrorKind {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            format!(
+                "{}: {}",
+                <Self as ErrorCode>::code(self),
+                <Self as ErrorCode>::message(self)
+            )
+            .fmt(f)
+        }
+    }
+
+    #[cfg(not(feature = "error-context"))]
+    pub type Error = ErrorKind;
+    #[cfg(feature = "error-context")]
+    pub type Error = ErrorContext;
+
+    pub type Result<T> = ::std::result::Result<T, Error>;
+
+    #[cfg(not(feature = "error-context"))]
+    impl ErrorKind {
+        #[inline]
+        pub fn error(&self) -> &Error {
+            self
+        }
+
+        #[inline]
+        pub fn context(&self) -> Option<&Context> {
+            None
+        }
+    }
+
+    #[cfg(not(feature = "error-context"))]
+    impl WithContext<ErrorKind> for ErrorKind {
+        #[inline]
+        fn add_err_context<K: Into<String>, V: Into<String>>(self, _name: K, _value: V) -> Error {
+            self
+        }
+
+        #[inline]
+        fn wrap_err(self, _error: Error) -> Error {
+            self
+        }
+    }
+
+    #[cfg(not(feature = "error-context"))]
+    impl<T, E> WithContext<std::result::Result<T, E>> for std::result::Result<T, E> {
+        #[inline]
+        fn add_err_context<K: Into<String>, V: Into<String>>(
+            self,
+            _name: K,
+            _value: V,
+        ) -> std::result::Result<T, E> {
+            self
+        }
+
+        #[inline]
+        fn wrap_err(self, _error: Error) -> std::result::Result<T, E> {
+            self
+        }
+    }
+
+    #[cfg(feature = "error-context")]
+    impl serde::Serialize for ErrorKind {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            use serde::ser::SerializeTuple;
+            let mut seq = serializer.serialize_tuple(2)?;
+            seq.serialize_element(&self.code())?;
+            seq.serialize_element(&self.message())?;
+            seq.end()
         }
     }
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("[{code}]: {message}")]
-    UserError { code: Code, message: String },
-    #[error("[errors.unknown]: Something went wrong")]
-    Unknown,
-}
+//#[deprecated(
+//    note = "the types in the error::legacy::* module are deprecated; use error::gb::Error and error::gb::Result instead"
+//)]
+mod legacy {
+    use core::fmt;
 
-impl Serialize for Error {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let (code, message) = match self {
-            Error::UserError { code, message } => (code.to_string(), message.to_string()),
-            Error::Unknown => (
-                Code::Unknown.to_string(),
-                "Something went wrong".to_string(),
-            ),
-        };
+    use serde::{ser::SerializeMap, Serialize};
 
-        let mut map = serializer.serialize_map(Some(2))?;
-        map.serialize_entry("code", &code)?;
-        map.serialize_entry("message", &message)?;
-        map.end()
+    #[derive(Debug)]
+    pub enum Code {
+        Unknown,
+        Validation,
+        Projects,
+        Branches,
+        ProjectGitAuth,
+        ProjectGitRemote,
+        ProjectConflict,
+        ProjectHead,
+        Menu,
+        Hook,
     }
-}
 
-impl From<anyhow::Error> for Error {
-    fn from(error: anyhow::Error) -> Self {
-        tracing::error!(?error);
-        Error::Unknown
+    impl fmt::Display for Code {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                Code::Menu => write!(f, "errors.menu"),
+                Code::Unknown => write!(f, "errors.unknown"),
+                Code::Validation => write!(f, "errors.validation"),
+                Code::Projects => write!(f, "errors.projects"),
+                Code::Branches => write!(f, "errors.branches"),
+                Code::ProjectGitAuth => write!(f, "errors.projects.git.auth"),
+                Code::ProjectGitRemote => write!(f, "errors.projects.git.remote"),
+                Code::ProjectHead => write!(f, "errors.projects.head"),
+                Code::ProjectConflict => write!(f, "errors.projects.conflict"),
+                Code::Hook => write!(f, "errors.hook"),
+            }
+        }
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum Error {
+        #[error("[{code}]: {message}")]
+        UserError { code: Code, message: String },
+        #[error("[errors.unknown]: Something went wrong")]
+        Unknown,
+    }
+
+    impl Serialize for Error {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let (code, message) = match self {
+                Error::UserError { code, message } => (code.to_string(), message.to_string()),
+                Error::Unknown => (
+                    Code::Unknown.to_string(),
+                    "Something went wrong".to_string(),
+                ),
+            };
+
+            let mut map = serializer.serialize_map(Some(2))?;
+            map.serialize_entry("code", &code)?;
+            map.serialize_entry("message", &message)?;
+            map.end()
+        }
+    }
+
+    impl From<anyhow::Error> for Error {
+        fn from(error: anyhow::Error) -> Self {
+            tracing::error!(?error);
+            Error::Unknown
+        }
     }
 }

--- a/packages/tauri/src/error/sentry.rs
+++ b/packages/tauri/src/error/sentry.rs
@@ -1,0 +1,89 @@
+use crate::error::gb::{ErrorCode, ErrorContext};
+use sentry::{
+    protocol::{value::Map, Event, Exception, Value},
+    types::Uuid,
+};
+use std::collections::BTreeMap;
+
+pub trait SentrySender {
+    fn send_to_sentry(self) -> Uuid;
+}
+
+impl<E: Into<ErrorContext>> SentrySender for E {
+    fn send_to_sentry(self) -> Uuid {
+        let sentry_event = self.into().into();
+        sentry::capture_event(sentry_event)
+    }
+}
+
+trait PopulateException {
+    fn populate_exception(
+        self,
+        exceptions: &mut Vec<Exception>,
+        vars: &mut BTreeMap<String, Value>,
+    );
+}
+
+impl PopulateException for ErrorContext {
+    fn populate_exception(
+        self,
+        exceptions: &mut Vec<Exception>,
+        vars: &mut BTreeMap<String, Value>,
+    ) {
+        let (error, mut context) = self.into_owned();
+
+        let mut exc = Exception {
+            ty: error.code(),
+            value: Some(error.message()),
+            ..Exception::default()
+        };
+
+        if let Some(cause) = context.caused_by {
+            cause.populate_exception(exceptions, vars);
+        }
+
+        // We don't resolve at capture time because it can DRASTICALLY
+        // slow down the application (can take up to 0.5s to resolve
+        // a *single* frame). We do it here, only when a Sentry event
+        // is being created.
+        context.backtrace.resolve();
+        exc.stacktrace =
+            sentry::integrations::backtrace::backtrace_to_stacktrace(&context.backtrace);
+
+        ::backtrace::clear_symbol_cache();
+
+        vars.insert(
+            error.code(),
+            Value::Object(
+                context
+                    .vars
+                    .into_iter()
+                    .map(|(k, v)| (k, v.into()))
+                    .collect(),
+            ),
+        );
+        exceptions.push(exc);
+    }
+}
+
+impl From<ErrorContext> for Event<'_> {
+    fn from(error_context: ErrorContext) -> Self {
+        let mut sentry_event = Event {
+            message: Some(format!(
+                "{}: {}",
+                error_context.error().code(),
+                error_context.error().message()
+            )),
+            ..Event::default()
+        };
+
+        let mut vars = BTreeMap::new();
+        error_context.populate_exception(&mut sentry_event.exception.values, &mut vars);
+
+        sentry_event
+            .extra
+            .insert("context_vars".into(), Value::Object(Map::from_iter(vars)));
+
+        sentry_event
+    }
+}

--- a/packages/tauri/src/lib.rs
+++ b/packages/tauri/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(error_generic_member_access)]
+
 pub mod analytics;
 pub mod app;
 pub mod assets;


### PR DESCRIPTION
WIP PR for the new error types.

- Old types have been put into a legacy module and deprecated, then re-exposed using a pub use legacy::*  so no existing code breaks, just warns.
- New types have been added to temporary gb module, which can be easily flattened out when we remove legacy in the future.
- New types currently manually impement `ErrorCode`, but I'll write a macro to easily attach error code information to them akin to `thiserror`.
- When `error-context` feature is enabled (it is by default, but will be off by default if/when we split codebase into lib + tauri crates) then the app-wide `Result` type uses a wrapper type that includes error context.
- When `sentry` feature is enabled, error context objects can be converted directly to Sentry events, which can further be enriched with context information before being sent off to Sentry.
- When serialized to e.g. Javascript, errors are 2-element tuples of `(code, message)`, where `code` is a unique dotpath error code of the error message, and `message` is a default English human-readable error message. When `error-context` is enabled, errors are lists of those tuples, where the first element is the highest level error cause and the last element is the most granule, "deepest" error cause.