### PR TITLE
Add windows metadata shim

### DIFF
--- a/packages/tauri/src/gb_repository/repository.rs
+++ b/packages/tauri/src/gb_repository/repository.rs
@@ -5,6 +5,8 @@ use std::{
     path, time,
 };
 
+#[cfg(target_os = "windows")]
+use crate::windows::*;
 #[cfg(target_family = "unix")]
 use std::os::unix::prelude::*;
 

--- a/packages/tauri/src/lib.rs
+++ b/packages/tauri/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(error_generic_member_access)]
+#![cfg_attr(target_os = "windows", feature(windows_by_handle))]
 
 pub mod analytics;
 pub mod app;
@@ -29,6 +30,8 @@ pub mod types;
 pub mod users;
 pub mod virtual_branches;
 pub mod watcher;
+#[cfg(target_os = "windows")]
+pub(crate) mod windows;
 pub mod writer;
 pub mod zip;
 

--- a/packages/tauri/src/windows.rs
+++ b/packages/tauri/src/windows.rs
@@ -1,0 +1,23 @@
+use std::os::windows::fs::MetadataExt;
+
+pub trait MetadataShim {
+    fn ino(&self) -> u64;
+    fn dev(&self) -> u64;
+    fn uid(&self) -> u32;
+    fn gid(&self) -> u32;
+}
+
+impl MetadataShim for std::fs::Metadata {
+    fn ino(&self) -> u64 {
+        self.file_index().expect("file metadata constructed based on directory listing instead of a file (see https://doc.rust-lang.org/std/os/windows/fs/trait.MetadataExt.html#tymethod.file_index)")
+    }
+    fn dev(&self) -> u64 {
+        self.volume_serial_number().expect("file metadata constructed based on directory listing instead of a file (see https://doc.rust-lang.org/std/os/windows/fs/trait.MetadataExt.html#tymethod.volume_serial_number)") as u64
+    }
+    fn uid(&self) -> u32 {
+        0
+    }
+    fn gid(&self) -> u32 {
+        0
+    }
+}


### PR DESCRIPTION
Adds a windows `Metadata[Ext]` shim. This is not the best way to do this (it's not even a _good_ way to do this) but it gets us to a Windows build quicker. I'd like to do a full audit of how we handle OS-specific stuff like this in the future anyway, and getting us to windows builds is a higher priority at the moment.