### PR TITLE
Add gitbutler-core package and move IDs to it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,6 +1792,7 @@ dependencies = [
  "futures",
  "git2",
  "git2-hooks",
+ "gitbutler-core",
  "governor",
  "itertools 0.12.0",
  "lazy_static",
@@ -1836,6 +1837,15 @@ dependencies = [
  "uuid",
  "walkdir",
  "zip",
+]
+
+[[package]]
+name = "gitbutler-core"
+version = "0.0.0"
+dependencies = [
+ "rusqlite",
+ "serde",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,15 @@
 [workspace]
 members = [
     "gitbutler-app",
+    "gitbutler-core",
 ]
 resolver = "2"
+
+[workspace.dependencies]
+gitbutler-core = { path = "gitbutler-core" }
+uuid = "1.6.1"
+serde = { version = "1.0", features = ["derive"] }
+rusqlite = { version = "0.29.0", features = [ "bundled", "blob" ] }
 
 [profile.release]
 codegen-units = 1 # Compile crates one after another so the compiler can optimize better

--- a/gitbutler-app/Cargo.toml
+++ b/gitbutler-app/Cargo.toml
@@ -35,6 +35,7 @@ fslock = "0.2.1"
 futures = "0.3"
 git2 = { version = "0.18.1", features = ["vendored-openssl", "vendored-libgit2"] }
 git2-hooks = "0.3"
+gitbutler-core = { workspace = true }
 governor = "0.6.0"
 itertools = "0.12"
 lazy_static = "1.4.0"
@@ -50,10 +51,10 @@ rand = "0.8.5"
 refinery = { version = "0.8", features = [ "rusqlite" ] }
 reqwest = "0.11.22"
 resolve-path = "0.1.0"
-rusqlite = { version = "0.29.0", features = [ "bundled", "blob" ] }
+rusqlite = { workspace = true }
 sentry = { version = "0.32", optional = true, features = ["backtrace", "contexts", "panic", "transport", "anyhow", "debug-images", "reqwest", "native-tls" ] }
 sentry-tracing = "0.32.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true }
 serde_json = { version = "1.0", features = [ "std", "arbitrary_precision" ] }
 sha1 = "0.10.6"
 sha2 = "0.10.8"
@@ -73,7 +74,7 @@ tracing-appender = "0.2.3"
 tracing-subscriber = "0.3.17"
 url = "2.4"
 urlencoding = "2.1.3"
-uuid = "1.6.1"
+uuid = { workspace = true }
 walkdir = "2.3.2"
 zip = "0.6.5"
 

--- a/gitbutler-app/src/lib.rs
+++ b/gitbutler-app/src/lib.rs
@@ -14,7 +14,6 @@ pub mod fs;
 pub mod gb_repository;
 pub mod git;
 pub mod github;
-pub mod id;
 pub mod keys;
 pub mod logs;
 pub mod menu;
@@ -37,3 +36,9 @@ pub mod zip;
 
 #[cfg(test)]
 pub mod test_utils;
+
+#[deprecated = "use `gitbutler-core` instead"]
+pub mod id {
+    #[deprecated = "use `gitbutler-core` instead"]
+    pub use gitbutler_core::id::Id;
+}

--- a/gitbutler-core/Cargo.toml
+++ b/gitbutler-core/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "gitbutler-core"
+version = "0.0.0"
+edition = "2021"
+
+[features]
+default = ["serde", "rusqlite"]
+serde = ["dep:serde"]
+rusqlite = ["dep:rusqlite"]
+
+[dependencies]
+rusqlite = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+uuid = { workspace = true }

--- a/gitbutler-core/src/id.rs
+++ b/gitbutler-core/src/id.rs
@@ -1,5 +1,6 @@
 use std::{fmt, hash::Hash, marker::PhantomData, str};
 
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use uuid::Uuid;
 
@@ -35,6 +36,7 @@ impl<T> Default for Id<T> {
     }
 }
 
+#[cfg(feature = "rusqlite")]
 impl<T> rusqlite::types::FromSql for Id<T> {
     fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
         Uuid::parse_str(value.as_str()?)
@@ -43,6 +45,7 @@ impl<T> rusqlite::types::FromSql for Id<T> {
     }
 }
 
+#[cfg(feature = "rusqlite")]
 impl<T> rusqlite::ToSql for Id<T> {
     fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
         Ok(rusqlite::types::ToSqlOutput::from(self.0.to_string()))
@@ -63,6 +66,7 @@ impl<T> From<Uuid> for Id<T> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de, T> Deserialize<'de> for Id<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -72,6 +76,7 @@ impl<'de, T> Deserialize<'de> for Id<T> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<T> Serialize for Id<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/gitbutler-core/src/lib.rs
+++ b/gitbutler-core/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod id;


### PR DESCRIPTION
This PR kicks off the `gitbutler-core` package, which is where core, non-Tauri GB functionality should ultimately live.