### PR TITLE
GB-781 Add is default to branch

### DIFF
--- a/gitbutler-app/src/reader.rs
+++ b/gitbutler-app/src/reader.rs
@@ -373,6 +373,23 @@ impl TryFrom<Content> for String {
     }
 }
 
+impl TryFrom<Content> for i64 {
+    type Error = FromError;
+
+    fn try_from(content: Content) -> Result<Self, Self::Error> {
+        Self::try_from(&content)
+    }
+}
+
+impl TryFrom<&Content> for i64 {
+    type Error = FromError;
+
+    fn try_from(content: &Content) -> Result<Self, Self::Error> {
+        let text: String = content.try_into()?;
+        text.parse().map_err(FromError::ParseInt)
+    }
+}
+
 impl TryFrom<Content> for u64 {
     type Error = FromError;
 

--- a/gitbutler-app/src/virtual_branches/base.rs
+++ b/gitbutler-app/src/virtual_branches/base.rs
@@ -191,7 +191,7 @@ pub fn set_base_branch(
                 )?,
                 ownership,
                 order: 0,
-                is_default: false,
+                selected_for_changes: false,
             };
 
             let branch_writer =

--- a/gitbutler-app/src/virtual_branches/base.rs
+++ b/gitbutler-app/src/virtual_branches/base.rs
@@ -191,7 +191,7 @@ pub fn set_base_branch(
                 )?,
                 ownership,
                 order: 0,
-                selected_for_changes: false,
+                selected_for_changes: None,
             };
 
             let branch_writer =

--- a/gitbutler-app/src/virtual_branches/base.rs
+++ b/gitbutler-app/src/virtual_branches/base.rs
@@ -191,6 +191,7 @@ pub fn set_base_branch(
                 )?,
                 ownership,
                 order: 0,
+                is_default: false,
             };
 
             let branch_writer =

--- a/gitbutler-app/src/virtual_branches/branch.rs
+++ b/gitbutler-app/src/virtual_branches/branch.rs
@@ -40,8 +40,10 @@ pub struct Branch {
     pub ownership: Ownership,
     // order is the number by which UI should sort branches
     pub order: usize,
-    // is default is true, this branch will become an owner of any new hunks.
-    pub is_default: bool,
+    // is true, this branch will become an owner of any new hunks.
+    // when more then one branch has this field set to true (shouldn't happen)
+    // the branch with the lowest order will be selected
+    pub selected_for_changes: bool,
 }
 
 impl Branch {
@@ -58,7 +60,7 @@ pub struct BranchUpdateRequest {
     pub ownership: Option<Ownership>,
     pub order: Option<usize>,
     pub upstream: Option<String>, // just the branch name, so not refs/remotes/origin/branchA, just branchA
-    pub is_default: Option<bool>,
+    pub selected_for_changes: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -66,7 +68,7 @@ pub struct BranchCreateRequest {
     pub name: Option<String>,
     pub ownership: Option<Ownership>,
     pub order: Option<usize>,
-    pub is_default: Option<bool>,
+    pub selected_for_changes: Option<bool>,
 }
 
 impl TryFrom<&crate::reader::Reader<'_>> for Branch {
@@ -86,7 +88,7 @@ impl TryFrom<&crate::reader::Reader<'_>> for Branch {
             "meta/created_timestamp_ms",
             "meta/updated_timestamp_ms",
             "meta/ownership",
-            "meta/is_default",
+            "meta/selected_for_changes",
         ])?;
 
         let id: String = results[0].clone()?.try_into()?;
@@ -167,11 +169,14 @@ impl TryFrom<&crate::reader::Reader<'_>> for Branch {
             )
         })?;
 
-        let default = match results[12].clone() {
+        let selected_for_changes = match results[12].clone() {
             Ok(default) => default.try_into().map_err(|e| {
                 crate::reader::Error::Io(
-                    std::io::Error::new(std::io::ErrorKind::Other, format!("meta/default: {}", e))
-                        .into(),
+                    std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        format!("meta/selected_for_changes: {}", e),
+                    )
+                    .into(),
                 )
             }),
             Err(crate::reader::Error::NotFound) => Ok(false),
@@ -201,7 +206,7 @@ impl TryFrom<&crate::reader::Reader<'_>> for Branch {
             updated_timestamp_ms,
             ownership,
             order,
-            is_default: default,
+            selected_for_changes,
         })
     }
 }

--- a/gitbutler-app/src/virtual_branches/branch/reader.rs
+++ b/gitbutler-app/src/virtual_branches/branch/reader.rs
@@ -79,7 +79,7 @@ mod tests {
                     .parse()
                     .unwrap()],
             },
-            is_default: false,
+            selected_for_changes: false,
         }
     }
 

--- a/gitbutler-app/src/virtual_branches/branch/reader.rs
+++ b/gitbutler-app/src/virtual_branches/branch/reader.rs
@@ -79,6 +79,7 @@ mod tests {
                     .parse()
                     .unwrap()],
             },
+            is_default: false,
         }
     }
 

--- a/gitbutler-app/src/virtual_branches/branch/reader.rs
+++ b/gitbutler-app/src/virtual_branches/branch/reader.rs
@@ -79,7 +79,7 @@ mod tests {
                     .parse()
                     .unwrap()],
             },
-            selected_for_changes: false,
+            selected_for_changes: Some(1),
         }
     }
 

--- a/gitbutler-app/src/virtual_branches/branch/writer.rs
+++ b/gitbutler-app/src/virtual_branches/branch/writer.rs
@@ -105,10 +105,17 @@ impl<'writer> BranchWriter<'writer> {
             branch.ownership.to_string(),
         ));
 
-        batch.push(writer::BatchTask::Write(
-            format!("branches/{}/meta/selected_for_changes", branch.id),
-            branch.selected_for_changes.to_string(),
-        ));
+        if let Some(selected_for_changes) = branch.selected_for_changes {
+            batch.push(writer::BatchTask::Write(
+                format!("branches/{}/meta/selected_for_changes", branch.id),
+                selected_for_changes.to_string(),
+            ));
+        } else {
+            batch.push(writer::BatchTask::Remove(format!(
+                "branches/{}/meta/selected_for_changes",
+                branch.id
+            )));
+        }
 
         self.writer.batch(&batch)?;
 
@@ -175,7 +182,7 @@ mod tests {
                 }],
             },
             order: TEST_INDEX.load(Ordering::Relaxed),
-            selected_for_changes: false,
+            selected_for_changes: Some(1),
         }
     }
 

--- a/gitbutler-app/src/virtual_branches/branch/writer.rs
+++ b/gitbutler-app/src/virtual_branches/branch/writer.rs
@@ -106,8 +106,8 @@ impl<'writer> BranchWriter<'writer> {
         ));
 
         batch.push(writer::BatchTask::Write(
-            format!("branches/{}/meta/is_default", branch.id),
-            branch.is_default.to_string(),
+            format!("branches/{}/meta/selected_for_changes", branch.id),
+            branch.selected_for_changes.to_string(),
         ));
 
         self.writer.batch(&batch)?;
@@ -175,7 +175,7 @@ mod tests {
                 }],
             },
             order: TEST_INDEX.load(Ordering::Relaxed),
-            is_default: false,
+            selected_for_changes: false,
         }
     }
 

--- a/gitbutler-app/src/virtual_branches/branch/writer.rs
+++ b/gitbutler-app/src/virtual_branches/branch/writer.rs
@@ -105,6 +105,11 @@ impl<'writer> BranchWriter<'writer> {
             branch.ownership.to_string(),
         ));
 
+        batch.push(writer::BatchTask::Write(
+            format!("branches/{}/meta/is_default", branch.id),
+            branch.is_default.to_string(),
+        ));
+
         self.writer.batch(&batch)?;
 
         Ok(())
@@ -170,6 +175,7 @@ mod tests {
                 }],
             },
             order: TEST_INDEX.load(Ordering::Relaxed),
+            is_default: false,
         }
     }
 

--- a/gitbutler-app/src/virtual_branches/iterator.rs
+++ b/gitbutler-app/src/virtual_branches/iterator.rs
@@ -106,6 +106,7 @@ mod tests {
             .unwrap(),
             ownership: branch::Ownership::default(),
             order: TEST_INDEX.load(Ordering::Relaxed),
+            is_default: false,
         }
     }
 

--- a/gitbutler-app/src/virtual_branches/iterator.rs
+++ b/gitbutler-app/src/virtual_branches/iterator.rs
@@ -106,7 +106,7 @@ mod tests {
             .unwrap(),
             ownership: branch::Ownership::default(),
             order: TEST_INDEX.load(Ordering::Relaxed),
-            selected_for_changes: false,
+            selected_for_changes: Some(1),
         }
     }
 

--- a/gitbutler-app/src/virtual_branches/iterator.rs
+++ b/gitbutler-app/src/virtual_branches/iterator.rs
@@ -106,7 +106,7 @@ mod tests {
             .unwrap(),
             ownership: branch::Ownership::default(),
             order: TEST_INDEX.load(Ordering::Relaxed),
-            is_default: false,
+            selected_for_changes: false,
         }
     }
 

--- a/gitbutler-app/src/virtual_branches/target/reader.rs
+++ b/gitbutler-app/src/virtual_branches/target/reader.rs
@@ -85,7 +85,7 @@ mod tests {
                 }],
             },
             order: TEST_INDEX.load(Ordering::Relaxed),
-            is_default: false,
+            selected_for_changes: false,
         }
     }
 

--- a/gitbutler-app/src/virtual_branches/target/reader.rs
+++ b/gitbutler-app/src/virtual_branches/target/reader.rs
@@ -85,7 +85,7 @@ mod tests {
                 }],
             },
             order: TEST_INDEX.load(Ordering::Relaxed),
-            selected_for_changes: false,
+            selected_for_changes: None,
         }
     }
 

--- a/gitbutler-app/src/virtual_branches/target/reader.rs
+++ b/gitbutler-app/src/virtual_branches/target/reader.rs
@@ -85,6 +85,7 @@ mod tests {
                 }],
             },
             order: TEST_INDEX.load(Ordering::Relaxed),
+            is_default: false,
         }
     }
 

--- a/gitbutler-app/src/virtual_branches/target/writer.rs
+++ b/gitbutler-app/src/virtual_branches/target/writer.rs
@@ -146,6 +146,7 @@ mod tests {
                 }],
             },
             order: TEST_INDEX.load(Ordering::Relaxed),
+            is_default: false,
         }
     }
 

--- a/gitbutler-app/src/virtual_branches/target/writer.rs
+++ b/gitbutler-app/src/virtual_branches/target/writer.rs
@@ -146,7 +146,7 @@ mod tests {
                 }],
             },
             order: TEST_INDEX.load(Ordering::Relaxed),
-            is_default: false,
+            selected_for_changes: false,
         }
     }
 

--- a/gitbutler-app/src/virtual_branches/target/writer.rs
+++ b/gitbutler-app/src/virtual_branches/target/writer.rs
@@ -146,7 +146,7 @@ mod tests {
                 }],
             },
             order: TEST_INDEX.load(Ordering::Relaxed),
-            selected_for_changes: false,
+            selected_for_changes: None,
         }
     }
 

--- a/gitbutler-app/src/virtual_branches/virtual.rs
+++ b/gitbutler-app/src/virtual_branches/virtual.rs
@@ -1784,17 +1784,24 @@ fn get_applied_status(
             .for_each(|file_ownership| branch.ownership.put(file_ownership));
     }
 
+    let default_vbranch_pos = virtual_branches
+        .iter()
+        .position(|b| b.is_default)
+        .unwrap_or(0);
+
     // put the remaining hunks into the default (first) branch
     for (filepath, hunks) in diff {
         for hunk in hunks {
-            virtual_branches[0].ownership.put(&FileOwnership {
-                file_path: filepath.clone(),
-                hunks: vec![Hunk::from(&hunk)
-                    .with_timestamp(get_mtime(&mut mtimes, &filepath))
-                    .with_hash(diff_hash(hunk.diff.as_str()).as_str())],
-            });
+            virtual_branches[default_vbranch_pos]
+                .ownership
+                .put(&FileOwnership {
+                    file_path: filepath.clone(),
+                    hunks: vec![Hunk::from(&hunk)
+                        .with_timestamp(get_mtime(&mut mtimes, &filepath))
+                        .with_hash(diff_hash(hunk.diff.as_str()).as_str())],
+                });
             hunks_by_branch_id
-                .entry(virtual_branches[0].id)
+                .entry(virtual_branches[default_vbranch_pos].id)
                 .or_default()
                 .entry(filepath.clone())
                 .or_default()

--- a/gitbutler-app/src/watcher/handlers/calculate_deltas_handler.rs
+++ b/gitbutler-app/src/watcher/handlers/calculate_deltas_handler.rs
@@ -243,6 +243,7 @@ mod test {
             .unwrap(),
             ownership: branch::Ownership::default(),
             order: TEST_INDEX.load(Ordering::Relaxed),
+            is_default: false,
         }
     }
 

--- a/gitbutler-app/src/watcher/handlers/calculate_deltas_handler.rs
+++ b/gitbutler-app/src/watcher/handlers/calculate_deltas_handler.rs
@@ -243,7 +243,7 @@ mod test {
             .unwrap(),
             ownership: branch::Ownership::default(),
             order: TEST_INDEX.load(Ordering::Relaxed),
-            selected_for_changes: false,
+            selected_for_changes: None,
         }
     }
 

--- a/gitbutler-app/src/watcher/handlers/calculate_deltas_handler.rs
+++ b/gitbutler-app/src/watcher/handlers/calculate_deltas_handler.rs
@@ -243,7 +243,7 @@ mod test {
             .unwrap(),
             ownership: branch::Ownership::default(),
             order: TEST_INDEX.load(Ordering::Relaxed),
-            is_default: false,
+            selected_for_changes: false,
         }
     }
 

--- a/gitbutler-app/tests/virtual_branches.rs
+++ b/gitbutler-app/tests/virtual_branches.rs
@@ -5560,11 +5560,11 @@ mod create_virtual_branch_from_branch {
     }
 }
 
-mod default_branch {
+mod selected_for_changes {
     use super::*;
 
     #[tokio::test]
-    async fn create_virtual_branch_should_set_is_default() {
+    async fn create_virtual_branch_should_set_selected_for_changes() {
         let Test {
             project_id,
             controller,
@@ -5588,7 +5588,7 @@ mod default_branch {
             .into_iter()
             .find(|b| b.id == b_id)
             .unwrap();
-        assert!(branch.is_default);
+        assert!(branch.selected_for_changes);
 
         // if default branch exists, new branch should not be created as default
         let b_id = controller
@@ -5602,14 +5602,14 @@ mod default_branch {
             .into_iter()
             .find(|b| b.id == b_id)
             .unwrap();
-        assert!(!branch.is_default);
+        assert!(!branch.selected_for_changes);
 
         // explicitly don't make this one default
         let b_id = controller
             .create_virtual_branch(
                 &project_id,
                 &branch::BranchCreateRequest {
-                    is_default: Some(false),
+                    selected_for_changes: Some(false),
                     ..Default::default()
                 },
             )
@@ -5622,14 +5622,14 @@ mod default_branch {
             .into_iter()
             .find(|b| b.id == b_id)
             .unwrap();
-        assert!(!branch.is_default);
+        assert!(!branch.selected_for_changes);
 
         // explicitly make this one default
         let b_id = controller
             .create_virtual_branch(
                 &project_id,
                 &branch::BranchCreateRequest {
-                    is_default: Some(true),
+                    selected_for_changes: Some(true),
                     ..Default::default()
                 },
             )
@@ -5642,11 +5642,11 @@ mod default_branch {
             .into_iter()
             .find(|b| b.id == b_id)
             .unwrap();
-        assert!(branch.is_default);
+        assert!(branch.selected_for_changes);
     }
 
     #[tokio::test]
-    async fn update_virtual_branch_should_reset_is_default() {
+    async fn update_virtual_branch_should_reset_selected_for_changes() {
         let Test {
             project_id,
             controller,
@@ -5669,7 +5669,7 @@ mod default_branch {
             .into_iter()
             .find(|b| b.id == b1_id)
             .unwrap();
-        assert!(b1.is_default);
+        assert!(b1.selected_for_changes);
 
         let b2_id = controller
             .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
@@ -5682,14 +5682,14 @@ mod default_branch {
             .into_iter()
             .find(|b| b.id == b2_id)
             .unwrap();
-        assert!(!b2.is_default);
+        assert!(!b2.selected_for_changes);
 
         controller
             .update_virtual_branch(
                 &project_id,
                 branch::BranchUpdateRequest {
                     id: b2_id,
-                    is_default: Some(true),
+                    selected_for_changes: Some(true),
                     ..Default::default()
                 },
             )
@@ -5703,7 +5703,7 @@ mod default_branch {
             .into_iter()
             .find(|b| b.id == b1_id)
             .unwrap();
-        assert!(!b1.is_default);
+        assert!(!b1.selected_for_changes);
 
         let b2 = controller
             .list_virtual_branches(&project_id)
@@ -5712,11 +5712,11 @@ mod default_branch {
             .into_iter()
             .find(|b| b.id == b2_id)
             .unwrap();
-        assert!(b2.is_default);
+        assert!(b2.selected_for_changes);
     }
 
     #[tokio::test]
-    async fn unapply_virtual_branch_should_reset_is_default() {
+    async fn unapply_virtual_branch_should_reset_selected_for_changes() {
         let Test {
             repository,
             project_id,
@@ -5742,7 +5742,7 @@ mod default_branch {
             .into_iter()
             .find(|b| b.id == b1_id)
             .unwrap();
-        assert!(b1.is_default);
+        assert!(b1.selected_for_changes);
 
         controller
             .unapply_virtual_branch(&project_id, &b1_id)
@@ -5756,7 +5756,7 @@ mod default_branch {
             .into_iter()
             .find(|b| b.id == b1_id)
             .unwrap();
-        assert!(!b1.is_default);
+        assert!(!b1.selected_for_changes);
     }
 
     #[tokio::test]
@@ -5782,7 +5782,7 @@ mod default_branch {
             .create_virtual_branch(
                 &project_id,
                 &branch::BranchCreateRequest {
-                    is_default: Some(true),
+                    selected_for_changes: Some(true),
                     ..Default::default()
                 },
             )

--- a/gitbutler-app/tests/virtual_branches.rs
+++ b/gitbutler-app/tests/virtual_branches.rs
@@ -5577,29 +5577,71 @@ mod default_branch {
             .unwrap();
 
         // first branch should be created as default
-        let b_id = controller.create_virtual_branch(&project_id, &branch::BranchCreateRequest::default()).await.unwrap();
-        let branch = controller.list_virtual_branches(&project_id).await.unwrap().into_iter().find(|b| b.id == b_id).unwrap();
+        let b_id = controller
+            .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+            .await
+            .unwrap();
+        let branch = controller
+            .list_virtual_branches(&project_id)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|b| b.id == b_id)
+            .unwrap();
         assert!(branch.is_default);
 
         // if default branch exists, new branch should not be created as default
-        let b_id = controller.create_virtual_branch(&project_id, &branch::BranchCreateRequest::default()).await.unwrap();
-        let branch = controller.list_virtual_branches(&project_id).await.unwrap().into_iter().find(|b| b.id == b_id).unwrap();
+        let b_id = controller
+            .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+            .await
+            .unwrap();
+        let branch = controller
+            .list_virtual_branches(&project_id)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|b| b.id == b_id)
+            .unwrap();
         assert!(!branch.is_default);
 
         // explicitly don't make this one default
-        let b_id = controller.create_virtual_branch(&project_id, &branch::BranchCreateRequest{
-            is_default: Some(false),
-            ..Default::default()
-        }).await.unwrap();
-        let branch = controller.list_virtual_branches(&project_id).await.unwrap().into_iter().find(|b| b.id == b_id).unwrap();
+        let b_id = controller
+            .create_virtual_branch(
+                &project_id,
+                &branch::BranchCreateRequest {
+                    is_default: Some(false),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let branch = controller
+            .list_virtual_branches(&project_id)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|b| b.id == b_id)
+            .unwrap();
         assert!(!branch.is_default);
 
         // explicitly make this one default
-        let b_id = controller.create_virtual_branch(&project_id, &branch::BranchCreateRequest{
-            is_default: Some(true),
-            ..Default::default()
-        }).await.unwrap();
-        let branch = controller.list_virtual_branches(&project_id).await.unwrap().into_iter().find(|b| b.id == b_id).unwrap();
+        let b_id = controller
+            .create_virtual_branch(
+                &project_id,
+                &branch::BranchCreateRequest {
+                    is_default: Some(true),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let branch = controller
+            .list_virtual_branches(&project_id)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|b| b.id == b_id)
+            .unwrap();
         assert!(branch.is_default);
     }
 
@@ -5616,24 +5658,60 @@ mod default_branch {
             .await
             .unwrap();
 
-        let b1_id = controller.create_virtual_branch(&project_id, &branch::BranchCreateRequest::default()).await.unwrap();
-        let b1 = controller.list_virtual_branches(&project_id).await.unwrap().into_iter().find(|b| b.id == b1_id).unwrap();
+        let b1_id = controller
+            .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+            .await
+            .unwrap();
+        let b1 = controller
+            .list_virtual_branches(&project_id)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|b| b.id == b1_id)
+            .unwrap();
         assert!(b1.is_default);
 
-        let b2_id = controller.create_virtual_branch(&project_id, &branch::BranchCreateRequest::default()).await.unwrap();
-        let b2 = controller.list_virtual_branches(&project_id).await.unwrap().into_iter().find(|b| b.id == b2_id).unwrap();
+        let b2_id = controller
+            .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+            .await
+            .unwrap();
+        let b2 = controller
+            .list_virtual_branches(&project_id)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|b| b.id == b2_id)
+            .unwrap();
         assert!(!b2.is_default);
 
-        controller.update_virtual_branch(&project_id, branch::BranchUpdateRequest {
-            id: b2_id,
-            is_default: Some(true),
-            ..Default::default() 
-        }).await.unwrap();
+        controller
+            .update_virtual_branch(
+                &project_id,
+                branch::BranchUpdateRequest {
+                    id: b2_id,
+                    is_default: Some(true),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
 
-        let b1 = controller.list_virtual_branches(&project_id).await.unwrap().into_iter().find(|b| b.id == b1_id).unwrap();
+        let b1 = controller
+            .list_virtual_branches(&project_id)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|b| b.id == b1_id)
+            .unwrap();
         assert!(!b1.is_default);
 
-        let b2 = controller.list_virtual_branches(&project_id).await.unwrap().into_iter().find(|b| b.id == b2_id).unwrap();
+        let b2 = controller
+            .list_virtual_branches(&project_id)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|b| b.id == b2_id)
+            .unwrap();
         assert!(b2.is_default);
     }
 
@@ -5651,15 +5729,33 @@ mod default_branch {
             .await
             .unwrap();
 
-        let b1_id = controller.create_virtual_branch(&project_id, &branch::BranchCreateRequest::default()).await.unwrap();
+        let b1_id = controller
+            .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+            .await
+            .unwrap();
         std::fs::write(repository.path().join("file.txt"), "content").unwrap();
 
-        let b1 = controller.list_virtual_branches(&project_id).await.unwrap().into_iter().find(|b| b.id == b1_id).unwrap();
+        let b1 = controller
+            .list_virtual_branches(&project_id)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|b| b.id == b1_id)
+            .unwrap();
         assert!(b1.is_default);
 
-        controller.unapply_virtual_branch(&project_id, &b1_id).await.unwrap();
+        controller
+            .unapply_virtual_branch(&project_id, &b1_id)
+            .await
+            .unwrap();
 
-        let b1 = controller.list_virtual_branches(&project_id).await.unwrap().into_iter().find(|b| b.id == b1_id).unwrap();
+        let b1 = controller
+            .list_virtual_branches(&project_id)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|b| b.id == b1_id)
+            .unwrap();
         assert!(!b1.is_default);
     }
 
@@ -5682,10 +5778,16 @@ mod default_branch {
         let branches = controller.list_virtual_branches(&project_id).await.unwrap();
         assert_eq!(branches[0].files.len(), 1);
 
-        controller.create_virtual_branch(&project_id, &branch::BranchCreateRequest{
-            is_default: Some(true),
-            ..Default::default()
-        }).await.unwrap();
+        controller
+            .create_virtual_branch(
+                &project_id,
+                &branch::BranchCreateRequest {
+                    is_default: Some(true),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
         std::fs::write(repository.path().join("another_file.txt"), "content").unwrap();
         let branches = controller.list_virtual_branches(&project_id).await.unwrap();
         assert_eq!(branches[0].files.len(), 1);


### PR DESCRIPTION
1. add `is_default` field to virtual branch, indicating if it's a selected default target for new hunks
1. add is_default to create / update parameters
1. consider is_default when looking for a default branch target