### PR TITLE
Add option for creating draft pull request

### DIFF
--- a/gitbutler-ui/src/lib/branches/service.ts
+++ b/gitbutler-ui/src/lib/branches/service.ts
@@ -39,6 +39,7 @@ export class BranchService {
 	async createPr(
 		branch: Branch,
 		baseBranch: string,
+		draft: boolean,
 		sentryTxn: Transaction
 	): Promise<PullRequest | undefined> {
 		// Using this mutable variable while investigating why branch variable
@@ -68,13 +69,16 @@ export class BranchService {
 		const createPrSpan = sentryTxn.startChild({ op: 'pr_api_create' });
 
 		try {
-			return await this.githubService.createPullRequest(
+			const resp = await this.githubService.createPullRequest(
 				baseBranch,
 				newBranch.name,
 				newBranch.notes,
 				newBranch.id,
-				newBranch.upstreamName
+				newBranch.upstreamName,
+				draft
 			);
+			if ('pr' in resp) return resp.pr;
+			if ('err' in resp) throw resp.err;
 		} finally {
 			createPrSpan.finish();
 		}

--- a/gitbutler-ui/src/lib/components/PushButton.svelte
+++ b/gitbutler-ui/src/lib/components/PushButton.svelte
@@ -1,26 +1,54 @@
+<script lang="ts" context="module">
+	export enum BranchAction {
+		Push = 'push',
+		Pr = 'pr',
+		DraftPr = 'draftPr'
+	}
+</script>
+
 <script lang="ts">
 	import DropDownButton from '$lib/components/DropDownButton.svelte';
 	import ContextMenu from '$lib/components/contextmenu/ContextMenu.svelte';
 	import ContextMenuItem from '$lib/components/contextmenu/ContextMenuItem.svelte';
 	import ContextMenuSection from '$lib/components/contextmenu/ContextMenuSection.svelte';
-	import { projectCreatePullRequestInsteadOfPush } from '$lib/config/config';
+	import { persisted, type Persisted } from '$lib/persisted/persisted';
+	import * as toasts from '$lib/utils/toasts';
 	import { createEventDispatcher } from 'svelte';
 
-	let disabled = false;
-
-	export let isLoading = false;
 	export let projectId: string;
-	export let wide = false;
+	export let isPushed: boolean;
+	export let isLoading = false;
 	export let githubEnabled: boolean;
+	export let wide = false;
 
-	const dispatch = createEventDispatcher<{ trigger: { with_pr: boolean } }>();
-	const createPr = projectCreatePullRequestInsteadOfPush(projectId);
+	function defaultAction(projectId: string): Persisted<BranchAction> {
+		const key = 'projectDefaultAction_';
+		return persisted<BranchAction>(BranchAction.Push, key + projectId);
+	}
+
+	const dispatch = createEventDispatcher<{ trigger: { action: BranchAction } }>();
+	const preferredAction = defaultAction(projectId);
 
 	let contextMenu: ContextMenu;
 	let dropDown: DropDownButton;
+	let disabled = false;
 
 	$: selection$ = contextMenu?.selection$;
-	$: mode = $createPr && githubEnabled ? 'pr' : 'push';
+	$: action = selectAction($preferredAction);
+
+	function selectAction(preferredAction: BranchAction) {
+		if (isPushed && !githubEnabled) {
+			// TODO: Refactor such that this is not necessary
+			console.log('No push actions possible');
+			return BranchAction.Push;
+		} else if (isPushed) {
+			if (preferredAction == BranchAction.Push) return BranchAction.Pr;
+			return preferredAction;
+		} else if (!githubEnabled) {
+			return BranchAction.Push;
+		}
+		return preferredAction;
+	}
 </script>
 
 <DropDownButton
@@ -31,7 +59,7 @@
 	{wide}
 	{disabled}
 	on:click={() => {
-		dispatch('trigger', { with_pr: $selection$?.id == 'pr' });
+		dispatch('trigger', { action });
 	}}
 >
 	{$selection$?.label}
@@ -40,17 +68,41 @@
 		slot="context-menu"
 		bind:this={contextMenu}
 		on:select={(e) => {
-			$createPr = e.detail?.id == 'pr';
+			// TODO: Refactor to use generics if/when that works with Svelte
+			switch (e.detail?.id) {
+				case BranchAction.Push:
+					$preferredAction = BranchAction.Push;
+					break;
+				case BranchAction.Pr:
+					$preferredAction = BranchAction.Pr;
+					break;
+				case BranchAction.DraftPr:
+					$preferredAction = BranchAction.DraftPr;
+					break;
+				default:
+					toasts.error('Uknown branch action');
+			}
 			dropDown.close();
 		}}
 	>
 		<ContextMenuSection>
-			<ContextMenuItem id="push" label="Push to remote" selected={mode == 'push'} />
+			<ContextMenuItem
+				id="push"
+				label="Push to remote"
+				selected={action == BranchAction.Push}
+				disabled={isPushed}
+			/>
 			<ContextMenuItem
 				id="pr"
-				label="Create Pull Request"
+				label="Create pull request"
 				disabled={!githubEnabled}
-				selected={mode == 'pr'}
+				selected={action == BranchAction.Pr}
+			/>
+			<ContextMenuItem
+				id="draftPr"
+				label="Create draft pull request"
+				disabled={!githubEnabled}
+				selected={action == BranchAction.DraftPr}
 			/>
 		</ContextMenuSection>
 	</ContextMenu>

--- a/gitbutler-ui/src/lib/config/config.ts
+++ b/gitbutler-ui/src/lib/config/config.ts
@@ -20,11 +20,6 @@ export function projectCommitGenerationUseEmojis(projectId: string): Persisted<b
 	return persisted(false, key + projectId);
 }
 
-export function projectCreatePullRequestInsteadOfPush(projectId: string): Persisted<boolean> {
-	const key = 'projectCreatePullRequestInsteadOfPush_';
-	return persisted(false, key + projectId);
-}
-
 export enum ListPRsFilter {
 	All = 'ALL',
 	ExcludeBots = 'EXCLUDE_BOTS',


### PR DESCRIPTION
- adds option for draft pr to the push button
- refactor error handling such that "draft pr not allowed" isn't retried

As a side note, we need to figure out a generics solution for the context menu component. In this change I have to switch on the selected item to convert it back to an enum.