### PR TITLE
Move file card resizer outside component

### DIFF
--- a/gitbutler-ui/src/lib/components/FileCard.svelte
+++ b/gitbutler-ui/src/lib/components/FileCard.svelte
@@ -1,21 +1,13 @@
 <script lang="ts">
 	import FileCardHeader from './FileCardHeader.svelte';
 	import FileDiff from './FileDiff.svelte';
-	import Resizer from '$lib/components/Resizer.svelte';
 	import ScrollableContainer from '$lib/components/ScrollableContainer.svelte';
-	import { persisted } from '$lib/persisted/persisted';
-	import { SETTINGS_CONTEXT, type SettingsStore } from '$lib/settings/userSettings';
 	import { ContentSection, HunkSection, parseFileSections } from '$lib/utils/fileSections';
-	import lscache from 'lscache';
-	import { getContext } from 'svelte';
-	import { quintOut } from 'svelte/easing';
-	import { slide } from 'svelte/transition';
 	import type { BranchController } from '$lib/vbranches/branchController';
 	import type { Ownership } from '$lib/vbranches/ownership';
 	import type { AnyFile } from '$lib/vbranches/types';
 	import type { Writable } from 'svelte/store';
 
-	export let projectId: string;
 	export let branchId: string;
 	export let file: AnyFile;
 	export let conflicted: boolean;
@@ -25,14 +17,6 @@
 	export let selectable = false;
 	export let readonly = false;
 	export let selectedOwnership: Writable<Ownership>;
-
-	let rsViewport: HTMLElement;
-
-	const defaultFileWidthRem = persisted<number | undefined>(30, 'defaulFileWidth' + projectId);
-	const fileWidthKey = 'fileWidth_';
-	let fileWidth: number;
-
-	const userSettings = getContext<SettingsStore>(SETTINGS_CONTEXT);
 
 	let sections: (HunkSection | ContentSection)[] = [];
 
@@ -47,61 +31,40 @@
 	$: isFileLocked = sections
 		.filter((section): section is HunkSection => section instanceof HunkSection)
 		.some((section) => section.hunk.locked);
-
-	fileWidth = lscache.get(fileWidthKey + file.id);
 </script>
 
-<div
-	class="resize-viewport"
-	bind:this={rsViewport}
-	in:slide={{ duration: 180, easing: quintOut, axis: 'x' }}
-	style:width={`${fileWidth || $defaultFileWidthRem}rem`}
->
-	<div id={`file-${file.id}`} class="file-card card">
-		<FileCardHeader {file} {isFileLocked} on:close />
-		{#if conflicted}
-			<div class="mb-2 bg-red-500 px-2 py-0 font-bold text-white">
-				<button
-					class="font-bold text-white"
-					on:click={() => branchController.markResolved(file.path)}
-				>
-					Mark resolved
-				</button>
-			</div>
-		{/if}
+<div id={`file-${file.id}`} class="file-card card">
+	<FileCardHeader {file} {isFileLocked} on:close />
+	{#if conflicted}
+		<div class="mb-2 bg-red-500 px-2 py-0 font-bold text-white">
+			<button
+				class="font-bold text-white"
+				on:click={() => branchController.markResolved(file.path)}
+			>
+				Mark resolved
+			</button>
+		</div>
+	{/if}
 
-		<ScrollableContainer wide>
-			<FileDiff
-				filePath={file.path}
-				isLarge={file.large}
-				isBinary={file.binary}
-				{readonly}
-				{sections}
-				{projectPath}
-				{isFileLocked}
-				{isUnapplied}
-				{branchController}
-				{selectable}
-				{branchId}
-				{selectedOwnership}
-			/>
-		</ScrollableContainer>
-	</div>
-
-	<div class="divider-line">
-		<Resizer
-			viewport={rsViewport}
-			direction="right"
-			inside
-			minWidth={240}
-			on:width={(e) => {
-				fileWidth = e.detail / (16 * $userSettings.zoom);
-				lscache.set(fileWidthKey + file.id, fileWidth, 7 * 1440); // 7 day ttl
-				$defaultFileWidthRem = fileWidth;
-			}}
+	<ScrollableContainer wide>
+		<FileDiff
+			filePath={file.path}
+			isLarge={file.large}
+			isBinary={file.binary}
+			{readonly}
+			{sections}
+			{projectPath}
+			{isFileLocked}
+			{isUnapplied}
+			{branchController}
+			{selectable}
+			{branchId}
+			{selectedOwnership}
 		/>
-	</div>
+	</ScrollableContainer>
 </div>
+
+<div class="divider-line"></div>
 
 <style lang="postcss">
 	.divider-line {
@@ -123,17 +86,9 @@
 			transform: translateX(50%);
 			width: 1px;
 			height: 100%;
-			background-color: var(--clr-theme-container-outline-light);
 		}
 	}
-	.resize-viewport {
-		position: relative;
-		display: flex;
-		height: 100%;
-		align-items: self-start;
-		overflow: hidden;
-		padding: var(--space-12) var(--space-12) var(--space-12) 0;
-	}
+
 	.file-card {
 		background: var(--clr-theme-container-light);
 		overflow: hidden;

--- a/gitbutler-ui/src/lib/components/HunkLine.svelte
+++ b/gitbutler-ui/src/lib/components/HunkLine.svelte
@@ -97,5 +97,6 @@
 		cursor: text;
 		display: inline-block;
 		text-indent: var(--space-4);
+		margin-right: var(--space-4);
 	}
 </style>

--- a/gitbutler-ui/src/lib/components/RemoteBranchPreview.svelte
+++ b/gitbutler-ui/src/lib/components/RemoteBranchPreview.svelte
@@ -89,7 +89,6 @@
 				conflicted={selected.conflicted}
 				branchId={'blah'}
 				file={selected}
-				{projectId}
 				{projectPath}
 				{branchController}
 				{selectedOwnership}
@@ -109,7 +108,6 @@
 		display: flex;
 		flex-grow: 1;
 		overflow-x: auto;
-		padding-right: var(--space-16);
 	}
 	.base__left {
 		display: flex;
@@ -119,9 +117,10 @@
 		position: relative;
 	}
 	.base__right {
-		flex-basis: 50%;
 		display: flex;
-		padding-left: var(--space-6);
+		overflow-x: auto;
+		align-items: flex-start;
+		padding: var(--space-12) var(--space-12) var(--space-12) var(--space-6);
 	}
 
 	.branch-preview {

--- a/gitbutler-ui/src/lib/components/Resizer.svelte
+++ b/gitbutler-ui/src/lib/components/Resizer.svelte
@@ -104,6 +104,7 @@
 		width: var(--space-4);
 		height: 100%;
 		cursor: col-resize;
+		top: 0;
 		&:hover {
 			width: var(--space-4);
 		}

--- a/gitbutler-ui/src/routes/[projectId]/base/+page.svelte
+++ b/gitbutler-ui/src/routes/[projectId]/base/+page.svelte
@@ -43,60 +43,58 @@
 	});
 </script>
 
-<div class="base">
-	<div
-		class="base__left"
-		bind:this={rsViewport}
-		style:width={`${laneWidth || defaultBranchWidthRem}rem`}
-	>
-		<ScrollableContainer>
-			<div class="card">
-				{#if $error$}
-					<p>Error...</p>
-				{:else if !$base$}
-					<p>Loading...</p>
-				{:else}
+{#if $error$}
+	<p>Error...</p>
+{:else if !$base$}
+	<p>Loading...</p>
+{:else}
+	<div class="base">
+		<div
+			class="base__left"
+			bind:this={rsViewport}
+			style:width={`${laneWidth || defaultBranchWidthRem}rem`}
+		>
+			<ScrollableContainer>
+				<div class="card">
 					<BaseBranch {projectId} base={$base$} {branchController} {selectedFiles} />
-				{/if}
-			</div>
-		</ScrollableContainer>
-		<Resizer
-			viewport={rsViewport}
-			direction="right"
-			minWidth={320}
-			on:width={(e) => {
-				laneWidth = e.detail / (16 * $userSettings.zoom);
-				lscache.set(laneWidthKey, laneWidth, 7 * 1440); // 7 day ttl
-			}}
-		/>
-	</div>
-	<div class="base__right">
-		{#if selected}
-			<FileCard
-				conflicted={selected.conflicted}
-				branchId={'blah'}
-				file={selected}
-				{projectId}
-				{projectPath}
-				{branchController}
-				{selectedOwnership}
-				isUnapplied={false}
-				readonly={true}
-				on:close={() => {
-					const selectedId = selected?.id;
-					selectedFiles.update((fileIds) => fileIds.filter((file) => file.id != selectedId));
+				</div>
+			</ScrollableContainer>
+			<Resizer
+				viewport={rsViewport}
+				direction="right"
+				minWidth={320}
+				on:width={(e) => {
+					laneWidth = e.detail / (16 * $userSettings.zoom);
+					lscache.set(laneWidthKey, laneWidth, 7 * 1440); // 7 day ttl
 				}}
 			/>
-		{/if}
+		</div>
+		<div class="base__right">
+			{#if selected}
+				<FileCard
+					conflicted={selected.conflicted}
+					branchId={'blah'}
+					file={selected}
+					{projectPath}
+					{branchController}
+					{selectedOwnership}
+					isUnapplied={false}
+					readonly={true}
+					on:close={() => {
+						const selectedId = selected?.id;
+						selectedFiles.update((fileIds) => fileIds.filter((file) => file.id != selectedId));
+					}}
+				/>
+			{/if}
+		</div>
 	</div>
-</div>
+{/if}
 
 <style lang="postcss">
 	.base {
 		display: flex;
 		flex-grow: 1;
 		overflow-x: auto;
-		padding-right: var(--space-16);
 	}
 	.base__left {
 		display: flex;
@@ -106,9 +104,11 @@
 		position: relative;
 	}
 	.base__right {
-		flex-basis: 50%;
 		display: flex;
-		padding-left: var(--space-6);
+		overflow-x: auto;
+		align-items: flex-start;
+		padding: var(--space-12) var(--space-12) var(--space-12) var(--space-6);
+		width: 50rem;
 	}
 	.card {
 		margin: var(--space-12) var(--space-6) var(--space-12) var(--space-12);


### PR DESCRIPTION
- used in multiple places, so resizing should be done in its context (e.g. branch lane)
- leaves branch previews with simpler max 50rem file previews
- no need for those pages to have resizers since we have no actual designs yet