### PR TITLE
Add authors in Packager.toml

### DIFF
--- a/gitbutler-app/Cargo.toml
+++ b/gitbutler-app/Cargo.toml
@@ -3,6 +3,7 @@ name = "gitbutler-app"
 version = "0.0.0"
 edition = "2021"
 rust-version = "1.57"
+authors = ["GitButler <opensource@gitbutler.com>"]
 
 [lib]
 name = "gblib"

--- a/gitbutler-app/Cargo.toml
+++ b/gitbutler-app/Cargo.toml
@@ -3,7 +3,7 @@ name = "gitbutler-app"
 version = "0.0.0"
 edition = "2021"
 rust-version = "1.57"
-authors = ["GitButler <opensource@gitbutler.com>"]
+authors = ["GitButler <gitbutler@gitbutler.com>"]
 
 [lib]
 name = "gblib"


### PR DESCRIPTION
Hi awesome GitButler team!

I am Naman Garg, and am working with [tauri-apps](https://tauri.app/) and [CrabNebula](https://crabnebula.dev/), and @naman-crabnebula is my work account.

( I am introducing myself because you might see a few pull requests by me in future as well )

So, this Pull Request adds the `Maintainer` field in the `.deb` package, and hence, close the issue https://github.com/gitbutlerapp/gitbutler/issues/2542

**Note :** I filled the `authors` as per my understanding from repo. Have a look before merging.