### PR TITLE
update dependabot schedule and grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,25 +8,21 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
     groups:
-      npm-minor-updates:
-        update-types: [minor]
-      npm-patch-updates:
-        update-types: [patch]
+      npm-updates:
+        update-types: [minor, patch]
 
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
     groups:
-      rust-minor-updates:
-        update-types: [minor]
-      rust-patch-updates:
-        update-types: [patch]
+      rust-updates:
+        update-types: [minor, patch]


### PR DESCRIPTION
Right now the PRs are a bit time consuming and mostly involve patch versions. Going to set this to monthly until we can figure out a better way to handle them.