### PR TITLE
Add get remote branch data function

### DIFF
--- a/gitbutler-app/src/bin.rs
+++ b/gitbutler-app/src/bin.rs
@@ -214,6 +214,7 @@ fn main() {
                     virtual_branches::commands::cherry_pick_onto_virtual_branch,
                     virtual_branches::commands::amend_virtual_branch,
                     virtual_branches::commands::list_remote_branches,
+                    virtual_branches::commands::get_remote_branch_data,
                     virtual_branches::commands::squash_branch_commit,
                     virtual_branches::commands::fetch_from_target,
                     menu::menu_item_set_enabled,

--- a/gitbutler-app/src/virtual_branches/errors.rs
+++ b/gitbutler-app/src/virtual_branches/errors.rs
@@ -751,6 +751,26 @@ pub enum ListRemoteBranchesError {
     Other(#[from] anyhow::Error),
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum GetRemoteBranchDataError {
+    #[error("default target not set")]
+    DefaultTargetNotSet(DefaultTargetNotSetError),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+impl From<GetRemoteBranchDataError> for Error {
+    fn from(value: GetRemoteBranchDataError) -> Self {
+        match value {
+            GetRemoteBranchDataError::DefaultTargetNotSet(error) => error.into(),
+            GetRemoteBranchDataError::Other(error) => {
+                tracing::error!(?error, "get remote branch data error");
+                Error::Unknown
+            }
+        }
+    }
+}
+
 impl From<ListRemoteBranchesError> for Error {
     fn from(value: ListRemoteBranchesError) -> Self {
         match value {

--- a/gitbutler-ui/src/lib/components/RemoteBranchPreview.svelte
+++ b/gitbutler-ui/src/lib/components/RemoteBranchPreview.svelte
@@ -5,6 +5,7 @@
 	import ScrollableContainer from './ScrollableContainer.svelte';
 	import CommitCard from '$lib/components/CommitCard.svelte';
 	import { type SettingsStore, SETTINGS_CONTEXT } from '$lib/settings/userSettings';
+	import { getRemoteBranchData } from '$lib/stores/remoteBranches';
 	import { Ownership } from '$lib/vbranches/ownership';
 	import lscache from 'lscache';
 	import { marked } from 'marked';
@@ -59,18 +60,20 @@
 						</div>
 					</div>
 				{/if}
-				{#if branch.commits && branch.commits.length > 0}
-					<div class="flex w-full flex-col gap-y-2">
-						{#each branch.commits as commit (commit.id)}
-							<CommitCard
-								{commit}
-								{projectId}
-								{selectedFiles}
-								commitUrl={base?.commitUrl(commit.id)}
-							/>
-						{/each}
-					</div>
-				{/if}
+				{#await getRemoteBranchData({ projectId, refname: branch.name }) then branchData}
+					{#if branchData.commits && branchData.commits.length > 0}
+						<div class="flex w-full flex-col gap-y-2">
+							{#each branchData.commits as commit (commit.id)}
+								<CommitCard
+									{commit}
+									{projectId}
+									{selectedFiles}
+									commitUrl={base?.commitUrl(commit.id)}
+								/>
+							{/each}
+						</div>
+					{/if}
+				{/await}
 			</div>
 		</ScrollableContainer>
 		<Resizer

--- a/gitbutler-ui/src/lib/stores/remoteBranches.ts
+++ b/gitbutler-ui/src/lib/stores/remoteBranches.ts
@@ -1,6 +1,6 @@
 import { invoke } from '$lib/backend/ipc';
 import * as toasts from '$lib/utils/toasts';
-import { RemoteBranch } from '$lib/vbranches/types';
+import { RemoteBranch, RemoteBranchData } from '$lib/vbranches/types';
 import { plainToInstance } from 'class-transformer';
 import {
 	BehaviorSubject,
@@ -25,7 +25,7 @@ export class RemoteBranchService {
 		baseBranch$: Observable<any>
 	) {
 		this.branches$ = combineLatest([baseBranch$, this.reload$, head$, fetches$]).pipe(
-			switchMap(() => getRemoteBranchesData({ projectId })),
+			switchMap(() => listRemoteBranches({ projectId })),
 			map((branches) => branches.filter((b) => b.ahead != 0)),
 			shareReplay(1),
 			catchError((e) => {
@@ -42,13 +42,23 @@ export class RemoteBranchService {
 	}
 }
 
-export async function getRemoteBranchesData(params: {
-	projectId: string;
-}): Promise<RemoteBranch[]> {
+async function listRemoteBranches(params: { projectId: string }): Promise<RemoteBranch[]> {
 	const branches = plainToInstance(
 		RemoteBranch,
 		await invoke<any[]>('list_remote_branches', params)
 	);
 
 	return branches;
+}
+
+export async function getRemoteBranchData(params: {
+	projectId: string;
+	refname: string;
+}): Promise<RemoteBranchData> {
+	const branchData = plainToInstance(
+		RemoteBranchData,
+		await invoke<any>('get_remote_branch_data', params)
+	);
+
+	return branchData;
 }

--- a/gitbutler-ui/src/lib/vbranches/types.ts
+++ b/gitbutler-ui/src/lib/vbranches/types.ts
@@ -216,6 +216,40 @@ export class RemoteBranch {
 	}
 }
 
+export class RemoteBranchData {
+	sha!: string;
+	name!: string;
+	upstream?: string;
+	behind!: number;
+	@Type(() => RemoteCommit)
+	commits!: RemoteCommit[];
+	isMergeable!: boolean | undefined;
+
+	get ahead(): number {
+		return this.commits.length;
+	}
+
+	get lastCommitTs(): Date | undefined {
+		return this.commits[0]?.createdAt;
+	}
+
+	get firstCommitAt(): Date {
+		return this.commits[this.commits.length - 1].createdAt;
+	}
+
+	get authors(): Author[] {
+		const allAuthors = this.commits.map((commit) => commit.author);
+		const uniqueAuthors = allAuthors.filter(
+			(author, index) => allAuthors.findIndex((a) => a.email == author.email) == index
+		);
+		return uniqueAuthors;
+	}
+
+	get displayName(): string {
+		return this.name.replace('refs/remotes/', '').replace('origin/', '').replace('refs/heads/', '');
+	}
+}
+
 export class BaseBranch {
 	branchName!: string;
 	remoteName!: string;


### PR DESCRIPTION
Currently remote branch data is retrieved while listing remote branches. This does not scale, therefore introducing an endpoint for fetching branch data (such as commits, ahead/behind metadata) separately.