### PR TITLE
chore: create tar.gz Linux release

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -258,19 +258,25 @@ if [ "$OS" = "macos" ]; then
 elif [ "$OS" = "linux" ]; then
 	APPIMAGE="$(find $BUNDLE_DIR/appimage -name \*.AppImage)"
 	APPIMAGE_UPDATER="$(find $BUNDLE_DIR/appimage -name \*.AppImage.tar.gz)"
+	APPDIR="$(find $BUNDLE_DIR/appimage -name \*.AppDir)"
 	APPIMAGE_UPDATER_SIG="$(find $BUNDLE_DIR/appimage -name \*.AppImage.tar.gz.sig)"
 	DEB="$(find $BUNDLE_DIR/deb -name \*.deb)"
+
+    tar --exclude=usr/bin/xdg-open --exclude=usr/lib --exclude=usr/share/doc --exclude=usr/share/glib-2.0 -zcvf "$BUNDLE_DIR/gitbutler.tar.gz" -C "$APPDIR" usr
+    TAR=$(find $BUNDLE_DIR -name gitbutler.tar.gz)
 
 	cp "$APPIMAGE" "$RELEASE_DIR"
 	cp "$APPIMAGE_UPDATER" "$RELEASE_DIR"
 	cp "$APPIMAGE_UPDATER_SIG" "$RELEASE_DIR"
 	cp "$DEB" "$RELEASE_DIR"
+    cp "$TAR" "$RELEASE_DIR"
 
 	info "built:"
 	info "  - $RELEASE_DIR/$(basename "$APPIMAGE")"
 	info "  - $RELEASE_DIR/$(basename "$APPIMAGE_UPDATER")"
 	info "  - $RELEASE_DIR/$(basename "$APPIMAGE_UPDATER_SIG")"
 	info "  - $RELEASE_DIR/$(basename "$DEB")"
+    info "  - $RELEASE_DIR/$(basename "$TAR")"
 fi
 
 info "done! bye!"


### PR DESCRIPTION
Creates a .tar.gz release so others can package and release GB for other distros.