### PR TITLE
Fix branch name change when pressing Enter

### DIFF
--- a/gitbutler-ui/src/lib/components/BranchLabel.svelte
+++ b/gitbutler-ui/src/lib/components/BranchLabel.svelte
@@ -44,7 +44,8 @@
 		on:blur={() => (inputActive = false)}
 		on:keydown={(e) => {
 			if (e.key == 'Enter') {
-				inputActive = false;
+				// Unmount input field asynchronously to ensure on:change gets executed.
+				setTimeout(() => (inputActive = false), 0);
 				setTimeout(() => label.focus(), 0);
 			}
 


### PR DESCRIPTION
This fixes a bug where the branch name could not be changed by pressing Enter after typing a new branch name in the `BranchHeader`'s `BranchLabel` field.

I believe the issue is that the `<input/>` field is unmounted by setting `inputActive = false` in `on:keydown` before the `on:change` function can be executed.

Running `inputActive = false` asynchronously, as is already done for `label.focus()`, seems to fix the issue for me.

I realize there may be better ways to fix this, but this is all I had time for. I also added a comment to explain the change but feel free to edit or remove it if it doesn't fit your style.

---

Versions of GitButler and OS where this was reproduced and fixed:

macOS 14.2.1 (23C71).
GitButler Version 0.10.7 (20240213.214246).
GitButler `master` as of now.

---

Discussed (briefly) on Discord: https://discord.com/channels/1060193121130000425/1206670506271707156/1207405803661951036.

---

Closes #2743.