### PR TITLE
Replace fork of Context Menu Plugin with Upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,17 +5547,21 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-context-menu"
-version = "0.5.0"
-source = "git+https://github.com/gitbutlerapp/tauri-plugin-context-menu?branch=main#4fd0410a48defc8ad21d6142181f490ed02fdefb"
+version = "0.7.0"
+source = "git+https://github.com/c2r0b/tauri-plugin-context-menu?branch=main#0845b1564806c5885d8d915b2ad7ac86c16f634d"
 dependencies = [
  "cocoa",
  "dispatch",
+ "gdk",
+ "glib",
+ "gtk",
  "image",
  "lazy_static",
  "libc",
  "objc",
  "serde",
  "tauri",
+ "time",
  "winapi",
 ]
 

--- a/gitbutler-app/Cargo.toml
+++ b/gitbutler-app/Cargo.toml
@@ -66,7 +66,7 @@ slug = "0.1.5"
 ssh-key = { version = "0.6.4", features = [ "alloc", "ed25519" ] }
 ssh2 = { version = "0.9.4", features = ["vendored-openssl"] }
 tauri = { version = "1.5.4", features = ["dialog-open", "fs-read-file", "path-all", "process-relaunch", "protocol-asset", "shell-open", "system-tray", "window-maximize", "window-start-dragging", "window-unmaximize"] }
-tauri-plugin-context-menu = { git = "https://github.com/gitbutlerapp/tauri-plugin-context-menu", branch = "main" }
+tauri-plugin-context-menu = { git = "https://github.com/c2r0b/tauri-plugin-context-menu", branch = "main" }
 tauri-plugin-single-instance = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 tauri-plugin-window-state = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 tauri-plugin-store = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }


### PR DESCRIPTION
Hi there!

(This PR is copy of https://github.com/gitbutlerapp/gitbutler/pull/2581, but is cleaner and cargo.lock is also updated )

So, Tauri Plugin Context Menu do have Linux Support now 🎉

Hence, the fork of it can be replaced with the upstream. I have not tested it yet though, and hence, making it as a draft PR for now.

Also, now looking at the source, I am wondering why tauri-plugins are explicitly fetched from git? This may cause issue because they might use unreleased version.

Thank You