### PR TITLE
Update gitbutler committer config

### DIFF
--- a/gitbutler-app/src/project_repository/config.rs
+++ b/gitbutler-app/src/project_repository/config.rs
@@ -24,13 +24,13 @@ impl Config<'_> {
     }
 
     pub fn user_real_comitter(&self) -> Result<bool, git::Error> {
-        let no_comitter = self
+        let gb_comitter = self
             .git_repository
             .config()?
-            .get_string("gitbutler.utmostDiscretion")
+            .get_string("gitbutler.gitbutlerCommitter")
             .unwrap_or(Some("0".to_string()))
             .unwrap_or("0".to_string());
-        Ok(no_comitter == "1")
+        Ok(gb_comitter == "0")
     }
 
     pub fn user_name(&self) -> Result<Option<String>, git::Error> {

--- a/gitbutler-ui/src/lib/components/CommitDialog.svelte
+++ b/gitbutler-ui/src/lib/components/CommitDialog.svelte
@@ -173,7 +173,7 @@
 			</div>
 			{#if annotateCommits}
 				<div class="commit-box__committer text-base-11">
-					GitButler will be the committer of this commit. <a
+					Consider spreading the word about GitButler. <a
 						class="text-bold"
 						target="_blank"
 						rel="noreferrer"


### PR DESCRIPTION
By default gitbutler will no longer set itself as a committer. 
For anybody who wishes to spread the word about GitButler by setting GB as a committer, you can enable it by running
```
git config --global gitbutler.gitbutlerCommitter 1
```