### PR TITLE
Minor Grammatical Update to Cargo.toml

### DIFF
--- a/gitbutler-app/Cargo.toml
+++ b/gitbutler-app/Cargo.toml
@@ -84,7 +84,7 @@ zip = "0.6.5"
 
 [features]
 # by default Tauri runs in production mode
-# when `tauri dev` runs it is executed with `cargo run --no-default-features` if `devPath` is an URL
+# when `tauri dev` runs it is executed with `cargo run --no-default-features` if `devPath` is a URL
 default = ["custom-protocol", "sentry", "error-context"]
 # this feature enables devtools
 devtools = ["tauri/devtools"]


### PR DESCRIPTION
Corrects the usage of the indefinite article from 'an' to 'a' before the acronym 'URL' in documentation and comments, aligning with grammatical rules regarding consonant-sounding acronyms.

Since "URL" is pronounced "you-are-el," it starts with a consonant sound, making "a" the correct article to use.