### PR TITLE
fix: discard diff hunk incorrectly replaces all "-" with "+"

### DIFF
--- a/gitbutler-app/src/git/diff.rs
+++ b/gitbutler-app/src/git/diff.rs
@@ -297,10 +297,10 @@ fn reverse_patch(patch: &str) -> Option<String> {
                 return None;
             }
         } else if line.starts_with('+') {
-            reversed.push_str(&line.replace('+', "-"));
+            reversed.push_str(&line.replacen('+', "-", 1));
             reversed.push('\n');
         } else if line.starts_with('-') {
-            reversed.push_str(&line.replace('-', "+"));
+            reversed.push_str(&line.replacen('-', "+", 1));
             reversed.push('\n');
         } else {
             reversed.push_str(line);


### PR DESCRIPTION
I noticed that when discarding a diff hunk that contains dashes (i.e. a line in a package.json like this `"@typescript-eslint/eslint-plugin": "^5.62.0"`), the discard action would replace all occurrences of `-` with a `+`.

This was caused by Rust's `str::replace` being a replace all by default.

Switched to `replacen()` to only replace the first occurrence of `-` (and applied the same logic for the opposite case, `+` -> `-`)
