### PR TITLE
Fixes #2708

### DIFF
--- a/gitbutler-ui/src/lib/vbranches/types.ts
+++ b/gitbutler-ui/src/lib/vbranches/types.ts
@@ -262,7 +262,7 @@ export class BaseBranch {
 	branchUrl(upstreamBranchName: string | undefined) {
 		if (!upstreamBranchName) return undefined;
 		const baseBranchName = this.branchName.split('/')[1];
-		const branchName = upstreamBranchName.split('refs/remotes/')[1].split('/').slice(1).join('/');
+		const branchName = upstreamBranchName.split('/').slice(3).join('/');
 		return `${this.repoBaseUrl.trim()}/compare/${baseBranchName}...${branchName}`;
 	}
 }

--- a/gitbutler-ui/src/lib/vbranches/types.ts
+++ b/gitbutler-ui/src/lib/vbranches/types.ts
@@ -262,8 +262,7 @@ export class BaseBranch {
 	branchUrl(upstreamBranchName: string | undefined) {
 		if (!upstreamBranchName) return undefined;
 		const baseBranchName = this.branchName.split('/')[1];
-		const parts = upstreamBranchName.split('/');
-		const branchName = parts[parts.length - 1];
+		const branchName = upstreamBranchName.split('refs/remotes/')[1].split('/').slice(1).join('/');
 		return `${this.repoBaseUrl.trim()}/compare/${baseBranchName}...${branchName}`;
 	}
 }


### PR DESCRIPTION
- Assumes all upstream branch names will start with 'refs/remotes/', then
- slices out the remote branch name without making any assumptions as to what it's named, and
- joins the rest of the split elements