### PR TITLE
fix: vite-plugin-svelte error on empty scoped-style element

### DIFF
--- a/gitbutler-ui/src/lib/components/FilterPopupMenu.svelte
+++ b/gitbutler-ui/src/lib/components/FilterPopupMenu.svelte
@@ -43,6 +43,3 @@
 		</ContextMenuSection>
 	</ContextMenu>
 {/if}
-
-<style lang="postcss">
-</style>


### PR DESCRIPTION
Remove empty style element to squash error:

> 8:24:35 PM [vite-plugin-svelte] /home/juan/gitbutler/gitbutler-ui/src/lib/components/FilterPopupMenu.svelte:44:1 No scopable elements found in template. If you're using global styles in the style tag, you should move it into an external stylesheet file and import it in JS. See https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#where-should-i-put-my-global-styles.