### PR TITLE
Ensure searches on PRs also includes the branch name

### DIFF
--- a/gitbutler-ui/src/lib/branches/types.ts
+++ b/gitbutler-ui/src/lib/branches/types.ts
@@ -85,6 +85,19 @@ export class CombinedBranch {
 		}
 	}
 
+	get searchableIdentifiers() {
+		const identifiers = [];
+
+		if (this.vbranch) identifiers.push(this.vbranch.name);
+		if (this.pr) {
+			identifiers.push(this.pr.title);
+			identifiers.push(this.pr.targetBranch);
+		}
+		if (this.remoteBranch) identifiers.push(this.remoteBranch.displayName);
+
+		return identifiers.map((identifier) => identifier.toLowerCase());
+	}
+
 	currentState(): BranchState | undefined {
 		if (this.vbranch) return BranchState.VirtualBranch;
 		if (this.pr) return BranchState.PR;

--- a/gitbutler-ui/src/lib/components/Branches.svelte
+++ b/gitbutler-ui/src/lib/components/Branches.svelte
@@ -91,7 +91,16 @@
 
 	function filterByText(branches: CombinedBranch[], search: string | undefined) {
 		if (search == undefined) return branches;
-		return branches.filter((b) => b.displayName.includes(search));
+
+		return branches.filter((b) => searchMatchesAnIdentifier(search, b.searchableIdentifiers));
+	}
+
+	function searchMatchesAnIdentifier(search: string, identifiers: string[]) {
+		for (const identifier of identifiers) {
+			if (identifier.includes(search.toLowerCase())) return true;
+		}
+
+		return false;
 	}
 
 	function filterInactive(branches: CombinedBranch[]) {


### PR DESCRIPTION
* Related https://github.com/gitbutlerapp/gitbutler/issues/2709

## The problem

For PRs in the branch list, I'm unable to search by the branch name; currently, I can only search by the PR title.

## The solution

I thought about how to do this and I didn't want to encode too many of the specifics of searching onto the CombinedBranch class, so I thought a happy medium would be to have a getter to access the various identifiers which would be relevant for searching, and then make use of them in the Branches component.