### PR TITLE
Disable auto completions in branch filter field

### DIFF
--- a/gitbutler-ui/src/lib/components/Branches.svelte
+++ b/gitbutler-ui/src/lib/components/Branches.svelte
@@ -163,7 +163,6 @@
 					<TextBox
 						icon="filter"
 						placeholder="Search"
-						spellcheck={false}
 						on:input={(e) => textFilter$.next(e.detail)}
 					/>
 					<div bind:this={contents} class="content">

--- a/gitbutler-ui/src/lib/components/Branches.svelte
+++ b/gitbutler-ui/src/lib/components/Branches.svelte
@@ -163,6 +163,7 @@
 					<TextBox
 						icon="filter"
 						placeholder="Search"
+						spellCheck={false}
 						on:input={(e) => textFilter$.next(e.detail)}
 					/>
 					<div bind:this={contents} class="content">

--- a/gitbutler-ui/src/lib/components/Branches.svelte
+++ b/gitbutler-ui/src/lib/components/Branches.svelte
@@ -163,7 +163,7 @@
 					<TextBox
 						icon="filter"
 						placeholder="Search"
-						spellCheck={false}
+						spellcheck={false}
 						on:input={(e) => textFilter$.next(e.detail)}
 					/>
 					<div bind:this={contents} class="content">

--- a/gitbutler-ui/src/lib/components/CommitDialog.svelte
+++ b/gitbutler-ui/src/lib/components/CommitDialog.svelte
@@ -134,6 +134,7 @@
 					use:focusTextareaOnMount
 					on:input={useAutoHeight}
 					on:focus={useAutoHeight}
+					spellcheck={false}
 					class="commit-box__textarea text-base-body-13"
 					rows="1"
 					disabled={isGeneratingCommigMessage}

--- a/gitbutler-ui/src/lib/components/TextArea.svelte
+++ b/gitbutler-ui/src/lib/components/TextArea.svelte
@@ -7,6 +7,7 @@
 	export let rows = 4;
 	export let id: string | undefined = undefined;
 	export let disabled = false;
+	export let spellcheck = false;
 
 	export let kind: 'default' | 'plain' = 'default';
 
@@ -22,6 +23,7 @@
 	{placeholder}
 	{required}
 	{rows}
+	{spellcheck}
 	on:input={(e) => dispatch('input', e.currentTarget.value)}
 	on:change={(e) => dispatch('change', e.currentTarget.value)}
 />

--- a/gitbutler-ui/src/lib/components/TextBox.svelte
+++ b/gitbutler-ui/src/lib/components/TextBox.svelte
@@ -16,6 +16,7 @@
 	export let noselect = false;
 	export let selectall = false;
 	export let element: HTMLElement | undefined = undefined;
+	export let spellCheck = true;
 
 	const dispatch = createEventDispatcher<{ input: string; change: string }>();
 </script>
@@ -43,6 +44,7 @@
 				{readonly}
 				{required}
 				{placeholder}
+				{spellCheck}
 				type="password"
 				class="textbox__input text-base-13"
 				class:select-none={noselect}
@@ -57,6 +59,7 @@
 				{readonly}
 				{required}
 				{placeholder}
+				{spellCheck}
 				class="textbox__input text-base-13"
 				class:select-none={noselect}
 				class:select-all={selectall}

--- a/gitbutler-ui/src/lib/components/TextBox.svelte
+++ b/gitbutler-ui/src/lib/components/TextBox.svelte
@@ -16,7 +16,7 @@
 	export let noselect = false;
 	export let selectall = false;
 	export let element: HTMLElement | undefined = undefined;
-	export let spellCheck = true;
+	export let spellcheck = true;
 
 	const dispatch = createEventDispatcher<{ input: string; change: string }>();
 </script>
@@ -44,7 +44,7 @@
 				{readonly}
 				{required}
 				{placeholder}
-				{spellCheck}
+				{spellcheck}
 				type="password"
 				class="textbox__input text-base-13"
 				class:select-none={noselect}
@@ -59,7 +59,7 @@
 				{readonly}
 				{required}
 				{placeholder}
-				{spellCheck}
+				{spellcheck}
 				class="textbox__input text-base-13"
 				class:select-none={noselect}
 				class:select-all={selectall}

--- a/gitbutler-ui/src/lib/components/TextBox.svelte
+++ b/gitbutler-ui/src/lib/components/TextBox.svelte
@@ -16,7 +16,7 @@
 	export let noselect = false;
 	export let selectall = false;
 	export let element: HTMLElement | undefined = undefined;
-	export let spellcheck = true;
+	export let spellcheck = false;
 
 	const dispatch = createEventDispatcher<{ input: string; change: string }>();
 </script>


### PR DESCRIPTION
* Related https://github.com/gitbutlerapp/gitbutler/issues/2709

## The problem

macOs spell checker is correcting words and capitalisation in the branch name filter.

Often we use incomplete words, non-word acronyms, and search terms that don't start with capitals, and it can be quite bothersome.

## The solution

The solution was to make use of the spellCheck property which does pretty much what it says on the tin