### PR TITLE
Fix hunk grab cursors

### DIFF
--- a/gitbutler-ui/src/lib/components/HunkLine.svelte
+++ b/gitbutler-ui/src/lib/components/HunkLine.svelte
@@ -11,6 +11,7 @@
 	export let selectable: boolean = false;
 	export let selected: boolean = true;
 	export let readonly: boolean = false;
+	export let draggingDisabled: boolean = false;
 
 	const dispatch = createEventDispatcher<{ selected: boolean }>();
 
@@ -63,6 +64,7 @@
 		class:readonly
 		class:diff-line-deletion={sectionType === SectionType.RemovedLines}
 		class:diff-line-addition={sectionType === SectionType.AddedLines}
+		style:cursor={draggingDisabled ? 'default' : 'grab'}
 	>
 		<span class="selectable-wrapper" data-no-drag>
 			{@html toTokens(line.content).join('')}
@@ -82,9 +84,6 @@
 
 	.line {
 		flex-grow: 1;
-		&:not(.readonly) {
-			cursor: grab;
-		}
 	}
 
 	.code-line__numbers-line {

--- a/gitbutler-ui/src/lib/components/HunkLine.svelte
+++ b/gitbutler-ui/src/lib/components/HunkLine.svelte
@@ -47,6 +47,7 @@
 			on:click={() => dispatch('selected', !selected)}
 			class="text-color-4 border-color-4 shrink-0 select-none border-r px-0.5 text-right text-xs {bgColor}"
 			style:min-width={minWidth + 'rem'}
+			style:cursor={draggingDisabled ? 'default' : 'grab'}
 		>
 			{line.beforeLineNumber || ''}
 		</button>
@@ -55,6 +56,7 @@
 			on:click={() => dispatch('selected', !selected)}
 			class="text-color-4 border-color-4 shrink-0 select-none border-r px-0.5 text-right text-xs {bgColor}"
 			style:min-width={minWidth + 'rem'}
+			style:cursor={draggingDisabled ? 'default' : 'grab'}
 		>
 			{line.afterLineNumber || ''}
 		</button>

--- a/gitbutler-ui/src/lib/components/HunkViewer.svelte
+++ b/gitbutler-ui/src/lib/components/HunkViewer.svelte
@@ -43,6 +43,8 @@
 
 	$: popupMenu = updateContextMenu(filePath);
 
+	$: draggingDisabled = readonly || isUnapplied || section.hunk.locked || !branchId;
+
 	onDestroy(() => {
 		if (popupMenu) {
 			popupMenu.$destroy();
@@ -55,7 +57,7 @@
 	role="cell"
 	use:draggable={{
 		...draggableHunk(branchId, section.hunk),
-		disabled: readonly || isUnapplied || section.hunk.locked || !branchId
+		disabled: draggingDisabled
 	}}
 	on:contextmenu|preventDefault
 	class="hunk"
@@ -72,6 +74,7 @@
 					{readonly}
 					{minWidth}
 					{selectable}
+					{draggingDisabled}
 					selected={$selectedOwnership?.containsHunk(hunk.filePath, hunk.id)}
 					on:selected={(e) => onHunkSelected(hunk, e.detail)}
 					sectionType={subsection.sectionType}


### PR DESCRIPTION
This PR fixes two issues with the cursor style for dragging hunks:

1. Fixes issue where the grab cursor would be shown when hovering diff lines, even though dragging was disabled (e.g. if the hunk was locked).
2. Fixes issue where a grab cursor would never show when hovering hunk diff line numbers, even though dragging on the line numbers was allowed.

Discord discussion: https://discord.com/channels/1060193121130000425/1208015050082619423.