### PR TITLE
Fix push button behaviour after undoing a commit

### DIFF
--- a/gitbutler-ui/src/lib/components/BranchCommits.svelte
+++ b/gitbutler-ui/src/lib/components/BranchCommits.svelte
@@ -18,50 +18,48 @@
 	export let branchCount: number;
 </script>
 
-{#if branch.commits.length > 0}
-	<CommitList
-		{branch}
-		{base}
-		{project}
-		{branchController}
-		{branchService}
-		{branchCount}
-		{githubService}
-		{isUnapplied}
-		{selectedFiles}
-		type="upstream"
-	/>
-	<CommitList
-		{branch}
-		{base}
-		{project}
-		{branchController}
-		{branchService}
-		{githubService}
-		{isUnapplied}
-		{selectedFiles}
-		type="local"
-	/>
-	<CommitList
-		{branch}
-		{base}
-		{project}
-		{branchController}
-		{branchService}
-		{githubService}
-		{isUnapplied}
-		{selectedFiles}
-		type="remote"
-	/>
-	<CommitList
-		{branch}
-		{base}
-		{project}
-		{branchController}
-		{branchService}
-		{githubService}
-		{isUnapplied}
-		{selectedFiles}
-		type="integrated"
-	/>
-{/if}
+<CommitList
+    {branch}
+    {base}
+    {project}
+    {branchController}
+    {branchService}
+    {branchCount}
+    {githubService}
+    {isUnapplied}
+    {selectedFiles}
+    type="upstream"
+/>
+<CommitList
+    {branch}
+    {base}
+    {project}
+    {branchController}
+    {branchService}
+    {githubService}
+    {isUnapplied}
+    {selectedFiles}
+    type="local"
+/>
+<CommitList
+    {branch}
+    {base}
+    {project}
+    {branchController}
+    {branchService}
+    {githubService}
+    {isUnapplied}
+    {selectedFiles}
+    type="remote"
+/>
+<CommitList
+    {branch}
+    {base}
+    {project}
+    {branchController}
+    {branchService}
+    {githubService}
+    {isUnapplied}
+    {selectedFiles}
+    type="integrated"
+/>

--- a/gitbutler-ui/src/lib/components/BranchCommits.svelte
+++ b/gitbutler-ui/src/lib/components/BranchCommits.svelte
@@ -19,47 +19,47 @@
 </script>
 
 <CommitList
-    {branch}
-    {base}
-    {project}
-    {branchController}
-    {branchService}
-    {branchCount}
-    {githubService}
-    {isUnapplied}
-    {selectedFiles}
-    type="upstream"
+	{branch}
+	{base}
+	{project}
+	{branchController}
+	{branchService}
+	{branchCount}
+	{githubService}
+	{isUnapplied}
+	{selectedFiles}
+	type="upstream"
 />
 <CommitList
-    {branch}
-    {base}
-    {project}
-    {branchController}
-    {branchService}
-    {githubService}
-    {isUnapplied}
-    {selectedFiles}
-    type="local"
+	{branch}
+	{base}
+	{project}
+	{branchController}
+	{branchService}
+	{githubService}
+	{isUnapplied}
+	{selectedFiles}
+	type="local"
 />
 <CommitList
-    {branch}
-    {base}
-    {project}
-    {branchController}
-    {branchService}
-    {githubService}
-    {isUnapplied}
-    {selectedFiles}
-    type="remote"
+	{branch}
+	{base}
+	{project}
+	{branchController}
+	{branchService}
+	{githubService}
+	{isUnapplied}
+	{selectedFiles}
+	type="remote"
 />
 <CommitList
-    {branch}
-    {base}
-    {project}
-    {branchController}
-    {branchService}
-    {githubService}
-    {isUnapplied}
-    {selectedFiles}
-    type="integrated"
+	{branch}
+	{base}
+	{project}
+	{branchController}
+	{branchService}
+	{githubService}
+	{isUnapplied}
+	{selectedFiles}
+	type="integrated"
 />

--- a/gitbutler-ui/src/lib/components/CommitList.svelte
+++ b/gitbutler-ui/src/lib/components/CommitList.svelte
@@ -25,10 +25,13 @@
 	$: headCommit = branch.commits[0];
 
 	$: commits = type == 'upstream' ? [] : branch.commits.filter((c) => c.status == type);
+    $: hasCommits = commits && commits.length > 0;
+    $: remoteRequiresForcePush = type === 'remote' && branch.requiresForce;
+
 	let expanded = true;
 </script>
 
-{#if commits && commits.length > 0}
+{#if hasCommits || remoteRequiresForcePush }
 	<div
 		class="commit-list card"
 		class:upstream={type == 'upstream'}

--- a/gitbutler-ui/src/lib/components/CommitList.svelte
+++ b/gitbutler-ui/src/lib/components/CommitList.svelte
@@ -25,13 +25,13 @@
 	$: headCommit = branch.commits[0];
 
 	$: commits = type == 'upstream' ? [] : branch.commits.filter((c) => c.status == type);
-    $: hasCommits = commits && commits.length > 0;
-    $: remoteRequiresForcePush = type === 'remote' && branch.requiresForce;
+	$: hasCommits = commits && commits.length > 0;
+	$: remoteRequiresForcePush = type === 'remote' && branch.requiresForce;
 
 	let expanded = true;
 </script>
 
-{#if hasCommits || remoteRequiresForcePush }
+{#if hasCommits || remoteRequiresForcePush}
 	<div
 		class="commit-list card"
 		class:upstream={type == 'upstream'}

--- a/gitbutler-ui/src/lib/components/CommitListFooter.svelte
+++ b/gitbutler-ui/src/lib/components/CommitListFooter.svelte
@@ -77,7 +77,7 @@
 				isLoading={isPushing || $githubServiceState$?.busy}
 				isPushed={type == 'remote' && !branch.requiresForce}
 				requiresForcePush={branch.requiresForce}
-				isPr={$pr$}
+				isPr={!!$pr$}
 				{projectId}
 				githubEnabled={$githubEnabled$}
 				on:trigger={async (e) => {

--- a/gitbutler-ui/src/lib/components/CommitListFooter.svelte
+++ b/gitbutler-ui/src/lib/components/CommitListFooter.svelte
@@ -71,7 +71,7 @@
 
 {#if !isUnapplied && type != 'integrated'}
 	<div class="actions">
-		{#if $githubEnabled$ && !$pr$ && (type == 'local' || type == 'remote')}
+		{#if $githubEnabled$ && (type == 'local' || type == 'remote')}
 			<PushButton
 				wide
 				isLoading={isPushing || $githubServiceState$?.busy}

--- a/gitbutler-ui/src/lib/components/CommitListFooter.svelte
+++ b/gitbutler-ui/src/lib/components/CommitListFooter.svelte
@@ -75,7 +75,9 @@
 			<PushButton
 				wide
 				isLoading={isPushing || $githubServiceState$?.busy}
-				isPushed={type == 'remote'}
+				isPushed={type == 'remote' && !branch.requiresForce}
+                requiresForcePush={branch.requiresForce}
+                isPr={$pr$}
 				{projectId}
 				githubEnabled={$githubEnabled$}
 				on:trigger={async (e) => {

--- a/gitbutler-ui/src/lib/components/CommitListFooter.svelte
+++ b/gitbutler-ui/src/lib/components/CommitListFooter.svelte
@@ -76,8 +76,8 @@
 				wide
 				isLoading={isPushing || $githubServiceState$?.busy}
 				isPushed={type == 'remote' && !branch.requiresForce}
-                requiresForcePush={branch.requiresForce}
-                isPr={$pr$}
+				requiresForcePush={branch.requiresForce}
+				isPr={$pr$}
 				{projectId}
 				githubEnabled={$githubEnabled$}
 				on:trigger={async (e) => {

--- a/gitbutler-ui/src/lib/components/PushButton.svelte
+++ b/gitbutler-ui/src/lib/components/PushButton.svelte
@@ -21,8 +21,8 @@
 	export let isLoading = false;
 	export let githubEnabled: boolean;
 	export let wide = false;
-    export let requiresForcePush = false;
-    export let isPr = false;
+	export let requiresForcePush = false;
+	export let isPr = false;
 
 	function defaultAction(projectId: string): Persisted<BranchAction> {
 		const key = 'projectDefaultAction_';
@@ -53,74 +53,74 @@
 		return preferredAction;
 	}
 
-    $: pushLabel = requiresForcePush ? 'Force push to remote' : 'Push to remote'
+	$: pushLabel = requiresForcePush ? 'Force push to remote' : 'Push to remote';
 </script>
 
-{#if isPr && requiresForcePush }
-    <Button
-        color="primary"
-        kind="outlined"
-        {wide}
-        disabled={isPushed}
-        on:click={() => {
-            dispatch('trigger', { action: BranchAction.Push });
-        }}>{pushLabel}</Button
-    >
-{:else if !isPr }
-    <DropDownButton
-        color="primary"
-        kind="outlined"
-        loading={isLoading}
-        bind:this={dropDown}
-        {wide}
-        {disabled}
-        on:click={() => {
-            dispatch('trigger', { action });
-        }}
-    >
-        {$selection$?.label}
-        <ContextMenu
-            type="select"
-            slot="context-menu"
-            bind:this={contextMenu}
-            on:select={(e) => {
-                // TODO: Refactor to use generics if/when that works with Svelte
-                switch (e.detail?.id) {
-                    case BranchAction.Push:
-                        $preferredAction = BranchAction.Push;
-                        break;
-                    case BranchAction.Pr:
-                        $preferredAction = BranchAction.Pr;
-                        break;
-                    case BranchAction.DraftPr:
-                        $preferredAction = BranchAction.DraftPr;
-                        break;
-                    default:
-                        toasts.error('Uknown branch action');
-                }
-                dropDown.close();
-            }}
-        >
-            <ContextMenuSection>
-                <ContextMenuItem
-                    id="push"
-                    label={pushLabel}
-                    selected={action == BranchAction.Push}
-                    disabled={isPushed}
-                />
-                <ContextMenuItem
-                    id="pr"
-                    label="Create pull request"
-                    disabled={!githubEnabled}
-                    selected={action == BranchAction.Pr}
-                />
-                <ContextMenuItem
-                    id="draftPr"
-                    label="Create draft pull request"
-                    disabled={!githubEnabled}
-                    selected={action == BranchAction.DraftPr}
-                />
-            </ContextMenuSection>
-        </ContextMenu>
-    </DropDownButton>
+{#if isPr && requiresForcePush}
+	<Button
+		color="primary"
+		kind="outlined"
+		{wide}
+		disabled={isPushed}
+		on:click={() => {
+			dispatch('trigger', { action: BranchAction.Push });
+		}}>{pushLabel}</Button
+	>
+{:else if !isPr}
+	<DropDownButton
+		color="primary"
+		kind="outlined"
+		loading={isLoading}
+		bind:this={dropDown}
+		{wide}
+		{disabled}
+		on:click={() => {
+			dispatch('trigger', { action });
+		}}
+	>
+		{$selection$?.label}
+		<ContextMenu
+			type="select"
+			slot="context-menu"
+			bind:this={contextMenu}
+			on:select={(e) => {
+				// TODO: Refactor to use generics if/when that works with Svelte
+				switch (e.detail?.id) {
+					case BranchAction.Push:
+						$preferredAction = BranchAction.Push;
+						break;
+					case BranchAction.Pr:
+						$preferredAction = BranchAction.Pr;
+						break;
+					case BranchAction.DraftPr:
+						$preferredAction = BranchAction.DraftPr;
+						break;
+					default:
+						toasts.error('Uknown branch action');
+				}
+				dropDown.close();
+			}}
+		>
+			<ContextMenuSection>
+				<ContextMenuItem
+					id="push"
+					label={pushLabel}
+					selected={action == BranchAction.Push}
+					disabled={isPushed}
+				/>
+				<ContextMenuItem
+					id="pr"
+					label="Create pull request"
+					disabled={!githubEnabled}
+					selected={action == BranchAction.Pr}
+				/>
+				<ContextMenuItem
+					id="draftPr"
+					label="Create draft pull request"
+					disabled={!githubEnabled}
+					selected={action == BranchAction.DraftPr}
+				/>
+			</ContextMenuSection>
+		</ContextMenu>
+	</DropDownButton>
 {/if}

--- a/gitbutler-ui/src/lib/components/PushButton.svelte
+++ b/gitbutler-ui/src/lib/components/PushButton.svelte
@@ -7,6 +7,7 @@
 </script>
 
 <script lang="ts">
+	import Button from '$lib/components/Button.svelte';
 	import DropDownButton from '$lib/components/DropDownButton.svelte';
 	import ContextMenu from '$lib/components/contextmenu/ContextMenu.svelte';
 	import ContextMenuItem from '$lib/components/contextmenu/ContextMenuItem.svelte';
@@ -20,6 +21,8 @@
 	export let isLoading = false;
 	export let githubEnabled: boolean;
 	export let wide = false;
+    export let requiresForcePush = false;
+    export let isPr = false;
 
 	function defaultAction(projectId: string): Persisted<BranchAction> {
 		const key = 'projectDefaultAction_';
@@ -49,61 +52,75 @@
 		}
 		return preferredAction;
 	}
+
+    $: pushLabel = requiresForcePush ? 'Force push to remote' : 'Push to remote'
 </script>
 
-<DropDownButton
-	color="primary"
-	kind="outlined"
-	loading={isLoading}
-	bind:this={dropDown}
-	{wide}
-	{disabled}
-	on:click={() => {
-		dispatch('trigger', { action });
-	}}
->
-	{$selection$?.label}
-	<ContextMenu
-		type="select"
-		slot="context-menu"
-		bind:this={contextMenu}
-		on:select={(e) => {
-			// TODO: Refactor to use generics if/when that works with Svelte
-			switch (e.detail?.id) {
-				case BranchAction.Push:
-					$preferredAction = BranchAction.Push;
-					break;
-				case BranchAction.Pr:
-					$preferredAction = BranchAction.Pr;
-					break;
-				case BranchAction.DraftPr:
-					$preferredAction = BranchAction.DraftPr;
-					break;
-				default:
-					toasts.error('Uknown branch action');
-			}
-			dropDown.close();
-		}}
-	>
-		<ContextMenuSection>
-			<ContextMenuItem
-				id="push"
-				label="Push to remote"
-				selected={action == BranchAction.Push}
-				disabled={isPushed}
-			/>
-			<ContextMenuItem
-				id="pr"
-				label="Create pull request"
-				disabled={!githubEnabled}
-				selected={action == BranchAction.Pr}
-			/>
-			<ContextMenuItem
-				id="draftPr"
-				label="Create draft pull request"
-				disabled={!githubEnabled}
-				selected={action == BranchAction.DraftPr}
-			/>
-		</ContextMenuSection>
-	</ContextMenu>
-</DropDownButton>
+{#if isPr && requiresForcePush }
+    <Button
+        color="primary"
+        kind="outlined"
+        {wide}
+        disabled={isPushed}
+        on:click={() => {
+            dispatch('trigger', { action: BranchAction.Push });
+        }}>{pushLabel}</Button
+    >
+{:else if !isPr }
+    <DropDownButton
+        color="primary"
+        kind="outlined"
+        loading={isLoading}
+        bind:this={dropDown}
+        {wide}
+        {disabled}
+        on:click={() => {
+            dispatch('trigger', { action });
+        }}
+    >
+        {$selection$?.label}
+        <ContextMenu
+            type="select"
+            slot="context-menu"
+            bind:this={contextMenu}
+            on:select={(e) => {
+                // TODO: Refactor to use generics if/when that works with Svelte
+                switch (e.detail?.id) {
+                    case BranchAction.Push:
+                        $preferredAction = BranchAction.Push;
+                        break;
+                    case BranchAction.Pr:
+                        $preferredAction = BranchAction.Pr;
+                        break;
+                    case BranchAction.DraftPr:
+                        $preferredAction = BranchAction.DraftPr;
+                        break;
+                    default:
+                        toasts.error('Uknown branch action');
+                }
+                dropDown.close();
+            }}
+        >
+            <ContextMenuSection>
+                <ContextMenuItem
+                    id="push"
+                    label={pushLabel}
+                    selected={action == BranchAction.Push}
+                    disabled={isPushed}
+                />
+                <ContextMenuItem
+                    id="pr"
+                    label="Create pull request"
+                    disabled={!githubEnabled}
+                    selected={action == BranchAction.Pr}
+                />
+                <ContextMenuItem
+                    id="draftPr"
+                    label="Create draft pull request"
+                    disabled={!githubEnabled}
+                    selected={action == BranchAction.DraftPr}
+                />
+            </ContextMenuSection>
+        </ContextMenu>
+    </DropDownButton>
+{/if}

--- a/gitbutler-ui/src/lib/components/PushButton.svelte
+++ b/gitbutler-ui/src/lib/components/PushButton.svelte
@@ -56,7 +56,7 @@
 	$: pushLabel = requiresForcePush ? 'Force push to remote' : 'Push to remote';
 </script>
 
-{#if isPr && requiresForcePush}
+{#if isPr && !isPushed}
 	<Button
 		color="primary"
 		kind="outlined"


### PR DESCRIPTION
* Closes https://github.com/gitbutlerapp/gitbutler/issues/2733

## The problem

Currently in git butler, after undoing a commit from the remote, there is no option to force push to get rid of the commit that is still on the remote.

## The solution

The solution was to change the logic of the PushButton to include a new state that will show if there should be the option to force push

## Video of the change in action:

https://youtu.be/puGAWTrq6xM