### PR TITLE
Fix bug where hunk lines numbers become undraggable when diff text is selected

### DIFF
--- a/gitbutler-ui/src/lib/components/HunkLine.svelte
+++ b/gitbutler-ui/src/lib/components/HunkLine.svelte
@@ -43,8 +43,7 @@
 <div class="code-line text-sm" role="group" on:contextmenu|preventDefault>
 	<div class="code-line__numbers-line">
 		<button
-			disabled={!selectable}
-			on:click={() => dispatch('selected', !selected)}
+			on:click={() => selectable && dispatch('selected', !selected)}
 			class="text-color-4 border-color-4 shrink-0 select-none border-r px-0.5 text-right text-xs {bgColor}"
 			style:min-width={minWidth + 'rem'}
 			style:cursor={draggingDisabled ? 'default' : 'grab'}
@@ -52,8 +51,7 @@
 			{line.beforeLineNumber || ''}
 		</button>
 		<button
-			disabled={!selectable}
-			on:click={() => dispatch('selected', !selected)}
+			on:click={() => selectable && dispatch('selected', !selected)}
 			class="text-color-4 border-color-4 shrink-0 select-none border-r px-0.5 text-right text-xs {bgColor}"
 			style:min-width={minWidth + 'rem'}
 			style:cursor={draggingDisabled ? 'default' : 'grab'}


### PR DESCRIPTION
This PR fixes a bug due to the hunk diff line numbers doubling as buttons. When looking at a hunk, and not in the process of committing, the line number buttons are disabled. This prevents the hunk from being dragged from the line numbers if any diff text has been selected. I'm not sure why this happens, but instead of disabling the line number buttons, this PR just nulls `on:click` for the buttons, unless you're in commit mode. That seems to fix the issue.

I couldn't come up with any downsides to not disabling the line number buttons (and just nulling `on:click` instead), but I might have missed something.

Note that line numbers serving two purposes (hunk dragging and hunk selection) during a commit might not be the most intuitive, but dragging hunks while committing seems to work fine, so I guess it's by design?

**Before:**

https://github.com/gitbutlerapp/gitbutler/assets/52106/0318f0c6-d977-422c-8e9b-3f1bca73b19c

**After:**

https://github.com/gitbutlerapp/gitbutler/assets/52106/5f851a99-e1ee-4004-a587-5bf889656a06

