### PR TITLE
Update the default value for signCommits in frontend to false to match backend

### DIFF
--- a/gitbutler-ui/src/routes/settings/+page.svelte
+++ b/gitbutler-ui/src/routes/settings/+page.svelte
@@ -121,7 +121,7 @@
 	});
 
 	git_get_config({ key: 'gitbutler.signCommits' }).then((value) => {
-		signCommits = value ? value === 'true' : true;
+		signCommits = value ? value === 'true' : false;
 	});
 
 	const onDeleteClicked = () =>


### PR DESCRIPTION
* Closes https://github.com/gitbutlerapp/gitbutler/issues/2763

## The problem

Enabling signCommits for the first time doesn't seem to enable signing commits.

## The solution

In the backend, a nil value was interpreted as false, whereas in the frontend it is interpreted as true, and it seems like this dissonance was the cause of the problem so I've chosen to default to false in both locations.