### PR TITLE
fix(docs): clean up some typos in documentation files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ So you're interested in contributing to GitButler. Amazing!
 ## Understand the License
 
 First thing to know, GitButler is not a side project, it is the product of a
-pretty cool company located in Berlin who develop this client and it's
+pretty cool company located in Berlin who develop this client and its
 associated services professionally. For this reason, we have licensed this
 software under the [Functional Source License](https://fsl.software/), a
 mostly permissive non-compete license that converts to Apache 2.0 or MIT after
@@ -24,13 +24,13 @@ As a private company, we have our own development processes that we try to be
 fairly open about, but we're all sitting in a room in Berlin, so external
 contributions and remote work aren't really a central part of our process.
 
-It's possible that you want to see a feature and we disagree, so if you want
-to get something accepted, please discuss it with us first so we can all be
+It's possible that you want to see a feature, and we disagree, so if you want
+to get something accepted, please discuss it with us first, so we can all be
 fairly confident that your work has a chance to be accepted before you spend
 your time or result in needing to maintain a fork.
 
 The two places to communicate with us are on Discord and GitHub (issues and
-discussions, etc).
+discussions, etc.).
 
 Join our Discord here: https://discord.gg/MmFkmaJ42D
 
@@ -44,14 +44,14 @@ maintaining this project.
 
 ## Submitting a Change
 
-If you talked it over with us and we agree that it's something we would take,
+If you talked it over with us, and we agree that it's something we would take,
 please do the familiar GitHub dance of forking the repository and submitting
-a Pull Request so we can review and possibly merge it.
+a Pull Request, so we can review and possibly merge it.
 
 Any contributions sent to us implicitly give us the right to redistribute that
 work under the same license and rights.
 
-[Why we don't explicity require a CLA for contributions to GitButler](https://ben.balter.com/2018/01/02/why-you-probably-shouldnt-add-a-cla-to-your-open-source-project/)
+[Why we don't explicitly require a CLA for contributions to GitButler](https://ben.balter.com/2018/01/02/why-you-probably-shouldnt-add-a-cla-to-your-open-source-project/)
 
 ## How will GitButler Stay in Business?
 
@@ -59,11 +59,11 @@ The client is open source and free to use, forever. If you want to use this
 as your Git client, it will never be pulled out from under you.
 
 In parallel with this client, we're also developing some rad cloud services
-that you can optionally enable but are not neccesary or limiting to your
+that you can optionally enable but are not necessary or limiting to your
 client experience. If we can provide some compelling team functionality that
 you can get your boss to pay for, then we would love to have your business
 in that area. If it's not interesting to you, then never fear, the client is
-fully functional on it's own and totally free.
+fully functional on its own and totally free.
 
 ## Kudos
 
@@ -73,7 +73,7 @@ care about what we're doing.
 
 However, helping us with our codebase is over the top. We'll call out our
 contributors in some way, though we haven't quite figured out how yet. But
-rest assured, we'll give you credit. Or schwag maybe. Or a beer, if you're
+rest assured, we'll give you credit. Or schwag, maybe. Or a beer, if you're
 ever in town.
 
 ## Get into the Code!

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -140,7 +140,7 @@ You'll need to fix the security permissions for the `nodejs` folder.
 > Node.js, this may pose a security concern. Be sure to understand
 > the implications of this before proceeding.
 
-1. Right click on the `nodejs` folder in `Program Files`.
+1. Right-click on the `nodejs` folder in `Program Files`.
 2. Click on `Properties`.
 3. Click on the `Security` tab.
 4. Click on `Edit` next to "change permissions".

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-<p align="center">
-  <p align="center">
-   <img width="128px" src="gitbutler-app/icons/128x128@2x.png" />
-  </p>
+<div align="center">
+   <img align="center" width="128px" src="gitbutler-app/icons/128x128@2x.png" />
 	<h1 align="center"><b>GitButler</b></h1>
 	<p align="center">
 		Git branch management tool, built from the ground up for modern workflows
@@ -17,7 +15,7 @@
     <br />
     <i>~ Link for Windows will be added once a release is available. ~</i>
   </p>
-</p>
+</div>
 
 <br/>
 
@@ -115,7 +113,7 @@ or [join our Discord server](https://discord.gg/wDKZCPEjXC).
 
 Commit message generation is an opt-in feature. You can enable it while adding your repository for the first time or later in the project settings.
 
-Currently GitButler uses OpenAI's API for diff summarization, which means that if enabled, code diffs would be sent to OpenAI's servers.
+Currently, GitButler uses OpenAI's API for diff summarization, which means that if enabled, code diffs would be sent to OpenAI's servers.
 
 Our goal is to make this feature more modular such that in the future you can modify the prompt as well as plug a different LLM endpoints (including a local ones).
 


### PR DESCRIPTION
This pull request fixes some typo or spelling mistakes I've found in the documentation files. Hope you agree with them, looking forward to merge this. 
