### PR TITLE
Add loading state to PushButton when in "pr" state

### DIFF
--- a/gitbutler-ui/src/lib/components/PushButton.svelte
+++ b/gitbutler-ui/src/lib/components/PushButton.svelte
@@ -62,6 +62,7 @@
 		kind="outlined"
 		{wide}
 		disabled={isPushed}
+		loading={isLoading}
 		on:click={() => {
 			dispatch('trigger', { action: BranchAction.Push });
 		}}>{pushLabel}</Button


### PR DESCRIPTION
## The problem

When clicking the push button in the PR state, it feels unresponsive because it doesn't have the loading state set up

## The solution

I added it :D 