### PR TITLE
Only show "Force push to remote" when pushing zero commits to a branch

### DIFF
--- a/gitbutler-ui/src/lib/components/CommitListFooter.svelte
+++ b/gitbutler-ui/src/lib/components/CommitListFooter.svelte
@@ -75,9 +75,9 @@
 			<PushButton
 				wide
 				isLoading={isPushing || $githubServiceState$?.busy}
-				isPushed={type == 'remote' && !branch.requiresForce}
-				requiresForcePush={branch.requiresForce}
 				isPr={!!$pr$}
+				{type}
+				{branch}
 				{projectId}
 				githubEnabled={$githubEnabled$}
 				on:trigger={async (e) => {

--- a/gitbutler-ui/src/lib/components/PushButton.svelte
+++ b/gitbutler-ui/src/lib/components/PushButton.svelte
@@ -8,7 +8,6 @@
 
 <script lang="ts">
 	import Button from '$lib/components/Button.svelte';
-	import type { Branch } from '$lib/vbranches/types';
 	import DropDownButton from '$lib/components/DropDownButton.svelte';
 	import ContextMenu from '$lib/components/contextmenu/ContextMenu.svelte';
 	import ContextMenuItem from '$lib/components/contextmenu/ContextMenuItem.svelte';
@@ -16,6 +15,7 @@
 	import { persisted, type Persisted } from '$lib/persisted/persisted';
 	import * as toasts from '$lib/utils/toasts';
 	import { createEventDispatcher } from 'svelte';
+	import type { Branch } from '$lib/vbranches/types';
 
 	export let projectId: string;
 	export let type: string;
@@ -39,11 +39,11 @@
 
 	$: selection$ = contextMenu?.selection$;
 
-    let action!: BranchAction;
+	let action!: BranchAction;
 	$: {
-        isPushed; // selectAction is dependant on isPushed
-        action = selectAction($preferredAction);
-    }
+		isPushed; // selectAction is dependant on isPushed
+		action = selectAction($preferredAction);
+	}
 
 	function selectAction(preferredAction: BranchAction) {
 		if (isPushed && !githubEnabled) {

--- a/gitbutler-ui/src/lib/components/PushButton.svelte
+++ b/gitbutler-ui/src/lib/components/PushButton.svelte
@@ -8,6 +8,7 @@
 
 <script lang="ts">
 	import Button from '$lib/components/Button.svelte';
+	import type { Branch } from '$lib/vbranches/types';
 	import DropDownButton from '$lib/components/DropDownButton.svelte';
 	import ContextMenu from '$lib/components/contextmenu/ContextMenu.svelte';
 	import ContextMenuItem from '$lib/components/contextmenu/ContextMenuItem.svelte';
@@ -17,11 +18,11 @@
 	import { createEventDispatcher } from 'svelte';
 
 	export let projectId: string;
-	export let isPushed: boolean;
+	export let type: string;
 	export let isLoading = false;
 	export let githubEnabled: boolean;
 	export let wide = false;
-	export let requiresForcePush = false;
+	export let branch: Branch;
 	export let isPr = false;
 
 	function defaultAction(projectId: string): Persisted<BranchAction> {
@@ -37,7 +38,12 @@
 	let disabled = false;
 
 	$: selection$ = contextMenu?.selection$;
-	$: action = selectAction($preferredAction);
+
+    let action!: BranchAction;
+	$: {
+        isPushed; // selectAction is dependant on isPushed
+        action = selectAction($preferredAction);
+    }
 
 	function selectAction(preferredAction: BranchAction) {
 		if (isPushed && !githubEnabled) {
@@ -53,15 +59,18 @@
 		return preferredAction;
 	}
 
-	$: pushLabel = requiresForcePush ? 'Force push to remote' : 'Push to remote';
+	$: pushLabel = branch.requiresForce ? 'Force push to remote' : 'Push to remote';
+	$: commits = branch.commits.filter((c) => c.status == type);
+	$: isPushed = type === 'remote' && !branch.requiresForce;
 </script>
 
-{#if isPr && !isPushed}
+{#if (isPr || commits.length === 0) && !isPushed}
 	<Button
 		color="primary"
 		kind="outlined"
 		{wide}
 		disabled={isPushed}
+		loading={isLoading}
 		on:click={() => {
 			dispatch('trigger', { action: BranchAction.Push });
 		}}>{pushLabel}</Button


### PR DESCRIPTION
## The problem

GitHub won't let you make a PR with zero commits in it, so when we have the PushButton component rendered on a remote branch with zero commits, we shouldn't give the option to make a PR.

Example: I've pushed a commit to a remote, and undone it. Having the option to create a PR is non-sensical, and confusing if its actually defaulted to that option on you.
![Screenshot 2024-02-17 at 12 33 04](https://github.com/gitbutlerapp/gitbutler/assets/13354155/8b1d9089-9db3-446c-b025-b2a298f89be3)

## The solution

I ended up passing in the branch and type into the PushButton component because there was a lot of PushButton specific logic sitting in the CommitListFooter, so moving it inside the PushButton felt like a sensible move.

I've added a second condition for only showing the single "Force push to remote" button.
Previously, it was:
- If the branch is a PR && its not pushed
Now its shown if either these conditions are met:
- If the branch is a PR && its not pushed
- If the branch has no commits && its not pushed

## Demo

In this screenshot, I've pushed a commit to remote and undone the commit. I'm no longer provided the option to make a PR.

![Screenshot 2024-02-17 at 12 31 49](https://github.com/gitbutlerapp/gitbutler/assets/13354155/0a745524-a4a2-49ec-9929-74eca6e1ecc4)