### PR TITLE
Fix surrounding context and file numbers

### DIFF
--- a/gitbutler-app/src/virtual_branches/context.rs
+++ b/gitbutler-app/src/virtual_branches/context.rs
@@ -36,37 +36,42 @@ pub fn hunk_with_context(
         .filter(|line| line.starts_with('+'))
         .count();
 
+    println!("######");
+    println!("{:?}", hunk_diff);
+    println!("{}", hunk_old_start_line);
+    println!("{}", hunk_new_start_line);
+    println!("{}", removed_count);
+    println!("{}", added_count);
+
     // Get context lines before the diff
     let mut context_before = Vec::new();
-    for i in 1..=context_lines {
-        if hunk_new_start_line > i {
-            let idx = hunk_new_start_line
-                .max(hunk_old_start_line)
-                .saturating_sub(i + 1); // +1
-            if idx < file_lines_before.len() {
-                if let Some(l) = file_lines_before.get(idx) {
-                    let mut s = (*l).to_string();
-                    s.insert(0, ' ');
-                    context_before.push(s);
-                }
-            }
+    let mut before_context_ending_index = hunk_old_start_line.saturating_sub(1);
+
+    if removed_count == 0 {
+        before_context_ending_index += 1;
+    }
+
+    let before_context_starting_index = before_context_ending_index.saturating_sub(context_lines);
+    context_before.reverse();
+
+    for index in before_context_starting_index..before_context_ending_index {
+        if let Some(l) = file_lines_before.get(index) {
+            let mut s = (*l).to_string();
+            s.insert(0, ' ');
+            context_before.push(s);
         }
     }
-    context_before.reverse();
 
     // Get context lines after the diff
     let mut context_after = Vec::new();
-    let end = context_lines - 1;
-    for i in 0..=end {
-        let idx = i
-            + hunk_new_start_line.min(hunk_old_start_line)
-            + removed_count.saturating_sub(added_count);
-        if idx < file_lines_before.len() {
-            if let Some(l) = file_lines_before.get(idx) {
-                let mut s = (*l).to_string();
-                s.insert(0, ' ');
-                context_after.push(s);
-            }
+    let after_context_starting_index = before_context_ending_index + removed_count;
+    let after_context_ending_index = after_context_starting_index + 3;
+
+    for index in after_context_starting_index..after_context_ending_index {
+        if let Some(l) = file_lines_before.get(index) {
+            let mut s = (*l).to_string();
+            s.insert(0, ' ');
+            context_after.push(s);
         }
     }
 

--- a/gitbutler-app/src/virtual_branches/context.rs
+++ b/gitbutler-app/src/virtual_branches/context.rs
@@ -506,7 +506,7 @@ mod tests {
  
    def invite
 ";
-        assert!(with_ctx.diff == expected);
+        assert_eq!(with_ctx.diff, expected);
         assert_eq!(with_ctx.old_start, 8);
         assert_eq!(with_ctx.old_lines, 8);
         assert_eq!(with_ctx.new_start, 8);

--- a/gitbutler-app/src/virtual_branches/context.rs
+++ b/gitbutler-app/src/virtual_branches/context.rs
@@ -77,17 +77,13 @@ pub fn hunk_with_context(
     }
 
 
-    let mut start_line_before = hunk_old_start_line
-        .max(hunk_new_start_line)
-        .saturating_sub(context_before.len());
-    let mut start_line_after = hunk_old_start_line
-        .max(hunk_new_start_line)
-        .saturating_sub(context_before.len());
-    // if there is no context to add (entire file is added / removed), leave the header as is
-    if context_after.len() + context_after.len() == 0 {
-        start_line_before = hunk_old_start_line;
-        start_line_after = hunk_new_start_line;
-    }
+    let start_line_before = before_context_starting_index;
+    let start_line_after =
+        if added_count == 0 {
+            hunk_new_start_line.saturating_sub(context_before.len())
+        } else {
+            hunk_new_start_line.saturating_sub(context_before.len() + 1)
+        };
 
     let line_count_before = removed_count + context_before.len() + context_after.len();
     let line_count_after = added_count + context_before.len() + context_after.len();

--- a/gitbutler-app/src/virtual_branches/context.rs
+++ b/gitbutler-app/src/virtual_branches/context.rs
@@ -54,7 +54,6 @@ pub fn hunk_with_context(
 
 
     let before_context_starting_index = before_context_ending_index.saturating_sub(context_lines);
-    context_before.reverse();
 
     for index in before_context_starting_index..before_context_ending_index {
         if let Some(l) = file_lines_before.get(index) {

--- a/gitbutler-app/src/virtual_branches/context.rs
+++ b/gitbutler-app/src/virtual_branches/context.rs
@@ -155,13 +155,13 @@ mod tests {
         )
         .unwrap();
         let expected = r#"@@ -5,7 +5,7 @@
- 
+
  [features]
  default = ["serde", "rusqlite"]
 -serde = ["dep:serde", "uuid/serde"]
 +SERDE = ["dep:serde", "uuid/serde"]
  rusqlite = ["dep:rusqlite"]
- 
+
  [dependencies]
 "#;
         assert_eq!(with_ctx.diff, expected);
@@ -195,7 +195,7 @@ mod tests {
 +NAME = "gitbutler-core"
  version = "0.0.0"
  edition = "2021"
- 
+
 "#
         );
         assert_eq!(with_ctx.old_start, 1);
@@ -255,7 +255,7 @@ mod tests {
         assert_eq!(
             with_ctx.diff,
             r#"@@ -10,5 +10,5 @@
- 
+
  [dependencies]
  rusqlite = { workspace = true, optional = true }
 -serde = { workspace = true, optional = true }
@@ -291,7 +291,7 @@ mod tests {
         assert_eq!(
             with_ctx.diff,
             r#"@@ -5,7 +5,10 @@
- 
+
  [features]
  default = ["serde", "rusqlite"]
 -serde = ["dep:serde", "uuid/serde"]
@@ -300,7 +300,7 @@ mod tests {
 +three
 +four
  rusqlite = ["dep:rusqlite"]
- 
+
  [dependencies]
 "#
         );
@@ -332,13 +332,13 @@ mod tests {
             with_ctx.diff,
             r#"@@ -4,9 +4,7 @@
  edition = "2021"
- 
+
  [features]
 -default = ["serde", "rusqlite"]
 -serde = ["dep:serde", "uuid/serde"]
 -rusqlite = ["dep:rusqlite"]
 +foo = ["foo"]
- 
+
  [dependencies]
  rusqlite = { workspace = true, optional = true }
 "#
@@ -450,7 +450,7 @@ mod tests {
 +two
 +three
  rusqlite = ["dep:rusqlite"]
- 
+
  [dependencies]
 "#;
         assert_eq!(with_ctx.diff, expected);
@@ -469,12 +469,12 @@ mod tests {
 "#;
         let expected = r#"@@ -4,9 +4,6 @@
  edition = "2021"
- 
+
  [features]
 -default = ["serde", "rusqlite"]
 -serde = ["dep:serde", "uuid/serde"]
 -rusqlite = ["dep:rusqlite"]
- 
+
  [dependencies]
  rusqlite = { workspace = true, optional = true }
 "#;
@@ -518,7 +518,7 @@ mod tests {
 -
 -    @waiting_users = User.where(approved: false).count
    end
- 
+
    def invite
 ";
         assert!(with_ctx.diff == expected);

--- a/gitbutler-app/src/virtual_branches/context.rs
+++ b/gitbutler-app/src/virtual_branches/context.rs
@@ -41,7 +41,8 @@ pub fn hunk_with_context(
 
     // Get context lines before the diff
     let mut context_before = Vec::new();
-    let before_context_ending_index = if removed_count == 0 { // Compensate for when the removed_count is 0
+    let before_context_ending_index = if removed_count == 0 {
+        // Compensate for when the removed_count is 0
         hunk_old_start_line
     } else {
         hunk_old_start_line.saturating_sub(1)
@@ -69,15 +70,18 @@ pub fn hunk_with_context(
         }
     }
 
-    let start_line_before = if new_file { // If we've created a new file, start_line_before should be 0
+    let start_line_before = if new_file {
+        // If we've created a new file, start_line_before should be 0
         0
     } else {
         before_context_starting_index + 1
     };
 
-    let start_line_after = if deleted_file { // If we've deleted a new file, start_line_after should be 0
+    let start_line_after = if deleted_file {
+        // If we've deleted a new file, start_line_after should be 0
         0
-    } else if added_count == 0 { // Compensate for when the added_count is 0
+    } else if added_count == 0 {
+        // Compensate for when the added_count is 0
         hunk_new_start_line.saturating_sub(context_before.len()) + 1
     } else {
         hunk_new_start_line.saturating_sub(context_before.len())

--- a/gitbutler-app/src/virtual_branches/context.rs
+++ b/gitbutler-app/src/virtual_branches/context.rs
@@ -503,7 +503,7 @@ mod tests {
 -
 -    @waiting_users = User.where(approved: false).count
    end
-
+ 
    def invite
 ";
         assert!(with_ctx.diff == expected);

--- a/gitbutler-app/src/virtual_branches/context.rs
+++ b/gitbutler-app/src/virtual_branches/context.rs
@@ -45,13 +45,11 @@ pub fn hunk_with_context(
 
     // Get context lines before the diff
     let mut context_before = Vec::new();
-    let mut before_context_ending_index =
-        if removed_count == 0 {
-            hunk_old_start_line
-        } else {
-            hunk_old_start_line.saturating_sub(1)
-        };
-
+    let mut before_context_ending_index = if removed_count == 0 {
+        hunk_old_start_line
+    } else {
+        hunk_old_start_line.saturating_sub(1)
+    };
 
     let before_context_starting_index = before_context_ending_index.saturating_sub(context_lines);
 
@@ -76,14 +74,12 @@ pub fn hunk_with_context(
         }
     }
 
-
     let start_line_before = before_context_starting_index;
-    let start_line_after =
-        if added_count == 0 {
-            hunk_new_start_line.saturating_sub(context_before.len())
-        } else {
-            hunk_new_start_line.saturating_sub(context_before.len() + 1)
-        };
+    let start_line_after = if added_count == 0 {
+        hunk_new_start_line.saturating_sub(context_before.len())
+    } else {
+        hunk_new_start_line.saturating_sub(context_before.len() + 1)
+    };
 
     let line_count_before = removed_count + context_before.len() + context_after.len();
     let line_count_after = added_count + context_before.len() + context_after.len();

--- a/gitbutler-app/src/virtual_branches/context.rs
+++ b/gitbutler-app/src/virtual_branches/context.rs
@@ -45,11 +45,13 @@ pub fn hunk_with_context(
 
     // Get context lines before the diff
     let mut context_before = Vec::new();
-    let mut before_context_ending_index = hunk_old_start_line.saturating_sub(1);
+    let mut before_context_ending_index =
+        if removed_count == 0 {
+            hunk_old_start_line
+        } else {
+            hunk_old_start_line.saturating_sub(1)
+        };
 
-    if removed_count == 0 {
-        before_context_ending_index += 1;
-    }
 
     let before_context_starting_index = before_context_ending_index.saturating_sub(context_lines);
     context_before.reverse();

--- a/gitbutler-app/src/virtual_branches/context.rs
+++ b/gitbutler-app/src/virtual_branches/context.rs
@@ -36,16 +36,9 @@ pub fn hunk_with_context(
         .filter(|line| line.starts_with('+'))
         .count();
 
-    println!("######");
-    println!("{:?}", hunk_diff);
-    println!("{}", hunk_old_start_line);
-    println!("{}", hunk_new_start_line);
-    println!("{}", removed_count);
-    println!("{}", added_count);
-
     // Get context lines before the diff
     let mut context_before = Vec::new();
-    let mut before_context_ending_index = if removed_count == 0 {
+    let before_context_ending_index = if removed_count == 0 {
         hunk_old_start_line
     } else {
         hunk_old_start_line.saturating_sub(1)


### PR DESCRIPTION
Please let me know if this doesn't make sense as an explanation. I'm more than happy to go over it on a call if wanted.

# The problem:

The surrounding context of files, and line numbers is incorrect when there have been additions or removals above another hunk:

#### Before
![Screenshot 2024-02-18 at 10 20 58](https://github.com/gitbutlerapp/gitbutler/assets/13354155/67385e84-4f28-4e60-8af7-32065278ddb5)

#### After
![Screenshot 2024-02-18 at 10 22 04](https://github.com/gitbutlerapp/gitbutler/assets/13354155/567784ad-cdca-4509-8ed8-73afb8865f0e)

#### Before
![Screenshot 2024-02-18 at 10 22 54](https://github.com/gitbutlerapp/gitbutler/assets/13354155/38dfb781-898a-4b17-bf81-13f78c982b85)

#### After
![Screenshot 2024-02-18 at 10 22 32](https://github.com/gitbutlerapp/gitbutler/assets/13354155/5de70e9e-b178-4a69-861c-96378f95b597)

#### Before
![Screenshot 2024-02-18 at 10 23 31](https://github.com/gitbutlerapp/gitbutler/assets/13354155/c024f7ed-f9e7-419f-9bb4-67e4154ffd40)

#### After
![Screenshot 2024-02-18 at 10 23 51](https://github.com/gitbutlerapp/gitbutler/assets/13354155/98bfe2f9-bfd8-4680-ac81-00c8cee0f091)

#### Before
![Screenshot 2024-02-18 at 10 24 59](https://github.com/gitbutlerapp/gitbutler/assets/13354155/51f4679e-120b-45c6-9c8e-90825dd5fee2)

#### After
![Screenshot 2024-02-18 at 10 25 16](https://github.com/gitbutlerapp/gitbutler/assets/13354155/214250ac-8739-4236-a3de-0692965e0862)

# How did the test suite miss this
The test suite never tested what would happen if any lines were added or removed before a particular hunk. All of the first hunks in those examples are correct. It's only the second hunks which have problematic line numbers and surrounding context.

# Let's talk about patches

## Patches with context
Patches with context are pretty sensible and whether you're adding, removing, or both, the old_start is going to be the line number that the first line of context had in the old file.

(examples generated with: `git diff --unified=3`)

### With no files added above

#### Addition
```patch
@@ -25,6 +25,9 @@
     console.log("testaroni1")
     console.log("testaroni2")
     console.log("testaroni3")
+    console.log("testaronix")
+    console.log("testaronix")
+    console.log("testaronix")
     console.log("testaroni4")
     console.log("testaroni5")
     console.log("testaroni6")
```

The old_start of the patch is 25; This is because the first line `console.log("testaroni1")` is on line 25. The new_start of the patch is also 25 because there has not been any file changes above this patch.

#### Removal
```patch
@@ -24,8 +24,6 @@
     console.log("testaroni")
     console.log("testaroni1")
     console.log("testaroni2")
-    console.log("testaroni3")
-    console.log("testaroni4")
     console.log("testaroni5")
     console.log("testaroni6")
```

The old_start of the patch is 24; This is because the first line `console.log("testaroni")` is on line 24. The new_start of the patch is also 24 because there has not been any file changes above this patch.

#### Both
```patch
@@ -24,8 +24,8 @@
     console.log("testaroni")
     console.log("testaroni1")
     console.log("testaroni2")
-    console.log("testaroni3")
-    console.log("testaroni4")
+    console.log("testaronix")
+    console.log("testaronix")
     console.log("testaroni5")
     console.log("testaroni6")
```

The old_start of the patch is 24; This is because the first line `console.log("testaroni")` is on line 24. The new_start of the patch is also 24 because there has not been any file changes above this patch.

### With changes above
These examples are with 2 lines added above the patch

#### Addition
```patch
@@ -25,6 +27,9 @@
     console.log("testaroni1")
     console.log("testaroni2")
     console.log("testaroni3")
+    console.log("testaronix")
+    console.log("testaronix")
+    console.log("testaronix")
     console.log("testaroni4")
     console.log("testaroni5")
     console.log("testaroni6")
```

The old_start of the patch is 25; This is because the first line `console.log("testaroni1")` is on line 25. The new_start of the patch is 27 because `console.log("testaroni1")` after the two lines have been added above will be on line 27.

#### Removal
```patch
@@ -24,8 +26,6 @@
     console.log("testaroni")
     console.log("testaroni1")
     console.log("testaroni2")
-    console.log("testaroni3")
-    console.log("testaroni4")
     console.log("testaroni5")
     console.log("testaroni6")

```

The old_start of the patch is 24; This is because the first line `console.log("testaroni")` is on line 24. The new_start of the patch is 26 because `console.log("testaroni")` after the two lines have been added above will be on line 26.

## Patches with zero context
Patches with zero context have their own quirks which is where the problems have creeped in.

(examples generated with: `git diff --unified=0`)

### With no lines added above

#### Addition
```patch
@@ -27,0 +28,3 @@
+    console.log("testaronix")
+    console.log("testaronix")
+    console.log("testaronix")
```

Here we see something interesting: The old_start is 27. This is because there is no context, and we don't need to instruct any lines to be removed. Line 27 is the line which the changes will be inserted after. The new_start is 28 because that is the line number of the first line to be added in the diff.

#### Removal
```patch
@@ -28,2 +27,0 @@
-    console.log("testaroni4")
-    console.log("testaroni5")
```

Here the old_start is 28. Line 28 is the first line to be removed (the line number of the line containing `console.log("testaroni4")`). The new_start is 27, this is the line before the changes happen.

#### Doomabotha
```patch
@@ -28,2 +28,2 @@
-    console.log("testaroni4")
-    console.log("testaroni5")
+    console.log("testaronix")
+    console.log("testaronix")
```

Here the old_start is 28 because `console.log("testaroni4")` is the first line of the removal context and has line 28. The new_start is 28 because `console.log("testaronix")` is the first line of the addition context.

### With lines changed above
Similar to when we had context, the new_start just gets translated by the number of lines added or removed.

# WTF is the pattern :laughing:
So, the key is that:
- For a removal, if there is no addition or addition context, the new_start will be the line before the removal happens.
- For an addition, if there is no removal or removal context, the old_start will be the line before the addition happens.

# The solution
I've ended up rewriting most of the functions because I found the logic quite hard to follow. I've incorporated the missing context compensation rules as well as including the file removal and additional compensations that were already there.


I'm looking forwards to those beers 😉 