### PR TITLE
fix: #2799 Add a custom renderer for links, same as in ToastController

### DIFF
--- a/gitbutler-ui/src/lib/components/RemoteBranchPreview.svelte
+++ b/gitbutler-ui/src/lib/components/RemoteBranchPreview.svelte
@@ -41,6 +41,12 @@
 	onMount(() => {
 		laneWidth = lscache.get(laneWidthKey);
 	});
+
+	var renderer = new marked.Renderer();
+	renderer.link = function (href, title, text) {
+		if (!title) title = text;
+		return '<a target="_blank" href="' + href + '" title="' + title + '">' + text + '</a>';
+	};
 </script>
 
 <div class="base">
@@ -56,7 +62,7 @@
 					<div class="card">
 						<div class="card__header">PR Description</div>
 						<div class="card__content">
-							{@html marked.parse(pr.body)}
+							{@html marked.parse(pr.body, { renderer })}
 						</div>
 					</div>
 				{/if}


### PR DESCRIPTION
Fixes: https://github.com/gitbutlerapp/gitbutler/issues/2799

The code I used is also inside the [ToastController](https://github.com/gitbutlerapp/gitbutler/blob/master/gitbutler-ui/src/lib/notifications/ToastController.svelte#L10-L13). I guess it would be appropriate to extract this an extra file in lib/marked ? 