### PR TITLE
Add tooltip to show full commit message

### DIFF
--- a/gitbutler-ui/src/lib/components/CommitCard.svelte
+++ b/gitbutler-ui/src/lib/components/CommitCard.svelte
@@ -6,7 +6,6 @@
 	import { projectCurrentCommitMessage } from '$lib/config/config';
 	import { draggable } from '$lib/dragging/draggable';
 	import { draggableCommit, nonDraggable } from '$lib/dragging/draggables';
-	import { tooltip } from '$lib/utils/tooltip';
 	import { openExternalUrl } from '$lib/utils/url';
 	import { Ownership } from '$lib/vbranches/ownership';
 	import { listRemoteCommitFiles } from '$lib/vbranches/remoteCommits';
@@ -51,7 +50,7 @@
 >
 	<div class="commit__header" on:click={onClick} on:keyup={onClick} role="button" tabindex="0">
 		<div class="commit__row">
-			<span class="commit__description text-base-12 truncate" use:tooltip={commit.description}>
+			<span class="commit__description text-base-12 truncate">
 				{commit.description}
 			</span>
 			{#if isHeadCommit && !isUnapplied}

--- a/gitbutler-ui/src/lib/components/CommitCard.svelte
+++ b/gitbutler-ui/src/lib/components/CommitCard.svelte
@@ -52,32 +52,34 @@
 	class:is-commit-open={showFiles}
 >
 	<div class="commit__header" on:click={onClick} on:keyup={onClick} role="button" tabindex="0">
-		<div class="commit__row">
-			<span class="commit__title text-base-12" class:truncate={!showFiles}>
-				{commit.descriptionTitle}
-			</span>
-			{#if isUndoable && !showFiles}
-				<Tag
-					color="ghost"
-					icon="undo-small"
-					border
-					clickable
-					on:click={(e) => {
-						currentCommitMessage.set(commit.description);
-						e.stopPropagation();
-						resetHeadCommit();
-					}}>Undo</Tag
-				>
+		<div class="commit__message">
+			<div class="commit__row">
+				<span class="commit__title text-semibold text-base-12" class:truncate={!showFiles}>
+					{commit.descriptionTitle}
+				</span>
+				{#if isUndoable && !showFiles}
+					<Tag
+						color="ghost"
+						icon="undo-small"
+						border
+						clickable
+						on:click={(e) => {
+							currentCommitMessage.set(commit.description);
+							e.stopPropagation();
+							resetHeadCommit();
+						}}>Undo</Tag
+					>
+				{/if}
+			</div>
+			{#if showFiles && commit.descriptionBody}
+				<div class="commit__row" transition:slide={{ duration: 100 }}>
+					<span class="commit__body text-base-body-12">
+						{commit.descriptionBody}
+					</span>
+				</div>
 			{/if}
 		</div>
-		{#if showFiles && commit.descriptionBody}
-			<div class="commit__row" transition:slide={{ duration: 100 }}>
-				<span class="commit__body text-base-12 whitespace-pre-line">
-					{commit.descriptionBody}
-				</span>
-			</div>
-		{/if}
-		<div class="commit__row mt-1">
+		<div class="commit__row">
 			<div class="commit__author">
 				<img
 					class="commit__avatar"
@@ -112,27 +114,27 @@
 			{#if hasCommitUrl || isUndoable}
 				<div class="files__footer">
 					{#if isUndoable}
-						<Button
-							color="neutral"
-							kind="outlined"
+						<Tag
+							color="ghost"
 							icon="undo-small"
-							iconAlign="left"
+							border
+							clickable
 							on:click={(e) => {
 								currentCommitMessage.set(commit.description);
 								e.stopPropagation();
 								resetHeadCommit();
-							}}>Undo</Button
+							}}>Undo</Tag
 						>
 					{/if}
 					{#if hasCommitUrl}
-						<Button
-							color="neutral"
-							kind="outlined"
+						<Tag
+							color="ghost"
 							icon="open-link"
-							grow
+							border
+							clickable
 							on:click={() => {
 								if (commitUrl) openExternalUrl(commitUrl);
-							}}>Open commit</Button
+							}}>Open commit</Tag
 						>
 					{/if}
 				</div>
@@ -163,7 +165,11 @@
 		&:not(.is-commit-open):hover {
 			border: 1px solid
 				color-mix(in srgb, var(--clr-theme-container-outline-light), var(--darken-tint-mid));
-			background-color: var(--clr-theme-container-pale);
+			background-color: color-mix(
+				in srgb,
+				var(--clr-theme-container-light),
+				var(--darken-tint-extralight)
+			);
 		}
 	}
 
@@ -178,7 +184,7 @@
 		background-color: color-mix(
 			in srgb,
 			var(--clr-theme-container-light),
-			var(--darken-tint-light)
+			var(--darken-tint-extralight)
 		);
 
 		& .commit__header {
@@ -189,29 +195,38 @@
 				background-color: color-mix(
 					in srgb,
 					var(--clr-theme-container-light),
-					var(--darken-tint-mid)
+					var(--darken-tint-light)
 				);
 			}
 		}
+
+		& .commit__message {
+			margin-bottom: var(--space-4);
+		}
+	}
+
+	.commit__message {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-6);
 	}
 
 	.commit__title {
 		flex: 1;
 		display: block;
 		color: var(--clr-theme-scale-ntrl-0);
-		line-height: 120%;
 		width: 100%;
 	}
 
+	.commit__body {
+		flex: 1;
+		display: block;
+		width: 100%;
+		color: var(--clr-theme-scale-ntrl-40);
+		white-space: pre-line;
+	}
+
 	.commit__row {
-		.commit__body {
-			flex: 1;
-			display: block;
-			color: var(--clr-theme-scale-ntrl-0);
-			line-height: 120%;
-			width: 100%;
-			color: var(--clr-theme-scale-ntrl-40);
-		}
 		display: flex;
 		align-items: center;
 		gap: var(--space-8);
@@ -245,11 +260,10 @@
 	}
 
 	.files__footer {
-		text-align: right;
 		display: flex;
-		gap: var(--space-16);
+		/* justify-content: flex-end; */
+		gap: var(--space-8);
 		padding: var(--space-12);
 		border-top: 1px solid var(--clr-theme-container-outline-light);
-		background-color: var(--clr-theme-container-pale);
 	}
 </style>

--- a/gitbutler-ui/src/lib/components/CommitCard.svelte
+++ b/gitbutler-ui/src/lib/components/CommitCard.svelte
@@ -6,6 +6,7 @@
 	import { projectCurrentCommitMessage } from '$lib/config/config';
 	import { draggable } from '$lib/dragging/draggable';
 	import { draggableCommit, nonDraggable } from '$lib/dragging/draggables';
+	import { tooltip } from '$lib/utils/tooltip';
 	import { openExternalUrl } from '$lib/utils/url';
 	import { Ownership } from '$lib/vbranches/ownership';
 	import { listRemoteCommitFiles } from '$lib/vbranches/remoteCommits';
@@ -50,7 +51,7 @@
 >
 	<div class="commit__header" on:click={onClick} on:keyup={onClick} role="button" tabindex="0">
 		<div class="commit__row">
-			<span class="commit__description text-base-12 truncate">
+			<span class="commit__description text-base-12 truncate" use:tooltip={commit.description}>
 				{commit.description}
 			</span>
 			{#if isHeadCommit && !isUnapplied}

--- a/gitbutler-ui/src/lib/components/CommitCard.svelte
+++ b/gitbutler-ui/src/lib/components/CommitCard.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import BranchFiles from './BranchFiles.svelte';
-	import Button from '$lib/components/Button.svelte';
 	import Tag from '$lib/components/Tag.svelte';
 	import TimeAgo from '$lib/components/TimeAgo.svelte';
 	import { projectCurrentCommitMessage } from '$lib/config/config';

--- a/gitbutler-ui/src/lib/components/CommitCard.svelte
+++ b/gitbutler-ui/src/lib/components/CommitCard.svelte
@@ -260,7 +260,7 @@
 
 	.files__footer {
 		display: flex;
-		/* justify-content: flex-end; */
+		justify-content: flex-end;
 		gap: var(--space-8);
 		padding: var(--space-12);
 		border-top: 1px solid var(--clr-theme-container-outline-light);

--- a/gitbutler-ui/src/lib/components/CommitCard.svelte
+++ b/gitbutler-ui/src/lib/components/CommitCard.svelte
@@ -39,6 +39,9 @@
 		showFiles = !showFiles;
 		if (showFiles) loadFiles();
 	}
+
+    const isUndoable = isHeadCommit && !isUnapplied;
+    const hasCommitUrl = !commit.isLocal && commitUrl;
 </script>
 
 <div
@@ -50,10 +53,10 @@
 >
 	<div class="commit__header" on:click={onClick} on:keyup={onClick} role="button" tabindex="0">
 		<div class="commit__row">
-			<span class="commit__description text-base-12 truncate">
-				{commit.description}
+			<span class="commit__title text-base-12" class:truncate={!showFiles}>
+				{commit.descriptionTitle}
 			</span>
-			{#if isHeadCommit && !isUnapplied}
+			{#if isUndoable && !showFiles}
 				<Tag
 					color="ghost"
 					icon="undo-small"
@@ -67,7 +70,14 @@
 				>
 			{/if}
 		</div>
-		<div class="commit__row">
+		{#if showFiles && commit.descriptionBody}
+			<div class="commit__row" transition:slide={{ duration: 100 }}>
+				<span class="commit__body text-base-12 whitespace-pre-line">
+					{commit.descriptionBody}
+				</span>
+			</div>
+		{/if}
+		<div class="commit__row mt-1">
 			<div class="commit__author">
 				<img
 					class="commit__avatar"
@@ -99,16 +109,31 @@
 				readonly={true}
 			/>
 
-			{#if !commit.isLocal && commitUrl}
+			{#if hasCommitUrl || isUndoable}
 				<div class="files__footer">
-					<Button
-						color="neutral"
-						kind="outlined"
-						icon="open-link"
-						on:click={() => {
-							if (commitUrl) openExternalUrl(commitUrl);
-						}}>Open commit</Button
-					>
+					{#if isUndoable}
+						<Button
+							color="neutral"
+							kind="outlined"
+							icon="undo-small"
+							on:click={(e) => {
+								currentCommitMessage.set(commit.description);
+								e.stopPropagation();
+								resetHeadCommit();
+							}}>Undo</Button
+						>
+					{/if}
+					{#if hasCommitUrl}
+						<Button
+							color="neutral"
+							kind="outlined"
+							icon="open-link"
+							grow
+							on:click={() => {
+								if (commitUrl) openExternalUrl(commitUrl);
+							}}>Open commit</Button
+						>
+					{/if}
 				</div>
 			{/if}
 		</div>
@@ -137,11 +162,7 @@
 		&:not(.is-commit-open):hover {
 			border: 1px solid
 				color-mix(in srgb, var(--clr-theme-container-outline-light), var(--darken-tint-mid));
-			background-color: color-mix(
-				in srgb,
-				var(--clr-theme-container-light),
-				var(--darken-tint-extralight)
-			);
+            background-color: var(--clr-theme-container-pale);
 		}
 	}
 
@@ -161,6 +182,7 @@
 
 		& .commit__header {
 			padding-bottom: var(--space-16);
+            border-bottom: 1px solid var(--clr-theme-container-outline-light);
 
 			&:hover {
 				background-color: color-mix(
@@ -172,7 +194,7 @@
 		}
 	}
 
-	.commit__description {
+	.commit__title {
 		flex: 1;
 		display: block;
 		color: var(--clr-theme-scale-ntrl-0);
@@ -181,6 +203,14 @@
 	}
 
 	.commit__row {
+	.commit__body {
+		flex: 1;
+		display: block;
+		color: var(--clr-theme-scale-ntrl-0);
+		line-height: 120%;
+		width: 100%;
+		color: var(--clr-theme-scale-ntrl-40);
+	}
 		display: flex;
 		align-items: center;
 		gap: var(--space-8);
@@ -206,7 +236,7 @@
 
 	.commit__time,
 	.commit__author-name {
-		color: var(--clr-theme-scale-ntrl-50);
+		color: var(--clr-theme-scale-ntrl-40);
 	}
 
 	.files-container {
@@ -215,7 +245,10 @@
 
 	.files__footer {
 		text-align: right;
+		display: flex;
+		gap: var(--space-16);
 		padding: var(--space-12);
 		border-top: 1px solid var(--clr-theme-container-outline-light);
+		background-color: var(--clr-theme-container-pale);
 	}
 </style>

--- a/gitbutler-ui/src/lib/components/CommitCard.svelte
+++ b/gitbutler-ui/src/lib/components/CommitCard.svelte
@@ -40,8 +40,8 @@
 		if (showFiles) loadFiles();
 	}
 
-    const isUndoable = isHeadCommit && !isUnapplied;
-    const hasCommitUrl = !commit.isLocal && commitUrl;
+	const isUndoable = isHeadCommit && !isUnapplied;
+	const hasCommitUrl = !commit.isLocal && commitUrl;
 </script>
 
 <div
@@ -116,6 +116,7 @@
 							color="neutral"
 							kind="outlined"
 							icon="undo-small"
+							iconAlign="left"
 							on:click={(e) => {
 								currentCommitMessage.set(commit.description);
 								e.stopPropagation();
@@ -162,7 +163,7 @@
 		&:not(.is-commit-open):hover {
 			border: 1px solid
 				color-mix(in srgb, var(--clr-theme-container-outline-light), var(--darken-tint-mid));
-            background-color: var(--clr-theme-container-pale);
+			background-color: var(--clr-theme-container-pale);
 		}
 	}
 
@@ -182,7 +183,7 @@
 
 		& .commit__header {
 			padding-bottom: var(--space-16);
-            border-bottom: 1px solid var(--clr-theme-container-outline-light);
+			border-bottom: 1px solid var(--clr-theme-container-outline-light);
 
 			&:hover {
 				background-color: color-mix(
@@ -203,14 +204,14 @@
 	}
 
 	.commit__row {
-	.commit__body {
-		flex: 1;
-		display: block;
-		color: var(--clr-theme-scale-ntrl-0);
-		line-height: 120%;
-		width: 100%;
-		color: var(--clr-theme-scale-ntrl-40);
-	}
+		.commit__body {
+			flex: 1;
+			display: block;
+			color: var(--clr-theme-scale-ntrl-0);
+			line-height: 120%;
+			width: 100%;
+			color: var(--clr-theme-scale-ntrl-40);
+		}
 		display: flex;
 		align-items: center;
 		gap: var(--space-8);
@@ -236,7 +237,7 @@
 
 	.commit__time,
 	.commit__author-name {
-		color: var(--clr-theme-scale-ntrl-40);
+		color: var(--clr-theme-scale-ntrl-50);
 	}
 
 	.files-container {

--- a/gitbutler-ui/src/lib/vbranches/types.ts
+++ b/gitbutler-ui/src/lib/vbranches/types.ts
@@ -116,19 +116,26 @@ export class Commit {
 	}
 
 	get descriptionTitle(): string | undefined {
-		return this.descriptionParagraphs[0];
+		return this.descriptionLines[0];
 	}
 
 	get descriptionBody(): string | undefined {
-		return this.descriptionParagraphs.slice(1).join('\n\n');
+		let sliceCount = 1;
+
+		// Remove a blank first line
+		if (this.descriptionLines[1] == '') {
+			sliceCount = 2;
+		}
+
+		return this.descriptionLines.slice(sliceCount).join('\n');
 	}
 
 	isParentOf(possibleChild: Commit) {
 		return possibleChild.parentIds.includes(this.id);
 	}
 
-	private get descriptionParagraphs() {
-		return this.description.split('\n\n');
+	private get descriptionLines() {
+		return this.description.split('\n');
 	}
 }
 
@@ -144,15 +151,22 @@ export class RemoteCommit {
 	}
 
 	get descriptionTitle(): string | undefined {
-		return this.descriptionParagraphs[0];
+		return this.descriptionLines[0];
 	}
 
 	get descriptionBody(): string | undefined {
-		return this.descriptionParagraphs.slice(1).join('\n\n');
+		let sliceCount = 1;
+
+		// Remove a blank first line
+		if (this.descriptionLines[1] == '') {
+			sliceCount = 2;
+		}
+
+		return this.descriptionLines.slice(sliceCount).join('\n');
 	}
 
-	private get descriptionParagraphs() {
-		return this.description.split('\n\n');
+	private get descriptionLines() {
+		return this.description.split('\n');
 	}
 }
 

--- a/gitbutler-ui/src/lib/vbranches/types.ts
+++ b/gitbutler-ui/src/lib/vbranches/types.ts
@@ -115,8 +115,20 @@ export class Commit {
 		}
 	}
 
+	get descriptionTitle(): string | undefined {
+		return this.descriptionParagraphs[0];
+	}
+
+	get descriptionBody(): string | undefined {
+		return this.descriptionParagraphs.slice(1).join('\n\n');
+	}
+
 	isParentOf(possibleChild: Commit) {
 		return possibleChild.parentIds.includes(this.id);
+	}
+
+	private get descriptionParagraphs() {
+		return this.description.split('\n\n');
 	}
 }
 
@@ -129,6 +141,18 @@ export class RemoteCommit {
 
 	get isLocal() {
 		return false;
+	}
+
+	get descriptionTitle(): string | undefined {
+		return this.descriptionParagraphs[0];
+	}
+
+	get descriptionBody(): string | undefined {
+		return this.descriptionParagraphs.slice(1).join('\n\n');
+	}
+
+	private get descriptionParagraphs() {
+		return this.description.split('\n\n');
 	}
 }
 


### PR DESCRIPTION
# The problem

Git butler only shows a portion of the first line of a commit

# The solution

Implement new designs which facilitate displaying the commit's full message.

<img width="706" alt="Screenshot 2024-02-19 at 22 04 52" src="https://github.com/gitbutlerapp/gitbutler/assets/13354155/1c386141-dc53-4272-8af5-330906cfbba5">

