### PR TITLE
fix: branch card's options menu is truncated 

### DIFF
--- a/gitbutler-ui/src/styles/card.css
+++ b/gitbutler-ui/src/styles/card.css
@@ -4,7 +4,6 @@
 	border: 1px solid var(--clr-theme-container-outline-light);
 	border-radius: var(--radius-m);
 	background: var(--clr-theme-container-light);
-	overflow: hidden;
 }
 
 .card__header {


### PR DESCRIPTION
A recently added `overflow:hidden` to the card.css has truncated the branch card's options menu (on master, no release has been affected yet, AFAIK). See video below:


https://github.com/gitbutlerapp/gitbutler/assets/298675/fa7364ac-9b9d-4a66-abe4-c3160b359d09

