### PR TITLE
fix: hunk and file context menu now correctly dismiss

### DIFF
--- a/gitbutler-ui/src/lib/components/FileContextMenu.svelte
+++ b/gitbutler-ui/src/lib/components/FileContextMenu.svelte
@@ -21,14 +21,20 @@
 	}
 </script>
 
-<PopupMenu bind:this={popupMenu} let:item>
+<PopupMenu bind:this={popupMenu} let:item let:dismiss>
 	<ContextMenu>
 		<ContextMenuSection>
 			{#if item.files !== undefined}
 				{#if containsBinaryFiles(item)}
 					<ContextMenuItem label="Discard file (Binary files not yet supported)" disabled />
 				{:else}
-					<ContextMenuItem label="Discard file" on:click={() => confirmationModal.show(item)} />
+					<ContextMenuItem
+						label="Discard file"
+						on:click={() => {
+							confirmationModal.show(item);
+							dismiss();
+						}}
+					/>
 				{/if}
 			{/if}
 		</ContextMenuSection>

--- a/gitbutler-ui/src/lib/components/HunkContextMenu.svelte
+++ b/gitbutler-ui/src/lib/components/HunkContextMenu.svelte
@@ -16,17 +16,25 @@
 	}
 </script>
 
-<PopupMenu bind:this={popupMenu} let:item>
+<PopupMenu bind:this={popupMenu} let:item let:dismiss>
 	<ContextMenu>
 		<ContextMenuSection>
 			{#if item.hunk !== undefined}
-				<ContextMenuItem label="Discard" on:click={() => branchController.unapplyHunk(item.hunk)} />
+				<ContextMenuItem
+					label="Discard"
+					on:click={() => {
+						branchController.unapplyHunk(item.hunk);
+						dismiss();
+					}}
+				/>
 			{/if}
 			{#if item.lineNumber}
 				<ContextMenuItem
 					label="Open in VS Code"
-					on:click={() =>
-						projectPath && open(`vscode://file${projectPath}/${filePath}:${item.lineNumber}`)}
+					on:click={() => {
+						projectPath && open(`vscode://file${projectPath}/${filePath}:${item.lineNumber}`);
+						dismiss();
+					}}
 				/>
 			{/if}
 		</ContextMenuSection>

--- a/gitbutler-ui/src/lib/components/PopupMenu.svelte
+++ b/gitbutler-ui/src/lib/components/PopupMenu.svelte
@@ -55,7 +55,7 @@
 		use:clickOutside={{ handler: () => onDismiss() }}
 		style="position: absolute; top:{pos.y}px; left:{pos.x}px"
 	>
-		<slot {item} />
+		<slot {item} dismiss={onDismiss} />
 	</div>
 {/if}
 


### PR DESCRIPTION
I noticed that sometimes the file and hunk context menu wouldn't dismiss itself after you take an action (i.e. click "Discard" in the menu).
I've added a `dismiss` callback to the `PopupMenu` component that consumers can use to dismiss it when the action requires no further interaction with the menu.

#### before: 
https://github.com/gitbutlerapp/gitbutler/assets/298675/07c4b023-b94b-4558-bcca-5e05338a7811

#### after:
https://github.com/gitbutlerapp/gitbutler/assets/298675/fce6bc5a-6436-4b05-ade7-995fe42ac52b

