### PR TITLE
chore: consider "contextmenu" event as a click outside event too

### DIFF
--- a/gitbutler-ui/src/lib/clickOutside.ts
+++ b/gitbutler-ui/src/lib/clickOutside.ts
@@ -15,15 +15,19 @@ export function clickOutside(
 		}
 	}
 	document.addEventListener('click', onClick, true);
+	document.addEventListener('contextmenu', onClick, true);
 	return {
 		destroy() {
 			document.removeEventListener('click', onClick, true);
+			document.removeEventListener('contextmenu', onClick, true);
 		},
 		update(opts: ClickOpts) {
 			document.removeEventListener('click', onClick, true);
+			document.removeEventListener('contextmenu', onClick, true);
 			if (opts.enabled !== undefined && !opts.enabled) return;
 			trigger = opts.trigger;
 			document.addEventListener('click', onClick, true);
+			document.addEventListener('contextmenu', onClick, true);
 		}
 	};
 }


### PR DESCRIPTION
Follow up to this PR https://github.com/gitbutlerapp/gitbutler/pull/2812

The `clickOutside` directive should also include the `contextmenu` event to correctly trigger when the user clicks outside by right-clicking.

#### before:

https://github.com/gitbutlerapp/gitbutler/assets/298675/c9220663-3ac2-4227-aff9-6fc60459d204

#### after:

https://github.com/gitbutlerapp/gitbutler/assets/298675/5f4820da-c7b4-4a94-bcdc-eb91cd1bdc6c

