### PR TITLE
Prevent divider line from scrolling up with branch card

### DIFF
--- a/gitbutler-ui/src/lib/components/BranchCard.svelte
+++ b/gitbutler-ui/src/lib/components/BranchCard.svelte
@@ -291,21 +291,20 @@
 				{selectedFiles}
 			/>
 		</div>
-
-		<div class="divider-line">
-			<Resizer
-				viewport={rsViewport}
-				direction="right"
-				inside={$selectedFiles.length > 0}
-				minWidth={320}
-				sticky
-				on:width={(e) => {
-					laneWidth = e.detail / (16 * $userSettings.zoom);
-					lscache.set(laneWidthKey + branch.id, laneWidth, 7 * 1440); // 7 day ttl
-					$defaultBranchWidthRem = laneWidth;
-				}}
-			/>
-		</div>
+	</div>
+	<div class="divider-line">
+		<Resizer
+			viewport={rsViewport}
+			direction="right"
+			inside={$selectedFiles.length > 0}
+			minWidth={320}
+			sticky
+			on:width={(e) => {
+				laneWidth = e.detail / (16 * $userSettings.zoom);
+				lscache.set(laneWidthKey + branch.id, laneWidth, 7 * 1440); // 7 day ttl
+				$defaultBranchWidthRem = laneWidth;
+			}}
+		/>
 	</div>
 {/if}
 


### PR DESCRIPTION
# The problem

Notice how the divider line in the middle is missing in the bottom part. When you scroll the branch card, the divider line will scroll with it.
![image](https://github.com/gitbutlerapp/gitbutler/assets/13354155/60eb1186-997a-4091-974f-5712dc245ea8)

# The solution

The issue was caused by the divider line being inside the scrollable container rather than outside it. Moving it outside solves the issue.