### PR TITLE
Allow front end periods in branch names

### DIFF
--- a/gitbutler-ui/src/lib/utils/branch.ts
+++ b/gitbutler-ui/src/lib/utils/branch.ts
@@ -1,3 +1,3 @@
 export function normalizeBranchName(value: string) {
-	return value.toLowerCase().replace(/[^0-9a-z/_]+/g, '-');
+	return value.toLowerCase().replace(/[^0-9a-z/_.]+/g, '-');
 }


### PR DESCRIPTION
Noticed a PR changing the branch name regex in the rust code, this pr fixes the same thing
in the typescript code.

https://github.com/gitbutlerapp/gitbutler/pull/2766/files