### PR TITLE
Add word wrap to commit body

### DIFF
--- a/gitbutler-ui/src/lib/components/CommitCard.svelte
+++ b/gitbutler-ui/src/lib/components/CommitCard.svelte
@@ -223,6 +223,7 @@
 		width: 100%;
 		color: var(--clr-theme-scale-ntrl-40);
 		white-space: pre-line;
+		word-wrap: anywhere;
 	}
 
 	.commit__row {


### PR DESCRIPTION
This PR allows URLs to wrap in commit body.

#### Before
<img width="381" alt="Screenshot 2024-02-20 at 12 08 59" src="https://github.com/gitbutlerapp/gitbutler/assets/13354155/d54fa5d8-78ed-4e8b-be2e-73001f9e8faf">

#### After
<img width="386" alt="Screenshot 2024-02-20 at 12 08 54" src="https://github.com/gitbutlerapp/gitbutler/assets/13354155/c4d74e1f-132c-4858-a693-09389760493f">
