### PR TITLE
feat: generate PR title and body from commit

### DIFF
--- a/gitbutler-ui/src/lib/branches/service.ts
+++ b/gitbutler-ui/src/lib/branches/service.ts
@@ -68,11 +68,22 @@ export class BranchService {
 
 		const createPrSpan = sentryTxn.startChild({ op: 'pr_api_create' });
 
+		let title = newBranch.name;
+		let body = newBranch.notes;
+
+		// In case of a single commit, use the commit summary and description for the title and
+		// description of the PR
+		if (newBranch.commits.length === 1) {
+			const commit = newBranch.commits[0];
+			if (commit.descriptionTitle) title = commit.descriptionTitle;
+			if (commit.descriptionBody) body = commit.descriptionBody;
+		}
+
 		try {
 			const resp = await this.githubService.createPullRequest(
 				baseBranch,
-				newBranch.name,
-				newBranch.notes,
+				title,
+				body,
 				newBranch.id,
 				newBranch.upstreamName,
 				draft


### PR DESCRIPTION
If the branch contains only 1 commit, we use the first line to generate the PR title and the remaining commit body to generate the PR body.
Co-author: @eyalch

Fixes #2795 