### PR TITLE
feat: add search branch by author functionality

### DIFF
--- a/gitbutler-ui/src/lib/components/Navigation.svelte
+++ b/gitbutler-ui/src/lib/components/Navigation.svelte
@@ -70,7 +70,7 @@
 			</DomainButton>
 		</div>
 	</div>
-	<Branches projectId={project.id} {branchService} {githubService} />
+	<Branches {user} projectId={project.id} {branchService} {githubService} />
 	<Footer {user} projectId={project.id} />
 
 	<Resizer


### PR DESCRIPTION
I thought it might be useful to someone else other than me to have a way to filter the branches list by author. I'm very forgetful so I have a hard time remembering what name I used for a specific branch and navigating through a long list other branches can be a nightmare 😅

So, I've come up with this solution where a user can type `author:` followed by any text, in the search field, and the search would trigger a "search by author" flow where the part after `author:` and before a space will be matched against committers' username or email.

I wonder if fetching the remote branches data is too expensive and that's why this component is currently using a very streamlined RemoteBranch structure with minimal properties. If, so, what could be the best way to fetch authors for each branch?

Secondly, I thought neat to enhance the search text field, but it's kinda limiting, as in, users can only search for one author at max. A nice select menu could be more useful in case one wants to filter by many authors. Thoughts?