### PR TITLE
Improve types for github error handling

### DIFF
--- a/gitbutler-ui/package.json
+++ b/gitbutler-ui/package.json
@@ -38,6 +38,7 @@
 		"@lezer/common": "^1.2.1",
 		"@lezer/highlight": "^1.2.0",
 		"@octokit/rest": "^20.0.2",
+		"@octokit/request-error": "5.0.1",
 		"@replit/codemirror-lang-svelte": "^6.0.0",
 		"@sentry/sveltekit": "^7.100.1",
 		"@sveltejs/adapter-static": "^2.0.3",

--- a/gitbutler-ui/src/lib/github/types.ts
+++ b/gitbutler-ui/src/lib/github/types.ts
@@ -77,3 +77,6 @@ export enum MergeMethod {
 	Rebase = 'rebase',
 	Squash = 'squash'
 }
+
+// TODO: Can we get this type from Octokit?
+export type GitHubErrorData = { message: string; errors: { message: string }[] };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@lezer/highlight':
         specifier: ^1.2.0
         version: 1.2.0
+      '@octokit/request-error':
+        specifier: 5.0.1
+        version: 5.0.1
       '@octokit/rest':
         specifier: ^20.0.2
         version: 20.0.2


### PR DESCRIPTION
- adds explicit dependency on @octokit/request-error

https://github.com/octokit/octokit.js?tab=readme-ov-file#request-error-handling