### PR TITLE
disallow adding of repositories with submodules due incomplete support

### DIFF
--- a/gitbutler-app/src/projects/commands.rs
+++ b/gitbutler-app/src/projects/commands.rs
@@ -70,6 +70,10 @@ impl From<controller::AddError> for Error {
                 code: Code::Projects,
                 message: "Path not found".to_string(),
             },
+            controller::AddError::SubmodulesNotSupported => Error::UserError {
+                code: Code::Projects,
+                message: "Repositories with git submodules are not supported".to_string(),
+            },
             controller::AddError::User(error) => error.into(),
             controller::AddError::Other(error) => {
                 tracing::error!(?error, "failed to add project");

--- a/gitbutler-app/src/projects/controller.rs
+++ b/gitbutler-app/src/projects/controller.rs
@@ -66,6 +66,10 @@ impl Controller {
             return Err(AddError::NotAGitRepository);
         };
 
+        if path.join(".gitmodules").exists() {
+            return Err(AddError::SubmodulesNotSupported);
+        }
+
         let id = uuid::Uuid::new_v4().to_string();
 
         // title is the base name of the file
@@ -254,6 +258,8 @@ pub enum AddError {
     PathNotFound,
     #[error("project already exists")]
     AlreadyExists,
+    #[error("submodules not supported")]
+    SubmodulesNotSupported,
     #[error(transparent)]
     User(#[from] users::GetError),
     #[error(transparent)]


### PR DESCRIPTION
The support for repositories with git submodules is not complete yet, so for now, disallow adding of repos with submodules:

<img width="384" alt="Screenshot 2024-02-26 at 13 36 25" src="https://github.com/gitbutlerapp/gitbutler/assets/4030927/f6b3d578-62a0-46ea-89ab-0a5a91d84930">

Fixes https://github.com/gitbutlerapp/gitbutler/issues/2891