### PR TITLE
The commit URL link in bitbucket is 'commits/', not 'commit/'. In gitlab, there is a '-'.

### DIFF
--- a/gitbutler-ui/src/lib/vbranches/types.ts
+++ b/gitbutler-ui/src/lib/vbranches/types.ts
@@ -290,6 +290,13 @@ export class BaseBranch {
 	}
 
 	commitUrl(commitId: string): string | undefined {
+		// if repoBaseUrl is bitbucket, then the commit url is different
+		if (this.repoBaseUrl.includes('bitbucket.org')) {
+			return `${this.repoBaseUrl}/commits/${commitId}`;
+		}
+		if (this.repoBaseUrl.includes('gitlab.com')) {
+			return `${this.repoBaseUrl}/-/commit/${commitId}`;
+		}
 		return `${this.repoBaseUrl}/commit/${commitId}`;
 	}
 


### PR DESCRIPTION
In gitlab, there is a '-'.

Interestingly, GitHub appears to support both 'commit/' and 'commits/' and GitLab will correct a missing '-'.