### PR TITLE
Add keyboard shortcut to commit

### DIFF
--- a/gitbutler-ui/src/lib/components/CommitDialog.svelte
+++ b/gitbutler-ui/src/lib/components/CommitDialog.svelte
@@ -134,6 +134,17 @@
 					on:input={useAutoHeight}
 					on:focus={useAutoHeight}
 					on:change={() => currentCommitMessage.set(commitMessage)}
+					on:keydown={(e) => {
+						if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+							if ($expanded) {
+								if (commitMessage) {
+									commit();
+								}
+							} else {
+								$expanded = true;
+							}
+						}
+					}}
 					spellcheck={false}
 					class="text-input text-base-body-13 commit-box__textarea"
 					rows="1"

--- a/gitbutler-ui/src/lib/components/CommitDialog.svelte
+++ b/gitbutler-ui/src/lib/components/CommitDialog.svelte
@@ -58,6 +58,7 @@
 	};
 
 	function commit() {
+		if (!commitMessage) return;
 		isCommitting = true;
 		branchController
 			.commitBranch(branch.id, commitMessage, $selectedOwnership.toString(), $runCommitHooks)
@@ -136,13 +137,7 @@
 					on:change={() => currentCommitMessage.set(commitMessage)}
 					on:keydown={(e) => {
 						if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-							if ($expanded) {
-								if (commitMessage) {
-									commit();
-								}
-							} else {
-								$expanded = true;
-							}
+							commit();
 						}
 					}}
 					spellcheck={false}
@@ -211,9 +206,7 @@
 			id="commit-to-branch"
 			on:click={() => {
 				if ($expanded) {
-					if (commitMessage) {
-						commit();
-					}
+					commit();
 				} else {
 					$expanded = true;
 				}

--- a/gitbutler-ui/src/lib/components/CommitDialog.svelte
+++ b/gitbutler-ui/src/lib/components/CommitDialog.svelte
@@ -72,7 +72,7 @@
 		return invoke<string>('git_get_global_config', params);
 	}
 
-	let isGeneratingCommigMessage = false;
+	let isGeneratingCommitMessage = false;
 	async function generateCommitMessage(files: LocalFile[]) {
 		const diff = files
 			.map((f) => f.hunks.filter((h) => $selectedOwnership.containsHunk(f.id, h.id)))
@@ -91,7 +91,7 @@
 		if (branch.name.toLowerCase().includes('virtual branch')) {
 			dispatch('action', 'generate-branch-name');
 		}
-		isGeneratingCommigMessage = true;
+		isGeneratingCommitMessage = true;
 		cloud.summarize
 			.commit(user.access_token, {
 				diff,
@@ -114,7 +114,7 @@
 				toasts.error('Failed to generate commit message');
 			})
 			.finally(() => {
-				isGeneratingCommigMessage = false;
+				isGeneratingCommitMessage = false;
 			});
 	}
 	const commitGenerationExtraConcise = projectCommitGenerationExtraConcise(projectId);
@@ -148,7 +148,7 @@
 					spellcheck={false}
 					class="text-input text-base-body-13 commit-box__textarea"
 					rows="1"
-					disabled={isGeneratingCommigMessage}
+					disabled={isGeneratingCommitMessage}
 					placeholder="Your commit message here"
 				/>
 
@@ -163,7 +163,7 @@
 						icon="ai-small"
 						color="neutral"
 						disabled={!$aiGenEnabled || !user}
-						loading={isGeneratingCommigMessage}
+						loading={isGeneratingCommitMessage}
 						on:click={() => generateCommitMessage(branch.files)}
 					>
 						Generate message


### PR DESCRIPTION
Fixes #2896 

Tested on Linux and `Ctrl + Enter` to commit works perfectly. It should work fine on Mac with `Cmd + Return` because of `e.metaKey` - please test this.

I have copy pasted a block of code from the click handler of the 'Commit' button. Another function `checkAndCommit` could be declared and reused in both places. I haven't done this, let me know if you want me to.