### PR TITLE
create windows gb repo path upon creation

### DIFF
--- a/gitbutler-app/src/gb_repository/repository.rs
+++ b/gitbutler-app/src/gb_repository/repository.rs
@@ -57,8 +57,8 @@ impl Repository {
         }
 
         let projects_dir = root.join("projects");
-
         let path = projects_dir.join(project.id.to_string());
+
         let lock_path = projects_dir.join(format!("{}.lock", project.id));
 
         if path.exists() {
@@ -75,6 +75,8 @@ impl Repository {
                 lock_path,
             })
         } else {
+            std::fs::create_dir_all(&path).context("failed to create project directory")?;
+
             let git_repository = git::Repository::init_opts(
                 &path,
                 git2::RepositoryInitOptions::new()


### PR DESCRIPTION
Unlocks project creation on Windows. Note that there are other issues related to windows that we're still working on but at least this will get to the point of creating projects on Windows.