### PR TITLE
fix:change the place where the tooltip should appear

### DIFF
--- a/gitbutler-ui/src/lib/components/ProjectSelector.svelte
+++ b/gitbutler-ui/src/lib/components/ProjectSelector.svelte
@@ -16,7 +16,6 @@
 
 <div
 	class="wrapper"
-	use:tooltip={isNavCollapsed ? project?.title : ''}
 	use:clickOutside={{
 		handler: () => {
 			popup.hide();
@@ -27,6 +26,7 @@
 >
 	<button
 		class="button"
+		use:tooltip={isNavCollapsed ? project?.title : ''}
 		on:click={(e) => {
 			visible = popup.toggle();
 			e.preventDefault();


### PR DESCRIPTION
The tooltip was displayed even when the project selector button wasn't hovered.

<img width="273" alt="image" src="https://github.com/gitbutlerapp/gitbutler/assets/18498712/5b80bbb3-e513-478f-9a0c-b3e3573c5ddd">
