### PR TITLE
re-add cargo config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]


### PR DESCRIPTION
Was a bit premature. Building with `cargo build` works fine but building via tauri does not. Need to investigate that.