### PR TITLE
'Add key to the GitHub' action from Project settings screen is not opening github in browser.

### DIFF
--- a/gitbutler-ui/src/lib/components/KeysForm.svelte
+++ b/gitbutler-ui/src/lib/components/KeysForm.svelte
@@ -9,7 +9,7 @@
 	import Link from '$lib/components/Link.svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { debounce } from '$lib/utils/debounce';
-	import { open } from '@tauri-apps/api/shell';
+	import { openExternalUrl } from '$lib/utils/url';
 	import { createEventDispatcher } from 'svelte';
 	import type { Key, Project } from '$lib/backend/projects';
 
@@ -211,7 +211,7 @@
 							color="neutral"
 							icon="open-link"
 							on:click={() => {
-								open('https://github.com/settings/ssh/new');
+								openExternalUrl('https://github.com/settings/ssh/new');
 							}}
 						>
 							Add key to GitHub

--- a/gitbutler-ui/src/lib/components/KeysForm.svelte
+++ b/gitbutler-ui/src/lib/components/KeysForm.svelte
@@ -5,6 +5,7 @@
 	import Spacer from './Spacer.svelte';
 	import TextBox from './TextBox.svelte';
 	import { invoke } from '$lib/backend/ipc';
+	import { open } from '@tauri-apps/api/shell';
 	import Button from '$lib/components/Button.svelte';
 	import Link from '$lib/components/Link.svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard';

--- a/gitbutler-ui/src/lib/components/KeysForm.svelte
+++ b/gitbutler-ui/src/lib/components/KeysForm.svelte
@@ -5,11 +5,11 @@
 	import Spacer from './Spacer.svelte';
 	import TextBox from './TextBox.svelte';
 	import { invoke } from '$lib/backend/ipc';
-	import { open } from '@tauri-apps/api/shell';
 	import Button from '$lib/components/Button.svelte';
 	import Link from '$lib/components/Link.svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { debounce } from '$lib/utils/debounce';
+	import { open } from '@tauri-apps/api/shell';
 	import { createEventDispatcher } from 'svelte';
 	import type { Key, Project } from '$lib/backend/projects';
 

--- a/gitbutler-ui/src/routes/settings/+page.svelte
+++ b/gitbutler-ui/src/routes/settings/+page.svelte
@@ -16,7 +16,7 @@
 	import ProfileSIdebar from '$lib/components/settings/ProfileSIdebar.svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import * as toasts from '$lib/utils/toasts';
-	import { open } from '@tauri-apps/api/shell';
+	import { openExternalUrl } from '$lib/utils/url';
 	import { invoke } from '@tauri-apps/api/tauri';
 	import type { PageData } from './$types';
 	import { goto } from '$app/navigation';
@@ -269,7 +269,7 @@
 						color="neutral"
 						icon="open-link"
 						on:click={() => {
-							open('https://github.com/settings/ssh/new');
+							openExternalUrl('https://github.com/settings/ssh/new');
 						}}
 					>
 						Add key to GitHub


### PR DESCRIPTION
 - Add missing import for `open` tauri api
Fix for #2983 