### PR TITLE
Fix missing prop error for FileTree component

### DIFF
--- a/gitbutler-ui/src/lib/components/FileTree.svelte
+++ b/gitbutler-ui/src/lib/components/FileTree.svelte
@@ -85,6 +85,7 @@
 					{allowMultiple}
 					{branchController}
 					{files}
+					{project}
 					on:checked
 					on:unchecked
 				/>
@@ -155,6 +156,7 @@
 						{allowMultiple}
 						{branchController}
 						{files}
+						{project}
 						on:checked
 						on:unchecked
 					/>


### PR DESCRIPTION
- project property was missing from svelte:self tags