### PR TITLE
Move over to evaluatePrompt endpoint for AI integration

### DIFF
--- a/gitbutler-ui/src/lib/backend/ai_providers.ts
+++ b/gitbutler-ui/src/lib/backend/ai_providers.ts
@@ -1,0 +1,30 @@
+import type { User, getCloudApiClient } from '$lib/backend/cloud';
+
+enum ButlerMessageRole {
+	User = 'user',
+	System = 'system'
+}
+
+export interface ButlerPromptMessage {
+	content: string;
+	role: ButlerMessageRole;
+}
+
+export interface AIProvider {
+	evaluate(prompt: string): Promise<string>;
+}
+
+export class ButlerAIProvider implements AIProvider {
+	constructor(
+		private cloud: ReturnType<typeof getCloudApiClient>,
+		private user: User
+	) {}
+
+	async evaluate(prompt: string) {
+		const messages: ButlerPromptMessage[] = [{ role: ButlerMessageRole.User, content: prompt }];
+
+		const response = await this.cloud.ai.evaluatePrompt(this.user.access_token, { messages });
+
+		return response.message;
+	}
+}

--- a/gitbutler-ui/src/lib/backend/cloud.ts
+++ b/gitbutler-ui/src/lib/backend/cloud.ts
@@ -184,27 +184,6 @@ export function getCloudApiClient(
 			}
 		},
 		summarize: {
-			commit: (
-				token: string,
-				params: { diff: string; uid?: string; brief?: boolean; emoji?: boolean }
-			): Promise<{ message: string }> =>
-				fetch(getUrl('summarize/commit.json'), {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json',
-						'X-Auth-Token': token
-					},
-					body: JSON.stringify(params)
-				}).then(parseResponseJSON),
-			hunk: (params: { hunk: string }): Promise<{ message: string }> =>
-				fetch(getUrl('summarize_hunk/hunk.json'), {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json'
-						// 'X-Auth-Token': token
-					},
-					body: JSON.stringify(params)
-				}).then(parseResponseJSON),
 			branch: (token: string, params: { diff: string }): Promise<{ message: string }> =>
 				fetch(getUrl('summarize_branch_name/branch.json'), {
 					method: 'POST',

--- a/gitbutler-ui/src/lib/backend/cloud.ts
+++ b/gitbutler-ui/src/lib/backend/cloud.ts
@@ -1,6 +1,6 @@
 import { isLoading, invoke } from './ipc';
 import { nanoid } from 'nanoid';
-import type { PromptMessage } from '$lib/backend/summarizing';
+import type { ButlerPromptMessage } from '$lib/backend/ai_providers';
 import { PUBLIC_API_BASE_URL, PUBLIC_CHAIN_API } from '$env/static/public';
 
 const apiUrl = new URL('/api/', new URL(PUBLIC_API_BASE_URL));
@@ -93,7 +93,7 @@ const withLog: FetchMiddleware = (fetch) => async (url, options) => {
 };
 
 interface EvaluatePromptParams {
-	messages: PromptMessage[];
+	messages: ButlerPromptMessage[];
 	temperature?: number;
 	max_tokens?: number;
 }

--- a/gitbutler-ui/src/lib/backend/cloud.ts
+++ b/gitbutler-ui/src/lib/backend/cloud.ts
@@ -183,16 +183,7 @@ export function getCloudApiClient(
 				}).then(parseResponseJSON);
 			}
 		},
-		summarize: {
-			branch: (token: string, params: { diff: string }): Promise<{ message: string }> =>
-				fetch(getUrl('summarize_branch_name/branch.json'), {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json',
-						'X-Auth-Token': token
-					},
-					body: JSON.stringify(params)
-				}).then(parseResponseJSON),
+		ai: {
             evaluatePrompt: (token: string, params: EvaluatePromptParams): Promise<{ message: string }> =>
                 fetch(getUrl('evaluate_prompt/predict.json'), {
                     method: 'POST',

--- a/gitbutler-ui/src/lib/backend/cloud.ts
+++ b/gitbutler-ui/src/lib/backend/cloud.ts
@@ -91,6 +91,17 @@ const withLog: FetchMiddleware = (fetch) => async (url, options) => {
 	}
 };
 
+interface PromptMessage {
+    content: string
+    role: 'user' | 'system'
+}
+
+interface EvaluatePromptParams {
+    messages: PromptMessage[]
+    temperature?: number
+    max_tokens?: number
+}
+
 export function getCloudApiClient(
 	{ fetch: realFetch }: { fetch: typeof window.fetch } = {
 		fetch: window.fetch
@@ -206,7 +217,16 @@ export function getCloudApiClient(
 						'X-Auth-Token': token
 					},
 					body: JSON.stringify(params)
-				}).then(parseResponseJSON)
+				}).then(parseResponseJSON),
+            evaluatePrompt: (token: string, params: EvaluatePromptParams): Promise<{ message: string }> =>
+                fetch(getUrl('evaluate_prompt/predict.json'), {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-Auth-Token': token
+                    },
+                    body: JSON.stringify(params)
+                }).then(parseResponseJSON),
 		},
 		chat: {
 			new: (token: string, repositoryId: string): Promise<{ id: string }> =>

--- a/gitbutler-ui/src/lib/backend/cloud.ts
+++ b/gitbutler-ui/src/lib/backend/cloud.ts
@@ -1,5 +1,6 @@
 import { isLoading, invoke } from './ipc';
 import { nanoid } from 'nanoid';
+import type { PromptMessage } from '$lib/backend/summarizing';
 import { PUBLIC_API_BASE_URL, PUBLIC_CHAIN_API } from '$env/static/public';
 
 const apiUrl = new URL('/api/', new URL(PUBLIC_API_BASE_URL));
@@ -90,11 +91,6 @@ const withLog: FetchMiddleware = (fetch) => async (url, options) => {
 		isLoading.pop(item);
 	}
 };
-
-interface PromptMessage {
-    content: string
-    role: 'user' | 'system'
-}
 
 interface EvaluatePromptParams {
     messages: PromptMessage[]

--- a/gitbutler-ui/src/lib/backend/cloud.ts
+++ b/gitbutler-ui/src/lib/backend/cloud.ts
@@ -93,9 +93,9 @@ const withLog: FetchMiddleware = (fetch) => async (url, options) => {
 };
 
 interface EvaluatePromptParams {
-    messages: PromptMessage[]
-    temperature?: number
-    max_tokens?: number
+	messages: PromptMessage[];
+	temperature?: number;
+	max_tokens?: number;
 }
 
 export function getCloudApiClient(
@@ -184,15 +184,15 @@ export function getCloudApiClient(
 			}
 		},
 		ai: {
-            evaluatePrompt: (token: string, params: EvaluatePromptParams): Promise<{ message: string }> =>
-                fetch(getUrl('evaluate_prompt/predict.json'), {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-Auth-Token': token
-                    },
-                    body: JSON.stringify(params)
-                }).then(parseResponseJSON),
+			evaluatePrompt: (token: string, params: EvaluatePromptParams): Promise<{ message: string }> =>
+				fetch(getUrl('evaluate_prompt/predict.json'), {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'X-Auth-Token': token
+					},
+					body: JSON.stringify(params)
+				}).then(parseResponseJSON)
 		},
 		chat: {
 			new: (token: string, repositoryId: string): Promise<{ id: string }> =>

--- a/gitbutler-ui/src/lib/backend/summarizer.ts
+++ b/gitbutler-ui/src/lib/backend/summarizer.ts
@@ -1,14 +1,4 @@
-import type { User, getCloudApiClient } from '$lib/backend/cloud';
-
-enum MessageRole {
-	User = 'user',
-	System = 'system'
-}
-
-export interface PromptMessage {
-	content: string;
-	role: MessageRole;
-}
+import type { AIProvider } from '$lib/backend/ai_providers';
 
 const diffLengthLimit = 20000;
 
@@ -35,25 +25,6 @@ Branch names should contain a maximum of 5 words.
 Here is my diff:
 %{diff}
 `;
-
-interface AIProvider {
-	evaluate(prompt: string): Promise<string>;
-}
-
-export class ButlerAIProvider implements AIProvider {
-	constructor(
-		private cloud: ReturnType<typeof getCloudApiClient>,
-		private user: User
-	) {}
-
-	async evaluate(prompt: string) {
-		const messages: PromptMessage[] = [{ role: MessageRole.User, content: prompt }];
-
-		const response = await this.cloud.ai.evaluatePrompt(this.user.access_token, { messages });
-
-		return response.message;
-	}
-}
 
 export class Summarizer {
 	constructor(private aiProvider: AIProvider) {}

--- a/gitbutler-ui/src/lib/backend/summarizing.ts
+++ b/gitbutler-ui/src/lib/backend/summarizing.ts
@@ -1,0 +1,64 @@
+import type { User, getCloudApiClient } from "$lib/backend/cloud"
+
+enum MessageRole {
+    User = 'user',
+    System = 'system'
+}
+
+export interface PromptMessage {
+    content: string
+    role: MessageRole
+}
+
+const commitTemplate = `
+Please could you write a commit message for my changes.
+Explain what were the changes and why the changes were done.
+Focus the most important changes.
+Use the present tense.
+Always use semantic commit prefixes.
+Hard wrap lines at 72 characters.
+%{brief_style}
+%{emoji_style}
+
+Here is my diff:
+%{diff}
+`
+
+export class Summarizer {
+    constructor(private cloud: ReturnType<typeof getCloudApiClient>, private user: User) {}
+
+    async commit(diff: string, useEmojiStyle: boolean, useBreifStyle: boolean) {
+        const briefStyle = "The commit message must be only one sentence and as short as possible."
+        const emojiStyle = "Make use of GitMoji in the title prefix."
+        const emojiStyleDisabled = "Don't use any emoji."
+
+        let prompt = commitTemplate.replaceAll("%{diff}", diff.slice(0, 20000))
+        if (useBreifStyle) {
+            prompt = prompt.replaceAll("%{brief_style}", briefStyle)
+        }
+        if (useEmojiStyle) {
+            prompt = prompt.replaceAll("%{emoji_style}", emojiStyle)
+        } else {
+            prompt = prompt.replaceAll("%{emoji_style}", emojiStyleDisabled)
+        }
+        prompt.replaceAll("%{breif_style}", "")
+
+        const messages: PromptMessage[] = [
+            { role: MessageRole.User, content: prompt }
+        ]
+
+        const response = await this.cloud.summarize.evaluatePrompt(this.user.access_token, { messages })
+        let message = response.message
+
+        if (useBreifStyle) {
+            message = message.split("\n")[0]
+        }
+
+        // trim and format output
+        const firstNewLine = message.indexOf('\n');
+        const summary = firstNewLine > -1 ? message.slice(0, firstNewLine).trim() : message;
+        const description = firstNewLine > -1 ? message.slice(firstNewLine + 1).trim() : '';
+
+        return description.length > 0 ? `${summary}\n\n${description}` : summary;
+    }
+}

--- a/gitbutler-ui/src/lib/backend/summarizing.ts
+++ b/gitbutler-ui/src/lib/backend/summarizing.ts
@@ -12,7 +12,7 @@ export interface PromptMessage {
 
 const diffLengthLimit = 20000;
 
-const commitTemplate = `
+const defaultCommitTemplate = `
 Please could you write a commit message for my changes.
 Explain what were the changes and why the changes were done.
 Focus the most important changes.
@@ -26,7 +26,7 @@ Here is my diff:
 %{diff}
 `
 
-const branchTemplate = `
+const defaultBranchTemplate = `
 Please could you write a branch name for my changes.
 A branch name represent a brief description of the changes in the diff (branch).
 Branch names should contain no whitespace and instead use dashes to separate words.
@@ -57,12 +57,17 @@ export class ButlerAIProvider implements AIProvider {
 export class Summarizer {
     constructor(private aiProvider: AIProvider) {}
 
-    async commit(diff: string, useEmojiStyle: boolean, useBreifStyle: boolean) {
+    async commit(
+        diff: string,
+        useEmojiStyle: boolean,
+        useBreifStyle: boolean,
+        commitTemplate?: string
+    ) {
         const briefStyle = "The commit message must be only one sentence and as short as possible."
         const emojiStyle = "Make use of GitMoji in the title prefix."
         const emojiStyleDisabled = "Don't use any emoji."
 
-        let prompt = commitTemplate.replaceAll("%{diff}", diff.slice(0, diffLengthLimit))
+        let prompt = (commitTemplate || defaultCommitTemplate).replaceAll("%{diff}", diff.slice(0, diffLengthLimit))
         if (useBreifStyle) {
             prompt = prompt.replaceAll("%{brief_style}", briefStyle)
         }
@@ -87,8 +92,8 @@ export class Summarizer {
         return description.length > 0 ? `${summary}\n\n${description}` : summary;
     }
 
-    async branch(diff: string) {
-        const prompt = branchTemplate.replaceAll("%{diff}", diff.slice(0, diffLengthLimit))
+    async branch(diff: string, branchTemplate?: string) {
+        const prompt = (branchTemplate || defaultBranchTemplate).replaceAll("%{diff}", diff.slice(0, diffLengthLimit))
 
         let message = await this.aiProvider.evaluate(prompt)
 

--- a/gitbutler-ui/src/lib/backend/summarizing.ts
+++ b/gitbutler-ui/src/lib/backend/summarizing.ts
@@ -24,6 +24,16 @@ Here is my diff:
 %{diff}
 `
 
+const branchTemplate = `
+Please could you write a branch name for my changes.
+A branch name represent a brief description of the changes in the diff (branch).
+Branch names should contain no whitespace and instead use dashes to separate words.
+Branch names should contain a maximum of 5 words.
+
+Here is my diff:
+%{diff}
+`
+
 export class Summarizer {
     constructor(private cloud: ReturnType<typeof getCloudApiClient>, private user: User) {}
 
@@ -60,5 +70,19 @@ export class Summarizer {
         const description = firstNewLine > -1 ? message.slice(firstNewLine + 1).trim() : '';
 
         return description.length > 0 ? `${summary}\n\n${description}` : summary;
+    }
+
+    async branch(diff: string) {
+        const prompt = branchTemplate.replaceAll("%{diff}", diff.slice(0, 20000))
+
+        const messages: PromptMessage[] = [
+            { role: MessageRole.User, content: prompt }
+        ]
+
+        const response = await this.cloud.summarize.evaluatePrompt(this.user.access_token, { messages })
+        let message = response.message
+        message = message.replaceAll(" ", "-")
+        message = message.replaceAll("\n", "-")
+        return message
     }
 }

--- a/gitbutler-ui/src/lib/backend/summarizing.ts
+++ b/gitbutler-ui/src/lib/backend/summarizing.ts
@@ -63,20 +63,18 @@ export class Summarizer {
         useBreifStyle: boolean,
         commitTemplate?: string
     ) {
-        const briefStyle = "The commit message must be only one sentence and as short as possible."
-        const emojiStyle = "Make use of GitMoji in the title prefix."
-        const emojiStyleDisabled = "Don't use any emoji."
 
         let prompt = (commitTemplate || defaultCommitTemplate).replaceAll("%{diff}", diff.slice(0, diffLengthLimit))
         if (useBreifStyle) {
-            prompt = prompt.replaceAll("%{brief_style}", briefStyle)
+            prompt = prompt.replaceAll("%{brief_style}", "The commit message must be only one sentence and as short as possible.")
+        } else {
+            prompt = prompt.replaceAll("%{breif_style}", "")
         }
         if (useEmojiStyle) {
-            prompt = prompt.replaceAll("%{emoji_style}", emojiStyle)
+            prompt = prompt.replaceAll("%{emoji_style}", "Make use of GitMoji in the title prefix.")
         } else {
-            prompt = prompt.replaceAll("%{emoji_style}", emojiStyleDisabled)
+            prompt = prompt.replaceAll("%{emoji_style}", "Don't use any emoji.")
         }
-        prompt.replaceAll("%{breif_style}", "")
 
         let message = await this.aiProvider.evaluate(prompt)
 

--- a/gitbutler-ui/src/lib/backend/summarizing.ts
+++ b/gitbutler-ui/src/lib/backend/summarizing.ts
@@ -48,7 +48,7 @@ export class ButlerAIProvider implements AIProvider {
             { role: MessageRole.User, content: prompt }
         ]
 
-        const response = await this.cloud.summarize.evaluatePrompt(this.user.access_token, { messages })
+        const response = await this.cloud.ai.evaluatePrompt(this.user.access_token, { messages })
 
         return response.message
     }

--- a/gitbutler-ui/src/lib/backend/summarizing.ts
+++ b/gitbutler-ui/src/lib/backend/summarizing.ts
@@ -10,6 +10,8 @@ export interface PromptMessage {
     role: MessageRole
 }
 
+const diffLengthLimit = 20000;
+
 const commitTemplate = `
 Please could you write a commit message for my changes.
 Explain what were the changes and why the changes were done.
@@ -38,7 +40,7 @@ interface AIProvider {
     evaluate(prompt: string): Promise<string>
 }
 
-export class ButlerAIProvider {
+export class ButlerAIProvider implements AIProvider {
     constructor(private cloud: ReturnType<typeof getCloudApiClient>, private user: User) {}
 
     async evaluate(prompt: string) {
@@ -60,7 +62,7 @@ export class Summarizer {
         const emojiStyle = "Make use of GitMoji in the title prefix."
         const emojiStyleDisabled = "Don't use any emoji."
 
-        let prompt = commitTemplate.replaceAll("%{diff}", diff.slice(0, 20000))
+        let prompt = commitTemplate.replaceAll("%{diff}", diff.slice(0, diffLengthLimit))
         if (useBreifStyle) {
             prompt = prompt.replaceAll("%{brief_style}", briefStyle)
         }
@@ -86,7 +88,7 @@ export class Summarizer {
     }
 
     async branch(diff: string) {
-        const prompt = branchTemplate.replaceAll("%{diff}", diff.slice(0, 20000))
+        const prompt = branchTemplate.replaceAll("%{diff}", diff.slice(0, diffLengthLimit))
 
         let message = await this.aiProvider.evaluate(prompt)
 

--- a/gitbutler-ui/src/lib/components/BranchCard.svelte
+++ b/gitbutler-ui/src/lib/components/BranchCard.svelte
@@ -42,7 +42,7 @@
 		RemoteBranchData,
 		RemoteCommit
 	} from '$lib/vbranches/types';
-	import { Summarizer } from '$lib/backend/summarizing';
+	import { ButlerAIProvider, Summarizer } from '$lib/backend/summarizing';
 
 	export let branch: Branch;
 	export let isUnapplied = false;
@@ -100,7 +100,9 @@
 			.slice(0, 5000);
 
 		if (user && aiGenEnabled) {
-            new Summarizer(cloud, user).branch(diff).then((message) => {
+            const aiProvider = new ButlerAIProvider(cloud, user)
+
+            new Summarizer(aiProvider).branch(diff).then((message) => {
 				if (message !== branch.name) {
 					branch.name = message;
 					branchController.updateBranchName(branch.id, branch.name);

--- a/gitbutler-ui/src/lib/components/BranchCard.svelte
+++ b/gitbutler-ui/src/lib/components/BranchCard.svelte
@@ -6,7 +6,8 @@
 	import DropzoneOverlay from './DropzoneOverlay.svelte';
 	import PullRequestCard from './PullRequestCard.svelte';
 	import UpstreamCommits from './UpstreamCommits.svelte';
-	import { ButlerAIProvider, Summarizer } from '$lib/backend/summarizing';
+	import { ButlerAIProvider } from '$lib/backend/ai_providers';
+	import { Summarizer } from '$lib/backend/summarizer';
 	import ImgThemed from '$lib/components/ImgThemed.svelte';
 	import Resizer from '$lib/components/Resizer.svelte';
 	import { projectAiGenAutoBranchNamingEnabled } from '$lib/config/config';
@@ -43,7 +44,6 @@
 		RemoteBranchData,
 		RemoteCommit
 	} from '$lib/vbranches/types';
-
 	export let branch: Branch;
 	export let isUnapplied = false;
 	export let project: Project;

--- a/gitbutler-ui/src/lib/components/BranchCard.svelte
+++ b/gitbutler-ui/src/lib/components/BranchCard.svelte
@@ -42,6 +42,7 @@
 		RemoteBranchData,
 		RemoteCommit
 	} from '$lib/vbranches/types';
+	import { Summarizer } from '$lib/backend/summarizing';
 
 	export let branch: Branch;
 	export let isUnapplied = false;
@@ -99,9 +100,9 @@
 			.slice(0, 5000);
 
 		if (user && aiGenEnabled) {
-			cloud.summarize.branch(user.access_token, { diff }).then((result) => {
-				if (result.message && result.message !== branch.name) {
-					branch.name = result.message;
+            new Summarizer(cloud, user).branch(diff).then((message) => {
+				if (message !== branch.name) {
+					branch.name = message;
 					branchController.updateBranchName(branch.id, branch.name);
 				}
 			});

--- a/gitbutler-ui/src/lib/components/BranchCard.svelte
+++ b/gitbutler-ui/src/lib/components/BranchCard.svelte
@@ -6,6 +6,7 @@
 	import DropzoneOverlay from './DropzoneOverlay.svelte';
 	import PullRequestCard from './PullRequestCard.svelte';
 	import UpstreamCommits from './UpstreamCommits.svelte';
+	import { ButlerAIProvider, Summarizer } from '$lib/backend/summarizing';
 	import ImgThemed from '$lib/components/ImgThemed.svelte';
 	import Resizer from '$lib/components/Resizer.svelte';
 	import { projectAiGenAutoBranchNamingEnabled } from '$lib/config/config';
@@ -42,7 +43,6 @@
 		RemoteBranchData,
 		RemoteCommit
 	} from '$lib/vbranches/types';
-	import { ButlerAIProvider, Summarizer } from '$lib/backend/summarizing';
 
 	export let branch: Branch;
 	export let isUnapplied = false;
@@ -100,9 +100,9 @@
 			.slice(0, 5000);
 
 		if (user && aiGenEnabled) {
-            const aiProvider = new ButlerAIProvider(cloud, user)
+			const aiProvider = new ButlerAIProvider(cloud, user);
 
-            new Summarizer(aiProvider).branch(diff).then((message) => {
+			new Summarizer(aiProvider).branch(diff).then((message) => {
 				if (message !== branch.name) {
 					branch.name = message;
 					branchController.updateBranchName(branch.id, branch.name);

--- a/gitbutler-ui/src/lib/components/CommitDialog.svelte
+++ b/gitbutler-ui/src/lib/components/CommitDialog.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { ButlerAIProvider, Summarizer } from '$lib/backend/summarizing';
 	import Button from '$lib/components/Button.svelte';
 	import Checkbox from '$lib/components/Checkbox.svelte';
 	import DropDownButton from '$lib/components/DropDownButton.svelte';
@@ -26,7 +27,6 @@
 	import type { Ownership } from '$lib/vbranches/ownership';
 	import type { Branch, LocalFile } from '$lib/vbranches/types';
 	import type { Writable } from 'svelte/store';
-	import { ButlerAIProvider, Summarizer } from '$lib/backend/summarizing';
 
 	const dispatch = createEventDispatcher<{
 		action: 'generate-branch-name';
@@ -74,12 +74,12 @@
 		return invoke<string>('git_get_global_config', params);
 	}
 
-    let summarizer: Summarizer | undefined
-    $: if (user) {
-        const aiProvider = new ButlerAIProvider(cloud, user)
+	let summarizer: Summarizer | undefined;
+	$: if (user) {
+		const aiProvider = new ButlerAIProvider(cloud, user);
 
-        summarizer = new Summarizer(aiProvider)
-    }
+		summarizer = new Summarizer(aiProvider);
+	}
 
 	let isGeneratingCommitMessage = false;
 	async function generateCommitMessage(files: LocalFile[]) {
@@ -92,7 +92,7 @@
 			.slice(0, 5000);
 
 		if (!user) return;
-        if (!summarizer) return;
+		if (!summarizer) return;
 
 		// Branches get their names generated only if there are at least 4 lines of code
 		// If the change is a 'one-liner', the branch name is either left as "virtual branch"
@@ -102,12 +102,11 @@
 			dispatch('action', 'generate-branch-name');
 		}
 
-        //@ts-ignore
-        window.cloud = cloud; window.user = user
 		isGeneratingCommitMessage = true;
-        summarizer.commit(diff, $commitGenerationUseEmojis, $commitGenerationExtraConcise)
+		summarizer
+			.commit(diff, $commitGenerationUseEmojis, $commitGenerationExtraConcise)
 			.then((message) => {
-                commitMessage = message;
+				commitMessage = message;
 				currentCommitMessage.set(message);
 
 				setTimeout(() => {

--- a/gitbutler-ui/src/lib/components/CommitDialog.svelte
+++ b/gitbutler-ui/src/lib/components/CommitDialog.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { ButlerAIProvider, Summarizer } from '$lib/backend/summarizing';
+	import { ButlerAIProvider } from '$lib/backend/ai_providers';
+	import { Summarizer } from '$lib/backend/summarizer';
 	import Button from '$lib/components/Button.svelte';
 	import Checkbox from '$lib/components/Checkbox.svelte';
 	import DropDownButton from '$lib/components/DropDownButton.svelte';

--- a/gitbutler-ui/src/lib/components/CommitDialog.svelte
+++ b/gitbutler-ui/src/lib/components/CommitDialog.svelte
@@ -26,7 +26,7 @@
 	import type { Ownership } from '$lib/vbranches/ownership';
 	import type { Branch, LocalFile } from '$lib/vbranches/types';
 	import type { Writable } from 'svelte/store';
-	import { Summarizer } from '$lib/backend/summarizing';
+	import { ButlerAIProvider, Summarizer } from '$lib/backend/summarizing';
 
 	const dispatch = createEventDispatcher<{
 		action: 'generate-branch-name';
@@ -76,7 +76,9 @@
 
     let summarizer: Summarizer | undefined
     $: if (user) {
-        summarizer = new Summarizer(cloud, user)
+        const aiProvider = new ButlerAIProvider(cloud, user)
+
+        summarizer = new Summarizer(aiProvider)
     }
 
 	let isGeneratingCommitMessage = false;

--- a/gitbutler-ui/tsconfig.json
+++ b/gitbutler-ui/tsconfig.json
@@ -2,7 +2,7 @@
 	"extends": "./.svelte-kit/tsconfig.json",
 	"compilerOptions": {
 		"target": "es6",
-		"lib": ["dom", "dom.iterable", "ES2020"],
+		"lib": ["dom", "dom.iterable", "ES2021"],
 		"allowJs": true,
 		"checkJs": true,
 		"esModuleInterop": true,


### PR DESCRIPTION
This PR stops using the old summarization endpoints in favour of the new evaluatePrompt endpoint. This enables us to generate the commit messages on the client side.

## AI Providers

We've already talked about having the ability to plug in different AI sources, and potentially have local models, so I decided to leave an open door there and create an AIProvider interface that can be implemented.

## Change from ES2020 to ES2021 target

ES2021 provides the `String#replaceAll` method which is handy so I've updated the target to 2021.

My UI seemed not to update after some commit operations but seemed to be fine after I properly restarted GB. However, it would be helpful if someone could try testing doing some gitty operations and see if the UI responds as expected.

## Summarizer

I'm not entirely happy with all the formatting logic in there, but at the minute I don't see a better way to achieve it without overcomplicating it for the sake of it, so any feedback would be appreciated 👍