### PR TITLE
fix `dev` script and DEVELOPMENT docs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -48,13 +48,13 @@ You'll have to re-run this occasionally when our deps change.
 Now you should be able to run the app in development mode:
 
 ```bash
-$ pnpm tauri dev
+$ pnpm devel
 ```
 
 By default it will not print debug logs to console. If you want debug logs, set `LOG_LEVEL` environment variable:
 
 ```bash
-$ LOG_LEVEL=debug pnpm tauri dev
+$ LOG_LEVEL=debug pnpm devel
 ```
 
 ## Lint & format

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "git-butler-tauri",
   "private": true,
   "scripts": {
+    "devel": "cd gitbutler-app/ && ../node_modules/.bin/tauri dev",
     "dev": "pnpm --filter @gitbutler/ui run dev",
     "test": "pnpm --filter @gitbutler/ui run test",
     "build": "pnpm --filter @gitbutler/ui run build",


### PR DESCRIPTION
i think in 746e8cca (new structure, 2023-09-06) you've migrated to workspaces,
but forgot to change the docs for running the application.

---

reading the DEVELOPMENT.md docs, i came accross an issue.

1. the `pnpm tauri dev` script did not work:

```sh
$ pnpm tauri dev

> git-butler-tauri@ tauri /Users/kipras/forkprojects/gitbutler
> tauri "dev"

thread '<unnamed>' panicked at src/helpers/app_paths.rs:85:5:
Couldn't recognize the current folder as a Tauri project. It must contain a `tauri.conf.json`, `tauri.conf.json5` or `Tauri.toml` file in any subfolder.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

2. alright, instead i tried running `pnpm dev`.

but it would only launch `dev` in `gitbutler-ui`,
which launches vite in a web browser, not the tauri window, so broken too:

```console
Unhandled exception TypeError: window.__TAURI_IPC__ is not a function
```

i.e., it only runs `vite dev`, not `tauri dev`.

3. trying to fix via `cd gitbutler-app && pnpm tauri dev`, nope - same issue as in (1).

... because pnpm scripts run in project root (i.e. `/` and not `/gitbutler-app`). i think if i had `tauri` installed and ran it directly there, it would've been fine, but i didn't have it installed.

4. if i cd inside `gitbutler-app` and run:

```sh
$ ../node_modules/.bin/tauri dev
```

everything works now.

5. well, shoes, proper fix then:

```sh
(cd gitbutler-app/ && ../node_modules/.bin/tauri dev)
```

apply it to the root package.json's "dev" script.

=> just gets stuck in infinite loop...

```sh
$ pnpm dev

> git-butler-tauri@ dev /Users/kipras/forkprojects/gitbutler
> cd gitbutler-app/ && ../node_modules/.bin/tauri dev

     Running BeforeDevCommand (`pnpm dev`)

> git-butler-tauri@ dev /Users/kipras/forkprojects/gitbutler
> cd gitbutler-app/ && ../node_modules/.bin/tauri dev

     Running BeforeDevCommand (`pnpm dev`)

> git-butler-tauri@ dev /Users/kipras/forkprojects/gitbutler
> cd gitbutler-app/ && ../node_modules/.bin/tauri dev

        Warn Waiting for your frontend dev server to start on http://localhost:1420/...
     Running BeforeDevCommand (`pnpm dev`)

^C ELIFECYCLE  Command failed with exit code 130.
 ELIFECYCLE  Command failed with exit code 130.
 ELIFECYCLE  Command failed with exit code 130.
```

...because i guess tauri's `dev` runs itself, and then the UI code via the root package.json's `dev` script, thus would end up in an infinite loop..

5. final fix - create a separate script for end-to-end dev, "devel", which works from project root, because avoids all of the issues above.

```json
    "devel": "cd gitbutler-app/ && ../node_modules/.bin/tauri dev",
```

it's ugly; too bad -- pnpm, unlike yarn v1, doesn't have `run --cwd` 🤷‍♀️