### PR TITLE
feat: Update button text from "Authenticate" to "Authorize" in GitHub authentication workflow

### DIFF
--- a/gitbutler-ui/src/lib/components/GithubIntegration.svelte
+++ b/gitbutler-ui/src/lib/components/GithubIntegration.svelte
@@ -68,9 +68,7 @@
 	{#if $user$?.github_access_token}
 		<Button {disabled} kind="filled" color="primary" on:click={forgetGitHub}>Forget</Button>
 	{:else}
-		<Button {disabled} kind="filled" color="primary" on:click={gitHubStartOauth}
-			>Authenticate</Button
-		>
+		<Button {disabled} kind="filled" color="primary" on:click={gitHubStartOauth}>Authorize</Button>
 	{/if}
 {:else}
 	<SectionCard orientation="row">
@@ -102,15 +100,15 @@
 		</svelte:fragment>
 		<Button {disabled} kind="filled" color="primary" on:click={gitHubStartOauth}>
 			{#if $user$?.github_access_token}
-				Reauthenticate
+				Reauthorize
 			{:else}
-				Authenticate
+				Authorize
 			{/if}
 		</Button>
 	</SectionCard>
 {/if}
 
-<Modal bind:this={gitHubOauthModal} width="small" title="Authenticate with GitHub">
+<Modal bind:this={gitHubOauthModal} width="small" title="Authorize with GitHub">
 	<div class="wrapper">
 		<div class="step-section">
 			<div class="step-default" />

--- a/gitbutler-ui/src/lib/components/GithubIntegration.svelte
+++ b/gitbutler-ui/src/lib/components/GithubIntegration.svelte
@@ -65,11 +65,7 @@
 </script>
 
 {#if minimal}
-	{#if $user$?.github_access_token}
-		<Button {disabled} kind="filled" color="primary" on:click={forgetGitHub}>Forget</Button>
-	{:else}
-		<Button {disabled} kind="filled" color="primary" on:click={gitHubStartOauth}>Authorize</Button>
-	{/if}
+	<Button {disabled} kind="filled" color="primary" on:click={gitHubStartOauth}>Authorize</Button>
 {:else}
 	<SectionCard orientation="row">
 		<svelte:fragment slot="iconSide">
@@ -98,13 +94,14 @@
 		<svelte:fragment slot="body">
 			Allows you to view and create Pull Requests from GitButler.
 		</svelte:fragment>
-		<Button {disabled} kind="filled" color="primary" on:click={gitHubStartOauth}>
-			{#if $user$?.github_access_token}
-				Reauthorize
-			{:else}
-				Authorize
-			{/if}
-		</Button>
+		{#if $user$?.github_access_token}
+			<Button {disabled} kind="outlined" color="neutral" icon="bin-small" on:click={forgetGitHub}
+				>Forget</Button
+			>
+		{:else}
+			<Button {disabled} kind="filled" color="primary" on:click={gitHubStartOauth}>Authorize</Button
+			>
+		{/if}
 	</SectionCard>
 {/if}
 

--- a/gitbutler-ui/src/lib/components/ProjectSetup.svelte
+++ b/gitbutler-ui/src/lib/components/ProjectSetup.svelte
@@ -175,7 +175,7 @@
 				</svelte:fragment>
 				<svelte:fragment slot="actions">
 					{#if !$user$?.github_access_token}
-						<GithubIntegration minimal {userService} disabled={!$user$} />
+						<GithubIntegration {userService} disabled={!$user$} />
 					{/if}
 				</svelte:fragment>
 			</SetupFeature>


### PR DESCRIPTION
Changed the button text from "Authenticate" to "Authorize" for better clarity.