### PR TITLE
Update merge button labels

### DIFF
--- a/gitbutler-ui/src/lib/components/MergeButton.svelte
+++ b/gitbutler-ui/src/lib/components/MergeButton.svelte
@@ -71,12 +71,12 @@
 			/>
 			<ContextMenuItem
 				id={MergeMethod.Rebase}
-				label="Rebase"
+				label="Rebase and merge"
 				selected={$action == MergeMethod.Rebase}
 			/>
 			<ContextMenuItem
 				id={MergeMethod.Squash}
-				label="Squash"
+				label="Squash and merge"
 				selected={$action == MergeMethod.Squash}
 			/>
 		</ContextMenuSection>


### PR DESCRIPTION
- corrects language to say e.g. "rebase and squash" instead of "rebase"