### PR TITLE
adds remote name and branch name as parameters to the git_test_push command

### DIFF
--- a/gitbutler-app/src/app.rs
+++ b/gitbutler-app/src/app.rs
@@ -121,24 +121,14 @@ impl App {
     pub fn git_test_push(
         &self,
         project_id: &ProjectId,
+        remote_name: &str,
+        branch_name: &str,
         credentials: &git::credentials::Helper,
     ) -> Result<(), Error> {
         let project = self.projects.get(project_id)?;
         let project_repository = project_repository::Repository::open(&project)?;
-        let user = self.users.get_user().unwrap_or(None);
-        let gb_repository = gb_repository::Repository::open(
-            &self.local_data_dir,
-            &project_repository,
-            user.as_ref(),
-        )
-        .map_err(|e| Error::Other(anyhow::anyhow!(e)))?;
-
-        let target = gb_repository
-            .default_target()?
-            .ok_or(Error::Other(anyhow::anyhow!("no default target set")))?;
-
         project_repository
-            .git_test_push(credentials, &target)
+            .git_test_push(credentials, remote_name, branch_name)
             .map_err(Error::Other)
     }
 

--- a/gitbutler-app/src/commands.rs
+++ b/gitbutler-app/src/commands.rs
@@ -64,14 +64,19 @@ pub async fn git_remote_branches(
 
 #[tauri::command(async)]
 #[instrument(skip(handle))]
-pub async fn git_test_push(handle: tauri::AppHandle, project_id: &str) -> Result<(), Error> {
+pub async fn git_test_push(
+    handle: tauri::AppHandle,
+    project_id: &str,
+    remote_name: &str,
+    branch_name: &str,
+) -> Result<(), Error> {
     let app = handle.state::<app::App>();
     let helper = handle.state::<crate::git::credentials::Helper>();
     let project_id = project_id.parse().map_err(|_| Error::UserError {
         code: Code::Validation,
         message: "Malformed project id".to_string(),
     })?;
-    app.git_test_push(&project_id, &helper)
+    app.git_test_push(&project_id, remote_name, branch_name, &helper)
         .map_err(|e| Error::UserError {
             code: Code::Unknown,
             message: e.to_string(),


### PR DESCRIPTION
@mtsgrd you can use it like this
```
invoke<string>('git_test_push', {
			projectId: projectId,
			remoteName: remoteName,
			branchName: branchName
		})
```