### PR TITLE
feat: adds a git_test_fetch command to check if fetch can be performed for a given remote

### DIFF
--- a/gitbutler-app/src/app.rs
+++ b/gitbutler-app/src/app.rs
@@ -132,6 +132,19 @@ impl App {
             .map_err(Error::Other)
     }
 
+    pub fn git_test_fetch(
+        &self,
+        project_id: &ProjectId,
+        remote_name: &str,
+        credentials: &git::credentials::Helper,
+    ) -> Result<(), Error> {
+        let project = self.projects.get(project_id)?;
+        let project_repository = project_repository::Repository::open(&project)?;
+        project_repository
+            .fetch(remote_name, credentials)
+            .map_err(|e| Error::Other(anyhow::anyhow!(e.to_string())))
+    }
+
     pub fn git_head(&self, project_id: &ProjectId) -> Result<String, Error> {
         let project = self.projects.get(project_id)?;
         let project_repository = project_repository::Repository::open(&project)?;

--- a/gitbutler-app/src/commands.rs
+++ b/gitbutler-app/src/commands.rs
@@ -85,6 +85,26 @@ pub async fn git_test_push(
 
 #[tauri::command(async)]
 #[instrument(skip(handle))]
+pub async fn git_test_fetch(
+    handle: tauri::AppHandle,
+    project_id: &str,
+    remote_name: &str,
+) -> Result<(), Error> {
+    let app = handle.state::<app::App>();
+    let helper = handle.state::<crate::git::credentials::Helper>();
+    let project_id = project_id.parse().map_err(|_| Error::UserError {
+        code: Code::Validation,
+        message: "Malformed project id".to_string(),
+    })?;
+    app.git_test_fetch(&project_id, remote_name, &helper)
+        .map_err(|e| Error::UserError {
+            code: Code::Unknown,
+            message: e.to_string(),
+        })
+}
+
+#[tauri::command(async)]
+#[instrument(skip(handle))]
 pub async fn git_head(handle: tauri::AppHandle, project_id: &str) -> Result<String, Error> {
     let app = handle.state::<app::App>();
     let project_id = project_id.parse().map_err(|_| Error::UserError {

--- a/gitbutler-app/src/main.rs
+++ b/gitbutler-app/src/main.rs
@@ -238,6 +238,7 @@ fn main() {
                     commands::git_get_global_config,
                     commands::project_flush_and_push,
                     commands::git_test_push,
+                    commands::git_test_fetch,
                     zip::commands::get_logs_archive_path,
                     zip::commands::get_project_archive_path,
                     zip::commands::get_project_data_archive_path,


### PR DESCRIPTION
This is an api to test fetching (not pushing) before the target has been set (as opposed to the `fetch_from_target` command that that the app uses after setup)

fyi @mtsgrd 

Can be used like this:
```
invoke<string>('git_test_fetch', {
			projectId: projectId,
			remoteName: remoteName,
		})
```