### PR TITLE
Fixed duplicated files on drag

### DIFF
--- a/gitbutler-ui/src/lib/components/FileListItem.svelte
+++ b/gitbutler-ui/src/lib/components/FileListItem.svelte
@@ -98,7 +98,7 @@
 	>
 		<div class="info-wrap">
 			<div class="info">
-				<img src={getVSIFileIcon(file.path)} alt="js" style="width: var(--space-12)" />
+				<img draggable="false" class="file-icon" src={getVSIFileIcon(file.path)} alt="js" />
 				<span class="text-base-12 name">
 					{file.filename}
 				</span>
@@ -159,6 +159,10 @@
 		flex-shrink: 1;
 		gap: var(--space-6);
 		overflow: hidden;
+	}
+
+	.file-icon {
+		width: var(--space-12);
 	}
 	.name {
 		color: var(--clr-theme-scale-ntrl-0);


### PR DESCRIPTION
The bug occurs when trying to drag the file by clicking on the icon of the file, then the function `handleDragStart` of the `use:draggable`action, starts the draggin, but the function `handleDragEnd` it's never called, because the dropzone wouldn't admit the image(file icon). This causes that the clean up function to never be called and leaves orphan cloned nodes arround that will be selected by the query selector ".selected-draggable" on the options of the `use:draggable`

So the easy solution was making the image not draggable and that's it.

This video is replicating the bug.

https://github.com/gitbutlerapp/gitbutler/assets/71847541/b7a04603-6e6d-4b4b-a4de-8f978bda15b4

This video was after adding `draggable="false"` attribute to the file-icon.

https://github.com/gitbutlerapp/gitbutler/assets/71847541/7d15a973-9620-4e3e-a872-531c176fc0cc

Solves: #2612




