### PR TITLE
Integrate alls-green in rust-check job to improve status checks

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -170,14 +170,28 @@ jobs:
           features: ${{ toJson(matrix.features) }}
           action: ${{ matrix.action }}
 
+# See: https://github.com/re-actors/alls-green
   check-rust:
+    if: always()
     needs:
       - changes
       - check-gitbutler-app
       - check-gitbutler-changeset
       - check-gitbutler-core
     runs-on: ubuntu-latest
-    if: ${{ needs.changes.outputs.rust == 'true' }}
     steps:
-      - run: ':'
-        shell: bash
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          allowed-skips: >-
+            ${{
+              needs.changes.outputs.rust != 'true'
+              && '
+              check-gitbutler-app,
+              check-gitbutler-changeset,
+              check-gitbutler-core,
+              '
+              || ''
+            }}
+          jobs: ${{ toJSON(needs) }}
+


### PR DESCRIPTION
This patch integrates alls-green, that checks whether all dependency jobs have passed successfully. This change also simplifies the CI setup by requiring only the rust-check job for status checks.

Resolves #2848