### PR TITLE
Fix new project redirect

### DIFF
--- a/gitbutler-ui/src/lib/components/ProjectSetup.svelte
+++ b/gitbutler-ui/src/lib/components/ProjectSetup.svelte
@@ -28,7 +28,7 @@
 		loading = true;
 		try {
 			await branchController.setTarget(selectedBranch);
-			goto('..');
+			goto(`/${project.id}/`);
 		} finally {
 			loading = false;
 		}


### PR DESCRIPTION
- `goto('..')` was redirecting to previous project