### PR TITLE
refactor: when fetching hunks by file return a map of DiffFile

### DIFF
--- a/gitbutler-app/src/git/diff.rs
+++ b/gitbutler-app/src/git/diff.rs
@@ -264,20 +264,19 @@ fn hunks_by_filepath(
                         change_type,
                     });
                 }
-
-                diff_files.insert(
-                    file_path.to_path_buf(),
-                    DiffFile {
-                        old_path: delta.old_file().path().map(std::path::Path::to_path_buf),
-                        new_path: delta.new_file().path().map(std::path::Path::to_path_buf),
-                        hunks: None,
-                        skipped: false,
-                        binary: is_binary,
-                        old_size_bytes: delta.old_file().size(),
-                        new_size_bytes: delta.new_file().size(),
-                    },
-                );
             }
+            diff_files.insert(
+                file_path.to_path_buf(),
+                DiffFile {
+                    old_path: delta.old_file().path().map(std::path::Path::to_path_buf),
+                    new_path: delta.new_file().path().map(std::path::Path::to_path_buf),
+                    hunks: None,
+                    skipped: false,
+                    binary: delta.new_file().is_binary(),
+                    old_size_bytes: delta.old_file().size(),
+                    new_size_bytes: delta.new_file().size(),
+                },
+            );
 
             true
         },

--- a/gitbutler-app/src/virtual_branches/base.rs
+++ b/gitbutler-app/src/virtual_branches/base.rs
@@ -208,7 +208,8 @@ pub fn set_base_branch(
             .use_diff_context
             .unwrap_or(false);
         let context_lines = if use_context { 3_u32 } else { 0_u32 };
-        let wd_diff = diff::workdir(repo, &current_head_commit.id(), context_lines)?.0;
+        let wd_diff = diff::workdir(repo, &current_head_commit.id(), context_lines)?;
+        let wd_diff = diff::diff_files_to_hunks(wd_diff);
         if !wd_diff.is_empty() || current_head_commit.id() != target.sha {
             let hunks_by_filepath =
                 super::virtual_hunks_by_filepath(&project_repository.project().path, &wd_diff);

--- a/gitbutler-app/src/virtual_branches/controller.rs
+++ b/gitbutler-app/src/virtual_branches/controller.rs
@@ -6,7 +6,7 @@ use tokio::sync::Semaphore;
 use crate::{
     error::Error,
     gb_repository,
-    git::{self, diff::SkippedFile},
+    git::{self},
     keys, project_repository,
     projects::{self, ProjectId},
     users,
@@ -106,7 +106,7 @@ impl Controller {
         &self,
         project_id: &ProjectId,
     ) -> Result<
-        (Vec<super::VirtualBranch>, bool, Vec<SkippedFile>),
+        (Vec<super::VirtualBranch>, bool, Vec<git::diff::DiffFile>),
         ControllerError<errors::ListVirtualBranchesError>,
     > {
         self.inner(project_id)
@@ -489,7 +489,7 @@ impl ControllerInner {
         &self,
         project_id: &ProjectId,
     ) -> Result<
-        (Vec<super::VirtualBranch>, bool, Vec<SkippedFile>),
+        (Vec<super::VirtualBranch>, bool, Vec<git::diff::DiffFile>),
         ControllerError<errors::ListVirtualBranchesError>,
     > {
         let _permit = self.semaphore.acquire().await;

--- a/gitbutler-app/src/virtual_branches/files.rs
+++ b/gitbutler-app/src/virtual_branches/files.rs
@@ -37,6 +37,7 @@ pub fn list_remote_commit_files(
     let commit_tree = commit.tree().context("failed to get commit tree")?;
     let parent_tree = parent.tree().context("failed to get parent tree")?;
     let diff = diff::trees(repository, &parent_tree, &commit_tree, context_lines)?;
+    let diff = diff::diff_files_to_hunks(diff);
 
     let mut files = diff
         .into_iter()

--- a/gitbutler-ui/src/lib/vbranches/types.ts
+++ b/gitbutler-ui/src/lib/vbranches/types.ts
@@ -56,8 +56,11 @@ export class LocalFile {
 }
 
 export class SkippedFile {
-	path!: string;
-	sizeBytes!: number;
+	oldPath!: string | undefined;
+	newPath!: string | undefined;
+	binary!: boolean;
+	oldSizeBytes!: number;
+	newSizeBytes!: number;
 }
 
 export class VirtualBranches {


### PR DESCRIPTION
Adding stonger types to the result will allow us to more easily propagate information like old/new files paths, size etc