### PR TITLE
Fix for merge button being incorrectly disabled

### DIFF
--- a/gitbutler-ui/src/lib/components/PullRequestCard.svelte
+++ b/gitbutler-ui/src/lib/components/PullRequestCard.svelte
@@ -208,11 +208,7 @@
 				<MergeButton
 					{projectId}
 					wide
-					disabled={isFetching ||
-						isUnapplied ||
-						!$pr$ ||
-						checksStatus === null ||
-						!checksStatus?.success}
+					disabled={isFetching || isUnapplied || !$pr$ || (!!checksStatus && !checksStatus.success)}
 					loading={isMerging}
 					help="Merge pull request and refresh"
 					on:click={async (e) => {


### PR DESCRIPTION
- disable only if checks exist and they have not succeeded

fixes: #3124