### PR TITLE
send more context with feedback (OS, browser, index size)

### DIFF
--- a/gitbutler-app/src/app.rs
+++ b/gitbutler-app/src/app.rs
@@ -145,6 +145,15 @@ impl App {
             .map_err(|e| Error::Other(anyhow::anyhow!(e.to_string())))
     }
 
+    pub fn git_index_size(&self, project_id: &ProjectId) -> Result<usize, Error> {
+        let project = self.projects.get(project_id)?;
+        let project_repository = project_repository::Repository::open(&project)?;
+        let size = project_repository
+            .git_index_size()
+            .context("failed to get index size")?;
+        Ok(size)
+    }
+
     pub fn git_head(&self, project_id: &ProjectId) -> Result<String, Error> {
         let project = self.projects.get(project_id)?;
         let project_repository = project_repository::Repository::open(&project)?;

--- a/gitbutler-app/src/commands.rs
+++ b/gitbutler-app/src/commands.rs
@@ -105,6 +105,17 @@ pub async fn git_test_fetch(
 
 #[tauri::command(async)]
 #[instrument(skip(handle))]
+pub async fn git_index_size(handle: tauri::AppHandle, project_id: &str) -> Result<usize, Error> {
+    let app = handle.state::<app::App>();
+    let project_id = project_id.parse().map_err(|_| Error::UserError {
+        code: Code::Validation,
+        message: "Malformed project id".to_string(),
+    })?;
+    Ok(app.git_index_size(&project_id).expect("git index size"))
+}
+
+#[tauri::command(async)]
+#[instrument(skip(handle))]
 pub async fn git_head(handle: tauri::AppHandle, project_id: &str) -> Result<String, Error> {
     let app = handle.state::<app::App>();
     let project_id = project_id.parse().map_err(|_| Error::UserError {

--- a/gitbutler-app/src/git/repository.rs
+++ b/gitbutler-app/src/git/repository.rs
@@ -224,6 +224,10 @@ impl Repository {
         self.0.index().map(Into::into).map_err(Into::into)
     }
 
+    pub fn index_size(&self) -> Result<usize> {
+        Ok(self.0.index()?.len())
+    }
+
     pub fn blob_path<P: AsRef<Path>>(&self, path: P) -> Result<Oid> {
         self.0
             .blob_path(path.as_ref())

--- a/gitbutler-app/src/main.rs
+++ b/gitbutler-app/src/main.rs
@@ -240,6 +240,7 @@ fn main() {
                     commands::project_flush_and_push,
                     commands::git_test_push,
                     commands::git_test_fetch,
+                    commands::git_index_size,
                     zip::commands::get_logs_archive_path,
                     zip::commands::get_project_archive_path,
                     zip::commands::get_project_data_archive_path,

--- a/gitbutler-app/src/project_repository/repository.rs
+++ b/gitbutler-app/src/project_repository/repository.rs
@@ -125,6 +125,11 @@ impl Repository {
         self.project = project.clone();
     }
 
+    pub fn git_index_size(&self) -> Result<usize, git::Error> {
+        let head = self.git_repository.index_size()?;
+        Ok(head)
+    }
+
     pub fn get_head(&self) -> Result<git::Reference, git::Error> {
         let head = self.git_repository.head()?;
         Ok(head)

--- a/gitbutler-ui/src/lib/backend/cloud.ts
+++ b/gitbutler-ui/src/lib/backend/cloud.ts
@@ -155,6 +155,7 @@ export function getCloudApiClient(
 				const formData = new FormData();
 				formData.append('message', params.message);
 				if (params.email) formData.append('email', params.email);
+				if (params.context) formData.append('context', params.context);
 				if (params.logs) formData.append('logs', params.logs);
 				if (params.repo) formData.append('repo', params.repo);
 				if (params.data) formData.append('data', params.data);

--- a/gitbutler-ui/src/lib/components/ShareIssueModal.svelte
+++ b/gitbutler-ui/src/lib/components/ShareIssueModal.svelte
@@ -8,6 +8,7 @@
 	import type { User, getCloudApiClient } from '$lib/backend/cloud';
 	import { page } from '$app/stores';
 	import { invoke } from '$lib/backend/ipc';
+	import { getVersion } from '@tauri-apps/api/app';
 
 	export let user: User | undefined;
 	export let cloud: ReturnType<typeof getCloudApiClient>;
@@ -51,9 +52,14 @@
 	async function onSubmit() {
 		const message = messageInputValue;
 		const email = user?.email ?? emailInputValue;
-		let context = 'Browser: ' + navigator.userAgent + '\n';
-		context += 'URL: ' + window.location.href + '\n';
+
+		// put together context information to send with the feedback
+		let context = '';
+		const appVersion = await getVersion();
 		const indexLength = await gitIndexLength();
+		context += 'GitButler Version: ' + appVersion + '\n';
+		context += 'Browser: ' + navigator.userAgent + '\n';
+		context += 'URL: ' + window.location.href + '\n';
 		context += 'Length of index: ' + indexLength + '\n';
 
 		toasts.promise(

--- a/gitbutler-ui/src/lib/components/ShareIssueModal.svelte
+++ b/gitbutler-ui/src/lib/components/ShareIssueModal.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
 	import TextArea from './TextArea.svelte';
+	import { invoke } from '$lib/backend/ipc';
 	import * as zip from '$lib/backend/zip';
 	import Button from '$lib/components/Button.svelte';
 	import Checkbox from '$lib/components/Checkbox.svelte';
 	import Modal from '$lib/components/Modal.svelte';
 	import * as toasts from '$lib/utils/toasts';
+	import { getVersion } from '@tauri-apps/api/app';
 	import type { User, getCloudApiClient } from '$lib/backend/cloud';
 	import { page } from '$app/stores';
-	import { invoke } from '$lib/backend/ipc';
-	import { getVersion } from '@tauri-apps/api/app';
 
 	export let user: User | undefined;
 	export let cloud: ReturnType<typeof getCloudApiClient>;


### PR DESCRIPTION
Now sends `context` field with feedback. Something like this:

```
GitButler Version: 0.5.346
Browser: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)
URL: http://localhost:1420/aa587eef-2aa2-4ed4-9fb7-f90c7e5f2527/board
Length of index: 133
```

Closes https://github.com/gitbutlerapp/gitbutler/issues/3148