### PR TITLE
test CI failure - DO NOT MERGE

### DIFF
--- a/gitbutler-app/src/git/commit.rs
+++ b/gitbutler-app/src/git/commit.rs
@@ -25,7 +25,7 @@ impl<'repo> From<&'repo Commit<'repo>> for &'repo git2::Commit<'repo> {
 }
 
 impl<'repo> Commit<'repo> {
-    pub fn id(&self) -> Oid {
+    pub fn id<'a>(&'a self) -> Oid {
         self.commit.id().into()
     }
 


### PR DESCRIPTION
Testing CI to make sure failures cause `check-rust` to fail.

# DO NOT MERGE THIS PULL REQUEST.