### PR TITLE
Move first service from prop drilling to Svelte context

### DIFF
--- a/gitbutler-ui/src/lib/components/CommitDialog.svelte
+++ b/gitbutler-ui/src/lib/components/CommitDialog.svelte
@@ -150,7 +150,6 @@
 					use:focusTextareaOnMount
 					use:useResize={() => {
 						setAutoHeight(titleTextArea);
-						setAutoHeight(descriptionTextArea);
 					}}
 					on:focus={(e) => setAutoHeight(e.currentTarget)}
 					on:input={(e) => {
@@ -175,6 +174,7 @@
 						spellcheck="false"
 						rows="1"
 						bind:this={descriptionTextArea}
+						use:useResize={() => setAutoHeight(descriptionTextArea)}
 						on:focus={(e) => setAutoHeight(e.currentTarget)}
 						on:input={(e) => {
 							$commitMessage = concatMessage(title, e.currentTarget.value);

--- a/gitbutler-ui/src/lib/components/KeysForm.svelte
+++ b/gitbutler-ui/src/lib/components/KeysForm.svelte
@@ -3,24 +3,26 @@
 	import RadioButton from './RadioButton.svelte';
 	import SectionCard from './SectionCard.svelte';
 	import TextBox from './TextBox.svelte';
+	import { ProjectService, type Key, type KeyType, type Project } from '$lib/backend/projects';
 	import Button from '$lib/components/Button.svelte';
 	import Link from '$lib/components/Link.svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard';
+	import { getContextByClass } from '$lib/utils/context';
 	import * as toasts from '$lib/utils/toasts';
 	import { openExternalUrl } from '$lib/utils/url';
 	import { onMount } from 'svelte';
 	import type { AuthService } from '$lib/backend/auth';
-	import type { Key, KeyType, Project, ProjectService } from '$lib/backend/projects';
 	import type { BaseBranchService } from '$lib/vbranches/branchStoresCache';
 
 	export let authService: AuthService;
 	export let baseBranchService: BaseBranchService;
-	export let projectService: ProjectService;
 	export let project: Project;
 
 	// Used by credential checker before target branch set
 	export let remoteName = '';
 	export let branchName = '';
+
+	const projectService = getContextByClass(ProjectService);
 
 	$: base$ = baseBranchService.base$;
 

--- a/gitbutler-ui/src/lib/components/Navigation.svelte
+++ b/gitbutler-ui/src/lib/components/Navigation.svelte
@@ -14,7 +14,7 @@
 	import { onMount } from 'svelte';
 	import { getContext } from 'svelte';
 	import type { User } from '$lib/backend/cloud';
-	import type { Project, ProjectService } from '$lib/backend/projects';
+	import type { Project } from '$lib/backend/projects';
 	import type { BranchService } from '$lib/branches/service';
 	import type { GitHubService } from '$lib/github/service';
 	import type { BranchController } from '$lib/vbranches/branchController';
@@ -26,7 +26,6 @@
 	export let project: Project;
 	export let user: User | undefined;
 	export let githubService: GitHubService;
-	export let projectService: ProjectService;
 
 	const minResizerWidth = 280;
 	const minResizerRatio = 150;
@@ -121,7 +120,7 @@
 				{#if $platformName == 'darwin'}
 					<div class="drag-region" data-tauri-drag-region />
 				{/if}
-				<ProjectSelector {project} {projectService} isNavCollapsed={$isNavCollapsed} />
+				<ProjectSelector {project} isNavCollapsed={$isNavCollapsed} />
 				<div class="domains">
 					<BaseBranchCard
 						{project}

--- a/gitbutler-ui/src/lib/components/NotOnGitButlerBranch.svelte
+++ b/gitbutler-ui/src/lib/components/NotOnGitButlerBranch.svelte
@@ -4,19 +4,21 @@
 	import Link from './Link.svelte';
 	import ProjectSwitcher from './ProjectSwitcher.svelte';
 	import RemoveProjectButton from './RemoveProjectButton.svelte';
+	import { ProjectService, type Project } from '$lib/backend/projects';
 	import Icon from '$lib/components/Icon.svelte';
+	import { getContextByClass } from '$lib/utils/context';
 	import * as toasts from '$lib/utils/toasts';
-	import type { Project, ProjectService } from '$lib/backend/projects';
 	import type { UserService } from '$lib/stores/user';
 	import type { BranchController } from '$lib/vbranches/branchController';
 	import type { BaseBranch } from '$lib/vbranches/types';
 	import { goto } from '$app/navigation';
 
-	export let projectService: ProjectService;
 	export let branchController: BranchController;
 	export let project: Project | undefined;
 	export let userService: UserService;
 	export let baseBranch: BaseBranch;
+
+	const projectService = getContextByClass(ProjectService);
 
 	$: user$ = userService.user$;
 
@@ -86,7 +88,7 @@
 		</div>
 
 		<div class="switchrepo__project">
-			<ProjectSwitcher {projectService} {project} />
+			<ProjectSwitcher {project} />
 		</div>
 	</div>
 </DecorativeSplitView>

--- a/gitbutler-ui/src/lib/components/ProblemLoadingRepo.svelte
+++ b/gitbutler-ui/src/lib/components/ProblemLoadingRepo.svelte
@@ -2,16 +2,18 @@
 	import DecorativeSplitView from './DecorativeSplitView.svelte';
 	import ProjectSwitcher from './ProjectSwitcher.svelte';
 	import RemoveProjectButton from './RemoveProjectButton.svelte';
+	import { ProjectService, type Project } from '$lib/backend/projects';
 	import Icon from '$lib/components/Icon.svelte';
+	import { getContextByClass } from '$lib/utils/context';
 	import * as toasts from '$lib/utils/toasts';
-	import type { Project, ProjectService } from '$lib/backend/projects';
 	import type { UserService } from '$lib/stores/user';
 	import { goto } from '$app/navigation';
 
-	export let projectService: ProjectService;
 	export let project: Project;
 	export let userService: UserService;
 	export let error: any = undefined;
+
+	const projectService = getContextByClass(ProjectService);
 
 	$: user$ = userService.user$;
 
@@ -63,7 +65,7 @@
 		</div>
 
 		<div class="problem__switcher">
-			<ProjectSwitcher {projectService} {project} />
+			<ProjectSwitcher {project} />
 		</div>
 	</div>
 </DecorativeSplitView>

--- a/gitbutler-ui/src/lib/components/ProjectSelector.svelte
+++ b/gitbutler-ui/src/lib/components/ProjectSelector.svelte
@@ -4,10 +4,9 @@
 	import { clickOutside } from '$lib/clickOutside';
 	import Icon from '$lib/components/Icon.svelte';
 	import { tooltip } from '$lib/utils/tooltip';
-	import type { Project, ProjectService } from '$lib/backend/projects';
+	import type { Project } from '$lib/backend/projects';
 
 	export let project: Project | undefined;
-	export let projectService: ProjectService;
 	export let isNavCollapsed: boolean;
 
 	let popup: ProjectsPopup;
@@ -40,7 +39,7 @@
 			</div>
 		{/if}
 	</button>
-	<ProjectsPopup bind:this={popup} {projectService} {isNavCollapsed} />
+	<ProjectsPopup bind:this={popup} {isNavCollapsed} />
 </div>
 
 <style lang="postcss">

--- a/gitbutler-ui/src/lib/components/ProjectSetup.svelte
+++ b/gitbutler-ui/src/lib/components/ProjectSetup.svelte
@@ -4,7 +4,7 @@
 	import ProjectSetupTarget from './ProjectSetupTarget.svelte';
 	import DecorativeSplitView from '$lib/components/DecorativeSplitView.svelte';
 	import type { AuthService } from '$lib/backend/auth';
-	import type { Project, ProjectService } from '$lib/backend/projects';
+	import type { Project } from '$lib/backend/projects';
 	import type { GitHubService } from '$lib/github/service';
 	import type { UserService } from '$lib/stores/user';
 	import type { BranchController } from '$lib/vbranches/branchController';
@@ -14,7 +14,6 @@
 	export let authService: AuthService;
 	export let branchController: BranchController;
 	export let baseBranchService: BaseBranchService;
-	export let projectService: ProjectService;
 	export let project: Project;
 	export let userService: UserService;
 	export let remoteBranches: { name: string }[];
@@ -46,14 +45,7 @@
 >
 	{#if selectedBranch}
 		{@const [remoteName, branchName] = selectedBranch.split(/\/(.*)/s)}
-		<KeysForm
-			{project}
-			{authService}
-			{baseBranchService}
-			{projectService}
-			{remoteName}
-			{branchName}
-		/>
+		<KeysForm {project} {authService} {baseBranchService} {remoteName} {branchName} />
 		<div class="actions">
 			<Button kind="outlined" color="neutral" on:mousedown={() => (selectedBranch = '')}
 				>Back</Button

--- a/gitbutler-ui/src/lib/components/ProjectSwitcher.svelte
+++ b/gitbutler-ui/src/lib/components/ProjectSwitcher.svelte
@@ -2,11 +2,13 @@
 	import Button from './Button.svelte';
 	import Select from './Select.svelte';
 	import SelectItem from './SelectItem.svelte';
-	import type { Project, ProjectService } from '$lib/backend/projects';
+	import { ProjectService, type Project } from '$lib/backend/projects';
+	import { getContextByClass } from '$lib/utils/context';
 	import { goto } from '$app/navigation';
 
-	export let projectService: ProjectService;
 	export let project: Project | undefined;
+
+	const projectService = getContextByClass(ProjectService);
 
 	$: projects$ = projectService.projects$;
 

--- a/gitbutler-ui/src/lib/components/ProjectsPopup.svelte
+++ b/gitbutler-ui/src/lib/components/ProjectsPopup.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
 	import ListItem from './ListItem.svelte';
-	import type { ProjectService } from '$lib/backend/projects';
+	import { ProjectService } from '$lib/backend/projects';
+	import { getContextByClass } from '$lib/utils/context';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
 
-	export let projectService: ProjectService;
 	export let isNavCollapsed: boolean;
 
-	$: projects$ = projectService.projects$;
+	const projectService = getContextByClass(ProjectService);
+	const projects$ = projectService.projects$;
 
 	let hidden = true;
 	let loading = false;

--- a/gitbutler-ui/src/lib/components/Scrollbar.svelte
+++ b/gitbutler-ui/src/lib/components/Scrollbar.svelte
@@ -149,7 +149,6 @@
 		observer.observe(contents);
 
 		return () => {
-			observer.unobserve(contents);
 			observer.disconnect();
 		};
 	}

--- a/gitbutler-ui/src/lib/components/Welcome.svelte
+++ b/gitbutler-ui/src/lib/components/Welcome.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
 	import WelcomeAction from './WelcomeAction.svelte';
 	import WelcomeSigninAction from './WelcomeSigninAction.svelte';
+	import { ProjectService } from '$lib/backend/projects';
 	import IconLink from '$lib/components/IconLink.svelte';
 	import ImgThemed from '$lib/components/ImgThemed.svelte';
-	import type { ProjectService } from '$lib/backend/projects';
+	import { getContextByClass } from '$lib/utils/context';
 	import type { UserService } from '$lib/stores/user';
 
-	export let projectService: ProjectService;
 	export let userService: UserService;
+
+	const projectService = getContextByClass(ProjectService);
 
 	let newProjectLoading = false;
 

--- a/gitbutler-ui/src/lib/utils/context.ts
+++ b/gitbutler-ui/src/lib/utils/context.ts
@@ -1,0 +1,6 @@
+import { getContext as svelteGetContext } from 'svelte';
+export function getContextByClass<T extends new (...args: any) => InstanceType<T>>(
+	key: T
+): InstanceType<T> {
+	return svelteGetContext<InstanceType<T>>(key);
+}

--- a/gitbutler-ui/src/routes/+layout.svelte
+++ b/gitbutler-ui/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import '../styles/main.postcss';
 
+	import { ProjectService } from '$lib/backend/projects';
 	import AppUpdater from '$lib/components/AppUpdater.svelte';
 	import ShareIssueModal from '$lib/components/ShareIssueModal.svelte';
 	import ToastController from '$lib/notifications/ToastController.svelte';
@@ -20,6 +21,8 @@
 	const userSettings = loadUserSettings();
 	initTheme(userSettings);
 	setContext(SETTINGS_CONTEXT, userSettings);
+
+	$: setContext(ProjectService, data.projectService);
 
 	let shareIssueModal: ShareIssueModal;
 

--- a/gitbutler-ui/src/routes/+page.svelte
+++ b/gitbutler-ui/src/routes/+page.svelte
@@ -1,18 +1,22 @@
 <script lang="ts">
+	import { ProjectService } from '$lib/backend/projects';
 	import AnalyticsConfirmation from '$lib/components/AnalyticsConfirmation.svelte';
 	import DecorativeSplitView from '$lib/components/DecorativeSplitView.svelte';
 	import FullscreenLoading from '$lib/components/FullscreenLoading.svelte';
 	import Welcome from '$lib/components/Welcome.svelte';
 	import { appAnalyticsConfirmed } from '$lib/config/appSettings';
+	import { getContextByClass } from '$lib/utils/context';
 	import { map } from 'rxjs';
 	import type { PageData } from './$types';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
 
 	export let data: PageData;
+	$: ({ userService } = data);
 
-	const { projectService, userService } = data;
+	const projectService = getContextByClass(ProjectService);
 	const projects$ = projectService.projects$;
+
 	$: user$ = userService.user$;
 	$: debug = $page.url.searchParams.get('debug');
 
@@ -51,6 +55,6 @@
 			dark: '/images/img_moon-door-dark.webp'
 		}}
 	>
-		<Welcome {projectService} {userService} />
+		<Welcome {userService} />
 	</DecorativeSplitView>
 {/if}

--- a/gitbutler-ui/src/routes/[projectId]/+layout.svelte
+++ b/gitbutler-ui/src/routes/[projectId]/+layout.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { syncToCloud } from '$lib/backend/cloud';
 	import { handleMenuActions } from '$lib/backend/menuActions';
-	import { ProjectService } from '$lib/backend/projects';
 	import FullscreenLoading from '$lib/components/FullscreenLoading.svelte';
 	import Navigation from '$lib/components/Navigation.svelte';
 	import NotOnGitButlerBranch from '$lib/components/NotOnGitButlerBranch.svelte';
@@ -15,8 +14,6 @@
 
 	export let data: LayoutData;
 
-	setContext(ProjectService, data.projectService);
-	$: projectService = data.projectService;
 	$: branchController = data.branchController;
 	$: githubService = data.githubService;
 	$: vbranchService = data.vbranchService;
@@ -75,13 +72,12 @@
 	<!-- Be careful, this works because of the redirect above -->
 	<slot />
 {:else if $baseError$}
-	<ProblemLoadingRepo {projectService} {userService} project={$project$} error={$baseError$} />
+	<ProblemLoadingRepo {userService} project={$project$} error={$baseError$} />
 {:else if $branchesError$}
-	<ProblemLoadingRepo {projectService} {userService} project={$project$} error={$branchesError$} />
+	<ProblemLoadingRepo {userService} project={$project$} error={$branchesError$} />
 {:else if !$gbBranchActive$ && $baseBranch$}
 	<NotOnGitButlerBranch
 		{userService}
-		{projectService}
 		{branchController}
 		project={$project$}
 		baseBranch={$baseBranch$}
@@ -95,7 +91,6 @@
 			project={$project$}
 			user={$user$}
 			{githubService}
-			{projectService}
 		/>
 		<slot />
 	</div>

--- a/gitbutler-ui/src/routes/[projectId]/settings/+page.svelte
+++ b/gitbutler-ui/src/routes/[projectId]/settings/+page.svelte
@@ -72,7 +72,7 @@
 	<ContentWrapper title="Project settings">
 		<CloudForm project={$project$} user={$user$} {userService} on:updated={onCloudUpdated} />
 		<DetailsForm project={$project$} on:updated={onDetailsUpdated} />
-		<KeysForm project={$project$} {authService} {baseBranchService} {projectService} />
+		<KeysForm project={$project$} {authService} {baseBranchService} />
 		<Spacer />
 		<PreferencesForm project={$project$} on:updated={onPreferencesUpdated} />
 		<SectionCard>

--- a/gitbutler-ui/src/routes/[projectId]/setup/+page.svelte
+++ b/gitbutler-ui/src/routes/[projectId]/setup/+page.svelte
@@ -9,7 +9,6 @@
 
 	$: branchController = data.branchController;
 	$: baseBranchService = data.baseBranchService;
-	$: projectService = data.projectService;
 	$: userService = data.userService;
 	$: authService = data.authService;
 	$: projectId = data.projectId;
@@ -24,7 +23,6 @@
 	{#if remoteBranches.length == 0}
 		<ProblemLoadingRepo
 			{userService}
-			{projectService}
 			project={$project$}
 			error="Currently, GitButler requires a remote branch to base its virtual branch work on. To
 						use virtual branches, please push your code to a remote branch to use as a base"
@@ -32,7 +30,6 @@
 	{:else}
 		<ProjectSetup
 			project={$project$}
-			{projectService}
 			{authService}
 			{baseBranchService}
 			{branchController}
@@ -44,7 +41,6 @@
 {:catch}
 	<ProblemLoadingRepo
 		{userService}
-		{projectService}
 		project={$project$}
 		error="Currently, GitButler requires a remote branch to base its virtual branch work on. To
 						use virtual branches, please push your code to a remote branch to use as a base"


### PR DESCRIPTION
- adds custom `getContext` to avoid extra typing when using classes as key
- project service no longer passed through component hierarchy
- switching projects require recreating components (already the case)