### PR TITLE
Prevent future DI bugs by throwing error

### DIFF
--- a/gitbutler-ui/src/lib/utils/context.ts
+++ b/gitbutler-ui/src/lib/utils/context.ts
@@ -4,11 +4,15 @@ import type { Readable } from 'svelte/store';
 export function getContextByClass<T extends new (...args: any) => InstanceType<T>>(
 	key: T
 ): InstanceType<T> {
-	return svelteGetContext<InstanceType<T>>(key);
+	const instance = svelteGetContext<InstanceType<T> | undefined>(key);
+	if (!instance) throw new Error(`no instance of \`${key.name}\` in context`);
+	return instance;
 }
 
 export function getContextStoreByClass<T extends new (...args: any) => InstanceType<T>>(
 	key: T
 ): Readable<InstanceType<T>> {
-	return svelteGetContext<Readable<InstanceType<T>>>(key);
+	const instance = svelteGetContext<Readable<InstanceType<T>> | undefined>(key);
+	if (!instance) throw new Error(`no instance of \`Readable<${key.name}>\` in context`);
+	return instance;
 }


### PR DESCRIPTION
At present we never get optional dependencies, and if that was necessary we'd be explicit about it.