### PR TITLE
fix: remove persisting of passphrases for projects

### DIFF
--- a/gitbutler-app/src/git/credentials.rs
+++ b/gitbutler-app/src/git/credentials.rs
@@ -144,10 +144,7 @@ impl Helper {
         }
 
         match &project_repository.project().preferred_key {
-            projects::AuthKey::Local {
-                private_key_path,
-                passphrase,
-            } => {
+            projects::AuthKey::Local { private_key_path } => {
                 let ssh_remote = if remote_url.scheme == super::Scheme::Ssh {
                     Ok(remote)
                 } else {
@@ -159,7 +156,7 @@ impl Helper {
                     ssh_remote,
                     vec![Credential::Ssh(SshCredential::Keyfile {
                         key_path: private_key_path.clone(),
-                        passphrase: passphrase.clone(),
+                        passphrase: None,
                     })],
                 )])
             }
@@ -457,7 +454,6 @@ mod tests {
                     github_access_token: Some("token"),
                     preferred_key: projects::AuthKey::Local {
                         private_key_path: PathBuf::from("/tmp/id_rsa"),
-                        passphrase: None,
                     },
                     ..Default::default()
                 };
@@ -483,7 +479,6 @@ mod tests {
                     github_access_token: Some("token"),
                     preferred_key: projects::AuthKey::Local {
                         private_key_path: PathBuf::from("/tmp/id_rsa"),
-                        passphrase: None,
                     },
                     ..Default::default()
                 };
@@ -660,7 +655,6 @@ mod tests {
                         github_access_token: Some("token"),
                         preferred_key: projects::AuthKey::Local {
                             private_key_path: PathBuf::from("/tmp/id_rsa"),
-                            passphrase: None,
                         },
                         ..Default::default()
                     };
@@ -686,7 +680,6 @@ mod tests {
                         github_access_token: Some("token"),
                         preferred_key: projects::AuthKey::Local {
                             private_key_path: PathBuf::from("/tmp/id_rsa"),
-                            passphrase: None,
                         },
                         ..Default::default()
                     };

--- a/gitbutler-app/src/projects/project.rs
+++ b/gitbutler-app/src/projects/project.rs
@@ -13,7 +13,6 @@ pub enum AuthKey {
     GitCredentialsHelper,
     Local {
         private_key_path: path::PathBuf,
-        passphrase: Option<String>,
     },
 }
 

--- a/gitbutler-app/src/projects/storage.rs
+++ b/gitbutler-app/src/projects/storage.rs
@@ -71,6 +71,13 @@ impl Storage {
 
     pub fn get(&self, id: &ProjectId) -> Result<project::Project, Error> {
         let projects = self.list()?;
+        for project in &projects {
+            self.update(&UpdateRequest {
+                id: project.id,
+                preferred_key: Some(project.preferred_key.clone()),
+                ..Default::default()
+            })?;
+        }
         match projects.into_iter().find(|p| p.id == *id) {
             Some(project) => Ok(project),
             None => Err(Error::NotFound),


### PR DESCRIPTION
Passphrases will no longer be persisted. When a project is read up, it will persist itself with the passphrase removed as a field.

This is the first step in addressing issues:
https://github.com/gitbutlerapp/gitbutler/issues/3187
https://github.com/gitbutlerapp/gitbutler/issues/3186

This also requires implementing just in time password prompting.