### PR TITLE
fix: remove setting of passphrases for projects

### DIFF
--- a/gitbutler-ui/src/lib/backend/projects.ts
+++ b/gitbutler-ui/src/lib/backend/projects.ts
@@ -18,7 +18,7 @@ import { goto } from '$app/navigation';
 
 export type KeyType = 'default' | 'generated' | 'gitCredentialsHelper' | 'local';
 export type LocalKey = {
-	local: { private_key_path: string; passphrase?: string };
+	local: { private_key_path: string };
 };
 
 export type Key = Exclude<KeyType, 'local'> | LocalKey;

--- a/gitbutler-ui/src/lib/components/KeysForm.svelte
+++ b/gitbutler-ui/src/lib/components/KeysForm.svelte
@@ -34,16 +34,12 @@
 	let privateKeyPath =
 		typeof project.preferred_key == 'string' ? '' : project.preferred_key.local.private_key_path;
 
-	let privateKeyPassphrase =
-		typeof project.preferred_key == 'string' ? '' : project.preferred_key.local.passphrase;
-
 	function setLocalKey() {
 		if (privateKeyPath.trim().length == 0) return;
 		updateKey({
 			preferred_key: {
 				local: {
-					private_key_path: privateKeyPath.trim(),
-					passphrase: privateKeyPassphrase || undefined
+					private_key_path: privateKeyPath.trim()
 				}
 			}
 		});
@@ -56,8 +52,6 @@
 			toasts.error(err.message);
 		}
 	}
-
-	let showPassphrase = false;
 
 	let form: HTMLFormElement;
 
@@ -124,25 +118,6 @@
 						placeholder="for example: ~/.ssh/id_rsa"
 						bind:value={privateKeyPath}
 					/>
-
-					<div class="input-with-button">
-						<TextBox
-							label="Passphrase (optional)"
-							type={showPassphrase ? 'text' : 'password'}
-							bind:value={privateKeyPassphrase}
-							wide
-						/>
-						<Button
-							size="large"
-							color="neutral"
-							kind="outlined"
-							icon={showPassphrase ? 'eye-shown' : 'eye-hidden'}
-							on:click={() => (showPassphrase = !showPassphrase)}
-							width={150}
-						>
-							{showPassphrase ? 'Hide passphrase' : 'Show passphrase'}
-						</Button>
-					</div>
 				</div>
 			</SectionCard>
 		{/if}


### PR DESCRIPTION
Passphrases for ssh keys will no longer be set and persisted in favour of prompting just in time

This is a step in addressing issues:
https://github.com/gitbutlerapp/gitbutler/issues/3187
https://github.com/gitbutlerapp/gitbutler/issues/3186

This also requires implementing just in time password prompting. (separately)