### PR TITLE
feat: write vbranch state to a flat file

### DIFF
--- a/gitbutler-app/src/gb_repository/repository.rs
+++ b/gitbutler-app/src/gb_repository/repository.rs
@@ -265,8 +265,9 @@ impl Repository {
             .collect::<Vec<_>>();
 
         let src_target_reader = virtual_branches::target::Reader::new(&last_session_reader);
-        let dst_target_writer = virtual_branches::target::Writer::new(self)
-            .context("failed to open target writer for current session")?;
+        let dst_target_writer =
+            virtual_branches::target::Writer::new(self, self.project.path.as_path())
+                .context("failed to open target writer for current session")?;
 
         // copy default target
         let default_target = match src_target_reader.read_default() {
@@ -295,8 +296,9 @@ impl Repository {
                 .with_context(|| format!("{}: failed to write target", branch.id))?;
         }
 
-        let dst_branch_writer = virtual_branches::branch::Writer::new(self)
-            .context("failed to open branch writer for current session")?;
+        let dst_branch_writer =
+            virtual_branches::branch::Writer::new(self, self.project.path.as_path())
+                .context("failed to open branch writer for current session")?;
 
         // copy branches that we don't already have
         for branch in &branches {

--- a/gitbutler-app/src/gb_repository/repository.rs
+++ b/gitbutler-app/src/gb_repository/repository.rs
@@ -265,9 +265,8 @@ impl Repository {
             .collect::<Vec<_>>();
 
         let src_target_reader = virtual_branches::target::Reader::new(&last_session_reader);
-        let dst_target_writer =
-            virtual_branches::target::Writer::new(self, self.project.path.as_path())
-                .context("failed to open target writer for current session")?;
+        let dst_target_writer = virtual_branches::target::Writer::new(self, &self.project.path)
+            .context("failed to open target writer for current session")?;
 
         // copy default target
         let default_target = match src_target_reader.read_default() {
@@ -296,9 +295,8 @@ impl Repository {
                 .with_context(|| format!("{}: failed to write target", branch.id))?;
         }
 
-        let dst_branch_writer =
-            virtual_branches::branch::Writer::new(self, self.project.path.as_path())
-                .context("failed to open branch writer for current session")?;
+        let dst_branch_writer = virtual_branches::branch::Writer::new(self, &self.project.path)
+            .context("failed to open branch writer for current session")?;
 
         // copy branches that we don't already have
         for branch in &branches {

--- a/gitbutler-app/src/projects/controller.rs
+++ b/gitbutler-app/src/projects/controller.rs
@@ -200,6 +200,13 @@ impl Controller {
             tracing::error!(project_id = %project.id, ?error, "failed to remove .git/gitbutler.json data",);
         }
 
+        let virtual_branches_path = project.path.join(".git/virtual_branches.toml");
+        if virtual_branches_path.exists() {
+            if let Err(error) = std::fs::remove_file(virtual_branches_path) {
+                tracing::error!(project_id = %project.id, ?error, "failed to remove .git/virtual_branches.toml data",);
+            }
+        }
+
         Ok(())
     }
 

--- a/gitbutler-app/src/virtual_branches/base.rs
+++ b/gitbutler-app/src/virtual_branches/base.rs
@@ -189,9 +189,8 @@ pub fn set_base_branch(
         sha: target_commit_oid,
     };
 
-    let target_writer =
-        target::Writer::new(gb_repository, project_repository.project().path.as_path())
-            .context("failed to create target writer")?;
+    let target_writer = target::Writer::new(gb_repository, &project_repository.project().path)
+        .context("failed to create target writer")?;
     target_writer.write_default(&target)?;
 
     let head_name: git::Refname = current_head
@@ -279,7 +278,7 @@ pub fn set_base_branch(
             };
 
             let branch_writer =
-                branch::Writer::new(gb_repository, project_repository.project().path.as_path())
+                branch::Writer::new(gb_repository, &project_repository.project().path)
                     .context("failed to create branch writer")?;
             branch_writer.write(&mut branch)?;
         }
@@ -381,9 +380,8 @@ pub fn update_base_branch(
             target.sha
         ))?;
 
-    let branch_writer =
-        branch::Writer::new(gb_repository, project_repository.project().path.as_path())
-            .context("failed to create branch writer")?;
+    let branch_writer = branch::Writer::new(gb_repository, &project_repository.project().path)
+        .context("failed to create branch writer")?;
 
     let use_context = project_repository
         .project()
@@ -601,9 +599,8 @@ pub fn update_base_branch(
     )?;
 
     // write new target oid
-    let target_writer =
-        target::Writer::new(gb_repository, project_repository.project().path.as_path())
-            .context("failed to create target writer")?;
+    let target_writer = target::Writer::new(gb_repository, &project_repository.project().path)
+        .context("failed to create target writer")?;
     target_writer.write_default(&target::Target {
         sha: new_target_commit.id(),
         ..target

--- a/gitbutler-app/src/virtual_branches/base.rs
+++ b/gitbutler-app/src/virtual_branches/base.rs
@@ -190,7 +190,8 @@ pub fn set_base_branch(
     };
 
     let target_writer =
-        target::Writer::new(gb_repository).context("failed to create target writer")?;
+        target::Writer::new(gb_repository, project_repository.project().path.as_path())
+            .context("failed to create target writer")?;
     target_writer.write_default(&target)?;
 
     let head_name: git::Refname = current_head
@@ -278,7 +279,8 @@ pub fn set_base_branch(
             };
 
             let branch_writer =
-                branch::Writer::new(gb_repository).context("failed to create branch writer")?;
+                branch::Writer::new(gb_repository, project_repository.project().path.as_path())
+                    .context("failed to create branch writer")?;
             branch_writer.write(&mut branch)?;
         }
     }
@@ -380,7 +382,8 @@ pub fn update_base_branch(
         ))?;
 
     let branch_writer =
-        branch::Writer::new(gb_repository).context("failed to create branch writer")?;
+        branch::Writer::new(gb_repository, project_repository.project().path.as_path())
+            .context("failed to create branch writer")?;
 
     let use_context = project_repository
         .project()
@@ -599,7 +602,8 @@ pub fn update_base_branch(
 
     // write new target oid
     let target_writer =
-        target::Writer::new(gb_repository).context("failed to create target writer")?;
+        target::Writer::new(gb_repository, project_repository.project().path.as_path())
+            .context("failed to create target writer")?;
     target_writer.write_default(&target::Target {
         sha: new_target_commit.id(),
         ..target

--- a/gitbutler-app/src/virtual_branches/branch/reader.rs
+++ b/gitbutler-app/src/virtual_branches/branch/reader.rs
@@ -100,11 +100,15 @@ mod tests {
 
     #[test]
     fn test_read_override() -> Result<()> {
-        let Case { gb_repository, .. } = Suite::default().new_case();
+        let Case {
+            gb_repository,
+            project,
+            ..
+        } = Suite::default().new_case();
 
         let mut branch = test_branch();
 
-        let writer = Writer::new(&gb_repository)?;
+        let writer = Writer::new(&gb_repository, project.path.as_path())?;
         writer.write(&mut branch)?;
 
         let session = gb_repository.get_current_session()?.unwrap();

--- a/gitbutler-app/src/virtual_branches/branch/reader.rs
+++ b/gitbutler-app/src/virtual_branches/branch/reader.rs
@@ -108,7 +108,7 @@ mod tests {
 
         let mut branch = test_branch();
 
-        let writer = Writer::new(&gb_repository, project.path.as_path())?;
+        let writer = Writer::new(&gb_repository, &project.path)?;
         writer.write(&mut branch)?;
 
         let session = gb_repository.get_current_session()?.unwrap();

--- a/gitbutler-app/src/virtual_branches/branch/writer.rs
+++ b/gitbutler-app/src/virtual_branches/branch/writer.rs
@@ -14,13 +14,13 @@ pub struct BranchWriter<'writer> {
 }
 
 impl<'writer> BranchWriter<'writer> {
-    pub fn new(
+    pub fn new<P: AsRef<path::Path>>(
         repository: &'writer gb_repository::Repository,
-        path: &path::Path,
+        path: P,
     ) -> Result<Self, std::io::Error> {
         let reader = reader::Reader::open(repository.root())?;
         let writer = writer::DirWriter::open(repository.root())?;
-        let state_handle = VirtualBranchesHandle::new(path.join(".git").as_path());
+        let state_handle = VirtualBranchesHandle::new(path.as_ref().join(".git").as_path());
         Ok(Self {
             repository,
             writer,
@@ -232,7 +232,7 @@ mod tests {
 
         let mut branch = test_branch();
 
-        let writer = BranchWriter::new(&gb_repository, project.path.as_path())?;
+        let writer = BranchWriter::new(&gb_repository, &project.path)?;
         writer.write(&mut branch)?;
 
         let root = gb_repository
@@ -297,7 +297,7 @@ mod tests {
 
         let mut branch = test_branch();
 
-        let writer = BranchWriter::new(&gb_repository, project.path.as_path())?;
+        let writer = BranchWriter::new(&gb_repository, &project.path)?;
         writer.write(&mut branch)?;
 
         assert!(gb_repository.get_current_session()?.is_some());
@@ -315,7 +315,7 @@ mod tests {
 
         let mut branch = test_branch();
 
-        let writer = BranchWriter::new(&gb_repository, project.path.as_path())?;
+        let writer = BranchWriter::new(&gb_repository, &project.path)?;
         writer.write(&mut branch)?;
 
         let mut updated_branch = Branch {

--- a/gitbutler-app/src/virtual_branches/integration.rs
+++ b/gitbutler-app/src/virtual_branches/integration.rs
@@ -263,9 +263,8 @@ fn verify_head_is_clean(
     .context("failed to create virtual branch")?;
 
     // rebasing the extra commits onto the new branch
-    let writer =
-        super::branch::Writer::new(gb_repository, project_repository.project().path.as_path())
-            .context("failed to create writer")?;
+    let writer = super::branch::Writer::new(gb_repository, &project_repository.project().path)
+        .context("failed to create writer")?;
     extra_commits.reverse();
     let mut head = new_branch.head;
     for commit in extra_commits {

--- a/gitbutler-app/src/virtual_branches/integration.rs
+++ b/gitbutler-app/src/virtual_branches/integration.rs
@@ -263,7 +263,9 @@ fn verify_head_is_clean(
     .context("failed to create virtual branch")?;
 
     // rebasing the extra commits onto the new branch
-    let writer = super::branch::Writer::new(gb_repository).context("failed to create writer")?;
+    let writer =
+        super::branch::Writer::new(gb_repository, project_repository.project().path.as_path())
+            .context("failed to create writer")?;
     extra_commits.reverse();
     let mut head = new_branch.head;
     for commit in extra_commits {

--- a/gitbutler-app/src/virtual_branches/iterator.rs
+++ b/gitbutler-app/src/virtual_branches/iterator.rs
@@ -146,12 +146,16 @@ mod tests {
 
     #[test]
     fn test_iterate_all() -> Result<()> {
-        let Case { gb_repository, .. } = Suite::default().new_case();
+        let Case {
+            gb_repository,
+            project,
+            ..
+        } = Suite::default().new_case();
 
-        let target_writer = target::Writer::new(&gb_repository)?;
+        let target_writer = target::Writer::new(&gb_repository, project.path.as_path())?;
         target_writer.write_default(&test_target())?;
 
-        let branch_writer = branch::Writer::new(&gb_repository)?;
+        let branch_writer = branch::Writer::new(&gb_repository, project.path.as_path())?;
         let mut branch_1 = test_branch();
         branch_writer.write(&mut branch_1)?;
         let mut branch_2 = test_branch();

--- a/gitbutler-app/src/virtual_branches/iterator.rs
+++ b/gitbutler-app/src/virtual_branches/iterator.rs
@@ -152,10 +152,10 @@ mod tests {
             ..
         } = Suite::default().new_case();
 
-        let target_writer = target::Writer::new(&gb_repository, project.path.as_path())?;
+        let target_writer = target::Writer::new(&gb_repository, &project.path)?;
         target_writer.write_default(&test_target())?;
 
-        let branch_writer = branch::Writer::new(&gb_repository, project.path.as_path())?;
+        let branch_writer = branch::Writer::new(&gb_repository, &project.path)?;
         let mut branch_1 = test_branch();
         branch_writer.write(&mut branch_1)?;
         let mut branch_2 = test_branch();

--- a/gitbutler-app/src/virtual_branches/target/reader.rs
+++ b/gitbutler-app/src/virtual_branches/target/reader.rs
@@ -143,7 +143,11 @@ mod tests {
 
     #[test]
     fn test_read_override_target() -> Result<()> {
-        let Case { gb_repository, .. } = Suite::default().new_case();
+        let Case {
+            gb_repository,
+            project,
+            ..
+        } = Suite::default().new_case();
 
         let mut branch = test_branch();
 
@@ -161,13 +165,13 @@ mod tests {
             sha: "0123456789abcdef0123456789abcdef01234567".parse().unwrap(),
         };
 
-        let branch_writer = branch::Writer::new(&gb_repository)?;
+        let branch_writer = branch::Writer::new(&gb_repository, project.path.as_path())?;
         branch_writer.write(&mut branch)?;
 
         let session = gb_repository.get_current_session()?.unwrap();
         let session_reader = sessions::Reader::open(&gb_repository, &session)?;
 
-        let target_writer = TargetWriter::new(&gb_repository)?;
+        let target_writer = TargetWriter::new(&gb_repository, project.path.as_path())?;
         let reader = TargetReader::new(&session_reader);
 
         target_writer.write_default(&default_target)?;

--- a/gitbutler-app/src/virtual_branches/target/reader.rs
+++ b/gitbutler-app/src/virtual_branches/target/reader.rs
@@ -165,13 +165,13 @@ mod tests {
             sha: "0123456789abcdef0123456789abcdef01234567".parse().unwrap(),
         };
 
-        let branch_writer = branch::Writer::new(&gb_repository, project.path.as_path())?;
+        let branch_writer = branch::Writer::new(&gb_repository, &project.path)?;
         branch_writer.write(&mut branch)?;
 
         let session = gb_repository.get_current_session()?.unwrap();
         let session_reader = sessions::Reader::open(&gb_repository, &session)?;
 
-        let target_writer = TargetWriter::new(&gb_repository, project.path.as_path())?;
+        let target_writer = TargetWriter::new(&gb_repository, &project.path)?;
         let reader = TargetReader::new(&session_reader);
 
         target_writer.write_default(&default_target)?;

--- a/gitbutler-app/src/virtual_branches/target/writer.rs
+++ b/gitbutler-app/src/virtual_branches/target/writer.rs
@@ -18,13 +18,13 @@ pub struct TargetWriter<'writer> {
 }
 
 impl<'writer> TargetWriter<'writer> {
-    pub fn new(
+    pub fn new<P: AsRef<path::Path>>(
         repository: &'writer gb_repository::Repository,
-        path: &path::Path,
+        path: P,
     ) -> Result<Self, std::io::Error> {
         let reader = reader::Reader::open(&repository.root())?;
         let writer = writer::DirWriter::open(repository.root())?;
-        let state_handle = VirtualBranchesHandle::new(path.join(".git").as_path());
+        let state_handle = VirtualBranchesHandle::new(path.as_ref().join(".git").as_path());
         Ok(Self {
             repository,
             writer,
@@ -183,10 +183,10 @@ mod tests {
             sha: "0123456789abcdef0123456789abcdef01234567".parse().unwrap(),
         };
 
-        let branch_writer = branch::Writer::new(&gb_repository, project.path.as_path())?;
+        let branch_writer = branch::Writer::new(&gb_repository, &project.path)?;
         branch_writer.write(&mut branch)?;
 
-        let target_writer = TargetWriter::new(&gb_repository, project.path.as_path())?;
+        let target_writer = TargetWriter::new(&gb_repository, &project.path)?;
         target_writer.write(&branch.id, &target)?;
 
         let root = gb_repository
@@ -274,9 +274,9 @@ mod tests {
             sha: "0123456789abcdef0123456789abcdef01234567".parse().unwrap(),
         };
 
-        let branch_writer = branch::Writer::new(&gb_repository, project.path.as_path())?;
+        let branch_writer = branch::Writer::new(&gb_repository, &project.path)?;
         branch_writer.write(&mut branch)?;
-        let target_writer = TargetWriter::new(&gb_repository, project.path.as_path())?;
+        let target_writer = TargetWriter::new(&gb_repository, &project.path)?;
         target_writer.write(&branch.id, &target)?;
 
         let updated_target = Target {

--- a/gitbutler-app/src/virtual_branches/tests.rs
+++ b/gitbutler-app/src/virtual_branches/tests.rs
@@ -31,7 +31,7 @@ pub fn set_test_target(
         .expect("failed to add remote");
     remote.push(&["refs/heads/master:refs/heads/master"], None)?;
 
-    target::Writer::new(gb_repo)?
+    target::Writer::new(gb_repo, project_repository.project().path.as_path())?
         .write_default(&target::Target {
             branch: "refs/remotes/origin/master".parse().unwrap(),
             remote_url: remote_repo.path().to_str().unwrap().parse().unwrap(),
@@ -634,7 +634,7 @@ fn test_move_hunks_multiple_sources() -> Result<()> {
     let current_session = gb_repository.get_or_create_current_session()?;
     let current_session_reader = sessions::Reader::open(&gb_repository, &current_session)?;
     let branch_reader = branch::Reader::new(&current_session_reader);
-    let branch_writer = branch::Writer::new(&gb_repository)?;
+    let branch_writer = branch::Writer::new(&gb_repository, project.path.as_path())?;
     let mut branch2 = branch_reader.read(&branch2_id)?;
     branch2.ownership = BranchOwnershipClaims {
         claims: vec!["test.txt:1-5".parse()?],
@@ -911,11 +911,12 @@ fn test_merge_vbranch_upstream_clean_rebase() -> Result<()> {
     )?;
 
     set_test_target(&gb_repository, &project_repository)?;
-    target::Writer::new(&gb_repository)?.write_default(&target::Target {
-        branch: "refs/remotes/origin/master".parse().unwrap(),
-        remote_url: "origin".to_string(),
-        sha: target_oid,
-    })?;
+    target::Writer::new(&gb_repository, project_repository.project().path.as_path())?
+        .write_default(&target::Target {
+            branch: "refs/remotes/origin/master".parse().unwrap(),
+            remote_url: "origin".to_string(),
+            sha: target_oid,
+        })?;
 
     // add some uncommitted work
     let file_path2 = std::path::Path::new("test2.txt");
@@ -925,7 +926,7 @@ fn test_merge_vbranch_upstream_clean_rebase() -> Result<()> {
     )?;
 
     let remote_branch: git::RemoteRefname = "refs/remotes/origin/master".parse().unwrap();
-    let branch_writer = branch::Writer::new(&gb_repository)?;
+    let branch_writer = branch::Writer::new(&gb_repository, project.path.as_path())?;
     let mut branch = create_virtual_branch(
         &gb_repository,
         &project_repository,
@@ -1035,11 +1036,13 @@ fn test_merge_vbranch_upstream_conflict() -> Result<()> {
     )?;
 
     set_test_target(&gb_repository, &project_repository)?;
-    target::Writer::new(&gb_repository)?.write_default(&target::Target {
-        branch: "refs/remotes/origin/master".parse().unwrap(),
-        remote_url: "origin".to_string(),
-        sha: target_oid,
-    })?;
+    target::Writer::new(&gb_repository, project.path.as_path())?.write_default(
+        &target::Target {
+            branch: "refs/remotes/origin/master".parse().unwrap(),
+            remote_url: "origin".to_string(),
+            sha: target_oid,
+        },
+    )?;
 
     // add some uncommitted work
     std::fs::write(
@@ -1048,7 +1051,7 @@ fn test_merge_vbranch_upstream_conflict() -> Result<()> {
     )?;
 
     let remote_branch: git::RemoteRefname = "refs/remotes/origin/master".parse().unwrap();
-    let branch_writer = branch::Writer::new(&gb_repository)?;
+    let branch_writer = branch::Writer::new(&gb_repository, project.path.as_path())?;
     let mut branch = create_virtual_branch(
         &gb_repository,
         &project_repository,
@@ -1410,7 +1413,7 @@ fn test_detect_mergeable_branch() -> Result<()> {
     let current_session = gb_repository.get_or_create_current_session()?;
     let current_session_reader = sessions::Reader::open(&gb_repository, &current_session)?;
     let branch_reader = branch::Reader::new(&current_session_reader);
-    let branch_writer = branch::Writer::new(&gb_repository)?;
+    let branch_writer = branch::Writer::new(&gb_repository, project.path.as_path())?;
 
     update_branch(
         &gb_repository,
@@ -1604,11 +1607,13 @@ fn test_upstream_integrated_vbranch() -> Result<()> {
         "update target",
     )?;
 
-    target::Writer::new(&gb_repository)?.write_default(&target::Target {
-        branch: "refs/remotes/origin/master".parse().unwrap(),
-        remote_url: "http://origin.com/project".to_string(),
-        sha: base_commit,
-    })?;
+    target::Writer::new(&gb_repository, project_repository.path())?.write_default(
+        &target::Target {
+            branch: "refs/remotes/origin/master".parse().unwrap(),
+            remote_url: "http://origin.com/project".to_string(),
+            sha: base_commit,
+        },
+    )?;
     project_repository
         .git_repository
         .remote("origin", &"http://origin.com/project".parse().unwrap())?;

--- a/gitbutler-app/src/virtual_branches/tests.rs
+++ b/gitbutler-app/src/virtual_branches/tests.rs
@@ -31,7 +31,7 @@ pub fn set_test_target(
         .expect("failed to add remote");
     remote.push(&["refs/heads/master:refs/heads/master"], None)?;
 
-    target::Writer::new(gb_repo, project_repository.project().path.as_path())?
+    target::Writer::new(gb_repo, &project_repository.project().path)?
         .write_default(&target::Target {
             branch: "refs/remotes/origin/master".parse().unwrap(),
             remote_url: remote_repo.path().to_str().unwrap().parse().unwrap(),
@@ -634,7 +634,7 @@ fn test_move_hunks_multiple_sources() -> Result<()> {
     let current_session = gb_repository.get_or_create_current_session()?;
     let current_session_reader = sessions::Reader::open(&gb_repository, &current_session)?;
     let branch_reader = branch::Reader::new(&current_session_reader);
-    let branch_writer = branch::Writer::new(&gb_repository, project.path.as_path())?;
+    let branch_writer = branch::Writer::new(&gb_repository, &project.path)?;
     let mut branch2 = branch_reader.read(&branch2_id)?;
     branch2.ownership = BranchOwnershipClaims {
         claims: vec!["test.txt:1-5".parse()?],
@@ -911,12 +911,13 @@ fn test_merge_vbranch_upstream_clean_rebase() -> Result<()> {
     )?;
 
     set_test_target(&gb_repository, &project_repository)?;
-    target::Writer::new(&gb_repository, project_repository.project().path.as_path())?
-        .write_default(&target::Target {
+    target::Writer::new(&gb_repository, &project_repository.project().path)?.write_default(
+        &target::Target {
             branch: "refs/remotes/origin/master".parse().unwrap(),
             remote_url: "origin".to_string(),
             sha: target_oid,
-        })?;
+        },
+    )?;
 
     // add some uncommitted work
     let file_path2 = std::path::Path::new("test2.txt");
@@ -926,7 +927,7 @@ fn test_merge_vbranch_upstream_clean_rebase() -> Result<()> {
     )?;
 
     let remote_branch: git::RemoteRefname = "refs/remotes/origin/master".parse().unwrap();
-    let branch_writer = branch::Writer::new(&gb_repository, project.path.as_path())?;
+    let branch_writer = branch::Writer::new(&gb_repository, &project.path)?;
     let mut branch = create_virtual_branch(
         &gb_repository,
         &project_repository,
@@ -1036,13 +1037,11 @@ fn test_merge_vbranch_upstream_conflict() -> Result<()> {
     )?;
 
     set_test_target(&gb_repository, &project_repository)?;
-    target::Writer::new(&gb_repository, project.path.as_path())?.write_default(
-        &target::Target {
-            branch: "refs/remotes/origin/master".parse().unwrap(),
-            remote_url: "origin".to_string(),
-            sha: target_oid,
-        },
-    )?;
+    target::Writer::new(&gb_repository, &project.path)?.write_default(&target::Target {
+        branch: "refs/remotes/origin/master".parse().unwrap(),
+        remote_url: "origin".to_string(),
+        sha: target_oid,
+    })?;
 
     // add some uncommitted work
     std::fs::write(
@@ -1051,7 +1050,7 @@ fn test_merge_vbranch_upstream_conflict() -> Result<()> {
     )?;
 
     let remote_branch: git::RemoteRefname = "refs/remotes/origin/master".parse().unwrap();
-    let branch_writer = branch::Writer::new(&gb_repository, project.path.as_path())?;
+    let branch_writer = branch::Writer::new(&gb_repository, &project.path)?;
     let mut branch = create_virtual_branch(
         &gb_repository,
         &project_repository,
@@ -1413,7 +1412,7 @@ fn test_detect_mergeable_branch() -> Result<()> {
     let current_session = gb_repository.get_or_create_current_session()?;
     let current_session_reader = sessions::Reader::open(&gb_repository, &current_session)?;
     let branch_reader = branch::Reader::new(&current_session_reader);
-    let branch_writer = branch::Writer::new(&gb_repository, project.path.as_path())?;
+    let branch_writer = branch::Writer::new(&gb_repository, &project.path)?;
 
     update_branch(
         &gb_repository,
@@ -1607,7 +1606,7 @@ fn test_upstream_integrated_vbranch() -> Result<()> {
         "update target",
     )?;
 
-    target::Writer::new(&gb_repository, project_repository.path())?.write_default(
+    target::Writer::new(&gb_repository, &project_repository.project().path)?.write_default(
         &target::Target {
             branch: "refs/remotes/origin/master".parse().unwrap(),
             remote_url: "http://origin.com/project".to_string(),

--- a/gitbutler-app/src/watcher/handlers/calculate_deltas_handler.rs
+++ b/gitbutler-app/src/watcher/handlers/calculate_deltas_handler.rs
@@ -828,10 +828,8 @@ mod test {
         )]));
         let listener = Handler::from_path(&suite.local_app_data);
 
-        let branch_writer =
-            virtual_branches::branch::Writer::new(&gb_repository, project.path.as_path())?;
-        let target_writer =
-            virtual_branches::target::Writer::new(&gb_repository, project.path.as_path())?;
+        let branch_writer = virtual_branches::branch::Writer::new(&gb_repository, &project.path)?;
+        let target_writer = virtual_branches::target::Writer::new(&gb_repository, &project.path)?;
         let default_target = test_target();
         target_writer.write_default(&default_target)?;
         let mut vbranch0 = test_branch();
@@ -886,10 +884,8 @@ mod test {
         )]));
         let listener = Handler::from_path(&suite.local_app_data);
 
-        let branch_writer =
-            virtual_branches::branch::Writer::new(&gb_repository, project.path.as_path())?;
-        let target_writer =
-            virtual_branches::target::Writer::new(&gb_repository, project.path.as_path())?;
+        let branch_writer = virtual_branches::branch::Writer::new(&gb_repository, &project.path)?;
+        let target_writer = virtual_branches::target::Writer::new(&gb_repository, &project.path)?;
         let default_target = test_target();
         target_writer.write_default(&default_target)?;
         let mut vbranch0 = test_branch();

--- a/gitbutler-app/src/watcher/handlers/calculate_deltas_handler.rs
+++ b/gitbutler-app/src/watcher/handlers/calculate_deltas_handler.rs
@@ -828,8 +828,10 @@ mod test {
         )]));
         let listener = Handler::from_path(&suite.local_app_data);
 
-        let branch_writer = virtual_branches::branch::Writer::new(&gb_repository)?;
-        let target_writer = virtual_branches::target::Writer::new(&gb_repository)?;
+        let branch_writer =
+            virtual_branches::branch::Writer::new(&gb_repository, project.path.as_path())?;
+        let target_writer =
+            virtual_branches::target::Writer::new(&gb_repository, project.path.as_path())?;
         let default_target = test_target();
         target_writer.write_default(&default_target)?;
         let mut vbranch0 = test_branch();
@@ -884,8 +886,10 @@ mod test {
         )]));
         let listener = Handler::from_path(&suite.local_app_data);
 
-        let branch_writer = virtual_branches::branch::Writer::new(&gb_repository)?;
-        let target_writer = virtual_branches::target::Writer::new(&gb_repository)?;
+        let branch_writer =
+            virtual_branches::branch::Writer::new(&gb_repository, project.path.as_path())?;
+        let target_writer =
+            virtual_branches::target::Writer::new(&gb_repository, project.path.as_path())?;
         let default_target = test_target();
         target_writer.write_default(&default_target)?;
         let mut vbranch0 = test_branch();


### PR DESCRIPTION
In addition to the default git storage, persist the state of virtual branches to a toml file in .git