### PR TITLE
Fix erroneous error message when adding project

### DIFF
--- a/gitbutler-ui/src/routes/[projectId]/+layout.svelte
+++ b/gitbutler-ui/src/routes/[projectId]/+layout.svelte
@@ -82,7 +82,7 @@
 		<ProblemLoadingRepo project={$project$} error={$branchesError} />
 	{:else if !$gbBranchActive$ && $baseBranch}
 		<NotOnGitButlerBranch project={$project$} baseBranch={$baseBranch} />
-	{:else}
+	{:else if $baseBranch}
 		<div class="view-wrap" role="group" on:dragover|preventDefault>
 			<Navigation project={$project$} user={$user$} />
 			<slot />


### PR DESCRIPTION
- for a split second the navigation bar comes into existence
- was trigger remote branches load