### PR TITLE
Keep showing commit description field if description provided

### DIFF
--- a/gitbutler-ui/src/lib/components/CommitDialog.svelte
+++ b/gitbutler-ui/src/lib/components/CommitDialog.svelte
@@ -172,7 +172,7 @@
 					}}
 				/>
 
-				{#if title.length > 0}
+				{#if title.length > 0 || description}
 					<textarea
 						value={description}
 						disabled={aiLoading}


### PR DESCRIPTION
Currently, in the commit dialog, the description field is only displayed if you have got a title greater than length one.

This means that if you have written (or AI generated) some long message, and then go to change the title, you have the description showing and hiding which is quite jarring.

Old behaviour:

https://github.com/gitbutlerapp/gitbutler/assets/13354155/564d1601-ad3a-47d9-851b-57ac79118046

I've updated the condition to keep showing the description if its thruthy

https://github.com/gitbutlerapp/gitbutler/assets/13354155/f157152c-bbbe-4843-aa03-672300efd6ff


