### PR TITLE
Pass in hunk array rather than diff

### DIFF
--- a/gitbutler-ui/src/lib/components/BranchCard.svelte
+++ b/gitbutler-ui/src/lib/components/BranchCard.svelte
@@ -83,16 +83,13 @@
 	async function generateBranchName() {
 		if (!aiGenEnabled) return;
 
-		const diff = branch.files
-			.map((f) => f.hunks)
-			.flat()
-			.map((h) => h.diff)
-			.flat()
-			.join('\n')
-			.slice(0, 5000);
+		const hunks = branch.files.flatMap((f) => f.hunks);
 
 		try {
-			const message = await aiService.summarizeBranch({ diff, userToken: $user?.access_token });
+			const message = await aiService.summarizeBranch({
+				hunks,
+				userToken: $user?.access_token
+			});
 
 			if (message && message !== branch.name) {
 				branch.name = message;

--- a/gitbutler-ui/src/lib/components/CommitDialog.svelte
+++ b/gitbutler-ui/src/lib/components/CommitDialog.svelte
@@ -90,14 +90,9 @@
 	}
 
 	async function generateCommitMessage(files: LocalFile[]) {
-		const diff = files
-			.map((f) => f.hunks.filter((h) => $selectedOwnership.containsHunk(f.id, h.id)))
-			.flat()
-			.map((h) => h.diff)
-			.flat()
-			.join('\n')
-			.slice(0, 5000);
-
+		const hunks = files.flatMap((f) =>
+			f.hunks.filter((h) => $selectedOwnership.containsHunk(f.id, h.id))
+		);
 		// Branches get their names generated only if there are at least 4 lines of code
 		// If the change is a 'one-liner', the branch name is either left as "virtual branch"
 		// or the user has to manually trigger the name generation from the meatball menu
@@ -109,7 +104,7 @@
 		aiLoading = true;
 		try {
 			const generatedMessage = await aiService.summarizeCommit({
-				diff,
+				hunks,
 				useEmojiStyle: $commitGenerationUseEmojis,
 				useBriefStyle: $commitGenerationExtraConcise,
 				userToken: $user?.access_token


### PR DESCRIPTION
I wanted to move the generation of the diff into a function inside the aiService.ts so we could perform standard formatting and shuffling operations.

This PR specifically:
- Updates the `diffLengthLimit` from `20000` to `5000`. Turns out that before the diff was getting passed to the models, it was getting trimmed down to 5000 characters and it seems to work fine, so I've updated this constant now that we are *actually* making use of it.
- Includes the file name before each hunk. This provides a little more context to the AI and I've found that it will occasionally pick up on the file names and include them in the generated commit messages
- Introduced hunk shuffling. This means that we're not going to fill up the context with 5000 characters of one particular file, and in stead take a smattering of changes from all the files present.
- Changed the summarizeXXX methods to take in `Hunk[]` so we can perform the diff generation in a consistent manner