### PR TITLE
refactor: Update function parameter to use sortedFiles instead of files

### DIFF
--- a/gitbutler-ui/src/lib/components/BranchFilesList.svelte
+++ b/gitbutler-ui/src/lib/components/BranchFilesList.svelte
@@ -42,7 +42,7 @@
 		}}
 		on:keydown={(e) => {
 			e.preventDefault();
-			maybeMoveSelection(e.key, files, selectedFiles);
+			maybeMoveSelection(e.key, sortedFiles, selectedFiles);
 		}}
 	/>
 {/each}


### PR DESCRIPTION
This fixes the issue where arrow keys seem to select random order of files. I think the `files` list is by last modified rather than alphabetical as it's shown visually.