### PR TITLE
Allow "#" in branch names #3280 

### DIFF
--- a/gitbutler-app/src/virtual_branches/virtual.rs
+++ b/gitbutler-app/src/virtual_branches/virtual.rs
@@ -174,7 +174,7 @@ impl From<git::Signature<'_>> for Author {
 }
 
 pub fn normalize_branch_name(name: &str) -> String {
-    let pattern = Regex::new("[^A-Za-z0-9_/.]+").unwrap();
+    let pattern = Regex::new("[^A-Za-z0-9_/.#]+").unwrap();
     pattern.replace_all(name, "-").to_string()
 }
 


### PR DESCRIPTION
Just as the person commented in #3280, I too use the "#"-character in my branch names, usually referring to issue ids.

resolves #3280 