### PR TITLE
fix: Change help text for lane icon to "Expand lane"

### DIFF
--- a/gitbutler-ui/src/lib/components/BranchHeader.svelte
+++ b/gitbutler-ui/src/lib/components/BranchHeader.svelte
@@ -57,7 +57,7 @@
 				icon="unfold-lane"
 				kind="outlined"
 				color="neutral"
-				help="Collapse lane"
+				help="Expand lane"
 				on:mousedown={expandLane}
 			/>
 		</div>


### PR DESCRIPTION
![CleanShot 2024-03-22 at 11 47 24@2x](https://github.com/gitbutlerapp/gitbutler/assets/70/b4136096-5569-49eb-8af0-b64bf77f78a6)
