### PR TITLE
refactor(AISettings): Remove unneeded config set calls

### DIFF
--- a/gitbutler-ui/src/lib/components/AISettings.svelte
+++ b/gitbutler-ui/src/lib/components/AISettings.svelte
@@ -15,29 +15,37 @@
 	import SectionCard from '$lib/components/SectionCard.svelte';
 	import { UserService } from '$lib/stores/user';
 	import { getContextByClass } from '$lib/utils/context';
-	import { onMount } from 'svelte';
+	import { onMount, tick } from 'svelte';
 
 	const gitConfigService = getContextByClass(GitConfigService);
 	const userService = getContextByClass(UserService);
 	const user = userService.user;
 
-	let modelKind: ModelKind;
-	let openAIKeyOption: KeyOption;
-	let anthropicKeyOption: KeyOption;
+	let initialized = false;
+
+	let modelKind: ModelKind | undefined;
+	let openAIKeyOption: KeyOption | undefined;
+	let anthropicKeyOption: KeyOption | undefined;
 	let openAIKey: string | undefined;
-	let openAIModelName: OpenAIModelName;
+	let openAIModelName: OpenAIModelName | undefined;
 	let anthropicKey: string | undefined;
-	let anthropicModelName: AnthropicModelName;
+	let anthropicModelName: AnthropicModelName | undefined;
 
-	$: gitConfigService.set('gitbutler.aiModelProvider', modelKind);
+	function setConfiguration(key: GitAIConfigKey, value: string | undefined) {
+		if (!initialized) return;
 
-	$: gitConfigService.set('gitbutler.aiOpenAIKeyOption', openAIKeyOption);
-	$: gitConfigService.set('gitbutler.aiOpenAIModelName', openAIModelName);
-	$: if (openAIKey) gitConfigService.set('gitbutler.aiOpenAIKey', openAIKey);
+		gitConfigService.set(key, value || '');
+	}
 
-	$: gitConfigService.set('gitbutler.aiAnthropicKeyOption', anthropicKeyOption);
-	$: gitConfigService.set('gitbutler.aiAnthropicModelName', anthropicModelName);
-	$: if (anthropicKey) gitConfigService.set('gitbutler.aiAnthropicKey', anthropicKey);
+	$: setConfiguration(GitAIConfigKey.ModelProvider, modelKind);
+
+	$: setConfiguration(GitAIConfigKey.OpenAIKeyOption, openAIKeyOption);
+	$: setConfiguration(GitAIConfigKey.OpenAIModelName, openAIModelName);
+	$: setConfiguration(GitAIConfigKey.OpenAIKey, openAIKey);
+
+	$: setConfiguration(GitAIConfigKey.AnthropicKeyOption, anthropicKeyOption);
+	$: setConfiguration(GitAIConfigKey.AnthropicModelName, anthropicModelName);
+	$: setConfiguration(GitAIConfigKey.AnthropicKey, anthropicKey);
 
 	onMount(async () => {
 		modelKind = await gitConfigService.getWithDefault<ModelKind>(
@@ -64,6 +72,11 @@
 			AnthropicModelName.Haiku
 		);
 		anthropicKey = await gitConfigService.get(GitAIConfigKey.AnthropicKey);
+
+		// Ensure reactive declarations have finished running before we set initialized to true
+		await tick();
+
+		initialized = true;
 	});
 
 	$: if (form) form.modelKind.value = modelKind;


### PR DESCRIPTION
There were still some calls to set the configuration values which where superfluous, so I've gone and fixed the problem by adding in a function which reads an `initialized` variable which is set after the onMount has finished running.

I have also made all the values optionally undefined as we were previously getting runtime errors because before it is set from in the onMount hook, it is an undefined value.

---

This is an behind the scenes change