### PR TITLE
Fix bugs occasionally preventing hunks from being moved

### DIFF
--- a/gitbutler-app/src/virtual_branches/branch/hunk.rs
+++ b/gitbutler-app/src/virtual_branches/branch/hunk.rs
@@ -26,7 +26,7 @@ impl From<&diff::GitHunk> for Hunk {
 impl PartialEq for Hunk {
     fn eq(&self, other: &Self) -> bool {
         if self.hash.is_some() && other.hash.is_some() {
-            self.hash == other.hash && self.start == other.start && self.end == other.end
+            self.hash == other.hash
         } else {
             self.start == other.start && self.end == other.end
         }
@@ -233,7 +233,7 @@ mod tests {
             (
                 "1-2-abc".parse::<Hunk>().unwrap(),
                 "2-3-abc".parse::<Hunk>().unwrap(),
-                false,
+                true,
             ),
             (
                 "1-2".parse::<Hunk>().unwrap(),

--- a/gitbutler-app/src/virtual_branches/virtual.rs
+++ b/gitbutler-app/src/virtual_branches/virtual.rs
@@ -2071,17 +2071,19 @@ fn get_applied_status(
                                     .or_default()
                                     .insert(0, git_diff_hunk.clone());
 
+                                let updated_hunk = Hunk {
+                                    start: git_diff_hunk.new_start,
+                                    end: git_diff_hunk.new_start + git_diff_hunk.new_lines,
+                                    timestamp_ms: Some(mtime),
+                                    hash: Some(hash.clone()),
+                                };
+
                                 // remove the hunk from the current hunks because each hunk can
                                 // only be owned once
                                 git_diff_hunks.remove(i);
 
                                 // return updated version, with new hash and/or timestamp
-                                return Some(
-                                    claimed_hunk
-                                        .clone()
-                                        .with_timestamp(mtime)
-                                        .with_hash(hash.as_str()),
-                                );
+                                return Some(updated_hunk);
                             }
                         }
                         None

--- a/gitbutler-ui/src/lib/vbranches/ownership.ts
+++ b/gitbutler-ui/src/lib/vbranches/ownership.ts
@@ -1,7 +1,9 @@
 import type { Branch, AnyFile } from './types';
 
 export function filesToOwnership(files: AnyFile[]) {
-	return files.map((f) => `${f.path}:${f.hunks.map(({ id }) => id).join(',')}`).join('\n');
+	return files
+		.map((f) => `${f.path}:${f.hunks.map(({ id, hash }) => `${id}-${hash}`).join(',')}`)
+		.join('\n');
 }
 
 export class Ownership {

--- a/gitbutler-ui/src/lib/vbranches/types.ts
+++ b/gitbutler-ui/src/lib/vbranches/types.ts
@@ -19,6 +19,7 @@ export class Hunk {
 	})
 	modifiedAt!: Date;
 	filePath!: string;
+	hash?: string;
 	locked!: boolean;
 	lockedTo!: string | undefined;
 	changeType!: ChangeType;
@@ -166,6 +167,7 @@ export class RemoteCommit {
 
 export class RemoteHunk {
 	diff!: string;
+	hash?: string;
 
 	get id(): string {
 		return hashCode(this.diff);


### PR DESCRIPTION
- hunks equal if hash is same, regardless of line numbers
- send hash from front end when updating ownership
- use updated line numbers after hunk intersection match