### PR TITLE
feat: Migrate use_diff_context to true if no active virtual branches

### DIFF
--- a/gitbutler-app/src/virtual_branches/commands.rs
+++ b/gitbutler-app/src/virtual_branches/commands.rs
@@ -115,7 +115,8 @@ pub async fn list_virtual_branches(
         .await?;
 
     // Migration: If use_diff_context is not already set and if there are no vbranches, set use_diff_context to true
-    if !uses_diff_context && branches.is_empty() {
+    let has_active_branches = branches.iter().any(|branch| branch.active);
+    if !uses_diff_context && !has_active_branches {
         let _ = handle
             .state::<projects::Controller>()
             .update(&projects::UpdateRequest {


### PR DESCRIPTION
Migrate to use diff context for any projects that have stale unapplied branches. This will facilitate removing the old code for supporting zero context hunks