### PR TITLE
feat(settings): Clarify tab size setting for code diffs

### DIFF
--- a/gitbutler-ui/src/routes/settings/+page.svelte
+++ b/gitbutler-ui/src/routes/settings/+page.svelte
@@ -181,7 +181,10 @@
 			</SectionCard>
 
 			<SectionCard orientation="row" centerAlign>
-				<svelte:fragment slot="title">Hunks tab size</svelte:fragment>
+				<svelte:fragment slot="title">Tab size</svelte:fragment>
+				<svelte:fragment slot="caption">
+					The number of spaces a tab is equal to when previewing code changes.
+				</svelte:fragment>
 
 				<svelte:fragment slot="actions">
 					<TextBox


### PR DESCRIPTION
"hunk" is confusing in this context. also added description in the caption

<img width="584" alt="image" src="https://github.com/gitbutlerapp/gitbutler/assets/4030927/9354ab3f-10ef-4a06-a1cd-adbdcee2c106">
