### PR TITLE
tests work with init.defaultBranch

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -262,7 +262,7 @@ PUBLIC_API_BASE_URL=https://app.gitbutler.com/
 
 ## Joining the GitButler Team
 
-If you are interested in joining our small but tightly knit engineering team, we are currenly looking for the following roles:
+If you are interested in joining our small but tightly knit engineering team, we are currently looking for the following roles:
 
 - [Senior Rust developer](https://gitbutler.homerun.co/senior-rust-developer) (Onsite Berlin)
 - [Senior TypeScript developer](https://gitbutler.homerun.co/senior-typescript-developer) (Onsite Berlin)

--- a/gitbutler-app/src/gb_repository/repository_tests.rs
+++ b/gitbutler-app/src/gb_repository/repository_tests.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, path, thread, time};
 use anyhow::Result;
 use pretty_assertions::assert_eq;
 
+use crate::tests::init_opts_bare;
 use crate::{
     deltas::{self, operations::Operation},
     projects::{self, ApiProject, ProjectId},
@@ -13,7 +14,7 @@ use crate::{
 
 fn test_remote_repository() -> Result<git2::Repository> {
     let path = tempfile::tempdir()?.path().to_str().unwrap().to_string();
-    let repo_a = git2::Repository::init_bare(path)?;
+    let repo_a = git2::Repository::init_opts(path, &init_opts_bare())?;
     Ok(repo_a)
 }
 

--- a/gitbutler-app/src/git/repository.rs
+++ b/gitbutler-app/src/git/repository.rs
@@ -28,7 +28,7 @@ impl From<git2::Repository> for Repository {
 impl Repository {
     #[cfg(test)]
     pub fn init_bare<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let inner = git2::Repository::init_bare(path)?;
+        let inner = git2::Repository::init_opts(path, &crate::tests::init_opts_bare())?;
         Ok(Repository(inner))
     }
 

--- a/gitbutler-app/src/tests.rs
+++ b/gitbutler-app/src/tests.rs
@@ -140,12 +140,13 @@ pub fn temp_dir() -> path::PathBuf {
 
 pub fn empty_bare_repository() -> git::Repository {
     let path = temp_dir();
-    git::Repository::init_bare(path).expect("failed to init repository")
+    git::Repository::init_opts(path, &init_opts_bare()).expect("failed to init repository")
 }
 
 pub fn test_repository() -> git::Repository {
     let path = temp_dir();
-    let repository = git::Repository::init(path).expect("failed to init repository");
+    let repository =
+        git::Repository::init_opts(path, &init_opts()).expect("failed to init repository");
     let mut index = repository.index().expect("failed to get index");
     let oid = index.write_tree().expect("failed to write tree");
     let signature = git::Signature::now("test", "test@email.com").unwrap();
@@ -188,4 +189,16 @@ pub fn commit_all(repository: &git::Repository) -> git::Oid {
         )
         .expect("failed to commit");
     commit_oid
+}
+
+fn init_opts() -> git2::RepositoryInitOptions {
+    let mut opts = git2::RepositoryInitOptions::new();
+    opts.initial_head("master");
+    opts
+}
+
+pub fn init_opts_bare() -> git2::RepositoryInitOptions {
+    let mut opts = init_opts();
+    opts.bare(true);
+    opts
 }

--- a/gitbutler-app/src/watcher/handlers.rs
+++ b/gitbutler-app/src/watcher/handlers.rs
@@ -199,7 +199,7 @@ impl Handler {
 #[cfg(test)]
 fn test_remote_repository() -> Result<git2::Repository> {
     let path = tempfile::tempdir()?.path().to_str().unwrap().to_string();
-    let repo_a = git2::Repository::init_bare(path)?;
+    let repo_a = git2::Repository::init_opts(path, &crate::tests::init_opts_bare())?;
 
     Ok(repo_a)
 }


### PR DESCRIPTION
The test-suite hardcodes `refs/heads/master`. However, `git` somewhat selectively picks up configuration that affects the default branch name, like `GIT_BRANCH_DEFAULT` and `init.defaultBranch`.

This causes `HEAD` to contain `refs/heads/main`, which typically isn't created, causing 199 tests to fail.

Now `git2` repository initialization will override the branch name. The only notable exception to this is a submodule test, which needs the `HEAD` branch to be set specifically after initialization.
