### PR TITLE
accessibility fix: commit card folding behaviour on keyup

### DIFF
--- a/gitbutler-ui/src/lib/components/CommitCard.svelte
+++ b/gitbutler-ui/src/lib/components/CommitCard.svelte
@@ -46,17 +46,14 @@
 		files = await listRemoteCommitFiles(project.id, commit.id);
 	}
 
-	function onClick() {
+	function toggleFiles() {
 		showFiles = !showFiles;
 		if (showFiles) loadFiles();
 	}
 
 	function onKeyup(e: KeyboardEvent) {
-		if (e.key === 'Enter' || e.key === ' ') {
-			showFiles = !showFiles;
-			if (showFiles) {
-				loadFiles();
-			}
+		if (e.key == 'Enter' || e.key == ' ') {
+			toggleFiles();
 		}
 	}
 
@@ -83,7 +80,7 @@
 	class="commit"
 	class:is-commit-open={showFiles}
 >
-	<div class="commit__header" on:click={onClick} on:keyup={onKeyup} role="button" tabindex="0">
+	<div class="commit__header" on:click={toggleFiles} on:keyup={onKeyup} role="button" tabindex="0">
 		<div class="commit__message">
 			<div class="commit__row">
 				<span class="commit__title text-semibold text-base-12" class:truncate={!showFiles}>

--- a/gitbutler-ui/src/lib/components/CommitCard.svelte
+++ b/gitbutler-ui/src/lib/components/CommitCard.svelte
@@ -51,6 +51,15 @@
 		if (showFiles) loadFiles();
 	}
 
+	function onKeyup(e: KeyboardEvent) {
+		if (e.key === 'Enter' || e.key === ' ') {
+			showFiles = !showFiles;
+			if (showFiles) {
+				loadFiles();
+			}
+		}
+	}
+
 	function resetHeadCommit() {
 		if (!branch || !$baseBranch) {
 			console.error('Unable to reset head commit');
@@ -74,7 +83,7 @@
 	class="commit"
 	class:is-commit-open={showFiles}
 >
-	<div class="commit__header" on:click={onClick} on:keyup={onClick} role="button" tabindex="0">
+	<div class="commit__header" on:click={onClick} on:keyup={onKeyup} role="button" tabindex="0">
 		<div class="commit__message">
 			<div class="commit__row">
 				<span class="commit__title text-semibold text-base-12" class:truncate={!showFiles}>


### PR DESCRIPTION
I was able to fold/unfold it pressing any key. Fixed to `Enter` and `Space` keys only

https://github.com/gitbutlerapp/gitbutler/assets/18498712/d126f527-add6-4b27-867f-d5afb9fd2210