### PR TITLE
dependabot re-enable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This makes a no-op change to dependabot.yml to force Dependabot to re-evaluate the config file.

<img width="928" alt="image" src="https://github.com/gitbutlerapp/gitbutler/assets/4030927/8906be26-7f33-4aad-a188-2a4715bd6190">

