### PR TITLE
use fork-exec flow as default fetch/push

### DIFF
--- a/crates/gitbutler-core/src/projects/project.rs
+++ b/crates/gitbutler-core/src/projects/project.rs
@@ -10,9 +10,9 @@ use crate::{git, id::Id, types::default_true::DefaultTrue};
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum AuthKey {
-    #[default]
     Default,
     Generated,
+    #[default]
     SystemExecutable,
     GitCredentialsHelper,
     Local {


### PR DESCRIPTION
Applies for new projects, the app will default to the git binary flow, with the option to change it still available