### PR TITLE
auto-remove tempdirs after testrun

### DIFF
--- a/.github/actions/check-crate/action.yaml
+++ b/.github/actions/check-crate/action.yaml
@@ -25,6 +25,8 @@ runs:
 
     - run: cargo test --locked -p ${{ inputs.crate }} --all-targets $(cat /tmp/features)
       if: inputs.action == 'test'
+      env:
+        GITBUTLER_TESTS_NO_CLEANUP: "1"
       shell: bash
 
     - run: cargo clippy -p ${{ inputs.crate }} --all-targets $(cat /tmp/features) -- -D warnings

--- a/gitbutler-app/src/gb_repository/repository.rs
+++ b/gitbutler-app/src/gb_repository/repository.rs
@@ -520,6 +520,10 @@ impl Repository {
         self.root().join("session")
     }
 
+    pub fn git_repository_path(&self) -> &std::path::Path {
+        self.git_repository.path()
+    }
+
     pub fn session_wd_path(&self) -> std::path::PathBuf {
         self.session_path().join("wd")
     }
@@ -961,38 +965,3 @@ pub enum RemoteError {
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
-
-// TODO: this is a unit-test - could use code from `tests::common` via custom module path
-//       to make it work.
-// #[cfg(test)]
-// mod test {
-//     use std::path::PathBuf;
-//
-//     use anyhow::Result;
-//     use pretty_assertions::assert_eq;
-//
-//     use crate::tests::{Case, Suite};
-//
-//     #[test]
-//     fn test_alternates_file_being_set() -> Result<()> {
-//         let Case {
-//             gb_repository,
-//             project_repository,
-//             ..
-//         } = Suite::default().new_case();
-//
-//         let file_content = std::fs::read_to_string(
-//             gb_repository
-//                 .git_repository
-//                 .path()
-//                 .join("objects/info/alternates"),
-//         )?;
-//
-//         let file_content = PathBuf::from(file_content.trim());
-//         let project_path = project_repository.path().to_path_buf().join(".git/objects");
-//
-//         assert_eq!(file_content, project_path);
-//
-//         Ok(())
-//     }
-// }

--- a/gitbutler-app/tests/database/mod.rs
+++ b/gitbutler-app/tests/database/mod.rs
@@ -4,7 +4,7 @@ use gitbutler_app::database::Database;
 #[test]
 fn smoke() {
     let data_dir = temp_dir();
-    let db = Database::open_in_directory(data_dir).unwrap();
+    let db = Database::open_in_directory(data_dir.path()).unwrap();
     db.transaction(|tx| {
         tx.execute("CREATE TABLE test (id INTEGER PRIMARY KEY)", [])
             .unwrap();

--- a/gitbutler-app/tests/deltas/mod.rs
+++ b/gitbutler-app/tests/deltas/mod.rs
@@ -7,7 +7,7 @@ mod database {
 
     #[test]
     fn insert_query() -> anyhow::Result<()> {
-        let db = test_database();
+        let (db, _tmp) = test_database();
         let database = Database::new(db);
 
         let project_id = ProjectId::generate();
@@ -33,7 +33,7 @@ mod database {
 
     #[test]
     fn insert_update() -> anyhow::Result<()> {
-        let db = test_database();
+        let (db, _tmp) = test_database();
         let database = Database::new(db);
 
         let project_id = ProjectId::generate();
@@ -66,7 +66,7 @@ mod database {
 
     #[test]
     fn aggregate_deltas_by_file() -> anyhow::Result<()> {
-        let db = test_database();
+        let (db, _tmp) = test_database();
         let database = Database::new(db);
 
         let project_id = ProjectId::generate();
@@ -115,12 +115,13 @@ mod writer {
 
     #[test]
     fn write_no_vbranches() -> anyhow::Result<()> {
-        let Case { gb_repository, .. } = Suite::default().new_case();
+        let suite = Suite::default();
+        let Case { gb_repository, .. } = &suite.new_case();
 
-        let deltas_writer = deltas::Writer::new(&gb_repository)?;
+        let deltas_writer = deltas::Writer::new(gb_repository)?;
 
         let session = gb_repository.get_or_create_current_session()?;
-        let session_reader = sessions::Reader::open(&gb_repository, &session)?;
+        let session_reader = sessions::Reader::open(gb_repository, &session)?;
         let deltas_reader = gitbutler_app::deltas::Reader::new(&session_reader);
 
         let path = "test.txt";

--- a/gitbutler-app/tests/gb_repository/mod.rs
+++ b/gitbutler-app/tests/gb_repository/mod.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, path, thread, time};
 
 use anyhow::Result;
 use pretty_assertions::assert_eq;
+use tempfile::TempDir;
 
 use crate::init_opts_bare;
 use crate::{Case, Suite};
@@ -22,11 +23,12 @@ mod repository {
 
     #[test]
     fn alternates_file_being_set() -> Result<()> {
+        let suite = Suite::default();
         let Case {
             gb_repository,
             project_repository,
             ..
-        } = Suite::default().new_case();
+        } = &suite.new_case();
 
         let file_content = std::fs::read_to_string(
             gb_repository
@@ -43,15 +45,17 @@ mod repository {
     }
 }
 
-fn new_test_remote_repository() -> Result<git2::Repository> {
-    let path = tempfile::tempdir()?.path().to_str().unwrap().to_string();
+fn new_test_remote_repository() -> Result<(git2::Repository, TempDir)> {
+    let tmp = tempfile::tempdir()?;
+    let path = tmp.path().to_str().unwrap().to_string();
     let repo_a = git2::Repository::init_opts(path, &init_opts_bare())?;
-    Ok(repo_a)
+    Ok((repo_a, tmp))
 }
 
 #[test]
 fn get_current_session_writer_should_use_existing_session() -> Result<()> {
-    let Case { gb_repository, .. } = Suite::default().new_case();
+    let suite = Suite::default();
+    let Case { gb_repository, .. } = &suite.new_case();
 
     let current_session_1 = gb_repository.get_or_create_current_session()?;
     let current_session_2 = gb_repository.get_or_create_current_session()?;
@@ -62,7 +66,8 @@ fn get_current_session_writer_should_use_existing_session() -> Result<()> {
 
 #[test]
 fn must_not_return_init_session() -> Result<()> {
-    let Case { gb_repository, .. } = Suite::default().new_case();
+    let suite = Suite::default();
+    let Case { gb_repository, .. } = &suite.new_case();
 
     assert!(gb_repository.get_current_session()?.is_none());
 
@@ -74,13 +79,14 @@ fn must_not_return_init_session() -> Result<()> {
 
 #[test]
 fn must_not_flush_without_current_session() -> Result<()> {
+    let suite = Suite::default();
     let Case {
         gb_repository,
         project_repository,
         ..
-    } = Suite::default().new_case();
+    } = &suite.new_case();
 
-    let session = gb_repository.flush(&project_repository, None)?;
+    let session = gb_repository.flush(project_repository, None)?;
     assert!(session.is_none());
 
     let iter = gb_repository.get_sessions_iterator()?;
@@ -91,30 +97,31 @@ fn must_not_flush_without_current_session() -> Result<()> {
 
 #[test]
 fn non_empty_repository() -> Result<()> {
+    let suite = Suite::default();
     let Case {
         gb_repository,
         project_repository,
         ..
-    } = Suite::default()
-        .new_case_with_files(HashMap::from([(path::PathBuf::from("test.txt"), "test")]));
+    } = &suite.new_case_with_files(HashMap::from([(path::PathBuf::from("test.txt"), "test")]));
 
     gb_repository.get_or_create_current_session()?;
-    gb_repository.flush(&project_repository, None)?;
+    gb_repository.flush(project_repository, None)?;
 
     Ok(())
 }
 
 #[test]
 fn must_flush_current_session() -> Result<()> {
+    let suite = Suite::default();
     let Case {
         gb_repository,
         project_repository,
         ..
-    } = Suite::default().new_case();
+    } = &suite.new_case();
 
     gb_repository.get_or_create_current_session()?;
 
-    let session = gb_repository.flush(&project_repository, None)?;
+    let session = gb_repository.flush(project_repository, None)?;
     assert!(session.is_some());
 
     let iter = gb_repository.get_sessions_iterator()?;
@@ -125,10 +132,11 @@ fn must_flush_current_session() -> Result<()> {
 
 #[test]
 fn list_deltas_from_current_session() -> Result<()> {
-    let Case { gb_repository, .. } = Suite::default().new_case();
+    let suite = Suite::default();
+    let Case { gb_repository, .. } = &suite.new_case();
 
     let current_session = gb_repository.get_or_create_current_session()?;
-    let writer = deltas::Writer::new(&gb_repository)?;
+    let writer = deltas::Writer::new(gb_repository)?;
     writer.write(
         "test.txt",
         &vec![deltas::Delta {
@@ -137,7 +145,7 @@ fn list_deltas_from_current_session() -> Result<()> {
         }],
     )?;
 
-    let session_reader = sessions::Reader::open(&gb_repository, &current_session)?;
+    let session_reader = sessions::Reader::open(gb_repository, &current_session)?;
     let deltas_reader = deltas::Reader::new(&session_reader);
     let deltas = deltas_reader.read(None)?;
 
@@ -156,13 +164,14 @@ fn list_deltas_from_current_session() -> Result<()> {
 
 #[test]
 fn list_deltas_from_flushed_session() {
+    let suite = Suite::default();
     let Case {
         gb_repository,
         project_repository,
         ..
-    } = Suite::default().new_case();
+    } = &suite.new_case();
 
-    let writer = deltas::Writer::new(&gb_repository).unwrap();
+    let writer = deltas::Writer::new(gb_repository).unwrap();
     writer
         .write(
             "test.txt",
@@ -172,9 +181,9 @@ fn list_deltas_from_flushed_session() {
             }],
         )
         .unwrap();
-    let session = gb_repository.flush(&project_repository, None).unwrap();
+    let session = gb_repository.flush(project_repository, None).unwrap();
 
-    let session_reader = sessions::Reader::open(&gb_repository, &session.unwrap()).unwrap();
+    let session_reader = sessions::Reader::open(gb_repository, &session.unwrap()).unwrap();
     let deltas_reader = deltas::Reader::new(&session_reader);
     let deltas = deltas_reader.read(None).unwrap();
 
@@ -191,13 +200,14 @@ fn list_deltas_from_flushed_session() {
 
 #[test]
 fn list_files_from_current_session() {
-    let Case { gb_repository, .. } = Suite::default().new_case_with_files(HashMap::from([(
+    let suite = Suite::default();
+    let Case { gb_repository, .. } = &suite.new_case_with_files(HashMap::from([(
         path::PathBuf::from("test.txt"),
         "Hello World",
     )]));
 
     let current = gb_repository.get_or_create_current_session().unwrap();
-    let reader = sessions::Reader::open(&gb_repository, &current).unwrap();
+    let reader = sessions::Reader::open(gb_repository, &current).unwrap();
     let files = reader.files(None).unwrap();
 
     assert_eq!(files.len(), 1);
@@ -209,21 +219,22 @@ fn list_files_from_current_session() {
 
 #[test]
 fn list_files_from_flushed_session() {
+    let suite = Suite::default();
     let Case {
         gb_repository,
         project_repository,
         ..
-    } = Suite::default().new_case_with_files(HashMap::from([(
+    } = &suite.new_case_with_files(HashMap::from([(
         path::PathBuf::from("test.txt"),
         "Hello World",
     )]));
 
     gb_repository.get_or_create_current_session().unwrap();
     let session = gb_repository
-        .flush(&project_repository, None)
+        .flush(project_repository, None)
         .unwrap()
         .unwrap();
-    let reader = sessions::Reader::open(&gb_repository, &session).unwrap();
+    let reader = sessions::Reader::open(gb_repository, &session).unwrap();
     let files = reader.files(None).unwrap();
 
     assert_eq!(files.len(), 1);
@@ -236,7 +247,7 @@ fn list_files_from_flushed_session() {
 #[tokio::test]
 async fn remote_syncronization() {
     // first, crate a remote, pretending it's a cloud
-    let cloud = new_test_remote_repository().unwrap();
+    let (cloud, _tmp) = new_test_remote_repository().unwrap();
     let api_project = ApiProject {
         name: "test-sync".to_string(),
         description: None,
@@ -331,7 +342,7 @@ async fn remote_syncronization() {
 #[tokio::test]
 async fn remote_sync_order() {
     // first, crate a remote, pretending it's a cloud
-    let cloud = new_test_remote_repository().unwrap();
+    let (cloud, _tmp) = new_test_remote_repository().unwrap();
     let api_project = projects::ApiProject {
         name: "test-sync".to_string(),
         description: None,
@@ -453,11 +464,12 @@ async fn remote_sync_order() {
 
 #[test]
 fn gitbutler_file() {
+    let suite = Suite::default();
     let Case {
         gb_repository,
         project_repository,
         ..
-    } = Suite::default().new_case();
+    } = &suite.new_case();
 
     let session = gb_repository.get_or_create_current_session().unwrap();
 

--- a/gitbutler-app/tests/gb_repository/mod.rs
+++ b/gitbutler-app/tests/gb_repository/mod.rs
@@ -13,6 +13,36 @@ use gitbutler_app::{
     sessions::{self, SessionId},
 };
 
+mod repository {
+    use std::path::PathBuf;
+
+    use crate::{Case, Suite};
+    use anyhow::Result;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn alternates_file_being_set() -> Result<()> {
+        let Case {
+            gb_repository,
+            project_repository,
+            ..
+        } = Suite::default().new_case();
+
+        let file_content = std::fs::read_to_string(
+            gb_repository
+                .git_repository_path()
+                .join("objects/info/alternates"),
+        )?;
+
+        let file_content = PathBuf::from(file_content.trim());
+        let project_path = project_repository.path().to_path_buf().join(".git/objects");
+
+        assert_eq!(file_content, project_path);
+
+        Ok(())
+    }
+}
+
 fn new_test_remote_repository() -> Result<git2::Repository> {
     let path = tempfile::tempdir()?.path().to_str().unwrap().to_string();
     let repo_a = git2::Repository::init_opts(path, &init_opts_bare())?;

--- a/gitbutler-app/tests/git/config.rs
+++ b/gitbutler-app/tests/git/config.rs
@@ -2,7 +2,7 @@ use crate::test_repository;
 
 #[test]
 pub fn set_str() {
-    let repo = test_repository();
+    let (repo, _tmp) = test_repository();
     let mut config = repo.config().unwrap();
     config.set_str("test.key", "test.value").unwrap();
     assert_eq!(
@@ -13,7 +13,7 @@ pub fn set_str() {
 
 #[test]
 pub fn set_bool() {
-    let repo = test_repository();
+    let (repo, _tmp) = test_repository();
     let mut config = repo.config().unwrap();
     config.set_bool("test.key", true).unwrap();
     assert!(config.get_bool("test.key").unwrap().unwrap());
@@ -21,14 +21,14 @@ pub fn set_bool() {
 
 #[test]
 pub fn get_string_none() {
-    let repo = test_repository();
+    let (repo, _tmp) = test_repository();
     let config = repo.config().unwrap();
     assert_eq!(config.get_string("test.key").unwrap(), None);
 }
 
 #[test]
 pub fn get_bool_none() {
-    let repo = test_repository();
+    let (repo, _tmp) = test_repository();
     let config = repo.config().unwrap();
     assert_eq!(config.get_bool("test.key").unwrap(), None);
 }

--- a/gitbutler-app/tests/git/credentials.rs
+++ b/gitbutler-app/tests/git/credentials.rs
@@ -26,7 +26,7 @@ impl TestCase<'_> {
         let keys = keys::Controller::from_path(&local_app_data);
         let helper = Helper::new(keys, users, self.home_dir.clone());
 
-        let repo = test_repository();
+        let (repo, _tmp) = test_repository();
         repo.remote(
             "origin",
             &self.remote_url.parse().expect("failed to parse remote url"),

--- a/gitbutler-app/tests/git/diff.rs
+++ b/gitbutler-app/tests/git/diff.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, path, thread, time};
 
 use anyhow::Result;
 use pretty_assertions::assert_eq;
+use tempfile::TempDir;
 
 use crate::init_opts_bare;
 use crate::{Case, Suite};
@@ -12,15 +13,16 @@ use gitbutler_app::{
     sessions::{self, SessionId},
 };
 
-fn new_test_remote_repository() -> Result<git2::Repository> {
-    let path = tempfile::tempdir()?.path().to_str().unwrap().to_string();
-    let repo_a = git2::Repository::init_opts(path, &init_opts_bare())?;
-    Ok(repo_a)
+fn new_test_remote_repository() -> Result<(git2::Repository, TempDir)> {
+    let tmp = tempfile::tempdir()?;
+    let repo_a = git2::Repository::init_opts(&tmp, &init_opts_bare())?;
+    Ok((repo_a, tmp))
 }
 
 #[test]
 fn get_current_session_writer_should_use_existing_session() -> Result<()> {
-    let Case { gb_repository, .. } = Suite::default().new_case();
+    let suite = Suite::default();
+    let Case { gb_repository, .. } = &suite.new_case();
 
     let current_session_1 = gb_repository.get_or_create_current_session()?;
     let current_session_2 = gb_repository.get_or_create_current_session()?;
@@ -31,7 +33,8 @@ fn get_current_session_writer_should_use_existing_session() -> Result<()> {
 
 #[test]
 fn must_not_return_init_session() -> Result<()> {
-    let Case { gb_repository, .. } = Suite::default().new_case();
+    let suite = Suite::default();
+    let Case { gb_repository, .. } = &suite.new_case();
 
     assert!(gb_repository.get_current_session()?.is_none());
 
@@ -43,13 +46,14 @@ fn must_not_return_init_session() -> Result<()> {
 
 #[test]
 fn must_not_flush_without_current_session() -> Result<()> {
+    let suite = Suite::default();
     let Case {
         gb_repository,
         project_repository,
         ..
-    } = Suite::default().new_case();
+    } = &suite.new_case();
 
-    let session = gb_repository.flush(&project_repository, None)?;
+    let session = gb_repository.flush(project_repository, None)?;
     assert!(session.is_none());
 
     let iter = gb_repository.get_sessions_iterator()?;
@@ -60,30 +64,31 @@ fn must_not_flush_without_current_session() -> Result<()> {
 
 #[test]
 fn non_empty_repository() -> Result<()> {
+    let suite = Suite::default();
     let Case {
         gb_repository,
         project_repository,
         ..
-    } = Suite::default()
-        .new_case_with_files(HashMap::from([(path::PathBuf::from("test.txt"), "test")]));
+    } = &suite.new_case_with_files(HashMap::from([(path::PathBuf::from("test.txt"), "test")]));
 
     gb_repository.get_or_create_current_session()?;
-    gb_repository.flush(&project_repository, None)?;
+    gb_repository.flush(project_repository, None)?;
 
     Ok(())
 }
 
 #[test]
 fn must_flush_current_session() -> Result<()> {
+    let suite = Suite::default();
     let Case {
         gb_repository,
         project_repository,
         ..
-    } = Suite::default().new_case();
+    } = &suite.new_case();
 
     gb_repository.get_or_create_current_session()?;
 
-    let session = gb_repository.flush(&project_repository, None)?;
+    let session = gb_repository.flush(project_repository, None)?;
     assert!(session.is_some());
 
     let iter = gb_repository.get_sessions_iterator()?;
@@ -94,10 +99,11 @@ fn must_flush_current_session() -> Result<()> {
 
 #[test]
 fn list_deltas_from_current_session() -> Result<()> {
-    let Case { gb_repository, .. } = Suite::default().new_case();
+    let suite = Suite::default();
+    let Case { gb_repository, .. } = &suite.new_case();
 
     let current_session = gb_repository.get_or_create_current_session()?;
-    let writer = deltas::Writer::new(&gb_repository)?;
+    let writer = deltas::Writer::new(gb_repository)?;
     writer.write(
         "test.txt",
         &vec![deltas::Delta {
@@ -106,7 +112,7 @@ fn list_deltas_from_current_session() -> Result<()> {
         }],
     )?;
 
-    let session_reader = sessions::Reader::open(&gb_repository, &current_session)?;
+    let session_reader = sessions::Reader::open(gb_repository, &current_session)?;
     let deltas_reader = deltas::Reader::new(&session_reader);
     let deltas = deltas_reader.read(None)?;
 
@@ -125,13 +131,14 @@ fn list_deltas_from_current_session() -> Result<()> {
 
 #[test]
 fn list_deltas_from_flushed_session() {
+    let suite = Suite::default();
     let Case {
         gb_repository,
         project_repository,
         ..
-    } = Suite::default().new_case();
+    } = &suite.new_case();
 
-    let writer = deltas::Writer::new(&gb_repository).unwrap();
+    let writer = deltas::Writer::new(gb_repository).unwrap();
     writer
         .write(
             "test.txt",
@@ -141,9 +148,9 @@ fn list_deltas_from_flushed_session() {
             }],
         )
         .unwrap();
-    let session = gb_repository.flush(&project_repository, None).unwrap();
+    let session = gb_repository.flush(project_repository, None).unwrap();
 
-    let session_reader = sessions::Reader::open(&gb_repository, &session.unwrap()).unwrap();
+    let session_reader = sessions::Reader::open(gb_repository, &session.unwrap()).unwrap();
     let deltas_reader = deltas::Reader::new(&session_reader);
     let deltas = deltas_reader.read(None).unwrap();
 
@@ -160,13 +167,14 @@ fn list_deltas_from_flushed_session() {
 
 #[test]
 fn list_files_from_current_session() {
-    let Case { gb_repository, .. } = Suite::default().new_case_with_files(HashMap::from([(
+    let suite = Suite::default();
+    let Case { gb_repository, .. } = &suite.new_case_with_files(HashMap::from([(
         path::PathBuf::from("test.txt"),
         "Hello World",
     )]));
 
     let current = gb_repository.get_or_create_current_session().unwrap();
-    let reader = sessions::Reader::open(&gb_repository, &current).unwrap();
+    let reader = sessions::Reader::open(gb_repository, &current).unwrap();
     let files = reader.files(None).unwrap();
 
     assert_eq!(files.len(), 1);
@@ -178,21 +186,22 @@ fn list_files_from_current_session() {
 
 #[test]
 fn list_files_from_flushed_session() {
+    let suite = Suite::default();
     let Case {
         gb_repository,
         project_repository,
         ..
-    } = Suite::default().new_case_with_files(HashMap::from([(
+    } = &suite.new_case_with_files(HashMap::from([(
         path::PathBuf::from("test.txt"),
         "Hello World",
     )]));
 
     gb_repository.get_or_create_current_session().unwrap();
     let session = gb_repository
-        .flush(&project_repository, None)
+        .flush(project_repository, None)
         .unwrap()
         .unwrap();
-    let reader = sessions::Reader::open(&gb_repository, &session).unwrap();
+    let reader = sessions::Reader::open(gb_repository, &session).unwrap();
     let files = reader.files(None).unwrap();
 
     assert_eq!(files.len(), 1);
@@ -205,7 +214,7 @@ fn list_files_from_flushed_session() {
 #[tokio::test]
 async fn remote_syncronization() {
     // first, crate a remote, pretending it's a cloud
-    let cloud = new_test_remote_repository().unwrap();
+    let (cloud, _tmp) = new_test_remote_repository().unwrap();
     let api_project = ApiProject {
         name: "test-sync".to_string(),
         description: None,
@@ -300,7 +309,7 @@ async fn remote_syncronization() {
 #[tokio::test]
 async fn remote_sync_order() {
     // first, crate a remote, pretending it's a cloud
-    let cloud = new_test_remote_repository().unwrap();
+    let (cloud, _tmp) = new_test_remote_repository().unwrap();
     let api_project = projects::ApiProject {
         name: "test-sync".to_string(),
         description: None,
@@ -422,11 +431,12 @@ async fn remote_sync_order() {
 
 #[test]
 fn gitbutler_file() {
+    let suite = Suite::default();
     let Case {
         gb_repository,
         project_repository,
         ..
-    } = Suite::default().new_case();
+    } = &suite.new_case();
 
     let session = gb_repository.get_or_create_current_session().unwrap();
 

--- a/gitbutler-app/tests/keys/mod.rs
+++ b/gitbutler-app/tests/keys/mod.rs
@@ -14,7 +14,7 @@ mod controller {
         #[test]
         fn get_or_create() {
             let suite = Suite::default();
-            let controller = Controller::new(Storage::from_path(&suite.local_app_data));
+            let controller = Controller::new(Storage::from_path(suite.local_app_data()));
 
             let once = controller.get_or_create().unwrap();
             let twice = controller.get_or_create().unwrap();

--- a/gitbutler-app/tests/keys/mod.rs
+++ b/gitbutler-app/tests/keys/mod.rs
@@ -21,7 +21,7 @@ mod controller {
             assert_eq!(once, twice);
 
             // check permissions of the private key
-            let permissions = fs::metadata(suite.local_app_data.join("keys/ed25519"))
+            let permissions = fs::metadata(suite.local_app_data().join("keys/ed25519"))
                 .unwrap()
                 .permissions();
             let perms = format!("{:o}", permissions.mode());

--- a/gitbutler-app/tests/lock/mod.rs
+++ b/gitbutler-app/tests/lock/mod.rs
@@ -5,8 +5,8 @@ use crate::temp_dir;
 #[tokio::test]
 async fn lock_same_instance() {
     let dir_path = temp_dir();
-    std::fs::write(dir_path.join("file.txt"), "").unwrap();
-    let dir = Dir::new(&dir_path).unwrap();
+    std::fs::write(dir_path.path().join("file.txt"), "").unwrap();
+    let dir = Dir::new(dir_path.path()).unwrap();
 
     let (tx, rx) = std::sync::mpsc::sync_channel(1);
 
@@ -39,7 +39,7 @@ async fn lock_same_instance() {
     .unwrap();
 
     assert_eq!(
-        std::fs::read_to_string(dir_path.join("file.txt")).unwrap(),
+        std::fs::read_to_string(dir_path.path().join("file.txt")).unwrap(),
         "2"
     );
 }
@@ -47,13 +47,13 @@ async fn lock_same_instance() {
 #[tokio::test]
 async fn lock_different_instances() {
     let dir_path = temp_dir();
-    std::fs::write(dir_path.join("file.txt"), "").unwrap();
+    std::fs::write(dir_path.path().join("file.txt"), "").unwrap();
 
     let (tx, rx) = std::sync::mpsc::sync_channel(1);
 
     // spawn a task that will signal right after aquireing the lock
     let _ = tokio::spawn({
-        let dir_path = dir_path.clone();
+        let dir_path = dir_path.path().to_owned();
         async move {
             // one dir instance is created on a separate thread
             let dir = Dir::new(&dir_path).unwrap();
@@ -85,7 +85,7 @@ async fn lock_different_instances() {
     .unwrap();
 
     assert_eq!(
-        std::fs::read_to_string(dir_path.join("file.txt")).unwrap(),
+        std::fs::read_to_string(dir_path.path().join("file.txt")).unwrap(),
         "2"
     );
 }

--- a/gitbutler-app/tests/reader/mod.rs
+++ b/gitbutler-app/tests/reader/mod.rs
@@ -10,9 +10,9 @@ fn directory_reader_read_file() -> Result<()> {
     let dir = temp_dir();
 
     let file_path = Path::new("test.txt");
-    fs::write(dir.join(file_path), "test")?;
+    fs::write(dir.path().join(file_path), "test")?;
 
-    let reader = Reader::open(dir.clone())?;
+    let reader = Reader::open(dir.path())?;
     assert_eq!(reader.read(file_path)?, Content::UTF8("test".to_string()));
 
     Ok(())
@@ -20,7 +20,7 @@ fn directory_reader_read_file() -> Result<()> {
 
 #[test]
 fn commit_reader_read_file() -> Result<()> {
-    let repository = test_repository();
+    let (repository, _tmp) = test_repository();
 
     let file_path = Path::new("test.txt");
     fs::write(repository.path().parent().unwrap().join(file_path), "test")?;
@@ -39,11 +39,11 @@ fn commit_reader_read_file() -> Result<()> {
 fn reader_list_files_should_return_relative() -> Result<()> {
     let dir = temp_dir();
 
-    fs::write(dir.join("test1.txt"), "test")?;
-    fs::create_dir_all(dir.join("dir"))?;
-    fs::write(dir.join("dir").join("test.txt"), "test")?;
+    fs::write(dir.path().join("test1.txt"), "test")?;
+    fs::create_dir_all(dir.path().join("dir"))?;
+    fs::write(dir.path().join("dir").join("test.txt"), "test")?;
 
-    let reader = Reader::open(dir.clone())?;
+    let reader = Reader::open(dir.path())?;
     let files = reader.list_files(Path::new("dir"))?;
     assert_eq!(files.len(), 1);
     assert!(files.contains(&Path::new("test.txt").to_path_buf()));
@@ -55,11 +55,11 @@ fn reader_list_files_should_return_relative() -> Result<()> {
 fn reader_list_files() -> Result<()> {
     let dir = temp_dir();
 
-    fs::write(dir.join("test.txt"), "test")?;
-    fs::create_dir_all(dir.join("dir"))?;
-    fs::write(dir.join("dir").join("test.txt"), "test")?;
+    fs::write(dir.path().join("test.txt"), "test")?;
+    fs::create_dir_all(dir.path().join("dir"))?;
+    fs::write(dir.path().join("dir").join("test.txt"), "test")?;
 
-    let reader = Reader::open(dir.clone())?;
+    let reader = Reader::open(dir.path())?;
     let files = reader.list_files(Path::new(""))?;
     assert_eq!(files.len(), 2);
     assert!(files.contains(&Path::new("test.txt").to_path_buf()));
@@ -70,7 +70,7 @@ fn reader_list_files() -> Result<()> {
 
 #[test]
 fn commit_reader_list_files_should_return_relative() -> Result<()> {
-    let repository = test_repository();
+    let (repository, _tmp) = test_repository();
 
     fs::write(
         repository.path().parent().unwrap().join("test1.txt"),
@@ -101,7 +101,7 @@ fn commit_reader_list_files_should_return_relative() -> Result<()> {
 
 #[test]
 fn commit_reader_list_files() -> Result<()> {
-    let repository = test_repository();
+    let (repository, _tmp) = test_repository();
 
     fs::write(repository.path().parent().unwrap().join("test.txt"), "test")?;
     fs::create_dir_all(repository.path().parent().unwrap().join("dir"))?;
@@ -132,9 +132,9 @@ fn commit_reader_list_files() -> Result<()> {
 fn directory_reader_exists() -> Result<()> {
     let dir = temp_dir();
 
-    fs::write(dir.join("test.txt"), "test")?;
+    fs::write(dir.path().join("test.txt"), "test")?;
 
-    let reader = Reader::open(dir.clone())?;
+    let reader = Reader::open(dir.path())?;
     assert!(reader.exists(Path::new("test.txt"))?);
     assert!(!reader.exists(Path::new("test2.txt"))?);
 
@@ -143,7 +143,7 @@ fn directory_reader_exists() -> Result<()> {
 
 #[test]
 fn commit_reader_exists() -> Result<()> {
-    let repository = test_repository();
+    let (repository, _tmp) = test_repository();
 
     fs::write(repository.path().parent().unwrap().join("test.txt"), "test")?;
 

--- a/gitbutler-app/tests/sessions/database.rs
+++ b/gitbutler-app/tests/sessions/database.rs
@@ -4,7 +4,7 @@ use gitbutler_app::sessions::{session, Database, Session, SessionId};
 
 #[test]
 fn insert_query() -> anyhow::Result<()> {
-    let db = test_database();
+    let (db, _tmp) = test_database();
     println!("0");
     let database = Database::new(db);
     println!("1");
@@ -47,7 +47,7 @@ fn insert_query() -> anyhow::Result<()> {
 
 #[test]
 fn update() -> anyhow::Result<()> {
-    let db = test_database();
+    let (db, _tmp) = test_database();
     let database = Database::new(db);
 
     let project_id = ProjectId::generate();

--- a/gitbutler-app/tests/sessions/mod.rs
+++ b/gitbutler-app/tests/sessions/mod.rs
@@ -7,7 +7,8 @@ use gitbutler_app::sessions::{self, session::SessionId};
 
 #[test]
 fn should_not_write_session_with_hash() {
-    let Case { gb_repository, .. } = Suite::default().new_case();
+    let suite = Suite::default();
+    let Case { gb_repository, .. } = &suite.new_case();
 
     let session = sessions::Session {
         id: SessionId::generate(),
@@ -20,7 +21,7 @@ fn should_not_write_session_with_hash() {
         },
     };
 
-    assert!(sessions::Writer::new(&gb_repository)
+    assert!(sessions::Writer::new(gb_repository)
         .unwrap()
         .write(&session)
         .is_err());
@@ -28,7 +29,8 @@ fn should_not_write_session_with_hash() {
 
 #[test]
 fn should_write_full_session() -> Result<()> {
-    let Case { gb_repository, .. } = Suite::default().new_case();
+    let suite = Suite::default();
+    let Case { gb_repository, .. } = &suite.new_case();
 
     let session = sessions::Session {
         id: SessionId::generate(),
@@ -41,7 +43,7 @@ fn should_write_full_session() -> Result<()> {
         },
     };
 
-    sessions::Writer::new(&gb_repository)?.write(&session)?;
+    sessions::Writer::new(gb_repository)?.write(&session)?;
 
     assert_eq!(
         std::fs::read_to_string(gb_repository.session_path().join("meta/id"))?,
@@ -69,7 +71,8 @@ fn should_write_full_session() -> Result<()> {
 
 #[test]
 fn should_write_partial_session() -> Result<()> {
-    let Case { gb_repository, .. } = Suite::default().new_case();
+    let suite = Suite::default();
+    let Case { gb_repository, .. } = &suite.new_case();
 
     let session = sessions::Session {
         id: SessionId::generate(),
@@ -82,7 +85,7 @@ fn should_write_partial_session() -> Result<()> {
         },
     };
 
-    sessions::Writer::new(&gb_repository)?.write(&session)?;
+    sessions::Writer::new(gb_repository)?.write(&session)?;
 
     assert_eq!(
         std::fs::read_to_string(gb_repository.session_path().join("meta/id"))?,

--- a/gitbutler-app/tests/suite/gb_repository.rs
+++ b/gitbutler-app/tests/suite/gb_repository.rs
@@ -21,7 +21,7 @@ mod init {
 
         let project_repository = project_repository::Repository::open(&project).unwrap();
 
-        gb_repository::Repository::open(&data_dir, &project_repository, None).unwrap();
+        gb_repository::Repository::open(data_dir.path(), &project_repository, None).unwrap();
     }
 
     #[test]
@@ -43,7 +43,7 @@ mod init {
 
         let project_repository = project_repository::Repository::open(&project).unwrap();
 
-        gb_repository::Repository::open(&data_dir, &project_repository, None).unwrap();
+        gb_repository::Repository::open(data_dir.path(), &project_repository, None).unwrap();
     }
 
     #[test]
@@ -70,7 +70,7 @@ mod init {
 
         let project_repository = project_repository::Repository::open(&project).unwrap();
 
-        gb_repository::Repository::open(&data_dir, &project_repository, None).unwrap();
+        gb_repository::Repository::open(data_dir.path(), &project_repository, None).unwrap();
     }
 }
 
@@ -91,7 +91,7 @@ mod flush {
         let project_repository = project_repository::Repository::open(&project).unwrap();
 
         let gb_repo =
-            gb_repository::Repository::open(&data_dir, &project_repository, None).unwrap();
+            gb_repository::Repository::open(data_dir.path(), &project_repository, None).unwrap();
 
         std::fs::write(project.path.join("file"), "content").unwrap();
         std::fs::hard_link(project.path.join("file"), project.path.join("link")).unwrap();
@@ -114,7 +114,7 @@ mod flush {
         let project_repository = project_repository::Repository::open(&project).unwrap();
 
         let gb_repo =
-            gb_repository::Repository::open(&data_dir, &project_repository, None).unwrap();
+            gb_repository::Repository::open(data_dir.path(), &project_repository, None).unwrap();
 
         std::fs::create_dir_all(project.path.join("dir")).unwrap();
         std::fs::write(project.path.join("dir/file"), "content").unwrap();
@@ -138,14 +138,10 @@ mod flush {
         let project_repository = project_repository::Repository::open(&project).unwrap();
 
         let gb_repo =
-            gb_repository::Repository::open(&data_dir, &project_repository, None).unwrap();
+            gb_repository::Repository::open(data_dir.path(), &project_repository, None).unwrap();
 
-        let submodule_url: git::Url = TestProject::default()
-            .path()
-            .display()
-            .to_string()
-            .parse()
-            .unwrap();
+        let project = TestProject::default();
+        let submodule_url: git::Url = project.path().display().to_string().parse().unwrap();
         test_project.add_submodule(&submodule_url, path::Path::new("submodule"));
 
         gb_repo.flush(&project_repository, None).unwrap();

--- a/gitbutler-app/tests/suite/virtual_branches/amend.rs
+++ b/gitbutler-app/tests/suite/virtual_branches/amend.rs
@@ -7,15 +7,15 @@ async fn to_default_target() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
@@ -24,7 +24,7 @@ async fn to_default_target() {
     let to_amend: branch::BranchOwnershipClaims = "file2.txt:1-2".parse().unwrap();
     assert!(matches!(
         controller
-            .amend(&project_id, &branch_id, &to_amend)
+            .amend(project_id, &branch_id, &to_amend)
             .await
             .unwrap_err(),
         ControllerError::Action(errors::AmendError::BranchHasNoCommits)
@@ -39,11 +39,11 @@ async fn forcepush_allowed() {
         controller,
         projects,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     projects
         .update(&projects::UpdateRequest {
-            id: project_id,
+            id: *project_id,
             ok_with_force_push: Some(false),
             ..Default::default()
         })
@@ -51,13 +51,13 @@ async fn forcepush_allowed() {
         .unwrap();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     projects
         .update(&projects::UpdateRequest {
-            id: project_id,
+            id: *project_id,
             ok_with_force_push: Some(true),
             ..Default::default()
         })
@@ -65,7 +65,7 @@ async fn forcepush_allowed() {
         .unwrap();
 
     let branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
@@ -73,13 +73,13 @@ async fn forcepush_allowed() {
         // create commit
         fs::write(repository.path().join("file.txt"), "content").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit one", None, false)
+            .create_commit(project_id, &branch_id, "commit one", None, false)
             .await
             .unwrap();
     };
 
     controller
-        .push_virtual_branch(&project_id, &branch_id, false, None)
+        .push_virtual_branch(project_id, &branch_id, false, None)
         .await
         .unwrap();
 
@@ -88,12 +88,12 @@ async fn forcepush_allowed() {
         fs::write(repository.path().join("file2.txt"), "content2").unwrap();
         let to_amend: branch::BranchOwnershipClaims = "file2.txt:1-2".parse().unwrap();
         controller
-            .amend(&project_id, &branch_id, &to_amend)
+            .amend(project_id, &branch_id, &to_amend)
             .await
             .unwrap();
 
         let branch = controller
-            .list_virtual_branches(&project_id)
+            .list_virtual_branches(project_id)
             .await
             .unwrap()
             .0
@@ -115,16 +115,16 @@ async fn forcepush_forbidden() {
         controller,
         projects,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     projects
         .update(&projects::UpdateRequest {
-            id: project_id,
+            id: *project_id,
             ok_with_force_push: Some(false),
             ..Default::default()
         })
@@ -132,7 +132,7 @@ async fn forcepush_forbidden() {
         .unwrap();
 
     let branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
@@ -140,13 +140,13 @@ async fn forcepush_forbidden() {
         // create commit
         fs::write(repository.path().join("file.txt"), "content").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit one", None, false)
+            .create_commit(project_id, &branch_id, "commit one", None, false)
             .await
             .unwrap();
     };
 
     controller
-        .push_virtual_branch(&project_id, &branch_id, false, None)
+        .push_virtual_branch(project_id, &branch_id, false, None)
         .await
         .unwrap();
 
@@ -155,7 +155,7 @@ async fn forcepush_forbidden() {
         let to_amend: branch::BranchOwnershipClaims = "file2.txt:1-2".parse().unwrap();
         assert!(matches!(
             controller
-                .amend(&project_id, &branch_id, &to_amend)
+                .amend(project_id, &branch_id, &to_amend)
                 .await
                 .unwrap_err(),
             ControllerError::Action(errors::AmendError::ForcePushNotAllowed(_))
@@ -170,15 +170,15 @@ async fn non_locked_hunk() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
@@ -186,12 +186,12 @@ async fn non_locked_hunk() {
         // create commit
         fs::write(repository.path().join("file.txt"), "content").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit one", None, false)
+            .create_commit(project_id, &branch_id, "commit one", None, false)
             .await
             .unwrap();
 
         let branch = controller
-            .list_virtual_branches(&project_id)
+            .list_virtual_branches(project_id)
             .await
             .unwrap()
             .0
@@ -208,12 +208,12 @@ async fn non_locked_hunk() {
         fs::write(repository.path().join("file2.txt"), "content2").unwrap();
         let to_amend: branch::BranchOwnershipClaims = "file2.txt:1-2".parse().unwrap();
         controller
-            .amend(&project_id, &branch_id, &to_amend)
+            .amend(project_id, &branch_id, &to_amend)
             .await
             .unwrap();
 
         let branch = controller
-            .list_virtual_branches(&project_id)
+            .list_virtual_branches(project_id)
             .await
             .unwrap()
             .0
@@ -233,15 +233,15 @@ async fn locked_hunk() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
@@ -249,12 +249,12 @@ async fn locked_hunk() {
         // create commit
         fs::write(repository.path().join("file.txt"), "content").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit one", None, false)
+            .create_commit(project_id, &branch_id, "commit one", None, false)
             .await
             .unwrap();
 
         let branch = controller
-            .list_virtual_branches(&project_id)
+            .list_virtual_branches(project_id)
             .await
             .unwrap()
             .0
@@ -275,12 +275,12 @@ async fn locked_hunk() {
         fs::write(repository.path().join("file.txt"), "more content").unwrap();
         let to_amend: branch::BranchOwnershipClaims = "file.txt:1-2".parse().unwrap();
         controller
-            .amend(&project_id, &branch_id, &to_amend)
+            .amend(project_id, &branch_id, &to_amend)
             .await
             .unwrap();
 
         let branch = controller
-            .list_virtual_branches(&project_id)
+            .list_virtual_branches(project_id)
             .await
             .unwrap()
             .0
@@ -305,15 +305,15 @@ async fn non_existing_ownership() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
@@ -321,12 +321,12 @@ async fn non_existing_ownership() {
         // create commit
         fs::write(repository.path().join("file.txt"), "content").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit one", None, false)
+            .create_commit(project_id, &branch_id, "commit one", None, false)
             .await
             .unwrap();
 
         let branch = controller
-            .list_virtual_branches(&project_id)
+            .list_virtual_branches(project_id)
             .await
             .unwrap()
             .0
@@ -343,7 +343,7 @@ async fn non_existing_ownership() {
         let to_amend: branch::BranchOwnershipClaims = "file2.txt:1-2".parse().unwrap();
         assert!(matches!(
             controller
-                .amend(&project_id, &branch_id, &to_amend)
+                .amend(project_id, &branch_id, &to_amend)
                 .await
                 .unwrap_err(),
             ControllerError::Action(errors::AmendError::TargetOwnerhshipNotFound(_))

--- a/gitbutler-app/tests/suite/virtual_branches/cherry_pick.rs
+++ b/gitbutler-app/tests/suite/virtual_branches/cherry_pick.rs
@@ -11,22 +11,22 @@ mod cleanly {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         let branch_id = controller
-            .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+            .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
             .await
             .unwrap();
 
         let commit_one = {
             fs::write(repository.path().join("file.txt"), "content").unwrap();
             controller
-                .create_commit(&project_id, &branch_id, "commit", None, false)
+                .create_commit(project_id, &branch_id, "commit", None, false)
                 .await
                 .unwrap()
         };
@@ -34,18 +34,18 @@ mod cleanly {
         let commit_two = {
             fs::write(repository.path().join("file.txt"), "content two").unwrap();
             controller
-                .create_commit(&project_id, &branch_id, "commit", None, false)
+                .create_commit(project_id, &branch_id, "commit", None, false)
                 .await
                 .unwrap()
         };
 
         controller
-            .push_virtual_branch(&project_id, &branch_id, false, None)
+            .push_virtual_branch(project_id, &branch_id, false, None)
             .await
             .unwrap();
 
         controller
-            .reset_virtual_branch(&project_id, &branch_id, commit_one)
+            .reset_virtual_branch(project_id, &branch_id, commit_one)
             .await
             .unwrap();
 
@@ -57,7 +57,7 @@ mod cleanly {
         );
 
         let cherry_picked_commit_oid = controller
-            .cherry_pick(&project_id, &branch_id, commit_two)
+            .cherry_pick(project_id, &branch_id, commit_two)
             .await
             .unwrap();
         assert!(cherry_picked_commit_oid.is_some());
@@ -67,7 +67,7 @@ mod cleanly {
             "content two"
         );
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
         assert_eq!(branches[0].id, branch_id);
         assert!(branches[0].active);
@@ -83,22 +83,22 @@ mod cleanly {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         let branch_id = controller
-            .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+            .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
             .await
             .unwrap();
 
         let commit_one = {
             fs::write(repository.path().join("file.txt"), "content").unwrap();
             controller
-                .create_commit(&project_id, &branch_id, "commit", None, false)
+                .create_commit(project_id, &branch_id, "commit", None, false)
                 .await
                 .unwrap()
         };
@@ -106,18 +106,18 @@ mod cleanly {
         let commit_two = {
             fs::write(repository.path().join("file_two.txt"), "content two").unwrap();
             controller
-                .create_commit(&project_id, &branch_id, "commit", None, false)
+                .create_commit(project_id, &branch_id, "commit", None, false)
                 .await
                 .unwrap()
         };
 
         controller
-            .push_virtual_branch(&project_id, &branch_id, false, None)
+            .push_virtual_branch(project_id, &branch_id, false, None)
             .await
             .unwrap();
 
         controller
-            .reset_virtual_branch(&project_id, &branch_id, commit_one)
+            .reset_virtual_branch(project_id, &branch_id, commit_one)
             .await
             .unwrap();
 
@@ -130,17 +130,17 @@ mod cleanly {
         assert!(!repository.path().join("file_two.txt").exists());
 
         let branch_two_id = controller
-            .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+            .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
             .await
             .unwrap();
 
         let cherry_picked_commit_oid = controller
-            .cherry_pick(&project_id, &branch_two_id, commit_two)
+            .cherry_pick(project_id, &branch_two_id, commit_two)
             .await
             .unwrap();
         assert!(cherry_picked_commit_oid.is_some());
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert!(repository.path().join("file_two.txt").exists());
         assert_eq!(
             fs::read_to_string(repository.path().join("file_two.txt")).unwrap(),
@@ -166,22 +166,22 @@ mod cleanly {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         let branch_id = controller
-            .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+            .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
             .await
             .unwrap();
 
         let commit_one_oid = {
             fs::write(repository.path().join("file.txt"), "content").unwrap();
             controller
-                .create_commit(&project_id, &branch_id, "commit", None, false)
+                .create_commit(project_id, &branch_id, "commit", None, false)
                 .await
                 .unwrap()
         };
@@ -189,7 +189,7 @@ mod cleanly {
         {
             fs::write(repository.path().join("file_two.txt"), "content two").unwrap();
             controller
-                .create_commit(&project_id, &branch_id, "commit", None, false)
+                .create_commit(project_id, &branch_id, "commit", None, false)
                 .await
                 .unwrap()
         };
@@ -197,24 +197,24 @@ mod cleanly {
         let commit_three_oid = {
             fs::write(repository.path().join("file_three.txt"), "content three").unwrap();
             controller
-                .create_commit(&project_id, &branch_id, "commit", None, false)
+                .create_commit(project_id, &branch_id, "commit", None, false)
                 .await
                 .unwrap()
         };
 
         controller
-            .reset_virtual_branch(&project_id, &branch_id, commit_one_oid)
+            .reset_virtual_branch(project_id, &branch_id, commit_one_oid)
             .await
             .unwrap();
 
         controller
-            .unapply_virtual_branch(&project_id, &branch_id)
+            .unapply_virtual_branch(project_id, &branch_id)
             .await
             .unwrap();
 
         assert!(matches!(
             controller
-                .cherry_pick(&project_id, &branch_id, commit_three_oid)
+                .cherry_pick(project_id, &branch_id, commit_three_oid)
                 .await,
             Err(ControllerError::Action(errors::CherryPickError::NotApplied))
         ));
@@ -232,22 +232,22 @@ mod with_conflicts {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         let branch_id = controller
-            .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+            .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
             .await
             .unwrap();
 
         let commit_one = {
             fs::write(repository.path().join("file.txt"), "content").unwrap();
             controller
-                .create_commit(&project_id, &branch_id, "commit one", None, false)
+                .create_commit(project_id, &branch_id, "commit one", None, false)
                 .await
                 .unwrap()
         };
@@ -255,7 +255,7 @@ mod with_conflicts {
         {
             fs::write(repository.path().join("file_two.txt"), "content two").unwrap();
             controller
-                .create_commit(&project_id, &branch_id, "commit two", None, false)
+                .create_commit(project_id, &branch_id, "commit two", None, false)
                 .await
                 .unwrap()
         };
@@ -263,18 +263,18 @@ mod with_conflicts {
         let commit_three = {
             fs::write(repository.path().join("file_three.txt"), "content three").unwrap();
             controller
-                .create_commit(&project_id, &branch_id, "commit three", None, false)
+                .create_commit(project_id, &branch_id, "commit three", None, false)
                 .await
                 .unwrap()
         };
 
         controller
-            .push_virtual_branch(&project_id, &branch_id, false, None)
+            .push_virtual_branch(project_id, &branch_id, false, None)
             .await
             .unwrap();
 
         controller
-            .reset_virtual_branch(&project_id, &branch_id, commit_one)
+            .reset_virtual_branch(project_id, &branch_id, commit_one)
             .await
             .unwrap();
 
@@ -292,7 +292,7 @@ mod with_conflicts {
         {
             // cherry picking leads to conflict
             let cherry_picked_commit_oid = controller
-                .cherry_pick(&project_id, &branch_id, commit_three)
+                .cherry_pick(project_id, &branch_id, commit_three)
                 .await
                 .unwrap();
             assert!(cherry_picked_commit_oid.is_none());
@@ -302,7 +302,7 @@ mod with_conflicts {
                 "<<<<<<< ours\nconflict\n=======\ncontent three\n>>>>>>> theirs\n"
             );
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(branches[0].active);
@@ -316,14 +316,14 @@ mod with_conflicts {
             // conflict can be resolved
             fs::write(repository.path().join("file_three.txt"), "resolved").unwrap();
             let commited_oid = controller
-                .create_commit(&project_id, &branch_id, "resolution", None, false)
+                .create_commit(project_id, &branch_id, "resolution", None, false)
                 .await
                 .unwrap();
 
             let commit = repository.find_commit(commited_oid).unwrap();
             assert_eq!(commit.parent_count(), 2);
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(branches[0].active);
@@ -343,7 +343,7 @@ mod with_conflicts {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         let commit_oid = {
             let first = repository.commit_all("commit");
@@ -355,12 +355,12 @@ mod with_conflicts {
         };
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         let branch_id = controller
-            .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+            .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
             .await
             .unwrap();
 
@@ -368,13 +368,13 @@ mod with_conflicts {
         fs::write(repository.path().join("file.txt"), "conflict").unwrap();
 
         controller
-            .unapply_virtual_branch(&project_id, &branch_id)
+            .unapply_virtual_branch(project_id, &branch_id)
             .await
             .unwrap();
 
         assert!(matches!(
             controller
-                .cherry_pick(&project_id, &branch_id, commit_oid)
+                .cherry_pick(project_id, &branch_id, commit_oid)
                 .await,
             Err(ControllerError::Action(errors::CherryPickError::NotApplied))
         ));

--- a/gitbutler-app/tests/suite/virtual_branches/create_commit.rs
+++ b/gitbutler-app/tests/suite/virtual_branches/create_commit.rs
@@ -7,15 +7,15 @@ async fn should_lock_updated_hunks() {
         controller,
         repository,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
@@ -25,7 +25,7 @@ async fn should_lock_updated_hunks() {
         fs::write(repository.path().join("file.txt"), "content").unwrap();
 
         let branch = controller
-            .list_virtual_branches(&project_id)
+            .list_virtual_branches(project_id)
             .await
             .unwrap()
             .0
@@ -39,7 +39,7 @@ async fn should_lock_updated_hunks() {
     }
 
     controller
-        .create_commit(&project_id, &branch_id, "test", None, false)
+        .create_commit(project_id, &branch_id, "test", None, false)
         .await
         .unwrap();
 
@@ -48,7 +48,7 @@ async fn should_lock_updated_hunks() {
         fs::write(repository.path().join("file.txt"), "updated content").unwrap();
 
         let branch = controller
-            .list_virtual_branches(&project_id)
+            .list_virtual_branches(project_id)
             .await
             .unwrap()
             .0
@@ -69,7 +69,7 @@ async fn should_not_lock_disjointed_hunks() {
         controller,
         repository,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     let mut lines: Vec<_> = (0_i32..24_i32).map(|i| format!("line {}", i)).collect();
     fs::write(repository.path().join("file.txt"), lines.clone().join("\n")).unwrap();
@@ -77,12 +77,12 @@ async fn should_not_lock_disjointed_hunks() {
     repository.push();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
@@ -91,7 +91,7 @@ async fn should_not_lock_disjointed_hunks() {
         lines[12] = "commited stuff".to_string();
         fs::write(repository.path().join("file.txt"), lines.clone().join("\n")).unwrap();
         let branch = controller
-            .list_virtual_branches(&project_id)
+            .list_virtual_branches(project_id)
             .await
             .unwrap()
             .0
@@ -105,11 +105,11 @@ async fn should_not_lock_disjointed_hunks() {
     }
 
     controller
-        .create_commit(&project_id, &branch_id, "test commit", None, false)
+        .create_commit(project_id, &branch_id, "test commit", None, false)
         .await
         .unwrap();
     controller
-        .push_virtual_branch(&project_id, &branch_id, false, None)
+        .push_virtual_branch(project_id, &branch_id, false, None)
         .await
         .unwrap();
 
@@ -119,7 +119,7 @@ async fn should_not_lock_disjointed_hunks() {
         changed_lines[0] = "updated line".to_string();
         fs::write(repository.path().join("file.txt"), changed_lines.join("\n")).unwrap();
         let branch = controller
-            .list_virtual_branches(&project_id)
+            .list_virtual_branches(project_id)
             .await
             .unwrap()
             .0
@@ -139,7 +139,7 @@ async fn should_not_lock_disjointed_hunks() {
         changed_lines[23] = "updated line".to_string();
         fs::write(repository.path().join("file.txt"), changed_lines.join("\n")).unwrap();
         let branch = controller
-            .list_virtual_branches(&project_id)
+            .list_virtual_branches(project_id)
             .await
             .unwrap()
             .0
@@ -159,7 +159,7 @@ async fn should_not_lock_disjointed_hunks() {
         changed_lines[10] = "updated line".to_string();
         fs::write(repository.path().join("file.txt"), changed_lines.join("\n")).unwrap();
         let branch = controller
-            .list_virtual_branches(&project_id)
+            .list_virtual_branches(project_id)
             .await
             .unwrap()
             .0
@@ -180,7 +180,7 @@ async fn should_not_lock_disjointed_hunks() {
         changed_lines[14] = "updated line".to_string();
         fs::write(repository.path().join("file.txt"), changed_lines.join("\n")).unwrap();
         let branch = controller
-            .list_virtual_branches(&project_id)
+            .list_virtual_branches(project_id)
             .await
             .unwrap()
             .0

--- a/gitbutler-app/tests/suite/virtual_branches/create_virtual_branch_from_branch.rs
+++ b/gitbutler-app/tests/suite/virtual_branches/create_virtual_branch_from_branch.rs
@@ -7,10 +7,10 @@ async fn integration() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
@@ -18,22 +18,22 @@ async fn integration() {
         // make a remote branch
 
         let branch_id = controller
-            .create_virtual_branch(&project_id, &super::branch::BranchCreateRequest::default())
+            .create_virtual_branch(project_id, &super::branch::BranchCreateRequest::default())
             .await
             .unwrap();
 
         std::fs::write(repository.path().join("file.txt"), "first\n").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "first", None, false)
+            .create_commit(project_id, &branch_id, "first", None, false)
             .await
             .unwrap();
         controller
-            .push_virtual_branch(&project_id, &branch_id, false, None)
+            .push_virtual_branch(project_id, &branch_id, false, None)
             .await
             .unwrap();
 
         let branch = controller
-            .list_virtual_branches(&project_id)
+            .list_virtual_branches(project_id)
             .await
             .unwrap()
             .0
@@ -44,7 +44,7 @@ async fn integration() {
         let name = branch.upstream.unwrap().name;
 
         controller
-            .delete_virtual_branch(&project_id, &branch_id)
+            .delete_virtual_branch(project_id, &branch_id)
             .await
             .unwrap();
 
@@ -53,7 +53,7 @@ async fn integration() {
 
     // checkout a existing remote branch
     let branch_id = controller
-        .create_virtual_branch_from_branch(&project_id, &branch_name)
+        .create_virtual_branch_from_branch(project_id, &branch_name)
         .await
         .unwrap();
 
@@ -62,7 +62,7 @@ async fn integration() {
         std::fs::write(repository.path().join("file.txt"), "first\nsecond").unwrap();
 
         controller
-            .create_commit(&project_id, &branch_id, "second", None, false)
+            .create_commit(project_id, &branch_id, "second", None, false)
             .await
             .unwrap();
     }
@@ -79,12 +79,12 @@ async fn integration() {
     {
         // merge branch into master
         controller
-            .push_virtual_branch(&project_id, &branch_id, false, None)
+            .push_virtual_branch(project_id, &branch_id, false, None)
             .await
             .unwrap();
 
         let branch = controller
-            .list_virtual_branches(&project_id)
+            .list_virtual_branches(project_id)
             .await
             .unwrap()
             .0
@@ -103,12 +103,12 @@ async fn integration() {
     {
         // should mark commits as integrated
         controller
-            .fetch_from_target(&project_id, None)
+            .fetch_from_target(project_id, None)
             .await
             .unwrap();
 
         let branch = controller
-            .list_virtual_branches(&project_id)
+            .list_virtual_branches(project_id)
             .await
             .unwrap()
             .0
@@ -130,7 +130,7 @@ async fn no_conflicts() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     {
         // create a remote branch
@@ -143,22 +143,22 @@ async fn no_conflicts() {
     }
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
     assert!(branches.is_empty());
 
     let branch_id = controller
         .create_virtual_branch_from_branch(
-            &project_id,
+            project_id,
             &"refs/remotes/origin/branch".parse().unwrap(),
         )
         .await
         .unwrap();
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
     assert_eq!(branches.len(), 1);
     assert_eq!(branches[0].id, branch_id);
     assert_eq!(branches[0].commits.len(), 1);
@@ -172,7 +172,7 @@ async fn conflicts_with_uncommited() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     {
         // create a remote branch
@@ -185,7 +185,7 @@ async fn conflicts_with_uncommited() {
     }
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
@@ -193,7 +193,7 @@ async fn conflicts_with_uncommited() {
     {
         std::fs::write(repository.path().join("file.txt"), "conflict").unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
     };
 
@@ -201,13 +201,13 @@ async fn conflicts_with_uncommited() {
 
     let new_branch_id = controller
         .create_virtual_branch_from_branch(
-            &project_id,
+            project_id,
             &"refs/remotes/origin/branch".parse().unwrap(),
         )
         .await
         .unwrap();
     let new_branch = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -226,7 +226,7 @@ async fn conflicts_with_commited() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     {
         // create a remote branch
@@ -239,7 +239,7 @@ async fn conflicts_with_commited() {
     }
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
@@ -247,11 +247,11 @@ async fn conflicts_with_commited() {
     {
         std::fs::write(repository.path().join("file.txt"), "conflict").unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
 
         controller
-            .create_commit(&project_id, &branches[0].id, "hej", None, false)
+            .create_commit(project_id, &branches[0].id, "hej", None, false)
             .await
             .unwrap();
     };
@@ -260,13 +260,13 @@ async fn conflicts_with_commited() {
 
     let new_branch_id = controller
         .create_virtual_branch_from_branch(
-            &project_id,
+            project_id,
             &"refs/remotes/origin/branch".parse().unwrap(),
         )
         .await
         .unwrap();
     let new_branch = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -284,10 +284,10 @@ async fn from_default_target() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
@@ -296,7 +296,7 @@ async fn from_default_target() {
     assert!(matches!(
         controller
             .create_virtual_branch_from_branch(
-                &project_id,
+                project_id,
                 &"refs/remotes/origin/master".parse().unwrap(),
             )
             .await
@@ -313,10 +313,10 @@ async fn from_non_existent_branch() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
@@ -325,7 +325,7 @@ async fn from_non_existent_branch() {
     assert!(matches!(
         controller
             .create_virtual_branch_from_branch(
-                &project_id,
+                project_id,
                 &"refs/remotes/origin/branch".parse().unwrap(),
             )
             .await
@@ -343,7 +343,7 @@ async fn from_state_remote_branch() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     {
         // create a remote branch
@@ -361,19 +361,19 @@ async fn from_state_remote_branch() {
     }
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch_id = controller
         .create_virtual_branch_from_branch(
-            &project_id,
+            project_id,
             &"refs/remotes/origin/branch".parse().unwrap(),
         )
         .await
         .unwrap();
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
     assert_eq!(branches.len(), 1);
     assert_eq!(branches[0].id, branch_id);
     assert_eq!(branches[0].commits.len(), 1);

--- a/gitbutler-app/tests/suite/virtual_branches/delete_virtual_branch.rs
+++ b/gitbutler-app/tests/suite/virtual_branches/delete_virtual_branch.rs
@@ -7,24 +7,24 @@ async fn should_unapply_diff() {
         controller,
         repository,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     // write some
     std::fs::write(repository.path().join("file.txt"), "content").unwrap();
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
 
     controller
-        .delete_virtual_branch(&project_id, &branches[0].id)
+        .delete_virtual_branch(project_id, &branches[0].id)
         .await
         .unwrap();
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
     assert_eq!(branches.len(), 0);
     assert!(!repository.path().join("file.txt").exists());
 
@@ -43,16 +43,16 @@ async fn should_remove_reference() {
         controller,
         repository,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let id = controller
         .create_virtual_branch(
-            &project_id,
+            project_id,
             &branch::BranchCreateRequest {
                 name: Some("name".to_string()),
                 ..Default::default()
@@ -62,11 +62,11 @@ async fn should_remove_reference() {
         .unwrap();
 
     controller
-        .delete_virtual_branch(&project_id, &id)
+        .delete_virtual_branch(project_id, &id)
         .await
         .unwrap();
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
     assert_eq!(branches.len(), 0);
 
     let refnames = repository

--- a/gitbutler-app/tests/suite/virtual_branches/fetch_from_target.rs
+++ b/gitbutler-app/tests/suite/virtual_branches/fetch_from_target.rs
@@ -6,34 +6,34 @@ async fn should_update_last_fetched() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
-    let before_fetch = controller.get_base_branch_data(&project_id).await.unwrap();
+    let before_fetch = controller.get_base_branch_data(project_id).await.unwrap();
     assert!(before_fetch.unwrap().last_fetched_ms.is_none());
 
     let fetch = controller
-        .fetch_from_target(&project_id, None)
+        .fetch_from_target(project_id, None)
         .await
         .unwrap();
     assert!(fetch.last_fetched_ms.is_some());
 
-    let after_fetch = controller.get_base_branch_data(&project_id).await.unwrap();
+    let after_fetch = controller.get_base_branch_data(project_id).await.unwrap();
     assert!(after_fetch.as_ref().unwrap().last_fetched_ms.is_some());
     assert_eq!(fetch.last_fetched_ms, after_fetch.unwrap().last_fetched_ms);
 
     let second_fetch = controller
-        .fetch_from_target(&project_id, None)
+        .fetch_from_target(project_id, None)
         .await
         .unwrap();
     assert!(second_fetch.last_fetched_ms.is_some());
     assert_ne!(fetch.last_fetched_ms, second_fetch.last_fetched_ms);
 
-    let after_second_fetch = controller.get_base_branch_data(&project_id).await.unwrap();
+    let after_second_fetch = controller.get_base_branch_data(project_id).await.unwrap();
     assert!(after_second_fetch
         .as_ref()
         .unwrap()

--- a/gitbutler-app/tests/suite/virtual_branches/mod.rs
+++ b/gitbutler-app/tests/suite/virtual_branches/mod.rs
@@ -1,4 +1,5 @@
 use std::{fs, path, str::FromStr};
+use tempfile::TempDir;
 
 use crate::common::{paths, TestProject};
 use gitbutler_app::{
@@ -13,6 +14,7 @@ struct Test {
     project_id: ProjectId,
     projects: projects::Controller,
     controller: Controller,
+    _data_dir: TempDir,
 }
 
 impl Default for Test {
@@ -31,8 +33,15 @@ impl Default for Test {
         Self {
             repository: test_project,
             project_id: project.id,
-            controller: Controller::new(data_dir, projects.clone(), users, keys, helper),
+            controller: Controller::new(
+                data_dir.path().into(),
+                projects.clone(),
+                users,
+                keys,
+                helper,
+            ),
             projects,
+            _data_dir: data_dir,
         }
     }
 }
@@ -64,7 +73,7 @@ async fn resolve_conflict_flow() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     // make sure we have an undiscovered commit in the remote branch
     {
@@ -77,19 +86,19 @@ async fn resolve_conflict_flow() {
     }
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch1_id = {
         // make a branch that conflicts with the remote branch, but doesn't know about it yet
         let branch1_id = controller
-            .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+            .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
             .await
             .unwrap();
         fs::write(repository.path().join("file.txt"), "conflict").unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
         assert_eq!(branches[0].id, branch1_id);
         assert!(branches[0].active);
@@ -99,10 +108,10 @@ async fn resolve_conflict_flow() {
 
     {
         // fetch remote
-        controller.update_base_branch(&project_id).await.unwrap();
+        controller.update_base_branch(project_id).await.unwrap();
 
         // there is a conflict now, so the branch should be inactive
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
         assert_eq!(branches[0].id, branch1_id);
         assert!(!branches[0].active);
@@ -111,11 +120,11 @@ async fn resolve_conflict_flow() {
     {
         // when we apply conflicted branch, it has conflict
         controller
-            .apply_virtual_branch(&project_id, &branch1_id)
+            .apply_virtual_branch(project_id, &branch1_id)
             .await
             .unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
         assert_eq!(branches[0].id, branch1_id);
         assert!(branches[0].active);
@@ -132,7 +141,7 @@ async fn resolve_conflict_flow() {
         // can't commit conflicts
         assert!(matches!(
             controller
-                .create_commit(&project_id, &branch1_id, "commit conflicts", None, false)
+                .create_commit(project_id, &branch1_id, "commit conflicts", None, false)
                 .await,
             Err(ControllerError::Action(errors::CommitError::Conflicted(_)))
         ));
@@ -142,14 +151,14 @@ async fn resolve_conflict_flow() {
         // fixing the conflict removes conflicted mark
         fs::write(repository.path().join("file.txt"), "resolved").unwrap();
         let commit_oid = controller
-            .create_commit(&project_id, &branch1_id, "resolution", None, false)
+            .create_commit(project_id, &branch1_id, "resolution", None, false)
             .await
             .unwrap();
 
         let commit = repository.find_commit(commit_oid).unwrap();
         assert_eq!(commit.parent_count(), 2);
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
         assert_eq!(branches[0].id, branch1_id);
         assert!(branches[0].active);

--- a/gitbutler-app/tests/suite/virtual_branches/mod.rs
+++ b/gitbutler-app/tests/suite/virtual_branches/mod.rs
@@ -2,6 +2,7 @@ use std::{fs, path, str::FromStr};
 use tempfile::TempDir;
 
 use crate::common::{paths, TestProject};
+use crate::VAR_NO_CLEANUP;
 use gitbutler_app::{
     git, keys,
     projects::{self, ProjectId},
@@ -14,7 +15,15 @@ struct Test {
     project_id: ProjectId,
     projects: projects::Controller,
     controller: Controller,
-    _data_dir: TempDir,
+    data_dir: Option<TempDir>,
+}
+
+impl Drop for Test {
+    fn drop(&mut self) {
+        if std::env::var_os(VAR_NO_CLEANUP).is_some() {
+            let _ = self.data_dir.take().unwrap().into_path();
+        }
+    }
 }
 
 impl Default for Test {
@@ -41,7 +50,7 @@ impl Default for Test {
                 helper,
             ),
             projects,
-            _data_dir: data_dir,
+            data_dir: Some(data_dir),
         }
     }
 }

--- a/gitbutler-app/tests/suite/virtual_branches/move_commit_to_vbranch.rs
+++ b/gitbutler-app/tests/suite/virtual_branches/move_commit_to_vbranch.rs
@@ -11,37 +11,37 @@ async fn no_diffs() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     std::fs::write(repository.path().join("file.txt"), "content").unwrap();
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
     assert_eq!(branches.len(), 1);
 
     let source_branch_id = branches[0].id;
 
     let commit_oid = controller
-        .create_commit(&project_id, &source_branch_id, "commit", None, false)
+        .create_commit(project_id, &source_branch_id, "commit", None, false)
         .await
         .unwrap();
 
     let target_branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
     controller
-        .move_commit(&project_id, &target_branch_id, commit_oid)
+        .move_commit(project_id, &target_branch_id, commit_oid)
         .await
         .unwrap();
 
     let destination_branch = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -50,7 +50,7 @@ async fn no_diffs() {
         .unwrap();
 
     let source_branch = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -71,22 +71,22 @@ async fn diffs_on_source_branch() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     std::fs::write(repository.path().join("file.txt"), "content").unwrap();
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
     assert_eq!(branches.len(), 1);
 
     let source_branch_id = branches[0].id;
 
     let commit_oid = controller
-        .create_commit(&project_id, &source_branch_id, "commit", None, false)
+        .create_commit(project_id, &source_branch_id, "commit", None, false)
         .await
         .unwrap();
 
@@ -97,17 +97,17 @@ async fn diffs_on_source_branch() {
     .unwrap();
 
     let target_branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
     controller
-        .move_commit(&project_id, &target_branch_id, commit_oid)
+        .move_commit(project_id, &target_branch_id, commit_oid)
         .await
         .unwrap();
 
     let destination_branch = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -116,7 +116,7 @@ async fn diffs_on_source_branch() {
         .unwrap();
 
     let source_branch = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -137,28 +137,28 @@ async fn diffs_on_target_branch() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     std::fs::write(repository.path().join("file.txt"), "content").unwrap();
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
     assert_eq!(branches.len(), 1);
 
     let source_branch_id = branches[0].id;
 
     let commit_oid = controller
-        .create_commit(&project_id, &source_branch_id, "commit", None, false)
+        .create_commit(project_id, &source_branch_id, "commit", None, false)
         .await
         .unwrap();
 
     let target_branch_id = controller
         .create_virtual_branch(
-            &project_id,
+            project_id,
             &branch::BranchCreateRequest {
                 selected_for_changes: Some(true),
                 ..Default::default()
@@ -174,12 +174,12 @@ async fn diffs_on_target_branch() {
     .unwrap();
 
     controller
-        .move_commit(&project_id, &target_branch_id, commit_oid)
+        .move_commit(project_id, &target_branch_id, commit_oid)
         .await
         .unwrap();
 
     let destination_branch = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -188,7 +188,7 @@ async fn diffs_on_target_branch() {
         .unwrap();
 
     let source_branch = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -209,35 +209,35 @@ async fn locked_hunks_on_source_branch() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     std::fs::write(repository.path().join("file.txt"), "content").unwrap();
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
     assert_eq!(branches.len(), 1);
 
     let source_branch_id = branches[0].id;
 
     let commit_oid = controller
-        .create_commit(&project_id, &source_branch_id, "commit", None, false)
+        .create_commit(project_id, &source_branch_id, "commit", None, false)
         .await
         .unwrap();
 
     std::fs::write(repository.path().join("file.txt"), "locked content").unwrap();
 
     let target_branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
     assert!(matches!(
         controller
-            .move_commit(&project_id, &target_branch_id, commit_oid)
+            .move_commit(project_id, &target_branch_id, commit_oid)
             .await
             .unwrap_err(),
         ControllerError::Action(errors::MoveCommitError::SourceLocked)
@@ -251,34 +251,34 @@ async fn no_commit() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     std::fs::write(repository.path().join("file.txt"), "content").unwrap();
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
     assert_eq!(branches.len(), 1);
 
     let source_branch_id = branches[0].id;
 
     controller
-        .create_commit(&project_id, &source_branch_id, "commit", None, false)
+        .create_commit(project_id, &source_branch_id, "commit", None, false)
         .await
         .unwrap();
 
     let target_branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
     assert!(matches!(
         controller
             .move_commit(
-                &project_id,
+                project_id,
                 &target_branch_id,
                 git::Oid::from_str("a99c95cca7a60f1a2180c2f86fb18af97333c192").unwrap()
             )
@@ -295,28 +295,28 @@ async fn no_branch() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     std::fs::write(repository.path().join("file.txt"), "content").unwrap();
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
     assert_eq!(branches.len(), 1);
 
     let source_branch_id = branches[0].id;
 
     let commit_oid = controller
-        .create_commit(&project_id, &source_branch_id, "commit", None, false)
+        .create_commit(project_id, &source_branch_id, "commit", None, false)
         .await
         .unwrap();
 
     assert!(matches!(
         controller
-            .move_commit(&project_id, &BranchId::generate(), commit_oid)
+            .move_commit(project_id, &BranchId::generate(), commit_oid)
             .await
             .unwrap_err(),
         ControllerError::Action(errors::MoveCommitError::BranchNotFound(_))

--- a/gitbutler-app/tests/suite/virtual_branches/references.rs
+++ b/gitbutler-app/tests/suite/virtual_branches/references.rs
@@ -10,19 +10,19 @@ mod create_virtual_branch {
             controller,
             repository,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         let branch_id = controller
-            .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+            .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
             .await
             .unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
         assert_eq!(branches[0].id, branch_id);
         assert_eq!(branches[0].name, "Virtual branch");
@@ -42,16 +42,16 @@ mod create_virtual_branch {
             controller,
             repository,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         let branch1_id = controller
             .create_virtual_branch(
-                &project_id,
+                project_id,
                 &gitbutler_app::virtual_branches::branch::BranchCreateRequest {
                     name: Some("name".to_string()),
                     ..Default::default()
@@ -62,7 +62,7 @@ mod create_virtual_branch {
 
         let branch2_id = controller
             .create_virtual_branch(
-                &project_id,
+                project_id,
                 &gitbutler_app::virtual_branches::branch::BranchCreateRequest {
                     name: Some("name".to_string()),
                     ..Default::default()
@@ -71,7 +71,7 @@ mod create_virtual_branch {
             .await
             .unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 2);
         assert_eq!(branches[0].id, branch1_id);
         assert_eq!(branches[0].name, "name");
@@ -98,16 +98,16 @@ mod update_virtual_branch {
             controller,
             repository,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         let branch_id = controller
             .create_virtual_branch(
-                &project_id,
+                project_id,
                 &branch::BranchCreateRequest {
                     name: Some("name".to_string()),
                     ..Default::default()
@@ -118,7 +118,7 @@ mod update_virtual_branch {
 
         controller
             .update_virtual_branch(
-                &project_id,
+                project_id,
                 branch::BranchUpdateRequest {
                     id: branch_id,
                     name: Some("new name".to_string()),
@@ -128,7 +128,7 @@ mod update_virtual_branch {
             .await
             .unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
         assert_eq!(branches[0].id, branch_id);
         assert_eq!(branches[0].name, "new name");
@@ -149,16 +149,16 @@ mod update_virtual_branch {
             controller,
             repository,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         let branch1_id = controller
             .create_virtual_branch(
-                &project_id,
+                project_id,
                 &branch::BranchCreateRequest {
                     name: Some("name".to_string()),
                     ..Default::default()
@@ -169,7 +169,7 @@ mod update_virtual_branch {
 
         let branch2_id = controller
             .create_virtual_branch(
-                &project_id,
+                project_id,
                 &branch::BranchCreateRequest {
                     ..Default::default()
                 },
@@ -179,7 +179,7 @@ mod update_virtual_branch {
 
         controller
             .update_virtual_branch(
-                &project_id,
+                project_id,
                 branch::BranchUpdateRequest {
                     id: branch2_id,
                     name: Some("name".to_string()),
@@ -189,7 +189,7 @@ mod update_virtual_branch {
             .await
             .unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 2);
         assert_eq!(branches[0].id, branch1_id);
         assert_eq!(branches[0].name, "name");
@@ -217,16 +217,16 @@ mod push_virtual_branch {
             controller,
             repository,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         let branch1_id = controller
             .create_virtual_branch(
-                &project_id,
+                project_id,
                 &branch::BranchCreateRequest {
                     name: Some("name".to_string()),
                     ..Default::default()
@@ -238,15 +238,15 @@ mod push_virtual_branch {
         fs::write(repository.path().join("file.txt"), "content").unwrap();
 
         controller
-            .create_commit(&project_id, &branch1_id, "test", None, false)
+            .create_commit(project_id, &branch1_id, "test", None, false)
             .await
             .unwrap();
         controller
-            .push_virtual_branch(&project_id, &branch1_id, false, None)
+            .push_virtual_branch(project_id, &branch1_id, false, None)
             .await
             .unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
         assert_eq!(branches[0].id, branch1_id);
         assert_eq!(branches[0].name, "name");
@@ -270,10 +270,10 @@ mod push_virtual_branch {
             controller,
             repository,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
@@ -281,7 +281,7 @@ mod push_virtual_branch {
             // create and push branch with some work
             let branch1_id = controller
                 .create_virtual_branch(
-                    &project_id,
+                    project_id,
                     &branch::BranchCreateRequest {
                         name: Some("name".to_string()),
                         ..Default::default()
@@ -291,11 +291,11 @@ mod push_virtual_branch {
                 .unwrap();
             fs::write(repository.path().join("file.txt"), "content").unwrap();
             controller
-                .create_commit(&project_id, &branch1_id, "test", None, false)
+                .create_commit(project_id, &branch1_id, "test", None, false)
                 .await
                 .unwrap();
             controller
-                .push_virtual_branch(&project_id, &branch1_id, false, None)
+                .push_virtual_branch(project_id, &branch1_id, false, None)
                 .await
                 .unwrap();
             branch1_id
@@ -304,7 +304,7 @@ mod push_virtual_branch {
         // rename first branch
         controller
             .update_virtual_branch(
-                &project_id,
+                project_id,
                 branch::BranchUpdateRequest {
                     id: branch1_id,
                     name: Some("updated name".to_string()),
@@ -318,7 +318,7 @@ mod push_virtual_branch {
             // create another branch with first branch's old name and push it
             let branch2_id = controller
                 .create_virtual_branch(
-                    &project_id,
+                    project_id,
                     &branch::BranchCreateRequest {
                         name: Some("name".to_string()),
                         ..Default::default()
@@ -328,17 +328,17 @@ mod push_virtual_branch {
                 .unwrap();
             fs::write(repository.path().join("file.txt"), "updated content").unwrap();
             controller
-                .create_commit(&project_id, &branch2_id, "test", None, false)
+                .create_commit(project_id, &branch2_id, "test", None, false)
                 .await
                 .unwrap();
             controller
-                .push_virtual_branch(&project_id, &branch2_id, false, None)
+                .push_virtual_branch(project_id, &branch2_id, false, None)
                 .await
                 .unwrap();
             branch2_id
         };
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 2);
         // first branch is pushing to old ref remotely
         assert_eq!(branches[0].id, branch1_id);

--- a/gitbutler-app/tests/suite/virtual_branches/reset_virtual_branch.rs
+++ b/gitbutler-app/tests/suite/virtual_branches/reset_virtual_branch.rs
@@ -11,15 +11,15 @@ async fn to_head() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch1_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
@@ -28,11 +28,11 @@ async fn to_head() {
 
         // commit changes
         let oid = controller
-            .create_commit(&project_id, &branch1_id, "commit", None, false)
+            .create_commit(project_id, &branch1_id, "commit", None, false)
             .await
             .unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
         assert_eq!(branches[0].id, branch1_id);
         assert_eq!(branches[0].commits.len(), 1);
@@ -49,11 +49,11 @@ async fn to_head() {
     {
         // reset changes to head
         controller
-            .reset_virtual_branch(&project_id, &branch1_id, oid)
+            .reset_virtual_branch(project_id, &branch1_id, oid)
             .await
             .unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
         assert_eq!(branches[0].id, branch1_id);
         assert_eq!(branches[0].commits.len(), 1);
@@ -73,15 +73,15 @@ async fn to_target() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     let base_branch = controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch1_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
@@ -90,11 +90,11 @@ async fn to_target() {
 
         // commit changes
         let oid = controller
-            .create_commit(&project_id, &branch1_id, "commit", None, false)
+            .create_commit(project_id, &branch1_id, "commit", None, false)
             .await
             .unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
         assert_eq!(branches[0].id, branch1_id);
         assert_eq!(branches[0].commits.len(), 1);
@@ -109,11 +109,11 @@ async fn to_target() {
     {
         // reset changes to head
         controller
-            .reset_virtual_branch(&project_id, &branch1_id, base_branch.base_sha)
+            .reset_virtual_branch(project_id, &branch1_id, base_branch.base_sha)
             .await
             .unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
         assert_eq!(branches[0].id, branch1_id);
         assert_eq!(branches[0].commits.len(), 0);
@@ -132,15 +132,15 @@ async fn to_commit() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch1_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
@@ -150,11 +150,11 @@ async fn to_commit() {
         fs::write(repository.path().join("file.txt"), "content").unwrap();
 
         let oid = controller
-            .create_commit(&project_id, &branch1_id, "commit", None, false)
+            .create_commit(project_id, &branch1_id, "commit", None, false)
             .await
             .unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
         assert_eq!(branches[0].id, branch1_id);
         assert_eq!(branches[0].commits.len(), 1);
@@ -173,11 +173,11 @@ async fn to_commit() {
         fs::write(repository.path().join("file.txt"), "more content").unwrap();
 
         let second_commit_oid = controller
-            .create_commit(&project_id, &branch1_id, "commit", None, false)
+            .create_commit(project_id, &branch1_id, "commit", None, false)
             .await
             .unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
         assert_eq!(branches[0].id, branch1_id);
         assert_eq!(branches[0].commits.len(), 2);
@@ -193,11 +193,11 @@ async fn to_commit() {
     {
         // reset changes to the first commit
         controller
-            .reset_virtual_branch(&project_id, &branch1_id, first_commit_oid)
+            .reset_virtual_branch(project_id, &branch1_id, first_commit_oid)
             .await
             .unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
         assert_eq!(branches[0].id, branch1_id);
         assert_eq!(branches[0].commits.len(), 1);
@@ -217,15 +217,15 @@ async fn to_non_existing() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch1_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
@@ -234,11 +234,11 @@ async fn to_non_existing() {
 
         // commit changes
         let oid = controller
-            .create_commit(&project_id, &branch1_id, "commit", None, false)
+            .create_commit(project_id, &branch1_id, "commit", None, false)
             .await
             .unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
         assert_eq!(branches[0].id, branch1_id);
         assert_eq!(branches[0].commits.len(), 1);
@@ -255,7 +255,7 @@ async fn to_non_existing() {
     assert!(matches!(
         controller
             .reset_virtual_branch(
-                &project_id,
+                project_id,
                 &branch1_id,
                 "fe14df8c66b73c6276f7bb26102ad91da680afcb".parse().unwrap()
             )

--- a/gitbutler-app/tests/suite/virtual_branches/selected_for_changes.rs
+++ b/gitbutler-app/tests/suite/virtual_branches/selected_for_changes.rs
@@ -7,10 +7,10 @@ async fn unapplying_selected_branch_selects_anther() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
@@ -18,17 +18,17 @@ async fn unapplying_selected_branch_selects_anther() {
 
     // first branch should be created as default
     let b_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
     // if default branch exists, new branch should not be created as default
     let b2_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
 
     let b = branches.iter().find(|b| b.id == b_id).unwrap();
 
@@ -38,11 +38,11 @@ async fn unapplying_selected_branch_selects_anther() {
     assert!(!b2.selected_for_changes);
 
     controller
-        .unapply_virtual_branch(&project_id, &b_id)
+        .unapply_virtual_branch(project_id, &b_id)
         .await
         .unwrap();
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
 
     assert_eq!(branches.len(), 2);
     assert_eq!(branches[0].id, b.id);
@@ -59,26 +59,26 @@ async fn deleting_selected_branch_selects_anther() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     // first branch should be created as default
     let b_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
     // if default branch exists, new branch should not be created as default
     let b2_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
 
     let b = branches.iter().find(|b| b.id == b_id).unwrap();
 
@@ -88,11 +88,11 @@ async fn deleting_selected_branch_selects_anther() {
     assert!(!b2.selected_for_changes);
 
     controller
-        .delete_virtual_branch(&project_id, &b_id)
+        .delete_virtual_branch(project_id, &b_id)
         .await
         .unwrap();
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
 
     assert_eq!(branches.len(), 1);
     assert_eq!(branches[0].id, b2.id);
@@ -105,20 +105,20 @@ async fn create_virtual_branch_should_set_selected_for_changes() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     // first branch should be created as default
     let b_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
     let branch = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -129,11 +129,11 @@ async fn create_virtual_branch_should_set_selected_for_changes() {
 
     // if default branch exists, new branch should not be created as default
     let b_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
     let branch = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -145,7 +145,7 @@ async fn create_virtual_branch_should_set_selected_for_changes() {
     // explicitly don't make this one default
     let b_id = controller
         .create_virtual_branch(
-            &project_id,
+            project_id,
             &branch::BranchCreateRequest {
                 selected_for_changes: Some(false),
                 ..Default::default()
@@ -154,7 +154,7 @@ async fn create_virtual_branch_should_set_selected_for_changes() {
         .await
         .unwrap();
     let branch = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -166,7 +166,7 @@ async fn create_virtual_branch_should_set_selected_for_changes() {
     // explicitly make this one default
     let b_id = controller
         .create_virtual_branch(
-            &project_id,
+            project_id,
             &branch::BranchCreateRequest {
                 selected_for_changes: Some(true),
                 ..Default::default()
@@ -175,7 +175,7 @@ async fn create_virtual_branch_should_set_selected_for_changes() {
         .await
         .unwrap();
     let branch = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -191,19 +191,19 @@ async fn update_virtual_branch_should_reset_selected_for_changes() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let b1_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
     let b1 = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -213,11 +213,11 @@ async fn update_virtual_branch_should_reset_selected_for_changes() {
     assert!(b1.selected_for_changes);
 
     let b2_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
     let b2 = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -228,7 +228,7 @@ async fn update_virtual_branch_should_reset_selected_for_changes() {
 
     controller
         .update_virtual_branch(
-            &project_id,
+            project_id,
             branch::BranchUpdateRequest {
                 id: b2_id,
                 selected_for_changes: Some(true),
@@ -239,7 +239,7 @@ async fn update_virtual_branch_should_reset_selected_for_changes() {
         .unwrap();
 
     let b1 = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -249,7 +249,7 @@ async fn update_virtual_branch_should_reset_selected_for_changes() {
     assert!(!b1.selected_for_changes);
 
     let b2 = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -266,21 +266,21 @@ async fn unapply_virtual_branch_should_reset_selected_for_changes() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let b1_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
     std::fs::write(repository.path().join("file.txt"), "content").unwrap();
 
     let b1 = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -290,12 +290,12 @@ async fn unapply_virtual_branch_should_reset_selected_for_changes() {
     assert!(b1.selected_for_changes);
 
     controller
-        .unapply_virtual_branch(&project_id, &b1_id)
+        .unapply_virtual_branch(project_id, &b1_id)
         .await
         .unwrap();
 
     let b1 = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -312,21 +312,21 @@ async fn hunks_distribution() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     std::fs::write(repository.path().join("file.txt"), "content").unwrap();
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
     assert_eq!(branches[0].files.len(), 1);
 
     controller
         .create_virtual_branch(
-            &project_id,
+            project_id,
             &branch::BranchCreateRequest {
                 selected_for_changes: Some(true),
                 ..Default::default()
@@ -335,7 +335,7 @@ async fn hunks_distribution() {
         .await
         .unwrap();
     std::fs::write(repository.path().join("another_file.txt"), "content").unwrap();
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
     assert_eq!(branches[0].files.len(), 1);
     assert_eq!(branches[1].files.len(), 1);
 }
@@ -347,28 +347,28 @@ async fn applying_first_branch() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     std::fs::write(repository.path().join("file.txt"), "content").unwrap();
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
     assert_eq!(branches.len(), 1);
 
     controller
-        .unapply_virtual_branch(&project_id, &branches[0].id)
+        .unapply_virtual_branch(project_id, &branches[0].id)
         .await
         .unwrap();
     controller
-        .apply_virtual_branch(&project_id, &branches[0].id)
+        .apply_virtual_branch(project_id, &branches[0].id)
         .await
         .unwrap();
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
     assert_eq!(branches.len(), 1);
     assert!(branches[0].active);
     assert!(branches[0].selected_for_changes);

--- a/gitbutler-app/tests/suite/virtual_branches/set_base_branch.rs
+++ b/gitbutler-app/tests/suite/virtual_branches/set_base_branch.rs
@@ -6,10 +6,10 @@ async fn success() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 }
@@ -23,12 +23,12 @@ mod error {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         assert!(matches!(
             controller
                 .set_base_branch(
-                    &project_id,
+                    project_id,
                     &git::RemoteRefname::from_str("refs/remotes/origin/missing").unwrap(),
                 )
                 .await
@@ -50,7 +50,7 @@ mod go_back_to_integration {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         std::fs::write(repository.path().join("file.txt"), "one").unwrap();
         let oid_one = repository.commit_all("one");
@@ -59,32 +59,32 @@ mod go_back_to_integration {
         repository.push();
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         let vbranch_id = controller
-            .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+            .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
             .await
             .unwrap();
 
         std::fs::write(repository.path().join("another file.txt"), "content").unwrap();
         controller
-            .create_commit(&project_id, &vbranch_id, "one", None, false)
+            .create_commit(project_id, &vbranch_id, "one", None, false)
             .await
             .unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
 
         repository.checkout_commit(oid_one);
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
         assert_eq!(branches[0].id, vbranch_id);
         assert!(branches[0].active);
@@ -97,7 +97,7 @@ mod go_back_to_integration {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         std::fs::write(repository.path().join("file.txt"), "one").unwrap();
         let oid_one = repository.commit_all("one");
@@ -106,11 +106,11 @@ mod go_back_to_integration {
         repository.push();
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert!(branches.is_empty());
 
         repository.checkout_commit(oid_one);
@@ -118,7 +118,7 @@ mod go_back_to_integration {
 
         assert!(matches!(
             controller
-                .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+                .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
                 .await
                 .unwrap_err(),
             ControllerError::Action(errors::SetBaseBranchError::DirtyWorkingDirectory)
@@ -132,7 +132,7 @@ mod go_back_to_integration {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         std::fs::write(repository.path().join("file.txt"), "one").unwrap();
         let oid_one = repository.commit_all("one");
@@ -141,11 +141,11 @@ mod go_back_to_integration {
         repository.push();
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert!(branches.is_empty());
 
         repository.checkout_commit(oid_one);
@@ -153,7 +153,7 @@ mod go_back_to_integration {
 
         assert!(matches!(
             controller
-                .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+                .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
                 .await
                 .map_err(|error| dbg!(error))
                 .unwrap_err(),
@@ -168,7 +168,7 @@ mod go_back_to_integration {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         std::fs::write(repository.path().join("file.txt"), "one").unwrap();
         let oid_one = repository.commit_all("one");
@@ -177,11 +177,11 @@ mod go_back_to_integration {
         repository.push();
 
         let base = controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert!(branches.is_empty());
 
         repository.checkout_commit(oid_one);
@@ -189,11 +189,11 @@ mod go_back_to_integration {
         repository.commit_all("three");
 
         let base_two = controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 0);
         assert_eq!(base_two, base);
     }
@@ -205,7 +205,7 @@ mod go_back_to_integration {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         std::fs::write(repository.path().join("file.txt"), "one").unwrap();
         let oid_one = repository.commit_all("one");
@@ -214,21 +214,21 @@ mod go_back_to_integration {
         repository.push();
 
         let base = controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert!(branches.is_empty());
 
         repository.checkout_commit(oid_one);
 
         let base_two = controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 0);
         assert_eq!(base_two, base);
     }

--- a/gitbutler-app/tests/suite/virtual_branches/squash.rs
+++ b/gitbutler-app/tests/suite/virtual_branches/squash.rs
@@ -7,22 +7,22 @@ async fn head() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
     {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit one", None, false)
+            .create_commit(project_id, &branch_id, "commit one", None, false)
             .await
             .unwrap()
     };
@@ -30,7 +30,7 @@ async fn head() {
     {
         fs::write(repository.path().join("file two.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit two", None, false)
+            .create_commit(project_id, &branch_id, "commit two", None, false)
             .await
             .unwrap()
     };
@@ -38,7 +38,7 @@ async fn head() {
     {
         fs::write(repository.path().join("file three.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit three", None, false)
+            .create_commit(project_id, &branch_id, "commit three", None, false)
             .await
             .unwrap()
     };
@@ -46,18 +46,18 @@ async fn head() {
     let commit_four_oid = {
         fs::write(repository.path().join("file four.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit four", None, false)
+            .create_commit(project_id, &branch_id, "commit four", None, false)
             .await
             .unwrap()
     };
 
     controller
-        .squash(&project_id, &branch_id, commit_four_oid)
+        .squash(project_id, &branch_id, commit_four_oid)
         .await
         .unwrap();
 
     let branch = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -83,22 +83,22 @@ async fn middle() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
     {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit one", None, false)
+            .create_commit(project_id, &branch_id, "commit one", None, false)
             .await
             .unwrap()
     };
@@ -106,7 +106,7 @@ async fn middle() {
     let commit_two_oid = {
         fs::write(repository.path().join("file two.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit two", None, false)
+            .create_commit(project_id, &branch_id, "commit two", None, false)
             .await
             .unwrap()
     };
@@ -114,7 +114,7 @@ async fn middle() {
     {
         fs::write(repository.path().join("file three.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit three", None, false)
+            .create_commit(project_id, &branch_id, "commit three", None, false)
             .await
             .unwrap()
     };
@@ -122,18 +122,18 @@ async fn middle() {
     {
         fs::write(repository.path().join("file four.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit four", None, false)
+            .create_commit(project_id, &branch_id, "commit four", None, false)
             .await
             .unwrap()
     };
 
     controller
-        .squash(&project_id, &branch_id, commit_two_oid)
+        .squash(project_id, &branch_id, commit_two_oid)
         .await
         .unwrap();
 
     let branch = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -160,11 +160,11 @@ async fn forcepush_allowed() {
         controller,
         projects,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     projects
         .update(&projects::UpdateRequest {
-            id: project_id,
+            id: *project_id,
             ok_with_force_push: Some(true),
             ..Default::default()
         })
@@ -172,32 +172,32 @@ async fn forcepush_allowed() {
         .unwrap();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
     {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit one", None, false)
+            .create_commit(project_id, &branch_id, "commit one", None, false)
             .await
             .unwrap()
     };
 
     controller
-        .push_virtual_branch(&project_id, &branch_id, false, None)
+        .push_virtual_branch(project_id, &branch_id, false, None)
         .await
         .unwrap();
 
     let commit_two_oid = {
         fs::write(repository.path().join("file two.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit two", None, false)
+            .create_commit(project_id, &branch_id, "commit two", None, false)
             .await
             .unwrap()
     };
@@ -205,7 +205,7 @@ async fn forcepush_allowed() {
     {
         fs::write(repository.path().join("file three.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit three", None, false)
+            .create_commit(project_id, &branch_id, "commit three", None, false)
             .await
             .unwrap()
     };
@@ -213,18 +213,18 @@ async fn forcepush_allowed() {
     {
         fs::write(repository.path().join("file four.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit four", None, false)
+            .create_commit(project_id, &branch_id, "commit four", None, false)
             .await
             .unwrap()
     };
 
     controller
-        .squash(&project_id, &branch_id, commit_two_oid)
+        .squash(project_id, &branch_id, commit_two_oid)
         .await
         .unwrap();
 
     let branch = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -252,34 +252,34 @@ async fn forcepush_forbidden() {
         controller,
         projects,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
     {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit one", None, false)
+            .create_commit(project_id, &branch_id, "commit one", None, false)
             .await
             .unwrap()
     };
 
     controller
-        .push_virtual_branch(&project_id, &branch_id, false, None)
+        .push_virtual_branch(project_id, &branch_id, false, None)
         .await
         .unwrap();
 
     projects
         .update(&projects::UpdateRequest {
-            id: project_id,
+            id: *project_id,
             ok_with_force_push: Some(false),
             ..Default::default()
         })
@@ -289,7 +289,7 @@ async fn forcepush_forbidden() {
     let commit_two_oid = {
         fs::write(repository.path().join("file two.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit two", None, false)
+            .create_commit(project_id, &branch_id, "commit two", None, false)
             .await
             .unwrap()
     };
@@ -297,7 +297,7 @@ async fn forcepush_forbidden() {
     {
         fs::write(repository.path().join("file three.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit three", None, false)
+            .create_commit(project_id, &branch_id, "commit three", None, false)
             .await
             .unwrap()
     };
@@ -305,14 +305,14 @@ async fn forcepush_forbidden() {
     {
         fs::write(repository.path().join("file four.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit four", None, false)
+            .create_commit(project_id, &branch_id, "commit four", None, false)
             .await
             .unwrap()
     };
 
     assert!(matches!(
         controller
-            .squash(&project_id, &branch_id, commit_two_oid)
+            .squash(project_id, &branch_id, commit_two_oid)
             .await
             .unwrap_err(),
         ControllerError::Action(errors::SquashError::ForcePushNotAllowed(_))
@@ -326,29 +326,29 @@ async fn root() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
     let commit_one_oid = {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit one", None, false)
+            .create_commit(project_id, &branch_id, "commit one", None, false)
             .await
             .unwrap()
     };
 
     assert!(matches!(
         controller
-            .squash(&project_id, &branch_id, commit_one_oid)
+            .squash(project_id, &branch_id, commit_one_oid)
             .await
             .unwrap_err(),
         ControllerError::Action(errors::SquashError::CantSquashRootCommit)

--- a/gitbutler-app/tests/suite/virtual_branches/unapply.rs
+++ b/gitbutler-app/tests/suite/virtual_branches/unapply.rs
@@ -7,26 +7,26 @@ async fn unapply_with_data() {
         controller,
         repository,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     std::fs::write(repository.path().join("file.txt"), "content").unwrap();
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
     assert_eq!(branches.len(), 1);
 
     controller
-        .unapply_virtual_branch(&project_id, &branches[0].id)
+        .unapply_virtual_branch(project_id, &branches[0].id)
         .await
         .unwrap();
 
     assert!(!repository.path().join("file.txt").exists());
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
     assert_eq!(branches.len(), 1);
     assert!(!branches[0].active);
 }
@@ -38,7 +38,7 @@ async fn conflicting() {
         controller,
         repository,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     // make sure we have an undiscovered commit in the remote branch
     {
@@ -51,7 +51,7 @@ async fn conflicting() {
     }
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
@@ -60,14 +60,14 @@ async fn conflicting() {
 
         std::fs::write(repository.path().join("file.txt"), "conflict").unwrap();
 
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
         assert!(branches[0].base_current);
         assert!(branches[0].active);
         assert_eq!(branches[0].files[0].hunks[0].diff, "@@ -1 +1 @@\n-first\n\\ No newline at end of file\n+conflict\n\\ No newline at end of file\n");
 
         controller
-            .unapply_virtual_branch(&project_id, &branches[0].id)
+            .unapply_virtual_branch(project_id, &branches[0].id)
             .await
             .unwrap();
 
@@ -76,7 +76,7 @@ async fn conflicting() {
 
     {
         // update base branch, causing conflict
-        controller.update_base_branch(&project_id).await.unwrap();
+        controller.update_base_branch(project_id).await.unwrap();
 
         assert_eq!(
             std::fs::read_to_string(repository.path().join("file.txt")).unwrap(),
@@ -84,7 +84,7 @@ async fn conflicting() {
         );
 
         let branch = controller
-            .list_virtual_branches(&project_id)
+            .list_virtual_branches(project_id)
             .await
             .unwrap()
             .0
@@ -98,7 +98,7 @@ async fn conflicting() {
     {
         // apply branch, it should conflict
         controller
-            .apply_virtual_branch(&project_id, &branch_id)
+            .apply_virtual_branch(project_id, &branch_id)
             .await
             .unwrap();
 
@@ -108,7 +108,7 @@ async fn conflicting() {
         );
 
         let branch = controller
-            .list_virtual_branches(&project_id)
+            .list_virtual_branches(project_id)
             .await
             .unwrap()
             .0
@@ -122,7 +122,7 @@ async fn conflicting() {
 
     {
         controller
-            .unapply_virtual_branch(&project_id, &branch_id)
+            .unapply_virtual_branch(project_id, &branch_id)
             .await
             .unwrap();
 
@@ -132,7 +132,7 @@ async fn conflicting() {
         );
 
         let branch = controller
-            .list_virtual_branches(&project_id)
+            .list_virtual_branches(project_id)
             .await
             .unwrap()
             .0
@@ -152,26 +152,26 @@ async fn delete_if_empty() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
     assert_eq!(branches.len(), 1);
 
     controller
-        .unapply_virtual_branch(&project_id, &branches[0].id)
+        .unapply_virtual_branch(project_id, &branches[0].id)
         .await
         .unwrap();
 
-    let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+    let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
     assert_eq!(branches.len(), 0);
 }

--- a/gitbutler-app/tests/suite/virtual_branches/unapply_ownership.rs
+++ b/gitbutler-app/tests/suite/virtual_branches/unapply_ownership.rs
@@ -10,15 +10,15 @@ async fn should_unapply_with_commits() {
         controller,
         repository,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
@@ -28,7 +28,7 @@ async fn should_unapply_with_commits() {
     )
     .unwrap();
     controller
-        .create_commit(&project_id, &branch_id, "test", None, false)
+        .create_commit(project_id, &branch_id, "test", None, false)
         .await
         .unwrap();
 
@@ -41,7 +41,7 @@ async fn should_unapply_with_commits() {
 
     controller
         .unapply_ownership(
-            &project_id,
+            project_id,
             &"file.txt:1-5,7-11"
                 .parse::<BranchOwnershipClaims>()
                 .unwrap(),
@@ -50,7 +50,7 @@ async fn should_unapply_with_commits() {
         .unwrap();
 
     let branch = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0

--- a/gitbutler-app/tests/suite/virtual_branches/update_base_branch.rs
+++ b/gitbutler-app/tests/suite/virtual_branches/update_base_branch.rs
@@ -11,7 +11,7 @@ mod unapplied_branch {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         // make sure we have an undiscovered commit in the remote branch
         {
@@ -24,20 +24,20 @@ mod unapplied_branch {
         }
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         let branch_id = {
             // make a branch that is unapplied and contains not commited conflict
             let branch_id = controller
-                .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+                .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
                 .await
                 .unwrap();
 
             fs::write(repository.path().join("file.txt"), "conflict").unwrap();
             controller
-                .unapply_virtual_branch(&project_id, &branch_id)
+                .unapply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
 
@@ -46,11 +46,11 @@ mod unapplied_branch {
 
         {
             // when fetching remote
-            controller.update_base_branch(&project_id).await.unwrap();
+            controller.update_base_branch(project_id).await.unwrap();
 
             // branch should not be changed.
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(!branches[0].active);
@@ -58,7 +58,7 @@ mod unapplied_branch {
             assert_eq!(branches[0].files.len(), 1);
             assert_eq!(branches[0].commits.len(), 0);
             assert!(!controller
-                .can_apply_virtual_branch(&project_id, &branch_id)
+                .can_apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap());
         }
@@ -66,10 +66,10 @@ mod unapplied_branch {
         {
             // applying the branch should produce conflict markers
             controller
-                .apply_virtual_branch(&project_id, &branch_id)
+                .apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(branches[0].active);
@@ -91,7 +91,7 @@ mod unapplied_branch {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         // make sure we have an undiscovered commit in the remote branch
         {
@@ -104,7 +104,7 @@ mod unapplied_branch {
         }
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
@@ -112,18 +112,18 @@ mod unapplied_branch {
             // make a branch with a commit that conflicts with upstream, and work that fixes
             // that conflict
             let branch_id = controller
-                .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+                .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
                 .await
                 .unwrap();
 
             fs::write(repository.path().join("file.txt"), "conflict").unwrap();
             controller
-                .create_commit(&project_id, &branch_id, "conflicting commit", None, false)
+                .create_commit(project_id, &branch_id, "conflicting commit", None, false)
                 .await
                 .unwrap();
 
             controller
-                .unapply_virtual_branch(&project_id, &branch_id)
+                .unapply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
 
@@ -132,11 +132,11 @@ mod unapplied_branch {
 
         {
             // when fetching remote
-            controller.update_base_branch(&project_id).await.unwrap();
+            controller.update_base_branch(project_id).await.unwrap();
 
             // should not change the branch.
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(!branches[0].active);
@@ -144,7 +144,7 @@ mod unapplied_branch {
             assert_eq!(branches[0].files.len(), 0);
             assert_eq!(branches[0].commits.len(), 1);
             assert!(!controller
-                .can_apply_virtual_branch(&project_id, &branch_id)
+                .can_apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap());
         }
@@ -152,10 +152,10 @@ mod unapplied_branch {
         {
             // applying the branch should produce conflict markers
             controller
-                .apply_virtual_branch(&project_id, &branch_id)
+                .apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(branches[0].active);
@@ -177,7 +177,7 @@ mod unapplied_branch {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         // make sure we have an undiscovered commit in the remote branch
         {
@@ -190,7 +190,7 @@ mod unapplied_branch {
         }
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
@@ -198,23 +198,23 @@ mod unapplied_branch {
             // make a branch with a commit that conflicts with upstream, and work that fixes
             // that conflict
             let branch_id = controller
-                .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+                .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
                 .await
                 .unwrap();
 
             fs::write(repository.path().join("file.txt"), "conflict").unwrap();
             controller
-                .create_commit(&project_id, &branch_id, "conflicting commit", None, false)
+                .create_commit(project_id, &branch_id, "conflicting commit", None, false)
                 .await
                 .unwrap();
 
             controller
-                .push_virtual_branch(&project_id, &branch_id, false, None)
+                .push_virtual_branch(project_id, &branch_id, false, None)
                 .await
                 .unwrap();
 
             controller
-                .unapply_virtual_branch(&project_id, &branch_id)
+                .unapply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
 
@@ -223,11 +223,11 @@ mod unapplied_branch {
 
         {
             // when fetching remote
-            controller.update_base_branch(&project_id).await.unwrap();
+            controller.update_base_branch(project_id).await.unwrap();
 
             // should not change the branch.
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(!branches[0].active);
@@ -235,7 +235,7 @@ mod unapplied_branch {
             assert_eq!(branches[0].files.len(), 0);
             assert_eq!(branches[0].commits.len(), 1);
             assert!(!controller
-                .can_apply_virtual_branch(&project_id, &branch_id)
+                .can_apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap());
         }
@@ -243,10 +243,10 @@ mod unapplied_branch {
         {
             // applying the branch should produce conflict markers
             controller
-                .apply_virtual_branch(&project_id, &branch_id)
+                .apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(branches[0].active);
@@ -268,7 +268,7 @@ mod unapplied_branch {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         // make sure we have an undiscovered commit in the remote branch
         {
@@ -281,7 +281,7 @@ mod unapplied_branch {
         }
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
@@ -289,20 +289,20 @@ mod unapplied_branch {
             // make a branch with a commit that conflicts with upstream, and work that fixes
             // that conflict
             let branch_id = controller
-                .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+                .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
                 .await
                 .unwrap();
 
             fs::write(repository.path().join("file.txt"), "conflict").unwrap();
             controller
-                .create_commit(&project_id, &branch_id, "conflicting commit", None, false)
+                .create_commit(project_id, &branch_id, "conflicting commit", None, false)
                 .await
                 .unwrap();
 
             fs::write(repository.path().join("file.txt"), "fix conflict").unwrap();
 
             controller
-                .unapply_virtual_branch(&project_id, &branch_id)
+                .unapply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
 
@@ -311,11 +311,11 @@ mod unapplied_branch {
 
         {
             // when fetching remote
-            controller.update_base_branch(&project_id).await.unwrap();
+            controller.update_base_branch(project_id).await.unwrap();
 
             // should rebase upstream, and leave uncommited file as is
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(!branches[0].active);
@@ -323,7 +323,7 @@ mod unapplied_branch {
             assert_eq!(branches[0].files.len(), 1);
             assert_eq!(branches[0].commits.len(), 1);
             assert!(!controller
-                .can_apply_virtual_branch(&project_id, &branch_id)
+                .can_apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap()); // TODO: should be true
         }
@@ -331,10 +331,10 @@ mod unapplied_branch {
         {
             // applying the branch should produce conflict markers
             controller
-                .apply_virtual_branch(&project_id, &branch_id)
+                .apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(branches[0].active);
@@ -356,7 +356,7 @@ mod unapplied_branch {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         // make sure we have an undiscovered commit in the remote branch
         {
@@ -369,7 +369,7 @@ mod unapplied_branch {
         }
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
@@ -377,20 +377,20 @@ mod unapplied_branch {
             // make a branch with a commit that conflicts with upstream, and work that fixes
             // that conflict
             let branch_id = controller
-                .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+                .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
                 .await
                 .unwrap();
 
             fs::write(repository.path().join("file.txt"), "conflict").unwrap();
             controller
-                .create_commit(&project_id, &branch_id, "conflicting commit", None, false)
+                .create_commit(project_id, &branch_id, "conflicting commit", None, false)
                 .await
                 .unwrap();
 
             fs::write(repository.path().join("file.txt"), "fix conflict").unwrap();
 
             controller
-                .unapply_virtual_branch(&project_id, &branch_id)
+                .unapply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
 
@@ -399,11 +399,11 @@ mod unapplied_branch {
 
         {
             // when fetching remote
-            controller.update_base_branch(&project_id).await.unwrap();
+            controller.update_base_branch(project_id).await.unwrap();
 
             // should not touch the branch
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(!branches[0].active);
@@ -411,7 +411,7 @@ mod unapplied_branch {
             assert_eq!(branches[0].commits.len(), 1);
             assert_eq!(branches[0].files.len(), 1);
             assert!(!controller
-                .can_apply_virtual_branch(&project_id, &branch_id)
+                .can_apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap());
         }
@@ -419,10 +419,10 @@ mod unapplied_branch {
         {
             // applying the branch should produce conflict markers
             controller
-                .apply_virtual_branch(&project_id, &branch_id)
+                .apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(branches[0].active);
@@ -444,7 +444,7 @@ mod unapplied_branch {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         // make sure we have an undiscovered commit in the remote branch
         {
@@ -457,14 +457,14 @@ mod unapplied_branch {
         }
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         let branch_id = {
             // make a branch that conflicts with the remote branch, but doesn't know about it yet
             let branch_id = controller
-                .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+                .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
                 .await
                 .unwrap();
 
@@ -472,7 +472,7 @@ mod unapplied_branch {
 
             controller
                 .create_commit(
-                    &project_id,
+                    project_id,
                     &branch_id,
                     "non conflicting commit",
                     None,
@@ -484,7 +484,7 @@ mod unapplied_branch {
             fs::write(repository.path().join("file2.txt"), "still no conflicts").unwrap();
 
             controller
-                .unapply_virtual_branch(&project_id, &branch_id)
+                .unapply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
 
@@ -493,11 +493,11 @@ mod unapplied_branch {
 
         {
             // fetching remote
-            controller.update_base_branch(&project_id).await.unwrap();
+            controller.update_base_branch(project_id).await.unwrap();
 
             // should update branch base
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(!branches[0].active);
@@ -506,7 +506,7 @@ mod unapplied_branch {
             assert_eq!(branches[0].commits.len(), 1);
             assert!(branches[0].upstream.is_none());
             assert!(controller
-                .can_apply_virtual_branch(&project_id, &branch_id)
+                .can_apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap());
         }
@@ -514,10 +514,10 @@ mod unapplied_branch {
         {
             // applying the branch should produce conflict markers
             controller
-                .apply_virtual_branch(&project_id, &branch_id)
+                .apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(branches[0].active);
@@ -539,7 +539,7 @@ mod unapplied_branch {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         {
             fs::write(repository.path().join("file.txt"), "first").unwrap();
@@ -548,20 +548,20 @@ mod unapplied_branch {
         }
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         let branch_id = {
             // make a branch that conflicts with the remote branch, but doesn't know about it yet
             let branch_id = controller
-                .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+                .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
                 .await
                 .unwrap();
 
             fs::write(repository.path().join("file.txt"), "second").unwrap();
             controller
-                .create_commit(&project_id, &branch_id, "second", None, false)
+                .create_commit(project_id, &branch_id, "second", None, false)
                 .await
                 .unwrap();
 
@@ -569,14 +569,14 @@ mod unapplied_branch {
             fs::write(repository.path().join("file2.txt"), "other").unwrap();
 
             controller
-                .push_virtual_branch(&project_id, &branch_id, false, None)
+                .push_virtual_branch(project_id, &branch_id, false, None)
                 .await
                 .unwrap();
 
             {
                 // merge branch upstream
                 let branch = controller
-                    .list_virtual_branches(&project_id)
+                    .list_virtual_branches(project_id)
                     .await
                     .unwrap()
                     .0
@@ -589,7 +589,7 @@ mod unapplied_branch {
             }
 
             controller
-                .unapply_virtual_branch(&project_id, &branch_id)
+                .unapply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
             branch_id
@@ -597,11 +597,11 @@ mod unapplied_branch {
 
         {
             // fetch remote
-            controller.update_base_branch(&project_id).await.unwrap();
+            controller.update_base_branch(project_id).await.unwrap();
 
             // should remove integrated commit, but leave work
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(!branches[0].active);
@@ -610,7 +610,7 @@ mod unapplied_branch {
             assert_eq!(branches[0].commits.len(), 0);
             assert!(branches[0].upstream.is_none());
             assert!(controller
-                .can_apply_virtual_branch(&project_id, &branch_id)
+                .can_apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap());
         }
@@ -618,10 +618,10 @@ mod unapplied_branch {
         {
             // applying the branch should produce conflict markers
             controller
-                .apply_virtual_branch(&project_id, &branch_id)
+                .apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(branches[0].active);
@@ -647,7 +647,7 @@ mod unapplied_branch {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         // make sure we have an undiscovered commit in the remote branch
         {
@@ -660,37 +660,37 @@ mod unapplied_branch {
         }
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         {
             // make a branch that conflicts with the remote branch, but doesn't know about it yet
             let branch_id = controller
-                .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+                .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
                 .await
                 .unwrap();
 
             fs::write(repository.path().join("file.txt"), "second").unwrap();
 
             controller
-                .create_commit(&project_id, &branch_id, "second", None, false)
+                .create_commit(project_id, &branch_id, "second", None, false)
                 .await
                 .unwrap();
 
             controller
-                .unapply_virtual_branch(&project_id, &branch_id)
+                .unapply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
         };
 
         {
             // fetch remote
-            controller.update_base_branch(&project_id).await.unwrap();
+            controller.update_base_branch(project_id).await.unwrap();
 
             // should remove identical branch
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 0);
         }
     }
@@ -702,7 +702,7 @@ mod unapplied_branch {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         // make sure we have an undiscovered commit in the remote branch
         {
@@ -715,12 +715,12 @@ mod unapplied_branch {
         }
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         let branch_id = controller
-            .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+            .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
             .await
             .unwrap();
 
@@ -728,24 +728,24 @@ mod unapplied_branch {
             // open pr
             fs::write(repository.path().join("file2.txt"), "new file").unwrap();
             controller
-                .create_commit(&project_id, &branch_id, "second", None, false)
+                .create_commit(project_id, &branch_id, "second", None, false)
                 .await
                 .unwrap();
             controller
-                .push_virtual_branch(&project_id, &branch_id, false, None)
+                .push_virtual_branch(project_id, &branch_id, false, None)
                 .await
                 .unwrap();
         }
 
         controller
-            .unapply_virtual_branch(&project_id, &branch_id)
+            .unapply_virtual_branch(project_id, &branch_id)
             .await
             .unwrap();
 
         {
             // merge pr
             let branch = controller
-                .list_virtual_branches(&project_id)
+                .list_virtual_branches(project_id)
                 .await
                 .unwrap()
                 .0[0]
@@ -756,10 +756,10 @@ mod unapplied_branch {
 
         {
             // fetch remote
-            controller.update_base_branch(&project_id).await.unwrap();
+            controller.update_base_branch(project_id).await.unwrap();
 
             // just removes integrated branch
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 0);
         }
     }
@@ -776,7 +776,7 @@ mod applied_branch {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         // make sure we have an undiscovered commit in the remote branch
         {
@@ -789,14 +789,14 @@ mod applied_branch {
         }
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         let branch_id = {
             // make a branch that conflicts with the remote branch, but doesn't know about it yet
             let branch_id = controller
-                .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+                .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
                 .await
                 .unwrap();
 
@@ -807,11 +807,11 @@ mod applied_branch {
 
         {
             // fetch remote
-            controller.update_base_branch(&project_id).await.unwrap();
+            controller.update_base_branch(project_id).await.unwrap();
 
             // should stash conflicing branch
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(!branches[0].active);
@@ -819,7 +819,7 @@ mod applied_branch {
             assert_eq!(branches[0].files.len(), 1);
             assert_eq!(branches[0].commits.len(), 0);
             assert!(!controller
-                .can_apply_virtual_branch(&project_id, &branch_id)
+                .can_apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap());
         }
@@ -827,10 +827,10 @@ mod applied_branch {
         {
             // applying the branch should produce conflict markers
             controller
-                .apply_virtual_branch(&project_id, &branch_id)
+                .apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(branches[0].active);
@@ -852,7 +852,7 @@ mod applied_branch {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         // make sure we have an undiscovered commit in the remote branch
         {
@@ -865,7 +865,7 @@ mod applied_branch {
         }
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
@@ -873,13 +873,13 @@ mod applied_branch {
             // make a branch with a commit that conflicts with upstream, and work that fixes
             // that conflict
             let branch_id = controller
-                .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+                .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
                 .await
                 .unwrap();
 
             fs::write(repository.path().join("file.txt"), "conflict").unwrap();
             controller
-                .create_commit(&project_id, &branch_id, "conflicting commit", None, false)
+                .create_commit(project_id, &branch_id, "conflicting commit", None, false)
                 .await
                 .unwrap();
 
@@ -888,11 +888,11 @@ mod applied_branch {
 
         {
             // when fetching remote
-            controller.update_base_branch(&project_id).await.unwrap();
+            controller.update_base_branch(project_id).await.unwrap();
 
             // should stash the branch.
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(!branches[0].active);
@@ -900,7 +900,7 @@ mod applied_branch {
             assert_eq!(branches[0].files.len(), 0);
             assert_eq!(branches[0].commits.len(), 1);
             assert!(!controller
-                .can_apply_virtual_branch(&project_id, &branch_id)
+                .can_apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap());
         }
@@ -908,10 +908,10 @@ mod applied_branch {
         {
             // applying the branch should produce conflict markers
             controller
-                .apply_virtual_branch(&project_id, &branch_id)
+                .apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(branches[0].active);
@@ -933,7 +933,7 @@ mod applied_branch {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         // make sure we have an undiscovered commit in the remote branch
         {
@@ -946,7 +946,7 @@ mod applied_branch {
         }
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
@@ -954,18 +954,18 @@ mod applied_branch {
             // make a branch with a commit that conflicts with upstream, and work that fixes
             // that conflict
             let branch_id = controller
-                .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+                .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
                 .await
                 .unwrap();
 
             fs::write(repository.path().join("file.txt"), "conflict").unwrap();
             controller
-                .create_commit(&project_id, &branch_id, "conflicting commit", None, false)
+                .create_commit(project_id, &branch_id, "conflicting commit", None, false)
                 .await
                 .unwrap();
 
             controller
-                .push_virtual_branch(&project_id, &branch_id, false, None)
+                .push_virtual_branch(project_id, &branch_id, false, None)
                 .await
                 .unwrap();
 
@@ -974,11 +974,11 @@ mod applied_branch {
 
         {
             // when fetching remote
-            controller.update_base_branch(&project_id).await.unwrap();
+            controller.update_base_branch(project_id).await.unwrap();
 
             // should stash the branch.
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(!branches[0].active);
@@ -986,7 +986,7 @@ mod applied_branch {
             assert_eq!(branches[0].files.len(), 0);
             assert_eq!(branches[0].commits.len(), 1);
             assert!(!controller
-                .can_apply_virtual_branch(&project_id, &branch_id)
+                .can_apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap());
         }
@@ -994,10 +994,10 @@ mod applied_branch {
         {
             // applying the branch should produce conflict markers
             controller
-                .apply_virtual_branch(&project_id, &branch_id)
+                .apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(branches[0].active);
@@ -1019,7 +1019,7 @@ mod applied_branch {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         // make sure we have an undiscovered commit in the remote branch
         {
@@ -1032,7 +1032,7 @@ mod applied_branch {
         }
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
@@ -1040,13 +1040,13 @@ mod applied_branch {
             // make a branch with a commit that conflicts with upstream, and work that fixes
             // that conflict
             let branch_id = controller
-                .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+                .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
                 .await
                 .unwrap();
 
             fs::write(repository.path().join("file.txt"), "conflict").unwrap();
             controller
-                .create_commit(&project_id, &branch_id, "conflicting commit", None, false)
+                .create_commit(project_id, &branch_id, "conflicting commit", None, false)
                 .await
                 .unwrap();
 
@@ -1057,11 +1057,11 @@ mod applied_branch {
 
         {
             // when fetching remote
-            controller.update_base_branch(&project_id).await.unwrap();
+            controller.update_base_branch(project_id).await.unwrap();
 
             // should rebase upstream, and leave uncommited file as is
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(!branches[0].active);
@@ -1069,7 +1069,7 @@ mod applied_branch {
             assert_eq!(branches[0].files.len(), 1);
             assert_eq!(branches[0].commits.len(), 1);
             assert!(!controller
-                .can_apply_virtual_branch(&project_id, &branch_id)
+                .can_apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap()); // TODO: should be true
         }
@@ -1077,10 +1077,10 @@ mod applied_branch {
         {
             // applying the branch should produce conflict markers
             controller
-                .apply_virtual_branch(&project_id, &branch_id)
+                .apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(branches[0].active);
@@ -1102,7 +1102,7 @@ mod applied_branch {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         // make sure we have an undiscovered commit in the remote branch
         {
@@ -1115,7 +1115,7 @@ mod applied_branch {
         }
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
@@ -1123,13 +1123,13 @@ mod applied_branch {
             // make a branch with a commit that conflicts with upstream, and work that fixes
             // that conflict
             let branch_id = controller
-                .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+                .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
                 .await
                 .unwrap();
 
             fs::write(repository.path().join("file.txt"), "conflict").unwrap();
             controller
-                .create_commit(&project_id, &branch_id, "conflicting commit", None, false)
+                .create_commit(project_id, &branch_id, "conflicting commit", None, false)
                 .await
                 .unwrap();
 
@@ -1140,11 +1140,11 @@ mod applied_branch {
 
         {
             // when fetching remote
-            controller.update_base_branch(&project_id).await.unwrap();
+            controller.update_base_branch(project_id).await.unwrap();
 
             // should merge upstream, and leave uncommited file as is.
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(!branches[0].active);
@@ -1152,7 +1152,7 @@ mod applied_branch {
             assert_eq!(branches[0].commits.len(), 1); // TODO: should be 2
             assert_eq!(branches[0].files.len(), 1);
             assert!(!controller
-                .can_apply_virtual_branch(&project_id, &branch_id)
+                .can_apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap()); // TODO: should be true
         }
@@ -1160,10 +1160,10 @@ mod applied_branch {
         {
             // applying the branch should produce conflict markers
             controller
-                .apply_virtual_branch(&project_id, &branch_id)
+                .apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(branches[0].active);
@@ -1189,7 +1189,7 @@ mod applied_branch {
                 controller,
                 projects,
                 ..
-            } = Test::default();
+            } = &Test::default();
 
             // make sure we have an undiscovered commit in the remote branch
             {
@@ -1203,7 +1203,7 @@ mod applied_branch {
 
             projects
                 .update(&projects::UpdateRequest {
-                    id: project_id,
+                    id: *project_id,
                     ok_with_force_push: Some(true),
                     ..Default::default()
                 })
@@ -1211,24 +1211,24 @@ mod applied_branch {
                 .unwrap();
 
             controller
-                .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+                .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
                 .await
                 .unwrap();
 
             let branch_id = {
                 let branch_id = controller
-                    .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+                    .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
                     .await
                     .unwrap();
 
                 fs::write(repository.path().join("file2.txt"), "no conflict").unwrap();
 
                 controller
-                    .create_commit(&project_id, &branch_id, "no conflicts", None, false)
+                    .create_commit(project_id, &branch_id, "no conflicts", None, false)
                     .await
                     .unwrap();
                 controller
-                    .push_virtual_branch(&project_id, &branch_id, false, None)
+                    .push_virtual_branch(project_id, &branch_id, false, None)
                     .await
                     .unwrap();
 
@@ -1239,12 +1239,12 @@ mod applied_branch {
 
             {
                 // fetch remote
-                controller.update_base_branch(&project_id).await.unwrap();
+                controller.update_base_branch(project_id).await.unwrap();
 
                 // rebases branch, since the branch is pushed and force pushing is
                 // allowed
 
-                let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+                let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
                 assert_eq!(branches.len(), 1);
                 assert_eq!(branches[0].id, branch_id);
                 assert!(branches[0].active);
@@ -1255,7 +1255,7 @@ mod applied_branch {
                 assert!(!branches[0].commits[0].is_remote);
                 assert!(!branches[0].commits[0].is_integrated);
                 assert!(controller
-                    .can_apply_virtual_branch(&project_id, &branch_id)
+                    .can_apply_virtual_branch(project_id, &branch_id)
                     .await
                     .unwrap());
             }
@@ -1269,7 +1269,7 @@ mod applied_branch {
                 controller,
                 projects,
                 ..
-            } = Test::default();
+            } = &Test::default();
 
             // make sure we have an undiscovered commit in the remote branch
             {
@@ -1282,24 +1282,24 @@ mod applied_branch {
             }
 
             controller
-                .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+                .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
                 .await
                 .unwrap();
 
             let branch_id = {
                 let branch_id = controller
-                    .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+                    .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
                     .await
                     .unwrap();
 
                 fs::write(repository.path().join("file2.txt"), "no conflict").unwrap();
 
                 controller
-                    .create_commit(&project_id, &branch_id, "no conflicts", None, false)
+                    .create_commit(project_id, &branch_id, "no conflicts", None, false)
                     .await
                     .unwrap();
                 controller
-                    .push_virtual_branch(&project_id, &branch_id, false, None)
+                    .push_virtual_branch(project_id, &branch_id, false, None)
                     .await
                     .unwrap();
 
@@ -1310,7 +1310,7 @@ mod applied_branch {
 
             projects
                 .update(&projects::UpdateRequest {
-                    id: project_id,
+                    id: *project_id,
                     ok_with_force_push: Some(false),
                     ..Default::default()
                 })
@@ -1319,11 +1319,11 @@ mod applied_branch {
 
             {
                 // fetch remote
-                controller.update_base_branch(&project_id).await.unwrap();
+                controller.update_base_branch(project_id).await.unwrap();
 
                 // creates a merge commit, since the branch is pushed
 
-                let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+                let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
                 assert_eq!(branches.len(), 1);
                 assert_eq!(branches[0].id, branch_id);
                 assert!(branches[0].active);
@@ -1336,7 +1336,7 @@ mod applied_branch {
                 assert!(branches[0].commits[1].is_remote);
                 assert!(!branches[0].commits[1].is_integrated);
                 assert!(controller
-                    .can_apply_virtual_branch(&project_id, &branch_id)
+                    .can_apply_virtual_branch(project_id, &branch_id)
                     .await
                     .unwrap());
             }
@@ -1350,7 +1350,7 @@ mod applied_branch {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         // make sure we have an undiscovered commit in the remote branch
         {
@@ -1363,20 +1363,20 @@ mod applied_branch {
         }
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         let branch_id = {
             let branch_id = controller
-                .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+                .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
                 .await
                 .unwrap();
 
             fs::write(repository.path().join("file2.txt"), "no conflict").unwrap();
 
             controller
-                .create_commit(&project_id, &branch_id, "no conflicts", None, false)
+                .create_commit(project_id, &branch_id, "no conflicts", None, false)
                 .await
                 .unwrap();
 
@@ -1387,11 +1387,11 @@ mod applied_branch {
 
         {
             // fetch remote
-            controller.update_base_branch(&project_id).await.unwrap();
+            controller.update_base_branch(project_id).await.unwrap();
 
             // just rebases branch
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(branches[0].active);
@@ -1399,17 +1399,17 @@ mod applied_branch {
             assert_eq!(branches[0].files.len(), 1);
             assert_eq!(branches[0].commits.len(), 1);
             assert!(controller
-                .can_apply_virtual_branch(&project_id, &branch_id)
+                .can_apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap());
         }
 
         {
             controller
-                .apply_virtual_branch(&project_id, &branch_id)
+                .apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(branches[0].active);
@@ -1435,7 +1435,7 @@ mod applied_branch {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         {
             fs::write(repository.path().join("file.txt"), "first").unwrap();
@@ -1444,32 +1444,32 @@ mod applied_branch {
         }
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         let branch_id = {
             // make a branch that conflicts with the remote branch, but doesn't know about it yet
             let branch_id = controller
-                .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+                .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
                 .await
                 .unwrap();
 
             fs::write(repository.path().join("file.txt"), "second").unwrap();
 
             controller
-                .create_commit(&project_id, &branch_id, "second", None, false)
+                .create_commit(project_id, &branch_id, "second", None, false)
                 .await
                 .unwrap();
             controller
-                .push_virtual_branch(&project_id, &branch_id, false, None)
+                .push_virtual_branch(project_id, &branch_id, false, None)
                 .await
                 .unwrap();
 
             {
                 // merge branch upstream
                 let branch = controller
-                    .list_virtual_branches(&project_id)
+                    .list_virtual_branches(project_id)
                     .await
                     .unwrap()
                     .0
@@ -1488,11 +1488,11 @@ mod applied_branch {
 
         {
             // fetch remote
-            controller.update_base_branch(&project_id).await.unwrap();
+            controller.update_base_branch(project_id).await.unwrap();
 
             // should remove integrated commit, but leave non integrated work as is
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(branches[0].active);
@@ -1500,7 +1500,7 @@ mod applied_branch {
             assert_eq!(branches[0].files.len(), 1);
             assert_eq!(branches[0].commits.len(), 0);
             assert!(controller
-                .can_apply_virtual_branch(&project_id, &branch_id)
+                .can_apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap());
         }
@@ -1508,10 +1508,10 @@ mod applied_branch {
         {
             // applying the branch should produce conflict markers
             controller
-                .apply_virtual_branch(&project_id, &branch_id)
+                .apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(branches[0].active);
@@ -1537,7 +1537,7 @@ mod applied_branch {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         // make sure we have an undiscovered commit in the remote branch
         {
@@ -1558,14 +1558,14 @@ mod applied_branch {
         }
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         // branch has no conflict
         let branch_id = {
             let branch_id = controller
-                .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+                .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
                 .await
                 .unwrap();
 
@@ -1576,7 +1576,7 @@ mod applied_branch {
             .unwrap();
 
             controller
-                .create_commit(&project_id, &branch_id, "first", None, false)
+                .create_commit(project_id, &branch_id, "first", None, false)
                 .await
                 .unwrap();
 
@@ -1585,7 +1585,7 @@ mod applied_branch {
 
         // push the branch
         controller
-            .push_virtual_branch(&project_id, &branch_id, false, None)
+            .push_virtual_branch(project_id, &branch_id, false, None)
             .await
             .unwrap();
 
@@ -1599,7 +1599,7 @@ mod applied_branch {
         {
             // merge branch remotely
             let branch = controller
-                .list_virtual_branches(&project_id)
+                .list_virtual_branches(project_id)
                 .await
                 .unwrap()
                 .0[0]
@@ -1610,11 +1610,11 @@ mod applied_branch {
         repository.fetch();
 
         {
-            controller.update_base_branch(&project_id).await.unwrap();
+            controller.update_base_branch(project_id).await.unwrap();
 
             // removes integrated commit, leaves non commited work as is
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(!branches[0].active);
@@ -1624,11 +1624,11 @@ mod applied_branch {
 
         {
             controller
-                .apply_virtual_branch(&project_id, &branch_id)
+                .apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert!(branches[0].active);
             assert!(branches[0].conflicted);
@@ -1648,11 +1648,11 @@ mod applied_branch {
             controller,
             projects,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         projects
             .update(&projects::UpdateRequest {
-                id: project_id,
+                id: *project_id,
                 ok_with_force_push: Some(false),
                 ..Default::default()
             })
@@ -1660,20 +1660,20 @@ mod applied_branch {
             .unwrap();
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         let branch_id = {
             let branch_id = controller
-                .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+                .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
                 .await
                 .unwrap();
 
             fs::write(repository.path().join("file.txt"), "first").unwrap();
 
             controller
-                .create_commit(&project_id, &branch_id, "first", None, false)
+                .create_commit(project_id, &branch_id, "first", None, false)
                 .await
                 .unwrap();
 
@@ -1681,7 +1681,7 @@ mod applied_branch {
         };
 
         controller
-            .push_virtual_branch(&project_id, &branch_id, false, None)
+            .push_virtual_branch(project_id, &branch_id, false, None)
             .await
             .unwrap();
 
@@ -1691,7 +1691,7 @@ mod applied_branch {
         {
             // push and merge branch remotely
             let branch = controller
-                .list_virtual_branches(&project_id)
+                .list_virtual_branches(project_id)
                 .await
                 .unwrap()
                 .0[0]
@@ -1702,11 +1702,11 @@ mod applied_branch {
         repository.fetch();
 
         {
-            controller.update_base_branch(&project_id).await.unwrap();
+            controller.update_base_branch(project_id).await.unwrap();
 
             // removes integrated commit, leaves non commited work as is
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(branches[0].active);
@@ -1717,11 +1717,11 @@ mod applied_branch {
 
         {
             controller
-                .apply_virtual_branch(&project_id, &branch_id)
+                .apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert!(branches[0].active);
             assert!(!branches[0].conflicted);
@@ -1738,24 +1738,24 @@ mod applied_branch {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         let branch_id = {
             // make a branch that conflicts with the remote branch, but doesn't know about it yet
             let branch_id = controller
-                .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+                .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
                 .await
                 .unwrap();
 
             fs::write(repository.path().join("file.txt"), "first").unwrap();
 
             controller
-                .create_commit(&project_id, &branch_id, "first", None, false)
+                .create_commit(project_id, &branch_id, "first", None, false)
                 .await
                 .unwrap();
 
@@ -1763,7 +1763,7 @@ mod applied_branch {
         };
 
         controller
-            .push_virtual_branch(&project_id, &branch_id, false, None)
+            .push_virtual_branch(project_id, &branch_id, false, None)
             .await
             .unwrap();
 
@@ -1773,7 +1773,7 @@ mod applied_branch {
         {
             // push and merge branch remotely
             let branch = controller
-                .list_virtual_branches(&project_id)
+                .list_virtual_branches(project_id)
                 .await
                 .unwrap()
                 .0[0]
@@ -1784,11 +1784,11 @@ mod applied_branch {
         repository.fetch();
 
         {
-            controller.update_base_branch(&project_id).await.unwrap();
+            controller.update_base_branch(project_id).await.unwrap();
 
             // removes integrated commit, leaves non commited work as is
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert_eq!(branches[0].id, branch_id);
             assert!(branches[0].active);
@@ -1799,11 +1799,11 @@ mod applied_branch {
 
         {
             controller
-                .apply_virtual_branch(&project_id, &branch_id)
+                .apply_virtual_branch(project_id, &branch_id)
                 .await
                 .unwrap();
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
             assert!(branches[0].active);
             assert!(!branches[0].conflicted);
@@ -1820,7 +1820,7 @@ mod applied_branch {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         // make sure we have an undiscovered commit in the remote branch
         {
@@ -1833,32 +1833,32 @@ mod applied_branch {
         }
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         {
             // make a branch that conflicts with the remote branch, but doesn't know about it yet
             let branch_id = controller
-                .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+                .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
                 .await
                 .unwrap();
 
             fs::write(repository.path().join("file.txt"), "second").unwrap();
 
             controller
-                .create_commit(&project_id, &branch_id, "second", None, false)
+                .create_commit(project_id, &branch_id, "second", None, false)
                 .await
                 .unwrap();
         };
 
         {
             // fetch remote
-            controller.update_base_branch(&project_id).await.unwrap();
+            controller.update_base_branch(project_id).await.unwrap();
 
             // just removes integrated branch
 
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 0);
         }
     }
@@ -1870,7 +1870,7 @@ mod applied_branch {
             project_id,
             controller,
             ..
-        } = Test::default();
+        } = &Test::default();
 
         // make sure we have an undiscovered commit in the remote branch
         {
@@ -1883,12 +1883,12 @@ mod applied_branch {
         }
 
         controller
-            .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+            .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
             .await
             .unwrap();
 
         let branch_id = controller
-            .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+            .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
             .await
             .unwrap();
 
@@ -1896,11 +1896,11 @@ mod applied_branch {
             // open pr
             fs::write(repository.path().join("file2.txt"), "new file").unwrap();
             controller
-                .create_commit(&project_id, &branch_id, "second", None, false)
+                .create_commit(project_id, &branch_id, "second", None, false)
                 .await
                 .unwrap();
             controller
-                .push_virtual_branch(&project_id, &branch_id, false, None)
+                .push_virtual_branch(project_id, &branch_id, false, None)
                 .await
                 .unwrap();
         }
@@ -1908,7 +1908,7 @@ mod applied_branch {
         {
             // merge pr
             let branch = controller
-                .list_virtual_branches(&project_id)
+                .list_virtual_branches(project_id)
                 .await
                 .unwrap()
                 .0[0]
@@ -1919,10 +1919,10 @@ mod applied_branch {
 
         {
             // fetch remote
-            controller.update_base_branch(&project_id).await.unwrap();
+            controller.update_base_branch(project_id).await.unwrap();
 
             // just removes integrated branch
-            let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+            let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 0);
         }
     }

--- a/gitbutler-app/tests/suite/virtual_branches/update_commit_message.rs
+++ b/gitbutler-app/tests/suite/virtual_branches/update_commit_message.rs
@@ -7,22 +7,22 @@ async fn head() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
     {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit one", None, false)
+            .create_commit(project_id, &branch_id, "commit one", None, false)
             .await
             .unwrap()
     };
@@ -30,7 +30,7 @@ async fn head() {
     {
         fs::write(repository.path().join("file two.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit two", None, false)
+            .create_commit(project_id, &branch_id, "commit two", None, false)
             .await
             .unwrap()
     };
@@ -38,14 +38,14 @@ async fn head() {
     let commit_three_oid = {
         fs::write(repository.path().join("file three.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit three", None, false)
+            .create_commit(project_id, &branch_id, "commit three", None, false)
             .await
             .unwrap()
     };
 
     controller
         .update_commit_message(
-            &project_id,
+            project_id,
             &branch_id,
             commit_three_oid,
             "commit three updated",
@@ -54,7 +54,7 @@ async fn head() {
         .unwrap();
 
     let branch = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -81,22 +81,22 @@ async fn middle() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
     {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit one", None, false)
+            .create_commit(project_id, &branch_id, "commit one", None, false)
             .await
             .unwrap()
     };
@@ -104,7 +104,7 @@ async fn middle() {
     let commit_two_oid = {
         fs::write(repository.path().join("file two.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit two", None, false)
+            .create_commit(project_id, &branch_id, "commit two", None, false)
             .await
             .unwrap()
     };
@@ -112,23 +112,18 @@ async fn middle() {
     {
         fs::write(repository.path().join("file three.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit three", None, false)
+            .create_commit(project_id, &branch_id, "commit three", None, false)
             .await
             .unwrap()
     };
 
     controller
-        .update_commit_message(
-            &project_id,
-            &branch_id,
-            commit_two_oid,
-            "commit two updated",
-        )
+        .update_commit_message(project_id, &branch_id, commit_two_oid, "commit two updated")
         .await
         .unwrap();
 
     let branch = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -155,16 +150,16 @@ async fn forcepush_allowed() {
         controller,
         projects,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     projects
         .update(&projects::UpdateRequest {
-            id: project_id,
+            id: *project_id,
             ok_with_force_push: Some(true),
             ..Default::default()
         })
@@ -172,35 +167,30 @@ async fn forcepush_allowed() {
         .unwrap();
 
     let branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
     let commit_one_oid = {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit one", None, false)
+            .create_commit(project_id, &branch_id, "commit one", None, false)
             .await
             .unwrap()
     };
 
     controller
-        .push_virtual_branch(&project_id, &branch_id, false, None)
+        .push_virtual_branch(project_id, &branch_id, false, None)
         .await
         .unwrap();
 
     controller
-        .update_commit_message(
-            &project_id,
-            &branch_id,
-            commit_one_oid,
-            "commit one updated",
-        )
+        .update_commit_message(project_id, &branch_id, commit_one_oid, "commit one updated")
         .await
         .unwrap();
 
     let branch = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -225,16 +215,16 @@ async fn forcepush_forbidden() {
         controller,
         projects,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     projects
         .update(&projects::UpdateRequest {
-            id: project_id,
+            id: *project_id,
             ok_with_force_push: Some(false),
             ..Default::default()
         })
@@ -242,31 +232,26 @@ async fn forcepush_forbidden() {
         .unwrap();
 
     let branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
     let commit_one_oid = {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit one", None, false)
+            .create_commit(project_id, &branch_id, "commit one", None, false)
             .await
             .unwrap()
     };
 
     controller
-        .push_virtual_branch(&project_id, &branch_id, false, None)
+        .push_virtual_branch(project_id, &branch_id, false, None)
         .await
         .unwrap();
 
     assert!(matches!(
         controller
-            .update_commit_message(
-                &project_id,
-                &branch_id,
-                commit_one_oid,
-                "commit one updated",
-            )
+            .update_commit_message(project_id, &branch_id, commit_one_oid, "commit one updated",)
             .await
             .unwrap_err(),
         ControllerError::Action(errors::UpdateCommitMessageError::ForcePushNotAllowed(_))
@@ -280,22 +265,22 @@ async fn root() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
     let commit_one_oid = {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit one", None, false)
+            .create_commit(project_id, &branch_id, "commit one", None, false)
             .await
             .unwrap()
     };
@@ -303,7 +288,7 @@ async fn root() {
     {
         fs::write(repository.path().join("file two.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit two", None, false)
+            .create_commit(project_id, &branch_id, "commit two", None, false)
             .await
             .unwrap()
     };
@@ -311,23 +296,18 @@ async fn root() {
     {
         fs::write(repository.path().join("file three.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit three", None, false)
+            .create_commit(project_id, &branch_id, "commit three", None, false)
             .await
             .unwrap()
     };
 
     controller
-        .update_commit_message(
-            &project_id,
-            &branch_id,
-            commit_one_oid,
-            "commit one updated",
-        )
+        .update_commit_message(project_id, &branch_id, commit_one_oid, "commit one updated")
         .await
         .unwrap();
 
     let branch = controller
-        .list_virtual_branches(&project_id)
+        .list_virtual_branches(project_id)
         .await
         .unwrap()
         .0
@@ -353,29 +333,29 @@ async fn empty() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
     let commit_one_oid = {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
         controller
-            .create_commit(&project_id, &branch_id, "commit one", None, false)
+            .create_commit(project_id, &branch_id, "commit one", None, false)
             .await
             .unwrap()
     };
 
     assert!(matches!(
         controller
-            .update_commit_message(&project_id, &branch_id, commit_one_oid, "",)
+            .update_commit_message(project_id, &branch_id, commit_one_oid, "",)
             .await,
         Err(ControllerError::Action(
             errors::UpdateCommitMessageError::EmptyMessage

--- a/gitbutler-app/tests/suite/virtual_branches/upstream.rs
+++ b/gitbutler-app/tests/suite/virtual_branches/upstream.rs
@@ -7,15 +7,15 @@ async fn detect_upstream_commits() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch1_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
@@ -23,7 +23,7 @@ async fn detect_upstream_commits() {
         // create first commit
         fs::write(repository.path().join("file.txt"), "content").unwrap();
         controller
-            .create_commit(&project_id, &branch1_id, "commit", None, false)
+            .create_commit(project_id, &branch1_id, "commit", None, false)
             .await
             .unwrap()
     };
@@ -32,14 +32,14 @@ async fn detect_upstream_commits() {
         // create second commit
         fs::write(repository.path().join("file.txt"), "content2").unwrap();
         controller
-            .create_commit(&project_id, &branch1_id, "commit", None, false)
+            .create_commit(project_id, &branch1_id, "commit", None, false)
             .await
             .unwrap()
     };
 
     // push
     controller
-        .push_virtual_branch(&project_id, &branch1_id, false, None)
+        .push_virtual_branch(project_id, &branch1_id, false, None)
         .await
         .unwrap();
 
@@ -47,14 +47,14 @@ async fn detect_upstream_commits() {
         // create third commit
         fs::write(repository.path().join("file.txt"), "content3").unwrap();
         controller
-            .create_commit(&project_id, &branch1_id, "commit", None, false)
+            .create_commit(project_id, &branch1_id, "commit", None, false)
             .await
             .unwrap()
     };
 
     {
         // should correctly detect pushed commits
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
         assert_eq!(branches[0].id, branch1_id);
         assert_eq!(branches[0].commits.len(), 3);
@@ -74,15 +74,15 @@ async fn detect_integrated_commits() {
         project_id,
         controller,
         ..
-    } = Test::default();
+    } = &Test::default();
 
     controller
-        .set_base_branch(&project_id, &"refs/remotes/origin/master".parse().unwrap())
+        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
         .await
         .unwrap();
 
     let branch1_id = controller
-        .create_virtual_branch(&project_id, &branch::BranchCreateRequest::default())
+        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
@@ -90,7 +90,7 @@ async fn detect_integrated_commits() {
         // create first commit
         fs::write(repository.path().join("file.txt"), "content").unwrap();
         controller
-            .create_commit(&project_id, &branch1_id, "commit", None, false)
+            .create_commit(project_id, &branch1_id, "commit", None, false)
             .await
             .unwrap()
     };
@@ -99,21 +99,21 @@ async fn detect_integrated_commits() {
         // create second commit
         fs::write(repository.path().join("file.txt"), "content2").unwrap();
         controller
-            .create_commit(&project_id, &branch1_id, "commit", None, false)
+            .create_commit(project_id, &branch1_id, "commit", None, false)
             .await
             .unwrap()
     };
 
     // push
     controller
-        .push_virtual_branch(&project_id, &branch1_id, false, None)
+        .push_virtual_branch(project_id, &branch1_id, false, None)
         .await
         .unwrap();
 
     {
         // merge branch upstream
         let branch = controller
-            .list_virtual_branches(&project_id)
+            .list_virtual_branches(project_id)
             .await
             .unwrap()
             .0
@@ -128,14 +128,14 @@ async fn detect_integrated_commits() {
         // create third commit
         fs::write(repository.path().join("file.txt"), "content3").unwrap();
         controller
-            .create_commit(&project_id, &branch1_id, "commit", None, false)
+            .create_commit(project_id, &branch1_id, "commit", None, false)
             .await
             .unwrap()
     };
 
     {
         // should correctly detect pushed commits
-        let (branches, _, _) = controller.list_virtual_branches(&project_id).await.unwrap();
+        let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
         assert_eq!(branches.len(), 1);
         assert_eq!(branches[0].id, branch1_id);
         assert_eq!(branches[0].commits.len(), 3);

--- a/gitbutler-app/tests/virtual_branches/branch/reader.rs
+++ b/gitbutler-app/tests/virtual_branches/branch/reader.rs
@@ -59,10 +59,11 @@ fn test_branch() -> Branch {
 
 #[test]
 fn read_not_found() -> Result<()> {
-    let Case { gb_repository, .. } = Suite::default().new_case();
+    let suite = Suite::default();
+    let Case { gb_repository, .. } = &suite.new_case();
 
     let session = gb_repository.get_or_create_current_session()?;
-    let session_reader = gitbutler_app::sessions::Reader::open(&gb_repository, &session)?;
+    let session_reader = gitbutler_app::sessions::Reader::open(gb_repository, &session)?;
 
     let reader = branch::Reader::new(&session_reader);
     let result = reader.read(&BranchId::generate());
@@ -74,19 +75,20 @@ fn read_not_found() -> Result<()> {
 
 #[test]
 fn read_override() -> Result<()> {
+    let suite = Suite::default();
     let Case {
         gb_repository,
         project,
         ..
-    } = Suite::default().new_case();
+    } = &suite.new_case();
 
     let mut branch = test_branch();
 
-    let writer = branch::Writer::new(&gb_repository, project.gb_dir())?;
+    let writer = branch::Writer::new(gb_repository, project.gb_dir())?;
     writer.write(&mut branch)?;
 
     let session = gb_repository.get_current_session()?.unwrap();
-    let session_reader = gitbutler_app::sessions::Reader::open(&gb_repository, &session)?;
+    let session_reader = gitbutler_app::sessions::Reader::open(gb_repository, &session)?;
 
     let reader = branch::Reader::new(&session_reader);
 

--- a/gitbutler-app/tests/virtual_branches/branch/writer.rs
+++ b/gitbutler-app/tests/virtual_branches/branch/writer.rs
@@ -59,15 +59,16 @@ fn new_test_branch() -> Branch {
 
 #[test]
 fn write_branch() -> anyhow::Result<()> {
+    let suite = Suite::default();
     let Case {
         gb_repository,
         project,
         ..
-    } = Suite::default().new_case();
+    } = &suite.new_case();
 
     let mut branch = new_test_branch();
 
-    let writer = branch::Writer::new(&gb_repository, project.gb_dir())?;
+    let writer = branch::Writer::new(gb_repository, project.gb_dir())?;
     writer.write(&mut branch)?;
 
     let root = gb_repository
@@ -124,15 +125,16 @@ fn write_branch() -> anyhow::Result<()> {
 
 #[test]
 fn should_create_session() -> anyhow::Result<()> {
+    let suite = Suite::default();
     let Case {
         gb_repository,
         project,
         ..
-    } = Suite::default().new_case();
+    } = &suite.new_case();
 
     let mut branch = new_test_branch();
 
-    let writer = branch::Writer::new(&gb_repository, project.gb_dir())?;
+    let writer = branch::Writer::new(gb_repository, project.gb_dir())?;
     writer.write(&mut branch)?;
 
     assert!(gb_repository.get_current_session()?.is_some());
@@ -142,15 +144,16 @@ fn should_create_session() -> anyhow::Result<()> {
 
 #[test]
 fn should_update() -> anyhow::Result<()> {
+    let suite = Suite::default();
     let Case {
         gb_repository,
         project,
         ..
-    } = Suite::default().new_case();
+    } = &suite.new_case();
 
     let mut branch = new_test_branch();
 
-    let writer = branch::Writer::new(&gb_repository, project.gb_dir())?;
+    let writer = branch::Writer::new(gb_repository, project.gb_dir())?;
     writer.write(&mut branch)?;
 
     let mut updated_branch = Branch {

--- a/gitbutler-app/tests/virtual_branches/iterator.rs
+++ b/gitbutler-app/tests/virtual_branches/iterator.rs
@@ -68,10 +68,11 @@ fn new_test_target() -> virtual_branches::target::Target {
 
 #[test]
 fn empty_iterator() -> Result<()> {
-    let Case { gb_repository, .. } = Suite::default().new_case();
+    let suite = Suite::default();
+    let Case { gb_repository, .. } = &suite.new_case();
 
     let session = gb_repository.get_or_create_current_session()?;
-    let session_reader = gitbutler_app::sessions::Reader::open(&gb_repository, &session)?;
+    let session_reader = gitbutler_app::sessions::Reader::open(gb_repository, &session)?;
 
     let iter = virtual_branches::Iterator::new(&session_reader)?;
 
@@ -82,18 +83,19 @@ fn empty_iterator() -> Result<()> {
 
 #[test]
 fn iterate_all() -> Result<()> {
+    let suite = Suite::default();
     let Case {
         gb_repository,
         project,
         ..
-    } = Suite::default().new_case();
+    } = &suite.new_case();
 
     let target_writer =
-        gitbutler_app::virtual_branches::target::Writer::new(&gb_repository, project.gb_dir())?;
+        gitbutler_app::virtual_branches::target::Writer::new(gb_repository, project.gb_dir())?;
     target_writer.write_default(&new_test_target())?;
 
     let branch_writer =
-        gitbutler_app::virtual_branches::branch::Writer::new(&gb_repository, project.gb_dir())?;
+        gitbutler_app::virtual_branches::branch::Writer::new(gb_repository, project.gb_dir())?;
     let mut branch_1 = new_test_branch();
     branch_writer.write(&mut branch_1)?;
     let mut branch_2 = new_test_branch();
@@ -102,7 +104,7 @@ fn iterate_all() -> Result<()> {
     branch_writer.write(&mut branch_3)?;
 
     let session = gb_repository.get_current_session()?.unwrap();
-    let session_reader = gitbutler_app::sessions::Reader::open(&gb_repository, &session)?;
+    let session_reader = gitbutler_app::sessions::Reader::open(gb_repository, &session)?;
 
     let iter = virtual_branches::Iterator::new(&session_reader)?
         .collect::<Result<Vec<_>, gitbutler_app::reader::Error>>()?;

--- a/gitbutler-app/tests/virtual_branches/target/reader.rs
+++ b/gitbutler-app/tests/virtual_branches/target/reader.rs
@@ -53,10 +53,11 @@ fn test_branch() -> gitbutler_app::virtual_branches::branch::Branch {
 
 #[test]
 fn read_not_found() -> Result<()> {
-    let Case { gb_repository, .. } = Suite::default().new_case();
+    let suite = Suite::default();
+    let Case { gb_repository, .. } = &suite.new_case();
 
     let session = gb_repository.get_or_create_current_session()?;
-    let session_reader = gitbutler_app::sessions::Reader::open(&gb_repository, &session)?;
+    let session_reader = gitbutler_app::sessions::Reader::open(gb_repository, &session)?;
 
     let reader = target::Reader::new(&session_reader);
     let result = reader.read(&BranchId::generate());
@@ -68,7 +69,8 @@ fn read_not_found() -> Result<()> {
 
 #[test]
 fn read_deprecated_format() -> Result<()> {
-    let Case { gb_repository, .. } = Suite::default().new_case();
+    let suite = Suite::default();
+    let Case { gb_repository, .. } = &suite.new_case();
 
     let writer = gitbutler_app::writer::DirWriter::open(gb_repository.root())?;
     writer
@@ -88,7 +90,7 @@ fn read_deprecated_format() -> Result<()> {
         .unwrap();
 
     let session = gb_repository.get_or_create_current_session()?;
-    let session_reader = gitbutler_app::sessions::Reader::open(&gb_repository, &session)?;
+    let session_reader = gitbutler_app::sessions::Reader::open(gb_repository, &session)?;
     let reader = target::Reader::new(&session_reader);
 
     let read = reader.read_default().unwrap();
@@ -105,11 +107,12 @@ fn read_deprecated_format() -> Result<()> {
 
 #[test]
 fn read_override_target() -> Result<()> {
+    let suite = Suite::default();
     let Case {
         gb_repository,
         project,
         ..
-    } = Suite::default().new_case();
+    } = &suite.new_case();
 
     let mut branch = test_branch();
 
@@ -128,13 +131,13 @@ fn read_override_target() -> Result<()> {
     };
 
     let branch_writer =
-        gitbutler_app::virtual_branches::branch::Writer::new(&gb_repository, project.gb_dir())?;
+        gitbutler_app::virtual_branches::branch::Writer::new(gb_repository, project.gb_dir())?;
     branch_writer.write(&mut branch)?;
 
     let session = gb_repository.get_current_session()?.unwrap();
-    let session_reader = gitbutler_app::sessions::Reader::open(&gb_repository, &session)?;
+    let session_reader = gitbutler_app::sessions::Reader::open(gb_repository, &session)?;
 
-    let target_writer = target::Writer::new(&gb_repository, project.gb_dir())?;
+    let target_writer = target::Writer::new(gb_repository, project.gb_dir())?;
     let reader = target::Reader::new(&session_reader);
 
     target_writer.write_default(&default_target)?;

--- a/gitbutler-app/tests/virtual_branches/target/writer.rs
+++ b/gitbutler-app/tests/virtual_branches/target/writer.rs
@@ -56,11 +56,12 @@ fn test_branch() -> branch::Branch {
 
 #[test]
 fn write() -> anyhow::Result<()> {
+    let suite = Suite::default();
     let Case {
         gb_repository,
         project,
         ..
-    } = Suite::default().new_case();
+    } = &suite.new_case();
 
     let mut branch = test_branch();
     let target = Target {
@@ -69,10 +70,10 @@ fn write() -> anyhow::Result<()> {
         sha: "0123456789abcdef0123456789abcdef01234567".parse().unwrap(),
     };
 
-    let branch_writer = branch::Writer::new(&gb_repository, project.gb_dir())?;
+    let branch_writer = branch::Writer::new(gb_repository, project.gb_dir())?;
     branch_writer.write(&mut branch)?;
 
-    let target_writer = target::Writer::new(&gb_repository, project.gb_dir())?;
+    let target_writer = target::Writer::new(gb_repository, project.gb_dir())?;
     target_writer.write(&branch.id, &target)?;
 
     let root = gb_repository
@@ -147,11 +148,12 @@ fn write() -> anyhow::Result<()> {
 
 #[test]
 fn should_update() -> anyhow::Result<()> {
+    let suite = Suite::default();
     let Case {
         gb_repository,
         project,
         ..
-    } = Suite::default().new_case();
+    } = &suite.new_case();
 
     let mut branch = test_branch();
     let target = Target {
@@ -160,9 +162,9 @@ fn should_update() -> anyhow::Result<()> {
         sha: "0123456789abcdef0123456789abcdef01234567".parse().unwrap(),
     };
 
-    let branch_writer = branch::Writer::new(&gb_repository, project.gb_dir())?;
+    let branch_writer = branch::Writer::new(gb_repository, project.gb_dir())?;
     branch_writer.write(&mut branch)?;
-    let target_writer = target::Writer::new(&gb_repository, project.gb_dir())?;
+    let target_writer = target::Writer::new(gb_repository, project.gb_dir())?;
     target_writer.write(&branch.id, &target)?;
 
     let updated_target = Target {

--- a/gitbutler-app/tests/watcher/handler/calculate_delta_handler.rs
+++ b/gitbutler-app/tests/watcher/handler/calculate_delta_handler.rs
@@ -85,7 +85,7 @@ fn register_existing_commited_file() -> Result<()> {
         project,
         ..
     } = &suite.new_case_with_files(HashMap::from([(PathBuf::from("test.txt"), "test")]));
-    let listener = Handler::from_path(&suite.local_app_data);
+    let listener = Handler::from_path(suite.local_app_data());
 
     std::fs::write(project.path.join("test.txt"), "test2")?;
     listener.handle("test.txt", &project.id)?;
@@ -116,7 +116,7 @@ fn register_must_init_current_session() -> Result<()> {
         project,
         ..
     } = &suite.new_case();
-    let listener = Handler::from_path(&suite.local_app_data);
+    let listener = Handler::from_path(suite.local_app_data());
 
     std::fs::write(project.path.join("test.txt"), "test")?;
     listener.handle("test.txt", &project.id)?;
@@ -134,7 +134,7 @@ fn register_must_not_override_current_session() -> Result<()> {
         project,
         ..
     } = &suite.new_case();
-    let listener = Handler::from_path(&suite.local_app_data);
+    let listener = Handler::from_path(suite.local_app_data());
 
     std::fs::write(project.path.join("test.txt"), "test")?;
     listener.handle("test.txt", &project.id)?;
@@ -157,7 +157,7 @@ fn register_binfile() -> Result<()> {
         project,
         ..
     } = &suite.new_case();
-    let listener = Handler::from_path(&suite.local_app_data);
+    let listener = Handler::from_path(suite.local_app_data());
 
     std::fs::write(
         project.path.join("test.bin"),
@@ -189,7 +189,7 @@ fn register_empty_new_file() -> Result<()> {
         project,
         ..
     } = &suite.new_case();
-    let listener = Handler::from_path(&suite.local_app_data);
+    let listener = Handler::from_path(suite.local_app_data());
 
     std::fs::write(project.path.join("test.txt"), "")?;
 
@@ -217,7 +217,7 @@ fn register_new_file() -> Result<()> {
         project,
         ..
     } = &suite.new_case();
-    let listener = Handler::from_path(&suite.local_app_data);
+    let listener = Handler::from_path(suite.local_app_data());
 
     std::fs::write(project.path.join("test.txt"), "test")?;
 
@@ -250,7 +250,7 @@ fn register_no_changes_saved_thgoughout_flushes() -> Result<()> {
         project,
         ..
     } = &suite.new_case();
-    let listener = Handler::from_path(&suite.local_app_data);
+    let listener = Handler::from_path(suite.local_app_data());
 
     // file change, wd and deltas are written
     std::fs::write(project.path.join("test.txt"), "test")?;
@@ -278,7 +278,7 @@ fn register_new_file_twice() -> Result<()> {
         project,
         ..
     } = &suite.new_case();
-    let listener = Handler::from_path(&suite.local_app_data);
+    let listener = Handler::from_path(suite.local_app_data());
 
     std::fs::write(project.path.join("test.txt"), "test")?;
     listener.handle("test.txt", &project.id)?;
@@ -330,7 +330,7 @@ fn register_file_deleted() -> Result<()> {
         project,
         ..
     } = &suite.new_case();
-    let listener = Handler::from_path(&suite.local_app_data);
+    let listener = Handler::from_path(suite.local_app_data());
 
     {
         // write file
@@ -409,7 +409,7 @@ fn flow_with_commits() -> Result<()> {
         project_repository,
         ..
     } = &suite.new_case();
-    let listener = Handler::from_path(&suite.local_app_data);
+    let listener = Handler::from_path(suite.local_app_data());
 
     let size = 10;
     let relative_file_path = Path::new("one/two/test.txt");
@@ -496,7 +496,7 @@ fn flow_no_commits() -> Result<()> {
         project_repository,
         ..
     } = &suite.new_case();
-    let listener = Handler::from_path(&suite.local_app_data);
+    let listener = Handler::from_path(suite.local_app_data());
 
     let size = 10;
     let relative_file_path = Path::new("one/two/test.txt");
@@ -581,7 +581,7 @@ fn flow_signle_session() -> Result<()> {
         project,
         ..
     } = &suite.new_case();
-    let listener = Handler::from_path(&suite.local_app_data);
+    let listener = Handler::from_path(suite.local_app_data());
 
     let size = 10_i32;
     let relative_file_path = Path::new("one/two/test.txt");
@@ -636,7 +636,7 @@ fn should_persist_branches_targets_state_between_sessions() -> Result<()> {
         project_repository,
         ..
     } = &suite.new_case_with_files(HashMap::from([(PathBuf::from("test.txt"), "hello world")]));
-    let listener = Handler::from_path(&suite.local_app_data);
+    let listener = Handler::from_path(suite.local_app_data());
 
     let branch_writer = branch::Writer::new(gb_repository, project.gb_dir())?;
     let target_writer = virtual_branches::target::Writer::new(gb_repository, project.gb_dir())?;
@@ -689,7 +689,7 @@ fn should_restore_branches_targets_state_from_head_session() -> Result<()> {
         project_repository,
         ..
     } = &suite.new_case_with_files(HashMap::from([(PathBuf::from("test.txt"), "hello world")]));
-    let listener = Handler::from_path(&suite.local_app_data);
+    let listener = Handler::from_path(suite.local_app_data());
 
     let branch_writer = branch::Writer::new(gb_repository, project.gb_dir())?;
     let target_writer = virtual_branches::target::Writer::new(gb_repository, project.gb_dir())?;
@@ -748,7 +748,7 @@ mod flush_wd {
             project_repository,
             ..
         } = &suite.new_case();
-        let listener = Handler::from_path(&suite.local_app_data);
+        let listener = Handler::from_path(suite.local_app_data());
 
         // write a file into session
         std::fs::write(project.path.join("test.txt"), "hello world!").unwrap();
@@ -821,7 +821,7 @@ mod flush_wd {
             project_repository,
             ..
         } = &suite.new_case();
-        let listener = Handler::from_path(&suite.local_app_data);
+        let listener = Handler::from_path(suite.local_app_data());
 
         // write a file into session
         std::fs::write(project.path.join("test.txt"), "hello world!").unwrap();
@@ -894,7 +894,7 @@ mod flush_wd {
             project_repository,
             ..
         } = &suite.new_case();
-        let listener = Handler::from_path(&suite.local_app_data);
+        let listener = Handler::from_path(suite.local_app_data());
 
         // write a file into session
         std::fs::write(project.path.join("test.txt"), "hello world!").unwrap();

--- a/gitbutler-app/tests/watcher/handler/calculate_delta_handler.rs
+++ b/gitbutler-app/tests/watcher/handler/calculate_delta_handler.rs
@@ -84,14 +84,14 @@ fn register_existing_commited_file() -> Result<()> {
         gb_repository,
         project,
         ..
-    } = suite.new_case_with_files(HashMap::from([(PathBuf::from("test.txt"), "test")]));
+    } = &suite.new_case_with_files(HashMap::from([(PathBuf::from("test.txt"), "test")]));
     let listener = Handler::from_path(&suite.local_app_data);
 
     std::fs::write(project.path.join("test.txt"), "test2")?;
     listener.handle("test.txt", &project.id)?;
 
     let session = gb_repository.get_current_session()?.unwrap();
-    let session_reader = sessions::Reader::open(&gb_repository, &session)?;
+    let session_reader = sessions::Reader::open(gb_repository, &session)?;
     let deltas_reader = deltas::Reader::new(&session_reader);
     let deltas = deltas_reader.read_file("test.txt")?.unwrap();
     assert_eq!(deltas.len(), 1);
@@ -115,7 +115,7 @@ fn register_must_init_current_session() -> Result<()> {
         gb_repository,
         project,
         ..
-    } = suite.new_case();
+    } = &suite.new_case();
     let listener = Handler::from_path(&suite.local_app_data);
 
     std::fs::write(project.path.join("test.txt"), "test")?;
@@ -133,7 +133,7 @@ fn register_must_not_override_current_session() -> Result<()> {
         gb_repository,
         project,
         ..
-    } = suite.new_case();
+    } = &suite.new_case();
     let listener = Handler::from_path(&suite.local_app_data);
 
     std::fs::write(project.path.join("test.txt"), "test")?;
@@ -156,7 +156,7 @@ fn register_binfile() -> Result<()> {
         gb_repository,
         project,
         ..
-    } = suite.new_case();
+    } = &suite.new_case();
     let listener = Handler::from_path(&suite.local_app_data);
 
     std::fs::write(
@@ -167,7 +167,7 @@ fn register_binfile() -> Result<()> {
     listener.handle("test.bin", &project.id)?;
 
     let session = gb_repository.get_current_session()?.unwrap();
-    let session_reader = sessions::Reader::open(&gb_repository, &session)?;
+    let session_reader = sessions::Reader::open(gb_repository, &session)?;
     let deltas_reader = deltas::Reader::new(&session_reader);
     let deltas = deltas_reader.read_file("test.bin")?.unwrap();
 
@@ -188,7 +188,7 @@ fn register_empty_new_file() -> Result<()> {
         gb_repository,
         project,
         ..
-    } = suite.new_case();
+    } = &suite.new_case();
     let listener = Handler::from_path(&suite.local_app_data);
 
     std::fs::write(project.path.join("test.txt"), "")?;
@@ -196,7 +196,7 @@ fn register_empty_new_file() -> Result<()> {
     listener.handle("test.txt", &project.id)?;
 
     let session = gb_repository.get_current_session()?.unwrap();
-    let session_reader = sessions::Reader::open(&gb_repository, &session)?;
+    let session_reader = sessions::Reader::open(gb_repository, &session)?;
     let deltas_reader = deltas::Reader::new(&session_reader);
     let deltas = deltas_reader.read_file("test.txt")?.unwrap();
     assert_eq!(deltas.len(), 1);
@@ -216,7 +216,7 @@ fn register_new_file() -> Result<()> {
         gb_repository,
         project,
         ..
-    } = suite.new_case();
+    } = &suite.new_case();
     let listener = Handler::from_path(&suite.local_app_data);
 
     std::fs::write(project.path.join("test.txt"), "test")?;
@@ -224,7 +224,7 @@ fn register_new_file() -> Result<()> {
     listener.handle("test.txt", &project.id)?;
 
     let session = gb_repository.get_current_session()?.unwrap();
-    let session_reader = sessions::Reader::open(&gb_repository, &session)?;
+    let session_reader = sessions::Reader::open(gb_repository, &session)?;
     let deltas_reader = deltas::Reader::new(&session_reader);
     let deltas = deltas_reader.read_file("test.txt")?.unwrap();
     assert_eq!(deltas.len(), 1);
@@ -249,7 +249,7 @@ fn register_no_changes_saved_thgoughout_flushes() -> Result<()> {
         project_repository,
         project,
         ..
-    } = suite.new_case();
+    } = &suite.new_case();
     let listener = Handler::from_path(&suite.local_app_data);
 
     // file change, wd and deltas are written
@@ -257,13 +257,13 @@ fn register_no_changes_saved_thgoughout_flushes() -> Result<()> {
     listener.handle("test.txt", &project.id)?;
 
     // make two more sessions.
-    gb_repository.flush(&project_repository, None)?;
+    gb_repository.flush(project_repository, None)?;
     gb_repository.get_or_create_current_session()?;
-    gb_repository.flush(&project_repository, None)?;
+    gb_repository.flush(project_repository, None)?;
 
     // after some sessions, files from the first change are still there.
     let session = gb_repository.get_or_create_current_session()?;
-    let session_reader = sessions::Reader::open(&gb_repository, &session)?;
+    let session_reader = sessions::Reader::open(gb_repository, &session)?;
     let files = session_reader.files(None)?;
     assert_eq!(files.len(), 1);
 
@@ -277,14 +277,14 @@ fn register_new_file_twice() -> Result<()> {
         gb_repository,
         project,
         ..
-    } = suite.new_case();
+    } = &suite.new_case();
     let listener = Handler::from_path(&suite.local_app_data);
 
     std::fs::write(project.path.join("test.txt"), "test")?;
     listener.handle("test.txt", &project.id)?;
 
     let session = gb_repository.get_current_session()?.unwrap();
-    let session_reader = sessions::Reader::open(&gb_repository, &session)?;
+    let session_reader = sessions::Reader::open(gb_repository, &session)?;
     let deltas_reader = deltas::Reader::new(&session_reader);
     let deltas = deltas_reader.read_file("test.txt")?.unwrap();
     assert_eq!(deltas.len(), 1);
@@ -329,7 +329,7 @@ fn register_file_deleted() -> Result<()> {
         project_repository,
         project,
         ..
-    } = suite.new_case();
+    } = &suite.new_case();
     let listener = Handler::from_path(&suite.local_app_data);
 
     {
@@ -341,7 +341,7 @@ fn register_file_deleted() -> Result<()> {
     {
         // current session must have the deltas, but not the file (it didn't exist)
         let session = gb_repository.get_current_session()?.unwrap();
-        let session_reader = sessions::Reader::open(&gb_repository, &session)?;
+        let session_reader = sessions::Reader::open(gb_repository, &session)?;
         let deltas_reader = deltas::Reader::new(&session_reader);
         let deltas = deltas_reader.read_file("test.txt")?.unwrap();
         assert_eq!(deltas.len(), 1);
@@ -359,12 +359,12 @@ fn register_file_deleted() -> Result<()> {
         assert!(files.is_empty());
     }
 
-    gb_repository.flush(&project_repository, None)?;
+    gb_repository.flush(project_repository, None)?;
 
     {
         // file should be available in the next session, but not deltas just yet.
         let session = gb_repository.get_or_create_current_session()?;
-        let session_reader = sessions::Reader::open(&gb_repository, &session)?;
+        let session_reader = sessions::Reader::open(gb_repository, &session)?;
         let files = session_reader.files(None).unwrap();
         assert_eq!(files.len(), 1);
         assert_eq!(
@@ -387,12 +387,12 @@ fn register_file_deleted() -> Result<()> {
         assert_eq!(deltas[0].operations[0], Operation::Delete((0, 4)),);
     }
 
-    gb_repository.flush(&project_repository, None)?;
+    gb_repository.flush(project_repository, None)?;
 
     {
         // since file was deleted in the previous session, it should not exist in the new one.
         let session = gb_repository.get_or_create_current_session()?;
-        let session_reader = sessions::Reader::open(&gb_repository, &session)?;
+        let session_reader = sessions::Reader::open(gb_repository, &session)?;
         let files = session_reader.files(None).unwrap();
         assert!(files.is_empty());
     }
@@ -408,7 +408,7 @@ fn flow_with_commits() -> Result<()> {
         project,
         project_repository,
         ..
-    } = suite.new_case();
+    } = &suite.new_case();
     let listener = Handler::from_path(&suite.local_app_data);
 
     let size = 10;
@@ -423,7 +423,7 @@ fn flow_with_commits() -> Result<()> {
 
         commit_all(&project_repository.git_repository);
         listener.handle(relative_file_path, &project.id)?;
-        assert!(gb_repository.flush(&project_repository, None)?.is_some());
+        assert!(gb_repository.flush(project_repository, None)?.is_some());
     }
 
     // get all the created sessions
@@ -450,7 +450,7 @@ fn flow_with_commits() -> Result<()> {
         // collect all operations from sessions in the reverse order
         let mut operations: Vec<Operation> = vec![];
         for session in &mut *sessions_slice {
-            let session_reader = sessions::Reader::open(&gb_repository, session).unwrap();
+            let session_reader = sessions::Reader::open(gb_repository, session).unwrap();
             let deltas_reader = deltas::Reader::new(&session_reader);
             let deltas_by_filepath = deltas_reader.read(None).unwrap();
             for deltas in deltas_by_filepath.values() {
@@ -463,7 +463,7 @@ fn flow_with_commits() -> Result<()> {
         }
 
         let reader =
-            sessions::Reader::open(&gb_repository, sessions_slice.first().unwrap()).unwrap();
+            sessions::Reader::open(gb_repository, sessions_slice.first().unwrap()).unwrap();
         let files = reader.files(None).unwrap();
 
         if i == 0 {
@@ -495,7 +495,7 @@ fn flow_no_commits() -> Result<()> {
         project,
         project_repository,
         ..
-    } = suite.new_case();
+    } = &suite.new_case();
     let listener = Handler::from_path(&suite.local_app_data);
 
     let size = 10;
@@ -509,7 +509,7 @@ fn flow_no_commits() -> Result<()> {
         )?;
 
         listener.handle(relative_file_path, &project.id)?;
-        assert!(gb_repository.flush(&project_repository, None)?.is_some());
+        assert!(gb_repository.flush(project_repository, None)?.is_some());
     }
 
     // get all the created sessions
@@ -536,7 +536,7 @@ fn flow_no_commits() -> Result<()> {
         // collect all operations from sessions in the reverse order
         let mut operations: Vec<Operation> = vec![];
         for session in &mut *sessions_slice {
-            let session_reader = sessions::Reader::open(&gb_repository, session).unwrap();
+            let session_reader = sessions::Reader::open(gb_repository, session).unwrap();
             let deltas_reader = deltas::Reader::new(&session_reader);
             let deltas_by_filepath = deltas_reader.read(None).unwrap();
             for deltas in deltas_by_filepath.values() {
@@ -549,7 +549,7 @@ fn flow_no_commits() -> Result<()> {
         }
 
         let reader =
-            sessions::Reader::open(&gb_repository, sessions_slice.first().unwrap()).unwrap();
+            sessions::Reader::open(gb_repository, sessions_slice.first().unwrap()).unwrap();
         let files = reader.files(None).unwrap();
 
         if i == 0 {
@@ -580,7 +580,7 @@ fn flow_signle_session() -> Result<()> {
         gb_repository,
         project,
         ..
-    } = suite.new_case();
+    } = &suite.new_case();
     let listener = Handler::from_path(&suite.local_app_data);
 
     let size = 10_i32;
@@ -599,7 +599,7 @@ fn flow_signle_session() -> Result<()> {
     // collect all operations from sessions in the reverse order
     let mut operations: Vec<Operation> = vec![];
     let session = gb_repository.get_current_session()?.unwrap();
-    let session_reader = sessions::Reader::open(&gb_repository, &session).unwrap();
+    let session_reader = sessions::Reader::open(gb_repository, &session).unwrap();
     let deltas_reader = deltas::Reader::new(&session_reader);
     let deltas_by_filepath = deltas_reader.read(None).unwrap();
     for deltas in deltas_by_filepath.values() {
@@ -610,7 +610,7 @@ fn flow_signle_session() -> Result<()> {
         }
     }
 
-    let reader = sessions::Reader::open(&gb_repository, &session).unwrap();
+    let reader = sessions::Reader::open(gb_repository, &session).unwrap();
     let files = reader.files(None).unwrap();
 
     let base_file = files.get(&relative_file_path.to_path_buf());
@@ -635,11 +635,11 @@ fn should_persist_branches_targets_state_between_sessions() -> Result<()> {
         project,
         project_repository,
         ..
-    } = suite.new_case_with_files(HashMap::from([(PathBuf::from("test.txt"), "hello world")]));
+    } = &suite.new_case_with_files(HashMap::from([(PathBuf::from("test.txt"), "hello world")]));
     let listener = Handler::from_path(&suite.local_app_data);
 
-    let branch_writer = branch::Writer::new(&gb_repository, project.gb_dir())?;
-    let target_writer = virtual_branches::target::Writer::new(&gb_repository, project.gb_dir())?;
+    let branch_writer = branch::Writer::new(gb_repository, project.gb_dir())?;
+    let target_writer = virtual_branches::target::Writer::new(gb_repository, project.gb_dir())?;
     let default_target = new_test_target();
     target_writer.write_default(&default_target)?;
     let mut vbranch0 = new_test_branch();
@@ -652,14 +652,14 @@ fn should_persist_branches_targets_state_between_sessions() -> Result<()> {
     std::fs::write(project.path.join("test.txt"), "hello world!").unwrap();
     listener.handle("test.txt", &project.id)?;
 
-    let flushed_session = gb_repository.flush(&project_repository, None).unwrap();
+    let flushed_session = gb_repository.flush(project_repository, None).unwrap();
 
     // create a new session
     let session = gb_repository.get_or_create_current_session().unwrap();
     assert_ne!(session.id, flushed_session.unwrap().id);
 
     // ensure that the virtual branch is still there and selected
-    let session_reader = sessions::Reader::open(&gb_repository, &session).unwrap();
+    let session_reader = sessions::Reader::open(gb_repository, &session).unwrap();
 
     let branches = virtual_branches::Iterator::new(&session_reader)
         .unwrap()
@@ -688,11 +688,11 @@ fn should_restore_branches_targets_state_from_head_session() -> Result<()> {
         project,
         project_repository,
         ..
-    } = suite.new_case_with_files(HashMap::from([(PathBuf::from("test.txt"), "hello world")]));
+    } = &suite.new_case_with_files(HashMap::from([(PathBuf::from("test.txt"), "hello world")]));
     let listener = Handler::from_path(&suite.local_app_data);
 
-    let branch_writer = branch::Writer::new(&gb_repository, project.gb_dir())?;
-    let target_writer = virtual_branches::target::Writer::new(&gb_repository, project.gb_dir())?;
+    let branch_writer = branch::Writer::new(gb_repository, project.gb_dir())?;
+    let target_writer = virtual_branches::target::Writer::new(gb_repository, project.gb_dir())?;
     let default_target = new_test_target();
     target_writer.write_default(&default_target)?;
     let mut vbranch0 = new_test_branch();
@@ -705,7 +705,7 @@ fn should_restore_branches_targets_state_from_head_session() -> Result<()> {
     std::fs::write(project.path.join("test.txt"), "hello world!").unwrap();
     listener.handle("test.txt", &project.id).unwrap();
 
-    let flushed_session = gb_repository.flush(&project_repository, None).unwrap();
+    let flushed_session = gb_repository.flush(project_repository, None).unwrap();
 
     // hard delete branches state from disk
     std::fs::remove_dir_all(gb_repository.root()).unwrap();
@@ -715,7 +715,7 @@ fn should_restore_branches_targets_state_from_head_session() -> Result<()> {
     assert_ne!(session.id, flushed_session.unwrap().id);
 
     // ensure that the virtual branch is still there and selected
-    let session_reader = sessions::Reader::open(&gb_repository, &session).unwrap();
+    let session_reader = sessions::Reader::open(gb_repository, &session).unwrap();
 
     let branches = virtual_branches::Iterator::new(&session_reader)
         .unwrap()
@@ -747,7 +747,7 @@ mod flush_wd {
             project,
             project_repository,
             ..
-        } = suite.new_case();
+        } = &suite.new_case();
         let listener = Handler::from_path(&suite.local_app_data);
 
         // write a file into session
@@ -755,7 +755,7 @@ mod flush_wd {
         listener.handle("test.txt", &project.id).unwrap();
 
         let flushed_session = gb_repository
-            .flush(&project_repository, None)
+            .flush(project_repository, None)
             .unwrap()
             .unwrap();
         {
@@ -783,7 +783,7 @@ mod flush_wd {
         listener.handle("one/two/test2.txt", &project.id).unwrap();
 
         let flushed_session = gb_repository
-            .flush(&project_repository, None)
+            .flush(project_repository, None)
             .unwrap()
             .unwrap();
         {
@@ -820,7 +820,7 @@ mod flush_wd {
             project,
             project_repository,
             ..
-        } = suite.new_case();
+        } = &suite.new_case();
         let listener = Handler::from_path(&suite.local_app_data);
 
         // write a file into session
@@ -831,7 +831,7 @@ mod flush_wd {
         listener.handle("one/two/test2.txt", &project.id).unwrap();
 
         let flushed_session = gb_repository
-            .flush(&project_repository, None)
+            .flush(project_repository, None)
             .unwrap()
             .unwrap();
         {
@@ -866,7 +866,7 @@ mod flush_wd {
         listener.handle("one/two/test2.txt", &project.id).unwrap();
 
         let flushed_session = gb_repository
-            .flush(&project_repository, None)
+            .flush(project_repository, None)
             .unwrap()
             .unwrap();
         {
@@ -893,7 +893,7 @@ mod flush_wd {
             project,
             project_repository,
             ..
-        } = suite.new_case();
+        } = &suite.new_case();
         let listener = Handler::from_path(&suite.local_app_data);
 
         // write a file into session
@@ -904,7 +904,7 @@ mod flush_wd {
         listener.handle("one/two/test2.txt", &project.id).unwrap();
 
         let flushed_session = gb_repository
-            .flush(&project_repository, None)
+            .flush(project_repository, None)
             .unwrap()
             .unwrap();
         {
@@ -940,7 +940,7 @@ mod flush_wd {
         listener.handle("one/two/test2.txt", &project.id).unwrap();
 
         let flushed_session = gb_repository
-            .flush(&project_repository, None)
+            .flush(project_repository, None)
             .unwrap()
             .unwrap();
         {

--- a/gitbutler-app/tests/watcher/handler/fetch_gitbutler_data.rs
+++ b/gitbutler-app/tests/watcher/handler/fetch_gitbutler_data.rs
@@ -34,7 +34,11 @@ async fn fetch_success() -> anyhow::Result<()> {
         })
         .await?;
 
-    let listener = Handler::new(suite.local_app_data().into(), suite.projects, suite.users);
+    let listener = Handler::new(
+        suite.local_app_data().into(),
+        suite.projects.clone(),
+        suite.users.clone(),
+    );
     listener
         .handle(&project.id, &SystemTime::now())
         .await
@@ -48,7 +52,11 @@ async fn fetch_fail_no_sync() {
     let suite = Suite::default();
     let Case { project, .. } = &suite.new_case();
 
-    let listener = Handler::new(suite.local_app_data().into(), suite.projects, suite.users);
+    let listener = Handler::new(
+        suite.local_app_data().into(),
+        suite.projects.clone(),
+        suite.users.clone(),
+    );
     let res = listener.handle(&project.id, &SystemTime::now()).await;
 
     assert_eq!(&res.unwrap_err().to_string(), "sync disabled");

--- a/gitbutler-app/tests/watcher/handler/fetch_gitbutler_data.rs
+++ b/gitbutler-app/tests/watcher/handler/fetch_gitbutler_data.rs
@@ -10,9 +10,9 @@ use gitbutler_app::watcher::handlers::fetch_gitbutler_data::Handler;
 #[tokio::test]
 async fn fetch_success() -> anyhow::Result<()> {
     let suite = Suite::default();
-    let Case { project, .. } = suite.new_case();
+    let Case { project, .. } = &suite.new_case();
 
-    let cloud = test_remote_repository()?;
+    let (cloud, _tmp) = test_remote_repository()?;
 
     let api_project = projects::ApiProject {
         name: "test-sync".to_string(),
@@ -34,7 +34,7 @@ async fn fetch_success() -> anyhow::Result<()> {
         })
         .await?;
 
-    let listener = Handler::new(suite.local_app_data, suite.projects, suite.users);
+    let listener = Handler::new(suite.local_app_data().into(), suite.projects, suite.users);
     listener
         .handle(&project.id, &SystemTime::now())
         .await
@@ -46,9 +46,9 @@ async fn fetch_success() -> anyhow::Result<()> {
 #[tokio::test]
 async fn fetch_fail_no_sync() {
     let suite = Suite::default();
-    let Case { project, .. } = suite.new_case();
+    let Case { project, .. } = &suite.new_case();
 
-    let listener = Handler::new(suite.local_app_data, suite.projects, suite.users);
+    let listener = Handler::new(suite.local_app_data().into(), suite.projects, suite.users);
     let res = listener.handle(&project.id, &SystemTime::now()).await;
 
     assert_eq!(&res.unwrap_err().to_string(), "sync disabled");

--- a/gitbutler-app/tests/watcher/handler/git_file_change.rs
+++ b/gitbutler-app/tests/watcher/handler/git_file_change.rs
@@ -15,13 +15,13 @@ fn flush_session() -> Result<()> {
         project,
         gb_repository,
         ..
-    } = suite.new_case();
+    } = &suite.new_case();
 
     assert!(gb_repository.get_current_session()?.is_none());
-    create_new_session_via_new_file(&project, &suite);
+    create_new_session_via_new_file(project, &suite);
     assert!(gb_repository.get_current_session()?.is_some());
 
-    let listener = Handler::new(suite.local_app_data, suite.projects, suite.users);
+    let listener = Handler::new(suite.local_app_data().into(), suite.projects, suite.users);
 
     let flush_file_path = project.path.join(".git/GB_FLUSH");
     fs::write(flush_file_path.as_path(), "")?;
@@ -43,13 +43,13 @@ fn do_not_flush_session_if_file_is_missing() -> Result<()> {
         project,
         gb_repository,
         ..
-    } = suite.new_case();
+    } = &suite.new_case();
 
     assert!(gb_repository.get_current_session()?.is_none());
-    create_new_session_via_new_file(&project, &suite);
+    create_new_session_via_new_file(project, &suite);
     assert!(gb_repository.get_current_session()?.is_some());
 
-    let listener = Handler::new(suite.local_app_data, suite.projects, suite.users);
+    let listener = Handler::new(suite.local_app_data().into(), suite.projects, suite.users);
 
     let result = listener.handle("GB_FLUSH", &project.id)?;
 
@@ -71,9 +71,9 @@ fn create_new_session_via_new_file(project: &projects::Project, suite: &Suite) {
 #[test]
 fn flush_deletes_flush_file_without_session_to_flush() -> Result<()> {
     let suite = Suite::default();
-    let Case { project, .. } = suite.new_case();
+    let Case { project, .. } = &suite.new_case();
 
-    let listener = Handler::new(suite.local_app_data, suite.projects, suite.users);
+    let listener = Handler::new(suite.local_app_data().into(), suite.projects, suite.users);
 
     let flush_file_path = project.path.join(".git/GB_FLUSH");
     fs::write(flush_file_path.as_path(), "")?;

--- a/gitbutler-app/tests/watcher/handler/git_file_change.rs
+++ b/gitbutler-app/tests/watcher/handler/git_file_change.rs
@@ -21,7 +21,11 @@ fn flush_session() -> Result<()> {
     create_new_session_via_new_file(project, &suite);
     assert!(gb_repository.get_current_session()?.is_some());
 
-    let listener = Handler::new(suite.local_app_data().into(), suite.projects, suite.users);
+    let listener = Handler::new(
+        suite.local_app_data().into(),
+        suite.projects.clone(),
+        suite.users.clone(),
+    );
 
     let flush_file_path = project.path.join(".git/GB_FLUSH");
     fs::write(flush_file_path.as_path(), "")?;
@@ -49,7 +53,11 @@ fn do_not_flush_session_if_file_is_missing() -> Result<()> {
     create_new_session_via_new_file(project, &suite);
     assert!(gb_repository.get_current_session()?.is_some());
 
-    let listener = Handler::new(suite.local_app_data().into(), suite.projects, suite.users);
+    let listener = Handler::new(
+        suite.local_app_data().into(),
+        suite.projects.clone(),
+        suite.users.clone(),
+    );
 
     let result = listener.handle("GB_FLUSH", &project.id)?;
 
@@ -62,7 +70,7 @@ fn create_new_session_via_new_file(project: &projects::Project, suite: &Suite) {
     fs::write(project.path.join("test.txt"), "test").unwrap();
 
     let file_change_listener =
-        handlers::calculate_deltas_handler::Handler::from_path(&suite.local_app_data);
+        handlers::calculate_deltas_handler::Handler::from_path(suite.local_app_data());
     file_change_listener
         .handle("test.txt", &project.id)
         .unwrap();
@@ -73,7 +81,11 @@ fn flush_deletes_flush_file_without_session_to_flush() -> Result<()> {
     let suite = Suite::default();
     let Case { project, .. } = &suite.new_case();
 
-    let listener = Handler::new(suite.local_app_data().into(), suite.projects, suite.users);
+    let listener = Handler::new(
+        suite.local_app_data().into(),
+        suite.projects.clone(),
+        suite.users.clone(),
+    );
 
     let flush_file_path = project.path.join(".git/GB_FLUSH");
     fs::write(flush_file_path.as_path(), "")?;

--- a/gitbutler-app/tests/watcher/handler/mod.rs
+++ b/gitbutler-app/tests/watcher/handler/mod.rs
@@ -1,10 +1,10 @@
 use crate::init_opts_bare;
+use tempfile::TempDir;
 
-fn test_remote_repository() -> anyhow::Result<git2::Repository> {
-    let path = tempfile::tempdir()?.path().to_str().unwrap().to_string();
-    let repo_a = git2::Repository::init_opts(path, &init_opts_bare())?;
-
-    Ok(repo_a)
+fn test_remote_repository() -> anyhow::Result<(git2::Repository, TempDir)> {
+    let tmp = tempfile::tempdir()?;
+    let repo_a = git2::Repository::init_opts(&tmp, &init_opts_bare())?;
+    Ok((repo_a, tmp))
 }
 
 mod calculate_delta_handler;

--- a/gitbutler-app/tests/watcher/handler/push_project_to_gitbutler.rs
+++ b/gitbutler-app/tests/watcher/handler/push_project_to_gitbutler.rs
@@ -42,8 +42,8 @@ async fn push_error() -> Result<()> {
 
     let listener = Handler::new(
         suite.local_app_data().into(),
-        suite.projects,
-        suite.users,
+        suite.projects.clone(),
+        suite.users.clone(),
         100,
     );
     let res = listener.handle(&project.id).await;
@@ -99,7 +99,7 @@ async fn push_simple() -> Result<()> {
         let listener = Handler::new(
             suite.local_app_data().into(),
             suite.projects.clone(),
-            suite.users,
+            suite.users.clone(),
             10,
         );
         let res = listener.handle(&project.id).await.unwrap();
@@ -195,7 +195,7 @@ async fn push_remote_ref() -> Result<()> {
         let listener = Handler::new(
             suite.local_app_data().into(),
             suite.projects.clone(),
-            suite.users,
+            suite.users.clone(),
             10,
         );
         listener.handle(&project.id).await.unwrap();
@@ -384,7 +384,7 @@ async fn push_again_no_change() -> Result<()> {
         let listener = Handler::new(
             suite.local_app_data().into(),
             suite.projects.clone(),
-            suite.users,
+            suite.users.clone(),
             10,
         );
         let res = listener.handle(&project.id).await.unwrap();

--- a/gitbutler-app/tests/watcher/handler/push_project_to_gitbutler.rs
+++ b/gitbutler-app/tests/watcher/handler/push_project_to_gitbutler.rs
@@ -18,7 +18,7 @@ fn log_walk(repo: &git2::Repository, head: git::Oid) -> Vec<git::Oid> {
 #[tokio::test]
 async fn push_error() -> Result<()> {
     let suite = Suite::default();
-    let Case { project, .. } = suite.new_case();
+    let Case { project, .. } = &suite.new_case();
 
     let api_project = projects::ApiProject {
         name: "test-sync".to_string(),
@@ -40,7 +40,12 @@ async fn push_error() -> Result<()> {
         })
         .await?;
 
-    let listener = Handler::new(suite.local_app_data, suite.projects, suite.users, 100);
+    let listener = Handler::new(
+        suite.local_app_data().into(),
+        suite.projects,
+        suite.users,
+        100,
+    );
     let res = listener.handle(&project.id).await;
 
     res.unwrap_err();
@@ -56,17 +61,17 @@ async fn push_simple() -> Result<()> {
         gb_repository,
         project_repository,
         ..
-    } = suite.new_case_with_files(HashMap::from([(PathBuf::from("test.txt"), "test")]));
+    } = &suite.new_case_with_files(HashMap::from([(PathBuf::from("test.txt"), "test")]));
 
     suite.sign_in();
 
-    set_test_target(&gb_repository, &project_repository).unwrap();
+    set_test_target(gb_repository, project_repository).unwrap();
 
     let target_id = gb_repository.default_target().unwrap().unwrap().sha;
 
     let reference = project_repository.l(target_id, LogUntil::End).unwrap();
 
-    let cloud_code = test_remote_repository()?;
+    let (cloud_code, _tmp) = test_remote_repository()?;
 
     let api_project = projects::ApiProject {
         name: "test-sync".to_string(),
@@ -92,7 +97,7 @@ async fn push_simple() -> Result<()> {
 
     {
         let listener = Handler::new(
-            suite.local_app_data,
+            suite.local_app_data().into(),
             suite.projects.clone(),
             suite.users,
             10,
@@ -129,15 +134,17 @@ async fn push_remote_ref() -> Result<()> {
         gb_repository,
         project_repository,
         ..
-    } = suite.new_case();
+    } = &suite.new_case();
 
     suite.sign_in();
 
-    set_test_target(&gb_repository, &project_repository).unwrap();
+    set_test_target(gb_repository, project_repository).unwrap();
 
-    let cloud_code: git::Repository = test_remote_repository()?.into();
+    let (cloud_code, _tmp) = test_remote_repository()?;
+    let cloud_code: git::Repository = cloud_code.into();
 
-    let remote_repo: git::Repository = test_remote_repository()?.into();
+    let (remote_repo, _tmp) = test_remote_repository()?;
+    let remote_repo: git::Repository = remote_repo.into();
 
     let last_commit = create_initial_commit(&remote_repo);
 
@@ -186,7 +193,7 @@ async fn push_remote_ref() -> Result<()> {
 
     {
         let listener = Handler::new(
-            suite.local_app_data,
+            suite.local_app_data().into(),
             suite.projects.clone(),
             suite.users,
             10,
@@ -252,7 +259,7 @@ async fn push_batches() -> Result<()> {
         gb_repository,
         project_repository,
         ..
-    } = suite.new_case();
+    } = &suite.new_case();
 
     suite.sign_in();
 
@@ -273,13 +280,13 @@ async fn push_batches() -> Result<()> {
         assert_eq!(reference.len(), 12);
     }
 
-    set_test_target(&gb_repository, &project_repository).unwrap();
+    set_test_target(gb_repository, project_repository).unwrap();
 
     let target_id = gb_repository.default_target().unwrap().unwrap().sha;
 
     let reference = project_repository.l(target_id, LogUntil::End).unwrap();
 
-    let cloud_code = test_remote_repository()?;
+    let (cloud_code, _tmp) = test_remote_repository()?;
 
     let api_project = projects::ApiProject {
         name: "test-sync".to_string(),
@@ -303,7 +310,7 @@ async fn push_batches() -> Result<()> {
 
     {
         let listener = Handler::new(
-            suite.local_app_data.clone(),
+            suite.local_app_data().into(),
             suite.projects.clone(),
             suite.users.clone(),
             2,
@@ -339,17 +346,17 @@ async fn push_again_no_change() -> Result<()> {
         gb_repository,
         project_repository,
         ..
-    } = suite.new_case_with_files(HashMap::from([(PathBuf::from("test.txt"), "test")]));
+    } = &suite.new_case_with_files(HashMap::from([(PathBuf::from("test.txt"), "test")]));
 
     suite.sign_in();
 
-    set_test_target(&gb_repository, &project_repository).unwrap();
+    set_test_target(gb_repository, project_repository).unwrap();
 
     let target_id = gb_repository.default_target().unwrap().unwrap().sha;
 
     let reference = project_repository.l(target_id, LogUntil::End).unwrap();
 
-    let cloud_code = test_remote_repository()?;
+    let (cloud_code, _tmp) = test_remote_repository()?;
 
     let api_project = projects::ApiProject {
         name: "test-sync".to_string(),
@@ -375,7 +382,7 @@ async fn push_again_no_change() -> Result<()> {
 
     {
         let listener = Handler::new(
-            suite.local_app_data,
+            suite.local_app_data().into(),
             suite.projects.clone(),
             suite.users,
             10,


### PR DESCRIPTION
Currently each test creates multiple temp-directories to place various disjoint portions of GitButler in. As only their path is used, these accumulate as they are never cleaned up, or in other words, `tempfile::TempDir` is only used to create a temporary directory name which then is racily re-created.

After having worked with the testsuite quite intensively, I noticed that 680k files in thousands of tempdirectories had accumulated already, each with their own set of files. After deleting them and running the tests just a few times, 38k files were there once again, surprisingly quickly.

Ideally, testfiles and directories are removed after usage so developers don't have to manually clean their machines (just judging from me, I'd probably be obsessive about it).

### Tasks

* [x] make all tests work again 
* [x] validate that directories don't accumulate
* [x] add a way to keep temporary directories on demand
* [x] possibly use this 'way' on CI to avoid unnecessary cleanup for the extra-bit of performance

Overall, I'd expect performance locally to not be worse, and performance on CI to be better (at least in theory) as temporary directories are only created once (instead of created, deleted, recreated).

### Notes for the Reviewer

* The first commit is another forgotten TODO and its fix as left-over from #3360 .
* I am not 100% sure that my CI environment adjustment has the desired effect on the basis that I might have gotten the yaml schema wrong. If that would be the case, CI would be slower than before.
* The `GITBUTLER_TESTS_NO_CLEANUP` name was made-up and naming is hard. It should be easy to change as it's mentioned in only two places.

### Before: files accumulate

```
❯ find /var/folders/x7/jgy95vjs3v3ffszwn0wg0gz80000gn/T/ -type f 2>/dev/null | wc -l
       1
```

After a full app test run with...

```
❯ time cargo test -p gitbutler-app
[.. no build happens, only tests run] 
test result: ok. 309 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.73s

cargo test -p gitbutler-app  3.78s user 30.58s system 505% cpu 6.792 tota
```

…and counting new files…

```
❯ find /var/folders/x7/jgy95vjs3v3ffszwn0wg0gz80000gn/T/ -type f 2>/dev/null | wc -l
   15201
```

…we see that 15k files accumulate per full run. This would mean to get 680k files  previously, I had to run the suite just 45 times, something that happens quickly since each run only takes 6s.

### After: auto-cleanup

```
❯ find /var/folders/x7/jgy95vjs3v3ffszwn0wg0gz80000gn/T/ -type f 2>/dev/null | wc -l
       1
```

Now run the app-tests:

```
❯ time cargo test -p gitbutler-app
[.. no build happens, only tests run] 
test result: ok. 310 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 8.50s

cargo test -p gitbutler-app  4.04s user 48.78s system 567% cpu 9.309 total
```

```
❯ find /var/folders/x7/jgy95vjs3v3ffszwn0wg0gz80000gn/T/ -type f 2>/dev/null | wc -l
      10
```

Some files with `.lock` extension still stay, and I couldn't see where these would be created easily, and didn't worry about these quite as much.
**It's notable that tests now run much more slowly, at 67% of the original speed.** Parallelism is reduced as well, probably due to increased filesystem load.

### After: auto-cleanup with GITBUTLER_TESTS_NO_CLEANUP

```
❯ find /var/folders/x7/jgy95vjs3v3ffszwn0wg0gz80000gn/T/ -type f 2>/dev/null | wc -l
       1
```

Now when running the tests with the environment variable set:

```
❯ time GITBUTLER_TESTS_NO_CLEANUP=1 cargo test -p gitbutler-app
[..]
test result: ok. 310 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.69s

GITBUTLER_TESTS_NO_CLEANUP=1 cargo test -p gitbutler-app  3.78s user 29.90s system 557% cpu 6.043 total
```

And we are back to where we were in terms of performance.

```
❯ find /var/folders/x7/jgy95vjs3v3ffszwn0wg0gz80000gn/T/ -type f 2>/dev/null | wc -l
   14412
```

It's notable that it now leaks about 700 files less, which is probably due to some self-contained tests that now also don't leak their files, but don't respect the environment variable either. It's good that these don't affect the runtime.