### PR TITLE
Open project in VSCode in new window

### DIFF
--- a/gitbutler-ui/src/lib/components/Board.svelte
+++ b/gitbutler-ui/src/lib/components/Board.svelte
@@ -142,8 +142,8 @@
 										class="empty-board__suggestions__link"
 										role="button"
 										tabindex="0"
-										on:keypress={() => open(`vscode://file${project.path}/`)}
-										on:click={() => open(`vscode://file${project.path}/`)}
+										on:keypress={() => open(`vscode://file${project.path}/?windowId=_blank`)}
+										on:click={() => open(`vscode://file${project.path}/?windowId=_blank`)}
 									>
 										<div class="empty-board__suggestions__link__icon">
 											<Icon name="vscode" />


### PR DESCRIPTION
I was running GitButler from a VSCode terminal, and clicked on a "Open in VSCode" button for another project, and the project that opened was opened in the same window, causing GitButler to stop.

IMO it would be a better behaviour to always open projects in new windows (note that even with this change, if the project is already opened in a VSCode window, it will not open a new one).

(Details about opening in new window [here](https://github.com/microsoft/vscode/issues/141548#issuecomment-1102200617))