### PR TITLE
[draft] Refactoring services

### DIFF
--- a/gitbutler-ui/src/lib/backend/projects.ts
+++ b/gitbutler-ui/src/lib/backend/projects.ts
@@ -29,7 +29,7 @@ export class Project {
 export class ProjectService {
 	private persistedId = persisted<string | undefined>(undefined, 'lastProject');
 	projects: Writable<Project[]> = writable([]);
-	error: Writable<undefined | any> = writable();
+	error: Writable<any> = writable();
 
 	constructor(private homeDir: string | undefined) {
 		this.loadProjects();

--- a/gitbutler-ui/src/lib/components/NotOnGitButlerBranch.svelte
+++ b/gitbutler-ui/src/lib/components/NotOnGitButlerBranch.svelte
@@ -35,7 +35,7 @@
 				toasts.error('Failed to delete project');
 			} finally {
 				isDeleting = false;
-				projectService.reload();
+				projectService.loadProjects();
 			}
 		}
 	}

--- a/gitbutler-ui/src/lib/components/ProblemLoadingRepo.svelte
+++ b/gitbutler-ui/src/lib/components/ProblemLoadingRepo.svelte
@@ -29,7 +29,7 @@
 			toasts.error('Failed to delete project');
 		} finally {
 			loading = false;
-			projectService.reload();
+			projectService.loadProjects();
 		}
 	}
 </script>

--- a/gitbutler-ui/src/routes/[projectId]/+layout.ts
+++ b/gitbutler-ui/src/routes/[projectId]/+layout.ts
@@ -11,7 +11,6 @@ export const prerender = false;
 export async function load({ params, parent }) {
 	// prettier-ignore
 	const {
-        authService,
         githubService,
         projectService,
         remoteUrl$,
@@ -50,11 +49,9 @@ export async function load({ params, parent }) {
 	);
 
 	return {
-		authService,
 		baseBranchService,
 		branchController,
 		branchService,
-		githubService,
 		projectId,
 		project,
 		remoteBranchService,

--- a/gitbutler-ui/src/routes/[projectId]/settings/+page.svelte
+++ b/gitbutler-ui/src/routes/[projectId]/settings/+page.svelte
@@ -32,7 +32,7 @@
 		isDeleting = true;
 		try {
 			await projectService.deleteProject(project.id);
-			await projectService.reload();
+			await projectService.loadProjects();
 			goto('/');
 			toasts.success('Project deleted');
 		} catch (err: any) {


### PR DESCRIPTION
This is a work in progress PR where I'm having a go at cleaning up some of the services, and hopefully will be able all state from services.

Here are some avenues of exploration:
- [ ] Removing RX.js from the public APIs exposed by services. (RX.js should only be used internally)
- [ ] Fix services that are dependant on the project
  - Services should have no state and have no need to reactively depend on the projectId.
- [ ] GitHubService
  - Demangle project specific code (get rid of remoteUrl$)
  - Make generic & replaceable (to allow the implementation GitLab/BitBucket clients)
- [ ] BaseBranchService, VBranchService, BranchController, BranchService, RemoteBranchService.
  - These are all dependant on the projectId, and some feel they should really be injected into some Project class (exploring options)

## Reviewing

I'm still getting an idea of the direction I want to take these services, so anything here may change drastically. I just wanted to open a Draft PR so it was visible.