### PR TITLE
refactor: move VirtualBranchesHandle construction out of branch reader/writer

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -35,6 +35,7 @@ jobs:
             rust: &any-rust
               - *rust
               - 'gitbutler-!(ui)/**'
+              - 'crates/**'
             gitbutler-app:
               - *any-rust
             gitbutler-core:
@@ -197,6 +198,7 @@ jobs:
     if: always()
     needs:
       - changes
+      - check-gitbutler
       - check-gitbutler-app
       - check-gitbutler-changeset
       - check-gitbutler-git

--- a/crates/gitbutler-core/src/gb_repository/repository.rs
+++ b/crates/gitbutler-core/src/gb_repository/repository.rs
@@ -17,10 +17,10 @@ use crate::windows::MetadataShim;
 use crate::{
     deltas, fs, git, project_repository,
     projects::{self, ProjectId},
-    reader, sessions,
-    sessions::SessionId,
+    reader,
+    sessions::{self, SessionId},
     users,
-    virtual_branches::{self, target},
+    virtual_branches::{self, target, VirtualBranchesHandle},
 };
 
 pub struct Repository {
@@ -264,8 +264,11 @@ impl Repository {
             .collect::<Vec<_>>();
 
         let src_target_reader = virtual_branches::target::Reader::new(&last_session_reader);
-        let dst_target_writer = virtual_branches::target::Writer::new(self, self.project.gb_dir())
-            .context("failed to open target writer for current session")?;
+        let dst_target_writer = virtual_branches::target::Writer::new(
+            self,
+            VirtualBranchesHandle::new(&self.project.gb_dir()),
+        )
+        .context("failed to open target writer for current session")?;
 
         // copy default target
         let default_target = match src_target_reader.read_default() {
@@ -294,8 +297,11 @@ impl Repository {
                 .with_context(|| format!("{}: failed to write target", branch.id))?;
         }
 
-        let dst_branch_writer = virtual_branches::branch::Writer::new(self, self.project.gb_dir())
-            .context("failed to open branch writer for current session")?;
+        let dst_branch_writer = virtual_branches::branch::Writer::new(
+            self,
+            VirtualBranchesHandle::new(&self.project.gb_dir()),
+        )
+        .context("failed to open branch writer for current session")?;
 
         // copy branches that we don't already have
         for branch in &branches {

--- a/crates/gitbutler-core/src/virtual_branches.rs
+++ b/crates/gitbutler-core/src/virtual_branches.rs
@@ -27,3 +27,4 @@ mod remote;
 pub use remote::*;
 
 mod state;
+pub use state::VirtualBranchesHandle;

--- a/crates/gitbutler-core/src/virtual_branches/base.rs
+++ b/crates/gitbutler-core/src/virtual_branches/base.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use super::{
     branch, errors,
     integration::{update_gitbutler_integration, GITBUTLER_INTEGRATION_REFERENCE},
-    target, BranchId, RemoteCommit,
+    target, BranchId, RemoteCommit, VirtualBranchesHandle,
 };
 use crate::{
     gb_repository,
@@ -188,8 +188,11 @@ pub fn set_base_branch(
         sha: target_commit_oid,
     };
 
-    let target_writer = target::Writer::new(gb_repository, project_repository.project().gb_dir())
-        .context("failed to create target writer")?;
+    let target_writer = target::Writer::new(
+        gb_repository,
+        VirtualBranchesHandle::new(&project_repository.project().gb_dir()),
+    )
+    .context("failed to create target writer")?;
     target_writer.write_default(&target)?;
 
     let head_name: git::Refname = current_head
@@ -276,9 +279,11 @@ pub fn set_base_branch(
                 selected_for_changes: None,
             };
 
-            let branch_writer =
-                branch::Writer::new(gb_repository, project_repository.project().gb_dir())
-                    .context("failed to create branch writer")?;
+            let branch_writer = branch::Writer::new(
+                gb_repository,
+                VirtualBranchesHandle::new(&project_repository.project().gb_dir()),
+            )
+            .context("failed to create branch writer")?;
             branch_writer.write(&mut branch)?;
         }
     }
@@ -379,8 +384,11 @@ pub fn update_base_branch(
             target.sha
         ))?;
 
-    let branch_writer = branch::Writer::new(gb_repository, project_repository.project().gb_dir())
-        .context("failed to create branch writer")?;
+    let branch_writer = branch::Writer::new(
+        gb_repository,
+        VirtualBranchesHandle::new(&project_repository.project().gb_dir()),
+    )
+    .context("failed to create branch writer")?;
 
     let use_context = project_repository
         .project()
@@ -598,8 +606,11 @@ pub fn update_base_branch(
     )?;
 
     // write new target oid
-    let target_writer = target::Writer::new(gb_repository, project_repository.project().gb_dir())
-        .context("failed to create target writer")?;
+    let target_writer = target::Writer::new(
+        gb_repository,
+        VirtualBranchesHandle::new(&project_repository.project().gb_dir()),
+    )
+    .context("failed to create target writer")?;
     target_writer.write_default(&target::Target {
         sha: new_target_commit.id(),
         ..target

--- a/crates/gitbutler-core/src/virtual_branches/branch/writer.rs
+++ b/crates/gitbutler-core/src/virtual_branches/branch/writer.rs
@@ -1,5 +1,3 @@
-use std::path;
-
 use anyhow::Result;
 
 use super::Branch;
@@ -13,13 +11,12 @@ pub struct BranchWriter<'writer> {
 }
 
 impl<'writer> BranchWriter<'writer> {
-    pub fn new<P: AsRef<path::Path>>(
+    pub fn new(
         repository: &'writer gb_repository::Repository,
-        path: P,
+        state_handle: VirtualBranchesHandle,
     ) -> Result<Self, std::io::Error> {
         let reader = reader::Reader::open(repository.root())?;
         let writer = writer::DirWriter::open(repository.root())?;
-        let state_handle = VirtualBranchesHandle::new(path.as_ref());
         Ok(Self {
             repository,
             writer,

--- a/crates/gitbutler-core/src/virtual_branches/integration.rs
+++ b/crates/gitbutler-core/src/virtual_branches/integration.rs
@@ -3,7 +3,7 @@ use std::io::{Read, Write};
 use anyhow::{Context, Result};
 use lazy_static::lazy_static;
 
-use super::errors;
+use super::{errors, VirtualBranchesHandle};
 use crate::{
     gb_repository,
     git::{self},
@@ -262,8 +262,11 @@ fn verify_head_is_clean(
     .context("failed to create virtual branch")?;
 
     // rebasing the extra commits onto the new branch
-    let writer = super::branch::Writer::new(gb_repository, project_repository.project().gb_dir())
-        .context("failed to create writer")?;
+    let writer = super::branch::Writer::new(
+        gb_repository,
+        VirtualBranchesHandle::new(&project_repository.project().gb_dir()),
+    )
+    .context("failed to create writer")?;
     extra_commits.reverse();
     let mut head = new_branch.head;
     for commit in extra_commits {

--- a/crates/gitbutler-core/src/virtual_branches/target/writer.rs
+++ b/crates/gitbutler-core/src/virtual_branches/target/writer.rs
@@ -1,5 +1,3 @@
-use std::path;
-
 use anyhow::{Context, Result};
 
 use super::Target;
@@ -17,13 +15,12 @@ pub struct TargetWriter<'writer> {
 }
 
 impl<'writer> TargetWriter<'writer> {
-    pub fn new<P: AsRef<path::Path>>(
+    pub fn new(
         repository: &'writer gb_repository::Repository,
-        path: P,
+        state_handle: VirtualBranchesHandle,
     ) -> Result<Self, std::io::Error> {
         let reader = reader::Reader::open(&repository.root())?;
         let writer = writer::DirWriter::open(repository.root())?;
-        let state_handle = VirtualBranchesHandle::new(path.as_ref());
         Ok(Self {
             repository,
             writer,

--- a/crates/gitbutler-core/tests/shared/mod.rs
+++ b/crates/gitbutler-core/tests/shared/mod.rs
@@ -17,7 +17,10 @@ pub mod paths {
 }
 
 pub mod virtual_branches {
-    use gitbutler_core::{gb_repository, project_repository, virtual_branches};
+    use gitbutler_core::{
+        gb_repository, project_repository,
+        virtual_branches::{self, VirtualBranchesHandle},
+    };
 
     use crate::shared::empty_bare_repository;
 
@@ -35,13 +38,16 @@ pub mod virtual_branches {
             .expect("failed to add remote");
         remote.push(&["refs/heads/master:refs/heads/master"], None)?;
 
-        virtual_branches::target::Writer::new(gb_repo, project_repository.project().gb_dir())?
-            .write_default(&virtual_branches::target::Target {
-                branch: "refs/remotes/origin/master".parse().unwrap(),
-                remote_url: remote_repo.path().to_str().unwrap().parse().unwrap(),
-                sha: remote_repo.head().unwrap().target().unwrap(),
-            })
-            .expect("failed to write target");
+        virtual_branches::target::Writer::new(
+            gb_repo,
+            VirtualBranchesHandle::new(&project_repository.project().gb_dir()),
+        )?
+        .write_default(&virtual_branches::target::Target {
+            branch: "refs/remotes/origin/master".parse().unwrap(),
+            remote_url: remote_repo.path().to_str().unwrap().parse().unwrap(),
+            sha: remote_repo.head().unwrap().target().unwrap(),
+        })
+        .expect("failed to write target");
 
         virtual_branches::integration::update_gitbutler_integration(gb_repo, project_repository)
             .expect("failed to update integration");

--- a/crates/gitbutler-core/tests/virtual_branches/branch/reader.rs
+++ b/crates/gitbutler-core/tests/virtual_branches/branch/reader.rs
@@ -1,7 +1,10 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::Result;
-use gitbutler_core::virtual_branches::{branch, branch::BranchOwnershipClaims, Branch, BranchId};
+use gitbutler_core::virtual_branches::{
+    branch::{self, BranchOwnershipClaims},
+    Branch, BranchId, VirtualBranchesHandle,
+};
 use once_cell::sync::Lazy;
 
 use crate::shared::{Case, Suite};
@@ -83,7 +86,7 @@ fn read_override() -> Result<()> {
 
     let mut branch = test_branch();
 
-    let writer = branch::Writer::new(gb_repository, project.gb_dir())?;
+    let writer = branch::Writer::new(gb_repository, VirtualBranchesHandle::new(&project.gb_dir()))?;
     writer.write(&mut branch)?;
 
     let session = gb_repository.get_current_session()?.unwrap();

--- a/crates/gitbutler-core/tests/virtual_branches/branch/writer.rs
+++ b/crates/gitbutler-core/tests/virtual_branches/branch/writer.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::Context;
-use gitbutler_core::virtual_branches::branch;
+use gitbutler_core::virtual_branches::{branch, VirtualBranchesHandle};
 use once_cell::sync::Lazy;
 
 use self::branch::BranchId;
@@ -66,7 +66,7 @@ fn write_branch() -> anyhow::Result<()> {
 
     let mut branch = new_test_branch();
 
-    let writer = branch::Writer::new(gb_repository, project.gb_dir())?;
+    let writer = branch::Writer::new(gb_repository, VirtualBranchesHandle::new(&project.gb_dir()))?;
     writer.write(&mut branch)?;
 
     let root = gb_repository
@@ -132,7 +132,7 @@ fn should_create_session() -> anyhow::Result<()> {
 
     let mut branch = new_test_branch();
 
-    let writer = branch::Writer::new(gb_repository, project.gb_dir())?;
+    let writer = branch::Writer::new(gb_repository, VirtualBranchesHandle::new(&project.gb_dir()))?;
     writer.write(&mut branch)?;
 
     assert!(gb_repository.get_current_session()?.is_some());
@@ -151,7 +151,7 @@ fn should_update() -> anyhow::Result<()> {
 
     let mut branch = new_test_branch();
 
-    let writer = branch::Writer::new(gb_repository, project.gb_dir())?;
+    let writer = branch::Writer::new(gb_repository, VirtualBranchesHandle::new(&project.gb_dir()))?;
     writer.write(&mut branch)?;
 
     let mut updated_branch = Branch {

--- a/crates/gitbutler-core/tests/virtual_branches/iterator.rs
+++ b/crates/gitbutler-core/tests/virtual_branches/iterator.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::Result;
-use gitbutler_core::virtual_branches;
+use gitbutler_core::virtual_branches::{self, VirtualBranchesHandle};
 use once_cell::sync::Lazy;
 
 use crate::shared::{Case, Suite};
@@ -90,12 +90,16 @@ fn iterate_all() -> Result<()> {
         ..
     } = &suite.new_case();
 
-    let target_writer =
-        gitbutler_core::virtual_branches::target::Writer::new(gb_repository, project.gb_dir())?;
+    let target_writer = gitbutler_core::virtual_branches::target::Writer::new(
+        gb_repository,
+        VirtualBranchesHandle::new(&project.gb_dir()),
+    )?;
     target_writer.write_default(&new_test_target())?;
 
-    let branch_writer =
-        gitbutler_core::virtual_branches::branch::Writer::new(gb_repository, project.gb_dir())?;
+    let branch_writer = gitbutler_core::virtual_branches::branch::Writer::new(
+        gb_repository,
+        VirtualBranchesHandle::new(&project.gb_dir()),
+    )?;
     let mut branch_1 = new_test_branch();
     branch_writer.write(&mut branch_1)?;
     let mut branch_2 = new_test_branch();

--- a/crates/gitbutler-core/tests/virtual_branches/target/reader.rs
+++ b/crates/gitbutler-core/tests/virtual_branches/target/reader.rs
@@ -1,7 +1,10 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::Result;
-use gitbutler_core::virtual_branches::{target, target::Target, BranchId};
+use gitbutler_core::virtual_branches::{
+    target::{self, Target},
+    BranchId, VirtualBranchesHandle,
+};
 use once_cell::sync::Lazy;
 
 use crate::shared::{Case, Suite};
@@ -129,14 +132,17 @@ fn read_override_target() -> Result<()> {
         sha: "0123456789abcdef0123456789abcdef01234567".parse().unwrap(),
     };
 
-    let branch_writer =
-        gitbutler_core::virtual_branches::branch::Writer::new(gb_repository, project.gb_dir())?;
+    let branch_writer = gitbutler_core::virtual_branches::branch::Writer::new(
+        gb_repository,
+        VirtualBranchesHandle::new(&project.gb_dir()),
+    )?;
     branch_writer.write(&mut branch)?;
 
     let session = gb_repository.get_current_session()?.unwrap();
     let session_reader = gitbutler_core::sessions::Reader::open(gb_repository, &session)?;
 
-    let target_writer = target::Writer::new(gb_repository, project.gb_dir())?;
+    let target_writer =
+        target::Writer::new(gb_repository, VirtualBranchesHandle::new(&project.gb_dir()))?;
     let reader = target::Reader::new(&session_reader);
 
     target_writer.write_default(&default_target)?;

--- a/crates/gitbutler-core/tests/virtual_branches/target/writer.rs
+++ b/crates/gitbutler-core/tests/virtual_branches/target/writer.rs
@@ -4,7 +4,11 @@ use std::{
 };
 
 use anyhow::Context;
-use gitbutler_core::virtual_branches::{branch, target, target::Target, BranchId};
+use gitbutler_core::virtual_branches::{
+    branch,
+    target::{self, Target},
+    BranchId, VirtualBranchesHandle,
+};
 use once_cell::sync::Lazy;
 
 use crate::shared::{Case, Suite};
@@ -69,10 +73,12 @@ fn write() -> anyhow::Result<()> {
         sha: "0123456789abcdef0123456789abcdef01234567".parse().unwrap(),
     };
 
-    let branch_writer = branch::Writer::new(gb_repository, project.gb_dir())?;
+    let branch_writer =
+        branch::Writer::new(gb_repository, VirtualBranchesHandle::new(&project.gb_dir()))?;
     branch_writer.write(&mut branch)?;
 
-    let target_writer = target::Writer::new(gb_repository, project.gb_dir())?;
+    let target_writer =
+        target::Writer::new(gb_repository, VirtualBranchesHandle::new(&project.gb_dir()))?;
     target_writer.write(&branch.id, &target)?;
 
     let root = gb_repository
@@ -161,9 +167,11 @@ fn should_update() -> anyhow::Result<()> {
         sha: "0123456789abcdef0123456789abcdef01234567".parse().unwrap(),
     };
 
-    let branch_writer = branch::Writer::new(gb_repository, project.gb_dir())?;
+    let branch_writer =
+        branch::Writer::new(gb_repository, VirtualBranchesHandle::new(&project.gb_dir()))?;
     branch_writer.write(&mut branch)?;
-    let target_writer = target::Writer::new(gb_repository, project.gb_dir())?;
+    let target_writer =
+        target::Writer::new(gb_repository, VirtualBranchesHandle::new(&project.gb_dir()))?;
     target_writer.write(&branch.id, &target)?;
 
     let updated_target = Target {

--- a/gitbutler-app/tests/watcher/handler/calculate_delta_handler.rs
+++ b/gitbutler-app/tests/watcher/handler/calculate_delta_handler.rs
@@ -9,7 +9,7 @@ use gitbutler_app::watcher::handlers::calculate_deltas_handler::Handler;
 use gitbutler_core::{
     deltas::{self, operations::Operation},
     reader, sessions,
-    virtual_branches::{self, branch},
+    virtual_branches::{self, branch, VirtualBranchesHandle},
 };
 use once_cell::sync::Lazy;
 
@@ -637,8 +637,12 @@ fn should_persist_branches_targets_state_between_sessions() -> Result<()> {
     } = &suite.new_case_with_files(HashMap::from([(PathBuf::from("test.txt"), "hello world")]));
     let listener = Handler::from_path(suite.local_app_data());
 
-    let branch_writer = branch::Writer::new(gb_repository, project.gb_dir())?;
-    let target_writer = virtual_branches::target::Writer::new(gb_repository, project.gb_dir())?;
+    let branch_writer =
+        branch::Writer::new(gb_repository, VirtualBranchesHandle::new(&project.gb_dir()))?;
+    let target_writer = virtual_branches::target::Writer::new(
+        gb_repository,
+        VirtualBranchesHandle::new(&project.gb_dir()),
+    )?;
     let default_target = new_test_target();
     target_writer.write_default(&default_target)?;
     let mut vbranch0 = new_test_branch();
@@ -690,8 +694,12 @@ fn should_restore_branches_targets_state_from_head_session() -> Result<()> {
     } = &suite.new_case_with_files(HashMap::from([(PathBuf::from("test.txt"), "hello world")]));
     let listener = Handler::from_path(suite.local_app_data());
 
-    let branch_writer = branch::Writer::new(gb_repository, project.gb_dir())?;
-    let target_writer = virtual_branches::target::Writer::new(gb_repository, project.gb_dir())?;
+    let branch_writer =
+        branch::Writer::new(gb_repository, VirtualBranchesHandle::new(&project.gb_dir()))?;
+    let target_writer = virtual_branches::target::Writer::new(
+        gb_repository,
+        VirtualBranchesHandle::new(&project.gb_dir()),
+    )?;
     let default_target = new_test_target();
     target_writer.write_default(&default_target)?;
     let mut vbranch0 = new_test_branch();


### PR DESCRIPTION
When the migration is complete there will be no branch/target reader/writer. For now, inject the handle