### PR TITLE
feature flag for reading vbranch state from the toml file

### DIFF
--- a/crates/gitbutler-core/src/projects/project.rs
+++ b/crates/gitbutler-core/src/projects/project.rs
@@ -83,6 +83,8 @@ pub struct Project {
     pub omit_certificate_check: Option<bool>,
     #[serde(default)]
     pub use_diff_context: Option<bool>,
+    #[serde(default)]
+    pub use_toml_vbranches_state: Option<bool>,
 }
 
 impl AsRef<Project> for Project {
@@ -108,5 +110,9 @@ impl Project {
     /// Normally this is `.git/gitbutler` in the project's repository.
     pub fn gb_dir(&self) -> PathBuf {
         self.path.join(".git").join("gitbutler")
+    }
+
+    pub fn use_toml_vbranches_state(&self) -> bool {
+        self.use_toml_vbranches_state.unwrap_or(false)
     }
 }

--- a/crates/gitbutler-core/src/virtual_branches/base.rs
+++ b/crates/gitbutler-core/src/virtual_branches/base.rs
@@ -71,10 +71,14 @@ fn go_back_to_integration(
         .context("no session found")?;
     let session_reader = sessions::Reader::open(gb_repository, &latest_session)?;
 
-    let all_virtual_branches = super::iterator::BranchIterator::new(&session_reader)
-        .context("failed to create branch iterator")?
-        .collect::<Result<Vec<super::branch::Branch>, reader::Error>>()
-        .context("failed to read virtual branches")?;
+    let all_virtual_branches = super::iterator::BranchIterator::new(
+        &session_reader,
+        VirtualBranchesHandle::new(&project_repository.project().gb_dir()),
+        project_repository.project().use_toml_vbranches_state(),
+    )
+    .context("failed to create branch iterator")?
+    .collect::<Result<Vec<super::branch::Branch>, reader::Error>>()
+    .context("failed to read virtual branches")?;
 
     let applied_virtual_branches = all_virtual_branches
         .iter()

--- a/crates/gitbutler-core/src/virtual_branches/branch/reader.rs
+++ b/crates/gitbutler-core/src/virtual_branches/branch/reader.rs
@@ -1,14 +1,22 @@
 use super::{Branch, BranchId};
-use crate::{reader, sessions};
+use crate::{reader, sessions, virtual_branches::VirtualBranchesHandle};
 
 pub struct BranchReader<'r> {
     reader: &'r reader::Reader<'r>,
+    state_handle: VirtualBranchesHandle,
+    use_state_handle: bool,
 }
 
 impl<'r> BranchReader<'r> {
-    pub fn new(reader: &'r sessions::Reader<'r>) -> Self {
+    pub fn new(
+        reader: &'r sessions::Reader<'r>,
+        state_handle: VirtualBranchesHandle,
+        use_state_handle: bool,
+    ) -> Self {
         Self {
             reader: reader.reader(),
+            state_handle,
+            use_state_handle,
         }
     }
 

--- a/crates/gitbutler-core/src/virtual_branches/controller.rs
+++ b/crates/gitbutler-core/src/virtual_branches/controller.rs
@@ -530,8 +530,16 @@ impl ControllerInner {
             .context("failed to get or create current session")?;
         let session_reader = crate::sessions::Reader::open(&gb_repository, &current_session)
             .context("failed to open current session")?;
-        let target_reader = super::target::Reader::new(&session_reader);
-        let branch_reader = super::branch::Reader::new(&session_reader);
+        let target_reader = super::target::Reader::new(
+            &session_reader,
+            VirtualBranchesHandle::new(&project.gb_dir()),
+            project.use_toml_vbranches_state(),
+        );
+        let branch_reader = super::branch::Reader::new(
+            &session_reader,
+            VirtualBranchesHandle::new(&project.gb_dir()),
+            project.use_toml_vbranches_state(),
+        );
 
         let default_target = target_reader
             .read_default()

--- a/crates/gitbutler-core/src/virtual_branches/integration.rs
+++ b/crates/gitbutler-core/src/virtual_branches/integration.rs
@@ -78,10 +78,14 @@ pub fn update_gitbutler_integration(
         .context("failed to open current session")?;
 
     // get all virtual branches, we need to try to update them all
-    let all_virtual_branches = super::iterator::BranchIterator::new(&session_reader)
-        .context("failed to create branch iterator")?
-        .collect::<Result<Vec<super::branch::Branch>, reader::Error>>()
-        .context("failed to read virtual branches")?;
+    let all_virtual_branches = super::iterator::BranchIterator::new(
+        &session_reader,
+        VirtualBranchesHandle::new(&project_repository.project().gb_dir()),
+        project_repository.project().use_toml_vbranches_state(),
+    )
+    .context("failed to create branch iterator")?
+    .collect::<Result<Vec<super::branch::Branch>, reader::Error>>()
+    .context("failed to read virtual branches")?;
 
     let applied_virtual_branches = all_virtual_branches
         .iter()

--- a/crates/gitbutler-core/src/virtual_branches/iterator.rs
+++ b/crates/gitbutler-core/src/virtual_branches/iterator.rs
@@ -2,7 +2,10 @@ use std::collections::HashSet;
 
 use anyhow::Result;
 
-use super::branch::{self, BranchId};
+use super::{
+    branch::{self, BranchId},
+    VirtualBranchesHandle,
+};
 use crate::sessions;
 
 pub struct BranchIterator<'i> {
@@ -11,8 +14,13 @@ pub struct BranchIterator<'i> {
 }
 
 impl<'i> BranchIterator<'i> {
-    pub fn new(session_reader: &'i sessions::Reader<'i>) -> Result<Self> {
+    pub fn new(
+        session_reader: &'i sessions::Reader<'i>,
+        state_handle: VirtualBranchesHandle,
+        use_state_handle: bool,
+    ) -> Result<Self> {
         let reader = session_reader.reader();
+        // TODO: If use_state_handle is true, we should read the branch ids from the state file
         let ids_itarator = reader
             .list_files("branches")?
             .into_iter()
@@ -34,7 +42,7 @@ impl<'i> BranchIterator<'i> {
             .collect();
         ids.sort();
         Ok(Self {
-            branch_reader: branch::Reader::new(session_reader),
+            branch_reader: branch::Reader::new(session_reader, state_handle, use_state_handle),
             ids,
         })
     }

--- a/crates/gitbutler-core/src/virtual_branches/state.rs
+++ b/crates/gitbutler-core/src/virtual_branches/state.rs
@@ -49,7 +49,6 @@ impl VirtualBranchesHandle {
     /// Gets the default target for the given repository.
     ///
     /// Errors if the file cannot be read or written.
-    #[allow(dead_code)]
     pub fn get_default_target(&self) -> Result<Option<Target>> {
         let virtual_branches = self.read_file()?;
         Ok(virtual_branches.default_target)
@@ -68,10 +67,9 @@ impl VirtualBranchesHandle {
     /// Gets the target for the given virtual branch.
     ///
     /// Errors if the file cannot be read or written.
-    #[allow(dead_code)]
-    pub fn get_branch_target(&self, id: BranchId) -> Result<Option<Target>> {
+    pub fn get_branch_target(&self, id: &BranchId) -> Result<Option<Target>> {
         let virtual_branches = self.read_file()?;
-        Ok(virtual_branches.branch_targets.get(&id).cloned())
+        Ok(virtual_branches.branch_targets.get(id).cloned())
     }
 
     /// Sets the state of the given virtual branch.
@@ -87,7 +85,6 @@ impl VirtualBranchesHandle {
     /// Removes the given virtual branch.
     ///
     /// Errors if the file cannot be read or written.
-    #[allow(dead_code)]
     pub fn remove_branch(&self, id: BranchId) -> Result<()> {
         let mut virtual_branches = self.read_file()?;
         virtual_branches.branches.remove(&id);
@@ -98,10 +95,21 @@ impl VirtualBranchesHandle {
     /// Gets the state of the given virtual branch.
     ///
     /// Errors if the file cannot be read or written.
-    #[allow(dead_code)]
-    pub fn get_branch(&self, id: BranchId) -> Result<Option<Branch>> {
+    pub fn get_branch(&self, id: &BranchId) -> Result<Option<Branch>> {
         let virtual_branches = self.read_file()?;
-        Ok(virtual_branches.branches.get(&id).cloned())
+        Ok(virtual_branches.branches.get(id).cloned())
+    }
+
+    pub fn list_branches(&self) -> Result<HashMap<BranchId, Branch>> {
+        let virtual_branches = self.read_file()?;
+        Ok(virtual_branches.branches)
+    }
+
+    /// Checks if the state file exists.
+    ///
+    /// This would only be false if the application just updated from a very old verion.
+    pub fn file_exists(&self) -> bool {
+        self.file_path.exists()
     }
 
     /// Reads and parses the state file.

--- a/crates/gitbutler-core/src/virtual_branches/target/reader.rs
+++ b/crates/gitbutler-core/src/virtual_branches/target/reader.rs
@@ -1,3 +1,5 @@
+use anyhow::anyhow;
+
 use super::Target;
 use crate::{
     reader, sessions,
@@ -24,18 +26,35 @@ impl<'r> TargetReader<'r> {
     }
 
     pub fn read_default(&self) -> Result<Target, reader::Error> {
-        Target::try_from(&self.reader.sub("branches/target"))
+        if self.use_state_handle && self.state_handle.file_exists() {
+            self.state_handle
+                .get_default_target()
+                .and_then(|op| op.ok_or(anyhow!("Branch not found")))
+                .map_err(|_| reader::Error::NotFound)
+        } else {
+            Target::try_from(&self.reader.sub("branches/target"))
+        }
     }
 
+    /// If the target for the specified branchid is not found, returns the default target
     pub fn read(&self, id: &BranchId) -> Result<Target, reader::Error> {
-        if !self
-            .reader
-            .exists(format!("branches/{}/target", id))
-            .map_err(reader::Error::from)?
-        {
-            return self.read_default();
-        }
+        if self.use_state_handle && self.state_handle.file_exists() {
+            let branch_target = self.state_handle.get_branch_target(id);
+            match branch_target {
+                Ok(Some(target)) => Ok(target),
+                Ok(None) => self.read_default(),
+                Err(_) => Err(reader::Error::NotFound),
+            }
+        } else {
+            if !self
+                .reader
+                .exists(format!("branches/{}/target", id))
+                .map_err(reader::Error::from)?
+            {
+                return self.read_default();
+            }
 
-        Target::try_from(&self.reader.sub(format!("branches/{}/target", id)))
+            Target::try_from(&self.reader.sub(format!("branches/{}/target", id)))
+        }
     }
 }

--- a/crates/gitbutler-core/src/virtual_branches/target/reader.rs
+++ b/crates/gitbutler-core/src/virtual_branches/target/reader.rs
@@ -1,14 +1,25 @@
 use super::Target;
-use crate::{reader, sessions, virtual_branches::BranchId};
+use crate::{
+    reader, sessions,
+    virtual_branches::{BranchId, VirtualBranchesHandle},
+};
 
 pub struct TargetReader<'r> {
     reader: &'r reader::Reader<'r>,
+    state_handle: VirtualBranchesHandle,
+    use_state_handle: bool,
 }
 
 impl<'r> TargetReader<'r> {
-    pub fn new(reader: &'r sessions::Reader<'r>) -> Self {
+    pub fn new(
+        reader: &'r sessions::Reader<'r>,
+        state_handle: VirtualBranchesHandle,
+        use_state_handle: bool,
+    ) -> Self {
         Self {
             reader: reader.reader(),
+            state_handle,
+            use_state_handle,
         }
     }
 

--- a/crates/gitbutler-core/tests/virtual_branches/branch/reader.rs
+++ b/crates/gitbutler-core/tests/virtual_branches/branch/reader.rs
@@ -62,12 +62,20 @@ fn test_branch() -> Branch {
 #[test]
 fn read_not_found() -> Result<()> {
     let suite = Suite::default();
-    let Case { gb_repository, .. } = &suite.new_case();
+    let Case {
+        gb_repository,
+        project,
+        ..
+    } = &suite.new_case();
 
     let session = gb_repository.get_or_create_current_session()?;
     let session_reader = gitbutler_core::sessions::Reader::open(gb_repository, &session)?;
 
-    let reader = branch::Reader::new(&session_reader);
+    let reader = branch::Reader::new(
+        &session_reader,
+        VirtualBranchesHandle::new(&project.gb_dir()),
+        project.use_toml_vbranches_state(),
+    );
     let result = reader.read(&BranchId::generate());
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().to_string(), "file not found");
@@ -92,7 +100,11 @@ fn read_override() -> Result<()> {
     let session = gb_repository.get_current_session()?.unwrap();
     let session_reader = gitbutler_core::sessions::Reader::open(gb_repository, &session)?;
 
-    let reader = branch::Reader::new(&session_reader);
+    let reader = branch::Reader::new(
+        &session_reader,
+        VirtualBranchesHandle::new(&project.gb_dir()),
+        project.use_toml_vbranches_state(),
+    );
 
     assert_eq!(branch, reader.read(&branch.id).unwrap());
 

--- a/crates/gitbutler-core/tests/virtual_branches/iterator.rs
+++ b/crates/gitbutler-core/tests/virtual_branches/iterator.rs
@@ -69,12 +69,20 @@ fn new_test_target() -> virtual_branches::target::Target {
 #[test]
 fn empty_iterator() -> Result<()> {
     let suite = Suite::default();
-    let Case { gb_repository, .. } = &suite.new_case();
+    let Case {
+        gb_repository,
+        project,
+        ..
+    } = &suite.new_case();
 
     let session = gb_repository.get_or_create_current_session()?;
     let session_reader = gitbutler_core::sessions::Reader::open(gb_repository, &session)?;
 
-    let iter = virtual_branches::Iterator::new(&session_reader)?;
+    let iter = virtual_branches::Iterator::new(
+        &session_reader,
+        VirtualBranchesHandle::new(&project.gb_dir()),
+        project.use_toml_vbranches_state(),
+    )?;
 
     assert_eq!(iter.count(), 0);
 
@@ -110,8 +118,12 @@ fn iterate_all() -> Result<()> {
     let session = gb_repository.get_current_session()?.unwrap();
     let session_reader = gitbutler_core::sessions::Reader::open(gb_repository, &session)?;
 
-    let iter = virtual_branches::Iterator::new(&session_reader)?
-        .collect::<Result<Vec<_>, gitbutler_core::reader::Error>>()?;
+    let iter = virtual_branches::Iterator::new(
+        &session_reader,
+        VirtualBranchesHandle::new(&project.gb_dir()),
+        project.use_toml_vbranches_state(),
+    )?
+    .collect::<Result<Vec<_>, gitbutler_core::reader::Error>>()?;
     assert_eq!(iter.len(), 3);
     assert!(iter.contains(&branch_1));
     assert!(iter.contains(&branch_2));

--- a/crates/gitbutler-core/tests/virtual_branches/mod.rs
+++ b/crates/gitbutler-core/tests/virtual_branches/mod.rs
@@ -310,7 +310,11 @@ fn create_branch_with_ownership() -> Result<()> {
 
     let current_session = gb_repository.get_or_create_current_session().unwrap();
     let current_session_reader = sessions::Reader::open(gb_repository, &current_session).unwrap();
-    let branch_reader = virtual_branches::branch::Reader::new(&current_session_reader);
+    let branch_reader = virtual_branches::branch::Reader::new(
+        &current_session_reader,
+        VirtualBranchesHandle::new(&project_repository.project().gb_dir()),
+        project_repository.project().use_toml_vbranches_state(),
+    );
     let branch0 = branch_reader.read(&branch0.id).unwrap();
 
     let branch1 = create_virtual_branch(
@@ -375,9 +379,13 @@ fn create_branch_in_the_middle() -> Result<()> {
     let current_session = gb_repository.get_or_create_current_session()?;
     let current_session_reader = sessions::Reader::open(gb_repository, &current_session)?;
 
-    let mut branches = virtual_branches::Iterator::new(&current_session_reader)?
-        .collect::<Result<Vec<virtual_branches::Branch>, reader::Error>>()
-        .expect("failed to read branches");
+    let mut branches = virtual_branches::Iterator::new(
+        &current_session_reader,
+        VirtualBranchesHandle::new(&project_repository.project().gb_dir()),
+        project_repository.project().use_toml_vbranches_state(),
+    )?
+    .collect::<Result<Vec<virtual_branches::Branch>, reader::Error>>()
+    .expect("failed to read branches");
     branches.sort_by_key(|b| b.order);
     assert_eq!(branches.len(), 3);
     assert_eq!(branches[0].name, "Virtual branch");
@@ -408,9 +416,13 @@ fn create_branch_no_arguments() -> Result<()> {
     let current_session = gb_repository.get_or_create_current_session()?;
     let current_session_reader = sessions::Reader::open(gb_repository, &current_session)?;
 
-    let branches = virtual_branches::Iterator::new(&current_session_reader)?
-        .collect::<Result<Vec<virtual_branches::branch::Branch>, reader::Error>>()
-        .expect("failed to read branches");
+    let branches = virtual_branches::Iterator::new(
+        &current_session_reader,
+        VirtualBranchesHandle::new(&project_repository.project().gb_dir()),
+        project_repository.project().use_toml_vbranches_state(),
+    )?
+    .collect::<Result<Vec<virtual_branches::branch::Branch>, reader::Error>>()
+    .expect("failed to read branches");
     assert_eq!(branches.len(), 1);
     assert_eq!(branches[0].name, "Virtual branch");
     assert!(branches[0].applied);
@@ -613,7 +625,11 @@ fn move_hunks_multiple_sources() -> Result<()> {
 
     let current_session = gb_repository.get_or_create_current_session()?;
     let current_session_reader = sessions::Reader::open(gb_repository, &current_session)?;
-    let branch_reader = virtual_branches::branch::Reader::new(&current_session_reader);
+    let branch_reader = virtual_branches::branch::Reader::new(
+        &current_session_reader,
+        VirtualBranchesHandle::new(&project_repository.project().gb_dir()),
+        project_repository.project().use_toml_vbranches_state(),
+    );
     let branch_writer = virtual_branches::branch::Writer::new(
         gb_repository,
         VirtualBranchesHandle::new(&project.gb_dir()),
@@ -1402,7 +1418,11 @@ fn detect_mergeable_branch() -> Result<()> {
 
     let current_session = gb_repository.get_or_create_current_session()?;
     let current_session_reader = sessions::Reader::open(gb_repository, &current_session)?;
-    let branch_reader = virtual_branches::branch::Reader::new(&current_session_reader);
+    let branch_reader = virtual_branches::branch::Reader::new(
+        &current_session_reader,
+        VirtualBranchesHandle::new(&project_repository.project().gb_dir()),
+        project_repository.project().use_toml_vbranches_state(),
+    );
     let branch_writer = virtual_branches::branch::Writer::new(
         gb_repository,
         VirtualBranchesHandle::new(&project.gb_dir()),

--- a/gitbutler-app/tests/watcher/handler/calculate_delta_handler.rs
+++ b/gitbutler-app/tests/watcher/handler/calculate_delta_handler.rs
@@ -664,18 +664,26 @@ fn should_persist_branches_targets_state_between_sessions() -> Result<()> {
     // ensure that the virtual branch is still there and selected
     let session_reader = sessions::Reader::open(gb_repository, &session).unwrap();
 
-    let branches = virtual_branches::Iterator::new(&session_reader)
-        .unwrap()
-        .collect::<Result<Vec<virtual_branches::Branch>, gitbutler_core::reader::Error>>()
-        .unwrap()
-        .into_iter()
-        .collect::<Vec<virtual_branches::Branch>>();
+    let branches = virtual_branches::Iterator::new(
+        &session_reader,
+        VirtualBranchesHandle::new(&project_repository.project().gb_dir()),
+        project_repository.project().use_toml_vbranches_state(),
+    )
+    .unwrap()
+    .collect::<Result<Vec<virtual_branches::Branch>, gitbutler_core::reader::Error>>()
+    .unwrap()
+    .into_iter()
+    .collect::<Vec<virtual_branches::Branch>>();
     assert_eq!(branches.len(), 2);
     let branch_ids = branches.iter().map(|b| b.id).collect::<Vec<_>>();
     assert!(branch_ids.contains(&vbranch0.id));
     assert!(branch_ids.contains(&vbranch1.id));
 
-    let target_reader = virtual_branches::target::Reader::new(&session_reader);
+    let target_reader = virtual_branches::target::Reader::new(
+        &session_reader,
+        VirtualBranchesHandle::new(&project_repository.project().gb_dir()),
+        project_repository.project().use_toml_vbranches_state(),
+    );
     assert_eq!(target_reader.read_default().unwrap(), default_target);
     assert_eq!(target_reader.read(&vbranch0.id).unwrap(), default_target);
     assert_eq!(target_reader.read(&vbranch1.id).unwrap(), vbranch1_target);
@@ -724,18 +732,26 @@ fn should_restore_branches_targets_state_from_head_session() -> Result<()> {
     // ensure that the virtual branch is still there and selected
     let session_reader = sessions::Reader::open(gb_repository, &session).unwrap();
 
-    let branches = virtual_branches::Iterator::new(&session_reader)
-        .unwrap()
-        .collect::<Result<Vec<virtual_branches::Branch>, gitbutler_core::reader::Error>>()
-        .unwrap()
-        .into_iter()
-        .collect::<Vec<virtual_branches::Branch>>();
+    let branches = virtual_branches::Iterator::new(
+        &session_reader,
+        VirtualBranchesHandle::new(&project_repository.project().gb_dir()),
+        project_repository.project().use_toml_vbranches_state(),
+    )
+    .unwrap()
+    .collect::<Result<Vec<virtual_branches::Branch>, gitbutler_core::reader::Error>>()
+    .unwrap()
+    .into_iter()
+    .collect::<Vec<virtual_branches::Branch>>();
     assert_eq!(branches.len(), 2);
     let branch_ids = branches.iter().map(|b| b.id).collect::<Vec<_>>();
     assert!(branch_ids.contains(&vbranch0.id));
     assert!(branch_ids.contains(&vbranch1.id));
 
-    let target_reader = virtual_branches::target::Reader::new(&session_reader);
+    let target_reader = virtual_branches::target::Reader::new(
+        &session_reader,
+        VirtualBranchesHandle::new(&project_repository.project().gb_dir()),
+        project_repository.project().use_toml_vbranches_state(),
+    );
     assert_eq!(target_reader.read_default().unwrap(), default_target);
     assert_eq!(target_reader.read(&vbranch0.id).unwrap(), default_target);
     assert_eq!(target_reader.read(&vbranch1.id).unwrap(), vbranch1_target);


### PR DESCRIPTION
if `use_state_handle` is set on the project, the app will use the virtual branches state from `.git/gitbutler/virtual_branches.toml`

Once this flow works properly, the goal is to remove the read and writers