### PR TITLE
Disable merge button when PR state != 'clean'

### DIFF
--- a/gitbutler-ui/src/lib/components/PullRequestCard.svelte
+++ b/gitbutler-ui/src/lib/components/PullRequestCard.svelte
@@ -271,7 +271,7 @@
 				<MergeButton
 					wide
 					projectId={project.id}
-					disabled={isFetchingChecks || isUnapplied || pr?.draft || mergeableState == 'blocked'}
+					disabled={isFetchingChecks || isUnapplied || pr?.draft || mergeableState != 'clean'}
 					loading={isMerging}
 					help="Merge pull request and refresh"
 					on:click={async (e) => {


### PR DESCRIPTION
These parameters don't seem well document, but looks like we should only enable merge button when it's mergeable_state == 'clean'