### PR TITLE
feat: Change commit button text to 'Start commit'

### DIFF
--- a/gitbutler-ui/src/lib/components/CommitDialog.svelte
+++ b/gitbutler-ui/src/lib/components/CommitDialog.svelte
@@ -270,7 +270,7 @@
 				}
 			}}
 		>
-			{$expanded ? 'Commit' : 'Commit changes'}
+			{$expanded ? 'Commit' : 'Start commit'}
 		</Button>
 	</div>
 </div>


### PR DESCRIPTION
With the commit expanded, the button still says "Commit"