### PR TITLE
Set scroll-behavior to none on `<html>` element

### DIFF
--- a/gitbutler-ui/src/styles/main.postcss
+++ b/gitbutler-ui/src/styles/main.postcss
@@ -52,6 +52,10 @@
 
 /* BOILERPLATE CSS */
 
+html {
+	overscroll-behavior: none;
+}
+
 body {
 	font-family: 'Inter', sans-serif;
 	height: 100vh;


### PR DESCRIPTION
- probably lost when removing tailwind css