### PR TITLE
Use Svelte context for file selection and ownership

### DIFF
--- a/gitbutler-ui/src/lib/components/BaseBranch.svelte
+++ b/gitbutler-ui/src/lib/components/BaseBranch.svelte
@@ -8,11 +8,9 @@
 	import { getContext } from '$lib/utils/context';
 	import { tooltip } from '$lib/utils/tooltip';
 	import { BranchController } from '$lib/vbranches/branchController';
-	import type { BaseBranch, AnyFile } from '$lib/vbranches/types';
-	import type { Writable } from 'svelte/store';
+	import type { BaseBranch } from '$lib/vbranches/types';
 
 	export let base: BaseBranch;
-	export let selectedFiles: Writable<AnyFile[]>;
 
 	const branchController = getContext(BranchController);
 
@@ -50,7 +48,7 @@
 		</Button>
 		<div class="commits-list">
 			{#each base.upstreamCommits as commit}
-				<CommitCard {commit} {selectedFiles} commitUrl={base.commitUrl(commit.id)} />
+				<CommitCard {commit} commitUrl={base.commitUrl(commit.id)} />
 			{/each}
 		</div>
 		<Spacer margin={2} />
@@ -64,7 +62,7 @@
 			Local
 		</h1>
 		{#each base.recentCommits as commit}
-			<CommitCard {commit} {selectedFiles} commitUrl={base.commitUrl(commit.id)} />
+			<CommitCard {commit} commitUrl={base.commitUrl(commit.id)} />
 		{/each}
 	</div>
 </div>

--- a/gitbutler-ui/src/lib/components/BranchCommits.svelte
+++ b/gitbutler-ui/src/lib/components/BranchCommits.svelte
@@ -6,10 +6,7 @@
 		getRemoteCommits,
 		getUnknownCommits
 	} from '$lib/vbranches/contexts';
-	import type { AnyFile } from '$lib/vbranches/types';
-	import type { Writable } from 'svelte/store';
 
-	export let selectedFiles: Writable<AnyFile[]>;
 	export let isUnapplied: boolean;
 
 	const localCommits = getLocalCommits();
@@ -19,8 +16,8 @@
 </script>
 
 {#if $unknownCommits && $unknownCommits.length > 0}
-	<CommitList {isUnapplied} {selectedFiles} commits={$unknownCommits} type="upstream" />
+	<CommitList {isUnapplied} commits={$unknownCommits} type="upstream" />
 {/if}
-<CommitList {isUnapplied} {selectedFiles} type="local" commits={$localCommits} />
-<CommitList {isUnapplied} {selectedFiles} type="remote" commits={$remoteCommits} />
-<CommitList {isUnapplied} {selectedFiles} type="integrated" commits={$integratedCommits} />
+<CommitList {isUnapplied} type="local" commits={$localCommits} />
+<CommitList {isUnapplied} type="remote" commits={$remoteCommits} />
+<CommitList {isUnapplied} type="integrated" commits={$integratedCommits} />

--- a/gitbutler-ui/src/lib/components/BranchFiles.svelte
+++ b/gitbutler-ui/src/lib/components/BranchFiles.svelte
@@ -2,19 +2,20 @@
 	import BranchFilesHeader from './BranchFilesHeader.svelte';
 	import BranchFilesList from './BranchFilesList.svelte';
 	import FileTree from './FileTree.svelte';
+	import { createCommitStore } from '$lib/vbranches/contexts';
 	import { filesToFileTree } from '$lib/vbranches/filetree';
 	import type { LocalFile, RemoteFile } from '$lib/vbranches/types';
-	import type { Writable } from 'svelte/store';
 
 	export let files: LocalFile[] | RemoteFile[];
 	export let isUnapplied: boolean;
-	export let selectedFiles: Writable<(LocalFile | RemoteFile)[]>;
 	export let showCheckboxes = false;
 
 	export let allowMultiple = false;
 	export let readonly = false;
 
 	let selectedListMode: string;
+
+	createCommitStore(undefined);
 </script>
 
 <div class="branch-files" class:isUnapplied>
@@ -24,14 +25,7 @@
 	{#if files.length > 0}
 		<div class="files-padding">
 			{#if selectedListMode == 'list'}
-				<BranchFilesList
-					{allowMultiple}
-					{readonly}
-					{files}
-					{selectedFiles}
-					{showCheckboxes}
-					{isUnapplied}
-				/>
+				<BranchFilesList {allowMultiple} {readonly} {files} {showCheckboxes} {isUnapplied} />
 			{:else}
 				<FileTree
 					{allowMultiple}
@@ -39,7 +33,6 @@
 					node={filesToFileTree(files)}
 					{showCheckboxes}
 					isRoot={true}
-					{selectedFiles}
 					{isUnapplied}
 					{files}
 				/>

--- a/gitbutler-ui/src/lib/components/CommitList.svelte
+++ b/gitbutler-ui/src/lib/components/CommitList.svelte
@@ -4,18 +4,10 @@
 	import CommitListItem from './CommitListItem.svelte';
 	import { getContext, getContextStore } from '$lib/utils/context';
 	import { VirtualBranchService } from '$lib/vbranches/branchStoresCache';
-	import {
-		Branch,
-		type AnyFile,
-		type Commit,
-		type CommitStatus,
-		type RemoteCommit
-	} from '$lib/vbranches/types';
+	import { Branch, type Commit, type CommitStatus, type RemoteCommit } from '$lib/vbranches/types';
 	import { map } from 'rxjs';
-	import type { Writable } from 'svelte/store';
 
 	export let type: CommitStatus;
-	export let selectedFiles: Writable<AnyFile[]>;
 	export let isUnapplied: boolean;
 	export let commits: Commit[] | RemoteCommit[];
 
@@ -49,7 +41,6 @@
 							<CommitListItem
 								{commit}
 								{isUnapplied}
-								{selectedFiles}
 								isChained={idx != commits.length - 1}
 								isHeadCommit={commit.id === headCommit?.id}
 							/>

--- a/gitbutler-ui/src/lib/components/CommitListItem.svelte
+++ b/gitbutler-ui/src/lib/components/CommitListItem.svelte
@@ -2,32 +2,17 @@
 	import CommitCard from './CommitCard.svelte';
 	import DropzoneOverlay from './DropzoneOverlay.svelte';
 	import { Project } from '$lib/backend/projects';
-	import {
-		isDraggableHunk,
-		type DraggableCommit,
-		type DraggableFile,
-		type DraggableHunk,
-		isDraggableFile,
-		isDraggableCommit
-	} from '$lib/dragging/draggables';
+	import { DraggableCommit, DraggableFile, DraggableHunk } from '$lib/dragging/draggables';
 	import { dropzone } from '$lib/dragging/dropzone';
 	import { getContext, getContextStore } from '$lib/utils/context';
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { filesToOwnership } from '$lib/vbranches/ownership';
-	import {
-		RemoteCommit,
-		Branch,
-		type Commit,
-		type AnyFile,
-		BaseBranch
-	} from '$lib/vbranches/types';
-	import { get, type Writable } from 'svelte/store';
+	import { RemoteCommit, Branch, type Commit, BaseBranch } from '$lib/vbranches/types';
 
 	export let commit: Commit | RemoteCommit;
 	export let isHeadCommit: boolean;
 	export let isChained: boolean;
 	export let isUnapplied = false;
-	export let selectedFiles: Writable<AnyFile[]>;
 
 	const branchController = getContext(BranchController);
 	const baseBranch = getContextStore(BaseBranch);
@@ -52,9 +37,9 @@
 				return false;
 			}
 
-			if (isDraggableHunk(data) && data.branchId == $branch.id) {
+			if (data instanceof DraggableHunk && data.branchId == $branch.id) {
 				return true;
-			} else if (isDraggableFile(data) && data.branchId == $branch.id) {
+			} else if (data instanceof DraggableFile && data.branchId == $branch.id) {
 				return true;
 			} else {
 				return false;
@@ -63,11 +48,11 @@
 	}
 
 	function onAmend(data: DraggableFile | DraggableHunk) {
-		if (isDraggableHunk(data)) {
+		if (data instanceof DraggableHunk) {
 			const newOwnership = `${data.hunk.filePath}:${data.hunk.id}`;
 			branchController.amendBranch($branch.id, newOwnership);
-		} else if (isDraggableFile(data)) {
-			const newOwnership = filesToOwnership([data.current, ...get(data.files)]);
+		} else if (data instanceof DraggableFile) {
+			const newOwnership = filesToOwnership(data.files);
 			branchController.amendBranch($branch.id, newOwnership);
 		}
 	}
@@ -77,7 +62,7 @@
 			return () => false;
 		}
 		return (data: any) => {
-			if (!isDraggableCommit(data)) return false;
+			if (!(data instanceof DraggableCommit)) return false;
 			if (data.branchId != $branch.id) return false;
 
 			if (data.commit.isParentOf(commit)) {
@@ -138,7 +123,6 @@
 			commitUrl={$baseBranch?.commitUrl(commit.id)}
 			{isHeadCommit}
 			{isUnapplied}
-			{selectedFiles}
 		/>
 	</div>
 </div>

--- a/gitbutler-ui/src/lib/components/HunkViewer.svelte
+++ b/gitbutler-ui/src/lib/components/HunkViewer.svelte
@@ -5,7 +5,7 @@
 	import Scrollbar from './Scrollbar.svelte';
 	import { Project } from '$lib/backend/projects';
 	import { draggable } from '$lib/dragging/draggable';
-	import { draggableHunk } from '$lib/dragging/draggables';
+	import { DraggableHunk } from '$lib/dragging/draggables';
 	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import { getContext, getContextStoreBySymbol, maybeGetContextStore } from '$lib/utils/context';
 	import { Ownership } from '$lib/vbranches/ownership';
@@ -66,7 +66,7 @@
 		tabindex="0"
 		role="cell"
 		use:draggable={{
-			...draggableHunk($branch?.id || '', section.hunk),
+			data: new DraggableHunk($branch?.id || '', section.hunk),
 			disabled: draggingDisabled
 		}}
 		on:contextmenu|preventDefault

--- a/gitbutler-ui/src/lib/components/NewBranchDropZone.svelte
+++ b/gitbutler-ui/src/lib/components/NewBranchDropZone.svelte
@@ -6,34 +6,24 @@
 	import topSheetSvg from '$lib/assets/new-branch/top-sheet.svg?raw';
 	// import components
 	import Button from '$lib/components/Button.svelte';
-	import {
-		isDraggableHunk,
-		isDraggableFile,
-		type DraggableFile,
-		type DraggableHunk
-	} from '$lib/dragging/draggables';
+	import { DraggableFile, DraggableHunk } from '$lib/dragging/draggables';
 	import { dropzone } from '$lib/dragging/dropzone';
 	import { getContext } from '$lib/utils/context';
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { filesToOwnership } from '$lib/vbranches/ownership';
-	import { get } from 'svelte/store';
 
 	const branchController = getContext(BranchController);
 
 	function accepts(data: any) {
-		return isDraggableFile(data) || isDraggableHunk(data);
+		return data instanceof DraggableFile || data instanceof DraggableHunk;
 	}
 
 	function onDrop(data: DraggableFile | DraggableHunk) {
-		if (isDraggableHunk(data)) {
+		if (data instanceof DraggableHunk) {
 			const ownership = `${data.hunk.filePath}:${data.hunk.id}`;
 			branchController.createBranch({ ownership });
-		} else if (isDraggableFile(data)) {
-			let files = get(data.files);
-			if (files.length == 0) {
-				files = [data.current];
-			}
-			const ownership = filesToOwnership(files);
+		} else if (data instanceof DraggableFile) {
+			const ownership = filesToOwnership(data.files);
 			branchController.createBranch({ ownership });
 		}
 	}

--- a/gitbutler-ui/src/lib/dragging/draggables.ts
+++ b/gitbutler-ui/src/lib/dragging/draggables.ts
@@ -1,63 +1,45 @@
-import type { AnyFile, Commit, LocalFile, Hunk, RemoteCommit } from '../vbranches/types';
-import type { Writable } from 'svelte/store';
+import { get, type Readable } from 'svelte/store';
+import type { AnyFile, Commit, Hunk, RemoteCommit } from '../vbranches/types';
 
 export function nonDraggable() {
 	return {
 		disabled: true,
-		data: {}
+		data: undefined
 	};
 }
 
-export type DraggableHunk = {
-	branchId: string;
-	hunk: Hunk;
-};
-
-export function draggableHunk(branchId: string | undefined, hunk: Hunk) {
-	return { data: { branchId, hunk } };
+export class DraggableHunk {
+	constructor(
+		public readonly branchId: string,
+		public readonly hunk: Hunk
+	) {}
 }
 
-export function isDraggableHunk(obj: any): obj is DraggableHunk {
-	return obj && obj.branchId && obj.hunk;
+export class DraggableFile {
+	constructor(
+		public readonly branchId: string,
+		private file: AnyFile,
+		private selection: Readable<AnyFile[]> | undefined
+	) {}
+
+	get files(): AnyFile[] {
+		const selection = this.selection ? get(this.selection) : undefined;
+		if (selection && selection.length > 0) return selection;
+		return [this.file];
+	}
 }
 
-export type DraggableFile = {
-	branchId: string;
-	files: Writable<AnyFile[]>;
-	current: LocalFile;
-};
-
-export function draggableFile(branchId: string, current: AnyFile, files: Writable<AnyFile[]>) {
-	return { data: { branchId, current, files } };
+export class DraggableCommit {
+	constructor(
+		public readonly branchId: string,
+		public readonly commit: Commit,
+		public readonly isHeadCommit: boolean
+	) {}
 }
 
-export function isDraggableFile(obj: any): obj is DraggableFile {
-	return obj && obj.branchId && obj.files && obj.current;
-}
-
-export type DraggableCommit = {
-	branchId: string;
-	commit: Commit;
-	isHeadCommit: boolean;
-};
-
-export function draggableCommit(branchId: string, commit: Commit, isHeadCommit: boolean) {
-	return { data: { branchId, commit, isHeadCommit } };
-}
-
-export function isDraggableCommit(obj: any): obj is DraggableCommit {
-	return obj && obj.branchId && obj.commit && obj.isHeadCommit;
-}
-
-export type DraggableRemoteCommit = {
-	branchId: string;
-	remoteCommit: RemoteCommit;
-};
-
-export function draggableRemoteCommit(branchId: string, remoteCommit: RemoteCommit) {
-	return { data: { branchId, remoteCommit } };
-}
-
-export function isDraggableRemoteCommit(obj: any): obj is DraggableRemoteCommit {
-	return obj && obj.branchId && obj.remoteCommit;
+export class DraggableRemoteCommit {
+	constructor(
+		public readonly branchId: string,
+		public readonly remoteCommit: RemoteCommit
+	) {}
 }

--- a/gitbutler-ui/src/lib/utils/context.ts
+++ b/gitbutler-ui/src/lib/utils/context.ts
@@ -69,11 +69,13 @@ export function createContextStore<T extends Class>(
  *   export const [getSpecialCommits, setSpecialCommits] = buildContextStore<Commit[]>();`
  * ```
  */
-export function buildContextStore<T>(): [() => Readable<T>, (value: T) => Writable<T>] {
-	const identifier = Symbol();
+export function buildContextStore<T, S extends Readable<T> = Readable<T>>(
+	name: string
+): [() => S, (value: T) => Writable<T>] {
+	const identifier = Symbol(name);
 	return [
 		() => {
-			return getContextStoreBySymbol<T>(identifier);
+			return getContextStoreBySymbol<T, S>(identifier);
 		},
 		(value: T) => {
 			return createContextStore(identifier, value);
@@ -88,6 +90,6 @@ export function buildContextStore<T>(): [() => Readable<T>, (value: T) => Writab
  */
 export function getContextStoreBySymbol<T, S extends Readable<T> = Readable<T>>(key: symbol): S {
 	const instance = svelteGetContext<S | undefined>(key);
-	if (!instance) throw new Error(`no instance of \`Readable<${key.toString}[]>\` in context`);
+	if (!instance) throw new Error(`no instance of \`Readable<${key.toString()}[]>\` in context`);
 	return instance;
 }

--- a/gitbutler-ui/src/lib/utils/selection.ts
+++ b/gitbutler-ui/src/lib/utils/selection.ts
@@ -2,19 +2,20 @@
  * Shared helper functions for manipulating selected files with keyboard.
  */
 import { get, type Writable } from 'svelte/store';
+import type { FileSelection } from '$lib/vbranches/fileSelection';
 import type { AnyFile } from '$lib/vbranches/types';
 
-export function getNextFile(files: AnyFile[], current: AnyFile) {
-	const fileIndex = files.findIndex((f) => f.id == current.id);
+export function getNextFile(files: AnyFile[], current: string) {
+	const fileIndex = files.findIndex((f) => f.id == current);
 	if (fileIndex != -1 && fileIndex + 1 < files.length) return files[fileIndex + 1];
 }
 
-export function getPreviousFile(files: AnyFile[], current: AnyFile) {
-	const fileIndex = files.findIndex((f) => f.id == current.id);
+export function getPreviousFile(files: AnyFile[], current: string) {
+	const fileIndex = files.findIndex((f) => f.id == current);
 	if (fileIndex > 0) return files[fileIndex - 1];
 }
 
-export function getFileByKey(key: string, current: AnyFile, files: AnyFile[]): AnyFile | undefined {
+export function getFileByKey(key: string, current: string, files: AnyFile[]): AnyFile | undefined {
 	if (key == 'ArrowUp') {
 		return getPreviousFile(files, current);
 	} else if (key == 'ArrowDown') {
@@ -29,21 +30,32 @@ export function getFileByKey(key: string, current: AnyFile, files: AnyFile[]): A
  * This has potential to slow things down since it's O(N) wrt to number of files, but it's less
  * prone to breakage than focusing using element ids at a distance.
  */
-export function updateFocus(elt: HTMLElement, file: AnyFile, selectedFiles: Writable<AnyFile[]>) {
+export function updateFocus(
+	elt: HTMLElement,
+	file: AnyFile,
+	selectedFiles: Writable<FileSelection>,
+	commitId?: string
+) {
 	const selection = get(selectedFiles);
-	if (selection.length == 1 && selection[0].id == file.id) elt.focus();
+
+	if (selection.length != 1) return;
+	const selected = selection.toOnly();
+	if (selected.fileId == file.id && selected.context == commitId) elt.focus();
 }
 
 export function maybeMoveSelection(
 	key: string,
 	files: AnyFile[],
-	selectedFiles: Writable<AnyFile[]>
+	selectedFileIds: Writable<FileSelection>
 ) {
 	if (key != 'ArrowUp' && key != 'ArrowDown') return;
 
-	const current = get(selectedFiles).at(0);
-	if (!current) return;
+	const currentSelection = get(selectedFileIds);
+	if (currentSelection.length == 0) return;
 
-	const newSelection = getFileByKey(key, current, files);
-	if (newSelection) selectedFiles.set([newSelection]);
+	const newSelection = getFileByKey(key, currentSelection.toOnly().fileId, files);
+	if (newSelection) {
+		currentSelection.clear();
+		currentSelection.add(newSelection.id);
+	}
 }

--- a/gitbutler-ui/src/lib/utils/typeguards.ts
+++ b/gitbutler-ui/src/lib/utils/typeguards.ts
@@ -1,0 +1,3 @@
+export function isDefined<T>(file: T | undefined): file is T {
+	return file !== undefined;
+}

--- a/gitbutler-ui/src/lib/vbranches/contexts.ts
+++ b/gitbutler-ui/src/lib/vbranches/contexts.ts
@@ -1,9 +1,28 @@
 import { buildContextStore } from '$lib/utils/context';
-import type { Commit, RemoteCommit } from './types';
+import type { FileSelection } from './fileSelection';
+import type { AnyCommit, AnyFile, Commit, RemoteCommit } from './types';
+import type { Writable } from 'svelte/store';
 
 // When we can't use type for context objects we build typed getter/setter pairs
 // to avoid using symbols explicitly.
-export const [getLocalCommits, createLocalContextStore] = buildContextStore<Commit[]>();
-export const [getRemoteCommits, createRemoteContextStore] = buildContextStore<Commit[]>();
-export const [getIntegratedCommits, createIntegratedContextStore] = buildContextStore<Commit[]>();
-export const [getUnknownCommits, createUnknownContextStore] = buildContextStore<RemoteCommit[]>();
+export const [getLocalCommits, createLocalContextStore] =
+	buildContextStore<Commit[]>('localCommits');
+export const [getRemoteCommits, createRemoteContextStore] =
+	buildContextStore<Commit[]>('remoteCommits');
+export const [getIntegratedCommits, createIntegratedContextStore] =
+	buildContextStore<Commit[]>('integratedCommits');
+export const [getUnknownCommits, createUnknownContextStore] =
+	buildContextStore<RemoteCommit[]>('unknownCommits');
+export const [getSelectedFileIds, createSelectedFileIds] = buildContextStore<
+	FileSelection,
+	Writable<FileSelection>
+>('selectedFileIds');
+
+export const [getSelectedFiles, createSelectedFiles] = buildContextStore<
+	AnyFile[],
+	Writable<AnyFile[]>
+>('selectedFiles');
+
+export const [getCommitStore, createCommitStore] = buildContextStore<AnyCommit | undefined>(
+	'commit'
+);

--- a/gitbutler-ui/src/lib/vbranches/fileSelection.ts
+++ b/gitbutler-ui/src/lib/vbranches/fileSelection.ts
@@ -1,0 +1,44 @@
+import { writable } from 'svelte/store';
+
+export type SelectedFile = {
+	context?: string;
+	fileId: string;
+};
+export class FileSelection {
+	private _fileIds = new Set<string>();
+	readonly fileIds = writable<string[]>([]);
+
+	constructor() {}
+
+	add(fileId: string, context?: string) {
+		this._fileIds.add(context ? fileId + '|' + context : fileId);
+		this.fileIds.set([...this._fileIds.values()]);
+	}
+
+	has(fileId: string, context?: string) {
+		return this._fileIds.has(context ? fileId + '|' + context : fileId);
+	}
+
+	remove(fileId: string, context?: string) {
+		this._fileIds.delete(context ? fileId + '|' + context : fileId);
+		this.fileIds.set([...this._fileIds.values()]);
+	}
+
+	map<T>(callback: (fileId: string) => T) {
+		return [...this._fileIds.values()].map((fileId) => callback(fileId));
+	}
+
+	clear() {
+		this._fileIds.clear();
+		this.fileIds.set([]);
+	}
+
+	get length() {
+		return this._fileIds.size;
+	}
+
+	toOnly() {
+		const [fileId, context] = [...this._fileIds.values()][0].split('|');
+		return { fileId, context };
+	}
+}

--- a/gitbutler-ui/src/lib/vbranches/types.ts
+++ b/gitbutler-ui/src/lib/vbranches/types.ts
@@ -186,6 +186,8 @@ export class RemoteCommit {
 	}
 }
 
+export type AnyCommit = Commit | RemoteCommit;
+
 export const LOCAL_COMMITS = Symbol('LocalCommtis');
 export const REMOTE_COMMITS = Symbol('RemoteCommits');
 export const INTEGRATED_COMMITS = Symbol('IntegratedCommits');

--- a/gitbutler-ui/src/routes/[projectId]/base/+page.svelte
+++ b/gitbutler-ui/src/routes/[projectId]/base/+page.svelte
@@ -7,29 +7,25 @@
 	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import { getContext, getContextStoreBySymbol } from '$lib/utils/context';
 	import { BaseBranchService } from '$lib/vbranches/branchStoresCache';
+	import { createSelectedFileIds, createSelectedFiles } from '$lib/vbranches/contexts';
+	import { FileSelection } from '$lib/vbranches/fileSelection';
 	import lscache from 'lscache';
 	import { onMount } from 'svelte';
-	import { writable } from 'svelte/store';
-	import type { AnyFile } from '$lib/vbranches/types';
-
 	const defaultBranchWidthRem = 30;
 	const laneWidthKey = 'historyLaneWidth';
-	const selectedFiles = writable<AnyFile[]>([]);
 	const userSettings = getContextStoreBySymbol<Settings>(SETTINGS);
 
 	const baseBranchService = getContext(BaseBranchService);
 	const baseBranch = baseBranchService.base;
 
+	createSelectedFileIds(new FileSelection());
+	const selectedFiles = createSelectedFiles([]);
+
 	let rsViewport: HTMLDivElement;
 	let laneWidth: number;
 
 	$: error$ = baseBranchService.error$;
-	$: selected = setSelected($selectedFiles);
-
-	function setSelected(files: AnyFile[]) {
-		if (files.length == 0) return undefined;
-		return files[0];
-	}
+	$: selected = $selectedFiles.length == 1 ? $selectedFiles[0] : undefined;
 
 	onMount(() => {
 		laneWidth = lscache.get(laneWidthKey);
@@ -49,7 +45,7 @@
 		>
 			<ScrollableContainer>
 				<div class="card">
-					<BaseBranch base={$baseBranch} {selectedFiles} />
+					<BaseBranch base={$baseBranch} />
 				</div>
 			</ScrollableContainer>
 			<Resizer


### PR DESCRIPTION
This commit needlessly entangles two changes, but they are part of the same effort. We replace the use of props for passing selected files and selected ownership with context getters.

Landing this now since it's functionally much better than before, but this code needs more work. We are currently using a store on the `FileSelection` object essentially for retriggering checks, it has a smell to it.

Note that the reason selectedFileIds is separate from selectedFiles is that our file objects mutate with every update from the back end. That's why until now has been clearing quite often.

TODO: Rename `SelectedOwnership` to something more true to its function