### PR TITLE
re-enable error tracing for tauri app

### DIFF
--- a/crates/gitbutler-tauri/src/commands.rs
+++ b/crates/gitbutler-tauri/src/commands.rs
@@ -15,7 +15,7 @@ use crate::error::Error;
 use crate::{app, watcher};
 
 #[tauri::command(async)]
-#[instrument(skip(handle))]
+#[instrument(skip(handle), err(Debug))]
 pub async fn list_session_files(
     handle: tauri::AppHandle,
     project_id: ProjectId,
@@ -28,7 +28,7 @@ pub async fn list_session_files(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(handle))]
+#[instrument(skip(handle), err(Debug))]
 pub async fn git_remote_branches(
     handle: tauri::AppHandle,
     project_id: ProjectId,
@@ -39,7 +39,7 @@ pub async fn git_remote_branches(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(handle))]
+#[instrument(skip(handle), err(Debug))]
 pub async fn git_test_push(
     handle: tauri::AppHandle,
     project_id: ProjectId,
@@ -62,7 +62,7 @@ pub async fn git_test_push(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(handle))]
+#[instrument(skip(handle), err(Debug))]
 pub async fn git_test_fetch(
     handle: tauri::AppHandle,
     project_id: ProjectId,
@@ -84,7 +84,7 @@ pub async fn git_test_fetch(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(handle))]
+#[instrument(skip(handle), err(Debug))]
 pub async fn git_index_size(
     handle: tauri::AppHandle,
     project_id: ProjectId,
@@ -94,7 +94,7 @@ pub async fn git_index_size(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(handle))]
+#[instrument(skip(handle), err(Debug))]
 pub async fn git_head(handle: tauri::AppHandle, project_id: ProjectId) -> Result<String, Error> {
     let app = handle.state::<app::App>();
     let head = app.git_head(&project_id)?;
@@ -102,7 +102,7 @@ pub async fn git_head(handle: tauri::AppHandle, project_id: ProjectId) -> Result
 }
 
 #[tauri::command(async)]
-#[instrument(skip(handle))]
+#[instrument(skip(handle), err(Debug))]
 pub async fn delete_all_data(handle: tauri::AppHandle) -> Result<(), Error> {
     let app = handle.state::<app::App>();
     app.delete_all_data().await?;
@@ -110,7 +110,7 @@ pub async fn delete_all_data(handle: tauri::AppHandle) -> Result<(), Error> {
 }
 
 #[tauri::command(async)]
-#[instrument(skip(handle))]
+#[instrument(skip(handle), err(Debug))]
 pub async fn mark_resolved(
     handle: tauri::AppHandle,
     project_id: ProjectId,
@@ -122,7 +122,7 @@ pub async fn mark_resolved(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(_handle))]
+#[instrument(skip(_handle), err(Debug))]
 pub async fn git_set_global_config(
     _handle: tauri::AppHandle,
     key: &str,
@@ -133,7 +133,7 @@ pub async fn git_set_global_config(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(_handle))]
+#[instrument(skip(_handle), err(Debug))]
 pub async fn git_get_global_config(
     _handle: tauri::AppHandle,
     key: &str,
@@ -143,7 +143,7 @@ pub async fn git_get_global_config(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(handle))]
+#[instrument(skip(handle), err(Debug))]
 pub async fn project_flush_and_push(handle: tauri::AppHandle, id: ProjectId) -> Result<(), Error> {
     let users = handle.state::<users::Controller>().inner().clone();
     let projects = handle.state::<projects::Controller>().inner().clone();

--- a/crates/gitbutler-tauri/src/deltas.rs
+++ b/crates/gitbutler-tauri/src/deltas.rs
@@ -11,7 +11,7 @@ pub mod commands {
     use crate::error::Error;
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn list_deltas(
         handle: AppHandle,
         project_id: &str,

--- a/crates/gitbutler-tauri/src/keys.rs
+++ b/crates/gitbutler-tauri/src/keys.rs
@@ -6,7 +6,7 @@ pub mod commands {
     use crate::error::Error;
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn get_public_key(handle: tauri::AppHandle) -> Result<PublicKey, Error> {
         handle
             .state::<controller::Controller>()

--- a/crates/gitbutler-tauri/src/menu.rs
+++ b/crates/gitbutler-tauri/src/menu.rs
@@ -11,7 +11,7 @@ use tracing::instrument;
 use crate::error::Error;
 
 #[tauri::command(async)]
-#[instrument(skip(handle))]
+#[instrument(skip(handle), err(Debug))]
 pub async fn menu_item_set_enabled(
     handle: AppHandle,
     menu_item_id: &str,

--- a/crates/gitbutler-tauri/src/projects.rs
+++ b/crates/gitbutler-tauri/src/projects.rs
@@ -11,7 +11,7 @@ pub mod commands {
     use crate::error::Error;
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn update_project(
         handle: tauri::AppHandle,
         project: projects::UpdateRequest,
@@ -24,7 +24,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn add_project(
         handle: tauri::AppHandle,
         path: &path::Path,
@@ -36,7 +36,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn get_project(
         handle: tauri::AppHandle,
         id: &str,
@@ -52,13 +52,13 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn list_projects(handle: tauri::AppHandle) -> Result<Vec<projects::Project>, Error> {
         handle.state::<Controller>().list().map_err(Into::into)
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn delete_project(handle: tauri::AppHandle, id: &str) -> Result<(), Error> {
         let id = id.parse().context(error::Context::new_static(
             Code::Validation,
@@ -72,7 +72,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn git_get_local_config(
         handle: tauri::AppHandle,
         id: &str,
@@ -89,7 +89,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn git_set_local_config(
         handle: tauri::AppHandle,
         id: &str,

--- a/crates/gitbutler-tauri/src/sessions.rs
+++ b/crates/gitbutler-tauri/src/sessions.rs
@@ -9,7 +9,7 @@ pub mod commands {
     use crate::error::Error;
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn list_sessions(
         handle: AppHandle,
         project_id: &str,

--- a/crates/gitbutler-tauri/src/users.rs
+++ b/crates/gitbutler-tauri/src/users.rs
@@ -10,7 +10,7 @@ pub mod commands {
     use crate::sentry;
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn get_user(handle: AppHandle) -> Result<Option<User>, Error> {
         let app = handle.state::<Controller>();
         let proxy = handle.state::<assets::Proxy>();
@@ -22,7 +22,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn set_user(handle: AppHandle, user: User) -> Result<User, Error> {
         let app = handle.state::<Controller>();
         let proxy = handle.state::<assets::Proxy>();
@@ -35,7 +35,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn delete_user(handle: AppHandle) -> Result<(), Error> {
         let app = handle.state::<Controller>();
 

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -19,7 +19,7 @@ pub mod commands {
     use crate::watcher;
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn commit_virtual_branch(
         handle: AppHandle,
         project_id: ProjectId,
@@ -38,7 +38,7 @@ pub mod commands {
 
     /// This is a test command. It retrieves the virtual branches state from the gitbutler repository (legacy state) and persists it into a flat TOML file
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn save_vbranches_state(
         handle: AppHandle,
         project_id: ProjectId,
@@ -52,7 +52,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn list_virtual_branches(
         handle: AppHandle,
         project_id: ProjectId,
@@ -84,7 +84,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn create_virtual_branch(
         handle: AppHandle,
         project_id: ProjectId,
@@ -99,7 +99,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn create_virtual_branch_from_branch(
         handle: AppHandle,
         project_id: ProjectId,
@@ -114,7 +114,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn merge_virtual_branch_upstream(
         handle: AppHandle,
         project_id: ProjectId,
@@ -129,7 +129,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn get_base_branch_data(
         handle: AppHandle,
         project_id: ProjectId,
@@ -148,7 +148,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn set_base_branch(
         handle: AppHandle,
         project_id: ProjectId,
@@ -170,7 +170,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn update_base_branch(handle: AppHandle, project_id: ProjectId) -> Result<(), Error> {
         handle
             .state::<Controller>()
@@ -181,7 +181,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn update_virtual_branch(
         handle: AppHandle,
         project_id: ProjectId,
@@ -197,7 +197,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn delete_virtual_branch(
         handle: AppHandle,
         project_id: ProjectId,
@@ -212,7 +212,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn apply_branch(
         handle: AppHandle,
         project_id: ProjectId,
@@ -227,7 +227,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn unapply_branch(
         handle: AppHandle,
         project_id: ProjectId,
@@ -242,7 +242,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn unapply_ownership(
         handle: AppHandle,
         project_id: ProjectId,
@@ -257,7 +257,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn reset_files(
         handle: AppHandle,
         project_id: ProjectId,
@@ -277,7 +277,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn push_virtual_branch(
         handle: AppHandle,
         project_id: ProjectId,
@@ -300,7 +300,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn can_apply_virtual_branch(
         handle: AppHandle,
         project_id: ProjectId,
@@ -314,7 +314,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn can_apply_remote_branch(
         handle: AppHandle,
         project_id: ProjectId,
@@ -327,7 +327,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn list_remote_commit_files(
         handle: AppHandle,
         project_id: ProjectId,
@@ -341,7 +341,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn reset_virtual_branch(
         handle: AppHandle,
         project_id: ProjectId,
@@ -357,7 +357,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn cherry_pick_onto_virtual_branch(
         handle: AppHandle,
         project_id: ProjectId,
@@ -373,7 +373,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn amend_virtual_branch(
         handle: AppHandle,
         project_id: ProjectId,
@@ -389,7 +389,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn list_remote_branches(
         handle: tauri::AppHandle,
         project_id: ProjectId,
@@ -402,7 +402,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn get_remote_branch_data(
         handle: tauri::AppHandle,
         project_id: ProjectId,
@@ -420,7 +420,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn squash_branch_commit(
         handle: tauri::AppHandle,
         project_id: ProjectId,
@@ -436,7 +436,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn fetch_from_target(
         handle: tauri::AppHandle,
         project_id: ProjectId,
@@ -458,7 +458,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn move_commit(
         handle: tauri::AppHandle,
         project_id: ProjectId,

--- a/crates/gitbutler-tauri/src/zip.rs
+++ b/crates/gitbutler-tauri/src/zip.rs
@@ -12,7 +12,7 @@ pub mod commands {
     use crate::error::Error;
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn get_project_archive_path(
         handle: AppHandle,
         project_id: &str,
@@ -28,7 +28,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn get_project_data_archive_path(
         handle: AppHandle,
         project_id: &str,
@@ -44,7 +44,7 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(handle))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn get_logs_archive_path(handle: AppHandle) -> Result<path::PathBuf, Error> {
         handle
             .state::<controller::Controller>()


### PR DESCRIPTION
Related to #3385.

In the related PR, error handling was consolodiated and all extra tracing was removed under the unvalidated assumption that `instrument` will always print errors anyway.
This wasn't that case, causing tauri application errors to not be displayed anymore, nor were errors highlighted.

With this change, each top-level `instrument` annotation now receives an `err(Debug)` suffix to debug-print the `Error` type. This will print the error chain as well as backtraces, if `RUST_BACKTRACE` was set in the environment.

### Preview

Please note that the example triggers the error in the top-level command itself while adding a `Code`  for context, hence the error source chain is flatter than it would otherwise be.

#### No error

```
2024-04-08T11:37:52.546812Z  INFO list_virtual_branches: crates/gitbutler-tauri/src/virtual_branches.rs:55: close time.busy=32.3ms time.idle=80.4µs project_id=f726020c-7762-4730-9ab3-28ce333a3d4
```

#### A command error

```
2024-04-08T11:23:11.370405Z ERROR list_virtual_branches: crates/gitbutler-tauri/src/virtual_branches.rs:55: error=Error(errors.branches

Caused by:
    fail message) project_id=f726020c-7762-4730-9ab3-28ce333a3d4f
```

#### A command error with `RUST_BACKTRACE=1`

```
2024-04-08T11:08:51.220920Z ERROR crates/gitbutler-tauri/src/error.rs:58: err=Error(errors.branches

Caused by:
    fail message

Stack backtrace:
   0: std::backtrace_rs::backtrace::libunwind::trace
             at /rustc/88c2f4f5f50ace5ddc7655ea311435104d3659bd/library/std/src/../../backtrace/src/backtrace/libunwind.rs:105:5
   1: std::backtrace_rs::backtrace::trace_unsynchronized
             at /rustc/88c2f4f5f50ace5ddc7655ea311435104d3659bd/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
[..50 lines or more..]
```

### Notes for the Reviewer

* I considered to put a single log message into `Error::serialize`, but found that this way the connection to the called method in which the error originated is entirely lost.
* Setting `RUST_BACKTRACE` on application level in `main` was considered, but I thought that's a step too far for this PR as backtraces are also a cause of significant noise.
