### PR TITLE
Revert "Remove unused (?) allow clippy statements"

### DIFF
--- a/crates/gitbutler-changeset/src/signature.rs
+++ b/crates/gitbutler-changeset/src/signature.rs
@@ -109,6 +109,7 @@ impl Signature {
             }
         }
 
+        #[allow(clippy::cast_precision_loss)]
         {
             (2 * matching_bigrams) as f64 / (original_length as usize + other.len() - 2) as f64
         }

--- a/crates/gitbutler-core/src/lib.rs
+++ b/crates/gitbutler-core/src/lib.rs
@@ -4,6 +4,14 @@
     all(windows, not(test), not(debug_assertions)),
     windows_subsystem = "windows"
 )]
+// FIXME(qix-): Stuff we want to fix but don't have a lot of time for.
+// FIXME(qix-): PRs welcome!
+#![allow(
+    clippy::used_underscore_binding,
+    clippy::module_name_repetitions,
+    clippy::struct_field_names,
+    clippy::too_many_lines
+)]
 
 pub mod askpass;
 pub mod assets;

--- a/crates/gitbutler-core/src/zip/controller.rs
+++ b/crates/gitbutler-core/src/zip/controller.rs
@@ -9,6 +9,7 @@ pub struct Controller {
     local_data_dir: path::PathBuf,
     logs_dir: path::PathBuf,
     zipper: Zipper,
+    #[allow(clippy::struct_field_names)]
     projects_controller: projects::Controller,
 }
 

--- a/crates/gitbutler-tauri/src/lib.rs
+++ b/crates/gitbutler-tauri/src/lib.rs
@@ -4,6 +4,14 @@
     all(windows, not(test), not(debug_assertions)),
     windows_subsystem = "windows"
 )]
+// FIXME(qix-): Stuff we want to fix but don't have a lot of time for.
+// FIXME(qix-): PRs welcome!
+#![allow(
+    clippy::used_underscore_binding,
+    clippy::module_name_repetitions,
+    clippy::struct_field_names,
+    clippy::too_many_lines
+)]
 
 pub mod analytics;
 pub mod app;

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -4,6 +4,14 @@
     all(windows, not(test), not(debug_assertions)),
     windows_subsystem = "windows"
 )]
+// FIXME(qix-): Stuff we want to fix but don't have a lot of time for.
+// FIXME(qix-): PRs welcome!
+#![allow(
+    clippy::used_underscore_binding,
+    clippy::module_name_repetitions,
+    clippy::struct_field_names,
+    clippy::too_many_lines
+)]
 
 use std::path::PathBuf;
 

--- a/crates/gitbutler-tauri/src/zip.rs
+++ b/crates/gitbutler-tauri/src/zip.rs
@@ -1,4 +1,5 @@
 pub mod commands {
+    #![allow(clippy::used_underscore_binding)]
     use anyhow::Context;
     use std::path;
 


### PR DESCRIPTION
Reverts gitbutlerapp/gitbutler#3448

The current codebase has a ton of clippy lints that we should be testing for but cannot because the changes would be widespread. The goal is to enable pedantic warnings but right now there's a lot that needs to be fixed to make them work. The solution to this isn't to revert the clippy lints we have already.