### PR TITLE
Update README.md to include a link to the nightly release page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
        <a href="https://app.gitbutler.com/downloads/release/linux/x86_64/deb">deb</a>)
     <br />
     <i>~ Link for Windows will be added once a release is available. ~</i>
+    <br />
+    Nightly releases can be found <a href="https://app.gitbutler.com/downloads">here</a>
   </p>
 </div>
 


### PR DESCRIPTION
I've added a link to "https://app.gitbutler.com/downloads" to download the nightly versions as I couldn't find them on Google and other users may be trying to find the links.