### PR TITLE
`Backspace` was navigation to the previous page

### DIFF
--- a/app/src/routes/+layout.svelte
+++ b/app/src/routes/+layout.svelte
@@ -62,6 +62,10 @@
 					...s,
 					theme: $userSettings.theme == 'light' ? 'dark' : 'light'
 				}));
+			}),
+			hotkeys.on('Backspace', (e) => {
+				// This prevent backspace from navigating back
+				e.preventDefault();
 			})
 		);
 	});


### PR DESCRIPTION
On each page, which wasn't expected when you accidentally hit it.