### PR TITLE
docs: Add link to Unstable Nightly releases in README (#123)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
       ·
 		Windows (<a href="https://app.gitbutler.com/downloads/release/windows/x86_64/msi">msi</a>)
     <br />
+    <br />
+    (Unstable Nightly releases can be found <a href="https://app.gitbutler.com/downloads">here</a>)
   </p>
 </div>
 


### PR DESCRIPTION
Added a link to the Unstable Nightly releases in the README file to make it
easier for users to access the latest experimental builds.