### PR TITLE
Use integration commit for calculating current diffs

### DIFF
--- a/app/src/lib/vbranches/branchController.ts
+++ b/app/src/lib/vbranches/branchController.ts
@@ -145,7 +145,7 @@ export class BranchController {
 	}
 
 	async unapplyHunk(hunk: Hunk) {
-		const ownership = `${hunk.filePath}:${hunk.id}`;
+		const ownership = `${hunk.filePath}:${hunk.id}-${hunk.hash}`;
 		try {
 			await invoke<void>('unapply_ownership', { projectId: this.projectId, ownership });
 		} catch (err) {

--- a/crates/gitbutler-core/src/virtual_branches/base.rs
+++ b/crates/gitbutler-core/src/virtual_branches/base.rs
@@ -401,194 +401,199 @@ pub fn update_base_branch(
     let context_lines = if use_context { 3_u32 } else { 0_u32 };
 
     // try to update every branch
-    let updated_vbranches = super::get_status_by_branch(gb_repository, project_repository)?
-        .0
-        .into_iter()
-        .map(|(branch, _)| branch)
-        .map(
-            |mut branch: branch::Branch| -> Result<Option<branch::Branch>> {
-                let branch_tree = repo.find_tree(branch.tree)?;
+    let updated_vbranches = super::get_status_by_branch(
+        gb_repository,
+        project_repository,
+        Some(&new_target_commit.id()),
+    )?
+    .0
+    .into_iter()
+    .map(|(branch, _)| branch)
+    .map(
+        |mut branch: branch::Branch| -> Result<Option<branch::Branch>> {
+            let branch_tree = repo.find_tree(branch.tree)?;
 
-                let branch_head_commit = repo.find_commit(branch.head).context(format!(
-                    "failed to find commit {} for branch {}",
-                    branch.head, branch.id
-                ))?;
-                let branch_head_tree = branch_head_commit.tree().context(format!(
-                    "failed to find tree for commit {} for branch {}",
-                    branch.head, branch.id
-                ))?;
+            let branch_head_commit = repo.find_commit(branch.head).context(format!(
+                "failed to find commit {} for branch {}",
+                branch.head, branch.id
+            ))?;
+            let branch_head_tree = branch_head_commit.tree().context(format!(
+                "failed to find tree for commit {} for branch {}",
+                branch.head, branch.id
+            ))?;
 
-                let result_integrated_detected =
-                    |mut branch: branch::Branch| -> Result<Option<branch::Branch>> {
-                        // branch head tree is the same as the new target tree.
-                        // meaning we can safely use the new target commit as the branch head.
+            let result_integrated_detected =
+                |mut branch: branch::Branch| -> Result<Option<branch::Branch>> {
+                    // branch head tree is the same as the new target tree.
+                    // meaning we can safely use the new target commit as the branch head.
 
-                        branch.head = new_target_commit.id();
-
-                        // it also means that the branch is fully integrated into the target.
-                        // disconnect it from the upstream
-                        branch.upstream = None;
-                        branch.upstream_head = None;
-
-                        let non_commited_files = diff::trees(
-                            &project_repository.git_repository,
-                            &branch_head_tree,
-                            &branch_tree,
-                            context_lines,
-                        )?;
-                        if non_commited_files.is_empty() {
-                            // if there are no commited files, then the branch is fully merged
-                            // and we can delete it.
-                            branch_writer.delete(&branch)?;
-                            project_repository.delete_branch_reference(&branch)?;
-                            Ok(None)
-                        } else {
-                            branch_writer.write(&mut branch)?;
-                            Ok(Some(branch))
-                        }
-                    };
-
-                if branch_head_tree.id() == new_target_tree.id() {
-                    return result_integrated_detected(branch);
-                }
-
-                // try to merge branch head with new target
-                let mut branch_tree_merge_index = repo
-                    .merge_trees(&old_target_tree, &branch_tree, &new_target_tree)
-                    .context(format!("failed to merge trees for branch {}", branch.id))?;
-
-                if branch_tree_merge_index.has_conflicts() {
-                    // branch tree conflicts with new target, unapply branch for now. we'll handle it later, when user applies it back.
-                    branch.applied = false;
-                    branch_writer.write(&mut branch)?;
-                    return Ok(Some(branch));
-                }
-
-                let branch_merge_index_tree_oid = branch_tree_merge_index.write_tree_to(repo)?;
-
-                if branch_merge_index_tree_oid == new_target_tree.id() {
-                    return result_integrated_detected(branch);
-                }
-
-                if branch.head == target.sha {
-                    // there are no commits on the branch, so we can just update the head to the new target and calculate the new tree
                     branch.head = new_target_commit.id();
-                    branch.tree = branch_merge_index_tree_oid;
-                    branch_writer.write(&mut branch)?;
-                    return Ok(Some(branch));
-                }
 
-                let mut branch_head_merge_index = repo
-                    .merge_trees(&old_target_tree, &branch_head_tree, &new_target_tree)
-                    .context(format!(
-                        "failed to merge head tree for branch {}",
-                        branch.id
-                    ))?;
+                    // it also means that the branch is fully integrated into the target.
+                    // disconnect it from the upstream
+                    branch.upstream = None;
+                    branch.upstream_head = None;
 
-                if branch_head_merge_index.has_conflicts() {
-                    // branch commits conflict with new target, make sure the branch is
-                    // unapplied. conflicts witll be dealt with when applying it back.
-                    branch.applied = false;
-                    branch_writer.write(&mut branch)?;
-                    return Ok(Some(branch));
-                }
+                    let non_commited_files = diff::trees(
+                        &project_repository.git_repository,
+                        &branch_head_tree,
+                        &branch_tree,
+                        context_lines,
+                    )?;
+                    if non_commited_files.is_empty() {
+                        // if there are no commited files, then the branch is fully merged
+                        // and we can delete it.
+                        branch_writer.delete(&branch)?;
+                        project_repository.delete_branch_reference(&branch)?;
+                        Ok(None)
+                    } else {
+                        branch_writer.write(&mut branch)?;
+                        Ok(Some(branch))
+                    }
+                };
 
-                // branch commits do not conflict with new target, so lets merge them
-                let branch_head_merge_tree_oid = branch_head_merge_index
+            if branch_head_tree.id() == new_target_tree.id() {
+                return result_integrated_detected(branch);
+            }
+
+            // try to merge branch head with new target
+            let mut branch_tree_merge_index = repo
+                .merge_trees(&old_target_tree, &branch_tree, &new_target_tree)
+                .context(format!("failed to merge trees for branch {}", branch.id))?;
+
+            if branch_tree_merge_index.has_conflicts() {
+                // branch tree conflicts with new target, unapply branch for now. we'll handle it later, when user applies it back.
+                branch.applied = false;
+                branch_writer.write(&mut branch)?;
+                return Ok(Some(branch));
+            }
+
+            let branch_merge_index_tree_oid = branch_tree_merge_index.write_tree_to(repo)?;
+
+            if branch_merge_index_tree_oid == new_target_tree.id() {
+                return result_integrated_detected(branch);
+            }
+
+            if branch.head == target.sha {
+                // there are no commits on the branch, so we can just update the head to the new target and calculate the new tree
+                branch.head = new_target_commit.id();
+                branch.tree = branch_merge_index_tree_oid;
+                branch_writer.write(&mut branch)?;
+                return Ok(Some(branch));
+            }
+
+            let mut branch_head_merge_index = repo
+                .merge_trees(&old_target_tree, &branch_head_tree, &new_target_tree)
+                .context(format!(
+                    "failed to merge head tree for branch {}",
+                    branch.id
+                ))?;
+
+            if branch_head_merge_index.has_conflicts() {
+                // branch commits conflict with new target, make sure the branch is
+                // unapplied. conflicts witll be dealt with when applying it back.
+                branch.applied = false;
+                branch_writer.write(&mut branch)?;
+                return Ok(Some(branch));
+            }
+
+            // branch commits do not conflict with new target, so lets merge them
+            let branch_head_merge_tree_oid =
+                branch_head_merge_index
                     .write_tree_to(repo)
                     .context(format!(
                         "failed to write head merge index for {}",
                         branch.id
                     ))?;
 
-                let ok_with_force_push = project_repository.project().ok_with_force_push;
+            let ok_with_force_push = project_repository.project().ok_with_force_push;
 
-                let result_merge = |mut branch: branch::Branch| -> Result<Option<branch::Branch>> {
-                    // branch was pushed to upstream, and user doesn't like force pushing.
-                    // create a merge commit to avoid the need of force pushing then.
-                    let branch_head_merge_tree = repo
-                        .find_tree(branch_head_merge_tree_oid)
-                        .context("failed to find tree")?;
+            let result_merge = |mut branch: branch::Branch| -> Result<Option<branch::Branch>> {
+                // branch was pushed to upstream, and user doesn't like force pushing.
+                // create a merge commit to avoid the need of force pushing then.
+                let branch_head_merge_tree = repo
+                    .find_tree(branch_head_merge_tree_oid)
+                    .context("failed to find tree")?;
 
-                    let new_target_head = project_repository
-                        .commit(
-                            user,
-                            format!(
-                                "Merged {}/{} into {}",
-                                target.branch.remote(),
-                                target.branch.branch(),
-                                branch.name
-                            )
-                            .as_str(),
-                            &branch_head_merge_tree,
-                            &[&branch_head_commit, &new_target_commit],
-                            signing_key,
+                let new_target_head = project_repository
+                    .commit(
+                        user,
+                        format!(
+                            "Merged {}/{} into {}",
+                            target.branch.remote(),
+                            target.branch.branch(),
+                            branch.name
                         )
-                        .context("failed to commit merge")?;
-
-                    branch.head = new_target_head;
-                    branch.tree = branch_merge_index_tree_oid;
-                    branch_writer.write(&mut branch)?;
-                    Ok(Some(branch))
-                };
-
-                if branch.upstream.is_some() && !ok_with_force_push {
-                    return result_merge(branch);
-                }
-
-                // branch was not pushed to upstream yet. attempt a rebase,
-                let (_, committer) = project_repository.git_signatures(user)?;
-                let mut rebase_options = git2::RebaseOptions::new();
-                rebase_options.quiet(true);
-                rebase_options.inmemory(true);
-                let mut rebase = repo
-                    .rebase(
-                        Some(branch.head),
-                        Some(new_target_commit.id()),
-                        None,
-                        Some(&mut rebase_options),
+                        .as_str(),
+                        &branch_head_merge_tree,
+                        &[&branch_head_commit, &new_target_commit],
+                        signing_key,
                     )
-                    .context("failed to rebase")?;
+                    .context("failed to commit merge")?;
 
-                let mut rebase_success = true;
-                // check to see if these commits have already been pushed
-                let mut last_rebase_head = branch.head;
-                while rebase.next().is_some() {
-                    let index = rebase
-                        .inmemory_index()
-                        .context("failed to get inmemory index")?;
-                    if index.has_conflicts() {
-                        rebase_success = false;
-                        break;
-                    }
+                branch.head = new_target_head;
+                branch.tree = branch_merge_index_tree_oid;
+                branch_writer.write(&mut branch)?;
+                Ok(Some(branch))
+            };
 
-                    if let Ok(commit_id) = rebase.commit(None, &committer.clone().into(), None) {
-                        last_rebase_head = commit_id.into();
-                    } else {
-                        rebase_success = false;
-                        break;
-                    }
+            if branch.upstream.is_some() && !ok_with_force_push {
+                return result_merge(branch);
+            }
+
+            // branch was not pushed to upstream yet. attempt a rebase,
+            let (_, committer) = project_repository.git_signatures(user)?;
+            let mut rebase_options = git2::RebaseOptions::new();
+            rebase_options.quiet(true);
+            rebase_options.inmemory(true);
+            let mut rebase = repo
+                .rebase(
+                    Some(branch.head),
+                    Some(new_target_commit.id()),
+                    None,
+                    Some(&mut rebase_options),
+                )
+                .context("failed to rebase")?;
+
+            let mut rebase_success = true;
+            // check to see if these commits have already been pushed
+            let mut last_rebase_head = branch.head;
+            while rebase.next().is_some() {
+                let index = rebase
+                    .inmemory_index()
+                    .context("failed to get inmemory index")?;
+                if index.has_conflicts() {
+                    rebase_success = false;
+                    break;
                 }
 
-                if rebase_success {
-                    // rebase worked out, rewrite the branch head
-                    rebase.finish(None).context("failed to finish rebase")?;
-                    branch.head = last_rebase_head;
-                    branch.tree = branch_merge_index_tree_oid;
-                    branch_writer.write(&mut branch)?;
-                    return Ok(Some(branch));
+                if let Ok(commit_id) = rebase.commit(None, &committer.clone().into(), None) {
+                    last_rebase_head = commit_id.into();
+                } else {
+                    rebase_success = false;
+                    break;
                 }
+            }
 
-                // rebase failed, do a merge commit
-                rebase.abort().context("failed to abort rebase")?;
+            if rebase_success {
+                // rebase worked out, rewrite the branch head
+                rebase.finish(None).context("failed to finish rebase")?;
+                branch.head = last_rebase_head;
+                branch.tree = branch_merge_index_tree_oid;
+                branch_writer.write(&mut branch)?;
+                return Ok(Some(branch));
+            }
 
-                result_merge(branch)
-            },
-        )
-        .collect::<Result<Vec<_>>>()?
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>();
+            // rebase failed, do a merge commit
+            rebase.abort().context("failed to abort rebase")?;
+
+            result_merge(branch)
+        },
+    )
+    .collect::<Result<Vec<_>>>()?
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>();
 
     // ok, now all the problematic branches have been unapplied
     // now we calculate and checkout new tree for the working directory

--- a/crates/gitbutler-core/src/virtual_branches/branch/hunk.rs
+++ b/crates/gitbutler-core/src/virtual_branches/branch/hunk.rs
@@ -161,7 +161,6 @@ impl Hunk {
         let addition = diff
             .lines()
             .skip(1) // skip the first line which is the diff header
-            .filter(|line| line.starts_with('+') || line.starts_with('-')) // exclude context lines
             .collect::<Vec<_>>()
             .join("\n");
         format!("{:x}", md5::compute(addition))

--- a/crates/gitbutler-core/src/virtual_branches/integration.rs
+++ b/crates/gitbutler-core/src/virtual_branches/integration.rs
@@ -23,7 +23,7 @@ const GITBUTLER_INTEGRATION_COMMIT_AUTHOR_EMAIL: &str = "gitbutler@gitbutler.com
 pub fn update_gitbutler_integration(
     gb_repository: &gb_repository::Repository,
     project_repository: &project_repository::Repository,
-) -> Result<()> {
+) -> Result<git::Oid> {
     let target = gb_repository
         .default_target()
         .context("failed to get target")?
@@ -151,7 +151,7 @@ pub fn update_gitbutler_integration(
         GITBUTLER_INTEGRATION_COMMIT_AUTHOR_EMAIL,
     )?;
 
-    repo.commit(
+    let final_commit = repo.commit(
         Some(&"refs/heads/gitbutler/integration".parse().unwrap()),
         &committer,
         &committer,
@@ -200,7 +200,7 @@ pub fn update_gitbutler_integration(
         )?;
     }
 
-    Ok(())
+    Ok(final_commit)
 }
 
 pub fn verify_branch(

--- a/crates/gitbutler-core/src/virtual_branches/virtual.rs
+++ b/crates/gitbutler-core/src/virtual_branches/virtual.rs
@@ -2717,9 +2717,11 @@ pub fn commit(
             })
         })?;
 
+    let uncommitted_base =
+        super::integration::update_gitbutler_integration(gb_repository, project_repository)?;
     // get the files to commit
     let (mut statuses, _) =
-        get_status_by_branch(gb_repository, project_repository, Some(&default_target.sha))
+        get_status_by_branch(gb_repository, project_repository, Some(&uncommitted_base))
             .context("failed to get status by branch")?;
 
     let (ref mut branch, files) = statuses

--- a/crates/gitbutler-core/src/virtual_branches/virtual.rs
+++ b/crates/gitbutler-core/src/virtual_branches/virtual.rs
@@ -515,10 +515,13 @@ pub fn unapply_ownership(
     .filter(|b| b.applied)
     .collect::<Vec<_>>();
 
+    let uncommitted_base =
+        super::integration::update_gitbutler_integration(gb_repository, project_repository)?;
+
     let (applied_statuses, _) = get_applied_status(
         gb_repository,
         project_repository,
-        &default_target.sha,
+        &uncommitted_base,
         &default_target.sha,
         applied_branches,
     )
@@ -720,10 +723,13 @@ pub fn unapply_branch(
         .filter(|b| b.applied)
         .collect::<Vec<_>>();
 
+        let uncommitted_base =
+            super::integration::update_gitbutler_integration(gb_repository, project_repository)?;
+
         let (applied_statuses, _) = get_applied_status(
             gb_repository,
             project_repository,
-            &default_target.sha,
+            &uncommitted_base,
             &default_target.sha,
             applied_branches,
         )
@@ -2062,7 +2068,7 @@ pub fn get_status_by_branch(
         project_repository,
         // TODO: Keep this optional or update lots of tests?
         uncommitted_base.unwrap_or(&default_target.sha),
-        uncommitted_base.unwrap_or(&default_target.sha),
+        &default_target.sha,
         applied_virtual_branches,
     )?;
 
@@ -3192,10 +3198,13 @@ pub fn amend(
             })
         })?;
 
+    let uncommitted_base =
+        super::integration::update_gitbutler_integration(gb_repository, project_repository)?;
+
     let (mut applied_statuses, _) = get_applied_status(
         gb_repository,
         project_repository,
-        &default_target.sha,
+        &uncommitted_base,
         &default_target.sha,
         applied_branches,
     )?;
@@ -3371,10 +3380,13 @@ pub fn cherry_pick(
     .filter(|b| b.applied)
     .collect::<Vec<_>>();
 
+    let uncommitted_base =
+        super::integration::update_gitbutler_integration(gb_repository, project_repository)?;
+
     let (applied_statuses, _) = get_applied_status(
         gb_repository,
         project_repository,
-        &default_target.sha,
+        &uncommitted_base,
         &default_target.sha,
         applied_branches,
     )?;
@@ -3940,10 +3952,13 @@ pub fn move_commit(
             })
         })?;
 
+    let uncommitted_base =
+        super::integration::update_gitbutler_integration(gb_repository, project_repository)?;
+
     let (mut applied_statuses, _) = get_applied_status(
         gb_repository,
         project_repository,
-        &default_target.sha,
+        &uncommitted_base,
         &default_target.sha,
         applied_branches,
     )?;

--- a/crates/gitbutler-core/tests/virtual_branches/mod.rs
+++ b/crates/gitbutler-core/tests/virtual_branches/mod.rs
@@ -305,7 +305,7 @@ fn create_branch_with_ownership() -> Result<()> {
     )
     .expect("failed to create virtual branch");
 
-    virtual_branches::get_status_by_branch(gb_repository, project_repository)
+    virtual_branches::get_status_by_branch(gb_repository, project_repository, None)
         .expect("failed to get status");
 
     let current_session = gb_repository.get_or_create_current_session().unwrap();
@@ -327,7 +327,7 @@ fn create_branch_with_ownership() -> Result<()> {
     )
     .expect("failed to create virtual branch");
 
-    let statuses = virtual_branches::get_status_by_branch(gb_repository, project_repository)
+    let statuses = virtual_branches::get_status_by_branch(gb_repository, project_repository, None)
         .expect("failed to get status")
         .0;
 
@@ -462,7 +462,7 @@ fn hunk_expantion() -> Result<()> {
     .expect("failed to create virtual branch")
     .id;
 
-    let statuses = virtual_branches::get_status_by_branch(gb_repository, project_repository)
+    let statuses = virtual_branches::get_status_by_branch(gb_repository, project_repository, None)
         .expect("failed to get status")
         .0;
 
@@ -501,7 +501,7 @@ fn hunk_expantion() -> Result<()> {
         "line1\nline2\nline3\n",
     )?;
 
-    let statuses = virtual_branches::get_status_by_branch(gb_repository, project_repository)
+    let statuses = virtual_branches::get_status_by_branch(gb_repository, project_repository, None)
         .expect("failed to get status")
         .0;
     let files_by_branch_id = statuses
@@ -527,7 +527,7 @@ fn get_status_files_by_branch_no_hunks_no_branches() -> Result<()> {
 
     set_test_target(gb_repository, project_repository)?;
 
-    let statuses = virtual_branches::get_status_by_branch(gb_repository, project_repository)
+    let statuses = virtual_branches::get_status_by_branch(gb_repository, project_repository, None)
         .expect("failed to get status")
         .0;
 
@@ -566,7 +566,7 @@ fn get_status_files_by_branch() -> Result<()> {
     .expect("failed to create virtual branch")
     .id;
 
-    let statuses = virtual_branches::get_status_by_branch(gb_repository, project_repository)
+    let statuses = virtual_branches::get_status_by_branch(gb_repository, project_repository, None)
         .expect("failed to get status")
         .0;
     let files_by_branch_id = statuses
@@ -645,7 +645,7 @@ fn move_hunks_multiple_sources() -> Result<()> {
     };
     branch_writer.write(&mut branch1)?;
 
-    let statuses = virtual_branches::get_status_by_branch(gb_repository, project_repository)
+    let statuses = virtual_branches::get_status_by_branch(gb_repository, project_repository, None)
         .expect("failed to get status")
         .0;
 
@@ -671,7 +671,7 @@ fn move_hunks_multiple_sources() -> Result<()> {
         },
     )?;
 
-    let statuses = virtual_branches::get_status_by_branch(gb_repository, project_repository)
+    let statuses = virtual_branches::get_status_by_branch(gb_repository, project_repository, None)
         .expect("failed to get status")
         .0;
 
@@ -726,6 +726,7 @@ fn move_hunks_partial_explicitly() -> Result<()> {
     )
     .expect("failed to create virtual branch")
     .id;
+
     let branch2_id = create_virtual_branch(
         gb_repository,
         project_repository,
@@ -734,7 +735,7 @@ fn move_hunks_partial_explicitly() -> Result<()> {
     .expect("failed to create virtual branch")
     .id;
 
-    let statuses = virtual_branches::get_status_by_branch(gb_repository, project_repository)
+    let statuses = virtual_branches::get_status_by_branch(gb_repository, project_repository, None)
         .expect("failed to get status")
         .0;
     let files_by_branch_id = statuses
@@ -757,7 +758,7 @@ fn move_hunks_partial_explicitly() -> Result<()> {
         },
     )?;
 
-    let statuses = virtual_branches::get_status_by_branch(gb_repository, project_repository)
+    let statuses = virtual_branches::get_status_by_branch(gb_repository, project_repository, None)
         .expect("failed to get status")
         .0;
 
@@ -817,7 +818,7 @@ fn add_new_hunk_to_the_end() -> Result<()> {
     )
     .expect("failed to create virtual branch");
 
-    let statuses = virtual_branches::get_status_by_branch(gb_repository, project_repository)
+    let statuses = virtual_branches::get_status_by_branch(gb_repository, project_repository, None)
         .expect("failed to get status")
         .0;
     assert_eq!(
@@ -830,7 +831,7 @@ fn add_new_hunk_to_the_end() -> Result<()> {
         "line0\nline1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11\nline12\nline13\nline14\nline15\n",
     )?;
 
-    let statuses = virtual_branches::get_status_by_branch(gb_repository, project_repository)
+    let statuses = virtual_branches::get_status_by_branch(gb_repository, project_repository, None)
         .expect("failed to get status")
         .0;
 


### PR DESCRIPTION
I investigated why you sometimes see pairs of inverse hunks when working on more than one branch. The main takeaway is that we've been needlessly including diffs for already committed code in the calculations about what uncommitted hunks belong to what branch.

When use the right base then we don't need any complicated `calculate_uncommitted_files`, we simply assign uncommitted hunks based on either branch lock or ownership claim.