### PR TITLE
Fix typos in "conflict" in error message, comments, and a variable name

### DIFF
--- a/app/src/lib/utils/fileSections.test.ts
+++ b/app/src/lib/utils/fileSections.test.ts
@@ -89,7 +89,7 @@ const multiChangeHunk = `@@ -1,12 +1,11 @@
                 <div style="display: contents">%sveltekit.body%</div>
         </body>
  </html>`;
-const conflitMarkersHunk = `@@ -3,7 +3,11 @@
+const conflictMarkersHunk = `@@ -3,7 +3,11 @@
  	<head>
  		<meta charset="utf-8" />
  		<meta name="viewport" content="width=device-width" />
@@ -198,7 +198,7 @@ test('parses a balanced hunk section', () => {
 test('parses a hunk with conflict markers', () => {
 	const balancedHunk = plainToInstance(Hunk, {
 		id: '1',
-		diff: conflitMarkersHunk,
+		diff: conflictMarkersHunk,
 		modifiedAt: new Date(2021, 1, 1),
 		filePath: 'foo.py',
 		locked: false

--- a/crates/gitbutler-core/src/virtual_branches/errors.rs
+++ b/crates/gitbutler-core/src/virtual_branches/errors.rs
@@ -92,7 +92,7 @@ impl ErrorWithContext for ApplyBranchError {
             ApplyBranchError::BranchNotFound(ctx) => ctx.to_context(),
             ApplyBranchError::BranchConflicts(id) => error::Context::new(
                 Code::Branches,
-                format!("Branch {} is in a conflicing state", id),
+                format!("Branch {} is in a conflicting state", id),
             ),
             ApplyBranchError::Other(error) => return error.custom_context(),
         })

--- a/crates/gitbutler-core/tests/suite/virtual_branches/update_base_branch.rs
+++ b/crates/gitbutler-core/tests/suite/virtual_branches/update_base_branch.rs
@@ -809,7 +809,7 @@ mod applied_branch {
             // fetch remote
             controller.update_base_branch(project_id).await.unwrap();
 
-            // should stash conflicing branch
+            // should stash conflicting branch
 
             let (branches, _, _) = controller.list_virtual_branches(project_id).await.unwrap();
             assert_eq!(branches.len(), 1);
@@ -1589,7 +1589,7 @@ mod applied_branch {
             .await
             .unwrap();
 
-        // another locked conflicing hunk
+        // another locked conflicting hunk
         fs::write(
             repository.path().join("file.txt"),
             "1\n2\n3\n4\n5\n6\n77\n8\n19\n10\n11\n12\n",


### PR DESCRIPTION
Noticed it in an error message, fixed all instances where "conflict" is missing a letter.