### PR TITLE
worktree support 

### DIFF
--- a/crates/gitbutler-core/src/projects/controller.rs
+++ b/crates/gitbutler-core/src/projects/controller.rs
@@ -74,6 +74,9 @@ impl Controller {
         if !path.join(".git").exists() {
             return Err(AddError::NotAGitRepository);
         };
+        if path.join(".git").is_file() {
+            return Err(AddError::WorktreeUnsupported);
+        };
 
         if path.join(".gitmodules").exists() {
             return Err(AddError::SubmodulesNotSupported);
@@ -370,6 +373,8 @@ pub enum AddError {
     NotADirectory,
     #[error("not a git repository")]
     NotAGitRepository,
+    #[error("worktrees unsupported")]
+    WorktreeUnsupported,
     #[error("path not found")]
     PathNotFound,
     #[error("project already exists")]
@@ -393,6 +398,9 @@ impl ErrorWithContext for AddError {
             }
             AddError::OpenProjectRepository(error) => return error.context(),
             AddError::NotADirectory => error::Context::new(Code::Projects, "Not a directory"),
+            AddError::WorktreeUnsupported => {
+                error::Context::new(Code::Projects, "Can only work in main worktrees")
+            }
             AddError::PathNotFound => error::Context::new(Code::Projects, "Path not found"),
             AddError::SubmodulesNotSupported => error::Context::new_static(
                 Code::Projects,

--- a/crates/gitbutler-core/tests/suite/projects.rs
+++ b/crates/gitbutler-core/tests/suite/projects.rs
@@ -67,5 +67,37 @@ mod add {
             controller.add(path).unwrap();
             assert!(matches!(controller.add(path), Err(AddError::AlreadyExists)));
         }
+
+        #[test]
+        fn worktree() {
+            let (controller, _tmp) = new();
+            let tmp = tempfile::tempdir().unwrap();
+            let main_worktree_dir = tmp.path().join("main");
+            let worktree_dir = tmp.path().join("worktree");
+
+            let repo = git2::Repository::init(&main_worktree_dir).unwrap();
+            create_initial_commit(&repo);
+
+            let worktree = repo.worktree("feature", &worktree_dir, None).unwrap();
+            let err = controller.add(worktree.path()).unwrap_err();
+            assert_eq!(err.to_string(), "TODO: this should say something about worktrees - right now it's about .git/objects not found");
+        }
+
+        fn create_initial_commit(repo: &git2::Repository) -> git2::Oid {
+            let signature = git2::Signature::now("test", "test@email.com").unwrap();
+
+            let mut index = repo.index().unwrap();
+            let oid = index.write_tree().unwrap();
+
+            repo.commit(
+                Some("HEAD"),
+                &signature,
+                &signature,
+                "initial commit",
+                &repo.find_tree(oid).unwrap(),
+                &[],
+            )
+            .unwrap()
+        }
     }
 }

--- a/crates/gitbutler-core/tests/suite/projects.rs
+++ b/crates/gitbutler-core/tests/suite/projects.rs
@@ -80,7 +80,7 @@ mod add {
 
             let worktree = repo.worktree("feature", &worktree_dir, None).unwrap();
             let err = controller.add(worktree.path()).unwrap_err();
-            assert_eq!(err.to_string(), "TODO: this should say something about worktrees - right now it's about .git/objects not found");
+            assert_eq!(err.to_string(), "worktrees unsupported");
         }
 
         fn create_initial_commit(repo: &git2::Repository) -> git2::Oid {


### PR DESCRIPTION
The goal of this PR is to make adding a worktree fail gracefully, at the very least, in case it's not possible to make it work which I would aim for.

This PR fixes #3062, one way or another.

### Tasks

* [x] A test to see what happens when a worktree is added
* [x] Make it fail gracefully if the added worktree isn't the main worktree
* [x] assure the UI shows a useful error message and acts correctly

### Before

<img width="500" alt="Screenshot 2024-04-17 at 18 40 17" src="https://github.com/gitbutlerapp/gitbutler/assets/63622/3e3feec4-a8bd-4a67-b799-4c81615cf3a3">

### After

<img width="450" alt="Screenshot 2024-04-17 at 18 38 40" src="https://github.com/gitbutlerapp/gitbutler/assets/63622/6a7a0a7c-7c52-46e3-b87c-f57df9bd4548">

### Out of Scope

- Allow to open worktree repositories. It could work if GB would keep track of the actual `.git` directory separately.

### Questions

* Does `git2` fail like Git does when a branch is already checked out in another worktree❓
    - This could happen if the project is added multiple times, and in one worktree the `gitbutler/integration` branch is already checked out.

### Research

* A worktree is started on some branch, but it's possible to checkout any other branch afterwards.
    - `fatal: 'shared-parallel' is already checked out at '/Users/byron/dev/github.com/Byron/gitoxide-feature'` is an error message that would be visible when trying to checkout a branch that is already checked out in another worktree.
