### PR TITLE
use more robust askpass frontend handling

### DIFF
--- a/app/src/lib/components/CommitListFooter.svelte
+++ b/app/src/lib/components/CommitListFooter.svelte
@@ -22,7 +22,7 @@
 	const baseBranch = getContextStore(BaseBranch);
 	const branch = getContextStore(Branch);
 
-	const [prompt, promptError] = promptService.filter({
+	const [prompt, promptError] = promptService.reactToPrompt({
 		branchId: $branch.id,
 		timeoutMs: 30000
 	});

--- a/app/src/lib/components/PassphraseBox.svelte
+++ b/app/src/lib/components/PassphraseBox.svelte
@@ -1,23 +1,20 @@
 <script lang="ts">
 	import Button from './Button.svelte';
 	import TextBox from './TextBox.svelte';
-	import { PromptService, type SystemPrompt } from '$lib/backend/prompt';
 	import { showError } from '$lib/notifications/toasts';
-	import { getContext } from '$lib/utils/context';
+	import type { SystemPromptHandle } from '$lib/backend/prompt';
 
-	export let prompt: SystemPrompt | undefined;
+	export let prompt: SystemPromptHandle | undefined;
 	export let error: any;
 	export let value: string = '';
 
 	let submitDisabled: boolean = false;
 	let isSubmitting = false;
 
-	const promptService = getContext(PromptService);
-
 	async function submit() {
 		if (!prompt) return;
 		isSubmitting = true;
-		await promptService.respond({ id: prompt.id, response: value });
+		prompt.respond(value);
 		isSubmitting = false;
 	}
 
@@ -44,7 +41,7 @@
 				disabled={isSubmitting}
 				on:click={async () => {
 					if (!prompt) return;
-					await promptService.cancel(prompt.id);
+					prompt.respond(null);
 				}}
 			>
 				Cancel


### PR DESCRIPTION
Removes observables from the `askpass` frontend flow in lieu of Svelte stores and moves to a handling mechanism that guarantees a response (thus preventing hangs). Also introduces a bit more robust of a filtering mechanism whereby filters with zero criteria are considered fallbacks (catch-all's) such that any askpass prompt that has come in from somewhere that isn't otherwise explicitly handled is still shown to the user.