### PR TITLE
binary diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2072,6 +2072,7 @@ dependencies = [
  "gitbutler-git",
  "gitbutler-testsupport",
  "gix",
+ "hex",
  "itertools 0.12.1",
  "lazy_static",
  "log",

--- a/crates/gitbutler-core/Cargo.toml
+++ b/crates/gitbutler-core/Cargo.toml
@@ -15,7 +15,7 @@ toml = "0.8.12"
 anyhow = "1.0.81"
 async-trait = "0.1.79"
 backtrace = { version = "0.3.71", optional = true }
-bstr = "1.9.1"
+bstr = { version = "1.9.1", features = ["serde"] }
 chrono = { version = "0.4.37", features = ["serde"] }
 diffy = "0.3.0"
 filetime = "0.2.23"

--- a/crates/gitbutler-core/Cargo.toml
+++ b/crates/gitbutler-core/Cargo.toml
@@ -15,7 +15,7 @@ toml = "0.8.12"
 anyhow = "1.0.81"
 async-trait = "0.1.79"
 backtrace = { version = "0.3.71", optional = true }
-bstr = { version = "1.9.1", features = ["serde"] }
+bstr = "1.9.1"
 chrono = { version = "0.4.37", features = ["serde"] }
 diffy = "0.3.0"
 filetime = "0.2.23"

--- a/crates/gitbutler-core/Cargo.toml
+++ b/crates/gitbutler-core/Cargo.toml
@@ -27,6 +27,7 @@ gix = { workspace = true, features = ["dirwalk"] }
 itertools = "0.12"
 lazy_static = "1.4.0"
 md5 = "0.7.0"
+hex = "0.4.3"
 r2d2 = "0.8.10"
 r2d2_sqlite = "0.22.0"
 rand = "0.8.5"

--- a/crates/gitbutler-core/src/deltas/operations.rs
+++ b/crates/gitbutler-core/src/deltas/operations.rs
@@ -8,6 +8,7 @@ use similar::{ChangeTag, TextDiff};
 #[serde(rename_all = "camelCase")]
 pub enum Operation {
     // corresponds to YText.insert(index, chunk)
+    // TODO(ST): Should probably be BString, but it's related to delta-code.
     Insert((usize, String)),
     // corresponds to YText.remove_range(index, len)
     Delete((usize, usize)),

--- a/crates/gitbutler-core/src/git/commit.rs
+++ b/crates/gitbutler-core/src/git/commit.rs
@@ -1,4 +1,5 @@
 use super::{Oid, Result, Signature, Tree};
+use bstr::BStr;
 
 pub struct Commit<'repo> {
     commit: git2::Commit<'repo>,
@@ -61,8 +62,9 @@ impl<'repo> Commit<'repo> {
         self.commit.author().into()
     }
 
-    pub fn message(&self) -> Option<&str> {
-        self.commit.message()
+    /// Obtain the commit-message as bytes, but without assuming any encoding.
+    pub fn message(&self) -> &BStr {
+        self.commit.message_bytes().as_ref()
     }
 
     pub fn committer(&self) -> Signature<'_> {

--- a/crates/gitbutler-core/src/git/diff.rs
+++ b/crates/gitbutler-core/src/git/diff.rs
@@ -43,6 +43,7 @@ pub struct GitHunk {
     pub old_lines: u32,
     pub new_start: u32,
     pub new_lines: u32,
+    #[serde(serialize_with = "crate::serde::as_string_lossy")]
     pub diff: BString,
     pub binary: bool,
     pub change_type: ChangeType,

--- a/crates/gitbutler-core/src/git/oid.rs
+++ b/crates/gitbutler-core/src/git/oid.rs
@@ -7,6 +7,14 @@ pub struct Oid {
     oid: git2::Oid,
 }
 
+impl Oid {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, git2::Error> {
+        Ok(Self {
+            oid: git2::Oid::from_bytes(bytes)?,
+        })
+    }
+}
+
 impl Default for Oid {
     fn default() -> Self {
         git2::Oid::zero().into()

--- a/crates/gitbutler-core/src/lib.rs
+++ b/crates/gitbutler-core/src/lib.rs
@@ -40,6 +40,7 @@ pub mod windows;
 pub mod writer;
 pub mod zip;
 pub mod serde {
+    use crate::virtual_branches::branch::HunkHash;
     use bstr::{BString, ByteSlice};
     use serde::Serialize;
 
@@ -48,5 +49,12 @@ pub mod serde {
         S: serde::Serializer,
     {
         v.to_str_lossy().serialize(s)
+    }
+
+    pub fn hash_to_hex<S>(v: &HunkHash, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        format!("{v:x}").serialize(s)
     }
 }

--- a/crates/gitbutler-core/src/lib.rs
+++ b/crates/gitbutler-core/src/lib.rs
@@ -39,3 +39,14 @@ pub mod virtual_branches;
 pub mod windows;
 pub mod writer;
 pub mod zip;
+pub mod serde {
+    use bstr::{BString, ByteSlice};
+    use serde::Serialize;
+
+    pub fn as_string_lossy<S>(v: &BString, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        v.to_str_lossy().serialize(s)
+    }
+}

--- a/crates/gitbutler-core/src/projects/project.rs
+++ b/crates/gitbutler-core/src/projects/project.rs
@@ -66,8 +66,7 @@ pub struct Project {
     pub id: ProjectId,
     pub title: String,
     pub description: Option<String>,
-    // TODO(ST): Keep track of the `git_dir` separately and use it, particularly in `file_monitor.rs` (#3062)
-    /// The worktree path of the projects repository.
+    /// The worktree directory of the project's repository.
     pub path: path::PathBuf,
     #[serde(default)]
     pub preferred_key: AuthKey,

--- a/crates/gitbutler-core/src/reader.rs
+++ b/crates/gitbutler-core/src/reader.rs
@@ -18,8 +18,11 @@ pub enum Error {
     Io(Arc<io::Error>),
     #[error(transparent)]
     From(FromError),
-    #[error("failed to parse virtual_branches.toml: {0}")]
-    ParseError(String),
+    #[error("failed to parse {}", path.display())]
+    ParseError {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
 }
 
 impl From<io::Error> for Error {

--- a/crates/gitbutler-core/src/virtual_branches/base.rs
+++ b/crates/gitbutler-core/src/virtual_branches/base.rs
@@ -192,10 +192,11 @@ pub fn set_base_branch(
         // put them into a virtual branch
 
         let wd_diff = diff::workdir(repo, &current_head_commit.id())?;
-        let wd_diff = diff::diff_files_to_hunks(&wd_diff);
         if !wd_diff.is_empty() || current_head_commit.id() != target.sha {
-            let hunks_by_filepath =
-                super::virtual_hunks_by_filepath(&project_repository.project().path, &wd_diff);
+            let hunks_by_filepath = super::virtual_hunks_by_filepath_from_file_diffs(
+                &project_repository.project().path,
+                &wd_diff,
+            );
 
             // assign ownership to the branch
             let ownership = hunks_by_filepath.values().flatten().fold(
@@ -253,7 +254,7 @@ pub fn set_base_branch(
                 tree: super::write_tree_onto_commit(
                     project_repository,
                     current_head_commit.id(),
-                    &wd_diff,
+                    &diff::diff_files_into_hunks(wd_diff),
                 )?,
                 ownership,
                 order: 0,

--- a/crates/gitbutler-core/src/virtual_branches/branch.rs
+++ b/crates/gitbutler-core/src/virtual_branches/branch.rs
@@ -4,7 +4,7 @@ mod ownership;
 
 use anyhow::Result;
 pub use file_ownership::OwnershipClaim;
-pub use hunk::Hunk;
+pub use hunk::{Hunk, HunkHash};
 pub use ownership::{reconcile_claims, BranchOwnershipClaims};
 use serde::{Deserialize, Serialize};
 

--- a/crates/gitbutler-core/src/virtual_branches/branch/hunk.rs
+++ b/crates/gitbutler-core/src/virtual_branches/branch/hunk.rs
@@ -121,24 +121,14 @@ impl Hunk {
         }
     }
 
-    // TODO(ST): self - prevent many unnecessary copies
-    pub fn with_hash(&self, hash: &str) -> Self {
-        Hunk {
-            start: self.start,
-            end: self.end,
-            hash: Some(hash.to_string()),
-            timestamp_ms: self.timestamp_ms,
-        }
+    pub fn with_hash(mut self, hash: &str) -> Self {
+        self.hash = Some(hash.to_owned());
+        self
     }
 
-    // TODO(ST): self - prevent many unnecessary copies
-    pub fn with_timestamp(&self, timestamp_ms: u128) -> Self {
-        Hunk {
-            start: self.start,
-            end: self.end,
-            hash: self.hash.clone(),
-            timestamp_ms: Some(timestamp_ms),
-        }
+    pub fn with_timestamp(mut self, timestamp_ms: u128) -> Self {
+        self.timestamp_ms = Some(timestamp_ms);
+        self
     }
 
     pub fn timestam_ms(&self) -> Option<u128> {

--- a/crates/gitbutler-core/src/virtual_branches/branch/hunk.rs
+++ b/crates/gitbutler-core/src/virtual_branches/branch/hunk.rs
@@ -167,9 +167,9 @@ impl Hunk {
             return Self::hash(diff);
         }
         let mut ctx = md5::Context::new();
-        diff.lines()
+        diff.lines_with_terminator()
             .skip(1) // skip the first line which is the diff header.
-            .for_each(|line_without_terminator| ctx.consume(line_without_terminator));
+            .for_each(|line| ctx.consume(line));
         ctx.compute()
     }
 

--- a/crates/gitbutler-core/src/virtual_branches/files.rs
+++ b/crates/gitbutler-core/src/virtual_branches/files.rs
@@ -33,16 +33,17 @@ pub fn list_remote_commit_files(
     let parent = commit.parent(0).context("failed to get parent commit")?;
     let commit_tree = commit.tree().context("failed to get commit tree")?;
     let parent_tree = parent.tree().context("failed to get parent tree")?;
-    let diff = diff::trees(repository, &parent_tree, &commit_tree)?;
-    let diff = diff::diff_files_to_hunks(&diff);
+    let diff_files = diff::trees(repository, &parent_tree, &commit_tree)?;
 
-    let files = diff
+    Ok(diff_files
         .into_iter()
-        .map(|(file_path, hunks)| RemoteBranchFile {
-            path: file_path.clone(),
-            hunks: hunks.clone(),
-            binary: hunks.iter().any(|h| h.binary),
+        .map(|(path, file)| {
+            let binary = file.hunks.iter().any(|h| h.binary);
+            RemoteBranchFile {
+                path,
+                hunks: file.hunks,
+                binary,
+            }
         })
-        .collect::<Vec<_>>();
-    Ok(files)
+        .collect())
 }

--- a/crates/gitbutler-core/src/virtual_branches/remote.rs
+++ b/crates/gitbutler-core/src/virtual_branches/remote.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use bstr::BString;
 use serde::Serialize;
 
 use super::{errors, target, Author, VirtualBranchesHandle};
@@ -42,7 +43,8 @@ pub struct RemoteBranchData {
 #[serde(rename_all = "camelCase")]
 pub struct RemoteCommit {
     pub id: String,
-    pub description: String,
+    #[serde(serialize_with = "crate::serde::as_string_lossy")]
+    pub description: BString,
     pub created_at: u128,
     pub author: Author,
 }
@@ -173,7 +175,7 @@ pub fn branch_to_remote_branch_data(
 pub fn commit_to_remote_commit(commit: &git::Commit) -> RemoteCommit {
     RemoteCommit {
         id: commit.id().to_string(),
-        description: commit.message().unwrap_or_default().to_string(),
+        description: commit.message().to_owned(),
         created_at: commit.time().seconds().try_into().unwrap(),
         author: commit.author().into(),
     }

--- a/crates/gitbutler-core/src/virtual_branches/state.rs
+++ b/crates/gitbutler-core/src/virtual_branches/state.rs
@@ -136,8 +136,11 @@ impl VirtualBranchesHandle {
         let mut file: File = File::open(self.file_path.as_path())?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;
-        let virtual_branches: VirtualBranches = toml::from_str(&contents)
-            .map_err(|e| crate::reader::Error::ParseError(e.to_string()))?;
+        let virtual_branches: VirtualBranches =
+            toml::from_str(&contents).map_err(|e| crate::reader::Error::ParseError {
+                path: self.file_path.clone(),
+                source: e,
+            })?;
         Ok(virtual_branches)
     }
 

--- a/crates/gitbutler-core/src/virtual_branches/virtual.rs
+++ b/crates/gitbutler-core/src/virtual_branches/virtual.rs
@@ -126,6 +126,7 @@ pub struct VirtualBranchFile {
 #[serde(rename_all = "camelCase")]
 pub struct VirtualBranchHunk {
     pub id: String,
+    #[serde(serialize_with = "crate::serde::as_string_lossy")]
     pub diff: BString,
     pub modified_at: u128,
     pub file_path: PathBuf,

--- a/crates/gitbutler-core/src/virtual_branches/virtual.rs
+++ b/crates/gitbutler-core/src/virtual_branches/virtual.rs
@@ -1838,6 +1838,7 @@ fn get_applied_status(
                                 git_diff_hunks.remove(i);
                                 return Some(
                                     claimed_hunk
+                                        .clone()
                                         .with_timestamp(timestamp)
                                         .with_hash(hash.as_str()),
                                 );

--- a/crates/gitbutler-core/src/virtual_branches/virtual.rs
+++ b/crates/gitbutler-core/src/virtual_branches/virtual.rs
@@ -20,6 +20,7 @@ use super::{
     },
     branch_to_remote_branch, errors, target, RemoteBranch, VirtualBranchesHandle,
 };
+use crate::virtual_branches::branch::HunkHash;
 use crate::{
     askpass::AskpassBroker,
     dedup::{dedup, dedup_fmt},
@@ -131,7 +132,8 @@ pub struct VirtualBranchHunk {
     pub diff: BString,
     pub modified_at: u128,
     pub file_path: PathBuf,
-    pub hash: String,
+    #[serde(serialize_with = "crate::serde::hash_to_hex")]
+    pub hash: HunkHash,
     pub old_start: u32,
     pub start: u32,
     pub end: u32,
@@ -1840,7 +1842,7 @@ fn get_applied_status(
                                     claimed_hunk
                                         .clone()
                                         .with_timestamp(timestamp)
-                                        .with_hash(hash.as_str()),
+                                        .with_hash(hash),
                                 );
                             } else if claimed_hunk.intersects(git_diff_hunk) {
                                 diffs_by_branch
@@ -1853,7 +1855,7 @@ fn get_applied_status(
                                     start: git_diff_hunk.new_start,
                                     end: git_diff_hunk.new_start + git_diff_hunk.new_lines,
                                     timestamp_ms: Some(mtime),
-                                    hash: Some(hash.clone()),
+                                    hash: Some(hash),
                                 };
                                 git_diff_hunks.remove(i);
                                 return Some(updated_hunk);
@@ -1907,7 +1909,7 @@ fn get_applied_status(
                     file_path: filepath.clone(),
                     hunks: vec![Hunk::from(&hunk)
                         .with_timestamp(get_mtime(&mut mtimes, &filepath))
-                        .with_hash(Hunk::hash(hunk.diff.as_ref()).as_str())],
+                        .with_hash(Hunk::hash(hunk.diff.as_ref()))],
                 });
 
             diffs_by_branch

--- a/crates/gitbutler-core/src/virtual_branches/virtual.rs
+++ b/crates/gitbutler-core/src/virtual_branches/virtual.rs
@@ -1607,7 +1607,7 @@ pub fn virtual_hunks_by_filepath(
                     start: hunk.new_start,
                     end: hunk.new_start + hunk.new_lines,
                     binary: hunk.binary,
-                    hash: Hunk::hash(hunk.diff_lines.as_ref()),
+                    hash: Hunk::hash_diff(hunk.diff_lines.as_ref()),
                     locked: false,
                     locked_to: None,
                     change_type: hunk.change_type,
@@ -1788,7 +1788,8 @@ fn get_applied_status(
                                     committed_git_hunk.new_start,
                                     committed_git_hunk.new_start + committed_git_hunk.new_lines,
                                 ) {
-                                    let hash = Hunk::hash(uncommitted_git_hunk.diff_lines.as_ref());
+                                    let hash =
+                                        Hunk::hash_diff(uncommitted_git_hunk.diff_lines.as_ref());
                                     git_hunk_map.insert(hash, branch.id);
                                 }
                             }
@@ -1821,7 +1822,7 @@ fn get_applied_status(
                     .filter_map(|claimed_hunk| {
                         // if any of the current hunks intersects with the owned hunk, we want to keep it
                         for (i, git_diff_hunk) in git_diff_hunks.iter().enumerate() {
-                            let hash = Hunk::hash(git_diff_hunk.diff_lines.as_ref());
+                            let hash = Hunk::hash_diff(git_diff_hunk.diff_lines.as_ref());
                             if let Some(locked_to) = git_hunk_map.get(&hash) {
                                 if locked_to != &branch.id {
                                     return None;
@@ -1892,7 +1893,7 @@ fn get_applied_status(
 
     for (filepath, hunks) in base_diffs {
         for hunk in hunks {
-            let hash = Hunk::hash(hunk.diff_lines.as_ref());
+            let hash = Hunk::hash_diff(hunk.diff_lines.as_ref());
             let vbranch_pos = if let Some(locked_to) = git_hunk_map.get(&hash) {
                 let p = virtual_branches.iter().position(|vb| vb.id == *locked_to);
                 match p {
@@ -1909,7 +1910,7 @@ fn get_applied_status(
                     file_path: filepath.clone(),
                     hunks: vec![Hunk::from(&hunk)
                         .with_timestamp(get_mtime(&mut mtimes, &filepath))
-                        .with_hash(Hunk::hash(hunk.diff_lines.as_ref()))],
+                        .with_hash(Hunk::hash_diff(hunk.diff_lines.as_ref()))],
                 });
 
             diffs_by_branch

--- a/crates/gitbutler-core/tests/suite/virtual_branches/unapply_ownership.rs
+++ b/crates/gitbutler-core/tests/suite/virtual_branches/unapply_ownership.rs
@@ -48,7 +48,7 @@ async fn should_unapply_with_commits() {
                 .unwrap(),
         )
         .await
-        .unwrap();
+        .unwrap_or_else(|err| panic!("{err:?}"));
 
     let branch = controller
         .list_virtual_branches(project_id)

--- a/crates/gitbutler-core/tests/virtual_branches/branch/hunk.rs
+++ b/crates/gitbutler-core/tests/virtual_branches/branch/hunk.rs
@@ -13,7 +13,7 @@ fn parse_invalid() {
 
 #[test]
 fn parse_with_hash() {
-    let hash = Hunk::hash("hash".into());
+    let hash = Hunk::hash("hash".as_ref());
     assert_eq!(
         format!("2-3-{hash:x}").parse::<Hunk>().unwrap(),
         Hunk::new(2, 3, Some(hash), None).unwrap()
@@ -42,16 +42,15 @@ fn to_string_no_hash() {
 }
 
 #[test]
-fn hash() {
-    let a_hash = Hunk::hash("a".into());
-    let b_hash = Hunk::hash("b".into());
-    assert_ne!(
-        a_hash, b_hash,
-        "even single-line input yields different hashes"
-    );
+#[should_panic]
+fn hash_diff_no_first_line_panics() {
+    let _a_hash = Hunk::hash_diff("a".into());
+}
 
-    let a_hash = Hunk::hash("first\na".into());
-    let b_hash = Hunk::hash("different-first\na".into());
+#[test]
+fn hash_diff() {
+    let a_hash = Hunk::hash_diff("first\na".into());
+    let b_hash = Hunk::hash_diff("different-first\na".into());
     assert_eq!(
         a_hash, b_hash,
         "it skips the first line which is assumed to be a diff-header.\
@@ -61,8 +60,8 @@ fn hash() {
 
 #[test]
 fn eq() {
-    let a_hash = Hunk::hash("a".into());
-    let b_hash = Hunk::hash("b".into());
+    let a_hash = Hunk::hash("a".as_ref());
+    let b_hash = Hunk::hash("b".as_ref());
     assert_ne!(a_hash, b_hash);
     for (a, b, expected) in vec![
         (

--- a/crates/gitbutler-core/tests/virtual_branches/branch/hunk.rs
+++ b/crates/gitbutler-core/tests/virtual_branches/branch/hunk.rs
@@ -42,15 +42,27 @@ fn to_string_no_hash() {
 }
 
 #[test]
-#[should_panic]
-fn hash_diff_no_first_line_panics() {
-    let _a_hash = Hunk::hash_diff("a".into());
+fn hash_diff_no_diff_header_is_normal_hash() {
+    let actual = Hunk::hash_diff("a".as_ref());
+    let expected = Hunk::hash("a".as_ref());
+    assert_eq!(actual, expected)
 }
 
 #[test]
-fn hash_diff() {
-    let a_hash = Hunk::hash_diff("first\na".into());
-    let b_hash = Hunk::hash_diff("different-first\na".into());
+fn hash_diff_empty_is_fine() {
+    let actual = Hunk::hash_diff("".as_ref());
+    let expected = Hunk::hash("".as_ref());
+    assert_eq!(
+        actual, expected,
+        "The special hash is the same as a normal one in case of empty input.\
+        Don't yet know why that should be except that more works then"
+    )
+}
+
+#[test]
+fn hash_diff_content_hash() {
+    let a_hash = Hunk::hash_diff("@@x\na".into());
+    let b_hash = Hunk::hash_diff("@@y\na".into());
     assert_eq!(
         a_hash, b_hash,
         "it skips the first line which is assumed to be a diff-header.\

--- a/crates/gitbutler-core/tests/virtual_branches/branch/ownership.rs
+++ b/crates/gitbutler-core/tests/virtual_branches/branch/ownership.rs
@@ -16,13 +16,13 @@ fn reconcile_ownership_simple() {
                     Hunk {
                         start: 1,
                         end: 3,
-                        hash: Some("1,3".to_string()),
+                        hash: Some(Hunk::hash("1,3".into())),
                         timestamp_ms: None,
                     },
                     Hunk {
                         start: 4,
                         end: 6,
-                        hash: Some("4,6".to_string()),
+                        hash: Some(Hunk::hash("4,6".into())),
                         timestamp_ms: None,
                     },
                 ],
@@ -39,7 +39,7 @@ fn reconcile_ownership_simple() {
                 hunks: vec![Hunk {
                     start: 7,
                     end: 9,
-                    hash: Some("7,9".to_string()),
+                    hash: Some(Hunk::hash("7,9".into())),
                     timestamp_ms: None,
                 }],
             }],
@@ -54,13 +54,13 @@ fn reconcile_ownership_simple() {
             Hunk {
                 start: 4,
                 end: 6,
-                hash: Some("4,6".to_string()),
+                hash: Some(Hunk::hash("4,6".into())),
                 timestamp_ms: None,
             },
             Hunk {
                 start: 7,
                 end: 9,
-                hash: Some("9,7".to_string()),
+                hash: Some(Hunk::hash("9,7".into())),
                 timestamp_ms: None,
             },
         ],
@@ -78,7 +78,7 @@ fn reconcile_ownership_simple() {
                 hunks: vec![Hunk {
                     start: 1,
                     end: 3,
-                    hash: Some("1,3".to_string()),
+                    hash: Some(Hunk::hash("1,3".into())),
                     timestamp_ms: None,
                 },],
             }],
@@ -94,13 +94,13 @@ fn reconcile_ownership_simple() {
                     Hunk {
                         start: 4,
                         end: 6,
-                        hash: Some("4,6".to_string()),
+                        hash: Some(Hunk::hash("4,6".into())),
                         timestamp_ms: None,
                     },
                     Hunk {
                         start: 7,
                         end: 9,
-                        hash: Some("9,7".to_string()),
+                        hash: Some(Hunk::hash("9,7".into())),
                         timestamp_ms: None,
                     },
                 ],

--- a/crates/gitbutler-core/tests/virtual_branches/branch/ownership.rs
+++ b/crates/gitbutler-core/tests/virtual_branches/branch/ownership.rs
@@ -16,13 +16,13 @@ fn reconcile_ownership_simple() {
                     Hunk {
                         start: 1,
                         end: 3,
-                        hash: Some(Hunk::hash("1,3".into())),
+                        hash: Some(Hunk::hash("1,3".as_ref())),
                         timestamp_ms: None,
                     },
                     Hunk {
                         start: 4,
                         end: 6,
-                        hash: Some(Hunk::hash("4,6".into())),
+                        hash: Some(Hunk::hash("4,6".as_ref())),
                         timestamp_ms: None,
                     },
                 ],
@@ -39,7 +39,7 @@ fn reconcile_ownership_simple() {
                 hunks: vec![Hunk {
                     start: 7,
                     end: 9,
-                    hash: Some(Hunk::hash("7,9".into())),
+                    hash: Some(Hunk::hash("7,9".as_ref())),
                     timestamp_ms: None,
                 }],
             }],
@@ -54,13 +54,13 @@ fn reconcile_ownership_simple() {
             Hunk {
                 start: 4,
                 end: 6,
-                hash: Some(Hunk::hash("4,6".into())),
+                hash: Some(Hunk::hash("4,6".as_ref())),
                 timestamp_ms: None,
             },
             Hunk {
                 start: 7,
                 end: 9,
-                hash: Some(Hunk::hash("9,7".into())),
+                hash: Some(Hunk::hash("9,7".as_ref())),
                 timestamp_ms: None,
             },
         ],
@@ -78,7 +78,7 @@ fn reconcile_ownership_simple() {
                 hunks: vec![Hunk {
                     start: 1,
                     end: 3,
-                    hash: Some(Hunk::hash("1,3".into())),
+                    hash: Some(Hunk::hash("1,3".as_ref())),
                     timestamp_ms: None,
                 },],
             }],
@@ -94,13 +94,13 @@ fn reconcile_ownership_simple() {
                     Hunk {
                         start: 4,
                         end: 6,
-                        hash: Some(Hunk::hash("4,6".into())),
+                        hash: Some(Hunk::hash("4,6".as_ref())),
                         timestamp_ms: None,
                     },
                     Hunk {
                         start: 7,
                         end: 9,
-                        hash: Some(Hunk::hash("9,7".into())),
+                        hash: Some(Hunk::hash("9,7".as_ref())),
                         timestamp_ms: None,
                     },
                 ],

--- a/crates/gitbutler-core/tests/virtual_branches/mod.rs
+++ b/crates/gitbutler-core/tests/virtual_branches/mod.rs
@@ -570,11 +570,11 @@ fn move_hunks_multiple_sources() -> Result<()> {
         2
     );
     assert_eq!(
-        files_by_branch_id[&branch3_id][Path::new("test.txt")][0].diff,
+        files_by_branch_id[&branch3_id][Path::new("test.txt")][0].diff_lines,
         "@@ -1,3 +1,4 @@\n+line0\n line1\n line2\n line3\n"
     );
     assert_eq!(
-        files_by_branch_id[&branch3_id][Path::new("test.txt")][1].diff,
+        files_by_branch_id[&branch3_id][Path::new("test.txt")][1].diff_lines,
         "@@ -10,3 +11,4 @@ line9\n line10\n line11\n line12\n+line13\n"
     );
     Ok(())
@@ -645,7 +645,7 @@ fn move_hunks_partial_explicitly() -> Result<()> {
         1
     );
     assert_eq!(
-        files_by_branch_id[&branch1_id][Path::new("test.txt")][0].diff,
+        files_by_branch_id[&branch1_id][Path::new("test.txt")][0].diff_lines,
         "@@ -11,3 +12,4 @@ line10\n line11\n line12\n line13\n+line14\n"
     );
 
@@ -655,7 +655,7 @@ fn move_hunks_partial_explicitly() -> Result<()> {
         1
     );
     assert_eq!(
-        files_by_branch_id[&branch2_id][Path::new("test.txt")][0].diff,
+        files_by_branch_id[&branch2_id][Path::new("test.txt")][0].diff_lines,
         "@@ -1,3 +1,4 @@\n+line0\n line1\n line2\n line3\n"
     );
 
@@ -688,7 +688,7 @@ fn add_new_hunk_to_the_end() -> Result<()> {
         .expect("failed to get status")
         .0;
     assert_eq!(
-        statuses[0].1[Path::new("test.txt")][0].diff,
+        statuses[0].1[Path::new("test.txt")][0].diff_lines,
         "@@ -11,5 +11,5 @@ line10\n line11\n line12\n line13\n-line13\n line14\n+line15\n"
     );
 
@@ -702,11 +702,11 @@ fn add_new_hunk_to_the_end() -> Result<()> {
         .0;
 
     assert_eq!(
-        statuses[0].1[Path::new("test.txt")][0].diff,
+        statuses[0].1[Path::new("test.txt")][0].diff_lines,
         "@@ -11,5 +12,5 @@ line10\n line11\n line12\n line13\n-line13\n line14\n+line15\n"
     );
     assert_eq!(
-        statuses[0].1[Path::new("test.txt")][1].diff,
+        statuses[0].1[Path::new("test.txt")][1].diff_lines,
         "@@ -1,3 +1,4 @@\n+line0\n line1\n line2\n line3\n"
     );
 

--- a/crates/gitbutler-core/tests/virtual_branches/mod.rs
+++ b/crates/gitbutler-core/tests/virtual_branches/mod.rs
@@ -198,9 +198,11 @@ fn track_binary_files() -> Result<()> {
         .find(|b| b.path.as_os_str() == "image.bin")
         .unwrap();
     assert!(img_file.binary);
+    let img_oid_hex = "944996dd82015a616247c72b251e41661e528ae1";
     assert_eq!(
-        img_file.hunks[0].diff,
-        "944996dd82015a616247c72b251e41661e528ae1"
+        img_file.hunks[0].diff, img_oid_hex,
+        "the binary file was stored in the ODB as otherwise we wouldn't have its contents. \
+        It cannot easily be reconstructed from the diff-lines, or we don't attempt it."
     );
 
     // commit
@@ -221,7 +223,10 @@ fn track_binary_files() -> Result<()> {
     let tree = commit_obj.tree()?;
     let files = tree_to_entry_list(&project_repository.git_repository, &tree);
     assert_eq!(files[0].0, "image.bin");
-    assert_eq!(files[0].3, "944996dd82015a616247c72b251e41661e528ae1");
+    assert_eq!(
+        files[0].3, img_oid_hex,
+        "our vbranch commit tree references the binary object we previously stored"
+    );
 
     let image_data: [u8; 12] = [
         0, 255, 0, // Green pixel

--- a/crates/gitbutler-watcher/src/events.rs
+++ b/crates/gitbutler-watcher/src/events.rs
@@ -114,8 +114,7 @@ pub enum Change {
     File {
         project_id: ProjectId,
         session_id: SessionId,
-        // TODO(ST): Should probably not be a string, but rather, relative.
-        file_path: String,
+        file_path: PathBuf,
         contents: Option<reader::Content>,
     },
     Session {
@@ -125,7 +124,6 @@ pub enum Change {
     Deltas {
         project_id: ProjectId,
         session_id: SessionId,
-        // TODO(ST): check if this is ever more than one
         deltas: Vec<deltas::Delta>,
         relative_file_path: PathBuf,
     },

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -123,7 +123,7 @@ impl Handler {
         self.emit_app_event(Change::File {
             project_id,
             session_id,
-            file_path: file_path.display().to_string(),
+            file_path: file_path.to_owned(),
             contents,
         })
     }


### PR DESCRIPTION
Currently, UTF-8 encoding is assumed in many places in code both for filesystem paths, as well as for file content.

This can lead to abnormal program behaviour in the worst case, or to diffs being considered binary in the best case.

This PR adjusts the types of struct-fields where needed to remove that assumption.

### Tasks

* [x] convert `diff` to `BString` and follow through, everywhere
* [x] graceful fallback if commit-messages can' t be (fully) decoded as UTF8
* [x] validate application
* [x] avoid unnecessary copies of hunks
* [x] ~~use blake3 binary digest as hash~~ abandoned, see "abandoned patch" section
* [x] use binary md5 digest and convert on demand
* [x] fix or resolve all added `TODOs` *(some deferred to review comments)*
* [x] figure out what to do with `Hunk::hash`
* [x] figure out hash-issue for good! (*kind-of*)
* [x] make the `SHA1 in difflines` case typesafe if feasible. (it might not be) *(limited to the hunk generator)*

### Questions

#### How do line-endings work?

- `GitHunk` - from `git2`, it pre-split lines, they contain terminators.

### Notes for the Reviewer

* For validation, I only moved hunks between virtual branches, and listed commits in trunk, also showing the diff of files.
* The change around `Hunk::hash` is bigger, as it fixes a hash-misuse at least to some extend. Still, it's somewhat unclear how this is supposed to work, despite tests now passing again.
    - **Special attention is needed to assure there is no side-effects with `virtual_branches.toml`** - it *seemed* alright, despite the hashes being changed. Maybe that file is rewritten a lot as the actual source of truth is Git itself.
* I didn't really do performance testing, but didn't notice anything either. In theory, it should be faster as it doesn't have to deal with chars anymore.
* https://github.com/gitbutlerapp/gitbutler/pull/3552/commits/73462182bed888293d73603888e67d93c936f1c2 accidentally pulled me into `virtual.rs`, a monstrosity that deserves attention separately, one day, and with care 😅. The PR was already big enough as well.

### Out of Scope

* I did not specifically look for file-paths which are converted to strings unnecessarily.

### Assumptions

* The GUI doesn't send strings back for the backend to process, at least not those that the backend previously sent to the frontend.

### Abandoned Patch

Trying to use a more efficient representation of hashes, and switching from md5 to `sip` failed, but only for a less obvious reason: the virtual-branches serialization relies on these hashes being MD5, and it's stored as MD5 hex. In order to remain consistent and backward compatible, one would have to put more effort in than I think is warranted as a 'side-task.

For posterity, below the fold is the patch that didn't make it.

<details>

```patch
commit f3849ab2ffa79c70a5df90cd521fba6055f23b18
Author: Sebastian Thiel <sebastian.thiel@icloud.com>
Date:   Sat Apr 20 14:03:03 2024 +0200

    Use binary hash digest but transform it at the boundary

diff --git a/Cargo.lock b/Cargo.lock
index e1e7b1d1f..a3d9b6323 100644
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,11 +136,10 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.9.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b3e585719c2358d2660232671ca8ca4ddb4be4ce8a1842d6c2dc8685303316"
+checksum = "b10202063978b3351199d68f8b22c4e47e4b1b822f8d43fd862d5ea8c006b29a"
 dependencies = [
- "async-lock 3.3.0",
  "async-task",
  "concurrent-queue",
  "fastrand 2.0.2",
@@ -325,7 +324,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
 ]
 
 [[package]]
@@ -674,7 +673,7 @@ checksum = "3c55d429bef56ac9172d25fecb85dc8068307d17acd74b377866b7a1ef25d3c8"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
 ]
 
 [[package]]
@@ -1848,7 +1847,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
 ]
 
 [[package]]
@@ -1865,7 +1864,7 @@ dependencies = [
  "libc",
  "pango-sys",
  "pkg-config",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
 ]
 
 [[package]]
@@ -1879,7 +1878,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "pkg-config",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
 ]
 
 [[package]]
@@ -1891,7 +1890,7 @@ dependencies = [
  "gdk-sys",
  "glib-sys",
  "libc",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
  "x11",
 ]
 
@@ -1983,7 +1982,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
  "winapi 0.3.9",
 ]
 
@@ -2072,6 +2071,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "similar",
+ "siphasher 1.0.1",
  "slug",
  "ssh-key",
  "ssh2",
@@ -2219,7 +2219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef4b192f8e65e9cf76cbf4ea71fa8e3be4a0e18ffe3d68b8da6836974cc5bad4"
 dependencies = [
  "libc",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
 ]
 
 [[package]]
@@ -2249,7 +2249,7 @@ checksum = "0d57ce44246becd17153bd035ab4d32cfee096a657fc01f2231c9278378d1e0a"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
 ]
 
 [[package]]
@@ -2321,7 +2321,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "pango-sys",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
 ]
 
 [[package]]
@@ -2442,12 +2442,6 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
 [[package]]
 name = "hermit-abi"
 version = "0.3.9"
@@ -3046,12 +3040,13 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
+ "redox_syscall 0.4.1",
 ]
 
 [[package]]
@@ -3724,7 +3719,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
 ]
 
 [[package]]
@@ -4458,9 +4453,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.5"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
  "getrandom 0.2.12",
  "libredox",
@@ -5608,15 +5603,15 @@ dependencies = [
 
 [[package]]
 name = "system-deps"
-version = "6.2.2"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+checksum = "2a2d580ff6a20c55dfb86be5f9c238f67835d0e81cbdea8bf5680e0897320331"
 dependencies = [
  "cfg-expr 0.15.7",
- "heck 0.5.0",
+ "heck 0.4.1",
  "pkg-config",
  "toml 0.8.12",
- "version-compare 0.2.0",
+ "version-compare 0.1.1",
 ]
 
 [[package]]
@@ -6523,9 +6518,9 @@ checksum = "1c18c859eead79d8b95d09e4678566e8d70105c4e7b251f707a03df32442661b"
 
 [[package]]
 name = "version-compare"
-version = "0.2.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
+checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
 
 [[package]]
 name = "version_check"
@@ -6723,7 +6718,7 @@ dependencies = [
  "pango-sys",
  "pkg-config",
  "soup2-sys",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
 ]
 
 [[package]]
diff --git a/app/src/lib/vbranches/types.ts b/app/src/lib/vbranches/types.ts
index 367b6c943..bc80999ce 100644
--- a/app/src/lib/vbranches/types.ts
+++ b/app/src/lib/vbranches/types.ts
@@ -19,7 +19,7 @@ export class Hunk {
 	})
 	modifiedAt!: Date;
 	filePath!: string;
-	hash?: string;
+	hash?: number;
 	locked!: boolean;
 	lockedTo!: string | undefined;
 	changeType!: ChangeType;
@@ -209,7 +209,7 @@ export const UNKNOWN_COMMITS = Symbol('UnknownCommits');
 
 export class RemoteHunk {
 	diff!: string;
-	hash?: string;
+	hash?: number;
 
 	get id(): string {
 		return hashCode(this.diff);
diff --git a/crates/gitbutler-core/Cargo.toml b/crates/gitbutler-core/Cargo.toml
index ca6b75459..711b4f35a 100644
--- a/crates/gitbutler-core/Cargo.toml
+++ b/crates/gitbutler-core/Cargo.toml
@@ -26,6 +26,7 @@ git2-hooks = "0.3"
 itertools = "0.12"
 lazy_static = "1.4.0"
 md5 = "0.7.0"
+siphasher = "1.0.1"
 r2d2 = "0.8.10"
 r2d2_sqlite = "0.22.0"
 rand = "0.8.5"
diff --git a/crates/gitbutler-core/src/assets.rs b/crates/gitbutler-core/src/assets.rs
index 510d330e8..276cd078b 100644
--- a/crates/gitbutler-core/src/assets.rs
+++ b/crates/gitbutler-core/src/assets.rs
@@ -135,7 +135,7 @@ impl Proxy {
         }
     }
 
-    // takes a url of a remote assets, downloads it into cache and returns a url that points to the cached file
+    // takes the of a remote assets, downloads it into cache and returns the url that points to the cached file
     pub async fn proxy(&self, src: &Url) -> Result<Url> {
         #[cfg(unix)]
         if src.scheme() == "asset" {
@@ -146,6 +146,8 @@ impl Proxy {
             return Ok(src.clone());
         }
 
+        // TODO(ST): when the remote asset handling is overhauled to be (more) lazy (see #3512),
+        //           then `md5` should be replaced with `blake3` so the `md5` dependency can be removed.
         let hash = md5::compute(src.to_string());
         let path = path::Path::new(src.path());
         let ext = path
diff --git a/crates/gitbutler-core/src/reader.rs b/crates/gitbutler-core/src/reader.rs
index b02f48089..e841975fb 100644
--- a/crates/gitbutler-core/src/reader.rs
+++ b/crates/gitbutler-core/src/reader.rs
@@ -18,8 +18,11 @@ pub enum Error {
     Io(Arc<io::Error>),
     #[error(transparent)]
     From(FromError),
-    #[error("failed to parse virtual_branches.toml: {0}")]
-    ParseError(String),
+    #[error("failed to parse {}", path.display())]
+    ParseError {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
 }
 
 impl From<io::Error> for Error {
diff --git a/crates/gitbutler-core/src/virtual_branches/branch.rs b/crates/gitbutler-core/src/virtual_branches/branch.rs
index f826c6e6d..b3f946d0c 100644
--- a/crates/gitbutler-core/src/virtual_branches/branch.rs
+++ b/crates/gitbutler-core/src/virtual_branches/branch.rs
@@ -4,7 +4,7 @@ mod ownership;
 
 use anyhow::Result;
 pub use file_ownership::OwnershipClaim;
-pub use hunk::Hunk;
+pub use hunk::{Hunk, HunkHash};
 pub use ownership::{reconcile_claims, BranchOwnershipClaims};
 use serde::{Deserialize, Serialize};
 
diff --git a/crates/gitbutler-core/src/virtual_branches/branch/hunk.rs b/crates/gitbutler-core/src/virtual_branches/branch/hunk.rs
index e95aac2be..2b650cf71 100644
--- a/crates/gitbutler-core/src/virtual_branches/branch/hunk.rs
+++ b/crates/gitbutler-core/src/virtual_branches/branch/hunk.rs
@@ -1,13 +1,17 @@
+use std::hash::Hasher;
 use std::{fmt::Display, ops::RangeInclusive, str::FromStr};
 
 use anyhow::{anyhow, Context, Result};
 use bstr::{BStr, ByteSlice};
+use siphasher::sip::SipHasher;
 
 use crate::git::diff;
 
+pub type HunkHash = u64;
+
 #[derive(Debug, Eq, Clone)]
 pub struct Hunk {
-    pub hash: Option<String>,
+    pub hash: Option<HunkHash>,
     pub timestamp_ms: Option<u128>,
     pub start: u32,
     pub end: u32,
@@ -70,7 +74,7 @@ impl FromStr for Hunk {
             if raw_hash.is_empty() {
                 None
             } else {
-                Some(raw_hash.to_string())
+                Some(raw_hash.parse()?)
             }
         } else {
             None
@@ -106,7 +110,7 @@ impl Hunk {
     pub fn new(
         start: u32,
         end: u32,
-        hash: Option<String>,
+        hash: Option<HunkHash>,
         timestamp_ms: Option<u128>,
     ) -> Result<Self> {
         if start > end {
@@ -121,8 +125,8 @@ impl Hunk {
         }
     }
 
-    pub fn with_hash(mut self, hash: &str) -> Self {
-        self.hash = Some(hash.to_owned());
+    pub fn with_hash(mut self, hash: HunkHash) -> Self {
+        self.hash = Some(hash);
         self
     }
 
@@ -150,12 +154,13 @@ impl Hunk {
         self.start == other.new_start && self.end == other.new_start + other.new_lines
     }
 
-    // TODO(perf): keep the hash as digest to avoid allocation.
-    pub fn hash(diff: &BStr) -> String {
-        let mut ctx = md5::Context::new();
+    pub fn hash(diff: &BStr) -> HunkHash {
+        let mut hasher = SipHasher::new();
         diff.lines()
             .skip(1) // skip the first line which is the diff header.
-            .for_each(|line| ctx.consume(line));
-        format!("{:x}", ctx.compute())
+            .for_each(|line| {
+                hasher.write(line);
+            });
+        hasher.finish()
     }
 }
diff --git a/crates/gitbutler-core/src/virtual_branches/state.rs b/crates/gitbutler-core/src/virtual_branches/state.rs
index 93a19db47..1709ab6e4 100644
--- a/crates/gitbutler-core/src/virtual_branches/state.rs
+++ b/crates/gitbutler-core/src/virtual_branches/state.rs
@@ -136,8 +136,11 @@ impl VirtualBranchesHandle {
         let mut file: File = File::open(self.file_path.as_path())?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;
-        let virtual_branches: VirtualBranches = toml::from_str(&contents)
-            .map_err(|e| crate::reader::Error::ParseError(e.to_string()))?;
+        let virtual_branches: VirtualBranches =
+            toml::from_str(&contents).map_err(|e| crate::reader::Error::ParseError {
+                path: self.file_path.clone(),
+                source: e,
+            })?;
         Ok(virtual_branches)
     }
 
diff --git a/crates/gitbutler-core/src/virtual_branches/virtual.rs b/crates/gitbutler-core/src/virtual_branches/virtual.rs
index 2c493acc6..8ced7b1dc 100644
--- a/crates/gitbutler-core/src/virtual_branches/virtual.rs
+++ b/crates/gitbutler-core/src/virtual_branches/virtual.rs
@@ -20,6 +20,7 @@ use super::{
     },
     branch_to_remote_branch, errors, target, RemoteBranch, VirtualBranchesHandle,
 };
+use crate::virtual_branches::branch::HunkHash;
 use crate::{
     askpass::AskpassBroker,
     dedup::{dedup, dedup_fmt},
@@ -131,7 +132,7 @@ pub struct VirtualBranchHunk {
     pub diff: BString,
     pub modified_at: u128,
     pub file_path: PathBuf,
-    pub hash: String,
+    pub hash: HunkHash,
     pub old_start: u32,
     pub start: u32,
     pub end: u32,
@@ -1840,7 +1841,7 @@ fn get_applied_status(
                                     claimed_hunk
                                         .clone()
                                         .with_timestamp(timestamp)
-                                        .with_hash(hash.as_str()),
+                                        .with_hash(hash),
                                 );
                             } else if claimed_hunk.intersects(git_diff_hunk) {
                                 diffs_by_branch
@@ -1907,7 +1908,7 @@ fn get_applied_status(
                     file_path: filepath.clone(),
                     hunks: vec![Hunk::from(&hunk)
                         .with_timestamp(get_mtime(&mut mtimes, &filepath))
-                        .with_hash(Hunk::hash(hunk.diff.as_ref()).as_str())],
+                        .with_hash(Hunk::hash(hunk.diff.as_ref()))],
                 });
 
             diffs_by_branch
diff --git a/crates/gitbutler-core/tests/virtual_branches/branch/hunk.rs b/crates/gitbutler-core/tests/virtual_branches/branch/hunk.rs
index 99049af31..c11eb2678 100644
--- a/crates/gitbutler-core/tests/virtual_branches/branch/hunk.rs
+++ b/crates/gitbutler-core/tests/virtual_branches/branch/hunk.rs
@@ -13,9 +13,10 @@ fn parse_invalid() {
 
 #[test]
 fn parse_with_hash() {
+    let hash = "123";
     assert_eq!(
-        "2-3-hash".parse::<Hunk>().unwrap(),
-        Hunk::new(2, 3, Some("hash".to_string()), None).unwrap()
+        format!("2-3-{hash}").parse::<Hunk>().unwrap(),
+        Hunk::new(2, 3, Some(hash.parse().unwrap()), None).unwrap()
     );
 }
 
@@ -54,33 +55,33 @@ fn eq() {
             false,
         ),
         (
-            "1-2-abc".parse::<Hunk>().unwrap(),
-            "1-2-abc".parse::<Hunk>().unwrap(),
+            "1-2-123".parse::<Hunk>().unwrap(),
+            "1-2-123".parse::<Hunk>().unwrap(),
             true,
         ),
         (
-            "1-2-abc".parse::<Hunk>().unwrap(),
-            "2-3-abc".parse::<Hunk>().unwrap(),
+            "1-2-123".parse::<Hunk>().unwrap(),
+            "2-3-123".parse::<Hunk>().unwrap(),
             false,
         ),
         (
             "1-2".parse::<Hunk>().unwrap(),
-            "1-2-abc".parse::<Hunk>().unwrap(),
+            "1-2-123".parse::<Hunk>().unwrap(),
             true,
         ),
         (
-            "1-2-abc".parse::<Hunk>().unwrap(),
+            "1-2-123".parse::<Hunk>().unwrap(),
             "1-2".parse::<Hunk>().unwrap(),
             true,
         ),
         (
-            "1-2-abc".parse::<Hunk>().unwrap(),
-            "1-2-bcd".parse::<Hunk>().unwrap(),
+            "1-2-123".parse::<Hunk>().unwrap(),
+            "1-2-456".parse::<Hunk>().unwrap(),
             false,
         ),
         (
-            "1-2-abc".parse::<Hunk>().unwrap(),
-            "2-3-bcd".parse::<Hunk>().unwrap(),
+            "1-2-123".parse::<Hunk>().unwrap(),
+            "2-3-234".parse::<Hunk>().unwrap(),
             false,
         ),
     ] {
diff --git a/crates/gitbutler-core/tests/virtual_branches/branch/ownership.rs b/crates/gitbutler-core/tests/virtual_branches/branch/ownership.rs
index d50f888ad..4a57eb845 100644
--- a/crates/gitbutler-core/tests/virtual_branches/branch/ownership.rs
+++ b/crates/gitbutler-core/tests/virtual_branches/branch/ownership.rs
@@ -16,13 +16,13 @@ fn reconcile_ownership_simple() {
                     Hunk {
                         start: 1,
                         end: 3,
-                        hash: Some("1,3".to_string()),
+                        hash: Some(Hunk::hash("1,3".into())),
                         timestamp_ms: None,
                     },
                     Hunk {
                         start: 4,
                         end: 6,
-                        hash: Some("4,6".to_string()),
+                        hash: Some(Hunk::hash("4,6".into())),
                         timestamp_ms: None,
                     },
                 ],
@@ -39,7 +39,7 @@ fn reconcile_ownership_simple() {
                 hunks: vec![Hunk {
                     start: 7,
                     end: 9,
-                    hash: Some("7,9".to_string()),
+                    hash: Some(Hunk::hash("7,9".into())),
                     timestamp_ms: None,
                 }],
             }],
@@ -54,13 +54,13 @@ fn reconcile_ownership_simple() {
             Hunk {
                 start: 4,
                 end: 6,
-                hash: Some("4,6".to_string()),
+                hash: Some(Hunk::hash("4,6".into())),
                 timestamp_ms: None,
             },
             Hunk {
                 start: 7,
                 end: 9,
-                hash: Some("9,7".to_string()),
+                hash: Some(Hunk::hash("9,7".into())),
                 timestamp_ms: None,
             },
         ],
@@ -78,7 +78,7 @@ fn reconcile_ownership_simple() {
                 hunks: vec![Hunk {
                     start: 1,
                     end: 3,
-                    hash: Some("1,3".to_string()),
+                    hash: Some(Hunk::hash("1,3".into())),
                     timestamp_ms: None,
                 },],
             }],
@@ -94,13 +94,13 @@ fn reconcile_ownership_simple() {
                     Hunk {
                         start: 4,
                         end: 6,
-                        hash: Some("4,6".to_string()),
+                        hash: Some(Hunk::hash("4,6".into())),
                         timestamp_ms: None,
                     },
                     Hunk {
                         start: 7,
                         end: 9,
-                        hash: Some("9,7".to_string()),
+                        hash: Some(Hunk::hash("9,7".into())),
                         timestamp_ms: None,
                     },
                 ],
```

</details>