### PR TITLE
Allow SSH remotes to use any port

### DIFF
--- a/crates/gitbutler-core/src/ssh.rs
+++ b/crates/gitbutler-core/src/ssh.rs
@@ -27,7 +27,7 @@ pub fn check_known_host(remote_url: &git::Url) -> Result<(), Error> {
         return Ok(());
     };
 
-    let port = remote_url.port.as_ref().unwrap_or(&22);
+    let port = remote_url.port.unwrap_or(22);
 
     let mut session = ssh2::Session::new().map_err(Error::Ssh)?;
     session.set_tcp_stream(

--- a/crates/gitbutler-core/src/ssh.rs
+++ b/crates/gitbutler-core/src/ssh.rs
@@ -27,9 +27,12 @@ pub fn check_known_host(remote_url: &git::Url) -> Result<(), Error> {
         return Ok(());
     };
 
+    let port = remote_url.port.as_ref().unwrap_or(&22);
+
     let mut session = ssh2::Session::new().map_err(Error::Ssh)?;
-    session
-        .set_tcp_stream(std::net::TcpStream::connect(format!("{}:22", host)).map_err(Error::Io)?);
+    session.set_tcp_stream(
+        std::net::TcpStream::connect(format!("{}:{}", host, port)).map_err(Error::Io)?,
+    );
     session.handshake().map_err(Error::Ssh)?;
 
     let mut known_hosts = session.known_hosts().map_err(Error::Ssh)?;


### PR DESCRIPTION
This PR solves the problem where a self-hosted gitea repository cannot have remote operations performed. (Pushing and fetching from the remote should now be working). This seems to have been due to poor handling of non-standard SSH ports. My testing setup had gitea's SSH happening on port 2222.

Related: https://github.com/gitbutlerapp/gitbutler/issues/2904

It should be noted that this PR does not close the above issue or claim the bounty because this doesn't add support for creating Pull requests (although making that area of the code more generic and supporting more providers is something I'm keen to do)

I've tested on GitHub and Gitea, but it would be great if another Gitea user could test it on their setup to ensure that the problem is in-fact resolved.