### PR TITLE
fix(ui): Properly wrap text on long error messages

### DIFF
--- a/app/src/lib/components/InfoMessage.svelte
+++ b/app/src/lib/components/InfoMessage.svelte
@@ -184,4 +184,8 @@
 		list-style-type: circle;
 		padding: 0 0 0 var(--size-16);
 	}
+	:global(.info-message__text pre) {
+		white-space: pre-wrap;
+		word-wrap: break-word;
+	}
 </style>


### PR DESCRIPTION

I made a small adjustment to allow some long error messages to be readable. The `<pre>` element by default will not wrap, so this should do the job!

<table>
<tr>
 <td> Before

 <td> After
<tr>
<tr>
 <td><img src="https://github.com/gitbutlerapp/gitbutler/assets/39922116/88350ca0-1e66-4c41-b86e-b56cef730c85"></td>

 <td> <img src="https://github.com/gitbutlerapp/gitbutler/assets/39922116/0908e8a6-0192-4993-b6de-cd4446b51c19">
</table>
