### PR TITLE
restore important error-messages

### DIFF
--- a/crates/gitbutler-core/src/error.rs
+++ b/crates/gitbutler-core/src/error.rs
@@ -212,6 +212,9 @@ pub trait AnyhowContextExt: private::Sealed {
     ///
     /// Note that it could not be named `context()` as this method already exists.
     fn custom_context(&self) -> Option<Context>;
+
+    /// Return our custom context or default it to the root-cause of the error.
+    fn custom_context_or_root_cause(&self) -> Context;
 }
 
 impl private::Sealed for anyhow::Error {}
@@ -222,6 +225,13 @@ impl AnyhowContextExt for anyhow::Error {
         } else {
             self.downcast_ref::<Code>().map(|code| (*code).into())
         }
+    }
+
+    fn custom_context_or_root_cause(&self) -> Context {
+        self.custom_context().unwrap_or_else(|| Context {
+            code: Code::Unknown,
+            message: Some(self.root_cause().to_string().into()),
+        })
     }
 }
 

--- a/crates/gitbutler-core/src/error.rs
+++ b/crates/gitbutler-core/src/error.rs
@@ -132,6 +132,8 @@ pub enum Code {
     Branches,
     ProjectGitAuth,
     ProjectGitRemote,
+    /// The push operation failed, specifically because the remote rejected it.
+    ProjectGitPush,
     ProjectConflict,
     ProjectHead,
     Menu,
@@ -149,6 +151,7 @@ impl std::fmt::Display for Code {
             Code::Branches => "errors.branches",
             Code::ProjectGitAuth => "errors.projects.git.auth",
             Code::ProjectGitRemote => "errors.projects.git.remote",
+            Code::ProjectGitPush => "errors.projects.git.push",
             Code::ProjectHead => "errors.projects.head",
             Code::ProjectConflict => "errors.projects.conflict",
             //TODO: rename js side to be more precise what kind of hook error this is

--- a/crates/gitbutler-core/src/git/credentials.rs
+++ b/crates/gitbutler-core/src/git/credentials.rs
@@ -95,7 +95,7 @@ impl ErrorWithContext for HelpError {
             }
             HelpError::UrlConvertError(_) => Code::ProjectGitRemote.into(),
             HelpError::Git(_) => return None,
-            HelpError::Other(error) => return error.custom_context(),
+            HelpError::Other(error) => return error.custom_context_or_root_cause().into(),
         })
     }
 }

--- a/crates/gitbutler-core/src/project_repository/repository.rs
+++ b/crates/gitbutler-core/src/project_repository/repository.rs
@@ -38,7 +38,7 @@ impl ErrorWithContext for OpenError {
             OpenError::NotFound(path) => {
                 error::Context::new(Code::Projects, format!("{} not found", path.display())).into()
             }
-            OpenError::Other(error) => error.custom_context(),
+            OpenError::Other(error) => error.custom_context_or_root_cause().into(),
         }
     }
 }

--- a/crates/gitbutler-core/src/project_repository/repository.rs
+++ b/crates/gitbutler-core/src/project_repository/repository.rs
@@ -630,7 +630,7 @@ impl ErrorWithContext for RemoteError {
         Some(match self {
             RemoteError::Help(error) => return error.context(),
             RemoteError::Network => {
-                error::Context::new_static(Code::ProjectGitRemote, "Network erorr occured")
+                error::Context::new_static(Code::ProjectGitRemote, "Network error occurred")
             }
             RemoteError::Auth => error::Context::new_static(
                 Code::ProjectGitAuth,

--- a/crates/gitbutler-core/src/project_repository/repository.rs
+++ b/crates/gitbutler-core/src/project_repository/repository.rs
@@ -529,11 +529,13 @@ impl Repository {
                         tracing::warn!(project_id = %self.project.id, ?error, "git push failed");
                         return Err(RemoteError::Network);
                     }
-                    Err(error) => {
-                        if let Some(e) = update_refs_error.as_ref() {
-                            return Err(RemoteError::Other(anyhow::anyhow!(e.to_string())));
+                    Err(err) => {
+                        if let Some(err) = update_refs_error.as_ref() {
+                            return Err(RemoteError::Other(
+                                anyhow::anyhow!(err.to_string()).context(Code::ProjectGitPush),
+                            ));
                         }
-                        return Err(RemoteError::Other(error.into()));
+                        return Err(RemoteError::Other(err.into()));
                     }
                 }
             }

--- a/crates/gitbutler-core/src/project_repository/repository.rs
+++ b/crates/gitbutler-core/src/project_repository/repository.rs
@@ -636,7 +636,9 @@ impl ErrorWithContext for RemoteError {
                 Code::ProjectGitAuth,
                 "Project remote authentication error",
             ),
-            RemoteError::Other(error) => return error.custom_context(),
+            RemoteError::Other(error) => {
+                return error.custom_context_or_root_cause().into();
+            }
         })
     }
 }

--- a/crates/gitbutler-core/src/projects/controller.rs
+++ b/crates/gitbutler-core/src/projects/controller.rs
@@ -331,7 +331,7 @@ impl error::ErrorWithContext for GetError {
             GetError::NotFound => {
                 error::Context::new_static(Code::Projects, "Project not found").into()
             }
-            GetError::Other(error) => error.custom_context(),
+            GetError::Other(error) => error.custom_context_or_root_cause().into(),
         }
     }
 }
@@ -361,7 +361,7 @@ impl ErrorWithContext for UpdateError {
             UpdateError::NotFound => {
                 error::Context::new_static(Code::Projects, "Project not found")
             }
-            UpdateError::Other(error) => return error.custom_context(),
+            UpdateError::Other(error) => return error.custom_context_or_root_cause().into(),
         })
     }
 }
@@ -418,7 +418,7 @@ impl ErrorWithContext for AddError {
                 Code::Projects,
                 "Repositories with git submodules are not supported",
             ),
-            AddError::Other(error) => return error.custom_context(),
+            AddError::Other(error) => return error.custom_context_or_root_cause().into(),
         })
     }
 }

--- a/crates/gitbutler-core/src/virtual_branches/errors.rs
+++ b/crates/gitbutler-core/src/virtual_branches/errors.rs
@@ -40,7 +40,7 @@ impl ErrorWithContext for VerifyError {
                 Code::ProjectHead,
                 "GibButler's integration commit not found on head.",
             ),
-            VerifyError::Other(error) => return error.custom_context(),
+            VerifyError::Other(error) => return error.custom_context_or_root_cause().into(),
         })
     }
 }
@@ -65,7 +65,7 @@ impl ErrorWithContext for ResetBranchError {
             ResetBranchError::CommitNotFoundInBranch(oid) => {
                 error::Context::new(Code::Branches, format!("commit {} not found", oid))
             }
-            ResetBranchError::Other(error) => return error.custom_context(),
+            ResetBranchError::Other(error) => return error.custom_context_or_root_cause().into(),
         })
     }
 }
@@ -94,7 +94,7 @@ impl ErrorWithContext for ApplyBranchError {
                 Code::Branches,
                 format!("Branch {} is in a conflicting state", id),
             ),
-            ApplyBranchError::Other(error) => return error.custom_context(),
+            ApplyBranchError::Other(error) => return error.custom_context_or_root_cause().into(),
         })
     }
 }
@@ -114,7 +114,9 @@ impl ErrorWithContext for UnapplyOwnershipError {
         Some(match self {
             UnapplyOwnershipError::DefaultTargetNotSet(error) => error.to_context(),
             UnapplyOwnershipError::Conflict(error) => error.to_context(),
-            UnapplyOwnershipError::Other(error) => return error.custom_context(),
+            UnapplyOwnershipError::Other(error) => {
+                return error.custom_context_or_root_cause().into()
+            }
         })
     }
 }
@@ -134,7 +136,7 @@ impl ErrorWithContext for UnapplyBranchError {
         Some(match self {
             UnapplyBranchError::DefaultTargetNotSet(ctx) => ctx.to_context(),
             UnapplyBranchError::BranchNotFound(ctx) => ctx.to_context(),
-            UnapplyBranchError::Other(error) => return error.custom_context(),
+            UnapplyBranchError::Other(error) => return error.custom_context_or_root_cause().into(),
         })
     }
 }
@@ -151,7 +153,7 @@ impl ErrorWithContext for ListVirtualBranchesError {
     fn context(&self) -> Option<Context> {
         match self {
             ListVirtualBranchesError::DefaultTargetNotSet(ctx) => ctx.to_context().into(),
-            ListVirtualBranchesError::Other(error) => error.custom_context(),
+            ListVirtualBranchesError::Other(error) => error.custom_context_or_root_cause().into(),
         }
     }
 }
@@ -168,7 +170,7 @@ impl ErrorWithContext for CreateVirtualBranchError {
     fn context(&self) -> Option<Context> {
         match self {
             CreateVirtualBranchError::DefaultTargetNotSet(ctx) => ctx.to_context().into(),
-            CreateVirtualBranchError::Other(error) => error.custom_context(),
+            CreateVirtualBranchError::Other(error) => error.custom_context_or_root_cause().into(),
         }
     }
 }
@@ -188,7 +190,9 @@ impl ErrorWithContext for MergeVirtualBranchUpstreamError {
         Some(match self {
             MergeVirtualBranchUpstreamError::BranchNotFound(ctx) => ctx.to_context(),
             MergeVirtualBranchUpstreamError::Conflict(ctx) => ctx.to_context(),
-            MergeVirtualBranchUpstreamError::Other(error) => return error.custom_context(),
+            MergeVirtualBranchUpstreamError::Other(error) => {
+                return error.custom_context_or_root_cause().into()
+            }
         })
     }
 }
@@ -221,7 +225,7 @@ impl ErrorWithContext for CommitError {
             CommitError::CommitMsgHookRejected(error) => {
                 error::Context::new(Code::CommitMsgHook, error)
             }
-            CommitError::Other(error) => return error.custom_context(),
+            CommitError::Other(error) => return error.custom_context_or_root_cause().into(),
         })
     }
 }
@@ -244,7 +248,7 @@ impl ErrorWithContext for PushError {
             PushError::DefaultTargetNotSet(ctx) => ctx.to_context(),
             PushError::BranchNotFound(ctx) => ctx.to_context(),
             PushError::Remote(error) => return error.context(),
-            PushError::Other(error) => return error.custom_context(),
+            PushError::Other(error) => return error.custom_context_or_root_cause().into(),
         })
     }
 }
@@ -266,7 +270,9 @@ impl ErrorWithContext for IsRemoteBranchMergableError {
                 error::Context::new(Code::Branches, format!("Remote branch {} not found", name))
             }
             IsRemoteBranchMergableError::DefaultTargetNotSet(ctx) => ctx.to_context(),
-            IsRemoteBranchMergableError::Other(error) => return error.custom_context(),
+            IsRemoteBranchMergableError::Other(error) => {
+                return error.custom_context_or_root_cause().into()
+            }
         })
     }
 }
@@ -286,7 +292,9 @@ impl ErrorWithContext for IsVirtualBranchMergeable {
         Some(match self {
             IsVirtualBranchMergeable::BranchNotFound(ctx) => ctx.to_context(),
             IsVirtualBranchMergeable::DefaultTargetNotSet(ctx) => ctx.to_context(),
-            IsVirtualBranchMergeable::Other(error) => return error.custom_context(),
+            IsVirtualBranchMergeable::Other(error) => {
+                return error.custom_context_or_root_cause().into()
+            }
         })
     }
 }
@@ -337,7 +345,7 @@ impl ErrorWithContext for AmendError {
             AmendError::TargetOwnerhshipNotFound(_) => {
                 error::Context::new_static(Code::Branches, "target ownership not found")
             }
-            AmendError::Other(error) => return error.custom_context(),
+            AmendError::Other(error) => return error.custom_context_or_root_cause().into(),
         })
     }
 }
@@ -364,7 +372,7 @@ impl ErrorWithContext for CherryPickError {
             CherryPickError::CommitNotFound(oid) => {
                 error::Context::new(Code::Branches, format!("commit {oid} not found"))
             }
-            CherryPickError::Other(error) => return error.custom_context(),
+            CherryPickError::Other(error) => return error.custom_context_or_root_cause().into(),
         })
     }
 }
@@ -401,7 +409,7 @@ impl ErrorWithContext for SquashError {
                 crate::error::Code::Branches,
                 format!("commit {oid} not found"),
             ),
-            SquashError::Other(error) => return error.custom_context(),
+            SquashError::Other(error) => return error.custom_context_or_root_cause().into(),
         })
     }
 }
@@ -421,7 +429,7 @@ impl ErrorWithContext for FetchFromTargetError {
         match self {
             FetchFromTargetError::DefaultTargetNotSet(ctx) => ctx.to_context().into(),
             FetchFromTargetError::Remote(error) => error.context(),
-            FetchFromTargetError::Other(error) => error.custom_context(),
+            FetchFromTargetError::Other(error) => error.custom_context_or_root_cause().into(),
         }
     }
 }
@@ -457,7 +465,9 @@ impl ErrorWithContext for UpdateCommitMessageError {
             }
             UpdateCommitMessageError::BranchNotFound(ctx) => ctx.to_context(),
             UpdateCommitMessageError::Conflict(ctx) => ctx.to_context(),
-            UpdateCommitMessageError::Other(error) => return error.custom_context(),
+            UpdateCommitMessageError::Other(error) => {
+                return error.custom_context_or_root_cause().into()
+            }
         })
     }
 }
@@ -482,7 +492,7 @@ impl ErrorWithContext for SetBaseBranchError {
                 Code::Branches,
                 format!("remote branch '{}' not found", name),
             ),
-            SetBaseBranchError::Other(error) => return error.custom_context(),
+            SetBaseBranchError::Other(error) => return error.custom_context_or_root_cause().into(),
         })
     }
 }
@@ -502,7 +512,9 @@ impl ErrorWithContext for UpdateBaseBranchError {
         Some(match self {
             UpdateBaseBranchError::Conflict(ctx) => ctx.to_context(),
             UpdateBaseBranchError::DefaultTargetNotSet(ctx) => ctx.to_context(),
-            UpdateBaseBranchError::Other(error) => return error.custom_context(),
+            UpdateBaseBranchError::Other(error) => {
+                return error.custom_context_or_root_cause().into()
+            }
         })
     }
 }
@@ -536,7 +548,7 @@ impl ErrorWithContext for MoveCommitError {
             MoveCommitError::CommitNotFound(oid) => {
                 error::Context::new(Code::Branches, format!("Commit {} not found", oid))
             }
-            MoveCommitError::Other(error) => return error.custom_context(),
+            MoveCommitError::Other(error) => return error.custom_context_or_root_cause().into(),
         })
     }
 }
@@ -569,7 +581,9 @@ impl ErrorWithContext for CreateVirtualBranchFromBranchError {
             CreateVirtualBranchFromBranchError::BranchNotFound(name) => {
                 error::Context::new(Code::Branches, format!("Branch {} not found", name))
             }
-            CreateVirtualBranchFromBranchError::Other(error) => return error.custom_context(),
+            CreateVirtualBranchFromBranchError::Other(error) => {
+                return error.custom_context_or_root_cause().into()
+            }
         })
     }
 }
@@ -635,7 +649,7 @@ impl ErrorWithContext for UpdateBranchError {
         Some(match self {
             UpdateBranchError::DefaultTargetNotSet(ctx) => ctx.to_context(),
             UpdateBranchError::BranchNotFound(ctx) => ctx.to_context(),
-            UpdateBranchError::Other(error) => return error.custom_context(),
+            UpdateBranchError::Other(error) => return error.custom_context_or_root_cause().into(),
         })
     }
 }
@@ -654,7 +668,7 @@ impl ErrorWithContext for ListRemoteCommitFilesError {
             ListRemoteCommitFilesError::CommitNotFound(oid) => {
                 error::Context::new(Code::Branches, format!("Commit {} not found", oid)).into()
             }
-            ListRemoteCommitFilesError::Other(error) => error.custom_context(),
+            ListRemoteCommitFilesError::Other(error) => error.custom_context_or_root_cause().into(),
         }
     }
 }
@@ -671,7 +685,7 @@ impl ErrorWithContext for ListRemoteBranchesError {
     fn context(&self) -> Option<Context> {
         match self {
             ListRemoteBranchesError::DefaultTargetNotSet(ctx) => ctx.to_context().into(),
-            ListRemoteBranchesError::Other(error) => error.custom_context(),
+            ListRemoteBranchesError::Other(error) => error.custom_context_or_root_cause().into(),
         }
     }
 }
@@ -688,7 +702,7 @@ impl ErrorWithContext for GetRemoteBranchDataError {
     fn context(&self) -> Option<Context> {
         match self {
             GetRemoteBranchDataError::DefaultTargetNotSet(ctx) => ctx.to_context().into(),
-            GetRemoteBranchDataError::Other(error) => error.custom_context(),
+            GetRemoteBranchDataError::Other(error) => error.custom_context_or_root_cause().into(),
         }
     }
 }


### PR DESCRIPTION
Related to #2886.

A catch-all PR for minor changes of things I notice while going through all issues, but it turned out to be an important restoration of error messages.

*(From the commit-message)*

> In the previous commit it was stated that the 'unfolding' of errors might
> have been intentional to surface root causes of error messages.
>
> However, this migth have been wrong, and this commit brings back root-causes explicitly,
> while erroring on the side of caution. That is, "Something went wrong" probably won't
> be shown anymore, instead, possibly too much will be displayed and we'd rather tune
> that down once it becomes clear which messages are needd, or should be improved.
>
> Overall, I think it's best to show more, and then tune errors with custom context
> where needed.

### Tasks

* [x] restore error messages (and probably show more than before, overall)
* [x] add a new `Code` variant to help the UI differentiate rejected pushes

### Notes for the Reviewer

* The commit messages contain more information this time.
* This PR cranks up the error messages in the frontend, and basically shows the root-cause of everything unless context was specifically provided. The idea is that it will help us to more easily see what the error is, and we can decide if that error should be improved or maybe even silenced.
* https://github.com/gitbutlerapp/gitbutler/pull/3582/commits/7f111cb76f23f54082a63aedc5896fa1476d82da is responsible for getting a lot of root-causes to bubble up to the UI. This might be too much, but can easily be reverted to only get the error messages when pushing.

### Out of Scope

* Update the UI to show a more specific message if the new `errors.projects.git.push` code is encountered.

### Notes

@PavelLaptev When the remote rejects a push, this *should* now be surfaced with the specific code `errors.projects.git.push`. The UI could now show specific text to help with the "cannot push yaml file" problem (#2886).

