### PR TITLE
don't fail if a ref can't be peeled (#3129)

### DIFF
--- a/crates/gitbutler-core/src/assets.rs
+++ b/crates/gitbutler-core/src/assets.rs
@@ -93,15 +93,12 @@ impl Proxy {
 
     async fn proxy_author(&self, author: Author) -> Author {
         Author {
-                gravatar_url: self
-                    .proxy(&author.gravatar_url)
-                    .await
-                    .unwrap_or_else(|error| {
-                        tracing::error!(gravatar_url = %author.gravatar_url, ?error, "failed to proxy gravatar url");
-                        author.gravatar_url
-                    }),
-                ..author
-            }
+            gravatar_url: self.proxy(&author.gravatar_url).await.unwrap_or_else(|error| {
+                tracing::error!(gravatar_url = %author.gravatar_url, ?error, "failed to proxy gravatar url");
+                author.gravatar_url
+            }),
+            ..author
+        }
     }
 
     async fn proxy_remote_commit(&self, commit: RemoteCommit) -> RemoteCommit {

--- a/crates/gitbutler-core/src/gb_repository/repository.rs
+++ b/crates/gitbutler-core/src/gb_repository/repository.rs
@@ -217,7 +217,8 @@ impl Repository {
 
         // Push to the remote
         remote
-            .push(&[&remote_refspec], Some(&mut push_options)).map_err(|error| match error {
+            .push(&[&remote_refspec], Some(&mut push_options))
+            .map_err(|error| match error {
                 git::Error::Network(error) => {
                     tracing::warn!(project_id = %self.project.id, error = %error, "failed to push gb repo");
                     RemoteError::Network

--- a/crates/gitbutler-core/src/git/reference/refname/remote.rs
+++ b/crates/gitbutler-core/src/git/reference/refname/remote.rs
@@ -64,6 +64,8 @@ impl FromStr for Refname {
             return Err(Error::NotRemote(value.to_string()));
         };
 
+        // TODO(ST): use `gix` (which respects refspecs and settings) to do this transformation
+        //           Alternatively, `git2` also has support for respecting refspecs.
         let value = value.strip_prefix("refs/remotes/").unwrap();
 
         if let Some((remote, branch)) = value.split_once('/') {

--- a/crates/gitbutler-core/src/project_repository/repository.rs
+++ b/crates/gitbutler-core/src/project_repository/repository.rs
@@ -61,7 +61,7 @@ impl Repository {
                 // XXX(qix-): We will ultimately move away from an internal repository for a variety
                 // XXX(qix-): of reasons, but for now, this is a simple, short-term solution that we
                 // XXX(qix-): can clean up later on. We're aware this isn't ideal.
-                if let Ok(config) = git_repository.config().as_mut(){
+                if let Ok(config) = git_repository.config().as_mut() {
                     let should_set = match config.get_bool("gitbutler.didSetPrune") {
                         Ok(None | Some(false)) => true,
                         Ok(Some(true)) => false,
@@ -76,7 +76,10 @@ impl Repository {
                     };
 
                     if should_set {
-                        if let Err(error) = config.set_str("gc.pruneExpire", "never").and_then(|()| config.set_bool("gitbutler.didSetPrune", true)) {
+                        if let Err(error) = config
+                            .set_str("gc.pruneExpire", "never")
+                            .and_then(|()| config.set_bool("gitbutler.didSetPrune", true))
+                        {
                             tracing::warn!(
                                 "failed to set gc.auto to false for repository at {}; cannot disable gc: {}",
                                 project.path.display(),

--- a/crates/gitbutler-core/src/virtual_branches/base.rs
+++ b/crates/gitbutler-core/src/virtual_branches/base.rs
@@ -569,9 +569,10 @@ pub fn update_base_branch(
         })
         .context("failed to calculate final tree")?;
 
-    repo.checkout_tree(&final_tree).force().checkout().context(
-        "failed to checkout index, this should not have happened, we should have already detected this",
-    )?;
+    repo.checkout_tree(&final_tree)
+        .force()
+        .checkout()
+        .context("failed to checkout index, this should not have happened, we should have already detected this")?;
 
     // write new target oid
     vb_state.set_default_target(target::Target {

--- a/crates/gitbutler-core/src/virtual_branches/remote.rs
+++ b/crates/gitbutler-core/src/virtual_branches/remote.rs
@@ -111,7 +111,17 @@ pub fn get_branch_data(
 }
 
 pub fn branch_to_remote_branch(branch: &git::Branch) -> Result<Option<RemoteBranch>> {
-    let commit = branch.peel_to_commit()?;
+    let commit = match branch.peel_to_commit() {
+        Ok(c) => c,
+        Err(err) => {
+            tracing::warn!(
+                ?err,
+                "ignoring branch {:?} as peeling failed",
+                branch.name()
+            );
+            return Ok(None);
+        }
+    };
     branch
         .target()
         .map(|sha| {

--- a/crates/gitbutler-core/tests/suite/virtual_branches/unapply.rs
+++ b/crates/gitbutler-core/tests/suite/virtual_branches/unapply.rs
@@ -64,7 +64,10 @@ async fn conflicting() {
         assert_eq!(branches.len(), 1);
         assert!(branches[0].base_current);
         assert!(branches[0].active);
-        assert_eq!(branches[0].files[0].hunks[0].diff, "@@ -1 +1 @@\n-first\n\\ No newline at end of file\n+conflict\n\\ No newline at end of file\n");
+        assert_eq!(
+            branches[0].files[0].hunks[0].diff,
+            "@@ -1 +1 @@\n-first\n\\ No newline at end of file\n+conflict\n\\ No newline at end of file\n"
+        );
 
         controller
             .unapply_virtual_branch(project_id, &branches[0].id)
@@ -142,7 +145,10 @@ async fn conflicting() {
         assert!(!branch.active);
         assert!(!branch.base_current);
         assert!(!branch.conflicted);
-        assert_eq!(branch.files[0].hunks[0].diff, "@@ -1 +1 @@\n-first\n\\ No newline at end of file\n+conflict\n\\ No newline at end of file\n");
+        assert_eq!(
+            branch.files[0].hunks[0].diff,
+            "@@ -1 +1 @@\n-first\n\\ No newline at end of file\n+conflict\n\\ No newline at end of file\n"
+        );
     }
 }
 

--- a/crates/gitbutler-core/tests/suite/virtual_branches/update_base_branch.rs
+++ b/crates/gitbutler-core/tests/suite/virtual_branches/update_base_branch.rs
@@ -1635,7 +1635,10 @@ mod applied_branch {
             assert!(branches[0].base_current);
             assert_eq!(branches[0].files.len(), 1);
             assert_eq!(branches[0].files[0].hunks.len(), 1);
-            assert_eq!(branches[0].files[0].hunks[0].diff, "@@ -4,7 +4,11 @@\n 4\n 5\n 6\n-7\n+<<<<<<< ours\n+77\n+=======\n+17\n+>>>>>>> theirs\n 8\n 19\n 10\n");
+            assert_eq!(
+                branches[0].files[0].hunks[0].diff,
+                "@@ -4,7 +4,11 @@\n 4\n 5\n 6\n-7\n+<<<<<<< ours\n+77\n+=======\n+17\n+>>>>>>> theirs\n 8\n 19\n 10\n"
+            );
             assert_eq!(branches[0].commits.len(), 0);
         }
     }

--- a/crates/gitbutler-git/src/bin/askpass.rs
+++ b/crates/gitbutler-git/src/bin/askpass.rs
@@ -15,7 +15,9 @@ use std::io::{BufRead, BufReader, BufWriter, Write};
 pub fn main() {
     let pipe_name = std::env::var("GITBUTLER_ASKPASS_PIPE").expect("do not run this binary yourself; it's only meant to be run by GitButler (missing GITBUTLER_ASKPASS_PIPE env var)");
     let pipe_secret = std::env::var("GITBUTLER_ASKPASS_SECRET").expect("do not run this binary yourself; it's only meant to be run by GitButler (missing GITBUTLER_ASKPASS_SECRET env var)");
-    let prompt = std::env::args().nth(1).expect("do not run this binary yourself; it's only meant to be run by GitButler (missing prompt arg)");
+    let prompt = std::env::args()
+        .nth(1)
+        .expect("do not run this binary yourself; it's only meant to be run by GitButler (missing prompt arg)");
 
     #[cfg(unix)]
     let raw_stream = self::unix::establish(&pipe_name);

--- a/crates/gitbutler-git/src/repository.rs
+++ b/crates/gitbutler-git/src/repository.rs
@@ -23,9 +23,7 @@ pub enum RepositoryError<
     AskpassServer(Easkpass),
     #[error("i/o error communicating with askpass utility: {0}")]
     AskpassIo(Esocket),
-    #[error(
-        "git command exited with non-zero exit code {status}: {args:?}\n\nSTDOUT:\n{stdout}\n\nSTDERR:\n{stderr}"
-    )]
+    #[error("git command exited with non-zero exit code {status}: {args:?}\n\nSTDOUT:\n{stdout}\n\nSTDERR:\n{stderr}")]
     Failed {
         status: usize,
         args: Vec<String>,

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -240,13 +240,11 @@ impl Handler {
             .build();
 
         let fetch_result = backoff::retry(policy, || {
-            gb_repo.fetch(user.as_ref()).map_err(|err| {
-                match err {
-                    gb_repository::RemoteError::Network => backoff::Error::permanent(err),
-                    err @ gb_repository::RemoteError::Other(_) => {
-                        tracing::warn!(%project_id, ?err, will_retry = true, "failed to fetch project data");
-                        backoff::Error::transient(err)
-                    }
+            gb_repo.fetch(user.as_ref()).map_err(|err| match err {
+                gb_repository::RemoteError::Network => backoff::Error::permanent(err),
+                err @ gb_repository::RemoteError::Other(_) => {
+                    tracing::warn!(%project_id, ?err, will_retry = true, "failed to fetch project data");
+                    backoff::Error::transient(err)
                 }
             })
         });


### PR DESCRIPTION
Sometimes, symbolic refs are used as tracking branches, like `refs/remotes/origin/HEAD`, and after some changes are dangling, pointing to a ref which doesn't exist anymore (maybe it was renamed from `master` to `main`).

Now, this isn't fatal anymore, but will be logged instead.

Fixes #3129 .

### Notes for the Reviewer

The PR contains a uboot to fix an unrelated issue with Rust code-formatting.
