### PR TITLE
use tempfiles for file mutations

### DIFF
--- a/crates/gitbutler-core/src/git/credentials.rs
+++ b/crates/gitbutler-core/src/git/credentials.rs
@@ -113,7 +113,8 @@ impl Helper {
         }
     }
 
-    pub fn from_path<P: AsRef<std::path::Path>>(path: P) -> Self {
+    pub fn from_path(path: impl Into<PathBuf>) -> Self {
+        let path = path.into();
         let keys = keys::Controller::from_path(&path);
         let users = users::Controller::from_path(path);
         let home_dir = std::env::var_os("HOME").map(PathBuf::from);

--- a/crates/gitbutler-core/src/keys/controller.rs
+++ b/crates/gitbutler-core/src/keys/controller.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use std::path::PathBuf;
 
 use super::{storage::Storage, PrivateKey};
 
@@ -12,7 +13,7 @@ impl Controller {
         Self { storage }
     }
 
-    pub fn from_path<P: AsRef<std::path::Path>>(path: P) -> Self {
+    pub fn from_path(path: impl Into<PathBuf>) -> Self {
         Self::new(Storage::from_path(path))
     }
 

--- a/crates/gitbutler-core/src/keys/storage.rs
+++ b/crates/gitbutler-core/src/keys/storage.rs
@@ -1,42 +1,40 @@
 use super::PrivateKey;
 use crate::storage;
+use std::path::PathBuf;
 
+// TODO(ST): get rid of this type, it's more trouble than it's worth.
 #[derive(Clone)]
 pub struct Storage {
-    storage: storage::Storage,
+    inner: storage::Storage,
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("IO error: {0}")]
-    Storage(#[from] storage::Error),
+    #[error(transparent)]
+    Storage(#[from] std::io::Error),
     #[error("SSH key error: {0}")]
     SSHKey(#[from] ssh_key::Error),
 }
 
 impl Storage {
     pub fn new(storage: storage::Storage) -> Storage {
-        Storage { storage }
+        Storage { inner: storage }
     }
 
-    pub fn from_path<P: AsRef<std::path::Path>>(path: P) -> Storage {
+    pub fn from_path(path: impl Into<PathBuf>) -> Storage {
         Storage::new(storage::Storage::new(path))
     }
 
     pub fn get(&self) -> Result<Option<PrivateKey>, Error> {
-        self.storage
-            .read("keys/ed25519")
-            .map_err(Error::Storage)
-            .and_then(|s| s.map(|s| s.parse().map_err(Error::SSHKey)).transpose())
+        let key = self.inner.read("keys/ed25519")?;
+        key.map(|s| s.parse().map_err(Into::into)).transpose()
     }
 
+    // TODO(ST): see if Key should rather deal with bytes instead for this kind of serialization.
     pub fn create(&self, key: &PrivateKey) -> Result<(), Error> {
-        self.storage
-            .write("keys/ed25519", &key.to_string())
-            .map_err(Error::Storage)?;
-        self.storage
-            .write("keys/ed25519.pub", &key.public_key().to_string())
-            .map_err(Error::Storage)?;
+        self.inner.write("keys/ed25519", &key.to_string())?;
+        self.inner
+            .write("keys/ed25519.pub", &key.public_key().to_string())?;
         Ok(())
     }
 }

--- a/crates/gitbutler-core/src/projects/controller.rs
+++ b/crates/gitbutler-core/src/projects/controller.rs
@@ -46,12 +46,12 @@ impl Controller {
         }
     }
 
-    pub fn from_path<P: AsRef<std::path::Path>>(path: P) -> Self {
-        let pathbuf = path.as_ref().to_path_buf();
+    pub fn from_path(path: impl Into<PathBuf>) -> Self {
+        let path = path.into();
         Self {
-            local_data_dir: pathbuf.clone(),
-            projects_storage: storage::Storage::from_path(&pathbuf),
-            users: users::Controller::from_path(&pathbuf),
+            projects_storage: storage::Storage::from_path(&path),
+            users: users::Controller::from_path(&path),
+            local_data_dir: path,
             watchers: None,
         }
     }

--- a/crates/gitbutler-core/src/projects/storage.rs
+++ b/crates/gitbutler-core/src/projects/storage.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 use crate::{
     projects::{project, ProjectId},
@@ -9,7 +10,7 @@ const PROJECTS_FILE: &str = "projects.json";
 
 #[derive(Debug, Clone)]
 pub struct Storage {
-    storage: storage::Storage,
+    inner: storage::Storage,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
@@ -30,7 +31,7 @@ pub struct UpdateRequest {
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error(transparent)]
-    Storage(#[from] storage::Error),
+    Storage(#[from] std::io::Error),
     #[error(transparent)]
     Json(#[from] serde_json::Error),
     #[error("project not found")]
@@ -38,16 +39,16 @@ pub enum Error {
 }
 
 impl Storage {
-    pub fn new(storage: storage::Storage) -> Storage {
-        Storage { storage }
+    pub fn new(storage: storage::Storage) -> Self {
+        Self { inner: storage }
     }
 
-    pub fn from_path<P: AsRef<std::path::Path>>(path: P) -> Storage {
-        Storage::new(storage::Storage::new(path))
+    pub fn from_path(path: impl Into<PathBuf>) -> Self {
+        Self::new(storage::Storage::new(path))
     }
 
     pub fn list(&self) -> Result<Vec<project::Project>, Error> {
-        match self.storage.read(PROJECTS_FILE)? {
+        match self.inner.read(PROJECTS_FILE)? {
             Some(projects) => {
                 let all_projects: Vec<project::Project> = serde_json::from_str(&projects)?;
                 let all_projects: Vec<project::Project> = all_projects
@@ -128,7 +129,7 @@ impl Storage {
             project.omit_certificate_check = Some(omit_certificate_check);
         }
 
-        self.storage
+        self.inner
             .write(PROJECTS_FILE, &serde_json::to_string_pretty(&projects)?)?;
 
         Ok(projects
@@ -142,7 +143,7 @@ impl Storage {
         let mut projects = self.list()?;
         if let Some(index) = projects.iter().position(|p| p.id == *id) {
             projects.remove(index);
-            self.storage
+            self.inner
                 .write(PROJECTS_FILE, &serde_json::to_string_pretty(&projects)?)?;
         }
         Ok(())
@@ -152,7 +153,7 @@ impl Storage {
         let mut projects = self.list()?;
         projects.push(project.clone());
         let projects = serde_json::to_string_pretty(&projects)?;
-        self.storage.write(PROJECTS_FILE, &projects)?;
+        self.inner.write(PROJECTS_FILE, &projects)?;
         Ok(())
     }
 }

--- a/crates/gitbutler-core/src/users/controller.rs
+++ b/crates/gitbutler-core/src/users/controller.rs
@@ -1,7 +1,9 @@
 use anyhow::Context;
+use std::path::PathBuf;
 
 use super::{storage::Storage, User};
 
+/// TODO(ST): useless intermediary - remove
 #[derive(Clone)]
 pub struct Controller {
     storage: Storage,
@@ -12,7 +14,7 @@ impl Controller {
         Controller { storage }
     }
 
-    pub fn from_path<P: AsRef<std::path::Path>>(path: P) -> Controller {
+    pub fn from_path(path: impl Into<PathBuf>) -> Controller {
         Controller::new(Storage::from_path(path))
     }
 

--- a/crates/gitbutler-core/tests/git/credentials.rs
+++ b/crates/gitbutler-core/tests/git/credentials.rs
@@ -19,14 +19,14 @@ impl TestCase<'_> {
     fn run(&self) -> Vec<(String, Vec<Credential>)> {
         let local_app_data = temp_dir();
 
-        let users = users::Controller::from_path(&local_app_data);
+        let users = users::Controller::from_path(local_app_data.path());
         let user = users::User {
             github_access_token: self.github_access_token.map(ToString::to_string),
             ..Default::default()
         };
         users.set_user(&user).unwrap();
 
-        let keys = keys::Controller::from_path(&local_app_data);
+        let keys = keys::Controller::from_path(local_app_data.path());
         let helper = Helper::new(keys, users, self.home_dir.clone());
 
         let (repo, _tmp) = test_repository();

--- a/crates/gitbutler-core/tests/suite/gb_repository.rs
+++ b/crates/gitbutler-core/tests/suite/gb_repository.rs
@@ -12,7 +12,7 @@ mod init {
         let test_project = TestProject::default();
 
         let data_dir = paths::data_dir();
-        let projects = projects::Controller::from_path(&data_dir);
+        let projects = projects::Controller::from_path(data_dir.path());
 
         let project = projects
             .add(test_project.path())
@@ -32,7 +32,7 @@ mod init {
         let test_project = TestProject::default();
 
         let data_dir = paths::data_dir();
-        let projects = projects::Controller::from_path(&data_dir);
+        let projects = projects::Controller::from_path(data_dir.path());
 
         let project = projects
             .add(test_project.path())
@@ -54,7 +54,7 @@ mod init {
         let test_project = TestProject::default();
 
         let data_dir = paths::data_dir();
-        let projects = projects::Controller::from_path(&data_dir);
+        let projects = projects::Controller::from_path(data_dir.path());
 
         let project = projects
             .add(test_project.path())
@@ -84,7 +84,7 @@ mod flush {
         let test_project = TestProject::default();
 
         let data_dir = paths::data_dir();
-        let projects = projects::Controller::from_path(&data_dir);
+        let projects = projects::Controller::from_path(data_dir.path());
 
         let project = projects
             .add(test_project.path())
@@ -107,7 +107,7 @@ mod flush {
         let test_project = TestProject::default();
 
         let data_dir = paths::data_dir();
-        let projects = projects::Controller::from_path(&data_dir);
+        let projects = projects::Controller::from_path(data_dir.path());
 
         let project = projects
             .add(test_project.path())
@@ -131,7 +131,7 @@ mod flush {
         let test_project = TestProject::default();
 
         let data_dir = paths::data_dir();
-        let projects = projects::Controller::from_path(&data_dir);
+        let projects = projects::Controller::from_path(data_dir.path());
 
         let project = projects
             .add(test_project.path())

--- a/crates/gitbutler-core/tests/suite/projects.rs
+++ b/crates/gitbutler-core/tests/suite/projects.rs
@@ -5,7 +5,7 @@ use gitbutler_testsupport::{self, paths};
 
 pub fn new() -> (Controller, TempDir) {
     let data_dir = paths::data_dir();
-    let controller = Controller::from_path(&data_dir);
+    let controller = Controller::from_path(data_dir.path());
     (controller, data_dir)
 }
 

--- a/crates/gitbutler-core/tests/suite/virtual_branches/init.rs
+++ b/crates/gitbutler-core/tests/suite/virtual_branches/init.rs
@@ -3,10 +3,10 @@ use super::*;
 #[tokio::test]
 async fn twice() {
     let data_dir = paths::data_dir();
-    let keys = keys::Controller::from_path(&data_dir);
-    let projects = projects::Controller::from_path(&data_dir);
-    let users = users::Controller::from_path(&data_dir);
-    let helper = git::credentials::Helper::from_path(&data_dir);
+    let keys = keys::Controller::from_path(data_dir.path());
+    let projects = projects::Controller::from_path(data_dir.path());
+    let users = users::Controller::from_path(data_dir.path());
+    let helper = git::credentials::Helper::from_path(data_dir.path());
 
     let test_project = TestProject::default();
 

--- a/crates/gitbutler-core/tests/suite/virtual_branches/mod.rs
+++ b/crates/gitbutler-core/tests/suite/virtual_branches/mod.rs
@@ -29,10 +29,10 @@ impl Drop for Test {
 impl Default for Test {
     fn default() -> Self {
         let data_dir = paths::data_dir();
-        let keys = keys::Controller::from_path(&data_dir);
-        let projects = projects::Controller::from_path(&data_dir);
-        let users = users::Controller::from_path(&data_dir);
-        let helper = git::credentials::Helper::from_path(&data_dir);
+        let keys = keys::Controller::from_path(data_dir.path());
+        let projects = projects::Controller::from_path(data_dir.path());
+        let users = users::Controller::from_path(data_dir.path());
+        let helper = git::credentials::Helper::from_path(data_dir.path());
 
         let test_project = TestProject::default();
         let project = projects

--- a/crates/gitbutler-testsupport/src/suite.rs
+++ b/crates/gitbutler-testsupport/src/suite.rs
@@ -27,10 +27,10 @@ impl Drop for Suite {
 impl Default for Suite {
     fn default() -> Self {
         let local_app_data = temp_dir();
-        let storage = gitbutler_core::storage::Storage::new(&local_app_data);
-        let users = gitbutler_core::users::Controller::from_path(&local_app_data);
-        let projects = gitbutler_core::projects::Controller::from_path(&local_app_data);
-        let keys = gitbutler_core::keys::Controller::from_path(&local_app_data);
+        let storage = gitbutler_core::storage::Storage::new(local_app_data.path());
+        let users = gitbutler_core::users::Controller::from_path(local_app_data.path());
+        let projects = gitbutler_core::projects::Controller::from_path(local_app_data.path());
+        let keys = gitbutler_core::keys::Controller::from_path(local_app_data.path());
         Self {
             storage,
             local_app_data: Some(local_app_data),


### PR DESCRIPTION
This will prevent half-written content on disk in case the write is interrupted.

Please note that for this to be safe and avoid stale lock files, one needs to add application support with signal handling.

Fixes #2807 (assuming that the app was indeed interrupted during a write)

> [!WARNING]
> This PR changes the way synchronization happens and assumes that a review of the actual usage of the `Storage` IO primitive is used. Callers can enforce this by being `&mut self`.

### Tasks

* [x] use `gix::tempfile` to facilitate write operations
* ~~setup signal handler in tauri-app to avoid stale locks~~ - no need, using tempfiles.

> [!NOTE]
> Git-style lock files can remain stale on disk if the application gets killed (SIGKILL), which will permanently lock a resource. The idea is that the error message contains the path to the lock file so users can remove it by themselves.
>
> The alternative is to write to tempfiles instead - these will never block each other (but may pile up on disk), but then there is no form of syncronization at all, which is what's happening currently anyway.
>
> Since the idea is to have one authoritative window per project, I think a central lock may be used for that instead with the existing `fslock` based locking mechanism. 
