### PR TITLE
use `gix::tempfile` in place of the `tempfile`.

### DIFF
--- a/crates/gitbutler-core/Cargo.toml
+++ b/crates/gitbutler-core/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dev-dependencies]
 once_cell = "1.19"
 pretty_assertions = "1.4"
+tempfile = "3.10"
 gitbutler-testsupport.workspace = true
 
 [dependencies]
@@ -52,7 +53,6 @@ urlencoding = "2.1.3"
 uuid.workspace = true
 walkdir = "2.5.0"
 zip = "0.6.5"
-tempfile = "3.10"
 gitbutler-git.workspace = true
 
 [features]


### PR DESCRIPTION
This allows to unify handling of filewrites in more places.
