### PR TITLE
use iterators and avoid copies

### DIFF
--- a/crates/gitbutler-core/src/git/diff.rs
+++ b/crates/gitbutler-core/src/git/diff.rs
@@ -9,7 +9,6 @@ use tracing::instrument;
 
 use super::Repository;
 use crate::git;
-use crate::virtual_branches::BranchStatus;
 
 pub type DiffByPathMap = HashMap<PathBuf, FileDiff>;
 
@@ -428,8 +427,8 @@ pub fn reverse_hunk(hunk: &GitHunk) -> Option<GitHunk> {
     }
 }
 
-// TODO(ST): turning this into an iterator will trigger a cascade of changes that
-//           mean less unnecessary copies. It also leads to `virtual.rs` - 4k SLOC!
-pub fn diff_files_into_hunks(files: DiffByPathMap) -> BranchStatus {
-    HashMap::from_iter(files.into_iter().map(|(path, file)| (path, file.hunks)))
+pub fn diff_files_into_hunks(
+    files: DiffByPathMap,
+) -> impl Iterator<Item = (PathBuf, Vec<GitHunk>)> {
+    files.into_iter().map(|(path, file)| (path, file.hunks))
 }

--- a/crates/gitbutler-core/src/project_repository/conflicts.rs
+++ b/crates/gitbutler-core/src/project_repository/conflicts.rs
@@ -95,6 +95,8 @@ pub fn conflicting_files(repository: &Repository) -> Result<Vec<String>> {
     Ok(reader.lines().map_while(Result::ok).collect())
 }
 
+/// Check if `path` is conflicting in `repository`, or if `None`, check if there is any conflict.
+// TODO(ST): Should this not rather check the conflicting state in the index?
 pub fn is_conflicting<P: AsRef<Path>>(repository: &Repository, path: Option<P>) -> Result<bool> {
     let conflicts_path = repository.git_repository.path().join("conflicts");
     if !conflicts_path.exists() {
@@ -105,6 +107,7 @@ pub fn is_conflicting<P: AsRef<Path>>(repository: &Repository, path: Option<P>) 
     let reader = std::io::BufReader::new(file);
     let mut files = reader.lines().map_ok(PathBuf::from);
     if let Some(pathname) = path {
+        // TODO(ST): This shouldn't work on UTF8 strings.
         let pathname = pathname.as_ref();
 
         // check if pathname is one of the lines in conflicts_path file

--- a/crates/gitbutler-core/src/virtual_branches/base.rs
+++ b/crates/gitbutler-core/src/virtual_branches/base.rs
@@ -199,7 +199,7 @@ pub fn set_base_branch(
                 |mut ownership, (file_path, diff)| {
                     for hunk in &diff.hunks {
                         ownership.put(
-                            &format!(
+                            format!(
                                 "{}:{}",
                                 file_path.display(),
                                 VirtualBranchHunk::gen_id(hunk.new_start, hunk.new_lines)

--- a/crates/gitbutler-core/src/virtual_branches/branch/ownership.rs
+++ b/crates/gitbutler-core/src/virtual_branches/branch/ownership.rs
@@ -80,7 +80,7 @@ impl BranchOwnershipClaims {
         true
     }
 
-    pub fn put(&mut self, ownership: &OwnershipClaim) {
+    pub fn put(&mut self, ownership: OwnershipClaim) {
         let target = self
             .claims
             .iter()
@@ -94,12 +94,11 @@ impl BranchOwnershipClaims {
         if let Some(target) = target {
             self.claims.insert(0, target.plus(ownership));
         } else {
-            self.claims.insert(0, ownership.clone());
+            self.claims.insert(0, ownership);
         }
     }
 
     // modifies the ownership in-place and returns the file ownership that was taken, if any.
-    // TODO(ST): better pass the necessary parts of `ownership` for flexibility - saves allocations
     pub fn take(&mut self, ownership: &OwnershipClaim) -> Vec<OwnershipClaim> {
         let mut taken = Vec::new();
         let mut remaining = Vec::new();

--- a/crates/gitbutler-core/src/virtual_branches/branch/ownership.rs
+++ b/crates/gitbutler-core/src/virtual_branches/branch/ownership.rs
@@ -99,6 +99,7 @@ impl BranchOwnershipClaims {
     }
 
     // modifies the ownership in-place and returns the file ownership that was taken, if any.
+    // TODO(ST): better pass the necessary parts of `ownership` for flexibility - saves allocations
     pub fn take(&mut self, ownership: &OwnershipClaim) -> Vec<OwnershipClaim> {
         let mut taken = Vec::new();
         let mut remaining = Vec::new();

--- a/crates/gitbutler-core/src/virtual_branches/virtual.rs
+++ b/crates/gitbutler-core/src/virtual_branches/virtual.rs
@@ -1923,14 +1923,12 @@ fn get_applied_status(
                 _ => vec![],
             };
 
-            virtual_branches[vbranch_pos]
-                .ownership
-                .put(&OwnershipClaim {
-                    file_path: filepath.clone(),
-                    hunks: vec![Hunk::from(&hunk)
-                        .with_timestamp(mtimes.mtime_by_path(filepath.as_path()))
-                        .with_hash(Hunk::hash_diff(hunk.diff_lines.as_ref()))],
-                });
+            virtual_branches[vbranch_pos].ownership.put(OwnershipClaim {
+                file_path: filepath.clone(),
+                hunks: vec![Hunk::from(&hunk)
+                    .with_timestamp(mtimes.mtime_by_path(filepath.as_path()))
+                    .with_hash(Hunk::hash_diff(hunk.diff_lines.as_ref()))],
+            });
 
             let hunk = match locked_to {
                 Some(locks) => hunk.with_locks(locks),
@@ -2064,7 +2062,7 @@ pub fn reset_branch(
         for hunk in filediff.hunks {
             let hash = Hunk::hash_diff(hunk.diff_lines.as_ref());
             branch.ownership.put(
-                &format!(
+                format!(
                     "{}:{}-{}-{:?}",
                     path.display(),
                     hunk.new_start,
@@ -3513,7 +3511,7 @@ pub fn move_commit(
                 })?;
 
         for ownership in ownerships_to_transfer {
-            destination_branch.ownership.put(&ownership);
+            destination_branch.ownership.put(ownership);
         }
 
         let new_destination_tree_oid = write_tree_onto_commit(
@@ -3654,7 +3652,7 @@ pub fn create_virtual_branch_from_branch(
         |mut ownership, (file_path, file)| {
             for hunk in &file.hunks {
                 ownership.put(
-                    &format!(
+                    format!(
                         "{}:{}",
                         file_path.display(),
                         VirtualBranchHunk::gen_id(hunk.new_start, hunk.new_lines)

--- a/crates/gitbutler-core/tests/virtual_branches/branch/file_ownership.rs
+++ b/crates/gitbutler-core/tests/virtual_branches/branch/file_ownership.rs
@@ -65,7 +65,7 @@ fn plus() {
         )
     })
     .for_each(|(a, b, expected)| {
-        let got = a.plus(&b);
+        let got = a.plus(b.clone());
         assert_eq!(
             got, expected,
             "{} plus {}, expected {}, got {}",

--- a/crates/gitbutler-core/tests/virtual_branches/branch/ownership.rs
+++ b/crates/gitbutler-core/tests/virtual_branches/branch/ownership.rs
@@ -154,7 +154,7 @@ fn put() {
     let mut ownership = "src/main.rs:0-100"
         .parse::<BranchOwnershipClaims>()
         .unwrap();
-    ownership.put(&"src/main.rs:200-300".parse::<OwnershipClaim>().unwrap());
+    ownership.put("src/main.rs:200-300".parse::<OwnershipClaim>().unwrap());
     assert_eq!(ownership.claims.len(), 1);
     assert_eq!(
         ownership.claims[0],
@@ -169,7 +169,7 @@ fn put_2() {
     let mut ownership = "src/main.rs:0-100"
         .parse::<BranchOwnershipClaims>()
         .unwrap();
-    ownership.put(&"src/main.rs2:200-300".parse::<OwnershipClaim>().unwrap());
+    ownership.put("src/main.rs2:200-300".parse::<OwnershipClaim>().unwrap());
     assert_eq!(ownership.claims.len(), 2);
     assert_eq!(
         ownership.claims[0],
@@ -186,7 +186,7 @@ fn put_3() {
     let mut ownership = "src/main.rs:0-100\nsrc/main2.rs:100-200"
         .parse::<BranchOwnershipClaims>()
         .unwrap();
-    ownership.put(&"src/main2.rs:200-300".parse::<OwnershipClaim>().unwrap());
+    ownership.put("src/main2.rs:200-300".parse::<OwnershipClaim>().unwrap());
     assert_eq!(ownership.claims.len(), 2);
     assert_eq!(
         ownership.claims[0],
@@ -205,7 +205,7 @@ fn put_4() {
     let mut ownership = "src/main.rs:0-100\nsrc/main2.rs:100-200"
         .parse::<BranchOwnershipClaims>()
         .unwrap();
-    ownership.put(&"src/main2.rs:100-200".parse::<OwnershipClaim>().unwrap());
+    ownership.put("src/main2.rs:100-200".parse::<OwnershipClaim>().unwrap());
     assert_eq!(ownership.claims.len(), 2);
     assert_eq!(
         ownership.claims[0],
@@ -222,7 +222,7 @@ fn put_7() {
     let mut ownership = "src/main.rs:100-200"
         .parse::<BranchOwnershipClaims>()
         .unwrap();
-    ownership.put(&"src/main.rs:100-200".parse::<OwnershipClaim>().unwrap());
+    ownership.put("src/main.rs:100-200".parse::<OwnershipClaim>().unwrap());
     assert_eq!(ownership.claims.len(), 1);
     assert_eq!(
         ownership.claims[0],

--- a/crates/gitbutler-git/src/repository.rs
+++ b/crates/gitbutler-git/src/repository.rs
@@ -105,10 +105,12 @@ where
         .to_string_lossy()
         .into_owned();
 
-    let askpath_stat = executor
-        .stat(&askpath_path)
-        .await
-        .map_err(Error::<E>::Exec)?;
+    let res = executor.stat(&askpath_path).await.map_err(Error::<E>::Exec);
+    debug_assert!(
+        res.is_ok(),
+        "Run `cargo build -p gitbutler-git` to get the binaries needed for this assertion to pass"
+    );
+    let askpath_stat = res?;
 
     #[cfg(unix)]
     let setsid_stat = executor


### PR DESCRIPTION
In virtual-branch code there are a lot of transformations happening, and often they clone even though
they wouldn't have to.

Try to see it through and update all transformations to move data is possible, avoiding a lot of allocations and
making the code's intend clearer.


### Tasks

* [x] remove TODO(ST) introduced earlier
* [x] mild ownership claim API improvements

### Note for the Reviewer

* There is probably a lot more of these opportunities, one would just have to look for `clone()`, but I limited myself to these parts.
* I consider this PR my leat impactful PRs thus far as it's more on principle, the improvements due to reduced allocations and earlier drops of memory have not been measured either. So it's mostly based on 'looking at code and thinking about it', which can be deceptive.
    - Generally, I'd hope that over time, more and more will get refactored, and once `gix` powers the diffing, I think that will happen naturally *and* will bring a decisive performance boost.
