### PR TITLE
windows improvements

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -225,4 +225,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
       - name: "cargo check"
-        run: cargo check --all --bins --examples
+        run: cargo check --all --bins --examples --features windows

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -63,6 +63,9 @@ features = [
     "window-unmaximize"
 ]
 
+[target."cfg(windows)".features]
+gitbutler-watcher = { workspace = true, features = ["adapt-to-windows"] }
+
 [lints.clippy]
 all = "deny"
 perf = "deny"
@@ -70,6 +73,8 @@ correctness = "deny"
 
 [features]
 default = ["custom-protocol", "sentry", "devtools"]
+## A forwarding to all crates that have windows-specific adjustments for testing on non-Windows.
+adapt-to-windows = ["gitbutler-watcher/adapt-to-windows"]
 devtools = ["tauri/devtools"]
 
 # this feature is used used for production builds where `devPath` points to the filesystem

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -63,9 +63,6 @@ features = [
     "window-unmaximize"
 ]
 
-[target."cfg(windows)".features]
-gitbutler-watcher = { workspace = true, features = ["adapt-to-windows"] }
-
 [lints.clippy]
 all = "deny"
 perf = "deny"
@@ -74,7 +71,7 @@ correctness = "deny"
 [features]
 default = ["custom-protocol", "sentry", "devtools"]
 ## A forwarding to all crates that have windows-specific adjustments for testing on non-Windows.
-adapt-to-windows = ["gitbutler-watcher/adapt-to-windows"]
+windows = ["gitbutler-watcher/windows"]
 devtools = ["tauri/devtools"]
 
 # this feature is used used for production builds where `devPath` points to the filesystem

--- a/crates/gitbutler-tauri/src/logs.rs
+++ b/crates/gitbutler-tauri/src/logs.rs
@@ -35,6 +35,7 @@ pub fn init(app_handle: &AppHandle) {
         .parse()
         .unwrap_or(LevelFilter::INFO);
 
+    let use_colors_in_logs = cfg!(not(feature = "adapt-to-windows"));
     let subscriber = tracing_subscriber::registry()
         .with(
             // subscriber for https://github.com/tokio-rs/console
@@ -49,6 +50,7 @@ pub fn init(app_handle: &AppHandle) {
             // subscriber that writes spans to stdout
             tracing_subscriber::fmt::layer()
                 .event_format(format_for_humans.clone())
+                .with_ansi(use_colors_in_logs)
                 .with_span_events(FmtSpan::CLOSE)
                 .with_filter(log_level_filter),
         )

--- a/crates/gitbutler-tauri/src/logs.rs
+++ b/crates/gitbutler-tauri/src/logs.rs
@@ -35,7 +35,7 @@ pub fn init(app_handle: &AppHandle) {
         .parse()
         .unwrap_or(LevelFilter::INFO);
 
-    let use_colors_in_logs = cfg!(not(feature = "adapt-to-windows"));
+    let use_colors_in_logs = cfg!(not(feature = "windows"));
     let subscriber = tracing_subscriber::registry()
         .with(
             // subscriber for https://github.com/tokio-rs/console

--- a/crates/gitbutler-watcher/Cargo.toml
+++ b/crates/gitbutler-watcher/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [features]
 default = []
 ## A trial to see if doing things differently on Windows helps with #3601
-adapt-to-windows = []
+windows = []
 
 [lib]
 doctest = false

--- a/crates/gitbutler-watcher/Cargo.toml
+++ b/crates/gitbutler-watcher/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[features]
+default = []
+## A trial to see if doing things differently on Windows helps with #3601
+adapt-to-windows = []
+
 [lib]
 doctest = false
 

--- a/crates/gitbutler-watcher/src/file_monitor.rs
+++ b/crates/gitbutler-watcher/src/file_monitor.rs
@@ -12,7 +12,11 @@ use tracing::Level;
 
 /// The timeout for debouncing file change events.
 /// This is used to prevent multiple events from being sent for a single file change.
-const DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(100);
+const DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(if cfg!(feature = "adapt-to-windows") {
+    2000
+} else {
+    100
+});
 
 /// This error is required only because `anyhow::Error` isn't implementing `std::error::Error`, and [`spawn()`]
 /// needs to wrap it into a `backoff::Error` which also has to implement the `Error` trait.
@@ -44,6 +48,10 @@ pub fn spawn(
     out: tokio::sync::mpsc::UnboundedSender<InternalEvent>,
 ) -> Result<()> {
     let (notify_tx, notify_rx) = std::sync::mpsc::channel();
+    tracing::info!(
+        "Starting filesystem monitor on {worktree_path:?} with debounce of {:02}s",
+        DEBOUNCE_TIMEOUT.as_secs_f32()
+    );
     let mut debouncer =
         new_debouncer(DEBOUNCE_TIMEOUT, None, notify_tx).context("failed to create debouncer")?;
 

--- a/crates/gitbutler-watcher/src/file_monitor.rs
+++ b/crates/gitbutler-watcher/src/file_monitor.rs
@@ -12,11 +12,8 @@ use tracing::Level;
 
 /// The timeout for debouncing file change events.
 /// This is used to prevent multiple events from being sent for a single file change.
-const DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(if cfg!(feature = "adapt-to-windows") {
-    2000
-} else {
-    100
-});
+const DEBOUNCE_TIMEOUT: Duration =
+    Duration::from_millis(if cfg!(feature = "windows") { 2000 } else { 100 });
 
 /// This error is required only because `anyhow::Error` isn't implementing `std::error::Error`, and [`spawn()`]
 /// needs to wrap it into a `backoff::Error` which also has to implement the `Error` trait.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -163,7 +163,11 @@ CONFIG_PATH=$(readlink -f "$PWD/../crates/gitbutler-tauri/tauri.conf.$CHANNEL.js
 # update the version in the tauri release config
 jq '.package.version="'"$VERSION"'"' "$CONFIG_PATH" >"$TMP_DIR/tauri.conf.json"
 
-FEATURES=""
+if [ "$OS" = "windows" ]; then
+  FEATURES="windows"
+else
+  FEATURES=""
+fi
 
 # build the app with release config
 SENTRY_RELEASE="$VERSION" tauri build \


### PR DESCRIPTION
This PR starts a Windows experiment that reduces the parallelism of the filesystem watcher, but it will also
reduce the snappiness of the UI.

Related to #3601 .

### Notes for the Reviewer

* Run with `LOG_LEVEL=debug pnpm tauri dev --features adapt-to-windows` to try the windows adaptations.