### PR TITLE
operation tonkotsu

### DIFF
--- a/app/src/lib/components/CommitCard.svelte
+++ b/app/src/lib/components/CommitCard.svelte
@@ -106,9 +106,11 @@
 	{/if}
 	<div class="commit__header" on:click={toggleFiles} on:keyup={onKeyup} role="button" tabindex="0">
 		<div class="commit__message">
+			{#if !showFiles}
 			<div class="commit__id">
 				<code>{commit.id.substring(0, 6)}</code>
 			</div>
+			{/if}
 			<div class="commit__row">
 				{#if isUndoable && !showFiles}
 					{#if commit.descriptionTitle}
@@ -308,7 +310,9 @@
 	}
 	.commit__edit_description textarea {
 		width: 100%;
-		padding: 5px 10px;
+		padding: 10px 14px;
+		margin: 0;
+		border-bottom: 1px solid #dddddd;
 	}
 
 	.commit__id {

--- a/app/src/lib/components/CommitCard.svelte
+++ b/app/src/lib/components/CommitCard.svelte
@@ -84,6 +84,9 @@
 	<div class="commit__header" on:click={toggleFiles} on:keyup={onKeyup} role="button" tabindex="0">
 		<div class="commit__message">
 			<div class="commit__row">
+				<code>{commit.id.substring(0, 6)}</code>
+			</div>
+			<div class="commit__row">
 				<span class="commit__title text-semibold text-base-12" class:truncate={!showFiles}>
 					{commit.descriptionTitle}
 				</span>

--- a/app/src/lib/components/CommitCard.svelte
+++ b/app/src/lib/components/CommitCard.svelte
@@ -133,7 +133,7 @@
 
 	{#if showFiles}
 		<div class="files-container" transition:slide={{ duration: 100 }}>
-			<BranchFilesList {files} {isUnapplied} readonly />
+			<BranchFilesList {files} {isUnapplied} />
 		</div>
 
 		{#if hasCommitUrl || isUndoable}

--- a/app/src/lib/components/CommitCard.svelte
+++ b/app/src/lib/components/CommitCard.svelte
@@ -47,6 +47,10 @@
 
 	function toggleFiles() {
 		showFiles = !showFiles;
+		if (!showFiles && branch) {
+			console.log("change description", description, commit.description);
+			branchController.updateCommitMessage(branch.id, commit.id, description);
+		}
 		if (showFiles) loadFiles();
 	}
 
@@ -67,6 +71,7 @@
 
 	const isUndoable = !isUnapplied;
 	const hasCommitUrl = !commit.isLocal && commitUrl;
+	let description = commit.description;
 </script>
 
 <div
@@ -78,16 +83,21 @@
 	class="commit"
 	class:is-commit-open={showFiles}
 >
+	{#if isUndoable && showFiles}
+		<div class="commit__edit_description">
+			<textarea bind:value={description} rows="{commit.description.split("\n").length + 1}"></textarea>
+		</div>
+	{/if}
 	<div class="commit__header" on:click={toggleFiles} on:keyup={onKeyup} role="button" tabindex="0">
 		<div class="commit__message">
-			<div class="commit__row">
+			<div class="commit__id">
 				<code>{commit.id.substring(0, 6)}</code>
 			</div>
 			<div class="commit__row">
+				{#if isUndoable && !showFiles}
 				<span class="commit__title text-semibold text-base-12" class:truncate={!showFiles}>
 					{commit.descriptionTitle}
 				</span>
-				{#if isUndoable && !showFiles}
 					<Tag
 						style="ghost"
 						kind="solid"
@@ -101,13 +111,6 @@
 					>
 				{/if}
 			</div>
-			{#if showFiles && commit.descriptionBody}
-				<div class="commit__row" transition:slide={{ duration: 100 }}>
-					<span class="commit__body text-base-body-12">
-						{commit.descriptionBody}
-					</span>
-				</div>
-			{/if}
 		</div>
 		<div class="commit__row">
 			<div class="commit__author">
@@ -235,6 +238,28 @@
 		display: flex;
 		align-items: center;
 		gap: var(--size-8);
+	}
+
+	.commit__edit_description {
+		width: 100%;
+	}
+	.commit__edit_description textarea {
+		width: 100%;
+		padding: 5px 10px;
+	}
+
+	.commit__id {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		margin-top: -14px;
+	}
+	.commit__id > code {
+		background-color: #eeeeee;
+		padding: 2px 12px;
+		color: #888888;
+		font-size: x-small;
+		border-radius: 0px 0px 6px 6px;
 	}
 
 	.commit__author {

--- a/app/src/lib/components/CommitCard.svelte
+++ b/app/src/lib/components/CommitCard.svelte
@@ -101,26 +101,33 @@
 >
 	{#if isUndoable && showFiles}
 		<div class="commit__edit_description">
-			<textarea placeholder="commit message here" bind:value={description} rows="{commit.description.split("\n").length + 1}"></textarea>
+			<textarea
+				placeholder="commit message here"
+				bind:value={description}
+				rows={commit.description.split('\n').length + 1}
+			></textarea>
 		</div>
 	{/if}
 	<div class="commit__header" on:click={toggleFiles} on:keyup={onKeyup} role="button" tabindex="0">
 		<div class="commit__message">
 			{#if !showFiles}
-			<div class="commit__id">
-				<code>{commit.id.substring(0, 6)}</code>
-			</div>
+				<div class="commit__id">
+					<code>{commit.id.substring(0, 6)}</code>
+				</div>
 			{/if}
 			<div class="commit__row">
 				{#if isUndoable && !showFiles}
 					{#if commit.descriptionTitle}
-					<span class="commit__title text-semibold text-base-12" class:truncate={!showFiles}>
+						<span class="commit__title text-semibold text-base-12" class:truncate={!showFiles}>
 							{commit.descriptionTitle}
-					</span>
+						</span>
 					{:else}
-					<span class="commit__title_no_desc text-zinc-400 text-base-12" class:truncate={!showFiles}>
-						<i>empty commit message</i>
-					</span>
+						<span
+							class="commit__title_no_desc text-base-12 text-zinc-400"
+							class:truncate={!showFiles}
+						>
+							<i>empty commit message</i>
+						</span>
 					{/if}
 					<Tag
 						style="ghost"

--- a/app/src/lib/components/CommitCard.svelte
+++ b/app/src/lib/components/CommitCard.svelte
@@ -48,7 +48,9 @@
 	function toggleFiles() {
 		showFiles = !showFiles;
 		if (!showFiles && branch) {
-			branchController.updateCommitMessage(branch.id, commit.id, description);
+			if (commit.description != description) {
+				branchController.updateCommitMessage(branch.id, commit.id, description);
+			}
 		}
 		if (showFiles) loadFiles();
 	}
@@ -73,6 +75,14 @@
 			return;
 		}
 		branchController.insertBlankCommit(branch.id, commit.id, offset);
+	}
+
+	function reorderCommit(commit: Commit | RemoteCommit, offset: number) {
+		if (!branch || !$baseBranch) {
+			console.error('Unable to move commit');
+			return;
+		}
+		branchController.reorderCommit(branch.id, commit.id, offset);
 	}
 
 	const isUndoable = !isUnapplied;
@@ -154,7 +164,24 @@
 					<Tag
 						style="ghost"
 						kind="solid"
-						icon="plus-small"
+						clickable
+						on:click={(e) => {
+							e.stopPropagation();
+							reorderCommit(commit, -1);
+						}}>Move Up</Tag
+					>
+					<Tag
+						style="ghost"
+						kind="solid"
+						clickable
+						on:click={(e) => {
+							e.stopPropagation();
+							reorderCommit(commit, 1);
+						}}>Move Down</Tag
+					>
+					<Tag
+						style="ghost"
+						kind="solid"
 						clickable
 						on:click={(e) => {
 							e.stopPropagation();
@@ -164,7 +191,6 @@
 					<Tag
 						style="ghost"
 						kind="solid"
-						icon="plus-small"
 						clickable
 						on:click={(e) => {
 							e.stopPropagation();

--- a/app/src/lib/components/CommitCard.svelte
+++ b/app/src/lib/components/CommitCard.svelte
@@ -56,19 +56,16 @@
 		}
 	}
 
-	function resetHeadCommit() {
+	function undoCommit(commit: Commit | RemoteCommit) {
 		if (!branch || !$baseBranch) {
-			console.error('Unable to reset head commit');
+			console.error('Unable to undo commit');
 			return;
 		}
-		if (branch.commits.length > 1) {
-			branchController.resetBranch(branch.id, branch.commits[1].id);
-		} else if (branch.commits.length === 1 && $baseBranch) {
-			branchController.resetBranch(branch.id, $baseBranch.baseSha);
-		}
+		console.log("undo commit", commit);
+		branchController.undoCommit(branch.id, commit.id);
 	}
 
-	const isUndoable = isHeadCommit && !isUnapplied;
+	const isUndoable = !isUnapplied;
 	const hasCommitUrl = !commit.isLocal && commitUrl;
 </script>
 
@@ -99,7 +96,7 @@
 						on:click={(e) => {
 							currentCommitMessage.set(commit.description);
 							e.stopPropagation();
-							resetHeadCommit();
+							undoCommit(commit);
 						}}>Undo</Tag
 					>
 				{/if}
@@ -147,7 +144,7 @@
 						on:click={(e) => {
 							currentCommitMessage.set(commit.description);
 							e.stopPropagation();
-							resetHeadCommit();
+							undoCommit(commit);
 						}}>Undo</Tag
 					>
 				{/if}

--- a/app/src/lib/components/CommitListItem.svelte
+++ b/app/src/lib/components/CommitListItem.svelte
@@ -6,7 +6,7 @@
 	import { dropzone } from '$lib/dragging/dropzone';
 	import { getContext, getContextStore } from '$lib/utils/context';
 	import { BranchController } from '$lib/vbranches/branchController';
-	import { filesToOwnership } from '$lib/vbranches/ownership';
+	import { filesToOwnership, filesToSimpleOwnership } from '$lib/vbranches/ownership';
 	import { RemoteCommit, Branch, type Commit, BaseBranch, LocalFile, RemoteFile } from '$lib/vbranches/types';
 
 	export let commit: Commit | RemoteCommit;
@@ -43,21 +43,28 @@
 	}
 
 	function onAmend(commit: Commit | RemoteCommit) {
-		return (data: DraggableCommit) => {
+		return (data: any) => {
 			console.log(commit);
 			console.log(data);
+			console.log(data.commit);
+			console.log(data.commit?.id);
 			if (data instanceof DraggableHunk) {
 				const newOwnership = `${data.hunk.filePath}:${data.hunk.id}`;
 				branchController.amendBranch($branch.id, commit.id, newOwnership);
 			} else if (data instanceof DraggableFile) {
 				if (data.file instanceof LocalFile) {
 					const newOwnership = filesToOwnership(data.files);
+					console.log(newOwnership);
 					branchController.amendBranch($branch.id, commit.id, newOwnership);
 				} else if (data.file instanceof RemoteFile) {
 					console.log(data.files);
 					console.log(commit.id);
 					console.log(data);
-					branchController.moveCommitFile($branch.id, commit.id, '');
+					const newOwnership = filesToSimpleOwnership(data.files);
+					console.log(newOwnership);
+					if (data.commit) {
+						branchController.moveCommitFile($branch.id, data.commit.id, commit.id, newOwnership);
+					}
 				}
 			}
 		}

--- a/app/src/lib/components/CommitListItem.svelte
+++ b/app/src/lib/components/CommitListItem.svelte
@@ -32,11 +32,6 @@
 				return false;
 			}
 
-			// only allow to amend the head commit
-			if (commit.id != $branch.commits.at(0)?.id) {
-				return false;
-			}
-
 			if (data instanceof DraggableHunk && data.branchId == $branch.id) {
 				return true;
 			} else if (data instanceof DraggableFile && data.branchId == $branch.id) {
@@ -47,13 +42,17 @@
 		};
 	}
 
-	function onAmend(data: DraggableFile | DraggableHunk) {
-		if (data instanceof DraggableHunk) {
-			const newOwnership = `${data.hunk.filePath}:${data.hunk.id}`;
-			branchController.amendBranch($branch.id, newOwnership);
-		} else if (data instanceof DraggableFile) {
-			const newOwnership = filesToOwnership(data.files);
-			branchController.amendBranch($branch.id, newOwnership);
+	function onAmend(commit: Commit | RemoteCommit) {
+		return (data: DraggableCommit) => {
+			console.log(commit);
+			console.log(data);
+			if (data instanceof DraggableHunk) {
+				const newOwnership = `${data.hunk.filePath}:${data.hunk.id}`;
+				branchController.amendBranch($branch.id, commit.id, newOwnership);
+			} else if (data instanceof DraggableFile) {
+				const newOwnership = filesToOwnership(data.files);
+				branchController.amendBranch($branch.id, commit.id, newOwnership);
+			}
 		}
 	}
 
@@ -104,7 +103,7 @@
 			active: 'amend-dz-active',
 			hover: 'amend-dz-hover',
 			accepts: acceptAmend(commit),
-			onDrop: onAmend
+			onDrop: onAmend(commit)
 		}}
 		use:dropzone={{
 			active: 'squash-dz-active',

--- a/app/src/lib/components/CommitListItem.svelte
+++ b/app/src/lib/components/CommitListItem.svelte
@@ -7,7 +7,7 @@
 	import { getContext, getContextStore } from '$lib/utils/context';
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { filesToOwnership } from '$lib/vbranches/ownership';
-	import { RemoteCommit, Branch, type Commit, BaseBranch } from '$lib/vbranches/types';
+	import { RemoteCommit, Branch, type Commit, BaseBranch, LocalFile, RemoteFile } from '$lib/vbranches/types';
 
 	export let commit: Commit | RemoteCommit;
 	export let isHeadCommit: boolean;
@@ -50,8 +50,15 @@
 				const newOwnership = `${data.hunk.filePath}:${data.hunk.id}`;
 				branchController.amendBranch($branch.id, commit.id, newOwnership);
 			} else if (data instanceof DraggableFile) {
-				const newOwnership = filesToOwnership(data.files);
-				branchController.amendBranch($branch.id, commit.id, newOwnership);
+				if (data.file instanceof LocalFile) {
+					const newOwnership = filesToOwnership(data.files);
+					branchController.amendBranch($branch.id, commit.id, newOwnership);
+				} else if (data.file instanceof RemoteFile) {
+					console.log(data.files);
+					console.log(commit.id);
+					console.log(data);
+					branchController.moveCommitFile($branch.id, commit.id, '');
+				}
 			}
 		}
 	}

--- a/app/src/lib/components/CommitListItem.svelte
+++ b/app/src/lib/components/CommitListItem.svelte
@@ -7,7 +7,14 @@
 	import { getContext, getContextStore } from '$lib/utils/context';
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { filesToOwnership, filesToSimpleOwnership } from '$lib/vbranches/ownership';
-	import { RemoteCommit, Branch, type Commit, BaseBranch, LocalFile, RemoteFile } from '$lib/vbranches/types';
+	import {
+		RemoteCommit,
+		Branch,
+		type Commit,
+		BaseBranch,
+		LocalFile,
+		RemoteFile
+	} from '$lib/vbranches/types';
 
 	export let commit: Commit | RemoteCommit;
 	export let isHeadCommit: boolean;
@@ -67,7 +74,7 @@
 					}
 				}
 			}
-		}
+		};
 	}
 
 	function acceptSquash(commit: Commit | RemoteCommit) {

--- a/app/src/lib/components/FileListItem.svelte
+++ b/app/src/lib/components/FileListItem.svelte
@@ -111,7 +111,7 @@
 			}
 		}}
 		use:draggable={{
-			data: new DraggableFile($branch?.id || '', file, selectedFiles),
+			data: new DraggableFile($branch?.id || '', file, $commit, selectedFiles),
 			disabled: readonly || isUnapplied,
 			viewportId: 'board-viewport',
 			selector: '.selected-draggable'

--- a/app/src/lib/dragging/draggables.ts
+++ b/app/src/lib/dragging/draggables.ts
@@ -18,7 +18,7 @@ export class DraggableHunk {
 export class DraggableFile {
 	constructor(
 		public readonly branchId: string,
-		private file: AnyFile,
+		public file: AnyFile,
 		private selection: Readable<AnyFile[]> | undefined
 	) {}
 

--- a/app/src/lib/dragging/draggables.ts
+++ b/app/src/lib/dragging/draggables.ts
@@ -1,5 +1,5 @@
 import { get, type Readable } from 'svelte/store';
-import type { AnyFile, Commit, Hunk, RemoteCommit } from '../vbranches/types';
+import type { AnyCommit, AnyFile, Commit, Hunk, RemoteCommit } from '../vbranches/types';
 
 export function nonDraggable() {
 	return {
@@ -19,6 +19,7 @@ export class DraggableFile {
 	constructor(
 		public readonly branchId: string,
 		public file: AnyFile,
+		public commit: AnyCommit | undefined,
 		private selection: Readable<AnyFile[]> | undefined
 	) {}
 

--- a/app/src/lib/vbranches/branchController.ts
+++ b/app/src/lib/vbranches/branchController.ts
@@ -293,11 +293,12 @@ export class BranchController {
 		}
 	}
 
-	async amendBranch(branchId: string, ownership: string) {
+	async amendBranch(branchId: string, commitOid: string, ownership: string) {
 		try {
 			await invoke<void>('amend_virtual_branch', {
 				projectId: this.projectId,
 				branchId,
+				commitOid,
 				ownership
 			});
 		} catch (err: any) {

--- a/app/src/lib/vbranches/branchController.ts
+++ b/app/src/lib/vbranches/branchController.ts
@@ -331,6 +331,19 @@ export class BranchController {
 		}
 	}
 
+	async updateCommitMessage(branchId: string, commitOid: string, message: string) {
+		try {
+			await invoke<void>('update_commit_message', {
+				projectId: this.projectId,
+				branchId,
+				commitOid,
+				message,
+			});
+		} catch (err: any) {
+			showError('Failed to change commit message', err);
+		}
+	}
+
 	async moveCommit(targetBranchId: string, commitOid: string) {
 		try {
 			await invoke<void>('move_commit', {

--- a/app/src/lib/vbranches/branchController.ts
+++ b/app/src/lib/vbranches/branchController.ts
@@ -319,6 +319,18 @@ export class BranchController {
 		}
 	}
 
+	async undoCommit(branchId: string, commitOid: string) {
+		try {
+			await invoke<void>('undo_commit', {
+				projectId: this.projectId,
+				branchId,
+				commitOid,
+			});
+		} catch (err: any) {
+			showError('Failed to amend commit', err);
+		}
+	}
+
 	async moveCommit(targetBranchId: string, commitOid: string) {
 		try {
 			await invoke<void>('move_commit', {

--- a/app/src/lib/vbranches/branchController.ts
+++ b/app/src/lib/vbranches/branchController.ts
@@ -344,6 +344,19 @@ export class BranchController {
 		}
 	}
 
+	async insertBlankCommit(branchId: string, commitOid: string, offset: number) {
+		try {
+			await invoke<void>('insert_blank_commit', {
+				projectId: this.projectId,
+				branchId,
+				commitOid,
+				offset,
+			});
+		} catch (err: any) {
+			showError('Failed to insert blank commit', err);
+		}
+	}
+
 	async moveCommit(targetBranchId: string, commitOid: string) {
 		try {
 			await invoke<void>('move_commit', {

--- a/app/src/lib/vbranches/branchController.ts
+++ b/app/src/lib/vbranches/branchController.ts
@@ -306,6 +306,19 @@ export class BranchController {
 		}
 	}
 
+	async moveCommitFile(branchId: string, commitOid: string, ownership: string) {
+		try {
+			await invoke<void>('move_commit_file', {
+				projectId: this.projectId,
+				branchId,
+				commitOid,
+				ownership
+			});
+		} catch (err: any) {
+			showError('Failed to amend commit', err);
+		}
+	}
+
 	async moveCommit(targetBranchId: string, commitOid: string) {
 		try {
 			await invoke<void>('move_commit', {

--- a/app/src/lib/vbranches/branchController.ts
+++ b/app/src/lib/vbranches/branchController.ts
@@ -306,12 +306,13 @@ export class BranchController {
 		}
 	}
 
-	async moveCommitFile(branchId: string, commitOid: string, ownership: string) {
+	async moveCommitFile(branchId: string, fromCommitOid: string, toCommitOid: string, ownership: string) {
 		try {
 			await invoke<void>('move_commit_file', {
 				projectId: this.projectId,
 				branchId,
-				commitOid,
+				fromCommitOid,
+				toCommitOid,
 				ownership
 			});
 		} catch (err: any) {

--- a/app/src/lib/vbranches/branchController.ts
+++ b/app/src/lib/vbranches/branchController.ts
@@ -306,7 +306,12 @@ export class BranchController {
 		}
 	}
 
-	async moveCommitFile(branchId: string, fromCommitOid: string, toCommitOid: string, ownership: string) {
+	async moveCommitFile(
+		branchId: string,
+		fromCommitOid: string,
+		toCommitOid: string,
+		ownership: string
+	) {
 		try {
 			await invoke<void>('move_commit_file', {
 				projectId: this.projectId,
@@ -325,7 +330,7 @@ export class BranchController {
 			await invoke<void>('undo_commit', {
 				projectId: this.projectId,
 				branchId,
-				commitOid,
+				commitOid
 			});
 		} catch (err: any) {
 			showError('Failed to amend commit', err);
@@ -338,7 +343,7 @@ export class BranchController {
 				projectId: this.projectId,
 				branchId,
 				commitOid,
-				message,
+				message
 			});
 		} catch (err: any) {
 			showError('Failed to change commit message', err);
@@ -351,7 +356,7 @@ export class BranchController {
 				projectId: this.projectId,
 				branchId,
 				commitOid,
-				offset,
+				offset
 			});
 		} catch (err: any) {
 			showError('Failed to insert blank commit', err);
@@ -364,7 +369,7 @@ export class BranchController {
 				projectId: this.projectId,
 				branchId,
 				commitOid,
-				offset,
+				offset
 			});
 		} catch (err: any) {
 			showError('Failed to reorder blank commit', err);

--- a/app/src/lib/vbranches/branchController.ts
+++ b/app/src/lib/vbranches/branchController.ts
@@ -357,6 +357,19 @@ export class BranchController {
 		}
 	}
 
+	async reorderCommit(branchId: string, commitOid: string, offset: number) {
+		try {
+			await invoke<void>('reorder_commit', {
+				projectId: this.projectId,
+				branchId,
+				commitOid,
+				offset,
+			});
+		} catch (err: any) {
+			showError('Failed to reorder blank commit', err);
+		}
+	}
+
 	async moveCommit(targetBranchId: string, commitOid: string) {
 		try {
 			await invoke<void>('move_commit', {

--- a/app/src/lib/vbranches/ownership.ts
+++ b/app/src/lib/vbranches/ownership.ts
@@ -1,8 +1,14 @@
-import type { Branch, AnyFile, Hunk, RemoteHunk } from './types';
+import type { Branch, AnyFile, Hunk, RemoteHunk, RemoteFile } from './types';
 
 export function filesToOwnership(files: AnyFile[]) {
 	return files
 		.map((f) => `${f.path}:${f.hunks.map(({ id, hash }) => `${id}-${hash}`).join(',')}`)
+		.join('\n');
+}
+
+export function filesToSimpleOwnership(files: RemoteFile[]) {
+	return files
+		.map((f) => `${f.path}:${f.hunks.map(({ new_start, new_lines }) => `${new_start}-${new_start + new_lines}`).join(',')}`)
 		.join('\n');
 }
 

--- a/app/src/lib/vbranches/ownership.ts
+++ b/app/src/lib/vbranches/ownership.ts
@@ -8,7 +8,10 @@ export function filesToOwnership(files: AnyFile[]) {
 
 export function filesToSimpleOwnership(files: RemoteFile[]) {
 	return files
-		.map((f) => `${f.path}:${f.hunks.map(({ new_start, new_lines }) => `${new_start}-${new_start + new_lines}`).join(',')}`)
+		.map(
+			(f) =>
+				`${f.path}:${f.hunks.map(({ new_start, new_lines }) => `${new_start}-${new_start + new_lines}`).join(',')}`
+		)
 		.join('\n');
 }
 

--- a/app/src/lib/vbranches/types.ts
+++ b/app/src/lib/vbranches/types.ts
@@ -212,6 +212,8 @@ export const UNKNOWN_COMMITS = Symbol('UnknownCommits');
 export class RemoteHunk {
 	diff!: string;
 	hash?: string;
+	new_start!: number;
+	new_lines!: number;
 
 	get id(): string {
 		return hashCode(this.diff);

--- a/app/src/lib/vbranches/types.ts
+++ b/app/src/lib/vbranches/types.ts
@@ -24,6 +24,8 @@ export class Hunk {
 	locked!: boolean;
 	lockedTo!: string[] | undefined;
 	changeType!: ChangeType;
+	new_start!: number;
+	new_lines!: number;
 }
 
 export type AnyFile = LocalFile | RemoteFile;

--- a/crates/gitbutler-core/src/virtual_branches/controller.rs
+++ b/crates/gitbutler-core/src/virtual_branches/controller.rs
@@ -225,11 +225,12 @@ impl Controller {
         &self,
         project_id: &ProjectId,
         branch_id: &BranchId,
+        commit_oid: git::Oid,
         ownership: &BranchOwnershipClaims,
     ) -> Result<git::Oid, Error> {
         self.inner(project_id)
             .await
-            .amend(project_id, branch_id, ownership)
+            .amend(project_id, branch_id, commit_oid, ownership)
             .await
     }
 
@@ -643,12 +644,13 @@ impl ControllerInner {
         &self,
         project_id: &ProjectId,
         branch_id: &BranchId,
+        commit_oid: git::Oid,
         ownership: &BranchOwnershipClaims,
     ) -> Result<git::Oid, Error> {
         let _permit = self.semaphore.acquire().await;
 
         self.with_verify_branch(project_id, |project_repository, _| {
-            super::amend(project_repository, branch_id, ownership).map_err(Into::into)
+            super::amend(project_repository, branch_id, commit_oid, ownership).map_err(Into::into)
         })
     }
 

--- a/crates/gitbutler-core/src/virtual_branches/controller.rs
+++ b/crates/gitbutler-core/src/virtual_branches/controller.rs
@@ -234,6 +234,18 @@ impl Controller {
             .await
     }
 
+    pub async fn undo_commit(
+        &self,
+        project_id: &ProjectId,
+        branch_id: &BranchId,
+        commit_oid: git::Oid,
+    ) -> Result<(), Error> {
+        self.inner(project_id)
+            .await
+            .undo_commit(project_id, branch_id, commit_oid)
+            .await
+    }
+
     pub async fn reset_virtual_branch(
         &self,
         project_id: &ProjectId,
@@ -651,6 +663,19 @@ impl ControllerInner {
 
         self.with_verify_branch(project_id, |project_repository, _| {
             super::amend(project_repository, branch_id, commit_oid, ownership).map_err(Into::into)
+        })
+    }
+
+    pub async fn undo_commit(
+        &self,
+        project_id: &ProjectId,
+        branch_id: &BranchId,
+        commit_oid: git::Oid,
+    ) -> Result<(), Error> {
+        let _permit = self.semaphore.acquire().await;
+
+        self.with_verify_branch(project_id, |project_repository, _| {
+            super::undo_commit(project_repository, branch_id, commit_oid).map_err(Into::into)
         })
     }
 

--- a/crates/gitbutler-core/src/virtual_branches/controller.rs
+++ b/crates/gitbutler-core/src/virtual_branches/controller.rs
@@ -259,6 +259,19 @@ impl Controller {
             .await
     }
 
+    pub async fn reorder_commit(
+        &self,
+        project_id: &ProjectId,
+        branch_id: &BranchId,
+        commit_oid: git::Oid,
+        offset: i32,
+    ) -> Result<(), Error> {
+        self.inner(project_id)
+            .await
+            .reorder_commit(project_id, branch_id, commit_oid, offset)
+            .await
+    }
+
     pub async fn reset_virtual_branch(
         &self,
         project_id: &ProjectId,
@@ -703,6 +716,21 @@ impl ControllerInner {
 
         self.with_verify_branch(project_id, |project_repository, user| {
             super::insert_blank_commit(project_repository, branch_id, commit_oid, user, offset)
+                .map_err(Into::into)
+        })
+    }
+
+    pub async fn reorder_commit(
+        &self,
+        project_id: &ProjectId,
+        branch_id: &BranchId,
+        commit_oid: git::Oid,
+        offset: i32,
+    ) -> Result<(), Error> {
+        let _permit = self.semaphore.acquire().await;
+
+        self.with_verify_branch(project_id, |project_repository, user| {
+            super::reorder_commit(project_repository, branch_id, commit_oid, user, offset)
                 .map_err(Into::into)
         })
     }

--- a/crates/gitbutler-core/src/virtual_branches/controller.rs
+++ b/crates/gitbutler-core/src/virtual_branches/controller.rs
@@ -246,6 +246,19 @@ impl Controller {
             .await
     }
 
+    pub async fn insert_blank_commit(
+        &self,
+        project_id: &ProjectId,
+        branch_id: &BranchId,
+        commit_oid: git::Oid,
+        offset: i32,
+    ) -> Result<(), Error> {
+        self.inner(project_id)
+            .await
+            .insert_blank_commit(project_id, branch_id, commit_oid, offset)
+            .await
+    }
+
     pub async fn reset_virtual_branch(
         &self,
         project_id: &ProjectId,
@@ -676,6 +689,21 @@ impl ControllerInner {
 
         self.with_verify_branch(project_id, |project_repository, _| {
             super::undo_commit(project_repository, branch_id, commit_oid).map_err(Into::into)
+        })
+    }
+
+    pub async fn insert_blank_commit(
+        &self,
+        project_id: &ProjectId,
+        branch_id: &BranchId,
+        commit_oid: git::Oid,
+        offset: i32,
+    ) -> Result<(), Error> {
+        let _permit = self.semaphore.acquire().await;
+
+        self.with_verify_branch(project_id, |project_repository, user| {
+            super::insert_blank_commit(project_repository, branch_id, commit_oid, user, offset)
+                .map_err(Into::into)
         })
     }
 

--- a/crates/gitbutler-core/src/virtual_branches/controller.rs
+++ b/crates/gitbutler-core/src/virtual_branches/controller.rs
@@ -234,6 +234,26 @@ impl Controller {
             .await
     }
 
+    pub async fn move_commit_file(
+        &self,
+        project_id: &ProjectId,
+        branch_id: &BranchId,
+        from_commit_oid: git::Oid,
+        to_commit_oid: git::Oid,
+        ownership: &BranchOwnershipClaims,
+    ) -> Result<git::Oid, Error> {
+        self.inner(project_id)
+            .await
+            .move_commit_file(
+                project_id,
+                branch_id,
+                from_commit_oid,
+                to_commit_oid,
+                ownership,
+            )
+            .await
+    }
+
     pub async fn undo_commit(
         &self,
         project_id: &ProjectId,
@@ -689,6 +709,28 @@ impl ControllerInner {
 
         self.with_verify_branch(project_id, |project_repository, _| {
             super::amend(project_repository, branch_id, commit_oid, ownership).map_err(Into::into)
+        })
+    }
+
+    pub async fn move_commit_file(
+        &self,
+        project_id: &ProjectId,
+        branch_id: &BranchId,
+        from_commit_oid: git::Oid,
+        to_commit_oid: git::Oid,
+        ownership: &BranchOwnershipClaims,
+    ) -> Result<git::Oid, Error> {
+        let _permit = self.semaphore.acquire().await;
+
+        self.with_verify_branch(project_id, |project_repository, _| {
+            super::move_commit_file(
+                project_repository,
+                branch_id,
+                from_commit_oid,
+                to_commit_oid,
+                ownership,
+            )
+            .map_err(Into::into)
         })
     }
 

--- a/crates/gitbutler-core/src/virtual_branches/controller.rs
+++ b/crates/gitbutler-core/src/virtual_branches/controller.rs
@@ -771,8 +771,8 @@ impl ControllerInner {
     ) -> Result<(), Error> {
         let _permit = self.semaphore.acquire().await;
 
-        self.with_verify_branch(project_id, |project_repository, user| {
-            super::reorder_commit(project_repository, branch_id, commit_oid, user, offset)
+        self.with_verify_branch(project_id, |project_repository, _| {
+            super::reorder_commit(project_repository, branch_id, commit_oid, offset)
                 .map_err(Into::into)
         })
     }

--- a/crates/gitbutler-core/src/virtual_branches/errors.rs
+++ b/crates/gitbutler-core/src/virtual_branches/errors.rs
@@ -367,43 +367,6 @@ impl ForcePushNotAllowed {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum AmendError {
-    #[error("force push not allowed")]
-    ForcePushNotAllowed(ForcePushNotAllowed),
-    #[error("target ownership not found")]
-    TargetOwnerhshipNotFound(BranchOwnershipClaims),
-    #[error("branch has no commits")]
-    BranchHasNoCommits,
-    #[error("default target not set")]
-    DefaultTargetNotSet(DefaultTargetNotSet),
-    #[error("branch not found")]
-    BranchNotFound(BranchNotFound),
-    #[error("project is in conflict state")]
-    Conflict(ProjectConflict),
-    #[error(transparent)]
-    Other(#[from] anyhow::Error),
-}
-
-impl ErrorWithContext for AmendError {
-    fn context(&self) -> Option<Context> {
-        Some(match self {
-            AmendError::ForcePushNotAllowed(ctx) => ctx.to_context(),
-            AmendError::Conflict(ctx) => ctx.to_context(),
-            AmendError::BranchNotFound(ctx) => ctx.to_context(),
-            AmendError::BranchHasNoCommits => error::Context::new_static(
-                Code::Branches,
-                "Branch has no commits - there is nothing to amend to",
-            ),
-            AmendError::DefaultTargetNotSet(ctx) => ctx.to_context(),
-            AmendError::TargetOwnerhshipNotFound(_) => {
-                error::Context::new_static(Code::Branches, "target ownership not found")
-            }
-            AmendError::Other(error) => return error.custom_context_or_root_cause().into(),
-        })
-    }
-}
-
-#[derive(Debug, thiserror::Error)]
 pub enum CherryPickError {
     #[error("target commit {0} not found ")]
     CommitNotFound(git::Oid),

--- a/crates/gitbutler-core/src/virtual_branches/virtual.rs
+++ b/crates/gitbutler-core/src/virtual_branches/virtual.rs
@@ -2671,6 +2671,13 @@ pub fn is_virtual_branch_mergeable(
     Ok(is_mergeable)
 }
 
+// this function takes a list of file ownership from a "from" commit and "moves"
+// those changes to a "to" commit in a branch. This allows users to drag changes
+// from one commit to another.
+// if the "to" commit is below the "from" commit, the changes are simply added to the "to" commit
+// and the rebase should be simple. if the "to" commit is above the "from" commit,
+// the changes need to be removed from the "from" commit, everything rebased,
+// then added to the "to" commit and everything above that rebased again.
 pub fn move_commit_file(
     project_repository: &project_repository::Repository,
     branch_id: &BranchId,
@@ -2695,22 +2702,24 @@ pub fn move_commit_file(
             })
         })?;
 
-    // see if we're moving up or down
     let mut to_amend_oid = to_commit_oid.clone();
     let mut amend_commit = project_repository
         .git_repository
         .find_commit(to_amend_oid)
         .context("failed to find commit")?;
 
+    // find all the commits upstream from the target "to" commit
     let mut upstream_commits = project_repository.l(
         target_branch.head,
         project_repository::LogUntil::Commit(amend_commit.id()),
     )?;
 
+    // get a list of all the diffs across all the virtual branches
     let base_file_diffs = diff::workdir(&project_repository.git_repository, &default_target.sha)
         .context("failed to diff workdir")?;
 
     // filter base_file_diffs to HashMap<filepath, Vec<GitHunk>> only for hunks in target_ownership
+    // this is essentially the group of patches that we're "moving"
     let diffs_to_amend = target_ownership
         .claims
         .iter()
@@ -2739,6 +2748,7 @@ pub fn move_commit_file(
         })
         .collect::<HashMap<_, _>>();
 
+    // if we're not moving anything, return an error
     if diffs_to_amend.is_empty() {
         return Err(errors::VirtualBranchError::TargetOwnerhshipNotFound(
             target_ownership.clone(),
@@ -2747,16 +2757,24 @@ pub fn move_commit_file(
 
     // is from_commit_oid in upstream_commits?
     if !upstream_commits.contains(&from_commit_oid) {
-        // get diffs introduced in from_commit_oid
+        // this means that the "from" commit is _below_ the "to" commit in the history
+        // which makes things a little more complicated because in this case we need to
+        // remove the changes from the lower "from" commit, rebase everything, then add the changes
+        // to the _rebased_ version of the "to" commit that is above it.
+
+        // first, let's get the from commit data and it's parent data
         let from_commit = project_repository
             .git_repository
             .find_commit(from_commit_oid)
             .context("failed to find commit")?;
-
         let from_tree = from_commit.tree().context("failed to find tree")?;
         let from_parent = from_commit.parent(0).context("failed to find parent")?;
         let from_parent_tree = from_parent.tree().context("failed to find parent tree")?;
 
+        // ok, what is the entire patch introduced in the "from" commit?
+        // we need to remove the parts of this patch that are in target_ownership (the parts we're moving)
+        // and then apply the rest to the parent tree of the "from" commit to
+        // create the new "from" commit without the changes we're moving
         let from_commit_diffs = diff::trees(
             &project_repository.git_repository,
             &from_parent_tree,
@@ -2765,6 +2783,7 @@ pub fn move_commit_file(
         .context("failed to diff trees")?;
 
         // filter from_commit_diffs to HashMap<filepath, Vec<GitHunk>> only for hunks NOT in target_ownership
+        // this is the patch parts we're keeping
         let diffs_to_keep = from_commit_diffs
             .iter()
             .filter_map(|(filepath, file_diff)| {
@@ -2792,6 +2811,7 @@ pub fn move_commit_file(
 
         let repo = &project_repository.git_repository;
 
+        // write our new tree and commit for the new "from" commit without the moved changes
         let new_from_tree_oid =
             write_tree_onto_commit(project_repository, from_parent.id(), &diffs_to_keep)?;
         let new_from_tree = &repo.find_tree(new_from_tree_oid).or_else(|_error| {
@@ -2799,7 +2819,6 @@ pub fn move_commit_file(
                 new_from_tree_oid,
             ));
         })?;
-
         let new_from_commit_oid = repo
             .commit(
                 None,
@@ -2813,6 +2832,7 @@ pub fn move_commit_file(
                 return Err(errors::VirtualBranchError::CommitFailed);
             })?;
 
+        // rebase everything above the new "from" commit that has the moved changes removed
         let new_head = match cherry_rebase(
             project_repository,
             new_from_commit_oid,
@@ -2825,6 +2845,9 @@ pub fn move_commit_file(
             }
         };
 
+        // ok, now we need to identify which the new "to" commit is in the rebased history
+        // so we'll take a list of the upstream oids and find it simply based on location
+        // (since the order should not have changed in our simple rebase)
         let old_upstream_commit_oids = project_repository.l(
             target_branch.head,
             project_repository::LogUntil::Commit(default_target.sha),
@@ -2843,34 +2866,39 @@ pub fn move_commit_file(
                 "failed to find commit in old commits"
             )))?;
 
-        // find the commit with that offset in the new_upstream_commits vector
+        // find the new "to" commit in our new rebased upstream commits
         to_amend_oid = *new_upstream_commit_oids.get(to_commit_offset).ok_or(
             errors::VirtualBranchError::Other(anyhow!("failed to find commit in new commits")),
         )?;
 
-        // reset these for writing the second part
+        // reset the "to" commit variable for writing the changes back to
         amend_commit = project_repository
             .git_repository
             .find_commit(to_amend_oid)
             .context("failed to find commit")?;
 
+        // reset the concept of what the upstream commits are to be the rebased ones
         upstream_commits = project_repository.l(
             new_head,
             project_repository::LogUntil::Commit(amend_commit.id()),
         )?;
     }
 
+    // ok, now we will apply the moved changes to the "to" commit.
+    // if we were moving the changes down, we didn't need to rewrite the "from" commit
+    // because it will be rewritten with the upcoming rebase.
+    // if we were moving the changes "up" we've already rewritten the "from" commit
+
     // apply diffs_to_amend to the commit tree
+    // and write a new commit with the changes we're moving
     let new_tree_oid = write_tree_onto_commit(project_repository, to_amend_oid, &diffs_to_amend)?;
     let new_tree = project_repository
         .git_repository
         .find_tree(new_tree_oid)
         .context("failed to find new tree")?;
-
     let parents = amend_commit
         .parents()
         .context("failed to find head commit parents")?;
-
     let commit_oid = project_repository
         .git_repository
         .commit(
@@ -2885,7 +2913,7 @@ pub fn move_commit_file(
 
     // now rebase upstream commits, if needed
 
-    // if there are no upstream commits, we're done
+    // if there are no upstream commits (the "to" commit was the branch head), then we're done
     if upstream_commits.is_empty() {
         target_branch.head = commit_oid;
         vb_state.set_branch(target_branch.clone())?;
@@ -2893,8 +2921,8 @@ pub fn move_commit_file(
         return Ok(commit_oid);
     }
 
+    // otherwise, rebase the upstream commits onto the new commit
     let last_commit = upstream_commits.first().cloned().unwrap();
-
     let new_head = cherry_rebase(
         project_repository,
         commit_oid,
@@ -2902,6 +2930,7 @@ pub fn move_commit_file(
         last_commit,
     )?;
 
+    // if that rebase worked, update the branch head and the gitbutler integration
     if let Some(new_head) = new_head {
         target_branch.head = new_head;
         vb_state.set_branch(target_branch.clone())?;
@@ -2912,6 +2941,9 @@ pub fn move_commit_file(
     }
 }
 
+// takes a list of file ownership and a commit oid and rewrites that commit to
+// add the file changes. The branch is then rebased onto the new commit
+// and the respective branch head is updated
 pub fn amend(
     project_repository: &project_repository::Repository,
     branch_id: &BranchId,
@@ -3096,6 +3128,10 @@ pub fn amend(
     }
 }
 
+// move a given commit in a branch up one or down one
+// if the offset is positive, move the commit down one
+// if the offset is negative, move the commit up one
+// rewrites the branch head to the new head commit
 pub fn reorder_commit(
     project_repository: &project_repository::Repository,
     branch_id: &BranchId,
@@ -3199,6 +3235,9 @@ pub fn reorder_commit(
     return Ok(());
 }
 
+// create and insert a blank commit (no tree change) either above or below a commit
+// if offset is positive, insert below, if negative, insert above
+// return the oid of the new head commit of the branch with the inserted blank commit
 pub fn insert_blank_commit(
     project_repository: &project_repository::Repository,
     branch_id: &BranchId,
@@ -3266,6 +3305,8 @@ pub fn insert_blank_commit(
     return Ok(());
 }
 
+// remove a commit in a branch by rebasing all commits _except_ for it onto it's parent
+// if successful, it will update the branch head to the new head commit
 pub fn undo_commit(
     project_repository: &project_repository::Repository,
     branch_id: &BranchId,
@@ -3298,7 +3339,7 @@ pub fn undo_commit(
         // if commit is not the head, rebase all commits above it onto it's parent
         let parent_commit_oid = commit.parent(0).context("failed to find parent")?.id();
 
-        match simple_rebase(
+        match cherry_rebase(
             project_repository,
             parent_commit_oid,
             commit_oid,
@@ -3308,7 +3349,7 @@ pub fn undo_commit(
                 new_commit_oid = new_head;
             }
             _ => {
-                return Ok(());
+                return Err(errors::VirtualBranchError::RebaseFailed);
             }
         }
     }
@@ -3327,6 +3368,8 @@ pub fn undo_commit(
 }
 
 // cherry-pick based rebase, which handles empty commits
+// this function takes a commit range and generates a Vector of commit oids
+// and then passes them to `cherry_rebase_group` to rebase them onto the target commit
 pub fn cherry_rebase(
     project_repository: &project_repository::Repository,
     target_commit_oid: git::Oid,
@@ -3349,6 +3392,10 @@ pub fn cherry_rebase(
     return Ok(new_head_id);
 }
 
+// takes a vector of commit oids and rebases them onto a target commit and returns the
+// new head commit oid if it's successful
+// the difference between this and a libgit2 based rebase is that this will successfully
+// rebase empty commits (two commits with identical trees)
 fn cherry_rebase_group(
     project_repository: &project_repository::Repository,
     target_commit_oid: git::Oid,
@@ -3413,6 +3460,8 @@ fn cherry_rebase_group(
     return Ok(Some(new_head_id));
 }
 
+// runs a simple libgit2 based in-memory rebase on a commit range onto a target commit
+// possibly not used in favor of cherry_rebase
 pub fn simple_rebase(
     project_repository: &project_repository::Repository,
     target_commit_oid: git::Oid,

--- a/crates/gitbutler-core/tests/suite/virtual_branches/amend.rs
+++ b/crates/gitbutler-core/tests/suite/virtual_branches/amend.rs
@@ -1,38 +1,6 @@
 use super::*;
 
 #[tokio::test]
-async fn to_default_target() {
-    let Test {
-        repository,
-        project_id,
-        controller,
-        ..
-    } = &Test::default();
-
-    controller
-        .set_base_branch(project_id, &"refs/remotes/origin/master".parse().unwrap())
-        .await
-        .unwrap();
-
-    let branch_id = controller
-        .create_virtual_branch(project_id, &branch::BranchCreateRequest::default())
-        .await
-        .unwrap();
-
-    // amend without head commit
-    fs::write(repository.path().join("file2.txt"), "content").unwrap();
-    let to_amend: branch::BranchOwnershipClaims = "file2.txt:1-2".parse().unwrap();
-    assert!(matches!(
-        controller
-            .amend(project_id, &branch_id, &to_amend)
-            .await
-            .unwrap_err()
-            .downcast_ref(),
-        Some(&errors::AmendError::BranchHasNoCommits)
-    ));
-}
-
-#[tokio::test]
 async fn forcepush_allowed() {
     let Test {
         repository,
@@ -70,14 +38,12 @@ async fn forcepush_allowed() {
         .await
         .unwrap();
 
-    {
-        // create commit
-        fs::write(repository.path().join("file.txt"), "content").unwrap();
-        controller
-            .create_commit(project_id, &branch_id, "commit one", None, false)
-            .await
-            .unwrap();
-    };
+    // create commit
+    fs::write(repository.path().join("file.txt"), "content").unwrap();
+    let commit_id = controller
+        .create_commit(project_id, &branch_id, "commit one", None, false)
+        .await
+        .unwrap();
 
     controller
         .push_virtual_branch(project_id, &branch_id, false, None)
@@ -89,7 +55,7 @@ async fn forcepush_allowed() {
         fs::write(repository.path().join("file2.txt"), "content2").unwrap();
         let to_amend: branch::BranchOwnershipClaims = "file2.txt:1-2".parse().unwrap();
         controller
-            .amend(project_id, &branch_id, &to_amend)
+            .amend(project_id, &branch_id, commit_id, &to_amend)
             .await
             .unwrap();
 
@@ -137,14 +103,12 @@ async fn forcepush_forbidden() {
         .await
         .unwrap();
 
-    {
-        // create commit
-        fs::write(repository.path().join("file.txt"), "content").unwrap();
-        controller
-            .create_commit(project_id, &branch_id, "commit one", None, false)
-            .await
-            .unwrap();
-    };
+    // create commit
+    fs::write(repository.path().join("file.txt"), "content").unwrap();
+    let commit_oid = controller
+        .create_commit(project_id, &branch_id, "commit one", None, false)
+        .await
+        .unwrap();
 
     controller
         .push_virtual_branch(project_id, &branch_id, false, None)
@@ -156,7 +120,7 @@ async fn forcepush_forbidden() {
         let to_amend: branch::BranchOwnershipClaims = "file2.txt:1-2".parse().unwrap();
         assert!(matches!(
             controller
-                .amend(project_id, &branch_id, &to_amend)
+                .amend(project_id, &branch_id, commit_oid, &to_amend)
                 .await
                 .unwrap_err()
                 .downcast_ref(),
@@ -184,33 +148,31 @@ async fn non_locked_hunk() {
         .await
         .unwrap();
 
-    {
-        // create commit
-        fs::write(repository.path().join("file.txt"), "content").unwrap();
-        controller
-            .create_commit(project_id, &branch_id, "commit one", None, false)
-            .await
-            .unwrap();
+    // create commit
+    fs::write(repository.path().join("file.txt"), "content").unwrap();
+    let commit_oid = controller
+        .create_commit(project_id, &branch_id, "commit one", None, false)
+        .await
+        .unwrap();
 
-        let branch = controller
-            .list_virtual_branches(project_id)
-            .await
-            .unwrap()
-            .0
-            .into_iter()
-            .find(|b| b.id == branch_id)
-            .unwrap();
-        assert_eq!(branch.commits.len(), 1);
-        assert_eq!(branch.files.len(), 0);
-        assert_eq!(branch.commits[0].files.len(), 1);
-    };
+    let branch = controller
+        .list_virtual_branches(project_id)
+        .await
+        .unwrap()
+        .0
+        .into_iter()
+        .find(|b| b.id == branch_id)
+        .unwrap();
+    assert_eq!(branch.commits.len(), 1);
+    assert_eq!(branch.files.len(), 0);
+    assert_eq!(branch.commits[0].files.len(), 1);
 
     {
         // amend another hunk
         fs::write(repository.path().join("file2.txt"), "content2").unwrap();
         let to_amend: branch::BranchOwnershipClaims = "file2.txt:1-2".parse().unwrap();
         controller
-            .amend(project_id, &branch_id, &to_amend)
+            .amend(project_id, &branch_id, commit_oid, &to_amend)
             .await
             .unwrap();
 
@@ -247,37 +209,35 @@ async fn locked_hunk() {
         .await
         .unwrap();
 
-    {
-        // create commit
-        fs::write(repository.path().join("file.txt"), "content").unwrap();
-        controller
-            .create_commit(project_id, &branch_id, "commit one", None, false)
-            .await
-            .unwrap();
+    // create commit
+    fs::write(repository.path().join("file.txt"), "content").unwrap();
+    let commit_oid = controller
+        .create_commit(project_id, &branch_id, "commit one", None, false)
+        .await
+        .unwrap();
 
-        let branch = controller
-            .list_virtual_branches(project_id)
-            .await
-            .unwrap()
-            .0
-            .into_iter()
-            .find(|b| b.id == branch_id)
-            .unwrap();
-        assert_eq!(branch.commits.len(), 1);
-        assert_eq!(branch.files.len(), 0);
-        assert_eq!(branch.commits[0].files.len(), 1);
-        assert_eq!(
-            branch.commits[0].files[0].hunks[0].diff,
-            "@@ -0,0 +1 @@\n+content\n\\ No newline at end of file\n"
-        );
-    };
+    let branch = controller
+        .list_virtual_branches(project_id)
+        .await
+        .unwrap()
+        .0
+        .into_iter()
+        .find(|b| b.id == branch_id)
+        .unwrap();
+    assert_eq!(branch.commits.len(), 1);
+    assert_eq!(branch.files.len(), 0);
+    assert_eq!(branch.commits[0].files.len(), 1);
+    assert_eq!(
+        branch.commits[0].files[0].hunks[0].diff,
+        "@@ -0,0 +1 @@\n+content\n\\ No newline at end of file\n"
+    );
 
     {
         // amend another hunk
         fs::write(repository.path().join("file.txt"), "more content").unwrap();
         let to_amend: branch::BranchOwnershipClaims = "file.txt:1-2".parse().unwrap();
         controller
-            .amend(project_id, &branch_id, &to_amend)
+            .amend(project_id, &branch_id, commit_oid, &to_amend)
             .await
             .unwrap();
 
@@ -319,33 +279,31 @@ async fn non_existing_ownership() {
         .await
         .unwrap();
 
-    {
-        // create commit
-        fs::write(repository.path().join("file.txt"), "content").unwrap();
-        controller
-            .create_commit(project_id, &branch_id, "commit one", None, false)
-            .await
-            .unwrap();
+    // create commit
+    fs::write(repository.path().join("file.txt"), "content").unwrap();
+    let commit_oid = controller
+        .create_commit(project_id, &branch_id, "commit one", None, false)
+        .await
+        .unwrap();
 
-        let branch = controller
-            .list_virtual_branches(project_id)
-            .await
-            .unwrap()
-            .0
-            .into_iter()
-            .find(|b| b.id == branch_id)
-            .unwrap();
-        assert_eq!(branch.commits.len(), 1);
-        assert_eq!(branch.files.len(), 0);
-        assert_eq!(branch.commits[0].files.len(), 1);
-    };
+    let branch = controller
+        .list_virtual_branches(project_id)
+        .await
+        .unwrap()
+        .0
+        .into_iter()
+        .find(|b| b.id == branch_id)
+        .unwrap();
+    assert_eq!(branch.commits.len(), 1);
+    assert_eq!(branch.files.len(), 0);
+    assert_eq!(branch.commits[0].files.len(), 1);
 
     {
         // amend non existing hunk
         let to_amend: branch::BranchOwnershipClaims = "file2.txt:1-2".parse().unwrap();
         assert!(matches!(
             controller
-                .amend(project_id, &branch_id, &to_amend)
+                .amend(project_id, &branch_id, commit_oid, &to_amend)
                 .await
                 .unwrap_err()
                 .downcast_ref(),

--- a/crates/gitbutler-core/tests/suite/virtual_branches/amend.rs
+++ b/crates/gitbutler-core/tests/suite/virtual_branches/amend.rs
@@ -124,7 +124,7 @@ async fn forcepush_forbidden() {
                 .await
                 .unwrap_err()
                 .downcast_ref(),
-            Some(errors::AmendError::ForcePushNotAllowed(_))
+            Some(errors::VirtualBranchError::ForcePushNotAllowed(_))
         ));
     }
 }
@@ -307,7 +307,7 @@ async fn non_existing_ownership() {
                 .await
                 .unwrap_err()
                 .downcast_ref(),
-            Some(errors::AmendError::TargetOwnerhshipNotFound(_))
+            Some(errors::VirtualBranchError::TargetOwnerhshipNotFound(_))
         ));
     }
 }

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -255,6 +255,7 @@ fn main() {
                     virtual_branches::commands::reset_virtual_branch,
                     virtual_branches::commands::cherry_pick_onto_virtual_branch,
                     virtual_branches::commands::amend_virtual_branch,
+                    virtual_branches::commands::move_commit_file,
                     virtual_branches::commands::undo_commit,
                     virtual_branches::commands::insert_blank_commit,
                     virtual_branches::commands::reorder_commit,

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -256,6 +256,7 @@ fn main() {
                     virtual_branches::commands::cherry_pick_onto_virtual_branch,
                     virtual_branches::commands::amend_virtual_branch,
                     virtual_branches::commands::undo_commit,
+                    virtual_branches::commands::insert_blank_commit,
                     virtual_branches::commands::update_commit_message,
                     virtual_branches::commands::list_remote_branches,
                     virtual_branches::commands::get_remote_branch_data,

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -257,6 +257,7 @@ fn main() {
                     virtual_branches::commands::amend_virtual_branch,
                     virtual_branches::commands::undo_commit,
                     virtual_branches::commands::insert_blank_commit,
+                    virtual_branches::commands::reorder_commit,
                     virtual_branches::commands::update_commit_message,
                     virtual_branches::commands::list_remote_branches,
                     virtual_branches::commands::get_remote_branch_data,

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -256,6 +256,7 @@ fn main() {
                     virtual_branches::commands::cherry_pick_onto_virtual_branch,
                     virtual_branches::commands::amend_virtual_branch,
                     virtual_branches::commands::undo_commit,
+                    virtual_branches::commands::update_commit_message,
                     virtual_branches::commands::list_remote_branches,
                     virtual_branches::commands::get_remote_branch_data,
                     virtual_branches::commands::squash_branch_commit,

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -255,6 +255,7 @@ fn main() {
                     virtual_branches::commands::reset_virtual_branch,
                     virtual_branches::commands::cherry_pick_onto_virtual_branch,
                     virtual_branches::commands::amend_virtual_branch,
+                    virtual_branches::commands::undo_commit,
                     virtual_branches::commands::list_remote_branches,
                     virtual_branches::commands::get_remote_branch_data,
                     virtual_branches::commands::squash_branch_commit,

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -462,6 +462,8 @@ pub mod commands {
         Ok(())
     }
 
+    #[tauri::command(async)]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn update_commit_message(
         handle: tauri::AppHandle,
         project_id: ProjectId,

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -363,6 +363,22 @@ pub mod commands {
 
     #[tauri::command(async)]
     #[instrument(skip(handle), err(Debug))]
+    pub async fn undo_commit(
+        handle: AppHandle,
+        project_id: ProjectId,
+        branch_id: BranchId,
+        commit_oid: git::Oid,
+    ) -> Result<(), Error> {
+        let oid = handle
+            .state::<Controller>()
+            .undo_commit(&project_id, &branch_id, commit_oid)
+            .await?;
+        emit_vbranches(&handle, &project_id).await;
+        Ok(oid)
+    }
+
+    #[tauri::command(async)]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn list_remote_branches(
         handle: tauri::AppHandle,
         project_id: ProjectId,

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -379,6 +379,23 @@ pub mod commands {
 
     #[tauri::command(async)]
     #[instrument(skip(handle), err(Debug))]
+    pub async fn insert_blank_commit(
+        handle: AppHandle,
+        project_id: ProjectId,
+        branch_id: BranchId,
+        commit_oid: git::Oid,
+        offset: i32,
+    ) -> Result<(), Error> {
+        let oid = handle
+            .state::<Controller>()
+            .insert_blank_commit(&project_id, &branch_id, commit_oid, offset)
+            .await?;
+        emit_vbranches(&handle, &project_id).await;
+        Ok(oid)
+    }
+
+    #[tauri::command(async)]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn list_remote_branches(
         handle: tauri::AppHandle,
         project_id: ProjectId,

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -350,11 +350,12 @@ pub mod commands {
         handle: AppHandle,
         project_id: ProjectId,
         branch_id: BranchId,
+        commit_oid: git::Oid,
         ownership: BranchOwnershipClaims,
     ) -> Result<git::Oid, Error> {
         let oid = handle
             .state::<Controller>()
-            .amend(&project_id, &branch_id, &ownership)
+            .amend(&project_id, &branch_id, commit_oid, &ownership)
             .await?;
         emit_vbranches(&handle, &project_id).await;
         Ok(oid)

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -363,6 +363,30 @@ pub mod commands {
 
     #[tauri::command(async)]
     #[instrument(skip(handle), err(Debug))]
+    pub async fn move_commit_file(
+        handle: AppHandle,
+        project_id: ProjectId,
+        branch_id: BranchId,
+        from_commit_oid: git::Oid,
+        to_commit_oid: git::Oid,
+        ownership: BranchOwnershipClaims,
+    ) -> Result<git::Oid, Error> {
+        let oid = handle
+            .state::<Controller>()
+            .move_commit_file(
+                &project_id,
+                &branch_id,
+                from_commit_oid,
+                to_commit_oid,
+                &ownership,
+            )
+            .await?;
+        emit_vbranches(&handle, &project_id).await;
+        Ok(oid)
+    }
+
+    #[tauri::command(async)]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn undo_commit(
         handle: AppHandle,
         project_id: ProjectId,

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -396,6 +396,23 @@ pub mod commands {
 
     #[tauri::command(async)]
     #[instrument(skip(handle), err(Debug))]
+    pub async fn reorder_commit(
+        handle: AppHandle,
+        project_id: ProjectId,
+        branch_id: BranchId,
+        commit_oid: git::Oid,
+        offset: i32,
+    ) -> Result<(), Error> {
+        let oid = handle
+            .state::<Controller>()
+            .reorder_commit(&project_id, &branch_id, commit_oid, offset)
+            .await?;
+        emit_vbranches(&handle, &project_id).await;
+        Ok(oid)
+    }
+
+    #[tauri::command(async)]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn list_remote_branches(
         handle: tauri::AppHandle,
         project_id: ProjectId,


### PR DESCRIPTION
This is an experiment in creating the operations needed to work in a more Jujutsu like manner. You can:

* Reword commit messages
* Insert blank commits
* Drag uncommitted work to any commit
* Drag committed file work to any other commit
* Reorder commits

Still need to:

- [ ] fix the error messaging
- [ ] add tests
- [ ] possibly deal with conflicts a little better