### PR TITLE
Revert 74eb7bd3 as debounce-timing has no effect (#3601)

### DIFF
--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -71,7 +71,7 @@ correctness = "deny"
 [features]
 default = ["custom-protocol", "sentry", "devtools"]
 ## A forwarding to all crates that have windows-specific adjustments for testing on non-Windows.
-windows = ["gitbutler-watcher/windows"]
+windows = []
 devtools = ["tauri/devtools"]
 
 # this feature is used used for production builds where `devPath` points to the filesystem

--- a/crates/gitbutler-watcher/Cargo.toml
+++ b/crates/gitbutler-watcher/Cargo.toml
@@ -4,11 +4,6 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
-[features]
-default = []
-## A trial to see if doing things differently on Windows helps with #3601
-windows = []
-
 [lib]
 doctest = false
 

--- a/crates/gitbutler-watcher/src/file_monitor.rs
+++ b/crates/gitbutler-watcher/src/file_monitor.rs
@@ -12,8 +12,7 @@ use tracing::Level;
 
 /// The timeout for debouncing file change events.
 /// This is used to prevent multiple events from being sent for a single file change.
-const DEBOUNCE_TIMEOUT: Duration =
-    Duration::from_millis(if cfg!(feature = "windows") { 2000 } else { 100 });
+const DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(100);
 
 /// This error is required only because `anyhow::Error` isn't implementing `std::error::Error`, and [`spawn()`]
 /// needs to wrap it into a `backoff::Error` which also has to implement the `Error` trait.
@@ -45,10 +44,6 @@ pub fn spawn(
     out: tokio::sync::mpsc::UnboundedSender<InternalEvent>,
 ) -> Result<()> {
     let (notify_tx, notify_rx) = std::sync::mpsc::channel();
-    tracing::info!(
-        "Starting filesystem monitor on {worktree_path:?} with debounce of {:02}s",
-        DEBOUNCE_TIMEOUT.as_secs_f32()
-    );
     let mut debouncer =
         new_debouncer(DEBOUNCE_TIMEOUT, None, notify_tx).context("failed to create debouncer")?;
 


### PR DESCRIPTION
This probably means the raciness is not due concurrency introduced by filesystem events, which leads me to think that having great 'disk-IO-hygiene` should improve things.'

Related to #3601 .