### PR TITLE
Surface warning if hunk locked to multiple branches

### DIFF
--- a/app/src/lib/components/FileDiff.svelte
+++ b/app/src/lib/components/FileDiff.svelte
@@ -55,7 +55,7 @@
 					<div class="indicators text-base-11">
 						<span class="added">+{added}</span>
 						<span class="removed">-{removed}</span>
-						{#if section.hunk.lockedTo && commits}
+						{#if section.hunk.lockedTo && section.hunk.lockedTo.length > 0 && commits}
 							<div
 								use:tooltip={{
 									text: getLockText(section.hunk.lockedTo, commits),

--- a/app/src/lib/vbranches/tooltip.ts
+++ b/app/src/lib/vbranches/tooltip.ts
@@ -1,15 +1,17 @@
+import { HunkLock, type Commit } from './types';
 import { unique } from '$lib/utils/filters';
-import type { Commit } from './types';
 
-export function getLockText(commitId: string[] | string, commits: Commit[]): string {
-	if (!commitId || commits === undefined) return 'Depends on a committed change';
+export function getLockText(hunkLocks: HunkLock | HunkLock[] | string, commits: Commit[]): string {
+	if (!hunkLocks || commits === undefined) return 'Depends on a committed change';
 
-	const lockedIds = typeof commitId == 'string' ? [commitId] : (commitId as string[]);
+	const locks = hunkLocks instanceof HunkLock ? [hunkLocks] : (hunkLocks as HunkLock[]);
 
-	const descriptions = lockedIds
+	const descriptions = locks
 		.filter(unique)
-		.map((id) => {
-			const commit = commits.find((commit) => commit.id == id);
+		.map((lock) => {
+			const commit = commits.find((commit) => {
+				commit.id == lock.commitId;
+			});
 			const shortCommitId = commit?.id.slice(0, 7);
 			if (commit) {
 				const shortTitle = commit.descriptionTitle?.slice(0, 35) + '...';
@@ -19,5 +21,13 @@ export function getLockText(commitId: string[] | string, commits: Commit[]): str
 			}
 		})
 		.join('\n');
-	return 'Locked due to dependency on:\n' + descriptions;
+	const branchCount = locks.map((lock) => lock.branchId).filter(unique).length;
+	if (branchCount > 1) {
+		return (
+			'Warning, undefined behavior due to lock on multiple branches!\n\n' +
+			'Locked because changes depend on:\n' +
+			descriptions
+		);
+	}
+	return 'Locked because changes depend on:\n' + descriptions;
 }

--- a/app/src/lib/vbranches/tooltip.ts
+++ b/app/src/lib/vbranches/tooltip.ts
@@ -9,8 +9,8 @@ export function getLockText(hunkLocks: HunkLock | HunkLock[] | string, commits: 
 	const descriptions = locks
 		.filter(unique)
 		.map((lock) => {
-			const commit = commits.find((commit) => {
-				commit.id == lock.commitId;
+			const commit = commits.find((c) => {
+				return c.id == lock.commitId;
 			});
 			const shortCommitId = commit?.id.slice(0, 7);
 			if (commit) {

--- a/app/src/lib/vbranches/types.ts
+++ b/app/src/lib/vbranches/types.ts
@@ -22,8 +22,14 @@ export class Hunk {
 	filePath!: string;
 	hash?: string;
 	locked!: boolean;
-	lockedTo!: string[] | undefined;
+	@Type(() => HunkLock)
+	lockedTo!: HunkLock[];
 	changeType!: ChangeType;
+}
+
+export class HunkLock {
+	branchId!: string;
+	commitId!: string;
 }
 
 export type AnyFile = LocalFile | RemoteFile;
@@ -63,7 +69,7 @@ export class LocalFile {
 			: false;
 	}
 
-	get lockedIds(): string[] {
+	get lockedIds(): HunkLock[] {
 		return this.hunks
 			.flatMap((hunk) => hunk.lockedTo)
 			.filter(notNull)
@@ -252,7 +258,7 @@ export class RemoteFile {
 		return this.hunks.map((h) => h.id);
 	}
 
-	get lockedIds(): string[] {
+	get lockedIds(): HunkLock[] {
 		return [];
 	}
 

--- a/crates/gitbutler-core/src/git/diff.rs
+++ b/crates/gitbutler-core/src/git/diff.rs
@@ -53,7 +53,7 @@ pub struct GitHunk {
     #[serde(rename = "diff", serialize_with = "crate::serde::as_string_lossy")]
     pub diff_lines: BString,
     pub binary: bool,
-    pub locked_to: Box<[git::Oid]>,
+    pub locked_to: Box<[HunkLock]>,
     pub change_type: ChangeType,
 }
 
@@ -95,10 +95,20 @@ impl GitHunk {
         self.new_start <= line && self.new_start + self.new_lines >= line
     }
 
-    pub fn with_locks(mut self, locks: &[git::Oid]) -> Self {
+    pub fn with_locks(mut self, locks: &[HunkLock]) -> Self {
         self.locked_to = locks.to_owned().into();
         self
     }
+}
+
+// A hunk is locked when it depends on changes in commits that are in your
+// workspace. A hunk can be locked to more than one branch if it overlaps
+// with more than one committed hunk.
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Copy)]
+#[serde(rename_all = "camelCase")]
+pub struct HunkLock {
+    pub branch_id: uuid::Uuid,
+    pub commit_id: git::Oid,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Default)]

--- a/crates/gitbutler-core/src/virtual_branches/branch/hunk.rs
+++ b/crates/gitbutler-core/src/virtual_branches/branch/hunk.rs
@@ -3,7 +3,7 @@ use std::{fmt::Display, ops::RangeInclusive, str::FromStr};
 use anyhow::{anyhow, Context, Result};
 use bstr::{BStr, ByteSlice};
 
-use crate::git::{self, diff};
+use crate::git::diff;
 
 pub type HunkHash = md5::Digest;
 
@@ -13,7 +13,7 @@ pub struct Hunk {
     pub timestamp_ms: Option<u128>,
     pub start: u32,
     pub end: u32,
-    pub locked_to: Vec<git::Oid>,
+    pub locked_to: Vec<diff::HunkLock>,
 }
 
 impl From<&diff::GitHunk> for Hunk {

--- a/crates/gitbutler-core/tests/suite/virtual_branches/create_commit.rs
+++ b/crates/gitbutler-core/tests/suite/virtual_branches/create_commit.rs
@@ -282,6 +282,7 @@ async fn should_double_lock() {
 
 // This test only validates that locks are detected across virtual branches, it does
 // not make any assertions about how said hunk is handled or what branch owns it.
+// TODO(mg): Figure out why we can't reduce line count down to three?
 #[tokio::test]
 async fn should_double_lock_across_branches() {
     let Test {
@@ -291,7 +292,7 @@ async fn should_double_lock_across_branches() {
         ..
     } = &Test::default();
 
-    let mut lines = gen_file(repository, "file.txt", 7);
+    let mut lines = gen_file(repository, "file.txt", 5);
     commit_and_push_initial(repository);
 
     controller
@@ -327,7 +328,7 @@ async fn should_double_lock_across_branches() {
         .await
         .unwrap();
 
-    lines[6] = "change 2".to_string();
+    lines[4] = "change 2".to_string();
     write_file(repository, "file.txt", &lines);
 
     let commit_2 = controller
@@ -335,7 +336,7 @@ async fn should_double_lock_across_branches() {
         .await
         .unwrap();
 
-    lines[3] = "change3".to_string();
+    lines[2] = "change3".to_string();
     write_file(repository, "file.txt", &lines);
 
     let branch_1 = get_virtual_branch(controller, project_id, branch_1_id).await;


### PR DESCRIPTION
- now returning `HunkLock` to front end
- detect if locked to more than one branch and warn user
- verifies branch ids in test `should_double_lock_across_branches`