### PR TITLE
sync-all on Windows

### DIFF
--- a/crates/gitbutler-core/src/fs.rs
+++ b/crates/gitbutler-core/src/fs.rs
@@ -87,7 +87,12 @@ fn persist_tempfile(
     to_path: impl AsRef<Path>,
 ) -> std::io::Result<()> {
     match tempfile.persist(to_path) {
-        Ok(Some(_opened_file)) => Ok(()),
+        Ok(Some(_opened_file)) => {
+            // EXPERIMENT: Does this fix #3601?
+            #[cfg(windows)]
+            _opened_file.sync_all()?;
+            Ok(())
+        }
         Ok(None) => unreachable!(
             "BUG: a signal has caused the tempfile to be removed, but we didn't install a handler"
         ),

--- a/crates/gitbutler-core/src/snapshots/reflog.rs
+++ b/crates/gitbutler-core/src/snapshots/reflog.rs
@@ -1,8 +1,7 @@
-use crate::storage;
+use crate::fs::write;
 use anyhow::Result;
-use gix::tempfile::{AutoRemove, ContainingDirectory};
 use itertools::Itertools;
-use std::{io::Write, path::PathBuf};
+use std::path::PathBuf;
 
 use crate::projects::Project;
 
@@ -64,7 +63,7 @@ fn set_target_ref(file_path: &PathBuf, sha: &str) -> Result<()> {
     let binding = first_line.join(" ");
     lines[0] = &binding;
     let content = format!("{}\n", lines.join("\n"));
-    write(file_path, &content)
+    write(file_path, content)
 }
 
 fn set_oplog_ref(file_path: &PathBuf, sha: &str) -> Result<()> {
@@ -83,17 +82,5 @@ fn set_oplog_ref(file_path: &PathBuf, sha: &str) -> Result<()> {
     let second_line = [target_ref, sha, &the_rest].join(" ");
 
     let content = format!("{}\n", [first_line, &second_line].join("\n"));
-    write(file_path, &content)
-}
-
-fn write(file_path: &PathBuf, content: &str) -> Result<()> {
-    let mut temp_file = gix::tempfile::new(
-        file_path.parent().unwrap(),
-        ContainingDirectory::Exists,
-        AutoRemove::Tempfile,
-    )?;
-    temp_file.write_all(content.as_bytes())?;
-    storage::persist_tempfile(temp_file, file_path)?;
-
-    Ok(())
+    write(file_path, content)
 }

--- a/crates/gitbutler-core/src/snapshots/state.rs
+++ b/crates/gitbutler-core/src/snapshots/state.rs
@@ -1,9 +1,7 @@
-use crate::storage;
 use anyhow::Result;
-use gix::tempfile::{AutoRemove, ContainingDirectory};
 use std::{
     fs::File,
-    io::{Read, Write},
+    io::Read,
     path::{Path, PathBuf},
 };
 
@@ -71,11 +69,5 @@ impl OplogHandle {
 
 fn write<P: AsRef<Path>>(file_path: P, oplog: &Oplog) -> anyhow::Result<()> {
     let contents = toml::to_string(&oplog)?;
-    let mut temp_file = gix::tempfile::new(
-        file_path.as_ref().parent().unwrap(),
-        ContainingDirectory::Exists,
-        AutoRemove::Tempfile,
-    )?;
-    temp_file.write_all(contents.as_bytes())?;
-    Ok(storage::persist_tempfile(temp_file, file_path)?)
+    crate::fs::write(file_path, contents)
 }

--- a/crates/gitbutler-core/src/virtual_branches/state.rs
+++ b/crates/gitbutler-core/src/virtual_branches/state.rs
@@ -1,12 +1,10 @@
-use gix::tempfile::{AutoRemove, ContainingDirectory};
 use std::{
     collections::HashMap,
     fs::File,
-    io::{Read, Write},
+    io::Read,
     path::{Path, PathBuf},
 };
 
-use crate::storage;
 use serde::{Deserialize, Serialize};
 
 use super::{target::Target, Branch};
@@ -152,12 +150,5 @@ impl VirtualBranchesHandle {
 }
 
 fn write<P: AsRef<Path>>(file_path: P, virtual_branches: &VirtualBranches) -> anyhow::Result<()> {
-    let contents = toml::to_string(&virtual_branches)?;
-    let mut temp_file = gix::tempfile::new(
-        file_path.as_ref().parent().unwrap(),
-        ContainingDirectory::Exists,
-        AutoRemove::Tempfile,
-    )?;
-    temp_file.write_all(contents.as_bytes())?;
-    Ok(storage::persist_tempfile(temp_file, file_path)?)
+    crate::fs::write(file_path, toml::to_string(&virtual_branches)?)
 }


### PR DESCRIPTION
After a file was moved into place on Windows, it's possible to call `sync_all`  on Windows to force it to arrive for good,
at least so we hope.
If it works, the access-denied errors should go away (#3601), for now.

Thanks a lot, @daniilS, for suggesting to try this!

If it doesn't turn out to be effective, it appears we can always go back to the previous version of the code until more
flags could be tried, and possible submit a patch upstream eventually. 

But even if it is effective, it introduces an extra syscall on Windows [which shouldn't be required](https://github.com/gitbutlerapp/gitbutler/issues/3601#issuecomment-2079594949),
so ultimately the effectiveness of such an improvement in `tempfile` will have to be verified and then submitted upstream.
