### PR TITLE
Fix annoying inconsistency in normalizeBranchName

### DIFF
--- a/app/src/lib/utils/branch.ts
+++ b/app/src/lib/utils/branch.ts
@@ -1,3 +1,3 @@
 export function normalizeBranchName(value: string) {
-	return value.toLowerCase().replace(/[^0-9a-z/_.]+/g, '-');
+	return value.replace(/[^0-9a-z/_.]+/g, '-');
 }


### PR DESCRIPTION
Both the rust code and typescript code have a normalization function, but the rust code doesn't lowercase the name.