### PR TITLE
fix: `.branch-switcher` styling in dark mode

### DIFF
--- a/app/src/lib/components/Board.svelte
+++ b/app/src/lib/components/Board.svelte
@@ -354,9 +354,9 @@
 	.branch-switcher {
 		margin-top: 8px;
 		padding: 8px;
-		background-color: #f5f5f5;
+		background-color: var(--clr-bg-2);
 		border-width: 1px;
-		border-color: #888888;
+		border-color: var(--clr-border-2);
 		border-radius: 4px;
 	}
 


### PR DESCRIPTION
Fixes a minor issue with the branch switcher not respecting Dark Mode

## Before
![image](https://github.com/gitbutlerapp/gitbutler/assets/16451892/bf164002-aeb8-4dd9-b4c6-1dda41394a8c)


## After
![image](https://github.com/gitbutlerapp/gitbutler/assets/16451892/2ea2bc2c-5560-4190-92a4-a24e620a6274)
