### PR TITLE
update CI runners

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,11 +29,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-private-repositories
         platform:
-          - macos-latest # [macOs, x64]
-          - macos-latest-xlarge # [macOs, ARM64]
+          - macos-13 # [macOs, x64]
+          - macos-latest # [macOs, ARM64]
           - ubuntu-20.04 # [linux, x64]
-          - windows-latest # [windows, x64]
+          - windows-2022 # [windows, x64]
 
     runs-on: ${{ matrix.platform }}
 
@@ -191,11 +192,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-private-repositories
         platform:
-          - macos-latest # [macOs, x64]
-          - macos-latest-xlarge # [macOs, ARM64]
+          - macos-13 # [macOs, x64]
+          - macos-latest # [macOs, ARM64]
           - ubuntu-20.04 # [linux, x64]
-          - windows-latest # [windows, x64]
+          - windows-2022 # [windows, x64]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
macos-latest is no longer x86, specifying 13 in order to have x86 builds back