### PR TITLE
Fix bug in updating base branch

### DIFF
--- a/crates/gitbutler-core/src/virtual_branches/base.rs
+++ b/crates/gitbutler-core/src/virtual_branches/base.rs
@@ -5,7 +5,9 @@ use serde::Serialize;
 
 use super::{
     branch, errors,
-    integration::{update_gitbutler_integration, GITBUTLER_INTEGRATION_REFERENCE},
+    integration::{
+        get_workspace_head, update_gitbutler_integration, GITBUTLER_INTEGRATION_REFERENCE,
+    },
     target, BranchId, RemoteCommit, VirtualBranchHunk, VirtualBranchesHandle,
 };
 use crate::{
@@ -340,14 +342,10 @@ pub fn update_base_branch(
         .peel_to_commit()
         .context(format!("failed to peel branch {} to commit", target.branch))?;
 
-    // if the target has not changed, do nothing
     if new_target_commit.id() == target.sha {
         return Ok(());
     }
 
-    // ok, target has changed, so now we need to merge it into our current work and update our branches
-
-    // get tree from new target
     let new_target_tree = new_target_commit
         .tree()
         .context("failed to get new target commit tree")?;
@@ -361,195 +359,200 @@ pub fn update_base_branch(
         ))?;
 
     let vb_state = VirtualBranchesHandle::new(&project_repository.project().gb_dir());
+    let integration_commit = get_workspace_head(&vb_state, project_repository)?;
 
     // try to update every branch
-    let updated_vbranches = super::get_status_by_branch(project_repository, None)?
-        .0
-        .into_iter()
-        .map(|(branch, _)| branch)
-        .map(
-            |mut branch: branch::Branch| -> Result<Option<branch::Branch>> {
-                let branch_tree = repo.find_tree(branch.tree)?;
+    let updated_vbranches =
+        super::get_status_by_branch(project_repository, Some(&integration_commit))?
+            .0
+            .into_iter()
+            .map(|(branch, _)| branch)
+            .map(
+                |mut branch: branch::Branch| -> Result<Option<branch::Branch>> {
+                    let branch_tree = repo.find_tree(branch.tree)?;
 
-                let branch_head_commit = repo.find_commit(branch.head).context(format!(
-                    "failed to find commit {} for branch {}",
-                    branch.head, branch.id
-                ))?;
-                let branch_head_tree = branch_head_commit.tree().context(format!(
-                    "failed to find tree for commit {} for branch {}",
-                    branch.head, branch.id
-                ))?;
+                    let branch_head_commit = repo.find_commit(branch.head).context(format!(
+                        "failed to find commit {} for branch {}",
+                        branch.head, branch.id
+                    ))?;
+                    let branch_head_tree = branch_head_commit.tree().context(format!(
+                        "failed to find tree for commit {} for branch {}",
+                        branch.head, branch.id
+                    ))?;
 
-                let result_integrated_detected =
-                    |mut branch: branch::Branch| -> Result<Option<branch::Branch>> {
-                        // branch head tree is the same as the new target tree.
-                        // meaning we can safely use the new target commit as the branch head.
+                    let result_integrated_detected =
+                        |mut branch: branch::Branch| -> Result<Option<branch::Branch>> {
+                            // branch head tree is the same as the new target tree.
+                            // meaning we can safely use the new target commit as the branch head.
 
+                            branch.head = new_target_commit.id();
+
+                            // it also means that the branch is fully integrated into the target.
+                            // disconnect it from the upstream
+                            branch.upstream = None;
+                            branch.upstream_head = None;
+
+                            let non_commited_files = diff::trees(
+                                &project_repository.git_repository,
+                                &branch_head_tree,
+                                &branch_tree,
+                            )?;
+                            if non_commited_files.is_empty() {
+                                // if there are no commited files, then the branch is fully merged
+                                // and we can delete it.
+                                vb_state.remove_branch(branch.id)?;
+                                project_repository.delete_branch_reference(&branch)?;
+                                Ok(None)
+                            } else {
+                                vb_state.set_branch(branch.clone())?;
+                                Ok(Some(branch))
+                            }
+                        };
+
+                    if branch_head_tree.id() == new_target_tree.id() {
+                        return result_integrated_detected(branch);
+                    }
+
+                    // try to merge branch head with new target
+                    let mut branch_tree_merge_index = repo
+                        .merge_trees(&old_target_tree, &branch_tree, &new_target_tree)
+                        .context(format!("failed to merge trees for branch {}", branch.id))?;
+
+                    if branch_tree_merge_index.has_conflicts() {
+                        // branch tree conflicts with new target, unapply branch for now. we'll handle it later, when user applies it back.
+                        branch.applied = false;
+                        vb_state.set_branch(branch.clone())?;
+                        return Ok(Some(branch));
+                    }
+
+                    let branch_merge_index_tree_oid =
+                        branch_tree_merge_index.write_tree_to(repo)?;
+
+                    if branch_merge_index_tree_oid == new_target_tree.id() {
+                        return result_integrated_detected(branch);
+                    }
+
+                    if branch.head == target.sha {
+                        // there are no commits on the branch, so we can just update the head to the new target and calculate the new tree
                         branch.head = new_target_commit.id();
+                        branch.tree = branch_merge_index_tree_oid;
+                        vb_state.set_branch(branch.clone())?;
+                        return Ok(Some(branch));
+                    }
 
-                        // it also means that the branch is fully integrated into the target.
-                        // disconnect it from the upstream
-                        branch.upstream = None;
-                        branch.upstream_head = None;
+                    let mut branch_head_merge_index = repo
+                        .merge_trees(&old_target_tree, &branch_head_tree, &new_target_tree)
+                        .context(format!(
+                            "failed to merge head tree for branch {}",
+                            branch.id
+                        ))?;
 
-                        let non_commited_files = diff::trees(
-                            &project_repository.git_repository,
-                            &branch_head_tree,
-                            &branch_tree,
-                        )?;
-                        if non_commited_files.is_empty() {
-                            // if there are no commited files, then the branch is fully merged
-                            // and we can delete it.
-                            vb_state.remove_branch(branch.id)?;
-                            project_repository.delete_branch_reference(&branch)?;
-                            Ok(None)
-                        } else {
+                    if branch_head_merge_index.has_conflicts() {
+                        // branch commits conflict with new target, make sure the branch is
+                        // unapplied. conflicts witll be dealt with when applying it back.
+                        branch.applied = false;
+                        vb_state.set_branch(branch.clone())?;
+                        return Ok(Some(branch));
+                    }
+
+                    // branch commits do not conflict with new target, so lets merge them
+                    let branch_head_merge_tree_oid = branch_head_merge_index
+                        .write_tree_to(repo)
+                        .context(format!(
+                            "failed to write head merge index for {}",
+                            branch.id
+                        ))?;
+
+                    let ok_with_force_push = project_repository.project().ok_with_force_push;
+
+                    let result_merge =
+                        |mut branch: branch::Branch| -> Result<Option<branch::Branch>> {
+                            // branch was pushed to upstream, and user doesn't like force pushing.
+                            // create a merge commit to avoid the need of force pushing then.
+                            let branch_head_merge_tree = repo
+                                .find_tree(branch_head_merge_tree_oid)
+                                .context("failed to find tree")?;
+
+                            let new_target_head = project_repository
+                                .commit(
+                                    user,
+                                    format!(
+                                        "Merged {}/{} into {}",
+                                        target.branch.remote(),
+                                        target.branch.branch(),
+                                        branch.name
+                                    )
+                                    .as_str(),
+                                    &branch_head_merge_tree,
+                                    &[&branch_head_commit, &new_target_commit],
+                                    signing_key,
+                                )
+                                .context("failed to commit merge")?;
+
+                            branch.head = new_target_head;
+                            branch.tree = branch_merge_index_tree_oid;
                             vb_state.set_branch(branch.clone())?;
                             Ok(Some(branch))
-                        }
-                    };
+                        };
 
-                if branch_head_tree.id() == new_target_tree.id() {
-                    return result_integrated_detected(branch);
-                }
+                    if branch.upstream.is_some() && !ok_with_force_push {
+                        return result_merge(branch);
+                    }
 
-                // try to merge branch head with new target
-                let mut branch_tree_merge_index = repo
-                    .merge_trees(&old_target_tree, &branch_tree, &new_target_tree)
-                    .context(format!("failed to merge trees for branch {}", branch.id))?;
-
-                if branch_tree_merge_index.has_conflicts() {
-                    // branch tree conflicts with new target, unapply branch for now. we'll handle it later, when user applies it back.
-                    branch.applied = false;
-                    vb_state.set_branch(branch.clone())?;
-                    return Ok(Some(branch));
-                }
-
-                let branch_merge_index_tree_oid = branch_tree_merge_index.write_tree_to(repo)?;
-
-                if branch_merge_index_tree_oid == new_target_tree.id() {
-                    return result_integrated_detected(branch);
-                }
-
-                if branch.head == target.sha {
-                    // there are no commits on the branch, so we can just update the head to the new target and calculate the new tree
-                    branch.head = new_target_commit.id();
-                    branch.tree = branch_merge_index_tree_oid;
-                    vb_state.set_branch(branch.clone())?;
-                    return Ok(Some(branch));
-                }
-
-                let mut branch_head_merge_index = repo
-                    .merge_trees(&old_target_tree, &branch_head_tree, &new_target_tree)
-                    .context(format!(
-                        "failed to merge head tree for branch {}",
-                        branch.id
-                    ))?;
-
-                if branch_head_merge_index.has_conflicts() {
-                    // branch commits conflict with new target, make sure the branch is
-                    // unapplied. conflicts witll be dealt with when applying it back.
-                    branch.applied = false;
-                    vb_state.set_branch(branch.clone())?;
-                    return Ok(Some(branch));
-                }
-
-                // branch commits do not conflict with new target, so lets merge them
-                let branch_head_merge_tree_oid = branch_head_merge_index
-                    .write_tree_to(repo)
-                    .context(format!(
-                        "failed to write head merge index for {}",
-                        branch.id
-                    ))?;
-
-                let ok_with_force_push = project_repository.project().ok_with_force_push;
-
-                let result_merge = |mut branch: branch::Branch| -> Result<Option<branch::Branch>> {
-                    // branch was pushed to upstream, and user doesn't like force pushing.
-                    // create a merge commit to avoid the need of force pushing then.
-                    let branch_head_merge_tree = repo
-                        .find_tree(branch_head_merge_tree_oid)
-                        .context("failed to find tree")?;
-
-                    let new_target_head = project_repository
-                        .commit(
-                            user,
-                            format!(
-                                "Merged {}/{} into {}",
-                                target.branch.remote(),
-                                target.branch.branch(),
-                                branch.name
-                            )
-                            .as_str(),
-                            &branch_head_merge_tree,
-                            &[&branch_head_commit, &new_target_commit],
-                            signing_key,
+                    // branch was not pushed to upstream yet. attempt a rebase,
+                    let (_, committer) = project_repository.git_signatures(user)?;
+                    let mut rebase_options = git2::RebaseOptions::new();
+                    rebase_options.quiet(true);
+                    rebase_options.inmemory(true);
+                    let mut rebase = repo
+                        .rebase(
+                            Some(branch.head),
+                            Some(new_target_commit.id()),
+                            None,
+                            Some(&mut rebase_options),
                         )
-                        .context("failed to commit merge")?;
+                        .context("failed to rebase")?;
 
-                    branch.head = new_target_head;
-                    branch.tree = branch_merge_index_tree_oid;
-                    vb_state.set_branch(branch.clone())?;
-                    Ok(Some(branch))
-                };
+                    let mut rebase_success = true;
+                    // check to see if these commits have already been pushed
+                    let mut last_rebase_head = branch.head;
+                    while rebase.next().is_some() {
+                        let index = rebase
+                            .inmemory_index()
+                            .context("failed to get inmemory index")?;
+                        if index.has_conflicts() {
+                            rebase_success = false;
+                            break;
+                        }
 
-                if branch.upstream.is_some() && !ok_with_force_push {
-                    return result_merge(branch);
-                }
-
-                // branch was not pushed to upstream yet. attempt a rebase,
-                let (_, committer) = project_repository.git_signatures(user)?;
-                let mut rebase_options = git2::RebaseOptions::new();
-                rebase_options.quiet(true);
-                rebase_options.inmemory(true);
-                let mut rebase = repo
-                    .rebase(
-                        Some(branch.head),
-                        Some(new_target_commit.id()),
-                        None,
-                        Some(&mut rebase_options),
-                    )
-                    .context("failed to rebase")?;
-
-                let mut rebase_success = true;
-                // check to see if these commits have already been pushed
-                let mut last_rebase_head = branch.head;
-                while rebase.next().is_some() {
-                    let index = rebase
-                        .inmemory_index()
-                        .context("failed to get inmemory index")?;
-                    if index.has_conflicts() {
-                        rebase_success = false;
-                        break;
+                        if let Ok(commit_id) = rebase.commit(None, &committer.clone().into(), None)
+                        {
+                            last_rebase_head = commit_id.into();
+                        } else {
+                            rebase_success = false;
+                            break;
+                        }
                     }
 
-                    if let Ok(commit_id) = rebase.commit(None, &committer.clone().into(), None) {
-                        last_rebase_head = commit_id.into();
-                    } else {
-                        rebase_success = false;
-                        break;
+                    if rebase_success {
+                        // rebase worked out, rewrite the branch head
+                        rebase.finish(None).context("failed to finish rebase")?;
+                        branch.head = last_rebase_head;
+                        branch.tree = branch_merge_index_tree_oid;
+                        vb_state.set_branch(branch.clone())?;
+                        return Ok(Some(branch));
                     }
-                }
 
-                if rebase_success {
-                    // rebase worked out, rewrite the branch head
-                    rebase.finish(None).context("failed to finish rebase")?;
-                    branch.head = last_rebase_head;
-                    branch.tree = branch_merge_index_tree_oid;
-                    vb_state.set_branch(branch.clone())?;
-                    return Ok(Some(branch));
-                }
+                    // rebase failed, do a merge commit
+                    rebase.abort().context("failed to abort rebase")?;
 
-                // rebase failed, do a merge commit
-                rebase.abort().context("failed to abort rebase")?;
-
-                result_merge(branch)
-            },
-        )
-        .collect::<Result<Vec<_>>>()?
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>();
+                    result_merge(branch)
+                },
+            )
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
 
     // ok, now all the problematic branches have been unapplied
     // now we calculate and checkout new tree for the working directory

--- a/crates/gitbutler-core/src/virtual_branches/virtual.rs
+++ b/crates/gitbutler-core/src/virtual_branches/virtual.rs
@@ -1961,7 +1961,7 @@ fn get_applied_status(
     if !project_repository.is_resolving() {
         let vb_state = VirtualBranchesHandle::new(&project_repository.project().gb_dir());
         for (vbranch, files) in &mut hunks_by_branch {
-            vbranch.tree = write_tree(project_repository, integration_commit, files)?;
+            vbranch.tree = write_tree(project_repository, &vbranch.head, files)?;
             vb_state
                 .set_branch(vbranch.clone())
                 .context(format!("failed to write virtual branch {}", vbranch.name))?;


### PR DESCRIPTION
- drop "double lock across branches" test because it can't happen
- save correct tree when updating branch states
- use correct integration commit when updating base branch