### PR TITLE
Update the normalizeBranchName function to match rust

### DIFF
--- a/app/src/lib/utils/branch.test.ts
+++ b/app/src/lib/utils/branch.test.ts
@@ -1,0 +1,16 @@
+import { normalizeBranchName } from '$lib/utils/branch';
+import { describe, expect, test } from 'vitest';
+
+describe.concurrent('normalizeBranchName', () => {
+	test('it should remove undesirable symbols', () => {
+		expect(normalizeBranchName('a£^&*() b')).toEqual('a-b');
+	});
+
+	test('it should preserve capital letters', () => {
+		expect(normalizeBranchName('Hello World')).toEqual('Hello-World');
+	});
+
+	test('it should preserve `#`, `_`, `/`, and `.`', () => {
+		expect(normalizeBranchName('hello#_./world')).toEqual('hello#_./world');
+	});
+});

--- a/app/src/lib/utils/branch.ts
+++ b/app/src/lib/utils/branch.ts
@@ -1,3 +1,3 @@
 export function normalizeBranchName(value: string) {
-	return value.replace(/[^0-9a-z/_.]+/g, '-');
+	return value.replace(/[^A-Za-z0-9_/.#]+/g, '-');
 }


### PR DESCRIPTION
Before, uppercase letters and hashes were missing from the regex. I've now coppied the regex from the rust code so they are now identical