### PR TITLE
tiny cli for snapshots

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -18,6 +18,7 @@ jobs:
       gitbutler-tauri: ${{ steps.filter.outputs.gitbutler-tauri }}
       gitbutler-changeset: ${{ steps.filter.outputs.gitbutler-changeset }}
       gitbutler-git: ${{ steps.filter.outputs.gitbutler-git }}
+      gitbutler-cli: ${{ steps.filter.outputs.gitbutler-cli }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -51,6 +52,9 @@ jobs:
             gitbutler-git:
               - *rust
               - 'crates/gitbutler-git/**'
+            gitbutler-cli:
+              - *rust
+              - 'crates/gitbutler-cli/**'
 
   lint-node:
     needs: changes
@@ -203,6 +207,31 @@ jobs:
           features: ${{ toJson(matrix.features) }}
           action: ${{ matrix.action }}
 
+  check-gitbutler-cli:
+    needs: changes
+    if: ${{ needs.changes.outputs.gitbutler-cli == 'true' }}
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/gitbutlerapp/ci-base-image:latest
+    strategy:
+      matrix:
+        action:
+          - test
+          - check
+          - check-tests
+        features:
+          - ''
+          - '*'
+          - []
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/init-env-rust
+      - uses: ./.github/actions/check-crate
+        with:
+          crate: gitbutler-cli
+          features: ${{ toJson(matrix.features) }}
+          action: ${{ matrix.action }}
+
   check-rust:
     if: always()
     needs:
@@ -211,6 +240,7 @@ jobs:
       - check-gitbutler-core
       - check-gitbutler-changeset
       - check-gitbutler-git
+      - check-gitbutler-cli
       - check-rust-windows
       - rust-lint
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +828,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
 name = "clru"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,6 +895,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "combine"
@@ -1098,7 +1180,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 2.0.58",
 ]
 
@@ -1410,12 +1492,33 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -2018,6 +2121,17 @@ version = "0.0.0"
 dependencies = [
  "paste",
  "thiserror",
+]
+
+[[package]]
+name = "gitbutler-cli"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "gitbutler-core",
+ "pager",
 ]
 
 [[package]]
@@ -3485,6 +3599,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4349,6 +4469,16 @@ dependencies = [
  "primeorder",
  "rand_core 0.6.4",
  "sha2",
+]
+
+[[package]]
+name = "pager"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2599211a5c97fbbb1061d3dc751fa15f404927e4846e07c643287d6d1f462880"
+dependencies = [
+ "errno 0.2.8",
+ "libc",
 ]
 
 [[package]]
@@ -5448,7 +5578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
 dependencies = [
  "bitflags 1.3.2",
- "errno",
+ "errno 0.3.8",
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.8",
@@ -5462,7 +5592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
  "bitflags 2.5.0",
- "errno",
+ "errno 0.3.8",
  "libc",
  "linux-raw-sys 0.4.13",
  "windows-sys 0.52.0",
@@ -6060,6 +6190,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -7054,6 +7190,12 @@ name = "utf8-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/gitbutler-git",
     "crates/gitbutler-watcher",
     "crates/gitbutler-testsupport",
+    "crates/gitbutler-cli",
 ]
 resolver = "2"
 
@@ -22,6 +23,7 @@ gitbutler-git = { path = "crates/gitbutler-git" }
 gitbutler-core = { path = "crates/gitbutler-core" }
 gitbutler-watcher = { path = "crates/gitbutler-watcher" }
 gitbutler-testsupport = { path = "crates/gitbutler-testsupport" }
+gitbutler-cli ={ path = "crates/gitbutler-cli" }
 
 [profile.release]
 codegen-units = 1 # Compile crates one after another so the compiler can optimize better

--- a/crates/gitbutler-cli/Cargo.toml
+++ b/crates/gitbutler-cli/Cargo.toml
@@ -14,4 +14,6 @@ gitbutler-core.workspace = true
 clap = "4.5.4"
 anyhow = "1.0.82"
 chrono = "0.4.10"
+
+[target."cfg(unix)".dependencies]
 pager = "0.16.1"

--- a/crates/gitbutler-cli/Cargo.toml
+++ b/crates/gitbutler-cli/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "gitbutler-cli"
+version = "0.0.0"
+edition = "2021"
+authors = ["GitButler <gitbutler@gitbutler.com>"]
+publish = false
+
+[[bin]]
+name = "gitbutler-cli"
+path = "src/main.rs"
+
+[dependencies]
+gitbutler-core.workspace = true
+clap = "4.5.4"
+anyhow = "1.0.82"
+chrono = "0.4.10"
+pager = "0.16.1"

--- a/crates/gitbutler-cli/src/main.rs
+++ b/crates/gitbutler-cli/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use gitbutler_core::{projects::Project, snapshots::snapshot};
 
 use clap::{arg, Command};
+#[cfg(not(windows))]
 use pager::Pager;
 
 fn cli() -> Command {
@@ -21,6 +22,7 @@ fn cli() -> Command {
 }
 
 fn main() -> Result<()> {
+    #[cfg(not(windows))]
     Pager::new().setup();
     let matches = cli().get_matches();
 

--- a/crates/gitbutler-cli/src/main.rs
+++ b/crates/gitbutler-cli/src/main.rs
@@ -1,0 +1,73 @@
+use anyhow::Result;
+use gitbutler_core::{projects::Project, snapshots::snapshot};
+
+use clap::{arg, Command};
+use pager::Pager;
+
+fn cli() -> Command {
+    Command::new("gitbutler-cli")
+        .about("A CLI tool for GitButler")
+        .arg(arg!(-C <path> "Run as if gitbutler-cli was started in <path> instead of the current working directory."))
+        .subcommand_required(true)
+        .arg_required_else_help(true)
+        .allow_external_subcommands(true)
+        .subcommand(
+            Command::new("snapshot")
+                .about("List and restore snapshots.")
+                .subcommand(Command::new("restore")
+                .about("Restores the state of the working direcory as well as virtual branches to a given snapshot.")
+                .arg(arg!(<SNAPSHOT_ID> "The snapshot to restore"))),
+        )
+}
+
+fn main() -> Result<()> {
+    Pager::new().setup();
+    let matches = cli().get_matches();
+
+    let cwd = std::env::current_dir()?.to_string_lossy().to_string();
+    let repo_dir = matches.get_one::<String>("path").unwrap_or(&cwd);
+
+    match matches.subcommand() {
+        Some(("snapshot", sub_matches)) => match sub_matches.subcommand() {
+            Some(("restore", sub_matches)) => {
+                let snapshot_id = sub_matches
+                    .get_one::<String>("SNAPSHOT_ID")
+                    .expect("required");
+                restore_snapshot(repo_dir, snapshot_id)?;
+            }
+            _ => {
+                list_snapshots(repo_dir)?;
+            }
+        },
+        _ => unreachable!(),
+    }
+
+    Ok(())
+}
+
+fn list_snapshots(repo_dir: &str) -> Result<()> {
+    let project = project_from_path(repo_dir);
+    let snapshots = snapshot::list(&project, 100)?;
+    for snapshot in snapshots {
+        let ts = chrono::DateTime::from_timestamp(snapshot.created_at / 1000, 0);
+        let details = snapshot.details;
+        if let (Some(ts), Some(details)) = (ts, details) {
+            println!("{} {} {}", ts, snapshot.id, details.operation);
+        }
+    }
+    Ok(())
+}
+
+fn restore_snapshot(repo_dir: &str, snapshot_id: &str) -> Result<()> {
+    let project = project_from_path(repo_dir);
+    snapshot::restore(&project, snapshot_id.to_owned())?;
+    Ok(())
+}
+
+fn project_from_path(repo_dir: &str) -> Project {
+    Project {
+        path: std::path::PathBuf::from(repo_dir),
+        enable_snapshots: Some(true),
+        ..Default::default()
+    }
+}

--- a/crates/gitbutler-core/src/snapshots/entry.rs
+++ b/crates/gitbutler-core/src/snapshots/entry.rs
@@ -92,7 +92,6 @@ impl FromStr for SnapshotDetails {
                 .value,
         )
         .unwrap_or(Default::default());
-        println!("Operation: {:?}", operation);
 
         // remove the version and operation attributes from the trailers since they have dedicated fields
         trailers.retain(|t| t.key != "Version" && t.key != "Operation");


### PR DESCRIPTION
this is a cli convenience tool for listing and restoring gitbutler snapshots even if the app can't start or if it's hung. of course this can be done with plain git, but this is more convenient.

In the future we could add more functionality to it