### PR TITLE
Optimize list_virtual_branches

### DIFF
--- a/app/src/lib/components/BranchFiles.svelte
+++ b/app/src/lib/components/BranchFiles.svelte
@@ -39,8 +39,6 @@
 <style lang="postcss">
 	.branch-files {
 		flex: 1;
-		display: flex;
-		flex-direction: column;
 		background: var(--clr-bg-1);
 		border-radius: var(--radius-m) var(--radius-m) 0 0;
 		padding: 0 var(--size-14) var(--size-14);

--- a/app/src/lib/components/FileListItem.svelte
+++ b/app/src/lib/components/FileListItem.svelte
@@ -59,7 +59,7 @@
 	});
 </script>
 
-<div class="list-item-wrapper">
+<div class:list-item-wrapper={showCheckbox}>
 	{#if showCheckbox}
 		<Checkbox
 			small
@@ -128,16 +128,14 @@
 			else console.error('No files selected');
 		}}
 	>
-		<div class="info-wrap">
-			<div class="info">
-				<img draggable="false" class="file-icon" src={getVSIFileIcon(file.path)} alt="js" />
-				<span class="text-base-12 name">
-					{file.filename}
-				</span>
-				<span class="text-base-12 path">
-					{file.justpath}
-				</span>
-			</div>
+		<div class="info">
+			<img draggable="false" class="file-icon" src={getVSIFileIcon(file.path)} alt="js" />
+			<span class="text-base-12 name">
+				{file.filename}
+			</span>
+			<span class="text-base-12 path">
+				{file.justpath}
+			</span>
 		</div>
 		<FileStatusIcons {file} />
 	</div>
@@ -170,14 +168,6 @@
 		}
 	}
 
-	.info-wrap {
-		display: flex;
-		align-items: center;
-		flex-grow: 1;
-		flex-shrink: 1;
-		gap: var(--size-10);
-		overflow: hidden;
-	}
 	.info {
 		display: flex;
 		align-items: center;

--- a/crates/gitbutler-core/src/virtual_branches/virtual.rs
+++ b/crates/gitbutler-core/src/virtual_branches/virtual.rs
@@ -901,24 +901,24 @@ pub fn list_virtual_branches(
             .flatten();
 
         let mut files = diffs_into_virtual_files(project_repository, files);
+
+        let path_claim_positions: HashMap<&PathBuf, usize> = branch
+            .ownership
+            .claims
+            .iter()
+            .enumerate()
+            .map(|(index, ownership_claim)| (&ownership_claim.file_path, index))
+            .collect();
+
         files.sort_by(|a, b| {
-            branch
-                .ownership
-                .claims
-                .iter()
-                .position(|o| o.file_path.eq(&a.path))
-                .unwrap_or(usize::MAX)
-                .cmp(
-                    &branch
-                        .ownership
-                        .claims
-                        .iter()
-                        .position(|id| id.file_path.eq(&b.path))
-                        .unwrap_or(usize::MAX),
-                )
+            path_claim_positions
+                .get(&a.path)
+                .unwrap_or(&usize::MAX)
+                .cmp(path_claim_positions.get(&b.path).unwrap_or(&usize::MAX))
         });
 
         let requires_force = is_requires_force(project_repository, &branch)?;
+
         let branch = VirtualBranch {
             id: branch.id,
             name: branch.name,

--- a/crates/gitbutler-core/src/virtual_branches/virtual.rs
+++ b/crates/gitbutler-core/src/virtual_branches/virtual.rs
@@ -1855,7 +1855,7 @@ fn get_applied_status(
                                     .or_default()
                                     .entry(claim.file_path.clone())
                                     .or_default()
-                                    .insert(0, git_diff_hunk.clone());
+                                    .push(git_diff_hunk.clone());
                                 let updated_hunk = Hunk {
                                     start: git_diff_hunk.new_start,
                                     end: git_diff_hunk.new_start + git_diff_hunk.new_lines,


### PR DESCRIPTION
I've marked this as ready for review, I'm certain there are still areas which could do with improving, but this should already be a great step forwards and shouldn't be held back

---

I've taken a look into the list_virtual_branches function and there appears to be three main places which slow it down:
- Ordering hunks within a vbranch
- Calling `get_applied_status`
  - It appears like the slowest part of this function is the blame locking, though I don't see a particularly easy way to tackle that.
- `diffs_into_virtual_files` -> `virtual_hunks_into_virtual_files`
  - This is O(n) and doesn't have anything particularly slow, its just a hot loop.
- Something about starting is blocking the UI thread which is certainly problematic

## Ordering the hunks within a vbranch

The changes in this commit optimize the sorting of virtual branch files
by pre-computing the index positions of the ownership claims for each
file path. This improves the performance of the sorting operation by
avoiding the need to repeatedly search for the index positions during
the comparison step.

With 1900 hunks in a vbranch, I've found that this helps reduce the run time from 9 seconds down to just 5.

I considered not sorting at all if we didn't have any branches, but this didn't provide any substantial change in performance.

## Something about starting is blocking the UI thread which is certainly problematic

Turns out that this is due to flex.... 🤦.

By removing some un-needed flex classes, I've reduced the render time from 11 seconds down to under 2

Before:
<img width="1728" alt="Screenshot 2024-05-06 at 00 22 14" src="https://github.com/gitbutlerapp/gitbutler/assets/13354155/cc1185fe-5b46-464d-9fd8-a7d5654b88fb">

After:
![image](https://github.com/gitbutlerapp/gitbutler/assets/13354155/7dfefea8-d1bc-49ff-84be-820c5347b223)

This is still far from perfect, and some form of virtual scroll (https://github.com/v1ack/svelte-virtual-scroll-list) would be ideal, but the pre-made solutions don't seem to quite fit how we want our designs to behave.

EDIT: with https://github.com/gitbutlerapp/gitbutler/pull/3688/commits/645726ab937e758b4c90ba65f0558c387e2bd4e2 the UI no longer is frozen on the loading wheel for that 2 seconds
