### PR TITLE
build: adopt to resolve.conditions: es2015

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -36,6 +36,9 @@ export default defineConfig({
 	// to make use of `TAURI_DEBUG` and other env variables
 	// https://tauri.studio/v1/api/config#buildconfig.beforedevcommand
 	envPrefix: ['VITE_', 'TAURI_'],
+	resolve: {
+		conditions: ['es2015']
+	},
 	build: {
 		// Tauri supports es2021
 		target: process.env.TAURI_PLATFORM == 'windows' ? 'chrome105' : 'safari13',


### PR DESCRIPTION
This tweak will letting the vite[^1] to leverage the ES2015 export condition in case of rxjs[^2].

[^1]: https://vitejs.dev/config/shared-options#resolve-conditions
[^2]: https://rxjs.dev/guide/installation#es2015-via-npm