### PR TITLE
Add cmd+R to reload the page

### DIFF
--- a/app/src/routes/+layout.svelte
+++ b/app/src/routes/+layout.svelte
@@ -73,7 +73,8 @@
 					...s,
 					showHistoryView: !$userSettings.showHistoryView
 				}));
-			})
+			}),
+			hotkeys.on('$mod+R', () => location.reload())
 		);
 	});
 </script>


### PR DESCRIPTION
I remember we talked about whether we wanted to have a slack-like cmd+R to reload the app and IIRC, it was somewhat resting on the idea that we shouldn't ever need to reload the app so we shouldn't have it and the counter was based on given the fact that we're not yet in that perfect state that it will be helpful to gracefully get out of those situations and could then be removed at a later date when we've achieved greater stability.

Either way, I've found having it super helpful when I do need to refresh (opposed to my current nightly workaround of navigating to and back from a second project or writing `location.reload()` manually in the dev tools)

@krlvi This is probably up to you whether you want to include it. I could add a check so its only registered on nightly and development if you preferred.