### PR TITLE
Don't reparse branch_id

### DIFF
--- a/crates/gitbutler-core/src/git/diff.rs
+++ b/crates/gitbutler-core/src/git/diff.rs
@@ -9,6 +9,8 @@ use tracing::instrument;
 
 use super::Repository;
 use crate::git;
+use crate::id::Id;
+use crate::virtual_branches::Branch;
 
 pub type DiffByPathMap = HashMap<PathBuf, FileDiff>;
 
@@ -106,7 +108,7 @@ impl GitHunk {
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Copy)]
 #[serde(rename_all = "camelCase")]
 pub struct HunkLock {
-    pub branch_id: uuid::Uuid,
+    pub branch_id: Id<Branch>,
     pub commit_id: git::Oid,
 }
 


### PR DESCRIPTION
This should make the situation where an error occurs even more absurd. It should also be saving some extra work which is always a bonus

This is a little bit of a continuation of @krlvi 's https://github.com/gitbutlerapp/gitbutler/pull/3708/files