### PR TITLE
Fix background switching between target.sha and integration commit

### DIFF
--- a/crates/gitbutler-core/src/virtual_branches/virtual.rs
+++ b/crates/gitbutler-core/src/virtual_branches/virtual.rs
@@ -794,12 +794,6 @@ pub fn list_virtual_branches(
         .find_commit(integration_commit_id)
         .unwrap();
 
-    super::integration::update_gitbutler_integration_with_commit(
-        &vb_state,
-        project_repository,
-        Some(integration_commit_id),
-    )?;
-
     let (statuses, skipped_files) =
         get_status_by_branch(project_repository, Some(&integration_commit.id()))?;
     let max_selected_for_changes = statuses


### PR DESCRIPTION
We have been switching back and forth between `default_target` and `gitbutler/integration` when updating the integration branch. This PR changes that so we stay on `gitbutler/integration`.