### PR TITLE
snapshot-get-diff

### DIFF
--- a/app/src/lib/components/History.svelte
+++ b/app/src/lib/components/History.svelte
@@ -45,6 +45,14 @@
 		});
 		return resp;
 	}
+	async function getSnapshotDiff(projectId: string, sha: string) {
+		const resp = await invoke<string>('snapshot_diff', {
+			projectId: projectId,
+			sha: sha
+		});
+		console.log(JSON.stringify(resp));
+		return resp;
+	}
 	async function restoreSnapshot(projectId: string, sha: string) {
 		await invoke<string>('restore_snapshot', {
 			projectId: projectId,
@@ -80,6 +88,16 @@
 				<div style="display: flex; align-items: center;">
 					<div>id: {entry.id.slice(0, 7)}</div>
 					<div style="flex-grow: 1;" />
+					<div>
+						{#if entry.linesAdded + entry.linesRemoved > 0}
+							<Button
+								style="pop"
+								size="tag"
+								icon="docs-filled"
+								on:click={async () => await getSnapshotDiff(projectId, entry.id)}>diff</Button
+							>
+						{/if}
+					</div>
 					<div>
 						{#if idx != 0}
 							<Button

--- a/crates/gitbutler-core/src/git/diff.rs
+++ b/crates/gitbutler-core/src/git/diff.rs
@@ -218,7 +218,7 @@ pub fn without_large_files(
 /// `repository` should be `None` if there is no reason to access the workdir, which it will do to
 /// keep the binary data in the object database, which otherwise would be lost to the system
 /// (it's not reconstructable from the delta, or it's not attempted).
-fn hunks_by_filepath(repo: Option<&Repository>, diff: &git2::Diff) -> Result<DiffByPathMap> {
+pub fn hunks_by_filepath(repo: Option<&Repository>, diff: &git2::Diff) -> Result<DiffByPathMap> {
     enum LineOrHexHash<'a> {
         Line(Cow<'a, BStr>),
         HexHashOfBinaryBlob(String),

--- a/crates/gitbutler-core/src/ops/oplog.rs
+++ b/crates/gitbutler-core/src/ops/oplog.rs
@@ -1,12 +1,14 @@
 use anyhow::anyhow;
 use git2::FileMode;
 use itertools::Itertools;
-use std::fs;
+use std::collections::HashMap;
 use std::str::FromStr;
+use std::{fs, path::PathBuf};
 
 use anyhow::Result;
 
-use crate::projects::Project;
+use crate::git::diff::FileDiff;
+use crate::{git::diff::hunks_by_filepath, projects::Project};
 
 use super::{
     entry::{OperationType, Snapshot, SnapshotDetails, Trailer},
@@ -54,6 +56,10 @@ pub trait Oplog {
     ///
     /// If there are no snapshots, 0 is returned.
     fn lines_since_snapshot(&self) -> Result<usize>;
+    /// Returns the diff of the snapshot and it's parent. It only includes the workdir changes.
+    ///
+    /// This is useful to show what has changed in this particular snapshot
+    fn snapshot_diff(&self, sha: String) -> Result<HashMap<PathBuf, FileDiff>>;
 }
 
 impl Oplog for Project {
@@ -323,6 +329,46 @@ impl Oplog for Project {
         let diff = repo.diff_tree_to_workdir_with_index(Some(&wd_tree), Some(&mut opts));
         let stats = diff?.stats()?;
         Ok(stats.deletions() + stats.insertions())
+    }
+
+    fn snapshot_diff(&self, sha: String) -> Result<HashMap<PathBuf, FileDiff>> {
+        let repo_path = self.path.as_path();
+        let repo = git2::Repository::init(repo_path)?;
+
+        let commit = repo.find_commit(git2::Oid::from_str(&sha)?)?;
+        // Top tree
+        let tree = commit.tree()?;
+        let old_tree = commit.parent(0)?.tree()?;
+
+        let wd_tree_entry = tree
+            .get_name("workdir")
+            .ok_or(anyhow!("failed to get workdir tree entry"))?;
+        let old_wd_tree_entry = old_tree
+            .get_name("workdir")
+            .ok_or(anyhow!("failed to get old workdir tree entry"))?;
+
+        // workdir tree
+        let wd_tree = repo.find_tree(wd_tree_entry.id())?;
+        let old_wd_tree = repo.find_tree(old_wd_tree_entry.id())?;
+
+        // Exclude files that are larger than the limit (eg. database.sql which may never be intended to be committed)
+        let files_to_exclude = get_exclude_list(&repo)?;
+        // In-memory, libgit2 internal ignore rule
+        repo.add_ignore_rule(&files_to_exclude)?;
+
+        let mut diff_opts = git2::DiffOptions::new();
+        diff_opts
+            .recurse_untracked_dirs(true)
+            .include_untracked(true)
+            .show_binary(true)
+            .ignore_submodules(true)
+            .show_untracked_content(true);
+
+        let diff =
+            repo.diff_tree_to_tree(Some(&old_wd_tree), Some(&wd_tree), Some(&mut diff_opts))?;
+
+        let hunks = hunks_by_filepath(None, &diff)?;
+        Ok(hunks)
     }
 }
 

--- a/crates/gitbutler-core/src/ops/oplog.rs
+++ b/crates/gitbutler-core/src/ops/oplog.rs
@@ -470,7 +470,7 @@ fn get_exclude_list(repo: &git2::Repository) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use std::{io::Write, path::PathBuf};
+    use std::io::Write;
 
     use crate::virtual_branches::Branch;
 

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -234,6 +234,7 @@ fn main() {
                     virtual_branches::commands::move_commit,
                     undo::list_snapshots,
                     undo::restore_snapshot,
+                    undo::snapshot_diff,
                     menu::menu_item_set_enabled,
                     keys::commands::get_public_key,
                     github::commands::init_device_oauth,

--- a/crates/gitbutler-tauri/src/undo.rs
+++ b/crates/gitbutler-tauri/src/undo.rs
@@ -1,9 +1,12 @@
 use crate::error::Error;
 use anyhow::Context;
+use gitbutler_core::git::diff::FileDiff;
 use gitbutler_core::{
     ops::{entry::Snapshot, oplog::Oplog},
     projects::{self, ProjectId},
 };
+use std::collections::HashMap;
+use std::path::PathBuf;
 use tauri::Manager;
 use tracing::instrument;
 
@@ -36,4 +39,19 @@ pub async fn restore_snapshot(
         .context("failed to get project")?;
     project.restore_snapshot(sha)?;
     Ok(())
+}
+
+#[tauri::command(async)]
+#[instrument(skip(handle), err(Debug))]
+pub async fn snapshot_diff(
+    handle: tauri::AppHandle,
+    project_id: ProjectId,
+    sha: String,
+) -> Result<HashMap<PathBuf, FileDiff>, Error> {
+    let project = handle
+        .state::<projects::Controller>()
+        .get(&project_id)
+        .context("failed to get project")?;
+    let diff = project.snapshot_diff(sha)?;
+    Ok(diff)
 }


### PR DESCRIPTION
a little endpoint for getting the diff of a snapshot (in relation to it's parent) since it's needed for https://github.com/gitbutlerapp/gitbutler/issues/3726
Maybe at some point we can add something for getting the diff with the workdir if we need it.