### PR TITLE
Use ScrollableContainer's bottomReached event to load more

### DIFF
--- a/app/src/lib/components/BranchCard.svelte
+++ b/app/src/lib/components/BranchCard.svelte
@@ -143,6 +143,12 @@
 			);
 		}
 	}
+
+	let branchFiles: BranchFiles | undefined;
+
+	function onBottomReached() {
+		branchFiles?.loadMore();
+	}
 </script>
 
 {#if $isLaneCollapsed}
@@ -171,6 +177,8 @@
 					top: `var(--size-12)`,
 					bottom: `var(--size-12)`
 				}}
+				bottomBuffer={300}
+				on:bottomReached={onBottomReached}
 			>
 				<div
 					bind:this={rsViewport}
@@ -227,6 +235,7 @@
 									{isUnapplied}
 									showCheckboxes={$commitBoxOpen}
 									allowMultiple
+									bind:this={branchFiles}
 								/>
 								{#if branch.active && branch.conflicted}
 									<div class="card-notifications">

--- a/app/src/lib/components/BranchFiles.svelte
+++ b/app/src/lib/components/BranchFiles.svelte
@@ -18,6 +18,12 @@
 	function unselectAllFiles() {
 		fileIdSelection.clear();
 	}
+
+	let branchFilesList: BranchFilesList | undefined;
+
+	export function loadMore() {
+		branchFilesList?.loadMore();
+	}
 </script>
 
 <div
@@ -32,7 +38,14 @@
 	on:click={unselectAllFiles}
 >
 	{#if files.length > 0}
-		<BranchFilesList {allowMultiple} {readonly} {files} {showCheckboxes} {isUnapplied} />
+		<BranchFilesList
+			bind:this={branchFilesList}
+			{allowMultiple}
+			{readonly}
+			{files}
+			{showCheckboxes}
+			{isUnapplied}
+		/>
 	{/if}
 </div>
 

--- a/app/src/lib/components/ScrollableContainer.svelte
+++ b/app/src/lib/components/ScrollableContainer.svelte
@@ -18,6 +18,9 @@
 	export let shift = '0';
 	export let thickness = '0.563rem';
 
+	// How much of a buffer there should be before we consider the bottom reached
+	export let bottomBuffer = 0;
+
 	let observer: ResizeObserver;
 
 	const dispatch = createEventDispatcher<{ dragging: boolean; bottomReached: boolean }>();
@@ -47,7 +50,7 @@
 			const target = e.currentTarget;
 			scrolled = target.scrollTop != 0;
 
-			if (target.scrollTop + target.clientHeight >= target.scrollHeight) {
+			if (target.scrollTop + target.clientHeight + bottomBuffer >= target.scrollHeight) {
 				dispatch('bottomReached', true);
 			}
 		}}


### PR DESCRIPTION
Bit of a refactor over my async/await based gradual rendering.

It was still struggling if you had in the neigherbourhood of 9000 files, so this will only render as the user scrolls down.

There is still the issue of scrolling taking quite a long time, but it feels like the solution would need to be a floating commit button.