### PR TITLE
Update IPC imports and remove old logic

### DIFF
--- a/app/src/lib/backend/auth.ts
+++ b/app/src/lib/backend/auth.ts
@@ -1,4 +1,4 @@
-import { invoke } from './ipc';
+import { invoke } from '$lib/backend/ipc';
 
 export type GitCredentialCheck = {
 	error?: string;

--- a/app/src/lib/backend/gitConfigService.ts
+++ b/app/src/lib/backend/gitConfigService.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/tauri';
+import { invoke } from '$lib/backend/ipc';
 
 export class GitConfigService {
 	async get<T extends string>(key: string): Promise<T | undefined> {

--- a/app/src/lib/vbranches/remoteCommits.ts
+++ b/app/src/lib/vbranches/remoteCommits.ts
@@ -3,8 +3,8 @@
  * it's here is because the type is in this package.
  */
 import { RemoteFile } from './types';
+import { invoke } from '$lib/backend/ipc';
 import { ContentSection, HunkSection, parseFileSections } from '$lib/utils/fileSections';
-import { invoke } from '@tauri-apps/api/tauri';
 import { plainToInstance } from 'class-transformer';
 
 export async function listRemoteCommitFiles(projectId: string, commitOid: string) {


### PR DESCRIPTION
I was taking a look into where certain invoke calls were coming from, and logging how long they took, so as part of that I made sure that all the calls went through our wrapper around `invoke`.

I've not included any of my extra logging as most of the same information can be gathered from the rust logs anyway.

I have however removed some extra code which appears to be now unused.