### PR TITLE
Refactor how we merge in commits from branch upstream

### DIFF
--- a/app/src/lib/components/BranchFooter.svelte
+++ b/app/src/lib/components/BranchFooter.svelte
@@ -20,13 +20,15 @@
 
 	const localCommits = getLocalCommits();
 	const remoteCommits = getRemoteCommits();
-	const unknownCommits = getUpstreamCommits();
+	const upstreamCommits = getUpstreamCommits();
+	$: unknownCommits = $upstreamCommits.filter((c) => !c.relatedTo || c.id != c.relatedTo.id);
+	$: console.log(unknownCommits);
 
 	$: hasCommits =
-		$localCommits.length > 0 || $remoteCommits.length > 0 || $unknownCommits.length > 0;
+		$localCommits.length > 0 || $remoteCommits.length > 0 || unknownCommits.length > 0;
 
 	let isLoading: boolean;
-	$: isPushed = $localCommits.length == 0 && $unknownCommits.length == 0;
+	$: isPushed = $localCommits.length == 0 && unknownCommits.length == 0;
 </script>
 
 {#if !isUnapplied && hasCommits}

--- a/app/src/lib/components/BranchFooter.svelte
+++ b/app/src/lib/components/BranchFooter.svelte
@@ -4,7 +4,7 @@
 	import { PromptService } from '$lib/backend/prompt';
 	import { getContext, getContextStore } from '$lib/utils/context';
 	import { BranchController } from '$lib/vbranches/branchController';
-	import { getLocalCommits, getRemoteCommits, getUnknownCommits } from '$lib/vbranches/contexts';
+	import { getLocalCommits, getRemoteCommits, getUpstreamCommits } from '$lib/vbranches/contexts';
 	import { Branch } from '$lib/vbranches/types';
 
 	export let isUnapplied: boolean;
@@ -20,7 +20,7 @@
 
 	const localCommits = getLocalCommits();
 	const remoteCommits = getRemoteCommits();
-	const unknownCommits = getUnknownCommits();
+	const unknownCommits = getUpstreamCommits();
 
 	$: hasCommits =
 		$localCommits.length > 0 || $remoteCommits.length > 0 || $unknownCommits.length > 0;

--- a/app/src/lib/components/BranchLane.svelte
+++ b/app/src/lib/components/BranchLane.svelte
@@ -6,18 +6,17 @@
 	import { projectLaneCollapsed } from '$lib/config/config';
 	import { persisted } from '$lib/persisted/persisted';
 	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
-	import { getRemoteBranchData } from '$lib/stores/remoteBranches';
 	import { getContext, getContextStoreBySymbol, createContextStore } from '$lib/utils/context';
 	import { isDefined } from '$lib/utils/typeguards';
 	import {
 		createLocalContextStore,
 		createRemoteContextStore,
 		createSelectedFiles,
-		createUnknownContextStore
+		createUpstreamContextStore
 	} from '$lib/vbranches/contexts';
 	import { FileIdSelection } from '$lib/vbranches/fileIdSelection';
 	import { Ownership } from '$lib/vbranches/ownership';
-	import { RemoteFile, Branch, commitCompare, RemoteCommit } from '$lib/vbranches/types';
+	import { RemoteFile, Branch } from '$lib/vbranches/types';
 	import lscache from 'lscache';
 	import { setContext } from 'svelte';
 	import { quintOut } from 'svelte/easing';
@@ -40,8 +39,9 @@
 	$: remoteCommits.set(branch.remoteCommits);
 
 	// Set the store immediately so it can be updated later.
-	const upstreamCommits = createUnknownContextStore([]);
-	$: if (branch.upstream?.name) loadRemoteBranch(branch.upstream?.name);
+	const upstreamCommits = createUpstreamContextStore([]);
+	$: upstreamCommits.set(branch.upstreamData?.commits ?? []);
+	// $: if (branch.upstream?.name) loadRemoteBranch(branch.upstream?.name);
 
 	const fileIdSelection = new FileIdSelection();
 	setContext(FileIdSelection, fileIdSelection);
@@ -57,23 +57,6 @@
 	}
 
 	$: displayedFile = $selectedFiles.length == 1 ? $selectedFiles[0] : undefined;
-
-	async function loadRemoteBranch(name: string) {
-		const upstream = await getRemoteBranchData(project.id, name);
-		if (!upstream.commits) return;
-		const unknownCommits: RemoteCommit[] = [];
-		upstream?.commits.forEach((upstreamCommit) => {
-			let match = branch.commits.find((commit) => commitCompare(upstreamCommit, commit));
-			if (match) {
-				match.relatedTo = upstreamCommit;
-			} else unknownCommits.push(upstreamCommit);
-		});
-		if (upstream.commits.length != unknownCommits.length) {
-			// Force update since we've mutated local commits
-			localCommits.set($localCommits);
-		}
-		upstreamCommits.set(unknownCommits);
-	}
 
 	const project = getContext(Project);
 	const userSettings = getContextStoreBySymbol<Settings>(SETTINGS);

--- a/app/src/lib/components/CommitLines.svelte
+++ b/app/src/lib/components/CommitLines.svelte
@@ -23,17 +23,21 @@
 			dashed={base}
 			{upstreamLine}
 			{remoteCommit}
-			{localCommit}
+			localCommit={localCommit?.relatedTo ? localCommit : undefined}
 			{first}
+			short={(!!localCommit && !localCommit?.children?.[0]?.relatedTo) ||
+				(!!remoteCommit && !remoteCommit?.children?.[0])}
 		/>
 	{/if}
 	<RemoteLine
 		commit={localCommit?.status == 'remote' ? localCommit : undefined}
 		line={localCommit?.status == 'remote' || remoteLine}
 		root={localLine}
-		{remoteCommit}
-		{upstreamLine}
+		remoteCommit={!hasShadowColumn ? remoteCommit : undefined}
+		upstreamLine={upstreamLine && !hasShadowColumn}
 		{first}
+		short={(!!localCommit && !localCommit?.children?.[0]?.relatedTo && !upstreamLine) ||
+			(!!remoteCommit && !remoteCommit?.children?.[0])}
 		{base}
 	/>
 	{#if hasLocalColumn}

--- a/app/src/lib/components/CommitLines.svelte
+++ b/app/src/lib/components/CommitLines.svelte
@@ -36,7 +36,7 @@
 		remoteCommit={!hasShadowColumn ? remoteCommit : undefined}
 		upstreamLine={upstreamLine && !hasShadowColumn}
 		{first}
-		short={(!!localCommit && !localCommit?.children?.[0]?.relatedTo && !upstreamLine) ||
+		short={(!!localCommit && !localCommit?.children?.[0] && !upstreamLine) ||
 			(!!remoteCommit && !remoteCommit?.children?.[0])}
 		{base}
 	/>

--- a/app/src/lib/components/CommitList.svelte
+++ b/app/src/lib/components/CommitList.svelte
@@ -14,16 +14,11 @@
 	const upstreamCommits = getUpstreamCommits();
 	const baseBranch = getContextStore(BaseBranch);
 
-	$: hasShadowColumn = $localCommits.some((c) => !c.relatedTo || c.id != c.relatedTo.id);
+	$: hasShadowColumn = $localCommits.some((c) => c.relatedTo && c.id != c.relatedTo.id);
 	$: hasLocalColumn = $localCommits.length > 0;
 	$: hasCommits = $branch.commits && $branch.commits.length > 0;
 	$: headCommit = $branch.commits.at(0);
-
 	$: unknownCommits = $upstreamCommits.filter((c) => !c.relatedTo || c.id != c.relatedTo.id);
-	$: $upstreamCommits.forEach((c) => console.log(`${c.id}, ${c.relatedTo?.id}`));
-	$: console.log(unknownCommits);
-	$: console.log($upstreamCommits);
-
 	$: hasUnknownCommits = unknownCommits.length > 0;
 </script>
 

--- a/app/src/lib/components/PushButton.svelte
+++ b/app/src/lib/components/PushButton.svelte
@@ -24,7 +24,8 @@
 
 	const project = getContext(Project);
 	const localCommits = getLocalCommits();
-	const unknownCommits = getUpstreamCommits();
+	const upstreamCommits = getUpstreamCommits();
+	$: unknownCommits = $upstreamCommits.filter((c) => !c.relatedTo || c.id != c.relatedTo.id);
 
 	function defaultAction(): Persisted<BranchAction> {
 		const key = 'projectDefaultAction_';
@@ -38,7 +39,7 @@
 	let dropDown: DropDownButton;
 	let disabled = false;
 	let isPushed = $localCommits.length == 0 && !branch.requiresForce;
-	$: canBeRebased = $unknownCommits.length > 0;
+	$: canBeRebased = $upstreamCommits.length != unknownCommits.length;
 	$: selection$ = contextMenu?.selection$;
 	$: action = selectAction(isPushed, $preferredAction);
 
@@ -100,7 +101,7 @@
 					id="rebase"
 					label="Rebase upstream"
 					selected={action == BranchAction.Rebase}
-					disabled={isPushed}
+					disabled={isPushed || unknownCommits.length == 0}
 				/>
 			{/if}
 			{#if canBeRebased}
@@ -108,7 +109,7 @@
 					id="rebase"
 					label="Rebase upstream"
 					selected={action == BranchAction.Rebase}
-					disabled={isPushed}
+					disabled={isPushed || unknownCommits.length == 0}
 				/>
 			{/if}
 		</ContextMenuSection>

--- a/app/src/lib/components/PushButton.svelte
+++ b/app/src/lib/components/PushButton.svelte
@@ -14,7 +14,7 @@
 	import { persisted, type Persisted } from '$lib/persisted/persisted';
 	import { getContext } from '$lib/utils/context';
 	import * as toasts from '$lib/utils/toasts';
-	import { getLocalCommits, getUnknownCommits } from '$lib/vbranches/contexts';
+	import { getLocalCommits, getUpstreamCommits } from '$lib/vbranches/contexts';
 	import { createEventDispatcher } from 'svelte';
 	import type { Branch } from '$lib/vbranches/types';
 
@@ -24,7 +24,7 @@
 
 	const project = getContext(Project);
 	const localCommits = getLocalCommits();
-	const unknownCommits = getUnknownCommits();
+	const unknownCommits = getUpstreamCommits();
 
 	function defaultAction(): Persisted<BranchAction> {
 		const key = 'projectDefaultAction_';

--- a/app/src/lib/components/RemoteLine.svelte
+++ b/app/src/lib/components/RemoteLine.svelte
@@ -6,6 +6,7 @@
 	export let remoteCommit: RemoteCommit | undefined;
 	export let base: boolean;
 	export let first: boolean;
+	export let short: boolean;
 	export let line: boolean;
 	export let root: boolean;
 	export let upstreamLine: boolean;
@@ -44,22 +45,22 @@
 			{#if upstreamLine}
 				<div class="remote-line tip" class:upstream={upstreamLine}></div>
 			{/if}
-			<div class="remote-line" class:short={first} />
+			<div class="remote-line" class:short class:first />
 		{:else if upstreamLine}
-			<div class="remote-line upstream" class:short={first} />
+			<div class="remote-line upstream" class:short class:first />
 		{/if}
 		{#if hasRoot}
 			<div class="root" />
 		{/if}
 		{#if commit}
 			{@const author = commit.author}
-			<div class="avatar" class:first>
+			<div class="avatar" class:first class:short>
 				<Avatar {author} status={commit.status} />
 			</div>
 		{/if}
 		{#if remoteCommit}
 			{@const author = remoteCommit.author}
-			<div class="avatar" class:first>
+			<div class="avatar" class:first class:short>
 				<Avatar {author} status={remoteCommit.status} />
 			</div>
 		{/if}
@@ -83,7 +84,10 @@
 			top: calc(var(--size-40) + var(--size-2));
 		}
 		&.short {
-			top: 3rem;
+			top: 1rem;
+			&.first {
+				top: 3rem;
+			}
 		}
 		&.tip {
 			bottom: calc(100% - 2.625rem);
@@ -99,6 +103,13 @@
 		}
 		&.upstream {
 			background-color: var(--clr-commit-upstream);
+			top: 0;
+			&.short {
+				top: 1rem;
+				&.first {
+					top: calc(var(--size-40) + var(--size-2));
+				}
+			}
 		}
 	}
 

--- a/app/src/lib/components/ShadowLine.svelte
+++ b/app/src/lib/components/ShadowLine.svelte
@@ -4,6 +4,7 @@
 
 	export let line: boolean;
 	export let first: boolean;
+	export let short: boolean;
 	export let remoteCommit: RemoteCommit | undefined;
 	export let localCommit: Commit | undefined;
 	export let dashed: boolean;
@@ -15,17 +16,22 @@
 		{#if upstreamLine}
 			<div class="shadow-line tip" class:upstream={upstreamLine}></div>
 		{/if}
-		<div class="shadow-line" class:dashed class:short={first} />
+		<div class="shadow-line" class:dashed class:short class:first />
 	{:else if upstreamLine}
-		<div class="shadow-line upstream" class:short={first} />
+		<div class="shadow-line upstream" class:short class:first />
 	{/if}
 	{#if localCommit}
-		<div class="shadow-marker" class:first use:tooltip={localCommit.descriptionTitle}></div>
+		<div
+			class="shadow-marker"
+			class:first
+			class:short
+			use:tooltip={localCommit.descriptionTitle}
+		></div>
 	{/if}
 	{#if remoteCommit}
 		{@const author = remoteCommit.author}
 		<img
-			class="avatar avatar"
+			class="avatar"
 			class:first
 			title={author.name}
 			alt="Gravatar for {author.email}"
@@ -54,7 +60,10 @@
 		bottom: 0;
 		top: 0;
 		&.short {
-			top: 3rem;
+			top: 1rem;
+			&.first {
+				top: 3rem;
+			}
 		}
 		&.dashed {
 			background: repeating-linear-gradient(

--- a/app/src/lib/vbranches/branchController.ts
+++ b/app/src/lib/vbranches/branchController.ts
@@ -72,7 +72,7 @@ export class BranchController {
 
 	async mergeUpstream(branch: string) {
 		try {
-			await invoke<void>('merge_virtual_branch_upstream', {
+			await invoke<void>('integrate_upstream_commits', {
 				projectId: this.projectId,
 				branch
 			});

--- a/app/src/lib/vbranches/contexts.ts
+++ b/app/src/lib/vbranches/contexts.ts
@@ -8,7 +8,7 @@ export const [getLocalCommits, createLocalContextStore] =
 	buildContextStore<Commit[]>('localCommits');
 export const [getRemoteCommits, createRemoteContextStore] =
 	buildContextStore<Commit[]>('remoteCommits');
-export const [getUnknownCommits, createUnknownContextStore] =
+export const [getUpstreamCommits, createUpstreamContextStore] =
 	buildContextStore<RemoteCommit[]>('unknownCommits');
 export const [getSelectedFiles, createSelectedFiles] = buildContextStore<
 	AnyFile[],

--- a/app/src/lib/vbranches/types.ts
+++ b/app/src/lib/vbranches/types.ts
@@ -109,6 +109,7 @@ export class Branch {
 	order!: number;
 	@Type(() => RemoteBranch)
 	upstream?: RemoteBranch;
+	upstreamData?: RemoteBranchData;
 	upstreamName?: string;
 	conflicted!: boolean;
 	// TODO: to be removed from the API
@@ -170,7 +171,7 @@ export class Commit {
 	}
 
 	get status(): CommitStatus {
-		if (this.isRemote) return 'remote';
+		if (this.isRemote && !this.relatedTo) return 'remote';
 		return 'local';
 	}
 
@@ -200,8 +201,9 @@ export class RemoteCommit {
 	changeId!: string;
 	isSigned!: boolean;
 
-	parent?: Commit;
-	children?: Commit[];
+	parent?: RemoteCommit;
+	children?: RemoteCommit[];
+	relatedTo?: Commit;
 
 	get isLocal() {
 		return false;
@@ -233,6 +235,8 @@ export const UNKNOWN_COMMITS = Symbol('UnknownCommits');
 
 export function commitCompare(left: AnyCommit, right: AnyCommit): boolean {
 	if (left.id == right.id) return true;
+	if (left.changeId && right.changeId && left.changeId == right.changeId) return true;
+
 	if (left.description != right.description) return false;
 	if (left.author.name != right.author.name) return false;
 	if (left.author.email != right.author.email) return false;

--- a/app/src/lib/vbranches/types.ts
+++ b/app/src/lib/vbranches/types.ts
@@ -171,7 +171,7 @@ export class Commit {
 	}
 
 	get status(): CommitStatus {
-		if (this.isRemote && !this.relatedTo) return 'remote';
+		if (this.isRemote && (!this.relatedTo || this.id == this.relatedTo.id)) return 'remote';
 		return 'local';
 	}
 

--- a/app/src/lib/vbranches/virtualBranch.ts
+++ b/app/src/lib/vbranches/virtualBranch.ts
@@ -159,7 +159,7 @@ function linkAsParentChildren(commits: Commit[] | RemoteCommit[]) {
 		if (j == 0) {
 			commit.children = [];
 		} else {
-			const commit = commits[j - 1];
+			const commit = commits[j];
 			if (commit instanceof Commit) commit.children = [commit];
 			if (commit instanceof RemoteCommit) commit.children = [commit];
 		}

--- a/crates/gitbutler-core/src/git/commit.rs
+++ b/crates/gitbutler-core/src/git/commit.rs
@@ -1,6 +1,7 @@
 use super::{Oid, Result, Signature, Tree};
 use bstr::BStr;
 
+#[derive(Debug)]
 pub struct Commit<'repo> {
     commit: git2::Commit<'repo>,
 }

--- a/crates/gitbutler-core/src/git/error.rs
+++ b/crates/gitbutler-core/src/git/error.rs
@@ -1,6 +1,9 @@
 use std::str::Utf8Error;
 
-use crate::keys;
+use crate::{
+    error::{Context, ErrorWithContext},
+    keys,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -46,6 +49,12 @@ impl From<git2::Error> for Error {
                 _ => Error::Other(err),
             },
         }
+    }
+}
+
+impl ErrorWithContext for Error {
+    fn context(&self) -> Option<Context> {
+        None
     }
 }
 

--- a/crates/gitbutler-core/src/project_repository/repository.rs
+++ b/crates/gitbutler-core/src/project_repository/repository.rs
@@ -313,6 +313,19 @@ impl Repository {
         .context("failed to collect oids")
     }
 
+    // returns a list of oids from the first oid to the second oid
+    pub fn list(&self, from: git::Oid, to: git::Oid) -> Result<Vec<git::Oid>> {
+        self.l(from, LogUntil::Commit(to))
+    }
+
+    pub fn list_commits(&self, from: git::Oid, to: git::Oid) -> Result<Vec<git::Commit>> {
+        Ok(self
+            .list(from, to)?
+            .into_iter()
+            .map(|oid| self.git_repository.find_commit(oid))
+            .collect::<Result<Vec<_>, _>>()?)
+    }
+
     // returns a list of commits from the first oid to the second oid
     pub fn log(&self, from: git::Oid, to: LogUntil) -> Result<Vec<git::Commit>> {
         self.l(from, to)?

--- a/crates/gitbutler-core/src/virtual_branches/controller.rs
+++ b/crates/gitbutler-core/src/virtual_branches/controller.rs
@@ -579,7 +579,7 @@ impl ControllerInner {
         let _permit = self.semaphore.acquire().await;
 
         self.with_verify_branch(project_id, |project_repository, user| {
-            let result = super::merge_virtual_branch_upstream(project_repository, branch_id, user)
+            let result = super::integrate_upstream_commits(project_repository, branch_id, user)
                 .map_err(Into::into);
             let _ = project_repository
                 .project()

--- a/crates/gitbutler-core/src/virtual_branches/controller.rs
+++ b/crates/gitbutler-core/src/virtual_branches/controller.rs
@@ -157,14 +157,14 @@ impl Controller {
             .set_target_push_remote(project_id, push_remote)
     }
 
-    pub async fn merge_virtual_branch_upstream(
+    pub async fn integrate_upstream_commits(
         &self,
         project_id: &ProjectId,
         branch_id: &BranchId,
     ) -> Result<(), Error> {
         self.inner(project_id)
             .await
-            .merge_virtual_branch_upstream(project_id, branch_id)
+            .integrate_upstream_commits(project_id, branch_id)
             .await
     }
 
@@ -571,7 +571,7 @@ impl ControllerInner {
         Ok(())
     }
 
-    pub async fn merge_virtual_branch_upstream(
+    pub async fn integrate_upstream_commits(
         &self,
         project_id: &ProjectId,
         branch_id: &BranchId,

--- a/crates/gitbutler-core/src/virtual_branches/errors.rs
+++ b/crates/gitbutler-core/src/virtual_branches/errors.rs
@@ -242,28 +242,6 @@ impl ErrorWithContext for CreateVirtualBranchError {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum MergeVirtualBranchUpstreamError {
-    #[error("project")]
-    Conflict(ProjectConflict),
-    #[error("branch not found")]
-    BranchNotFound(BranchNotFound),
-    #[error(transparent)]
-    Other(#[from] anyhow::Error),
-}
-
-impl ErrorWithContext for MergeVirtualBranchUpstreamError {
-    fn context(&self) -> Option<Context> {
-        Some(match self {
-            MergeVirtualBranchUpstreamError::BranchNotFound(ctx) => ctx.to_context(),
-            MergeVirtualBranchUpstreamError::Conflict(ctx) => ctx.to_context(),
-            MergeVirtualBranchUpstreamError::Other(error) => {
-                return error.custom_context_or_root_cause().into()
-            }
-        })
-    }
-}
-
-#[derive(Debug, thiserror::Error)]
 pub enum CommitError {
     #[error("branch not found")]
     BranchNotFound(BranchNotFound),

--- a/crates/gitbutler-core/src/virtual_branches/remote.rs
+++ b/crates/gitbutler-core/src/virtual_branches/remote.rs
@@ -47,6 +47,7 @@ pub struct RemoteCommit {
     pub description: BString,
     pub created_at: u128,
     pub author: Author,
+    pub change_id: Option<String>,
 }
 
 pub fn list_remote_branches(
@@ -176,6 +177,7 @@ pub fn commit_to_remote_commit(commit: &git::Commit) -> RemoteCommit {
         description: commit.message().to_owned(),
         created_at: commit.time().seconds().try_into().unwrap(),
         author: commit.author().into(),
+        change_id: commit.change_id(),
     }
 }
 

--- a/crates/gitbutler-core/src/virtual_branches/virtual.rs
+++ b/crates/gitbutler-core/src/virtual_branches/virtual.rs
@@ -12,7 +12,6 @@ use std::{
 use anyhow::{anyhow, bail, Context, Result};
 use bstr::{BString, ByteSlice, ByteVec};
 use diffy::{apply_bytes as diffy_apply, Line, Patch};
-use git2::IndexConflicts;
 use git2_hooks::HookResult;
 use hex::ToHex;
 use regex::Regex;

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -177,7 +177,7 @@ fn main() {
                     virtual_branches::commands::get_base_branch_data,
                     virtual_branches::commands::set_base_branch,
                     virtual_branches::commands::update_base_branch,
-                    virtual_branches::commands::merge_virtual_branch_upstream,
+                    virtual_branches::commands::integrate_upstream_commits,
                     virtual_branches::commands::update_virtual_branch,
                     virtual_branches::commands::delete_virtual_branch,
                     virtual_branches::commands::apply_branch,

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -86,14 +86,14 @@ pub mod commands {
 
     #[tauri::command(async)]
     #[instrument(skip(handle), err(Debug))]
-    pub async fn merge_virtual_branch_upstream(
+    pub async fn integrate_upstream_commits(
         handle: AppHandle,
         project_id: ProjectId,
         branch: BranchId,
     ) -> Result<(), Error> {
         handle
             .state::<Controller>()
-            .merge_virtual_branch_upstream(&project_id, &branch)
+            .integrate_upstream_commits(&project_id, &branch)
             .await?;
         emit_vbranches(&handle, &project_id).await;
         Ok(())


### PR DESCRIPTION
- send change_id to frontend for `RemoteCommit`
- associate upstream <-> local using change_id
- split up long "merge_virtual_branch_upstream" function
- add a couple of checks to prevent unexpected state
- rebase if force push allowed (we should let user choose merge over rebase still)