### PR TITLE
refactor: Replace manual rebase with cherry-rebase function.

### DIFF
--- a/crates/gitbutler-core/src/virtual_branches/base.rs
+++ b/crates/gitbutler-core/src/virtual_branches/base.rs
@@ -514,9 +514,7 @@ pub fn update_base_branch(
                     }
 
                     // branch was not pushed to upstream yet. attempt a rebase,
-                    let (_, committer) = project_repository.git_signatures(user)?;
-                    let rebased_head_oid = cherry_rebase(project_repository, new_target_commit.id(), new_target_commit.id(), branch_head)?;
-
+                    let rebased_head_oid = cherry_rebase(project_repository, new_target_commit.id(), new_target_commit.id(), branch.head)?;
                     if let Some(rebased_head_oid) = rebased_head_oid {
                         // rebase worked out, rewrite the branch head
                         branch.head = rebased_head_oid;

--- a/crates/gitbutler-core/src/virtual_branches/base.rs
+++ b/crates/gitbutler-core/src/virtual_branches/base.rs
@@ -514,7 +514,12 @@ pub fn update_base_branch(
                     }
 
                     // branch was not pushed to upstream yet. attempt a rebase,
-                    let rebased_head_oid = cherry_rebase(project_repository, new_target_commit.id(), new_target_commit.id(), branch.head)?;
+                    let rebased_head_oid = cherry_rebase(
+                        project_repository,
+                        new_target_commit.id(),
+                        new_target_commit.id(),
+                        branch.head,
+                    )?;
                     if let Some(rebased_head_oid) = rebased_head_oid {
                         // rebase worked out, rewrite the branch head
                         branch.head = rebased_head_oid;


### PR DESCRIPTION
This is another place we're using the libgit2 rebase function, which won't preserve our change-id headers