### PR TITLE
Set branch/commit stores only once on init

### DIFF
--- a/app/src/lib/components/BranchLane.svelte
+++ b/app/src/lib/components/BranchLane.svelte
@@ -30,13 +30,13 @@
 	// TODO: Update store here rather than reset it
 	$: ownershipStore.set(Ownership.fromBranch(branch));
 
-	const branchStore = createContextStore(Branch, branch);
+	const branchStore = createContextStore(Branch, undefined);
 	$: branchStore.set(branch);
 
-	const localCommits = createLocalContextStore(branch.localCommits);
+	const localCommits = createLocalContextStore(undefined);
 	$: localCommits.set(branch.localCommits);
 
-	const remoteCommits = createRemoteContextStore(branch.remoteCommits);
+	const remoteCommits = createRemoteContextStore(undefined);
 	$: remoteCommits.set(branch.remoteCommits);
 
 	// Set the store immediately so it can be updated later.

--- a/app/src/lib/utils/context.ts
+++ b/app/src/lib/utils/context.ts
@@ -52,8 +52,8 @@ export function maybeGetContextStore<
  */
 export function createContextStore<T extends Class>(
 	key: T | symbol,
-	value: InstanceType<T>
-): Writable<InstanceType<T>> {
+	value: InstanceType<T> | undefined
+): Writable<InstanceType<T> | undefined> {
 	const instance = svelteGetContext<Writable<InstanceType<T>> | undefined>(key);
 	if (instance) {
 		throw new Error('Context store already defined for key: ' + key.toString());
@@ -78,13 +78,13 @@ export function createContextStore<T extends Class>(
  */
 export function buildContextStore<T, S extends Readable<T> = Readable<T>>(
 	name: string
-): [() => S, (value: T) => Writable<T>] {
+): [() => S, (value: T | undefined) => Writable<T>] {
 	const identifier = Symbol(name);
 	return [
 		() => {
 			return getContextStoreBySymbol<T, S>(identifier);
 		},
-		(value: T) => {
+		(value: T | undefined) => {
 			return createContextStore(identifier, value);
 		}
 	];


### PR DESCRIPTION
- initialse context stores with undefined
- simpler logic for reducing outbound requests/flicker