### PR TITLE
Return the merge result in the case the rebase bails

### DIFF
--- a/crates/gitbutler-core/src/virtual_branches/base.rs
+++ b/crates/gitbutler-core/src/virtual_branches/base.rs
@@ -523,7 +523,7 @@ pub fn update_base_branch(
 
                     // rebase failed, just do the merge
                     if rebased_head_oid.is_err() {
-                        return result_merge(branch)
+                        return result_merge(branch);
                     }
 
                     if let Some(rebased_head_oid) = rebased_head_oid? {

--- a/crates/gitbutler-core/src/virtual_branches/base.rs
+++ b/crates/gitbutler-core/src/virtual_branches/base.rs
@@ -519,8 +519,14 @@ pub fn update_base_branch(
                         new_target_commit.id(),
                         new_target_commit.id(),
                         branch.head,
-                    )?;
-                    if let Some(rebased_head_oid) = rebased_head_oid {
+                    );
+
+                    // rebase failed, just do the merge
+                    if rebased_head_oid.is_err() {
+                        return result_merge(branch)
+                    }
+
+                    if let Some(rebased_head_oid) = rebased_head_oid? {
                         // rebase worked out, rewrite the branch head
                         branch.head = rebased_head_oid;
                         branch.tree = branch_merge_index_tree_oid;


### PR DESCRIPTION
We changed the logic to where if a rebase fails it just bails, which can be because there is a merge commit in the branch. In this case, if we were even trying a rebase, it's because the merge worked. So if the `cherry_rebase()` bails, just do what we did before, which is return the merge result.