### PR TITLE
remove `chrono` from `core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,7 +2113,6 @@ dependencies = [
  "async-trait",
  "backtrace",
  "bstr",
- "chrono",
  "diffy",
  "dirs 5.0.1",
  "filetime",

--- a/crates/gitbutler-core/Cargo.toml
+++ b/crates/gitbutler-core/Cargo.toml
@@ -17,7 +17,6 @@ anyhow = "1.0.82"
 async-trait = "0.1.80"
 backtrace = { version = "0.3.71", optional = true }
 bstr = "1.9.1"
-chrono = { version = "0.4.38", features = ["serde"] }
 diffy = "0.3.0"
 dirs = "5.0.1"
 filetime = "0.2.23"

--- a/crates/gitbutler-core/src/time.rs
+++ b/crates/gitbutler-core/src/time.rs
@@ -10,3 +10,18 @@ pub fn now_ms() -> u128 {
         .expect("system time is set before the Unix epoch")
         .as_millis()
 }
+
+pub fn now_since_unix_epoch_ms() -> i64 {
+    UNIX_EPOCH
+        .elapsed()
+        .map(|d| i64::try_from(d.as_millis()).expect("no system date is this far in the future"))
+        .unwrap_or_else(|_| {
+            i64::try_from(
+                UNIX_EPOCH
+                    .duration_since(std::time::SystemTime::now())
+                    .expect("a date in the past")
+                    .as_millis(),
+            )
+            .expect("no time is that far in the past")
+        })
+}

--- a/crates/gitbutler-core/src/virtual_branches/virtual.rs
+++ b/crates/gitbutler-core/src/virtual_branches/virtual.rs
@@ -27,6 +27,7 @@ use super::{
 use crate::error::{self, AnyhowContextExt, Code};
 use crate::git::diff::{diff_files_into_hunks, trees, FileDiff};
 use crate::ops::snapshot::Snapshot;
+use crate::time::now_since_unix_epoch_ms;
 use crate::virtual_branches::branch::HunkHash;
 use crate::{
     dedup::{dedup, dedup_fmt},
@@ -1078,7 +1079,7 @@ pub fn create_virtual_branch(
                 other_branch.selected_for_changes = None;
                 vb_state.set_branch(other_branch.clone())?;
             }
-            Some(chrono::Utc::now().timestamp_millis())
+            Some(now_since_unix_epoch_ms())
         } else {
             None
         }
@@ -1086,7 +1087,7 @@ pub fn create_virtual_branch(
         (!all_virtual_branches
             .iter()
             .any(|b| b.selected_for_changes.is_some()))
-        .then_some(chrono::Utc::now().timestamp_millis())
+        .then_some(now_since_unix_epoch_ms())
     };
 
     // make space for the new branch
@@ -1435,7 +1436,7 @@ pub fn update_branch(
                 other_branch.selected_for_changes = None;
                 vb_state.set_branch(other_branch.clone())?;
             }
-            Some(chrono::Utc::now().timestamp_millis())
+            Some(now_since_unix_epoch_ms())
         } else {
             None
         };
@@ -1500,7 +1501,7 @@ fn ensure_selected_for_changes(vb_state: &VirtualBranchesHandle) -> Result<()> {
 
     applied_branches.sort_by_key(|branch| branch.order);
 
-    applied_branches[0].selected_for_changes = Some(chrono::Utc::now().timestamp_millis());
+    applied_branches[0].selected_for_changes = Some(now_since_unix_epoch_ms());
     vb_state.set_branch(applied_branches[0].clone())?;
     Ok(())
 }
@@ -4071,7 +4072,7 @@ pub fn create_virtual_branch_from_branch(
     let selected_for_changes = (!all_virtual_branches
         .iter()
         .any(|b| b.selected_for_changes.is_some()))
-    .then_some(chrono::Utc::now().timestamp_millis());
+    .then_some(now_since_unix_epoch_ms());
 
     let now = crate::time::now_ms();
 


### PR DESCRIPTION
### Rationale

`chrono` was only used to get the milliseconds since unix-epoch, which seems unnecessary given the (relative) simplicity of a hand-rolled function.

I argue that more steps should be taken to avoid this approach entirely and use `SystemTime` or better, `Instant` for that.

### Tasks

* [x] remove `chrono` in `core` with a 1:1 replacement

### Notes for the Reviewer

I didn't change the type of fields that currently are `i64` as these are serialized, and I didn't want to risk the format being off.
That way, the PR stays minimal as well.
