### PR TITLE
`now_since_unix_epoch_ms` now uses negative dates for times pre Unix-epoch

### DIFF
--- a/crates/gitbutler-core/src/time.rs
+++ b/crates/gitbutler-core/src/time.rs
@@ -16,10 +16,10 @@ pub fn now_since_unix_epoch_ms() -> i64 {
         .elapsed()
         .map(|d| i64::try_from(d.as_millis()).expect("no system date is this far in the future"))
         .unwrap_or_else(|_| {
-            i64::try_from(
+            -i64::try_from(
                 UNIX_EPOCH
                     .duration_since(std::time::SystemTime::now())
-                    .expect("a date in the past")
+                    .expect("'now' is in the past")
                     .as_millis(),
             )
             .expect("no time is that far in the past")


### PR DESCRIPTION
Follow-up to #3857.
