### PR TITLE
minor Windows adjustments

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,6 +20,7 @@ you right. Let's get started.
     - [Building on Windows](#building-on-windows)
     - [File permissions](#file-permissions)
     - [Perl](#perl)
+    - [Crosscompilation](#crosscompilation)
 - [Design](#design)
 - [Contributing](#contributing)
 - [Some Other Random Notes](#some-other-random-notes)
@@ -195,6 +196,41 @@ after installation, just make sure to restart the terminal after installing).
 Note that it might appear that the build has hung or frozen on the `openssl-sys` crate.
 It's not, it's just that Cargo can't report the status of a C/C++ build happening
 under the hood, and openssl is _large_. It'll take a while to compile.
+
+### Crosscompilation
+
+This paragraph is about crosscompilation to x86_64-MSVC from ARM Windows,
+a configuration typical for people with Apple Silicon and Parallels VMs,
+which only allow ARM Windows to be used.
+
+The `winapi` dependency on `gitbutler-git` doesn't currently compile on ARM,
+which means cross-compilation to x86-64 is required to workaround that. Besides,
+most users will probably still be on INTEL machines, making this capability 
+a common requirement.
+
+In a Git `bash`, *with MSVC for x86-64 installed on the system*, run the following
+to prepare the environment.
+
+```bash
+export TRIPLE_OVERRIDE=x86_64-pc-windows-msvc
+export CARGO_BUILD_TARGET=x86_64-pc-windows-msvc
+export OPENSSL_SRC_PERL="c:/Strawberry/perl/bin/perl.exe"
+```
+
+Here is how to produce a nightly release build:
+
+```
+pnpm tauri build --features windows,devtools --config  crates/gitbutler-tauri/tauri.conf.nightly.json
+```
+
+And this is how to get a local developer debug build:
+
+```bash
+pnpm tauri dev --features windows --target x86_64-pc-windows-msvc
+```
+
+Note that it's necessary to repeat the `--target` specification as otherwise the final copy operation doesn't work,
+triggered by `tauri` itself.
 
 ---
 

--- a/crates/gitbutler-core/src/fs.rs
+++ b/crates/gitbutler-core/src/fs.rs
@@ -85,18 +85,12 @@ pub(crate) fn create_dirs_then_write<P: AsRef<Path>>(
     persist_tempfile(temp_file, file_path)
 }
 
-#[allow(dead_code)]
 fn persist_tempfile(
     tempfile: gix::tempfile::Handle<gix::tempfile::handle::Writable>,
     to_path: impl AsRef<Path>,
 ) -> std::io::Result<()> {
     match tempfile.persist(to_path) {
-        Ok(Some(_opened_file)) => {
-            // EXPERIMENT: Does this fix #3601?
-            #[cfg(windows)]
-            _opened_file.sync_all()?;
-            Ok(())
-        }
+        Ok(Some(_opened_file)) => Ok(()),
         Ok(None) => unreachable!(
             "BUG: a signal has caused the tempfile to be removed, but we didn't install a handler"
         ),

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -17,7 +17,6 @@ test = false
 tauri-build = { version = "1.5", features = [] }
 
 [dev-dependencies]
-#once_cell = "1.19"
 pretty_assertions = "1.4"
 tempfile = "3.10"
 gitbutler-testsupport.workspace = true

--- a/crates/gitbutler-tauri/inject-git-binaries.sh
+++ b/crates/gitbutler-tauri/inject-git-binaries.sh
@@ -7,16 +7,15 @@ function log {
 }
 
 ROOT="$(dirname "$THIS")/../.."
-TARGET_ROOT="$ROOT/target/release"
+TRIPLE=${TRIPLE_OVERRIDE:-$(rustc -vV | sed -n 's|host: ||p')}
+TARGET_ROOT="$ROOT/target/${TRIPLE_OVERRIDE:-}/release"
 CRATE_ROOT="$ROOT/crates/gitbutler-tauri"
 
 if [ -f "$TARGET_ROOT/gitbutler-git-askpass" ] && [ -f "$TARGET_ROOT/gitbutler-git-setsid" ]; then
-    TRIPLE="$(rustc -vV | sed -n 's|host: ||p')"
     log injecting gitbutler-git binaries into crates/gitbutler-tauri "(TRIPLE=${TRIPLE})"
     cp -v "$TARGET_ROOT/gitbutler-git-askpass" "$CRATE_ROOT/gitbutler-git-askpass-${TRIPLE}"
     cp -v "$TARGET_ROOT/gitbutler-git-setsid" "$CRATE_ROOT/gitbutler-git-setsid-${TRIPLE}"
 elif [ -f "$TARGET_ROOT/gitbutler-git-askpass.exe" ] && [ -f "$TARGET_ROOT/gitbutler-git-setsid.exe" ]; then
-    TRIPLE="$(rustc.exe -vV | sed -n 's|host: ||p')"
     log injecting gitbutler-git binaries into crates/gitbutler-tauri "(TRIPLE=${TRIPLE})"
     cp -v "$TARGET_ROOT/gitbutler-git-askpass.exe" "$CRATE_ROOT/gitbutler-git-askpass-${TRIPLE}.exe"
     cp -v "$TARGET_ROOT/gitbutler-git-setsid.exe" "$CRATE_ROOT/gitbutler-git-setsid-${TRIPLE}.exe"

--- a/crates/gitbutler-tauri/src/watcher.rs
+++ b/crates/gitbutler-tauri/src/watcher.rs
@@ -117,7 +117,11 @@ impl Watchers {
         {
             handle.post(action).await.context("failed to post event")
         } else {
-            Err(anyhow::anyhow!("watcher not found",))
+            Err(anyhow::anyhow!(
+                "matching watcher to post event not found, wanted {wanted}, got {actual:?}",
+                wanted = action.project_id(),
+                actual = watcher.as_ref().map(|w| w.project_id())
+            ))
         }
     }
 


### PR DESCRIPTION
This PR is a side-effect of getting local VM builds to work, specifically x86-64 builds on ARM Windows VMs (running on Macs via Parallels).

Besides some cleanup, there is one commit that adjusts a script so that it's easier to use in these situations. Finally, there now is documentation for how to crosscompile.

Note that despite producing a release binary, the build still fails on the final rename from `gitbutler-tauri.exe` to `GitButler Nightly.exe`, but that's not fixed here nor considered a problem.

### Notes for the Reviewer

The script change *might* break the Windows build even though it shouldn't.
