### PR TITLE
oplog review (part 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,6 +2123,7 @@ dependencies = [
  "gitbutler-git",
  "gitbutler-testsupport",
  "gix",
+ "glob",
  "hex",
  "itertools 0.12.1",
  "lazy_static",

--- a/crates/gitbutler-core/Cargo.toml
+++ b/crates/gitbutler-core/Cargo.toml
@@ -10,6 +10,7 @@ once_cell = "1.19"
 pretty_assertions = "1.4"
 gitbutler-testsupport.workspace = true
 gitbutler-git = { workspace = true, features = ["test-askpass-path"] }
+glob = "0.3.1"
 
 [dependencies]
 toml = "0.8.12"

--- a/crates/gitbutler-core/src/git/mod.rs
+++ b/crates/gitbutler-core/src/git/mod.rs
@@ -38,7 +38,7 @@ mod url;
 pub use self::url::*;
 
 mod repository_ext;
-pub use repository_ext::*;
+pub use repository_ext::RepositoryExt;
 
 mod tree_ext;
 pub use tree_ext::*;

--- a/crates/gitbutler-core/src/git/repository_ext.rs
+++ b/crates/gitbutler-core/src/git/repository_ext.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
 use git2::{Repository, Tree};
 use tracing::instrument;
 
@@ -8,6 +8,13 @@ use tracing::instrument;
 pub trait RepositoryExt {
     /// Based on the index, add all data similar to `git add .` and create a tree from it, which is returned.
     fn get_wd_tree(&self) -> Result<Tree>;
+
+    /// Returns the `gitbutler/integration` branch if the head currently points to it, or fail otherwise.
+    /// Use it before any modification to the repository, or extra defensively each time the
+    /// integration is needed.
+    ///
+    /// This is for safety to assure the repository actually is in 'gitbutler mode'.
+    fn integration_ref_from_head(&self) -> Result<git2::Reference<'_>>;
 }
 
 impl RepositoryExt for Repository {
@@ -17,5 +24,14 @@ impl RepositoryExt for Repository {
         index.add_all(["*"], git2::IndexAddOption::DEFAULT, None)?;
         let oid = index.write_tree()?;
         self.find_tree(oid).map(Into::into).map_err(Into::into)
+    }
+
+    fn integration_ref_from_head(&self) -> Result<git2::Reference<'_>> {
+        let head_ref = self.head().context("BUG: head must point to a reference")?;
+        if head_ref.name_bytes() == b"refs/heads/gitbutler/integration" {
+            Ok(head_ref)
+        } else {
+            bail!("Unexpected state: cannot perform operation on non-integration branch")
+        }
     }
 }

--- a/crates/gitbutler-core/src/git/repository_ext.rs
+++ b/crates/gitbutler-core/src/git/repository_ext.rs
@@ -1,14 +1,17 @@
 use anyhow::Result;
 use git2::{Repository, Tree};
+use tracing::instrument;
 
 /// Extension trait for `git2::Repository`.
 ///
 /// For now, it collects useful methods from `gitbutler-core::git::Repository`
 pub trait RepositoryExt {
+    /// Based on the index, add all data similar to `git add .` and create a tree from it, which is returned.
     fn get_wd_tree(&self) -> Result<Tree>;
 }
 
 impl RepositoryExt for Repository {
+    #[instrument(level = tracing::Level::DEBUG, skip(self), err(Debug))]
     fn get_wd_tree(&self) -> Result<Tree> {
         let mut index = self.index()?;
         index.add_all(["*"], git2::IndexAddOption::DEFAULT, None)?;

--- a/crates/gitbutler-core/src/project_repository/repository.rs
+++ b/crates/gitbutler-core/src/project_repository/repository.rs
@@ -615,8 +615,7 @@ impl Repository {
     }
 
     pub fn repo(&self) -> &git2::Repository {
-        let r = &self.git_repository;
-        r.into()
+        (&self.git_repository).into()
     }
 }
 

--- a/crates/gitbutler-core/tests/suite/virtual_branches/mod.rs
+++ b/crates/gitbutler-core/tests/suite/virtual_branches/mod.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::{fs, path, str::FromStr};
 
 use gitbutler_core::{
@@ -47,6 +48,16 @@ impl Default for Test {
             project,
             data_dir: Some(data_dir),
         }
+    }
+}
+
+impl Test {
+    /// Consume this instance and keep the temp directory that held the local repository, returning it.
+    /// Best used inside a `dbg!(test.debug_local_repo())`
+    #[allow(dead_code)]
+    pub fn debug_local_repo(mut self) -> PathBuf {
+        let repo = std::mem::take(&mut self.repository);
+        repo.debug_local_repo()
     }
 }
 

--- a/crates/gitbutler-testsupport/src/test_project.rs
+++ b/crates/gitbutler-testsupport/src/test_project.rs
@@ -1,4 +1,5 @@
 use std::path;
+use std::path::PathBuf;
 
 use gitbutler_core::git::{self, CommitExt};
 use tempfile::TempDir;
@@ -85,6 +86,11 @@ impl Default for TestProject {
 }
 
 impl TestProject {
+    /// Consume this instance and keep the temp directory that held the local repository, returning it.
+    /// Best used inside a `dbg!(test_project.debug_local_repo())`
+    pub fn debug_local_repo(mut self) -> PathBuf {
+        self.local_tmp.take().unwrap().into_path()
+    }
     pub fn path(&self) -> &std::path::Path {
         self.local_repository.workdir().unwrap()
     }


### PR DESCRIPTION
Follow up to #3867

### Tasks

* [x] assure snapshot doesn't happen outside of the integration branch (figure out why it's flaky)
    - don't know why it was flaky though.
* [x] fix worktree-merge when creating a snapshot
* ~~store commit data directly (as object)~~ - not possible with `git2`, besides, it's safe to assume newline-separation between headers and message.
* ~~assure test index restore~~
* ~~assure test vbranch-commit restore~~
* ~~assure test vbranch-tree restore~~
* ~~assure test integration restore~~
* ~~review everything else of oplog.rs and assure important parts have basic tests at least~~


### Notes for the Reviewer

* When restoring a snapshot, I have made the integration branch mandatory when restoring it due to the way `set_head()` is used unconditionally. The prepare-snapshot code is still flexible and treats it as optional.
* The tests are still needed, but I have trouble to align the state of the integration branch with what it should be, so it's hard for me to make assertions as they aren't what I think it should be. I would like to take a break from that.

### Open questions

#### Can the usage of oplog be more abstract? 

Right now it's hand-rolled prepare-commit steps everywhere, could that be more 'automatic'?
TBD❗️

### General Thoughts

#### On `core.git`

* When encountering `core::git::*` and all its wrapped types I was wondering if this is going to be a god-sent or a burden. Time will tell.
* The `git` wrapped types don't seem to be used much/consistently within `ops`, which makes it a potential burden.
* Somehow I think that it's easier to go with `git2` while it's there as long as repositories aren't kept around but opened mostly when needed. This is what I have seen. I have also seen a simple API wrapper for configuration handling (get/set) and though that such improvements could be done with so that we'd have `git2::Repository::open()?.config().easy().use_easy_api()` - this is just a general idea. Right now I can't tell, but I will keep an eye out for that.
* I chose not to replace `git2` usage with `git` except for in the API (where `git::Oid` is used instead of `git2::Oid`) until I know what's the right choice here.

#### On worktree-handling

Due to variable naming, it's not always clear what `Project::path` is. It's a worktree-directory, and whenever it's used like `project.path.join(".git/gitbutler")` it's a problem that will prevent GB from dealing with ALL the repository configurations out there as `.git` doesn't have to be a directory, nor does it have to be there at all. The only way to handle this correctly is to open a repo with `gix::open()` and then use the `git_dir()` and `worktree_dir()` methods respectively to get the actual directories. These do have to be treated separately, but it's definitely a good idea start from a working-tree directory as it matches with the single-worktree paradigm of GB.

When the is a `repo` already, definitely use its `path()` (which is its `git_dir`), instead of doing `wd.join(".git/gitbutler/...")`.

#### Avoid `sha` in variable names

As everything should be strongly typed, as opposed to stringly typed, by the type it's already clear that it's a hash. What's not usually clear is what the hash points to. If I read `target_sha` I don't know much, especially because `target` is GB lingo for `trunk to merge with`. Instead, I'd call it `target_commit`, which tells me something important that's not obvious from the type otherwise.


#### Don't predict the compiler

Sometimes code feels like it tries to anticipate what the compiler would say, even though the most direct (or intuitive) way of doing things would actually work. It's usually easiest to try first, and then make it work if needed. Sometimes, it just works.


#### Don't repeat module-names in test-functions

That way, they read well both on the command-line and in IDEs.

<img width="469" alt="Screenshot 2024-05-28 at 09 45 35" src="https://github.com/gitbutlerapp/gitbutler/assets/63622/c74d5ec8-57ee-4ae9-99d7-5006518df804">

From there, it's also easier to find more descriptive names.


