### PR TITLE
don't choke on .gitignore directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2506,9 +2506,9 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f78f7d6dcda7a5809efd73a33b145e3dce7421c460df21f32126f9732736b0c"
+checksum = "c3338ff92a2164f5209f185ec0cd316f571a72676bb01d27e22f2867ba69f77a"
 dependencies = [
  "fastrand 2.1.0",
  "gix-features",
@@ -2517,9 +2517,9 @@ dependencies = [
 
 [[package]]
 name = "gix-glob"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "682bdc43cb3c00dbedfcc366de2a849b582efd8d886215dbad2ea662ec156bb5"
+checksum = "c2a29ad0990cf02c48a7aac76ed0dbddeb5a0d070034b83675cc3bbf937eace4"
 dependencies = [
  "bitflags 2.5.0",
  "bstr",


### PR DESCRIPTION
This is also effective for `.gitattributes` directories, making `gitoxide` act just like Git.

Note that `gix-fs` is updated just for a potential Windows fix which probably
doesn't matter.

Fixes #3876.
