### PR TITLE
move get_wd_tree to git2::Repository extension trait

### DIFF
--- a/crates/gitbutler-core/src/git/mod.rs
+++ b/crates/gitbutler-core/src/git/mod.rs
@@ -39,3 +39,6 @@ pub use config::*;
 
 mod url;
 pub use self::url::*;
+
+mod repository_ext;
+pub use repository_ext::*;

--- a/crates/gitbutler-core/src/git/repository.rs
+++ b/crates/gitbutler-core/src/git/repository.rs
@@ -580,13 +580,6 @@ impl Repository {
             .map_err(Into::into)
     }
 
-    pub fn get_wd_tree(&self) -> Result<Tree> {
-        let mut index = self.0.index()?;
-        index.add_all(["*"], git2::IndexAddOption::DEFAULT, None)?;
-        let oid = index.write_tree()?;
-        self.0.find_tree(oid).map(Into::into).map_err(Into::into)
-    }
-
     pub fn remote(&self, name: &str, url: &Url) -> Result<Remote> {
         self.0
             .remote(name, &url.to_string())

--- a/crates/gitbutler-core/src/git/repository.rs
+++ b/crates/gitbutler-core/src/git/repository.rs
@@ -43,19 +43,6 @@ impl Repository {
         Ok(Repository(inner))
     }
 
-    pub fn add_disk_alternate<P: AsRef<Path>>(&self, path: P) -> Result<()> {
-        let alternates_path = self.0.path().join("objects/info/alternates");
-        if !alternates_path.exists() {
-            let path = path.as_ref().normalize();
-            let mut alternates_file = std::fs::File::create(&alternates_path)?;
-            alternates_file.write_all(path.as_path().as_os_str().as_encoded_bytes())?;
-            alternates_file.write_all(b"\n")?;
-            self.0.odb().and_then(|odb| odb.refresh())?;
-        }
-
-        Ok(())
-    }
-
     pub fn add_submodule<P: AsRef<Path>>(&self, url: &Url, path: P) -> Result<Submodule<'_>> {
         self.0
             .submodule(&url.to_string(), path.as_ref(), false)

--- a/crates/gitbutler-core/src/git/repository.rs
+++ b/crates/gitbutler-core/src/git/repository.rs
@@ -2,7 +2,6 @@ use super::{
     Blob, Branch, Commit, Config, Index, Oid, Reference, Refname, Remote, Result, Signature, Tree,
     TreeBuilder, Url,
 };
-use crate::path::Normalize;
 use git2::{BlameOptions, Submodule};
 use git2_hooks::HookResult;
 #[cfg(unix)]

--- a/crates/gitbutler-core/src/git/repository_ext.rs
+++ b/crates/gitbutler-core/src/git/repository_ext.rs
@@ -1,0 +1,18 @@
+use anyhow::Result;
+use git2::{Repository, Tree};
+
+/// Extension trait for `git2::Repository`.
+///
+/// For now, it collects useful methods from `gitbutler-core::git::Repository`
+pub trait RepositoryExt {
+    fn get_wd_tree(&self) -> Result<Tree>;
+}
+
+impl RepositoryExt for Repository {
+    fn get_wd_tree(&self) -> Result<Tree> {
+        let mut index = self.index()?;
+        index.add_all(["*"], git2::IndexAddOption::DEFAULT, None)?;
+        let oid = index.write_tree()?;
+        self.find_tree(oid).map(Into::into).map_err(Into::into)
+    }
+}

--- a/crates/gitbutler-core/src/project_repository/repository.rs
+++ b/crates/gitbutler-core/src/project_repository/repository.rs
@@ -136,11 +136,6 @@ impl Repository {
         Ok(head)
     }
 
-    pub fn get_wd_tree(&self) -> Result<git::Tree> {
-        let tree = self.git_repository.get_wd_tree()?;
-        Ok(tree)
-    }
-
     pub fn is_path_ignored<P: AsRef<std::path::Path>>(&self, path: P) -> Result<bool> {
         let path = path.as_ref();
         let ignored = self.git_repository.is_path_ignored(path)?;
@@ -616,6 +611,11 @@ impl Repository {
         self.git_repository
             .add_remote(name, url)
             .map_err(anyhow::Error::from)
+    }
+
+    pub fn repo(&self) -> &git2::Repository {
+        let r = &self.git_repository;
+        r.into()
     }
 }
 


### PR DESCRIPTION
This way we reduce drilling and allow ourselves to eventually remove core::git types