### PR TITLE
fix: cannot close file card from Trunk's commit history

### DIFF
--- a/app/src/routes/[projectId]/base/+page.svelte
+++ b/app/src/routes/[projectId]/base/+page.svelte
@@ -61,13 +61,14 @@
 			/>
 		</div>
 		<div class="base__right">
-			{#if selected}
+			{#if selected && $fileIdSelection.length > 0}
 				<FileCard
 					conflicted={selected.conflicted}
 					file={selected}
 					isUnapplied={false}
 					readonly={true}
 					on:close={() => {
+						selectedFiles.set([]);
 						fileIdSelection.clear();
 					}}
 				/>


### PR DESCRIPTION
![CleanShot 2024-05-29 at 15 49 35](https://github.com/gitbutlerapp/gitbutler/assets/15188817/53364b7d-2734-45c7-a114-d16ed8a8e95b)

Currently, we cannot close the file card on the right side by clicking the 'Close' button or
canceling the selection of files. This PR fixes the issue.