### PR TITLE
assure reflog is recreated if not present even if ref is present

### DIFF
--- a/crates/gitbutler-core/src/git/commit_ext.rs
+++ b/crates/gitbutler-core/src/git/commit_ext.rs
@@ -1,7 +1,5 @@
 // use anyhow::Result;
-use super::Result;
 use bstr::BStr;
-use git2::Commit;
 
 /// Extension trait for `git2::Commit`.
 ///
@@ -10,9 +8,7 @@ pub trait CommitExt {
     /// Obtain the commit-message as bytes, but without assuming any encoding.
     fn message_bstr(&self) -> &BStr;
     fn change_id(&self) -> Option<String>;
-    fn parents_gb(&self) -> Result<Vec<Commit<'_>>>;
     fn is_signed(&self) -> bool;
-    fn tree_gb(&self) -> Result<git2::Tree<'_>>;
 }
 
 impl<'repo> CommitExt for git2::Commit<'repo> {
@@ -24,23 +20,10 @@ impl<'repo> CommitExt for git2::Commit<'repo> {
         if cid.is_empty() {
             None
         } else {
-            // convert the Buf to a string
-            let ch_id = std::str::from_utf8(&cid).ok()?.to_owned();
-            Some(ch_id)
+            String::from_utf8(cid.to_owned()).ok()
         }
-    }
-    fn parents_gb(&self) -> Result<Vec<Commit<'repo>>> {
-        let mut parents = vec![];
-        for i in 0..self.parent_count() {
-            parents.push(self.parent(i)?);
-        }
-        Ok(parents)
     }
     fn is_signed(&self) -> bool {
-        let cid = self.header_field_bytes("gpgsig").ok();
-        cid.is_some()
-    }
-    fn tree_gb(&self) -> Result<git2::Tree<'repo>> {
-        self.tree().map_err(Into::into)
+        self.header_field_bytes("gpgsig").is_ok()
     }
 }

--- a/crates/gitbutler-core/src/git/repository.rs
+++ b/crates/gitbutler-core/src/git/repository.rs
@@ -223,15 +223,9 @@ impl Repository {
         parents: &[&git2::Commit<'_>],
         change_id: Option<&str>,
     ) -> Result<Oid> {
-        let parents: Vec<&git2::Commit> = parents.iter().map(|c| c.to_owned()).collect::<Vec<_>>();
-
-        let commit_buffer = self.0.commit_create_buffer(
-            author.into(),
-            committer.into(),
-            message,
-            tree,
-            &parents,
-        )?;
+        let commit_buffer =
+            self.0
+                .commit_create_buffer(author.into(), committer.into(), message, tree, parents)?;
 
         let commit_buffer = Self::inject_change_id(&commit_buffer, change_id)?;
 

--- a/crates/gitbutler-testsupport/src/test_project.rs
+++ b/crates/gitbutler-testsupport/src/test_project.rs
@@ -1,7 +1,7 @@
 use std::path;
 use std::path::PathBuf;
 
-use gitbutler_core::git::{self, CommitExt};
+use gitbutler_core::git::{self};
 use tempfile::TempDir;
 
 use crate::{init_opts, VAR_NO_CLEANUP};
@@ -276,16 +276,15 @@ impl TestProject {
             .peel_to_commit()
             .unwrap();
         let tree = match self.local_repository.find_branch(&branch) {
-            Ok(branch) => branch.peel_to_tree(),
+            Ok(branch) => branch.peel_to_tree().unwrap(),
             Err(git::Error::NotFound(_)) => {
                 self.local_repository
                     .reference(&branch, head_commit.id().into(), false, "new branch")
                     .unwrap();
-                head_commit.tree_gb()
+                head_commit.tree().unwrap()
             }
-            Err(error) => Err(error),
-        }
-        .unwrap();
+            Err(error) => panic!("{:?}", error),
+        };
         self.local_repository.set_head(&branch).unwrap();
         self.local_repository
             .checkout_tree(&tree)


### PR DESCRIPTION
What's unclear though is how the reflog happens to be missing in the first place.

On the bright side, the reflog is just a formality and now any invocation of the oplog will recreate the data it needs.

### Tasks

* [x] fix issue with test
* [x] more refactoring

### Notes for the Reviewer

* After `CommitExt::tree_gb()` was removed, the call-sites look a bit more wordy now. However, I think there is a chance this goes away once I get to simplifying the error handling.