### PR TITLE
fixes reflog timestamps

### DIFF
--- a/crates/gitbutler-core/src/ops/reflog.rs
+++ b/crates/gitbutler-core/src/ops/reflog.rs
@@ -86,7 +86,7 @@ fn standard_signature() -> gix::actor::SignatureRef<'static> {
     gix::actor::SignatureRef {
         name: GITBUTLER_INTEGRATION_COMMIT_AUTHOR_NAME.into(),
         email: GITBUTLER_INTEGRATION_COMMIT_AUTHOR_EMAIL.into(),
-        time: Default::default(),
+        time: gix::date::Time::now_local_or_utc(),
     }
 }
 


### PR DESCRIPTION
Time stapms are super imporatant for this (thanks @schacon) - without a correct time stamp, the trees will be GC'd