### PR TITLE
Remove error logging related to blame

### DIFF
--- a/crates/gitbutler-core/src/virtual_branches/virtual.rs
+++ b/crates/gitbutler-core/src/virtual_branches/virtual.rs
@@ -1745,7 +1745,6 @@ fn compute_locks(
                 }
                 let hash = Hunk::hash_diff(&hunk.diff_lines);
                 let Some(branch_id) = commit_to_branch.get(&commit_id.into()) else {
-                    tracing::error!("Commit not found in branch map");
                     continue;
                 };
 


### PR DESCRIPTION
- blame range can include commits not in vbranch
- lookup returning none expected behavior