### PR TITLE
feat: Open with VS Code also opens VS Codium if available, partial fix for #3646

### DIFF
--- a/app/src/lib/components/Board.svelte
+++ b/app/src/lib/components/Board.svelte
@@ -12,6 +12,7 @@
 	import { BaseBranch } from '$lib/vbranches/types';
 	import { VirtualBranchService } from '$lib/vbranches/virtualBranch';
 	import { open } from '@tauri-apps/api/shell';
+	import { editor } from '$lib/utils/systemEditor';
 
 	const vbranchService = getContext(VirtualBranchService);
 	const branchController = getContext(BranchController);
@@ -149,9 +150,9 @@
 										role="button"
 										tabindex="0"
 										on:keypress={async () =>
-											await open(`vscode://file${project.vscodePath}/?windowId=_blank`)}
+											await open(`${editor.get()}://file${project.vscodePath}/?windowId=_blank`)}
 										on:click={async () =>
-											await open(`vscode://file${project.vscodePath}/?windowId=_blank`)}
+											await open(`${editor.get()}://file${project.vscodePath}/?windowId=_blank`)}
 									>
 										<div class="empty-board__suggestions__link__icon">
 											<Icon name="vscode" />

--- a/app/src/lib/components/Board.svelte
+++ b/app/src/lib/components/Board.svelte
@@ -8,11 +8,11 @@
 	import { cloneWithRotation } from '$lib/dragging/draggable';
 	import { persisted } from '$lib/persisted/persisted';
 	import { getContext, getContextStore } from '$lib/utils/context';
+	import { editor } from '$lib/utils/systemEditor';
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { BaseBranch } from '$lib/vbranches/types';
 	import { VirtualBranchService } from '$lib/vbranches/virtualBranch';
 	import { open } from '@tauri-apps/api/shell';
-	import { editor } from '$lib/utils/systemEditor';
 
 	const vbranchService = getContext(VirtualBranchService);
 	const branchController = getContext(BranchController);

--- a/app/src/lib/components/FileContextMenu.svelte
+++ b/app/src/lib/components/FileContextMenu.svelte
@@ -8,12 +8,12 @@
 	import ContextMenuSection from '$lib/components/contextmenu/ContextMenuSection.svelte';
 	import { getContext } from '$lib/utils/context';
 	import { computeFileStatus } from '$lib/utils/fileStatus';
+	import { editor } from '$lib/utils/systemEditor';
 	import * as toasts from '$lib/utils/toasts';
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { LocalFile, type AnyFile } from '$lib/vbranches/types';
 	import { join } from '@tauri-apps/api/path';
 	import { open } from '@tauri-apps/api/shell';
-	import { editor } from '$lib/utils/systemEditor';
 
 	const branchController = getContext(BranchController);
 	const project = getContext(Project);

--- a/app/src/lib/components/FileContextMenu.svelte
+++ b/app/src/lib/components/FileContextMenu.svelte
@@ -13,6 +13,7 @@
 	import { LocalFile, type AnyFile } from '$lib/vbranches/types';
 	import { join } from '@tauri-apps/api/path';
 	import { open } from '@tauri-apps/api/shell';
+	import { editor } from '$lib/utils/systemEditor';
 
 	const branchController = getContext(BranchController);
 	const project = getContext(Project);
@@ -89,7 +90,7 @@
 							if (!project) return;
 							for (let file of item.files) {
 								const absPath = await join(project.path, file.path);
-								open(`vscode://file${absPath}`);
+								open(`${editor.get()}://file${absPath}`);
 							}
 							dismiss();
 						} catch {

--- a/app/src/lib/components/HunkContextMenu.svelte
+++ b/app/src/lib/components/HunkContextMenu.svelte
@@ -4,6 +4,7 @@
 	import ContextMenuItem from '$lib/components/contextmenu/ContextMenuItem.svelte';
 	import ContextMenuSection from '$lib/components/contextmenu/ContextMenuSection.svelte';
 	import { getContext } from '$lib/utils/context';
+	import { editor } from '$lib/utils/systemEditor';
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { open } from '@tauri-apps/api/shell';
 
@@ -36,7 +37,8 @@
 				<ContextMenuItem
 					label="Open in VS Code"
 					on:mousedown={() => {
-						projectPath && open(`vscode://file${projectPath}/${filePath}:${item.lineNumber}`);
+						projectPath &&
+							open(`${editor.get()}://file${projectPath}/${filePath}:${item.lineNumber}`);
 						dismiss();
 					}}
 				/>

--- a/app/src/lib/components/ProjectSettingsMenuAction.svelte
+++ b/app/src/lib/components/ProjectSettingsMenuAction.svelte
@@ -2,8 +2,8 @@
 	import { listen } from '$lib/backend/ipc';
 	import { Project } from '$lib/backend/projects';
 	import { getContext } from '$lib/utils/context';
+	import { editor } from '$lib/utils/systemEditor';
 	import { open } from '@tauri-apps/api/shell';
-	import { invoke } from '@tauri-apps/api/tauri';
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 
@@ -17,8 +17,7 @@
 		const unsubscribeOpenInVSCode = listen<string>(
 			'menu://project/open-in-vscode/clicked',
 			async () => {
-				const editor = await invoke('resolve_vscode_variant');
-				const path = `${editor}://file${project.path}`;
+				const path = `${editor.get()}://file${project.path}`;
 				open(path);
 			}
 		);

--- a/app/src/lib/components/ProjectSettingsMenuAction.svelte
+++ b/app/src/lib/components/ProjectSettingsMenuAction.svelte
@@ -3,6 +3,7 @@
 	import { Project } from '$lib/backend/projects';
 	import { getContext } from '$lib/utils/context';
 	import { open } from '@tauri-apps/api/shell';
+	import { invoke } from '@tauri-apps/api/tauri';
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 
@@ -13,10 +14,14 @@
 			goto(`/${project.id}/settings/`);
 		});
 
-		const unsubscribeOpenInVSCode = listen<string>('menu://project/open-in-vscode/clicked', () => {
-			const pathToProject = `vscode://file${project.path}`;
-			open(pathToProject);
-		});
+		const unsubscribeOpenInVSCode = listen<string>(
+			'menu://project/open-in-vscode/clicked',
+			async () => {
+				const editor = await invoke('resolve_vscode_variant');
+				const path = `${editor}://file${project.path}`;
+				open(path);
+			}
+		);
 
 		return () => {
 			unsubscribeSettings();

--- a/app/src/lib/utils/systemEditor.ts
+++ b/app/src/lib/utils/systemEditor.ts
@@ -1,0 +1,23 @@
+import { invoke } from '@tauri-apps/api/tauri';
+
+class SystemEditor {
+	constructor() {
+		this.resolveEditorVariant();
+	}
+
+	static instance = new SystemEditor();
+
+	private systemEditor = '';
+
+	async resolveEditorVariant() {
+		this.systemEditor = (await invoke('resolve_vscode_variant')) as string;
+	}
+
+	get() {
+		return this.systemEditor;
+	}
+}
+
+const editor = SystemEditor.instance;
+
+export { editor };

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -210,6 +210,7 @@ fn main() {
                     undo::restore_snapshot,
                     undo::snapshot_diff,
                     menu::menu_item_set_enabled,
+                    menu::resolve_vscode_variant,
                     keys::commands::get_public_key,
                     github::commands::init_device_oauth,
                     github::commands::check_auth_status,

--- a/crates/gitbutler-tauri/src/menu.rs
+++ b/crates/gitbutler-tauri/src/menu.rs
@@ -49,13 +49,10 @@ pub fn resolve_vscode_variant() -> &'static str {
 
 fn check_if_installed(executable_name: &str) -> bool {
     match env::var_os("PATH") {
-        Some(env_path) => env::split_paths(&env_path)
-            .filter_map(|mut path| {
-                path.push(executable_name);
-                fs::metadata(path).ok()
-            })
-            .next()
-            .is_some(),
+        Some(env_path) => env::split_paths(&env_path).any(|mut path| {
+            path.push(executable_name);
+            fs::metadata(path).is_ok()
+        }),
         None => false,
     }
 }

--- a/crates/gitbutler-tauri/src/menu.rs
+++ b/crates/gitbutler-tauri/src/menu.rs
@@ -48,16 +48,16 @@ pub fn resolve_vscode_variant() -> &'static str {
 }
 
 fn check_if_installed(executable_name: &str) -> bool {
-    let paths = match env::var_os("PATH") {
-        Some(path) => env::split_paths(&path).collect::<Vec<_>>(),
-        None => vec![],
-    };
-
-    paths.into_iter().any(|mut path| {
-        path.push(executable_name);
-        //println!("{}", path.to_string_lossy());
-        fs::metadata(path).is_ok()
-    })
+    match env::var_os("PATH") {
+        Some(env_path) => env::split_paths(&env_path)
+            .filter_map(|mut path| {
+                path.push(executable_name);
+                fs::metadata(path).ok()
+            })
+            .next()
+            .is_some(),
+        None => false,
+    }
 }
 
 pub fn build(_package_info: &PackageInfo) -> Menu {

--- a/crates/gitbutler-tauri/src/menu.rs
+++ b/crates/gitbutler-tauri/src/menu.rs
@@ -1,3 +1,5 @@
+use std::{env, fs};
+
 use anyhow::Context;
 use gitbutler_core::error;
 use gitbutler_core::error::Code;
@@ -32,6 +34,30 @@ pub async fn menu_item_set_enabled(
     menu_item.set_enabled(enabled).context(Code::Unknown)?;
 
     Ok(())
+}
+
+#[tauri::command()]
+pub fn resolve_vscode_variant() -> &'static str {
+    let vscodium_installed = check_if_installed("codium");
+    if vscodium_installed {
+        "vscodium"
+    } else {
+        // Fallback to vscode, as it was the previous behavior
+        "vscode"
+    }
+}
+
+fn check_if_installed(executable_name: &str) -> bool {
+    let paths = match env::var_os("PATH") {
+        Some(path) => env::split_paths(&path).collect::<Vec<_>>(),
+        None => vec![],
+    };
+
+    paths.into_iter().any(|mut path| {
+        path.push(executable_name);
+        //println!("{}", path.to_string_lossy());
+        fs::metadata(path).is_ok()
+    })
 }
 
 pub fn build(_package_info: &PackageInfo) -> Menu {

--- a/crates/gitbutler-tauri/tauri.conf.json
+++ b/crates/gitbutler-tauri/tauri.conf.json
@@ -16,7 +16,7 @@
 				"scope": ["$APPCACHE/archives/*", "$RESOURCE/_up_/scripts/*"]
 			},
 			"shell": {
-				"open": "^((https://)|(http://)|(mailto:)|(vscode://)).+"
+				"open": "^((https://)|(http://)|(mailto:)|(vscode://)|(vscodium://)).+"
 			},
 			"dialog": {
 				"open": true


### PR DESCRIPTION
I initially implemented this looking through the PATH variable. On Linux and Mac this should be good enough, but I'm not sure if it works on Windows out of the box, for that reason, VS Code remains as the Fallback if VS Codium is not found.

Suggestions to improve, if necessary, are welcome!!

Also, there are many open() shell invocations, and this PR should also take this into account, but for now, I did the basic only.