### PR TITLE
applying a branch should use cherry rebase

### DIFF
--- a/crates/gitbutler-core/src/virtual_branches/errors.rs
+++ b/crates/gitbutler-core/src/virtual_branches/errors.rs
@@ -11,6 +11,8 @@ pub enum Marker {
     ///
     /// See usages for details on what these conflicts can be.
     ProjectConflict,
+    /// An indicator that a branch conflicted during applying to the workspace.
+    BranchConflict,
 }
 
 impl std::fmt::Display for Marker {
@@ -18,6 +20,7 @@ impl std::fmt::Display for Marker {
         match self {
             Marker::VerificationFailure => f.write_str("<verification-failed>"),
             Marker::ProjectConflict => f.write_str("<project-conflict>"),
+            Marker::BranchConflict => f.write_str("<branch-conflict>"),
         }
     }
 }


### PR DESCRIPTION
This allows the app to correctly detect when the commits are the same, here's the before / after:

 
![cherry-rebase](https://github.com/gitbutlerapp/gitbutler/assets/4030927/9da82d8e-3522-4a95-bb0a-862afee5e330)
