### PR TITLE
fix: cleanup Toggle event handling

### DIFF
--- a/app/src/lib/components/AnalyticsSettings.svelte
+++ b/app/src/lib/components/AnalyticsSettings.svelte
@@ -12,16 +12,19 @@
 	const metricsEnabled = appMetricsEnabled();
 	const nonAnonMetricsEnabled = appNonAnonMetricsEnabled();
 
-	function toggleErrorReporting() {
+	function toggleErrorReporting(e: MouseEvent | CustomEvent<boolean>) {
 		$errorReportingEnabled = !$errorReportingEnabled;
+		e.preventDefault();
 	}
 
-	function toggleMetrics() {
+	function toggleMetrics(e: MouseEvent | CustomEvent<boolean>) {
 		$metricsEnabled = !$metricsEnabled;
+		e.preventDefault();
 	}
 
-	function toggleNonAnonMetrics() {
+	function toggleNonAnonMetrics(e: MouseEvent | CustomEvent<boolean>) {
 		$nonAnonMetricsEnabled = !$nonAnonMetricsEnabled;
+		e.preventDefault();
 	}
 </script>
 
@@ -72,7 +75,11 @@
 			</svelte:fragment>
 		</SectionCard>
 
-		<SectionCard labelFor="nonAnonMetricsEnabledToggle" on:click={toggleMetrics} orientation="row">
+		<SectionCard
+			labelFor="nonAnonMetricsEnabledToggle"
+			on:click={toggleNonAnonMetrics}
+			orientation="row"
+		>
 			<svelte:fragment slot="title">Non-anonymous usage metrics</svelte:fragment>
 			<svelte:fragment slot="caption"
 				>Toggle sharing of identifiable usage statistics.</svelte:fragment

--- a/app/src/lib/components/AnalyticsSettings.svelte
+++ b/app/src/lib/components/AnalyticsSettings.svelte
@@ -12,17 +12,17 @@
 	const metricsEnabled = appMetricsEnabled();
 	const nonAnonMetricsEnabled = appNonAnonMetricsEnabled();
 
-	function toggleErrorReporting(e: MouseEvent | CustomEvent<boolean>) {
+	function toggleErrorReporting(e: MouseEvent) {
 		$errorReportingEnabled = !$errorReportingEnabled;
 		e.preventDefault();
 	}
 
-	function toggleMetrics(e: MouseEvent | CustomEvent<boolean>) {
+	function toggleMetrics(e: MouseEvent) {
 		$metricsEnabled = !$metricsEnabled;
 		e.preventDefault();
 	}
 
-	function toggleNonAnonMetrics(e: MouseEvent | CustomEvent<boolean>) {
+	function toggleNonAnonMetrics(e: MouseEvent) {
 		$nonAnonMetricsEnabled = !$nonAnonMetricsEnabled;
 		e.preventDefault();
 	}
@@ -53,7 +53,7 @@
 	</div>
 
 	<div class="analytics-settings__actions">
-		<SectionCard labelFor="errorReportngToggle" on:click={toggleErrorReporting} orientation="row">
+		<SectionCard labelFor="errorReportngToggle" orientation="row">
 			<svelte:fragment slot="title">Error reporting</svelte:fragment>
 			<svelte:fragment slot="caption">
 				Toggle reporting of application crashes and errors.
@@ -62,24 +62,20 @@
 				<Toggle
 					id="errorReportngToggle"
 					checked={$errorReportingEnabled}
-					on:change={toggleErrorReporting}
+					on:click={toggleErrorReporting}
 				/>
 			</svelte:fragment>
 		</SectionCard>
 
-		<SectionCard labelFor="metricsEnabledToggle" on:click={toggleMetrics} orientation="row">
+		<SectionCard labelFor="metricsEnabledToggle" orientation="row">
 			<svelte:fragment slot="title">Usage metrics</svelte:fragment>
 			<svelte:fragment slot="caption">Toggle sharing of usage statistics.</svelte:fragment>
 			<svelte:fragment slot="actions">
-				<Toggle id="metricsEnabledToggle" checked={$metricsEnabled} on:change={toggleMetrics} />
+				<Toggle id="metricsEnabledToggle" checked={$metricsEnabled} on:click={toggleMetrics} />
 			</svelte:fragment>
 		</SectionCard>
 
-		<SectionCard
-			labelFor="nonAnonMetricsEnabledToggle"
-			on:click={toggleNonAnonMetrics}
-			orientation="row"
-		>
+		<SectionCard labelFor="nonAnonMetricsEnabledToggle" orientation="row">
 			<svelte:fragment slot="title">Non-anonymous usage metrics</svelte:fragment>
 			<svelte:fragment slot="caption"
 				>Toggle sharing of identifiable usage statistics.</svelte:fragment
@@ -88,7 +84,7 @@
 				<Toggle
 					id="nonAnonMetricsEnabledToggle"
 					checked={$nonAnonMetricsEnabled}
-					on:change={toggleNonAnonMetrics}
+					on:click={toggleNonAnonMetrics}
 				/>
 			</svelte:fragment>
 		</SectionCard>

--- a/app/src/lib/components/AnalyticsSettings.svelte
+++ b/app/src/lib/components/AnalyticsSettings.svelte
@@ -38,8 +38,8 @@
 			</Link>).
 		</p>
 		<p class="text-base-body-13 analytics-settings__text">
-			We kindly ask you to consider keeping these settings enabled as it helps us catch issues
-			more quickly. If you choose to disable them, please feel to share your feedback on our <Link
+			We kindly ask you to consider keeping these settings enabled as it helps us catch issues more
+			quickly. If you choose to disable them, please feel to share your feedback on our <Link
 				target="_blank"
 				rel="noreferrer"
 				href="https://discord.gg/MmFkmaJ42D"
@@ -68,11 +68,7 @@
 			<svelte:fragment slot="title">Usage metrics</svelte:fragment>
 			<svelte:fragment slot="caption">Toggle sharing of usage statistics.</svelte:fragment>
 			<svelte:fragment slot="actions">
-				<Toggle
-					id="metricsEnabledToggle"
-					checked={$metricsEnabled}
-					on:click={toggleMetrics}
-				/>
+				<Toggle id="metricsEnabledToggle" checked={$metricsEnabled} on:click={toggleMetrics} />
 			</svelte:fragment>
 		</SectionCard>
 

--- a/app/src/lib/components/AnalyticsSettings.svelte
+++ b/app/src/lib/components/AnalyticsSettings.svelte
@@ -12,19 +12,16 @@
 	const metricsEnabled = appMetricsEnabled();
 	const nonAnonMetricsEnabled = appNonAnonMetricsEnabled();
 
-	function toggleErrorReporting(e: MouseEvent) {
+	function toggleErrorReporting() {
 		$errorReportingEnabled = !$errorReportingEnabled;
-		e.preventDefault();
 	}
 
-	function toggleMetrics(e: MouseEvent) {
+	function toggleMetrics() {
 		$metricsEnabled = !$metricsEnabled;
-		e.preventDefault();
 	}
 
-	function toggleNonAnonMetrics(e: MouseEvent) {
+	function toggleNonAnonMetrics() {
 		$nonAnonMetricsEnabled = !$nonAnonMetricsEnabled;
-		e.preventDefault();
 	}
 </script>
 
@@ -41,8 +38,8 @@
 			</Link>).
 		</p>
 		<p class="text-base-body-13 analytics-settings__text">
-			We kindly ask you to consider keeping these settings enabled as it helps us catch issues more
-			quickly. If you choose to disable them, please feel to share your feedback on our <Link
+			We kindly ask you to consider keeping these settings enabled as it helps us catch issues
+			more quickly. If you choose to disable them, please feel to share your feedback on our <Link
 				target="_blank"
 				rel="noreferrer"
 				href="https://discord.gg/MmFkmaJ42D"
@@ -53,14 +50,14 @@
 	</div>
 
 	<div class="analytics-settings__actions">
-		<SectionCard labelFor="errorReportngToggle" orientation="row">
+		<SectionCard labelFor="errorReportingToggle" orientation="row">
 			<svelte:fragment slot="title">Error reporting</svelte:fragment>
 			<svelte:fragment slot="caption">
 				Toggle reporting of application crashes and errors.
 			</svelte:fragment>
 			<svelte:fragment slot="actions">
 				<Toggle
-					id="errorReportngToggle"
+					id="errorReportingToggle"
 					checked={$errorReportingEnabled}
 					on:click={toggleErrorReporting}
 				/>
@@ -71,7 +68,11 @@
 			<svelte:fragment slot="title">Usage metrics</svelte:fragment>
 			<svelte:fragment slot="caption">Toggle sharing of usage statistics.</svelte:fragment>
 			<svelte:fragment slot="actions">
-				<Toggle id="metricsEnabledToggle" checked={$metricsEnabled} on:click={toggleMetrics} />
+				<Toggle
+					id="metricsEnabledToggle"
+					checked={$metricsEnabled}
+					on:click={toggleMetrics}
+				/>
 			</svelte:fragment>
 		</SectionCard>
 

--- a/app/src/lib/components/CloudForm.svelte
+++ b/app/src/lib/components/CloudForm.svelte
@@ -79,30 +79,25 @@
 	</svelte:fragment>
 
 	<div class="options">
-		<SectionCard labelFor="aiGenEnabled" on:click={aiGenToggle} orientation="row">
+		<SectionCard labelFor="aiGenEnabled" orientation="row">
 			<svelte:fragment slot="title">Enable branch and commit message generation</svelte:fragment>
 			<svelte:fragment slot="caption">
 				If enabled, diffs will sent to OpenAI or Anthropic's servers when pressing the "Generate
 				message" and "Generate branch name" button.
 			</svelte:fragment>
 			<svelte:fragment slot="actions">
-				<Toggle id="aiGenEnabled" checked={$aiGenEnabled} on:change={aiGenToggle} />
+				<Toggle id="aiGenEnabled" checked={$aiGenEnabled} on:click={aiGenToggle} />
 			</svelte:fragment>
 		</SectionCard>
 
-		<SectionCard
-			labelFor="branchNameGen"
-			disabled={!$aiGenEnabled}
-			on:click={aiGenBranchNamesToggle}
-			orientation="row"
-		>
+		<SectionCard labelFor="branchNameGen" disabled={!$aiGenEnabled} orientation="row">
 			<svelte:fragment slot="title">Automatically generate branch names</svelte:fragment>
 			<svelte:fragment slot="actions">
 				<Toggle
 					id="branchNameGen"
 					disabled={!$aiGenEnabled}
 					checked={$aiGenAutoBranchNamingEnabled}
-					on:change={aiGenBranchNamesToggle}
+					on:click={aiGenBranchNamesToggle}
 				/>
 			</svelte:fragment>
 		</SectionCard>
@@ -133,11 +128,7 @@
 	<Section spacer>
 		<svelte:fragment slot="title">Full data synchronization</svelte:fragment>
 
-		<SectionCard
-			labelFor="historySync"
-			on:change={async (e) => await onSyncChange(e.detail)}
-			orientation="row"
-		>
+		<SectionCard labelFor="historySync" orientation="row">
 			<svelte:fragment slot="caption">
 				Sync my history, repository and branch data for backup, sharing and team features.
 			</svelte:fragment>
@@ -145,7 +136,7 @@
 				<Toggle
 					id="historySync"
 					checked={project.api?.sync || false}
-					on:change={async (e) => await onSyncChange(e.detail)}
+					on:click={async (e) => await onSyncChange(e.detail)}
 				/>
 			</svelte:fragment>
 		</SectionCard>

--- a/app/src/lib/components/CloudForm.svelte
+++ b/app/src/lib/components/CloudForm.svelte
@@ -136,7 +136,7 @@
 				<Toggle
 					id="historySync"
 					checked={project.api?.sync || false}
-					on:click={async (e) => await onSyncChange(e.detail)}
+					on:click={async (e) => await onSyncChange(!!e.detail)}
 				/>
 			</svelte:fragment>
 		</SectionCard>

--- a/app/src/lib/components/PreferencesForm.svelte
+++ b/app/src/lib/components/PreferencesForm.svelte
@@ -56,7 +56,7 @@
 			<Toggle
 				id="allowForcePush"
 				bind:checked={allowForcePushing}
-				on:change={async () => await setWithForcePush(allowForcePushing)}
+				on:click={async () => await setWithForcePush(allowForcePushing)}
 			/>
 		</svelte:fragment>
 	</SectionCard>
@@ -84,7 +84,7 @@
 			<Toggle
 				id="omitCertificateCheck"
 				bind:checked={omitCertificateCheck}
-				on:change={async () => await setOmitCertificateCheck(omitCertificateCheck)}
+				on:click={async () => await setOmitCertificateCheck(omitCertificateCheck)}
 			/>
 		</svelte:fragment>
 	</SectionCard>

--- a/app/src/lib/components/Toggle.svelte
+++ b/app/src/lib/components/Toggle.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { tooltip } from '$lib/utils/tooltip';
-	import { createEventDispatcher } from 'svelte';
 
 	export let small = false;
 	export let disabled = false;
@@ -8,18 +7,11 @@
 	export let value = '';
 	export let help = '';
 	export let id = '';
-
-	let input: HTMLInputElement;
-	const dispatch = createEventDispatcher<{ change: boolean }>();
 </script>
 
 <input
-	bind:this={input}
 	bind:checked
 	on:click|stopPropagation
-	on:change={() => {
-		dispatch('change', checked);
-	}}
 	type="checkbox"
 	class="toggle"
 	class:small

--- a/app/src/routes/settings/experimental/+page.svelte
+++ b/app/src/routes/settings/experimental/+page.svelte
@@ -21,7 +21,7 @@
 			<Toggle
 				id="baseBranchSwitching"
 				checked={$baseBranchSwitching}
-				on:change={() => ($baseBranchSwitching = !$baseBranchSwitching)}
+				on:click={() => ($baseBranchSwitching = !$baseBranchSwitching)}
 			/>
 		</svelte:fragment>
 	</SectionCard>

--- a/app/src/routes/settings/git/+page.svelte
+++ b/app/src/routes/settings/git/+page.svelte
@@ -45,7 +45,7 @@
 			</Link>
 		</svelte:fragment>
 		<svelte:fragment slot="actions">
-			<Toggle id="committerSigning" checked={annotateCommits} on:change={toggleCommitterSigning} />
+			<Toggle id="committerSigning" checked={annotateCommits} on:click={toggleCommitterSigning} />
 		</svelte:fragment>
 	</SectionCard>
 

--- a/app/src/routes/settings/profile/+page.svelte
+++ b/app/src/routes/settings/profile/+page.svelte
@@ -100,7 +100,7 @@
 	{#if $user}
 		<SectionCard>
 			<form on:submit={onSubmit} class="profile-form">
-				<label id="profile-picture" class="focus-state profile-pic-wrapper" for="picture">
+				<label id="profile-picture" class="profile-pic-wrapper focus-state" for="picture">
 					<input
 						on:change={onPictureChange}
 						type="file"
@@ -174,7 +174,7 @@
 			<Toggle
 				id="hoverScrollbarVisability"
 				checked={$userSettings.scrollbarVisabilityOnHover}
-				on:change={() =>
+				on:click={() =>
 					userSettings.update((s) => ({
 						...s,
 						scrollbarVisabilityOnHover: !s.scrollbarVisabilityOnHover


### PR DESCRIPTION
Small bug I ran into while familiarizing myself with the app

- Refactor `<Toggle />` to just handle click instead of custom `change` events. 

## Before
- Toggling when clicking on the section (as opposed to the little toggle in the top right) would execute the callback twice because it had both an `on:click` handler and was the `<label />` for the `<input type="checkbox" />`

https://github.com/gitbutlerapp/gitbutler/assets/7415984/b755ea15-08fb-4875-a14a-244370cc6945

## After

- Toggling when clicking on the section (as opposed to the little toggle in the top right) only toggles the state once now
- Also the `AnonMetrics` section `on:click` handler was calling the wrong fn