### PR TITLE
Select input improvements: Arrow navigation & text filtering

### DIFF
--- a/app/src/lib/ai/types.ts
+++ b/app/src/lib/ai/types.ts
@@ -39,11 +39,11 @@ export interface AIClient {
 	defaultCommitTemplate: Prompt;
 }
 
-export interface UserPrompt {
+export type UserPrompt = {
 	id: string;
 	name: string;
 	prompt: Prompt;
-}
+};
 
 export interface Prompts {
 	defaultPrompt: Prompt;

--- a/app/src/lib/components/BaseBranchSwitch.svelte
+++ b/app/src/lib/components/BaseBranchSwitch.svelte
@@ -76,7 +76,14 @@
 					wide={true}
 					label="Current target branch"
 				>
-					<SelectItem slot="template" let:item let:selected {selected}>
+					<SelectItem
+						slot="template"
+						let:item
+						let:selected
+						{selected}
+						let:highlighted
+						{highlighted}
+					>
 						{item.name}
 					</SelectItem>
 				</Select>
@@ -91,7 +98,14 @@
 						disabled={targetChangeDisabled}
 						label="Create branches on remote"
 					>
-						<SelectItem slot="template" let:item let:selected {selected}>
+						<SelectItem
+							slot="template"
+							let:item
+							let:selected
+							{selected}
+							let:highlighted
+							{highlighted}
+						>
 							{item.name}
 						</SelectItem>
 					</Select>

--- a/app/src/lib/components/ProjectSwitcher.svelte
+++ b/app/src/lib/components/ProjectSwitcher.svelte
@@ -4,6 +4,7 @@
 	import SelectItem from './SelectItem.svelte';
 	import { ProjectService, Project } from '$lib/backend/projects';
 	import { getContext, maybeGetContext } from '$lib/utils/context';
+	import { derived } from 'svelte/store';
 	import { goto } from '$app/navigation';
 
 	const projectService = getContext(ProjectService);
@@ -14,17 +15,13 @@
 		title: string;
 	};
 
-	let mappedProjects: ProjectRecord[] = [];
-
-	projectService.projects.subscribe((projectList) => {
-		// Map the projectList to fit the ProjectRecord type
-		mappedProjects = projectList.map((project) => {
-			return {
-				id: project.id,
-				title: project.title
-			};
-		});
-	});
+	// Create a derived store that maps the projects to a simpler structure
+	const mappedProjects = derived(projectService.projects, ($projects) =>
+		$projects.map((project) => ({
+			id: project.id,
+			title: project.title
+		}))
+	);
 
 	let loading = false;
 	let select: Select<ProjectRecord>;
@@ -37,7 +34,7 @@
 		label="Switch to another project"
 		itemId="id"
 		labelId="title"
-		items={mappedProjects}
+		items={$mappedProjects}
 		placeholder="Select a project..."
 		wide
 		bind:value={selectValue}

--- a/app/src/lib/components/ProjectSwitcher.svelte
+++ b/app/src/lib/components/ProjectSwitcher.svelte
@@ -15,7 +15,6 @@
 		title: string;
 	};
 
-	// Create a derived store that maps the projects to a simpler structure
 	const mappedProjects = derived(projectService.projects, ($projects) =>
 		$projects.map((project) => ({
 			id: project.id,

--- a/app/src/lib/components/ProjectSwitcher.svelte
+++ b/app/src/lib/components/ProjectSwitcher.svelte
@@ -9,11 +9,26 @@
 	const projectService = getContext(ProjectService);
 	const project = maybeGetContext(Project);
 
-	const projects = projectService.projects;
+	type ProjectRecord = {
+		id: string;
+		title: string;
+	};
+
+	let mappedProjects: ProjectRecord[] = [];
+
+	projectService.projects.subscribe((projectList) => {
+		// Map the projectList to fit the ProjectRecord type
+		mappedProjects = projectList.map((project) => {
+			return {
+				id: project.id,
+				title: project.title
+			};
+		});
+	});
 
 	let loading = false;
-	let select: Select;
-	let selectValue = project;
+	let select: Select<ProjectRecord>;
+	let selectValue: ProjectRecord | undefined = project;
 </script>
 
 <div class="project-switcher">
@@ -22,7 +37,7 @@
 		label="Switch to another project"
 		itemId="id"
 		labelId="title"
-		items={$projects}
+		items={mappedProjects}
 		placeholder="Select a project..."
 		wide
 		bind:value={selectValue}

--- a/app/src/lib/components/Select.svelte
+++ b/app/src/lib/components/Select.svelte
@@ -1,18 +1,30 @@
-<script lang="ts">
+<script lang="ts" context="module">
+	export type SelectItemType<S extends string> = Record<S, unknown>;
+</script>
+
+<script lang="ts" generics="SelectItemType extends Record<string, unknown>">
 	import ScrollableContainer from './ScrollableContainer.svelte';
 	import TextBox from './TextBox.svelte';
 	import { clickOutside } from '$lib/clickOutside';
+	import { filterStringByKey } from '$lib/utils/filters';
+	import { KeyName } from '$lib/utils/hotkeys';
+	import { throttle } from '$lib/utils/misc';
 	import { pxToRem } from '$lib/utils/pxToRem';
+	import { isChar } from '$lib/utils/string';
 	import { createEventDispatcher } from 'svelte';
+
+	const INPUT_THROTTLE_TIME = 100;
+
+	type SelectItemKeyType = keyof SelectItemType;
 
 	export let id: undefined | string = undefined;
 	export let label = '';
 	export let disabled = false;
 	export let loading = false;
 	export let wide = false;
-	export let items: any[];
-	export let labelId = 'label';
-	export let itemId = 'value';
+	export let items: SelectItemType[];
+	export let labelId: SelectItemKeyType = 'label';
+	export let itemId: SelectItemKeyType = 'value';
 	export let value: any = undefined;
 	export let selectedItemId: any = undefined;
 	export let placeholder = '';
@@ -27,8 +39,21 @@
 	let listOpen = false;
 	let element: HTMLElement;
 	let options: HTMLDivElement;
+	let highlightIndex: number | undefined = undefined;
+	let highlightedItem: SelectItemType | undefined = undefined;
+	let filterText: string | undefined = undefined;
+	let filteredItems: SelectItemType[] = items;
 
-	function handleItemClick(item: any) {
+	$: filterText === undefined
+		? (filteredItems = items)
+		: (filteredItems = filterStringByKey(items, labelId, filterText));
+
+	// Set highlighted item based on index
+	$: highlightIndex !== undefined
+		? (highlightedItem = filteredItems[highlightIndex])
+		: (highlightedItem = undefined);
+
+	function handleItemClick(item: SelectItemType) {
 		if (item?.selectable === false) return;
 		if (value && value[itemId] === item[itemId]) return closeList();
 		selectedItemId = item[itemId];
@@ -52,6 +77,78 @@
 
 	function closeList() {
 		listOpen = false;
+		highlightIndex = undefined;
+		filterText = undefined;
+	}
+
+	function handleEnter() {
+		if (highlightIndex !== undefined) {
+			handleItemClick(filteredItems[highlightIndex]);
+		}
+		closeList();
+	}
+
+	function handleArrowUp() {
+		if (highlightIndex === undefined) {
+			highlightIndex = filteredItems.length - 1;
+		} else {
+			highlightIndex = highlightIndex === 0 ? filteredItems.length - 1 : highlightIndex - 1;
+		}
+	}
+
+	function handleArrowDown() {
+		if (highlightIndex === undefined) {
+			highlightIndex = 0;
+		} else {
+			highlightIndex = highlightIndex === filteredItems.length - 1 ? 0 : highlightIndex + 1;
+		}
+	}
+
+	const handleChar = throttle((char: string) => {
+		highlightIndex = undefined;
+		filterText ??= '';
+		filterText += char;
+	}, INPUT_THROTTLE_TIME);
+
+	const handleDelete = throttle(() => {
+		if (filterText === undefined) return;
+
+		if (filterText.length === 1) {
+			filterText = undefined;
+			return;
+		}
+
+		filterText = filterText.slice(0, -1);
+	}, INPUT_THROTTLE_TIME);
+
+	function handleKeyDown(event: CustomEvent<KeyboardEvent>) {
+		if (!listOpen) {
+			return;
+		}
+		event.detail.stopPropagation();
+		event.detail.preventDefault();
+
+		const { key } = event.detail;
+		switch (key) {
+			case KeyName.Escape:
+				closeList();
+				break;
+			case KeyName.Up:
+				handleArrowUp();
+				break;
+			case KeyName.Down:
+				handleArrowDown();
+				break;
+			case KeyName.Enter:
+				handleEnter();
+				break;
+			case KeyName.Delete:
+				handleDelete();
+				break;
+			default:
+				if (isChar(key)) handleChar(key);
+				break;
+		}
 	}
 </script>
 
@@ -67,9 +164,10 @@
 		type="select"
 		reversedDirection
 		icon="select-chevron"
-		value={value?.[labelId]}
+		value={filterText ?? value?.[labelId]}
 		disabled={disabled || loading}
 		on:mousedown={() => toggleList()}
+		on:keydown={(ev) => handleKeyDown(ev)}
 	/>
 	<div
 		class="options card"
@@ -78,14 +176,14 @@
 		style:max-height={maxHeight && pxToRem(maxHeight)}
 		use:clickOutside={{
 			trigger: element,
-			handler: () => (listOpen = !listOpen),
+			handler: closeList,
 			enabled: listOpen
 		}}
 	>
 		<ScrollableContainer initiallyVisible>
-			{#if items}
+			{#if filteredItems}
 				<div class="options__group">
-					{#each items as item}
+					{#each filteredItems as item}
 						<div
 							class="option"
 							class:selected={item === value}
@@ -94,7 +192,12 @@
 							on:mousedown={() => handleItemClick(item)}
 							on:keydown|preventDefault|stopPropagation
 						>
-							<slot name="template" {item} selected={item === value} />
+							<slot
+								name="template"
+								{item}
+								selected={item === value}
+								highlighted={item === highlightedItem}
+							/>
 						</div>
 					{/each}
 				</div>

--- a/app/src/lib/components/Select.svelte
+++ b/app/src/lib/components/Select.svelte
@@ -89,6 +89,7 @@
 	}
 
 	function handleArrowUp() {
+		if (filteredItems.length === 0) return;
 		if (highlightIndex === undefined) {
 			highlightIndex = filteredItems.length - 1;
 		} else {
@@ -97,6 +98,7 @@
 	}
 
 	function handleArrowDown() {
+		if (filteredItems.length === 0) return;
 		if (highlightIndex === undefined) {
 			highlightIndex = 0;
 		} else {

--- a/app/src/lib/components/SelectItem.svelte
+++ b/app/src/lib/components/SelectItem.svelte
@@ -7,12 +7,19 @@
 	export let selected = false;
 	export let disabled = false;
 	export let loading = false;
+	export let highlighted = false;
 	export let value: string | undefined = undefined;
 
 	const dispatch = createEventDispatcher<{ click: string | undefined }>();
 </script>
 
-<button {disabled} class="button" class:selected on:click={() => dispatch('click', value)}>
+<button
+	{disabled}
+	class="button"
+	class:selected
+	class:highlighted
+	on:click={() => dispatch('click', value)}
+>
 	<div class="label text-base-13">
 		<slot />
 	</div>
@@ -66,5 +73,9 @@
 		& .label {
 			opacity: 0.5;
 		}
+	}
+
+	.highlighted {
+		background-color: var(--clr-bg-3);
 	}
 </style>

--- a/app/src/lib/utils/filters.ts
+++ b/app/src/lib/utils/filters.ts
@@ -1,28 +1,4 @@
-import { isStr } from '$lib/utils/string';
-
 // If a value occurs > 1 times then all but one will fail this condition.
 export function unique(value: any, index: number, array: any[]) {
 	return array.indexOf(value) === index;
-}
-
-/**
- * Filters an array of objects based on a specific string value in a given key.
- *
- * @template T - The type of objects in the array.
- * @template K - The key of the object to filter by.
- * @param {T[]} arr - The array of objects to filter.
- * @param {K} key - The key to filter by.
- * @param {string} value - The string value to search for in the specified key.
- * @returns {T[]} - The filtered array of objects.
- */
-export function filterStringByKey<T, K extends keyof T>(arr: T[], key: K, value: string): T[] {
-	const result: T[] = [];
-	for (const item of arr) {
-		const attribute = item[key];
-		if (!isStr(attribute)) continue;
-		if (attribute.includes(value)) {
-			result.push(item);
-		}
-	}
-	return result;
 }

--- a/app/src/lib/utils/filters.ts
+++ b/app/src/lib/utils/filters.ts
@@ -1,4 +1,28 @@
+import { isStr } from '$lib/utils/string';
+
 // If a value occurs > 1 times then all but one will fail this condition.
 export function unique(value: any, index: number, array: any[]) {
 	return array.indexOf(value) === index;
+}
+
+/**
+ * Filters an array of objects based on a specific string value in a given key.
+ *
+ * @template T - The type of objects in the array.
+ * @template K - The key of the object to filter by.
+ * @param {T[]} arr - The array of objects to filter.
+ * @param {K} key - The key to filter by.
+ * @param {string} value - The string value to search for in the specified key.
+ * @returns {T[]} - The filtered array of objects.
+ */
+export function filterStringByKey<T, K extends keyof T>(arr: T[], key: K, value: string): T[] {
+	const result: T[] = [];
+	for (const item of arr) {
+		const attribute = item[key];
+		if (!isStr(attribute)) continue;
+		if (attribute.includes(value)) {
+			result.push(item);
+		}
+	}
+	return result;
 }

--- a/app/src/lib/utils/hotkeys.ts
+++ b/app/src/lib/utils/hotkeys.ts
@@ -4,6 +4,21 @@ interface KeybindDefinitions {
 	[combo: string]: (event: KeyboardEvent) => void;
 }
 
+export enum KeyName {
+	Space = ' ',
+	Meta = 'Meta',
+	Alt = 'Alt',
+	Ctrl = 'Ctrl',
+	Enter = 'Enter',
+	Escape = 'Escape',
+	Tab = 'Tab',
+	Up = 'ArrowUp',
+	Down = 'ArrowDown',
+	Left = 'ArrowLeft',
+	Right = 'ArrowRight',
+	Delete = 'Backspace'
+}
+
 export function createKeybind(keybinds: KeybindDefinitions) {
 	const keys: KeybindDefinitions = {
 		// Ignore backspace keydown events always

--- a/app/src/lib/utils/misc.ts
+++ b/app/src/lib/utils/misc.ts
@@ -1,9 +1,3 @@
-/**
- * Throttles the execution of a function.
- * @param fn The function to be throttled.
- * @param wait The time to wait between function invocations in milliseconds.
- * @returns A throttled version of the original function.
- */
 export function throttle<T extends (...args: any[]) => any>(
 	fn: T,
 	wait: number

--- a/app/src/lib/utils/misc.ts
+++ b/app/src/lib/utils/misc.ts
@@ -1,0 +1,24 @@
+/**
+ * Throttles the execution of a function.
+ * @param fn The function to be throttled.
+ * @param wait The time to wait between function invocations in milliseconds.
+ * @returns A throttled version of the original function.
+ */
+export function throttle<T extends (...args: any[]) => any>(
+	fn: T,
+	wait: number
+): (...args: Parameters<T>) => ReturnType<T> {
+	let inThrottle: boolean;
+	let lastResult: ReturnType<T>;
+
+	return function (...args: Parameters<T>) {
+		if (!inThrottle) {
+			inThrottle = true;
+			lastResult = fn(...args);
+			setTimeout(() => {
+				inThrottle = false;
+			}, wait);
+		}
+		return lastResult;
+	};
+}

--- a/app/src/lib/utils/string.ts
+++ b/app/src/lib/utils/string.ts
@@ -12,22 +12,10 @@ export function hashCode(s: string) {
 	return hash.toString();
 }
 
-/**
- * Checks if a string is a single character.
- *
- * @param char - The string to check.
- * @returns `true` if the string is a single character, `false` otherwise.
- */
 export function isChar(char: string) {
 	return char.length === 1;
 }
 
-/**
- * Checks if a value is a string.
- *
- * @param s - The value to check.
- * @returns A boolean indicating whether the value is a string.
- */
 export function isStr(s: unknown): s is string {
 	return typeof s === 'string';
 }

--- a/app/src/lib/utils/string.ts
+++ b/app/src/lib/utils/string.ts
@@ -11,3 +11,23 @@ export function hashCode(s: string) {
 	}
 	return hash.toString();
 }
+
+/**
+ * Checks if a string is a single character.
+ *
+ * @param char - The string to check.
+ * @returns `true` if the string is a single character, `false` otherwise.
+ */
+export function isChar(char: string) {
+	return char.length === 1;
+}
+
+/**
+ * Checks if a value is a string.
+ *
+ * @param s - The value to check.
+ * @returns A boolean indicating whether the value is a string.
+ */
+export function isStr(s: unknown): s is string {
+	return typeof s === 'string';
+}


### PR DESCRIPTION
Related to #2590

This adds type-to-filter and up-down-arrow navigation to the Select component. 
This should enable easy & fast switching between remote branches 😊

This is how it looks when using it on my local fork of gitbutler.
Once the dropdown is open, one can navigate up and down the options and click enter to select.
Added to that, one can type text (shown in the Select component's text field) and the list will be filtered based on whether or not the typed context is included in the label displayed.

![select-optimization](https://github.com/gitbutlerapp/gitbutler/assets/35891811/dc28bccf-642d-45c3-b58b-f10dd36d03dc)

### Style
The way this shows what option is being 'highlighted' when navigating with the arrows, if by changing the background to
```
background-color: var(--clr-bg-3);
```

I'm not sure this is consistent with design guidelines or not. Happy to change that accordingly if not
