### PR TITLE
Convert parent/children into prev/next for commit traversal

### DIFF
--- a/app/src/lib/components/CommitList.svelte
+++ b/app/src/lib/components/CommitList.svelte
@@ -49,7 +49,7 @@
 
 	function getRemoteOutType(commit: Commit): CommitStatus | undefined {
 		if (!hasShadowedCommits) {
-			const childStatus = commit.children?.[0]?.status;
+			const childStatus = commit.next?.status;
 			return childStatus != 'local' ? childStatus : undefined;
 		}
 
@@ -58,19 +58,19 @@
 		let upstreamCommit = commit.relatedTo;
 
 		while (!upstreamCommit && pointer) {
-			pointer = pointer.parent;
+			pointer = pointer.prev;
 			upstreamCommit = pointer?.relatedTo;
 		}
 
 		if (!upstreamCommit) return hasUnknownCommits ? 'upstream' : undefined;
 
-		let nextUpstreamCommit = upstreamCommit.children?.[0]?.relatedTo;
+		let nextUpstreamCommit = upstreamCommit.next?.relatedTo;
 		if (nextUpstreamCommit) return nextUpstreamCommit.status;
 		if (hasUnknownCommits) return 'upstream';
 	}
 
 	function getRemoteInType(commit: Commit): CommitStatus | undefined {
-		if (commit.parent) return getRemoteOutType(commit.parent || commit);
+		if (commit.prev) return getRemoteOutType(commit.prev || commit);
 		if (commit.status == 'remote' || commit.relatedTo) return 'remote';
 		if (commit.status == 'integrated') return 'integrated';
 	}
@@ -209,7 +209,7 @@
 							shadowHelp={getAvatarTooltip(commit.relatedTo)}
 							integrated={commit.isIntegrated}
 							localRoot={idx == 0 && hasLocalCommits}
-							outDashed={idx == 0 && commit.parent?.status == 'local'}
+							outDashed={idx == 0 && commit.prev?.status == 'local'}
 							remoteIn={!isRebased ? getRemoteInType(commit) : undefined}
 							remoteOut={!isRebased ? getRemoteOutType(commit) : undefined}
 							shadowIn={isRebased ? getRemoteInType(commit) : undefined}

--- a/app/src/lib/vbranches/types.ts
+++ b/app/src/lib/vbranches/types.ts
@@ -179,8 +179,8 @@ export class Commit {
 	isSigned!: boolean;
 	relatedTo?: RemoteCommit;
 
-	parent?: Commit;
-	children?: Commit[];
+	prev?: Commit;
+	next?: Commit;
 
 	get isLocal() {
 		return !this.isRemote && !this.isIntegrated;
@@ -223,8 +223,8 @@ export class RemoteCommit {
 	isSigned!: boolean;
 	parentIds!: string[];
 
-	parent?: RemoteCommit;
-	children?: RemoteCommit[];
+	prev?: RemoteCommit;
+	next?: RemoteCommit;
 	relatedTo?: Commit;
 
 	get isLocal() {

--- a/app/src/lib/vbranches/virtualBranch.ts
+++ b/app/src/lib/vbranches/virtualBranch.ts
@@ -48,11 +48,6 @@ export class VirtualBranchService {
 						)
 					: of([])
 			),
-			// Make the commits on each branch aware of parents and children. There will only
-			// evern be one child per commit until we load upstream commits. For example, a commit
-			// will have two children if you have pushed a child commit to the remote, but you
-			// then amend it. We need to know of both of these child commits in order to draw the
-			// branch correctly.
 			tap((branches) => {
 				for (let i = 0; i < branches.length; i++) {
 					const branch = branches[i];
@@ -161,19 +156,18 @@ export async function listVirtualBranches(params: { projectId: string }): Promis
 		.branches;
 }
 
-// TODO(mg): I think we can make it a doubly linked list instead of a tree.
 function linkAsParentChildren(commits: Commit[] | RemoteCommit[]) {
 	for (let j = 0; j < commits.length; j++) {
 		const commit = commits[j];
 		if (j == 0) {
-			commit.children = [];
+			commit.next = undefined;
 		} else {
 			const child = commits[j - 1];
-			if (child instanceof Commit) commit.children = [child];
-			if (child instanceof RemoteCommit) commit.children = [child];
+			if (child instanceof Commit) commit.next = child;
+			if (child instanceof RemoteCommit) commit.next = child;
 		}
 		if (j != commits.length - 1) {
-			commit.parent = commits[j + 1];
+			commit.prev = commits[j + 1];
 		}
 	}
 }


### PR DESCRIPTION
- used in creating commit graphs