### PR TITLE
Memoize derive calls

### DIFF
--- a/app/src/lib/components/BranchLane.svelte
+++ b/app/src/lib/components/BranchLane.svelte
@@ -20,6 +20,7 @@
 	import lscache from 'lscache';
 	import { setContext } from 'svelte';
 	import { quintOut } from 'svelte/easing';
+	import { writable } from 'svelte/store';
 	import { slide } from 'svelte/transition';
 
 	export let branch: Branch;
@@ -50,10 +51,12 @@
 
 	const project = getContext(Project);
 
-	const fileIdSelection = new FileIdSelection();
+	const branchFiles = writable(branch.files);
+	$: branchFiles.set(branch.files);
+	const fileIdSelection = new FileIdSelection(project.id, branchFiles);
 	setContext(FileIdSelection, fileIdSelection);
 
-	$: selectedFile = fileIdSelection.selectedFile(branch.files, project.id);
+	$: selectedFile = fileIdSelection.selectedFile;
 
 	const userSettings = getContextStoreBySymbol<Settings>(SETTINGS);
 

--- a/app/src/lib/components/FileListItem.svelte
+++ b/app/src/lib/components/FileListItem.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import FileContextMenu from './FileContextMenu.svelte';
 	import FileStatusIcons from './FileStatusIcons.svelte';
-	import { Project } from '$lib/backend/projects';
 	import Checkbox from '$lib/components/Checkbox.svelte';
 	import { draggable } from '$lib/dragging/draggable';
 	import { DraggableFile } from '$lib/dragging/draggables';
@@ -24,10 +23,9 @@
 	const branch = maybeGetContextStore(Branch);
 	const selectedOwnership: Writable<Ownership> | undefined = maybeGetContextStore(Ownership);
 	const fileIdSelection = getContext(FileIdSelection);
-	const project = getContext(Project);
 	const commit = getCommitStore();
 
-	$: selectedFiles = fileIdSelection.files($branch?.files || [], project.id);
+	const selectedFiles = fileIdSelection.files;
 
 	let checked = false;
 	let indeterminate = false;

--- a/app/src/lib/components/RemoteBranchPreview.svelte
+++ b/app/src/lib/components/RemoteBranchPreview.svelte
@@ -13,6 +13,7 @@
 	import lscache from 'lscache';
 	import { marked } from 'marked';
 	import { onMount, setContext } from 'svelte';
+	import { writable } from 'svelte/store';
 	import type { PullRequest } from '$lib/github/types';
 
 	export let branch: RemoteBranch;
@@ -21,10 +22,10 @@
 	const project = getContext(Project);
 	const baseBranch = getContextStore(BaseBranch);
 
-	const fileIdSelection = new FileIdSelection();
+	const fileIdSelection = new FileIdSelection(project.id, writable([]));
 	setContext(FileIdSelection, fileIdSelection);
 
-	$: selectedFile = fileIdSelection.selectedFile([], project.id);
+	$: selectedFile = fileIdSelection.selectedFile;
 
 	const defaultBranchWidthRem = 30;
 	const laneWidthKey = 'branchPreviewLaneWidth';

--- a/app/src/routes/[projectId]/base/+page.svelte
+++ b/app/src/routes/[projectId]/base/+page.svelte
@@ -11,6 +11,8 @@
 	import { FileIdSelection } from '$lib/vbranches/fileIdSelection';
 	import lscache from 'lscache';
 	import { onMount, setContext } from 'svelte';
+	import { writable } from 'svelte/store';
+
 	const defaultBranchWidthRem = 30;
 	const laneWidthKey = 'historyLaneWidth';
 	const userSettings = getContextStoreBySymbol<Settings>(SETTINGS);
@@ -19,10 +21,10 @@
 	const baseBranch = baseBranchService.base;
 	const project = getContext(Project);
 
-	const fileIdSelection = new FileIdSelection();
+	const fileIdSelection = new FileIdSelection(project.id, writable([]));
 	setContext(FileIdSelection, fileIdSelection);
 
-	$: selectedFile = fileIdSelection.selectedFile([], project.id);
+	$: selectedFile = fileIdSelection.selectedFile;
 
 	let rsViewport: HTMLDivElement;
 	let laneWidth: number;


### PR DESCRIPTION
If we call files() 90 odd times, it will create 90 different derived stores. This means that we're going to do an awful lot of extra work as each update to the selected ids will trigger 90 jobs.

By memoizing the store, we will only ever create one derived object and as such eliminate the dupilcate work.