### PR TITLE
feat: enable using frontend in development without tauri

### DIFF
--- a/app/e2e/playwright/basic.spec.ts
+++ b/app/e2e/playwright/basic.spec.ts
@@ -9,7 +9,7 @@ test('has empty title', async ({ page }) => {
 test('has text package.json', async ({ page }) => {
 	await page.goto('http://localhost:1420');
 
-	const listBox = page.getByRole('listbox').getByRole('button');
+	const listBox = page.getByRole('listbox').getByRole('button').first();
 
 	await expect(listBox).toHaveText('package.json');
 });

--- a/app/src/lib/components/Navigation.svelte
+++ b/app/src/lib/components/Navigation.svelte
@@ -14,6 +14,7 @@
 	import { platform } from '@tauri-apps/api/os';
 	import { from } from 'rxjs';
 	import { onMount } from 'svelte';
+	import { env } from '$env/dynamic/public';
 
 	const platformName = from(platform());
 	const minResizerWidth = 280;
@@ -106,7 +107,7 @@
 		tabindex="0"
 	>
 		<!-- condition prevents split second UI shift -->
-		{#if $platformName}
+		{#if $platformName || env.PUBLIC_TESTING}
 			<div class="navigation-top">
 				{#if $platformName === 'darwin'}
 					<div class="drag-region" data-tauri-drag-region />

--- a/app/src/lib/testing/fileHunks.ts
+++ b/app/src/lib/testing/fileHunks.ts
@@ -1,0 +1,4803 @@
+export const packageJson = `
+@@ -0,0 +1,102 @@
++{
++	"name": "@gitbutler/ui",
++	"private": true,
++	"version": "0.0.0",
++	"type": "module",
++	"scripts": {
++		"dev": "vite dev",
++		"test": "vitest run --mode development",
++		"test:watch": "vitest --watch --mode development",
++		"test:e2e": "playwright test -c ./playwright.config.ts",
++		"test:e2e:watch": "playwright test -c ./playwright.config.ts --ui",
++		"test:e2e:run": "vite dev --mode testing",
++		"build:development": "vite build --mode development",
++		"build:nightly": "vite build --mode nightly",
++		"build": "vite build",
++		"check": "svelte-check --tsconfig ./tsconfig.json",
++		"check:watch": "pnpm check --watch",
++		"lint": "prettier --no-editorconfig --check . && eslint .",
++		"format": "prettier --no-editorconfig --write .",
++		"fix": "eslint --fix .",
++		"tauri": "tauri",
++		"prepare": "svelte-kit sync"
++	},
++	"devDependencies": {
++		"@codemirror/lang-cpp": "^6.0.2",
++		"@codemirror/lang-css": "^6.2.1",
++		"@codemirror/lang-html": "^6.4.9",
++		"@codemirror/lang-java": "^6.0.1",
++		"@codemirror/lang-javascript": "^6.2.2",
++		"@codemirror/lang-json": "^6.0.1",
++		"@codemirror/lang-markdown": "^6.2.5",
++		"@codemirror/lang-php": "^6.0.1",
++		"@codemirror/lang-python": "^6.1.6",
++		"@codemirror/lang-rust": "^6.0.1",
++		"@codemirror/lang-vue": "^0.1.3",
++		"@codemirror/lang-wast": "^6.0.2",
++		"@codemirror/lang-xml": "^6.1.0",
++		"@codemirror/language": "^6.10.1",
++		"@codemirror/legacy-modes": "^6.4.0",
++		"@codemirror/state": "^6.4.1",
++		"@codemirror/view": "^6.26.3",
++		"@lezer/common": "^1.2.1",
++		"@lezer/highlight": "^1.2.0",
++		"@octokit/rest": "^20.1.1",
++		"@playwright/test": "^1.44.1",
++		"@replit/codemirror-lang-svelte": "^6.0.0",
++		"@sentry/sveltekit": "^7.114.0",
++		"@sveltejs/adapter-static": "^2.0.3",
++		"@sveltejs/kit": "^1.30.4",
++		"@tauri-apps/api": "^1.5.5",
++		"@types/crypto-js": "^4.2.2",
++		"@types/diff": "^5.2.1",
++		"@types/diff-match-patch": "^1.0.36",
++		"@types/lscache": "^1.3.4",
++		"@types/marked": "^5.0.2",
++		"@typescript-eslint/eslint-plugin": "^7.10.0",
++		"@typescript-eslint/parser": "^7.10.0",
++		"autoprefixer": "^10.4.19",
++		"class-transformer": "^0.5.1",
++		"crypto-js": "^4.2.0",
++		"date-fns": "^2.30.0",
++		"diff-match-patch": "^1.0.5",
++		"eslint": "^8.57.0",
++		"eslint-config-prettier": "^9.1.0",
++		"eslint-import-resolver-typescript": "^3.6.1",
++		"eslint-plugin-import": "^2.29.1",
++		"eslint-plugin-square-svelte-store": "^1.0.0",
++		"eslint-plugin-svelte": "^2.39.0",
++		"inter-ui": "^4.0.2",
++		"leven": "^4.0.0",
++		"lscache": "^1.3.2",
++		"marked": "^10.0.0",
++		"mm-jsr": "^3.0.2",
++		"nanoevents": "^9.0.0",
++		"nanoid": "^5.0.7",
++		"postcss": "^8.4.38",
++		"postcss-load-config": "^5.1.0",
++		"posthog-js": "1.135.2",
++		"prettier": "^3.2.5",
++		"prettier-plugin-svelte": "^3.2.3",
++		"reflect-metadata": "^0.2.2",
++		"rxjs": "^7.8.1",
++		"svelte": "^4.2.16",
++		"svelte-check": "^3.7.1",
++		"svelte-floating-ui": "^1.5.8",
++		"svelte-french-toast": "^1.2.0",
++		"svelte-loadable-store": "^2.0.1",
++		"svelte-outclick": "^3.7.1",
++		"svelte-resize-observer": "^2.0.0",
++		"tauri-plugin-context-menu": "^0.7.0",
++		"tauri-plugin-log-api": "github:tauri-apps/tauri-plugin-log#v1",
++		"tauri-plugin-store-api": "github:tauri-apps/tauri-plugin-store#v1",
++		"tinykeys": "^2.1.0",
++		"tslib": "^2.6.2",
++		"typescript": "^5.4.5",
++		"vite": "^4.5.3",
++		"vitest": "^0.34.6"
++	},
++	"dependencies": {
++		"openai": "^4.45.0"
++	}
++}
+`;
+
+export const pnpmLock = `
+@@ -0,0 +1,4694 @@
++lockfileVersion: '6.0'
++
++settings:
++  autoInstallPeers: true
++  excludeLinksFromLockfile: false
++
++importers:
++
++  .:
++    devDependencies:
++      '@tauri-apps/cli':
++        specifier: ^1.5.13
++        version: 1.5.14
++
++  app:
++    dependencies:
++      openai:
++        specifier: ^4.45.0
++        version: 4.47.1
++    devDependencies:
++      '@codemirror/lang-cpp':
++        specifier: ^6.0.2
++        version: 6.0.2
++      '@codemirror/lang-css':
++        specifier: ^6.2.1
++        version: 6.2.1(@codemirror/view@6.26.3)
++      '@codemirror/lang-html':
++        specifier: ^6.4.9
++        version: 6.4.9
++      '@codemirror/lang-java':
++        specifier: ^6.0.1
++        version: 6.0.1
++      '@codemirror/lang-javascript':
++        specifier: ^6.2.2
++        version: 6.2.2
++      '@codemirror/lang-json':
++        specifier: ^6.0.1
++        version: 6.0.1
++      '@codemirror/lang-markdown':
++        specifier: ^6.2.5
++        version: 6.2.5
++      '@codemirror/lang-php':
++        specifier: ^6.0.1
++        version: 6.0.1
++      '@codemirror/lang-python':
++        specifier: ^6.1.6
++        version: 6.1.6(@codemirror/view@6.26.3)
++      '@codemirror/lang-rust':
++        specifier: ^6.0.1
++        version: 6.0.1
++      '@codemirror/lang-vue':
++        specifier: ^0.1.3
++        version: 0.1.3
++      '@codemirror/lang-wast':
++        specifier: ^6.0.2
++        version: 6.0.2
++      '@codemirror/lang-xml':
++        specifier: ^6.1.0
++        version: 6.1.0
++      '@codemirror/language':
++        specifier: ^6.10.1
++        version: 6.10.1
++      '@codemirror/legacy-modes':
++        specifier: ^6.4.0
++        version: 6.4.0
++      '@codemirror/state':
++        specifier: ^6.4.1
++        version: 6.4.1
++      '@codemirror/view':
++        specifier: ^6.26.3
++        version: 6.26.3
++      '@lezer/common':
++        specifier: ^1.2.1
++        version: 1.2.1
++      '@lezer/highlight':
++        specifier: ^1.2.0
++        version: 1.2.0
++      '@octokit/rest':
++        specifier: ^20.1.1
++        version: 20.1.1
++      '@playwright/test':
++        specifier: ^1.44.1
++        version: 1.44.1
++      '@replit/codemirror-lang-svelte':
++        specifier: ^6.0.0
++        version: 6.0.0(@codemirror/autocomplete@6.16.0)(@codemirror/lang-css@6.2.1)(@codemirror/lang-html@6.4.9)(@codemirror/lang-javascript@6.2.2)(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/javascript@1.4.16)(@lezer/lr@1.4.0)
++      '@sentry/sveltekit':
++        specifier: ^7.114.0
++        version: 7.116.0(@sveltejs/kit@1.30.4)(svelte@4.2.17)
++      '@sveltejs/adapter-static':
++        specifier: ^2.0.3
++        version: 2.0.3(@sveltejs/kit@1.30.4)
++      '@sveltejs/kit':
++        specifier: ^1.30.4
++        version: 1.30.4(svelte@4.2.17)(vite@4.5.3)
++      '@tauri-apps/api':
++        specifier: ^1.5.5
++        version: 1.5.6
++      '@types/crypto-js':
++        specifier: ^4.2.2
++        version: 4.2.2
++      '@types/diff':
++        specifier: ^5.2.1
++        version: 5.2.1
++      '@types/diff-match-patch':
++        specifier: ^1.0.36
++        version: 1.0.36
++      '@types/lscache':
++        specifier: ^1.3.4
++        version: 1.3.4
++      '@types/marked':
++        specifier: ^5.0.2
++        version: 5.0.2
++      '@typescript-eslint/eslint-plugin':
++        specifier: ^7.10.0
++        version: 7.10.0(@typescript-eslint/parser@7.10.0)(eslint@8.57.0)(typescript@5.4.5)
++      '@typescript-eslint/parser':
++        specifier: ^7.10.0
++        version: 7.10.0(eslint@8.57.0)(typescript@5.4.5)
++      autoprefixer:
++        specifier: ^10.4.19
++        version: 10.4.19(postcss@8.4.38)
++      class-transformer:
++        specifier: ^0.5.1
++        version: 0.5.1
++      crypto-js:
++        specifier: ^4.2.0
++        version: 4.2.0
++      date-fns:
++        specifier: ^2.30.0
++        version: 2.30.0
++      diff-match-patch:
++        specifier: ^1.0.5
++        version: 1.0.5
++      eslint:
++        specifier: ^8.57.0
++        version: 8.57.0
++      eslint-config-prettier:
++        specifier: ^9.1.0
++        version: 9.1.0(eslint@8.57.0)
++      eslint-import-resolver-typescript:
++        specifier: ^3.6.1
++        version: 3.6.1(@typescript-eslint/parser@7.10.0)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
++      eslint-plugin-import:
++        specifier: ^2.29.1
++        version: 2.29.1(@typescript-eslint/parser@7.10.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
++      eslint-plugin-square-svelte-store:
++        specifier: ^1.0.0
++        version: 1.0.0
++      eslint-plugin-svelte:
++        specifier: ^2.39.0
++        version: 2.39.0(eslint@8.57.0)(svelte@4.2.17)
++      inter-ui:
++        specifier: ^4.0.2
++        version: 4.0.2
++      leven:
++        specifier: ^4.0.0
++        version: 4.0.0
++      lscache:
++        specifier: ^1.3.2
++        version: 1.3.2
++      marked:
++        specifier: ^10.0.0
++        version: 10.0.0
++      mm-jsr:
++        specifier: ^3.0.2
++        version: 3.0.2
++      nanoevents:
++        specifier: ^9.0.0
++        version: 9.0.0
++      nanoid:
++        specifier: ^5.0.7
++        version: 5.0.7
++      postcss:
++        specifier: ^8.4.38
++        version: 8.4.38
++      postcss-load-config:
++        specifier: ^5.1.0
++        version: 5.1.0(postcss@8.4.38)
++      posthog-js:
++        specifier: 1.135.2
++        version: 1.135.2
++      prettier:
++        specifier: ^3.2.5
++        version: 3.2.5
++      prettier-plugin-svelte:
++        specifier: ^3.2.3
++        version: 3.2.3(prettier@3.2.5)(svelte@4.2.17)
++      reflect-metadata:
++        specifier: ^0.2.2
++        version: 0.2.2
++      rxjs:
++        specifier: ^7.8.1
++        version: 7.8.1
++      svelte:
++        specifier: ^4.2.16
++        version: 4.2.17
++      svelte-check:
++        specifier: ^3.7.1
++        version: 3.7.1(postcss-load-config@5.1.0)(postcss@8.4.38)(svelte@4.2.17)
++      svelte-floating-ui:
++        specifier: ^1.5.8
++        version: 1.5.8
++      svelte-french-toast:
++        specifier: ^1.2.0
++        version: 1.2.0(svelte@4.2.17)
++      svelte-loadable-store:
++        specifier: ^2.0.1
++        version: 2.0.1(svelte@4.2.17)
++      svelte-outclick:
++        specifier: ^3.7.1
++        version: 3.7.1(svelte@4.2.17)
++      svelte-resize-observer:
++        specifier: ^2.0.0
++        version: 2.0.0
++      tauri-plugin-context-menu:
++        specifier: ^0.7.0
++        version: 0.7.0
++      tauri-plugin-log-api:
++        specifier: github:tauri-apps/tauri-plugin-log#v1
++        version: github.com/tauri-apps/tauri-plugin-log/db7255ca2e07fc4d3e6cc5d93f9ccfceacb28901
++      tauri-plugin-store-api:
++        specifier: github:tauri-apps/tauri-plugin-store#v1
++        version: github.com/tauri-apps/tauri-plugin-store/02243686d0507d2aeeb2924cd889dd0bcb47ecef
++      tinykeys:
++        specifier: ^2.1.0
++        version: 2.1.0
++      tslib:
++        specifier: ^2.6.2
++        version: 2.6.2
++      typescript:
++        specifier: ^5.4.5
++        version: 5.4.5
++      vite:
++        specifier: ^4.5.3
++        version: 4.5.3(@types/node@20.5.9)
++      vitest:
++        specifier: ^0.34.6
++        version: 0.34.6
++
++packages:
++
++  /@aashutoshrathi/word-wrap@1.2.6:
++    resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
++    engines: {node: '>=0.10.0'}
++    dev: true
++
++  /@ampproject/remapping@2.2.1:
++    resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
++    engines: {node: '>=6.0.0'}
++    dependencies:
++      '@jridgewell/gen-mapping': 0.3.3
++      '@jridgewell/trace-mapping': 0.3.19
++    dev: true
++
++  /@babel/helper-string-parser@7.22.5:
++    resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
++    engines: {node: '>=6.9.0'}
++    dev: true
++
++  /@babel/helper-validator-identifier@7.22.15:
++    resolution: {integrity: sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ==}
++    engines: {node: '>=6.9.0'}
++    dev: true
++
++  /@babel/parser@7.22.15:
++    resolution: {integrity: sha512-RWmQ/sklUN9BvGGpCDgSubhHWfAx24XDTDObup4ffvxaYsptOg2P3KG0j+1eWKLxpkX0j0uHxmpq2Z1SP/VhxA==}
++    engines: {node: '>=6.0.0'}
++    hasBin: true
++    dependencies:
++      '@babel/types': 7.22.15
++    dev: true
++
++  /@babel/runtime@7.22.15:
++    resolution: {integrity: sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==}
++    engines: {node: '>=6.9.0'}
++    dependencies:
++      regenerator-runtime: 0.14.0
++    dev: true
++
++  /@babel/types@7.22.15:
++    resolution: {integrity: sha512-X+NLXr0N8XXmN5ZsaQdm9U2SSC3UbIYq/doL++sueHOTisgZHoKaQtZxGuV2cUPQHMfjKEfg/g6oy7Hm6SKFtA==}
++    engines: {node: '>=6.9.0'}
++    dependencies:
++      '@babel/helper-string-parser': 7.22.5
++      '@babel/helper-validator-identifier': 7.22.15
++      to-fast-properties: 2.0.0
++    dev: true
++
++  /@codemirror/autocomplete@6.15.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1):
++    resolution: {integrity: sha512-G2Zm0mXznxz97JhaaOdoEG2cVupn4JjPaS4AcNvZzhOsnnG9YVN68VzfoUw6dYTsIxT6a/cmoFEN47KAWhXaOg==}
++    peerDependencies:
++      '@codemirror/language': ^6.0.0
++      '@codemirror/state': ^6.0.0
++      '@codemirror/view': ^6.0.0
++      '@lezer/common': ^1.0.0
++    dependencies:
++      '@codemirror/language': 6.10.1
++      '@codemirror/state': 6.4.1
++      '@codemirror/view': 6.26.3
++      '@lezer/common': 1.2.1
++    dev: true
++
++  /@codemirror/autocomplete@6.16.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1):
++    resolution: {integrity: sha512-P/LeCTtZHRTCU4xQsa89vSKWecYv1ZqwzOd5topheGRf+qtacFgBeIMQi3eL8Kt/BUNvxUWkx+5qP2jlGoARrg==}
++    peerDependencies:
++      '@codemirror/language': ^6.0.0
++      '@codemirror/state': ^6.0.0
++      '@codemirror/view': ^6.0.0
++      '@lezer/common': ^1.0.0
++    dependencies:
++      '@codemirror/language': 6.10.1
++      '@codemirror/state': 6.4.1
++      '@codemirror/view': 6.26.3
++      '@lezer/common': 1.2.1
++    dev: true
++
++  /@codemirror/lang-cpp@6.0.2:
++    resolution: {integrity: sha512-6oYEYUKHvrnacXxWxYa6t4puTlbN3dgV662BDfSH8+MfjQjVmP697/KYTDOqpxgerkvoNm7q5wlFMBeX8ZMocg==}
++    dependencies:
++      '@codemirror/language': 6.10.1
++      '@lezer/cpp': 1.1.1
++    dev: true
++
++  /@codemirror/lang-css@6.2.1(@codemirror/view@6.26.3):
++    resolution: {integrity: sha512-/UNWDNV5Viwi/1lpr/dIXJNWiwDxpw13I4pTUAsNxZdg6E0mI2kTQb0P2iHczg1Tu+H4EBgJR+hYhKiHKko7qg==}
++    dependencies:
++      '@codemirror/autocomplete': 6.15.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)
++      '@codemirror/language': 6.10.1
++      '@codemirror/state': 6.4.1
++      '@lezer/common': 1.2.1
++      '@lezer/css': 1.1.3
++    transitivePeerDependencies:
++      - '@codemirror/view'
++    dev: true
++
++  /@codemirror/lang-html@6.4.9:
++    resolution: {integrity: sha512-aQv37pIMSlueybId/2PVSP6NPnmurFDVmZwzc7jszd2KAF8qd4VBbvNYPXWQq90WIARjsdVkPbw29pszmHws3Q==}
++    dependencies:
++      '@codemirror/autocomplete': 6.16.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)
++      '@codemirror/lang-css': 6.2.1(@codemirror/view@6.26.3)
++      '@codemirror/lang-javascript': 6.2.2
++      '@codemirror/language': 6.10.1
++      '@codemirror/state': 6.4.1
++      '@codemirror/view': 6.26.3
++      '@lezer/common': 1.2.1
++      '@lezer/css': 1.1.3
++      '@lezer/html': 1.3.6
++    dev: true
++
++  /@codemirror/lang-java@6.0.1:
++    resolution: {integrity: sha512-OOnmhH67h97jHzCuFaIEspbmsT98fNdhVhmA3zCxW0cn7l8rChDhZtwiwJ/JOKXgfm4J+ELxQihxaI7bj7mJRg==}
++    dependencies:
++      '@codemirror/language': 6.10.1
++      '@lezer/java': 1.0.4
++    dev: true
++
++  /@codemirror/lang-javascript@6.2.2:
++    resolution: {integrity: sha512-VGQfY+FCc285AhWuwjYxQyUQcYurWlxdKYT4bqwr3Twnd5wP5WSeu52t4tvvuWmljT4EmgEgZCqSieokhtY8hg==}
++    dependencies:
++      '@codemirror/autocomplete': 6.15.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)
++      '@codemirror/language': 6.10.1
++      '@codemirror/lint': 6.4.1
++      '@codemirror/state': 6.4.1
++      '@codemirror/view': 6.26.3
++      '@lezer/common': 1.2.1
++      '@lezer/javascript': 1.4.14
++    dev: true
++
++  /@codemirror/lang-json@6.0.1:
++    resolution: {integrity: sha512-+T1flHdgpqDDlJZ2Lkil/rLiRy684WMLc74xUnjJH48GQdfJo/pudlTRreZmKwzP8/tGdKf83wlbAdOCzlJOGQ==}
++    dependencies:
++      '@codemirror/language': 6.10.1
++      '@lezer/json': 1.0.1
++    dev: true
++
++  /@codemirror/lang-markdown@6.2.5:
++    resolution: {integrity: sha512-Hgke565YcO4fd9pe2uLYxnMufHO5rQwRr+AAhFq8ABuhkrjyX8R5p5s+hZUTdV60O0dMRjxKhBLxz8pu/MkUVA==}
++    dependencies:
++      '@codemirror/autocomplete': 6.16.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)
++      '@codemirror/lang-html': 6.4.9
++      '@codemirror/language': 6.10.1
++      '@codemirror/state': 6.4.1
++      '@codemirror/view': 6.26.3
++      '@lezer/common': 1.2.1
++      '@lezer/markdown': 1.1.0
++    dev: true
++
++  /@codemirror/lang-php@6.0.1:
++    resolution: {integrity: sha512-ublojMdw/PNWa7qdN5TMsjmqkNuTBD3k6ndZ4Z0S25SBAiweFGyY68AS3xNcIOlb6DDFDvKlinLQ40vSLqf8xA==}
++    dependencies:
++      '@codemirror/lang-html': 6.4.9
++      '@codemirror/language': 6.10.1
++      '@codemirror/state': 6.4.1
++      '@lezer/common': 1.2.1
++      '@lezer/php': 1.0.1
++    dev: true
++
++  /@codemirror/lang-python@6.1.6(@codemirror/view@6.26.3):
++    resolution: {integrity: sha512-ai+01WfZhWqM92UqjnvorkxosZ2aq2u28kHvr+N3gu012XqY2CThD67JPMHnGceRfXPDBmn1HnyqowdpF57bNg==}
++    dependencies:
++      '@codemirror/autocomplete': 6.16.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)
++      '@codemirror/language': 6.10.1
++      '@codemirror/state': 6.4.1
++      '@lezer/common': 1.2.1
++      '@lezer/python': 1.1.8
++    transitivePeerDependencies:
++      - '@codemirror/view'
++    dev: true
++
++  /@codemirror/lang-rust@6.0.1:
++    resolution: {integrity: sha512-344EMWFBzWArHWdZn/NcgkwMvZIWUR1GEBdwG8FEp++6o6vT6KL9V7vGs2ONsKxxFUPXKI0SPcWhyYyl2zPYxQ==}
++    dependencies:
++      '@codemirror/language': 6.10.1
++      '@lezer/rust': 1.0.1
++    dev: true
++
++  /@codemirror/lang-vue@0.1.3:
++    resolution: {integrity: sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug==}
++    dependencies:
++      '@codemirror/lang-html': 6.4.9
++      '@codemirror/lang-javascript': 6.2.2
++      '@codemirror/language': 6.10.1
++      '@lezer/common': 1.2.1
++      '@lezer/highlight': 1.2.0
++      '@lezer/lr': 1.4.0
++    dev: true
++
++  /@codemirror/lang-wast@6.0.2:
++    resolution: {integrity: sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q==}
++    dependencies:
++      '@codemirror/language': 6.10.1
++      '@lezer/common': 1.2.1
++      '@lezer/highlight': 1.2.0
++      '@lezer/lr': 1.4.0
++    dev: true
++
++  /@codemirror/lang-xml@6.1.0:
++    resolution: {integrity: sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==}
++    dependencies:
++      '@codemirror/autocomplete': 6.15.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)
++      '@codemirror/language': 6.10.1
++      '@codemirror/state': 6.4.1
++      '@codemirror/view': 6.26.3
++      '@lezer/common': 1.2.1
++      '@lezer/xml': 1.0.2
++    dev: true
++
++  /@codemirror/language@6.10.1:
++    resolution: {integrity: sha512-5GrXzrhq6k+gL5fjkAwt90nYDmjlzTIJV8THnxNFtNKWotMIlzzN+CpqxqwXOECnUdOndmSeWntVrVcv5axWRQ==}
++    dependencies:
++      '@codemirror/state': 6.4.1
++      '@codemirror/view': 6.26.3
++      '@lezer/common': 1.2.1
++      '@lezer/highlight': 1.2.0
++      '@lezer/lr': 1.4.0
++      style-mod: 4.1.0
++    dev: true
++
++  /@codemirror/legacy-modes@6.4.0:
++    resolution: {integrity: sha512-5m/K+1A6gYR0e+h/dEde7LoGimMjRtWXZFg4Lo70cc8HzjSdHe3fLwjWMR0VRl5KFT1SxalSap7uMgPKF28wBA==}
++    dependencies:
++      '@codemirror/language': 6.10.1
++    dev: true
++
++  /@codemirror/lint@6.4.1:
++    resolution: {integrity: sha512-2Hx945qKX7FBan5/gUdTM8fsMYrNG9clIgEcPXestbLVFAUyQYFAuju/5BMNf/PwgpVaX5pvRm4+ovjbp9D9gQ==}
++    dependencies:
++      '@codemirror/state': 6.4.1
++      '@codemirror/view': 6.26.3
++      crelt: 1.0.6
++    dev: true
++
++  /@codemirror/state@6.4.1:
++    resolution: {integrity: sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==}
++    dev: true
++
++  /@codemirror/view@6.26.3:
++    resolution: {integrity: sha512-gmqxkPALZjkgSxIeeweY/wGQXBfwTUaLs8h7OKtSwfbj9Ct3L11lD+u1sS7XHppxFQoMDiMDp07P9f3I2jWOHw==}
++    dependencies:
++      '@codemirror/state': 6.4.1
++      style-mod: 4.1.0
++      w3c-keyname: 2.2.8
++    dev: true
++
++  /@esbuild/android-arm64@0.18.20:
++    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
++    engines: {node: '>=12'}
++    cpu: [arm64]
++    os: [android]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@esbuild/android-arm@0.18.20:
++    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
++    engines: {node: '>=12'}
++    cpu: [arm]
++    os: [android]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@esbuild/android-x64@0.18.20:
++    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
++    engines: {node: '>=12'}
++    cpu: [x64]
++    os: [android]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@esbuild/darwin-arm64@0.18.20:
++    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
++    engines: {node: '>=12'}
++    cpu: [arm64]
++    os: [darwin]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@esbuild/darwin-x64@0.18.20:
++    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
++    engines: {node: '>=12'}
++    cpu: [x64]
++    os: [darwin]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@esbuild/freebsd-arm64@0.18.20:
++    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
++    engines: {node: '>=12'}
++    cpu: [arm64]
++    os: [freebsd]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@esbuild/freebsd-x64@0.18.20:
++    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
++    engines: {node: '>=12'}
++    cpu: [x64]
++    os: [freebsd]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@esbuild/linux-arm64@0.18.20:
++    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
++    engines: {node: '>=12'}
++    cpu: [arm64]
++    os: [linux]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@esbuild/linux-arm@0.18.20:
++    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
++    engines: {node: '>=12'}
++    cpu: [arm]
++    os: [linux]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@esbuild/linux-ia32@0.18.20:
++    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
++    engines: {node: '>=12'}
++    cpu: [ia32]
++    os: [linux]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@esbuild/linux-loong64@0.18.20:
++    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
++    engines: {node: '>=12'}
++    cpu: [loong64]
++    os: [linux]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@esbuild/linux-mips64el@0.18.20:
++    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
++    engines: {node: '>=12'}
++    cpu: [mips64el]
++    os: [linux]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@esbuild/linux-ppc64@0.18.20:
++    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
++    engines: {node: '>=12'}
++    cpu: [ppc64]
++    os: [linux]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@esbuild/linux-riscv64@0.18.20:
++    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
++    engines: {node: '>=12'}
++    cpu: [riscv64]
++    os: [linux]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@esbuild/linux-s390x@0.18.20:
++    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
++    engines: {node: '>=12'}
++    cpu: [s390x]
++    os: [linux]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@esbuild/linux-x64@0.18.20:
++    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
++    engines: {node: '>=12'}
++    cpu: [x64]
++    os: [linux]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@esbuild/netbsd-x64@0.18.20:
++    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
++    engines: {node: '>=12'}
++    cpu: [x64]
++    os: [netbsd]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@esbuild/openbsd-x64@0.18.20:
++    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
++    engines: {node: '>=12'}
++    cpu: [x64]
++    os: [openbsd]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@esbuild/sunos-x64@0.18.20:
++    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
++    engines: {node: '>=12'}
++    cpu: [x64]
++    os: [sunos]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@esbuild/win32-arm64@0.18.20:
++    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
++    engines: {node: '>=12'}
++    cpu: [arm64]
++    os: [win32]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@esbuild/win32-ia32@0.18.20:
++    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
++    engines: {node: '>=12'}
++    cpu: [ia32]
++    os: [win32]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@esbuild/win32-x64@0.18.20:
++    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
++    engines: {node: '>=12'}
++    cpu: [x64]
++    os: [win32]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@eslint-community/eslint-utils@4.4.0(eslint@8.57.0):
++    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
++    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
++    peerDependencies:
++      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
++    dependencies:
++      eslint: 8.57.0
++      eslint-visitor-keys: 3.4.3
++    dev: true
++
++  /@eslint-community/regexpp@4.10.0:
++    resolution: {integrity: sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==}
++    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
++    dev: true
++
++  /@eslint-community/regexpp@4.8.0:
++    resolution: {integrity: sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==}
++    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
++    dev: true
++
++  /@eslint/eslintrc@2.1.4:
++    resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
++    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
++    dependencies:
++      ajv: 6.12.6
++      debug: 4.3.4
++      espree: 9.6.1
++      globals: 13.21.0
++      ignore: 5.3.1
++      import-fresh: 3.3.0
++      js-yaml: 4.1.0
++      minimatch: 3.1.2
++      strip-json-comments: 3.1.1
++    transitivePeerDependencies:
++      - supports-color
++    dev: true
++
++  /@eslint/js@8.57.0:
++    resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
++    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
++    dev: true
++
++  /@fastify/busboy@2.0.0:
++    resolution: {integrity: sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==}
++    engines: {node: '>=14'}
++    dev: true
++
++  /@floating-ui/core@1.5.2:
++    resolution: {integrity: sha512-Ii3MrfY/GAIN3OhXNzpCKaLxHQfJF9qvwq/kEJYdqDxeIHa01K8sldugal6TmeeXl+WMvhv9cnVzUTaFFJF09A==}
++    dependencies:
++      '@floating-ui/utils': 0.1.6
++    dev: true
++
++  /@floating-ui/dom@1.5.3:
++    resolution: {integrity: sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==}
++    dependencies:
++      '@floating-ui/core': 1.5.2
++      '@floating-ui/utils': 0.1.6
++    dev: true
++
++  /@floating-ui/utils@0.1.6:
++    resolution: {integrity: sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==}
++    dev: true
++
++  /@humanwhocodes/config-array@0.11.14:
++    resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
++    engines: {node: '>=10.10.0'}
++    dependencies:
++      '@humanwhocodes/object-schema': 2.0.2
++      debug: 4.3.4
++      minimatch: 3.1.2
++    transitivePeerDependencies:
++      - supports-color
++    dev: true
++
++  /@humanwhocodes/module-importer@1.0.1:
++    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
++    engines: {node: '>=12.22'}
++    dev: true
++
++  /@humanwhocodes/object-schema@2.0.2:
++    resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
++    dev: true
++
++  /@jest/schemas@29.6.3:
++    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
++    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
++    dependencies:
++      '@sinclair/typebox': 0.27.8
++    dev: true
++
++  /@jridgewell/gen-mapping@0.3.3:
++    resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
++    engines: {node: '>=6.0.0'}
++    dependencies:
++      '@jridgewell/set-array': 1.1.2
++      '@jridgewell/sourcemap-codec': 1.4.15
++      '@jridgewell/trace-mapping': 0.3.19
++    dev: true
++
++  /@jridgewell/resolve-uri@3.1.1:
++    resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
++    engines: {node: '>=6.0.0'}
++    dev: true
++
++  /@jridgewell/set-array@1.1.2:
++    resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
++    engines: {node: '>=6.0.0'}
++    dev: true
++
++  /@jridgewell/sourcemap-codec@1.4.15:
++    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
++    dev: true
++
++  /@jridgewell/trace-mapping@0.3.19:
++    resolution: {integrity: sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==}
++    dependencies:
++      '@jridgewell/resolve-uri': 3.1.1
++      '@jridgewell/sourcemap-codec': 1.4.15
++    dev: true
++
++  /@lezer/common@1.2.1:
++    resolution: {integrity: sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ==}
++    dev: true
++
++  /@lezer/cpp@1.1.1:
++    resolution: {integrity: sha512-eS1M3L3U2mDowoFVPG7tEp01SWu9/68Nx3HEBgLJVn3N9ku7g5S7WdFv0jzmcTipAyONYfZJ+7x4WRkfdB2Ung==}
++    dependencies:
++      '@lezer/highlight': 1.2.0
++      '@lezer/lr': 1.4.0
++    dev: true
++
++  /@lezer/css@1.1.3:
++    resolution: {integrity: sha512-SjSM4pkQnQdJDVc80LYzEaMiNy9txsFbI7HsMgeVF28NdLaAdHNtQ+kB/QqDUzRBV/75NTXjJ/R5IdC8QQGxMg==}
++    dependencies:
++      '@lezer/highlight': 1.2.0
++      '@lezer/lr': 1.4.0
++    dev: true
++
++  /@lezer/highlight@1.2.0:
++    resolution: {integrity: sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==}
++    dependencies:
++      '@lezer/common': 1.2.1
++    dev: true
++
++  /@lezer/html@1.3.6:
++    resolution: {integrity: sha512-Kk9HJARZTc0bAnMQUqbtuhFVsB4AnteR2BFUWfZV7L/x1H0aAKz6YabrfJ2gk/BEgjh9L3hg5O4y2IDZRBdzuQ==}
++    dependencies:
++      '@lezer/common': 1.2.1
++      '@lezer/highlight': 1.2.0
++      '@lezer/lr': 1.4.0
++    dev: true
++
++  /@lezer/java@1.0.4:
++    resolution: {integrity: sha512-POc53LHf2AuNeRXjqZbXNu88GKj0KZTjjSx0L7tYeXlrEHF+3NAQx+dEwKVuCbkl0ZMtpRy2VsDYOV7KKV0oyg==}
++    dependencies:
++      '@lezer/highlight': 1.2.0
++      '@lezer/lr': 1.4.0
++    dev: true
++
++  /@lezer/javascript@1.4.14:
++    resolution: {integrity: sha512-GEdUyspTRgc5dwIGebUk+f3BekvqEWVIYsIuAC3pA8e8wcikGwBZRWRa450L0s8noGWuULwnmi4yjxTnYz9PpA==}
++    dependencies:
++      '@lezer/common': 1.2.1
++      '@lezer/highlight': 1.2.0
++      '@lezer/lr': 1.4.0
++    dev: true
++
++  /@lezer/javascript@1.4.16:
++    resolution: {integrity: sha512-84UXR3N7s11MPQHWgMnjb9571fr19MmXnr5zTv2XX0gHXXUvW3uPJ8GCjKrfTXmSdfktjRK0ayKklw+A13rk4g==}
++    dependencies:
++      '@lezer/common': 1.2.1
++      '@lezer/highlight': 1.2.0
++      '@lezer/lr': 1.4.0
++    dev: true
++
++  /@lezer/json@1.0.1:
++    resolution: {integrity: sha512-nkVC27qiEZEjySbi6gQRuMwa2sDu2PtfjSgz0A4QF81QyRGm3kb2YRzLcOPcTEtmcwvrX/cej7mlhbwViA4WJw==}
++    dependencies:
++      '@lezer/highlight': 1.2.0
++      '@lezer/lr': 1.4.0
++    dev: true
++
++  /@lezer/lr@1.4.0:
++    resolution: {integrity: sha512-Wst46p51km8gH0ZUmeNrtpRYmdlRHUpN1DQd3GFAyKANi8WVz8c2jHYTf1CVScFaCjQw1iO3ZZdqGDxQPRErTg==}
++    dependencies:
++      '@lezer/common': 1.2.1
++    dev: true
++
++  /@lezer/markdown@1.1.0:
++    resolution: {integrity: sha512-JYOI6Lkqbl83semCANkO3CKbKc0pONwinyagBufWBm+k4yhIcqfCF8B8fpEpvJLmIy7CAfwiq7dQ/PzUZA340g==}
++    dependencies:
++      '@lezer/common': 1.2.1
++      '@lezer/highlight': 1.2.0
++    dev: true
++
++  /@lezer/php@1.0.1:
++    resolution: {integrity: sha512-aqdCQJOXJ66De22vzdwnuC502hIaG9EnPK2rSi+ebXyUd+j7GAX1mRjWZOVOmf3GST1YUfUCu6WXDiEgDGOVwA==}
++    dependencies:
++      '@lezer/highlight': 1.2.0
++      '@lezer/lr': 1.4.0
++    dev: true
++
++  /@lezer/python@1.1.8:
++    resolution: {integrity: sha512-1T/XsmeF57ijrjpC0Zmrf9YeO5mn2zC1XeSNrOnc0KB+6PgxJ5m7kWKt0CnwyS74oHQXbJxUUL+QDQJR26c1Gw==}
++    dependencies:
++      '@lezer/highlight': 1.2.0
++      '@lezer/lr': 1.4.0
++    dev: true
++
++  /@lezer/rust@1.0.1:
++    resolution: {integrity: sha512-j+ToFKM6Wpglv3OQ4ebHYdYIMT2dh0ziCCV0rTf47AWiHOVhR0WjaKrBq+yuvDQNEhr5sxPxVI7+naJIgpqcsQ==}
++    dependencies:
++      '@lezer/highlight': 1.2.0
++      '@lezer/lr': 1.4.0
++    dev: true
++
++  /@lezer/xml@1.0.2:
++    resolution: {integrity: sha512-dlngsWceOtQBMuBPw5wtHpaxdPJ71aVntqjbpGkFtWsp4WtQmCnuTjQGocviymydN6M18fhj6UQX3oiEtSuY7w==}
++    dependencies:
++      '@lezer/highlight': 1.2.0
++      '@lezer/lr': 1.4.0
++    dev: true
++
++  /@nodelib/fs.scandir@2.1.5:
++    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
++    engines: {node: '>= 8'}
++    dependencies:
++      '@nodelib/fs.stat': 2.0.5
++      run-parallel: 1.2.0
++    dev: true
++
++  /@nodelib/fs.stat@2.0.5:
++    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
++    engines: {node: '>= 8'}
++    dev: true
++
++  /@nodelib/fs.walk@1.2.8:
++    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
++    engines: {node: '>= 8'}
++    dependencies:
++      '@nodelib/fs.scandir': 2.1.5
++      fastq: 1.15.0
++    dev: true
++
++  /@octokit/auth-token@4.0.0:
++    resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
++    engines: {node: '>= 18'}
++    dev: true
++
++  /@octokit/core@5.2.0:
++    resolution: {integrity: sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==}
++    engines: {node: '>= 18'}
++    dependencies:
++      '@octokit/auth-token': 4.0.0
++      '@octokit/graphql': 7.1.0
++      '@octokit/request': 8.3.1
++      '@octokit/request-error': 5.1.0
++      '@octokit/types': 13.1.0
++      before-after-hook: 2.2.3
++      universal-user-agent: 6.0.0
++    dev: true
++
++  /@octokit/endpoint@9.0.1:
++    resolution: {integrity: sha512-hRlOKAovtINHQPYHZlfyFwaM8OyetxeoC81lAkBy34uLb8exrZB50SQdeW3EROqiY9G9yxQTpp5OHTV54QD+vA==}
++    engines: {node: '>= 18'}
++    dependencies:
++      '@octokit/types': 12.6.0
++      is-plain-object: 5.0.0
++      universal-user-agent: 6.0.0
++    dev: true
++
++  /@octokit/graphql@7.1.0:
++    resolution: {integrity: sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==}
++    engines: {node: '>= 18'}
++    dependencies:
++      '@octokit/request': 8.3.1
++      '@octokit/types': 13.1.0
++      universal-user-agent: 6.0.0
++    dev: true
++
++  /@octokit/openapi-types@20.0.0:
++    resolution: {integrity: sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==}
++    dev: true
++
++  /@octokit/openapi-types@21.2.0:
++    resolution: {integrity: sha512-xx+Xd6I7rYvul/hgUDqv6TeGX0IOGnhSg9IOeYgd/uI7IAqUy6DE2B6Ipv2M4mWoxaMcWjIzgTIcv8pMO3F3vw==}
++    dev: true
++
++  /@octokit/openapi-types@22.2.0:
++    resolution: {integrity: sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==}
++    dev: true
++
++  /@octokit/plugin-paginate-rest@11.3.1(@octokit/core@5.2.0):
++    resolution: {integrity: sha512-ryqobs26cLtM1kQxqeZui4v8FeznirUsksiA+RYemMPJ7Micju0WSkv50dBksTuZks9O5cg4wp+t8fZ/cLY56g==}
++    engines: {node: '>= 18'}
++    peerDependencies:
++      '@octokit/core': '5'
++    dependencies:
++      '@octokit/core': 5.2.0
++      '@octokit/types': 13.5.0
++    dev: true
++
++  /@octokit/plugin-request-log@4.0.0(@octokit/core@5.2.0):
++    resolution: {integrity: sha512-2uJI1COtYCq8Z4yNSnM231TgH50bRkheQ9+aH8TnZanB6QilOnx8RMD2qsnamSOXtDj0ilxvevf5fGsBhBBzKA==}
++    engines: {node: '>= 18'}
++    peerDependencies:
++      '@octokit/core': '>=5'
++    dependencies:
++      '@octokit/core': 5.2.0
++    dev: true
++
++  /@octokit/plugin-rest-endpoint-methods@13.2.2(@octokit/core@5.2.0):
++    resolution: {integrity: sha512-EI7kXWidkt3Xlok5uN43suK99VWqc8OaIMktY9d9+RNKl69juoTyxmLoWPIZgJYzi41qj/9zU7G/ljnNOJ5AFA==}
++    engines: {node: '>= 18'}
++    peerDependencies:
++      '@octokit/core': ^5
++    dependencies:
++      '@octokit/core': 5.2.0
++      '@octokit/types': 13.5.0
++    dev: true
++
++  /@octokit/request-error@5.1.0:
++    resolution: {integrity: sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==}
++    engines: {node: '>= 18'}
++    dependencies:
++      '@octokit/types': 13.1.0
++      deprecation: 2.3.1
++      once: 1.4.0
++    dev: true
++
++  /@octokit/request@8.3.1:
++    resolution: {integrity: sha512-fin4cl5eHN5Ybmb/gtn7YZ+ycyUlcyqqkg5lfxeSChqj7sUt6TNaJPehREi+0PABKLREYL8pfaUhH3TicEWNoA==}
++    engines: {node: '>= 18'}
++    dependencies:
++      '@octokit/endpoint': 9.0.1
++      '@octokit/request-error': 5.1.0
++      '@octokit/types': 13.1.0
++      universal-user-agent: 6.0.0
++    dev: true
++
++  /@octokit/rest@20.1.1:
++    resolution: {integrity: sha512-MB4AYDsM5jhIHro/dq4ix1iWTLGToIGk6cWF5L6vanFaMble5jTX/UBQyiv05HsWnwUtY8JrfHy2LWfKwihqMw==}
++    engines: {node: '>= 18'}
++    dependencies:
++      '@octokit/core': 5.2.0
++      '@octokit/plugin-paginate-rest': 11.3.1(@octokit/core@5.2.0)
++      '@octokit/plugin-request-log': 4.0.0(@octokit/core@5.2.0)
++      '@octokit/plugin-rest-endpoint-methods': 13.2.2(@octokit/core@5.2.0)
++    dev: true
++
++  /@octokit/types@12.6.0:
++    resolution: {integrity: sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==}
++    dependencies:
++      '@octokit/openapi-types': 20.0.0
++    dev: true
++
++  /@octokit/types@13.1.0:
++    resolution: {integrity: sha512-nBwAFOYqVUUJ2AZFK4ZzESQptaAVqdTDKk8gE0Xr0o99WuPDSrhUC38x0F40xD9OUxXhOOuZKWNNVVLPSHQDvQ==}
++    dependencies:
++      '@octokit/openapi-types': 21.2.0
++    dev: true
++
++  /@octokit/types@13.5.0:
++    resolution: {integrity: sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==}
++    dependencies:
++      '@octokit/openapi-types': 22.2.0
++    dev: true
++
++  /@playwright/test@1.44.1:
++    resolution: {integrity: sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==}
++    engines: {node: '>=16'}
++    hasBin: true
++    dependencies:
++      playwright: 1.44.1
++    dev: true
++
++  /@polka/url@1.0.0-next.21:
++    resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
++    dev: true
++
++  /@replit/codemirror-lang-svelte@6.0.0(@codemirror/autocomplete@6.16.0)(@codemirror/lang-css@6.2.1)(@codemirror/lang-html@6.4.9)(@codemirror/lang-javascript@6.2.2)(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/javascript@1.4.16)(@lezer/lr@1.4.0):
++    resolution: {integrity: sha512-U2OqqgMM6jKelL0GNWbAmqlu1S078zZNoBqlJBW+retTc5M4Mha6/Y2cf4SVg6ddgloJvmcSpt4hHrVoM4ePRA==}
++    peerDependencies:
++      '@codemirror/autocomplete': ^6.0.0
++      '@codemirror/lang-css': ^6.0.1
++      '@codemirror/lang-html': ^6.2.0
++      '@codemirror/lang-javascript': ^6.1.1
++      '@codemirror/language': ^6.0.0
++      '@codemirror/state': ^6.0.0
++      '@codemirror/view': ^6.0.0
++      '@lezer/common': ^1.0.0
++      '@lezer/highlight': ^1.0.0
++      '@lezer/javascript': ^1.2.0
++      '@lezer/lr': ^1.0.0
++    dependencies:
++      '@codemirror/autocomplete': 6.16.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)
++      '@codemirror/lang-css': 6.2.1(@codemirror/view@6.26.3)
++      '@codemirror/lang-html': 6.4.9
++      '@codemirror/lang-javascript': 6.2.2
++      '@codemirror/language': 6.10.1
++      '@codemirror/state': 6.4.1
++      '@codemirror/view': 6.26.3
++      '@lezer/common': 1.2.1
++      '@lezer/highlight': 1.2.0
++      '@lezer/javascript': 1.4.16
++      '@lezer/lr': 1.4.0
++    dev: true
++
++  /@sentry-internal/feedback@7.116.0:
++    resolution: {integrity: sha512-tmfO+RTCrhIWMs3yg8X0axhbjWRZLsldSfoXBgfjNCk/XwkYiVGp7WnYVbb+IO+01mHCsis9uaYOBggLgFRB5Q==}
++    engines: {node: '>=12'}
++    dependencies:
++      '@sentry/core': 7.116.0
++      '@sentry/types': 7.116.0
++      '@sentry/utils': 7.116.0
++    dev: true
++
++  /@sentry-internal/replay-canvas@7.116.0:
++    resolution: {integrity: sha512-Sy0ydY7A97JY/IFTIj8U25kHqR5rL9oBk3HFE5EK9Phw56irVhHzEwLWae0jlFeCQEWoBYqpPgO5vXsaYzrWvw==}
++    engines: {node: '>=12'}
++    dependencies:
++      '@sentry/core': 7.116.0
++      '@sentry/replay': 7.116.0
++      '@sentry/types': 7.116.0
++      '@sentry/utils': 7.116.0
++    dev: true
++
++  /@sentry-internal/tracing@7.116.0:
++    resolution: {integrity: sha512-y5ppEmoOlfr77c/HqsEXR72092qmGYS4QE5gSz5UZFn9CiinEwGfEorcg2xIrrCuU7Ry/ZU2VLz9q3xd04drRA==}
++    engines: {node: '>=8'}
++    dependencies:
++      '@sentry/core': 7.116.0
++      '@sentry/types': 7.116.0
++      '@sentry/utils': 7.116.0
++    dev: true
++
++  /@sentry-internal/tracing@7.67.0:
++    resolution: {integrity: sha512-+3wpnzW2HczPlZsp1pWtdOavBKLK/tu1qDEg+blqLfW7b/qZZ8hqQ+A+2mEWRLgWfIoGZ8t4U84nN4tzDXv+nQ==}
++    engines: {node: '>=8'}
++    dependencies:
++      '@sentry/core': 7.67.0
++      '@sentry/types': 7.67.0
++      '@sentry/utils': 7.67.0
++      tslib: 2.6.2
++    dev: true
++
++  /@sentry/browser@7.116.0:
++    resolution: {integrity: sha512-2aosATT5qE+QLKgTmyF9t5Emsluy1MBczYNuPmLhDxGNfB+MA86S8u7Hb0CpxdwjS0nt14gmbiOtJHoeAF3uTw==}
++    engines: {node: '>=8'}
++    dependencies:
++      '@sentry-internal/feedback': 7.116.0
++      '@sentry-internal/replay-canvas': 7.116.0
++      '@sentry-internal/tracing': 7.116.0
++      '@sentry/core': 7.116.0
++      '@sentry/integrations': 7.116.0
++      '@sentry/replay': 7.116.0
++      '@sentry/types': 7.116.0
++      '@sentry/utils': 7.116.0
++    dev: true
++
++  /@sentry/bundler-plugin-core@0.6.1:
++    resolution: {integrity: sha512-EecCJKp9ERM7J93DNDJTvkY78UiD/IfOjBdXWnaUVE0n619O7LfMVjwlXzxRJKl2x05dBE3lDraILLDGxCf6fg==}
++    engines: {node: '>= 10'}
++    dependencies:
++      '@sentry/cli': 2.20.6
++      '@sentry/node': 7.116.0
++      '@sentry/tracing': 7.67.0
++      find-up: 5.0.0
++      glob: 9.3.2
++      magic-string: 0.27.0
++      unplugin: 1.0.1
++      webpack-sources: 3.2.3
++    transitivePeerDependencies:
++      - encoding
++      - supports-color
++    dev: true
++
++  /@sentry/cli@2.20.6:
++    resolution: {integrity: sha512-j4OFbDCIo/dB/uXDmXnRqCbku0KquekSFSG0Wb6RKwkGqpKwFMRauKXZJrgL4as3qIfDX8HrjNRv257QYMwdQA==}
++    engines: {node: '>= 10'}
++    hasBin: true
++    requiresBuild: true
++    dependencies:
++      https-proxy-agent: 5.0.1
++      node-fetch: 2.7.0
++      progress: 2.0.3
++      proxy-from-env: 1.1.0
++      which: 2.0.2
++    transitivePeerDependencies:
++      - encoding
++      - supports-color
++    dev: true
++
++  /@sentry/core@7.116.0:
++    resolution: {integrity: sha512-J6Wmjjx+o7RwST0weTU1KaKUAlzbc8MGkJV1rcHM9xjNTWTva+nrcCM3vFBagnk2Gm/zhwv3h0PvWEqVyp3U1Q==}
++    engines: {node: '>=8'}
++    dependencies:
++      '@sentry/types': 7.116.0
++      '@sentry/utils': 7.116.0
++    dev: true
++
++  /@sentry/core@7.67.0:
++    resolution: {integrity: sha512-apk0WHnFJTHX86TvN4LOa2GBfguKwvV94WsssyizMi4qurGN2V0I8ZUmlypjBxvMY9MOBZ/2LwgYPf3U1QeE5g==}
++    engines: {node: '>=8'}
++    dependencies:
++      '@sentry/types': 7.67.0
++      '@sentry/utils': 7.67.0
++      tslib: 2.6.2
++    dev: true
++
++  /@sentry/integrations@7.116.0:
++    resolution: {integrity: sha512-UZb60gaF+7veh1Yv79RiGvgGYOnU6xA97H+hI6tKgc1uT20YpItO4X56Vhp0lvyEyUGFZzBRRH1jpMDPNGPkqw==}
++    engines: {node: '>=8'}
++    dependencies:
++      '@sentry/core': 7.116.0
++      '@sentry/types': 7.116.0
++      '@sentry/utils': 7.116.0
++      localforage: 1.10.0
++    dev: true
++
++  /@sentry/node@7.116.0:
++    resolution: {integrity: sha512-HB/4TrJWbnu6swNzkid+MlwzLwY/D/klGt3R0aatgrgWPo2jJm6bSl4LUT39Cr2eg5I1gsREQtXE2mAlC6gm8w==}
++    engines: {node: '>=8'}
++    dependencies:
++      '@sentry-internal/tracing': 7.116.0
++      '@sentry/core': 7.116.0
++      '@sentry/integrations': 7.116.0
++      '@sentry/types': 7.116.0
++      '@sentry/utils': 7.116.0
++    dev: true
++
++  /@sentry/replay@7.116.0:
++    resolution: {integrity: sha512-OrpDtV54pmwZuKp3g7PDiJg6ruRMJKOCzK08TF7IPsKrr4x4UQn56rzMOiABVuTjuS8lNfAWDar6c6vxXFz5KA==}
++    engines: {node: '>=12'}
++    dependencies:
++      '@sentry-internal/tracing': 7.116.0
++      '@sentry/core': 7.116.0
++      '@sentry/types': 7.116.0
++      '@sentry/utils': 7.116.0
++    dev: true
++
++  /@sentry/svelte@7.116.0(svelte@4.2.17):
++    resolution: {integrity: sha512-3WnFFm+/Zt31asdnn7Q3ND8FSGZ2aCRapSG/4levnvH3J7KgS7DNPmdepRT6G291cCScC0JOL7eDM9vIifvrqg==}
++    engines: {node: '>=8'}
++    peerDependencies:
++      svelte: 3.x || 4.x
++    dependencies:
++      '@sentry/browser': 7.116.0
++      '@sentry/core': 7.116.0
++      '@sentry/types': 7.116.0
++      '@sentry/utils': 7.116.0
++      magic-string: 0.30.5
++      svelte: 4.2.17
++    dev: true
++
++  /@sentry/sveltekit@7.116.0(@sveltejs/kit@1.30.4)(svelte@4.2.17):
++    resolution: {integrity: sha512-6qsTHydHefjPxyQnrRVa94U3BtdPy2+usI4OZi6jWRUTcOlulLLAaTouoNA1vU3Ze0DmRt205szK6B7N+kLuEw==}
++    engines: {node: '>=16'}
++    peerDependencies:
++      '@sveltejs/kit': 1.x || 2.x
++    dependencies:
++      '@sentry-internal/tracing': 7.116.0
++      '@sentry/core': 7.116.0
++      '@sentry/integrations': 7.116.0
++      '@sentry/node': 7.116.0
++      '@sentry/svelte': 7.116.0(svelte@4.2.17)
++      '@sentry/types': 7.116.0
++      '@sentry/utils': 7.116.0
++      '@sentry/vite-plugin': 0.6.1
++      '@sveltejs/kit': 1.30.4(svelte@4.2.17)(vite@4.5.3)
++      magicast: 0.2.8
++      sorcery: 0.11.0
++    transitivePeerDependencies:
++      - encoding
++      - supports-color
++      - svelte
++    dev: true
++
++  /@sentry/tracing@7.67.0:
++    resolution: {integrity: sha512-IJtJ0g6oMp46BBK8KV8wAGZ+1rNcw/LmC6y1H1rwur9aCXlla3+tMFtQMJdqUSIx0rcnC9THa+rktddCqXKNtQ==}
++    engines: {node: '>=8'}
++    dependencies:
++      '@sentry-internal/tracing': 7.67.0
++    dev: true
++
++  /@sentry/types@7.116.0:
++    resolution: {integrity: sha512-QCCvG5QuQrwgKzV11lolNQPP2k67Q6HHD9vllZ/C4dkxkjoIym8Gy+1OgAN3wjsR0f/kG9o5iZyglgNpUVRapQ==}
++    engines: {node: '>=8'}
++    dev: true
++
++  /@sentry/types@7.67.0:
++    resolution: {integrity: sha512-GV/Hxdsp/hes1YQGPGgSUG1IHRNQVJMnCfYcpuZtZI6CvNJ+7qNOLkdmC/xGFwfpYH9kYsFBvmGsmeC6yUENYA==}
++    engines: {node: '>=8'}
++    dev: true
++
++  /@sentry/utils@7.116.0:
++    resolution: {integrity: sha512-Vn9fcvwTq91wJvCd7WTMWozimqMi+dEZ3ie3EICELC2diONcN16ADFdzn65CQQbYwmUzRjN9EjDN2k41pKZWhQ==}
++    engines: {node: '>=8'}
++    dependencies:
++      '@sentry/types': 7.116.0
++    dev: true
++
++  /@sentry/utils@7.67.0:
++    resolution: {integrity: sha512-OstjIfAD0xPWVnIRzoAtFBW+YTmxix4h3ehgtFxhA4VJHkC9KXchaTNwk+nlRy/nx4phx5vW9p7YWhO3kJBJmA==}
++    engines: {node: '>=8'}
++    dependencies:
++      '@sentry/types': 7.67.0
++      tslib: 2.6.2
++    dev: true
++
++  /@sentry/vite-plugin@0.6.1:
++    resolution: {integrity: sha512-qkvKaSOcNhNWcdxRXLSs+8cF3ey0XIRmEzTl8U7sTTcZwuOMHsJB+HsYij6aTGaqsKfP8w1ozVt9szBAiL4//w==}
++    engines: {node: '>= 10'}
++    dependencies:
++      '@sentry/bundler-plugin-core': 0.6.1
++    transitivePeerDependencies:
++      - encoding
++      - supports-color
++    dev: true
++
++  /@sinclair/typebox@0.27.8:
++    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
++    dev: true
++
++  /@sveltejs/adapter-static@2.0.3(@sveltejs/kit@1.30.4):
++    resolution: {integrity: sha512-VUqTfXsxYGugCpMqQv1U0LIdbR3S5nBkMMDmpjGVJyM6Q2jHVMFtdWJCkeHMySc6mZxJ+0eZK3T7IgmUCDrcUQ==}
++    peerDependencies:
++      '@sveltejs/kit': ^1.5.0
++    dependencies:
++      '@sveltejs/kit': 1.30.4(svelte@4.2.17)(vite@4.5.3)
++    dev: true
++
++  /@sveltejs/kit@1.30.4(svelte@4.2.17)(vite@4.5.3):
++    resolution: {integrity: sha512-JSQIQT6XvdchCRQEm7BABxPC56WP5RYVONAi+09S8tmzeP43fBsRlr95bFmsTQM2RHBldfgQk+jgdnsKI75daA==}
++    engines: {node: ^16.14 || >=18}
++    hasBin: true
++    requiresBuild: true
++    peerDependencies:
++      svelte: ^3.54.0 || ^4.0.0-next.0 || ^5.0.0-next.0
++      vite: ^4.0.0
++    dependencies:
++      '@sveltejs/vite-plugin-svelte': 2.5.2(svelte@4.2.17)(vite@4.5.3)
++      '@types/cookie': 0.5.2
++      cookie: 0.5.0
++      devalue: 4.3.2
++      esm-env: 1.0.0
++      kleur: 4.1.5
++      magic-string: 0.30.5
++      mrmime: 1.0.1
++      sade: 1.8.1
++      set-cookie-parser: 2.6.0
++      sirv: 2.0.3
++      svelte: 4.2.17
++      tiny-glob: 0.2.9
++      undici: 5.28.3
++      vite: 4.5.3(@types/node@20.5.9)
++    transitivePeerDependencies:
++      - supports-color
++    dev: true
++
++  /@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.5.2)(svelte@4.2.17)(vite@4.5.3):
++    resolution: {integrity: sha512-zjiuZ3yydBtwpF3bj0kQNV0YXe+iKE545QGZVTaylW3eAzFr+pJ/cwK8lZEaRp4JtaJXhD5DyWAV4AxLh6DgaQ==}
++    engines: {node: ^14.18.0 || >= 16}
++    peerDependencies:
++      '@sveltejs/vite-plugin-svelte': ^2.2.0
++      svelte: ^3.54.0 || ^4.0.0
++      vite: ^4.0.0
++    dependencies:
++      '@sveltejs/vite-plugin-svelte': 2.5.2(svelte@4.2.17)(vite@4.5.3)
++      debug: 4.3.4
++      svelte: 4.2.17
++      vite: 4.5.3(@types/node@20.5.9)
++    transitivePeerDependencies:
++      - supports-color
++    dev: true
++
++  /@sveltejs/vite-plugin-svelte@2.5.2(svelte@4.2.17)(vite@4.5.3):
++    resolution: {integrity: sha512-Dfy0Rbl+IctOVfJvWGxrX/3m6vxPLH8o0x+8FA5QEyMUQMo4kGOVIojjryU7YomBAexOTAuYf1RT7809yDziaA==}
++    engines: {node: ^14.18.0 || >= 16}
++    peerDependencies:
++      svelte: ^3.54.0 || ^4.0.0 || ^5.0.0-next.0
++      vite: ^4.0.0
++    dependencies:
++      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.5.2)(svelte@4.2.17)(vite@4.5.3)
++      debug: 4.3.4
++      deepmerge: 4.3.1
++      kleur: 4.1.5
++      magic-string: 0.30.5
++      svelte: 4.2.17
++      svelte-hmr: 0.15.3(svelte@4.2.17)
++      vite: 4.5.3(@types/node@20.5.9)
++      vitefu: 0.2.4(vite@4.5.3)
++    transitivePeerDependencies:
++      - supports-color
++    dev: true
++
++  /@tauri-apps/api@1.5.3:
++    resolution: {integrity: sha512-zxnDjHHKjOsrIzZm6nO5Xapb/BxqUq1tc7cGkFXsFkGTsSWgCPH1D8mm0XS9weJY2OaR73I3k3S+b7eSzJDfqA==}
++    engines: {node: '>= 14.6.0', npm: '>= 6.6.0', yarn: '>= 1.19.1'}
++    dev: true
++
++  /@tauri-apps/api@1.5.6:
++    resolution: {integrity: sha512-LH5ToovAHnDVe5Qa9f/+jW28I6DeMhos8bNDtBOmmnaDpPmJmYLyHdeDblAWWWYc7KKRDg9/66vMuKyq0WIeFA==}
++    engines: {node: '>= 14.6.0', npm: '>= 6.6.0', yarn: '>= 1.19.1'}
++    dev: true
++
++  /@tauri-apps/cli-darwin-arm64@1.5.14:
++    resolution: {integrity: sha512-lxoSOp3KKSqzHJa7iT32dukPGMlfsTuja1xXSgwR8o/fqzpYJY7FY/3ZxesP8HR66FcK+vtqa//HNqeOQ0mHkA==}
++    engines: {node: '>= 10'}
++    cpu: [arm64]
++    os: [darwin]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@tauri-apps/cli-darwin-x64@1.5.14:
++    resolution: {integrity: sha512-EXSwN1n5spfG8FoXuyc90ACtmDJXzaZ1gxyENaq9xEpQoo7j/Q1vb6qXxmr6azKr8zmqY4h08ZFbv3exh93xJg==}
++    engines: {node: '>= 10'}
++    cpu: [x64]
++    os: [darwin]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@tauri-apps/cli-linux-arm-gnueabihf@1.5.14:
++    resolution: {integrity: sha512-Yb8BH/KYR7Tl+de40sZPfrqbhcU3Jlu+UPIrnXt05sjn48xqIps74Xjz8zzVp0TuHxUp8FmIGtCVhQgsbrsvvg==}
++    engines: {node: '>= 10'}
++    cpu: [arm]
++    os: [linux]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@tauri-apps/cli-linux-arm64-gnu@1.5.14:
++    resolution: {integrity: sha512-QrKHP4gRaHiup478rPBZ+BmNd88yze9jMmheoNy9mN1K/aECRmTHO+tWhsxv5moFHZzRhO0QDWxxvTtiaPXaGg==}
++    engines: {node: '>= 10'}
++    cpu: [arm64]
++    os: [linux]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@tauri-apps/cli-linux-arm64-musl@1.5.14:
++    resolution: {integrity: sha512-Hb1C1VMxmUcyGjW/K/INKF87zzzgLEVRmWZZnQd7M1P4uue4xPyIwUELSdX12Z2jREPgmLW4AXPD0m6wsNu7iw==}
++    engines: {node: '>= 10'}
++    cpu: [arm64]
++    os: [linux]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@tauri-apps/cli-linux-x64-gnu@1.5.14:
++    resolution: {integrity: sha512-kD9v/UwPDuhIgq2TJj/s2/7rqk+vmExVV6xHPKI8vVbIvlNAOZqmx3fpxjej1241vhJ/piGd/m6q6YMWGsL0oQ==}
++    engines: {node: '>= 10'}
++    cpu: [x64]
++    os: [linux]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@tauri-apps/cli-linux-x64-musl@1.5.14:
++    resolution: {integrity: sha512-204Drgg9Zx0+THKndqASz4+iPCwqA3gQVF9C0CDIArNXrjPyJjVvW8VP5CHiZYaTNWxlz/ltyxluM6UFWbXNFw==}
++    engines: {node: '>= 10'}
++    cpu: [x64]
++    os: [linux]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@tauri-apps/cli-win32-arm64-msvc@1.5.14:
++    resolution: {integrity: sha512-sqPSni2MnWNCm+8YZnLdWCclxfSHaYqKuPFSz8q7Tn1G1m/cA9gyPoC1G0esHftY7bu/ZM5lB4kM3I4U0KlLiA==}
++    engines: {node: '>= 10'}
++    cpu: [arm64]
++    os: [win32]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@tauri-apps/cli-win32-ia32-msvc@1.5.14:
++    resolution: {integrity: sha512-8xN8W0zTs8oFsQmvYLxHFeqhzVI7oTaPK1xQMc5gbpFP45jN41c21aCXfjnvzT+h90EfCHUF9EWj2HTEJSb7Iw==}
++    engines: {node: '>= 10'}
++    cpu: [ia32]
++    os: [win32]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@tauri-apps/cli-win32-x64-msvc@1.5.14:
++    resolution: {integrity: sha512-U0slee5tNM2PYECBpPHavLSwkT3szGMZ+qhcikQQbDan84bQdLn/kHWjyXOgLJs4KSve4+KxcrN+AVqj0VyHnw==}
++    engines: {node: '>= 10'}
++    cpu: [x64]
++    os: [win32]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /@tauri-apps/cli@1.5.14:
++    resolution: {integrity: sha512-JOSMKymlg116UdEXSj69eg5p1OtZnQkUE0qIGbtNDO1sk3X/KgBN6+oHBW0BzPStp/W0AjBgrMWCqjHPwEpOug==}
++    engines: {node: '>= 10'}
++    hasBin: true
++    optionalDependencies:
++      '@tauri-apps/cli-darwin-arm64': 1.5.14
++      '@tauri-apps/cli-darwin-x64': 1.5.14
++      '@tauri-apps/cli-linux-arm-gnueabihf': 1.5.14
++      '@tauri-apps/cli-linux-arm64-gnu': 1.5.14
++      '@tauri-apps/cli-linux-arm64-musl': 1.5.14
++      '@tauri-apps/cli-linux-x64-gnu': 1.5.14
++      '@tauri-apps/cli-linux-x64-musl': 1.5.14
++      '@tauri-apps/cli-win32-arm64-msvc': 1.5.14
++      '@tauri-apps/cli-win32-ia32-msvc': 1.5.14
++      '@tauri-apps/cli-win32-x64-msvc': 1.5.14
++    dev: true
++
++  /@types/chai-subset@1.3.3:
++    resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
++    dependencies:
++      '@types/chai': 4.3.6
++    dev: true
++
++  /@types/chai@4.3.6:
++    resolution: {integrity: sha512-VOVRLM1mBxIRxydiViqPcKn6MIxZytrbMpd6RJLIWKxUNr3zux8no0Oc7kJx0WAPIitgZ0gkrDS+btlqQpubpw==}
++    dev: true
++
++  /@types/cookie@0.5.2:
++    resolution: {integrity: sha512-DBpRoJGKJZn7RY92dPrgoMew8xCWc2P71beqsjyhEI/Ds9mOyVmBwtekyfhpwFIVt1WrxTonFifiOZ62V8CnNA==}
++    dev: true
++
++  /@types/crypto-js@4.2.2:
++    resolution: {integrity: sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==}
++    dev: true
++
++  /@types/diff-match-patch@1.0.36:
++    resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
++    dev: true
++
++  /@types/diff@5.2.1:
++    resolution: {integrity: sha512-uxpcuwWJGhe2AR1g8hD9F5OYGCqjqWnBUQFD8gMZsDbv8oPHzxJF6iMO6n8Tk0AdzlxoaaoQhOYlIg/PukVU8g==}
++    dev: true
++
++  /@types/estree@1.0.1:
++    resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
++    dev: true
++
++  /@types/json5@0.0.29:
++    resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
++    dev: true
++
++  /@types/lscache@1.3.4:
++    resolution: {integrity: sha512-boZGIpx9t9lISW2EllC4APDwMQAouwViERSZU2T1p5gYs/SVM1ohq29+eBDb8g6D3FDPgeUsOALZIH0IGwLNvw==}
++    dev: true
++
++  /@types/marked@5.0.2:
++    resolution: {integrity: sha512-OucS4KMHhFzhz27KxmWg7J+kIYqyqoW5kdIEI319hqARQQUTqhao3M/F+uFnDXD0Rg72iDDZxZNxq5gvctmLlg==}
++    dev: true
++
++  /@types/node-fetch@2.6.11:
++    resolution: {integrity: sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==}
++    dependencies:
++      '@types/node': 20.5.9
++      form-data: 4.0.0
++    dev: false
++
++  /@types/node@18.19.22:
++    resolution: {integrity: sha512-p3pDIfuMg/aXBmhkyanPshdfJuX5c5+bQjYLIikPLXAUycEogij/c50n/C+8XOA5L93cU4ZRXtn+dNQGi0IZqQ==}
++    dependencies:
++      undici-types: 5.26.5
++    dev: false
++
++  /@types/node@20.5.9:
++    resolution: {integrity: sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ==}
++
++  /@types/pug@2.0.6:
++    resolution: {integrity: sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==}
++    dev: true
++
++  /@typescript-eslint/eslint-plugin@7.10.0(@typescript-eslint/parser@7.10.0)(eslint@8.57.0)(typescript@5.4.5):
++    resolution: {integrity: sha512-PzCr+a/KAef5ZawX7nbyNwBDtM1HdLIT53aSA2DDlxmxMngZ43O8SIePOeX8H5S+FHXeI6t97mTt/dDdzY4Fyw==}
++    engines: {node: ^18.18.0 || >=20.0.0}
++    peerDependencies:
++      '@typescript-eslint/parser': ^7.0.0
++      eslint: ^8.56.0
++      typescript: '*'
++    peerDependenciesMeta:
++      typescript:
++        optional: true
++    dependencies:
++      '@eslint-community/regexpp': 4.10.0
++      '@typescript-eslint/parser': 7.10.0(eslint@8.57.0)(typescript@5.4.5)
++      '@typescript-eslint/scope-manager': 7.10.0
++      '@typescript-eslint/type-utils': 7.10.0(eslint@8.57.0)(typescript@5.4.5)
++      '@typescript-eslint/utils': 7.10.0(eslint@8.57.0)(typescript@5.4.5)
++      '@typescript-eslint/visitor-keys': 7.10.0
++      eslint: 8.57.0
++      graphemer: 1.4.0
++      ignore: 5.3.1
++      natural-compare: 1.4.0
++      ts-api-utils: 1.3.0(typescript@5.4.5)
++      typescript: 5.4.5
++    transitivePeerDependencies:
++      - supports-color
++    dev: true
++
++  /@typescript-eslint/parser@7.10.0(eslint@8.57.0)(typescript@5.4.5):
++    resolution: {integrity: sha512-2EjZMA0LUW5V5tGQiaa2Gys+nKdfrn2xiTIBLR4fxmPmVSvgPcKNW+AE/ln9k0A4zDUti0J/GZXMDupQoI+e1w==}
++    engines: {node: ^18.18.0 || >=20.0.0}
++    peerDependencies:
++      eslint: ^8.56.0
++      typescript: '*'
++    peerDependenciesMeta:
++      typescript:
++        optional: true
++    dependencies:
++      '@typescript-eslint/scope-manager': 7.10.0
++      '@typescript-eslint/types': 7.10.0
++      '@typescript-eslint/typescript-estree': 7.10.0(typescript@5.4.5)
++      '@typescript-eslint/visitor-keys': 7.10.0
++      debug: 4.3.4
++      eslint: 8.57.0
++      typescript: 5.4.5
++    transitivePeerDependencies:
++      - supports-color
++    dev: true
++
++  /@typescript-eslint/scope-manager@7.10.0:
++    resolution: {integrity: sha512-7L01/K8W/VGl7noe2mgH0K7BE29Sq6KAbVmxurj8GGaPDZXPr8EEQ2seOeAS+mEV9DnzxBQB6ax6qQQ5C6P4xg==}
++    engines: {node: ^18.18.0 || >=20.0.0}
++    dependencies:
++      '@typescript-eslint/types': 7.10.0
++      '@typescript-eslint/visitor-keys': 7.10.0
++    dev: true
++
++  /@typescript-eslint/type-utils@7.10.0(eslint@8.57.0)(typescript@5.4.5):
++    resolution: {integrity: sha512-D7tS4WDkJWrVkuzgm90qYw9RdgBcrWmbbRkrLA4d7Pg3w0ttVGDsvYGV19SH8gPR5L7OtcN5J1hTtyenO9xE9g==}
++    engines: {node: ^18.18.0 || >=20.0.0}
++    peerDependencies:
++      eslint: ^8.56.0
++      typescript: '*'
++    peerDependenciesMeta:
++      typescript:
++        optional: true
++    dependencies:
++      '@typescript-eslint/typescript-estree': 7.10.0(typescript@5.4.5)
++      '@typescript-eslint/utils': 7.10.0(eslint@8.57.0)(typescript@5.4.5)
++      debug: 4.3.4
++      eslint: 8.57.0
++      ts-api-utils: 1.3.0(typescript@5.4.5)
++      typescript: 5.4.5
++    transitivePeerDependencies:
++      - supports-color
++    dev: true
++
++  /@typescript-eslint/types@7.10.0:
++    resolution: {integrity: sha512-7fNj+Ya35aNyhuqrA1E/VayQX9Elwr8NKZ4WueClR3KwJ7Xx9jcCdOrLW04h51de/+gNbyFMs+IDxh5xIwfbNg==}
++    engines: {node: ^18.18.0 || >=20.0.0}
++    dev: true
++
++  /@typescript-eslint/typescript-estree@7.10.0(typescript@5.4.5):
++    resolution: {integrity: sha512-LXFnQJjL9XIcxeVfqmNj60YhatpRLt6UhdlFwAkjNc6jSUlK8zQOl1oktAP8PlWFzPQC1jny/8Bai3/HPuvN5g==}
++    engines: {node: ^18.18.0 || >=20.0.0}
++    peerDependencies:
++      typescript: '*'
++    peerDependenciesMeta:
++      typescript:
++        optional: true
++    dependencies:
++      '@typescript-eslint/types': 7.10.0
++      '@typescript-eslint/visitor-keys': 7.10.0
++      debug: 4.3.4
++      globby: 11.1.0
++      is-glob: 4.0.3
++      minimatch: 9.0.4
++      semver: 7.6.0
++      ts-api-utils: 1.3.0(typescript@5.4.5)
++      typescript: 5.4.5
++    transitivePeerDependencies:
++      - supports-color
++    dev: true
++
++  /@typescript-eslint/utils@7.10.0(eslint@8.57.0)(typescript@5.4.5):
++    resolution: {integrity: sha512-olzif1Fuo8R8m/qKkzJqT7qwy16CzPRWBvERS0uvyc+DHd8AKbO4Jb7kpAvVzMmZm8TrHnI7hvjN4I05zow+tg==}
++    engines: {node: ^18.18.0 || >=20.0.0}
++    peerDependencies:
++      eslint: ^8.56.0
++    dependencies:
++      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
++      '@typescript-eslint/scope-manager': 7.10.0
++      '@typescript-eslint/types': 7.10.0
++      '@typescript-eslint/typescript-estree': 7.10.0(typescript@5.4.5)
++      eslint: 8.57.0
++    transitivePeerDependencies:
++      - supports-color
++      - typescript
++    dev: true
++
++  /@typescript-eslint/visitor-keys@7.10.0:
++    resolution: {integrity: sha512-9ntIVgsi6gg6FIq9xjEO4VQJvwOqA3jaBFQJ/6TK5AvEup2+cECI6Fh7QiBxmfMHXU0V0J4RyPeOU1VDNzl9cg==}
++    engines: {node: ^18.18.0 || >=20.0.0}
++    dependencies:
++      '@typescript-eslint/types': 7.10.0
++      eslint-visitor-keys: 3.4.3
++    dev: true
++
++  /@ungap/structured-clone@1.2.0:
++    resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
++    dev: true
++
++  /@vitest/expect@0.34.6:
++    resolution: {integrity: sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==}
++    dependencies:
++      '@vitest/spy': 0.34.6
++      '@vitest/utils': 0.34.6
++      chai: 4.3.10
++    dev: true
++
++  /@vitest/runner@0.34.6:
++    resolution: {integrity: sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==}
++    dependencies:
++      '@vitest/utils': 0.34.6
++      p-limit: 4.0.0
++      pathe: 1.1.1
++    dev: true
++
++  /@vitest/snapshot@0.34.6:
++    resolution: {integrity: sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==}
++    dependencies:
++      magic-string: 0.30.5
++      pathe: 1.1.1
++      pretty-format: 29.6.3
++    dev: true
++
++  /@vitest/spy@0.34.6:
++    resolution: {integrity: sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==}
++    dependencies:
++      tinyspy: 2.1.1
++    dev: true
++
++  /@vitest/utils@0.34.6:
++    resolution: {integrity: sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==}
++    dependencies:
++      diff-sequences: 29.6.3
++      loupe: 2.3.6
++      pretty-format: 29.6.3
++    dev: true
++
++  /abort-controller@3.0.0:
++    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
++    engines: {node: '>=6.5'}
++    dependencies:
++      event-target-shim: 5.0.1
++    dev: false
++
++  /acorn-jsx@5.3.2(acorn@8.10.0):
++    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
++    peerDependencies:
++      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
++    dependencies:
++      acorn: 8.10.0
++    dev: true
++
++  /acorn-walk@8.2.0:
++    resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
++    engines: {node: '>=0.4.0'}
++    dev: true
++
++  /acorn@8.10.0:
++    resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
++    engines: {node: '>=0.4.0'}
++    hasBin: true
++    dev: true
++
++  /agent-base@6.0.2:
++    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
++    engines: {node: '>= 6.0.0'}
++    dependencies:
++      debug: 4.3.4
++    transitivePeerDependencies:
++      - supports-color
++    dev: true
++
++  /agentkeepalive@4.5.0:
++    resolution: {integrity: sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==}
++    engines: {node: '>= 8.0.0'}
++    dependencies:
++      humanize-ms: 1.2.1
++    dev: false
++
++  /ajv@6.12.6:
++    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
++    dependencies:
++      fast-deep-equal: 3.1.3
++      fast-json-stable-stringify: 2.1.0
++      json-schema-traverse: 0.4.1
++      uri-js: 4.4.1
++    dev: true
++
++  /ansi-regex@5.0.1:
++    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
++    engines: {node: '>=8'}
++    dev: true
++
++  /ansi-styles@4.3.0:
++    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
++    engines: {node: '>=8'}
++    dependencies:
++      color-convert: 2.0.1
++    dev: true
++
++  /ansi-styles@5.2.0:
++    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
++    engines: {node: '>=10'}
++    dev: true
++
++  /anymatch@3.1.3:
++    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
++    engines: {node: '>= 8'}
++    dependencies:
++      normalize-path: 3.0.0
++      picomatch: 2.3.1
++    dev: true
++
++  /argparse@2.0.1:
++    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
++    dev: true
++
++  /aria-query@5.3.0:
++    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
++    dependencies:
++      dequal: 2.0.3
++    dev: true
++
++  /array-buffer-byte-length@1.0.0:
++    resolution: {integrity: sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==}
++    dependencies:
++      call-bind: 1.0.2
++      is-array-buffer: 3.0.2
++    dev: true
++
++  /array-includes@3.1.7:
++    resolution: {integrity: sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      call-bind: 1.0.2
++      define-properties: 1.2.0
++      es-abstract: 1.22.1
++      get-intrinsic: 1.2.1
++      is-string: 1.0.7
++    dev: true
++
++  /array-union@2.1.0:
++    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
++    engines: {node: '>=8'}
++    dev: true
++
++  /array.prototype.findlastindex@1.2.3:
++    resolution: {integrity: sha512-LzLoiOMAxvy+Gd3BAq3B7VeIgPdo+Q8hthvKtXybMvRV0jrXfJM/t8mw7nNlpEcVlVUnCnM2KSX4XU5HmpodOA==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      call-bind: 1.0.2
++      define-properties: 1.2.0
++      es-abstract: 1.22.1
++      es-shim-unscopables: 1.0.0
++      get-intrinsic: 1.2.1
++    dev: true
++
++  /array.prototype.flat@1.3.2:
++    resolution: {integrity: sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      call-bind: 1.0.2
++      define-properties: 1.2.0
++      es-abstract: 1.22.1
++      es-shim-unscopables: 1.0.0
++    dev: true
++
++  /array.prototype.flatmap@1.3.2:
++    resolution: {integrity: sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      call-bind: 1.0.2
++      define-properties: 1.2.0
++      es-abstract: 1.22.1
++      es-shim-unscopables: 1.0.0
++    dev: true
++
++  /arraybuffer.prototype.slice@1.0.2:
++    resolution: {integrity: sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      array-buffer-byte-length: 1.0.0
++      call-bind: 1.0.2
++      define-properties: 1.2.0
++      es-abstract: 1.22.1
++      get-intrinsic: 1.2.1
++      is-array-buffer: 3.0.2
++      is-shared-array-buffer: 1.0.2
++    dev: true
++
++  /assert@2.0.0:
++    resolution: {integrity: sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==}
++    dependencies:
++      es6-object-assign: 1.1.0
++      is-nan: 1.3.2
++      object-is: 1.1.5
++      util: 0.12.5
++    dev: true
++
++  /assertion-error@1.1.0:
++    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
++    dev: true
++
++  /ast-types@0.16.1:
++    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
++    engines: {node: '>=4'}
++    dependencies:
++      tslib: 2.6.2
++    dev: true
++
++  /asynckit@0.4.0:
++    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
++    dev: false
++
++  /autoprefixer@10.4.19(postcss@8.4.38):
++    resolution: {integrity: sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==}
++    engines: {node: ^10 || ^12 || >=14}
++    hasBin: true
++    peerDependencies:
++      postcss: ^8.1.0
++    dependencies:
++      browserslist: 4.23.0
++      caniuse-lite: 1.0.30001600
++      fraction.js: 4.3.7
++      normalize-range: 0.1.2
++      picocolors: 1.0.0
++      postcss: 8.4.38
++      postcss-value-parser: 4.2.0
++    dev: true
++
++  /available-typed-arrays@1.0.5:
++    resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
++    engines: {node: '>= 0.4'}
++    dev: true
++
++  /axobject-query@4.0.0:
++    resolution: {integrity: sha512-+60uv1hiVFhHZeO+Lz0RYzsVHy5Wr1ayX0mwda9KPDVLNJgZ1T9Ny7VmFbLDzxsH0D87I86vgj3gFrjTJUYznw==}
++    dependencies:
++      dequal: 2.0.3
++    dev: true
++
++  /balanced-match@1.0.2:
++    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
++    dev: true
++
++  /before-after-hook@2.2.3:
++    resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
++    dev: true
++
++  /binary-extensions@2.2.0:
++    resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
++    engines: {node: '>=8'}
++    dev: true
++
++  /brace-expansion@1.1.11:
++    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
++    dependencies:
++      balanced-match: 1.0.2
++      concat-map: 0.0.1
++    dev: true
++
++  /brace-expansion@2.0.1:
++    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
++    dependencies:
++      balanced-match: 1.0.2
++    dev: true
++
++  /braces@3.0.2:
++    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
++    engines: {node: '>=8'}
++    dependencies:
++      fill-range: 7.0.1
++    dev: true
++
++  /browserslist@4.23.0:
++    resolution: {integrity: sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==}
++    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
++    hasBin: true
++    dependencies:
++      caniuse-lite: 1.0.30001600
++      electron-to-chromium: 1.4.717
++      node-releases: 2.0.14
++      update-browserslist-db: 1.0.13(browserslist@4.23.0)
++    dev: true
++
++  /buffer-crc32@0.2.13:
++    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
++    dev: true
++
++  /cac@6.7.14:
++    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
++    engines: {node: '>=8'}
++    dev: true
++
++  /call-bind@1.0.2:
++    resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
++    dependencies:
++      function-bind: 1.1.2
++      get-intrinsic: 1.2.1
++    dev: true
++
++  /callsites@3.1.0:
++    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
++    engines: {node: '>=6'}
++    dev: true
++
++  /caniuse-lite@1.0.30001600:
++    resolution: {integrity: sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==}
++    dev: true
++
++  /chai@4.3.10:
++    resolution: {integrity: sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==}
++    engines: {node: '>=4'}
++    dependencies:
++      assertion-error: 1.1.0
++      check-error: 1.0.3
++      deep-eql: 4.1.3
++      get-func-name: 2.0.2
++      loupe: 2.3.6
++      pathval: 1.1.1
++      type-detect: 4.0.8
++    dev: true
++
++  /chalk@4.1.2:
++    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
++    engines: {node: '>=10'}
++    dependencies:
++      ansi-styles: 4.3.0
++      supports-color: 7.2.0
++    dev: true
++
++  /check-error@1.0.3:
++    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
++    dependencies:
++      get-func-name: 2.0.2
++    dev: true
++
++  /chokidar@3.5.3:
++    resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
++    engines: {node: '>= 8.10.0'}
++    dependencies:
++      anymatch: 3.1.3
++      braces: 3.0.2
++      glob-parent: 5.1.2
++      is-binary-path: 2.1.0
++      is-glob: 4.0.3
++      normalize-path: 3.0.0
++      readdirp: 3.6.0
++    optionalDependencies:
++      fsevents: 2.3.3
++    dev: true
++
++  /class-transformer@0.5.1:
++    resolution: {integrity: sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==}
++    dev: true
++
++  /code-red@1.0.4:
++    resolution: {integrity: sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==}
++    dependencies:
++      '@jridgewell/sourcemap-codec': 1.4.15
++      '@types/estree': 1.0.1
++      acorn: 8.10.0
++      estree-walker: 3.0.3
++      periscopic: 3.1.0
++    dev: true
++
++  /color-convert@2.0.1:
++    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
++    engines: {node: '>=7.0.0'}
++    dependencies:
++      color-name: 1.1.4
++    dev: true
++
++  /color-name@1.1.4:
++    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
++    dev: true
++
++  /combined-stream@1.0.8:
++    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
++    engines: {node: '>= 0.8'}
++    dependencies:
++      delayed-stream: 1.0.0
++    dev: false
++
++  /concat-map@0.0.1:
++    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
++    dev: true
++
++  /cookie@0.5.0:
++    resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
++    engines: {node: '>= 0.6'}
++    dev: true
++
++  /crelt@1.0.6:
++    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
++    dev: true
++
++  /cross-spawn@7.0.3:
++    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
++    engines: {node: '>= 8'}
++    dependencies:
++      path-key: 3.1.1
++      shebang-command: 2.0.0
++      which: 2.0.2
++    dev: true
++
++  /crypto-js@4.2.0:
++    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
++    dev: true
++
++  /css-tree@2.3.1:
++    resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
++    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
++    dependencies:
++      mdn-data: 2.0.30
++      source-map-js: 1.2.0
++    dev: true
++
++  /cssesc@3.0.0:
++    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
++    engines: {node: '>=4'}
++    hasBin: true
++    dev: true
++
++  /date-fns@2.30.0:
++    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
++    engines: {node: '>=0.11'}
++    dependencies:
++      '@babel/runtime': 7.22.15
++    dev: true
++
++  /debug@3.2.7:
++    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
++    peerDependencies:
++      supports-color: '*'
++    peerDependenciesMeta:
++      supports-color:
++        optional: true
++    dependencies:
++      ms: 2.1.3
++    dev: true
++
++  /debug@4.3.4:
++    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
++    engines: {node: '>=6.0'}
++    peerDependencies:
++      supports-color: '*'
++    peerDependenciesMeta:
++      supports-color:
++        optional: true
++    dependencies:
++      ms: 2.1.2
++    dev: true
++
++  /deep-eql@4.1.3:
++    resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
++    engines: {node: '>=6'}
++    dependencies:
++      type-detect: 4.0.8
++    dev: true
++
++  /deep-is@0.1.4:
++    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
++    dev: true
++
++  /deepmerge@4.3.1:
++    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
++    engines: {node: '>=0.10.0'}
++    dev: true
++
++  /define-properties@1.2.0:
++    resolution: {integrity: sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      has-property-descriptors: 1.0.0
++      object-keys: 1.1.1
++    dev: true
++
++  /delayed-stream@1.0.0:
++    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
++    engines: {node: '>=0.4.0'}
++    dev: false
++
++  /deprecation@2.3.1:
++    resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
++    dev: true
++
++  /dequal@2.0.3:
++    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
++    engines: {node: '>=6'}
++    dev: true
++
++  /detect-indent@6.1.0:
++    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
++    engines: {node: '>=8'}
++    dev: true
++
++  /devalue@4.3.2:
++    resolution: {integrity: sha512-KqFl6pOgOW+Y6wJgu80rHpo2/3H07vr8ntR9rkkFIRETewbf5GaYYcakYfiKz89K+sLsuPkQIZaXDMjUObZwWg==}
++    dev: true
++
++  /diff-match-patch@1.0.5:
++    resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
++    dev: true
++
++  /diff-sequences@29.6.3:
++    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
++    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
++    dev: true
++
++  /dir-glob@3.0.1:
++    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
++    engines: {node: '>=8'}
++    dependencies:
++      path-type: 4.0.0
++    dev: true
++
++  /doctrine@2.1.0:
++    resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
++    engines: {node: '>=0.10.0'}
++    dependencies:
++      esutils: 2.0.3
++    dev: true
++
++  /doctrine@3.0.0:
++    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
++    engines: {node: '>=6.0.0'}
++    dependencies:
++      esutils: 2.0.3
++    dev: true
++
++  /electron-to-chromium@1.4.717:
++    resolution: {integrity: sha512-6Fmg8QkkumNOwuZ/5mIbMU9WI3H2fmn5ajcVya64I5Yr5CcNmO7vcLt0Y7c96DCiMO5/9G+4sI2r6eEvdg1F7A==}
++    dev: true
++
++  /enhanced-resolve@5.15.0:
++    resolution: {integrity: sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==}
++    engines: {node: '>=10.13.0'}
++    dependencies:
++      graceful-fs: 4.2.11
++      tapable: 2.2.1
++    dev: true
++
++  /es-abstract@1.22.1:
++    resolution: {integrity: sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      array-buffer-byte-length: 1.0.0
++      arraybuffer.prototype.slice: 1.0.2
++      available-typed-arrays: 1.0.5
++      call-bind: 1.0.2
++      es-set-tostringtag: 2.0.1
++      es-to-primitive: 1.2.1
++      function.prototype.name: 1.1.6
++      get-intrinsic: 1.2.1
++      get-symbol-description: 1.0.0
++      globalthis: 1.0.3
++      gopd: 1.0.1
++      has: 1.0.3
++      has-property-descriptors: 1.0.0
++      has-proto: 1.0.1
++      has-symbols: 1.0.3
++      internal-slot: 1.0.5
++      is-array-buffer: 3.0.2
++      is-callable: 1.2.7
++      is-negative-zero: 2.0.2
++      is-regex: 1.1.4
++      is-shared-array-buffer: 1.0.2
++      is-string: 1.0.7
++      is-typed-array: 1.1.12
++      is-weakref: 1.0.2
++      object-inspect: 1.12.3
++      object-keys: 1.1.1
++      object.assign: 4.1.4
++      regexp.prototype.flags: 1.5.0
++      safe-array-concat: 1.0.1
++      safe-regex-test: 1.0.0
++      string.prototype.trim: 1.2.7
++      string.prototype.trimend: 1.0.6
++      string.prototype.trimstart: 1.0.7
++      typed-array-buffer: 1.0.0
++      typed-array-byte-length: 1.0.0
++      typed-array-byte-offset: 1.0.0
++      typed-array-length: 1.0.4
++      unbox-primitive: 1.0.2
++      which-typed-array: 1.1.11
++    dev: true
++
++  /es-set-tostringtag@2.0.1:
++    resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      get-intrinsic: 1.2.1
++      has: 1.0.3
++      has-tostringtag: 1.0.0
++    dev: true
++
++  /es-shim-unscopables@1.0.0:
++    resolution: {integrity: sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==}
++    dependencies:
++      has: 1.0.3
++    dev: true
++
++  /es-to-primitive@1.2.1:
++    resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      is-callable: 1.2.7
++      is-date-object: 1.0.5
++      is-symbol: 1.0.4
++    dev: true
++
++  /es6-object-assign@1.1.0:
++    resolution: {integrity: sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==}
++    dev: true
++
++  /es6-promise@3.3.1:
++    resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
++    dev: true
++
++  /esbuild@0.18.20:
++    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
++    engines: {node: '>=12'}
++    hasBin: true
++    requiresBuild: true
++    optionalDependencies:
++      '@esbuild/android-arm': 0.18.20
++      '@esbuild/android-arm64': 0.18.20
++      '@esbuild/android-x64': 0.18.20
++      '@esbuild/darwin-arm64': 0.18.20
++      '@esbuild/darwin-x64': 0.18.20
++      '@esbuild/freebsd-arm64': 0.18.20
++      '@esbuild/freebsd-x64': 0.18.20
++      '@esbuild/linux-arm': 0.18.20
++      '@esbuild/linux-arm64': 0.18.20
++      '@esbuild/linux-ia32': 0.18.20
++      '@esbuild/linux-loong64': 0.18.20
++      '@esbuild/linux-mips64el': 0.18.20
++      '@esbuild/linux-ppc64': 0.18.20
++      '@esbuild/linux-riscv64': 0.18.20
++      '@esbuild/linux-s390x': 0.18.20
++      '@esbuild/linux-x64': 0.18.20
++      '@esbuild/netbsd-x64': 0.18.20
++      '@esbuild/openbsd-x64': 0.18.20
++      '@esbuild/sunos-x64': 0.18.20
++      '@esbuild/win32-arm64': 0.18.20
++      '@esbuild/win32-ia32': 0.18.20
++      '@esbuild/win32-x64': 0.18.20
++    dev: true
++
++  /escalade@3.1.1:
++    resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
++    engines: {node: '>=6'}
++    dev: true
++
++  /escape-string-regexp@4.0.0:
++    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
++    engines: {node: '>=10'}
++    dev: true
++
++  /eslint-compat-utils@0.5.0(eslint@8.57.0):
++    resolution: {integrity: sha512-dc6Y8tzEcSYZMHa+CMPLi/hyo1FzNeonbhJL7Ol0ccuKQkwopJcJBA9YL/xmMTLU1eKigXo9vj9nALElWYSowg==}
++    engines: {node: '>=12'}
++    peerDependencies:
++      eslint: '>=6.0.0'
++    dependencies:
++      eslint: 8.57.0
++      semver: 7.6.0
++    dev: true
++
++  /eslint-config-prettier@9.1.0(eslint@8.57.0):
++    resolution: {integrity: sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==}
++    hasBin: true
++    peerDependencies:
++      eslint: '>=7.0.0'
++    dependencies:
++      eslint: 8.57.0
++    dev: true
++
++  /eslint-import-resolver-node@0.3.9:
++    resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
++    dependencies:
++      debug: 3.2.7
++      is-core-module: 2.13.1
++      resolve: 1.22.4
++    transitivePeerDependencies:
++      - supports-color
++    dev: true
++
++  /eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.10.0)(eslint-plugin-import@2.29.1)(eslint@8.57.0):
++    resolution: {integrity: sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==}
++    engines: {node: ^14.18.0 || >=16.0.0}
++    peerDependencies:
++      eslint: '*'
++      eslint-plugin-import: '*'
++    dependencies:
++      debug: 4.3.4
++      enhanced-resolve: 5.15.0
++      eslint: 8.57.0
++      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.10.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
++      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.10.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
++      fast-glob: 3.3.1
++      get-tsconfig: 4.7.0
++      is-core-module: 2.13.1
++      is-glob: 4.0.3
++    transitivePeerDependencies:
++      - '@typescript-eslint/parser'
++      - eslint-import-resolver-node
++      - eslint-import-resolver-webpack
++      - supports-color
++    dev: true
++
++  /eslint-module-utils@2.8.0(@typescript-eslint/parser@7.10.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
++    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
++    engines: {node: '>=4'}
++    peerDependencies:
++      '@typescript-eslint/parser': '*'
++      eslint: '*'
++      eslint-import-resolver-node: '*'
++      eslint-import-resolver-typescript: '*'
++      eslint-import-resolver-webpack: '*'
++    peerDependenciesMeta:
++      '@typescript-eslint/parser':
++        optional: true
++      eslint:
++        optional: true
++      eslint-import-resolver-node:
++        optional: true
++      eslint-import-resolver-typescript:
++        optional: true
++      eslint-import-resolver-webpack:
++        optional: true
++    dependencies:
++      '@typescript-eslint/parser': 7.10.0(eslint@8.57.0)(typescript@5.4.5)
++      debug: 3.2.7
++      eslint: 8.57.0
++      eslint-import-resolver-node: 0.3.9
++      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.10.0)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
++    transitivePeerDependencies:
++      - supports-color
++    dev: true
++
++  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
++    resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
++    engines: {node: '>=4'}
++    peerDependencies:
++      '@typescript-eslint/parser': '*'
++      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
++    peerDependenciesMeta:
++      '@typescript-eslint/parser':
++        optional: true
++    dependencies:
++      '@typescript-eslint/parser': 7.10.0(eslint@8.57.0)(typescript@5.4.5)
++      array-includes: 3.1.7
++      array.prototype.findlastindex: 1.2.3
++      array.prototype.flat: 1.3.2
++      array.prototype.flatmap: 1.3.2
++      debug: 3.2.7
++      doctrine: 2.1.0
++      eslint: 8.57.0
++      eslint-import-resolver-node: 0.3.9
++      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.10.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
++      hasown: 2.0.0
++      is-core-module: 2.13.1
++      is-glob: 4.0.3
++      minimatch: 3.1.2
++      object.fromentries: 2.0.7
++      object.groupby: 1.0.1
++      object.values: 1.1.7
++      semver: 6.3.1
++      tsconfig-paths: 3.15.0
++    transitivePeerDependencies:
++      - eslint-import-resolver-typescript
++      - eslint-import-resolver-webpack
++      - supports-color
++    dev: true
++
++  /eslint-plugin-square-svelte-store@1.0.0:
++    resolution: {integrity: sha512-QLybNNEPcBKVrgAeow/7ouOqbTVsWwEdStFab9ZMZaW19Y//ZEhhtuEb92P69n9u/JRL6EFhArV9AfS+LgS4mA==}
++    dev: true
++
++  /eslint-plugin-svelte@2.39.0(eslint@8.57.0)(svelte@4.2.17):
++    resolution: {integrity: sha512-FXktBLXsrxbA+6ZvJK2z/sQOrUKyzSg3fNWK5h0reSCjr2fjAsc9ai/s/JvSl4Hgvz3nYVtTIMwarZH5RcB7BA==}
++    engines: {node: ^14.17.0 || >=16.0.0}
++    peerDependencies:
++      eslint: ^7.0.0 || ^8.0.0-0 || ^9.0.0-0
++      svelte: ^3.37.0 || ^4.0.0 || ^5.0.0-next.112
++    peerDependenciesMeta:
++      svelte:
++        optional: true
++    dependencies:
++      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
++      '@jridgewell/sourcemap-codec': 1.4.15
++      debug: 4.3.4
++      eslint: 8.57.0
++      eslint-compat-utils: 0.5.0(eslint@8.57.0)
++      esutils: 2.0.3
++      known-css-properties: 0.31.0
++      postcss: 8.4.38
++      postcss-load-config: 3.1.4(postcss@8.4.38)
++      postcss-safe-parser: 6.0.0(postcss@8.4.38)
++      postcss-selector-parser: 6.0.16
++      semver: 7.6.0
++      svelte: 4.2.17
++      svelte-eslint-parser: 0.36.0(svelte@4.2.17)
++    transitivePeerDependencies:
++      - supports-color
++      - ts-node
++    dev: true
++
++  /eslint-scope@7.2.2:
++    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
++    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
++    dependencies:
++      esrecurse: 4.3.0
++      estraverse: 5.3.0
++    dev: true
++
++  /eslint-visitor-keys@3.4.3:
++    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
++    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
++    dev: true
++
++  /eslint@8.57.0:
++    resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
++    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
++    hasBin: true
++    dependencies:
++      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
++      '@eslint-community/regexpp': 4.8.0
++      '@eslint/eslintrc': 2.1.4
++      '@eslint/js': 8.57.0
++      '@humanwhocodes/config-array': 0.11.14
++      '@humanwhocodes/module-importer': 1.0.1
++      '@nodelib/fs.walk': 1.2.8
++      '@ungap/structured-clone': 1.2.0
++      ajv: 6.12.6
++      chalk: 4.1.2
++      cross-spawn: 7.0.3
++      debug: 4.3.4
++      doctrine: 3.0.0
++      escape-string-regexp: 4.0.0
++      eslint-scope: 7.2.2
++      eslint-visitor-keys: 3.4.3
++      espree: 9.6.1
++      esquery: 1.5.0
++      esutils: 2.0.3
++      fast-deep-equal: 3.1.3
++      file-entry-cache: 6.0.1
++      find-up: 5.0.0
++      glob-parent: 6.0.2
++      globals: 13.21.0
++      graphemer: 1.4.0
++      ignore: 5.2.4
++      imurmurhash: 0.1.4
++      is-glob: 4.0.3
++      is-path-inside: 3.0.3
++      js-yaml: 4.1.0
++      json-stable-stringify-without-jsonify: 1.0.1
++      levn: 0.4.1
++      lodash.merge: 4.6.2
++      minimatch: 3.1.2
++      natural-compare: 1.4.0
++      optionator: 0.9.3
++      strip-ansi: 6.0.1
++      text-table: 0.2.0
++    transitivePeerDependencies:
++      - supports-color
++    dev: true
++
++  /esm-env@1.0.0:
++    resolution: {integrity: sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==}
++    dev: true
++
++  /espree@9.6.1:
++    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
++    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
++    dependencies:
++      acorn: 8.10.0
++      acorn-jsx: 5.3.2(acorn@8.10.0)
++      eslint-visitor-keys: 3.4.3
++    dev: true
++
++  /esprima@4.0.1:
++    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
++    engines: {node: '>=4'}
++    hasBin: true
++    dev: true
++
++  /esquery@1.5.0:
++    resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
++    engines: {node: '>=0.10'}
++    dependencies:
++      estraverse: 5.3.0
++    dev: true
++
++  /esrecurse@4.3.0:
++    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
++    engines: {node: '>=4.0'}
++    dependencies:
++      estraverse: 5.3.0
++    dev: true
++
++  /estraverse@5.3.0:
++    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
++    engines: {node: '>=4.0'}
++    dev: true
++
++  /estree-walker@3.0.3:
++    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
++    dependencies:
++      '@types/estree': 1.0.1
++    dev: true
++
++  /esutils@2.0.3:
++    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
++    engines: {node: '>=0.10.0'}
++    dev: true
++
++  /event-target-shim@5.0.1:
++    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
++    engines: {node: '>=6'}
++    dev: false
++
++  /fast-deep-equal@3.1.3:
++    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
++    dev: true
++
++  /fast-glob@3.3.1:
++    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
++    engines: {node: '>=8.6.0'}
++    dependencies:
++      '@nodelib/fs.stat': 2.0.5
++      '@nodelib/fs.walk': 1.2.8
++      glob-parent: 5.1.2
++      merge2: 1.4.1
++      micromatch: 4.0.5
++    dev: true
++
++  /fast-json-stable-stringify@2.1.0:
++    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
++    dev: true
++
++  /fast-levenshtein@2.0.6:
++    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
++    dev: true
++
++  /fastq@1.15.0:
++    resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
++    dependencies:
++      reusify: 1.0.4
++    dev: true
++
++  /fflate@0.4.8:
++    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
++    dev: true
++
++  /file-entry-cache@6.0.1:
++    resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
++    engines: {node: ^10.12.0 || >=12.0.0}
++    dependencies:
++      flat-cache: 3.1.0
++    dev: true
++
++  /fill-range@7.0.1:
++    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
++    engines: {node: '>=8'}
++    dependencies:
++      to-regex-range: 5.0.1
++    dev: true
++
++  /find-up@5.0.0:
++    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
++    engines: {node: '>=10'}
++    dependencies:
++      locate-path: 6.0.0
++      path-exists: 4.0.0
++    dev: true
++
++  /flat-cache@3.1.0:
++    resolution: {integrity: sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==}
++    engines: {node: '>=12.0.0'}
++    dependencies:
++      flatted: 3.2.7
++      keyv: 4.5.3
++      rimraf: 3.0.2
++    dev: true
++
++  /flatted@3.2.7:
++    resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
++    dev: true
++
++  /for-each@0.3.3:
++    resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
++    dependencies:
++      is-callable: 1.2.7
++    dev: true
++
++  /form-data-encoder@1.7.2:
++    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
++    dev: false
++
++  /form-data@4.0.0:
++    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
++    engines: {node: '>= 6'}
++    dependencies:
++      asynckit: 0.4.0
++      combined-stream: 1.0.8
++      mime-types: 2.1.35
++    dev: false
++
++  /formdata-node@4.4.1:
++    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
++    engines: {node: '>= 12.20'}
++    dependencies:
++      node-domexception: 1.0.0
++      web-streams-polyfill: 4.0.0-beta.3
++    dev: false
++
++  /fraction.js@4.3.7:
++    resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
++    dev: true
++
++  /fs.realpath@1.0.0:
++    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
++    dev: true
++
++  /fsevents@2.3.2:
++    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
++    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
++    os: [darwin]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /fsevents@2.3.3:
++    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
++    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
++    os: [darwin]
++    requiresBuild: true
++    dev: true
++    optional: true
++
++  /function-bind@1.1.2:
++    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
++    dev: true
++
++  /function.prototype.name@1.1.6:
++    resolution: {integrity: sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      call-bind: 1.0.2
++      define-properties: 1.2.0
++      es-abstract: 1.22.1
++      functions-have-names: 1.2.3
++    dev: true
++
++  /functions-have-names@1.2.3:
++    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
++    dev: true
++
++  /get-func-name@2.0.2:
++    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
++    dev: true
++
++  /get-intrinsic@1.2.1:
++    resolution: {integrity: sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==}
++    dependencies:
++      function-bind: 1.1.2
++      has: 1.0.3
++      has-proto: 1.0.1
++      has-symbols: 1.0.3
++    dev: true
++
++  /get-symbol-description@1.0.0:
++    resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      call-bind: 1.0.2
++      get-intrinsic: 1.2.1
++    dev: true
++
++  /get-tsconfig@4.7.0:
++    resolution: {integrity: sha512-pmjiZ7xtB8URYm74PlGJozDNyhvsVLUcpBa8DZBG3bWHwaHa9bPiRpiSfovw+fjhwONSCWKRyk+JQHEGZmMrzw==}
++    dependencies:
++      resolve-pkg-maps: 1.0.0
++    dev: true
++
++  /glob-parent@5.1.2:
++    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
++    engines: {node: '>= 6'}
++    dependencies:
++      is-glob: 4.0.3
++    dev: true
++
++  /glob-parent@6.0.2:
++    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
++    engines: {node: '>=10.13.0'}
++    dependencies:
++      is-glob: 4.0.3
++    dev: true
++
++  /glob@7.2.3:
++    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
++    dependencies:
++      fs.realpath: 1.0.0
++      inflight: 1.0.6
++      inherits: 2.0.4
++      minimatch: 3.1.2
++      once: 1.4.0
++      path-is-absolute: 1.0.1
++    dev: true
++
++  /glob@9.3.2:
++    resolution: {integrity: sha512-BTv/JhKXFEHsErMte/AnfiSv8yYOLLiyH2lTg8vn02O21zWFgHPTfxtgn1QRe7NRgggUhC8hacR2Re94svHqeA==}
++    engines: {node: '>=16 || 14 >=14.17'}
++    dependencies:
++      fs.realpath: 1.0.0
++      minimatch: 7.4.6
++      minipass: 4.2.8
++      path-scurry: 1.10.1
++    dev: true
++
++  /globals@13.21.0:
++    resolution: {integrity: sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==}
++    engines: {node: '>=8'}
++    dependencies:
++      type-fest: 0.20.2
++    dev: true
++
++  /globalthis@1.0.3:
++    resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      define-properties: 1.2.0
++    dev: true
++
++  /globalyzer@0.1.0:
++    resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
++    dev: true
++
++  /globby@11.1.0:
++    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
++    engines: {node: '>=10'}
++    dependencies:
++      array-union: 2.1.0
++      dir-glob: 3.0.1
++      fast-glob: 3.3.1
++      ignore: 5.3.1
++      merge2: 1.4.1
++      slash: 3.0.0
++    dev: true
++
++  /globrex@0.1.2:
++    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
++    dev: true
++
++  /gopd@1.0.1:
++    resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
++    dependencies:
++      get-intrinsic: 1.2.1
++    dev: true
++
++  /graceful-fs@4.2.11:
++    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
++    dev: true
++
++  /graphemer@1.4.0:
++    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
++    dev: true
++
++  /has-bigints@1.0.2:
++    resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
++    dev: true
++
++  /has-flag@4.0.0:
++    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
++    engines: {node: '>=8'}
++    dev: true
++
++  /has-property-descriptors@1.0.0:
++    resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
++    dependencies:
++      get-intrinsic: 1.2.1
++    dev: true
++
++  /has-proto@1.0.1:
++    resolution: {integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==}
++    engines: {node: '>= 0.4'}
++    dev: true
++
++  /has-symbols@1.0.3:
++    resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
++    engines: {node: '>= 0.4'}
++    dev: true
++
++  /has-tostringtag@1.0.0:
++    resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      has-symbols: 1.0.3
++    dev: true
++
++  /has@1.0.3:
++    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
++    engines: {node: '>= 0.4.0'}
++    dependencies:
++      function-bind: 1.1.2
++    dev: true
++
++  /hasown@2.0.0:
++    resolution: {integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      function-bind: 1.1.2
++    dev: true
++
++  /https-proxy-agent@5.0.1:
++    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
++    engines: {node: '>= 6'}
++    dependencies:
++      agent-base: 6.0.2
++      debug: 4.3.4
++    transitivePeerDependencies:
++      - supports-color
++    dev: true
++
++  /humanize-ms@1.2.1:
++    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
++    dependencies:
++      ms: 2.1.3
++    dev: false
++
++  /ignore@5.2.4:
++    resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
++    engines: {node: '>= 4'}
++    dev: true
++
++  /ignore@5.3.1:
++    resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
++    engines: {node: '>= 4'}
++    dev: true
++
++  /immediate@3.0.6:
++    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
++    dev: true
++
++  /import-fresh@3.3.0:
++    resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
++    engines: {node: '>=6'}
++    dependencies:
++      parent-module: 1.0.1
++      resolve-from: 4.0.0
++    dev: true
++
++  /imurmurhash@0.1.4:
++    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
++    engines: {node: '>=0.8.19'}
++    dev: true
++
++  /inflight@1.0.6:
++    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
++    dependencies:
++      once: 1.4.0
++      wrappy: 1.0.2
++    dev: true
++
++  /inherits@2.0.4:
++    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
++    dev: true
++
++  /inter-ui@4.0.2:
++    resolution: {integrity: sha512-YmfzwEtzuVzEenQwSB/tmmqi/A0a2GnFk4mG4ZFULXiO5DNk0fJWiO3o9i1sdVKuMVGx9iiNQnCq8ghWZJVVHw==}
++    engines: {node: '>=16.0.0'}
++    dev: true
++
++  /internal-slot@1.0.5:
++    resolution: {integrity: sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      get-intrinsic: 1.2.1
++      has: 1.0.3
++      side-channel: 1.0.4
++    dev: true
++
++  /is-arguments@1.1.1:
++    resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      call-bind: 1.0.2
++      has-tostringtag: 1.0.0
++    dev: true
++
++  /is-array-buffer@3.0.2:
++    resolution: {integrity: sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==}
++    dependencies:
++      call-bind: 1.0.2
++      get-intrinsic: 1.2.1
++      is-typed-array: 1.1.12
++    dev: true
++
++  /is-bigint@1.0.4:
++    resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
++    dependencies:
++      has-bigints: 1.0.2
++    dev: true
++
++  /is-binary-path@2.1.0:
++    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
++    engines: {node: '>=8'}
++    dependencies:
++      binary-extensions: 2.2.0
++    dev: true
++
++  /is-boolean-object@1.1.2:
++    resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      call-bind: 1.0.2
++      has-tostringtag: 1.0.0
++    dev: true
++
++  /is-callable@1.2.7:
++    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
++    engines: {node: '>= 0.4'}
++    dev: true
++
++  /is-core-module@2.13.1:
++    resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
++    dependencies:
++      hasown: 2.0.0
++    dev: true
++
++  /is-date-object@1.0.5:
++    resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      has-tostringtag: 1.0.0
++    dev: true
++
++  /is-extglob@2.1.1:
++    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
++    engines: {node: '>=0.10.0'}
++    dev: true
++
++  /is-generator-function@1.0.10:
++    resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      has-tostringtag: 1.0.0
++    dev: true
++
++  /is-glob@4.0.3:
++    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
++    engines: {node: '>=0.10.0'}
++    dependencies:
++      is-extglob: 2.1.1
++    dev: true
++
++  /is-nan@1.3.2:
++    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      call-bind: 1.0.2
++      define-properties: 1.2.0
++    dev: true
++
++  /is-negative-zero@2.0.2:
++    resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
++    engines: {node: '>= 0.4'}
++    dev: true
++
++  /is-number-object@1.0.7:
++    resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      has-tostringtag: 1.0.0
++    dev: true
++
++  /is-number@7.0.0:
++    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
++    engines: {node: '>=0.12.0'}
++    dev: true
++
++  /is-path-inside@3.0.3:
++    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
++    engines: {node: '>=8'}
++    dev: true
++
++  /is-plain-object@5.0.0:
++    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
++    engines: {node: '>=0.10.0'}
++    dev: true
++
++  /is-reference@3.0.1:
++    resolution: {integrity: sha512-baJJdQLiYaJdvFbJqXrcGv3WU3QCzBlUcI5QhbesIm6/xPsvmO+2CDoi/GMOFBQEQm+PXkwOPrp9KK5ozZsp2w==}
++    dependencies:
++      '@types/estree': 1.0.1
++    dev: true
++
++  /is-regex@1.1.4:
++    resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      call-bind: 1.0.2
++      has-tostringtag: 1.0.0
++    dev: true
++
++  /is-shared-array-buffer@1.0.2:
++    resolution: {integrity: sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==}
++    dependencies:
++      call-bind: 1.0.2
++    dev: true
++
++  /is-string@1.0.7:
++    resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      has-tostringtag: 1.0.0
++    dev: true
++
++  /is-symbol@1.0.4:
++    resolution: {integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      has-symbols: 1.0.3
++    dev: true
++
++  /is-typed-array@1.1.12:
++    resolution: {integrity: sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      which-typed-array: 1.1.11
++    dev: true
++
++  /is-weakref@1.0.2:
++    resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
++    dependencies:
++      call-bind: 1.0.2
++    dev: true
++
++  /isarray@2.0.5:
++    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
++    dev: true
++
++  /isexe@2.0.0:
++    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
++    dev: true
++
++  /js-yaml@4.1.0:
++    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
++    hasBin: true
++    dependencies:
++      argparse: 2.0.1
++    dev: true
++
++  /json-buffer@3.0.1:
++    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
++    dev: true
++
++  /json-schema-traverse@0.4.1:
++    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
++    dev: true
++
++  /json-stable-stringify-without-jsonify@1.0.1:
++    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
++    dev: true
++
++  /json5@1.0.2:
++    resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
++    hasBin: true
++    dependencies:
++      minimist: 1.2.8
++    dev: true
++
++  /jsonc-parser@3.2.0:
++    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
++    dev: true
++
++  /keyv@4.5.3:
++    resolution: {integrity: sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==}
++    dependencies:
++      json-buffer: 3.0.1
++    dev: true
++
++  /kleur@4.1.5:
++    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
++    engines: {node: '>=6'}
++    dev: true
++
++  /known-css-properties@0.31.0:
++    resolution: {integrity: sha512-sBPIUGTNF0czz0mwGGUoKKJC8Q7On1GPbCSFPfyEsfHb2DyBG0Y4QtV+EVWpINSaiGKZblDNuF5AezxSgOhesQ==}
++    dev: true
++
++  /leven@4.0.0:
++    resolution: {integrity: sha512-puehA3YKku3osqPlNuzGDUHq8WpwXupUg1V6NXdV38G+gr+gkBwFC8g1b/+YcIvp8gnqVIus+eJCH/eGsRmJNw==}
++    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
++    dev: true
++
++  /levn@0.4.1:
++    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
++    engines: {node: '>= 0.8.0'}
++    dependencies:
++      prelude-ls: 1.2.1
++      type-check: 0.4.0
++    dev: true
++
++  /lie@3.1.1:
++    resolution: {integrity: sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==}
++    dependencies:
++      immediate: 3.0.6
++    dev: true
++
++  /lilconfig@2.1.0:
++    resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
++    engines: {node: '>=10'}
++    dev: true
++
++  /lilconfig@3.1.1:
++    resolution: {integrity: sha512-O18pf7nyvHTckunPWCV1XUNXU1piu01y2b7ATJ0ppkUkk8ocqVWBrYjJBCwHDjD/ZWcfyrA0P4gKhzWGi5EINQ==}
++    engines: {node: '>=14'}
++    dev: true
++
++  /local-pkg@0.4.3:
++    resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
++    engines: {node: '>=14'}
++    dev: true
++
++  /localforage@1.10.0:
++    resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
++    dependencies:
++      lie: 3.1.1
++    dev: true
++
++  /locate-character@3.0.0:
++    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
++    dev: true
++
++  /locate-path@6.0.0:
++    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
++    engines: {node: '>=10'}
++    dependencies:
++      p-locate: 5.0.0
++    dev: true
++
++  /lodash.merge@4.6.2:
++    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
++    dev: true
++
++  /loupe@2.3.6:
++    resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
++    deprecated: Please upgrade to 2.3.7 which fixes GHSA-4q6p-r6v2-jvc5
++    dependencies:
++      get-func-name: 2.0.2
++    dev: true
++
++  /lru-cache@10.0.1:
++    resolution: {integrity: sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==}
++    engines: {node: 14 || >=16.14}
++    dev: true
++
++  /lru-cache@6.0.0:
++    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
++    engines: {node: '>=10'}
++    dependencies:
++      yallist: 4.0.0
++    dev: true
++
++  /lscache@1.3.2:
++    resolution: {integrity: sha512-CBZT/pDcaK3I3XGwDLaszDe8hj0pCgbuxd3W79gvHApBSdKVXvR9fillbp6eLvp7dLgtaWm3a1mvmhAqn9uCXQ==}
++    dev: true
++
++  /magic-string@0.27.0:
++    resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
++    engines: {node: '>=12'}
++    dependencies:
++      '@jridgewell/sourcemap-codec': 1.4.15
++    dev: true
++
++  /magic-string@0.30.5:
++    resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
++    engines: {node: '>=12'}
++    dependencies:
++      '@jridgewell/sourcemap-codec': 1.4.15
++    dev: true
++
++  /magicast@0.2.8:
++    resolution: {integrity: sha512-zEnqeb3E6TfMKYXGyHv3utbuHNixr04o3/gVGviSzVQkbFiU46VZUd+Ea/1npKfvEsEWxBYuIksKzoztTDPg0A==}
++    dependencies:
++      '@babel/parser': 7.22.15
++      '@babel/types': 7.22.15
++      recast: 0.23.4
++    dev: true
++
++  /marked@10.0.0:
++    resolution: {integrity: sha512-YiGcYcWj50YrwBgNzFoYhQ1hT6GmQbFG8SksnYJX1z4BXTHSOrz1GB5/Jm2yQvMg4nN1FHP4M6r03R10KrVUiA==}
++    engines: {node: '>= 18'}
++    hasBin: true
++    dev: true
++
++  /mdn-data@2.0.30:
++    resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
++    dev: true
++
++  /merge2@1.4.1:
++    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
++    engines: {node: '>= 8'}
++    dev: true
++
++  /micromatch@4.0.5:
++    resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
++    engines: {node: '>=8.6'}
++    dependencies:
++      braces: 3.0.2
++      picomatch: 2.3.1
++    dev: true
++
++  /mime-db@1.52.0:
++    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
++    engines: {node: '>= 0.6'}
++    dev: false
++
++  /mime-types@2.1.35:
++    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
++    engines: {node: '>= 0.6'}
++    dependencies:
++      mime-db: 1.52.0
++    dev: false
++
++  /min-indent@1.0.1:
++    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
++    engines: {node: '>=4'}
++    dev: true
++
++  /minimatch@3.1.2:
++    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
++    dependencies:
++      brace-expansion: 1.1.11
++    dev: true
++
++  /minimatch@7.4.6:
++    resolution: {integrity: sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==}
++    engines: {node: '>=10'}
++    dependencies:
++      brace-expansion: 2.0.1
++    dev: true
++
++  /minimatch@9.0.4:
++    resolution: {integrity: sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==}
++    engines: {node: '>=16 || 14 >=14.17'}
++    dependencies:
++      brace-expansion: 2.0.1
++    dev: true
++
++  /minimist@1.2.8:
++    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
++    dev: true
++
++  /minipass@4.2.8:
++    resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
++    engines: {node: '>=8'}
++    dev: true
++
++  /minipass@7.0.3:
++    resolution: {integrity: sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==}
++    engines: {node: '>=16 || 14 >=14.17'}
++    dev: true
++
++  /mkdirp@0.5.6:
++    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
++    hasBin: true
++    dependencies:
++      minimist: 1.2.8
++    dev: true
++
++  /mlly@1.4.2:
++    resolution: {integrity: sha512-i/Ykufi2t1EZ6NaPLdfnZk2AX8cs0d+mTzVKuPfqPKPatxLApaBoxJQ9x1/uckXtrS/U5oisPMDkNs0yQTaBRg==}
++    dependencies:
++      acorn: 8.10.0
++      pathe: 1.1.1
++      pkg-types: 1.0.3
++      ufo: 1.3.0
++    dev: true
++
++  /mm-jsr@3.0.2:
++    resolution: {integrity: sha512-ATbSVKgOU9i54eBLPV+QETFKhGODnCDKsi18TLsET7BCJnX00LjcbOZYvw6ODplJpRY7JCrA861mYfViCDnh3w==}
++    dev: true
++
++  /mri@1.2.0:
++    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
++    engines: {node: '>=4'}
++    dev: true
++
++  /mrmime@1.0.1:
++    resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
++    engines: {node: '>=10'}
++    dev: true
++
++  /ms@2.1.2:
++    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
++    dev: true
++
++  /ms@2.1.3:
++    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
++
++  /nanoevents@9.0.0:
++    resolution: {integrity: sha512-X8pU7IOpgKXVLPxYUI55ymXc8XuBE+uypfEyEFBtHkD1EX9KavYTVc+vXZHFyHKzA1TaZoVDqklLdQBBrxIuAw==}
++    engines: {node: ^18.0.0 || >=20.0.0}
++    dev: true
++
++  /nanoid@3.3.7:
++    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
++    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
++    hasBin: true
++    dev: true
++
++  /nanoid@5.0.7:
++    resolution: {integrity: sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==}
++    engines: {node: ^18 || >=20}
++    hasBin: true
++    dev: true
++
++  /natural-compare@1.4.0:
++    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
++    dev: true
++
++  /node-domexception@1.0.0:
++    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
++    engines: {node: '>=10.5.0'}
++    dev: false
++
++  /node-fetch@2.7.0:
++    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
++    engines: {node: 4.x || >=6.0.0}
++    peerDependencies:
++      encoding: ^0.1.0
++    peerDependenciesMeta:
++      encoding:
++        optional: true
++    dependencies:
++      whatwg-url: 5.0.0
++
++  /node-releases@2.0.14:
++    resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
++    dev: true
++
++  /normalize-path@3.0.0:
++    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
++    engines: {node: '>=0.10.0'}
++    dev: true
++
++  /normalize-range@0.1.2:
++    resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
++    engines: {node: '>=0.10.0'}
++    dev: true
++
++  /object-inspect@1.12.3:
++    resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
++    dev: true
++
++  /object-is@1.1.5:
++    resolution: {integrity: sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      call-bind: 1.0.2
++      define-properties: 1.2.0
++    dev: true
++
++  /object-keys@1.1.1:
++    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
++    engines: {node: '>= 0.4'}
++    dev: true
++
++  /object.assign@4.1.4:
++    resolution: {integrity: sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      call-bind: 1.0.2
++      define-properties: 1.2.0
++      has-symbols: 1.0.3
++      object-keys: 1.1.1
++    dev: true
++
++  /object.fromentries@2.0.7:
++    resolution: {integrity: sha512-UPbPHML6sL8PI/mOqPwsH4G6iyXcCGzLin8KvEPenOZN5lpCNBZZQ+V62vdjB1mQHrmqGQt5/OJzemUA+KJmEA==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      call-bind: 1.0.2
++      define-properties: 1.2.0
++      es-abstract: 1.22.1
++    dev: true
++
++  /object.groupby@1.0.1:
++    resolution: {integrity: sha512-HqaQtqLnp/8Bn4GL16cj+CUYbnpe1bh0TtEaWvybszDG4tgxCJuRpV8VGuvNaI1fAnI4lUJzDG55MXcOH4JZcQ==}
++    dependencies:
++      call-bind: 1.0.2
++      define-properties: 1.2.0
++      es-abstract: 1.22.1
++      get-intrinsic: 1.2.1
++    dev: true
++
++  /object.values@1.1.7:
++    resolution: {integrity: sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      call-bind: 1.0.2
++      define-properties: 1.2.0
++      es-abstract: 1.22.1
++    dev: true
++
++  /once@1.4.0:
++    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
++    dependencies:
++      wrappy: 1.0.2
++    dev: true
++
++  /openai@4.47.1:
++    resolution: {integrity: sha512-WWSxhC/69ZhYWxH/OBsLEirIjUcfpQ5+ihkXKp06hmeYXgBBIUCa9IptMzYx6NdkiOCsSGYCnTIsxaic3AjRCQ==}
++    hasBin: true
++    dependencies:
++      '@types/node': 18.19.22
++      '@types/node-fetch': 2.6.11
++      abort-controller: 3.0.0
++      agentkeepalive: 4.5.0
++      form-data-encoder: 1.7.2
++      formdata-node: 4.4.1
++      node-fetch: 2.7.0
++      web-streams-polyfill: 3.3.3
++    transitivePeerDependencies:
++      - encoding
++    dev: false
++
++  /optionator@0.9.3:
++    resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
++    engines: {node: '>= 0.8.0'}
++    dependencies:
++      '@aashutoshrathi/word-wrap': 1.2.6
++      deep-is: 0.1.4
++      fast-levenshtein: 2.0.6
++      levn: 0.4.1
++      prelude-ls: 1.2.1
++      type-check: 0.4.0
++    dev: true
++
++  /p-limit@3.1.0:
++    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
++    engines: {node: '>=10'}
++    dependencies:
++      yocto-queue: 0.1.0
++    dev: true
++
++  /p-limit@4.0.0:
++    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
++    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
++    dependencies:
++      yocto-queue: 1.0.0
++    dev: true
++
++  /p-locate@5.0.0:
++    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
++    engines: {node: '>=10'}
++    dependencies:
++      p-limit: 3.1.0
++    dev: true
++
++  /parent-module@1.0.1:
++    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
++    engines: {node: '>=6'}
++    dependencies:
++      callsites: 3.1.0
++    dev: true
++
++  /path-exists@4.0.0:
++    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
++    engines: {node: '>=8'}
++    dev: true
++
++  /path-is-absolute@1.0.1:
++    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
++    engines: {node: '>=0.10.0'}
++    dev: true
++
++  /path-key@3.1.1:
++    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
++    engines: {node: '>=8'}
++    dev: true
++
++  /path-parse@1.0.7:
++    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
++    dev: true
++
++  /path-scurry@1.10.1:
++    resolution: {integrity: sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==}
++    engines: {node: '>=16 || 14 >=14.17'}
++    dependencies:
++      lru-cache: 10.0.1
++      minipass: 7.0.3
++    dev: true
++
++  /path-type@4.0.0:
++    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
++    engines: {node: '>=8'}
++    dev: true
++
++  /pathe@1.1.1:
++    resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
++    dev: true
++
++  /pathval@1.1.1:
++    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
++    dev: true
++
++  /periscopic@3.1.0:
++    resolution: {integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==}
++    dependencies:
++      '@types/estree': 1.0.1
++      estree-walker: 3.0.3
++      is-reference: 3.0.1
++    dev: true
++
++  /picocolors@1.0.0:
++    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
++    dev: true
++
++  /picomatch@2.3.1:
++    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
++    engines: {node: '>=8.6'}
++    dev: true
++
++  /pkg-types@1.0.3:
++    resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
++    dependencies:
++      jsonc-parser: 3.2.0
++      mlly: 1.4.2
++      pathe: 1.1.1
++    dev: true
++
++  /playwright-core@1.44.1:
++    resolution: {integrity: sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==}
++    engines: {node: '>=16'}
++    hasBin: true
++    dev: true
++
++  /playwright@1.44.1:
++    resolution: {integrity: sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==}
++    engines: {node: '>=16'}
++    hasBin: true
++    dependencies:
++      playwright-core: 1.44.1
++    optionalDependencies:
++      fsevents: 2.3.2
++    dev: true
++
++  /postcss-load-config@3.1.4(postcss@8.4.38):
++    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
++    engines: {node: '>= 10'}
++    peerDependencies:
++      postcss: '>=8.0.9'
++      ts-node: '>=9.0.0'
++    peerDependenciesMeta:
++      postcss:
++        optional: true
++      ts-node:
++        optional: true
++    dependencies:
++      lilconfig: 2.1.0
++      postcss: 8.4.38
++      yaml: 1.10.2
++    dev: true
++
++  /postcss-load-config@5.1.0(postcss@8.4.38):
++    resolution: {integrity: sha512-G5AJ+IX0aD0dygOE0yFZQ/huFFMSNneyfp0e3/bT05a8OfPC5FUoZRPfGijUdGOJNMewJiwzcHJXFafFzeKFVA==}
++    engines: {node: '>= 18'}
++    peerDependencies:
++      jiti: '>=1.21.0'
++      postcss: '>=8.0.9'
++      tsx: ^4.8.1
++    peerDependenciesMeta:
++      jiti:
++        optional: true
++      postcss:
++        optional: true
++      tsx:
++        optional: true
++    dependencies:
++      lilconfig: 3.1.1
++      postcss: 8.4.38
++      yaml: 2.4.2
++    dev: true
++
++  /postcss-safe-parser@6.0.0(postcss@8.4.38):
++    resolution: {integrity: sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==}
++    engines: {node: '>=12.0'}
++    peerDependencies:
++      postcss: ^8.3.3
++    dependencies:
++      postcss: 8.4.38
++    dev: true
++
++  /postcss-scss@4.0.9(postcss@8.4.38):
++    resolution: {integrity: sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==}
++    engines: {node: '>=12.0'}
++    peerDependencies:
++      postcss: ^8.4.29
++    dependencies:
++      postcss: 8.4.38
++    dev: true
++
++  /postcss-selector-parser@6.0.16:
++    resolution: {integrity: sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==}
++    engines: {node: '>=4'}
++    dependencies:
++      cssesc: 3.0.0
++      util-deprecate: 1.0.2
++    dev: true
++
++  /postcss-value-parser@4.2.0:
++    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
++    dev: true
++
++  /postcss@8.4.38:
++    resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
++    engines: {node: ^10 || ^12 || >=14}
++    dependencies:
++      nanoid: 3.3.7
++      picocolors: 1.0.0
++      source-map-js: 1.2.0
++    dev: true
++
++  /posthog-js@1.135.2:
++    resolution: {integrity: sha512-kqix067CyrlcNKUhVxrys8Qp0O/8FUtlkp7lfM+tkJFJAMZsKjIDVslz2AjI9y79CvyyZX+pddfA7F3YFYlS0Q==}
++    dependencies:
++      fflate: 0.4.8
++      preact: 10.19.3
++    dev: true
++
++  /preact@10.19.3:
++    resolution: {integrity: sha512-nHHTeFVBTHRGxJXKkKu5hT8C/YWBkPso4/Gad6xuj5dbptt9iF9NZr9pHbPhBrnT2klheu7mHTxTZ/LjwJiEiQ==}
++    dev: true
++
++  /prelude-ls@1.2.1:
++    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
++    engines: {node: '>= 0.8.0'}
++    dev: true
++
++  /prettier-plugin-svelte@3.2.3(prettier@3.2.5)(svelte@4.2.17):
++    resolution: {integrity: sha512-wJq8RunyFlWco6U0WJV5wNCM7zpBFakS76UBSbmzMGpncpK98NZABaE+s7n8/APDCEVNHXC5Mpq+MLebQtsRlg==}
++    peerDependencies:
++      prettier: ^3.0.0
++      svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
++    dependencies:
++      prettier: 3.2.5
++      svelte: 4.2.17
++    dev: true
++
++  /prettier@3.2.5:
++    resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
++    engines: {node: '>=14'}
++    hasBin: true
++    dev: true
++
++  /pretty-format@29.6.3:
++    resolution: {integrity: sha512-ZsBgjVhFAj5KeK+nHfF1305/By3lechHQSMWCTl8iHSbfOm2TN5nHEtFc/+W7fAyUeCs2n5iow72gld4gW0xDw==}
++    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
++    dependencies:
++      '@jest/schemas': 29.6.3
++      ansi-styles: 5.2.0
++      react-is: 18.2.0
++    dev: true
++
++  /progress@2.0.3:
++    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
++    engines: {node: '>=0.4.0'}
++    dev: true
++
++  /proxy-from-env@1.1.0:
++    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
++    dev: true
++
++  /punycode@2.3.0:
++    resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
++    engines: {node: '>=6'}
++    dev: true
++
++  /queue-microtask@1.2.3:
++    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
++    dev: true
++
++  /react-is@18.2.0:
++    resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
++    dev: true
++
++  /readdirp@3.6.0:
++    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
++    engines: {node: '>=8.10.0'}
++    dependencies:
++      picomatch: 2.3.1
++    dev: true
++
++  /recast@0.23.4:
++    resolution: {integrity: sha512-qtEDqIZGVcSZCHniWwZWbRy79Dc6Wp3kT/UmDA2RJKBPg7+7k51aQBZirHmUGn5uvHf2rg8DkjizrN26k61ATw==}
++    engines: {node: '>= 4'}
++    dependencies:
++      assert: 2.0.0
++      ast-types: 0.16.1
++      esprima: 4.0.1
++      source-map: 0.6.1
++      tslib: 2.6.2
++    dev: true
++
++  /reflect-metadata@0.2.2:
++    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
++    dev: true
++
++  /regenerator-runtime@0.14.0:
++    resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
++    dev: true
++
++  /regexp.prototype.flags@1.5.0:
++    resolution: {integrity: sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      call-bind: 1.0.2
++      define-properties: 1.2.0
++      functions-have-names: 1.2.3
++    dev: true
++
++  /resize-observer-polyfill@1.5.1:
++    resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
++    dev: true
++
++  /resolve-from@4.0.0:
++    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
++    engines: {node: '>=4'}
++    dev: true
++
++  /resolve-pkg-maps@1.0.0:
++    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
++    dev: true
++
++  /resolve@1.22.4:
++    resolution: {integrity: sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==}
++    hasBin: true
++    dependencies:
++      is-core-module: 2.13.1
++      path-parse: 1.0.7
++      supports-preserve-symlinks-flag: 1.0.0
++    dev: true
++
++  /reusify@1.0.4:
++    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
++    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
++    dev: true
++
++  /rimraf@2.7.1:
++    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
++    hasBin: true
++    dependencies:
++      glob: 7.2.3
++    dev: true
++
++  /rimraf@3.0.2:
++    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
++    hasBin: true
++    dependencies:
++      glob: 7.2.3
++    dev: true
++
++  /rollup@3.29.0:
++    resolution: {integrity: sha512-nszM8DINnx1vSS+TpbWKMkxem0CDWk3cSit/WWCBVs9/JZ1I/XLwOsiUglYuYReaeWWSsW9kge5zE5NZtf/a4w==}
++    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
++    hasBin: true
++    optionalDependencies:
++      fsevents: 2.3.3
++    dev: true
++
++  /run-parallel@1.2.0:
++    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
++    dependencies:
++      queue-microtask: 1.2.3
++    dev: true
++
++  /rxjs@7.8.1:
++    resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
++    dependencies:
++      tslib: 2.6.2
++    dev: true
++
++  /sade@1.8.1:
++    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
++    engines: {node: '>=6'}
++    dependencies:
++      mri: 1.2.0
++    dev: true
++
++  /safe-array-concat@1.0.1:
++    resolution: {integrity: sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==}
++    engines: {node: '>=0.4'}
++    dependencies:
++      call-bind: 1.0.2
++      get-intrinsic: 1.2.1
++      has-symbols: 1.0.3
++      isarray: 2.0.5
++    dev: true
++
++  /safe-regex-test@1.0.0:
++    resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
++    dependencies:
++      call-bind: 1.0.2
++      get-intrinsic: 1.2.1
++      is-regex: 1.1.4
++    dev: true
++
++  /sander@0.5.1:
++    resolution: {integrity: sha512-3lVqBir7WuKDHGrKRDn/1Ye3kwpXaDOMsiRP1wd6wpZW56gJhsbp5RqQpA6JG/P+pkXizygnr1dKR8vzWaVsfA==}
++    dependencies:
++      es6-promise: 3.3.1
++      graceful-fs: 4.2.11
++      mkdirp: 0.5.6
++      rimraf: 2.7.1
++    dev: true
++
++  /semver@6.3.1:
++    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
++    hasBin: true
++    dev: true
++
++  /semver@7.6.0:
++    resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}
++    engines: {node: '>=10'}
++    hasBin: true
++    dependencies:
++      lru-cache: 6.0.0
++    dev: true
++
++  /set-cookie-parser@2.6.0:
++    resolution: {integrity: sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==}
++    dev: true
++
++  /shebang-command@2.0.0:
++    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
++    engines: {node: '>=8'}
++    dependencies:
++      shebang-regex: 3.0.0
++    dev: true
++
++  /shebang-regex@3.0.0:
++    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
++    engines: {node: '>=8'}
++    dev: true
++
++  /side-channel@1.0.4:
++    resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
++    dependencies:
++      call-bind: 1.0.2
++      get-intrinsic: 1.2.1
++      object-inspect: 1.12.3
++    dev: true
++
++  /siginfo@2.0.0:
++    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
++    dev: true
++
++  /sirv@2.0.3:
++    resolution: {integrity: sha512-O9jm9BsID1P+0HOi81VpXPoDxYP374pkOLzACAoyUQ/3OUVndNpsz6wMnY2z+yOxzbllCKZrM+9QrWsv4THnyA==}
++    engines: {node: '>= 10'}
++    dependencies:
++      '@polka/url': 1.0.0-next.21
++      mrmime: 1.0.1
++      totalist: 3.0.1
++    dev: true
++
++  /slash@3.0.0:
++    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
++    engines: {node: '>=8'}
++    dev: true
++
++  /sorcery@0.11.0:
++    resolution: {integrity: sha512-J69LQ22xrQB1cIFJhPfgtLuI6BpWRiWu1Y3vSsIwK/eAScqJxd/+CJlUuHQRdX2C9NGFamq+KqNywGgaThwfHw==}
++    hasBin: true
++    dependencies:
++      '@jridgewell/sourcemap-codec': 1.4.15
++      buffer-crc32: 0.2.13
++      minimist: 1.2.8
++      sander: 0.5.1
++    dev: true
++
++  /source-map-js@1.2.0:
++    resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
++    engines: {node: '>=0.10.0'}
++    dev: true
++
++  /source-map@0.6.1:
++    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
++    engines: {node: '>=0.10.0'}
++    dev: true
++
++  /stackback@0.0.2:
++    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
++    dev: true
++
++  /std-env@3.4.3:
++    resolution: {integrity: sha512-f9aPhy8fYBuMN+sNfakZV18U39PbalgjXG3lLB9WkaYTxijru61wb57V9wxxNthXM5Sd88ETBWi29qLAsHO52Q==}
++    dev: true
++
++  /string.prototype.trim@1.2.7:
++    resolution: {integrity: sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      call-bind: 1.0.2
++      define-properties: 1.2.0
++      es-abstract: 1.22.1
++    dev: true
++
++  /string.prototype.trimend@1.0.6:
++    resolution: {integrity: sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==}
++    dependencies:
++      call-bind: 1.0.2
++      define-properties: 1.2.0
++      es-abstract: 1.22.1
++    dev: true
++
++  /string.prototype.trimstart@1.0.7:
++    resolution: {integrity: sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==}
++    dependencies:
++      call-bind: 1.0.2
++      define-properties: 1.2.0
++      es-abstract: 1.22.1
++    dev: true
++
++  /strip-ansi@6.0.1:
++    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
++    engines: {node: '>=8'}
++    dependencies:
++      ansi-regex: 5.0.1
++    dev: true
++
++  /strip-bom@3.0.0:
++    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
++    engines: {node: '>=4'}
++    dev: true
++
++  /strip-indent@3.0.0:
++    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
++    engines: {node: '>=8'}
++    dependencies:
++      min-indent: 1.0.1
++    dev: true
++
++  /strip-json-comments@3.1.1:
++    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
++    engines: {node: '>=8'}
++    dev: true
++
++  /strip-literal@1.3.0:
++    resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
++    dependencies:
++      acorn: 8.10.0
++    dev: true
++
++  /style-mod@4.1.0:
++    resolution: {integrity: sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA==}
++    dev: true
++
++  /supports-color@7.2.0:
++    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
++    engines: {node: '>=8'}
++    dependencies:
++      has-flag: 4.0.0
++    dev: true
++
++  /supports-preserve-symlinks-flag@1.0.0:
++    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
++    engines: {node: '>= 0.4'}
++    dev: true
++
++  /svelte-check@3.7.1(postcss-load-config@5.1.0)(postcss@8.4.38)(svelte@4.2.17):
++    resolution: {integrity: sha512-U4uJoLCzmz2o2U33c7mPDJNhRYX/DNFV11XTUDlFxaKLsO7P+40gvJHMPpoRfa24jqZfST4/G9fGNcUGMO8NAQ==}
++    hasBin: true
++    peerDependencies:
++      svelte: ^3.55.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0
++    dependencies:
++      '@jridgewell/trace-mapping': 0.3.19
++      chokidar: 3.5.3
++      fast-glob: 3.3.1
++      import-fresh: 3.3.0
++      picocolors: 1.0.0
++      sade: 1.8.1
++      svelte: 4.2.17
++      svelte-preprocess: 5.1.3(postcss-load-config@5.1.0)(postcss@8.4.38)(svelte@4.2.17)(typescript@5.4.5)
++      typescript: 5.4.5
++    transitivePeerDependencies:
++      - '@babel/core'
++      - coffeescript
++      - less
++      - postcss
++      - postcss-load-config
++      - pug
++      - sass
++      - stylus
++      - sugarss
++    dev: true
++
++  /svelte-eslint-parser@0.36.0(svelte@4.2.17):
++    resolution: {integrity: sha512-/6YmUSr0FAVxW8dXNdIMydBnddPMHzaHirAZ7RrT21XYdgGGZMh0LQG6CZsvAFS4r2Y4ItUuCQc8TQ3urB30mQ==}
++    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
++    peerDependencies:
++      svelte: ^3.37.0 || ^4.0.0 || ^5.0.0-next.115
++    peerDependenciesMeta:
++      svelte:
++        optional: true
++    dependencies:
++      eslint-scope: 7.2.2
++      eslint-visitor-keys: 3.4.3
++      espree: 9.6.1
++      postcss: 8.4.38
++      postcss-scss: 4.0.9(postcss@8.4.38)
++      svelte: 4.2.17
++    dev: true
++
++  /svelte-floating-ui@1.5.8:
++    resolution: {integrity: sha512-dVvJhZ2bT+kQDHlE4Lep8t+sgEc0XD96fXLzAi2DDI2bsaegBbClxXVNMma0C2WsG+n9GJSYx292dTvA8CYRtw==}
++    dependencies:
++      '@floating-ui/core': 1.5.2
++      '@floating-ui/dom': 1.5.3
++    dev: true
++
++  /svelte-french-toast@1.2.0(svelte@4.2.17):
++    resolution: {integrity: sha512-5PW+6RFX3xQPbR44CngYAP1Sd9oCq9P2FOox4FZffzJuZI2mHOB7q5gJBVnOiLF5y3moVGZ7u2bYt7+yPAgcEQ==}
++    peerDependencies:
++      svelte: ^3.57.0 || ^4.0.0
++    dependencies:
++      svelte: 4.2.17
++      svelte-writable-derived: 3.1.0(svelte@4.2.17)
++    dev: true
++
++  /svelte-hmr@0.15.3(svelte@4.2.17):
++    resolution: {integrity: sha512-41snaPswvSf8TJUhlkoJBekRrABDXDMdpNpT2tfHIv4JuhgvHqLMhEPGtaQn0BmbNSTkuz2Ed20DF2eHw0SmBQ==}
++    engines: {node: ^12.20 || ^14.13.1 || >= 16}
++    peerDependencies:
++      svelte: ^3.19.0 || ^4.0.0
++    dependencies:
++      svelte: 4.2.17
++    dev: true
++
++  /svelte-loadable-store@2.0.1(svelte@4.2.17):
++    resolution: {integrity: sha512-qmkgJuo3kcPtt9EG7ZocBXL7plkEHNnNkqtEhRVCHCv3RywpnUF5BoU3VCbG8aYjsQESlI8INHkOlfnr9RpJZQ==}
++    peerDependencies:
++      svelte: 3.x.x || 4.x.x
++    dependencies:
++      svelte: 4.2.17
++    dev: true
++
++  /svelte-outclick@3.7.1(svelte@4.2.17):
++    resolution: {integrity: sha512-+TmDaG8yX4cIhmvflujvgV+NbFHxkUdYfeSczp67UJvkkMO9m6x1ugBQSDnjHD6J1z4tE5alkp5pC5LpoNqOKg==}
++    peerDependencies:
++      svelte: '>= 4.2.12'
++    dependencies:
++      svelte: 4.2.17
++    dev: true
++
++  /svelte-preprocess@5.1.3(postcss-load-config@5.1.0)(postcss@8.4.38)(svelte@4.2.17)(typescript@5.4.5):
++    resolution: {integrity: sha512-xxAkmxGHT+J/GourS5mVJeOXZzne1FR5ljeOUAMXUkfEhkLEllRreXpbl3dIYJlcJRfL1LO1uIAPpBpBfiqGPw==}
++    engines: {node: '>= 16.0.0', pnpm: ^8.0.0}
++    requiresBuild: true
++    peerDependencies:
++      '@babel/core': ^7.10.2
++      coffeescript: ^2.5.1
++      less: ^3.11.3 || ^4.0.0
++      postcss: ^7 || ^8
++      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
++      pug: ^3.0.0
++      sass: ^1.26.8
++      stylus: ^0.55.0
++      sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
++      svelte: ^3.23.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0
++      typescript: '>=3.9.5 || ^4.0.0 || ^5.0.0'
++    peerDependenciesMeta:
++      '@babel/core':
++        optional: true
++      coffeescript:
++        optional: true
++      less:
++        optional: true
++      postcss:
++        optional: true
++      postcss-load-config:
++        optional: true
++      pug:
++        optional: true
++      sass:
++        optional: true
++      stylus:
++        optional: true
++      sugarss:
++        optional: true
++      typescript:
++        optional: true
++    dependencies:
++      '@types/pug': 2.0.6
++      detect-indent: 6.1.0
++      magic-string: 0.30.5
++      postcss: 8.4.38
++      postcss-load-config: 5.1.0(postcss@8.4.38)
++      sorcery: 0.11.0
++      strip-indent: 3.0.0
++      svelte: 4.2.17
++      typescript: 5.4.5
++    dev: true
++
++  /svelte-resize-observer@2.0.0:
++    resolution: {integrity: sha512-hMG30MeUFiVhAeAGWoasBGNAFWa/K8mAIvbpjdaYRqNcU5nkxvjZYhzOhQ8rYbHSd2Hflk2s21yFR7CNKEHZpw==}
++    dependencies:
++      resize-observer-polyfill: 1.5.1
++    dev: true
++
++  /svelte-writable-derived@3.1.0(svelte@4.2.17):
++    resolution: {integrity: sha512-cTvaVFNIJ036vSDIyPxJYivKC7ZLtcFOPm1Iq6qWBDo1fOHzfk6ZSbwaKrxhjgy52Rbl5IHzRcWgos6Zqn9/rg==}
++    peerDependencies:
++      svelte: ^3.2.1 || ^4.0.0-next.1
++    dependencies:
++      svelte: 4.2.17
++    dev: true
++
++  /svelte@4.2.17:
++    resolution: {integrity: sha512-N7m1YnoXtRf5wya5Gyx3TWuTddI4nAyayyIWFojiWV5IayDYNV5i2mRp/7qNGol4DtxEYxljmrbgp1HM6hUbmQ==}
++    engines: {node: '>=16'}
++    dependencies:
++      '@ampproject/remapping': 2.2.1
++      '@jridgewell/sourcemap-codec': 1.4.15
++      '@jridgewell/trace-mapping': 0.3.19
++      '@types/estree': 1.0.1
++      acorn: 8.10.0
++      aria-query: 5.3.0
++      axobject-query: 4.0.0
++      code-red: 1.0.4
++      css-tree: 2.3.1
++      estree-walker: 3.0.3
++      is-reference: 3.0.1
++      locate-character: 3.0.0
++      magic-string: 0.30.5
++      periscopic: 3.1.0
++    dev: true
++
++  /tapable@2.2.1:
++    resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
++    engines: {node: '>=6'}
++    dev: true
++
++  /tauri-plugin-context-menu@0.7.0:
++    resolution: {integrity: sha512-NtFyhP2lQrUqs2ZWxw5j75p0K/3+5xPAckKh8yvpn0Bjq6WpKpBRli5chmcP44ltUoHBfXl2yRnpU14G1G5ucg==}
++    dependencies:
++      '@tauri-apps/api': 1.5.6
++    dev: true
++
++  /text-table@0.2.0:
++    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
++    dev: true
++
++  /tiny-glob@0.2.9:
++    resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
++    dependencies:
++      globalyzer: 0.1.0
++      globrex: 0.1.2
++    dev: true
++
++  /tinybench@2.5.0:
++    resolution: {integrity: sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==}
++    dev: true
++
++  /tinykeys@2.1.0:
++    resolution: {integrity: sha512-/MESnqBD1xItZJn5oGQ4OsNORQgJfPP96XSGoyu4eLpwpL0ifO0SYR5OD76u0YMhMXsqkb0UqvI9+yXTh4xv8Q==}
++    dev: true
++
++  /tinypool@0.7.0:
++    resolution: {integrity: sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==}
++    engines: {node: '>=14.0.0'}
++    dev: true
++
++  /tinyspy@2.1.1:
++    resolution: {integrity: sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==}
++    engines: {node: '>=14.0.0'}
++    dev: true
++
++  /to-fast-properties@2.0.0:
++    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
++    engines: {node: '>=4'}
++    dev: true
++
++  /to-regex-range@5.0.1:
++    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
++    engines: {node: '>=8.0'}
++    dependencies:
++      is-number: 7.0.0
++    dev: true
++
++  /totalist@3.0.1:
++    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
++    engines: {node: '>=6'}
++    dev: true
++
++  /tr46@0.0.3:
++    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
++
++  /ts-api-utils@1.3.0(typescript@5.4.5):
++    resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
++    engines: {node: '>=16'}
++    peerDependencies:
++      typescript: '>=4.2.0'
++    dependencies:
++      typescript: 5.4.5
++    dev: true
++
++  /tsconfig-paths@3.15.0:
++    resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
++    dependencies:
++      '@types/json5': 0.0.29
++      json5: 1.0.2
++      minimist: 1.2.8
++      strip-bom: 3.0.0
++    dev: true
++
++  /tslib@2.6.2:
++    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
++    dev: true
++
++  /type-check@0.4.0:
++    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
++    engines: {node: '>= 0.8.0'}
++    dependencies:
++      prelude-ls: 1.2.1
++    dev: true
++
++  /type-detect@4.0.8:
++    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
++    engines: {node: '>=4'}
++    dev: true
++
++  /type-fest@0.20.2:
++    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
++    engines: {node: '>=10'}
++    dev: true
++
++  /typed-array-buffer@1.0.0:
++    resolution: {integrity: sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      call-bind: 1.0.2
++      get-intrinsic: 1.2.1
++      is-typed-array: 1.1.12
++    dev: true
++
++  /typed-array-byte-length@1.0.0:
++    resolution: {integrity: sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      call-bind: 1.0.2
++      for-each: 0.3.3
++      has-proto: 1.0.1
++      is-typed-array: 1.1.12
++    dev: true
++
++  /typed-array-byte-offset@1.0.0:
++    resolution: {integrity: sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      available-typed-arrays: 1.0.5
++      call-bind: 1.0.2
++      for-each: 0.3.3
++      has-proto: 1.0.1
++      is-typed-array: 1.1.12
++    dev: true
++
++  /typed-array-length@1.0.4:
++    resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
++    dependencies:
++      call-bind: 1.0.2
++      for-each: 0.3.3
++      is-typed-array: 1.1.12
++    dev: true
++
++  /typescript@5.4.5:
++    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
++    engines: {node: '>=14.17'}
++    hasBin: true
++    dev: true
++
++  /ufo@1.3.0:
++    resolution: {integrity: sha512-bRn3CsoojyNStCZe0BG0Mt4Nr/4KF+rhFlnNXybgqt5pXHNFRlqinSoQaTrGyzE4X8aHplSb+TorH+COin9Yxw==}
++    dev: true
++
++  /unbox-primitive@1.0.2:
++    resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
++    dependencies:
++      call-bind: 1.0.2
++      has-bigints: 1.0.2
++      has-symbols: 1.0.3
++      which-boxed-primitive: 1.0.2
++    dev: true
++
++  /undici-types@5.26.5:
++    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
++    dev: false
++
++  /undici@5.28.3:
++    resolution: {integrity: sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==}
++    engines: {node: '>=14.0'}
++    dependencies:
++      '@fastify/busboy': 2.0.0
++    dev: true
++
++  /universal-user-agent@6.0.0:
++    resolution: {integrity: sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==}
++    dev: true
++
++  /unplugin@1.0.1:
++    resolution: {integrity: sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==}
++    dependencies:
++      acorn: 8.10.0
++      chokidar: 3.5.3
++      webpack-sources: 3.2.3
++      webpack-virtual-modules: 0.5.0
++    dev: true
++
++  /update-browserslist-db@1.0.13(browserslist@4.23.0):
++    resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
++    hasBin: true
++    peerDependencies:
++      browserslist: '>= 4.21.0'
++    dependencies:
++      browserslist: 4.23.0
++      escalade: 3.1.1
++      picocolors: 1.0.0
++    dev: true
++
++  /uri-js@4.4.1:
++    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
++    dependencies:
++      punycode: 2.3.0
++    dev: true
++
++  /util-deprecate@1.0.2:
++    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
++    dev: true
++
++  /util@0.12.5:
++    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
++    dependencies:
++      inherits: 2.0.4
++      is-arguments: 1.1.1
++      is-generator-function: 1.0.10
++      is-typed-array: 1.1.12
++      which-typed-array: 1.1.11
++    dev: true
++
++  /vite-node@0.34.6(@types/node@20.5.9):
++    resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
++    engines: {node: '>=v14.18.0'}
++    hasBin: true
++    dependencies:
++      cac: 6.7.14
++      debug: 4.3.4
++      mlly: 1.4.2
++      pathe: 1.1.1
++      picocolors: 1.0.0
++      vite: 4.5.3(@types/node@20.5.9)
++    transitivePeerDependencies:
++      - '@types/node'
++      - less
++      - lightningcss
++      - sass
++      - stylus
++      - sugarss
++      - supports-color
++      - terser
++    dev: true
++
++  /vite@4.5.3(@types/node@20.5.9):
++    resolution: {integrity: sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==}
++    engines: {node: ^14.18.0 || >=16.0.0}
++    hasBin: true
++    peerDependencies:
++      '@types/node': '>= 14'
++      less: '*'
++      lightningcss: ^1.21.0
++      sass: '*'
++      stylus: '*'
++      sugarss: '*'
++      terser: ^5.4.0
++    peerDependenciesMeta:
++      '@types/node':
++        optional: true
++      less:
++        optional: true
++      lightningcss:
++        optional: true
++      sass:
++        optional: true
++      stylus:
++        optional: true
++      sugarss:
++        optional: true
++      terser:
++        optional: true
++    dependencies:
++      '@types/node': 20.5.9
++      esbuild: 0.18.20
++      postcss: 8.4.38
++      rollup: 3.29.0
++    optionalDependencies:
++      fsevents: 2.3.3
++    dev: true
++
++  /vitefu@0.2.4(vite@4.5.3):
++    resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
++    peerDependencies:
++      vite: ^3.0.0 || ^4.0.0
++    peerDependenciesMeta:
++      vite:
++        optional: true
++    dependencies:
++      vite: 4.5.3(@types/node@20.5.9)
++    dev: true
++
++  /vitest@0.34.6:
++    resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}
++    engines: {node: '>=v14.18.0'}
++    hasBin: true
++    peerDependencies:
++      '@edge-runtime/vm': '*'
++      '@vitest/browser': '*'
++      '@vitest/ui': '*'
++      happy-dom: '*'
++      jsdom: '*'
++      playwright: '*'
++      safaridriver: '*'
++      webdriverio: '*'
++    peerDependenciesMeta:
++      '@edge-runtime/vm':
++        optional: true
++      '@vitest/browser':
++        optional: true
++      '@vitest/ui':
++        optional: true
++      happy-dom:
++        optional: true
++      jsdom:
++        optional: true
++      playwright:
++        optional: true
++      safaridriver:
++        optional: true
++      webdriverio:
++        optional: true
++    dependencies:
++      '@types/chai': 4.3.6
++      '@types/chai-subset': 1.3.3
++      '@types/node': 20.5.9
++      '@vitest/expect': 0.34.6
++      '@vitest/runner': 0.34.6
++      '@vitest/snapshot': 0.34.6
++      '@vitest/spy': 0.34.6
++      '@vitest/utils': 0.34.6
++      acorn: 8.10.0
++      acorn-walk: 8.2.0
++      cac: 6.7.14
++      chai: 4.3.10
++      debug: 4.3.4
++      local-pkg: 0.4.3
++      magic-string: 0.30.5
++      pathe: 1.1.1
++      picocolors: 1.0.0
++      std-env: 3.4.3
++      strip-literal: 1.3.0
++      tinybench: 2.5.0
++      tinypool: 0.7.0
++      vite: 4.5.3(@types/node@20.5.9)
++      vite-node: 0.34.6(@types/node@20.5.9)
++      why-is-node-running: 2.2.2
++    transitivePeerDependencies:
++      - less
++      - lightningcss
++      - sass
++      - stylus
++      - sugarss
++      - supports-color
++      - terser
++    dev: true
++
++  /w3c-keyname@2.2.8:
++    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
++    dev: true
++
++  /web-streams-polyfill@3.3.3:
++    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
++    engines: {node: '>= 8'}
++    dev: false
++
++  /web-streams-polyfill@4.0.0-beta.3:
++    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
++    engines: {node: '>= 14'}
++    dev: false
++
++  /webidl-conversions@3.0.1:
++    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
++
++  /webpack-sources@3.2.3:
++    resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
++    engines: {node: '>=10.13.0'}
++    dev: true
++
++  /webpack-virtual-modules@0.5.0:
++    resolution: {integrity: sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==}
++    dev: true
++
++  /whatwg-url@5.0.0:
++    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
++    dependencies:
++      tr46: 0.0.3
++      webidl-conversions: 3.0.1
++
++  /which-boxed-primitive@1.0.2:
++    resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
++    dependencies:
++      is-bigint: 1.0.4
++      is-boolean-object: 1.1.2
++      is-number-object: 1.0.7
++      is-string: 1.0.7
++      is-symbol: 1.0.4
++    dev: true
++
++  /which-typed-array@1.1.11:
++    resolution: {integrity: sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==}
++    engines: {node: '>= 0.4'}
++    dependencies:
++      available-typed-arrays: 1.0.5
++      call-bind: 1.0.2
++      for-each: 0.3.3
++      gopd: 1.0.1
++      has-tostringtag: 1.0.0
++    dev: true
++
++  /which@2.0.2:
++    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
++    engines: {node: '>= 8'}
++    hasBin: true
++    dependencies:
++      isexe: 2.0.0
++    dev: true
++
++  /why-is-node-running@2.2.2:
++    resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}
++    engines: {node: '>=8'}
++    hasBin: true
++    dependencies:
++      siginfo: 2.0.0
++      stackback: 0.0.2
++    dev: true
++
++  /wrappy@1.0.2:
++    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
++    dev: true
++
++  /yallist@4.0.0:
++    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
++    dev: true
++
++  /yaml@1.10.2:
++    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
++    engines: {node: '>= 6'}
++    dev: true
++
++  /yaml@2.4.2:
++    resolution: {integrity: sha512-B3VqDZ+JAg1nZpaEmWtTXUlBneoGx6CPM9b0TENK6aoSu5t73dItudwdgmi6tHlIZZId4dZ9skcAQ2UbcyAeVA==}
++    engines: {node: '>= 14'}
++    hasBin: true
++    dev: true
++
++  /yocto-queue@0.1.0:
++    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
++    engines: {node: '>=10'}
++    dev: true
++
++  /yocto-queue@1.0.0:
++    resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
++    engines: {node: '>=12.20'}
++    dev: true
++
++  github.com/tauri-apps/tauri-plugin-log/db7255ca2e07fc4d3e6cc5d93f9ccfceacb28901:
++    resolution: {tarball: https://codeload.github.com/tauri-apps/tauri-plugin-log/tar.gz/db7255ca2e07fc4d3e6cc5d93f9ccfceacb28901}
++    name: tauri-plugin-log-api
++    version: 0.0.0
++    dependencies:
++      '@tauri-apps/api': 1.5.3
++    dev: true
++
++  github.com/tauri-apps/tauri-plugin-store/02243686d0507d2aeeb2924cd889dd0bcb47ecef:
++    resolution: {tarball: https://codeload.github.com/tauri-apps/tauri-plugin-store/tar.gz/02243686d0507d2aeeb2924cd889dd0bcb47ecef}
++    name: tauri-plugin-store-api
++    version: 0.0.0
++    dependencies:
++      '@tauri-apps/api': 1.5.3
++    dev: true
+`;

--- a/app/src/lib/testing/fixtures.ts
+++ b/app/src/lib/testing/fixtures.ts
@@ -1,3 +1,4 @@
+import { pnpmLock } from './fileHunks';
 import type { User } from '$lib/stores/user';
 
 export type Constructor<T = any> = new (...args: any[]) => T;
@@ -94,6 +95,21 @@ export const remoteBranchData = {
 	isMergeable: true
 };
 
+export const fileHunk2 = {
+	binary: false,
+	changeType: 'added',
+	diff: pnpmLock,
+	end: 4696,
+	filePath: 'pnpm-lock.yaml',
+	hash: 'dc79c984a36b2f8a29007633bde4daf4',
+	id: '63-71',
+	locked: false,
+	lockedTo: null,
+	modifiedAt: 1714829527993,
+	oldStart: 0,
+	start: 0
+};
+
 export const fileHunk = {
 	binary: false,
 	changeType: 'modified',
@@ -129,12 +145,22 @@ export const file0 = {
 	path: 'package.json'
 };
 
+export const file1 = {
+	binary: false,
+	conflicted: false,
+	hunks: [fileHunk2],
+	id: 'pnpm-lock.yaml',
+	large: false,
+	modifiedAt: 1714829589111,
+	path: 'pnpm-lock.yaml'
+};
+
 export const virtualBranch = {
 	active: true,
 	baseCurrent: true,
 	commits: [],
 	conflicted: false,
-	files: [file0],
+	files: [file0, file1],
 	head: '90c225edcc74b31718a9cd8963c1bc89c17d8864',
 	id: '29cdc7a7-3462-4c14-a037-0a6cdad68da3',
 	name: 'Virtual branch',


### PR DESCRIPTION
- Fixes `Navigation.svelte` component in this local dev mode
- Adds a test diff for a huge file
- Can be run with the `test:e2e:run` npm script in `app/`
