### PR TITLE
if an oplog entry had an error, show it

### DIFF
--- a/app/src/lib/components/SnapshotCard.svelte
+++ b/app/src/lib/components/SnapshotCard.svelte
@@ -149,6 +149,7 @@
 	}
 
 	const isRestoreSnapshot = entry.details?.operation === 'RestoreFromSnapshot';
+	const error = entry.details?.trailers.find((t) => t.key === 'error')?.value;
 
 	const operation = mapOperation(entry.details);
 
@@ -258,10 +259,16 @@
 				</div>
 			</SnapshotAttachment>
 		{/if}
+		{#if error}
+			<span class="error-text">Error: {error}</span>
+		{/if}
 	</div>
 </div>
 
 <style lang="postcss">
+	.error-text {
+		color: #e53e3e;
+	}
 	/* SNAPSHOT CARD */
 	.snapshot-card {
 		position: relative;


### PR DESCRIPTION
looks something like this:
<img width="449" alt="image" src="https://github.com/gitbutlerapp/gitbutler/assets/4030927/0efc7127-bc30-4f7d-a752-97042e73b38c">
<img width="395" alt="image" src="https://github.com/gitbutlerapp/gitbutler/assets/4030927/11b6171c-eac2-454d-a8fb-af6a583470b5">
