### PR TITLE
Hide error div in toast when no error present

### DIFF
--- a/app/src/lib/components/InfoMessage.svelte
+++ b/app/src/lib/components/InfoMessage.svelte
@@ -16,6 +16,7 @@
 	export let primary: string | undefined = undefined;
 	export let secondary: string | undefined = undefined;
 	export let shadow = false;
+	export let error: string | undefined = undefined;
 
 	const SLOTS = $$props.$$slots;
 	const dispatch = createEventDispatcher<{ primary: void; secondary: void }>();
@@ -67,9 +68,9 @@
 			{/if}
 		</div>
 
-		{#if SLOTS.error}
+		{#if error}
 			<code class="info-message__error-block">
-				<slot name="error" />
+				{error}
 			</code>
 		{/if}
 

--- a/app/src/lib/notifications/ToastController.svelte
+++ b/app/src/lib/notifications/ToastController.svelte
@@ -17,6 +17,7 @@
 			<InfoMessage
 				style={toast.style ?? 'neutral'}
 				secondary="Dismiss"
+				error={toast.error}
 				on:secondary={() => dismissToast(toast.id)}
 				shadow
 			>
@@ -26,10 +27,6 @@
 
 				<svelte:fragment slot="content">
 					{@html marked.parse(toast.message ?? '', { renderer })}
-				</svelte:fragment>
-
-				<svelte:fragment slot="error">
-					{toast.error}
 				</svelte:fragment>
 			</InfoMessage>
 		</div>


### PR DESCRIPTION
Slots cannot be conditionally filled with an if statement, and there is no way to check if a slot has content. So.. feels like we can either switch between two `<InfoMessage>` components, or pass error as a prop. @PavelLaptev wdyt?