### PR TITLE
improve oplog snapshot creation performance

### DIFF
--- a/crates/gitbutler-core/src/ops/entry.rs
+++ b/crates/gitbutler-core/src/ops/entry.rs
@@ -176,7 +176,7 @@ impl fmt::Display for OperationKind {
 pub struct Version(u32);
 impl Default for Version {
     fn default() -> Self {
-        Version(1)
+        Version(2)
     }
 }
 

--- a/crates/gitbutler-core/src/ops/oplog.rs
+++ b/crates/gitbutler-core/src/ops/oplog.rs
@@ -528,20 +528,11 @@ impl Project {
         let repo = git2::Repository::init(worktree_dir)?;
 
         let commit = repo.find_commit(sha)?;
-        // Top tree
-        let tree = commit.tree()?;
-        let old_tree = commit.parent(0)?.tree()?;
 
-        let wd_tree_entry = tree
-            .get_name("workdir")
-            .context("failed to get workdir tree entry")?;
-        let old_wd_tree_entry = old_tree
-            .get_name("workdir")
-            .context("failed to get old workdir tree entry")?;
-
-        // workdir tree
-        let wd_tree = repo.find_tree(wd_tree_entry.id())?;
-        let old_wd_tree = repo.find_tree(old_wd_tree_entry.id())?;
+        let wd_tree_id = tree_from_applied_vbranches(&repo, commit.id())?;
+        let wd_tree = repo.find_tree(wd_tree_id)?;
+        let old_wd_tree_id = tree_from_applied_vbranches(&repo, commit.parent(0)?.id())?;
+        let old_wd_tree = repo.find_tree(old_wd_tree_id)?;
 
         // Exclude files that are larger than the limit (eg. database.sql which may never be intended to be committed)
         let files_to_exclude =

--- a/crates/gitbutler-core/src/virtual_branches/mod.rs
+++ b/crates/gitbutler-core/src/virtual_branches/mod.rs
@@ -23,4 +23,5 @@ mod remote;
 pub use remote::*;
 
 mod state;
+pub use state::VirtualBranches as VirtualBranchesState;
 pub use state::VirtualBranchesHandle;

--- a/crates/gitbutler-core/tests/ops/entry.rs
+++ b/crates/gitbutler-core/tests/ops/entry.rs
@@ -33,10 +33,18 @@ mod version {
 
     #[test]
     fn from_trailer() {
-        let s = "Version: 1";
+        let s = "Version: 2";
         let trailer = Trailer::from_str(s).unwrap();
         let version = Version::from_str(&trailer.value).unwrap();
         assert_eq!(version, Version::default());
+    }
+
+    #[test]
+    fn non_default() {
+        let s = "Version: 1";
+        let trailer = Trailer::from_str(s).unwrap();
+        let version = Version::from_str(&trailer.value).unwrap();
+        assert_eq!(version, Version::from_str("1").unwrap());
     }
 
     #[test]
@@ -62,7 +70,7 @@ mod operation_kind {
 
     #[test]
     fn unknown() {
-        let commit_message = "Create a new snapshot\n\nBody text 1\nBody text2\n\nBody text 3\n\nVersion: 1\nOperation: Asdf\nFoo: Bar\n";
+        let commit_message = "Create a new snapshot\n\nBody text 1\nBody text2\n\nBody text 3\n\nVersion: 2\nOperation: Asdf\nFoo: Bar\n";
         let details = SnapshotDetails::from_str(commit_message).unwrap();
         assert_eq!(details.version, Version::default());
         assert_eq!(details.operation, OperationKind::Unknown);
@@ -90,7 +98,7 @@ mod snapshot_details {
     fn new() {
         let commit_sha = git2::Oid::zero();
         let commit_message =
-            "Create a new snapshot\n\nBody text 1\nBody text2\n\nBody text 3\n\nVersion: 1\nOperation: CreateCommit\nFoo: Bar\n".to_string();
+            "Create a new snapshot\n\nBody text 1\nBody text2\n\nBody text 3\n\nVersion: 2\nOperation: CreateCommit\nFoo: Bar\n".to_string();
         let timezone_offset_does_not_matter = 1234;
         let created_at = git2::Time::new(1234567890, timezone_offset_does_not_matter);
         let details = SnapshotDetails::from_str(&commit_message.clone()).unwrap();


### PR DESCRIPTION
We learned that the tree creation that happens during oplog entry creation can be slow on repos with large indexes/many files:
<img width="1085" alt="image" src="https://github.com/gitbutlerapp/gitbutler/assets/4030927/39bb38ad-7dbf-401e-8c55-09b3d40d7610">
In general, GitButler performance takes a hit on repos with large indexes due to the aggressive tree writing (something for us to address). 

In this PR, i am removing the "workdir" subtree of the snapshot because that can be created on demand if/when needed.

One downside of this implementation is the fact that computing the workdir tree on the fly means potentially doing extra work when listing / getting the diff of a snapshot. There is a small cache outside the "list snapshots" loop, but that is not available between different invocations.