### PR TITLE
Fix empty commit marked as integrated

### DIFF
--- a/crates/gitbutler-core/src/virtual_branches/virtual.rs
+++ b/crates/gitbutler-core/src/virtual_branches/virtual.rs
@@ -2504,6 +2504,11 @@ fn is_commit_integrated(
         return Ok(true);
     }
 
+    // if it's an empty commit we can't base integration status on merge trees.
+    if commit.parent_count() == 1 && commit.parent(0)?.tree_id() == commit.tree_id() {
+        return Ok(false);
+    }
+
     // try to merge our tree into the upstream tree
     let mut merge_index = project_repository
         .repo()


### PR DESCRIPTION
- we can't say an empty commit is integrated based on tree ids