### PR TITLE
Handle loading and disable states for large projects

### DIFF
--- a/app/src/lib/components/Button.svelte
+++ b/app/src/lib/components/Button.svelte
@@ -73,11 +73,11 @@
 		</span>
 	{/if}
 
-	{#if icon}
+	{#if icon || loading}
 		<div class="btn-icon">
 			{#if loading}
 				<Icon name="spinner" />
-			{:else}
+			{:else if icon}
 				<Icon name={icon} />
 			{/if}
 		</div>

--- a/app/src/lib/components/Button.svelte
+++ b/app/src/lib/components/Button.svelte
@@ -76,7 +76,7 @@
 	{#if icon || loading}
 		<div class="btn-icon">
 			{#if loading}
-				<Icon name="spinner" />
+				<Icon name="spinner" spinnerRadius={4.5} />
 			{:else if icon}
 				<Icon name={icon} />
 			{/if}

--- a/app/src/lib/components/KeysForm.svelte
+++ b/app/src/lib/components/KeysForm.svelte
@@ -26,6 +26,7 @@
 	export let remoteName = '';
 	export let branchName = '';
 	export let showProjectName = false;
+	export let disabled = false;
 
 	let sshKey = '';
 	let credentialCheck: CredentialCheck;
@@ -85,7 +86,12 @@
 		provider.
 	</svelte:fragment>
 
-	<form class="git-radio" bind:this={form} on:change={(e) => onFormChange(e.currentTarget)}>
+	<form
+		class="git-radio"
+		class:disabled
+		bind:this={form}
+		on:change={(e) => onFormChange(e.currentTarget)}
+	>
 		<SectionCard roundedBottom={false} orientation="row" labelFor="git-executable">
 			<svelte:fragment slot="title"
 				>Use a Git executable <span style="color: var(--clr-text-2)">(default)</span
@@ -233,5 +239,10 @@
 	.git-radio {
 		display: flex;
 		flex-direction: column;
+
+		&.disabled {
+			pointer-events: none;
+			opacity: 0.5;
+		}
 	}
 </style>

--- a/app/src/lib/components/ProjectSetup.svelte
+++ b/app/src/lib/components/ProjectSetup.svelte
@@ -41,9 +41,11 @@
 <DecorativeSplitView img={newProjectSvg}>
 	{#if selectedBranch[0] !== '' && $platformName !== 'win32'}
 		{@const [remoteName, branchName] = selectedBranch[0].split(/\/(.*)/s)}
-		<KeysForm {remoteName} {branchName} />
+		<KeysForm {remoteName} {branchName} disabled={loading} />
 		<div class="actions">
-			<Button style="ghost" outline on:mousedown={() => (selectedBranch[0] = '')}>Back</Button>
+			<Button style="ghost" outline disabled={loading} on:mousedown={() => (selectedBranch[0] = '')}
+				>Back</Button
+			>
 			<Button style="pop" kind="solid" {loading} on:click={setTarget}>Let's go!</Button>
 		</div>
 	{:else}


### PR DESCRIPTION
Partially solving issue this https://github.com/gitbutlerapp/gitbutler/issues/2916

### Changes:
- Project setup: disable actions while waiting for response
- Show "loading" icon for a button even if it doesn't have the "icon" prop.
- Made the "spinner" icon smaller for the button

![image](https://github.com/gitbutlerapp/gitbutler/assets/18498712/cb480d5f-536c-47a1-8d2a-ab4dd6e06202)
