### PR TITLE
Button styles updated

### DIFF
--- a/app/src/lib/components/BranchHeader.svelte
+++ b/app/src/lib/components/BranchHeader.svelte
@@ -127,7 +127,7 @@
 						isLaneCollapsed={$isLaneCollapsed}
 					/>
 					{#if branch.selectedForChanges}
-						<Button size="tag" clickable={false} style="pop" kind="solid" icon="target"
+						<Button style="pop" kind="soft" size="tag" clickable={false} icon="target"
 							>Default branch</Button
 						>
 					{/if}
@@ -186,7 +186,7 @@
 						{#if branch.selectedForChanges}
 							<Button
 								style="pop"
-								kind="solid"
+								kind="soft"
 								help="New changes will land here"
 								icon="target"
 								clickable={false}

--- a/app/src/lib/components/CommitDialog.svelte
+++ b/app/src/lib/components/CommitDialog.svelte
@@ -65,8 +65,9 @@
 			</Button>
 		{/if}
 		<Button
-			style="neutral"
+			style={$expanded ? 'neutral' : 'ghost'}
 			kind="solid"
+			outline={!$expanded}
 			grow
 			loading={isCommitting}
 			disabled={(isCommitting || !commitMessageValid || $selectedOwnership.isEmpty()) && $expanded}

--- a/app/src/lib/components/PushButton.svelte
+++ b/app/src/lib/components/PushButton.svelte
@@ -45,7 +45,7 @@
 
 <DropDownButton
 	style="pop"
-	kind="soft"
+	kind="solid"
 	loading={isLoading}
 	bind:this={dropDown}
 	{wide}


### PR DESCRIPTION
Some buttons had incorrect priorities due to their colors. For example, the 'Default' branch was too bright, and the 'Push' button looked like it was disabled.

![image](https://github.com/gitbutlerapp/gitbutler/assets/18498712/d982dd34-2b38-4b2c-bda2-5512f386a711)
