### PR TITLE
Select component: Minor filtering fix

### DIFF
--- a/app/src/lib/components/Select.svelte
+++ b/app/src/lib/components/Select.svelte
@@ -64,7 +64,7 @@
 		if (value && value[itemId] === item[itemId]) return closeList();
 		selectedItemId = item[itemId];
 		dispatch('select', { value });
-		listOpen = false;
+		closeList();
 	}
 	function setMaxHeight() {
 		if (maxHeight) return;


### PR DESCRIPTION
Filtering and then selecting with the cursor would not reset the filter. Trying to filter the list after that would only append to the remaining filter string content. This is now fixed by always reseting the filter text