### PR TITLE
Show branch filters even if branch count is 0

### DIFF
--- a/app/src/lib/components/Branches.svelte
+++ b/app/src/lib/components/Branches.svelte
@@ -110,7 +110,6 @@
 
 <div class="branch-list">
 	<BranchesHeader
-		totalBranchCount={$branches$.length}
 		filteredBranchCount={$filteredBranches$?.length}
 		filtersActive={$filtersActive}
 	>

--- a/app/src/lib/components/BranchesHeader.svelte
+++ b/app/src/lib/components/BranchesHeader.svelte
@@ -31,24 +31,22 @@
 			<Badge count={filteredBranchCount} />
 		{/if}
 	</div>
-	{#if totalBranchCount > 0}
-		<div class="header__filter-btn" bind:this={filterButton}>
-			<Button
-				style="ghost"
-				outline
-				icon={filtersActive ? 'filter-applied-small' : 'filter-small'}
-				on:mousedown={onFilterClick}
-			>
-				Filter
-			</Button>
-			<div
-				class="filter-popup-menu"
-				use:clickOutside={{ trigger: filterButton, handler: () => (visible = false) }}
-			>
-				{@render contextMenu({ visible })}
-			</div>
+	<div class="header__filter-btn" bind:this={filterButton}>
+		<Button
+			style="ghost"
+			outline
+			icon={filtersActive ? 'filter-applied-small' : 'filter-small'}
+			on:mousedown={onFilterClick}
+		>
+			Filter
+		</Button>
+		<div
+			class="filter-popup-menu"
+			use:clickOutside={{ trigger: filterButton, handler: () => (visible = false) }}
+		>
+			{@render contextMenu({ visible })}
 		</div>
-	{/if}
+	</div>
 </div>
 
 <style lang="postcss">

--- a/app/src/lib/components/BranchesHeader.svelte
+++ b/app/src/lib/components/BranchesHeader.svelte
@@ -6,12 +6,11 @@
 
 	interface Props {
 		filteredBranchCount?: number;
-		totalBranchCount: number;
 		filtersActive: boolean;
 		contextMenu: Snippet<[{ visible: boolean }]>;
 	}
 
-	const { filteredBranchCount, totalBranchCount, filtersActive, contextMenu }: Props = $props();
+	const { filteredBranchCount, filtersActive, contextMenu }: Props = $props();
 
 	let visible = $state(false);
 	let filterButton = $state<HTMLDivElement>();


### PR DESCRIPTION
There is an issue when unchecking all the branch filters where if the branch count is 0, the filters are removed. This removes that check and opts to always show the filters.

Related issue: https://github.com/gitbutlerapp/gitbutler/issues/4106

