### PR TITLE
Fix: Wrong throttling in Select components

### DIFF
--- a/app/src/lib/components/Select.svelte
+++ b/app/src/lib/components/Select.svelte
@@ -42,7 +42,7 @@
 	let filterText: string | undefined = undefined;
 	let filteredItems: Selectable[] = items;
 
-	function filterItems(items: Selectable[], filterText: string | undefined) {
+	const filterItems = throttle((items: Selectable[], filterText: string | undefined) => {
 		if (!filterText) {
 			return items;
 		}
@@ -52,7 +52,7 @@
 			if (!isStr(property)) return false;
 			return property.includes(filterText);
 		});
-	}
+	}, INPUT_THROTTLE_TIME);
 
 	$: filteredItems = filterItems(items, filterText);
 
@@ -111,13 +111,13 @@
 		}
 	}
 
-	const handleChar = throttle((char: string) => {
+	function handleChar(char: string) {
 		highlightIndex = undefined;
 		filterText ??= '';
 		filterText += char;
-	}, INPUT_THROTTLE_TIME);
+	}
 
-	const handleDelete = throttle(() => {
+	function handleDelete() {
 		if (filterText === undefined) return;
 
 		if (filterText.length === 1) {
@@ -126,7 +126,7 @@
 		}
 
 		filterText = filterText.slice(0, -1);
-	}, INPUT_THROTTLE_TIME);
+	}
 
 	function handleKeyDown(e: CustomEvent<KeyboardEvent>) {
 		if (!listOpen) {


### PR DESCRIPTION
## ☕️ Reasoning

In our `Select` component, we need to throttle the actions performed on the user input in order to prevent unneeded filtering. While filtering is usually pretty fast, it can lead to performance issues in huge repositories. 

However, previously, we throttled _all_ actions performed after the user performed some input (including storing the actual input). This lead to lost characters if the user typed fast, thus triggering the throttle. This PR changes is behaviour, moving the throttling to only the filtering process, leaving everything else unthrottled.

## 🧢 Changes

- Moved throttling from input handling to filtering