### PR TITLE
fix: adjust permissions of labeller workflow

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   prs:
     name: Triage
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v4


### PR DESCRIPTION
## ☕️ Reasoning

In order for the labeller workflow to set and adjust labels of PRs in forks, it needs to things: 

- the `pull_request_target` event trigger
- requested permissions for `contents` (read) and `pull-requests` (write)

This PR adds the latter one (since the first one is already present).

## 🧢 Changes

- add permission requests to labeller workflow
