### PR TITLE
feat: Trunk search

### DIFF
--- a/app/src/routes/[projectId]/base/+page.svelte
+++ b/app/src/routes/[projectId]/base/+page.svelte
@@ -5,6 +5,7 @@
 	import FullviewLoading from '$lib/components/FullviewLoading.svelte';
 	import Resizer from '$lib/components/Resizer.svelte';
 	import ScrollableContainer from '$lib/components/ScrollableContainer.svelte';
+	import TextBox from '$lib/components/TextBox.svelte';
 	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import { getContext, getContextStoreBySymbol } from '$lib/utils/context';
 	import { BaseBranchService } from '$lib/vbranches/baseBranch';
@@ -28,6 +29,7 @@
 
 	let rsViewport: HTMLDivElement;
 	let laneWidth: number;
+	let searchQuery: string | undefined = undefined;
 
 	$: error$ = baseBranchService.error$;
 
@@ -41,46 +43,61 @@
 {:else if !$baseBranch}
 	<FullviewLoading />
 {:else}
-	<div class="base">
-		<div
-			class="base__left"
-			bind:this={rsViewport}
-			style:width={`${laneWidth || defaultBranchWidthRem}rem`}
-		>
-			<ScrollableContainer>
-				<div class="card">
-					<BaseBranch base={$baseBranch} />
-				</div>
-			</ScrollableContainer>
-			<Resizer
-				viewport={rsViewport}
-				direction="right"
-				minWidth={320}
-				on:width={(e) => {
-					laneWidth = e.detail / (16 * $userSettings.zoom);
-					lscache.set(laneWidthKey, laneWidth, 7 * 1440); // 7 day ttl
-				}}
-			/>
+	<div class="container">
+		<div class="search">
+			<TextBox icon="search" placeholder="Search" bind:value={searchQuery} />
 		</div>
-		<div class="base__right">
-			{#await $selectedFile then selected}
-				{#if selected}
-					<FileCard
-						conflicted={selected.conflicted}
-						file={selected}
-						isUnapplied={false}
-						readonly={true}
-						on:close={() => {
-							fileIdSelection.clear();
-						}}
-					/>
-				{/if}
-			{/await}
+		<div class="base">
+			<div
+				class="base__left"
+				bind:this={rsViewport}
+				style:width={`${laneWidth || defaultBranchWidthRem}rem`}
+			>
+				<ScrollableContainer wide>
+					<div class="card">
+						<BaseBranch base={$baseBranch} {searchQuery} />
+					</div>
+				</ScrollableContainer>
+				<Resizer
+					viewport={rsViewport}
+					direction="right"
+					minWidth={320}
+					on:width={(e) => {
+						laneWidth = e.detail / (16 * $userSettings.zoom);
+						lscache.set(laneWidthKey, laneWidth, 7 * 1440); // 7 day ttl
+					}}
+				/>
+			</div>
+			<div class="base__right">
+				{#await $selectedFile then selected}
+					{#if selected}
+						<FileCard
+							conflicted={selected.conflicted}
+							file={selected}
+							isUnapplied={false}
+							readonly={true}
+							on:close={() => {
+								fileIdSelection.clear();
+							}}
+						/>
+					{/if}
+				{/await}
+			</div>
 		</div>
 	</div>
 {/if}
 
 <style lang="postcss">
+	.container {
+		display: flex;
+		flex-direction: column;
+		flex-grow: 1;
+		overflow: hidden;
+	}
+
+	.search {
+		padding: 12px;
+	}
 	.base {
 		display: flex;
 		flex-grow: 1;
@@ -101,6 +118,7 @@
 		width: 800px;
 	}
 	.card {
+		width: auto;
 		margin: 12px 6px 12px 12px;
 		padding: 16px;
 	}


### PR DESCRIPTION
Naive search of the trunk branch by commit message.

## ☕️ Reasoning
Was thinking that there is still some areas of opportunity wrt git-archeology 🤠 and thought the best place to start would be to have a nice and simple commit search bar.

This is a very simple filter-by-commit-message contents.
But down-the-line we could start adding a way of filtering by remote/local, author, files, etc.
All that is a bit more design-heavy and so probably requires a bit more of a thorough conversation about it.

In any case, I think this already bring some value to the archeology side of GitButler.

## 🧢 Changes
- Add a search bar at the top of the trunk page, that receives the filter string
- How the resizing of the lanes behave (not sure if that's what is wanted)

## GIFS 👾

This is how searching works. Searching does not close the file viewer (that's by design but I can change it).
Also, the button to merge into common base disappears on search.
And there is an empty state with the message *"No commits found that match the current search"*
![naive-trunk-search](https://github.com/gitbutlerapp/gitbutler/assets/35891811/5e69002a-6d5c-4dd8-bd75-e16e4121d869)


The second change mentioned is there so that the commit lane doesn't resize when being filtered, but also I'd say that's a bit more how I'd expect it to work, even without the filtering mechanism. Happy to change that if you think otherwise.

How it was before (you can't even resize it without first opening the file viewer I think):
![resizing-now](https://github.com/gitbutlerapp/gitbutler/assets/35891811/91caa3ec-59f4-4d35-82bb-7abeb774d6a8)

How it is implemented in this change:
![resize-change](https://github.com/gitbutlerapp/gitbutler/assets/35891811/57a44672-6978-4f8d-a042-dc0225102bd2)


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
