### PR TITLE
fix(ui): GitHubService correct split of remoteUrl in case of alias

### DIFF
--- a/app/src/lib/github/service.ts
+++ b/app/src/lib/github/service.ts
@@ -78,7 +78,7 @@ export class GitHubService {
 						baseUrl: 'https://api.github.com'
 					});
 					if (remoteUrl) {
-						const [owner, repo] = remoteUrl.split('.git')[0].split(/\/|:/).slice(-2);
+						const [owner, repo] = remoteUrl.split(/.git$/)[0].split(/\/|:/).slice(-2);
 						this._repo = repo;
 						this._owner = owner;
 					}


### PR DESCRIPTION
## ☕️ Reasoning

If you use a github aliases using SSH to use different SSH keys it's common to just prefix address like `git@arilas.github.com:Arilas/my-repo.git`. But GitButler is incorrectly parse this string, because it's splitting url by `.git`

## 🧢 Changes

Split remoteUrl by last `.git` not the first

## 🎫 Affected issues

Fixes: #4132


With this changes GitHub integration is working for me:

![image](https://github.com/gitbutlerapp/gitbutler/assets/3540524/1ddaae9d-a2af-4dd1-812b-bd067cca6f30)
