### PR TITLE
Persist FileListItem checkbox detail

### DIFF
--- a/app/src/lib/components/FileListItem.svelte
+++ b/app/src/lib/components/FileListItem.svelte
@@ -30,9 +30,10 @@
 
 	let checked = false;
 	let draggableElt: HTMLDivElement;
+	let lastCheckboxDetail = true;
 
 	$: if (file && $selectedOwnership) {
-		checked = file.hunks.every((hunk) => $selectedOwnership?.contains(file.id, hunk.id));
+		checked = file.hunks.every((hunk) => $selectedOwnership?.contains(file.id, hunk.id)) && lastCheckboxDetail;
 	}
 
 	$: if ($fileIdSelection && draggableElt)
@@ -120,6 +121,7 @@
 			{checked}
 			on:change={(e) => {
 				const isChecked = e.detail;
+				lastCheckboxDetail = isChecked;
 				selectedOwnership?.update((ownership) => {
 					if (isChecked) {
 						file.hunks.forEach((h) => ownership.add(file.id, h));

--- a/app/src/lib/components/FileListItem.svelte
+++ b/app/src/lib/components/FileListItem.svelte
@@ -32,8 +32,17 @@
 	let draggableElt: HTMLDivElement;
 	let lastCheckboxDetail = true;
 
+	$: if (!lastCheckboxDetail) {
+		selectedOwnership?.update((ownership) => {
+			file.hunks.forEach((h) => ownership.remove(file.id, h.id));
+			return ownership;
+		});
+	}
+
 	$: if (file && $selectedOwnership) {
-		checked = file.hunks.every((hunk) => $selectedOwnership?.contains(file.id, hunk.id)) && lastCheckboxDetail;
+		checked =
+			file.hunks.every((hunk) => $selectedOwnership?.contains(file.id, hunk.id)) &&
+			lastCheckboxDetail;
 	}
 
 	$: if ($fileIdSelection && draggableElt)


### PR DESCRIPTION
## ☕️ Reasoning

There are multiple lanes on the board and I tend to work on the left-most one hosting a lot of changed files. Eventually I would like to make a commit but maybe only 1/3rd of the files in my file list are relevant so I: "start commit", unselect the other 2/3rds and notice there's actually a file or two in a lane to the right I would also like to include in this WIP commit BUT on file 'drop' the entire file list was reselected and added to `selectedOwnership`, which is very annoying to deal with.

## 🧢 Changes

Changes are all in the FileListItem component it tracks the last state of the checkbox detail and attempts to make sure to exclude the file from the `selectedOwnership` set to keep it coherent.
