### PR TITLE
Use `gitoxide` to more reliably find the Git executable on Windows. (#1419)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2166,6 +2166,7 @@ name = "gitbutler-git"
 version = "0.0.0"
 dependencies = [
  "futures",
+ "gix-path",
  "nix 0.29.0",
  "rand 0.8.5",
  "serde",
@@ -2692,9 +2693,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23623cf0f475691a6d943f898c4d0b89f5c1a2a64d0f92bce0e0322ee6528783"
+checksum = "ca987128ffb056d732bd545db5db3d8b103d252fbf083c2567bb0796876619a4"
 dependencies = [
  "bstr",
  "gix-trace",

--- a/crates/gitbutler-git/Cargo.toml
+++ b/crates/gitbutler-git/Cargo.toml
@@ -39,6 +39,7 @@ uuid = { workspace = true, features = ["v4", "fast-rng"] }
 rand = "0.8.5"
 futures = "0.3.30"
 sysinfo = "0.30.12"
+gix-path = "0.10.7"
 
 [target."cfg(unix)".dependencies]
 nix = { version = "0.29.0", features = ["process", "socket", "user"] }

--- a/crates/gitbutler-git/src/executor/tokio/mod.rs
+++ b/crates/gitbutler-git/src/executor/tokio/mod.rs
@@ -28,17 +28,7 @@ unsafe impl super::GitExecutor for TokioExecutor {
         cwd: P,
         envs: Option<HashMap<String, String>>,
     ) -> Result<(usize, String, String), Self::Error> {
-        let git_exe = {
-            #[cfg(unix)]
-            {
-                "git"
-            }
-            #[cfg(windows)]
-            {
-                "git.exe"
-            }
-        };
-
+        let git_exe = gix_path::env::exe_invocation();
         let mut cmd = Command::new(git_exe);
 
         // Output the command being executed to stderr, for debugging purposes
@@ -56,7 +46,7 @@ unsafe impl super::GitExecutor for TokioExecutor {
                 .map(|s| format!("{s:?}"))
                 .collect::<Vec<_>>()
                 .join(" ");
-            eprintln!("env {envs_str} {git_exe} {args_str}");
+            eprintln!("env {envs_str} {git_exe:?} {args_str}");
         }
 
         cmd.kill_on_drop(true);


### PR DESCRIPTION
Previously, Windows installations that didn't put git.exe into their PATH
were unable to have their executable found.

`gitoxide` has the same problem to solve and can now 'find harder' in
known installation locations.

This capability is now used here, instead of hard-coding `git.exe` or `git`.

### Tasks

* [x] validate it works on Windows without Git in path


Fixes #4142 