### PR TITLE
Add an 'allow rebasing' toggle on per-branch basis

### DIFF
--- a/app/src/lib/branch/BranchLanePopupMenu.svelte
+++ b/app/src/lib/branch/BranchLanePopupMenu.svelte
@@ -106,7 +106,13 @@
 			/>
 
 			<ContextMenuItem label="Allow rebasing" on:click={toggleAllowRebasing}>
-				<Toggle small slot="control" bind:checked={allowRebasing} on:click={toggleAllowRebasing} />
+				<Toggle
+					small
+					slot="control"
+					bind:checked={allowRebasing}
+					on:click={toggleAllowRebasing}
+					help="Having this enabled permits commit amending and reordering after a branch has been pushed, which would subsequently require force pushing"
+				/>
 			</ContextMenuItem>
 		</ContextMenuSection>
 		<ContextMenuSection>

--- a/app/src/lib/branch/BranchLanePopupMenu.svelte
+++ b/app/src/lib/branch/BranchLanePopupMenu.svelte
@@ -8,6 +8,7 @@
 	import Button from '$lib/shared/Button.svelte';
 	import Modal from '$lib/shared/Modal.svelte';
 	import TextBox from '$lib/shared/TextBox.svelte';
+	import Toggle from '$lib/shared/Toggle.svelte';
 	import { User } from '$lib/stores/user';
 	import { normalizeBranchName } from '$lib/utils/branch';
 	import { getContext, getContextStore } from '$lib/utils/context';
@@ -37,6 +38,11 @@
 	$: branch = $branchStore;
 	$: commits = branch.commits;
 	$: setAIConfigurationValid($user);
+	$: allowRebasing = branch.allowRebasing;
+
+	async function toggleAllowRebasing() {
+		branchController.updateBranchAllowRebasing(branch.id, !allowRebasing);
+	}
 
 	async function setAIConfigurationValid(user: User | undefined) {
 		aiConfigurationValid = await aiService.validateConfiguration(user?.access_token);
@@ -98,6 +104,10 @@
 					branch.files?.length === 0 ||
 					!branch.active}
 			/>
+
+			<ContextMenuItem label="Allow rebasing" on:click={toggleAllowRebasing}>
+				<Toggle small slot="control" bind:checked={allowRebasing} on:click={toggleAllowRebasing} />
+			</ContextMenuItem>
 		</ContextMenuSection>
 		<ContextMenuSection>
 			<ContextMenuItem

--- a/app/src/lib/vbranches/branchController.ts
+++ b/app/src/lib/vbranches/branchController.ts
@@ -107,6 +107,17 @@ export class BranchController {
 		}
 	}
 
+	async updateBranchAllowRebasing(branchId: string, allowRebasing: boolean) {
+		try {
+			await invoke<void>('update_virtual_branch', {
+				projectId: this.projectId,
+				branch: { id: branchId, allow_rebasing: allowRebasing }
+			});
+		} catch (err) {
+			showError('Failed to update branch allow rebasing', err);
+		}
+	}
+
 	async updateBranchNotes(branchId: string, notes: string) {
 		try {
 			await invoke<void>('update_virtual_branch', {

--- a/app/src/lib/vbranches/types.ts
+++ b/app/src/lib/vbranches/types.ts
@@ -130,6 +130,7 @@ export class Branch {
 	mergeBase!: string;
 	/// The fork point between the target branch and the virtual branch
 	forkPoint!: string;
+	allowRebasing!: boolean;
 
 	get localCommits() {
 		return this.commits.filter((c) => c.status === 'local');

--- a/crates/gitbutler-core/src/virtual_branches/base.rs
+++ b/crates/gitbutler-core/src/virtual_branches/base.rs
@@ -255,7 +255,7 @@ pub fn set_base_branch(
                 ownership,
                 order: 0,
                 selected_for_changes: None,
-                allow_rebasing: true,
+                allow_rebasing: project_repository.project().ok_with_force_push.into(),
             };
 
             vb_state.set_branch(branch)?;
@@ -472,7 +472,7 @@ pub fn update_base_branch(
                             branch.id
                         ))?;
 
-                    let ok_with_force_push = project_repository.project().ok_with_force_push;
+                    let ok_with_force_push = branch.allow_rebasing;
 
                     let result_merge =
                         |mut branch: branch::Branch| -> Result<Option<branch::Branch>> {

--- a/crates/gitbutler-core/src/virtual_branches/base.rs
+++ b/crates/gitbutler-core/src/virtual_branches/base.rs
@@ -255,6 +255,7 @@ pub fn set_base_branch(
                 ownership,
                 order: 0,
                 selected_for_changes: None,
+                allow_rebasing: true,
             };
 
             vb_state.set_branch(branch)?;

--- a/crates/gitbutler-core/src/virtual_branches/branch/mod.rs
+++ b/crates/gitbutler-core/src/virtual_branches/branch/mod.rs
@@ -48,6 +48,12 @@ pub struct Branch {
     // is Some(timestamp), the branch is considered a default destination for new changes.
     // if more than one branch is selected, the branch with the highest timestamp wins.
     pub selected_for_changes: Option<i64>,
+    #[serde(default = "default_true")]
+    pub allow_rebasing: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 fn serialize_u128<S>(x: &u128, s: S) -> Result<S::Ok, S::Error>

--- a/crates/gitbutler-core/src/virtual_branches/branch/mod.rs
+++ b/crates/gitbutler-core/src/virtual_branches/branch/mod.rs
@@ -87,6 +87,7 @@ pub struct BranchUpdateRequest {
     pub order: Option<usize>,
     pub upstream: Option<String>, // just the branch name, so not refs/remotes/origin/branchA, just branchA
     pub selected_for_changes: Option<bool>,
+    pub allow_rebasing: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]

--- a/crates/gitbutler-core/src/virtual_branches/virtual.rs
+++ b/crates/gitbutler-core/src/virtual_branches/virtual.rs
@@ -1059,6 +1059,7 @@ pub fn create_virtual_branch(
         ownership: BranchOwnershipClaims::default(),
         order,
         selected_for_changes,
+        allow_rebasing: true,
     };
 
     if let Some(ownership) = &create.ownership {
@@ -3903,6 +3904,7 @@ pub fn create_virtual_branch_from_branch(
         ownership,
         order,
         selected_for_changes,
+        allow_rebasing: true,
     };
 
     vb_state.set_branch(branch.clone())?;

--- a/crates/gitbutler-core/src/virtual_branches/virtual.rs
+++ b/crates/gitbutler-core/src/virtual_branches/virtual.rs
@@ -71,6 +71,7 @@ pub struct VirtualBranch {
     pub ownership: BranchOwnershipClaims,
     pub updated_at: u128,
     pub selected_for_changes: bool,
+    pub allow_rebasing: bool,
     #[serde(with = "crate::serde::oid")]
     pub head: git2::Oid,
     /// The merge base between the target branch and the virtual branch
@@ -850,6 +851,7 @@ pub fn list_virtual_branches(
             ownership: branch.ownership,
             updated_at: branch.updated_timestamp_ms,
             selected_for_changes: branch.selected_for_changes == Some(max_selected_for_changes),
+            allow_rebasing: branch.allow_rebasing,
             head: branch.head,
             merge_base,
             fork_point,

--- a/crates/gitbutler-core/tests/suite/virtual_branches/amend.rs
+++ b/crates/gitbutler-core/tests/suite/virtual_branches/amend.rs
@@ -13,7 +13,6 @@ async fn forcepush_allowed() {
     projects
         .update(&projects::UpdateRequest {
             id: *project_id,
-            ok_with_force_push: Some(false),
             ..Default::default()
         })
         .await
@@ -27,7 +26,6 @@ async fn forcepush_allowed() {
     projects
         .update(&projects::UpdateRequest {
             id: *project_id,
-            ok_with_force_push: Some(true),
             ..Default::default()
         })
         .await
@@ -80,7 +78,6 @@ async fn forcepush_forbidden() {
         repository,
         project_id,
         controller,
-        projects,
         ..
     } = &Test::default();
 
@@ -89,17 +86,20 @@ async fn forcepush_forbidden() {
         .await
         .unwrap();
 
-    projects
-        .update(&projects::UpdateRequest {
-            id: *project_id,
-            ok_with_force_push: Some(false),
-            ..Default::default()
-        })
+    let branch_id = controller
+        .create_virtual_branch(*project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
-    let branch_id = controller
-        .create_virtual_branch(*project_id, &branch::BranchCreateRequest::default())
+    controller
+        .update_virtual_branch(
+            *project_id,
+            branch::BranchUpdateRequest {
+                id: branch_id,
+                allow_rebasing: Some(false),
+                ..Default::default()
+            },
+        )
         .await
         .unwrap();
 

--- a/crates/gitbutler-core/tests/suite/virtual_branches/squash.rs
+++ b/crates/gitbutler-core/tests/suite/virtual_branches/squash.rs
@@ -165,7 +165,6 @@ async fn forcepush_allowed() {
     projects
         .update(&projects::UpdateRequest {
             id: *project_id,
-            ok_with_force_push: Some(true),
             ..Default::default()
         })
         .await
@@ -250,7 +249,6 @@ async fn forcepush_forbidden() {
         repository,
         project_id,
         controller,
-        projects,
         ..
     } = &Test::default();
 
@@ -264,6 +262,18 @@ async fn forcepush_forbidden() {
         .await
         .unwrap();
 
+    controller
+        .update_virtual_branch(
+            *project_id,
+            branch::BranchUpdateRequest {
+                id: branch_id,
+                allow_rebasing: Some(false),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
     {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
         controller
@@ -274,15 +284,6 @@ async fn forcepush_forbidden() {
 
     controller
         .push_virtual_branch(*project_id, branch_id, false, None)
-        .await
-        .unwrap();
-
-    projects
-        .update(&projects::UpdateRequest {
-            id: *project_id,
-            ok_with_force_push: Some(false),
-            ..Default::default()
-        })
         .await
         .unwrap();
 

--- a/crates/gitbutler-core/tests/suite/virtual_branches/update_base_branch.rs
+++ b/crates/gitbutler-core/tests/suite/virtual_branches/update_base_branch.rs
@@ -1204,7 +1204,6 @@ mod applied_branch {
             projects
                 .update(&projects::UpdateRequest {
                     id: *project_id,
-                    ok_with_force_push: Some(true),
                     ..Default::default()
                 })
                 .await
@@ -1267,7 +1266,6 @@ mod applied_branch {
                 repository,
                 project_id,
                 controller,
-                projects,
                 ..
             } = &Test::default();
 
@@ -1308,12 +1306,15 @@ mod applied_branch {
                 branch_id
             };
 
-            projects
-                .update(&projects::UpdateRequest {
-                    id: *project_id,
-                    ok_with_force_push: Some(false),
-                    ..Default::default()
-                })
+            controller
+                .update_virtual_branch(
+                    *project_id,
+                    branch::BranchUpdateRequest {
+                        id: branch_id,
+                        allow_rebasing: Some(false),
+                        ..Default::default()
+                    },
+                )
                 .await
                 .unwrap();
 
@@ -1656,7 +1657,6 @@ mod applied_branch {
         projects
             .update(&projects::UpdateRequest {
                 id: *project_id,
-                ok_with_force_push: Some(false),
                 ..Default::default()
             })
             .await

--- a/crates/gitbutler-core/tests/suite/virtual_branches/update_commit_message.rs
+++ b/crates/gitbutler-core/tests/suite/virtual_branches/update_commit_message.rs
@@ -171,7 +171,6 @@ async fn forcepush_allowed() {
     projects
         .update(&projects::UpdateRequest {
             id: *project_id,
-            ok_with_force_push: Some(true),
             ..Default::default()
         })
         .await
@@ -224,7 +223,6 @@ async fn forcepush_forbidden() {
         repository,
         project_id,
         controller,
-        projects,
         ..
     } = &Test::default();
 
@@ -233,17 +231,20 @@ async fn forcepush_forbidden() {
         .await
         .unwrap();
 
-    projects
-        .update(&projects::UpdateRequest {
-            id: *project_id,
-            ok_with_force_push: Some(false),
-            ..Default::default()
-        })
+    let branch_id = controller
+        .create_virtual_branch(*project_id, &branch::BranchCreateRequest::default())
         .await
         .unwrap();
 
-    let branch_id = controller
-        .create_virtual_branch(*project_id, &branch::BranchCreateRequest::default())
+    controller
+        .update_virtual_branch(
+            *project_id,
+            branch::BranchUpdateRequest {
+                id: branch_id,
+                allow_rebasing: Some(false),
+                ..Default::default()
+            },
+        )
         .await
         .unwrap();
 

--- a/crates/gitbutler-core/tests/virtual_branches/branch/ownership.rs
+++ b/crates/gitbutler-core/tests/virtual_branches/branch/ownership.rs
@@ -39,6 +39,7 @@ fn reconcile_ownership_simple() {
         updated_timestamp_ms: u128::default(),
         order: usize::default(),
         selected_for_changes: None,
+        allow_rebasing: true,
     };
     let branch_b = Branch {
         name: "b".to_string(),
@@ -64,6 +65,7 @@ fn reconcile_ownership_simple() {
         updated_timestamp_ms: u128::default(),
         order: usize::default(),
         selected_for_changes: None,
+        allow_rebasing: true,
     };
     let all_branches: Vec<Branch> = vec![branch_a.clone(), branch_b.clone()];
     let claim: Vec<OwnershipClaim> = vec![OwnershipClaim {

--- a/crates/gitbutler-core/tests/virtual_branches/iterator.rs
+++ b/crates/gitbutler-core/tests/virtual_branches/iterator.rs
@@ -42,6 +42,7 @@ fn new_test_branch() -> virtual_branches::branch::Branch {
         ownership: virtual_branches::branch::BranchOwnershipClaims::default(),
         order: TEST_INDEX.load(Ordering::Relaxed),
         selected_for_changes: Some(1),
+        allow_rebasing: true,
     }
 }
 


### PR DESCRIPTION
The app has a project/repo wide setting `allow force pushing`, which defaults to true. This config is responsible for the following:
- If the app should use a merge commit or perform a rebase for the branches when the workspace is being updated with new changes from master, after a branch has been pushed to a remote.
- If the app should use a merge commit or perform a rebase for a branch when the user clicks "Integrate upstream" (to add new commits locally from the remote upstream, i.e. when collaborating with someone else)
- If the app should allow amending / reordering of commits that have already been pushed

In the scenarios above, a subsequent push will need to be a "force push", which may be undesirable in some cases, hence the ability to disable that behavior with the `allow force pushing` config.

<img width="714" alt="Screenshot 2024-06-26 at 14 02 08" src="https://github.com/gitbutlerapp/gitbutler/assets/4030927/9de7bd5a-face-4e9f-af22-dc8adeef44ee">

This PR adds the ability to control this behavior on a per-branch basis. For example, if one branch is used for collaborating with another developer, it may be desirable to toggle this off for that specific branch only, while keeping it enabled for other branches (since rebasing offers more flexibility in the workflow).

This can be toggled with the "Allow rebasing" toggle on the branch lane. 

<img width="508" alt="Screenshot 2024-06-26 at 14 01 57" src="https://github.com/gitbutlerapp/gitbutler/assets/4030927/7a7e0583-effa-45eb-8486-3fe835c09bdb">

The default value will follow the value of the project/repo-wide `allow force pushing` (which is enabled by default).

