### PR TITLE
more robust login handling by deleting corrupt user.json file

### DIFF
--- a/crates/gitbutler-core/src/users/controller.rs
+++ b/crates/gitbutler-core/src/users/controller.rs
@@ -19,7 +19,13 @@ impl Controller {
     }
 
     pub fn get_user(&self) -> anyhow::Result<Option<User>> {
-        self.storage.get().context("failed to get user")
+        match self.storage.get().context("failed to get user") {
+            Ok(user) => Ok(user),
+            Err(err) => {
+                self.storage.delete().ok();
+                Err(err)
+            }
+        }
     }
 
     pub fn set_user(&self, user: &User) -> anyhow::Result<()> {


### PR DESCRIPTION
> [!NOTE]
> Related to #4165, and should be merged before it, followed by a release (if possible).

> [!NOTE]
> This PR is entirely optional.

If a user.json file cannot be loaded, delete it automatically to avoid users to get stuck in 'something went wrong' during layout.

Older versions of GB wouldn't find the access-token in the user.json file anymore, which would be completely removed via #4165.

### Tasks

* [x] improve compatibilty with `user.json`
* [ ] possibly improve compatibility with missing secrets in git configuration

### Review Notes

* This only has any effect if a release with this change is created before one that incorporates the linked PR.

