### PR TITLE
Fix `overflow` issue for the Generate msg dropdown

### DIFF
--- a/app/src/lib/commit/CommitMessageInput.svelte
+++ b/app/src/lib/commit/CommitMessageInput.svelte
@@ -222,7 +222,6 @@
 		padding: 0 0 48px;
 		flex-direction: column;
 		gap: 4px;
-		overflow: hidden;
 		animation: expand-box 0.2s ease forwards;
 		/* props to animate on mount */
 		max-height: 40px;


### PR DESCRIPTION
Before:
<img width="436" alt="image" src="https://github.com/gitbutlerapp/gitbutler/assets/18498712/f42e5de4-5e0f-4fb5-996a-35d9447f3892">

After:
<img width="419" alt="image" src="https://github.com/gitbutlerapp/gitbutler/assets/18498712/c2f1f879-580e-4274-9929-ba54811ba886">
