### PR TITLE
Show remote branch using name instead of sha

### DIFF
--- a/app/src/lib/branches/types.ts
+++ b/app/src/lib/branches/types.ts
@@ -31,7 +31,7 @@ export class CombinedBranch {
 	}
 
 	get displayName(): string {
-		return this.pr?.title || this.remoteBranch?.displayName || this.vbranch?.name || 'unknown';
+		return this.remoteBranch?.displayName || this.vbranch?.name || 'unknown';
 	}
 
 	get authors(): Author[] {

--- a/app/src/lib/components/RemoteBranchPreview.svelte
+++ b/app/src/lib/components/RemoteBranchPreview.svelte
@@ -54,12 +54,14 @@
 		<ScrollableContainer wide>
 			<div class="branch-preview">
 				<BranchPreviewHeader base={$baseBranch} {branch} {pr} />
-				{#if pr?.body}
+				{#if pr}
 					<div class="card">
-						<div class="card__header text-base-body-14 text-semibold">PR Description</div>
-						<div class="markdown card__content text-base-body-13">
-							{@html marked.parse(pr.body, { renderer })}
-						</div>
+						<div class="card__header text-base-body-14 text-semibold">{pr.title}</div>
+						{#if pr.body}
+							<div class="markdown card__content text-base-body-13">
+								{@html marked.parse(pr.body, { renderer })}
+							</div>
+						{/if}
 					</div>
 				{/if}
 				{#await getRemoteBranchData(project.id, branch.name) then branchData}

--- a/app/src/lib/navigation/BranchItem.svelte
+++ b/app/src/lib/navigation/BranchItem.svelte
@@ -11,7 +11,7 @@
 	function getBranchLink(b: CombinedBranch): string | undefined {
 		if (b.vbranch?.active) return `/${projectId}/board/`;
 		if (b.vbranch) return `/${projectId}/stashed/${b.vbranch.id}`;
-		if (b.remoteBranch) return `/${projectId}/remote/${branch?.remoteBranch?.sha}`;
+		if (b.remoteBranch) return `/${projectId}/remote/${branch?.displayName}`;
 		if (b.pr) return `/${projectId}/pull/${b.pr.number}`;
 	}
 

--- a/app/src/routes/[projectId]/remote/[...name]/+page.svelte
+++ b/app/src/routes/[projectId]/remote/[...name]/+page.svelte
@@ -16,7 +16,7 @@
 
 	$: ({ error, branches } = data.remoteBranchService);
 
-	$: branch = $branches?.find((b) => b.sha === $page.params.sha);
+	$: branch = $branches?.find((b) => b.displayName === $page.params.name);
 	$: pr = branch && githubService.getListedPr(branch.sha);
 </script>
 


### PR DESCRIPTION
- multiple branches can have the same sha