### PR TITLE
Do not allow `pxToRem` function get `undifined`

### DIFF
--- a/app/src/lib/shared/Scrollbar.svelte
+++ b/app/src/lib/shared/Scrollbar.svelte
@@ -34,10 +34,10 @@
 
 	$: vert = !horz;
 
-	$: paddingTop = pxToRem(padding.top) ?? '0px';
-	$: paddingBottom = pxToRem(padding.bottom) ?? '0px';
-	$: paddingRight = pxToRem(padding.right) ?? '0px';
-	$: paddingLeft = pxToRem(padding.left) ?? '0px';
+	$: paddingTop = pxToRem(padding.top ?? 0);
+	$: paddingBottom = pxToRem(padding.bottom ?? 0);
+	$: paddingRight = pxToRem(padding.right ?? 0);
+	$: paddingLeft = pxToRem(padding.left ?? 0);
 
 	$: wholeHeight = viewport?.scrollHeight ?? 0;
 	$: wholeWidth = viewport?.scrollWidth ?? 0;

--- a/app/src/lib/shared/TextBox.svelte
+++ b/app/src/lib/shared/TextBox.svelte
@@ -49,7 +49,7 @@
 	class="textbox"
 	bind:this={element}
 	class:wide
-	style:width={pxToRem(width)}
+	style:width={width ? pxToRem(width) : undefined}
 	class:wiggle={!isInputValid}
 >
 	{#if label}

--- a/app/src/lib/utils/pxToRem.ts
+++ b/app/src/lib/utils/pxToRem.ts
@@ -1,4 +1,3 @@
-export function pxToRem(px: number | undefined, base: number = 16) {
-	if (!px) return;
+export function pxToRem(px: number, base: number = 16) {
 	return `${px / base}rem`;
 }


### PR DESCRIPTION
To simplify the function and make its behavior more predictable for different cases.