### PR TITLE
refactor: Use normalizeBranchName in ActiveBranchStatus component for virtual branch names

### DIFF
--- a/app/src/lib/branch/ActiveBranchStatus.svelte
+++ b/app/src/lib/branch/ActiveBranchStatus.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Button from '$lib/shared/Button.svelte';
+	import { normalizeBranchName } from '$lib/utils/branch';
 	import { getContextStore } from '$lib/utils/context';
 	import { openExternalUrl } from '$lib/utils/url';
 	import { BaseBranch, Branch } from '$lib/vbranches/types';
@@ -52,7 +53,7 @@
 			disabled
 			help="Branch name that will be used when pushing. You can change it from the lane menu."
 		>
-			{isLaneCollapsed ? 'View branch' : $branch.displayName}
+			{normalizeBranchName($branch.displayName)}
 		</Button>
 	{/if}
 {:else}


### PR DESCRIPTION
The correct way of displaying the virtual names in the `ActiveBranchStatus` is to display them the same way we do for remote branches, as it also represents the branch name on the remote.

<img width="443" alt="image" src="https://github.com/gitbutlerapp/gitbutler/assets/18498712/a73cfae3-c9ad-450a-817f-3f65d2a9a5e8">
