### PR TITLE
Preserve line breaks in commit descriptions

### DIFF
--- a/app/src/lib/commit/CommitCard.svelte
+++ b/app/src/lib/commit/CommitCard.svelte
@@ -435,6 +435,7 @@
 
 	.commit__description {
 		color: var(--clr-text-2);
+		white-space: pre-wrap;
 	}
 
 	.commit__empty-title {


### PR DESCRIPTION
Before:
![image](https://github.com/gitbutlerapp/gitbutler/assets/1300356/4fe72f20-98b3-4f60-8008-02950b879950)
After:
![image](https://github.com/gitbutlerapp/gitbutler/assets/1300356/6b164ead-8b92-4aad-8d44-cb0ae851b778)
