### PR TITLE
remove the gitbutler generated key flow

### DIFF
--- a/app/src/lib/backend/projects.ts
+++ b/app/src/lib/backend/projects.ts
@@ -8,7 +8,7 @@ import { get, writable } from 'svelte/store';
 import type { HttpClient } from './httpClient';
 import { goto } from '$app/navigation';
 
-export type KeyType = 'generated' | 'gitCredentialsHelper' | 'local' | 'systemExecutable';
+export type KeyType = 'gitCredentialsHelper' | 'local' | 'systemExecutable';
 export type LocalKey = {
 	local: { private_key_path: string };
 };

--- a/app/src/lib/settings/KeysForm.svelte
+++ b/app/src/lib/settings/KeysForm.svelte
@@ -1,24 +1,19 @@
 <script lang="ts">
-	import { AuthService } from '$lib/backend/auth';
 	import { ProjectService, type Key, type KeyType, Project } from '$lib/backend/projects';
 	import SectionCard from '$lib/components/SectionCard.svelte';
 	import { showError } from '$lib/notifications/toasts';
 	import Section from '$lib/settings/Section.svelte';
-	import Button from '$lib/shared/Button.svelte';
 	import CredentialCheck from '$lib/shared/CredentialCheck.svelte';
 	import Link from '$lib/shared/Link.svelte';
 	import ProjectNameLabel from '$lib/shared/ProjectNameLabel.svelte';
 	import RadioButton from '$lib/shared/RadioButton.svelte';
 	import TextBox from '$lib/shared/TextBox.svelte';
-	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { getContext, getContextStore } from '$lib/utils/context';
-	import { openExternalUrl } from '$lib/utils/url';
 	import { BaseBranch } from '$lib/vbranches/types';
 	import { onMount } from 'svelte';
 
 	const project = getContext(Project);
 
-	const authService = getContext(AuthService);
 	const baseBranch = getContextStore(BaseBranch);
 	const projectService = getContext(ProjectService);
 
@@ -28,7 +23,6 @@
 	export let showProjectName = false;
 	export let disabled = false;
 
-	let sshKey = '';
 	let credentialCheck: CredentialCheck;
 
 	let selectedType: KeyType =
@@ -72,7 +66,6 @@
 
 	onMount(async () => {
 		form.credentialType.value = selectedType;
-		sshKey = await authService.getPublicKey();
 	});
 </script>
 
@@ -144,48 +137,6 @@
 		<SectionCard
 			roundedTop={false}
 			roundedBottom={false}
-			bottomBorder={selectedType !== 'generated'}
-			orientation="row"
-			labelFor="credential-generated"
-		>
-			<svelte:fragment slot="title">Use locally generated SSH key</svelte:fragment>
-
-			<svelte:fragment slot="actions">
-				<RadioButton name="credentialType" id="credential-generated" value="generated" />
-			</svelte:fragment>
-
-			<svelte:fragment slot="caption">
-				{#if selectedType === 'generated'}
-					GitButler will use a locally generated SSH key. For this to work you need to add the
-					following public key to your Git remote provider:
-				{/if}
-			</svelte:fragment>
-		</SectionCard>
-
-		{#if selectedType === 'generated'}
-			<SectionCard topDivider roundedTop={false} roundedBottom={false}>
-				<TextBox id="sshKey" readonly bind:value={sshKey} wide />
-				<div class="row-buttons">
-					<Button style="pop" kind="solid" icon="copy" on:mousedown={() => copyToClipboard(sshKey)}>
-						Copy to Clipboard
-					</Button>
-					<Button
-						style="ghost"
-						outline
-						icon="open-link"
-						on:mousedown={() => {
-							openExternalUrl('https://github.com/settings/ssh/new');
-						}}
-					>
-						Add key to GitHub
-					</Button>
-				</div>
-			</SectionCard>
-		{/if}
-
-		<SectionCard
-			roundedTop={false}
-			roundedBottom={false}
 			orientation="row"
 			labelFor="credential-helper"
 		>
@@ -222,12 +173,6 @@
 		flex-direction: column;
 		gap: 16px;
 		width: 100%;
-	}
-
-	.row-buttons {
-		display: flex;
-		justify-content: flex-end;
-		gap: 8px;
 	}
 
 	.git-radio {

--- a/crates/gitbutler-core/src/projects/project.rs
+++ b/crates/gitbutler-core/src/projects/project.rs
@@ -10,7 +10,6 @@ use crate::{id::Id, types::default_true::DefaultTrue, virtual_branches::VirtualB
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum AuthKey {
-    Generated,
     GitCredentialsHelper,
     Local {
         private_key_path: path::PathBuf,

--- a/crates/gitbutler-core/tests/git/credentials.rs
+++ b/crates/gitbutler-core/tests/git/credentials.rs
@@ -3,7 +3,7 @@ use std::str;
 
 use gitbutler_core::{
     git::credentials::{Credential, Helper, SshCredential},
-    keys, project_repository, projects, users,
+    project_repository, projects, users,
 };
 
 use gitbutler_testsupport::{temp_dir, test_repository};
@@ -29,8 +29,7 @@ impl TestCase<'_> {
         .expect("valid v1 sample user");
         users.set_user(&user).unwrap();
 
-        let keys = keys::Controller::from_path(local_app_data.path());
-        let helper = Helper::new(keys);
+        let helper = Helper::default();
 
         let (repo, _tmp) = test_repository();
         repo.remote("origin", self.remote_url).unwrap();

--- a/crates/gitbutler-core/tests/suite/virtual_branches/init.rs
+++ b/crates/gitbutler-core/tests/suite/virtual_branches/init.rs
@@ -4,7 +4,7 @@ use super::*;
 async fn twice() {
     let data_dir = paths::data_dir();
     let projects = projects::Controller::from_path(data_dir.path());
-    let helper = git::credentials::Helper::from_path(data_dir.path());
+    let helper = git::credentials::Helper::default();
 
     let test_project = TestProject::default();
 

--- a/crates/gitbutler-core/tests/suite/virtual_branches/mod.rs
+++ b/crates/gitbutler-core/tests/suite/virtual_branches/mod.rs
@@ -32,7 +32,7 @@ impl Default for Test {
     fn default() -> Self {
         let data_dir = paths::data_dir();
         let projects = projects::Controller::from_path(data_dir.path());
-        let helper = git::credentials::Helper::from_path(data_dir.path());
+        let helper = git::credentials::Helper::default();
 
         let test_project = TestProject::default();
         let project = projects

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -132,9 +132,7 @@ fn main() {
                     let keys_controller = gitbutler_core::keys::Controller::new(keys_storage_controller.clone());
                     app_handle.manage(keys_controller.clone());
 
-                    let git_credentials_controller = git::credentials::Helper::new(
-                        keys_controller.clone(),
-                    );
+                    let git_credentials_controller = git::credentials::Helper::default();
                     app_handle.manage(git_credentials_controller.clone());
 
                     app_handle.manage(gitbutler_core::virtual_branches::controller::Controller::new(

--- a/crates/gitbutler-testsupport/src/suite.rs
+++ b/crates/gitbutler-testsupport/src/suite.rs
@@ -80,7 +80,7 @@ impl Suite {
 
     pub fn new_case_with_files(&self, fs: HashMap<PathBuf, &str>) -> Case {
         let (project, project_tmp) = self.project(fs);
-        Case::new(self, project, project_tmp)
+        Case::new(project, project_tmp)
     }
 
     pub fn new_case(&self) -> Case {
@@ -109,15 +109,10 @@ impl Drop for Case {
 }
 
 impl Case {
-    fn new(
-        suite: &Suite,
-        project: gitbutler_core::projects::Project,
-        project_tmp: TempDir,
-    ) -> Case {
+    fn new(project: gitbutler_core::projects::Project, project_tmp: TempDir) -> Case {
         let project_repository = gitbutler_core::project_repository::Repository::open(&project)
             .expect("failed to create project repository");
-        let credentials =
-            gitbutler_core::git::credentials::Helper::from_path(suite.local_app_data());
+        let credentials = gitbutler_core::git::credentials::Helper::default();
         Case {
             project,
             project_repository,
@@ -133,8 +128,7 @@ impl Case {
             .expect("failed to get project");
         let project_repository = gitbutler_core::project_repository::Repository::open(&project)
             .expect("failed to create project repository");
-        let credentials =
-            gitbutler_core::git::credentials::Helper::from_path(suite.local_app_data());
+        let credentials = gitbutler_core::git::credentials::Helper::default();
         Self {
             credentials,
             project_repository,


### PR DESCRIPTION
The git executable flows works better, it's faster, and more secure keys wise. Furthermore removing this allows us to simplify the application state
