### PR TITLE
feature flag for disabling the project semaphore

### DIFF
--- a/app/src/lib/backend/projects.ts
+++ b/app/src/lib/backend/projects.ts
@@ -27,6 +27,7 @@ export class Project {
 	use_diff_context: boolean | undefined;
 	snapshot_lines_threshold!: number | undefined;
 	use_new_locking!: boolean;
+	ignore_project_semaphore!: boolean;
 
 	get vscodePath() {
 		return this.path.includes('\\') ? '/' + this.path.replace('\\', '/') : this.path;

--- a/app/src/lib/settings/PreferencesForm.svelte
+++ b/app/src/lib/settings/PreferencesForm.svelte
@@ -23,6 +23,7 @@
 	let allowForcePushing = project?.ok_with_force_push;
 	let omitCertificateCheck = project?.omit_certificate_check;
 	let useNewLocking = project?.use_new_locking || false;
+	let ignoreProjectSemaphore = project?.ignore_project_semaphore || false;
 	let signCommits = false;
 
 	const gitConfig = getContext(GitConfigService);
@@ -101,8 +102,13 @@
 		project.use_new_locking = value;
 		await projectService.updateProject(project);
 	}
+	async function setIgnoreProjectSemaphore(value: boolean) {
+		project.ignore_project_semaphore = value;
+		await projectService.updateProject(project);
+	}
 
 	$: setUseNewLocking(useNewLocking);
+	$: setIgnoreProjectSemaphore(ignoreProjectSemaphore);
 
 	onMount(async () => {
 		let gitConfigSettings = await gitConfig.getGbConfig(project.id);
@@ -286,6 +292,17 @@
 		</svelte:fragment>
 		<svelte:fragment slot="actions">
 			<Toggle id="useNewLocking" bind:checked={useNewLocking} />
+		</svelte:fragment>
+	</SectionCard>
+
+	<SectionCard labelFor="ignoreProjectSemaphore" orientation="row">
+		<svelte:fragment slot="title">Disable project semaphore usage</svelte:fragment>
+		<svelte:fragment slot="caption">
+			This is an experimental setting used to test if the project semaphore used in the GitButler
+			app API is necessary, or if it can be removed.
+		</svelte:fragment>
+		<svelte:fragment slot="actions">
+			<Toggle id="ignoreProjectSemaphore" bind:checked={ignoreProjectSemaphore} />
 		</svelte:fragment>
 	</SectionCard>
 </Section>

--- a/crates/gitbutler-core/src/projects/project.rs
+++ b/crates/gitbutler-core/src/projects/project.rs
@@ -90,6 +90,8 @@ pub struct Project {
 
     #[serde(default = "default_true")]
     pub use_new_locking: bool,
+    #[serde(default)]
+    pub ignore_project_semaphore: bool,
 }
 
 fn default_true() -> bool {

--- a/crates/gitbutler-core/src/projects/storage.rs
+++ b/crates/gitbutler-core/src/projects/storage.rs
@@ -29,6 +29,7 @@ pub struct UpdateRequest {
     pub use_diff_context: Option<bool>,
     pub snapshot_lines_threshold: Option<usize>,
     pub use_new_locking: Option<bool>,
+    pub ignore_project_semaphore: Option<bool>,
 }
 
 impl Storage {
@@ -125,6 +126,10 @@ impl Storage {
 
         if let Some(use_new_locking) = update_request.use_new_locking {
             project.use_new_locking = use_new_locking;
+        }
+
+        if let Some(ignore_project_semaphore) = update_request.ignore_project_semaphore {
+            project.ignore_project_semaphore = ignore_project_semaphore;
         }
 
         self.inner

--- a/crates/gitbutler-core/src/virtual_branches/controller.rs
+++ b/crates/gitbutler-core/src/virtual_branches/controller.rs
@@ -41,7 +41,7 @@ impl Controller {
         ownership: Option<&BranchOwnershipClaims>,
         run_hooks: bool,
     ) -> Result<git2::Oid> {
-        let _permit = self.semaphore.acquire().await;
+        self.permit(project.ignore_project_semaphore).await;
         let project_repository = open_with_verify(project)?;
         let snapshot_tree = project_repository.project().prepare_snapshot();
         let result = super::commit(
@@ -76,7 +76,7 @@ impl Controller {
         &self,
         project: &Project,
     ) -> Result<(Vec<super::VirtualBranch>, Vec<git::diff::FileDiff>)> {
-        let _permit = self.semaphore.acquire().await;
+        self.permit(project.ignore_project_semaphore).await;
 
         let project_repository = open_with_verify(project)?;
         super::list_virtual_branches(&project_repository).map_err(Into::into)
@@ -87,7 +87,7 @@ impl Controller {
         project: &Project,
         create: &super::branch::BranchCreateRequest,
     ) -> Result<BranchId> {
-        let _permit = self.semaphore.acquire().await;
+        self.permit(project.ignore_project_semaphore).await;
 
         let project_repository = open_with_verify(project)?;
         let branch_id = super::create_virtual_branch(&project_repository, create)?.id;
@@ -99,7 +99,7 @@ impl Controller {
         project: &Project,
         branch: &git::Refname,
     ) -> Result<BranchId> {
-        let _permit = self.semaphore.acquire().await;
+        self.permit(project.ignore_project_semaphore).await;
 
         let project_repository = open_with_verify(project)?;
         super::create_virtual_branch_from_branch(&project_repository, branch).map_err(Into::into)
@@ -141,7 +141,7 @@ impl Controller {
         project: &Project,
         branch_id: BranchId,
     ) -> Result<()> {
-        let _permit = self.semaphore.acquire().await;
+        self.permit(project.ignore_project_semaphore).await;
 
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
@@ -151,7 +151,7 @@ impl Controller {
     }
 
     pub async fn update_base_branch(&self, project: &Project) -> Result<Vec<ReferenceName>> {
-        let _permit = self.semaphore.acquire().await;
+        self.permit(project.ignore_project_semaphore).await;
 
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
@@ -172,7 +172,7 @@ impl Controller {
         project: &Project,
         branch_update: super::branch::BranchUpdateRequest,
     ) -> Result<()> {
-        let _permit = self.semaphore.acquire().await;
+        self.permit(project.ignore_project_semaphore).await;
 
         let project_repository = open_with_verify(project)?;
         let snapshot_tree = project_repository.project().prepare_snapshot();
@@ -197,7 +197,7 @@ impl Controller {
         project: &Project,
         branch_id: BranchId,
     ) -> Result<()> {
-        let _permit = self.semaphore.acquire().await;
+        self.permit(project.ignore_project_semaphore).await;
 
         let project_repository = open_with_verify(project)?;
         super::delete_branch(&project_repository, branch_id)
@@ -208,7 +208,7 @@ impl Controller {
         project: &Project,
         ownership: &BranchOwnershipClaims,
     ) -> Result<()> {
-        let _permit = self.semaphore.acquire().await;
+        self.permit(project.ignore_project_semaphore).await;
 
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
@@ -218,7 +218,7 @@ impl Controller {
     }
 
     pub async fn reset_files(&self, project: &Project, files: &Vec<String>) -> Result<()> {
-        let _permit = self.semaphore.acquire().await;
+        self.permit(project.ignore_project_semaphore).await;
 
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
@@ -234,7 +234,7 @@ impl Controller {
         commit_oid: git2::Oid,
         ownership: &BranchOwnershipClaims,
     ) -> Result<git2::Oid> {
-        let _permit = self.semaphore.acquire().await;
+        self.permit(project.ignore_project_semaphore).await;
 
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
@@ -251,7 +251,7 @@ impl Controller {
         to_commit_oid: git2::Oid,
         ownership: &BranchOwnershipClaims,
     ) -> Result<git2::Oid> {
-        let _permit = self.semaphore.acquire().await;
+        self.permit(project.ignore_project_semaphore).await;
 
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
@@ -273,7 +273,7 @@ impl Controller {
         branch_id: BranchId,
         commit_oid: git2::Oid,
     ) -> Result<()> {
-        let _permit = self.semaphore.acquire().await;
+        self.permit(project.ignore_project_semaphore).await;
 
         let project_repository = open_with_verify(project)?;
         let snapshot_tree = project_repository.project().prepare_snapshot();
@@ -296,7 +296,7 @@ impl Controller {
         commit_oid: git2::Oid,
         offset: i32,
     ) -> Result<()> {
-        let _permit = self.semaphore.acquire().await;
+        self.permit(project.ignore_project_semaphore).await;
 
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
@@ -313,7 +313,7 @@ impl Controller {
         commit_oid: git2::Oid,
         offset: i32,
     ) -> Result<()> {
-        let _permit = self.semaphore.acquire().await;
+        self.permit(project.ignore_project_semaphore).await;
 
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
@@ -329,7 +329,7 @@ impl Controller {
         branch_id: BranchId,
         target_commit_oid: git2::Oid,
     ) -> Result<()> {
-        let _permit = self.semaphore.acquire().await;
+        self.permit(project.ignore_project_semaphore).await;
 
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
@@ -344,7 +344,7 @@ impl Controller {
         branch_id: BranchId,
         name_conflict_resolution: NameConflitResolution,
     ) -> Result<ReferenceName> {
-        let _permit = self.semaphore.acquire().await;
+        self.permit(project.ignore_project_semaphore).await;
 
         let project_repository = open_with_verify(project)?;
         let snapshot_tree = project_repository.project().prepare_snapshot();
@@ -366,7 +366,7 @@ impl Controller {
         with_force: bool,
         askpass: Option<Option<BranchId>>,
     ) -> Result<()> {
-        let _permit = self.semaphore.acquire().await;
+        self.permit(project.ignore_project_semaphore).await;
         let helper = Helper::default();
         let project_repository = open_with_verify(project)?;
         super::push(&project_repository, branch_id, with_force, &helper, askpass)
@@ -392,7 +392,7 @@ impl Controller {
         branch_id: BranchId,
         commit_oid: git2::Oid,
     ) -> Result<()> {
-        let _permit = self.semaphore.acquire().await;
+        self.permit(project.ignore_project_semaphore).await;
 
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
@@ -408,7 +408,7 @@ impl Controller {
         commit_oid: git2::Oid,
         message: &str,
     ) -> Result<()> {
-        let _permit = self.semaphore.acquire().await;
+        self.permit(project.ignore_project_semaphore).await;
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
             .project()
@@ -466,13 +466,19 @@ impl Controller {
         target_branch_id: BranchId,
         commit_oid: git2::Oid,
     ) -> Result<()> {
-        let _permit = self.semaphore.acquire().await;
+        self.permit(project.ignore_project_semaphore).await;
 
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
             .project()
             .create_snapshot(SnapshotDetails::new(OperationKind::MoveCommit));
         super::move_commit(&project_repository, target_branch_id, commit_oid).map_err(Into::into)
+    }
+
+    async fn permit(&self, ignore: bool) {
+        if !ignore {
+            let _permit = self.semaphore.acquire().await;
+        }
     }
 }
 


### PR DESCRIPTION
It's possible that the sempahore state in the virtual branches controller is completely unnecessary. This feature flag allows us to test this hypothesis