### PR TITLE
better logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -390,7 +390,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
 ]
 
 [[package]]
@@ -740,7 +740,7 @@ checksum = "3c55d429bef56ac9172d25fecb85dc8068307d17acd74b377866b7a1ef25d3c8"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
 ]
 
 [[package]]
@@ -1936,7 +1936,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
 ]
 
 [[package]]
@@ -1953,7 +1953,7 @@ dependencies = [
  "libc",
  "pango-sys",
  "pkg-config",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
 ]
 
 [[package]]
@@ -1967,7 +1967,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "pkg-config",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
 ]
 
 [[package]]
@@ -1979,7 +1979,7 @@ dependencies = [
  "gdk-sys",
  "glib-sys",
  "libc",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
  "x11",
 ]
 
@@ -2071,7 +2071,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
  "winapi",
 ]
 
@@ -3224,7 +3224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef4b192f8e65e9cf76cbf4ea71fa8e3be4a0e18ffe3d68b8da6836974cc5bad4"
 dependencies = [
  "libc",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
 ]
 
 [[package]]
@@ -3254,7 +3254,7 @@ checksum = "0d57ce44246becd17153bd035ab4d32cfee096a657fc01f2231c9278378d1e0a"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
 ]
 
 [[package]]
@@ -3306,7 +3306,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "pango-sys",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
 ]
 
 [[package]]
@@ -4814,7 +4814,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
 ]
 
 [[package]]
@@ -6638,15 +6638,15 @@ dependencies = [
 
 [[package]]
 name = "system-deps"
-version = "6.2.2"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+checksum = "2a2d580ff6a20c55dfb86be5f9c238f67835d0e81cbdea8bf5680e0897320331"
 dependencies = [
  "cfg-expr 0.15.8",
- "heck 0.5.0",
+ "heck 0.4.1",
  "pkg-config",
  "toml 0.8.14",
- "version-compare 0.2.0",
+ "version-compare 0.1.1",
 ]
 
 [[package]]
@@ -7556,9 +7556,9 @@ checksum = "1c18c859eead79d8b95d09e4678566e8d70105c4e7b251f707a03df32442661b"
 
 [[package]]
 name = "version-compare"
-version = "0.2.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
+checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
 
 [[package]]
 name = "version_check"
@@ -7765,7 +7765,7 @@ dependencies = [
  "pango-sys",
  "pkg-config",
  "soup2-sys",
- "system-deps 6.2.2",
+ "system-deps 6.2.0",
 ]
 
 [[package]]
@@ -7970,9 +7970,9 @@ checksum = "9ee5e275231f07c6e240d14f34e1b635bf1faa1c76c57cfd59a5cdb9848e4278"
 
 [[package]]
 name = "windows-result"
-version = "0.1.2"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+checksum = "749f0da9cc72d82e600d8d2e44cadd0b9eedb9038f71a1c58556ac1c5791813b"
 dependencies = [
  "windows-targets 0.52.5",
 ]
@@ -8073,9 +8073,9 @@ checksum = "f838de2fe15fe6bac988e74b798f26499a8b21a9d97edec321e79b28d1d7f597"
 
 [[package]]
 name = "windows-version"
-version = "0.1.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6998aa457c9ba8ff2fb9f13e9d2a930dabcea28f1d0ab94d687d8b3654844515"
+checksum = "75aa004c988e080ad34aff5739c39d0312f4684699d6d71fc8a198d057b8b9b4"
 dependencies = [
  "windows-targets 0.52.5",
 ]
@@ -8391,12 +8391,12 @@ dependencies = [
 
 [[package]]
 name = "xdg-home"
-version = "1.2.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca91dcf8f93db085f3a0a29358cd0b9d670915468f4290e8b85d118a34211ab8"
+checksum = "21e5a325c3cb8398ad6cf859c1135b25dd29e186679cf2da7581d9679f63b38e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "winapi",
 ]
 
 [[package]]

--- a/crates/gitbutler-tauri/src/logs.rs
+++ b/crates/gitbutler-tauri/src/logs.rs
@@ -12,18 +12,20 @@ pub fn init(app_handle: &AppHandle) {
         .expect("failed to get logs dir");
     fs::create_dir_all(&logs_dir).expect("failed to create logs dir");
 
-    let log_prefix = "GitButler.log";
+    let log_prefix = "GitButler";
+    let log_suffix = "log";
     let max_log_files = 14;
     let file_appender = RollingFileAppender::builder()
         .rotation(Rotation::DAILY)
         .max_log_files(max_log_files)
         .filename_prefix(log_prefix)
+        .filename_suffix(log_suffix)
         .build(&logs_dir)
         .expect("initializing rolling file appender failed");
     let (file_writer, guard) = tracing_appender::non_blocking(file_appender);
     // As the file-writer only checks `max_log_files` on file rotation, it bascially never happens.
     // Run it now.
-    prune_old_logs(&logs_dir, Some(log_prefix), None, max_log_files).ok();
+    prune_old_logs(&logs_dir, Some(log_prefix), Some(log_suffix), max_log_files).ok();
 
     app_handle.manage(guard); // keep the guard alive for the lifetime of the app
 


### PR DESCRIPTION
This PR improves on application logging in various ways, see tasks.

### Tasks

* [x] make sure we don't keep all the logs (`max_log_files(14)`) seems ineffective
    - The problem is that this is  only activated on roll-over, not on initialization or other events we actually have
* [x] make log filename simpler and purge all non-conforming logs


### Notes for the Reviewer

* I performed manual testing on each commit, which worked well as there were many stray log files in my case. For safety, I compressed the `com.gitbutler.app.dev` folder to be able to restore and re-test if necessary, but didn't end up using it.
* Logs are now named `GitButler.<date>.log` consistently.
* This needs a documentation change which needs to be timed with a release, or be written so it's flexible enough.
* The docs-update [is available here](https://github.com/gitbutlerapp/docs/pull/19), and ideally it's synced with the release of this PR in stable. But even if it was released before people will probably still find their logs without problems.