### PR TITLE
move oplog to its own crate

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -21,6 +21,7 @@ jobs:
       gitbutler-watcher: ${{ steps.filter.outputs.gitbutler-watcher }}
       gitbutler-branch: ${{ steps.filter.outputs.gitbutler-branch }}
       gitbutler-sync: ${{ steps.filter.outputs.gitbutler-sync }}
+      gitbutler-oplog: ${{ steps.filter.outputs.gitbutler-oplog }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -63,6 +64,9 @@ jobs:
             gitbutler-sync:
               - *rust
               - 'crates/gitbutler-sync/**'
+            gitbutler-oplog:
+              - *rust
+              - 'crates/gitbutler-oplog/**'
 
   lint-node:
     needs: changes
@@ -238,6 +242,30 @@ jobs:
           features: ${{ toJson(matrix.features) }}
           action: ${{ matrix.action }}
 
+  check-gitbutler-oplog:
+    needs: changes
+    if: ${{ needs.changes.outputs.gitbutler-oplog == 'true' }}
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/gitbutlerapp/ci-base-image:latest
+    strategy:
+      matrix:
+        action:
+          - test
+          - check
+        features:
+          - ''
+          - '*'
+          - []
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/init-env-rust
+      - uses: ./.github/actions/check-crate
+        with:
+          crate: gitbutler-oplog
+          features: ${{ toJson(matrix.features) }}
+          action: ${{ matrix.action }}
+
   check-gitbutler-cli:
     needs: changes
     if: ${{ needs.changes.outputs.gitbutler-cli == 'true' }}
@@ -296,6 +324,7 @@ jobs:
       - check-gitbutler-core
       - check-gitbutler-branch
       - check-gitbutler-sync
+      - check-gitbutler-oplog
       - check-gitbutler-git
       - check-gitbutler-cli
       - check-gitbutler-watcher

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,6 +2114,7 @@ dependencies = [
  "git2-hooks",
  "gitbutler-core",
  "gitbutler-git",
+ "gitbutler-oplog",
  "gitbutler-testsupport",
  "glob",
  "hex",
@@ -2138,6 +2139,7 @@ dependencies = [
  "chrono",
  "clap",
  "gitbutler-core",
+ "gitbutler-oplog",
  "pager",
 ]
 
@@ -2227,12 +2229,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "gitbutler-oplog"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "git2",
+ "gitbutler-core",
+ "gix",
+ "itertools 0.13.0",
+ "pretty_assertions",
+ "serde",
+ "strum",
+ "tempfile",
+ "toml 0.8.14",
+ "tracing",
+]
+
+[[package]]
 name = "gitbutler-sync"
 version = "0.0.0"
 dependencies = [
  "anyhow",
  "git2",
  "gitbutler-core",
+ "gitbutler-oplog",
  "itertools 0.13.0",
  "tracing",
 ]
@@ -2250,6 +2270,7 @@ dependencies = [
  "git2",
  "gitbutler-branch",
  "gitbutler-core",
+ "gitbutler-oplog",
  "gitbutler-testsupport",
  "gitbutler-watcher",
  "log",
@@ -2300,6 +2321,7 @@ dependencies = [
  "gitbutler-branch",
  "gitbutler-core",
  "gitbutler-notify-debouncer",
+ "gitbutler-oplog",
  "gitbutler-sync",
  "gix",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/gitbutler-cli", 
     "crates/gitbutler-branch", 
     "crates/gitbutler-sync",
+    "crates/gitbutler-oplog",
 ]
 resolver = "2"
 
@@ -29,6 +30,7 @@ gitbutler-testsupport = { path = "crates/gitbutler-testsupport" }
 gitbutler-cli ={ path = "crates/gitbutler-cli" }
 gitbutler-branch = { path = "crates/gitbutler-branch" }
 gitbutler-sync = { path = "crates/gitbutler-sync" }
+gitbutler-oplog = { path = "crates/gitbutler-oplog" }
 
 [profile.release]
 codegen-units = 1 # Compile crates one after another so the compiler can optimize better

--- a/crates/gitbutler-branch/Cargo.toml
+++ b/crates/gitbutler-branch/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.86"
 git2.workspace = true
 tokio.workspace = true
 gitbutler-core.workspace = true
+gitbutler-oplog.workspace = true
 serde = { workspace = true, features = ["std"]}
 bstr = "1.9.1"
 diffy = "0.3.0"

--- a/crates/gitbutler-branch/src/controller.rs
+++ b/crates/gitbutler-branch/src/controller.rs
@@ -1,10 +1,14 @@
 use anyhow::Result;
 use gitbutler_core::{
     git::{credentials::Helper, BranchExt},
-    ops::entry::{OperationKind, SnapshotDetails},
     project_repository::Repository,
     projects::FetchResult,
     types::ReferenceName,
+};
+use gitbutler_oplog::{
+    entry::{OperationKind, SnapshotDetails},
+    oplog::Oplog,
+    snapshot::Snapshot,
 };
 use std::{path::Path, sync::Arc};
 

--- a/crates/gitbutler-branch/src/virtual.rs
+++ b/crates/gitbutler-branch/src/virtual.rs
@@ -1,3 +1,4 @@
+use gitbutler_oplog::snapshot::Snapshot;
 use std::borrow::Borrow;
 #[cfg(target_family = "unix")]
 use std::os::unix::prelude::PermissionsExt;

--- a/crates/gitbutler-branch/tests/virtual_branches/oplog.rs
+++ b/crates/gitbutler-branch/tests/virtual_branches/oplog.rs
@@ -1,4 +1,5 @@
 use super::*;
+use gitbutler_oplog::oplog::Oplog;
 use itertools::Itertools;
 use std::io::Write;
 use std::path::Path;

--- a/crates/gitbutler-cli/Cargo.toml
+++ b/crates/gitbutler-cli/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 gitbutler-core.workspace = true
+gitbutler-oplog.workspace = true
 clap = "4.5.4"
 anyhow = "1.0.86"
 chrono = "0.4.10"

--- a/crates/gitbutler-cli/src/main.rs
+++ b/crates/gitbutler-cli/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use gitbutler_core::projects::Project;
+use gitbutler_oplog::oplog::Oplog;
 
 use clap::{arg, Command};
 #[cfg(not(windows))]

--- a/crates/gitbutler-core/src/fs.rs
+++ b/crates/gitbutler-core/src/fs.rs
@@ -60,10 +60,7 @@ pub fn iter_worktree_files(
 
 /// Write a single file so that the write either fully succeeds, or fully fails,
 /// assuming the containing directory already exists.
-pub(crate) fn write<P: AsRef<Path>>(
-    file_path: P,
-    contents: impl AsRef<[u8]>,
-) -> anyhow::Result<()> {
+pub fn write<P: AsRef<Path>>(file_path: P, contents: impl AsRef<[u8]>) -> anyhow::Result<()> {
     let mut temp_file = gix::tempfile::new(
         file_path.as_ref().parent().unwrap(),
         ContainingDirectory::Exists,
@@ -104,7 +101,7 @@ fn persist_tempfile(
 /// Reads and parses the state file.
 ///
 /// If the file does not exist, it will be created.
-pub(crate) fn read_toml_file_or_default<T: DeserializeOwned + Default>(path: &Path) -> Result<T> {
+pub fn read_toml_file_or_default<T: DeserializeOwned + Default>(path: &Path) -> Result<T> {
     let mut file = match File::open(path) {
         Ok(f) => f,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(T::default()),

--- a/crates/gitbutler-core/src/lib.rs
+++ b/crates/gitbutler-core/src/lib.rs
@@ -23,7 +23,6 @@ pub mod git;
 pub mod id;
 pub mod keys;
 pub mod lock;
-pub mod ops;
 pub mod path;
 pub mod project_repository;
 pub mod projects;

--- a/crates/gitbutler-core/tests/core.rs
+++ b/crates/gitbutler-core/tests/core.rs
@@ -5,7 +5,6 @@ mod suite {
 mod git;
 mod keys;
 mod lock;
-mod ops;
 mod types;
 pub mod virtual_branches;
 mod zip;

--- a/crates/gitbutler-core/tests/ops/mod.rs
+++ b/crates/gitbutler-core/tests/ops/mod.rs
@@ -1,1 +1,0 @@
-mod entry;

--- a/crates/gitbutler-oplog/Cargo.toml
+++ b/crates/gitbutler-oplog/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "gitbutler-oplog"
+version = "0.0.0"
+edition = "2021"
+authors = ["GitButler <gitbutler@gitbutler.com>"]
+publish = false
+
+[dependencies]
+anyhow = "1.0.86"
+git2.workspace = true
+gitbutler-core.workspace = true
+serde = { workspace = true, features = ["std"]}
+itertools = "0.13"
+strum = { version = "0.26", features = ["derive"] }
+tracing = "0.1.40"
+gix = { workspace = true, features = ["dirwalk", "credentials", "parallel"] }
+toml = "0.8.13"
+
+[[test]]
+name="oplog"
+path = "tests/mod.rs"
+
+[dev-dependencies]
+pretty_assertions = "1.4"
+tempfile = "3.10"

--- a/crates/gitbutler-oplog/src/entry.rs
+++ b/crates/gitbutler-oplog/src/entry.rs
@@ -17,10 +17,10 @@ use serde::Serialize;
 #[serde(rename_all = "camelCase")]
 pub struct Snapshot {
     /// The id of the commit that represents the snapshot
-    #[serde(rename = "id", with = "crate::serde::oid")]
+    #[serde(rename = "id", with = "gitbutler_core::serde::oid")]
     pub commit_id: git2::Oid,
     /// Snapshot creation time in seconds from Unix epoch seconds, based on a commit as `commit_id`.
-    #[serde(serialize_with = "crate::serde::as_time_seconds_from_unix_epoch")]
+    #[serde(serialize_with = "gitbutler_core::serde::as_time_seconds_from_unix_epoch")]
     pub created_at: git2::Time,
     /// The number of working directory lines added in the snapshot
     pub lines_added: usize,

--- a/crates/gitbutler-oplog/src/lib.rs
+++ b/crates/gitbutler-oplog/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod entry;
-mod oplog;
+pub mod oplog;
 mod reflog;
-mod snapshot;
+pub mod snapshot;
 mod state;
 
 /// The name of the file holding our state, useful for watching for changes.

--- a/crates/gitbutler-oplog/src/reflog.rs
+++ b/crates/gitbutler-oplog/src/reflog.rs
@@ -1,10 +1,10 @@
-use crate::{
+use anyhow::{Context, Result};
+use gitbutler_core::{
     fs::write,
     virtual_branches::{
         GITBUTLER_INTEGRATION_COMMIT_AUTHOR_EMAIL, GITBUTLER_INTEGRATION_COMMIT_AUTHOR_NAME,
     },
 };
-use anyhow::{Context, Result};
 use gix::config::tree::Key;
 use std::path::Path;
 

--- a/crates/gitbutler-oplog/src/state.rs
+++ b/crates/gitbutler-oplog/src/state.rs
@@ -4,7 +4,7 @@ use std::{
     time::SystemTime,
 };
 
-use crate::fs::read_toml_file_or_default;
+use gitbutler_core::fs::read_toml_file_or_default;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use super::OPLOG_FILE_NAME;
@@ -26,7 +26,7 @@ fn unix_epoch() -> SystemTime {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Oplog {
     /// This is the sha of the last oplog commit
-    #[serde(with = "crate::serde::oid_opt", default)]
+    #[serde(with = "gitbutler_core::serde::oid_opt", default)]
     pub head_sha: Option<git2::Oid>,
     /// The time when the last snapshot was created. Seconds since Epoch
     #[serde(
@@ -92,6 +92,6 @@ impl OplogHandle {
 
     fn write_file(&self, mut oplog: Oplog) -> Result<()> {
         oplog.modified_at = SystemTime::now();
-        crate::fs::write(&self.file_path, toml::to_string(&oplog)?)
+        gitbutler_core::fs::write(&self.file_path, toml::to_string(&oplog)?)
     }
 }

--- a/crates/gitbutler-oplog/tests/mod.rs
+++ b/crates/gitbutler-oplog/tests/mod.rs
@@ -1,5 +1,6 @@
 mod trailer {
-    use gitbutler_core::ops::entry::Trailer;
+    use gitbutler_oplog::entry::Trailer;
+    // use gitbutler_core::ops::entry::Trailer;
     use std::str::FromStr;
 
     #[test]
@@ -28,7 +29,7 @@ mod trailer {
 }
 
 mod version {
-    use gitbutler_core::ops::entry::{Trailer, Version};
+    use gitbutler_oplog::entry::{Trailer, Version};
     use std::str::FromStr;
 
     #[test]
@@ -57,7 +58,7 @@ mod version {
 }
 
 mod operation_kind {
-    use gitbutler_core::ops::entry::{OperationKind, SnapshotDetails, Trailer, Version};
+    use gitbutler_oplog::entry::{OperationKind, SnapshotDetails, Trailer, Version};
     use std::str::FromStr;
 
     #[test]
@@ -90,7 +91,7 @@ mod operation_kind {
 }
 
 mod snapshot_details {
-    use gitbutler_core::ops::entry::{OperationKind, Snapshot, SnapshotDetails, Trailer, Version};
+    use gitbutler_oplog::entry::{OperationKind, Snapshot, SnapshotDetails, Trailer, Version};
     use std::path::PathBuf;
     use std::str::FromStr;
 

--- a/crates/gitbutler-sync/Cargo.toml
+++ b/crates/gitbutler-sync/Cargo.toml
@@ -11,3 +11,4 @@ tracing = "0.1.40"
 itertools = "0.13"
 git2.workspace = true
 gitbutler-core.workspace = true
+gitbutler-oplog.workspace = true

--- a/crates/gitbutler-sync/src/cloud.rs
+++ b/crates/gitbutler-sync/src/cloud.rs
@@ -8,6 +8,7 @@ use gitbutler_core::{
     projects::{self, CodePushState},
     users,
 };
+use gitbutler_oplog::oplog::Oplog;
 use itertools::Itertools;
 
 pub async fn sync_with_gitbutler(

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -49,6 +49,7 @@ tracing-subscriber = "0.3.17"
 gitbutler-core.workspace = true
 gitbutler-watcher.workspace = true
 gitbutler-branch.workspace = true
+gitbutler-oplog.workspace = true
 open = "5"
 
 [dependencies.tauri]

--- a/crates/gitbutler-tauri/src/undo.rs
+++ b/crates/gitbutler-tauri/src/undo.rs
@@ -1,10 +1,9 @@
 use crate::error::Error;
 use anyhow::Context;
 use gitbutler_core::git::diff::FileDiff;
-use gitbutler_core::{
-    ops::entry::Snapshot,
-    projects::{self, ProjectId},
-};
+use gitbutler_core::projects::{self, ProjectId};
+use gitbutler_oplog::entry::Snapshot;
+use gitbutler_oplog::oplog::Oplog;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use tauri::Manager;

--- a/crates/gitbutler-watcher/Cargo.toml
+++ b/crates/gitbutler-watcher/Cargo.toml
@@ -12,6 +12,7 @@ doctest = false
 gitbutler-core.workspace = true
 gitbutler-branch.workspace = true
 gitbutler-sync.workspace = true
+gitbutler-oplog.workspace = true
 thiserror.workspace = true
 anyhow = "1.0.86"
 futures = "0.3.30"

--- a/crates/gitbutler-watcher/src/file_monitor.rs
+++ b/crates/gitbutler-watcher/src/file_monitor.rs
@@ -4,9 +4,9 @@ use std::time::Duration;
 
 use crate::events::InternalEvent;
 use anyhow::{anyhow, Context, Result};
-use gitbutler_core::ops::OPLOG_FILE_NAME;
 use gitbutler_core::projects::ProjectId;
 use gitbutler_notify_debouncer::{new_debouncer, Debouncer, NoCache};
+use gitbutler_oplog::OPLOG_FILE_NAME;
 use notify::RecommendedWatcher;
 use notify::Watcher;
 use tokio::task;

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -4,9 +4,12 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use gitbutler_branch::VirtualBranches;
 use gitbutler_core::error::Marker;
-use gitbutler_core::ops::entry::{OperationKind, SnapshotDetails};
 use gitbutler_core::projects::ProjectId;
 use gitbutler_core::{assets, git, project_repository, projects, users};
+use gitbutler_oplog::{
+    entry::{OperationKind, SnapshotDetails},
+    oplog::Oplog,
+};
 use gitbutler_sync::cloud::sync_with_gitbutler;
 use tracing::instrument;
 


### PR DESCRIPTION
This protects us from cyclic dependencies. Unfortunatelly as part of this, i had to introduce the imp Project as trait implementations since now Project is foreign