### PR TITLE
fix: set defaults for workflow_dispatch

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,6 +14,7 @@ on:
         type: choice
         required: true
         description: channel
+        default: nightly
         options:
           - release
           - nightly
@@ -21,6 +22,7 @@ on:
         type: choice
         required: true
         description: update type
+        default: patch
         options:
           - undefined
           - patch


### PR DESCRIPTION
## ☕️ Reasoning

- Previous defaults were only for triggering events other than `workflow_dispatch` (i.e. the `cron` event)
- Now also the manual workflow dispatch UI should default to the appropriate values


## 🧢 Changes


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
