### PR TITLE
Fix switcing between projects disabled state

### DIFF
--- a/app/src/lib/components/ProjectSwitcher.svelte
+++ b/app/src/lib/components/ProjectSwitcher.svelte
@@ -61,7 +61,7 @@
 		style="pop"
 		kind="solid"
 		icon="chevron-right-small"
-		disabled={selectedProjectId === project}
+		disabled={selectedProjectId === project?.id}
 		on:mousedown={() => {
 			if (selectedProjectId) goto(`/${selectedProjectId}/`);
 		}}


### PR DESCRIPTION
`Open project` button wasn't disabled

<img width="657" alt="image" src="https://github.com/gitbutlerapp/gitbutler/assets/18498712/90633f86-69b9-4397-831b-ccf2d84ae199">
