### PR TITLE
feat: add GHA to trigger vercel deploy hook

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,16 +1,14 @@
-name: Trigger Vercel Docs Build
+name: Trigger Docs Build
 on:
   release:
     types: [published]
 
 jobs:
   vercel:
-    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger Vercel Webhook
+      - name: Trigger Vercel Deploy Hook
         env:
           VERCEL_HOOK_URL: ${{ secrets.VERCEL_HOOK_URL }}
-        run: |
-          curl -ks $VERCEL_HOOK_URL
+        run: curl -s $VERCEL_HOOK_URL
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,16 @@
+name: Trigger Vercel Docs Build
+on:
+  release:
+    types: [published]
+
+jobs:
+  vercel:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Vercel Webhook
+        env:
+          VERCEL_HOOK_URL: ${{ secrets.VERCEL_HOOK_URL }}
+        run: |
+          curl -ks $VERCEL_HOOK_URL
+


### PR DESCRIPTION
## ☕️ Reasoning

- We're publishing releases on GitHub now
- Therefore, after every new release publish, we can trigger a Vercel deploy hook which will kick off a new build of our docs.
- The new build can then pick up the new release details and plug them right into [the releases page](https://docs.gitbutler.com/releases/releases)

## 🧢 Changes

- Add GitHub Action to call Vercel deploy webhook

### TODO

- [x] Still requires adding a GHA secret to this repo

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
