### PR TITLE
multi-window safety

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,7 +2175,6 @@ name = "gitbutler-project"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "git2",
  "gitbutler-error",
  "gitbutler-id",
@@ -2292,7 +2291,6 @@ name = "gitbutler-tauri"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "backtrace",
  "console-subscriber",
  "dirs 5.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,6 +1609,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2286,6 +2296,7 @@ dependencies = [
  "backtrace",
  "console-subscriber",
  "dirs 5.0.1",
+ "fslock",
  "futures",
  "git2",
  "gitbutler-branch",

--- a/app/src/lib/backend/projects.ts
+++ b/app/src/lib/backend/projects.ts
@@ -29,6 +29,9 @@ export class Project {
 	use_new_locking!: boolean;
 	ignore_project_semaphore!: boolean;
 
+	// Produced just for the frontend
+	is_open!: boolean;
+
 	get vscodePath() {
 		return this.path.includes('\\') ? '/' + this.path.replace('\\', '/') : this.path;
 	}

--- a/app/src/lib/backend/projects.ts
+++ b/app/src/lib/backend/projects.ts
@@ -99,6 +99,10 @@ export class ProjectService {
 		}
 	}
 
+	async openProjectInNewWindow(projectId: string) {
+		await invoke('open_project_in_window', { id: projectId });
+	}
+
 	async addProject() {
 		const path = await this.promptForDirectory();
 		if (!path) return;

--- a/app/src/lib/backend/projects.ts
+++ b/app/src/lib/backend/projects.ts
@@ -29,7 +29,7 @@ export class Project {
 	use_new_locking!: boolean;
 	ignore_project_semaphore!: boolean;
 
-	// Produced just for the frontend
+	// Produced just for the frontend to determine if the project is open in any window.
 	is_open!: boolean;
 
 	get vscodePath() {

--- a/app/src/lib/navigation/ProjectsPopup.svelte
+++ b/app/src/lib/navigation/ProjectsPopup.svelte
@@ -13,7 +13,7 @@
 		label: string;
 		selected?: boolean;
 		icon?: string;
-		onclick: () => void;
+		onclick: (event?: any) => void;
 	}
 
 	interface ProjectsPopupProps {
@@ -110,8 +110,12 @@
 								label: project.title,
 								selected,
 								icon: selected ? 'tick' : undefined,
-								onclick: () => {
-									goto(`/${project.id}/`);
+								onclick: async (event: any) => {
+									if (event.altKey) {
+										await projectService.openProjectInNewWindow(project.id);
+									} else {
+										goto(`/${project.id}/`);
+									}
 									hide();
 								}
 							})}

--- a/app/src/lib/navigation/ProjectsPopup.svelte
+++ b/app/src/lib/navigation/ProjectsPopup.svelte
@@ -105,7 +105,9 @@
 				<ScrollableContainer maxHeight="20rem">
 					<div class="popup__projects">
 						{#each $projects as project}
-							{@const selected = project.id === $page.params.projectId}
+							{@const selected =
+								project.id === $page.params.projectId ||
+								$projects.some((p) => p.is_open && p.id === project.id)}
 							{@render itemSnippet({
 								label: project.title,
 								selected,

--- a/app/src/routes/[projectId]/+layout.ts
+++ b/app/src/routes/[projectId]/+layout.ts
@@ -35,7 +35,7 @@ export async function load({ params, parent }) {
 	let project: Project | undefined = undefined;
 	try {
 		project = await projectService.getProject(projectId);
-		await invoke('set_project_active', { id: projectId }).then((_r) => {});
+		await invoke('set_project_active', { id: projectId });
 	} catch (err: any) {
 		throw error(400, {
 			message: err.message

--- a/app/src/routes/[projectId]/+layout.ts
+++ b/app/src/routes/[projectId]/+layout.ts
@@ -30,10 +30,12 @@ export async function load({ params, parent }) {
 	// Getting the project should be one of few, if not the only await expression in
 	// this function. It delays drawing the page, but currently the benefit from having this
 	// synchronously available are much greater than the cost.
+	// However, what's awaited here is required for proper error handling,
+	// and by now this is fast enough to not be an impediment.
 	let project: Project | undefined = undefined;
 	try {
 		project = await projectService.getProject(projectId);
-		invoke('set_project_active', { id: projectId }).then((_r) => {});
+		await invoke('set_project_active', { id: projectId }).then((_r) => {});
 	} catch (err: any) {
 		throw error(400, {
 			message: err.message

--- a/crates/gitbutler-project/Cargo.toml
+++ b/crates/gitbutler-project/Cargo.toml
@@ -14,7 +14,6 @@ gitbutler-serde.workspace = true
 gitbutler-id.workspace = true
 gitbutler-storage.workspace = true
 git2.workspace = true
-async-trait = "0.1.80"
 gix = { workspace = true, features = ["dirwalk", "credentials", "parallel"] }
 uuid.workspace = true
 tracing = "0.1.40"

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -27,6 +27,7 @@ async-trait = "0.1.80"
 backtrace = { version = "0.3.72", optional = true }
 console-subscriber = "0.2.0"
 dirs = "5.0.1"
+fslock = "0.2.1"
 futures = "0.3"
 git2.workspace = true
 once_cell = "1.19"

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -23,7 +23,6 @@ gitbutler-testsupport.workspace = true
 
 [dependencies]
 anyhow = "1.0.86"
-async-trait = "0.1.80"
 backtrace = { version = "0.3.72", optional = true }
 console-subscriber = "0.2.0"
 dirs = "5.0.1"

--- a/crates/gitbutler-tauri/src/lib.rs
+++ b/crates/gitbutler-tauri/src/lib.rs
@@ -18,7 +18,8 @@ pub mod commands;
 
 pub mod logs;
 pub mod menu;
-pub mod watcher;
+mod window;
+pub use window::WindowState;
 
 pub mod askpass;
 pub mod config;

--- a/crates/gitbutler-tauri/src/lib.rs
+++ b/crates/gitbutler-tauri/src/lib.rs
@@ -18,8 +18,8 @@ pub mod commands;
 
 pub mod logs;
 pub mod menu;
-mod window;
-pub use window::WindowState;
+pub mod window;
+pub use window::state::WindowState;
 
 pub mod askpass;
 pub mod config;

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -101,8 +101,7 @@ fn main() {
                     let storage_controller = storage::Storage::new(&app_data_dir);
                     app_handle.manage(storage_controller.clone());
 
-                    let windows = WindowState::new(app_handle.clone());
-                    app_handle.manage(windows.clone());
+                    app_handle.manage(WindowState::new(app_handle.clone()));
 
                     let projects_storage_controller = gitbutler_project::storage::Storage::new(storage_controller.clone());
                     app_handle.manage(projects_storage_controller.clone());
@@ -115,8 +114,7 @@ fn main() {
 
                     let projects_controller = gitbutler_project::Controller::new(
                         app_data_dir.clone(),
-                        projects_storage_controller.clone(),
-                        Some(windows.clone())
+                        projects_storage_controller.clone()
                     );
                     app_handle.manage(projects_controller.clone());
 

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -40,21 +40,10 @@ fn main() {
                 .target(LogTarget::LogDir)
                 .level(log::LevelFilter::Error);
 
-            let builder = tauri::Builder::default();
-
-            #[cfg(target_os = "macos")]
-            let builder = builder
-                .on_window_event(|event| {
-                    if let tauri::WindowEvent::CloseRequested { api, .. } = event.event() {
-                        hide_window(&event.window().app_handle()).expect("Failed to hide window");
-                        api.prevent_close();
-                    }
-                });
-
-            builder
+            tauri::Builder::default()
                 .setup(move |tauri_app| {
                     let window =
-                        create_window(&tauri_app.handle()).expect("Failed to create window");
+                        gitbutler_tauri::window::create(&tauri_app.handle(), "main", "index.html".into()).expect("Failed to create window");
                     #[cfg(debug_assertions)]
                     window.open_devtools();
 
@@ -162,6 +151,7 @@ fn main() {
                     projects::commands::delete_project,
                     projects::commands::list_projects,
                     projects::commands::set_project_active,
+                    projects::commands::open_project_in_window,
                     repo::commands::git_get_local_config,
                     repo::commands::git_set_local_config,
                     repo::commands::check_signing_settings,
@@ -213,6 +203,14 @@ fn main() {
                 .on_window_event(|event| {
                     let window = event.window();
                     match event.event() {
+                        #[cfg(target_os = "macos")]
+                        tauri::WindowEvent::CloseRequested { api, .. } => {
+                            if window.app_handle().windows().len() == 1 {
+                                tracing::debug!("Hiding all application windows and preventing exit");
+                                window.app_handle().hide().ok();
+                                api.prevent_close();
+                            }
+                        }
                         tauri::WindowEvent::Destroyed  => {
                             window.app_handle()
                                 .state::<WindowState>()
@@ -231,7 +229,8 @@ fn main() {
                 .run(|app_handle, event| {
                     #[cfg(target_os = "macos")]
                     if let tauri::RunEvent::ExitRequested { api, .. } = event {
-                        hide_window(app_handle).expect("Failed to hide window");
+                        tracing::debug!("Hiding all windows and preventing exit");
+                        app_handle.hide().ok();
                         api.prevent_exit();
                     }
 
@@ -242,41 +241,4 @@ fn main() {
                     }
                 });
         });
-}
-
-#[cfg(not(target_os = "macos"))]
-fn create_window(handle: &tauri::AppHandle) -> tauri::Result<tauri::Window> {
-    let app_title = handle.package_info().name.clone();
-    let window =
-        tauri::WindowBuilder::new(handle, "main", tauri::WindowUrl::App("index.html".into()))
-            .resizable(true)
-            .title(app_title)
-            .disable_file_drop_handler()
-            .min_inner_size(800.0, 600.0)
-            .inner_size(1160.0, 720.0)
-            .build()?;
-    tracing::info!("app window created");
-    Ok(window)
-}
-
-#[cfg(target_os = "macos")]
-fn create_window(handle: &tauri::AppHandle) -> tauri::Result<tauri::Window> {
-    let window =
-        tauri::WindowBuilder::new(handle, "main", tauri::WindowUrl::App("index.html".into()))
-            .resizable(true)
-            .title(handle.package_info().name.clone())
-            .min_inner_size(800.0, 600.0)
-            .inner_size(1160.0, 720.0)
-            .hidden_title(true)
-            .disable_file_drop_handler()
-            .title_bar_style(tauri::TitleBarStyle::Overlay)
-            .build()?;
-    tracing::info!("window created");
-    Ok(window)
-}
-
-#[cfg(target_os = "macos")]
-fn hide_window(handle: &tauri::AppHandle) -> tauri::Result<()> {
-    handle.hide()?;
-    Ok(())
 }

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -17,7 +17,7 @@ use gitbutler_repo::credentials::Helper;
 use gitbutler_storage::storage;
 use gitbutler_tauri::{
     app, askpass, commands, config, github, logs, menu, projects, remotes, repo, secret, undo,
-    users, virtual_branches, watcher, zip,
+    users, virtual_branches, zip, WindowState,
 };
 use tauri::{generate_context, Manager};
 use tauri_plugin_log::LogTarget;
@@ -101,8 +101,8 @@ fn main() {
                     let storage_controller = storage::Storage::new(&app_data_dir);
                     app_handle.manage(storage_controller.clone());
 
-                    let watcher_controller = watcher::Watchers::new(app_handle.clone());
-                    app_handle.manage(watcher_controller.clone());
+                    let windows = WindowState::new(app_handle.clone());
+                    app_handle.manage(windows.clone());
 
                     let projects_storage_controller = gitbutler_project::storage::Storage::new(storage_controller.clone());
                     app_handle.manage(projects_storage_controller.clone());
@@ -116,7 +116,7 @@ fn main() {
                     let projects_controller = gitbutler_project::Controller::new(
                         app_data_dir.clone(),
                         projects_storage_controller.clone(),
-                        Some(watcher_controller.clone())
+                        Some(windows.clone())
                     );
                     app_handle.manage(projects_controller.clone());
 
@@ -217,7 +217,7 @@ fn main() {
                         if *focused {
                             tokio::task::spawn(async move {
                                 let _ = event.window().app_handle()
-                                    .state::<watcher::Watchers>()
+                                    .state::<WindowState>()
                                     .flush().await;
                             });
                         }

--- a/crates/gitbutler-tauri/src/projects.rs
+++ b/crates/gitbutler-tauri/src/projects.rs
@@ -56,7 +56,7 @@ pub mod commands {
         id: ProjectId,
     ) -> Result<(), Error> {
         let project = controller.get(id).context("project not found")?;
-        Ok(watchers.watch(&project)?)
+        Ok(watchers.set_project_to_window(&project)?)
     }
 
     #[tauri::command(async)]

--- a/crates/gitbutler-tauri/src/projects.rs
+++ b/crates/gitbutler-tauri/src/projects.rs
@@ -8,7 +8,7 @@ pub mod commands {
     use tracing::instrument;
 
     use crate::error::Error;
-    use crate::watcher::Watchers;
+    use crate::window::WindowState;
 
     #[tauri::command(async)]
     #[instrument(skip(controller), err(Debug))]
@@ -52,7 +52,7 @@ pub mod commands {
     #[instrument(skip(controller, watchers), err(Debug))]
     pub async fn set_project_active(
         controller: State<'_, Controller>,
-        watchers: State<'_, Watchers>,
+        watchers: State<'_, WindowState>,
         id: ProjectId,
     ) -> Result<(), Error> {
         let project = controller.get(id).context("project not found")?;

--- a/crates/gitbutler-tauri/src/projects.rs
+++ b/crates/gitbutler-tauri/src/projects.rs
@@ -4,7 +4,7 @@ pub mod commands {
 
     use gitbutler_project::ProjectId;
     use gitbutler_project::{self as projects, Controller};
-    use tauri::State;
+    use tauri::{State, Window};
     use tracing::instrument;
 
     use crate::error::Error;
@@ -49,14 +49,15 @@ pub mod commands {
     ///
     /// We use it to start watching for filesystem events.
     #[tauri::command(async)]
-    #[instrument(skip(controller, watchers), err(Debug))]
+    #[instrument(skip(controller, watchers, window), err(Debug))]
     pub async fn set_project_active(
         controller: State<'_, Controller>,
         watchers: State<'_, WindowState>,
+        window: Window,
         id: ProjectId,
     ) -> Result<(), Error> {
         let project = controller.get(id).context("project not found")?;
-        Ok(watchers.set_project_to_window(&project)?)
+        Ok(watchers.set_project_to_window(window.label(), &project)?)
     }
 
     #[tauri::command(async)]

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -15,7 +15,7 @@ pub mod commands {
     use tauri::{AppHandle, Manager};
     use tracing::instrument;
 
-    use crate::window;
+    use crate::WindowState;
 
     #[tauri::command(async)]
     #[instrument(skip(handle), err(Debug))]
@@ -511,7 +511,7 @@ pub mod commands {
 
     async fn emit_vbranches(handle: &AppHandle, project_id: projects::ProjectId) {
         if let Err(error) = handle
-            .state::<window::WindowState>()
+            .state::<WindowState>()
             .post(gitbutler_watcher::Action::CalculateVirtualBranches(
                 project_id,
             ))

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -15,7 +15,7 @@ pub mod commands {
     use tauri::{AppHandle, Manager};
     use tracing::instrument;
 
-    use crate::watcher;
+    use crate::window;
 
     #[tauri::command(async)]
     #[instrument(skip(handle), err(Debug))]
@@ -511,7 +511,7 @@ pub mod commands {
 
     async fn emit_vbranches(handle: &AppHandle, project_id: projects::ProjectId) {
         if let Err(error) = handle
-            .state::<watcher::Watchers>()
+            .state::<window::WindowState>()
             .post(gitbutler_watcher::Action::CalculateVirtualBranches(
                 project_id,
             ))

--- a/crates/gitbutler-tauri/src/window.rs
+++ b/crates/gitbutler-tauri/src/window.rs
@@ -205,6 +205,15 @@ pub(super) mod state {
             let mut state_by_label = block_on(self.state.lock());
             state_by_label.remove(window);
         }
+
+        /// Return the list of project ids that are currently open.
+        pub fn open_projects(&self) -> Vec<ProjectId> {
+            let state_by_label = block_on(self.state.lock());
+            state_by_label
+                .values()
+                .map(|state| state.project_id)
+                .collect()
+        }
     }
 }
 

--- a/crates/gitbutler-tauri/src/window.rs
+++ b/crates/gitbutler-tauri/src/window.rs
@@ -1,195 +1,242 @@
-use std::collections::BTreeMap;
-use std::sync::Arc;
+pub(super) mod state {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
 
-use anyhow::{Context, Result};
-use futures::executor::block_on;
-use gitbutler_project as projects;
-use gitbutler_project::ProjectId;
-use gitbutler_user as users;
-use tauri::{AppHandle, Manager};
-use tracing::instrument;
-
-mod event {
     use anyhow::{Context, Result};
+    use futures::executor::block_on;
+    use gitbutler_project as projects;
     use gitbutler_project::ProjectId;
-    use gitbutler_watcher::Change;
-    use tauri::Manager;
+    use gitbutler_user as users;
+    use tauri::{AppHandle, Manager};
+    use tracing::instrument;
 
-    /// A change we want to inform the frontend about.
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    pub(super) struct ChangeForFrontend {
-        name: String,
-        payload: serde_json::Value,
+    mod event {
+        use anyhow::{Context, Result};
+        use gitbutler_project::ProjectId;
+        use gitbutler_watcher::Change;
+        use tauri::Manager;
+
+        /// A change we want to inform the frontend about.
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        pub(super) struct ChangeForFrontend {
+            name: String,
+            payload: serde_json::Value,
+            project_id: ProjectId,
+        }
+
+        impl From<Change> for ChangeForFrontend {
+            fn from(value: Change) -> Self {
+                match value {
+                    Change::GitFetch(project_id) => ChangeForFrontend {
+                        name: format!("project://{}/git/fetch", project_id),
+                        payload: serde_json::json!({}),
+                        project_id,
+                    },
+                    Change::GitHead { project_id, head } => ChangeForFrontend {
+                        name: format!("project://{}/git/head", project_id),
+                        payload: serde_json::json!({ "head": head }),
+                        project_id,
+                    },
+                    Change::GitActivity(project_id) => ChangeForFrontend {
+                        name: format!("project://{}/git/activity", project_id),
+                        payload: serde_json::json!({}),
+                        project_id,
+                    },
+                    Change::VirtualBranches {
+                        project_id,
+                        virtual_branches,
+                    } => ChangeForFrontend {
+                        name: format!("project://{}/virtual-branches", project_id),
+                        payload: serde_json::json!(virtual_branches),
+                        project_id,
+                    },
+                }
+            }
+        }
+
+        impl ChangeForFrontend {
+            pub(super) fn send(&self, app_handle: &tauri::AppHandle) -> Result<()> {
+                app_handle
+                    .emit_all(&self.name, Some(&self.payload))
+                    .context("emit event")?;
+                tracing::trace!(event_name = self.name);
+                Ok(())
+            }
+        }
+    }
+    use event::ChangeForFrontend;
+
+    /// The name of the lock file to signal exclusive access to other windows.
+    const WINDOW_LOCK_FILE: &str = "window.lock";
+
+    struct State {
+        /// The id of the project displayed by the window.
         project_id: ProjectId,
+        /// The watcher of the currently active project.
+        watcher: gitbutler_watcher::WatcherHandle,
+        /// An active lock to signal that the entire project is locked for the Window this state belongs to.
+        exclusive_access: fslock::LockFile,
     }
 
-    impl From<Change> for ChangeForFrontend {
-        fn from(value: Change) -> Self {
-            match value {
-                Change::GitFetch(project_id) => ChangeForFrontend {
-                    name: format!("project://{}/git/fetch", project_id),
-                    payload: serde_json::json!({}),
-                    project_id,
-                },
-                Change::GitHead { project_id, head } => ChangeForFrontend {
-                    name: format!("project://{}/git/head", project_id),
-                    payload: serde_json::json!({ "head": head }),
-                    project_id,
-                },
-                Change::GitActivity(project_id) => ChangeForFrontend {
-                    name: format!("project://{}/git/activity", project_id),
-                    payload: serde_json::json!({}),
-                    project_id,
-                },
-                Change::VirtualBranches {
-                    project_id,
-                    virtual_branches,
-                } => ChangeForFrontend {
-                    name: format!("project://{}/virtual-branches", project_id),
-                    payload: serde_json::json!(virtual_branches),
-                    project_id,
-                },
+    impl Drop for State {
+        fn drop(&mut self) {
+            // We only do this to display an error if it fails - `LockFile` also implements `Drop`.
+            if let Err(err) = self.exclusive_access.unlock() {
+                tracing::error!(err = ?err, "Failed to release the project-wide lock");
             }
         }
     }
 
-    impl ChangeForFrontend {
-        pub(super) fn send(&self, app_handle: &tauri::AppHandle) -> Result<()> {
-            app_handle
-                .emit_all(&self.name, Some(&self.payload))
-                .context("emit event")?;
-            tracing::trace!(event_name = self.name);
+    type WindowLabel = String;
+    pub(super) type WindowLabelRef = str;
+
+    /// State associated to windows
+    /// Note that this type is managed in Tauri and thus needs to be `Send` and `Sync`.
+    #[derive(Clone)]
+    pub struct WindowState {
+        /// NOTE: This handle is required for this type to be self-contained as it's used by `core` through a trait.
+        app_handle: AppHandle,
+        /// The state for every open application window.
+        /// NOTE: This is a `tokio` mutex as this needs to lock the inner option from within async.
+        state: Arc<tokio::sync::Mutex<BTreeMap<WindowLabel, State>>>,
+    }
+
+    fn handler_from_app(app: &AppHandle) -> Result<gitbutler_watcher::Handler> {
+        let projects = app.state::<projects::Controller>().inner().clone();
+        let users = app.state::<users::Controller>().inner().clone();
+        let vbranches = gitbutler_branch_actions::VirtualBranchActions::default();
+
+        Ok(gitbutler_watcher::Handler::new(
+            projects,
+            users,
+            vbranches,
+            {
+                let app = app.clone();
+                move |change| ChangeForFrontend::from(change).send(&app)
+            },
+        ))
+    }
+
+    impl WindowState {
+        pub fn new(app_handle: AppHandle) -> Self {
+            Self {
+                app_handle,
+                state: Default::default(),
+            }
+        }
+
+        /// Watch the `project`, assure no other instance can access it, and associate it with the window
+        /// uniquely identified by `window`.
+        ///
+        /// Previous state will be removed and its resources cleaned up.
+        #[instrument(skip(self, project), err(Debug))]
+        pub fn set_project_to_window(
+            &self,
+            window: &WindowLabelRef,
+            project: &projects::Project,
+        ) -> Result<()> {
+            let mut lock_file =
+                fslock::LockFile::open(project.gb_dir().join(WINDOW_LOCK_FILE).as_os_str())?;
+            lock_file
+                .try_lock()
+                .context("Another GitButler Window already has the project opened")?;
+
+            let handler = handler_from_app(&self.app_handle)?;
+            let worktree_dir = project.path.clone();
+            let project_id = project.id;
+            let watcher =
+                gitbutler_watcher::watch_in_background(handler, worktree_dir, project_id)?;
+            let mut state_by_label = block_on(self.state.lock());
+            state_by_label.insert(
+                window.to_owned(),
+                State {
+                    project_id,
+                    watcher,
+                    exclusive_access: lock_file,
+                },
+            );
+            tracing::debug!("Maintaining {} Windows", state_by_label.len());
             Ok(())
         }
-    }
-}
-use event::ChangeForFrontend;
 
-/// The name of the lock file to signal exclusive access to other windows.
-const WINDOW_LOCK_FILE: &str = "window.lock";
+        pub async fn post(&self, action: gitbutler_watcher::Action) -> Result<()> {
+            let mut state_by_label = self.state.lock().await;
+            let state = state_by_label
+                .values_mut()
+                .find(|state| state.project_id == action.project_id());
+            if let Some(state) = state {
+                state
+                    .watcher
+                    .post(action)
+                    .await
+                    .context("failed to post event")
+            } else {
+                Err(anyhow::anyhow!(
+                    "matching watcher to post event not found, wanted {wanted}",
+                    wanted = action.project_id(),
+                ))
+            }
+        }
 
-struct State {
-    /// The id of the project displayed by the window.
-    project_id: ProjectId,
-    /// The watcher of the currently active project.
-    watcher: gitbutler_watcher::WatcherHandle,
-    /// An active lock to signal that the entire project is locked for the Window this state belongs to.
-    exclusive_access: fslock::LockFile,
-}
+        /// Flush file-monitor watcher events once the windows regains focus for it to respond instantly
+        /// instead of according to the tick-rate.
+        pub fn flush(&self, window: &WindowLabelRef) -> Result<()> {
+            let state_by_label = block_on(self.state.lock());
+            if let Some(state) = state_by_label.get(window) {
+                state.watcher.flush()?;
+            }
 
-impl Drop for State {
-    fn drop(&mut self) {
-        // We only do this to display an error if it fails - `LockFile` also implements `Drop`.
-        if let Err(err) = self.exclusive_access.unlock() {
-            tracing::error!(err = ?err, "Failed to release the project-wide lock");
+            Ok(())
+        }
+
+        /// Remove the state associated with `window`, typically upon its destruction.
+        pub fn remove(&self, window: &WindowLabelRef) {
+            let mut state_by_label = block_on(self.state.lock());
+            state_by_label.remove(window);
         }
     }
 }
 
-type WindowLabel = String;
-type WindowLabelRef = str;
-
-/// State associated to windows
-/// Note that this type is managed in Tauri and thus needs to be `Send` and `Sync`.
-#[derive(Clone)]
-pub struct WindowState {
-    /// NOTE: This handle is required for this type to be self-contained as it's used by `core` through a trait.
-    app_handle: AppHandle,
-    /// The state for every open application window.
-    /// NOTE: This is a `tokio` mutex as this needs to lock the inner option from within async.
-    state: Arc<tokio::sync::Mutex<BTreeMap<WindowLabel, State>>>,
+#[cfg(not(target_os = "macos"))]
+pub fn create(
+    handle: &tauri::AppHandle,
+    label: &state::WindowLabelRef,
+    window_relative_url: String,
+) -> tauri::Result<tauri::Window> {
+    tracing::info!("creating window '{label}' created at '{window_relative_url}'");
+    let window = tauri::WindowBuilder::new(
+        handle,
+        label,
+        tauri::WindowUrl::App(window_relative_url.into()),
+    )
+    .resizable(true)
+    .title(handle.package_info().name.clone())
+    .disable_file_drop_handler()
+    .min_inner_size(800.0, 600.0)
+    .inner_size(1160.0, 720.0)
+    .build()?;
+    Ok(window)
 }
 
-fn handler_from_app(app: &AppHandle) -> Result<gitbutler_watcher::Handler> {
-    let projects = app.state::<projects::Controller>().inner().clone();
-    let users = app.state::<users::Controller>().inner().clone();
-    let vbranches = gitbutler_branch_actions::VirtualBranchActions::default();
-
-    Ok(gitbutler_watcher::Handler::new(
-        projects,
-        users,
-        vbranches,
-        {
-            let app = app.clone();
-            move |change| ChangeForFrontend::from(change).send(&app)
-        },
-    ))
-}
-
-impl WindowState {
-    pub fn new(app_handle: AppHandle) -> Self {
-        Self {
-            app_handle,
-            state: Default::default(),
-        }
-    }
-
-    /// Watch the `project`, assure no other instance can access it, and associate it with the window
-    /// uniquely identified by `window`.
-    ///
-    /// Previous state will be removed and its resources cleaned up.
-    #[instrument(skip(self, project), err(Debug))]
-    pub fn set_project_to_window(
-        &self,
-        window: &WindowLabelRef,
-        project: &projects::Project,
-    ) -> Result<()> {
-        let mut lock_file =
-            fslock::LockFile::open(project.gb_dir().join(WINDOW_LOCK_FILE).as_os_str())?;
-        lock_file
-            .lock()
-            .context("Another GitButler Window already has the project opened")?;
-
-        let handler = handler_from_app(&self.app_handle)?;
-        let worktree_dir = project.path.clone();
-        let project_id = project.id;
-        let watcher = gitbutler_watcher::watch_in_background(handler, worktree_dir, project_id)?;
-        let mut state_by_label = block_on(self.state.lock());
-        state_by_label.insert(
-            window.to_owned(),
-            State {
-                project_id,
-                watcher,
-                exclusive_access: lock_file,
-            },
-        );
-        tracing::debug!("Maintaining {} Windows", state_by_label.len());
-        Ok(())
-    }
-
-    pub async fn post(&self, action: gitbutler_watcher::Action) -> Result<()> {
-        let mut state_by_label = self.state.lock().await;
-        let state = state_by_label
-            .values_mut()
-            .find(|state| state.project_id == action.project_id());
-        if let Some(state) = state {
-            state
-                .watcher
-                .post(action)
-                .await
-                .context("failed to post event")
-        } else {
-            Err(anyhow::anyhow!(
-                "matching watcher to post event not found, wanted {wanted}",
-                wanted = action.project_id(),
-            ))
-        }
-    }
-
-    /// Flush file-monitor watcher events once the windows regains focus for it to respond instantly
-    /// instead of according to the tick-rate.
-    pub fn flush(&self, window: &WindowLabelRef) -> Result<()> {
-        let state_by_label = block_on(self.state.lock());
-        if let Some(state) = state_by_label.get(window) {
-            state.watcher.flush()?;
-        }
-
-        Ok(())
-    }
-
-    /// Remove the state associated with `window`, typically upon its destruction.
-    pub fn remove(&self, window: &WindowLabelRef) {
-        let mut state_by_label = block_on(self.state.lock());
-        state_by_label.remove(window);
-    }
+#[cfg(target_os = "macos")]
+pub fn create(
+    handle: &tauri::AppHandle,
+    label: &state::WindowLabelRef,
+    window_relative_url: String,
+) -> tauri::Result<tauri::Window> {
+    tracing::info!("creating window '{label}' created at '{window_relative_url}'");
+    let window = tauri::WindowBuilder::new(
+        handle,
+        label,
+        tauri::WindowUrl::App(window_relative_url.into()),
+    )
+    .resizable(true)
+    .title(handle.package_info().name.clone())
+    .min_inner_size(800.0, 600.0)
+    .inner_size(1160.0, 720.0)
+    .hidden_title(true)
+    .disable_file_drop_handler()
+    .title_bar_style(tauri::TitleBarStyle::Overlay)
+    .build()?;
+    Ok(window)
 }

--- a/crates/gitbutler-watcher/src/file_monitor.rs
+++ b/crates/gitbutler-watcher/src/file_monitor.rs
@@ -114,8 +114,8 @@ pub fn spawn(
 
     let worktree_path = worktree_path.to_owned();
     task::spawn_blocking(move || {
-        tracing::debug!(%project_id, "file watcher started");
         let _runtime = tracing::span!(Level::INFO, "file monitor", %project_id ).entered();
+        tracing::debug!(%project_id, "file watcher started");
 
         'outer: for result in notify_rx {
             let stats = tracing::span!(

--- a/crates/gitbutler-watcher/src/lib.rs
+++ b/crates/gitbutler-watcher/src/lib.rs
@@ -112,6 +112,7 @@ pub fn watch_in_background(
                     debounce.flush_nonblocking();
                 }
                 () = cancellation_token.cancelled() => {
+                    tracing::debug!(%project_id, "stopped watcher");
                     break;
                 }
             }


### PR DESCRIPTION
Currently, mutliple instance of GitButler will interfere (and race) with each other when opened on the same project.
This PR makes this safe by preventing this by means of filesystem locking, using locks that can't go stale.

This mechanism prevents multiple instaces (processes) or windows (within one process) to observe the same repository,
making it exclusive to the respective 'owning' window.

This PR also implements early support for multiple windows for good measure.

### Tasks

* [x] encourage more 'mordern' `tauri` commands by example
* [x] Lock per project, which follows the active project
    - there now is an issue with newly added projects being 'always on', so somehow changing back to an older project doesn't setup watchers. Ignoring, but setting up multi-window support right away.
* [x] multi-window support
    - this should force some cleanup in how events are fired, needs to touch the UI

### Tasks: practical multi-window support

Generally
 - keep state per Window to handle watchers and don't rely on a single-window to exit
 - `listProjects` provides information about the window that has a project open (could be used to focus it)

* [x] per-window state, respond to open/close
* [x] open new project window with `alt+click` on existing project
* [x] fix strange close-behaviour/make it possible to close these
* [x] make sure multiple windows actually clash if displaying the same project
* [x] UI displays which projects are currently opened, no matter which window


https://github.com/gitbutlerapp/gitbutler/assets/63622/2cc81f6c-f216-47ce-b9a3-4e58cac35415



### Out of Scope

* Differentiate between 'observing' (read-only) Windows which cannot change things.
    - Doing this would require the Window to watch all relevant state and be able to update itself automatically.
      Right now, file-watching is only implemented for particular cases.

### Notes for the Reviewer

* Sometimes, when a window is closed, the application half-crashes - all Windows close, without coming back. I'd think that this is some `tauri` issue as safe Rust simply doesn't do that.
* I validated that multi-window project handling works as well as multi-instance handling, i.e. they won't allow to open a project in more than one window at a time no matter where the window is coming from. However, that test was only on MacOS, but should act the same also on Linux and Windows.
* The UI part can certainly use some tuning to have better UX around discovering how to open new windows, and probably the entire flow around opening windows. What's here is just a bare minimum, even though I personally like the UX of it, coincidentally, as decent UX wasn't the goal.
* I have implemented the 'is open' information for the project picker in the backend, even though in theory it could be done in the frontend if it would be able to list all windows. But I couldn't figure out how, without relying on lower-level `tauri://` messages that the implementation seems to be using under the hood. What's there is neat too though, and feels quite alright.

### Known UI Bugs

#### Empty `ProjectSwitcher`
When opening a new Window and it fails as the same project is already opened elsewhere, then the project list will be empty. This seems to be due to it being called twice, the first time it's empty which is shown, the second time it gets projects, but that's ineffective. It's notable that the first time when it's deemed empty, there is no call to `list_projects`.

<img width="1054" alt="Screenshot 2024-07-11 at 10 20 07" src="https://github.com/gitbutlerapp/gitbutler/assets/63622/dc7ca72f-e67a-4109-91e9-8899e5f12195">

Note that this bug now is much harder to run into, and really needs multiple instance of the application to be used as a single application will make it hard to open a project that is already opened (in the same instance).

### Known Shortcomings

* Each Window of the UI acts like it's the main window, which is notable when the updater popup shows in each of them. 
* Even though the main `ProjectSelector` (in Navigation) merges the state of other Windows to avoid trying to open those that it knows are opened, the `ProjectSwitcher` doesn't currently do that.
* The `ProjectSelector` should update its list each time it is opened, otherwise it's still quite easy to run into "the Project is locked" problem as the listing of projects isn't uptodate in terms of which one is opened.

