### PR TITLE
remove virtual branch controller

### DIFF
--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -128,8 +128,6 @@ fn main() {
                     let git_credentials_controller = Helper::default();
                     app_handle.manage(git_credentials_controller.clone());
 
-                    app_handle.manage(gitbutler_virtual::controller::Controller::default());
-
                     let app = app::App::new(
                         projects_controller,
                     );

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -28,8 +28,7 @@ pub mod commands {
         run_hooks: bool,
     ) -> Result<String, Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
-        let oid = handle
-            .state::<Controller>()
+        let oid = Controller::default()
             .create_commit(&project, branch, message, ownership.as_ref(), run_hooks)
             .await?;
         emit_vbranches(&handle, project_id).await;
@@ -43,8 +42,7 @@ pub mod commands {
         project_id: ProjectId,
     ) -> Result<VirtualBranches, Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
-        let (branches, skipped_files) = handle
-            .state::<Controller>()
+        let (branches, skipped_files) = Controller::default()
             .list_virtual_branches(&project)
             .await?;
 
@@ -62,8 +60,7 @@ pub mod commands {
         branch: BranchCreateRequest,
     ) -> Result<BranchId, Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
-        let branch_id = handle
-            .state::<Controller>()
+        let branch_id = Controller::default()
             .create_virtual_branch(&project, &branch)
             .await?;
         emit_vbranches(&handle, project_id).await;
@@ -78,8 +75,7 @@ pub mod commands {
         branch: Refname,
     ) -> Result<BranchId, Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
-        let branch_id = handle
-            .state::<Controller>()
+        let branch_id = Controller::default()
             .create_virtual_branch_from_branch(&project, &branch)
             .await?;
         emit_vbranches(&handle, project_id).await;
@@ -94,8 +90,7 @@ pub mod commands {
         branch: BranchId,
     ) -> Result<(), Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
-        handle
-            .state::<Controller>()
+        Controller::default()
             .integrate_upstream_commits(&project, branch)
             .await?;
         emit_vbranches(&handle, project_id).await;
@@ -109,11 +104,7 @@ pub mod commands {
         project_id: ProjectId,
     ) -> Result<Option<BaseBranch>, Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
-        if let Ok(base_branch) = handle
-            .state::<Controller>()
-            .get_base_branch_data(&project)
-            .await
-        {
+        if let Ok(base_branch) = Controller::default().get_base_branch_data(&project).await {
             Ok(Some(base_branch))
         } else {
             Ok(None)
@@ -132,8 +123,7 @@ pub mod commands {
         let branch_name = format!("refs/remotes/{}", branch)
             .parse()
             .context("Invalid branch name")?;
-        let base_branch = handle
-            .state::<Controller>()
+        let base_branch = Controller::default()
             .set_base_branch(&project, &branch_name)
             .await?;
 
@@ -155,10 +145,7 @@ pub mod commands {
         project_id: ProjectId,
     ) -> Result<Vec<ReferenceName>, Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
-        let unapplied_branches = handle
-            .state::<Controller>()
-            .update_base_branch(&project)
-            .await?;
+        let unapplied_branches = Controller::default().update_base_branch(&project).await?;
         emit_vbranches(&handle, project_id).await;
         Ok(unapplied_branches)
     }
@@ -171,8 +158,7 @@ pub mod commands {
         branch: BranchUpdateRequest,
     ) -> Result<(), Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
-        handle
-            .state::<Controller>()
+        Controller::default()
             .update_virtual_branch(&project, branch)
             .await?;
 
@@ -188,8 +174,7 @@ pub mod commands {
         branch_id: BranchId,
     ) -> Result<(), Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
-        handle
-            .state::<Controller>()
+        Controller::default()
             .delete_virtual_branch(&project, branch_id)
             .await?;
         emit_vbranches(&handle, project_id).await;
@@ -205,8 +190,7 @@ pub mod commands {
         name_conflict_resolution: NameConflitResolution,
     ) -> Result<(), Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
-        handle
-            .state::<Controller>()
+        Controller::default()
             .convert_to_real_branch(&project, branch, name_conflict_resolution)
             .await?;
         emit_vbranches(&handle, project_id).await;
@@ -221,8 +205,7 @@ pub mod commands {
         ownership: BranchOwnershipClaims,
     ) -> Result<(), Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
-        handle
-            .state::<Controller>()
+        Controller::default()
             .unapply_ownership(&project, &ownership)
             .await?;
         emit_vbranches(&handle, project_id).await;
@@ -242,10 +225,7 @@ pub mod commands {
             .split('\n')
             .map(std::string::ToString::to_string)
             .collect::<Vec<String>>();
-        handle
-            .state::<Controller>()
-            .reset_files(&project, &files)
-            .await?;
+        Controller::default().reset_files(&project, &files).await?;
         emit_vbranches(&handle, project_id).await;
         Ok(())
     }
@@ -259,8 +239,7 @@ pub mod commands {
         with_force: bool,
     ) -> Result<(), Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
-        handle
-            .state::<Controller>()
+        Controller::default()
             .push_virtual_branch(&project, branch_id, with_force, Some(Some(branch_id)))
             .await
             .map_err(|err| err.context(Code::Unknown))?;
@@ -276,8 +255,7 @@ pub mod commands {
         branch: RemoteRefname,
     ) -> Result<bool, Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
-        Ok(handle
-            .state::<Controller>()
+        Ok(Controller::default()
             .can_apply_remote_branch(&project, &branch)
             .await?)
     }
@@ -291,8 +269,7 @@ pub mod commands {
     ) -> Result<Vec<RemoteBranchFile>, Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
         let commit_oid = git2::Oid::from_str(&commit_oid).map_err(|e| anyhow!(e))?;
-        handle
-            .state::<Controller>()
+        Controller::default()
             .list_remote_commit_files(&project, commit_oid)
             .await
             .map_err(Into::into)
@@ -308,8 +285,7 @@ pub mod commands {
     ) -> Result<(), Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
         let target_commit_oid = git2::Oid::from_str(&target_commit_oid).map_err(|e| anyhow!(e))?;
-        handle
-            .state::<Controller>()
+        Controller::default()
             .reset_virtual_branch(&project, branch_id, target_commit_oid)
             .await?;
         emit_vbranches(&handle, project_id).await;
@@ -327,8 +303,7 @@ pub mod commands {
     ) -> Result<String, Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
         let commit_oid = git2::Oid::from_str(&commit_oid).map_err(|e| anyhow!(e))?;
-        let oid = handle
-            .state::<Controller>()
+        let oid = Controller::default()
             .amend(&project, branch_id, commit_oid, &ownership)
             .await?;
         emit_vbranches(&handle, project_id).await;
@@ -348,8 +323,7 @@ pub mod commands {
         let project = handle.state::<projects::Controller>().get(project_id)?;
         let from_commit_oid = git2::Oid::from_str(&from_commit_oid).map_err(|e| anyhow!(e))?;
         let to_commit_oid = git2::Oid::from_str(&to_commit_oid).map_err(|e| anyhow!(e))?;
-        let oid = handle
-            .state::<Controller>()
+        let oid = Controller::default()
             .move_commit_file(
                 &project,
                 branch_id,
@@ -372,8 +346,7 @@ pub mod commands {
     ) -> Result<(), Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
         let commit_oid = git2::Oid::from_str(&commit_oid).map_err(|e| anyhow!(e))?;
-        handle
-            .state::<Controller>()
+        Controller::default()
             .undo_commit(&project, branch_id, commit_oid)
             .await?;
         emit_vbranches(&handle, project_id).await;
@@ -391,8 +364,7 @@ pub mod commands {
     ) -> Result<(), Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
         let commit_oid = git2::Oid::from_str(&commit_oid).map_err(|e| anyhow!(e))?;
-        handle
-            .state::<Controller>()
+        Controller::default()
             .insert_blank_commit(&project, branch_id, commit_oid, offset)
             .await?;
         emit_vbranches(&handle, project_id).await;
@@ -410,8 +382,7 @@ pub mod commands {
     ) -> Result<(), Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
         let commit_oid = git2::Oid::from_str(&commit_oid).map_err(|e| anyhow!(e))?;
-        handle
-            .state::<Controller>()
+        Controller::default()
             .reorder_commit(&project, branch_id, commit_oid, offset)
             .await?;
         emit_vbranches(&handle, project_id).await;
@@ -425,10 +396,7 @@ pub mod commands {
         project_id: ProjectId,
     ) -> Result<Vec<RemoteBranch>, Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
-        let branches = handle
-            .state::<Controller>()
-            .list_remote_branches(project)
-            .await?;
+        let branches = Controller::default().list_remote_branches(project).await?;
         Ok(branches)
     }
 
@@ -440,8 +408,7 @@ pub mod commands {
         refname: Refname,
     ) -> Result<RemoteBranchData, Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
-        let branch_data = handle
-            .state::<Controller>()
+        let branch_data = Controller::default()
             .get_remote_branch_data(&project, &refname)
             .await?;
         Ok(branch_data)
@@ -457,8 +424,7 @@ pub mod commands {
     ) -> Result<(), Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
         let target_commit_oid = git2::Oid::from_str(&target_commit_oid).map_err(|e| anyhow!(e))?;
-        handle
-            .state::<Controller>()
+        Controller::default()
             .squash(&project, branch_id, target_commit_oid)
             .await?;
         emit_vbranches(&handle, project_id).await;
@@ -475,8 +441,7 @@ pub mod commands {
         let projects = handle.state::<projects::Controller>();
         let project = projects.get(project_id)?;
 
-        let project_data_last_fetched = handle
-            .state::<Controller>()
+        let project_data_last_fetched = Controller::default()
             .fetch_from_remotes(
                 &project,
                 Some(action.unwrap_or_else(|| "unknown".to_string())),
@@ -495,10 +460,7 @@ pub mod commands {
             .await
             .context("failed to update project with last fetched timestamp")?;
 
-        let base_branch = handle
-            .state::<Controller>()
-            .get_base_branch_data(&project)
-            .await?;
+        let base_branch = Controller::default().get_base_branch_data(&project).await?;
         Ok(base_branch)
     }
 
@@ -512,8 +474,7 @@ pub mod commands {
     ) -> Result<(), Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
         let commit_oid = git2::Oid::from_str(&commit_oid).map_err(|e| anyhow!(e))?;
-        handle
-            .state::<Controller>()
+        Controller::default()
             .move_commit(&project, target_branch_id, commit_oid)
             .await?;
         emit_vbranches(&handle, project_id).await;
@@ -531,8 +492,7 @@ pub mod commands {
     ) -> Result<(), Error> {
         let project = handle.state::<projects::Controller>().get(project_id)?;
         let commit_oid = git2::Oid::from_str(&commit_oid).map_err(|e| anyhow!(e))?;
-        handle
-            .state::<Controller>()
+        Controller::default()
             .update_commit_message(&project, branch_id, commit_oid, message)
             .await?;
         emit_vbranches(&handle, project_id).await;

--- a/crates/gitbutler-tauri/src/watcher.rs
+++ b/crates/gitbutler-tauri/src/watcher.rs
@@ -77,7 +77,7 @@ pub struct Watchers {
 fn handler_from_app(app: &AppHandle) -> anyhow::Result<gitbutler_watcher::Handler> {
     let projects = app.state::<projects::Controller>().inner().clone();
     let users = app.state::<users::Controller>().inner().clone();
-    let vbranches = gitbutler_virtual::Controller::default();
+    let vbranches = gitbutler_virtual::VirtualBranchActions::default();
 
     Ok(gitbutler_watcher::Handler::new(
         projects,

--- a/crates/gitbutler-tauri/src/watcher.rs
+++ b/crates/gitbutler-tauri/src/watcher.rs
@@ -77,7 +77,7 @@ pub struct Watchers {
 fn handler_from_app(app: &AppHandle) -> anyhow::Result<gitbutler_watcher::Handler> {
     let projects = app.state::<projects::Controller>().inner().clone();
     let users = app.state::<users::Controller>().inner().clone();
-    let vbranches = app.state::<gitbutler_virtual::Controller>().inner().clone();
+    let vbranches = gitbutler_virtual::Controller::default();
 
     Ok(gitbutler_watcher::Handler::new(
         projects,

--- a/crates/gitbutler-virtual/src/actions.rs
+++ b/crates/gitbutler-virtual/src/actions.rs
@@ -32,9 +32,9 @@ use crate::files::RemoteBranchFile;
 use gitbutler_branch::target;
 
 #[derive(Clone, Default)]
-pub struct Controller {}
+pub struct VirtualBranchActions {}
 
-impl Controller {
+impl VirtualBranchActions {
     pub async fn create_commit(
         &self,
         project: &Project,

--- a/crates/gitbutler-virtual/src/controller.rs
+++ b/crates/gitbutler-virtual/src/controller.rs
@@ -15,9 +15,7 @@ use gitbutler_project::{FetchResult, Project};
 use gitbutler_reference::{Refname, RemoteRefname};
 use gitbutler_repo::{credentials::Helper, RepoActions, RepositoryExt};
 use gitbutler_tagged_string::ReferenceName;
-use std::{path::Path, sync::Arc};
-
-use tokio::sync::Semaphore;
+use std::path::Path;
 
 use crate::{
     base::{
@@ -33,18 +31,8 @@ use super::r#virtual as branch;
 use crate::files::RemoteBranchFile;
 use gitbutler_branch::target;
 
-#[derive(Clone)]
-pub struct Controller {
-    semaphore: Arc<Semaphore>,
-}
-
-impl Default for Controller {
-    fn default() -> Self {
-        Self {
-            semaphore: Arc::new(Semaphore::new(1)),
-        }
-    }
-}
+#[derive(Clone, Default)]
+pub struct Controller {}
 
 impl Controller {
     pub async fn create_commit(
@@ -55,7 +43,6 @@ impl Controller {
         ownership: Option<&BranchOwnershipClaims>,
         run_hooks: bool,
     ) -> Result<git2::Oid> {
-        self.permit(project.ignore_project_semaphore).await;
         let project_repository = open_with_verify(project)?;
         let snapshot_tree = project_repository.project().prepare_snapshot();
         let result = branch::commit(
@@ -90,8 +77,6 @@ impl Controller {
         &self,
         project: &Project,
     ) -> Result<(Vec<branch::VirtualBranch>, Vec<diff::FileDiff>)> {
-        self.permit(project.ignore_project_semaphore).await;
-
         let project_repository = open_with_verify(project)?;
         branch::list_virtual_branches(&project_repository).map_err(Into::into)
     }
@@ -101,8 +86,6 @@ impl Controller {
         project: &Project,
         create: &BranchCreateRequest,
     ) -> Result<BranchId> {
-        self.permit(project.ignore_project_semaphore).await;
-
         let project_repository = open_with_verify(project)?;
         let branch_manager = project_repository.branch_manager();
         let branch_id = branch_manager.create_virtual_branch(create)?.id;
@@ -146,8 +129,6 @@ impl Controller {
         project: &Project,
         branch_id: BranchId,
     ) -> Result<()> {
-        self.permit(project.ignore_project_semaphore).await;
-
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
             .project()
@@ -156,8 +137,6 @@ impl Controller {
     }
 
     pub async fn update_base_branch(&self, project: &Project) -> Result<Vec<ReferenceName>> {
-        self.permit(project.ignore_project_semaphore).await;
-
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
             .project()
@@ -170,8 +149,6 @@ impl Controller {
         project: &Project,
         branch_update: BranchUpdateRequest,
     ) -> Result<()> {
-        self.permit(project.ignore_project_semaphore).await;
-
         let project_repository = open_with_verify(project)?;
         let snapshot_tree = project_repository.project().prepare_snapshot();
         let old_branch = project_repository
@@ -195,8 +172,6 @@ impl Controller {
         project: &Project,
         branch_id: BranchId,
     ) -> Result<()> {
-        self.permit(project.ignore_project_semaphore).await;
-
         let project_repository = open_with_verify(project)?;
         let branch_manager = project_repository.branch_manager();
         branch_manager.delete_branch(branch_id)
@@ -207,8 +182,6 @@ impl Controller {
         project: &Project,
         ownership: &BranchOwnershipClaims,
     ) -> Result<()> {
-        self.permit(project.ignore_project_semaphore).await;
-
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
             .project()
@@ -217,8 +190,6 @@ impl Controller {
     }
 
     pub async fn reset_files(&self, project: &Project, files: &Vec<String>) -> Result<()> {
-        self.permit(project.ignore_project_semaphore).await;
-
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
             .project()
@@ -233,8 +204,6 @@ impl Controller {
         commit_oid: git2::Oid,
         ownership: &BranchOwnershipClaims,
     ) -> Result<git2::Oid> {
-        self.permit(project.ignore_project_semaphore).await;
-
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
             .project()
@@ -250,8 +219,6 @@ impl Controller {
         to_commit_oid: git2::Oid,
         ownership: &BranchOwnershipClaims,
     ) -> Result<git2::Oid> {
-        self.permit(project.ignore_project_semaphore).await;
-
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
             .project()
@@ -272,8 +239,6 @@ impl Controller {
         branch_id: BranchId,
         commit_oid: git2::Oid,
     ) -> Result<()> {
-        self.permit(project.ignore_project_semaphore).await;
-
         let project_repository = open_with_verify(project)?;
         let snapshot_tree = project_repository.project().prepare_snapshot();
         let result: Result<()> =
@@ -295,8 +260,6 @@ impl Controller {
         commit_oid: git2::Oid,
         offset: i32,
     ) -> Result<()> {
-        self.permit(project.ignore_project_semaphore).await;
-
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
             .project()
@@ -312,8 +275,6 @@ impl Controller {
         commit_oid: git2::Oid,
         offset: i32,
     ) -> Result<()> {
-        self.permit(project.ignore_project_semaphore).await;
-
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
             .project()
@@ -328,8 +289,6 @@ impl Controller {
         branch_id: BranchId,
         target_commit_oid: git2::Oid,
     ) -> Result<()> {
-        self.permit(project.ignore_project_semaphore).await;
-
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
             .project()
@@ -343,8 +302,6 @@ impl Controller {
         branch_id: BranchId,
         name_conflict_resolution: branch::NameConflitResolution,
     ) -> Result<ReferenceName> {
-        self.permit(project.ignore_project_semaphore).await;
-
         let project_repository = open_with_verify(project)?;
         let snapshot_tree = project_repository.project().prepare_snapshot();
         let branch_manager = project_repository.branch_manager();
@@ -366,7 +323,6 @@ impl Controller {
         with_force: bool,
         askpass: Option<Option<BranchId>>,
     ) -> Result<()> {
-        self.permit(project.ignore_project_semaphore).await;
         let helper = Helper::default();
         let project_repository = open_with_verify(project)?;
         branch::push(&project_repository, branch_id, with_force, &helper, askpass)
@@ -392,8 +348,6 @@ impl Controller {
         branch_id: BranchId,
         commit_oid: git2::Oid,
     ) -> Result<()> {
-        self.permit(project.ignore_project_semaphore).await;
-
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
             .project()
@@ -408,7 +362,6 @@ impl Controller {
         commit_oid: git2::Oid,
         message: &str,
     ) -> Result<()> {
-        self.permit(project.ignore_project_semaphore).await;
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
             .project()
@@ -466,8 +419,6 @@ impl Controller {
         target_branch_id: BranchId,
         commit_oid: git2::Oid,
     ) -> Result<()> {
-        self.permit(project.ignore_project_semaphore).await;
-
         let project_repository = open_with_verify(project)?;
         let _ = project_repository
             .project()
@@ -480,19 +431,11 @@ impl Controller {
         project: &Project,
         branch: &Refname,
     ) -> Result<BranchId> {
-        self.permit(project.ignore_project_semaphore).await;
-
         let project_repository = open_with_verify(project)?;
         let branch_manager = project_repository.branch_manager();
         branch_manager
             .create_virtual_branch_from_branch(branch)
             .map_err(Into::into)
-    }
-
-    async fn permit(&self, ignore: bool) {
-        if !ignore {
-            let _ = self.semaphore.acquire().await.unwrap();
-        }
     }
 }
 

--- a/crates/gitbutler-virtual/src/lib.rs
+++ b/crates/gitbutler-virtual/src/lib.rs
@@ -1,6 +1,6 @@
 //! GitButler internal library containing functionaliry related to branches, i.e. the virtual branches implementation
-pub mod controller;
-pub use controller::Controller;
+pub mod actions;
+pub use actions::VirtualBranchActions;
 
 pub mod r#virtual;
 pub use r#virtual::*;

--- a/crates/gitbutler-virtual/tests/virtual_branches/create_commit.rs
+++ b/crates/gitbutler-virtual/tests/virtual_branches/create_commit.rs
@@ -134,7 +134,7 @@ fn commit_and_push_initial(repository: &TestProject) {
 }
 
 async fn get_virtual_branch(
-    controller: &Controller,
+    controller: &VirtualBranchActions,
     project: &Project,
     branch_id: Id<Branch>,
 ) -> VirtualBranch {

--- a/crates/gitbutler-virtual/tests/virtual_branches/init.rs
+++ b/crates/gitbutler-virtual/tests/virtual_branches/init.rs
@@ -7,7 +7,7 @@ async fn twice() {
 
     let test_project = TestProject::default();
 
-    let controller = Controller::default();
+    let controller = Controller {};
 
     {
         let project = projects

--- a/crates/gitbutler-virtual/tests/virtual_branches/init.rs
+++ b/crates/gitbutler-virtual/tests/virtual_branches/init.rs
@@ -7,7 +7,7 @@ async fn twice() {
 
     let test_project = TestProject::default();
 
-    let controller = Controller {};
+    let controller = VirtualBranchActions {};
 
     {
         let project = projects

--- a/crates/gitbutler-virtual/tests/virtual_branches/mod.rs
+++ b/crates/gitbutler-virtual/tests/virtual_branches/mod.rs
@@ -40,7 +40,7 @@ impl Default for Test {
         Self {
             repository: test_project,
             project_id: project.id,
-            controller: Controller::default(),
+            controller: Controller {},
             projects,
             project,
             data_dir: Some(data_dir),

--- a/crates/gitbutler-virtual/tests/virtual_branches/mod.rs
+++ b/crates/gitbutler-virtual/tests/virtual_branches/mod.rs
@@ -5,7 +5,7 @@ use gitbutler_branch::branch;
 use gitbutler_error::error::Marker;
 use gitbutler_project::{self as projects, Project, ProjectId};
 use gitbutler_reference::Refname;
-use gitbutler_virtual::Controller;
+use gitbutler_virtual::VirtualBranchActions;
 use tempfile::TempDir;
 
 use gitbutler_testsupport::{paths, TestProject, VAR_NO_CLEANUP};
@@ -15,7 +15,7 @@ struct Test {
     project_id: ProjectId,
     project: Project,
     projects: projects::Controller,
-    controller: Controller,
+    controller: VirtualBranchActions,
     data_dir: Option<TempDir>,
 }
 
@@ -40,7 +40,7 @@ impl Default for Test {
         Self {
             repository: test_project,
             project_id: project.id,
-            controller: Controller {},
+            controller: VirtualBranchActions {},
             projects,
             project,
             data_dir: Some(data_dir),

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -30,7 +30,7 @@ pub struct Handler {
     // need extra protection.
     projects: projects::Controller,
     users: users::Controller,
-    vbranch_controller: gitbutler_virtual::Controller,
+    vbranch_controller: gitbutler_virtual::VirtualBranchActions,
 
     /// A function to send events - decoupled from app-handle for testing purposes.
     #[allow(clippy::type_complexity)]
@@ -43,7 +43,7 @@ impl Handler {
     pub fn new(
         projects: projects::Controller,
         users: users::Controller,
-        vbranch_controller: gitbutler_virtual::Controller,
+        vbranch_controller: gitbutler_virtual::VirtualBranchActions,
         send_event: impl Fn(Change) -> Result<()> + Send + Sync + 'static,
     ) -> Self {
         Handler {


### PR DESCRIPTION
there is no more state in the virtual branches controller. Renaming the type to _Actions to signify that this is a collection of functions. 

@Byron I am thinking there is probably a nicer pattern to express this... so this is just a starting point