### PR TITLE
Rename VirtualBrancesAccess to _Ext since it's the convention

### DIFF
--- a/crates/gitbutler-branchstate/src/lib.rs
+++ b/crates/gitbutler-branchstate/src/lib.rs
@@ -1,4 +1,4 @@
 mod state;
 pub use state::VirtualBranches as VirtualBranchesState;
-pub use state::VirtualBranchesAccess;
+pub use state::VirtualBranchesExt;
 pub use state::VirtualBranchesHandle;

--- a/crates/gitbutler-branchstate/src/state.rs
+++ b/crates/gitbutler-branchstate/src/state.rs
@@ -57,11 +57,11 @@ pub struct VirtualBranchesHandle {
     file_path: PathBuf,
 }
 
-pub trait VirtualBranchesAccess {
+pub trait VirtualBranchesExt {
     fn virtual_branches(&self) -> VirtualBranchesHandle;
 }
 
-impl VirtualBranchesAccess for Project {
+impl VirtualBranchesExt for Project {
     fn virtual_branches(&self) -> VirtualBranchesHandle {
         VirtualBranchesHandle::new(self.gb_dir())
     }

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, bail, Context};
 use git2::{DiffOptions, FileMode};
 use gitbutler_branch::branch::Branch;
 use gitbutler_branch::diff::{hunks_by_filepath, FileDiff};
-use gitbutler_branchstate::{VirtualBranchesAccess, VirtualBranchesState};
+use gitbutler_branchstate::{VirtualBranchesExt, VirtualBranchesState};
 use gitbutler_project::Project;
 use gitbutler_repo::RepositoryExt;
 use std::collections::HashMap;

--- a/crates/gitbutler-sync/src/cloud.rs
+++ b/crates/gitbutler-sync/src/cloud.rs
@@ -4,7 +4,7 @@ use std::time;
 
 use anyhow::{anyhow, Context, Result};
 use gitbutler_branch::target::Target;
-use gitbutler_branchstate::VirtualBranchesAccess;
+use gitbutler_branchstate::VirtualBranchesExt;
 use gitbutler_command_context::ProjectRepository;
 use gitbutler_error::error::Code;
 use gitbutler_id::id::Id;

--- a/crates/gitbutler-testsupport/src/lib.rs
+++ b/crates/gitbutler-testsupport/src/lib.rs
@@ -19,7 +19,7 @@ pub mod paths {
 
 pub mod virtual_branches {
     use gitbutler_branch::target::Target;
-    use gitbutler_branchstate::VirtualBranchesAccess;
+    use gitbutler_branchstate::VirtualBranchesExt;
     use gitbutler_command_context::ProjectRepository;
 
     use crate::empty_bare_repository;

--- a/crates/gitbutler-virtual/src/actions.rs
+++ b/crates/gitbutler-virtual/src/actions.rs
@@ -4,7 +4,7 @@ use gitbutler_branch::{
     diff,
     ownership::BranchOwnershipClaims,
 };
-use gitbutler_branchstate::{VirtualBranchesAccess, VirtualBranchesHandle};
+use gitbutler_branchstate::{VirtualBranchesExt, VirtualBranchesHandle};
 use gitbutler_command_context::ProjectRepository;
 use gitbutler_oplog::{
     entry::{OperationKind, SnapshotDetails},

--- a/crates/gitbutler-virtual/src/base.rs
+++ b/crates/gitbutler-virtual/src/base.rs
@@ -6,7 +6,7 @@ use gitbutler_branch::branch::{self, BranchId};
 use gitbutler_branch::diff;
 use gitbutler_branch::ownership::BranchOwnershipClaims;
 use gitbutler_branch::target::Target;
-use gitbutler_branchstate::{VirtualBranchesAccess, VirtualBranchesHandle};
+use gitbutler_branchstate::{VirtualBranchesExt, VirtualBranchesHandle};
 use gitbutler_command_context::ProjectRepository;
 use gitbutler_project::FetchResult;
 use gitbutler_reference::{Refname, RemoteRefname};

--- a/crates/gitbutler-virtual/src/branch_manager.rs
+++ b/crates/gitbutler-virtual/src/branch_manager.rs
@@ -13,7 +13,7 @@ use gitbutler_branch::{
     diff,
     ownership::BranchOwnershipClaims,
 };
-use gitbutler_branchstate::VirtualBranchesAccess;
+use gitbutler_branchstate::VirtualBranchesExt;
 use gitbutler_command_context::ProjectRepository;
 use gitbutler_commit::commit_headers::{CommitHeadersV2, HasCommitHeaders};
 use gitbutler_error::error::Marker;

--- a/crates/gitbutler-virtual/src/integration.rs
+++ b/crates/gitbutler-virtual/src/integration.rs
@@ -8,7 +8,7 @@ use gitbutler_branch::{
     GITBUTLER_INTEGRATION_COMMIT_AUTHOR_EMAIL, GITBUTLER_INTEGRATION_COMMIT_AUTHOR_NAME,
     GITBUTLER_INTEGRATION_REFERENCE,
 };
-use gitbutler_branchstate::{VirtualBranchesAccess, VirtualBranchesHandle};
+use gitbutler_branchstate::{VirtualBranchesExt, VirtualBranchesHandle};
 use gitbutler_command_context::ProjectRepository;
 use gitbutler_commit::commit_ext::CommitExt;
 use gitbutler_error::error::Marker;

--- a/crates/gitbutler-virtual/src/virtual.rs
+++ b/crates/gitbutler-virtual/src/virtual.rs
@@ -4,7 +4,7 @@ use gitbutler_branch::diff::{self, diff_files_into_hunks, trees, FileDiff, GitHu
 use gitbutler_branch::file_ownership::OwnershipClaim;
 use gitbutler_branch::hunk::{Hunk, HunkHash};
 use gitbutler_branch::ownership::{reconcile_claims, BranchOwnershipClaims};
-use gitbutler_branchstate::{VirtualBranchesAccess, VirtualBranchesHandle};
+use gitbutler_branchstate::{VirtualBranchesExt, VirtualBranchesHandle};
 use gitbutler_command_context::ProjectRepository;
 use gitbutler_commit::commit_ext::CommitExt;
 use gitbutler_commit::commit_headers::HasCommitHeaders;

--- a/crates/gitbutler-virtual/tests/extra/mod.rs
+++ b/crates/gitbutler-virtual/tests/extra/mod.rs
@@ -17,7 +17,7 @@ use gitbutler_branch::{
     ownership::BranchOwnershipClaims,
     target::Target,
 };
-use gitbutler_branchstate::VirtualBranchesAccess;
+use gitbutler_branchstate::VirtualBranchesExt;
 use gitbutler_commit::{commit_ext::CommitExt, commit_headers::CommitHeadersV2};
 use gitbutler_reference::{Refname, RemoteRefname};
 use gitbutler_repo::RepositoryExt;

--- a/crates/gitbutler-virtual/tests/virtual_branches/oplog.rs
+++ b/crates/gitbutler-virtual/tests/virtual_branches/oplog.rs
@@ -1,5 +1,5 @@
 use super::*;
-use gitbutler_branchstate::VirtualBranchesAccess;
+use gitbutler_branchstate::VirtualBranchesExt;
 use gitbutler_oplog::oplog::Oplog;
 use itertools::Itertools;
 use std::io::Write;


### PR DESCRIPTION
After discussing it, seems like a better way of naming this is to use the Ext convention