### PR TITLE
fix: add vite build timestamp output to eslint ignores

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -66,6 +66,7 @@ export default tsEslint.config(
 			'**/postcss.config.cjs',
 			'**/playwright.config.ts',
 			'**/.pnpm-store',
+			'**/vite.config.ts.timestamp-*',
 			'!.storybook',
 			'target/',
 			'crates/'


### PR DESCRIPTION
## ☕️ Reasoning

- When doing a build locally, vite generates a file for its internal use. This file will then trip up eslint the next time it is run

## 🧢 Changes

- Add this `vite.config.ts.timestamp-*` file to eslint ignores

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
