### PR TITLE
fix: gitbutler/ui hot reload

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,12 +3,8 @@
 	"private": true,
 	"version": "0.0.0",
 	"type": "module",
-	"engines": {
-		"node": ">=20.11"
-	},
-	"packageManager": "pnpm@9.2.0",
 	"scripts": {
-		"dev": "vite --clearScreen false --debug hmr",
+		"dev": "vite --clearScreen false",
 		"test": "vitest run --mode development",
 		"test:watch": "vitest --watch --mode development",
 		"test:e2e": "playwright test -c ./playwright.config.ts",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	"type": "module",
 	"packageManager": "pnpm@9.2.0",
 	"scripts": {
-		"dev": "turbo run --filter @gitbutler/app dev --no-daemon",
+		"dev": "turbo watch --filter @gitbutler/app dev --no-update-notifier",
 		"dev:ui": "pnpm --filter @gitbutler/ui dev",
 		"dev:tauri": "pnpm tauri dev",
 		"test": "pnpm --filter @gitbutler/app run test",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,10 +9,6 @@
 		"SvelteKit"
 	],
 	"type": "module",
-	"engines": {
-		"node": ">=20.11"
-	},
-	"packageManager": "pnpm@9.2.0",
 	"scripts": {
 		"dev": "vite dev",
 		"check": "svelte-check --tsconfig ./tsconfig.json",


### PR DESCRIPTION
## ☕️ Reasoning

- When we migrated to [turborepo](https://turbo.build), the watch-and-rebuild of `@gitbutler/ui` files no longer worked.


## 🧢 Changes

- Use `turbo` in `watch` mode, which leverages its own filesystem watcher to re-execute the `package` npm script in `@gitbutler/ui` whenever anything in there changes. That will get picked up by the main `@gitbutler/app` process and reload to show the new content again!
- Also only define `packageManager` and `engines.node` once in the root `package.json` avoid duplicated info that can easily get out of sync over time..

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
