### PR TITLE
Fix double loading of things on open

### DIFF
--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -163,7 +163,6 @@ impl Handler {
             match file_name {
                 "FETCH_HEAD" => {
                     self.emit_app_event(Change::GitFetch(project_id))?;
-                    self.calculate_virtual_branches(project_id).await?;
                 }
                 "logs/HEAD" => {
                     self.emit_app_event(Change::GitActivity(project.id))?;


### PR DESCRIPTION
No need to emit vbranches when a fetch is detected, we already use this signal in the front end to e.g. refetch the base branch data.