### PR TITLE
Change: preferred action for commit integration

### DIFF
--- a/app/src/lib/branch/BranchFooter.svelte
+++ b/app/src/lib/branch/BranchFooter.svelte
@@ -71,7 +71,7 @@
 				wide
 				projectId={project.id}
 				requiresForce={$branch.requiresForce}
-				integrate={hasRemoteCommits}
+				canIntegrate={hasRemoteCommits}
 				{isLoading}
 				trigger={async (action) => {
 					isLoading = true;

--- a/app/src/lib/branch/BranchFooter.svelte
+++ b/app/src/lib/branch/BranchFooter.svelte
@@ -73,15 +73,15 @@
 				requiresForce={$branch.requiresForce}
 				integrate={hasRemoteCommits}
 				{isLoading}
-				on:trigger={async (e) => {
+				trigger={async (action) => {
 					isLoading = true;
 					try {
-						if (e.detail.action === BranchAction.Push) {
+						if (action === BranchAction.Push) {
 							await branchController.pushBranch($branch.id, $branch.requiresForce);
 							$listingService?.refresh();
 							$prMonitor?.refresh();
 							$checksMonitor?.update();
-						} else if (e.detail.action === BranchAction.Integrate) {
+						} else if (action === BranchAction.Integrate) {
 							await branchController.mergeUpstream($branch.id);
 						}
 					} catch (e) {

--- a/app/src/lib/components/PushButton.svelte
+++ b/app/src/lib/components/PushButton.svelte
@@ -35,6 +35,10 @@
 		[BranchAction.Integrate]: 'Integrate upstream'
 	};
 
+	$: if (requiresForce) {
+		$preferredAction = BranchAction.Integrate;
+	}
+
 	function selectAction(preferredAction: BranchAction) {
 		if (preferredAction === BranchAction.Integrate && integrate) return BranchAction.Integrate;
 		return BranchAction.Push;

--- a/app/src/lib/components/PushButton.svelte
+++ b/app/src/lib/components/PushButton.svelte
@@ -18,14 +18,14 @@
 		projectId,
 		requiresForce,
 		isLoading = false,
-		integrate = false,
+		canIntegrate = false,
 		wide = false,
 		trigger
 	}: {
 		projectId: string;
 		requiresForce: boolean;
 		isLoading: boolean;
-		integrate: boolean;
+		canIntegrate: boolean;
 		wide: boolean;
 		trigger: (action: BranchAction) => void;
 	} = $props();
@@ -46,11 +46,11 @@
 	});
 
 	$effect(() => {
-		if (requiresForce) $preferredAction = BranchAction.Integrate;
+		if (canIntegrate) $preferredAction = BranchAction.Integrate;
 	});
 
 	function selectAction(preferredAction: BranchAction) {
-		if (preferredAction === BranchAction.Integrate && integrate) return BranchAction.Integrate;
+		if (preferredAction === BranchAction.Integrate && canIntegrate) return BranchAction.Integrate;
 		return BranchAction.Push;
 	}
 </script>
@@ -76,7 +76,7 @@
 		/>
 		<ContextMenuItem
 			label={labels[BranchAction.Integrate]}
-			disabled={!integrate}
+			disabled={!canIntegrate}
 			on:click={() => {
 				$preferredAction = BranchAction.Integrate;
 				dropDown.close();


### PR DESCRIPTION
Currently, if there are no integrated remote commits, the preferred action is to `Force push`, which deletes remote commits. The preferred action in this case should be `Integrate upstream`.

<img width="524" alt="image" src="https://github.com/user-attachments/assets/34cc3edf-40cc-4158-866d-4a91f87d8d4d">
  