### PR TITLE
CSS: fix for long code strings in the modal component, update the code sting style

### DIFF
--- a/app/src/lib/shared/Modal.svelte
+++ b/app/src/lib/shared/Modal.svelte
@@ -61,7 +61,7 @@
 				</div>
 			{/if}
 
-			<div class="modal__body custom-scrollbar">
+			<div class="modal__body custom-scrollbar text-base-body-13">
 				{@render children(item)}
 			</div>
 
@@ -119,8 +119,13 @@
 
 	.modal__body {
 		overflow: auto;
-		padding: 14px;
-		line-height: 1.4rem;
+		padding: 16px;
+		line-height: 160%;
+	}
+
+	.modal__body > :global(code),
+	.modal__body > :global(pre) {
+		word-wrap: break-word;
 	}
 
 	.modal__footer {

--- a/app/src/styles/main.css
+++ b/app/src/styles/main.css
@@ -118,8 +118,8 @@ pre {
 .code-string {
 	font-family: 'Spline Sans Mono', monospace;
 	border-radius: var(--radius-s);
-	background: oklch(from var(--clr-scale-ntrl-50) l c h / 0.2);
-	padding: 2px 4px;
+	background: var(--clr-scale-ntrl-80);
+	padding: 1px 4px;
 }
 
 /* TRANSITION ANIMATION */


### PR DESCRIPTION
Small update in addition to this PR: https://github.com/gitbutlerapp/gitbutler/pull/4337

The paddings should be set to 16px, as they are consistent with other modal elements. Changing the paddings won't resolve the issue due to varying modal sizes, which may be too small for certain code strings. The best approach is to break the word if it's too long, preventing the scrollbar from appearing.