### PR TITLE
fix: rm workflow_dispatch from docs GHA

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,5 @@
 name: Trigger Docs Build
 on:
-  workflow_dispatch:
   release:
     types: [published]
 


### PR DESCRIPTION
## ☕️ Reasoning
- Remove `workflow_dispatch` trigger event

## 🧢 Changes

- Removed `workflow_dispatch` trigger event from GitHub Action to build docs and update `releases.mdx` page. The `workflow_dispatch` event won't have all the necessary `github.event.release.*` info in its payload, so without additional work (fetching latest release manually, etc.) this wouldn't work anyway. So long story short, removing for now

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
