### PR TITLE
fix: rm duplicate showError calls

### DIFF
--- a/app/src/routes/+layout.svelte
+++ b/app/src/routes/+layout.svelte
@@ -19,7 +19,6 @@
 	} from '$lib/gitHost/github/githubUserService';
 	import { octokitFromAccessToken } from '$lib/gitHost/github/octokit';
 	import ToastController from '$lib/notifications/ToastController.svelte';
-	import { showError } from '$lib/notifications/toasts';
 	import { RemotesService } from '$lib/remotes/service';
 	import { setSecretsService } from '$lib/secrets/secretsService';
 	import { SETTINGS, loadUserSettings } from '$lib/settings/userSettings';
@@ -34,7 +33,6 @@
 	import type { LayoutData } from './$types';
 	import { dev } from '$app/environment';
 	import { goto } from '$app/navigation';
-	import { page } from '$app/stores';
 
 	const { data, children }: { data: LayoutData; children: Snippet } = $props();
 

--- a/app/src/routes/+layout.svelte
+++ b/app/src/routes/+layout.svelte
@@ -79,13 +79,6 @@
 	});
 
 	onMount(() => {
-		if ($page.error?.message) {
-			let message = $page.error.message;
-			if ($page.error.errorId) {
-				message += `\n\nError ID: ${$page.error.errorId}`;
-			}
-			showError('There was a problem', message);
-		}
 		return unsubscribe(
 			events.on('goto', async (path: string) => await goto(path)),
 			events.on('openSendIssueModal', () => shareIssueModal?.show())


### PR DESCRIPTION
## ☕️ Reasoning

- `handleError` hook was modified in https://github.com/gitbutlerapp/gitbutler/pull/4366, so this is no longer necessary

## 🧢 Changes

- Remove this additional `showError()` call. We're doign it in the client hooks file directly now so this is unnecessary. Also we're not returning the `errorId` anymore.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
