### PR TITLE
feat: add `io.wp.com` to `img-src` CSP for gravatar / auth0 fallback avatars

### DIFF
--- a/crates/gitbutler-tauri/tauri.conf.nightly.json
+++ b/crates/gitbutler-tauri/tauri.conf.nightly.json
@@ -26,7 +26,7 @@
 		"security": {
 			"csp": {
 				"default-src": "'self'",
-				"img-src": "'self' asset: https://asset.localhost data: tauri://localhost https://avatars.githubusercontent.com https://*.gitbutler.com  https://gitbutler-public.s3.amazonaws.com https://*.gravatar.com",
+				"img-src": "'self' asset: https://asset.localhost data: tauri://localhost https://avatars.githubusercontent.com https://*.gitbutler.com  https://gitbutler-public.s3.amazonaws.com https://*.gravatar.com https://io.wp.com",
 				"connect-src": "'self' https://eu.posthog.com https://eu.i.posthog.com https://app.gitbutler.com https://o4504644069687296.ingest.sentry.io ws://localhost:7703 https://github.com https://api.github.com https://api.openai.com",
 				"script-src": "'self' https://eu.posthog.com https://eu.i.posthog.com",
 				"style-src": "'self' 'unsafe-inline'"

--- a/crates/gitbutler-tauri/tauri.conf.release.json
+++ b/crates/gitbutler-tauri/tauri.conf.release.json
@@ -26,7 +26,7 @@
 		"security": {
 			"csp": {
 				"default-src": "'self'",
-				"img-src": "'self' asset: https://asset.localhost data: tauri://localhost https://avatars.githubusercontent.com https://*.gitbutler.com  https://gitbutler-public.s3.amazonaws.com https://*.gravatar.com",
+				"img-src": "'self' asset: https://asset.localhost data: tauri://localhost https://avatars.githubusercontent.com https://*.gitbutler.com  https://gitbutler-public.s3.amazonaws.com https://*.gravatar.com https://io.wp.com",
 				"connect-src": "'self' https://eu.posthog.com https://eu.i.posthog.com https://app.gitbutler.com https://o4504644069687296.ingest.sentry.io ws://localhost:7703 https://github.com https://api.github.com https://api.openai.com",
 				"script-src": "'self' https://eu.posthog.com https://eu.i.posthog.com",
 				"style-src": "'self' 'unsafe-inline'"


### PR DESCRIPTION
## ☕️ Reasoning

- Since we removed our Rust image proxy, we've notice images loading from domains we previously weren't aware of, like this Auth0 induced gravatar fallback domain
	- For more info: https://community.auth0.com/t/gravatar-usage-with-auth0/128753

## 🧢 Changes

- Add `io.wp.com` to the `img-src` CSP for nightly and release
 


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

-->
## 🎫 Affected issues

Fixes #4377


<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
