### PR TITLE
fix: change button tooltip event listeners to `pointer*` versions

### DIFF
--- a/app/src/lib/shared/Button.svelte
+++ b/app/src/lib/shared/Button.svelte
@@ -103,7 +103,6 @@
 
 		&:disabled {
 			cursor: default;
-			pointer-events: none;
 			opacity: 0.5;
 		}
 		&.wide {

--- a/app/src/lib/utils/tooltip.ts
+++ b/app/src/lib/utils/tooltip.ts
@@ -102,8 +102,8 @@ export function tooltip(node: HTMLElement, optsOrString: ToolTipOptions | string
 		tooltip.style.left = `${leftPos}px`;
 	}
 
-	node.addEventListener('mouseover', onMouseOver);
-	node.addEventListener('mouseleave', onMouseLeave);
+	node.addEventListener('pointerenter', onMouseOver);
+	node.addEventListener('pointerleave', onMouseLeave);
 
 	return {
 		update(opts: ToolTipOptions | string | undefined) {
@@ -112,8 +112,8 @@ export function tooltip(node: HTMLElement, optsOrString: ToolTipOptions | string
 		destroy() {
 			tooltip?.remove();
 			timeoutId && clearTimeout(timeoutId);
-			node.removeEventListener('mouseover', onMouseOver);
-			node.removeEventListener('mouseleave', onMouseLeave);
+			node.removeEventListener('pointerenter', onMouseOver);
+			node.removeEventListener('pointerleave', onMouseLeave);
 		}
 	};
 }


### PR DESCRIPTION
## ☕️ Reasoning

- Show tooltip even on disabled btns

## 🧢 Changes

- Changed the tooltip event listeners from `mouseover`/`mouseleave` to `pointerenter`/`pointerleave`, which still fire on `disabled` buttons.
- Didn't work previously as we explicitly also set `.disable { pointer-evnets: none; }` in the button's CSS

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
