### PR TITLE
clearer read-write separation

### DIFF
--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -49,7 +49,6 @@ impl VirtualBranchActions {
             message,
             ownership,
             run_hooks,
-            guard.write_permission(),
         )
         .map_err(Into::into);
         let _ = snapshot_tree.and_then(|snapshot_tree| {
@@ -233,13 +232,7 @@ impl VirtualBranchActions {
             SnapshotDetails::new(OperationKind::AmendCommit),
             guard.write_permission(),
         );
-        branch::amend(
-            &project_repository,
-            branch_id,
-            commit_oid,
-            ownership,
-            guard.write_permission(),
-        )
+        branch::amend(&project_repository, branch_id, commit_oid, ownership)
     }
 
     pub async fn move_commit_file(
@@ -473,13 +466,7 @@ impl VirtualBranchActions {
             SnapshotDetails::new(OperationKind::MoveCommit),
             guard.write_permission(),
         );
-        branch::move_commit(
-            &project_repository,
-            target_branch_id,
-            commit_oid,
-            guard.write_permission(),
-        )
-        .map_err(Into::into)
+        branch::move_commit(&project_repository, target_branch_id, commit_oid).map_err(Into::into)
     }
 
     pub async fn create_virtual_branch_from_branch(

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -367,7 +367,7 @@ pub(crate) fn update_base_branch(
 
     // try to update every branch
     let updated_vbranches =
-        vb::get_status_by_branch(project_repository, Some(&integration_commit), perm)?
+        vb::get_status_by_branch(project_repository, Some(&integration_commit), None)?
             .0
             .into_iter()
             .map(|(branch, _)| branch)

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
@@ -82,7 +82,7 @@ impl BranchManager<'_> {
             self.project_repository,
             &integration_commit.id(),
             virtual_branches,
-            perm,
+            None,
         )
         .context("failed to get status by branch")?;
 

--- a/crates/gitbutler-branch-actions/tests/extra/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/extra/mod.rs
@@ -61,14 +61,7 @@ fn commit_on_branch_then_change_file_then_get_status() -> Result<()> {
     assert_eq!(branch.commits.len(), 0);
 
     // commit
-    commit(
-        project_repository,
-        branch1_id,
-        "test commit",
-        None,
-        false,
-        guard.write_permission(),
-    )?;
+    commit(project_repository, branch1_id, "test commit", None, false)?;
 
     // status (no files)
     let (branches, _) = list_virtual_branches(project_repository, guard.write_permission())?;
@@ -162,14 +155,7 @@ fn track_binary_files() -> Result<()> {
     );
 
     // commit
-    commit(
-        project_repository,
-        branch1_id,
-        "test commit",
-        None,
-        false,
-        guard.write_permission(),
-    )?;
+    commit(project_repository, branch1_id, "test commit", None, false)?;
 
     // status (no files)
     let (branches, _) =
@@ -196,14 +182,7 @@ fn track_binary_files() -> Result<()> {
     file.write_all(&image_data)?;
 
     // commit
-    commit(
-        project_repository,
-        branch1_id,
-        "test commit",
-        None,
-        false,
-        guard.write_permission(),
-    )?;
+    commit(project_repository, branch1_id, "test commit", None, false)?;
 
     let (branches, _) =
         list_virtual_branches(project_repository, guard.write_permission()).unwrap();
@@ -241,8 +220,7 @@ fn create_branch_with_ownership() -> Result<()> {
         .create_virtual_branch(&BranchCreateRequest::default(), guard.write_permission())
         .expect("failed to create virtual branch");
 
-    get_status_by_branch(project_repository, None, guard.write_permission())
-        .expect("failed to get status");
+    get_status_by_branch(project_repository, None, None).expect("failed to get status");
 
     let vb_state = VirtualBranchesHandle::new(project_repository.project().gb_dir());
     let branch0 = vb_state.get_branch_in_workspace(branch0.id).unwrap();
@@ -257,7 +235,7 @@ fn create_branch_with_ownership() -> Result<()> {
         )
         .expect("failed to create virtual branch");
 
-    let statuses = get_status_by_branch(project_repository, None, guard.write_permission())
+    let statuses = get_status_by_branch(project_repository, None, None)
         .expect("failed to get status")
         .0;
 
@@ -376,7 +354,7 @@ fn hunk_expantion() -> Result<()> {
         .expect("failed to create virtual branch")
         .id;
 
-    let statuses = get_status_by_branch(project_repository, None, guard.write_permission())
+    let statuses = get_status_by_branch(project_repository, None, None)
         .expect("failed to get status")
         .0;
 
@@ -413,7 +391,7 @@ fn hunk_expantion() -> Result<()> {
         "line1\nline2\nline3\n",
     )?;
 
-    let statuses = get_status_by_branch(project_repository, None, guard.write_permission())
+    let statuses = get_status_by_branch(project_repository, None, None)
         .expect("failed to get status")
         .0;
     let files_by_branch_id = statuses
@@ -432,20 +410,14 @@ fn hunk_expantion() -> Result<()> {
 fn get_status_files_by_branch_no_hunks_no_branches() -> Result<()> {
     let suite = Suite::default();
     let Case {
-        project_repository,
-        project,
-        ..
+        project_repository, ..
     } = &suite.new_case();
 
     set_test_target(project_repository)?;
 
-    let statuses = get_status_by_branch(
-        project_repository,
-        None,
-        project.exclusive_worktree_access().write_permission(),
-    )
-    .expect("failed to get status")
-    .0;
+    let statuses = get_status_by_branch(project_repository, None, None)
+        .expect("failed to get status")
+        .0;
 
     assert_eq!(statuses.len(), 0);
 
@@ -477,7 +449,7 @@ fn get_status_files_by_branch() -> Result<()> {
         .expect("failed to create virtual branch")
         .id;
 
-    let statuses = get_status_by_branch(project_repository, None, guard.write_permission())
+    let statuses = get_status_by_branch(project_repository, None, None)
         .expect("failed to get status")
         .0;
     let files_by_branch_id = statuses
@@ -538,7 +510,7 @@ fn move_hunks_multiple_sources() -> Result<()> {
     };
     vb_state.set_branch(branch1.clone())?;
 
-    let statuses = get_status_by_branch(project_repository, None, guard.write_permission())
+    let statuses = get_status_by_branch(project_repository, None, None)
         .expect("failed to get status")
         .0;
 
@@ -563,7 +535,7 @@ fn move_hunks_multiple_sources() -> Result<()> {
         },
     )?;
 
-    let statuses = get_status_by_branch(project_repository, None, guard.write_permission())
+    let statuses = get_status_by_branch(project_repository, None, None)
         .expect("failed to get status")
         .0;
 
@@ -622,7 +594,7 @@ fn move_hunks_partial_explicitly() -> Result<()> {
         .expect("failed to create virtual branch")
         .id;
 
-    let statuses = get_status_by_branch(project_repository, None, guard.write_permission())
+    let statuses = get_status_by_branch(project_repository, None, None)
         .expect("failed to get status")
         .0;
     let files_by_branch_id = statuses
@@ -644,7 +616,7 @@ fn move_hunks_partial_explicitly() -> Result<()> {
         },
     )?;
 
-    let statuses = get_status_by_branch(project_repository, None, guard.write_permission())
+    let statuses = get_status_by_branch(project_repository, None, None)
         .expect("failed to get status")
         .0;
 
@@ -702,7 +674,7 @@ fn add_new_hunk_to_the_end() -> Result<()> {
         .create_virtual_branch(&BranchCreateRequest::default(), guard.write_permission())
         .expect("failed to create virtual branch");
 
-    let statuses = get_status_by_branch(project_repository, None, guard.write_permission())
+    let statuses = get_status_by_branch(project_repository, None, None)
         .expect("failed to get status")
         .0;
     assert_eq!(
@@ -715,7 +687,7 @@ fn add_new_hunk_to_the_end() -> Result<()> {
         "line0\nline1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11\nline12\nline13\nline14\nline15\n",
     )?;
 
-    let statuses = get_status_by_branch(project_repository, None, guard.write_permission())
+    let statuses = get_status_by_branch(project_repository, None, None)
         .expect("failed to get status")
         .0;
 
@@ -1028,7 +1000,6 @@ async fn merge_vbranch_upstream_conflict() -> Result<()> {
         "fix merge conflict",
         None,
         false,
-        guard.write_permission(),
     )?;
 
     let (branches, _) = list_virtual_branches(project_repository, guard.write_permission())?;
@@ -1563,7 +1534,6 @@ fn upstream_integrated_vbranch() -> Result<()> {
         "integrated commit",
         None,
         false,
-        guard.write_permission(),
     )?;
     commit(
         project_repository,
@@ -1571,7 +1541,6 @@ fn upstream_integrated_vbranch() -> Result<()> {
         "non-integrated commit",
         None,
         false,
-        guard.write_permission(),
     )?;
 
     let (branches, _) = list_virtual_branches(project_repository, guard.write_permission())?;
@@ -1634,7 +1603,6 @@ fn commit_same_hunk_twice() -> Result<()> {
         "first commit to test.txt",
         None,
         false,
-        guard.write_permission(),
     )?;
 
     let (branches, _) = list_virtual_branches(project_repository, guard.write_permission())?;
@@ -1669,7 +1637,6 @@ fn commit_same_hunk_twice() -> Result<()> {
         "second commit to test.txt",
         None,
         false,
-        guard.write_permission(),
     )?;
 
     let (branches, _) = list_virtual_branches(project_repository, guard.write_permission())?;
@@ -1730,7 +1697,6 @@ fn commit_same_file_twice() -> Result<()> {
         "first commit to test.txt",
         None,
         false,
-        guard.write_permission(),
     )?;
 
     let (branches, _) = list_virtual_branches(project_repository, guard.write_permission())?;
@@ -1765,7 +1731,6 @@ fn commit_same_file_twice() -> Result<()> {
         "second commit to test.txt",
         None,
         false,
-        guard.write_permission(),
     )?;
 
     let (branches, _) = list_virtual_branches(project_repository, guard.write_permission())?;
@@ -1826,7 +1791,6 @@ fn commit_partial_by_hunk() -> Result<()> {
         "first commit to test.txt",
         Some(&"test.txt:1-6".parse::<BranchOwnershipClaims>().unwrap()),
         false,
-        guard.write_permission(),
     )?;
 
     let (branches, _) = list_virtual_branches(project_repository, guard.write_permission())?;
@@ -1844,7 +1808,6 @@ fn commit_partial_by_hunk() -> Result<()> {
         "second commit to test.txt",
         Some(&"test.txt:16-22".parse::<BranchOwnershipClaims>().unwrap()),
         false,
-        guard.write_permission(),
     )?;
 
     let (branches, _) = list_virtual_branches(project_repository, guard.write_permission())?;
@@ -1897,7 +1860,6 @@ fn commit_partial_by_file() -> Result<()> {
         "branch1 commit",
         None,
         false,
-        guard.write_permission(),
     )?;
 
     let (branches, _) = list_virtual_branches(project_repository, guard.write_permission())?;
@@ -1959,7 +1921,6 @@ fn commit_add_and_delete_files() -> Result<()> {
         "branch1 commit",
         None,
         false,
-        guard.write_permission(),
     )?;
 
     let (branches, _) = list_virtual_branches(project_repository, guard.write_permission())?;
@@ -2027,7 +1988,6 @@ fn commit_executable_and_symlinks() -> Result<()> {
         "branch1 commit",
         None,
         false,
-        guard.write_permission(),
     )?;
 
     let (branches, _) = list_virtual_branches(project_repository, guard.write_permission())?;
@@ -2200,14 +2160,7 @@ fn pre_commit_hook_rejection() -> Result<()> {
 
     git2_hooks::create_hook(project_repository.repo(), git2_hooks::HOOK_PRE_COMMIT, hook);
 
-    let res = commit(
-        project_repository,
-        branch1_id,
-        "test commit",
-        None,
-        true,
-        guard.write_permission(),
-    );
+    let res = commit(project_repository, branch1_id, "test commit", None, true);
 
     let err = res.unwrap_err();
     assert_eq!(err.to_string(), "commit hook rejected: rejected");
@@ -2260,14 +2213,7 @@ fn post_commit_hook() -> Result<()> {
 
     assert!(!hook_ran_proof.exists());
 
-    commit(
-        project_repository,
-        branch1_id,
-        "test commit",
-        None,
-        true,
-        guard.write_permission(),
-    )?;
+    commit(project_repository, branch1_id, "test commit", None, true)?;
 
     assert!(hook_ran_proof.exists());
 
@@ -2307,14 +2253,7 @@ fn commit_msg_hook_rejection() -> Result<()> {
 
     git2_hooks::create_hook(project_repository.repo(), git2_hooks::HOOK_COMMIT_MSG, hook);
 
-    let res = commit(
-        project_repository,
-        branch1_id,
-        "test commit",
-        None,
-        true,
-        guard.write_permission(),
-    );
+    let res = commit(project_repository, branch1_id, "test commit", None, true);
 
     let err = res.unwrap_err();
     assert_eq!(err.to_string(), "commit-msg hook rejected: rejected");


### PR DESCRIPTION
This PR makes clearer where the feature of creating vbranches on the fly is actually needed,
and reduces it to only `list_virtual_branches()`.

There, changes are only done conditionally, which means that upgrades of read locks to write locks
will best represent what's going on, so this capability is added as well.

This *would* allow `list_virtual_branches()` to run in parallel.


### Tasks

* [x] limit write-permission to where it is needed (`list_virtual_branches()`)
* ~~upgradable lock for conditional upgrades when needed~~ - let's skip this, as `list_virtual_branches()`
  doesn't run in parallel. And if it does, then it probably shouldn't.
