### PR TITLE
Files-list-refactor

### DIFF
--- a/app/e2e/playwright/basic.spec.ts
+++ b/app/e2e/playwright/basic.spec.ts
@@ -9,7 +9,7 @@ test('has empty title', async ({ page }) => {
 test('has text package.json', async ({ page }) => {
 	await page.goto('http://localhost:1420');
 
-	const listBox = page.getByRole('listbox').getByRole('button').first();
+	const listBox = page.getByRole('listbox').getByRole('treeitem').first();
 
 	await expect(listBox).toHaveText('package.json');
 });

--- a/app/src/lib/components/Board.svelte
+++ b/app/src/lib/components/Board.svelte
@@ -86,8 +86,10 @@
 		}}
 	>
 		{#each $branches.sort((a, b) => a.order - b.order) as branch (branch.id)}
-			<!-- svelte-ignore a11y_no_static_element_interactions -->
 			<div
+				role="presentation"
+				aria-label="Branch"
+				tabindex="-1"
 				class="branch draggable-branch"
 				draggable="true"
 				on:mousedown={(e) => (dragHandle = e.target)}

--- a/app/src/lib/file/BranchFiles.svelte
+++ b/app/src/lib/file/BranchFiles.svelte
@@ -14,23 +14,9 @@
 
 	createCommitStore(undefined);
 	const fileIdSelection = getContext(FileIdSelection);
-
-	function unselectAllFiles() {
-		fileIdSelection.clear();
-	}
 </script>
 
-<div
-	class="branch-files"
-	role="listbox"
-	tabindex="-1"
-	on:keydown={(e) => {
-		if (e.key === 'Escape') {
-			unselectAllFiles();
-		}
-	}}
-	on:click={unselectAllFiles}
->
+<div class="branch-files" role="presentation" on:click={() => fileIdSelection.clear()}>
 	{#if files.length > 0}
 		<BranchFilesList {allowMultiple} {readonly} {files} {showCheckboxes} {isUnapplied} />
 	{/if}
@@ -39,5 +25,9 @@
 <style lang="postcss">
 	.branch-files {
 		flex: 1;
+	}
+
+	.branch-files:focus {
+		outline: none;
 	}
 </style>

--- a/app/src/lib/file/BranchFilesList.svelte
+++ b/app/src/lib/file/BranchFilesList.svelte
@@ -79,6 +79,7 @@
 			console.log('loading more files...');
 			loadMore();
 		}}
+		role="listbox"
 	>
 		{#each displayedFiles as file (file.id)}
 			<FileListItem

--- a/app/src/lib/file/BranchFilesList.svelte
+++ b/app/src/lib/file/BranchFilesList.svelte
@@ -94,13 +94,16 @@
 				on:keydown={(e) => {
 					e.preventDefault();
 					maybeMoveSelection(
-						allowMultiple,
-						e.shiftKey,
-						e.key,
-						file,
-						displayedFiles,
-						$fileIdSelection,
-						fileIdSelection
+						{
+							allowMultiple,
+							shiftKey: e.shiftKey,
+							key: e.key,
+							targetElement: e.currentTarget as HTMLElement,
+							file,
+							files: displayedFiles,
+							selectedFileIds: $fileIdSelection,
+							fileIdSelection
+						}
 					);
 
 					if (e.key === 'Escape') {

--- a/app/src/lib/file/BranchFilesList.svelte
+++ b/app/src/lib/file/BranchFilesList.svelte
@@ -101,6 +101,13 @@
 						$fileIdSelection,
 						fileIdSelection
 					);
+
+					if (e.key === 'Escape') {
+						fileIdSelection.clear();
+						
+						const targetEl = e.target as HTMLElement;
+						targetEl.blur();
+					}
 				}}
 			/>
 		{/each}

--- a/app/src/lib/file/FileListItem.svelte
+++ b/app/src/lib/file/FileListItem.svelte
@@ -100,8 +100,9 @@
 			contextMenu.open(e, { files: [file] });
 		}
 	}}
-	role="button"
-	tabindex="0"
+	role="treeitem"
+	aria-selected={selected}
+	tabindex="-1"
 	use:draggableChips={{
 		label: `${file.filename}`,
 		filePath: file.path,

--- a/app/src/lib/file/FileListItem.svelte
+++ b/app/src/lib/file/FileListItem.svelte
@@ -56,6 +56,9 @@
 	class:draggable={isDraggable}
 	id={`file-${file.id}`}
 	data-locked={file.locked}
+	role="treeitem"
+	aria-selected={selected}
+	tabindex="-1"
 	on:click
 	on:keydown
 	on:dragstart={async () => {
@@ -95,9 +98,6 @@
 			contextMenu.open(e, { files: [file] });
 		}
 	}}
-	role="treeitem"
-	aria-selected={selected}
-	tabindex="-1"
 	use:draggableChips={{
 		label: `${file.filename}`,
 		filePath: file.path,

--- a/app/src/lib/file/FileListItem.svelte
+++ b/app/src/lib/file/FileListItem.svelte
@@ -7,7 +7,6 @@
 	import Checkbox from '$lib/shared/Checkbox.svelte';
 	import Icon from '$lib/shared/Icon.svelte';
 	import { getContext, maybeGetContextStore } from '$lib/utils/context';
-	import { updateFocus } from '$lib/utils/selection';
 	import { getCommitStore } from '$lib/vbranches/contexts';
 	import { FileIdSelection } from '$lib/vbranches/fileIdSelection';
 	import { Ownership } from '$lib/vbranches/ownership';
@@ -44,10 +43,6 @@
 			file.hunks.every((hunk) => $selectedOwnership?.contains(file.id, hunk.id)) &&
 			lastCheckboxDetail;
 	}
-
-	// Don't focus if it's multiple selection. Issue #4139
-	$: if ($fileIdSelection && draggableElt && $fileIdSelection.length === 1)
-		updateFocus(draggableElt, file, fileIdSelection, $commit?.id);
 
 	const isDraggable = !readonly && !isUnapplied;
 </script>

--- a/app/src/lib/file/FileListItem.svelte
+++ b/app/src/lib/file/FileListItem.svelte
@@ -31,6 +31,19 @@
 	let draggableElt: HTMLDivElement;
 	let lastCheckboxDetail = true;
 
+	function updateFocus(
+		elt: HTMLElement,
+		file: AnyFile,
+		fileIdSelection: FileIdSelection,
+		commitId?: string
+	) {
+		const selected = fileIdSelection.only();
+		// console.log(selected);
+		if (selected && selected.fileId === file.id && selected.commitId === commitId) {
+			// elt.focus();
+		}
+	}
+
 	$: if (!lastCheckboxDetail) {
 		selectedOwnership?.update((ownership) => {
 			file.hunks.forEach((h) => ownership.remove(file.id, h.id));
@@ -43,6 +56,10 @@
 			file.hunks.every((hunk) => $selectedOwnership?.contains(file.id, hunk.id)) &&
 			lastCheckboxDetail;
 	}
+
+	// Don't focus if it's multiple selection. Issue #4139
+	$: if ($fileIdSelection && draggableElt && $fileIdSelection.length === 1)
+		updateFocus(draggableElt, file, fileIdSelection, $commit?.id);
 
 	const isDraggable = !readonly && !isUnapplied;
 </script>

--- a/app/src/lib/shared/LazyloadContainer.svelte
+++ b/app/src/lib/shared/LazyloadContainer.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import type { AriaRole } from 'svelte/elements';
 
 	interface Props {
 		children: any;
 		minTriggerCount: number;
+		role?: AriaRole | undefined | null;
 		ontrigger: (lastChild: Element) => void;
 	}
 
-	let { children, minTriggerCount, ontrigger }: Props = $props();
+	let { children, minTriggerCount, role, ontrigger }: Props = $props();
 
 	let lazyContainerEl: HTMLDivElement;
 
@@ -40,7 +42,7 @@
 	});
 </script>
 
-<div class="lazy-container" bind:this={lazyContainerEl}>
+<div class="lazy-container" {role} bind:this={lazyContainerEl}>
 	{@render children()}
 </div>
 

--- a/app/src/lib/utils/selection.ts
+++ b/app/src/lib/utils/selection.ts
@@ -16,25 +16,6 @@ export function getPreviousFile(files: AnyFile[], currentId: string): AnyFile | 
 	return fileIndex > 0 ? files[fileIndex - 1] : undefined;
 }
 
-/**
- * When the selectedFiles store updates we run this function for every rendered file to determine
- * if it is the only selected file. If so we focus the containing element.
- *
- * This has potential to slow things down since it's O(N) wrt to number of files, but it's less
- * prone to breakage than focusing using element ids at a distance.
- */
-export function updateFocus(
-	elt: HTMLElement,
-	file: AnyFile,
-	fileIdSelection: FileIdSelection,
-	commitId?: string
-) {
-	const selected = fileIdSelection.only();
-	if (selected && selected.fileId === file.id && selected.commitId === commitId) {
-		elt.focus();
-	}
-}
-
 export function maybeMoveSelection(
 	allowMultiple: boolean,
 	shiftKey: boolean,

--- a/app/src/lib/utils/selection.ts
+++ b/app/src/lib/utils/selection.ts
@@ -16,16 +16,30 @@ export function getPreviousFile(files: AnyFile[], currentId: string): AnyFile | 
 	return fileIndex > 0 ? files[fileIndex - 1] : undefined;
 }
 
-export function maybeMoveSelection(
-	allowMultiple: boolean,
-	shiftKey: boolean,
-	key: string,
-	file: AnyFile,
-	files: AnyFile[],
-	selectedFileIds: string[],
-	fileIdSelection: FileIdSelection
-) {
+interface MoveSelectionParams {
+	allowMultiple: boolean;
+	shiftKey: boolean;
+	key: string;
+	targetElement: HTMLElement;
+	file: AnyFile;
+	files: AnyFile[];
+	selectedFileIds: string[];
+	fileIdSelection: FileIdSelection;
+}
+
+export function maybeMoveSelection({
+	allowMultiple,
+	shiftKey,
+	key,
+	targetElement,
+	file,
+	files,
+	selectedFileIds,
+	fileIdSelection
+}: MoveSelectionParams) {
 	if (selectedFileIds.length === 0) return;
+
+	// console.log('targetElement', targetElement, elementIndex);
 
 	const firstFileId = unstringifyFileKey(selectedFileIds[0]);
 	const lastFileId = unstringifyFileKey(selectedFileIds[selectedFileIds.length - 1]);
@@ -70,6 +84,10 @@ export function maybeMoveSelection(
 				}
 				getAndAddFile(getPreviousFile, lastFileId);
 			} else {
+				// focus previous file
+				const previousElement = targetElement.previousElementSibling as HTMLElement;
+				if (previousElement) previousElement.focus();
+
 				// Handle reset of selection
 				if (selectedFileIds.length > 1) {
 					getAndClearAndAddFile(getPreviousFile, lastFileId);
@@ -90,6 +108,10 @@ export function maybeMoveSelection(
 				}
 				getAndAddFile(getNextFile, lastFileId);
 			} else {
+				// focus next file
+				const nextElement = targetElement.nextElementSibling as HTMLElement;
+				if (nextElement) nextElement.focus();
+
 				// Handle reset of selection
 				if (selectedFileIds.length > 1) {
 					getAndClearAndAddFile(getNextFile, lastFileId);


### PR DESCRIPTION
There was a bug: when you select a file in one branch and then submit a commit or undo it on another branch, the focus returns to the previously selected file, causing auto-scroll to that element.

See this capture:

https://github.com/user-attachments/assets/099851f0-bb93-4d26-b730-2cb46adb135e

Looks like the `updateFocus` caused this issue. It also seems like it doesn't do anything, so I removed it completely.

Fixed version:

https://github.com/user-attachments/assets/d365c303-8fc3-463f-b3ac-e726a7cd8673