### PR TITLE
update `gix` to the latest version for its improved `git.exe` discovery on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ resolver = "2"
 
 [workspace.dependencies]
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
-gix = { git = "https://github.com/Byron/gitoxide", rev = "55cbc1b9d6f210298a86502a7f20f9736c7e963e", default-features = false, features = [
+gix = { git = "https://github.com/Byron/gitoxide", rev = "15f1cf76764221d14afa66d03a6528b19b9c30c9", default-features = false, features = [
 ] }
 git2 = { version = "0.18.3", features = [
     "vendored-openssl",


### PR DESCRIPTION
Instead of hard-coding two known paths, it will dynamically discover the right location, handling different Windows install-locations automatically, using the very portable and easy-to-use environment variables.

### Tasks

* [x] validate that this works on Windows through a Windowed Application (i.e. no terminal)
    - Done by building a nightly, launching it from the explorer and validating that it can find git for updates.

Related advisory: https://github.com/Byron/gitoxide/security/advisories/GHSA-mgvv-9p9g-3jv4

### Notes

Work is on the way to bring `git.exe` discovery en-par with VSCode, which also looks for user-specific application directories, which is used for users without admin permissions.