### PR TITLE
refactor: Normalize branch name by replacing invalid characters with hyphens.

### DIFF
--- a/crates/gitbutler-reference/src/lib.rs
+++ b/crates/gitbutler-reference/src/lib.rs
@@ -5,8 +5,8 @@ use regex::Regex;
 
 pub fn normalize_branch_name(name: &str) -> String {
     // Remove specific symbols
-    let exclude_pattern = Regex::new(r"[|\+^~<>\\*]").unwrap();
-    let mut result = exclude_pattern.replace_all(name, "").to_string();
+    let exclude_pattern = Regex::new(r"[|\+^~<>\\:*]").unwrap();
+    let mut result = exclude_pattern.replace_all(name, "-").to_string();
 
     // Replace spaces with hyphens
     let space_pattern = Regex::new(r"\s+").unwrap();


### PR DESCRIPTION
- Handle the `:` sign
- Replace invalid characters with hyphens