### PR TITLE
improved `conflict` file handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2020,6 +2020,7 @@ dependencies = [
  "gitbutler-time",
  "gitbutler-url",
  "gitbutler-user",
+ "gix",
  "glob",
  "hex",
  "itertools 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2131,7 +2131,7 @@ version = "0.0.0"
 dependencies = [
  "assert_cmd",
  "futures",
- "gix-path 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-path 0.10.8",
  "nix 0.29.0",
  "rand 0.8.5",
  "serde",
@@ -2434,7 +2434,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.63.0"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "gix-actor",
  "gix-attributes",
@@ -2460,7 +2460,7 @@ dependencies = [
  "gix-object",
  "gix-odb",
  "gix-pack",
- "gix-path 0.10.8 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-path 0.10.9",
  "gix-pathspec",
  "gix-prompt",
  "gix-ref",
@@ -2470,7 +2470,7 @@ dependencies = [
  "gix-sec",
  "gix-submodule",
  "gix-tempfile",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9)",
  "gix-traverse",
  "gix-url",
  "gix-utils",
@@ -2483,8 +2483,8 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.31.2"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+version = "0.31.4"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
  "gix-date",
@@ -2497,13 +2497,13 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.22.2"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
  "gix-glob",
- "gix-path 0.10.8 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-path 0.10.9",
  "gix-quote",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9)",
  "kstring",
  "smallvec",
  "thiserror",
@@ -2513,7 +2513,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.11"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "thiserror",
 ]
@@ -2521,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.8"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "thiserror",
 ]
@@ -2529,18 +2529,18 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.3.7"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
- "gix-path 0.10.8 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-path 0.10.9",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9)",
  "shell-words",
 ]
 
 [[package]]
 name = "gix-commitgraph"
 version = "0.24.2"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -2553,13 +2553,13 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.37.0"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
  "gix-config-value",
  "gix-features",
  "gix-glob",
- "gix-path 0.10.8 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-path 0.10.9",
  "gix-ref",
  "gix-sec",
  "memchr",
@@ -2573,11 +2573,11 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.14.6"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-path 0.10.8 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-path 0.10.9",
  "libc",
  "thiserror",
 ]
@@ -2585,15 +2585,15 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.24.2"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-config-value",
- "gix-path 0.10.8 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-path 0.10.9",
  "gix-prompt",
  "gix-sec",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9)",
  "gix-url",
  "thiserror",
 ]
@@ -2601,7 +2601,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.8.7"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
  "itoa 1.0.11",
@@ -2612,7 +2612,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.44.0"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -2623,7 +2623,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.5.0"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -2631,9 +2631,9 @@ dependencies = [
  "gix-ignore",
  "gix-index",
  "gix-object",
- "gix-path 0.10.8 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-path 0.10.9",
  "gix-pathspec",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9)",
  "gix-utils",
  "gix-worktree",
  "thiserror",
@@ -2642,13 +2642,13 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.32.0"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
  "dunce",
  "gix-fs",
  "gix-hash",
- "gix-path 0.10.8 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-path 0.10.9",
  "gix-ref",
  "gix-sec",
  "thiserror",
@@ -2657,13 +2657,13 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.38.2"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",
  "flate2",
  "gix-hash",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9)",
  "gix-utils",
  "libc",
  "once_cell",
@@ -2677,7 +2677,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.11.2"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -2686,9 +2686,9 @@ dependencies = [
  "gix-hash",
  "gix-object",
  "gix-packetline-blocking",
- "gix-path 0.10.8 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-path 0.10.9",
  "gix-quote",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9)",
  "gix-utils",
  "smallvec",
  "thiserror",
@@ -2697,7 +2697,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.11.1"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "fastrand 2.1.0",
  "gix-features",
@@ -2707,18 +2707,18 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.16.3"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "gix-features",
- "gix-path 0.10.8 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-path 0.10.9",
 ]
 
 [[package]]
 name = "gix-hash"
 version = "0.14.2"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "faster-hex",
  "thiserror",
@@ -2727,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.5.2"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "gix-hash",
  "hashbrown 0.14.5",
@@ -2737,19 +2737,19 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.11.2"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
  "gix-glob",
- "gix-path 0.10.8 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-path 0.10.9",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9)",
  "unicode-bom",
 ]
 
 [[package]]
 name = "gix-index"
 version = "0.33.0"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -2776,7 +2776,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "14.0.0"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -2786,7 +2786,7 @@ dependencies = [
 [[package]]
 name = "gix-macros"
 version = "0.1.5"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2796,7 +2796,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.13.1"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bitflags 2.6.0",
  "gix-commitgraph",
@@ -2810,8 +2810,8 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.42.2"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+version = "0.42.3"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -2829,7 +2829,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.61.0"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "arc-swap",
  "gix-date",
@@ -2838,7 +2838,7 @@ dependencies = [
  "gix-hash",
  "gix-object",
  "gix-pack",
- "gix-path 0.10.8 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-path 0.10.9",
  "gix-quote",
  "parking_lot 0.12.3",
  "tempfile",
@@ -2848,7 +2848,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.51.0"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "clru",
  "gix-chunk",
@@ -2856,7 +2856,7 @@ dependencies = [
  "gix-hash",
  "gix-hashtable",
  "gix-object",
- "gix-path 0.10.8 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-path 0.10.9",
  "memmap2",
  "smallvec",
  "thiserror",
@@ -2865,11 +2865,11 @@ dependencies = [
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.17.4"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9)",
  "thiserror",
 ]
 
@@ -2888,11 +2888,11 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.10.8"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+version = "0.10.9"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9)",
  "home",
  "once_cell",
  "thiserror",
@@ -2901,21 +2901,21 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.7.5"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "gix-attributes",
  "gix-config-value",
  "gix-glob",
- "gix-path 0.10.8 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-path 0.10.9",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-prompt"
 version = "0.8.5"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -2927,7 +2927,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.4.12"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
  "gix-utils",
@@ -2937,7 +2937,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.44.1"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -2945,7 +2945,7 @@ dependencies = [
  "gix-hash",
  "gix-lock",
  "gix-object",
- "gix-path 0.10.8 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-path 0.10.9",
  "gix-tempfile",
  "gix-utils",
  "gix-validate",
@@ -2957,7 +2957,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.23.0"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -2970,7 +2970,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.27.1"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
  "gix-date",
@@ -2983,7 +2983,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.13.1"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -2997,10 +2997,10 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.10.6"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bitflags 2.6.0",
- "gix-path 0.10.8 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-path 0.10.9",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -3008,11 +3008,11 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.11.0"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
  "gix-config",
- "gix-path 0.10.8 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-path 0.10.9",
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
@@ -3022,7 +3022,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "14.0.0"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "gix-fs",
  "libc",
@@ -3040,12 +3040,12 @@ checksum = "f924267408915fddcd558e3f37295cc7d6a3e50f8bd8b606cee0808c3915157e"
 [[package]]
 name = "gix-trace"
 version = "0.1.9"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 
 [[package]]
 name = "gix-traverse"
 version = "0.39.1"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bitflags 2.6.0",
  "gix-commitgraph",
@@ -3061,11 +3061,11 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.27.3"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
  "gix-features",
- "gix-path 0.10.8 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-path 0.10.9",
  "home",
  "thiserror",
  "url",
@@ -3074,7 +3074,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.1.12"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
  "fastrand 2.1.0",
@@ -3084,7 +3084,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.8.5"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
  "thiserror",
@@ -3093,7 +3093,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.34.0"
-source = "git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e#55cbc1b9d6f210298a86502a7f20f9736c7e963e"
+source = "git+https://github.com/Byron/gitoxide?rev=15f1cf76764221d14afa66d03a6528b19b9c30c9#15f1cf76764221d14afa66d03a6528b19b9c30c9"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -3104,7 +3104,7 @@ dependencies = [
  "gix-ignore",
  "gix-index",
  "gix-object",
- "gix-path 0.10.8 (git+https://github.com/Byron/gitoxide?rev=55cbc1b9d6f210298a86502a7f20f9736c7e963e)",
+ "gix-path 0.10.9",
  "gix-validate",
 ]
 

--- a/crates/gitbutler-branch-actions/Cargo.toml
+++ b/crates/gitbutler-branch-actions/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 tracing = "0.1.40"
 anyhow = "1.0.86"
 git2.workspace = true
+gix.workspace = true
 tokio.workspace = true
 gitbutler-oplog.workspace = true
 gitbutler-repo.workspace = true

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -16,6 +16,7 @@ use gitbutler_project::access::WorktreeWritePermission;
 use gitbutler_reference::Refname;
 use gitbutler_repo::{rebase::cherry_rebase, RepoActionsExt, RepositoryExt};
 use gitbutler_time::time::now_since_unix_epoch_ms;
+use std::borrow::Cow;
 
 impl BranchManager<'_> {
     pub fn create_virtual_branch(
@@ -346,9 +347,7 @@ impl BranchManager<'_> {
                 let mut merge_conflicts = Vec::new();
                 for path in conflicts.flatten() {
                     if let Some(ours) = path.our {
-                        let path = std::str::from_utf8(&ours.path)
-                            .context("failed to convert path to utf8")?
-                            .to_string();
+                        let path = gix::path::try_from_bstr(Cow::Owned(ours.path.into()))?;
                         merge_conflicts.push(path);
                     }
                 }
@@ -472,9 +471,7 @@ impl BranchManager<'_> {
             let mut merge_conflicts = Vec::new();
             for path in conflicts.flatten() {
                 if let Some(ours) = path.our {
-                    let path = std::str::from_utf8(&ours.path)
-                        .context("failed to convert path to utf8")?
-                        .to_string();
+                    let path = gix::path::try_from_bstr(Cow::Owned(ours.path.into()))?;
                     merge_conflicts.push(path);
                 }
             }

--- a/crates/gitbutler-branch-actions/src/conflicts.rs
+++ b/crates/gitbutler-branch-actions/src/conflicts.rs
@@ -1,3 +1,8 @@
+use anyhow::{anyhow, Context, Result};
+use bstr::ByteSlice;
+use gitbutler_command_context::ProjectRepository;
+use gitbutler_error::error::Marker;
+use std::ffi::OsStr;
 /// stuff to manage merge conflict state.
 /// This is the dumbest possible way to do this, but it is a placeholder.
 /// Conflicts are stored one path per line in .git/conflicts.
@@ -5,18 +10,12 @@
 /// Conflicts are removed as they are resolved, the conflicts file is removed when there are no more conflicts
 /// or when the merge is complete.
 use std::{
-    io::{BufRead, Write},
+    io::Write,
     path::{Path, PathBuf},
 };
 
-use anyhow::{anyhow, Context, Result};
-use gitbutler_command_context::ProjectRepository;
-use itertools::Itertools;
-
-use gitbutler_error::error::Marker;
-
 pub(crate) fn mark<P: AsRef<Path>, A: AsRef<[P]>>(
-    repository: &ProjectRepository,
+    ctx: &ProjectRepository,
     paths: A,
     parent: Option<git2::Oid>,
 ) -> Result<()> {
@@ -30,21 +29,28 @@ pub(crate) fn mark<P: AsRef<Path>, A: AsRef<[P]>>(
         buf.write_all(path.as_ref().as_os_str().as_encoded_bytes())?;
         buf.write_all(b"\n")?;
     }
-    gitbutler_fs::write(repository.repo().path().join("conflicts"), buf)?;
+    gitbutler_fs::write(conflicts_path(ctx), &buf)?;
 
     if let Some(parent) = parent {
         // write all the file paths to a file on disk
-        gitbutler_fs::write(
-            repository.repo().path().join("base_merge_parent"),
-            parent.to_string().as_bytes(),
-        )?;
+        gitbutler_fs::write(merge_parent_path(ctx), parent.to_string().as_bytes())?;
     }
 
     Ok(())
 }
 
-pub(crate) fn merge_parent(repository: &ProjectRepository) -> Result<Option<git2::Oid>> {
-    let merge_path = repository.repo().path().join("base_merge_parent");
+fn conflicts_path(ctx: &ProjectRepository) -> PathBuf {
+    ctx.repo().path().join("conflicts")
+}
+
+fn merge_parent_path(ctx: &ProjectRepository) -> PathBuf {
+    ctx.repo().path().join("base_merge_parent")
+}
+
+pub(crate) fn merge_parent(ctx: &ProjectRepository) -> Result<Option<git2::Oid>> {
+    use std::io::BufRead;
+
+    let merge_path = merge_parent_path(ctx);
     if !merge_path.exists() {
         return Ok(None);
     }
@@ -61,78 +67,71 @@ pub(crate) fn merge_parent(repository: &ProjectRepository) -> Result<Option<git2
     }
 }
 
-pub fn resolve<P: AsRef<Path>>(repository: &ProjectRepository, path: P) -> Result<()> {
-    let path = path.as_ref();
-    let conflicts_path = repository.repo().path().join("conflicts");
-    let file = std::fs::File::open(conflicts_path.clone())?;
-    let reader = std::io::BufReader::new(file);
-    let mut remaining = Vec::new();
-    for line in reader.lines().map_ok(PathBuf::from) {
-        let line = line?;
-        if line != path {
-            remaining.push(line);
-        }
-    }
+pub fn resolve<P: AsRef<Path>>(ctx: &ProjectRepository, path_to_resolve: P) -> Result<()> {
+    let path_to_resolve = path_to_resolve.as_ref();
+    let path_to_resolve = path_to_resolve.as_os_str().as_encoded_bytes();
+    let conflicts_path = conflicts_path(ctx);
+    let path_per_line = std::fs::read(&conflicts_path)?;
+    let remaining: Vec<_> = path_per_line
+        .lines()
+        .filter(|path| *path != path_to_resolve)
+        .map(|path| unsafe { OsStr::from_encoded_bytes_unchecked(path) })
+        .collect();
 
     // re-write file if needed, otherwise remove file entirely
     if remaining.is_empty() {
         std::fs::remove_file(conflicts_path)?;
     } else {
-        mark(repository, &remaining, None)?;
+        mark(ctx, &remaining, None)?;
     }
     Ok(())
 }
 
-pub(crate) fn conflicting_files(repository: &ProjectRepository) -> Result<Vec<String>> {
-    let conflicts_path = repository.repo().path().join("conflicts");
+pub(crate) fn conflicting_files(ctx: &ProjectRepository) -> Result<Vec<PathBuf>> {
+    let conflicts_path = conflicts_path(ctx);
     if !conflicts_path.exists() {
         return Ok(vec![]);
     }
 
-    let file = std::fs::File::open(conflicts_path)?;
-    let reader = std::io::BufReader::new(file);
-    Ok(reader.lines().map_while(Result::ok).collect())
+    let path_per_line = std::fs::read(conflicts_path)?;
+    Ok(path_per_line
+        .lines()
+        .map(|path| unsafe { OsStr::from_encoded_bytes_unchecked(path) }.into())
+        .collect())
 }
 
 /// Check if `path` is conflicting in `repository`, or if `None`, check if there is any conflict.
 // TODO(ST): Should this not rather check the conflicting state in the index?
 pub(crate) fn is_conflicting(repository: &ProjectRepository, path: Option<&Path>) -> Result<bool> {
-    let conflicts_path = repository.repo().path().join("conflicts");
+    let conflicts_path = conflicts_path(repository);
     if !conflicts_path.exists() {
         return Ok(false);
     }
 
-    let file = std::fs::File::open(conflicts_path)?;
-    let reader = std::io::BufReader::new(file);
-    // TODO(ST): This shouldn't work on UTF8 strings.
-    let mut files = reader.lines().map_ok(PathBuf::from);
-    if let Some(pathname) = path {
-        // check if pathname is one of the lines in conflicts_path file
-        for line in files {
-            let line = line?;
-
-            if line == pathname {
-                return Ok(true);
-            }
-        }
-        Ok(false)
+    let path_per_line = std::fs::read(conflicts_path)?;
+    let mut files = path_per_line
+        .lines()
+        .map(|path| unsafe { OsStr::from_encoded_bytes_unchecked(path) });
+    let is_in_conflicts_file_or_has_conflicts = if let Some(path) = path {
+        files.any(|p| p == path)
     } else {
-        Ok(files.next().transpose().map(|x| x.is_some())?)
-    }
+        files.next().is_some()
+    };
+    Ok(is_in_conflicts_file_or_has_conflicts)
 }
 
 // is this project still in a resolving conflict state?
 // - could be that there are no more conflicts, but the state is not committed
-pub(crate) fn is_resolving(repository: &ProjectRepository) -> bool {
-    repository.repo().path().join("base_merge_parent").exists()
+pub(crate) fn is_resolving(ctx: &ProjectRepository) -> bool {
+    merge_parent_path(ctx).exists()
 }
 
-pub(crate) fn clear(repository: &ProjectRepository) -> Result<()> {
-    let merge_path = repository.repo().path().join("base_merge_parent");
+pub(crate) fn clear(ctx: &ProjectRepository) -> Result<()> {
+    let merge_path = merge_parent_path(ctx);
     std::fs::remove_file(merge_path)?;
 
-    for file in conflicting_files(repository)? {
-        resolve(repository, &file)?;
+    for file in conflicting_files(ctx)? {
+        resolve(ctx, &file)?;
     }
 
     Ok(())

--- a/crates/gitbutler-branch-actions/src/conflicts.rs
+++ b/crates/gitbutler-branch-actions/src/conflicts.rs
@@ -127,14 +127,19 @@ pub(crate) fn is_resolving(ctx: &ProjectRepository) -> bool {
 }
 
 pub(crate) fn clear(ctx: &ProjectRepository) -> Result<()> {
-    let merge_path = merge_parent_path(ctx);
-    std::fs::remove_file(merge_path)?;
-
-    for file in conflicting_files(ctx)? {
-        resolve(ctx, &file)?;
-    }
-
+    remove_file_ignore_missing(merge_parent_path(ctx))?;
+    remove_file_ignore_missing(conflicts_path(ctx))?;
     Ok(())
+}
+
+fn remove_file_ignore_missing(path: impl AsRef<Path>) -> std::io::Result<()> {
+    std::fs::remove_file(path).or_else(|err| {
+        if err.kind() == std::io::ErrorKind::NotFound {
+            Ok(())
+        } else {
+            Err(err)
+        }
+    })
 }
 
 pub(crate) trait RepoConflictsExt {


### PR DESCRIPTION
### Tasks

* [x] handle encoding properly (`as_encoded_bytes()`) requires `from_encoded_bytes()` for creation
* [x] avoid `String` as return value
* [x] avoid repeated writes and reads of conflict file in case there are multiple conflicts (might help with #3601)
