### PR TITLE
don't fail hard if there is no project metadata

### DIFF
--- a/app/src/lib/components/ShareIssueModal.svelte
+++ b/app/src/lib/components/ShareIssueModal.svelte
@@ -82,6 +82,7 @@
 					? zip
 							.gitbutlerData({ projectId })
 							.then(async (path) => await readZipFile(path, 'data.zip'))
+							.catch(() => undefined)
 					: undefined,
 				sendProjectRepository
 					? zip


### PR DESCRIPTION
This fixes #4371.

### Tasks

* [x] validate by hand that the respective issue is truly fixed