### PR TITLE
fix 4389

### DIFF
--- a/app/src/lib/baseBranch/baseBranchService.ts
+++ b/app/src/lib/baseBranch/baseBranchService.ts
@@ -45,7 +45,7 @@ export class BaseBranchService {
 				return;
 			} else if (err.code === Code.ProjectsGitAuth) {
 				showError('Failed to authenticate', err);
-			} else {
+			} else if (action !== undefined) {
 				showError('Failed to fetch', err);
 			}
 			console.error(err);


### PR DESCRIPTION
This PR fixes #4389 by causing loud errors in the backend if a remote failed to fetch, and selectively ignoring them when a background fetch is performed.
That way, the original behaviour is kept while showing errors on user action.

### Tasks

* [x] reproduce the issue
* [x] fix it
* [x] validate it's fixed and we see error messages only on explicit user action


### How to reproduce the original bug

* open a project that is cloned via SSH and setup a password protected SSH key
* trigger a fetch using the refresh button
* cancel the popup that asks for a password, possibly multiple times, until it gives up and errors

With this PR, the error is visible, without it is isn't.

