### PR TITLE
Convert Button component to svelte5

### DIFF
--- a/app/src/lib/branch/ActiveBranchStatus.svelte
+++ b/app/src/lib/branch/ActiveBranchStatus.svelte
@@ -81,7 +81,7 @@
 		style="ghost"
 		outline
 		shrinkable
-		on:click={(e) => {
+		onclick={(e) => {
 			const url = $baseBranch?.branchUrl($branch.upstream?.name);
 			if (url) openExternalUrl(url);
 			e.preventDefault();

--- a/app/src/lib/branch/BranchDropzone.svelte
+++ b/app/src/lib/branch/BranchDropzone.svelte
@@ -64,7 +64,7 @@
 						style="ghost"
 						outline
 						icon="plus-small"
-						on:mousedown={async () => await branchController.createBranch({})}>New branch</Button
+						onmousedown={async () => await branchController.createBranch({})}>New branch</Button
 					>
 				</div>
 			</div>

--- a/app/src/lib/branch/BranchHeader.svelte
+++ b/app/src/lib/branch/BranchHeader.svelte
@@ -4,7 +4,6 @@
 	import BranchLaneContextMenu from './BranchLaneContextMenu.svelte';
 	import PullRequestButton from '../pr/PullRequestButton.svelte';
 	import { BaseBranchService } from '$lib/baseBranch/baseBranchService';
-	import ContextMenu from '$lib/components/contextmenu/ContextMenu.svelte';
 	import { mapErrorToToast } from '$lib/gitHost/github/errorMap';
 	import { getGitHost } from '$lib/gitHost/interface/gitHost';
 	import { getGitHostListingService } from '$lib/gitHost/interface/gitHostListingService';
@@ -36,8 +35,6 @@
 	$: branch = $branchStore;
 	$: pr = $prMonitor?.pr;
 
-	let contextMenu: ContextMenu;
-	let meatballButtonEl: HTMLDivElement;
 	let isLoading: boolean;
 	let isTargetBranchAnimated = false;
 
@@ -245,21 +242,11 @@
 								loading={isLoading}
 							/>
 						{/if}
-						<Button
-							bind:el={meatballButtonEl}
-							style="ghost"
-							outline
-							icon="kebab"
-							on:click={() => {
-								contextMenu.toggle();
-							}}
-						/>
-						<BranchLaneContextMenu
-							bind:contextMenuEl={contextMenu}
-							target={meatballButtonEl}
-							onCollapse={collapseLane}
-							{onGenerateBranchName}
-						/>
+						<Button style="ghost" outline icon="kebab">
+							{#snippet menu(target)}
+								<BranchLaneContextMenu {target} {onGenerateBranchName} onCollapse={collapseLane} />
+							{/snippet}
+						</Button>
 					</div>
 				</div>
 			</div>

--- a/app/src/lib/branch/BranchHeader.svelte
+++ b/app/src/lib/branch/BranchHeader.svelte
@@ -128,7 +128,7 @@
 			<div class="collapsed-lane__draggable" data-drag-handle>
 				<Icon name="draggable" />
 			</div>
-			<Button style="ghost" outline icon="unfold-lane" help="Expand lane" on:click={expandLane} />
+			<Button style="ghost" outline icon="unfold-lane" help="Expand lane" onclick={expandLane} />
 		</div>
 
 		<div class="collapsed-lane__info-wrap" bind:clientHeight={headerInfoHeight}>
@@ -225,7 +225,7 @@
 							outline
 							help="When selected, new changes will land here"
 							icon="target"
-							on:click={async () => {
+							onclick={async () => {
 								isTargetBranchAnimated = true;
 								await branchController.setSelectedForChanges(branch.id);
 							}}

--- a/app/src/lib/branch/BranchLaneContextMenu.svelte
+++ b/app/src/lib/branch/BranchLaneContextMenu.svelte
@@ -164,11 +164,11 @@
 		{/if}
 	</div>
 	{#snippet controls()}
-		<Button style="ghost" outline on:click={() => unapplyBranchModal.close()}>Cancel</Button>
+		<Button style="ghost" outline onclick={() => unapplyBranchModal.close()}>Cancel</Button>
 		<Button
 			style="pop"
 			kind="solid"
-			on:click={unapplyBranchWithSelectedResolution}
+			onclick={unapplyBranchWithSelectedResolution}
 			disabled={!newBranchName && selectedResolution === 'rename'}
 		>
 			{setButtonCoppy()}
@@ -269,11 +269,11 @@
 	<TextBox label="Remote branch name" id="newRemoteName" bind:value={newRemoteName} focus />
 
 	{#snippet controls(close)}
-		<Button style="ghost" outline type="reset" on:click={close}>Cancel</Button>
+		<Button style="ghost" outline type="reset" onclick={close}>Cancel</Button>
 		<Button
 			style="pop"
 			kind="solid"
-			on:click={() => {
+			onclick={() => {
 				branchController.updateBranchRemoteName(branch.id, newRemoteName);
 				close();
 			}}
@@ -288,11 +288,11 @@
 		Are you sure you want to delete <code class="code-string">{branch.name}</code>?
 	{/snippet}
 	{#snippet controls(close)}
-		<Button style="ghost" outline on:click={close}>Cancel</Button>
+		<Button style="ghost" outline onclick={close}>Cancel</Button>
 		<Button
 			style="error"
 			kind="solid"
-			on:click={async () => {
+			onclick={async () => {
 				await branchController.deleteBranch(branch.id);
 				close();
 			}}

--- a/app/src/lib/branch/BranchLaneContextMenu.svelte
+++ b/app/src/lib/branch/BranchLaneContextMenu.svelte
@@ -17,7 +17,6 @@
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { VirtualBranch, type NameConflictResolution } from '$lib/vbranches/types';
 
-	export let contextMenuEl: ContextMenu;
 	export let target: HTMLElement;
 	export let onCollapse: () => void;
 	export let onGenerateBranchName: () => void;
@@ -32,6 +31,7 @@
 	const nameNormalizationService = getNameNormalizationServiceContext();
 
 	let aiConfigurationValid = false;
+	let contextMenuEl: ContextMenu;
 	let deleteBranchModal: Modal;
 	let renameRemoteModal: Modal;
 	let newRemoteName: string;
@@ -176,7 +176,7 @@
 	{/snippet}
 </Modal>
 
-<ContextMenu bind:this={contextMenuEl} {target}>
+<ContextMenu bind:this={contextMenuEl} {target} eventType="mousedown">
 	<ContextMenuSection>
 		<ContextMenuItem
 			label="Collapse lane"

--- a/app/src/lib/branch/BranchPreviewHeader.svelte
+++ b/app/src/lib/branch/BranchPreviewHeader.svelte
@@ -40,7 +40,7 @@
 					style="ghost"
 					outline
 					shrinkable
-					on:click={(e) => {
+					onclick={(e) => {
 						const url = base?.branchUrl(branch.name);
 						if (url) openExternalUrl(url);
 						e.preventDefault();
@@ -56,7 +56,7 @@
 						icon="pr-small"
 						style="ghost"
 						outline
-						on:click={(e) => {
+						onclick={(e) => {
 							const url = pr?.htmlUrl;
 							if (url) openExternalUrl(url);
 							e.preventDefault();
@@ -76,7 +76,7 @@
 					help="Restores these changes into your working directory"
 					icon="plus-small"
 					loading={isApplying}
-					on:click={async () => {
+					onclick={async () => {
 						isApplying = true;
 						try {
 							await branchController.createvBranchFromBranch(branch.name);

--- a/app/src/lib/branch/PassphraseBox.svelte
+++ b/app/src/lib/branch/PassphraseBox.svelte
@@ -39,7 +39,7 @@
 				style="ghost"
 				outline
 				disabled={isSubmitting}
-				on:click={async () => {
+				onclick={async () => {
 					if (!prompt) return;
 					prompt.respond(null);
 				}}
@@ -50,7 +50,7 @@
 				style="pop"
 				kind="solid"
 				grow
-				on:click={async () => await submit()}
+				onclick={async () => await submit()}
 				disabled={submitDisabled || isSubmitting}
 				loading={isSubmitting}
 			>

--- a/app/src/lib/commit/CommitCard.svelte
+++ b/app/src/lib/commit/CommitCard.svelte
@@ -125,13 +125,13 @@
 		isExpanded={true}
 	/>
 	{#snippet controls(close)}
-		<Button style="ghost" outline on:click={close}>Cancel</Button>
+		<Button style="ghost" outline onclick={close}>Cancel</Button>
 		<Button
 			style="neutral"
 			kind="solid"
 			grow
 			disabled={!commitMessageValid}
-			on:click={submitCommitMessageModal}
+			onclick={submitCommitMessageModal}
 		>
 			Submit
 		</Button>
@@ -304,7 +304,7 @@
 										style="ghost"
 										outline
 										icon="undo-small"
-										on:click={(e) => {
+										onclick={(e) => {
 											currentCommitMessage.set(commit.description);
 											e.stopPropagation();
 											undoCommit(commit);
@@ -315,7 +315,7 @@
 										style="ghost"
 										outline
 										icon="edit-small"
-										on:click={openCommitMessageModal}>Edit message</Button
+										onclick={openCommitMessageModal}>Edit message</Button
 									>
 								{/if}
 							</div>

--- a/app/src/lib/commit/CommitDialog.svelte
+++ b/app/src/lib/commit/CommitDialog.svelte
@@ -90,7 +90,7 @@
 			loading={isCommitting}
 			disabled={(isCommitting || !commitMessageValid || $selectedOwnership.isEmpty()) && $expanded}
 			id="commit-to-branch"
-			on:click={() => {
+			onclick={() => {
 				if ($expanded) {
 					commit();
 				} else {

--- a/app/src/lib/commit/CommitMessageInput.svelte
+++ b/app/src/lib/commit/CommitMessageInput.svelte
@@ -205,7 +205,7 @@
 				disabled={!($aiGenEnabled && aiConfigurationValid)}
 				loading={aiLoading}
 				menuPosition="top"
-				on:click={async () => await generateCommitMessage($branch.files)}
+				onclick={async () => await generateCommitMessage($branch.files)}
 			>
 				Generate message
 

--- a/app/src/lib/components/AppUpdater.svelte
+++ b/app/src/lib/components/AppUpdater.svelte
@@ -18,7 +18,7 @@
 {#if $update?.version && $update?.status !== 'UPTODATE' && !dismissed}
 	<div class="update-banner" class:busy={$update?.status === 'PENDING'}>
 		<div class="floating-button">
-			<Button icon="cross-small" style="ghost" on:click={() => (dismissed = true)} />
+			<Button icon="cross-small" style="ghost" onclick={() => (dismissed = true)} />
 		</div>
 		<div class="img">
 			<div class="circle-img">
@@ -106,7 +106,7 @@
 			<Button
 				style="ghost"
 				outline
-				on:mousedown={() => {
+				onmousedown={() => {
 					const notes = $update?.body?.trim() || 'no release notes available';
 					showToast({
 						id: 'release-notes',
@@ -128,7 +128,7 @@
 							wide
 							style="pop"
 							kind="solid"
-							on:mousedown={async () => {
+							onmousedown={async () => {
 								await updaterService.installUpdate();
 							}}
 						>
@@ -137,7 +137,7 @@
 					</div>
 				{:else if $update.status === 'DONE'}
 					<div class="cta-btn" transition:fade={{ duration: 100 }}>
-						<Button style="pop" kind="solid" wide on:click={() => updaterService.relaunchApp()}
+						<Button style="pop" kind="solid" wide onclick={() => updaterService.relaunchApp()}
 							>Restart</Button
 						>
 					</div>

--- a/app/src/lib/components/BackButton.svelte
+++ b/app/src/lib/components/BackButton.svelte
@@ -6,7 +6,7 @@
 <Button
 	style="ghost"
 	outline
-	on:mousedown={() => {
+	onmousedown={() => {
 		if (history.length > 0) {
 			history.back();
 		} else {

--- a/app/src/lib/components/BaseBranch.svelte
+++ b/app/src/lib/components/BaseBranch.svelte
@@ -44,7 +44,7 @@
 			style="pop"
 			kind="solid"
 			help={`Merges the commits from ${base.branchName} into the base of all applied virtual branches`}
-			on:click={() => {
+			onclick={() => {
 				if ($mergeUpstreamWarningDismissed) {
 					updateBaseBranch();
 				} else {
@@ -114,11 +114,11 @@
 	</label>
 
 	{#snippet controls(close)}
-		<Button style="ghost" outline on:click={close}>Cancel</Button>
+		<Button style="ghost" outline onclick={close}>Cancel</Button>
 		<Button
 			style="pop"
 			kind="solid"
-			on:click={() => {
+			onclick={() => {
 				updateBaseBranch();
 				if (mergeUpstreamWarningDismissedCheckbox) {
 					mergeUpstreamWarningDismissed.set(true);

--- a/app/src/lib/components/BaseBranchSwitch.svelte
+++ b/app/src/lib/components/BaseBranchSwitch.svelte
@@ -115,7 +115,7 @@
 						size="cta"
 						style="ghost"
 						outline
-						on:click={onSetBaseBranchClick}
+						onclick={onSetBaseBranchClick}
 						id="set-base-branch"
 						loading={isSwitching}
 						disabled={(selectedBranch.name === $baseBranch.branchName &&

--- a/app/src/lib/components/FilterBranchesButton.svelte
+++ b/app/src/lib/components/FilterBranchesButton.svelte
@@ -15,7 +15,6 @@
 	export let hideBots: Writable<boolean | undefined>;
 	export let hideInactive: Writable<boolean | undefined>;
 
-	let target: HTMLElement;
 	let contextMenu: ContextMenu;
 
 	export function onFilterClick() {
@@ -25,33 +24,34 @@
 
 <div class="header__filter-btn">
 	<Button
-		bind:el={target}
 		style="ghost"
 		outline
 		icon={$filtersActive ? 'filter-applied-small' : 'filter-small'}
-		on:mousedown={onFilterClick}
+		onmousedown={onFilterClick}
 	>
 		Filter
-	</Button>
-	<ContextMenu bind:this={contextMenu} {target}>
-		<ContextMenuSection>
-			{#if showPrCheckbox}
-				<ContextMenuItem label="Pull requests" on:click={() => ($includePrs = !$includePrs)}>
-					<Checkbox small bind:checked={$includePrs} slot="control" />
-				</ContextMenuItem>
-			{/if}
-			<ContextMenuItem label="Branches" on:click={() => ($includeRemote = !$includeRemote)}>
-				<Checkbox small bind:checked={$includeRemote} slot="control" />
-			</ContextMenuItem>
-		</ContextMenuSection>
+		{#snippet menu(target)}
+			<ContextMenu bind:this={contextMenu} {target}>
+				<ContextMenuSection>
+					{#if showPrCheckbox}
+						<ContextMenuItem label="Pull requests" on:click={() => ($includePrs = !$includePrs)}>
+							<Checkbox small bind:checked={$includePrs} slot="control" />
+						</ContextMenuItem>
+					{/if}
+					<ContextMenuItem label="Branches" on:click={() => ($includeRemote = !$includeRemote)}>
+						<Checkbox small bind:checked={$includeRemote} slot="control" />
+					</ContextMenuItem>
+				</ContextMenuSection>
 
-		<ContextMenuSection>
-			<ContextMenuItem label="Hide bots" on:click={() => ($hideBots = !$hideBots)}>
-				<Toggle small slot="control" bind:checked={$hideBots} />
-			</ContextMenuItem>
-			<ContextMenuItem label="Hide inactive" on:click={() => ($hideInactive = !$hideInactive)}>
-				<Toggle small slot="control" bind:checked={$hideInactive} />
-			</ContextMenuItem>
-		</ContextMenuSection>
-	</ContextMenu>
+				<ContextMenuSection>
+					<ContextMenuItem label="Hide bots" on:click={() => ($hideBots = !$hideBots)}>
+						<Toggle small slot="control" bind:checked={$hideBots} />
+					</ContextMenuItem>
+					<ContextMenuItem label="Hide inactive" on:click={() => ($hideInactive = !$hideInactive)}>
+						<Toggle small slot="control" bind:checked={$hideInactive} />
+					</ContextMenuItem>
+				</ContextMenuSection>
+			</ContextMenu>
+		{/snippet}
+	</Button>
 </div>

--- a/app/src/lib/components/InsertEmptyCommitAction.svelte
+++ b/app/src/lib/components/InsertEmptyCommitAction.svelte
@@ -20,7 +20,7 @@
 			width={26}
 			help="Insert empty commit"
 			helpShowDelay={500}
-			on:click={() => dispatch('click')}
+			onclick={() => dispatch('click')}
 		/>
 	</div>
 </div>

--- a/app/src/lib/components/Login.svelte
+++ b/app/src/lib/components/Login.svelte
@@ -19,7 +19,7 @@
 		kind="solid"
 		{wide}
 		icon="signout"
-		on:click={async () => {
+		onclick={async () => {
 			await userService.logout();
 		}}>Log out</Button
 	>
@@ -44,7 +44,7 @@
 			loading={$loading}
 			icon="signin"
 			{wide}
-			on:mousedown={async () => {
+			onmousedown={async () => {
 				await userService.login();
 			}}
 		>

--- a/app/src/lib/components/NotOnGitButlerBranch.svelte
+++ b/app/src/lib/components/NotOnGitButlerBranch.svelte
@@ -65,7 +65,7 @@
 				kind="solid"
 				icon="undo-small"
 				reversedDirection
-				on:click={() => {
+				onclick={() => {
 					if (baseBranch) branchController.setTarget(baseBranch.branchName);
 				}}
 			>

--- a/app/src/lib/components/ProjectSetup.svelte
+++ b/app/src/lib/components/ProjectSetup.svelte
@@ -44,10 +44,10 @@
 		{@const [remoteName, branchName] = selectedBranch[0].split(/\/(.*)/s)}
 		<KeysForm {remoteName} {branchName} disabled={loading} />
 		<div class="actions">
-			<Button style="ghost" outline disabled={loading} on:mousedown={() => (selectedBranch[0] = '')}
+			<Button style="ghost" outline disabled={loading} onmousedown={() => (selectedBranch[0] = '')}
 				>Back</Button
 			>
-			<Button style="pop" kind="solid" {loading} on:click={setTarget}>Let's go!</Button>
+			<Button style="pop" kind="solid" {loading} onclick={setTarget}>Let's go!</Button>
 		</div>
 	{:else}
 		<ProjectSetupTarget

--- a/app/src/lib/components/ProjectSetupTarget.svelte
+++ b/app/src/lib/components/ProjectSetupTarget.svelte
@@ -253,7 +253,7 @@
 			style="pop"
 			kind="solid"
 			{loading}
-			on:click={onSetTargetClick}
+			onclick={onSetTargetClick}
 			icon="chevron-right-small"
 			id="set-base-branch"
 		>

--- a/app/src/lib/components/ProjectSwitcher.svelte
+++ b/app/src/lib/components/ProjectSwitcher.svelte
@@ -63,7 +63,7 @@
 		kind="solid"
 		icon="chevron-right-small"
 		disabled={selectedProjectId === project?.id}
-		on:mousedown={() => {
+		onmousedown={() => {
 			if (selectedProjectId) goto(`/${selectedProjectId}/`);
 		}}
 	>

--- a/app/src/lib/components/PushButton.svelte
+++ b/app/src/lib/components/PushButton.svelte
@@ -49,7 +49,7 @@
 	{wide}
 	{disabled}
 	menuPosition="top"
-	on:click={() => {
+	onclick={() => {
 		dispatch('trigger', { action });
 	}}
 >

--- a/app/src/lib/components/SyncButton.svelte
+++ b/app/src/lib/components/SyncButton.svelte
@@ -24,7 +24,7 @@
 	icon="update-small"
 	help="Last fetch from upstream"
 	{loading}
-	on:mousedown={async (e) => {
+	onmousedown={async (e) => {
 		e.preventDefault();
 		e.stopPropagation();
 		loading = true;

--- a/app/src/lib/components/contextmenu/ContextMenu.svelte
+++ b/app/src/lib/components/contextmenu/ContextMenu.svelte
@@ -2,7 +2,7 @@
 	import { clickOutside } from '$lib/clickOutside';
 	import { portal } from '$lib/utils/portal';
 	import { resizeObserver } from '$lib/utils/resizeObserver';
-	import { type Snippet } from 'svelte';
+	import { onMount, type Snippet } from 'svelte';
 
 	// TYPES AND INTERFACES
 	interface Props {
@@ -10,6 +10,7 @@
 		openByMouse?: boolean;
 		verticalAlign?: 'top' | 'bottom';
 		horizontalAlign?: 'left' | 'right';
+		eventType?: 'mousedown' | 'contextmenu';
 		children: Snippet<[item: any]>;
 		onclose?: () => void;
 		onopen?: () => void;
@@ -20,6 +21,7 @@
 		openByMouse,
 		verticalAlign = 'bottom',
 		horizontalAlign = 'right',
+		eventType = 'contextmenu',
 		children,
 		onclose,
 		onopen
@@ -113,6 +115,19 @@
 			return 'top left';
 		}
 	}
+
+	function handleContextMenu(e: MouseEvent) {
+		e.preventDefault();
+		if (!isVisibile) open(e);
+		else close();
+	}
+
+	onMount(() => {
+		target?.addEventListener(eventType, handleContextMenu);
+		return () => {
+			target?.removeEventListener(eventType, handleContextMenu);
+		};
+	});
 </script>
 
 {#snippet contextMenu()}

--- a/app/src/lib/file/BranchFilesList.svelte
+++ b/app/src/lib/file/BranchFilesList.svelte
@@ -64,7 +64,7 @@
 				icon="copy"
 				style="ghost"
 				outline
-				on:mousedown={() => copyToClipboard(mergeDiffCommand + $commit.id.slice(0, 7))}
+				onmousedown={() => copyToClipboard(mergeDiffCommand + $commit.id.slice(0, 7))}
 			/>
 		</div>
 	</div>

--- a/app/src/lib/file/FileContextMenu.svelte
+++ b/app/src/lib/file/FileContextMenu.svelte
@@ -118,7 +118,7 @@
 		</div>
 	{/snippet}
 	{#snippet controls(close, item)}
-		<Button style="ghost" outline on:click={close}>Cancel</Button>
+		<Button style="ghost" outline onclick={close}>Cancel</Button>
 		<Button
 			style="error"
 			kind="solid"

--- a/app/src/lib/navigation/Footer.svelte
+++ b/app/src/lib/navigation/Footer.svelte
@@ -15,7 +15,7 @@
 			style="ghost"
 			size="cta"
 			help="Share feedback"
-			on:click={() => events.emit('openSendIssueModal')}
+			onclick={() => events.emit('openSendIssueModal')}
 			wide={isNavCollapsed}
 		/>
 		<Button
@@ -23,7 +23,7 @@
 			style="ghost"
 			size="cta"
 			help="Project settings"
-			on:click={async () => await goto(`/${projectId}/settings`)}
+			onclick={async () => await goto(`/${projectId}/settings`)}
 			wide={isNavCollapsed}
 		/>
 		<Button
@@ -31,7 +31,7 @@
 			style="ghost"
 			size="cta"
 			help="Project history"
-			on:click={() => events.emit('openHistory')}
+			onclick={() => events.emit('openHistory')}
 			wide={isNavCollapsed}
 		/>
 	</div>

--- a/app/src/lib/pr/MergeButton.svelte
+++ b/app/src/lib/pr/MergeButton.svelte
@@ -37,7 +37,7 @@
 	{wide}
 	{help}
 	{disabled}
-	on:click={() => {
+	onclick={() => {
 		dispatch('click', { method: $action });
 	}}
 >

--- a/app/src/lib/pr/PullRequestButton.svelte
+++ b/app/src/lib/pr/PullRequestButton.svelte
@@ -42,7 +42,7 @@
 	{disabled}
 	{loading}
 	bind:this={dropDown}
-	on:click={() => click({ draft: $preferredAction === Action.CreateDraft })}
+	onclick={() => click({ draft: $preferredAction === Action.CreateDraft })}
 >
 	{labels[$preferredAction]}
 	<ContextMenuSection slot="context-menu">

--- a/app/src/lib/pr/PullRequestCard.svelte
+++ b/app/src/lib/pr/PullRequestCard.svelte
@@ -170,7 +170,7 @@
 				outline
 				loading={$mrLoading || $checksLoading}
 				help={$timeAgo ? 'Updated ' + $timeAgo : ''}
-				on:click={async () => {
+				onclick={async () => {
 					$checksMonitor?.update();
 					$prMonitor?.refresh();
 				}}

--- a/app/src/lib/pr/ViewPrButton.svelte
+++ b/app/src/lib/pr/ViewPrButton.svelte
@@ -4,9 +4,6 @@
 	import { openExternalUrl } from '$lib/utils/url';
 
 	const { url }: { url: string } = $props();
-
-	let copyLinkContextMenu = $state<CopyLinkContextMenu>();
-	let viewPrButton = $state<HTMLElement>();
 </script>
 
 <Button
@@ -15,17 +12,14 @@
 	style="ghost"
 	outline
 	shrinkable
-	bind:el={viewPrButton}
-	on:click={(e) => {
+	onclick={(e) => {
 		openExternalUrl(url);
 		e.preventDefault();
 		e.stopPropagation();
 	}}
-	on:contextmenu={(e) => {
-		e.preventDefault();
-		copyLinkContextMenu?.openByMouse(e);
-	}}
 >
 	Open in browser
+	{#snippet menu(target)}
+		<CopyLinkContextMenu {target} {url} />
+	{/snippet}
 </Button>
-<CopyLinkContextMenu bind:this={copyLinkContextMenu} target={viewPrButton} {url} />

--- a/app/src/lib/settings/AnalyticsConfirmation.svelte
+++ b/app/src/lib/settings/AnalyticsConfirmation.svelte
@@ -16,7 +16,7 @@
 			style="pop"
 			kind="solid"
 			icon="chevron-right-small"
-			on:click={() => {
+			onclick={() => {
 				$analyticsConfirmed = true;
 				initAnalyticsIfEnabled();
 			}}

--- a/app/src/lib/settings/AuthorizationBanner.svelte
+++ b/app/src/lib/settings/AuthorizationBanner.svelte
@@ -34,7 +34,7 @@
 			loading={$loading}
 			style="pop"
 			kind="solid"
-			on:click={async () => {
+			onclick={async () => {
 				await userService.login();
 			}}>Log in or Sign up</Button
 		>

--- a/app/src/lib/settings/CredentialCheck.svelte
+++ b/app/src/lib/settings/CredentialCheck.svelte
@@ -107,7 +107,7 @@
 		wide
 		icon="item-tick"
 		disabled={loading}
-		on:click={checkCredentials}
+		onclick={checkCredentials}
 	>
 		{#if loading || checks.length === 0}
 			Test credentials

--- a/app/src/lib/settings/GithubIntegration.svelte
+++ b/app/src/lib/settings/GithubIntegration.svelte
@@ -67,7 +67,7 @@
 </script>
 
 {#if minimal}
-	<Button style="pop" kind="solid" {disabled} on:click={gitHubStartOauth}>Authorize</Button>
+	<Button style="pop" kind="solid" {disabled} onclick={gitHubStartOauth}>Authorize</Button>
 {:else}
 	<SectionCard orientation="row">
 		<svelte:fragment slot="iconSide">
@@ -97,11 +97,11 @@
 			Allows you to view and create Pull Requests from GitButler.
 		</svelte:fragment>
 		{#if $user?.github_access_token}
-			<Button style="ghost" outline {disabled} icon="bin-small" on:click={forgetGitHub}
+			<Button style="ghost" outline {disabled} icon="bin-small" onclick={forgetGitHub}
 				>Forget</Button
 			>
 		{:else}
-			<Button style="pop" kind="solid" {disabled} on:click={gitHubStartOauth}>Authorize</Button>
+			<Button style="pop" kind="solid" {disabled} onclick={gitHubStartOauth}>Authorize</Button>
 		{/if}
 	</SectionCard>
 {/if}
@@ -131,7 +131,7 @@
 						kind="soft"
 						icon="copy"
 						disabled={codeCopied}
-						on:click={() => {
+						onclick={() => {
 							copyToClipboard(userCode);
 							codeCopied = true;
 						}}
@@ -154,7 +154,7 @@
 						kind="solid"
 						disabled={GhActivationLinkPressed}
 						icon="open-link"
-						on:click={() => {
+						onclick={() => {
 							openExternalUrl('https://github.com/login/device');
 							GhActivationLinkPressed = true;
 
@@ -179,7 +179,7 @@
 						kind="solid"
 						{loading}
 						disabled={loading}
-						on:click={async () => {
+						onclick={async () => {
 							await gitHubOauthCheckStatus(deviceCode);
 						}}
 					>

--- a/app/src/lib/settings/Sidebar.svelte
+++ b/app/src/lib/settings/Sidebar.svelte
@@ -29,7 +29,7 @@
 					<Button
 						icon="chevron-left"
 						style="ghost"
-						on:mousedown={() => {
+						onmousedown={() => {
 							if (history.length > 0) {
 								history.back();
 							} else {

--- a/app/src/lib/shared/Button.svelte
+++ b/app/src/lib/shared/Button.svelte
@@ -4,34 +4,80 @@
 	import { tooltip } from '@gitbutler/ui/utils/tooltip';
 	import type iconsJson from '$lib/icons/icons.json';
 	import type { ComponentColor, ComponentStyleKind } from '$lib/vbranches/types';
+	import type { Snippet } from 'svelte';
+
+	type Props = {
+		disabled?: boolean;
+		clickable?: boolean;
+		id?: string;
+		loading?: boolean;
+		tabindex?: number;
+		type?: 'submit' | 'reset' | 'button';
+		// Layout props
+		shrinkable?: boolean;
+		reversedDirection?: boolean;
+		width?: number;
+		size?: 'tag' | 'button' | 'cta';
+		wide?: boolean;
+		grow?: boolean;
+		align?: 'flex-start' | 'center' | 'flex-end' | 'stretch' | 'baseline' | 'auto';
+		isDropdownChild?: boolean;
+		// Style props
+		style?: ComponentColor;
+		kind?: ComponentStyleKind;
+		outline?: boolean;
+		dashed?: boolean;
+		solidBackground?: boolean;
+		// Additional elements
+		icon?: keyof typeof iconsJson | undefined;
+		help?: string;
+		helpShowDelay?: number;
+		// Snippets
+		children?: Snippet<[]>;
+		menu?: Snippet<[el: HTMLElement]>;
+		// Event handlers
+		onclick?: (e: MouseEvent) => void;
+		onmousedown?: (e: MouseEvent) => void;
+		oncontextmenu?: (e: MouseEvent) => void;
+	};
 
 	// Interaction props
-	export let el: HTMLAnchorElement | HTMLButtonElement | HTMLElement | null = null;
-	export let disabled = false;
-	export let clickable = true;
-	export let id: string | undefined = undefined;
-	export let loading = false;
-	export let tabindex: number | undefined = undefined;
-	export let type: 'submit' | 'reset' | 'button' | undefined = undefined;
-	// Layout props
-	export let shrinkable = false;
-	export let reversedDirection: boolean = false;
-	export let width: number | undefined = undefined;
-	export let size: 'tag' | 'button' | 'cta' = 'button';
-	export let wide = false;
-	export let grow = false;
-	export let align: 'flex-start' | 'center' | 'flex-end' | 'stretch' | 'baseline' | 'auto' = 'auto';
-	export let isDropdownChild = false;
-	// Style props
-	export let style: ComponentColor = 'neutral';
-	export let kind: ComponentStyleKind = 'soft';
-	export let outline = false;
-	export let dashed = false;
-	export let solidBackground = false;
-	// Additional elements
-	export let icon: keyof typeof iconsJson | undefined = undefined;
-	export let help = '';
-	export let helpShowDelay = 1200;
+	const {
+		disabled = false,
+		clickable = true,
+		id = undefined,
+		loading = false,
+		tabindex = undefined,
+		type = undefined,
+		// Layout props
+		shrinkable = false,
+		reversedDirection = false,
+		width = undefined,
+		size = 'button',
+		wide = false,
+		grow = false,
+		align = 'auto',
+		isDropdownChild = false,
+		// Style props
+		style = 'neutral',
+		kind = 'soft',
+		outline = false,
+		dashed = false,
+		solidBackground = false,
+		// Additional elements
+		icon = undefined,
+		help = '',
+		helpShowDelay = 1200,
+		// Optional context menu
+		menu,
+		children,
+		// Event handlers
+		onclick,
+		onmousedown,
+		oncontextmenu
+	}: Props = $props();
+
+	let el: HTMLElement | undefined = $state();
 </script>
 
 <button
@@ -44,7 +90,7 @@
 	class:wide
 	class:grow
 	class:not-clickable={!clickable}
-	class:fixed-width={!$$slots.default && !wide}
+	class:fixed-width={!children && !wide}
 	class:is-dropdown={isDropdownChild}
 	style:align-self={align}
 	style:width={width ? pxToRem(width) : undefined}
@@ -54,20 +100,20 @@
 	}}
 	bind:this={el}
 	disabled={disabled || loading}
-	on:click
-	on:mousedown
-	on:contextmenu
+	{onclick}
+	{onmousedown}
+	{oncontextmenu}
 	{type}
 	{id}
 	tabindex={clickable ? tabindex : -1}
 >
-	{#if $$slots.default}
+	{#if children}
 		<span
 			class="label text-semibold"
 			class:text-base-12={size === 'button' || size === 'cta'}
 			class:text-base-11={size === 'tag'}
 		>
-			<slot />
+			{@render children()}
 		</span>
 	{/if}
 
@@ -81,6 +127,9 @@
 		</div>
 	{/if}
 </button>
+{#if menu && el}
+	{@render menu(el)}
+{/if}
 
 <style lang="postcss">
 	.btn {

--- a/app/src/lib/shared/Button.svelte
+++ b/app/src/lib/shared/Button.svelte
@@ -38,7 +38,6 @@
 		// Event handlers
 		onclick?: (e: MouseEvent) => void;
 		onmousedown?: (e: MouseEvent) => void;
-		oncontextmenu?: (e: MouseEvent) => void;
 	};
 
 	// Interaction props
@@ -68,13 +67,12 @@
 		icon = undefined,
 		help = '',
 		helpShowDelay = 1200,
-		// Optional context menu
+		// Snippets
 		menu,
 		children,
 		// Event handlers
 		onclick,
-		onmousedown,
-		oncontextmenu
+		onmousedown
 	}: Props = $props();
 
 	let el: HTMLElement | undefined = $state();
@@ -102,7 +100,6 @@
 	disabled={disabled || loading}
 	{onclick}
 	{onmousedown}
-	{oncontextmenu}
 	{type}
 	{id}
 	tabindex={clickable ? tabindex : -1}

--- a/app/src/lib/shared/CredentialCheck.svelte
+++ b/app/src/lib/shared/CredentialCheck.svelte
@@ -107,7 +107,7 @@
 		wide
 		icon="item-tick"
 		disabled={loading}
-		on:click={checkCredentials}
+		onclick={checkCredentials}
 	>
 		{#if loading || checks.length === 0}
 			Test credentials

--- a/app/src/lib/shared/DropDownButton.svelte
+++ b/app/src/lib/shared/DropDownButton.svelte
@@ -13,10 +13,9 @@
 	export let wide = false;
 	export let help = '';
 	export let menuPosition: 'top' | 'bottom' = 'bottom';
+	export let onclick: (e: MouseEvent) => void;
 
 	let contextMenu: ContextMenu;
-	let iconEl: HTMLElement;
-
 	let visible = false;
 
 	export function show() {
@@ -41,12 +40,11 @@
 			reversedDirection
 			disabled={disabled || loading}
 			isDropdownChild
-			on:click
+			{onclick}
 		>
 			<slot />
 		</Button>
 		<Button
-			bind:el={iconEl}
 			{style}
 			{kind}
 			{help}
@@ -55,22 +53,22 @@
 			{loading}
 			disabled={disabled || loading}
 			isDropdownChild
-			on:click={() => {
-				visible = !visible;
-				contextMenu.toggle();
-			}}
-		/>
+		>
+			{#snippet menu(target)}
+				<ContextMenu
+					bind:this={contextMenu}
+					{target}
+					verticalAlign={menuPosition}
+					eventType="mousedown"
+					onclose={() => {
+						visible = false;
+					}}
+				>
+					<slot name="context-menu" />
+				</ContextMenu>
+			{/snippet}
+		</Button>
 	</div>
-	<ContextMenu
-		bind:this={contextMenu}
-		target={iconEl}
-		verticalAlign={menuPosition}
-		onclose={() => {
-			visible = false;
-		}}
-	>
-		<slot name="context-menu" />
-	</ContextMenu>
 </div>
 
 <style lang="postcss">

--- a/app/src/lib/shared/InfoMessage.svelte
+++ b/app/src/lib/shared/InfoMessage.svelte
@@ -76,12 +76,12 @@
 		{#if primary || secondary}
 			<div class="info-message__actions">
 				{#if secondary}
-					<Button style="ghost" outline on:click={() => dispatch('secondary')}>
+					<Button style="ghost" outline onclick={() => dispatch('secondary')}>
 						{secondary}
 					</Button>
 				{/if}
 				{#if primary}
-					<Button style={primaryButtonMap[style]} kind="solid" on:click={() => dispatch('primary')}>
+					<Button style={primaryButtonMap[style]} kind="solid" onclick={() => dispatch('primary')}>
 						{primary}
 					</Button>
 				{/if}

--- a/app/src/lib/shared/LargeDiffMessage.svelte
+++ b/app/src/lib/shared/LargeDiffMessage.svelte
@@ -14,7 +14,7 @@
 <div class="large-diff-message" class:frame-box={showFrame}>
 	<p class="text-base-13">Change hidden as large diffs may slow down the UI</p>
 
-	<Button style="ghost" outline on:click={show}>Show anyways</Button>
+	<Button style="ghost" outline onclick={show}>Show anyways</Button>
 </div>
 
 <style>


### PR DESCRIPTION
Tied into this commit I also refactor the `ContextMenu` use such that it doesn't need local variables. It's in the same PR because of the removal of the 2-way binding that let us acquire the `HTMLElement` of a `Button`.