### PR TITLE
Match pull requests on their given names rather than display names

### DIFF
--- a/app/src/lib/branch/BranchLane.svelte
+++ b/app/src/lib/branch/BranchLane.svelte
@@ -53,7 +53,7 @@
 	const prStore = $derived($hostedListingServiceStore?.prs);
 	const prs = $derived(prStore ? $prStore : undefined);
 
-	const listedPr = $derived(prs?.find((pr) => pr.sourceBranch === branch.upstreamName));
+	const listedPr = $derived(prs?.find((pr) => pr.sourceBranch === branch.upstream?.givenName));
 	const sourceBranch = $derived(listedPr?.sourceBranch);
 	const prNumber = $derived(listedPr?.number);
 


### PR DESCRIPTION
While we would ideally like to have PRs match on owner+repo+branchname, using the given name is a step forwards as the display name doesn't always accuratly map to the branchname