### PR TITLE
fix: cleanup repo organisation

### DIFF
--- a/.github/actions/init-env-node/action.yaml
+++ b/.github/actions/init-env-node/action.yaml
@@ -36,4 +36,5 @@ runs:
 
     - name: Build UI
       shell: bash
-      run: cd packages/ui && pnpm package
+      run: cd packages/ui && pnpm build
+

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -4,10 +4,14 @@ rust:
 - changed-files:
   - any-glob-to-any-file: crates/**/*
 
-app:
+"@gitbutler/desktop":
 - changed-files:
-  - any-glob-to-any-file: app/**/*
+  - any-glob-to-any-file: apps/desktop/**/*
 
-ui:
+"@gitbutler/web":
+- changed-files:
+  - any-glob-to-any-file: app/web/**/*
+
+"@gitbutler/ui":
 - changed-files:
   - any-glob-to-any-file: packages/ui/**/*

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Build @gitbutler/ui
-        run: cd packages/ui && pnpm package
+        run: cd packages/ui && pnpm build
       - name: Get installed Playwright version
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./apps/desktop/package.json').devDependencies['@playwright/test'].substring(1))")" >> $GITHUB_ENV

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -86,13 +86,13 @@ $ cargo build
 Now you should be able to run the app in development mode:
 
 ```bash
-$ pnpm tauri dev
+$ pnpm dev:desktop
 ```
 
 By default it will not print debug logs to console. If you want debug logs, set `LOG_LEVEL` environment variable:
 
 ```bash
-$ LOG_LEVEL=debug pnpm tauri dev
+$ LOG_LEVEL=debug pnpm dev:desktop
 ```
 
 ### Lint & format

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@gitbutler/app",
+	"name": "@gitbutler/desktop",
 	"private": true,
 	"version": "0.0.0",
 	"type": "module",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,8 +8,8 @@
 		"build": "vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync",
-		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
+		"check": "svelte-check --tsconfig ./tsconfig.json",
+		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"devDependencies": {
 		"@fontsource/fira-mono": "^4.5.10",

--- a/crates/gitbutler-tauri/tauri.conf.json
+++ b/crates/gitbutler-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
 	"build": {
-		"beforeDevCommand": "pnpm dev",
+		"beforeDevCommand": "pnpm dev:internal-tauri",
 		"beforeBuildCommand": "[ $CI = true ] || pnpm build -- --mode development",
 		"devPath": "http://localhost:1420",
 		"distDir": "../../apps/desktop/build",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
 	"type": "module",
 	"packageManager": "pnpm@9.5.0",
 	"scripts": {
-		"dev": "turbo watch --filter @gitbutler/app dev --no-update-notifier",
-		"dev:ui": "pnpm --filter @gitbutler/ui dev",
+		"dev:ui": "pnpm --filter @gitbutler/ui storybook",
 		"dev:web": "pnpm --filter @gitbutler/web dev",
 		"dev:desktop": "pnpm tauri dev",
+    "dev:internal-tauri": "turbo watch --filter @gitbutler/app dev --no-update-notifier",
 		"test": "pnpm --filter @gitbutler/app run test",
 		"test:watch": "pnpm --filter @gitbutler/app run test:watch",
 		"build": "turbo run build --no-daemon",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"prettier": "^3.3.2",
 		"prettier-plugin-svelte": "^3.2.4",
 		"svelte-eslint-parser": "^0.41.0",
-		"turbo": "2.0.7-canary.1",
+		"turbo": "2.0.9",
 		"typescript": "5.4.5",
 		"typescript-eslint": "^7.13.1"
 	}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"dev:ui": "pnpm --filter @gitbutler/ui storybook",
 		"dev:web": "pnpm --filter @gitbutler/web dev",
 		"dev:desktop": "pnpm tauri dev",
-    "dev:internal-tauri": "turbo watch --filter @gitbutler/app dev --no-update-notifier",
+		"dev:internal-tauri": "turbo run --filter @gitbutler/app dev --no-daemon",
 		"test": "pnpm --filter @gitbutler/app run test",
 		"test:watch": "pnpm --filter @gitbutler/app run test:watch",
 		"build": "turbo run build --no-daemon",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"packageManager": "pnpm@9.5.0",
 	"scripts": {
 		"dev:ui": "pnpm --filter @gitbutler/ui storybook",
-		"dev:web": "pnpm --filter @gitbutler/web dev",
+		"dev:web": "turbo run --filter @gitbutler/web dev --no-daemon",
 		"dev:desktop": "pnpm tauri dev",
 		"dev:internal-tauri": "turbo run --filter @gitbutler/desktop dev --no-daemon",
 		"test": "turbo run test --no-daemon",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
 		"dev:ui": "pnpm --filter @gitbutler/ui storybook",
 		"dev:web": "pnpm --filter @gitbutler/web dev",
 		"dev:desktop": "pnpm tauri dev",
-		"dev:internal-tauri": "turbo run --filter @gitbutler/app dev --no-daemon",
-		"test": "pnpm --filter @gitbutler/app run test",
-		"test:watch": "pnpm --filter @gitbutler/app run test:watch",
+		"dev:internal-tauri": "turbo run --filter @gitbutler/desktop dev --no-daemon",
+		"test": "pnpm --filter @gitbutler/desktop run test",
+		"test:watch": "pnpm --filter @gitbutler/desktop run test:watch",
 		"build": "turbo run build --no-daemon",
 		"check": "turbo run check --no-daemon",
 		"tauri": "tauri",
@@ -21,7 +21,7 @@
 		"globallint": "prettier --check . && eslint .",
 		"format": "prettier --write .",
 		"fix": "eslint --fix .",
-		"prepare": "pnpm --filter @gitbutler/app run prepare",
+		"prepare": "pnpm --filter @gitbutler/desktop run prepare",
 		"rustfmt": "cargo +nightly fmt -- --config-path rustfmt-nightly.toml"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"dev:web": "pnpm --filter @gitbutler/web dev",
 		"dev:desktop": "pnpm tauri dev",
 		"dev:internal-tauri": "turbo run --filter @gitbutler/desktop dev --no-daemon",
-		"test": "pnpm --filter @gitbutler/desktop run test",
+		"test": "turbo run test --no-daemon",
 		"test:watch": "pnpm --filter @gitbutler/desktop run test:watch",
 		"build": "turbo run build --no-daemon",
 		"check": "turbo run check --no-daemon",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,7 +13,7 @@
 		"dev": "vite dev",
 		"check": "svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "pnpm check --watch",
-		"package": "svelte-kit sync && svelte-package",
+		"build": "svelte-kit sync && svelte-package",
 		"prepublishOnly": "npm run package",
 		"prepare": "svelte-kit sync",
 		"storybook": "storybook dev --no-open -p 6006",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,8 +73,8 @@ importers:
         specifier: ^0.41.0
         version: 0.41.0(svelte@5.0.0-next.196)
       turbo:
-        specifier: 2.0.7-canary.1
-        version: 2.0.7-canary.1
+        specifier: 2.0.9
+        version: 2.0.9
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -5540,38 +5540,38 @@ packages:
   tslib@2.6.3:
     resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
 
-  turbo-darwin-64@2.0.7-canary.1:
-    resolution: {integrity: sha512-P4xXSOygmNc05HSEQIbgwGy+wncEf71gTN43EjsDh3s6PorWwdO12GrYTVffArOPWeDoD9NW9soUGPdLEOzl7Q==}
+  turbo-darwin-64@2.0.9:
+    resolution: {integrity: sha512-owlGsOaExuVGBUfrnJwjkL1BWlvefjSKczEAcpLx4BI7Oh6ttakOi+JyomkPkFlYElRpjbvlR2gP8WIn6M/+xQ==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.0.7-canary.1:
-    resolution: {integrity: sha512-o6OxtTHyuSSyJXgJk3BZD6fGBQpjE+HKPoj5dys6ASmTJA6uVq98m5qFsXvSbI60UM57Krkmz2PwLzm59m9MDA==}
+  turbo-darwin-arm64@2.0.9:
+    resolution: {integrity: sha512-XAXkKkePth5ZPPE/9G9tTnPQx0C8UTkGWmNGYkpmGgRr8NedW+HrPsi9N0HcjzzIH9A4TpNYvtiV+WcwdaEjKA==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.0.7-canary.1:
-    resolution: {integrity: sha512-xaCsGULpi040p/7lymnQWxR7m2HRhGdO5xlYtG+e8eBIUZBtQrUgucD+ULxEyg08WTI4+rLyxSz6jfsD/bavWA==}
+  turbo-linux-64@2.0.9:
+    resolution: {integrity: sha512-l9wSgEjrCFM1aG16zItBsZ206ZlhSSx1owB8Cgskfv0XyIXRGHRkluihiaxkp+UeU5WoEfz4EN5toc+ICA0q0w==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.0.7-canary.1:
-    resolution: {integrity: sha512-Ic8senZjMfrv67B348FZDOJSCu0+kczSXCT5sB6eBQOj0WBMf4hqKI3wVh9Wh5Wql1tzS83GbgSbSA4y/xW2ZQ==}
+  turbo-linux-arm64@2.0.9:
+    resolution: {integrity: sha512-gRnjxXRne18B27SwxXMqL3fJu7jw/8kBrOBTBNRSmZZiG1Uu3nbnP7b4lgrA/bCku6C0Wligwqurvtpq6+nFHA==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.0.7-canary.1:
-    resolution: {integrity: sha512-keYghBcwecEpg10Dr3mhny/VIuErWqLDhed0M9R5b7dkLkD/x9bkKzbwEIzXtwZaTlvpYe2gPGlU2nLs2oawjw==}
+  turbo-windows-64@2.0.9:
+    resolution: {integrity: sha512-ZVo0apxUvaRq4Vm1qhsfqKKhtRgReYlBVf9MQvVU1O9AoyydEQvLDO1ryqpXDZWpcHoFxHAQc9msjAMtE5K2lA==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.0.7-canary.1:
-    resolution: {integrity: sha512-6/M9Yj7CfjhpVIKYVOBPHeChby/WwhKAd/LxwtjTC8RGt85htBCqeuPpOOaLKAgj0H2ThqQTQ9ufght4j0bVUA==}
+  turbo-windows-arm64@2.0.9:
+    resolution: {integrity: sha512-sGRz7c5Pey6y7y9OKi8ypbWNuIRPF9y8xcMqL56OZifSUSo+X2EOsOleR9MKxQXVaqHPGOUKWsE6y8hxBi9pag==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.0.7-canary.1:
-    resolution: {integrity: sha512-zhWs4lpDiJtJLItB7XXFQWAjdfe+gVi8xIb3aiCkalRBkuUR9PfOoaYyP/sSWWK96rhxY/eyigi7nZqGZDk4Zg==}
+  turbo@2.0.9:
+    resolution: {integrity: sha512-QaLaUL1CqblSKKPgLrFW3lZWkWG4pGBQNW+q1ScJB5v1D/nFWtsrD/yZljW/bdawg90ihi4/ftQJ3h6fz1FamA==}
     hasBin: true
 
   type-check@0.4.0:
@@ -12266,32 +12266,32 @@ snapshots:
 
   tslib@2.6.3: {}
 
-  turbo-darwin-64@2.0.7-canary.1:
+  turbo-darwin-64@2.0.9:
     optional: true
 
-  turbo-darwin-arm64@2.0.7-canary.1:
+  turbo-darwin-arm64@2.0.9:
     optional: true
 
-  turbo-linux-64@2.0.7-canary.1:
+  turbo-linux-64@2.0.9:
     optional: true
 
-  turbo-linux-arm64@2.0.7-canary.1:
+  turbo-linux-arm64@2.0.9:
     optional: true
 
-  turbo-windows-64@2.0.7-canary.1:
+  turbo-windows-64@2.0.9:
     optional: true
 
-  turbo-windows-arm64@2.0.7-canary.1:
+  turbo-windows-arm64@2.0.9:
     optional: true
 
-  turbo@2.0.7-canary.1:
+  turbo@2.0.9:
     optionalDependencies:
-      turbo-darwin-64: 2.0.7-canary.1
-      turbo-darwin-arm64: 2.0.7-canary.1
-      turbo-linux-64: 2.0.7-canary.1
-      turbo-linux-arm64: 2.0.7-canary.1
-      turbo-windows-64: 2.0.7-canary.1
-      turbo-windows-arm64: 2.0.7-canary.1
+      turbo-darwin-64: 2.0.9
+      turbo-darwin-arm64: 2.0.9
+      turbo-linux-64: 2.0.9
+      turbo-linux-arm64: 2.0.9
+      turbo-windows-64: 2.0.9
+      turbo-windows-arm64: 2.0.9
 
   type-check@0.4.0:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -2,13 +2,13 @@
 	"$schema": "https://turborepo.org/schema.json",
 	"tasks": {
 		"package": {
-			"outputs": ["dist"]
+			"outputs": ["dist/**"]
 		},
 		"build": {
 			"dependsOn": ["^build"],
 			"passThroughEnv": ["SENTRY_AUTH_TOKEN", "GITHUB_TOKEN"],
 			"env": ["SENTRY_RELEASE"],
-			"outputs": [".svelte-kit", "!.sveltekit/types", "!.sveltekit/*.d.ts"]
+			"outputs": [".svelte-kit/**", "!.sveltekit/types", "!.sveltekit/*.d.ts"]
 		},
 		"dev": {
 			"dependsOn": ["@gitbutler/ui#build"],

--- a/turbo.json
+++ b/turbo.json
@@ -5,24 +5,25 @@
 			"outputs": ["dist"]
 		},
 		"build": {
-			"dependsOn": ["^package"],
+			"dependsOn": ["^build"],
 			"passThroughEnv": ["SENTRY_AUTH_TOKEN", "GITHUB_TOKEN"],
 			"env": ["SENTRY_RELEASE"],
 			"outputs": [".svelte-kit", "!.sveltekit/types", "!.sveltekit/*.d.ts"]
 		},
 		"dev": {
-			"dependsOn": ["^package"],
+			"dependsOn": ["@gitbutler/ui#build"],
 			"cache": false,
 			"persistent": true
 		},
 		"check": {
-			"dependsOn": ["^package"],
-			"cache": true
+			"dependsOn": ["@gitbutler/ui#build"]
+		},
+		"test": {
+			"dependsOn": ["@gitbutler/ui#build"]
 		},
 		"//#globallint": {
 			// Root rules require dependencies to manually be listed https://github.com/vercel/turbo/discussions/7481
-			"dependsOn": ["@gitbutler/ui#package"],
-			"cache": true
+			"dependsOn": ["@gitbutler/ui#build"]
 		}
 	}
 }

--- a/turbo.json
+++ b/turbo.json
@@ -2,13 +2,13 @@
 	"$schema": "https://turborepo.org/schema.json",
 	"tasks": {
 		"package": {
-			"cache": false
+			"outputs": ["dist"]
 		},
 		"build": {
 			"dependsOn": ["^package"],
 			"passThroughEnv": ["SENTRY_AUTH_TOKEN", "GITHUB_TOKEN"],
 			"env": ["SENTRY_RELEASE"],
-			"cache": false
+			"outputs": [".svelte-kit", "!.sveltekit/types", "!.sveltekit/*.d.ts"]
 		},
 		"dev": {
 			"dependsOn": ["^package"],


### PR DESCRIPTION
## ☕️ Reasoning


## 🧢 Changes

- `dev` npm script was misleading, this is never used by us as developers, only by Tauri itself, renamed it to not confuse new contributors / our future selves
- `dev:ui` changed to start up the storybook in the UI package, instead of the irrelevant dev server in that directory
- Rename `@gitbutler/app` to `@gitbutler/desktop` everywhere else
- Small update to `DEVELOPMENT.md` due to new repo structure / cmds

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
