### PR TITLE
Introduce operating modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2024,6 +2024,7 @@ dependencies = [
  "gitbutler-fs",
  "gitbutler-git",
  "gitbutler-id",
+ "gitbutler-operating-modes",
  "gitbutler-oplog",
  "gitbutler-project",
  "gitbutler-reference",
@@ -2186,6 +2187,16 @@ dependencies = [
  "serde",
  "tracing",
  "walkdir",
+]
+
+[[package]]
+name = "gitbutler-operating-modes"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "git2",
+ "gitbutler-command-context",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,6 +2453,7 @@ dependencies = [
  "gitbutler-command-context",
  "gitbutler-error",
  "gitbutler-notify-debouncer",
+ "gitbutler-operating-modes",
  "gitbutler-oplog",
  "gitbutler-project",
  "gitbutler-reference",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,15 +26,15 @@ members = [
     "crates/gitbutler-time",
     "crates/gitbutler-commit",
     "crates/gitbutler-tagged-string",
-    "crates/gitbutler-url", 
+    "crates/gitbutler-url",
     "crates/gitbutler-diff",
+    "crates/gitbutler-operating-modes",
 ]
 resolver = "2"
 
 [workspace.dependencies]
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
-gix = { version = "0.64", default-features = false, features = [
-] }
+gix = { version = "0.64", default-features = false, features = [] }
 git2 = { version = "0.18.3", features = [
     "vendored-openssl",
     "vendored-libgit2",
@@ -75,6 +75,7 @@ gitbutler-commit = { path = "crates/gitbutler-commit" }
 gitbutler-tagged-string = { path = "crates/gitbutler-tagged-string" }
 gitbutler-url = { path = "crates/gitbutler-url" }
 gitbutler-diff = { path = "crates/gitbutler-diff" }
+gitbutler-operating-modes = { path = "crates/gitbutler-operating-modes" }
 
 [profile.release]
 codegen-units = 1 # Compile crates one after another so the compiler can optimize better

--- a/crates/gitbutler-branch-actions/Cargo.toml
+++ b/crates/gitbutler-branch-actions/Cargo.toml
@@ -24,6 +24,7 @@ gitbutler-commit.workspace = true
 gitbutler-url.workspace = true
 gitbutler-fs.workspace = true
 gitbutler-diff.workspace = true
+gitbutler-operating-modes.workspace = true
 serde = { workspace = true, features = ["std"] }
 bstr = "1.9.1"
 diffy = "0.4.0"

--- a/crates/gitbutler-branch-actions/src/status.rs
+++ b/crates/gitbutler-branch-actions/src/status.rs
@@ -6,6 +6,7 @@ use gitbutler_branch::{
 };
 use gitbutler_command_context::CommandContext;
 use gitbutler_diff::{diff_files_into_hunks, GitHunk, Hunk, HunkHash};
+use gitbutler_operating_modes::assure_open_workspace_mode;
 use gitbutler_project::access::WorktreeWritePermission;
 use gitbutler_repo::RepositoryExt;
 
@@ -32,6 +33,8 @@ pub fn get_applied_status(
     ctx: &CommandContext,
     perm: Option<&mut WorktreeWritePermission>,
 ) -> Result<VirtualBranchesStatus> {
+    assure_open_workspace_mode(ctx)
+        .context("Getting applied status requires open workspace mode")?;
     let integration_commit = get_workspace_head(ctx)?;
     let mut virtual_branches = ctx
         .project()

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -16,6 +16,7 @@ use gitbutler_command_context::CommandContext;
 use gitbutler_commit::{commit_ext::CommitExt, commit_headers::HasCommitHeaders};
 use gitbutler_diff::{trees, GitHunk, Hunk};
 use gitbutler_error::error::{Code, Marker};
+use gitbutler_operating_modes::assure_open_workspace_mode;
 use gitbutler_project::access::WorktreeWritePermission;
 use gitbutler_reference::{normalize_branch_name, Refname, RemoteRefname};
 use gitbutler_repo::{
@@ -258,6 +259,8 @@ pub fn list_virtual_branches(
     //           that conditionally write things.
     perm: &mut WorktreeWritePermission,
 ) -> Result<(Vec<VirtualBranch>, Vec<gitbutler_diff::FileDiff>)> {
+    assure_open_workspace_mode(ctx)
+        .context("Listing virtual branches requires open workspace mode")?;
     let mut branches: Vec<VirtualBranch> = Vec::new();
 
     let vb_state = ctx.project().virtual_branches();

--- a/crates/gitbutler-operating-modes/Cargo.toml
+++ b/crates/gitbutler-operating-modes/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "gitbutler-operating-modes"
+version = "0.0.0"
+edition = "2021"
+authors = ["GitButler <gitbutler@gitbutler.com>"]
+publish = false
+
+[dependencies]
+serde = { workspace = true, features = ["std"] }
+git2.workspace = true
+anyhow.workspace = true
+gitbutler-command-context.workspace = true

--- a/crates/gitbutler-operating-modes/src/lib.rs
+++ b/crates/gitbutler-operating-modes/src/lib.rs
@@ -1,0 +1,38 @@
+use anyhow::{bail, Context, Result};
+use gitbutler_command_context::CommandContext;
+
+/// Operating Modes:
+/// Gitbutler currently has two main operating modes:
+/// - `in workspace mode`: When the app is on the gitbutler/integration branch.
+///     This is when normal operations can be performed.
+/// - `outside workspace mode`: When the user has left the gitbutler/integration
+///     branch to perform regular git commands.
+
+const INTEGRATION_BRANCH_REF: &str = "refs/heads/gitbutler/integration";
+
+pub fn in_open_workspace_mode(ctx: &CommandContext) -> Result<bool> {
+    let head_ref = ctx.repository().head().context("failed to get head")?;
+    let head_ref_name = head_ref.name().context("failed to get head name")?;
+
+    Ok(head_ref_name == INTEGRATION_BRANCH_REF)
+}
+
+pub fn assure_open_workspace_mode(ctx: &CommandContext) -> Result<()> {
+    if in_open_workspace_mode(ctx)? {
+        Ok(())
+    } else {
+        bail!("Unexpected state: cannot perform operation on non-integration branch")
+    }
+}
+
+pub fn in_outside_workspace_mode(ctx: &CommandContext) -> Result<bool> {
+    in_open_workspace_mode(ctx).map(|open_mode| !open_mode)
+}
+
+pub fn assure_outside_workspace_mode(ctx: &CommandContext) -> Result<()> {
+    if in_open_workspace_mode(ctx)? {
+        Ok(())
+    } else {
+        bail!("Unexpected state: cannot perform operation on non-integration branch")
+    }
+}

--- a/crates/gitbutler-watcher/Cargo.toml
+++ b/crates/gitbutler-watcher/Cargo.toml
@@ -24,6 +24,7 @@ gitbutler-project.workspace = true
 gitbutler-user.workspace = true
 gitbutler-reference.workspace = true
 gitbutler-error.workspace = true
+gitbutler-operating-modes.workspace = true
 
 backoff = "0.4.0"
 notify = { version = "6.0.1" }


### PR DESCRIPTION
It should be noted that I've not replaced all instances where we check for refs/heads/gitbutler/integration as they were in contexts it didn't have access to the project or command context, or it didn't feel appropriate to create a command context.