### PR TITLE
Use seperate folder for rust analzyer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ storybook-static
 
 # Vercel
 .vercel
+
+# Rust analyzer
+.rust-analyzer/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,9 @@
 	"rust-analyzer.check.command": "clippy",
 	"rust-analyzer.check.allTargets": true,
 	"rust-analyzer.check.features": "all",
+	"rust-analyzer.check.extraArgs": [
+		"--target-dir", ".rust-analyzer/target"
+	],
 	"[rust]": {
 		"editor.defaultFormatter": "rust-lang.rust-analyzer"
 	},


### PR DESCRIPTION
By asking rust analzyer to use a seperate
folder, it means the cache doesn't get
invalidated when running tests or by
running the application under different 
compiler flags.

Having the cache invalidated
dramatically increases the compile times.