### PR TITLE
`gitbutler-git` now specifies the minimum required rustc version. (#4514)

### DIFF
--- a/crates/gitbutler-cli/Cargo.toml
+++ b/crates/gitbutler-cli/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
+rust-version = "1.74"
 
 [[bin]]
 name = "gitbutler-cli"


### PR DESCRIPTION
That way, the error message will be clear and it's more obvious how to overcome issues related to older-than-needed compiler versions.

When the version is too low, it looks like this:

```
error: package `gitbutiler-git v0.0.0` cannot be built because it requires rustc 1.75 or newer, while the currently active rustc version is 1.70.0
Either upgrade to rustc 1.75 or newer, or [..]
```
I adapted the message above from one I found on my own CI, but the first part already shows
it will be reasonably clear what to do.
