### PR TITLE
fix: skip turbo in init-node-env

### DIFF
--- a/.github/actions/init-env-node/action.yaml
+++ b/.github/actions/init-env-node/action.yaml
@@ -36,5 +36,5 @@ runs:
 
     - name: Build UI
       shell: bash
-      run: pnpm exec turbo run package # build UI package
+      run: cd packages/ui && pnpm run package
 

--- a/.github/actions/init-env-node/action.yaml
+++ b/.github/actions/init-env-node/action.yaml
@@ -36,5 +36,5 @@ runs:
 
     - name: Build UI
       shell: bash
-      run: cd packages/ui && pnpm run package
+      run: pnpm exec turbo run package
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,7 +13,7 @@
 		"dev": "vite dev",
 		"check": "svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "pnpm check --watch",
-		"package": "pnpm run --sequential '/^package:.*/'",
+		"package": "pnpm run --sequential \"/^package:.*/\"",
 		"package:svelte": "svelte-kit sync && svelte-package",
 		"package:styles": "postcss ./src/styles/main.css -o ./dist/styles/main.css && pnpm run copy-fonts",
 		"copy-fonts": "postcss ./src/styles/fonts.css -o ./dist/fonts.css && cpy './src/styles/fonts/**/*.woff2' './dist/fonts' --parents",


### PR DESCRIPTION
## ☕️ Reasoning


## 🧢 Changes

- Skip turbo and use pnpm cmd directly in the correct directory


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
