### PR TITLE
fix: add Sentry cron monitoring to nightly release and fix git tag creation

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,6 +35,9 @@ jobs:
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
+      - name: Trigger Sentry Cron - In Progress
+        if: ${{ github.event_name == 'schedule' }}
+        run: curl "${SENTRY_CRONS}?status=in_progress"
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.PAT_JUNON }}
@@ -296,6 +299,15 @@ jobs:
             --header 'X-Auth-Token: ${{ secrets.BOT_AUTH_TOKEN }}' \
             --data '{"channel":"${{ needs.build-tauri.outputs.channel }}","version":"${{ env.version }}-${{ github.run_number }}","sha":"${{ github.sha }}"}'
 
+  create-git-tag:
+    needs: [publish-tauri, build-tauri]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version
+        shell: bash
+        run: |
+          VERSION="$(cat release/version)"
+          echo "version=$VERSION" >> $GITHUB_ENV
       - name: Create git tag
         shell: bash
         env:
@@ -320,3 +332,6 @@ jobs:
             delete_tag "$TAG_NAME"
           fi
           create_tag "$TAG_NAME"
+      - name: Trigger Sentry Cron - Complete
+        if: ${{ github.event_name == 'schedule' }}
+        run: curl "${SENTRY_CRONS}?status=ok"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,7 +37,8 @@ jobs:
     steps:
       - name: Trigger Sentry Cron - In Progress
         if: ${{ github.event_name == 'schedule' }}
-        run: curl "${SENTRY_CRONS}?status=in_progress"
+        shell: bash
+        run: curl "${{ secrets.SENTRY_CRONS }}?status=in_progress"
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.PAT_JUNON }}
@@ -248,6 +249,8 @@ jobs:
   publish-tauri:
     needs: [sign-tauri, build-tauri]
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ env.version }}
     strategy:
       fail-fast: false
       matrix:
@@ -303,15 +306,13 @@ jobs:
     needs: [publish-tauri, build-tauri]
     runs-on: ubuntu-latest
     steps:
-      - name: Extract version
-        shell: bash
-        run: |
-          VERSION="$(cat release/version)"
-          echo "version=$VERSION" >> $GITHUB_ENV
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT_JUNON }} # custom token here so that we can push tags later
       - name: Create git tag
         shell: bash
         env:
-          TAG_NAME: "${{ needs.build-tauri.outputs.channel }}/${{ env.version }}"
+          TAG_NAME: "${{ needs.build-tauri.outputs.channel }}/${{ needs.publish-tauri.outputs.version }}"
         run: |
           function tag_exists() {
             git tag --list | grep -q "^$1$"
@@ -334,4 +335,5 @@ jobs:
           create_tag "$TAG_NAME"
       - name: Trigger Sentry Cron - Complete
         if: ${{ github.event_name == 'schedule' }}
-        run: curl "${SENTRY_CRONS}?status=ok"
+        shell: bash
+        run: curl "${{ secrets.SENTRY_CRONS }}?status=ok"


### PR DESCRIPTION
## ☕️ Reasoning

- Add Sentry Cron monitoring to nightly release (run only on `event_name="schedule"`)
- Extract git tag creation to its own job so it's not run 4x due to the job matrix
- Requires new runner secret (CC: @krlvi)

## 🧢 Changes


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
