### PR TITLE
fix: use SvelteKit auto-generated types for load fns

### DIFF
--- a/apps/desktop/src/routes/+layout.ts
+++ b/apps/desktop/src/routes/+layout.ts
@@ -13,6 +13,7 @@ import { UserService } from '$lib/stores/user';
 import { mockTauri } from '$lib/testing/index';
 import { LineManagerFactory } from '@gitbutler/ui/CommitLines/lineManager';
 import lscache from 'lscache';
+import type { LayoutLoad } from './$types';
 import { env } from '$env/dynamic/public';
 
 // call on startup so we don't accumulate old items
@@ -22,7 +23,8 @@ export const ssr = false;
 export const prerender = false;
 export const csr = true;
 
-export async function load() {
+// eslint-disable-next-line
+export const load: LayoutLoad = async () => {
 	// Mock Tauri API during E2E tests
 	if (env.PUBLIC_TESTING) {
 		mockTauri();
@@ -61,4 +63,4 @@ export async function load() {
 		lineManagerFactory,
 		secretsService
 	};
-}
+};

--- a/apps/desktop/src/routes/[projectId]/+layout.ts
+++ b/apps/desktop/src/routes/[projectId]/+layout.ts
@@ -12,10 +12,12 @@ import { BranchController } from '$lib/vbranches/branchController';
 import { VirtualBranchService } from '$lib/vbranches/virtualBranch';
 import { error } from '@sveltejs/kit';
 import type { Project } from '$lib/backend/projects';
+import type { LayoutLoad } from './$types';
 
 export const prerender = false;
 
-export async function load({ params, parent }) {
+// eslint-disable-next-line
+export const load: LayoutLoad = async ({ params, parent }) => {
 	// prettier-ignore
 	const {
         authService,
@@ -78,4 +80,4 @@ export async function load({ params, parent }) {
 		commitDragActionsFactory,
 		reorderDropzoneManagerFactory
 	};
-}
+};


### PR DESCRIPTION
## ☕️ Reasoning

- Svelte auto-generates dynamic types for these `load()`

## 🧢 Changes

- Only applicable when not using function style declaration, otherwise could hack it with `Parameters<>`, etc.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
