### PR TITLE
fix: default to `VITEMODE=nightly`

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -46,11 +46,9 @@ jobs:
         shell: bash
         if: ${{ !github.event.workflow_run }}
         run: |
-          VITEMODE=development
+          VITEMODE=nightly
           if [[ "${{ github.event.inputs.channel }}" == "release" ]]; then
             VITEMODE=production
-          elif [[ "${{ github.event.inputs.channel }}" == "nightly" ]]; then
-            VITEMODE=nightly
           fi
 
           echo "vitemode=$VITEMODE" >> $GITHUB_ENV


### PR DESCRIPTION
## ☕️ Reasoning


## 🧢 Changes

- Default to `VITEMODE=nightly` and remove optino for `development` as we dont even have that option in the dropdown to select from.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
