### PR TITLE
fix: `AppUpdater` popover not able to be closed

### DIFF
--- a/apps/desktop/src/lib/backend/updater.ts
+++ b/apps/desktop/src/lib/backend/updater.ts
@@ -1,4 +1,5 @@
 import { showToast } from '$lib/notifications/toasts';
+import { getVersion } from '@tauri-apps/api/app';
 import { relaunch } from '@tauri-apps/api/process';
 import {
 	checkUpdate,
@@ -10,7 +11,7 @@ import {
 import posthog from 'posthog-js';
 import { derived, writable, type Readable } from 'svelte/store';
 
-// TOOD: Investigate why 'DOWNLOADED' is not in the type provided by Tauri.
+// TODO: Investigate why 'DOWNLOADED' is not in the type provided by Tauri.
 export type Update =
 	| { version?: string; status?: UpdateStatus | 'DOWNLOADED'; body?: string }
 	| undefined;
@@ -33,6 +34,7 @@ export class UpdaterService {
 		undefined
 	);
 
+	private currentVersion = writable<string | undefined>(undefined);
 	readonly version = derived(this.update, (update) => update?.version);
 
 	prev: Update | undefined;
@@ -42,6 +44,8 @@ export class UpdaterService {
 	constructor() {}
 
 	private async start() {
+		const currentVersion = await getVersion();
+		this.currentVersion.set(currentVersion);
 		await this.checkForUpdate();
 		setInterval(async () => await this.checkForUpdate(), 3600000); // hourly
 		this.unlistenFn = await onUpdaterEvent((status) => {

--- a/apps/desktop/src/lib/backend/updater.ts
+++ b/apps/desktop/src/lib/backend/updater.ts
@@ -34,7 +34,7 @@ export class UpdaterService {
 		undefined
 	);
 
-	private currentVersion = writable<string | undefined>(undefined);
+	currentVersion = writable<string | undefined>(undefined);
 	readonly version = derived(this.update, (update) => update?.version);
 
 	prev: Update | undefined;

--- a/apps/desktop/src/lib/components/AppUpdater.svelte
+++ b/apps/desktop/src/lib/components/AppUpdater.svelte
@@ -8,10 +8,13 @@
 	const updaterService = getContext(UpdaterService);
 	const update = updaterService.update;
 	const version = updaterService.version;
+	const currentVersion = updaterService.currentVersion;
 
 	let dismissed = $state(false);
 	$effect(() => {
-		if (version && dismissed) dismissed = false;
+		if ($version !== $currentVersion && dismissed) {
+			dismissed = false;
+		}
 	});
 </script>
 
@@ -120,9 +123,8 @@
 				Release notes
 			</Button>
 			<div class="status-section">
-				<div class="sliding-gradient"></div>
-
 				{#if !$update.status}
+					<div class="sliding-gradient"></div>
 					<div class="cta-btn" transition:fade={{ duration: 100 }}>
 						<Button
 							wide
@@ -136,6 +138,7 @@
 						</Button>
 					</div>
 				{:else if $update.status === 'DONE'}
+					<div class="sliding-gradient"></div>
 					<div class="cta-btn" transition:fade={{ duration: 100 }}>
 						<Button style="pop" kind="solid" wide on:click={() => updaterService.relaunchApp()}
 							>Restart</Button
@@ -190,7 +193,6 @@
 		flex-direction: column;
 		align-items: center;
 
-		height: var(--size-button);
 		width: 100%;
 		border-radius: var(--radius-m);
 


### PR DESCRIPTION
## ☕️ Reasoning

- `AppUpdater` popover wasn't able to be closed with the "X" button in its top-right corner

## 🧢 Changes

- Add a `currentVersion` writable to the `updaterService`
	- Check if `currentVersion !== version` when determining whether to show the updater popover or not
- Moved gradient slide thing that was always visible, even if there wasn't a button in the second slot, so its only rendered with a button.

![image](https://github.com/user-attachments/assets/e6915cd8-80cf-42f9-a70f-f63f26a4c4e6)



<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
