### PR TITLE
branch-listing tests and refactors

### DIFF
--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -299,10 +299,10 @@ pub struct BranchListingFilter {
 #[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct BranchListing {
-    /// The name of the branch (e.g. `main`, `feature/branch`), excluding the remote name
+    /// The `identity` of the branch (e.g. `main`, `feature/branch`), excluding the remote name.
     pub name: String,
-    /// This is a list of remote that this branch can be found on (e.g. `origin`, `upstream` etc.).
-    /// If this branch is a local branch, this list will be empty.
+    /// This is a list of remotes that this branch can be found on (e.g. `origin`, `upstream` etc.),
+    /// by collecting remotes from all local branches with the same identity that have a tracking setup.
     #[serde(serialize_with = "gitbutler_serde::serde::as_string_lossy_vec")]
     pub remotes: Vec<BString>,
     /// The branch may or may not have a virtual branch associated with it
@@ -316,7 +316,8 @@ pub struct BranchListing {
     /// This includes any commits, uncommited changes or even updates to the branch metadata (e.g. renaming).
     pub updated_at: u128,
     /// A list of authors that have contributes commits to this branch.
-    /// In the case of multiple remote tracking branches, it takes the full list of unique authors.
+    /// In the case of multiple remote tracking branches, or branches whose commits are evaluated,
+    /// it takes the full list of unique authors, without applying a mailmap.
     pub authors: Vec<Author>,
     /// Determines if the current user is involved with this branch.
     /// Returns true if the author has created a commit on this branch
@@ -328,10 +329,10 @@ pub struct BranchListing {
     /// 2. The head of the local branch
     /// 3. The head of the first remote branch
     #[serde(skip)]
-    head: git2::Oid,
+    pub head: git2::Oid,
 }
 
-/// Represents a "commit author" or "signature", based on the data from ther git history
+/// Represents a "commit author" or "signature", based on the data from the git history
 #[derive(Debug, Clone, Serialize, PartialEq, Eq, Hash)]
 pub struct Author {
     /// The name of the author as configured in the git config

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -88,7 +88,7 @@ fn combine_branches(
             continue;
         };
         // Skip branches that should not be listed, e.g. the target 'main' or the gitbutler technical branches like 'gitbutler/integration'
-        if !should_list_git_branch(&identity, &target_branch) {
+        if !should_list_git_branch(&identity, &target_branch, &branch) {
             continue;
         }
         groups.entry(identity).or_default().push(branch);
@@ -255,12 +255,17 @@ impl GroupBranch<'_> {
             }
         }
     }
+
+    /// Returns true if this is a virtual branch.
+    fn is_virtual(&self) -> bool {
+        matches!(self, Self::Virtual(_))
+    }
 }
 
 /// Determines if a branch should be listed in the UI.
 /// This excludes the target branch as well as gitbutler specific branches.
-fn should_list_git_branch(identity: &str, target: &Target) -> bool {
-    if identity == target.branch.branch() {
+fn should_list_git_branch(identity: &str, target: &Target, branch: &GroupBranch) -> bool {
+    if !branch.is_virtual() && identity == target.branch.branch() {
         return false;
     }
     // Exclude gitbutler technical branches (not useful for the user)

--- a/crates/gitbutler-branch-actions/tests/fixtures/for-listing.sh
+++ b/crates/gitbutler-branch-actions/tests/fixtures/for-listing.sh
@@ -61,3 +61,24 @@ git clone remote a-vbranch-named-like-target-branch-short-name
   tick
   $CLI branch commit main -m "virtual branch change in index and worktree"
 )
+
+git clone remote one-vbranch-on-integration-two-remotes
+(cd one-vbranch-on-integration-two-remotes
+  $CLI project add --switch-to-integration "$(git rev-parse --symbolic-full-name @{u})"
+  $CLI branch create main
+
+  git remote add other-remote ../remote
+  git fetch other-remote
+)
+
+git clone remote one-branch-one-commit-other-branch-without-commit
+(cd one-branch-one-commit-other-branch-without-commit
+  local_tracking_ref="$(git rev-parse --symbolic-full-name @{u})";
+
+  git checkout -b feature main
+  echo change >> file
+  git add . && git commit -m "change standard git feature branch"
+
+  git checkout -b other-feature main
+  $CLI project add --switch-to-integration "$local_tracking_ref"
+)

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/list.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/list.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
-use gitbutler_branch_actions::{list_branches, Author, BranchListingFilter};
-use gitbutler_command_context::CommandContext;
+use gitbutler_branch_actions::{list_branches, BranchListingFilter};
 
 #[test]
 fn one_vbranch_on_integration() -> Result<()> {
@@ -8,19 +7,16 @@ fn one_vbranch_on_integration() -> Result<()> {
     let list = list_branches(&project_ctx("one-vbranch-on-integration")?, None)?;
     assert_eq!(list.len(), 1);
 
-    let branch = &list[0];
-    assert_eq!(branch.name, "virtual");
-    assert!(branch.remotes.is_empty(), "no remote is associated yet");
-    assert_eq!(branch.number_of_commits, 0);
-    assert_eq!(
-        branch
-            .virtual_branch
-            .as_ref()
-            .map(|v| v.given_name.as_str()),
-        Some("virtual")
+    assert_equal(
+        &list[0],
+        ExpectedBranchListing {
+            identity: "virtual",
+            virtual_branch_given_name: Some("virtual"),
+            virtual_branch_in_workspace: true,
+            ..Default::default()
+        },
+        "It's a bare virtual branch with no commit",
     );
-    assert_eq!(branch.authors, []);
-    assert!(branch.own_branch, "zero commits means user owns the branch");
     Ok(())
 }
 
@@ -31,19 +27,17 @@ fn one_vbranch_on_integration_one_commit() -> Result<()> {
     let list = list_branches(&ctx, None)?;
     assert_eq!(list.len(), 1);
 
-    let branch = &list[0];
-    assert_eq!(branch.name, "virtual");
-    assert!(branch.remotes.is_empty(), "no remote is associated yet");
-    assert_eq!(
-        branch
-            .virtual_branch
-            .as_ref()
-            .map(|v| v.given_name.as_str()),
-        Some("virtual")
+    assert_equal(
+        &list[0],
+        ExpectedBranchListing {
+            identity: "virtual",
+            virtual_branch_given_name: Some("virtual"),
+            virtual_branch_in_workspace: true,
+            number_of_commits: 1,
+            ..Default::default()
+        },
+        "It's a bare virtual branch with a single commit",
     );
-    assert_eq!(branch.number_of_commits, 1, "one commit created on vbranch");
-    assert_eq!(branch.authors, [default_author()]);
-    assert!(branch.own_branch);
     Ok(())
 }
 
@@ -51,9 +45,6 @@ fn one_vbranch_on_integration_one_commit() -> Result<()> {
 fn two_vbranches_on_integration_one_commit() -> Result<()> {
     init_env();
     let ctx = project_ctx("two-vbranches-on-integration-one-applied")?;
-    // let list = list_branches(&ctx, None)?;
-    // assert_eq!(list.len(), 2, "all branches are listed");
-
     let list = list_branches(
         &ctx,
         Some(BranchListingFilter {
@@ -62,24 +53,15 @@ fn two_vbranches_on_integration_one_commit() -> Result<()> {
         }),
     )?;
     assert_eq!(list.len(), 1, "only one of these is applied");
-    let branch = &list[0];
-    assert_eq!(branch.name, "other");
-    assert!(branch.remotes.is_empty(), "no remote is associated yet");
-    assert_eq!(
-        branch
-            .virtual_branch
-            .as_ref()
-            .map(|v| v.given_name.as_str()),
-        Some("other")
-    );
-    assert_eq!(
-        branch.number_of_commits, 0,
-        "this one has only pending changes in the worktree"
-    );
-    assert_eq!(branch.authors, []);
-    assert!(
-        branch.own_branch,
-        "empty branches are always considered owned (or something the user is involved in)"
+    assert_equal(
+        &list[0],
+        ExpectedBranchListing {
+            identity: "other",
+            virtual_branch_given_name: Some("other"),
+            virtual_branch_in_workspace: true,
+            ..Default::default()
+        },
+        "It's a bare virtual branch without any branches with the same identity",
     );
 
     let list = list_branches(
@@ -90,21 +72,16 @@ fn two_vbranches_on_integration_one_commit() -> Result<()> {
         }),
     )?;
     assert_eq!(list.len(), 1, "only one of these is *not* applied");
-    let branch = &list[0];
-    assert_eq!(branch.name, "virtual");
-    assert!(branch.remotes.is_empty(), "no remote is associated yet");
-    assert_eq!(
-        branch
-            .virtual_branch
-            .as_ref()
-            .map(|v| v.given_name.as_str()),
-        Some("virtual")
-    );
-    assert_eq!(branch.number_of_commits, 1, "here we have a commit");
-    assert_eq!(branch.authors, [default_author()]);
-    assert!(
-        branch.own_branch,
-        "the current user (as identified by signature) created the commit"
+    assert_equal(
+        &list[0],
+        ExpectedBranchListing {
+            identity: "virtual",
+            virtual_branch_given_name: Some("virtual"),
+            virtual_branch_in_workspace: false,
+            number_of_commits: 1,
+            ..Default::default()
+        },
+        "It's a bare virtual branch without any branches with the same identity",
     );
     Ok(())
 }
@@ -119,34 +96,124 @@ fn one_feature_branch_and_one_vbranch_on_integration_one_commit() -> Result<()> 
         1,
         "it finds our single virtual branch despit it having the same 'identity' as the target branch: 'main'"
     );
+    assert_equal(
+        &list[0],
+        ExpectedBranchListing {
+            identity: "main",
+            remotes: vec![],
+            // remotes: vec!["origin"], // TODO: should be this
+            virtual_branch_given_name: Some("main"),
+            virtual_branch_in_workspace: true,
+            number_of_commits: 1,
+            ..Default::default()
+        },
+        "virtual branches can have the name of the target, even though it's probably not going to work when pushing. \
+        The remotes of the local `refs/heads/main` are shown."
+    );
 
     Ok(())
 }
 
-/// This function affects all tests, but those who care should just call it, assuming
-/// they all care for the same default value.
-/// If not, they should be placed in their own integration test or run with `#[serial_test:serial]`.
-/// For `list_branches` it's needed as it compares the current author with commit authors to determine ownership.
-fn init_env() {
-    for (name, value) in [
-        ("GIT_AUTHOR_DATE", "2000-01-01 00:00:00 +0000"),
-        ("GIT_AUTHOR_EMAIL", "author@example.com"),
-        ("GIT_AUTHOR_NAME", "author"),
-        ("GIT_COMMITTER_DATE", "2000-01-02 00:00:00 +0000"),
-        ("GIT_COMMITTER_EMAIL", "committer@example.com"),
-        ("GIT_COMMITTER_NAME", "committer"),
-    ] {
-        std::env::set_var(name, value);
-    }
+#[test]
+#[ignore = "TBD"]
+fn push_to_two_remotes() -> Result<()> {
+    Ok(())
 }
 
-fn default_author() -> Author {
-    Author {
-        name: Some("author".into()),
-        email: Some("author@example.com".into()),
-    }
+#[test]
+#[ignore = "TBD"]
+fn own_branch_without_virtual_branch() -> Result<()> {
+    Ok(())
 }
 
-fn project_ctx(name: &str) -> anyhow::Result<CommandContext> {
-    gitbutler_testsupport::read_only::fixture("for-listing.sh", name)
+mod util {
+    use bstr::BString;
+    use gitbutler_branch_actions::{Author, BranchListing};
+    use gitbutler_command_context::CommandContext;
+
+    /// A flattened and simplified mirror of `BranchListing` for comparing the actual and expected data.
+    #[derive(Default, Debug, PartialEq)]
+    pub struct ExpectedBranchListing<'a> {
+        pub identity: &'a str,
+        pub remotes: Vec<&'a str>,
+        pub virtual_branch_given_name: Option<&'a str>,
+        pub virtual_branch_in_workspace: bool,
+        pub number_of_commits: usize,
+        pub authors: Vec<Author>,
+        pub own_branch: bool,
+    }
+
+    pub fn assert_equal(
+        BranchListing {
+            name,
+            remotes,
+            virtual_branch,
+            number_of_commits,
+            updated_at: _,
+            authors,
+            own_branch,
+            head: _, // NOTE: can't have stable commits while `gitbutler-change-id` is not stable/is a UUID.
+        }: &BranchListing,
+        mut expected: ExpectedBranchListing,
+        msg: &str,
+    ) {
+        assert_eq!(*name, expected.identity, "{msg}");
+        assert_eq!(
+            *remotes,
+            expected
+                .remotes
+                .into_iter()
+                .map(BString::from)
+                .collect::<Vec<_>>(),
+            "{msg}"
+        );
+        assert_eq!(
+            virtual_branch.as_ref().map(|b| b.given_name.as_str()),
+            expected.virtual_branch_given_name,
+            "{msg}"
+        );
+        assert_eq!(
+            virtual_branch.as_ref().map_or(false, |b| b.in_workspace),
+            expected.virtual_branch_in_workspace,
+            "{msg}"
+        );
+        assert_eq!(*number_of_commits, expected.number_of_commits, "{msg}");
+        if expected.number_of_commits > 0 && expected.authors.is_empty() {
+            expected.authors = vec![default_author()];
+        }
+        assert_eq!(*authors, expected.authors, "{msg}");
+        if expected.virtual_branch_given_name.is_some() {
+            expected.own_branch = true;
+        }
+        assert_eq!(*own_branch, expected.own_branch, "{msg}");
+    }
+
+    /// This function affects all tests, but those who care should just call it, assuming
+    /// they all care for the same default value.
+    /// If not, they should be placed in their own integration test or run with `#[serial_test:serial]`.
+    /// For `list_branches` it's needed as it compares the current author with commit authors to determine ownership.
+    pub fn init_env() {
+        for (name, value) in [
+            ("GIT_AUTHOR_DATE", "2000-01-01 00:00:00 +0000"),
+            ("GIT_AUTHOR_EMAIL", "author@example.com"),
+            ("GIT_AUTHOR_NAME", "author"),
+            ("GIT_COMMITTER_DATE", "2000-01-02 00:00:00 +0000"),
+            ("GIT_COMMITTER_EMAIL", "committer@example.com"),
+            ("GIT_COMMITTER_NAME", "committer"),
+        ] {
+            std::env::set_var(name, value);
+        }
+    }
+
+    pub fn default_author() -> Author {
+        Author {
+            name: Some("author".into()),
+            email: Some("author@example.com".into()),
+        }
+    }
+
+    pub fn project_ctx(name: &str) -> anyhow::Result<CommandContext> {
+        gitbutler_testsupport::read_only::fixture("for-listing.sh", name)
+    }
 }
+use util::{assert_equal, init_env, project_ctx, ExpectedBranchListing};

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/list.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/list.rs
@@ -116,9 +116,8 @@ fn one_feature_branch_and_one_vbranch_on_integration_one_commit() -> Result<()> 
     let list = list_branches(&ctx, None)?;
     assert_eq!(
         list.len(),
-        0,
-        "Strange, one is definitely there and it seems valid to name vbranches\
-            after the target branch but it's filtered out here"
+        1,
+        "it finds our single virtual branch despit it having the same 'identity' as the target branch: 'main'"
     );
 
     Ok(())

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/list.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/list.rs
@@ -100,8 +100,7 @@ fn one_feature_branch_and_one_vbranch_on_integration_one_commit() -> Result<()> 
         &list[0],
         ExpectedBranchListing {
             identity: "main",
-            remotes: vec![],
-            // remotes: vec!["origin"], // TODO: should be this
+            remotes: vec!["origin"],
             virtual_branch_given_name: Some("main"),
             virtual_branch_in_workspace: true,
             number_of_commits: 1,

--- a/crates/gitbutler-commit/src/commit_headers.rs
+++ b/crates/gitbutler-commit/src/commit_headers.rs
@@ -27,6 +27,9 @@ impl Default for CommitHeadersV2 {
     fn default() -> Self {
         CommitHeadersV2 {
             // Change ID using base16 encoding
+            // NOTE(ST): Ideally, this could be a computed hash based on the patch applied, similar
+            //           to what would happen during a rebase (if that is even the intention).
+            //           That way, they would be stable, so tests could have reproducible hashes as well.
             change_id: Uuid::new_v4().to_string(),
         }
     }


### PR DESCRIPTION
This PR is a follow-up to #4543 and contains a thorough review of the new branch-listing feature, with a focus on adding tests to pin-point (and understand) the current behaviour and intentions.
It's fair to use this PR to do refactorings as well.
When done, it should be trivial to use `gix` for the initial branch listing.

<details>

<img width="390" alt="352271590-6604004a-4553-4b23-9675-cdf4069b3f0c" src="https://github.com/user-attachments/assets/dbe4b603-3e17-4ffc-a0dc-015c1846e8e4">

</details>

### Tasks

* [x] fix first logic bug
* [x] more testing

### Follow-up

* make `Identity` clear in the type system.

### Notes for the reviewer

* I started making the commit-graph stable (to allow making assertions on it using the commit ID), and the only thing preventing it is the `gitbutler-change-id` which currently is a UUID. It seems unused right now, but it would be good do learn what is planned there.