### PR TITLE
improve git revert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2474,48 +2474,48 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.64.0"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
- "gix-actor 0.31.5 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-actor 0.31.5 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-command",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-config",
  "gix-credentials",
  "gix-date 0.9.0",
  "gix-diff",
  "gix-dir",
  "gix-discover 0.33.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-filter",
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-ignore 0.11.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-index 0.33.1 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-ignore 0.11.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-index 0.33.1 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-macros",
  "gix-negotiate",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-odb",
  "gix-pack",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-pathspec",
  "gix-prompt",
  "gix-ref 0.45.0",
  "gix-refspec",
  "gix-revision",
- "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-submodule",
- "gix-tempfile 14.0.1 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-traverse 0.39.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-tempfile 14.0.1 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-traverse 0.39.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-url",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-worktree 0.34.1 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-worktree 0.34.1 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "once_cell",
  "smallvec",
  "thiserror",
@@ -2538,11 +2538,11 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.31.5"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
  "gix-date 0.9.0",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "itoa 1.0.11",
  "thiserror",
  "winnow 0.6.16",
@@ -2568,13 +2568,13 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.22.3"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
- "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "kstring",
  "smallvec",
  "thiserror",
@@ -2593,7 +2593,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.11"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "thiserror",
 ]
@@ -2610,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.8"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "thiserror",
 ]
@@ -2618,11 +2618,11 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.3.8"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "shell-words",
 ]
 
@@ -2643,12 +2643,12 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.24.3"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
- "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "memmap2",
  "thiserror",
 ]
@@ -2656,15 +2656,15 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.38.0"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-ref 0.45.0",
- "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "memchr",
  "once_cell",
  "smallvec",
@@ -2676,11 +2676,11 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.14.7"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "libc",
  "thiserror",
 ]
@@ -2688,15 +2688,15 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.24.4"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-config-value",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-prompt",
- "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-url",
  "thiserror",
 ]
@@ -2716,7 +2716,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.9.0"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
  "itoa 1.0.11",
@@ -2727,30 +2727,30 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.44.1"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-dir"
 version = "0.6.0"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
  "gix-discover 0.33.0",
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-ignore 0.11.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-index 0.33.1 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-ignore 0.11.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-index 0.33.1 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-pathspec",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-worktree 0.34.1 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-worktree 0.34.1 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "thiserror",
 ]
 
@@ -2773,15 +2773,15 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.33.0"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
  "dunce",
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-ref 0.45.0",
- "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "thiserror",
 ]
 
@@ -2803,14 +2803,14 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.38.2"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",
  "flate2",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "libc",
  "once_cell",
  "parking_lot 0.12.3",
@@ -2823,19 +2823,19 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.11.3"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
  "encoding_rs",
- "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-command",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-packetline-blocking",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "smallvec",
  "thiserror",
 ]
@@ -2854,11 +2854,11 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.11.2"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "fastrand 2.1.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
 ]
 
 [[package]]
@@ -2876,12 +2876,12 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.16.4"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
 ]
 
 [[package]]
@@ -2897,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.14.2"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "faster-hex",
  "thiserror",
@@ -2917,9 +2917,9 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.5.2"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "hashbrown 0.14.5",
  "parking_lot 0.12.3",
 ]
@@ -2940,12 +2940,12 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.11.3"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
- "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "unicode-bom",
 ]
 
@@ -2980,21 +2980,21 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.33.1"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "filetime",
  "fnv",
- "gix-bitmap 0.2.11 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-traverse 0.39.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-bitmap 0.2.11 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-traverse 0.39.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "hashbrown 0.14.5",
  "itoa 1.0.11",
  "libc",
@@ -3018,17 +3018,17 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "14.0.0"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
- "gix-tempfile 14.0.1 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-tempfile 14.0.1 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-macros"
 version = "0.1.5"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3038,14 +3038,14 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.13.2"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bitflags 2.6.0",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "smallvec",
  "thiserror",
 ]
@@ -3072,15 +3072,15 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.42.3"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
- "gix-actor 0.31.5 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-actor 0.31.5 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-date 0.9.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "itoa 1.0.11",
  "smallvec",
  "thiserror",
@@ -3090,17 +3090,17 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.61.1"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "arc-swap",
  "gix-date 0.9.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-pack",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "parking_lot 0.12.3",
  "tempfile",
  "thiserror",
@@ -3109,15 +3109,15 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.51.1"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "clru",
- "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "memmap2",
  "smallvec",
  "thiserror",
@@ -3126,11 +3126,11 @@ dependencies = [
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.17.4"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "thiserror",
 ]
 
@@ -3150,10 +3150,10 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.9"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "home",
  "once_cell",
  "thiserror",
@@ -3162,21 +3162,21 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.7.6"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-config-value",
- "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-prompt"
 version = "0.8.6"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -3199,10 +3199,10 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.4.12"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "thiserror",
 ]
 
@@ -3231,18 +3231,18 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.45.0"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
- "gix-actor 0.31.5 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-tempfile 14.0.1 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-actor 0.31.5 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-tempfile 14.0.1 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "memmap2",
  "thiserror",
  "winnow 0.6.16",
@@ -3251,12 +3251,12 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.23.1"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-revision",
- "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "smallvec",
  "thiserror",
 ]
@@ -3264,13 +3264,13 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.27.2"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "thiserror",
 ]
 
@@ -3292,13 +3292,13 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.13.2"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "smallvec",
  "thiserror",
 ]
@@ -3318,10 +3318,10 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.10.7"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bitflags 2.6.0",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -3329,11 +3329,11 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.12.0"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
  "gix-config",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
@@ -3358,9 +3358,9 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "14.0.1"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "libc",
  "once_cell",
  "parking_lot 0.12.3",
@@ -3402,7 +3402,7 @@ checksum = "f924267408915fddcd558e3f37295cc7d6a3e50f8bd8b606cee0808c3915157e"
 [[package]]
 name = "gix-trace"
 version = "0.1.9"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 
 [[package]]
 name = "gix-traverse"
@@ -3424,15 +3424,15 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.39.2"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bitflags 2.6.0",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "smallvec",
  "thiserror",
 ]
@@ -3440,11 +3440,11 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.27.4"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "home",
  "thiserror",
  "url",
@@ -3463,7 +3463,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.1.12"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
  "fastrand 2.1.0",
@@ -3483,7 +3483,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.8.5"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
  "thiserror",
@@ -3511,19 +3511,19 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.34.1"
-source = "git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3#1d37bf6a773d56eea9003aa626ced413e8e0eaa3"
+source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
 dependencies = [
  "bstr",
- "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-ignore 0.11.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-index 0.33.1 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
- "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=1d37bf6a773d56eea9003aa626ced413e8e0eaa3)",
+ "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-ignore 0.11.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-index 0.33.1 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ resolver = "2"
 
 [workspace.dependencies]
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
-gix = { git = "https://github.com/Byron/gitoxide", rev = "1d37bf6a773d56eea9003aa626ced413e8e0eaa3", default-features = false, features = [] }
+gix = { git = "https://github.com/Byron/gitoxide", rev = "12313f2720bb509cb8fa5d7033560823beafb91c", default-features = false, features = [] }
 git2 = { version = "0.18.3", features = [
     "vendored-openssl",
     "vendored-libgit2",

--- a/crates/gitbutler-reference/tests/reference.rs
+++ b/crates/gitbutler-reference/tests/reference.rs
@@ -37,6 +37,15 @@ mod normalize_branch_name {
             normalize_branch_name("#[test]").unwrap_err().to_string(),
             "Could not turn \"#[test]\" into a valid reference name"
         );
+
+        let input = r#"Revert "GitButler Integration Commit"
+
+This reverts commit d6efa5fd96d36da445d5d1345b84163f05f5f229."#;
+        let err = normalize_branch_name(input).unwrap_err().to_string();
+        assert_eq!(
+            err,
+            "Could not turn \"Revert-\\\"GitButler-Integration-Commit\\\"-This-reverts-commit-d6efa5fd96d36da445d5d1345b84163f05f5f229.\" into a valid reference name"
+        );
     }
 
     #[test]


### PR DESCRIPTION
This PR improves the `git revert` handling from #4570 .

### Tasks

* [x] get latest `gix` from `main`
* [x] assure currently failing CI works
* [x] test workflow from issue