### PR TITLE
improve ref normalization

### DIFF
--- a/crates/gitbutler-reference/src/lib.rs
+++ b/crates/gitbutler-reference/src/lib.rs
@@ -14,8 +14,8 @@ pub fn normalize_branch_name(name: &str) -> anyhow::Result<String> {
     let space_pattern = Regex::new(r"\s+").unwrap();
     result = space_pattern.replace_all(&result, "-").to_string();
 
-    // Remove leading and trailing hyphens and slashes
-    let trim_pattern = Regex::new(r"^[-/]+|[-/]+$").unwrap();
+    // Remove leading and trailing hyphens and slashes and dots
+    let trim_pattern = Regex::new(r"^[-/\.]+|[-/\.]+$").unwrap();
     result = trim_pattern.replace_all(&result, "").to_string();
 
     let refname = format!("refs/gitbutler/{result}");

--- a/crates/gitbutler-reference/tests/reference.rs
+++ b/crates/gitbutler-reference/tests/reference.rs
@@ -22,6 +22,7 @@ mod normalize_branch_name {
             ("/a/", "a"),
             ("-/a/-", "a"),
             ("/-a-/", "a"),
+            (".a.", "a"),
         ] {
             assert_eq!(normalize_branch_name(input).expect("valid"), expected);
         }
@@ -37,15 +38,6 @@ mod normalize_branch_name {
             normalize_branch_name("#[test]").unwrap_err().to_string(),
             "Could not turn \"#[test]\" into a valid reference name"
         );
-
-        let input = r#"Revert "GitButler Integration Commit"
-
-This reverts commit d6efa5fd96d36da445d5d1345b84163f05f5f229."#;
-        let err = normalize_branch_name(input).unwrap_err().to_string();
-        assert_eq!(
-            err,
-            "Could not turn \"Revert-\\\"GitButler-Integration-Commit\\\"-This-reverts-commit-d6efa5fd96d36da445d5d1345b84163f05f5f229.\" into a valid reference name"
-        );
     }
 
     #[test]
@@ -53,6 +45,10 @@ This reverts commit d6efa5fd96d36da445d5d1345b84163f05f5f229."#;
         assert_eq!(normalize_branch_name("feature/branch")?, "feature/branch");
         assert_eq!(normalize_branch_name("foo#branch")?, "foo#branch");
         assert_eq!(normalize_branch_name("foo!branch")?, "foo!branch");
+        let input = r#"Revert "GitButler Integration Commit"
+
+This reverts commit d6efa5fd96d36da445d5d1345b84163f05f5f229."#;
+        assert_eq!(normalize_branch_name(input)?, "Revert-\"GitButler-Integration-Commit\"-This-reverts-commit-d6efa5fd96d36da445d5d1345b84163f05f5f229");
         Ok(())
     }
 }


### PR DESCRIPTION
This is a quick-fix for a specific case, even though the actual fix should be offering branch normalization as part of the validation.

Related to #4570.

### Tasks

* [x] See what this does to the 'revert' issue.
