### PR TITLE
Add GPT 4o mini and Claude 3.5 Sonnet models to AI options

### DIFF
--- a/apps/desktop/src/lib/ai/types.ts
+++ b/apps/desktop/src/lib/ai/types.ts
@@ -21,7 +21,7 @@ export enum AnthropicModelName {
 	Opus = 'claude-3-opus-20240229',
 	Sonnet = 'claude-3-sonnet-20240229',
 	Haiku = 'claude-3-haiku-20240307',
-	Claude35Sonnet = 'claude-3.5-sonnet-20240620',
+	Claude35Sonnet = 'claude-3.5-sonnet-20240620'
 }
 
 export enum MessageRole {

--- a/apps/desktop/src/lib/ai/types.ts
+++ b/apps/desktop/src/lib/ai/types.ts
@@ -7,17 +7,21 @@ export enum ModelKind {
 	Ollama = 'ollama'
 }
 
+// https://platform.openai.com/docs/models
 export enum OpenAIModelName {
 	GPT35Turbo = 'gpt-3.5-turbo',
 	GPT4 = 'gpt-4',
 	GPT4Turbo = 'gpt-4-turbo',
-	GPT4o = 'gpt-4o'
+	GPT4o = 'gpt-4o',
+	GPT4oMini = 'gpt-4o-mini'
 }
 
+// https://docs.anthropic.com/en/docs/about-claude/models
 export enum AnthropicModelName {
 	Opus = 'claude-3-opus-20240229',
 	Sonnet = 'claude-3-sonnet-20240229',
-	Haiku = 'claude-3-haiku-20240307'
+	Haiku = 'claude-3-haiku-20240307',
+	Claud35Sonnet = 'claude-3.5-sonnet-20240620',
 }
 
 export enum MessageRole {

--- a/apps/desktop/src/lib/ai/types.ts
+++ b/apps/desktop/src/lib/ai/types.ts
@@ -21,7 +21,7 @@ export enum AnthropicModelName {
 	Opus = 'claude-3-opus-20240229',
 	Sonnet = 'claude-3-sonnet-20240229',
 	Haiku = 'claude-3-haiku-20240307',
-	Claud35Sonnet = 'claude-3.5-sonnet-20240620',
+	Claude35Sonnet = 'claude-3.5-sonnet-20240620',
 }
 
 export enum MessageRole {

--- a/apps/desktop/src/routes/settings/ai/+page.svelte
+++ b/apps/desktop/src/routes/settings/ai/+page.svelte
@@ -109,8 +109,12 @@
 			value: OpenAIModelName.GPT4Turbo
 		},
 		{
-			label: 'GPT 4 Omni',
+			label: 'GPT 4o',
 			value: OpenAIModelName.GPT4o
+		},
+		{
+			label: 'GPT 4o mini',
+			value: OpenAIModelName.GPT4oMini
 		}
 	];
 
@@ -126,6 +130,10 @@
 		{
 			label: 'Haiku',
 			value: AnthropicModelName.Haiku
+		},
+		{
+			label: 'Claude 3.5 Sonnet',
+			value: AnthropicModelName.Claude35Sonnet
 		}
 	];
 


### PR DESCRIPTION
## ☕️ Reasoning

Claude 3.5 Sonnet is out, and so is GPT 4o mini, I thought it would be nice to add support for both of them. 

## 🧢 Changes

apps/desktop/src/lib/ai/types.ts 

apps/desktop/src/routes/settings/ai/+page.svelte
