### PR TITLE
fix: commit message component behaviour

### DIFF
--- a/apps/desktop/src/lib/clickOutside.ts
+++ b/apps/desktop/src/lib/clickOutside.ts
@@ -10,11 +10,11 @@ export function clickOutside(node: HTMLElement, params: ClickOpts) {
 			params.handler();
 		}
 	}
-	document.addEventListener('mousedown', onClick, true);
+	document.addEventListener('pointerdown', onClick, true);
 	document.addEventListener('contextmenu', onClick, true);
 	return {
 		destroy() {
-			document.removeEventListener('mousedown', onClick, true);
+			document.removeEventListener('pointerdown', onClick, true);
 			document.removeEventListener('contextmenu', onClick, true);
 		}
 	};

--- a/apps/desktop/src/lib/commit/CommitMessageInput.svelte
+++ b/apps/desktop/src/lib/commit/CommitMessageInput.svelte
@@ -194,9 +194,11 @@
 		<div
 			class="commit-box__texarea-actions"
 			class:commit-box-actions_expanded={isExpanded}
-			use:tooltip={$aiGenEnabled && aiConfigurationValid
-				? ''
-				: 'You must be logged in or have provided your own API key and have summary generation enabled to use this feature'}
+			use:tooltip={!aiConfigurationValid
+				? 'You must be logged in or have provided your own API key to use this feature'
+				: !$aiGenEnabled
+					? 'You must have summary generation enabled to use this feature'
+					: ''}
 		>
 			<DropDownButton
 				style="ghost"

--- a/apps/desktop/src/lib/shared/Modal.svelte
+++ b/apps/desktop/src/lib/shared/Modal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { clickOutside } from '$lib/clickOutside';
 	import Icon from '$lib/shared/Icon.svelte';
 	import { portal } from '$lib/utils/portal';
 	import type iconsJson from '$lib/icons/icons.json';
@@ -15,7 +16,6 @@
 
 	const { width = 'default', title, icon, onclose, children, controls }: Props = $props();
 
-	let dialog = $state<HTMLDivElement>();
 	let item = $state<any>();
 	let open = $state(false);
 
@@ -32,23 +32,16 @@
 </script>
 
 {#if open}
-	<div
-		bind:this={dialog}
-		use:portal={'body'}
-		role="presentation"
-		class="modal-container"
-		class:open
-		onclick={(e) => {
-			// Close the modal if the user clicks outside of it
-			e.target === e.currentTarget && close();
-		}}
-	>
+	<div use:portal={'body'} role="presentation" class="modal-container" class:open>
 		<div
 			class="modal-content"
 			class:s-default={width === 'default'}
 			class:s-small={width === 'small'}
 			class:s-large={width === 'large'}
 			class:round-top-corners={!title}
+			use:clickOutside={{
+				handler: close
+			}}
 		>
 			{#if title}
 				<div class="modal__header">


### PR DESCRIPTION
## ☕️ Reasoning

- Click outside handler was a bit too eager; closing on only `mouseup` when releasing from a drag, for example.

## 🧢 Changes

- Use out `clickOutside` util
- Split out error messages for AI generation, as multiple users reported being confused by the merged message (i.e. one _longer_ error message for both types of error states)

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

Fixes: INSERT_ISSUE_NUMBER

-->

## 🎫 Affected issues

Fixes #4582

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
