### PR TITLE
fix: add additional 'open' boolean to AppUpdater.svelte

### DIFF
--- a/apps/desktop/src/lib/components/AppUpdater.svelte
+++ b/apps/desktop/src/lib/components/AppUpdater.svelte
@@ -11,17 +11,24 @@
 	const currentVersion = updaterService.currentVersion;
 
 	let dismissed = $state(false);
+	let open = $state(false);
+
 	$effect(() => {
-		if ($version !== $currentVersion && dismissed) {
-			dismissed = false;
+		if ($version !== $currentVersion && !dismissed) {
+			open = true;
 		}
 	});
+
+	function handleDismiss() {
+		dismissed = true;
+		open = false;
+	}
 </script>
 
-{#if $update?.version && $update?.status !== 'UPTODATE' && !dismissed}
+{#if $update?.version && $update?.status !== 'UPTODATE' && !dismissed && open}
 	<div class="update-banner" class:busy={$update?.status === 'PENDING'}>
 		<div class="floating-button">
-			<Button icon="cross-small" style="ghost" onclick={() => (dismissed = true)} />
+			<Button icon="cross-small" style="ghost" onclick={handleDismiss} />
 		</div>
 		<div class="img">
 			<div class="circle-img">


### PR DESCRIPTION
## ☕️ Reasoning

- AppUpdater dismissing was broken again

## 🧢 Changes

- Add additional boolean, to not share (1) has been manually dismissed and (2) isModalOpen in 1 boolean variable

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
