### PR TITLE
fix: add .vercel and dist to turbo cached outptus

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -8,7 +8,7 @@
 			"dependsOn": ["^package"],
 			"passThroughEnv": ["SENTRY_AUTH_TOKEN", "GITHUB_TOKEN"],
 			"env": ["SENTRY_RELEASE"],
-			"outputs": [".svelte-kit/**", "!.sveltekit/types", "!.sveltekit/*.d.ts"]
+			"outputs": [".svelte-kit/**", "!.sveltekit/types", "!.sveltekit/*.d.ts", "dist/**", ".vercel/**"]
 		},
 		"dev": {
 			"dependsOn": ["@gitbutler/ui#package"],


### PR DESCRIPTION
## ☕️ Reasoning

- When cache is replayed on Vercel (i.e. after building a commit once for preview deploy, then tryign to replay that build from cache for prod deploy), the build output / artifact directory is not found
- Requires `turbo` to also cache `.vercel/**` and `dist/**`

## 🧢 Changes


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
