### PR TITLE
fix: Add selected state for sidebar entries

### DIFF
--- a/apps/desktop/src/lib/navigation/BranchListingSidebarEntry.svelte
+++ b/apps/desktop/src/lib/navigation/BranchListingSidebarEntry.svelte
@@ -13,6 +13,7 @@
 	import SidebarEntry from '@gitbutler/ui/sidebarEntry/SidebarEntry.svelte';
 	import type { Readable } from 'svelte/store';
 	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
 
 	interface Props {
 		branchListing: BranchListing;
@@ -42,7 +43,13 @@
 	}
 
 	function onMouseDown() {
-		goto(`/${project.id}/branch/${encodeURIComponent(branchListing.name)}`);
+		goto(formatBranchURL(project, branchListing.name));
+	}
+
+	const selected = $derived($page.url.pathname === formatBranchURL(project, branchListing.name));
+
+	function formatBranchURL(project: Project, name: string) {
+		return `/${project.id}/branch/${encodeURIComponent(name)}`;
 	}
 </script>
 
@@ -65,6 +72,7 @@
 	}}
 	onFirstSeen={() => (hasBeenSeen = true)}
 	{onMouseDown}
+	{selected}
 >
 	{#snippet authorAvatars()}
 		<AvatarGrouping>

--- a/apps/desktop/src/lib/navigation/PullRequestSidebarEntry.svelte
+++ b/apps/desktop/src/lib/navigation/PullRequestSidebarEntry.svelte
@@ -6,6 +6,7 @@
 	import SidebarEntry from '@gitbutler/ui/sidebarEntry/SidebarEntry.svelte';
 	import type { PullRequest } from '$lib/gitHost/interface/types';
 	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
 
 	interface Props {
 		pullRequest: PullRequest;
@@ -16,8 +17,16 @@
 	const project = getContext(Project);
 
 	function onMouseDown() {
-		goto(`/${project.id}/pull/${pullRequest.number}`);
+		goto(formatPullRequestURL(project, pullRequest.number));
 	}
+
+	function formatPullRequestURL(project: Project, pullRequestNumber: number) {
+		return `/${project.id}/pull/${pullRequestNumber}`;
+	}
+
+	const selected = $derived(
+		$page.url.pathname === formatPullRequestURL(project, pullRequest.number)
+	);
 </script>
 
 <SidebarEntry
@@ -33,6 +42,7 @@
 		title: pullRequest.title
 	}}
 	{onMouseDown}
+	{selected}
 >
 	{#snippet authorAvatars()}
 		<AvatarGrouping>


### PR DESCRIPTION
Refactors sidebar entries for branches and pull requests to show
selected state based on the current URL. This improves the visual
indication of the current active view. Introduces helper methods
for formatting URLs to prevent duplication.