### PR TITLE
feat(ui): Improve SidebarEntry layout and styling

### DIFF
--- a/packages/ui/src/lib/sidebarEntry/SidebarEntry.svelte
+++ b/packages/ui/src/lib/sidebarEntry/SidebarEntry.svelte
@@ -63,7 +63,7 @@
 	</h4>
 
 	<div class="row">
-		<div class="row-group">
+		<div class="row-group authors-and-tags">
 			{@render authorAvatars()}
 			<div class="branch-remotes">
 				<!-- NEED API -->
@@ -134,6 +134,12 @@
 
 		&:last-child {
 			border-bottom: none;
+		}
+	}
+
+	.authors-and-tags {
+		:global(& > *:first-child:empty) {
+			display: none;
 		}
 	}
 


### PR DESCRIPTION
Add 'authors-and-tags' class to row-group for better organization.
Hide empty first child in authors-and-tags group to prevent gaps.
Enhances visual consistency and reduces unnecessary white space.