### PR TITLE
feat(SidebarEntry): Enhance commit info display

### DIFF
--- a/packages/ui/src/lib/sidebarEntry/SidebarEntry.svelte
+++ b/packages/ui/src/lib/sidebarEntry/SidebarEntry.svelte
@@ -96,12 +96,15 @@
 	</div>
 
 	<div class="row">
-		<span class="branch-time text-base-11 details truncate">
-			{#if lastCommitDetails}
-				<TimeAgo date={lastCommitDetails.lastCommitAt} />
+		{#if lastCommitDetails}
+			<span
+				class="branch-time text-base-11 details truncate"
+				use:tooltip={lastCommitDetails.lastCommitAt.toLocaleString('en-GB')}
+			>
+				<TimeAgo date={lastCommitDetails.lastCommitAt} addSuffix />
 				by {lastCommitDetails.authorName}
-			{/if}
-		</span>
+			</span>
+		{/if}
 
 		<div class="stats">
 			{#if branchDetails}


### PR DESCRIPTION
Improve last commit details presentation in sidebar entry
- Add tooltip with full date on hover
- Include 'ago' suffix in TimeAgo component
- Wrap commit info in conditional block for cleaner rendering