### PR TITLE
Ensure ignored/submodule files and dirs are ignored

### DIFF
--- a/crates/gitbutler-repo/src/repository_ext.rs
+++ b/crates/gitbutler-repo/src/repository_ext.rs
@@ -131,7 +131,7 @@ impl RepositoryExt for git2::Repository {
     #[instrument(level = tracing::Level::DEBUG, skip(self), err(Debug))]
     fn get_wd_tree(&self) -> Result<Tree> {
         let mut index = self.index()?;
-        index.add_all(["*"], git2::IndexAddOption::DEFAULT, None)?;
+        index.add_all(["*"], git2::IndexAddOption::CHECK_PATHSPEC, None)?;
         let oid = index.write_tree()?;
         self.find_tree(oid).map(Into::into).map_err(Into::into)
     }


### PR DESCRIPTION
From the libgit2 docs: https://github.com/libgit2/libgit2/blob/503b66cf00ad7dca940148529f60b1a409ccc462/include/git2/index.h#L654