### PR TITLE
fix: add `turbo telemetry disable` to "prepare" root npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"globallint": "prettier --check . && eslint .",
 		"format": "prettier --write .",
 		"fix": "eslint --fix .",
-		"prepare": "pnpm --filter @gitbutler/desktop run prepare",
+		"prepare": "pnpm --filter @gitbutler/desktop run prepare && pnpm exec turbo telemetry disable",
 		"rustfmt": "cargo +nightly fmt -- --config-path rustfmt-nightly.toml"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## ☕️ Reasoning


## 🧢 Changes

- Execute 'turbo telemetry disable' on people's machines when they `pnpm install` via the auto-executed "prepare" script


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
