### PR TITLE
branch-listing with `gix`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,15 +928,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
 
 [[package]]
-name = "cmake"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "cocoa"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,19 +1149,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1194,15 +1172,6 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1674,7 +1643,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
- "libz-ng-sys",
  "miniz_oxide",
 ]
 
@@ -2582,48 +2550,48 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.64.0"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
- "gix-actor 0.31.5 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-actor 0.31.5 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-command",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-config",
  "gix-credentials",
  "gix-date 0.9.0",
  "gix-diff",
  "gix-dir",
  "gix-discover 0.33.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-filter",
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-ignore 0.11.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-index 0.33.1 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-ignore 0.11.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-index 0.33.1 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-macros",
  "gix-negotiate",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-odb",
  "gix-pack",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-pathspec",
  "gix-prompt",
  "gix-ref 0.45.0",
  "gix-refspec",
  "gix-revision",
- "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-submodule",
- "gix-tempfile 14.0.1 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-traverse 0.39.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-tempfile 14.0.1 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-traverse 0.39.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-url",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-worktree 0.34.1 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-worktree 0.34.1 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "once_cell",
  "smallvec",
  "thiserror",
@@ -2646,11 +2614,11 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.31.5"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
  "gix-date 0.9.0",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "itoa 1.0.11",
  "thiserror",
  "winnow 0.6.16",
@@ -2676,13 +2644,13 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.22.3"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
- "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "kstring",
  "smallvec",
  "thiserror",
@@ -2701,7 +2669,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.11"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "thiserror",
 ]
@@ -2718,7 +2686,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.8"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "thiserror",
 ]
@@ -2726,11 +2694,11 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.3.8"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "shell-words",
 ]
 
@@ -2751,12 +2719,12 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.24.3"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
- "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "memmap2",
  "thiserror",
 ]
@@ -2764,15 +2732,15 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.38.0"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-ref 0.45.0",
- "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "memchr",
  "once_cell",
  "smallvec",
@@ -2784,11 +2752,11 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.14.7"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "libc",
  "thiserror",
 ]
@@ -2796,15 +2764,15 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.24.4"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-config-value",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-prompt",
- "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-url",
  "thiserror",
 ]
@@ -2824,7 +2792,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.9.0"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
  "itoa 1.0.11",
@@ -2835,30 +2803,30 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.44.1"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-dir"
 version = "0.6.0"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
  "gix-discover 0.33.0",
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-ignore 0.11.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-index 0.33.1 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-ignore 0.11.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-index 0.33.1 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-pathspec",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-worktree 0.34.1 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-worktree 0.34.1 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "thiserror",
 ]
 
@@ -2881,15 +2849,15 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.33.0"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
  "dunce",
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-ref 0.45.0",
- "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "thiserror",
 ]
 
@@ -2911,20 +2879,18 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.38.2"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",
  "flate2",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "jwalk",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "libc",
  "once_cell",
  "parking_lot 0.12.3",
  "prodash 29.0.0",
- "sha1",
  "sha1_smol",
  "thiserror",
  "walkdir",
@@ -2933,19 +2899,19 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.11.3"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
  "encoding_rs",
- "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-command",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-packetline-blocking",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "smallvec",
  "thiserror",
 ]
@@ -2964,11 +2930,11 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.11.2"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "fastrand 2.1.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
 ]
 
 [[package]]
@@ -2986,12 +2952,12 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.16.4"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
 ]
 
 [[package]]
@@ -3007,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.14.2"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "faster-hex",
  "thiserror",
@@ -3027,9 +2993,9 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.5.2"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "hashbrown 0.14.5",
  "parking_lot 0.12.3",
 ]
@@ -3050,12 +3016,12 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.11.3"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
- "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "unicode-bom",
 ]
 
@@ -3090,21 +3056,21 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.33.1"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "filetime",
  "fnv",
- "gix-bitmap 0.2.11 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-traverse 0.39.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-bitmap 0.2.11 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-traverse 0.39.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "hashbrown 0.14.5",
  "itoa 1.0.11",
  "libc",
@@ -3128,17 +3094,17 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "14.0.0"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
- "gix-tempfile 14.0.1 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-tempfile 14.0.1 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-macros"
 version = "0.1.5"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3148,14 +3114,14 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.13.2"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bitflags 2.6.0",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "smallvec",
  "thiserror",
 ]
@@ -3182,15 +3148,15 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.42.3"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
- "gix-actor 0.31.5 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-actor 0.31.5 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-date 0.9.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "itoa 1.0.11",
  "smallvec",
  "thiserror",
@@ -3200,17 +3166,17 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.61.1"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "arc-swap",
  "gix-date 0.9.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-pack",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "parking_lot 0.12.3",
  "tempfile",
  "thiserror",
@@ -3219,15 +3185,15 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.51.1"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "clru",
- "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "memmap2",
  "smallvec",
  "thiserror",
@@ -3237,11 +3203,11 @@ dependencies = [
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.17.4"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "thiserror",
 ]
 
@@ -3261,10 +3227,10 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.9"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "home",
  "once_cell",
  "thiserror",
@@ -3273,21 +3239,21 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.7.6"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-config-value",
- "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-prompt"
 version = "0.8.6"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -3310,10 +3276,10 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.4.12"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "thiserror",
 ]
 
@@ -3342,18 +3308,18 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.45.0"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
- "gix-actor 0.31.5 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-tempfile 14.0.1 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-actor 0.31.5 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-tempfile 14.0.1 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "memmap2",
  "thiserror",
  "winnow 0.6.16",
@@ -3362,12 +3328,12 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.23.1"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-revision",
- "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "smallvec",
  "thiserror",
 ]
@@ -3375,13 +3341,13 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.27.2"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "thiserror",
 ]
 
@@ -3403,13 +3369,13 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.13.2"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "smallvec",
  "thiserror",
 ]
@@ -3429,10 +3395,10 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.10.7"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bitflags 2.6.0",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -3440,11 +3406,11 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.12.0"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
  "gix-config",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
@@ -3469,9 +3435,9 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "14.0.1"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "libc",
  "once_cell",
  "parking_lot 0.12.3",
@@ -3513,7 +3479,7 @@ checksum = "f924267408915fddcd558e3f37295cc7d6a3e50f8bd8b606cee0808c3915157e"
 [[package]]
 name = "gix-trace"
 version = "0.1.9"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 
 [[package]]
 name = "gix-traverse"
@@ -3535,15 +3501,15 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.39.2"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bitflags 2.6.0",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "smallvec",
  "thiserror",
 ]
@@ -3551,11 +3517,11 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.27.4"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
  "home",
  "thiserror",
  "url",
@@ -3574,7 +3540,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.1.12"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
  "fastrand 2.1.0",
@@ -3594,7 +3560,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.8.5"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
  "thiserror",
@@ -3622,19 +3588,19 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.34.1"
-source = "git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c#12313f2720bb509cb8fa5d7033560823beafb91c"
+source = "git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa#29898e3010bd3332418c683f2ac96aff5c8e72fa"
 dependencies = [
  "bstr",
- "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-ignore 0.11.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-index 0.33.1 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
- "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-ignore 0.11.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-index 0.33.1 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
+ "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=29898e3010bd3332418c683f2ac96aff5c8e72fa)",
 ]
 
 [[package]]
@@ -4490,16 +4456,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jwalk"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
-dependencies = [
- "crossbeam",
- "rayon",
-]
-
-[[package]]
 name = "keyring"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4609,16 +4565,6 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "libz-ng-sys"
-version = "1.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6409efc61b12687963e602df8ecf70e8ddacf95bc6576bcf16e3ac6328083c5"
-dependencies = [
- "cmake",
- "libc",
 ]
 
 [[package]]
@@ -6636,16 +6582,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
- "sha1-asm",
-]
-
-[[package]]
-name = "sha1-asm"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "286acebaf8b67c1130aedffad26f594eff0c1292389158135327d2e23aed582b"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +756,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,6 +845,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +926,15 @@ name = "clru"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "cocoa"
@@ -1074,6 +1122,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,6 +1194,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1568,6 +1674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
+ "libz-ng-sys",
  "miniz_oxide",
 ]
 
@@ -2002,7 +2109,7 @@ dependencies = [
  "gitbutler-serde",
  "gix",
  "hex",
- "itertools",
+ "itertools 0.13.0",
  "lazy_static",
  "md5",
  "serde",
@@ -2016,6 +2123,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bstr",
+ "criterion",
  "diffy",
  "git2",
  "git2-hooks",
@@ -2040,7 +2148,7 @@ dependencies = [
  "gix",
  "glob",
  "hex",
- "itertools",
+ "itertools 0.13.0",
  "md5",
  "once_cell",
  "pretty_assertions",
@@ -2079,7 +2187,7 @@ dependencies = [
  "anyhow",
  "git2",
  "gitbutler-project",
- "itertools",
+ "itertools 0.13.0",
  "tracing",
 ]
 
@@ -2216,7 +2324,7 @@ dependencies = [
  "gitbutler-repo",
  "gitbutler-serde",
  "gix",
- "itertools",
+ "itertools 0.13.0",
  "pretty_assertions",
  "serde",
  "strum",
@@ -2335,7 +2443,7 @@ dependencies = [
  "gitbutler-reference",
  "gitbutler-url",
  "gitbutler-user",
- "itertools",
+ "itertools 0.13.0",
  "tracing",
 ]
 
@@ -2811,10 +2919,12 @@ dependencies = [
  "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
  "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=12313f2720bb509cb8fa5d7033560823beafb91c)",
+ "jwalk",
  "libc",
  "once_cell",
  "parking_lot 0.12.3",
  "prodash 29.0.0",
+ "sha1",
  "sha1_smol",
  "thiserror",
  "walkdir",
@@ -3121,6 +3231,7 @@ dependencies = [
  "memmap2",
  "smallvec",
  "thiserror",
+ "uluru",
 ]
 
 [[package]]
@@ -4210,6 +4321,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "is-wsl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4230,6 +4352,15 @@ name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -4359,6 +4490,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
+dependencies = [
+ "crossbeam",
+ "rayon",
+]
+
+[[package]]
 name = "keyring"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4468,6 +4609,16 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libz-ng-sys"
+version = "1.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6409efc61b12687963e602df8ecf70e8ddacf95bc6576bcf16e3ac6328083c5"
+dependencies = [
+ "cmake",
+ "libc",
 ]
 
 [[package]]
@@ -4982,6 +5133,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "oorandom"
+version = "11.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
 name = "open"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5400,6 +5557,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "plotters"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "png"
 version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5585,7 +5770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18bec9b0adc4eba778b33684b7ba3e7137789434769ee3ce3930463ef904cfca"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.68",
@@ -6451,6 +6636,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+ "sha1-asm",
+]
+
+[[package]]
+name = "sha1-asm"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "286acebaf8b67c1130aedffad26f594eff0c1292389158135327d2e23aed582b"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -7277,6 +7472,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7601,6 +7806,15 @@ dependencies = [
  "memoffset 0.9.1",
  "tempfile",
  "winapi",
+]
+
+[[package]]
+name = "uluru"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -8085,7 +8299,7 @@ checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
  "windows-implement 0.57.0",
  "windows-interface 0.57.0",
- "windows-result 0.1.2",
+ "windows-result 0.1.1",
  "windows-targets 0.52.6",
 ]
 
@@ -8164,9 +8378,9 @@ checksum = "9ee5e275231f07c6e240d14f34e1b635bf1faa1c76c57cfd59a5cdb9848e4278"
 
 [[package]]
 name = "windows-result"
-version = "0.1.2"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+checksum = "749f0da9cc72d82e600d8d2e44cadd0b9eedb9038f71a1c58556ac1c5791813b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2450,6 +2450,7 @@ dependencies = [
  "gitbutler-testsupport",
  "gitbutler-user",
  "gitbutler-watcher",
+ "gix",
  "log",
  "once_cell",
  "open 5.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ resolver = "2"
 
 [workspace.dependencies]
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
-gix = { git = "https://github.com/Byron/gitoxide", rev = "12313f2720bb509cb8fa5d7033560823beafb91c", default-features = false, features = [] }
+gix = { git = "https://github.com/Byron/gitoxide", rev = "29898e3010bd3332418c683f2ac96aff5c8e72fa", default-features = false, features = [] }
 git2 = { version = "0.18.3", features = [
     "vendored-openssl",
     "vendored-libgit2",

--- a/crates/gitbutler-branch-actions/Cargo.toml
+++ b/crates/gitbutler-branch-actions/Cargo.toml
@@ -43,7 +43,7 @@ reqwest = { version = "0.12.4", features = ["json"] }
 once_cell = "1.19"
 pretty_assertions = "1.4"
 gitbutler-testsupport.workspace = true
-gix = { workspace = true, features = ["max-performance"] }
+gix = { workspace = true, features = ["max-performance-safe"] }
 gitbutler-git = { workspace = true, features = ["test-askpass-path"] }
 glob = "0.3.1"
 serial_test = "3.1.1"

--- a/crates/gitbutler-branch-actions/Cargo.toml
+++ b/crates/gitbutler-branch-actions/Cargo.toml
@@ -43,7 +43,17 @@ reqwest = { version = "0.12.4", features = ["json"] }
 once_cell = "1.19"
 pretty_assertions = "1.4"
 gitbutler-testsupport.workspace = true
+gix = { workspace = true, features = ["max-performance"] }
 gitbutler-git = { workspace = true, features = ["test-askpass-path"] }
 glob = "0.3.1"
 serial_test = "3.1.1"
 tempfile = "3.10"
+criterion = "0.5.1"
+
+[features]
+## Only enabled when benchmark runs are performed.
+benches = ["gitbutler-git/benches"]
+
+[[bench]]
+name = "branches"
+harness = false

--- a/crates/gitbutler-branch-actions/benches/README.md
+++ b/crates/gitbutler-branch-actions/benches/README.md
@@ -1,0 +1,13 @@
+To run benchmarks, add the `benches` feature.
+
+```shell
+cargo bench --features benches
+```
+
+It's used to get past a safety check in `gitbutler-git`.
+
+For faster compile times, specify the benchmark file directly, i.e.
+
+```shell
+cargo bench --bench branches --features benches
+```

--- a/crates/gitbutler-branch-actions/benches/branches.rs
+++ b/crates/gitbutler-branch-actions/benches/branches.rs
@@ -1,0 +1,59 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use gitbutler_branch_actions::list_branches;
+use gitbutler_command_context::CommandContext;
+use gitbutler_project::Project;
+
+pub fn fixture_project(name: &str, script: &str) -> Project {
+    gitbutler_testsupport::read_only::fixture_project(script, name).unwrap()
+}
+
+pub fn benchmark_list_branches(c: &mut Criterion) {
+    const NUM_BRANCHES: u64 = 300;
+    for (bench_name, num_references, (repo_name, script_name)) in [
+        (
+            "list-branches[many local branches]",
+            NUM_BRANCHES,
+            ("many-local", "branch-benches.sh"),
+        ),
+        (
+            "list-branches[tiny repo]",
+            3,
+            ("one-vbranch-on-integration-two-remotes", "for-listing.sh"),
+        ),
+        (
+            "list-branches[many local branches [packed]]",
+            NUM_BRANCHES,
+            ("many-local-packed", "branch-benches.sh"),
+        ),
+        (
+            "list-branches[many local branches [tracked]]",
+            NUM_BRANCHES * 2,
+            ("many-local-tracked", "branch-benches.sh"),
+        ),
+        (
+            "list-branches[many local branches [tracked & packed]]",
+            NUM_BRANCHES * 2,
+            ("many-local-tracked-packed", "branch-benches.sh"),
+        ),
+    ] {
+        let mut group = c.benchmark_group(bench_name);
+        let project = fixture_project(repo_name, script_name);
+        group.throughput(Throughput::Elements(num_references));
+        group
+            .bench_function("no filter", |b| {
+                b.iter(|| {
+                    let ctx = CommandContext::open(&project).unwrap();
+                    list_branches(black_box(&ctx), None, None)
+                })
+            })
+            .bench_function("name-filter rejecting all", |b| {
+                b.iter(|| {
+                    let ctx = CommandContext::open(&project).unwrap();
+                    list_branches(black_box(&ctx), None, Some(vec!["not available".into()]))
+                })
+            });
+    }
+}
+
+criterion_group!(benches, benchmark_list_branches);
+criterion_main!(benches);

--- a/crates/gitbutler-branch-actions/benches/branches.rs
+++ b/crates/gitbutler-branch-actions/benches/branches.rs
@@ -38,19 +38,14 @@ pub fn benchmark_list_branches(c: &mut Criterion) {
     ] {
         let mut group = c.benchmark_group(bench_name);
         let project = fixture_project(repo_name, script_name);
+        let ctx = CommandContext::open(&project).unwrap();
         group.throughput(Throughput::Elements(num_references));
         group
             .bench_function("no filter", |b| {
-                b.iter(|| {
-                    let ctx = CommandContext::open(&project).unwrap();
-                    list_branches(black_box(&ctx), None, None)
-                })
+                b.iter(|| list_branches(black_box(&ctx), None, None))
             })
             .bench_function("name-filter rejecting all", |b| {
-                b.iter(|| {
-                    let ctx = CommandContext::open(&project).unwrap();
-                    list_branches(black_box(&ctx), None, Some(vec!["not available".into()]))
-                })
+                b.iter(|| list_branches(black_box(&ctx), None, Some(vec!["not available".into()])))
             });
     }
 }

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -1,4 +1,15 @@
+use crate::VirtualBranchesExt;
+use anyhow::{Context, Result};
+use bstr::{BStr, BString, ByteSlice};
 use core::fmt;
+use gitbutler_branch::{Branch as GitButlerBranch, BranchId, ReferenceExtGix, Target};
+use gitbutler_command_context::CommandContext;
+use gitbutler_reference::normalize_branch_name;
+use gix::prelude::ObjectIdExt;
+use gix::reference::Category;
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+use std::collections::BTreeSet;
 use std::{
     cmp::max,
     collections::{HashMap, HashSet},
@@ -6,49 +17,41 @@ use std::{
     vec,
 };
 
-use anyhow::{Context, Result};
-use bstr::{BString, ByteSlice};
-use gitbutler_branch::{Branch as GitButlerBranch, BranchId, ReferenceExt, Target};
-use gitbutler_command_context::CommandContext;
-use gitbutler_reference::normalize_branch_name;
-use serde::{Deserialize, Serialize};
-
-use crate::VirtualBranchesExt;
-
 /// Returns a list of branches associated with this project.
 pub fn list_branches(
     ctx: &CommandContext,
     filter: Option<BranchListingFilter>,
     filter_branch_names: Option<Vec<BranchIdentity>>,
 ) -> Result<Vec<BranchListing>> {
+    let mut repo = gix::open(ctx.repository().path())?;
+    repo.object_cache_size_if_unset(1024 * 1024);
     let has_filter = filter.is_some();
     let filter = filter.unwrap_or_default();
     let vb_handle = ctx.project().virtual_branches();
+    let platform = repo.references()?;
     let mut branches: Vec<GroupBranch> = vec![];
-    for (branch, branch_type) in ctx.repository().branches(None)?.filter_map(Result::ok) {
+    for reference in platform.all()?.filter_map(Result::ok) {
         // Loosely match on branch names
         if let Some(branch_names) = &filter_branch_names {
-            let has_matching_name = branch_names.iter().any(|branch_name| {
-                if let Ok(Some(name)) = branch.name() {
-                    name.ends_with(&branch_name.0)
-                } else {
-                    false
-                }
-            });
+            let has_matching_name = branch_names
+                .iter()
+                .any(|branch_name| reference.name().as_bstr().ends_with_str(&branch_name.0));
 
             if !has_matching_name {
                 continue;
             }
         }
 
-        match branch_type {
-            git2::BranchType::Local => {
-                branches.push(GroupBranch::Local(branch));
-            }
-            git2::BranchType::Remote => {
-                branches.push(GroupBranch::Remote(branch));
-            }
+        let is_local_branch = match reference.name().category() {
+            Some(Category::LocalBranch) => true,
+            Some(Category::RemoteBranch) => false,
+            _ => continue,
         };
+        branches.push(if is_local_branch {
+            GroupBranch::Local(reference)
+        } else {
+            GroupBranch::Remote(reference)
+        });
     }
 
     let virtual_branches = vb_handle.list_all_branches()?;
@@ -56,7 +59,7 @@ pub fn list_branches(
     for branch in virtual_branches {
         branches.push(GroupBranch::Virtual(branch));
     }
-    let mut branches = combine_branches(branches, ctx, vb_handle.get_default_target()?)?;
+    let mut branches = combine_branches(branches, &repo, vb_handle.get_default_target()?)?;
 
     // Apply the filter
     branches.retain(|branch| !has_filter || matches_all(branch, filter));
@@ -111,11 +114,11 @@ fn matches_all(branch: &BranchListing, filter: BranchListingFilter) -> bool {
 
 fn combine_branches(
     group_branches: Vec<GroupBranch>,
-    ctx: &CommandContext,
+    repo: &gix::Repository,
     target_branch: Target,
 ) -> Result<Vec<BranchListing>> {
-    let repo = ctx.repository();
-    let remotes = repo.remotes()?;
+    let remotes = repo.remote_names();
+    let packed = repo.refs.cached_packed_buffer()?;
 
     // Group branches by identity
     let mut groups: HashMap<BranchIdentity, Vec<GroupBranch>> = HashMap::new();
@@ -134,8 +137,14 @@ fn combine_branches(
     Ok(groups
         .into_iter()
         .filter_map(|(identity, group_branches)| {
-            let res =
-                branch_group_to_branch(&identity, group_branches, repo, &remotes, &target_branch);
+            let res = branch_group_to_branch(
+                &identity,
+                group_branches,
+                repo,
+                packed.as_ref().map(|p| &***p),
+                &remotes,
+                &target_branch,
+            );
             match res {
                 Ok(branch_entry) => branch_entry,
                 Err(err) => {
@@ -155,17 +164,22 @@ fn combine_branches(
 fn branch_group_to_branch(
     identity: &BranchIdentity,
     group_branches: Vec<GroupBranch>,
-    repo: &git2::Repository,
-    remotes: &git2::string_array::StringArray,
+    repo: &gix::Repository,
+    packed: Option<&gix::refs::packed::Buffer>,
+    remotes: &BTreeSet<Cow<'_, BStr>>,
     target: &Target,
 ) -> Result<Option<BranchListing>> {
-    let mut vbranches = group_branches
-        .iter()
-        .filter_map(|branch| match branch {
-            GroupBranch::Virtual(vb) => Some(vb),
-            _ => None,
-        })
-        .collect::<Vec<_>>();
+    let (local_branches, remote_branches, mut vbranches) =
+        group_branches
+            .into_iter()
+            .fold((Vec::new(), Vec::new(), Vec::new()), |mut acc, item| {
+                match item {
+                    GroupBranch::Local(branch) => acc.0.push(branch),
+                    GroupBranch::Remote(branch) => acc.1.push(branch),
+                    GroupBranch::Virtual(branch) => acc.2.push(branch),
+                }
+                acc
+            });
 
     let virtual_branch = if vbranches.len() > 1 {
         vbranches.sort_by_key(|virtual_branch| virtual_branch.updated_timestamp_ms);
@@ -174,25 +188,10 @@ fn branch_group_to_branch(
         vbranches.first()
     };
 
-    let remote_branches: Vec<&git2::Branch> = group_branches
-        .iter()
-        .filter_map(|branch| match branch {
-            GroupBranch::Remote(gb) => Some(gb),
-            _ => None,
-        })
-        .collect();
-    let local_branches: Vec<&git2::Branch> = group_branches
-        .iter()
-        .filter_map(|branch| match branch {
-            GroupBranch::Local(gb) => Some(gb),
-            _ => None,
-        })
-        .collect();
-
     if virtual_branch.is_none()
         && local_branches
             .iter()
-            .any(|b| b.get().given_name(remotes).as_deref().ok() == Some(target.branch.branch()))
+            .any(|b| b.name().given_name(remotes).as_deref().ok() == Some(target.branch.branch()))
     {
         return Ok(None);
     }
@@ -204,12 +203,11 @@ fn branch_group_to_branch(
         in_workspace: branch.in_workspace,
     });
 
+    // TODO(ST): keep the type alive, don't reduce to BString
     let mut remotes: Vec<BString> = Vec::new();
     for branch in remote_branches.iter() {
-        if let Some(name) = branch.get().name() {
-            if let Ok(remote_name) = repo.branch_remote_name(name) {
-                remotes.push(remote_name.as_bstr().into());
-            }
+        if let Some(remote_name) = branch.remote_name(gix::remote::Direction::Fetch) {
+            remotes.push(remote_name.as_bstr().into());
         }
     }
 
@@ -218,21 +216,22 @@ fn branch_group_to_branch(
     // The head commit for which we calculate statistics.
     // If there is a virtual branch let's get it's head. Alternatively, pick the first local branch and use it's head.
     // If there are no local branches, pick the first remote branch.
-    let head = if let Some(vbranch) = virtual_branch {
-        Some(vbranch.head)
-    } else if let Some(branch) = local_branches.first().cloned() {
-        branch.get().peel_to_commit().ok().map(|c| c.id())
-    } else if let Some(branch) = remote_branches.first().cloned() {
-        branch.get().peel_to_commit().ok().map(|c| c.id())
+    let head_commit = if let Some(vbranch) = virtual_branch {
+        Some(git2_to_gix_object_id(vbranch.head).attach(repo))
+    } else if let Some(mut branch) = local_branches.into_iter().next() {
+        branch.peel_to_id_in_place_packed(packed).ok()
+    } else if let Some(mut branch) = remote_branches.into_iter().next() {
+        branch.peel_to_id_in_place_packed(packed).ok()
     } else {
         None
     }
     .context("Could not get any valid reference in order to build branch stats")?;
 
-    let head_commit = repo.find_commit(head)?;
-    // If this was a virtual branch and there was never any remote set, use the virtual branch name as the identity
+    let head = gix_to_git2_oid(head_commit.detach());
+    let head_commit = head_commit.object()?.try_into_commit()?;
+    let head_commit = head_commit.decode()?;
     let last_modified_ms = max(
-        (head_commit.time().seconds() * 1000) as u128,
+        (head_commit.time().seconds * 1000) as u128,
         virtual_branch.map_or(0, |x| x.updated_timestamp_ms),
     );
     let last_commiter = head_commit.author().into();
@@ -248,30 +247,37 @@ fn branch_group_to_branch(
     }))
 }
 
+fn gix_to_git2_oid(id: gix::ObjectId) -> git2::Oid {
+    git2::Oid::from_bytes(id.as_bytes()).expect("always valid")
+}
+
+fn git2_to_gix_object_id(id: git2::Oid) -> gix::ObjectId {
+    gix::ObjectId::try_from(id.as_bytes()).expect("git2 oid is always valid")
+}
+
 /// A sum type of branch that can be a plain git branch or a virtual branch
 #[allow(clippy::large_enum_variant)]
 enum GroupBranch<'a> {
-    Local(git2::Branch<'a>),
-    Remote(git2::Branch<'a>),
+    Local(gix::Reference<'a>),
+    Remote(gix::Reference<'a>),
     Virtual(GitButlerBranch),
 }
 
 impl fmt::Debug for GroupBranch<'_> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            GroupBranch::Local(branch) | GroupBranch::Remote(branch) => {
-                let reference = branch.get();
-                let target = reference
-                    .target()
-                    .expect("Failed to reference target in debug formatting");
-                let name = reference
-                    .name()
-                    .expect("Failed to get reference name in debug");
-                formatter
-                    .debug_struct("GroupBranch::Local/Remote")
-                    .field("0", &&format!("id: {}, name: {}", target, name).as_str())
-                    .finish()
-            }
+            GroupBranch::Local(branch) | GroupBranch::Remote(branch) => formatter
+                .debug_struct("GroupBranch::Local/Remote")
+                .field(
+                    "0",
+                    &format!(
+                        "id: {:?}, name: {}",
+                        branch.target(),
+                        branch.name().as_bstr()
+                    )
+                    .as_str(),
+                )
+                .finish(),
             GroupBranch::Virtual(branch) => formatter
                 .debug_struct("GroupBranch::Virtal")
                 .field("0", branch)
@@ -284,10 +290,11 @@ impl GroupBranch<'_> {
     /// A name identifier for the branch. When multiple branches (e.g. virtual, local, remote) have the same identity,
     /// they are grouped together under the same `Branch` entry.
     /// `None` means an identity could not be obtained, which makes this branch odd enough to ignore.
-    fn identity(&self, remotes: &git2::string_array::StringArray) -> Option<BranchIdentity> {
+    fn identity(&self, remotes: &BTreeSet<Cow<'_, BStr>>) -> Option<BranchIdentity> {
         match self {
-            GroupBranch::Local(branch) => branch.get().given_name(remotes).ok(),
-            GroupBranch::Remote(branch) => branch.get().given_name(remotes).ok(),
+            GroupBranch::Local(branch) | GroupBranch::Remote(branch) => {
+                branch.name().given_name(remotes).ok()
+            }
             // The identity of a Virtual branch is derived from the source refname, upstream or the branch given name, in that order
             GroupBranch::Virtual(branch) => {
                 let name_from_source = branch.source_refname.as_ref().and_then(|n| n.branch());
@@ -354,7 +361,7 @@ pub struct BranchListing {
     /// The head of interest for the branch group, used for calculating branch statistics.
     /// If there is a virtual branch, a local branch and remote branches, the head is determined in the following order:
     /// 1. The head of the virtual branch
-    /// 2. The head of the local branch
+    /// 2. The head of the first local branch
     /// 3. The head of the first remote branch
     #[serde(skip)]
     pub head: git2::Oid,
@@ -363,6 +370,7 @@ pub struct BranchListing {
 /// Represents a "commit author" or "signature", based on the data from the git history
 #[derive(Debug, Clone, Serialize, PartialEq, Eq, Hash)]
 pub struct Author {
+    // TODO(ST): use `BString` here to not degenerate information
     /// The name of the author as configured in the git config
     pub name: Option<String>,
     /// The email of the author as configured in the git config
@@ -400,6 +408,15 @@ impl From<git2::Signature<'_>> for Author {
         let name = value.name().map(str::to_string);
         let email = value.email().map(str::to_string);
         Author { name, email }
+    }
+}
+
+impl From<gix::actor::SignatureRef<'_>> for Author {
+    fn from(value: gix::actor::SignatureRef<'_>) -> Self {
+        Author {
+            name: Some(value.name.to_string()),
+            email: Some(value.email.to_string()),
+        }
     }
 }
 

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -73,7 +73,7 @@ pub fn list_branches(
             return true;
         }
 
-        // If the virtual virtual branch has a local branch, keep the grouping
+        // If the virtual branch has a local branch, keep the grouping
         if branch.has_local {
             return true;
         };

--- a/crates/gitbutler-branch-actions/tests/fixtures/branch-benches.sh
+++ b/crates/gitbutler-branch-actions/tests/fixtures/branch-benches.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+CLI=${1:?The first argument is the GitButler CLI}
+
+git init remote
+(cd remote
+  echo first > file
+  git add . && git commit -m "init"
+)
+
+function init-virtual() {
+  $CLI project add --switch-to-integration "$(git rev-parse --symbolic-full-name @{u})"
+  $CLI branch create virtual
+}
+
+function pack-refs() {
+    git pack-refs --prune --all
+    git config core.precomposeUnicode false
+}
+
+function unpack-packed-refs() {
+    local git_dir=$(git rev-parse --git-dir)
+    local packed_refs_file="$git_dir/packed-refs"
+
+    if [[ ! -f "$packed_refs_file" ]]; then
+        echo "No packed-refs file found."
+        return 1
+    fi
+
+    while IFS= read -r line; do
+        # Skip comments and peel lines
+        [[ "$line" =~ ^# ]] && continue
+        [[ "$line" =~ ^\^ ]] && continue
+
+        # Split line into hash and ref
+        hash=$(echo "$line" | awk '{print $1}')
+        ref=$(echo "$line" | awk '{print $2}')
+
+        # Skip invalid lines
+        [[ -z "$hash" || -z "$ref" ]] && continue
+
+        # Create directory for the ref if it does not exist
+        ref_dir=$(dirname "$git_dir/$ref")
+        mkdir -p "$ref_dir"
+
+        # Write the hash to the ref file
+        echo "$hash" > "$git_dir/$ref"
+    done < "$packed_refs_file"
+
+    rm $packed_refs_file
+
+    git config core.precomposeUnicode false
+}
+
+
+export GITBUTLER_CLI_DATA_DIR=../user/gitbutler/app-data
+branch_count=300
+git clone remote many-local
+(cd many-local
+  init-virtual
+
+  for name in $(seq $branch_count); do
+    git branch "$name"
+  done
+  unpack-packed-refs
+)
+
+git clone remote many-local-packed
+(cd many-local-packed
+  init-virtual
+
+  for name in $(seq $branch_count); do
+    git branch "$name"
+  done
+  pack-refs
+)
+
+git clone many-local many-local-tracked
+(cd many-local-tracked
+  init-virtual
+
+  for name in $(seq $branch_count); do
+    git branch --track "$name"
+  done
+  unpack-packed-refs
+)
+
+git clone many-local-packed many-local-tracked-packed
+(cd many-local-tracked-packed
+  init-virtual
+
+  for name in $(seq $branch_count); do
+    git branch --track "$name"
+  done
+  pack-refs
+)

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/list.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/list.rs
@@ -125,7 +125,7 @@ fn one_branch_on_integration_multiple_remotes() -> Result<()> {
         &list[0],
         ExpectedBranchListing {
             identity: "main".into(),
-            remotes: vec!["other-remote", "origin"],
+            remotes: vec!["origin", "other-remote"],
             virtual_branch_given_name: Some("main"),
             virtual_branch_in_workspace: true,
             has_local: true,

--- a/crates/gitbutler-branch/src/lib.rs
+++ b/crates/gitbutler-branch/src/lib.rs
@@ -6,7 +6,7 @@ use bstr::ByteSlice;
 mod branch_ext;
 pub use branch_ext::BranchExt;
 mod reference_ext;
-pub use reference_ext::ReferenceExt;
+pub use reference_ext::{ReferenceExt, ReferenceExtGix};
 mod dedup;
 pub use dedup::{dedup, dedup_fmt};
 mod file_ownership;

--- a/crates/gitbutler-branch/src/reference_ext.rs
+++ b/crates/gitbutler-branch/src/reference_ext.rs
@@ -1,5 +1,9 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
+use bstr::{BStr, ByteSlice};
+use gix::refs::Category;
 use itertools::Itertools;
+use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 pub trait ReferenceExt {
     /// Fetches a branches name without the remote name attached
@@ -11,6 +15,19 @@ pub trait ReferenceExt {
     /// An ideal implementation wouldn't require us to list all the references,
     /// but there doesn't seem to be a libgit2 solution to this.
     fn given_name(&self, remotes: &git2::string_array::StringArray) -> Result<String>;
+}
+
+// TODO(ST): replace the original with this one.
+pub trait ReferenceExtGix {
+    /// Fetches a branches name without the remote name attached
+    ///
+    /// refs/heads/my-branch -> my-branch
+    /// refs/remotes/origin/my-branch -> my-branch
+    /// refs/remotes/Byron/gitbutler/my-branch -> my-branch (where the remote is Byron/gitbutler)
+    ///
+    /// An ideal implementation wouldn't require us to list all the references,
+    /// but there doesn't seem to be a libgit2 solution to this.
+    fn given_name(&self, remotes: &BTreeSet<Cow<'_, BStr>>) -> Result<String>;
 }
 
 impl<'repo> ReferenceExt for git2::Reference<'repo> {
@@ -44,5 +61,37 @@ impl<'repo> ReferenceExt for git2::Reference<'repo> {
                 .ok_or(anyhow::anyhow!("Branch name was not utf-8"))
                 .map(String::from)
         }
+    }
+}
+
+impl ReferenceExtGix for &gix::refs::FullNameRef {
+    // TODO: make this `identity()`, and use `BranchIdentity` type.
+    fn given_name(&self, remotes: &BTreeSet<Cow<'_, BStr>>) -> Result<String> {
+        let (category, shorthand_name) = self
+            .category_and_short_name()
+            .context("Branch could not be categorized")?;
+        if !matches!(category, Category::RemoteBranch) {
+            return Ok(shorthand_name.to_string());
+        }
+
+        let longest_remote = remotes
+            .iter()
+            .rfind(|reference_name| shorthand_name.starts_with(reference_name))
+            .ok_or(anyhow::anyhow!(
+                "Failed to find remote branch's corresponding remote"
+            ))?;
+
+        let shorthand_name: &BStr = shorthand_name
+            .strip_prefix(longest_remote.as_bytes())
+            .and_then(|str| str.strip_prefix(b"/"))
+            .ok_or(anyhow::anyhow!(
+                "Failed to cut remote name {} off of shorthand name {}",
+                longest_remote,
+                shorthand_name
+            ))?
+            .into();
+
+        // TODO(correctness): this should be `BString`, but can't change it yet.
+        Ok(shorthand_name.to_string())
     }
 }

--- a/crates/gitbutler-cli/Cargo.toml
+++ b/crates/gitbutler-cli/Cargo.toml
@@ -17,7 +17,7 @@ gitbutler-reference.workspace = true
 gitbutler-branch-actions.workspace = true
 gitbutler-branch.workspace = true
 gitbutler-diff.workspace = true
-gix.workspace = true
+gix = { workspace = true, features = ["max-performance-safe"] }
 dirs-next = "2.0.0"
 clap = { version = "4.5.13", features = ["derive", "env"] }
 anyhow = "1.0.86"

--- a/crates/gitbutler-git/Cargo.toml
+++ b/crates/gitbutler-git/Cargo.toml
@@ -24,6 +24,8 @@ serde = ["dep:serde"]
 tokio = ["dep:tokio"]
 ## a flag that is needed for integration tests that run this code to work.
 test-askpass-path = []
+## a flag to indicate benchmarks are run
+benches = []
 
 [dependencies]
 thiserror.workspace = true

--- a/crates/gitbutler-git/src/lib.rs
+++ b/crates/gitbutler-git/src/lib.rs
@@ -9,8 +9,12 @@
 #![allow(unknown_lints)]
 #![cfg_attr(windows, feature(windows_by_handle))]
 
-#[cfg(all(not(debug_assertions), feature = "test-askpass-path"))]
-compile_error!("BUG: in production code this flag should not be set, nor do we run test with `cargo test --release`");
+#[cfg(all(
+    not(debug_assertions),
+    not(feature = "benches"),
+    feature = "test-askpass-path"
+))]
+compile_error!("BUG: in production code this flag should not be set, nor do we run test with `cargo test --release`. Benches must use `--features benches`");
 
 mod error;
 pub(crate) mod executor;

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -29,6 +29,7 @@ dirs = "5.0.1"
 fslock.workspace = true
 futures.workspace = true
 git2.workspace = true
+gix = { workspace = true, features = ["max-performance-safe"] }
 once_cell = "1.19"
 reqwest = { version = "0.12.4", features = ["json"] }
 serde.workspace = true

--- a/crates/gitbutler-testsupport/src/lib.rs
+++ b/crates/gitbutler-testsupport/src/lib.rs
@@ -103,6 +103,12 @@ pub mod read_only {
     ///
     /// Returns the project that is strictly for read-only use.
     pub fn fixture(script_name: &str, project_directory: &str) -> anyhow::Result<CommandContext> {
+        let project = fixture_project(script_name, project_directory)?;
+        CommandContext::open(&project)
+    }
+
+    /// Like [`fixture()`], but will return only the `Project` at `project_directory` after executing `script_name`.
+    pub fn fixture_project(script_name: &str, project_directory: &str) -> anyhow::Result<Project> {
         static IS_VALID_PROJECT: Lazy<Mutex<BTreeSet<(String, String)>>> =
             Lazy::new(|| Mutex::new(Default::default()));
 
@@ -128,7 +134,7 @@ pub mod read_only {
                 ..Default::default()
             }
         };
-        CommandContext::open(&project)
+        Ok(project)
     }
 }
 


### PR DESCRIPTION
This PR adds brnach-listings using `gix`, but without branch details, to increase performance or at least make for more maintainable code.

### Tasks

* [x] basic benchmarking support using `criterion`
* [x] baseline benchmark to capture `git2` performance
    - needs with and without packed-refs, and also a version with a lot of references
* [x] replace branch listing with `gix`
* [x] fix tests (remote name from remote branch)
* [x] assure that performance isn't getting worse.
* [x] assure local overrides are removed and GitHub version is used.

### Follow Ups
* `check --all-targets` #4651 
* ~~figure out how to build `max-performance` on CI - needs `cmake` which isn't installed - relevant for object database performance later.~~
    - Let's keep it for now but remember this might be an opportunity later. After all, benchmarks to check related performance are still missing.
* fix TODOs, additional refactors #4652
* normalization/sanitization built into `gitoxide`
     - It takes ~5% of the time, but the majority of that is the creation of regexes. Thus, creating these statically would already solve this problem even though it's still not necessarily correct.
     - #4665

### Performance

When switching from `git2` to `gitx` we see that `git2` *can* be 7,5% faster on MacOS when traversing refs. But we also see that handling many tracked branches is super slow (20x to 200x!), and when dealing with tiny repositories, `gix` also is much faster as for `git2` the time to open the repository dominates.
More testing showed that it's all about `core.precomposeUnicode`, which consumes a lot of power in `gix` and which seems to be ignored by `git2`. When turned off, `gix` is the clear winner - a win which didn't come easily by the way.

<img width="955" alt="Screenshot 2024-08-07 at 20 05 28" src="https://github.com/user-attachments/assets/86d3bf89-3884-417f-9a9f-981ccab66d29">

**Note that the picture above was done with `max-performance`**, something that I had to remove as it didn't work on CI just yet.

### Git2 Performance Notes

* Instrumenting a `git2` based run, one thing stuck out: In a repo with 300 tracked branches, getting the remote name is very slow <img width="1166" alt="Screenshot 2024-08-07 at 10 50 19" src="https://github.com/user-attachments/assets/393f15c0-c05b-409d-884f-35dda79f05e4">
* Listing branches typically gets a 10x speedup when they are packed.
* Another hot function is `normalize_branch_name` - this will be faster when implemented in `gitoxide` as it won't use `regex` substitution, but edits in-line. <img width="1083" alt="Screenshot 2024-08-07 at 10 30 59" src="https://github.com/user-attachments/assets/720a7c7e-2598-4b0d-86f7-93ee875e37f8">
*  Otherwise, traversing loose branches is quite time-consuming due to the amount of IO done here <img width="1132" alt="Screenshot 2024-08-07 at 10 32 10" src="https://github.com/user-attachments/assets/a0fbeb6c-de94-4be6-8ac5-352ba8cb875d">

### Gix Performance Notes

When listing branches, `gix` isn't naturally faster. Major consumers overall are…

* Opening a repository in full and reading global configuration.
* Unicode precomposition/decomposition during iteration.
* References are eagerly read, which makes the name-filter pruning most of them very expensive. It looked like `git2` is also eagerly loading though, so I guess it's OK to hope for packed refs to be present if there are too many refs.

### Comparison

This is the `criteron` output (with the profiler attached) running the `git2` after having recorded the `gix` version.
It's notable that some tests are from 4x to 20x faster in `git2` initially.

It turned out all the time was spent reading and re-reading the same commit object, as object caches aren't enabled by default. The second factor was rechecking for packed-refs freshness too often - now it's done once for the operation.

<details>

```
list-branches[many local branches]/no filter
                        time:   [3.9939 ms 4.0238 ms 4.0560 ms]
                        thrpt:  [73.965 Kelem/s 74.556 Kelem/s 75.114 Kelem/s]
                 change:
                        time:   [-81.402% -81.120% -80.849%] (p = 0.00 < 0.05)
                        thrpt:  [+422.17% +429.67% +437.68%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  8 (8.00%) high mild
Benchmarking list-branches[many local branches]/name-filter rejecting all: Collecting 100 samples in estimated 5.0014 s (1200 iteratilist-branches[many local branches]/name-filter rejecting all
                        time:   [4.0703 ms 4.1143 ms 4.1633 ms]
                        thrpt:  [72.059 Kelem/s 72.916 Kelem/s 73.705 Kelem/s]
                 change:
                        time:   [-9.5855% -8.2445% -6.9103%] (p = 0.00 < 0.05)
                        thrpt:  [+7.4233% +8.9853% +10.602%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

list-branches[tiny repo]/no filter
                        time:   [853.29 µs 857.06 µs 860.89 µs]
                        thrpt:  [3.4848 Kelem/s 3.5003 Kelem/s 3.5158 Kelem/s]
                 change:
                        time:   [+50.118% +52.354% +54.490%] (p = 0.00 < 0.05)
                        thrpt:  [-35.271% -34.364% -33.386%]
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
list-branches[tiny repo]/name-filter rejecting all
                        time:   [544.09 µs 546.69 µs 549.36 µs]
                        thrpt:  [5.4609 Kelem/s 5.4876 Kelem/s 5.5138 Kelem/s]
                 change:
                        time:   [-0.9418% +0.0285% +1.0737%] (p = 0.96 > 0.05)
                        thrpt:  [-1.0623% -0.0285% +0.9507%]
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe

list-branches[many local branches [packed]]/no filter
                        time:   [806.29 µs 816.63 µs 828.63 µs]
                        thrpt:  [362.04 Kelem/s 367.37 Kelem/s 372.08 Kelem/s]
                 change:
                        time:   [-95.403% -95.356% -95.306%] (p = 0.00 < 0.05)
                        thrpt:  [+2030.4% +2053.3% +2075.1%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
Benchmarking list-branches[many local branches [packed]]/name-filter rejecting all: Collecting 100 samples in estimated 6.0408 s (10klist-branches[many local branches [packed]]/name-filter rejecting all
                        time:   [587.43 µs 590.73 µs 594.02 µs]
                        thrpt:  [505.03 Kelem/s 507.85 Kelem/s 510.70 Kelem/s]
                 change:
                        time:   [+16.923% +18.061% +19.170%] (p = 0.00 < 0.05)
                        thrpt:  [-16.086% -15.298% -14.473%]
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

Benchmarking list-branches[many local branches [tracked]]/no filter: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 29.1s, or reduce sample count to 10.
list-branches[many local branches [tracked]]/no filter
                        time:   [285.91 ms 286.44 ms 287.06 ms]
                        thrpt:  [2.0901 Kelem/s 2.0947 Kelem/s 2.0985 Kelem/s]
                 change:
                        time:   [+1275.4% +1282.7% +1290.2%] (p = 0.00 < 0.05)
                        thrpt:  [-92.807% -92.768% -92.729%]
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
Benchmarking list-branches[many local branches [tracked]]/name-filter rejecting all: Collecting 100 samples in estimated 5.5596 s (60list-branches[many local branches [tracked]]/name-filter rejecting all
                        time:   [9.1789 ms 9.2784 ms 9.3756 ms]
                        thrpt:  [63.996 Kelem/s 64.666 Kelem/s 65.367 Kelem/s]
                 change:
                        time:   [-6.3340% -5.0751% -3.7357%] (p = 0.00 < 0.05)
                        thrpt:  [+3.8806% +5.3464% +6.7624%]
                        Performance has improved.

Benchmarking list-branches[many local branches [tracked & packed]]/no filter: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 28.0s, or reduce sample count to 10.
Benchmarking list-branches[many local branches [tracked & packed]]/no filter: Collecting 100 samples in estimated 28.018 s (100 iteralist-branches[many local branches [tracked & packed]]/no filter
                        time:   [279.69 ms 280.71 ms 281.98 ms]
                        thrpt:  [2.1278 Kelem/s 2.1375 Kelem/s 2.1452 Kelem/s]
                 change:
                        time:   [+2244.0% +2258.0% +2272.5%] (p = 0.00 < 0.05)
                        thrpt:  [-95.785% -95.759% -95.734%]
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe
Benchmarking list-branches[many local branches [tracked & packed]]/name-filter rejecting all: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.7s, enable flat sampling, or reduce sample count to 50.
Benchmarking list-branches[many local branches [tracked & packed]]/name-filter rejecting all: Collecting 100 samples in estimated 7.6list-branches[many local branches [tracked & packed]]/name-filter rejecting all
                        time:   [1.5051 ms 1.5118 ms 1.5185 ms]
                        thrpt:  [395.13 Kelem/s 396.89 Kelem/s 398.65 Kelem/s]
                 change:
                        time:   [+58.172% +59.370% +60.574%] (p = 0.00 < 0.05)
                        thrpt:  [-37.723% -37.253% -36.778%]
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) low mild 
  2 (2.00%) high mild
```

Here is the 20x run in isolation and with instrumentation, coming from `git2` and going to `gix`.

```
list-branches[many local branches [packed]]/no filter
                        time:   [18.303 ms 19.898 ms 22.018 ms]
                        thrpt:  [13.626 Kelem/s 15.077 Kelem/s 16.390 Kelem/s]
                 change:
                        time:   [+2190.2% +2371.2% +2669.1%] (p = 0.00 < 0.05)
                        thrpt:  [-96.389% -95.953% -95.634%]
                        Performance has regressed.
Found 13 outliers among 100 measurements (13.00%)
  9 (9.00%) high mild
  4 (4.00%) high severe
Benchmarking list-branches[many local branches [packed]]/name-filter rejecting all: Collecting 100 samples in estimated 5.0540 s (10klist-branches[many local branches [packed]]/name-filter rejecting all
                        time:   [493.38 µs 496.64 µs 499.71 µs]
                        thrpt:  [600.35 Kelem/s 604.06 Kelem/s 608.05 Kelem/s]
                 change:
                        time:   [-16.453% -15.824% -15.143%] (p = 0.00 < 0.05)
                        thrpt:  [+17.846% +18.799% +19.693%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
```

After adding an object cache and reusing packed refs buffers it's much better, but still up to 10% slower in some cases. Let's see if the performance of 20x in the bad `git2` case gets worse for us when remote names can be extracted from local tracking branches.

```
list-branches[many local branches]/no filter
                        time:   [4.6951 ms 5.0242 ms 5.4801 ms]
                        thrpt:  [54.744 Kelem/s 59.711 Kelem/s 63.896 Kelem/s]
                 change:
                        time:   [+0.1315% +12.645% +27.003%] (p = 0.04 < 0.05)
                        thrpt:  [-21.262% -11.225% -0.1313%]
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
Benchmarking list-branches[many local branches]/name-filter rejecting all: Collecting 100 samples in estimated 5.3305 s (1300 iteratilist-branches[many local branches]/name-filter rejecting all
                        time:   [4.0972 ms 4.1088 ms 4.1217 ms]
                        thrpt:  [72.785 Kelem/s 73.014 Kelem/s 73.220 Kelem/s]
                 change:
                        time:   [+10.886% +11.347% +11.833%] (p = 0.00 < 0.05)
                        thrpt:  [-10.581% -10.190% -9.8176%]
                        Performance has regressed.
Found 14 outliers among 100 measurements (14.00%)
  9 (9.00%) high mild
  5 (5.00%) high severe

list-branches[tiny repo]/no filter
                        time:   [518.92 µs 520.24 µs 521.71 µs]
                        thrpt:  [5.7504 Kelem/s 5.7666 Kelem/s 5.7812 Kelem/s]
                 change:
                        time:   [-35.568% -35.326% -35.073%] (p = 0.00 < 0.05)
                        thrpt:  [+54.018% +54.622% +55.203%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe
list-branches[tiny repo]/name-filter rejecting all
                        time:   [517.98 µs 519.15 µs 520.47 µs]
                        thrpt:  [5.7640 Kelem/s 5.7787 Kelem/s 5.7918 Kelem/s]
                 change:
                        time:   [+1.6697% +2.0104% +2.3665%] (p = 0.00 < 0.05)
                        thrpt:  [-2.3118% -1.9708% -1.6423%]
                        Performance has regressed.
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) high mild
  7 (7.00%) high severe

list-branches[many local branches [packed]]/no filter
                        time:   [798.65 µs 801.38 µs 804.44 µs]
                        thrpt:  [372.93 Kelem/s 374.35 Kelem/s 375.64 Kelem/s]
                 change:
                        time:   [+7.3188% +8.1308% +8.8618%] (p = 0.00 < 0.05)
                        thrpt:  [-8.1404% -7.5194% -6.8197%]
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  8 (8.00%) high mild
  2 (2.00%) high severe
Benchmarking list-branches[many local branches [packed]]/name-filter rejecting all: Collecting 100 samples in estimated 7.1028 s (15klist-branches[many local branches [packed]]/name-filter rejecting all
                        time:   [467.18 µs 468.33 µs 469.65 µs]
                        thrpt:  [638.77 Kelem/s 640.57 Kelem/s 642.15 Kelem/s]
                 change:
                        time:   [-16.433% -15.821% -15.217%] (p = 0.00 < 0.05)
                        thrpt:  [+17.948% +18.794% +19.665%]
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  5 (5.00%) high mild
  8 (8.00%) high severe

list-branches[many local branches [tracked]]/no filter
                        time:   [8.9093 ms 8.9516 ms 8.9987 ms]
                        thrpt:  [66.676 Kelem/s 67.027 Kelem/s 67.345 Kelem/s]
                 change:
                        time:   [-96.796% -96.781% -96.764%] (p = 0.00 < 0.05)
                        thrpt:  [+2990.5% +3006.5% +3021.5%]
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  4 (4.00%) high mild
  10 (10.00%) high severe
Benchmarking list-branches[many local branches [tracked]]/name-filter rejecting all: Collecting 100 samples in estimated 5.1016 s (60list-branches[many local branches [tracked]]/name-filter rejecting all
                        time:   [8.4425 ms 8.4848 ms 8.5339 ms]
                        thrpt:  [70.308 Kelem/s 70.715 Kelem/s 71.069 Kelem/s]
                 change:
                        time:   [+2.3070% +3.1059% +3.9172%] (p = 0.00 < 0.05)
                        thrpt:  [-3.7695% -3.0124% -2.2550%]
                        Performance has regressed.
Found 14 outliers among 100 measurements (14.00%)
  4 (4.00%) high mild
  10 (10.00%) high severe

Benchmarking list-branches[many local branches [tracked & packed]]/no filter: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.8s, enable flat sampling, or reduce sample count to 60.
Benchmarking list-branches[many local branches [tracked & packed]]/no filter: Collecting 100 samples in estimated 6.8154 s (5050 iterlist-branches[many local branches [tracked & packed]]/no filter
                        time:   [1.3169 ms 1.3252 ms 1.3351 ms]
                        thrpt:  [449.39 Kelem/s 452.76 Kelem/s 455.61 Kelem/s]
                 change:
                        time:   [-99.511% -99.505% -99.499%] (p = 0.00 < 0.05)
                        thrpt:  [+19848% +20119% +20335%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
Benchmarking list-branches[many local branches [tracked & packed]]/name-filter rejecting all: Collecting 100 samples in estimated 8.8list-branches[many local branches [tracked & packed]]/name-filter rejecting all
                        time:   [872.31 µs 877.61 µs 882.88 µs]
                        thrpt:  [679.59 Kelem/s 683.67 Kelem/s 687.83 Kelem/s]
                 change:
                        time:   [-38.986% -38.602% -38.215%] (p = 0.00 < 0.05)
                        thrpt:  [+61.852% +62.873% +63.897%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
```

**Finally**, a run going from `gix` to `git2` but with `core.precomposeUnicode` enabled. `gix` looses quite a bit of performance then.

```
list-branches[many local branches]/no filter
                        time:   [4.3731 ms 4.6555 ms 5.0195 ms]
                        thrpt:  [59.767 Kelem/s 64.440 Kelem/s 68.601 Kelem/s]
                 change:
                        time:   [-5.5547% +0.6503% +8.8473%] (p = 0.88 > 0.05)
                        thrpt:  [-8.1282% -0.6461% +5.8814%]
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe
Benchmarking list-branches[many local branches]/name-filter rejecting all: Collecting 100 samples in estimated 5.0987 s (1400 iteratilist-branches[many local branches]/name-filter rejecting all
                        time:   [3.6591 ms 3.6841 ms 3.7148 ms]
                        thrpt:  [80.759 Kelem/s 81.431 Kelem/s 81.987 Kelem/s]
                 change:
                        time:   [-15.107% -14.055% -12.957%] (p = 0.00 < 0.05)
                        thrpt:  [+14.886% +16.353% +17.796%]
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  10 (10.00%) high mild
  6 (6.00%) high severe

list-branches[tiny repo]/no filter
                        time:   [809.92 µs 811.54 µs 813.35 µs]
                        thrpt:  [3.6884 Kelem/s 3.6967 Kelem/s 3.7041 Kelem/s]
                 change:
                        time:   [+48.732% +49.885% +50.971%] (p = 0.00 < 0.05)
                        thrpt:  [-33.762% -33.282% -32.765%]
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe
list-branches[tiny repo]/name-filter rejecting all
                        time:   [514.74 µs 516.26 µs 518.13 µs]
                        thrpt:  [5.7901 Kelem/s 5.8110 Kelem/s 5.8282 Kelem/s]
                 change:
                        time:   [-3.9443% -3.2164% -2.5378%] (p = 0.00 < 0.05)
                        thrpt:  [+2.6039% +3.3233% +4.1062%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild

list-branches[many local branches [packed]]/no filter
                        time:   [741.43 µs 744.00 µs 746.54 µs]
                        thrpt:  [401.85 Kelem/s 403.23 Kelem/s 404.62 Kelem/s]
                 change:
                        time:   [-8.8907% -8.1606% -7.4633%] (p = 0.00 < 0.05)
                        thrpt:  [+8.0652% +8.8857% +9.7583%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
Benchmarking list-branches[many local branches [packed]]/name-filter rejecting all: Collecting 100 samples in estimated 5.5949 s (10klist-branches[many local branches [packed]]/name-filter rejecting all
                        time:   [550.22 µs 551.25 µs 552.40 µs]
                        thrpt:  [543.08 Kelem/s 544.22 Kelem/s 545.23 Kelem/s]
                 change:
                        time:   [+11.743% +12.698% +13.644%] (p = 0.00 < 0.05)
                        thrpt:  [-12.006% -11.267% -10.509%]
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  7 (7.00%) high mild
  1 (1.00%) high severe

Benchmarking list-branches[many local branches [tracked]]/no filter: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 28.0s, or reduce sample count to 10.
list-branches[many local branches [tracked]]/no filter
                        time:   [276.61 ms 276.90 ms 277.20 ms]
                        thrpt:  [2.1645 Kelem/s 2.1669 Kelem/s 2.1691 Kelem/s]
                 change:
                        time:   [+2749.9% +2777.0% +2803.2%] (p = 0.00 < 0.05)
                        thrpt:  [-96.555% -96.524% -96.491%]
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Benchmarking list-branches[many local branches [tracked]]/name-filter rejecting all: Collecting 100 samples in estimated 5.7763 s (70list-branches[many local branches [tracked]]/name-filter rejecting all
                        time:   [8.1693 ms 8.2156 ms 8.2679 ms]
                        thrpt:  [72.570 Kelem/s 73.032 Kelem/s 73.446 Kelem/s]
                 change:
                        time:   [-10.791% -9.7886% -8.7425%] (p = 0.00 < 0.05)
                        thrpt:  [+9.5800% +10.851% +12.096%]
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  7 (7.00%) high mild
  5 (5.00%) high severe

Benchmarking list-branches[many local branches [tracked & packed]]/no filter: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 27.0s, or reduce sample count to 10.
Benchmarking list-branches[many local branches [tracked & packed]]/no filter: Collecting 100 samples in estimated 27.003 s (100 iteralist-branches[many local branches [tracked & packed]]/no filter
                        time:   [269.66 ms 270.02 ms 270.43 ms]
                        thrpt:  [2.2187 Kelem/s 2.2221 Kelem/s 2.2250 Kelem/s]
                 change:
                        time:   [+19464% +19600% +19729%] (p = 0.00 < 0.05)
                        thrpt:  [-99.496% -99.492% -99.489%]
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
Benchmarking list-branches[many local branches [tracked & packed]]/name-filter rejecting all: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.1s, enable flat sampling, or reduce sample count to 50.
Benchmarking list-branches[many local branches [tracked & packed]]/name-filter rejecting all: Collecting 100 samples in estimated 7.0list-branches[many local branches [tracked & packed]]/name-filter rejecting all
                        time:   [1.3909 ms 1.3935 ms 1.3966 ms]
                        thrpt:  [429.61 Kelem/s 430.56 Kelem/s 431.38 Kelem/s]
                 change:
                        time:   [+56.323% +57.769% +59.095%] (p = 0.00 < 0.05)
                        thrpt:  [-37.144% -36.616% -36.030%]
                        Performance has regressed.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe
```

</details>