### PR TITLE
Fix branch preview remote link

### DIFF
--- a/apps/desktop/src/lib/branch/BranchPreviewHeader.svelte
+++ b/apps/desktop/src/lib/branch/BranchPreviewHeader.svelte
@@ -18,12 +18,12 @@
 	export let pr: PullRequest | undefined;
 
 	$: branch = remoteBranch || localBranch!;
-	$: upstream = branch.upstream;
+	$: upstream = remoteBranch?.givenName;
 
 	const branchController = getContext(BranchController);
 	const project = getContext(Project);
 	const gitHost = getGitHost();
-	const gitHostBranch = upstream ? $gitHost?.branch(upstream) : undefined;
+	$: gitHostBranch = upstream ? $gitHost?.branch(upstream) : undefined;
 
 	let isApplying = false;
 </script>
@@ -41,21 +41,23 @@
 						<Icon name="remote-branch-small" />
 						{localBranch ? 'local and remote' : 'remote'}
 					</div>
-					<Button
-						size="tag"
-						icon="open-link"
-						style="ghost"
-						outline
-						shrinkable
-						onclick={(e) => {
-							const url = gitHostBranch?.url;
-							if (url) openExternalUrl(url);
-							e.preventDefault();
-							e.stopPropagation();
-						}}
-					>
-						{branch.displayName}
-					</Button>
+					{#if gitHostBranch}
+						<Button
+							size="tag"
+							icon="open-link"
+							style="ghost"
+							outline
+							shrinkable
+							onclick={(e) => {
+								const url = gitHostBranch.url;
+								if (url) openExternalUrl(url);
+								e.preventDefault();
+								e.stopPropagation();
+							}}
+						>
+							{branch.displayName}
+						</Button>
+					{/if}
 				{:else}
 					<div class="status-tag text-base-11 text-semibold remote">
 						<Icon name="remote-branch-small" /> local


### PR DESCRIPTION
One of the main issues with link was that we were not reacting to the upstream string when it changed, or when the gitHost was created. This meant we had the `gitHostBranch` remaining as undefined which is how we ended up with the button but when it was clicked, it ended up going nowhere rather than giving some form of bad result or error.
```diff
	const gitHost = getGitHost();
-	const gitHostBranch = upstream ? $gitHost?.branch(upstream) : undefined;
+	$: gitHostBranch = upstream ? $gitHost?.branch(upstream) : undefined;
	let isApplying = false;
</script>
```

Another issue that was uncovered when looking into this was that we were actually always providing `undefined`. We were more or less saying `remoteBranch.upstream` which always evaluates to `undefined`. We also know that we only ever want to show the button when a remoteBranch is provided (there is no point linking to a branch that isn't pushed!), so I changed to to fetch the given name of the remote branch, if present.

We want to use the given name as github/lab/ea has no concept of remotes or refs, so if we asked it to diff origin/my-branch, it would end up not being able to find the branch.
```diff
	export let pr: PullRequest | undefined;
	$: branch = remoteBranch || localBranch!;
-	$: upstream = branch.upstream;
+	$: upstream = remoteBranch?.givenName;
	const branchController = getContext(BranchController);
	const project = getContext(Project);
```

My last change was to add an additional condition which simply checked for the gitHostBranch to be present. This is the object returned by the `GitHost` implementation. The GitHost may return undefined for a handful of reasons, so its safer to add in the condition just hide the link if we don't have the object.
```diff
@@ -41,21 +41,23 @@
						<Icon name="remote-branch-small" />
						{localBranch ? 'local and remote' : 'remote'}
					</div>
-					<Button
-						size="tag"
-						icon="open-link"
-						style="ghost"
-						outline
-						shrinkable
-						onclick={(e) => {
-							const url = gitHostBranch?.url;
-							if (url) openExternalUrl(url);
-							e.preventDefault();
-							e.stopPropagation();
-						}}
-					>
-						{branch.displayName}
-					</Button>
+					{#if gitHostBranch}
+						<Button
+							size="tag"
+							icon="open-link"
+							style="ghost"
+							outline
+							shrinkable
+							onclick={(e) => {
+								const url = gitHostBranch.url;
+								if (url) openExternalUrl(url);
+								e.preventDefault();
+								e.stopPropagation();
+							}}
+						>
+							{branch.displayName}
+						</Button>
+					{/if}
				{:else}
					<div class="status-tag text-base-11 text-semibold remote">
						<Icon name="remote-branch-small" /> local
```
