### PR TITLE
Make branch listing sort more stable

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -78,7 +78,6 @@ You'll have to re-run this occasionally when our deps change.
 > [!NOTE]  
 > We use [turborepo](https://turbo.build/repo) as our monorepo tooling and by default Vercel collects some [basic telemetry](https://turbo.build/repo/docs/telemetry). If you'd like to disable this, please run `pnpm exec turbo telemetry disable` once in the project's root directory after installing dependencies.
 
-
 ### Run the app
 
 First, run cargo build such that supplementary bins such as `gitbutler-git-askpass` and `gitbutler-git-setsid` are created:

--- a/apps/desktop/src/lib/navigation/Branches.svelte
+++ b/apps/desktop/src/lib/navigation/Branches.svelte
@@ -6,6 +6,7 @@
 	import BranchListingSidebarEntry from '$lib/navigation/BranchListingSidebarEntry.svelte';
 	import PullRequestSidebarEntry from '$lib/navigation/PullRequestSidebarEntry.svelte';
 	import {
+		getEntryName,
 		getEntryUpdatedDate,
 		getEntryWorkspaceStatus,
 		type SidebarEntrySubject
@@ -49,7 +50,12 @@
 		);
 
 		output.sort((a, b) => {
-			return getEntryUpdatedDate(b).getTime() - getEntryUpdatedDate(a).getTime();
+			const timeDifference = getEntryUpdatedDate(b).getTime() - getEntryUpdatedDate(a).getTime();
+			if (timeDifference !== 0) {
+				return timeDifference;
+			}
+
+			return getEntryName(a).localeCompare(getEntryName(b));
 		});
 
 		sidebarEntries = output;

--- a/apps/desktop/src/lib/navigation/types.ts
+++ b/apps/desktop/src/lib/navigation/types.ts
@@ -15,6 +15,10 @@ export function getEntryUpdatedDate(entry: SidebarEntrySubject) {
 	return entry.type === 'branchListing' ? entry.subject.updatedAt : entry.subject.modifiedAt;
 }
 
+export function getEntryName(entry: SidebarEntrySubject) {
+	return entry.type === 'branchListing' ? entry.subject.name : entry.subject.title;
+}
+
 export function getEntryWorkspaceStatus(entry: SidebarEntrySubject) {
 	return entry.type === 'branchListing' ? entry.subject.virtualBranch?.inWorkspace : undefined;
 }


### PR DESCRIPTION
Previously if you had two applied branches, they would end up flickering between different orderings in the sidebar. This is because applied branches have the same timestamp.

I've added a fallback to an alphanumeric sort if the date sort fails.

Unfortunately we don't have the virtual branches order in this context and I thought that this change would be sufficient.

```diff
		);
		output.sort((a, b) => {
-			return getEntryUpdatedDate(b).getTime() - getEntryUpdatedDate(a).getTime();
+			const timeDifference = getEntryUpdatedDate(b).getTime() - getEntryUpdatedDate(a).getTime();
+			if (timeDifference !== 0) {
+				return timeDifference;
+			}
+			return getEntryName(a).localeCompare(getEntryName(b));
		});
		sidebarEntries = output;
```