### PR TITLE
Add conditional author display branch sidebar

### DIFF
--- a/apps/desktop/src/lib/navigation/BranchListingSidebarEntry.svelte
+++ b/apps/desktop/src/lib/navigation/BranchListingSidebarEntry.svelte
@@ -63,8 +63,12 @@
 	let lastCommitDetails: { authorName: string; lastCommitAt?: Date } | undefined = $state();
 
 	$effect(() => {
+		let canceled = false;
+
 		if (ownedByUser) {
 			gitConfigService.get('user.name').then((userName) => {
+				if (canceled) return;
+
 				if (userName) {
 					lastCommitDetails = { authorName: userName };
 				} else {

--- a/apps/desktop/src/lib/navigation/BranchListingSidebarEntry.svelte
+++ b/apps/desktop/src/lib/navigation/BranchListingSidebarEntry.svelte
@@ -60,7 +60,7 @@
 	// If there are zero commits we should not show the author
 	const ownedByUser = $derived($branchListingDetails?.numberOfCommits === 0);
 
-	let lastCommitDetails: { authorName: string; lastCommitAt?: Date } | undefined = $state();
+	let lastCommitDetails = $state<{ authorName: string; lastCommitAt?: Date }>();
 
 	$effect(() => {
 		let canceled = false;
@@ -83,7 +83,7 @@
 		}
 	});
 
-	let avatars: { name: string; gravatarUrl: string }[] = $state([]);
+	let avatars = $state<{ name: string; gravatarUrl: string }[]>([]);
 
 	$effect(() => {
 		setAvatars(ownedByUser, $branchListingDetails);

--- a/packages/ui/src/lib/sidebarEntry/SidebarEntry.svelte
+++ b/packages/ui/src/lib/sidebarEntry/SidebarEntry.svelte
@@ -11,7 +11,7 @@
 		title: string;
 		applied?: boolean;
 		pullRequestDetails?: { title: string };
-		lastCommitDetails?: { authorName: string; lastCommitAt: Date };
+		lastCommitDetails?: { authorName: string; lastCommitAt?: Date };
 		branchDetails?: { commitCount: number; linesAdded: number; linesRemoved: number };
 		remotes?: string[];
 		local?: boolean;
@@ -101,13 +101,21 @@
 	</div>
 
 	<div class="row">
-		{#if lastCommitDetails}
+		{#if lastCommitDetails?.lastCommitAt}
 			<span
 				class="branch-time text-base-11 details truncate"
 				use:tooltip={lastCommitDetails.lastCommitAt.toLocaleString('en-GB')}
 			>
-				<TimeAgo date={lastCommitDetails.lastCommitAt} addSuffix />
-				by {lastCommitDetails.authorName}
+				{#if lastCommitDetails}
+					<TimeAgo date={lastCommitDetails.lastCommitAt} addSuffix />
+					by {lastCommitDetails.authorName}
+				{/if}
+			</span>
+		{:else}
+			<span class="branch-time text-base-11 details truncate">
+				{#if lastCommitDetails}
+					by {lastCommitDetails.authorName}
+				{/if}
 			</span>
 		{/if}
 


### PR DESCRIPTION
When there are zero commits in a branch, we have chosen to make the assumption that the user has created it. There may be some edge cases where a remote ref has zero commits and it was actually created by someone else, but this is going to generally be a good "best effort".


I've changed to computing the lastCommitDetails in an effect block so I can await the results from the gitConfigService. I tried making a little function which converted promises to stores, but couldn't figure out a way to only make the fetch if required required that way, so the effect seemed like the best option.
```diff
@@ -51,6 +56,28 @@
 	function formatBranchURL(project: Project, name: string) {
 		return `/${project.id}/branch/${encodeURIComponent(name)}`;
 	}
+
+	// If there are zero commits we should not show the author
+	const ownedByUser = $derived($branchListingDetails?.numberOfCommits === 0);
+
+	let lastCommitDetails: { authorName: string; lastCommitAt?: Date } | undefined = $state();
+
+	$effect(() => {
+		if (ownedByUser) {
+			gitConfigService.get('user.name').then((userName) => {
+				if (userName) {
+					lastCommitDetails = { authorName: userName };
+				} else {
+					lastCommitDetails = undefined;
+				}
+			});
+		} else {
+			lastCommitDetails = {
+				authorName: branchListing.lastCommiter.name || unknownName,
+				lastCommitAt: branchListing.updatedAt
+			};
+		}
+	});
 </script>
 
 <SidebarEntry
@@ -58,10 +85,7 @@
 	remotes={branchListing.remotes}
 	local={branchListing.hasLocal}
 	applied={branchListing.virtualBranch?.inWorkspace}
-	lastCommitDetails={{
-		authorName: branchListing.lastCommiter.name || 'Unknown',
-		lastCommitAt: branchListing.updatedAt
-	}}
+	{lastCommitDetails}
 	pullRequestDetails={pr && {
 		title: pr.title
 	}}
```

I also added a condition for the authors icons as they would display no icon when there are no commits, and it is good for visual consistency if they also display the user avatar under the "ownedByUser" condition.

Similarly I moved the logic out of the markup and into an effect to handle the async await more neatly.
```diff
+	let avatars: { name: string; gravatarUrl: string }[] = $state([]);
+
+	$effect(() => {
+		setAvatars(ownedByUser, $branchListingDetails);
+	});
+
+	async function setAvatars(ownedByUser: boolean, branchListingDetails?: BranchListingDetails) {
+		if (ownedByUser) {
+			const name = (await gitConfigService.get('user.name')) || unknownName;
+			const email = (await gitConfigService.get('user.email')) || unknownEmail;
+			const gravatarUrl = await gravatarUrlFromEmail(email);
+
+			avatars = [{ name, gravatarUrl }];
+		} else if (branchListingDetails) {
+			avatars = await Promise.all(
+				branchListingDetails.authors.map(async (author) => {
+					return {
+						name: author.name || unknownName,
+						gravatarUrl: await gravatarUrlFromEmail(author.email || unknownEmail)
+					};
+				})
+			);
+		} else {
+			avatars = [];
+		}
+	}
```
```patch
@@ -76,18 +127,14 @@
 >
 	{#snippet authorAvatars()}
 		<AvatarGrouping>
-			{#if $branchListingDetails}
-				{#each $branchListingDetails.authors as author}
-					{#await gravatarUrlFromEmail(author.email || 'example@example.com') then gravatarUrl}
-						<Avatar
-							srcUrl={gravatarUrl}
-							size="medium"
-							tooltipText={author.name || 'unknown'}
-							altText={author.name || 'unknown'}
-						/>
-					{/await}
-				{/each}
-			{/if}
+			{#each avatars as avatar}
+				<Avatar
+					srcUrl={avatar.gravatarUrl}
+					size="medium"
+					tooltipText={avatar.name}
+					altText={avatar.name}
+				/>
+			{/each}
 		</AvatarGrouping>
 	{/snippet}
 </SidebarEntry>
```