### PR TITLE
Add inline unified word diffs

### DIFF
--- a/apps/desktop/src/lib/config/uiFeatureFlags.ts
+++ b/apps/desktop/src/lib/config/uiFeatureFlags.ts
@@ -10,3 +10,8 @@ export function featureBaseBranchSwitching(): Persisted<boolean> {
 	const key = 'featureBaseBranchSwitching';
 	return persisted(false, key);
 }
+
+export function featureInlineUnifiedDiffs(): Persisted<boolean> {
+	const key = 'inlineUnifiedDiffs';
+	return persisted(false, key);
+}

--- a/apps/desktop/src/routes/settings/experimental/+page.svelte
+++ b/apps/desktop/src/routes/settings/experimental/+page.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
 	import SectionCard from '$lib/components/SectionCard.svelte';
-	import { featureBaseBranchSwitching } from '$lib/config/uiFeatureFlags';
+	import {
+		featureBaseBranchSwitching,
+		featureInlineUnifiedDiffs
+	} from '$lib/config/uiFeatureFlags';
 	import ContentWrapper from '$lib/settings/ContentWrapper.svelte';
 	import Toggle from '$lib/shared/Toggle.svelte';
 
 	const baseBranchSwitching = featureBaseBranchSwitching();
+	const inlineUnifiedDiffs = featureInlineUnifiedDiffs();
 </script>
 
 <ContentWrapper title="Experimental features">
@@ -23,6 +27,21 @@
 				id="baseBranchSwitching"
 				checked={$baseBranchSwitching}
 				on:click={() => ($baseBranchSwitching = !$baseBranchSwitching)}
+			/>
+		</svelte:fragment>
+	</SectionCard>
+	<SectionCard labelFor="inlineUnifiedDiffs" orientation="row">
+		<svelte:fragment slot="title">Display word diffs inline</svelte:fragment>
+		<svelte:fragment slot="caption">
+			Rather than showing one line which is the all the removals and another line which is all the
+			additions, with the specific words emboldened. With the feature flag enabled, only one line
+			with both the words added and removed is displayed.
+		</svelte:fragment>
+		<svelte:fragment slot="actions">
+			<Toggle
+				id="inlineUnifiedDiffs"
+				checked={$inlineUnifiedDiffs}
+				on:click={() => ($inlineUnifiedDiffs = !$inlineUnifiedDiffs)}
 			/>
 		</svelte:fragment>
 	</SectionCard>

--- a/packages/ui/src/styles/sharable/syntax-highlighting.css
+++ b/packages/ui/src/styles/sharable/syntax-highlighting.css
@@ -77,7 +77,7 @@
 	}
 
 	.token-strikethrough {
-		text-decoration: strike-through;
+		text-decoration: line-through;
 	}
 
 	.token-strong {


### PR DESCRIPTION
Introducing inline unified word diffs.

This adds in an experimental feature flag which changes the behavior of word diffs. Rather than showing one line which is the all the removals and additions with the specific words emboldened. With the feature flag enabled, only one line with both the words added and removed is displayed.

Enabled:

<img width="480" alt="Screenshot 2024-08-07 at 18 55 29" src="https://github.com/user-attachments/assets/386f78c2-fffd-4711-80fa-4bac20fa3f3c">


Disabled:

<img width="481" alt="Screenshot 2024-08-07 at 18 56 12" src="https://github.com/user-attachments/assets/985e3335-41b6-483b-b7a7-1c0612009654">


This PR introduces a new funciton `computeInlineWordDiff(prevSection: ContentSection, nextSection: ContentSection): Row[]` which is very similar to the old `computeWordDiff` but returns a single section of tokens.

```ts
	function computeInlineWordDiff(prevSection: ContentSection, nextSection: ContentSection): Row[] {
		const numberOfLines = nextSection.lines.length;

		const rows = [];

		// Loop through every line in the section
		// We're only bothered with prev/next sections with equal # of lines changes
		for (let i = 0; i < numberOfLines; i++) {
			const oldLine = prevSection.lines[i] as Line;
			const newLine = nextSection.lines[i] as Line;

			const sectionRow = {
				beforeLineNumber: newLine.beforeLineNumber,
				afterLineNumber: newLine.afterLineNumber,
				tokens: [] as string[],
				type: nextSection.sectionType,
				size: newLine.content.length
			};

			const diff = charDiff(oldLine.content, newLine.content);

			for (const token of diff) {
				const text = token[1];
				const type = token[0];

				if (type === Operation.Equal) {
					sectionRow.tokens.push(...toTokens(text));
				} else if (type === Operation.Insert) {
					sectionRow.tokens.push(`<span data-no-drag class="token-inserted">${text}</span>`);
				} else if (type === Operation.Delete) {
					sectionRow.tokens.push(
						`<span data-no-drag class="token-deleted token-strikethrough">${text}</span>`
					);
				}
			}
			rows.push(sectionRow);
		}

		return rows;
	}
```

We loop over all the sections like before, but look at a feature flag to determine which function to call.

I did simplify the `computeWordDiff` path as it was previously iterating through all previous rows to try and find the previous sections to modify. I've changed it to some simpler indexing operations which should be more performant on larger diffs.

```diff
@@ -186,24 +230,26 @@
 				return acc;
 			}
 
-			const { prevRows, nextRows } = computeWordDiff(prevSection, nextSection);
+			if ($inlineUnifiedDiffs) {
+				const rows = computeInlineWordDiff(prevSection, nextSection);
 
-			// Insert returned row datastructures into the correct place
-			// Find and replace previous rows with tokenized version
-			prevRows.forEach((row) => {
-				const accIndex = acc.findIndex(
-					(accRow) =>
-						accRow.beforeLineNumber === row.beforeLineNumber &&
-						accRow.afterLineNumber === row.afterLineNumber
-				);
-				if (!accIndex) return;
+				acc.splice(-prevSection.lines.length);
 
-				acc[accIndex] = row;
-			});
+				acc.push(...rows);
+				return acc;
+			} else {
+				const { prevRows, nextRows } = computeWordDiff(prevSection, nextSection);
+
+				// Insert returned row datastructures into the correct place
+				// Find and replace previous rows with tokenized version
+				prevRows.forEach((row, previousRowIndex) => {
+					acc[acc.length - (prevRows.length - previousRowIndex)] = row;
+				});
 
-			acc.push(...nextRows);
+				acc.push(...nextRows);
 
-			return acc;
+				return acc;
+			}
```

