### PR TITLE
Use `gix` for branch normalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2333,7 +2333,6 @@ dependencies = [
  "git2",
  "gitbutler-tagged-string",
  "gix",
- "regex",
  "serde",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2553,48 +2553,48 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.64.0"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
- "gix-actor 0.31.5 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-actor 0.31.5 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-command",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-config",
  "gix-credentials",
  "gix-date 0.9.0",
  "gix-diff",
  "gix-dir",
  "gix-discover 0.33.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-filter",
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-ignore 0.11.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-index 0.33.1 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-ignore 0.11.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-index 0.33.1 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-macros",
  "gix-negotiate",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-odb",
  "gix-pack",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-pathspec",
  "gix-prompt",
  "gix-ref 0.45.0",
  "gix-refspec",
  "gix-revision",
- "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-submodule",
- "gix-tempfile 14.0.1 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-traverse 0.39.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-tempfile 14.0.1 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-traverse 0.39.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-url",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-worktree 0.34.1 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-worktree 0.34.1 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "once_cell",
  "smallvec",
  "thiserror",
@@ -2617,11 +2617,11 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.31.5"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
  "gix-date 0.9.0",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "itoa 1.0.11",
  "thiserror",
  "winnow 0.6.16",
@@ -2647,13 +2647,13 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.22.3"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
- "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "kstring",
  "smallvec",
  "thiserror",
@@ -2672,7 +2672,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.11"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "thiserror",
 ]
@@ -2689,7 +2689,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.8"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "thiserror",
 ]
@@ -2697,11 +2697,11 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.3.8"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "shell-words",
 ]
 
@@ -2722,12 +2722,12 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.24.3"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
- "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "memmap2",
  "thiserror",
 ]
@@ -2735,15 +2735,15 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.38.0"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-ref 0.45.0",
- "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "memchr",
  "once_cell",
  "smallvec",
@@ -2755,11 +2755,11 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.14.7"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "libc",
  "thiserror",
 ]
@@ -2767,15 +2767,15 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.24.4"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-config-value",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-prompt",
- "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-url",
  "thiserror",
 ]
@@ -2795,7 +2795,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.9.0"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
  "itoa 1.0.11",
@@ -2806,30 +2806,30 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.44.1"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-dir"
 version = "0.6.0"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
  "gix-discover 0.33.0",
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-ignore 0.11.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-index 0.33.1 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-ignore 0.11.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-index 0.33.1 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-pathspec",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-worktree 0.34.1 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-worktree 0.34.1 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "thiserror",
 ]
 
@@ -2852,15 +2852,15 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.33.0"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
  "dunce",
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-ref 0.45.0",
- "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "thiserror",
 ]
 
@@ -2882,14 +2882,14 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.38.2"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",
  "flate2",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "libc",
  "once_cell",
  "parking_lot 0.12.3",
@@ -2902,19 +2902,19 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.11.3"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
  "encoding_rs",
- "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-command",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-packetline-blocking",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "smallvec",
  "thiserror",
 ]
@@ -2933,11 +2933,11 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.11.2"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "fastrand 2.1.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
 ]
 
 [[package]]
@@ -2955,12 +2955,12 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.16.4"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
 ]
 
 [[package]]
@@ -2976,7 +2976,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.14.2"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "faster-hex",
  "thiserror",
@@ -2996,9 +2996,9 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.5.2"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "hashbrown 0.14.5",
  "parking_lot 0.12.3",
 ]
@@ -3019,12 +3019,12 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.11.3"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
- "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "unicode-bom",
 ]
 
@@ -3059,21 +3059,21 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.33.1"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "filetime",
  "fnv",
- "gix-bitmap 0.2.11 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-traverse 0.39.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-bitmap 0.2.11 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-traverse 0.39.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "hashbrown 0.14.5",
  "itoa 1.0.11",
  "libc",
@@ -3097,17 +3097,17 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "14.0.0"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
- "gix-tempfile 14.0.1 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-tempfile 14.0.1 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-macros"
 version = "0.1.5"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3117,14 +3117,14 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.13.2"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bitflags 2.6.0",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "smallvec",
  "thiserror",
 ]
@@ -3151,15 +3151,15 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.42.3"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
- "gix-actor 0.31.5 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-actor 0.31.5 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-date 0.9.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "itoa 1.0.11",
  "smallvec",
  "thiserror",
@@ -3169,17 +3169,17 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.61.1"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "arc-swap",
  "gix-date 0.9.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-pack",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "parking_lot 0.12.3",
  "tempfile",
  "thiserror",
@@ -3188,15 +3188,15 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.51.1"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "clru",
- "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "memmap2",
  "smallvec",
  "thiserror",
@@ -3206,11 +3206,11 @@ dependencies = [
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.17.4"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "thiserror",
 ]
 
@@ -3230,10 +3230,10 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.9"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "home",
  "once_cell",
  "thiserror",
@@ -3242,21 +3242,21 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.7.6"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-config-value",
- "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-prompt"
 version = "0.8.6"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -3279,10 +3279,10 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.4.12"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "thiserror",
 ]
 
@@ -3311,18 +3311,18 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.45.0"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
- "gix-actor 0.31.5 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-tempfile 14.0.1 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-actor 0.31.5 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-tempfile 14.0.1 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "memmap2",
  "thiserror",
  "winnow 0.6.16",
@@ -3331,12 +3331,12 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.23.1"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-revision",
- "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "smallvec",
  "thiserror",
 ]
@@ -3344,13 +3344,13 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.27.2"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "thiserror",
 ]
 
@@ -3372,13 +3372,13 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.13.2"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "smallvec",
  "thiserror",
 ]
@@ -3398,10 +3398,10 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.10.7"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bitflags 2.6.0",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -3409,11 +3409,11 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.12.0"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
  "gix-config",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
@@ -3438,9 +3438,9 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "14.0.1"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "libc",
  "once_cell",
  "parking_lot 0.12.3",
@@ -3482,7 +3482,7 @@ checksum = "f924267408915fddcd558e3f37295cc7d6a3e50f8bd8b606cee0808c3915157e"
 [[package]]
 name = "gix-trace"
 version = "0.1.9"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 
 [[package]]
 name = "gix-traverse"
@@ -3504,15 +3504,15 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.39.2"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bitflags 2.6.0",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-revwalk 0.13.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "smallvec",
  "thiserror",
 ]
@@ -3520,11 +3520,11 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.27.4"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "home",
  "thiserror",
  "url",
@@ -3543,7 +3543,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.1.12"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
  "fastrand 2.1.0",
@@ -3563,7 +3563,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.8.5"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
  "thiserror",
@@ -3591,19 +3591,19 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.34.1"
-source = "git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a#7dff44754e0fdc369f92221468fb953bad9be60a"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 dependencies = [
  "bstr",
- "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-ignore 0.11.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-index 0.33.1 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
- "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=7dff44754e0fdc369f92221468fb953bad9be60a)",
+ "gix-attributes 0.22.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-ignore 0.11.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-index 0.33.1 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ resolver = "2"
 [workspace.dependencies]
 bstr = "1.10.0"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
-gix = { git = "https://github.com/Byron/gitoxide", rev = "7dff44754e0fdc369f92221468fb953bad9be60a", default-features = false, features = [] }
+gix = { git = "https://github.com/Byron/gitoxide", rev = "d51f330e9d364c6f7b068116b59bf5c0160e47af", default-features = false, features = [] }
 git2 = { version = "0.18.3", features = [
     "vendored-openssl",
     "vendored-libgit2",

--- a/crates/gitbutler-branch-actions/benches/branches.rs
+++ b/crates/gitbutler-branch-actions/benches/branches.rs
@@ -45,7 +45,7 @@ pub fn benchmark_list_branches(c: &mut Criterion) {
                 b.iter(|| list_branches(black_box(&ctx), None, None))
             })
             .bench_function("name-filter rejecting all", |b| {
-                b.iter(|| list_branches(black_box(&ctx), None, Some(vec!["not available".into()])))
+                b.iter(|| list_branches(black_box(&ctx), None, Some(vec!["not-available".into()])))
             });
     }
 }

--- a/crates/gitbutler-reference/Cargo.toml
+++ b/crates/gitbutler-reference/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
 
 [dependencies]
-regex = "1.10"
 anyhow.workspace = true
 git2.workspace = true
 gix.workspace = true

--- a/crates/gitbutler-reference/src/lib.rs
+++ b/crates/gitbutler-reference/src/lib.rs
@@ -3,27 +3,45 @@ mod refname;
 use anyhow::bail;
 use gitbutler_tagged_string::TaggedString;
 pub use refname::{LocalRefname, Refname, RemoteRefname, VirtualRefname};
-use regex::Regex;
 
+// TODO(ST): return `BString`, probably take BString, as branch names don't have to be valid UTF8
 pub fn normalize_branch_name(name: &str) -> anyhow::Result<String> {
-    // Remove specific symbols
-    let exclude_pattern = Regex::new(r"[|\+^~<>\\:*]").unwrap();
-    let mut result = exclude_pattern.replace_all(name, "-").to_string();
-
-    // Replace spaces with hyphens
-    let space_pattern = Regex::new(r"\s+").unwrap();
-    result = space_pattern.replace_all(&result, "-").to_string();
-
-    // Remove leading and trailing hyphens and slashes and dots
-    let trim_pattern = Regex::new(r"^[-/\.]+|[-/\.]+$").unwrap();
-    result = trim_pattern.replace_all(&result, "").to_string();
-
-    let refname = format!("refs/gitbutler/{result}");
-    if gix::validate::reference::name(refname.as_str().into()).is_err() {
-        bail!("Could not turn {result:?} into a valid reference name")
+    let mut sanitized = gix::validate::reference::name_partial_or_sanitize(name.into());
+    fn is_forbidden_in_trailer_or_leader(b: u8) -> bool {
+        b == b'-' || b == b'.' || b == b'/'
+    }
+    while let Some(last) = sanitized.last() {
+        if is_forbidden_in_trailer_or_leader(*last) {
+            sanitized.pop();
+        } else {
+            break;
+        }
+    }
+    while let Some(first) = sanitized.first() {
+        if is_forbidden_in_trailer_or_leader(*first) {
+            sanitized.remove(0);
+        } else {
+            break;
+        }
     }
 
-    Ok(result)
+    let mut previous_is_hyphen = false;
+    sanitized.retain(|b| {
+        if *b == b'-' {
+            if previous_is_hyphen {
+                return false;
+            }
+            previous_is_hyphen = true;
+        } else {
+            previous_is_hyphen = false;
+        }
+        true
+    });
+
+    if sanitized.is_empty() {
+        bail!("Could not turn {name:?} into a valid reference name")
+    }
+    Ok(sanitized.to_string())
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
This promises to never create invalidate branch names, while being similar to what Git already does when adding worktrees,
it implements the same rules.

The current implementation uses Regex and creates them on the fly, which takes a lot of time, thus the new implementation promises to shave-off 5% off the runtime in some benchmarks.

### Tasks

* [x] Use latest `main` of `gix`
* [x] Use sanitization when normalizing branches
* [x] check benchmarks to assure it didn't get slower, but hopefully to show it's faster.

### Performance

This image compares `master` with this branch.

<img width="1042" alt="Screenshot 2024-08-09 at 21 49 49" src="https://github.com/user-attachments/assets/53505d3d-735e-4e3b-aece-85f80db6693e">

The reason for the few regressions I simply don't understand - I wasn't holding my breath while running the benchmark, maybe I was using more resources than I thought I did.