### PR TITLE
Lazy load sidebar entries and conditionally show PRs option

### DIFF
--- a/apps/desktop/src/lib/branches/branchListing.ts
+++ b/apps/desktop/src/lib/branches/branchListing.ts
@@ -2,53 +2,34 @@
 import 'reflect-metadata';
 
 import { invoke } from '$lib/backend/ipc';
+import {
+	getEntryName,
+	getEntryUpdatedDate,
+	getEntryWorkspaceStatus,
+	type SidebarEntrySubject
+} from '$lib/navigation/types';
 import { persisted } from '$lib/persisted/persisted';
+import { debouncedDerive } from '$lib/utils/debounce';
 import { Transform, Type, plainToInstance } from 'class-transformer';
-import { get, writable, type Readable, type Writable } from 'svelte/store';
+import Fuse from 'fuse.js';
+import { derived, readable, writable, type Readable, type Writable } from 'svelte/store';
+import type { GitHostListingService } from '$lib/gitHost/interface/gitHostListingService';
+import type { PullRequest } from '$lib/gitHost/interface/types';
 
-const FILTER_STORAGE_KEY = 'branchListingService-selectedFilter';
 export class BranchListingService {
-	private selectedFilterPresisted = persisted<BranchListingFilter>(
-		{ local: undefined, applied: undefined },
-		FILTER_STORAGE_KEY
-	);
-
 	private branchListingsWritable = writable<BranchListing[]>([]);
 
 	constructor(private projectId: string) {
-		// For now we're not using the selected filter
-		this.selectedFilter = {};
-		this.refresh();
-	}
-
-	async refresh() {
-		const listedValues = (await this.list(get(this.selectedFilterPresisted))) || [];
-		this.branchListingsWritable.set(listedValues);
-
-		const listedBranchNames = new Set(listedValues.map((entry) => entry.name));
-
-		// Remove branch listings details stores that no longer have cooresponding branches
-		for (const key of this.branchListingDetails.keys()) {
-			if (!listedBranchNames.has(key)) {
-				this.branchListingDetails.delete(key);
-			}
-		}
-
-		const branchNames = Array.from(this.branchListingDetails.keys());
-		this.updateBranchListingDetails(branchNames);
-	}
-
-	get selectedFilter(): Readable<BranchListingFilter> {
-		return this.selectedFilterPresisted;
-	}
-
-	set selectedFilter(value: BranchListingFilter) {
-		this.selectedFilterPresisted.set(value);
 		this.refresh();
 	}
 
 	get branchListings(): Readable<BranchListing[]> {
 		return this.branchListingsWritable;
+	}
+
+	async refresh() {
+		const listedValues = (await this.list({})) || [];
+		this.branchListingsWritable.set(listedValues);
 	}
 
 	private async list(filter: BranchListingFilter | undefined = undefined) {
@@ -70,9 +51,25 @@ export class BranchListingService {
 		const store = writable<BranchListingDetails | undefined>();
 		this.branchListingDetails.set(branchName, store);
 
-		this.updateBranchListingDetails([branchName]);
+		this.updateBranchListing(branchName);
 
 		return store;
+	}
+
+	private accumulatedBranchListings: string[] = [];
+	private updateBranchListingTimeout: ReturnType<typeof setTimeout> | undefined;
+	// Accumulates multiple update calls
+	private async updateBranchListing(branchName: string) {
+		this.accumulatedBranchListings.push(branchName);
+
+		clearTimeout(this.updateBranchListingTimeout);
+		this.updateBranchListingTimeout = setTimeout(
+			(() => {
+				this.updateBranchListingDetails(this.accumulatedBranchListings);
+				this.accumulatedBranchListings = [];
+			}).bind(this),
+			50
+		);
 	}
 
 	private async updateBranchListingDetails(branchNames: string[]) {
@@ -90,6 +87,179 @@ export class BranchListingService {
 
 			store.set(branchListingDetails);
 		});
+	}
+}
+
+const oneDay = 1000 * 60 * 60 * 24;
+export type GroupedSidebarEntries = Record<
+	'applied' | 'today' | 'yesterday' | 'lastWeek' | 'older',
+	SidebarEntrySubject[]
+>;
+
+export class CombinedBranchListingService {
+	private pullRequests: Readable<PullRequest[]>;
+	selectedOption = persisted<'all' | 'pullRequest' | 'local'>('all', 'branches-selectedOption');
+
+	combinedSidebarEntries: Readable<SidebarEntrySubject[]>;
+	groupedSidebarEntries: Readable<GroupedSidebarEntries>;
+	pullRequestsListed: Readable<boolean>;
+
+	constructor(
+		branchListingService: BranchListingService,
+		gitHostListingService: Readable<GitHostListingService | undefined>
+	) {
+		this.pullRequests = readable([] as PullRequest[], (set) => {
+			const unsubscribeListingService = gitHostListingService.subscribe((gitHostListingService) => {
+				if (!gitHostListingService) return;
+
+				const unsubscribePullRequests = gitHostListingService.prs.subscribe((prs) => {
+					set(prs);
+				});
+
+				return unsubscribePullRequests;
+			});
+
+			return unsubscribeListingService;
+		});
+
+		this.pullRequestsListed = derived(
+			gitHostListingService,
+			(gitHostListingService) => {
+				return !!gitHostListingService;
+			},
+			false
+		);
+
+		const branchListingsByName = derived(branchListingService.branchListings, (branchListings) => {
+			const set = new Set<string>(branchListings.map((branchListing) => branchListing.name));
+			return set;
+		});
+
+		this.combinedSidebarEntries = debouncedDerive(
+			[
+				branchListingsByName,
+				this.pullRequests,
+				branchListingService.branchListings,
+				this.selectedOption
+			],
+			([branchListingsByName, pullRequests, branchListings, selectedOption]) => {
+				const pullRequestSubjects: SidebarEntrySubject[] = pullRequests
+					.filter((pullRequests) => !branchListingsByName.has(pullRequests.sourceBranch))
+					.map((pullRequests) => ({ type: 'pullRequest', subject: pullRequests }));
+
+				const branchListingSubjects: SidebarEntrySubject[] = branchListings.map(
+					(branchListing) => ({
+						type: 'branchListing',
+						subject: branchListing
+					})
+				);
+
+				const output = [...pullRequestSubjects, ...branchListingSubjects];
+
+				output.sort((a, b) => {
+					const timeDifference =
+						getEntryUpdatedDate(b).getTime() - getEntryUpdatedDate(a).getTime();
+					if (timeDifference !== 0) {
+						return timeDifference;
+					}
+
+					return getEntryName(a).localeCompare(getEntryName(b));
+				});
+
+				const filtered = this.filterSidebarEntries(pullRequests, selectedOption, output);
+
+				return filtered;
+			},
+			[] as SidebarEntrySubject[],
+			50
+		);
+
+		this.groupedSidebarEntries = derived(this.combinedSidebarEntries, (combinedSidebarEntries) => {
+			const groupings = this.groupBranches(combinedSidebarEntries);
+			return groupings;
+		});
+	}
+
+	search(searchTerm: Readable<string | undefined>) {
+		return derived(
+			[searchTerm, this.combinedSidebarEntries],
+			([searchTerm, combinedSidebarEntries]) => {
+				if (!searchTerm) return [];
+
+				const fuse = new Fuse(combinedSidebarEntries, {
+					keys: ['subject.name', 'subject.title']
+				});
+
+				return fuse
+					.search(searchTerm)
+					.slice(0, 100)
+					.map((searchResult) => searchResult.item);
+			},
+			[] as SidebarEntrySubject[]
+		);
+	}
+
+	private groupBranches(branches: SidebarEntrySubject[]) {
+		const grouped: GroupedSidebarEntries = {
+			applied: [],
+			today: [],
+			yesterday: [],
+			lastWeek: [],
+			older: []
+		};
+
+		const now = Date.now();
+
+		branches.forEach((b) => {
+			if (!getEntryUpdatedDate(b)) {
+				grouped.older.push(b);
+				return;
+			}
+
+			const msSinceLastCommit = now - getEntryUpdatedDate(b).getTime();
+
+			if (getEntryWorkspaceStatus(b)) {
+				grouped.applied.push(b);
+			} else if (msSinceLastCommit < oneDay) {
+				grouped.today.push(b);
+			} else if (msSinceLastCommit < 2 * oneDay) {
+				grouped.yesterday.push(b);
+			} else if (msSinceLastCommit < 7 * oneDay) {
+				grouped.lastWeek.push(b);
+			} else {
+				grouped.older.push(b);
+			}
+		});
+
+		return grouped;
+	}
+
+	private filterSidebarEntries(
+		pullRequests: PullRequest[],
+		selectedOption: string,
+		sidebarEntries: SidebarEntrySubject[]
+	): SidebarEntrySubject[] {
+		switch (selectedOption) {
+			case 'pullRequest': {
+				return sidebarEntries.filter(
+					(sidebarEntry) =>
+						sidebarEntry.type === 'pullRequest' ||
+						pullRequests.some(
+							(pullRequest) => pullRequest.sourceBranch === sidebarEntry.subject.name
+						)
+				);
+			}
+			case 'local': {
+				return sidebarEntries.filter(
+					(sidebarEntry) =>
+						sidebarEntry.type === 'branchListing' &&
+						(sidebarEntry.subject.hasLocal || sidebarEntry.subject.virtualBranch)
+				);
+			}
+			default: {
+				return sidebarEntries;
+			}
+		}
 	}
 }
 

--- a/apps/desktop/src/lib/navigation/ChunkyList.svelte
+++ b/apps/desktop/src/lib/navigation/ChunkyList.svelte
@@ -1,0 +1,57 @@
+<script lang="ts" context="module">
+	// If this is not present, eslint complains that T is not defined below
+	type T = unknown;
+</script>
+
+<script lang="ts" generics="T">
+	/**
+	 * Lazily renders a list of many many items. This is intended to be used
+	 * in contexts where simply rendering the quanity of items causes the DOM
+	 * to have poor performance, rather than computing the initial list being
+	 * the blocker.
+	 */
+
+	import LazyloadContainer from '$lib/shared/LazyloadContainer.svelte';
+	import { chunk } from '$lib/utils/chunk';
+	import { type Snippet } from 'svelte';
+
+	interface Props {
+		items: T[];
+		item: Snippet<[T]>;
+		chunkSize?: number;
+	}
+
+	const { items, item, chunkSize = 100 }: Props = $props();
+
+	let chunkedItems: T[][] = [];
+	let displayedItems = $state<T[]>([]);
+	let currentDisplayIndex = $state(0);
+
+	// Make sure we display when the file list is reset
+	$effect(() => {
+		chunkedItems = chunk(items, chunkSize);
+		displayedItems = chunkedItems[0] || [];
+		currentDisplayIndex = 0;
+	});
+
+	function loadMore() {
+		if (currentDisplayIndex + 1 >= chunkedItems.length) return;
+
+		currentDisplayIndex += 1;
+		const currentChunkedFiles = chunkedItems[currentDisplayIndex] ?? [];
+		displayedItems = [...displayedItems, ...currentChunkedFiles];
+	}
+</script>
+
+{#if items.length > 0}
+	<LazyloadContainer
+		minTriggerCount={Math.min(items.length, chunkSize - 5)}
+		ontrigger={() => {
+			loadMore();
+		}}
+	>
+		{#each displayedItems as displayedItem}
+			{@render item(displayedItem)}
+		{/each}
+	</LazyloadContainer>
+{/if}

--- a/apps/desktop/src/lib/utils/chunk.ts
+++ b/apps/desktop/src/lib/utils/chunk.ts
@@ -1,0 +1,5 @@
+export function chunk<T>(arr: T[], size: number) {
+	return Array.from({ length: Math.ceil(arr.length / size) }, (_v, i) =>
+		arr.slice(i * size, i * size + size)
+	);
+}

--- a/apps/desktop/src/lib/utils/debounce.ts
+++ b/apps/desktop/src/lib/utils/debounce.ts
@@ -1,7 +1,55 @@
-export function debounce<T extends (...args: unknown[]) => void>(fn: T, delay: number): T {
+import { derived, type Readable } from 'svelte/store';
+
+type Timeout = ReturnType<typeof setTimeout>;
+
+export function debounce<Args extends unknown[], Return, Fn extends (...args: Args) => Return>(
+	fn: Fn,
+	delay: number
+): (...args: Args) => void {
 	let timeout: ReturnType<typeof setTimeout> | undefined;
-	return ((...args: unknown[]) => {
+	return (...args: Args) => {
 		clearTimeout(timeout);
 		timeout = setTimeout(() => fn(...args), delay);
-	}) as T;
+	};
+}
+
+// Borrowed from svelte
+type Stores =
+	| Readable<unknown>
+	| [Readable<unknown>, ...Array<Readable<unknown>>]
+	| Array<Readable<unknown>>;
+
+type StoresValues<T> =
+	T extends Readable<infer U> ? U : { [K in keyof T]: T[K] extends Readable<infer U> ? U : never };
+
+/**
+ * A function similar to svelte's `derived` but debounces the calls.
+ *
+ * It does not support a set argument or returning cleanup functions in the
+ * subject function. as it is already complex enough as is.
+ */
+export function debouncedDerive<S extends Stores, Return, DefaultValue>(
+	targets: S,
+	subject: (args: StoresValues<S>) => Return,
+	defaultValue: DefaultValue,
+	delay: number
+): Readable<Return | DefaultValue> {
+	let timeout: Timeout | undefined;
+
+	const store = derived(
+		targets,
+		(derivedArgs, set) => {
+			clearTimeout(timeout);
+			timeout = setTimeout(() => {
+				set(subject(derivedArgs));
+			}, delay);
+
+			return () => clearTimeout(timeout);
+		},
+		defaultValue as Return | DefaultValue
+	);
+
+	return {
+		subscribe: store.subscribe
+	};
 }

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -4,7 +4,7 @@
 	import ProjectSettingsMenuAction from '$lib/barmenuActions/ProjectSettingsMenuAction.svelte';
 	import { BaseBranch, NoDefaultTarget } from '$lib/baseBranch/baseBranch';
 	import { BaseBranchService } from '$lib/baseBranch/baseBranchService';
-	import { BranchListingService } from '$lib/branches/branchListing';
+	import { BranchListingService, CombinedBranchListingService } from '$lib/branches/branchListing';
 	import { BranchDragActionsFactory } from '$lib/branches/dragActions';
 	import { getNameNormalizationServiceContext } from '$lib/branches/nameNormalizationService';
 	import { BranchService, createBranchServiceStore } from '$lib/branches/service';
@@ -84,6 +84,15 @@
 	const listServiceStore = createGitHostListingServiceStore(undefined);
 	const gitHostStore = createGitHostStore(undefined);
 	const branchServiceStore = createBranchServiceStore(undefined);
+
+	$effect.pre(() => {
+		const combinedBranchListingService = new CombinedBranchListingService(
+			data.branchListingService,
+			listServiceStore
+		);
+
+		setContext(CombinedBranchListingService, combinedBranchListingService);
+	});
 
 	// Refresh base branch if git fetch event is detected.
 	const head = $derived(headService.head);


### PR DESCRIPTION
## Background

The latest version of the sidebar was causing some performance issues for users.

In the implementation of this PR, part of the aim was to make some of the logic more straight forwards and benchmark-able, and ensure that there were no major slow-downs in the TS code.

Now, even when running with 19k branches, the TS portion runs in about 10ms.

The most impactful gain in application performance actually came from lazily rendering the sidebar entries. Not because there was any expensive compute behind them, but because the browser's templating engine simply couldn't handle it.

---

## Structural Changes

It used to be that there was one `BranchListingService` which was consumed by the `Branches` component. There was a considerable amount of logic in the `Branches` component, and as part of ensuring there was no performance issue with that code (or accidental reactivity loops) I moved it all into a new service called the `CombinedBranchListingService` which contains all the logic for listing both the PRs from forks and BranchListings.

---

## Code of note
### Accumulating details requests

Previously we were almost exclusively requesting details one by one. I've now implemented a method of accumulating many requests into one which should make the job easier on the rust side when scrolling through the list or performing searches.

```diff
 		const store = writable<BranchListingDetails | undefined>();
 		this.branchListingDetails.set(branchName, store);
 
-		this.updateBranchListingDetails([branchName]);
+		this.updateBranchListing(branchName);
 
 		return store;
 	}
 
+	private accumulatedBranchListings: string[] = [];
+	private updateBranchListingTimeout: ReturnType<typeof setTimeout> | undefined;
+	// Accumulates multiple update calls
+	private async updateBranchListing(branchName: string) {
+		this.accumulatedBranchListings.push(branchName);
+
+		clearTimeout(this.updateBranchListingTimeout);
+		this.updateBranchListingTimeout = setTimeout(
+			(() => {
+				this.updateBranchListingDetails(this.accumulatedBranchListings);
+				this.accumulatedBranchListings = [];
+			}).bind(this),
+			50
+		);
+	}
+
 	private async updateBranchListingDetails(branchNames: string[]) {
 		const plainDetails = await invoke<unknown[]>('get_branch_listing_details', {
 			projectId: this.projectId,
```

### CombinedBranchListingService

One potentially odd looking part is where I'm calculating `this.pullRequests`. Nested `Readable`s are just hard to deal with. I looked at having some form of `derived` with a subscription inside of it, but in the end I thought the double subscription looked best. If we need to do this more, we could look into defining a `flatten` function.

Near the end I use this `debouncedDerive` function which is the same as a derived but has debouncing. I chose to use this because in some cases it seems like the list was getting updated twice in a row. Given that the rendering is in some ways the most expensive part of this process, I thought it made sense to just debounce it to prevent frivolous re-rendering.
```ts
export class CombinedBranchListingService {
	private pullRequests: Readable<PullRequest[]>;
	selectedOption = persisted<'all' | 'pullRequest' | 'local'>('all', 'branches-selectedOption');

	combinedSidebarEntries: Readable<SidebarEntrySubject[]>;
	groupedSidebarEntries: Readable<GroupedSidebarEntries>;
	pullRequestsListed: Readable<boolean>;

	constructor(
		branchListingService: BranchListingService,
		gitHostListingService: Readable<GitHostListingService | undefined>
	) {
		this.pullRequests = readable([] as PullRequest[], (set) => {
			const unsubscribeListingService = gitHostListingService.subscribe((gitHostListingService) => {
				if (!gitHostListingService) return;

				const unsubscribePullRequests = gitHostListingService.prs.subscribe((prs) => {
					set(prs);
				});

				return unsubscribePullRequests;
			});

			return unsubscribeListingService;
		});

		this.pullRequestsListed = derived(
			gitHostListingService,
			(gitHostListingService) => {
				return !!gitHostListingService;
			},
			false
		);

		const branchListingsByName = derived(branchListingService.branchListings, (branchListings) => {
			const set = new Set<string>(branchListings.map((branchListing) => branchListing.name));
			return set;
		});

		this.combinedSidebarEntries = debouncedDerive(
			[
				branchListingsByName,
				this.pullRequests,
				branchListingService.branchListings,
				this.selectedOption
			],
			([branchListingsByName, pullRequests, branchListings, selectedOption]) => {
				const pullRequestSubjects: SidebarEntrySubject[] = pullRequests
					.filter((pullRequests) => !branchListingsByName.has(pullRequests.sourceBranch))
					.map((pullRequests) => ({ type: 'pullRequest', subject: pullRequests }));

				const branchListingSubjects: SidebarEntrySubject[] = branchListings.map(
					(branchListing) => ({
						type: 'branchListing',
						subject: branchListing
					})
				);

				const output = [...pullRequestSubjects, ...branchListingSubjects];

				output.sort((a, b) => {
					const timeDifference =
						getEntryUpdatedDate(b).getTime() - getEntryUpdatedDate(a).getTime();
					if (timeDifference !== 0) {
						return timeDifference;
					}

					return getEntryName(a).localeCompare(getEntryName(b));
				});

				const filtered = this.filterSidebarEntries(pullRequests, selectedOption, output);

				return filtered;
			},
			[] as SidebarEntrySubject[],
			200
		);

		this.groupedSidebarEntries = derived(this.combinedSidebarEntries, (combinedSidebarEntries) => {
			const groupings = this.groupBranches(combinedSidebarEntries);
			return groupings;
		});
	}

	search(searchTerm: Readable<string | undefined>) {
		return derived(
			[searchTerm, this.combinedSidebarEntries],
			([searchTerm, combinedSidebarEntries]) => {
				if (!searchTerm) return [];

				const fuse = new Fuse(combinedSidebarEntries, {
					keys: ['subject.name', 'subject.title']
				});

				return fuse
					.search(searchTerm)
					.slice(0, 100)
					.map((searchResult) => searchResult.item);
			},
			[] as SidebarEntrySubject[]
		);
	}

	private groupBranches(branches: SidebarEntrySubject[]) {
		const grouped: GroupedSidebarEntries = {
			applied: [],
			today: [],
			yesterday: [],
			lastWeek: [],
			older: []
		};

		const now = Date.now();

		branches.forEach((b) => {
			if (!getEntryUpdatedDate(b)) {
				grouped.older.push(b);
				return;
			}

			const msSinceLastCommit = now - getEntryUpdatedDate(b).getTime();

			if (getEntryWorkspaceStatus(b)) {
				grouped.applied.push(b);
			} else if (msSinceLastCommit < oneDay) {
				grouped.today.push(b);
			} else if (msSinceLastCommit < 2 * oneDay) {
				grouped.yesterday.push(b);
			} else if (msSinceLastCommit < 7 * oneDay) {
				grouped.lastWeek.push(b);
			} else {
				grouped.older.push(b);
			}
		});

		return grouped;
	}

	private filterSidebarEntries(
		pullRequests: PullRequest[],
		selectedOption: string,
		sidebarEntries: SidebarEntrySubject[]
	): SidebarEntrySubject[] {
		switch (selectedOption) {
			case 'pullRequest': {
				return sidebarEntries.filter(
					(sidebarEntry) =>
						sidebarEntry.type === 'pullRequest' ||
						pullRequests.some(
							(pullRequest) => pullRequest.sourceBranch === sidebarEntry.subject.name
						)
				);
			}
			case 'local': {
				return sidebarEntries.filter(
					(sidebarEntry) =>
						sidebarEntry.type === 'branchListing' &&
						(sidebarEntry.subject.hasLocal || sidebarEntry.subject.virtualBranch)
				);
			}
			default: {
				return sidebarEntries;
			}
		}
	}
}
```

### LazyLoadContainer

I ended up re-writing the LazyLoadContainer as it wouldn't work if it was initially rendered with no children, and then the children were added after. I re-wrote it to mount the mutationObserver and monitor whether the quanity of children changes.

```diff
 
 	let lazyContainerEl: HTMLDivElement;
 
-	onMount(() => {
-		const containerChildren = lazyContainerEl.children;
-
-		if (containerChildren.length < minTriggerCount) return;
-
-		const iObserver = new IntersectionObserver((entries) => {
-			const lastChild = containerChildren[containerChildren.length - 1] as HTMLElement;
-			if (entries[0]?.target === lastChild && entries[0]?.isIntersecting) {
-				ontrigger(lastChild);
+	const mutuationObserver = new MutationObserver(attachIntersectionObserver);
+	$effect(() => {
+		if (lazyContainerEl) {
+			mutuationObserver.disconnect();
+			mutuationObserver.observe(lazyContainerEl, { childList: true });
+		}
+	});
+	const intersectionObserver = new IntersectionObserver((entries) => {
+		entries.forEach((entry) => {
+			if (entry.isIntersecting) {
+				ontrigger(entry.target);
+				intersectionObserver.unobserve(entry.target);
 			}
 		});
+	});
 
-		const mObserver = new MutationObserver(() => {
-			const lastChild = containerChildren[containerChildren.length - 1];
-			if (lastChild) {
-				iObserver.observe(lastChild);
-			}
-		});
+	function attachIntersectionObserver() {
+		// unattach all intersection observers
+		intersectionObserver.disconnect();
 
-		iObserver.observe(containerChildren[containerChildren.length - 1] as HTMLElement);
-		mObserver.observe(lazyContainerEl, { childList: true });
+		const containerChildren = lazyContainerEl.children;
+		if (containerChildren.length < minTriggerCount) return;
 
+		intersectionObserver.observe(containerChildren[containerChildren.length - 1] as HTMLElement);
+	}
+
+	onMount(() => {
 		return () => {
-			iObserver.disconnect();
-			mObserver.disconnect();
+			intersectionObserver.disconnect();
+			mutuationObserver.disconnect();
 		};
 	});
```