### PR TITLE
Have selected filter be specific to a project

### DIFF
--- a/apps/desktop/src/lib/branches/branchListing.ts
+++ b/apps/desktop/src/lib/branches/branchListing.ts
@@ -8,7 +8,7 @@ import {
 	getEntryWorkspaceStatus,
 	type SidebarEntrySubject
 } from '$lib/navigation/types';
-import { persisted } from '$lib/persisted/persisted';
+import { persisted, type Persisted } from '$lib/persisted/persisted';
 import { debouncedDerive } from '$lib/utils/debounce';
 import { Transform, Type, plainToInstance } from 'class-transformer';
 import Fuse from 'fuse.js';
@@ -98,7 +98,7 @@ export type GroupedSidebarEntries = Record<
 
 export class CombinedBranchListingService {
 	private pullRequests: Readable<PullRequest[]>;
-	selectedOption = persisted<'all' | 'pullRequest' | 'local'>('all', 'branches-selectedOption');
+	selectedOption: Persisted<'all' | 'pullRequest' | 'local'>;
 
 	combinedSidebarEntries: Readable<SidebarEntrySubject[]>;
 	groupedSidebarEntries: Readable<GroupedSidebarEntries>;
@@ -106,8 +106,13 @@ export class CombinedBranchListingService {
 
 	constructor(
 		branchListingService: BranchListingService,
-		gitHostListingService: Readable<GitHostListingService | undefined>
+		gitHostListingService: Readable<GitHostListingService | undefined>,
+		projectId: string
 	) {
+		this.selectedOption = persisted<'all' | 'pullRequest' | 'local'>(
+			'all',
+			`branches-selectedOption-${projectId}`
+		);
 		this.pullRequests = readable([] as PullRequest[], (set) => {
 			const unsubscribeListingService = gitHostListingService.subscribe((gitHostListingService) => {
 				if (!gitHostListingService) return;

--- a/apps/desktop/src/lib/navigation/Branches.svelte
+++ b/apps/desktop/src/lib/navigation/Branches.svelte
@@ -71,9 +71,11 @@
 		}
 	});
 
-	const selectedFilterIndex = $derived(
-		Object.keys(filterOptions).findIndex((item) => $selectedOption === item)
-	);
+	const selectedFilterIndex = $derived.by(() => {
+		const index = Object.keys(filterOptions).findIndex((item) => $selectedOption === item);
+		if (index === -1) return 0;
+		return index;
+	});
 
 	function setFilter(id: string) {
 		if (Object.keys(filterOptions).includes(id)) {

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -88,7 +88,8 @@
 	$effect.pre(() => {
 		const combinedBranchListingService = new CombinedBranchListingService(
 			data.branchListingService,
-			listServiceStore
+			listServiceStore,
+			projectId
 		);
 
 		setContext(CombinedBranchListingService, combinedBranchListingService);


### PR DESCRIPTION
Previously it was scoped globally but that doesn't make sense as some projects have the PR tab and others don't.

I've also made it correctly default to index 0 if the stored value in LS is not found.