### PR TITLE
better handling of missing projects

### DIFF
--- a/crates/gitbutler-error/src/error.rs
+++ b/crates/gitbutler-error/src/error.rs
@@ -133,6 +133,7 @@ pub enum Code {
     CommitSigningFailed,
     CommitHookFailed,
     CommitMergeConflictFailure,
+    ProjectMissing,
     AuthorMissing,
 }
 
@@ -147,6 +148,7 @@ impl std::fmt::Display for Code {
             Code::CommitHookFailed => "errors.commit.hook_failed",
             Code::CommitMergeConflictFailure => "errors.commit.merge_conflict_failure",
             Code::AuthorMissing => "errors.git.author_missing",
+            Code::ProjectMissing => "errors.projects.missing",
         };
         f.write_str(code)
     }

--- a/crates/gitbutler-tauri/src/projects.rs
+++ b/crates/gitbutler-tauri/src/projects.rs
@@ -34,7 +34,7 @@ pub mod commands {
         projects: State<'_, Controller>,
         id: ProjectId,
     ) -> Result<projects::Project, Error> {
-        Ok(projects.get(id)?)
+        Ok(projects.get_validated(id)?)
     }
 
     #[tauri::command(async)]
@@ -66,7 +66,7 @@ pub mod commands {
         window: Window,
         id: ProjectId,
     ) -> Result<(), Error> {
-        let project = projects.get(id).context("project not found")?;
+        let project = projects.get_validated(id).context("project not found")?;
         Ok(window_state.set_project_to_window(window.label(), &project)?)
     }
 


### PR DESCRIPTION
Fix #4688

### Tasks

* [x] a clearer error with marker for the frontend


### Notes for the reviewer

* The patch below shows how the UI can detect what kind of error occurred and respond to it accordingly. It's unfit in that stage unfortunately, and I propose that a follow-up does the UI work to complete the flow. As it stands, it's impossible to remove a project from the list once the folder is missing (or it was moved to another place).

```patch
commit cbbaf7ff986037ea63f9eeb11f645addeff33ddb
Author: Sebastian Thiel <sebastian.thiel@icloud.com>
Date:   Wed Aug 14 15:10:03 2024 +0200

    The UI deletes missing projects automatically
    
    But for now, it doesn't communicate anything else.

diff --git a/apps/desktop/src/lib/backend/ipc.ts b/apps/desktop/src/lib/backend/ipc.ts
index 18deb233d..f25948038 100644
--- a/apps/desktop/src/lib/backend/ipc.ts
+++ b/apps/desktop/src/lib/backend/ipc.ts
@@ -7,7 +7,8 @@ export enum Code {
 	Validation = 'errors.validation',
 	ProjectsGitAuth = 'errors.projects.git.auth',
 	DefaultTargetNotFound = 'errors.projects.default_target.not_found',
-	CommitSigningFailed = 'errors.commit.signing_failed'
+	CommitSigningFailed = 'errors.commit.signing_failed',
+	ProjectMissing = 'errors.projects.missing'
 }
 
 export class UserError extends Error {
diff --git a/apps/desktop/src/routes/[projectId]/+layout.ts b/apps/desktop/src/routes/[projectId]/+layout.ts
index f3929b0b9..93285148e 100644
--- a/apps/desktop/src/routes/[projectId]/+layout.ts
+++ b/apps/desktop/src/routes/[projectId]/+layout.ts
@@ -1,4 +1,4 @@
-import { invoke } from '$lib/backend/ipc';
+import {Code, invoke, UserError} from '$lib/backend/ipc';
 import { BaseBranchService } from '$lib/baseBranch/baseBranchService';
 import { BranchListingService } from '$lib/branches/branchListing';
 import { BranchDragActionsFactory } from '$lib/branches/dragActions.js';
@@ -38,6 +38,11 @@ export const load: LayoutLoad = async ({ params, parent }) => {
 		project = await projectService.getProject(projectId);
 		await invoke('set_project_active', { id: projectId });
 	} catch (err: any) {
+		if (err instanceof UserError) {
+			if (err.code === Code.ProjectMissing) {
+				projectService.deleteProject(projectId);
+			}
+		}
 		throw error(400, {
 			message: err.message
 		});
```

