### PR TITLE
fail if Git author is missing

### DIFF
--- a/crates/gitbutler-error/src/error.rs
+++ b/crates/gitbutler-error/src/error.rs
@@ -133,6 +133,7 @@ pub enum Code {
     CommitSigningFailed,
     CommitHookFailed,
     CommitMergeConflictFailure,
+    AuthorMissing,
 }
 
 impl std::fmt::Display for Code {
@@ -145,6 +146,7 @@ impl std::fmt::Display for Code {
             Code::CommitSigningFailed => "errors.commit.signing_failed",
             Code::CommitHookFailed => "errors.commit.hook_failed",
             Code::CommitMergeConflictFailure => "errors.commit.merge_conflict_failure",
+            Code::AuthorMissing => "errors.git.author_missing",
         };
         f.write_str(code)
     }

--- a/crates/gitbutler-repo/src/repository.rs
+++ b/crates/gitbutler-repo/src/repository.rs
@@ -429,7 +429,9 @@ impl RepoActionsExt for CommandContext {
             .author()
             .transpose()?
             .map(gitbutler_branch::gix_to_git2_signature)
-            .unwrap_or_else(|| gitbutler_branch::signature(SignaturePurpose::Author))?;
+            .transpose()?
+            .context("No author is configured in Git")
+            .context(Code::AuthorMissing)?;
 
         let config: Config = self.repository().into();
         let committer = if config.user_real_comitter()? {

--- a/crates/gitbutler-testsupport/src/suite.rs
+++ b/crates/gitbutler-testsupport/src/suite.rs
@@ -8,6 +8,7 @@ use gitbutler_command_context::CommandContext;
 use gitbutler_repo::{credentials::Helper, RepositoryExt};
 use tempfile::{tempdir, TempDir};
 
+use crate::test_project::setup_config;
 use crate::{init_opts, init_opts_bare, VAR_NO_CLEANUP};
 
 pub struct Suite {
@@ -150,9 +151,7 @@ pub fn test_repository() -> (git2::Repository, TempDir) {
     let tmp = temp_dir();
     let repository =
         git2::Repository::init_opts(&tmp, &init_opts()).expect("failed to init repository");
-    gitbutler_repo::Config::from(&repository)
-        .set_local("commit.gpgsign", "false")
-        .unwrap();
+    setup_config(&repository.config().unwrap()).unwrap();
     let mut index = repository.index().expect("failed to get index");
     let oid = index.write_tree().expect("failed to write tree");
     let signature = git2::Signature::now("test", "test@email.com").unwrap();

--- a/crates/gitbutler-testsupport/src/test_project.rs
+++ b/crates/gitbutler-testsupport/src/test_project.rs
@@ -1,7 +1,6 @@
-use std::{fs, path, path::PathBuf};
-
 use gitbutler_reference::{LocalRefname, Refname};
 use gitbutler_repo::RepositoryExt;
+use std::{fs, path, path::PathBuf};
 use tempfile::TempDir;
 
 use crate::{init_opts, VAR_NO_CLEANUP};
@@ -403,9 +402,14 @@ impl TestProject {
     }
 }
 
-fn setup_config(config: &git2::Config) -> anyhow::Result<()> {
+pub(crate) fn setup_config(config: &git2::Config) -> anyhow::Result<()> {
     match config.open_level(git2::ConfigLevel::Local) {
-        Ok(mut local) => local.set_str("commit.gpgsign", "false").map_err(Into::into),
+        Ok(mut local) => {
+            local.set_str("commit.gpgsign", "false")?;
+            local.set_str("user.name", "gitbutler-test")?;
+            local.set_str("user.email", "gitbutler-test@example.com")?;
+            Ok(())
+        }
         Err(err) => Err(err.into()),
     }
 }


### PR DESCRIPTION
Fixes #4677 in a minimal way.

### Tasks

* [x] fix


### Notes for the Reviewer

* The error will currently surface as error popup, but ideally the UI catches this and brings up a new flow for the user that makes it easy to set the author, maybe even from GitButler.
* There is also a fix to assure the author is set - locally this doesn't show as the author is set and picked up by the user executing the tests. Unfortunately it seems quite impossible to isolate `git2` repositories, and I really did try by setting environment variables and by setting global options.