### PR TITLE
faster E2E runs

### DIFF
--- a/apps/desktop/wdio.conf.ts
+++ b/apps/desktop/wdio.conf.ts
@@ -15,7 +15,7 @@ export const config: Options.WebdriverIO = {
 			// @ts-expect-error custom tauri capabilities
 			maxInstances: 1,
 			'tauri:options': {
-				application: '../../target/release/git-butler-dev'
+				application: '../../target/debug/git-butler-dev'
 			}
 		}
 	],

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"act:test:e2e": "act -j test -W .github/workflows/test-e2e.yml -P catthehacker/ubuntu:act-22.04",
 		"build": "turbo run build --no-daemon",
 		"build:desktop": "turbo run --filter @gitbutler/desktop build --no-daemon",
-		"build:test": "pnpm exec tauri build --config crates/gitbutler-tauri/tauri.conf.test.json",
+		"build:test": "pnpm exec tauri build --debug --config crates/gitbutler-tauri/tauri.conf.test.json",
 		"check": "turbo run check --no-daemon",
 		"tauri": "tauri",
 		"lint": "turbo run //#globallint --no-daemon",


### PR DESCRIPTION
For E2E, there isn't much data processing happening which makes release builds less useful. Instead, build in debug mode **to cut the compile time from 4m to 2.5m**, and see the e2e test start faster, and complete sooner.

It's notable that it's still much slower than it has any right to be, probably because the `--debug` of a tauri-build boils down to slightly different settings that prevent it from reusing the caches that have been created when building `gitbutler-cli`.

### Tasks

* [x] make the change
* [ ] figure out if the test is now flaky as the backend is too slow?

Seem to not work, and the saving isn't great anyway.