### PR TITLE
chore(deps): bump `turbo`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"prettier": "^3.3.2",
 		"prettier-plugin-svelte": "^3.2.4",
 		"svelte-eslint-parser": "^0.41.0",
-		"turbo": "2.0.9",
+		"turbo": "2.0.13-canary.1",
 		"typescript": "5.4.5",
 		"typescript-eslint": "^7.13.1"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,8 +73,8 @@ importers:
         specifier: ^0.41.0
         version: 0.41.0(svelte@5.0.0-next.196)
       turbo:
-        specifier: 2.0.9
-        version: 2.0.9
+        specifier: 2.0.13-canary.1
+        version: 2.0.13-canary.1
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -5985,38 +5985,38 @@ packages:
   tslib@2.6.3:
     resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
 
-  turbo-darwin-64@2.0.9:
-    resolution: {integrity: sha512-owlGsOaExuVGBUfrnJwjkL1BWlvefjSKczEAcpLx4BI7Oh6ttakOi+JyomkPkFlYElRpjbvlR2gP8WIn6M/+xQ==}
+  turbo-darwin-64@2.0.13-canary.1:
+    resolution: {integrity: sha512-/dV3H6HmfYXd/DgE5kAxoDnuAkzKJWPkBGUt9D4YKSYK3LJxbzK5ZOklzL8X2zEs9U5nvCPYAEKK6CdIhEGSsQ==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.0.9:
-    resolution: {integrity: sha512-XAXkKkePth5ZPPE/9G9tTnPQx0C8UTkGWmNGYkpmGgRr8NedW+HrPsi9N0HcjzzIH9A4TpNYvtiV+WcwdaEjKA==}
+  turbo-darwin-arm64@2.0.13-canary.1:
+    resolution: {integrity: sha512-DjnRLEz76NSsmhfQzrHuI9hYhutREaiZcCFTRqdErGrHYHe+S9xM2iaceUfy1bRt7I5an7zhCfnQCsq4m3t95g==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.0.9:
-    resolution: {integrity: sha512-l9wSgEjrCFM1aG16zItBsZ206ZlhSSx1owB8Cgskfv0XyIXRGHRkluihiaxkp+UeU5WoEfz4EN5toc+ICA0q0w==}
+  turbo-linux-64@2.0.13-canary.1:
+    resolution: {integrity: sha512-kTTP0yMhNVYXAmFLYv3p2VWYVdIJdGEdUPUf/TvmY1SCQS3uLZ+VLTVuzmM8XZRqFf8pcVwVWXF8ntkiRdLukg==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.0.9:
-    resolution: {integrity: sha512-gRnjxXRne18B27SwxXMqL3fJu7jw/8kBrOBTBNRSmZZiG1Uu3nbnP7b4lgrA/bCku6C0Wligwqurvtpq6+nFHA==}
+  turbo-linux-arm64@2.0.13-canary.1:
+    resolution: {integrity: sha512-LH1Xy589wMmU+BEhWIh5DCxVw0BneoK3UEMD8+RdpzRDBnLdHT2YLPKc9h8LXTA9CpG6K47WtPRgDCaVDY14uA==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.0.9:
-    resolution: {integrity: sha512-ZVo0apxUvaRq4Vm1qhsfqKKhtRgReYlBVf9MQvVU1O9AoyydEQvLDO1ryqpXDZWpcHoFxHAQc9msjAMtE5K2lA==}
+  turbo-windows-64@2.0.13-canary.1:
+    resolution: {integrity: sha512-cE9zKWUejcML72+b8UdrIbSKJhwZCHxBye0jqdSDlZIXSXCFUdnsID1CpmTqlypx53hPKS8wWIRzj8ONSqJIQw==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.0.9:
-    resolution: {integrity: sha512-sGRz7c5Pey6y7y9OKi8ypbWNuIRPF9y8xcMqL56OZifSUSo+X2EOsOleR9MKxQXVaqHPGOUKWsE6y8hxBi9pag==}
+  turbo-windows-arm64@2.0.13-canary.1:
+    resolution: {integrity: sha512-NHFz4SpL20Fs/BV2sefr6mzMhbD7EzpT3mVAX2Cybf+f88skSbXD3T41o1qu4hNAu7+YWf7vsDA5DfoYHhW+Bg==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.0.9:
-    resolution: {integrity: sha512-QaLaUL1CqblSKKPgLrFW3lZWkWG4pGBQNW+q1ScJB5v1D/nFWtsrD/yZljW/bdawg90ihi4/ftQJ3h6fz1FamA==}
+  turbo@2.0.13-canary.1:
+    resolution: {integrity: sha512-aRbF8GIiqpN02pf5RyJPbTrFtVwOANS9mD+T5I2Dfr3hEuO8+nBJ3hZ3/9rl6pBLCtgKXcTDbJ63PUXM9/LX8w==}
     hasBin: true
 
   type-check@0.4.0:
@@ -13228,32 +13228,32 @@ snapshots:
 
   tslib@2.6.3: {}
 
-  turbo-darwin-64@2.0.9:
+  turbo-darwin-64@2.0.13-canary.1:
     optional: true
 
-  turbo-darwin-arm64@2.0.9:
+  turbo-darwin-arm64@2.0.13-canary.1:
     optional: true
 
-  turbo-linux-64@2.0.9:
+  turbo-linux-64@2.0.13-canary.1:
     optional: true
 
-  turbo-linux-arm64@2.0.9:
+  turbo-linux-arm64@2.0.13-canary.1:
     optional: true
 
-  turbo-windows-64@2.0.9:
+  turbo-windows-64@2.0.13-canary.1:
     optional: true
 
-  turbo-windows-arm64@2.0.9:
+  turbo-windows-arm64@2.0.13-canary.1:
     optional: true
 
-  turbo@2.0.9:
+  turbo@2.0.13-canary.1:
     optionalDependencies:
-      turbo-darwin-64: 2.0.9
-      turbo-darwin-arm64: 2.0.9
-      turbo-linux-64: 2.0.9
-      turbo-linux-arm64: 2.0.9
-      turbo-windows-64: 2.0.9
-      turbo-windows-arm64: 2.0.9
+      turbo-darwin-64: 2.0.13-canary.1
+      turbo-darwin-arm64: 2.0.13-canary.1
+      turbo-linux-64: 2.0.13-canary.1
+      turbo-linux-arm64: 2.0.13-canary.1
+      turbo-windows-64: 2.0.13-canary.1
+      turbo-windows-arm64: 2.0.13-canary.1
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
## ☕️ Reasoning

- Bump `turbo` dependency

## 🧢 Changes

- Bump `turbo@2.0.9` -> `turbo@2.0.13-canary.1` 
- Seems to fix the common "grpc disconnect" error on linux (see my [issue](https://github.com/vercel/turborepo/issues/9002))


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
