### PR TITLE
Add edit mode actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,6 +2206,7 @@ dependencies = [
  "gitbutler-command-context",
  "gitbutler-commit",
  "gitbutler-operating-modes",
+ "gitbutler-oplog",
  "gitbutler-project",
  "gitbutler-reference",
  "gitbutler-repo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2195,6 +2195,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "gitbutler-edit-mode"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "bstr",
+ "git2",
+ "gitbutler-branch",
+ "gitbutler-branch-actions",
+ "gitbutler-command-context",
+ "gitbutler-commit",
+ "gitbutler-operating-modes",
+ "gitbutler-project",
+ "gitbutler-reference",
+ "gitbutler-repo",
+ "gitbutler-time",
+]
+
+[[package]]
 name = "gitbutler-error"
 version = "0.0.0"
 dependencies = [
@@ -2445,6 +2463,7 @@ dependencies = [
  "gitbutler-command-context",
  "gitbutler-config",
  "gitbutler-diff",
+ "gitbutler-edit-mode",
  "gitbutler-error",
  "gitbutler-feedback",
  "gitbutler-id",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "crates/gitbutler-url",
     "crates/gitbutler-diff",
     "crates/gitbutler-operating-modes",
+    "crates/gitbutler-edit-mode",
 ]
 resolver = "2"
 
@@ -79,6 +80,7 @@ gitbutler-tagged-string = { path = "crates/gitbutler-tagged-string" }
 gitbutler-url = { path = "crates/gitbutler-url" }
 gitbutler-diff = { path = "crates/gitbutler-diff" }
 gitbutler-operating-modes = { path = "crates/gitbutler-operating-modes" }
+gitbutler-edit-mode = { path = "crates/gitbutler-edit-mode" }
 
 [profile.release]
 codegen-units = 1 # Compile crates one after another so the compiler can optimize better

--- a/apps/desktop/src/lib/commit/CommitCard.svelte
+++ b/apps/desktop/src/lib/commit/CommitCard.svelte
@@ -4,6 +4,7 @@
 	import { BaseBranch } from '$lib/baseBranch/baseBranch';
 	import CommitMessageInput from '$lib/commit/CommitMessageInput.svelte';
 	import { persistedCommitMessage } from '$lib/config/config';
+	import { featureEditMode } from '$lib/config/uiFeatureFlags';
 	import { draggableCommit } from '$lib/dragging/draggable';
 	import { DraggableCommit, nonDraggable } from '$lib/dragging/draggables';
 	import BranchFilesList from '$lib/file/BranchFilesList.svelte';
@@ -38,12 +39,12 @@
 	export let type: CommitStatus;
 	export let lines: Snippet<[number]> | undefined = undefined;
 
-	$: console.log(branch);
-
 	const branchController = getContext(BranchController);
 	const baseBranch = getContextStore(BaseBranch);
 	const project = getContext(Project);
 	const modeService = maybeGetContext(ModeService);
+
+	const editModeEnabled = featureEditMode();
 
 	const commitStore = createCommitStore(commit);
 	$: commitStore.set(commit);
@@ -129,7 +130,7 @@
 		return true;
 	}
 
-	async function edit() {
+	async function editPatch() {
 		if (!canEdit()) return;
 
 		modeService!.enterEditMode(commit.id, branch!.refname);
@@ -336,8 +337,8 @@
 										onclick={openCommitMessageModal}>Edit message</Button
 									>
 								{/if}
-								{#if canEdit()}
-									<Button size="tag" style="ghost" outline onclick={edit}>Edit patch</Button>
+								{#if canEdit() && $editModeEnabled}
+									<Button size="tag" style="ghost" outline onclick={editPatch}>Edit patch</Button>
 								{/if}
 							</div>
 						{/if}

--- a/apps/desktop/src/lib/components/EditMode.svelte
+++ b/apps/desktop/src/lib/components/EditMode.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+	import DecorativeSplitView from './DecorativeSplitView.svelte';
+	import ProjectNameLabel from '../shared/ProjectNameLabel.svelte';
+	import dzenPc from '$lib/assets/dzen-pc.svg?raw';
+	import { Project } from '$lib/backend/projects';
+	import { ModeService, type EditModeMetadata } from '$lib/modes/service';
+	import { getContext } from '$lib/utils/context';
+	import Button from '@gitbutler/ui/Button.svelte';
+
+	interface Props {
+		editModeMetadata: EditModeMetadata;
+	}
+
+	const { editModeMetadata }: Props = $props();
+
+	const project = getContext(Project);
+	const modeService = getContext(ModeService);
+
+	let modeServiceSaving = $state<'inert' | 'loading' | 'completed'>('inert');
+
+	async function save() {
+		modeServiceSaving = 'loading';
+
+		await modeService.saveEditAndReturnToWorkspace();
+
+		modeServiceSaving = 'completed';
+	}
+</script>
+
+<DecorativeSplitView img={dzenPc}>
+	<div class="switchrepo">
+		<div class="project-name">
+			<ProjectNameLabel projectName={project?.title} />
+		</div>
+		<p class="switchrepo__title text-18 text-body text-bold">
+			You are currently editing commit <span class="code-string">
+				{editModeMetadata.editeeCommitSha.slice(0, 7)}
+			</span>
+		</p>
+
+		<p class="switchrepo__message text-13 text-body">Bla bla bla</p>
+
+		<div class="switchrepo__actions">
+			<Button
+				style="pop"
+				kind="solid"
+				icon="undo-small"
+				reversedDirection
+				onclick={save}
+				loading={modeServiceSaving === 'loading'}
+			>
+				Save changes
+			</Button>
+		</div>
+	</div>
+</DecorativeSplitView>
+
+<style lang="postcss">
+	.project-name {
+		margin-bottom: 12px;
+	}
+
+	.switchrepo__title {
+		color: var(--clr-scale-ntrl-30);
+		margin-bottom: 12px;
+	}
+
+	.switchrepo__message {
+		color: var(--clr-scale-ntrl-50);
+		margin-bottom: 20px;
+	}
+	.switchrepo__actions {
+		display: flex;
+		gap: 8px;
+		padding-bottom: 24px;
+		flex-wrap: wrap;
+	}
+</style>

--- a/apps/desktop/src/lib/components/EditMode.svelte
+++ b/apps/desktop/src/lib/components/EditMode.svelte
@@ -34,7 +34,7 @@
 		</div>
 		<p class="switchrepo__title text-18 text-body text-bold">
 			You are currently editing commit <span class="code-string">
-				{editModeMetadata.editeeCommitSha.slice(0, 7)}
+				{editModeMetadata.commitOid.slice(0, 7)}
 			</span>
 		</p>
 

--- a/apps/desktop/src/lib/config/uiFeatureFlags.ts
+++ b/apps/desktop/src/lib/config/uiFeatureFlags.ts
@@ -15,3 +15,8 @@ export function featureInlineUnifiedDiffs(): Persisted<boolean> {
 	const key = 'inlineUnifiedDiffs';
 	return persisted(false, key);
 }
+
+export function featureEditMode(): Persisted<boolean> {
+	const key = 'editMode';
+	return persisted(false, key);
+}

--- a/apps/desktop/src/lib/history/SnapshotCard.svelte
+++ b/apps/desktop/src/lib/history/SnapshotCard.svelte
@@ -144,6 +144,8 @@
 				return { text: 'Update workspace base', icon: 'rebase' };
 			case 'RestoreFromSnapshot':
 				return { text: 'Revert snapshot', icon: 'empty' };
+			case 'EnterEditMode':
+				return { text: 'Enter Edit Mode', icon: 'edit-text' };
 			default:
 				return { text: snapshotDetails.operation, icon: 'commit' };
 		}

--- a/apps/desktop/src/lib/history/types.ts
+++ b/apps/desktop/src/lib/history/types.ts
@@ -29,7 +29,8 @@ export type Operation =
 	| 'ReorderCommit'
 	| 'InsertBlankCommit'
 	| 'MoveCommitFile'
-	| 'FileChanges';
+	| 'FileChanges'
+	| 'EnterEditMode';
 
 export class Trailer {
 	key!: string;

--- a/apps/desktop/src/lib/modes/service.ts
+++ b/apps/desktop/src/lib/modes/service.ts
@@ -2,8 +2,8 @@ import { invoke, listen } from '$lib/backend/ipc';
 import { derived, writable } from 'svelte/store';
 
 export interface EditModeMetadata {
-	editeeCommitSha: string;
-	editeeBranch: string;
+	commitOid: string;
+	branchReference: string;
 }
 
 type Mode =
@@ -41,11 +41,11 @@ export class ModeService {
 		this.headAndMode.set({ head, operatingMode });
 	}
 
-	async enterEditMode(editeeCommitId: string, editeeBranchRef: string) {
+	async enterEditMode(commitOid: string, branchReference: string) {
 		await invoke('enter_edit_mode', {
 			projectId: this.projectId,
-			editee: editeeCommitId,
-			editeeBranch: editeeBranchRef
+			commitOid,
+			branchReference
 		});
 	}
 

--- a/apps/desktop/src/lib/modes/service.ts
+++ b/apps/desktop/src/lib/modes/service.ts
@@ -1,7 +1,18 @@
 import { invoke, listen } from '$lib/backend/ipc';
 import { derived, writable } from 'svelte/store';
 
-type Mode = { type: 'OpenWorkspace' } | { type: 'OutsideWorksapce' } | { type: 'Edit' };
+export interface EditModeMetadata {
+	editeeCommitSha: string;
+	editeeBranch: string;
+}
+
+type Mode =
+	| { type: 'OpenWorkspace' }
+	| { type: 'OutsideWorkspace' }
+	| {
+			type: 'Edit';
+			subject: EditModeMetadata;
+	  };
 interface HeadAndMode {
 	head?: string;
 	operatingMode?: Mode;
@@ -28,6 +39,20 @@ export class ModeService {
 		const operatingMode = await invoke<Mode>('operating_mode', { projectId: this.projectId });
 
 		this.headAndMode.set({ head, operatingMode });
+	}
+
+	async enterEditMode(editeeCommitId: string, editeeBranchRef: string) {
+		await invoke('enter_edit_mode', {
+			projectId: this.projectId,
+			editee: editeeCommitId,
+			editeeBranch: editeeBranchRef
+		});
+	}
+
+	async saveEditAndReturnToWorkspace() {
+		await invoke('save_edit_and_return_to_workspace', {
+			projectId: this.projectId
+		});
 	}
 }
 

--- a/apps/desktop/src/lib/navigation/WorkspaceButton.svelte
+++ b/apps/desktop/src/lib/navigation/WorkspaceButton.svelte
@@ -38,29 +38,10 @@
 </DomainButton>
 
 <style lang="postcss">
-	.domain-button {
-		display: flex;
-		align-items: center;
-		gap: 10px;
-		border-radius: var(--radius-m);
-		padding: 10px;
-		color: var(--clr-text-1);
-		transition: background-color var(--transition-fast);
-	}
-
 	.icon {
 		border-radius: var(--radius-s);
 		height: 20px;
 		width: 20px;
 		flex-shrink: 0;
-	}
-
-	.domain-button:not(.selected):hover,
-	.domain-button:not(.selected):focus {
-		background-color: var(--clr-bg-1-muted);
-	}
-
-	.selected {
-		background-color: var(--clr-bg-2);
 	}
 </style>

--- a/apps/desktop/src/lib/vbranches/types.ts
+++ b/apps/desktop/src/lib/vbranches/types.ts
@@ -132,6 +132,7 @@ export class VirtualBranch {
 	forkPoint!: string;
 	allowRebasing!: boolean;
 	pr?: PullRequest;
+	refname!: string;
 
 	get localCommits() {
 		return this.commits.filter((c) => c.status === 'local');

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -162,8 +162,6 @@
 	onDestroy(() => {
 		clearFetchInterval();
 	});
-
-	$inspect($mode);
 </script>
 
 <!-- forces components to be recreated when projectId changes -->

--- a/apps/desktop/src/routes/settings/experimental/+page.svelte
+++ b/apps/desktop/src/routes/settings/experimental/+page.svelte
@@ -2,6 +2,7 @@
 	import SectionCard from '$lib/components/SectionCard.svelte';
 	import {
 		featureBaseBranchSwitching,
+		featureEditMode,
 		featureInlineUnifiedDiffs
 	} from '$lib/config/uiFeatureFlags';
 	import ContentWrapper from '$lib/settings/ContentWrapper.svelte';
@@ -9,6 +10,7 @@
 
 	const baseBranchSwitching = featureBaseBranchSwitching();
 	const inlineUnifiedDiffs = featureInlineUnifiedDiffs();
+	const editMode = featureEditMode();
 </script>
 
 <ContentWrapper title="Experimental features">
@@ -43,6 +45,20 @@
 				checked={$inlineUnifiedDiffs}
 				on:click={() => ($inlineUnifiedDiffs = !$inlineUnifiedDiffs)}
 			/>
+		</svelte:fragment>
+	</SectionCard>
+	<SectionCard labelFor="editMode" orientation="row">
+		<svelte:fragment slot="title">Edit mode</svelte:fragment>
+		<svelte:fragment slot="caption">
+			Provides an "Edit patch" button on each commit which puts you into edit mode. Edit mode checks
+			out a particular commit so you can make changes to a particular commit, and then have the
+			child commits automatically rebased on top of the new changes.
+			<br /><br />
+			Please note that creating conflicts whilst inside edit mode is currently not supported. This feature
+			is still experimental and may result in loss of work.
+		</svelte:fragment>
+		<svelte:fragment slot="actions">
+			<Toggle id="editMode" checked={$editMode} on:click={() => ($editMode = !$editMode)} />
 		</svelte:fragment>
 	</SectionCard>
 </ContentWrapper>

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -76,6 +76,7 @@ pub struct VirtualBranch {
     /// The fork point between the target branch and the virtual branch
     #[serde(with = "gitbutler_serde::oid_opt", default)]
     pub fork_point: Option<git2::Oid>,
+    pub refname: Refname,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize)]
@@ -366,6 +367,8 @@ pub fn list_virtual_branches(
             .and_then(|c| c.parent(0).ok())
             .map(|c| c.id());
 
+        let refname = branch.refname()?.into();
+
         let branch = VirtualBranch {
             id: branch.id,
             name: branch.name,
@@ -388,6 +391,7 @@ pub fn list_virtual_branches(
             head: branch.head,
             merge_base,
             fork_point,
+            refname,
         };
         branches.push(branch);
     }

--- a/crates/gitbutler-edit-mode/Cargo.toml
+++ b/crates/gitbutler-edit-mode/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "gitbutler-edit-mode"
+version = "0.0.0"
+edition = "2021"
+authors = ["GitButler <gitbutler@gitbutler.com>"]
+publish = false
+
+[dependencies]
+git2.workspace = true
+anyhow.workspace = true
+bstr.workspace = true
+gitbutler-branch.workspace = true
+gitbutler-commit.workspace = true
+gitbutler-repo.workspace = true
+gitbutler-command-context.workspace = true
+gitbutler-operating-modes.workspace = true
+gitbutler-project.workspace = true
+gitbutler-branch-actions.workspace = true
+gitbutler-reference.workspace = true
+gitbutler-time.workspace = true

--- a/crates/gitbutler-edit-mode/Cargo.toml
+++ b/crates/gitbutler-edit-mode/Cargo.toml
@@ -18,3 +18,4 @@ gitbutler-project.workspace = true
 gitbutler-branch-actions.workspace = true
 gitbutler-reference.workspace = true
 gitbutler-time.workspace = true
+gitbutler-oplog.workspace = true

--- a/crates/gitbutler-edit-mode/src/commands.rs
+++ b/crates/gitbutler-edit-mode/src/commands.rs
@@ -1,0 +1,42 @@
+use anyhow::{Context, Result};
+use gitbutler_command_context::CommandContext;
+use gitbutler_operating_modes::{assure_edit_mode, assure_open_workspace_mode, EditModeMetadata};
+use gitbutler_project::{access::WriteWorkspaceGuard, Project};
+use gitbutler_reference::ReferenceName;
+
+pub fn enter_edit_mode(
+    project: &Project,
+    editee: git2::Oid,
+    editee_branch: ReferenceName,
+) -> Result<EditModeMetadata> {
+    let (ctx, mut guard) = open_with_permission(project)?;
+
+    assure_open_workspace_mode(&ctx)
+        .context("Entering edit mode may only be done when the workspace is open")?;
+
+    let editee = ctx
+        .repository()
+        .find_commit(editee)
+        .context("Failed to find editee commit")?;
+
+    let editee_branch = ctx
+        .repository()
+        .find_reference(&editee_branch)
+        .context("Failed to find editee branch reference")?;
+
+    crate::enter_edit_mode(&ctx, &editee, &editee_branch, guard.write_permission())
+}
+
+pub fn save_and_return_to_workspace(project: &Project) -> Result<()> {
+    let (ctx, mut guard) = open_with_permission(project)?;
+
+    assure_edit_mode(&ctx).context("Edit mode may only be left while in edit mode")?;
+
+    crate::save_and_return_to_workspace(&ctx, guard.write_permission())
+}
+
+fn open_with_permission(project: &Project) -> Result<(CommandContext, WriteWorkspaceGuard)> {
+    let ctx = CommandContext::open(project)?;
+    let guard = project.exclusive_worktree_access();
+    Ok((ctx, guard))
+}

--- a/crates/gitbutler-edit-mode/src/commands.rs
+++ b/crates/gitbutler-edit-mode/src/commands.rs
@@ -1,6 +1,10 @@
 use anyhow::{Context, Result};
 use gitbutler_command_context::CommandContext;
 use gitbutler_operating_modes::{assure_edit_mode, assure_open_workspace_mode, EditModeMetadata};
+use gitbutler_oplog::{
+    entry::{OperationKind, SnapshotDetails},
+    OplogExt,
+};
 use gitbutler_project::{access::WriteWorkspaceGuard, Project};
 use gitbutler_reference::ReferenceName;
 
@@ -24,7 +28,20 @@ pub fn enter_edit_mode(
         .find_reference(&editee_branch)
         .context("Failed to find editee branch reference")?;
 
-    crate::enter_edit_mode(&ctx, &editee, &editee_branch, guard.write_permission())
+    let snapshot = project
+        .prepare_snapshot(guard.read_permission())
+        .context("Failed to prepare snapshot")?;
+
+    let edit_mode_metadata =
+        crate::enter_edit_mode(&ctx, &editee, &editee_branch, guard.write_permission())?;
+
+    let _ = project.commit_snapshot(
+        snapshot,
+        SnapshotDetails::new(OperationKind::EnterEditMode),
+        guard.write_permission(),
+    );
+
+    Ok(edit_mode_metadata)
 }
 
 pub fn save_and_return_to_workspace(project: &Project) -> Result<()> {

--- a/crates/gitbutler-edit-mode/src/commands.rs
+++ b/crates/gitbutler-edit-mode/src/commands.rs
@@ -10,30 +10,30 @@ use gitbutler_reference::ReferenceName;
 
 pub fn enter_edit_mode(
     project: &Project,
-    editee: git2::Oid,
-    editee_branch: ReferenceName,
+    commit_oid: git2::Oid,
+    branch_reference_name: ReferenceName,
 ) -> Result<EditModeMetadata> {
     let (ctx, mut guard) = open_with_permission(project)?;
 
     assure_open_workspace_mode(&ctx)
         .context("Entering edit mode may only be done when the workspace is open")?;
 
-    let editee = ctx
+    let commit = ctx
         .repository()
-        .find_commit(editee)
-        .context("Failed to find editee commit")?;
+        .find_commit(commit_oid)
+        .context("Failed to find commit")?;
 
-    let editee_branch = ctx
+    let branch = ctx
         .repository()
-        .find_reference(&editee_branch)
-        .context("Failed to find editee branch reference")?;
+        .find_reference(&branch_reference_name)
+        .context("Failed to find branch reference")?;
 
     let snapshot = project
         .prepare_snapshot(guard.read_permission())
         .context("Failed to prepare snapshot")?;
 
     let edit_mode_metadata =
-        crate::enter_edit_mode(&ctx, &editee, &editee_branch, guard.write_permission())?;
+        crate::enter_edit_mode(&ctx, &commit, &branch, guard.write_permission())?;
 
     let _ = project.commit_snapshot(
         snapshot,

--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -1,0 +1,250 @@
+use std::str::FromStr;
+
+use anyhow::{bail, Context, Result};
+use bstr::ByteSlice;
+use git2::build::CheckoutBuilder;
+use gitbutler_branch::{signature, Branch, SignaturePurpose, VirtualBranchesHandle};
+use gitbutler_branch_actions::{list_virtual_branches, update_gitbutler_integration};
+use gitbutler_command_context::CommandContext;
+use gitbutler_commit::{commit_ext::CommitExt, commit_headers::HasCommitHeaders};
+use gitbutler_operating_modes::{
+    read_edit_mode_metadata, write_edit_mode_metadata, EditModeMetadata, EDIT_BRANCH_REF,
+    INTEGRATION_BRANCH_REF,
+};
+use gitbutler_project::access::WorktreeWritePermission;
+use gitbutler_reference::{ReferenceName, Refname};
+use gitbutler_repo::{
+    rebase::{cherry_rebase, cherry_rebase_group},
+    RepositoryExt,
+};
+
+pub mod commands;
+
+pub const EDIT_UNCOMMITED_FILES_REF: &str = "refs/gitbutler/edit_uncommited_files";
+
+fn save_uncommited_files(ctx: &CommandContext) -> Result<()> {
+    let repository = ctx.repository();
+
+    // Create a tree of all uncommited files
+    let mut index = repository.index().context("Failed to get index")?;
+    index
+        .add_all(["*"], git2::IndexAddOption::DEFAULT, None)
+        .context("Failed to add all to index")?;
+    index.write().context("Failed to write index")?;
+    let tree_oid = index
+        .write_tree()
+        .context("Failed to create tree from index")?;
+    let tree = repository
+        .find_tree(tree_oid)
+        .context("Failed to find tree")?;
+
+    // Commit tree and reference it
+    let author_signature =
+        signature(SignaturePurpose::Author).context("Failed to get gitbutler signature")?;
+    let committer_signature =
+        signature(SignaturePurpose::Committer).context("Failed to get gitbutler signature")?;
+    let head = repository.head().context("Failed to get head")?;
+    let head_commit = head.peel_to_commit().context("Failed to get head commit")?;
+    let commit = repository
+        .commit(
+            None,
+            &author_signature,
+            &committer_signature,
+            "Edit mode saved changes",
+            &tree,
+            &[&head_commit],
+        )
+        .context("Failed to write stash commit")?;
+
+    repository
+        .reference(EDIT_UNCOMMITED_FILES_REF, commit, true, "")
+        .context("Failed to reference uncommited files")?;
+
+    Ok(())
+}
+
+fn checkout_edit_branch(ctx: &CommandContext, editee: &git2::Commit) -> Result<()> {
+    let repository = ctx.repository();
+
+    // Checkout editee's parent
+    let editee_parent = editee.parent(0).context("Failed to get editee's parent")?;
+    repository
+        .reference(EDIT_BRANCH_REF, editee_parent.id(), true, "")
+        .context("Failed to update edit branch reference")?;
+    repository
+        .set_head(EDIT_BRANCH_REF)
+        .context("Failed to set head reference")?;
+    repository
+        .checkout_head(Some(CheckoutBuilder::new().force().remove_untracked(true)))
+        .context("Failed to checkout head")?;
+
+    // Checkout the editee as unstaged changes
+    let editee_tree = editee.tree().context("Failed to get editee's tree")?;
+    repository
+        .checkout_tree(
+            editee_tree.as_object(),
+            Some(CheckoutBuilder::new().force().remove_untracked(true)),
+        )
+        .context("Failed to checkout editee")?;
+
+    Ok(())
+}
+
+fn find_virtual_branch_by_reference(
+    ctx: &CommandContext,
+    reference: &ReferenceName,
+) -> Result<Option<Branch>> {
+    let vb_state = VirtualBranchesHandle::new(ctx.project().gb_dir());
+    let all_virtual_branches = vb_state
+        .list_branches_in_workspace()
+        .context("Failed to read virtual branches")?;
+
+    Ok(all_virtual_branches.into_iter().find(|virtual_branch| {
+        let Ok(refname) = virtual_branch.refname() else {
+            return false;
+        };
+
+        let Ok(editee_refname) = Refname::from_str(reference) else {
+            return false;
+        };
+
+        editee_refname == refname.into()
+    }))
+}
+
+pub(crate) fn enter_edit_mode(
+    ctx: &CommandContext,
+    editee: &git2::Commit,
+    editee_branch: &git2::Reference,
+    _perm: &mut WorktreeWritePermission,
+) -> Result<EditModeMetadata> {
+    let Some(editee_branch) = editee_branch.name() else {
+        bail!("Failed to get editee branch name");
+    };
+
+    let edit_mode_metadata = EditModeMetadata {
+        editee_commit_sha: editee.id(),
+        editee_branch: editee_branch.to_string().into(),
+    };
+
+    if find_virtual_branch_by_reference(ctx, &edit_mode_metadata.editee_branch)?.is_none() {
+        bail!("Can not enter edit mode for a reference which does not have a cooresponding virtual branch")
+    }
+
+    save_uncommited_files(ctx).context("Failed to save uncommited files")?;
+    checkout_edit_branch(ctx, editee).context("Failed to checkout edit branch")?;
+    write_edit_mode_metadata(ctx, &edit_mode_metadata).context("Failed to persist metadata")?;
+
+    Ok(edit_mode_metadata)
+}
+
+pub(crate) fn save_and_return_to_workspace(
+    ctx: &CommandContext,
+    perm: &mut WorktreeWritePermission,
+) -> Result<()> {
+    let edit_mode_metadata = read_edit_mode_metadata(ctx).context("Failed to read metadata")?;
+    let repository = ctx.repository();
+    let vb_state = VirtualBranchesHandle::new(ctx.project().gb_dir());
+
+    // Get important references
+    let editee = repository
+        .find_commit(edit_mode_metadata.editee_commit_sha)
+        .context("Failed to find editee")?;
+    let editee_parent = editee.parent(0).context("Failed to get editee's parent")?;
+    let stashed_integration_changes_reference = repository
+        .find_reference(EDIT_UNCOMMITED_FILES_REF)
+        .context("Failed to find stashed integration changes")?;
+    let stashed_integration_changes_commit = stashed_integration_changes_reference
+        .peel_to_commit()
+        .context("Failed to get stashed changes commit")?;
+
+    let Some(mut editee_virtual_branch) =
+        find_virtual_branch_by_reference(ctx, &edit_mode_metadata.editee_branch)?
+    else {
+        bail!("Failed to find virtual branch for this reference. Entering and leaving edit mode for non-virtual branches is unsupported")
+    };
+
+    // Recommit editee
+    let mut index = repository.index().context("Failed to get index")?;
+    index
+        .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+        .context("Failed to add all to index")?;
+    index.write().context("Failed to write index")?;
+    let tree_oid = index
+        .write_tree()
+        .context("Failed to create tree from index")?;
+    let tree = repository
+        .find_tree(tree_oid)
+        .context("Failed to find tree")?;
+    let new_editee_oid = ctx
+        .repository()
+        .commit_with_signature(
+            None,
+            &editee.author(),
+            &editee.committer(),
+            &editee.message_bstr().to_str_lossy(),
+            &tree,
+            &[&editee_parent],
+            editee.gitbutler_headers(),
+        )
+        .context("Failed to commit new editee")?;
+
+    // Rebase all all commits on top of the new editee and update reference
+    let new_editee_branch_head =
+        cherry_rebase(ctx, new_editee_oid, editee.id(), editee_virtual_branch.head)
+            .context("Failed to rebase commits onto new editee")?
+            .unwrap_or(new_editee_oid);
+    repository
+        .reference(
+            &edit_mode_metadata.editee_branch,
+            new_editee_branch_head,
+            true,
+            "",
+        )
+        .context("Failed to reference new editee branch head")?;
+
+    // Move back to gitbutler/integration and restore stashed changes
+    {
+        repository
+            .set_head(INTEGRATION_BRANCH_REF)
+            .context("Failed to set head reference")?;
+        repository
+            .checkout_head(Some(CheckoutBuilder::new().force().remove_untracked(true)))
+            .context("Failed to checkout gitbutler/integration")?;
+
+        editee_virtual_branch.head = new_editee_branch_head;
+        editee_virtual_branch.updated_timestamp_ms = gitbutler_time::time::now_ms();
+        vb_state
+            .set_branch(editee_virtual_branch)
+            .context("Failed to update vbstate")?;
+
+        let integration_commit_oid = update_gitbutler_integration(&vb_state, ctx)
+            .context("Failed to update gitbutler integration")?;
+
+        let rebased_stashed_integration_changes_commit = cherry_rebase_group(
+            ctx,
+            integration_commit_oid,
+            &mut [stashed_integration_changes_commit.id()],
+        )
+        .context("Failed to rebase stashed integration commit changes")?;
+
+        let commit_thing = repository
+            .find_commit(rebased_stashed_integration_changes_commit)
+            .context("Failed to find commit of rebased stashed integration changes commit oid")?;
+
+        let tree_thing = commit_thing
+            .tree()
+            .context("Failed to get tree of commit of rebased stashed integration changes")?;
+
+        repository
+            .checkout_tree(
+                tree_thing.as_object(),
+                Some(CheckoutBuilder::new().force().remove_untracked(true)),
+            )
+            .context("Failed to checkout stashed changes tree")?;
+
+        list_virtual_branches(ctx, perm).context("Failed to list virtual branches")?;
+    }
+
+    Ok(())
+}

--- a/crates/gitbutler-operating-modes/src/lib.rs
+++ b/crates/gitbutler-operating-modes/src/lib.rs
@@ -42,6 +42,7 @@ pub fn write_edit_mode_metadata(
 
 /// Holds relevant state required to switch to and from edit mode
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct EditModeMetadata {
     /// The sha of the commit getting edited.
     #[serde(with = "gitbutler_serde::oid")]

--- a/crates/gitbutler-operating-modes/src/lib.rs
+++ b/crates/gitbutler-operating-modes/src/lib.rs
@@ -46,9 +46,9 @@ pub fn write_edit_mode_metadata(
 pub struct EditModeMetadata {
     /// The sha of the commit getting edited.
     #[serde(with = "gitbutler_serde::oid")]
-    pub editee_commit_sha: git2::Oid,
+    pub commit_oid: git2::Oid,
     /// The ref of the vbranch which owns this commit.
-    pub editee_branch: ReferenceName,
+    pub branch_reference: ReferenceName,
 }
 
 #[derive(PartialEq, Debug, Clone, Serialize)]

--- a/crates/gitbutler-operating-modes/tests/operating_modes.rs
+++ b/crates/gitbutler-operating-modes/tests/operating_modes.rs
@@ -21,8 +21,8 @@ fn create_edit_mode_metadata(ctx: &CommandContext) {
     write_edit_mode_metadata(
         ctx,
         &EditModeMetadata {
-            editee_branch: "asdf".into(),
-            editee_commit_sha: git2::Oid::zero(),
+            branch_reference: "asdf".into(),
+            commit_oid: git2::Oid::zero(),
         },
     )
     .unwrap();

--- a/crates/gitbutler-oplog/src/entry.rs
+++ b/crates/gitbutler-oplog/src/entry.rs
@@ -155,6 +155,7 @@ pub enum OperationKind {
     InsertBlankCommit,
     MoveCommitFile,
     FileChanges,
+    EnterEditMode,
     #[default]
     Unknown,
 }

--- a/crates/gitbutler-repo/src/rebase.rs
+++ b/crates/gitbutler-repo/src/rebase.rs
@@ -9,14 +9,18 @@ use crate::{LogUntil, RepoActionsExt, RepositoryExt};
 /// cherry-pick based rebase, which handles empty commits
 /// this function takes a commit range and generates a Vector of commit oids
 /// and then passes them to `cherry_rebase_group` to rebase them onto the target commit
+///
+/// Returns the new head commit id
 pub fn cherry_rebase(
     ctx: &CommandContext,
     target_commit_oid: git2::Oid,
-    start_commit_oid: git2::Oid,
-    end_commit_oid: git2::Oid,
+    to_commit_oid: git2::Oid,
+    from_commit_oid: git2::Oid,
 ) -> Result<Option<git2::Oid>> {
     // get a list of the commits to rebase
-    let mut ids_to_rebase = ctx.l(end_commit_oid, LogUntil::Commit(start_commit_oid))?;
+    let mut ids_to_rebase = ctx.l(from_commit_oid, LogUntil::Commit(to_commit_oid))?;
+
+    dbg!(&ids_to_rebase);
 
     if ids_to_rebase.is_empty() {
         return Ok(None);

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -64,6 +64,7 @@ gitbutler-id.workspace = true
 gitbutler-storage.workspace = true
 gitbutler-diff.workspace = true
 gitbutler-operating-modes.workspace = true
+gitbutler-edit-mode.workspace = true
 open = "5"
 
 [dependencies.tauri]

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -195,6 +195,8 @@ fn main() {
                     remotes::list_remotes,
                     remotes::add_remote,
                     modes::operating_mode,
+                    modes::enter_edit_mode,
+                    modes::save_edit_and_return_to_workspace
                 ])
                 .menu(menu::build(tauri_context.package_info()))
                 .on_menu_event(|event| menu::handle_event(&event))

--- a/crates/gitbutler-tauri/src/modes.rs
+++ b/crates/gitbutler-tauri/src/modes.rs
@@ -23,14 +23,14 @@ pub fn operating_mode(
 pub fn enter_edit_mode(
     projects: State<'_, Controller>,
     project_id: ProjectId,
-    editee: String,
-    editee_branch: String,
+    commit_oid: String,
+    branch_reference: String,
 ) -> Result<EditModeMetadata, Error> {
     let project = projects.get(project_id)?;
 
-    let editee = git2::Oid::from_str(&editee).context("Failed to parse editee oid")?;
+    let commit = git2::Oid::from_str(&commit_oid).context("Failed to parse commit oid")?;
 
-    gitbutler_edit_mode::commands::enter_edit_mode(&project, editee, editee_branch.into())
+    gitbutler_edit_mode::commands::enter_edit_mode(&project, commit, branch_reference.into())
         .map_err(Into::into)
 }
 


### PR DESCRIPTION
Introduces some basic actions for entering and leaving edit mode. Its all hidden behind a feature flag in the experimental settings, with a warning not to use it :D.


The key logic is introduced here: https://github.com/gitbutlerapp/gitbutler/blob/4a9114f4f3a02136d12c7d13cd6fb631ddc5dca1/crates/gitbutler-edit-mode/src/lib.rs


