### PR TITLE
chore(deps): bump all svelte related dependencies

### DIFF
--- a/apps/desktop/e2e/utils.ts
+++ b/apps/desktop/e2e/utils.ts
@@ -1,5 +1,5 @@
-import { spawnSync } from 'node:child_process';
 import { browser } from '@wdio/globals';
+import { spawnSync } from 'node:child_process';
 
 const DEFAULT_TIMEOUT = 5_000;
 

--- a/apps/desktop/src/lib/branch/BranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/BranchHeader.svelte
@@ -21,9 +21,13 @@
 	import type { PullRequest } from '$lib/gitHost/interface/types';
 	import type { Persisted } from '$lib/persisted/persisted';
 
-	export let uncommittedChanges = 0;
-	export let isLaneCollapsed: Persisted<boolean>;
-	export let onGenerateBranchName: () => void;
+	interface Props {
+		uncommittedChanges?: number;
+		isLaneCollapsed: Persisted<boolean>;
+		onGenerateBranchName: () => void;
+	}
+
+	const { uncommittedChanges = 0, isLaneCollapsed, onGenerateBranchName }: Props = $props();
 
 	const branchController = getContext(BranchController);
 	const baseBranchService = getContext(BaseBranchService);
@@ -33,13 +37,13 @@
 	const prMonitor = getGitHostPrMonitor();
 	const gitHost = getGitHost();
 
-	$: branch = $branchStore;
-	$: pr = $prMonitor?.pr;
+	const branch = $derived($branchStore);
+	const pr = $derived($prMonitor?.pr);
 
-	let contextMenu: ContextMenu;
-	let meatballButtonEl: HTMLDivElement;
-	let isLoading: boolean;
-	let isTargetBranchAnimated = false;
+	let contextMenu = $state<ContextMenu>();
+	let meatballButtonEl = $state<HTMLDivElement>();
+	let isLoading = $state<boolean>(false);
+	let isTargetBranchAnimated = $state(false);
 
 	function handleBranchNameChange(title: string) {
 		if (title === '') return;
@@ -55,9 +59,9 @@
 		$isLaneCollapsed = true;
 	}
 
-	$: hasIntegratedCommits = branch.commits?.some((b) => b.isIntegrated);
+	const hasIntegratedCommits = $derived(branch.commits?.some((b) => b.isIntegrated));
 
-	let headerInfoHeight = 0;
+	let headerInfoHeight = $state(0);
 
 	interface CreatePrOpts {
 		draft: boolean;
@@ -120,7 +124,7 @@
 	<div
 		class="card collapsed-lane"
 		class:collapsed-lane_target-branch={branch.selectedForChanges}
-		on:keydown={(e) => e.key === 'Enter' && expandLane()}
+		onkeydown={(e) => e.key === 'Enter' && expandLane()}
 		tabindex="0"
 		role="button"
 	>
@@ -251,7 +255,7 @@
 							outline
 							icon="kebab"
 							onclick={() => {
-								contextMenu.toggle();
+								contextMenu?.toggle();
 							}}
 						/>
 						<BranchLaneContextMenu

--- a/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
@@ -15,10 +15,14 @@
 	import Button from '@gitbutler/ui/inputs/Button.svelte';
 	import Modal from '@gitbutler/ui/modal/Modal.svelte';
 
-	export let contextMenuEl: ContextMenu;
-	export let target: HTMLElement;
-	export let onCollapse: () => void;
-	export let onGenerateBranchName: () => void;
+	interface Props {
+		contextMenuEl?: ContextMenu;
+		target?: HTMLElement;
+		onCollapse: () => void;
+		onGenerateBranchName: () => void;
+	}
+
+	let { contextMenuEl = $bindable(), target, onCollapse, onGenerateBranchName }: Props = $props();
 
 	const user = getContextStore(User);
 	const project = getContext(Project);
@@ -29,15 +33,21 @@
 
 	const nameNormalizationService = getNameNormalizationServiceContext();
 
-	let aiConfigurationValid = false;
+	let aiConfigurationValid = $state(false);
 	let deleteBranchModal: Modal;
 	let renameRemoteModal: Modal;
-	let newRemoteName: string;
+	let newRemoteName = $state('');
 
-	$: branch = $branchStore;
-	$: commits = branch.commits;
-	$: setAIConfigurationValid($user);
-	$: allowRebasing = branch.allowRebasing;
+	const branch = $derived($branchStore);
+	const commits = $derived(branch.commits);
+	$effect(() => {
+		setAIConfigurationValid($user);
+	});
+
+	let allowRebasing = $state(false);
+	$effect(() => {
+		allowRebasing = branch.allowRebasing;
+	});
 
 	async function toggleAllowRebasing() {
 		branchController.updateBranchAllowRebasing(branch.id, !allowRebasing);
@@ -53,16 +63,18 @@
 
 	let normalizedBranchName: string;
 
-	$: if (branch.name) {
-		nameNormalizationService
-			.normalize(branch.name)
-			.then((name) => {
-				normalizedBranchName = name;
-			})
-			.catch((e) => {
-				console.error('Failed to normalize branch name', e);
-			});
-	}
+	$effect(() => {
+		if (branch.name) {
+			nameNormalizationService
+				.normalize(branch.name)
+				.then((name) => {
+					normalizedBranchName = name;
+				})
+				.catch((e) => {
+					console.error('Failed to normalize branch name', e);
+				});
+		}
+	});
 </script>
 
 <ContextMenu bind:this={contextMenuEl} {target}>
@@ -71,7 +83,7 @@
 			label="Collapse lane"
 			on:click={() => {
 				onCollapse();
-				contextMenuEl.close();
+				contextMenuEl?.close();
 			}}
 		/>
 	</ContextMenuSection>
@@ -80,7 +92,7 @@
 			label="Unapply"
 			on:click={() => {
 				unapplyBranch();
-				contextMenuEl.close();
+				contextMenuEl?.close();
 			}}
 		/>
 
@@ -96,7 +108,7 @@
 				} else {
 					deleteBranchModal.show(branch);
 				}
-				contextMenuEl.close();
+				contextMenuEl?.close();
 			}}
 		/>
 
@@ -104,7 +116,7 @@
 			label="Generate branch name"
 			on:click={() => {
 				onGenerateBranchName();
-				contextMenuEl.close();
+				contextMenuEl?.close();
 			}}
 			disabled={!($aiGenEnabled && aiConfigurationValid) || branch.files?.length === 0}
 		/>
@@ -118,7 +130,7 @@
 
 				newRemoteName = branch.upstreamName || normalizedBranchName || '';
 				renameRemoteModal.show(branch);
-				contextMenuEl.close();
+				contextMenuEl?.close();
 			}}
 		/>
 	</ContextMenuSection>
@@ -128,7 +140,7 @@
 			<Toggle
 				small
 				slot="control"
-				bind:checked={allowRebasing}
+				checked={allowRebasing}
 				on:click={toggleAllowRebasing}
 				help="Having this enabled permits commit amending and reordering after a branch has been pushed, which would subsequently require force pushing"
 			/>
@@ -140,7 +152,7 @@
 			label="Create branch to the left"
 			on:click={() => {
 				branchController.createBranch({ order: branch.order });
-				contextMenuEl.close();
+				contextMenuEl?.close();
 			}}
 		/>
 
@@ -148,7 +160,7 @@
 			label="Create branch to the right"
 			on:click={() => {
 				branchController.createBranch({ order: branch.order + 1 });
-				contextMenuEl.close();
+				contextMenuEl?.close();
 			}}
 		/>
 	</ContextMenuSection>

--- a/apps/desktop/src/lib/pr/PullRequestButton.svelte
+++ b/apps/desktop/src/lib/pr/PullRequestButton.svelte
@@ -1,16 +1,3 @@
-<script lang="ts" context="module">
-	export enum Action {
-		Create = 'createPr',
-		CreateDraft = 'createDraftPr'
-	}
-
-	const actions = Object.values(Action);
-	const labels = {
-		[Action.Create]: 'Create PR',
-		[Action.CreateDraft]: 'Create Draft PR'
-	};
-</script>
-
 <script lang="ts">
 	import ContextMenuItem from '$lib/components/contextmenu/ContextMenuItem.svelte';
 	import ContextMenuSection from '$lib/components/contextmenu/ContextMenuSection.svelte';
@@ -23,6 +10,18 @@
 		help: string;
 		click: (opts: { draft: boolean }) => void;
 	};
+
+	enum Action {
+		Create = 'createPr',
+		CreateDraft = 'createDraftPr'
+	}
+
+	const actions = Object.values(Action);
+	const labels = {
+		[Action.Create]: 'Create PR',
+		[Action.CreateDraft]: 'Create Draft PR'
+	};
+
 	const { loading, disabled, help, click }: Props = $props();
 
 	const preferredAction = persisted<Action>(Action.Create, 'projectDefaultPrAction');

--- a/apps/desktop/src/lib/settings/PreferencesForm.svelte
+++ b/apps/desktop/src/lib/settings/PreferencesForm.svelte
@@ -146,7 +146,7 @@
 			GitButler will sign commits as per your git configuration.
 		</svelte:fragment>
 		<svelte:fragment slot="actions">
-			<Toggle id="signCommits" checked={signCommits} on:click={handleSignCommitsClick} />
+			<Toggle id="signCommits" checked={signCommits} onclick={handleSignCommitsClick} />
 		</svelte:fragment>
 	</SectionCard>
 	{#if signCommits}
@@ -232,11 +232,7 @@
 			GitButler will never force push to the target branch.
 		</svelte:fragment>
 		<svelte:fragment slot="actions">
-			<Toggle
-				id="allowForcePush"
-				checked={allowForcePushing}
-				on:click={handleAllowForcePushClick}
-			/>
+			<Toggle id="allowForcePush" checked={allowForcePushing} onclick={handleAllowForcePushClick} />
 		</svelte:fragment>
 	</SectionCard>
 
@@ -249,7 +245,7 @@
 			<Toggle
 				id="omitCertificateCheck"
 				checked={omitCertificateCheck}
-				on:click={handleOmitCertificateCheckClick}
+				onclick={handleOmitCertificateCheckClick}
 			/>
 		</svelte:fragment>
 	</SectionCard>

--- a/apps/desktop/src/lib/shared/Toggle.svelte
+++ b/apps/desktop/src/lib/shared/Toggle.svelte
@@ -1,17 +1,28 @@
 <script lang="ts">
 	import { tooltip } from '@gitbutler/ui/utils/tooltip';
 
-	export let small = false;
-	export let disabled = false;
-	export let checked = false;
-	export let value = '';
-	export let help = '';
-	export let id = '';
+	interface Props {
+		small?: boolean;
+		disabled?: boolean;
+		checked?: boolean;
+		value?: string;
+		help?: string;
+		id?: string;
+	}
+
+	let {
+		small = false,
+		disabled = false,
+		checked = $bindable(false),
+		value = '',
+		help = '',
+		id = ''
+	}: Props = $props();
 </script>
 
 <input
 	bind:checked
-	on:click|stopPropagation
+	onclick={(e) => e.stopPropagation()}
 	type="checkbox"
 	class="toggle"
 	class:small

--- a/apps/desktop/src/lib/shared/Toggle.svelte
+++ b/apps/desktop/src/lib/shared/Toggle.svelte
@@ -2,6 +2,7 @@
 	import { tooltip } from '@gitbutler/ui/utils/tooltip';
 
 	interface Props {
+		onclick?: (e: MouseEvent) => Promise<void>;
 		small?: boolean;
 		disabled?: boolean;
 		checked?: boolean;
@@ -11,6 +12,7 @@
 	}
 
 	let {
+		onclick,
 		small = false,
 		disabled = false,
 		checked = $bindable(false),
@@ -22,7 +24,10 @@
 
 <input
 	bind:checked
-	onclick={(e) => e.stopPropagation()}
+	onclick={(e) => {
+		e.stopPropagation();
+		onclick?.(e);
+	}}
 	type="checkbox"
 	class="toggle"
 	class:small

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,9 @@ export default tsEslint.config(
 			globals: {
 				...globals.node,
 				...globals.browser,
+				...globals.mocha,
+				...globals.chai,
+				...globals.protractor,
 				$state: 'readonly',
 				$derived: 'readonly',
 				$props: 'readonly',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,7 +50,6 @@ export default tsEslint.config(
 			'**/dist',
 			'.svelte-kit',
 			'**/package',
-			'**/e2e',
 			'**/.env',
 			'**/.env.*',
 			'!**/.env.example',
@@ -61,7 +60,6 @@ export default tsEslint.config(
 			'.vscode',
 			'src-tauri',
 			'**/eslint.config.js',
-			'**/eslint.config.mjs',
 			'**/svelte.config.js',
 			'**/.pnpm-store',
 			'**/vite.config.ts.timestamp-*',
@@ -83,7 +81,6 @@ export default tsEslint.config(
 		rules: {
 			eqeqeq: ['error', 'always'],
 			'import-x/no-cycle': 'error',
-
 			'import-x/order': [
 				'error',
 				{
@@ -107,20 +104,24 @@ export default tsEslint.config(
 					'newlines-between': 'never'
 				}
 			],
-
 			'import-x/no-unresolved': [
 				'error',
 				{
 					ignore: ['^\\$app', '^\\$env']
 				}
 			],
+			'import-x/no-relative-packages': 'error',
 
-			'import-x/no-relative-packages': 'error', // Don't allow packages to have relative imports between each other
 			'func-style': [2, 'declaration'],
+			'no-return-await': 'off',
+			'svelte/no-at-html-tags': 'off',
+
 			'@typescript-eslint/no-namespace': 'off',
 			'@typescript-eslint/no-empty-function': 'off',
 			'@typescript-eslint/no-explicit-any': 'off',
-
+			'@typescript-eslint/return-await': ['error', 'always'],
+			'@typescript-eslint/promise-function-async': 'error',
+			'@typescript-eslint/await-thenable': 'error',
 			'@typescript-eslint/no-unused-vars': [
 				'error',
 				{
@@ -128,13 +129,7 @@ export default tsEslint.config(
 					varsIgnorePattern: '^_',
 					caughtErrorsIgnorePattern: '^_'
 				}
-			],
-
-			'no-return-await': 'off',
-			'@typescript-eslint/return-await': ['error', 'always'],
-			'@typescript-eslint/promise-function-async': 'error',
-			'@typescript-eslint/await-thenable': 'error',
-			'svelte/no-at-html-tags': 'off'
+			]
 		},
 		settings: {
 			'import-x/extensions': ['.ts'],

--- a/packages/ui/src/lib/utils/tooltip.ts
+++ b/packages/ui/src/lib/utils/tooltip.ts
@@ -54,6 +54,7 @@ export function tooltip(node: HTMLElement, optsOrString: ToolTipOptions | string
 		tooltip = document.createElement('div') as HTMLDivElement;
 		// TODO: Can we co-locate tooltip.js & tooltip.postcss?
 		tooltip.classList.add('tooltip', 'text-11'); // see tooltip.postcss
+		tooltip.style.zIndex = '9999';
 		if (noMaxWidth) tooltip.classList.add('no-max-width');
 		tooltip.innerText = text;
 		document.body.appendChild(tooltip);

--- a/packages/ui/src/stories/Button/DemoAllButtons.svelte
+++ b/packages/ui/src/stories/Button/DemoAllButtons.svelte
@@ -1,15 +1,18 @@
 <script lang="ts">
 	import Button from '$lib/inputs/Button.svelte';
+	import type { ComponentColor } from '$lib/utils/colorTypes';
 
 	interface Props {
 		label: string;
 		reversedDirection?: boolean;
+		outline?: boolean;
+		style?: ComponentColor;
 	}
 
 	const { label, reversedDirection }: Props = $props();
 </script>
 
-{#snippet buttons({ label, outline, style, reversedDirection })}
+{#snippet buttons({ label, outline, style, reversedDirection }: Props)}
 	<div class="group">
 		<Button size="cta" {style} icon="plus" {reversedDirection}>{label}</Button>
 		<Button size="cta" {style} kind="solid" {outline} icon="plus" {reversedDirection}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,20 +11,20 @@ catalogs:
       version: 5.2.13
   svelte:
     '@sveltejs/adapter-static':
-      specifier: 3.0.2
-      version: 3.0.2
+      specifier: 3.0.4
+      version: 3.0.4
     '@sveltejs/kit':
-      specifier: 2.5.18
-      version: 2.5.18
+      specifier: 2.5.22
+      version: 2.5.22
     '@sveltejs/vite-plugin-svelte':
-      specifier: 3.1.1
-      version: 3.1.1
+      specifier: 4.0.0-next.6
+      version: 4.0.0-next.6
     svelte:
-      specifier: 5.0.0-next.196
-      version: 5.0.0-next.196
+      specifier: 5.0.0-next.222
+      version: 5.0.0-next.222
     svelte-check:
-      specifier: 3.8.4
-      version: 3.8.4
+      specifier: 3.8.5
+      version: 3.8.5
 
 importers:
 
@@ -59,7 +59,7 @@ importers:
         version: 0.9.0--canary.156.ed236ca.0(eslint@9.5.0)(typescript@5.4.5)
       eslint-plugin-svelte:
         specifier: 2.40.0
-        version: 2.40.0(eslint@9.5.0)(svelte@5.0.0-next.196)(ts-node@10.9.2(typescript@5.4.5))
+        version: 2.40.0(eslint@9.5.0)(svelte@5.0.0-next.222)(ts-node@10.9.2(typescript@5.4.5))
       globals:
         specifier: ^15.6.0
         version: 15.6.0
@@ -68,10 +68,10 @@ importers:
         version: 3.3.2
       prettier-plugin-svelte:
         specifier: ^3.2.4
-        version: 3.2.4(prettier@3.3.2)(svelte@5.0.0-next.196)
+        version: 3.2.4(prettier@3.3.2)(svelte@5.0.0-next.222)
       svelte-eslint-parser:
         specifier: ^0.41.0
-        version: 0.41.0(svelte@5.0.0-next.196)
+        version: 0.41.0(svelte@5.0.0-next.222)
       turbo:
         specifier: 2.0.9
         version: 2.0.9
@@ -150,16 +150,16 @@ importers:
         version: 6.0.0(@codemirror/autocomplete@6.16.2(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1))(@codemirror/lang-css@6.2.1(@codemirror/view@6.26.3))(@codemirror/lang-html@6.4.9)(@codemirror/lang-javascript@6.2.2)(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/javascript@1.4.16)(@lezer/lr@1.4.1)
       '@sentry/sveltekit':
         specifier: ^8.9.2
-        version: 8.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.0)(@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.196)
+        version: 8.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.0)(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)
       '@sveltejs/adapter-static':
         specifier: catalog:svelte
-        version: 3.0.2(@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9)))
+        version: 3.0.4(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))
       '@sveltejs/kit':
         specifier: catalog:svelte
-        version: 2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9))
+        version: 2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))
       '@sveltejs/vite-plugin-svelte':
         specifier: catalog:svelte
-        version: 3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9))
+        version: 4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))
       '@tauri-apps/api':
         specifier: ^1.6.0
         version: 1.6.0
@@ -246,13 +246,13 @@ importers:
         version: 0.2.2
       svelte:
         specifier: catalog:svelte
-        version: 5.0.0-next.196
+        version: 5.0.0-next.222
       svelte-check:
         specifier: catalog:svelte
-        version: 3.8.4(@babel/core@7.24.7)(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(svelte@5.0.0-next.196)
+        version: 3.8.5(@babel/core@7.24.7)(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(svelte@5.0.0-next.222)
       svelte-french-toast:
         specifier: ^1.2.0
-        version: 1.2.0(svelte@5.0.0-next.196)
+        version: 1.2.0(svelte@5.0.0-next.222)
       tauri-plugin-log-api:
         specifier: github:tauri-apps/tauri-plugin-log#v1
         version: https://codeload.github.com/tauri-apps/tauri-plugin-log/tar.gz/2bb26e22f7f7b4f164bad02f0ae4085796f77fff
@@ -276,7 +276,7 @@ importers:
     dependencies:
       '@sentry/sveltekit':
         specifier: ^8.9.2
-        version: 8.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.0)(@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.196)
+        version: 8.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.0)(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)
     devDependencies:
       '@fontsource/fira-mono':
         specifier: ^4.5.10
@@ -289,19 +289,19 @@ importers:
         version: 1.0.0
       '@sveltejs/adapter-auto':
         specifier: ^3.0.0
-        version: 3.2.2(@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))
+        version: 3.2.2(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))
       '@sveltejs/kit':
         specifier: catalog:svelte
-        version: 2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13))
+        version: 2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
       '@sveltejs/vite-plugin-svelte':
         specifier: catalog:svelte
-        version: 3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13))
+        version: 4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
       svelte:
         specifier: catalog:svelte
-        version: 5.0.0-next.196
+        version: 5.0.0-next.222
       svelte-check:
         specifier: catalog:svelte
-        version: 3.8.4(@babel/core@7.24.7)(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(svelte@5.0.0-next.196)
+        version: 3.8.5(@babel/core@7.24.7)(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(svelte@5.0.0-next.222)
       vite:
         specifier: 'catalog:'
         version: 5.2.13(@types/node@20.14.13)
@@ -325,22 +325,22 @@ importers:
         version: 8.2.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))
       '@storybook/svelte':
         specifier: ^8.2.7
-        version: 8.2.7(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.196)
+        version: 8.2.7(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.222)
       '@storybook/sveltekit':
         specifier: ^8.2.7
-        version: 8.2.7(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.196)(typescript@5.4.5)(vite@5.2.13(@types/node@20.14.13))
+        version: 8.2.7(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.222)(typescript@5.4.5)(vite@5.2.13(@types/node@20.14.13))
       '@sveltejs/adapter-static':
         specifier: catalog:svelte
-        version: 3.0.2(@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))
+        version: 3.0.4(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))
       '@sveltejs/kit':
         specifier: catalog:svelte
-        version: 2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13))
+        version: 2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
       '@sveltejs/package':
         specifier: ^2.3.2
-        version: 2.3.2(svelte@5.0.0-next.196)(typescript@5.4.5)
+        version: 2.3.2(svelte@5.0.0-next.222)(typescript@5.4.5)
       '@sveltejs/vite-plugin-svelte':
         specifier: catalog:svelte
-        version: 3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13))
+        version: 4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
       '@terrazzo/cli':
         specifier: ^0.0.11
         version: 0.0.11
@@ -385,10 +385,10 @@ importers:
         version: 4.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))
       svelte:
         specifier: catalog:svelte
-        version: 5.0.0-next.196
+        version: 5.0.0-next.222
       svelte-check:
         specifier: catalog:svelte
-        version: 3.8.4(@babel/core@7.24.7)(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(svelte@5.0.0-next.196)
+        version: 3.8.5(@babel/core@7.24.7)(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(svelte@5.0.0-next.222)
       vite:
         specifier: 'catalog:'
         version: 5.2.13(@types/node@20.14.13)
@@ -1350,6 +1350,9 @@ packages:
   '@jridgewell/sourcemap-codec@1.4.15':
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
 
+  '@jridgewell/sourcemap-codec@1.5.0':
+    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
@@ -2070,13 +2073,13 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
 
-  '@sveltejs/adapter-static@3.0.2':
-    resolution: {integrity: sha512-/EBFydZDwfwFfFEuF1vzUseBoRziwKP7AoHAwv+Ot3M084sE/HTVBHf9mCmXfdM9ijprY5YEugZjleflncX5fQ==}
+  '@sveltejs/adapter-static@3.0.4':
+    resolution: {integrity: sha512-Qm4GAHCnRXwfWG9/AtnQ7mqjyjTs7i0Opyb8H2KH9rMR7fLxqiPx/tXeoE6HHo66+72CjyOb4nFH3lrejY4vzA==}
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
 
-  '@sveltejs/kit@2.5.18':
-    resolution: {integrity: sha512-+g06hvpVAnH7b4CDjhnTDgFWBKBiQJpuSmQeGYOuzbO3SC3tdYjRNlDCrafvDtKbGiT2uxY5Dn9qdEUGVZdWOQ==}
+  '@sveltejs/kit@2.5.22':
+    resolution: {integrity: sha512-PQ98baF2WzvG5yiO4cZKJZJG60XjHTZD1jyho3u9Kmthx2ytdGYyVPPvKXgKXpKSq4wwctD9dl0d2blSbJMcOg==}
     engines: {node: '>=18.13'}
     hasBin: true
     peerDependencies:
@@ -2091,19 +2094,19 @@ packages:
     peerDependencies:
       svelte: ^3.44.0 || ^4.0.0 || ^5.0.0-next.1
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0':
-    resolution: {integrity: sha512-9QX28IymvBlSCqsCll5t0kQVxipsfhFFL+L2t3nTWfXnddYwxBuAEtTtlaVQpRz9c37BhJjltSeY4AJSC03SSg==}
-    engines: {node: ^18.0.0 || >=20}
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.0-next.3':
+    resolution: {integrity: sha512-kuGJ2CZ5lAw3gKF8Kw0AfKtUJWbwdlDHY14K413B0MCyrzvQvsKTorwmwZcky0+QqY6RnVIZ/5FttB9bQmkLXg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
     peerDependencies:
-      '@sveltejs/vite-plugin-svelte': ^3.0.0
-      svelte: ^4.0.0 || ^5.0.0-next.0
+      '@sveltejs/vite-plugin-svelte': ^4.0.0-next.0||^4.0.0
+      svelte: ^5.0.0-next.96 || ^5.0.0
       vite: ^5.0.0
 
-  '@sveltejs/vite-plugin-svelte@3.1.1':
-    resolution: {integrity: sha512-rimpFEAboBBHIlzISibg94iP09k/KYdHgVhJlcsTfn7KMBhc70jFX/GRWkRdFCc2fdnk+4+Bdfej23cMDnJS6A==}
-    engines: {node: ^18.0.0 || >=20}
+  '@sveltejs/vite-plugin-svelte@4.0.0-next.6':
+    resolution: {integrity: sha512-7+bEFN5F9pthG6nOEHNz9yioHxNXK6yl+0GnTy9WOfxN/SvPykkH/Hs6MqTGjo47a9G2q3QXQnzuxG5WXNX4Tg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
     peerDependencies:
-      svelte: ^4.0.0 || ^5.0.0-next.0
+      svelte: ^5.0.0-next.96 || ^5.0.0
       vite: ^5.0.0
 
   '@szmarczak/http-timer@5.0.1':
@@ -4557,6 +4560,9 @@ packages:
   magic-string@0.30.10:
     resolution: {integrity: sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==}
 
+  magic-string@0.30.11:
+    resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
+
   magic-string@0.30.7:
     resolution: {integrity: sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==}
     engines: {node: '>=12'}
@@ -5762,8 +5768,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  svelte-check@3.8.4:
-    resolution: {integrity: sha512-61aHMkdinWyH8BkkTX9jPLYxYzaAAz/FK/VQqdr2FiCQQ/q04WCwDlpGbHff1GdrMYTmW8chlTFvRWL9k0A8vg==}
+  svelte-check@3.8.5:
+    resolution: {integrity: sha512-3OGGgr9+bJ/+1nbPgsvulkLC48xBsqsgtc8Wam281H4G9F5v3mYGa2bHRsPuwHC5brKl4AxJH95QF73kmfihGQ==}
     hasBin: true
     peerDependencies:
       svelte: ^3.55.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0
@@ -5790,12 +5796,6 @@ packages:
     resolution: {integrity: sha512-5PW+6RFX3xQPbR44CngYAP1Sd9oCq9P2FOox4FZffzJuZI2mHOB7q5gJBVnOiLF5y3moVGZ7u2bYt7+yPAgcEQ==}
     peerDependencies:
       svelte: ^3.57.0 || ^4.0.0
-
-  svelte-hmr@0.16.0:
-    resolution: {integrity: sha512-Gyc7cOS3VJzLlfj7wKS0ZnzDVdv3Pn2IuVeJPk9m2skfhcu5bq3wtIZyQGggr7/Iim5rH5cncyQft/kRLupcnA==}
-    engines: {node: ^12.20 || ^14.13.1 || >= 16}
-    peerDependencies:
-      svelte: ^3.19.0 || ^4.0.0
 
   svelte-preprocess@5.1.3:
     resolution: {integrity: sha512-xxAkmxGHT+J/GourS5mVJeOXZzne1FR5ljeOUAMXUkfEhkLEllRreXpbl3dIYJlcJRfL1LO1uIAPpBpBfiqGPw==}
@@ -5845,8 +5845,8 @@ packages:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0
 
-  svelte@5.0.0-next.196:
-    resolution: {integrity: sha512-O4OO+HoPEwKP+0Z8BR90DI0R9Nb3GkXaN2hTagNWWJwyWB92uO4vPcufYoO41C9aReWELob/yODRDwXuuVqKZA==}
+  svelte@5.0.0-next.222:
+    resolution: {integrity: sha512-+dPkIIyoqDYVwBBJL/nu3at8oCfg5jsUx+/qLl6/l2QpLrXVN4zfe9VS4rc//qNJmA59i/TBzWGRl/KTplQVTw==}
     engines: {node: '>=18'}
 
   sveltedoc-parser@4.2.1:
@@ -7646,6 +7646,8 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.4.15': {}
 
+  '@jridgewell/sourcemap-codec@1.5.0': {}
+
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
@@ -8272,25 +8274,25 @@ snapshots:
       '@sentry/types': 8.9.2
       '@sentry/utils': 8.9.2
 
-  '@sentry/svelte@8.9.2(svelte@5.0.0-next.196)':
+  '@sentry/svelte@8.9.2(svelte@5.0.0-next.222)':
     dependencies:
       '@sentry/browser': 8.9.2
       '@sentry/core': 8.9.2
       '@sentry/types': 8.9.2
       '@sentry/utils': 8.9.2
       magic-string: 0.30.10
-      svelte: 5.0.0-next.196
+      svelte: 5.0.0-next.222
 
-  '@sentry/sveltekit@8.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.0)(@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.196)':
+  '@sentry/sveltekit@8.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.0)(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)':
     dependencies:
       '@sentry/core': 8.9.2
       '@sentry/node': 8.9.2
       '@sentry/opentelemetry': 8.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.0)
-      '@sentry/svelte': 8.9.2(svelte@5.0.0-next.196)
+      '@sentry/svelte': 8.9.2(svelte@5.0.0-next.222)
       '@sentry/types': 8.9.2
       '@sentry/utils': 8.9.2
       '@sentry/vite-plugin': 2.18.0
-      '@sveltejs/kit': 2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13))
+      '@sveltejs/kit': 2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
       magic-string: 0.30.7
       magicast: 0.2.8
       sorcery: 0.11.0
@@ -8304,16 +8306,16 @@ snapshots:
       - supports-color
       - svelte
 
-  '@sentry/sveltekit@8.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.0)(@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.196)':
+  '@sentry/sveltekit@8.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.0)(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)':
     dependencies:
       '@sentry/core': 8.9.2
       '@sentry/node': 8.9.2
       '@sentry/opentelemetry': 8.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.0)
-      '@sentry/svelte': 8.9.2(svelte@5.0.0-next.196)
+      '@sentry/svelte': 8.9.2(svelte@5.0.0-next.222)
       '@sentry/types': 8.9.2
       '@sentry/utils': 8.9.2
       '@sentry/vite-plugin': 2.18.0
-      '@sveltejs/kit': 2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9))
+      '@sveltejs/kit': 2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))
       magic-string: 0.30.7
       magicast: 0.2.8
       sorcery: 0.11.0
@@ -8567,15 +8569,15 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7))
 
-  '@storybook/svelte-vite@8.2.7(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.196)(typescript@5.4.5)(vite@5.2.13(@types/node@20.14.13))':
+  '@storybook/svelte-vite@8.2.7(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.222)(typescript@5.4.5)(vite@5.2.13(@types/node@20.14.13))':
     dependencies:
       '@storybook/builder-vite': 8.2.7(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(typescript@5.4.5)(vite@5.2.13(@types/node@20.14.13))
-      '@storybook/svelte': 8.2.7(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.196)
-      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13))
+      '@storybook/svelte': 8.2.7(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.222)
+      '@sveltejs/vite-plugin-svelte': 4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
       magic-string: 0.30.10
       storybook: 8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7))
-      svelte: 5.0.0-next.196
-      svelte-preprocess: 5.1.3(@babel/core@7.24.7)(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(svelte@5.0.0-next.196)(typescript@5.4.5)
+      svelte: 5.0.0-next.222
+      svelte-preprocess: 5.1.3(@babel/core@7.24.7)(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(svelte@5.0.0-next.222)(typescript@5.4.5)
       sveltedoc-parser: 4.2.1
       ts-dedent: 2.2.0
       vite: 5.2.13(@types/node@20.14.13)
@@ -8594,7 +8596,7 @@ snapshots:
       - typescript
       - vite-plugin-glimmerx
 
-  '@storybook/svelte@8.2.7(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.196)':
+  '@storybook/svelte@8.2.7(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.222)':
     dependencies:
       '@storybook/components': 8.2.7(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))
       '@storybook/global': 5.0.0
@@ -8602,21 +8604,21 @@ snapshots:
       '@storybook/preview-api': 8.2.7(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))
       '@storybook/theming': 8.2.7(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))
       storybook: 8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7))
-      svelte: 5.0.0-next.196
+      svelte: 5.0.0-next.222
       sveltedoc-parser: 4.2.1
       ts-dedent: 2.2.0
       type-fest: 2.19.0
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/sveltekit@8.2.7(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.196)(typescript@5.4.5)(vite@5.2.13(@types/node@20.14.13))':
+  '@storybook/sveltekit@8.2.7(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.222)(typescript@5.4.5)(vite@5.2.13(@types/node@20.14.13))':
     dependencies:
       '@storybook/addon-actions': 8.2.7(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))
       '@storybook/builder-vite': 8.2.7(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(typescript@5.4.5)(vite@5.2.13(@types/node@20.14.13))
-      '@storybook/svelte': 8.2.7(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.196)
-      '@storybook/svelte-vite': 8.2.7(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.196)(typescript@5.4.5)(vite@5.2.13(@types/node@20.14.13))
+      '@storybook/svelte': 8.2.7(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.222)
+      '@storybook/svelte-vite': 8.2.7(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.222)(typescript@5.4.5)(vite@5.2.13(@types/node@20.14.13))
       storybook: 8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7))
-      svelte: 5.0.0-next.196
+      svelte: 5.0.0-next.222
       vite: 5.2.13(@types/node@20.14.13)
     transitivePeerDependencies:
       - '@babel/core'
@@ -8638,22 +8640,22 @@ snapshots:
     dependencies:
       storybook: 8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7))
 
-  '@sveltejs/adapter-auto@3.2.2(@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))':
+  '@sveltejs/adapter-auto@3.2.2(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))':
     dependencies:
-      '@sveltejs/kit': 2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13))
+      '@sveltejs/kit': 2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/adapter-static@3.0.2(@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))':
+  '@sveltejs/adapter-static@3.0.4(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))':
     dependencies:
-      '@sveltejs/kit': 2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13))
+      '@sveltejs/kit': 2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
 
-  '@sveltejs/adapter-static@3.0.2(@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9)))':
+  '@sveltejs/adapter-static@3.0.4(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))':
     dependencies:
-      '@sveltejs/kit': 2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9))
+      '@sveltejs/kit': 2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))
 
-  '@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13))':
+  '@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13))
+      '@sveltejs/vite-plugin-svelte': 4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.0.0
@@ -8665,13 +8667,13 @@ snapshots:
       sade: 1.8.1
       set-cookie-parser: 2.6.0
       sirv: 2.0.4
-      svelte: 5.0.0-next.196
+      svelte: 5.0.0-next.222
       tiny-glob: 0.2.9
       vite: 5.2.13(@types/node@20.14.13)
 
-  '@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9))':
+  '@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9))
+      '@sveltejs/vite-plugin-svelte': 4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.0.0
@@ -8683,62 +8685,60 @@ snapshots:
       sade: 1.8.1
       set-cookie-parser: 2.6.0
       sirv: 2.0.4
-      svelte: 5.0.0-next.196
+      svelte: 5.0.0-next.222
       tiny-glob: 0.2.9
       vite: 5.2.13(@types/node@20.5.9)
 
-  '@sveltejs/package@2.3.2(svelte@5.0.0-next.196)(typescript@5.4.5)':
+  '@sveltejs/package@2.3.2(svelte@5.0.0-next.222)(typescript@5.4.5)':
     dependencies:
       chokidar: 3.6.0
       kleur: 4.1.5
       sade: 1.8.1
       semver: 7.6.2
-      svelte: 5.0.0-next.196
-      svelte2tsx: 0.7.13(svelte@5.0.0-next.196)(typescript@5.4.5)
+      svelte: 5.0.0-next.222
+      svelte2tsx: 0.7.13(svelte@5.0.0-next.222)(typescript@5.4.5)
     transitivePeerDependencies:
       - typescript
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13))':
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.0-next.3(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13))
+      '@sveltejs/vite-plugin-svelte': 4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
       debug: 4.3.6(supports-color@8.1.1)
-      svelte: 5.0.0-next.196
+      svelte: 5.0.0-next.222
       vite: 5.2.13(@types/node@20.14.13)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9))':
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.0-next.3(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9))
+      '@sveltejs/vite-plugin-svelte': 4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))
       debug: 4.3.6(supports-color@8.1.1)
-      svelte: 5.0.0-next.196
+      svelte: 5.0.0-next.222
       vite: 5.2.13(@types/node@20.5.9)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13))':
+  '@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.14.13))
+      '@sveltejs/vite-plugin-svelte-inspector': 3.0.0-next.3(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
       debug: 4.3.6(supports-color@8.1.1)
       deepmerge: 4.3.1
       kleur: 4.1.5
-      magic-string: 0.30.10
-      svelte: 5.0.0-next.196
-      svelte-hmr: 0.16.0(svelte@5.0.0-next.196)
+      magic-string: 0.30.11
+      svelte: 5.0.0-next.222
       vite: 5.2.13(@types/node@20.14.13)
       vitefu: 0.2.5(vite@5.2.13(@types/node@20.14.13))
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9))':
+  '@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.196)(vite@5.2.13(@types/node@20.5.9))
+      '@sveltejs/vite-plugin-svelte-inspector': 3.0.0-next.3(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))
       debug: 4.3.6(supports-color@8.1.1)
       deepmerge: 4.3.1
       kleur: 4.1.5
-      magic-string: 0.30.10
-      svelte: 5.0.0-next.196
-      svelte-hmr: 0.16.0(svelte@5.0.0-next.196)
+      magic-string: 0.30.11
+      svelte: 5.0.0-next.222
       vite: 5.2.13(@types/node@20.5.9)
       vitefu: 0.2.5(vite@5.2.13(@types/node@20.5.9))
     transitivePeerDependencies:
@@ -9115,7 +9115,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.13.1(typescript@5.4.5)
       '@typescript-eslint/utils': 7.13.1(eslint@9.5.0)(typescript@5.4.5)
-      debug: 4.3.4
+      debug: 4.3.6(supports-color@8.1.1)
       eslint: 9.5.0
       ts-api-utils: 1.3.0(typescript@5.4.5)
     optionalDependencies:
@@ -9146,7 +9146,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.16.0
       '@typescript-eslint/visitor-keys': 7.16.0
-      debug: 4.3.4
+      debug: 4.3.6(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.4
@@ -10452,7 +10452,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-svelte@2.40.0(eslint@9.5.0)(svelte@5.0.0-next.196)(ts-node@10.9.2(typescript@5.4.5)):
+  eslint-plugin-svelte@2.40.0(eslint@9.5.0)(svelte@5.0.0-next.222)(ts-node@10.9.2(typescript@5.4.5)):
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.5.0)
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -10465,9 +10465,9 @@ snapshots:
       postcss-safe-parser: 6.0.0(postcss@8.4.39)
       postcss-selector-parser: 6.1.0
       semver: 7.6.2
-      svelte-eslint-parser: 0.39.2(svelte@5.0.0-next.196)
+      svelte-eslint-parser: 0.39.2(svelte@5.0.0-next.222)
     optionalDependencies:
-      svelte: 5.0.0-next.196
+      svelte: 5.0.0-next.222
     transitivePeerDependencies:
       - ts-node
 
@@ -11710,6 +11710,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
 
+  magic-string@0.30.11:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+
   magic-string@0.30.7:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -12332,10 +12336,10 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-svelte@3.2.4(prettier@3.3.2)(svelte@5.0.0-next.196):
+  prettier-plugin-svelte@3.2.4(prettier@3.3.2)(svelte@5.0.0-next.222):
     dependencies:
       prettier: 3.3.2
-      svelte: 5.0.0-next.196
+      svelte: 5.0.0-next.222
 
   prettier@3.3.2: {}
 
@@ -12565,7 +12569,7 @@ snapshots:
 
   require-in-the-middle@7.3.0:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.6(supports-color@8.1.1)
       module-details-from-path: 1.0.3
       resolve: 1.22.4
     transitivePeerDependencies:
@@ -12996,14 +13000,14 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@3.8.4(@babel/core@7.24.7)(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(svelte@5.0.0-next.196):
+  svelte-check@3.8.5(@babel/core@7.24.7)(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(svelte@5.0.0-next.222):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 3.6.0
       picocolors: 1.0.1
       sade: 1.8.1
-      svelte: 5.0.0-next.196
-      svelte-preprocess: 5.1.3(@babel/core@7.24.7)(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(svelte@5.0.0-next.196)(typescript@5.4.5)
+      svelte: 5.0.0-next.222
+      svelte-preprocess: 5.1.3(@babel/core@7.24.7)(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(svelte@5.0.0-next.222)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -13016,7 +13020,7 @@ snapshots:
       - stylus
       - sugarss
 
-  svelte-eslint-parser@0.39.2(svelte@5.0.0-next.196):
+  svelte-eslint-parser@0.39.2(svelte@5.0.0-next.222):
     dependencies:
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -13024,9 +13028,9 @@ snapshots:
       postcss: 8.4.39
       postcss-scss: 4.0.9(postcss@8.4.39)
     optionalDependencies:
-      svelte: 5.0.0-next.196
+      svelte: 5.0.0-next.222
 
-  svelte-eslint-parser@0.41.0(svelte@5.0.0-next.196):
+  svelte-eslint-parser@0.41.0(svelte@5.0.0-next.222):
     dependencies:
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -13034,43 +13038,39 @@ snapshots:
       postcss: 8.4.39
       postcss-scss: 4.0.9(postcss@8.4.39)
     optionalDependencies:
-      svelte: 5.0.0-next.196
+      svelte: 5.0.0-next.222
 
-  svelte-french-toast@1.2.0(svelte@5.0.0-next.196):
+  svelte-french-toast@1.2.0(svelte@5.0.0-next.222):
     dependencies:
-      svelte: 5.0.0-next.196
-      svelte-writable-derived: 3.1.0(svelte@5.0.0-next.196)
+      svelte: 5.0.0-next.222
+      svelte-writable-derived: 3.1.0(svelte@5.0.0-next.222)
 
-  svelte-hmr@0.16.0(svelte@5.0.0-next.196):
-    dependencies:
-      svelte: 5.0.0-next.196
-
-  svelte-preprocess@5.1.3(@babel/core@7.24.7)(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(svelte@5.0.0-next.196)(typescript@5.4.5):
+  svelte-preprocess@5.1.3(@babel/core@7.24.7)(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(svelte@5.0.0-next.222)(typescript@5.4.5):
     dependencies:
       '@types/pug': 2.0.6
       detect-indent: 6.1.0
       magic-string: 0.30.10
       sorcery: 0.11.0
       strip-indent: 3.0.0
-      svelte: 5.0.0-next.196
+      svelte: 5.0.0-next.222
     optionalDependencies:
       '@babel/core': 7.24.7
       postcss: 8.4.39
       postcss-load-config: 5.1.0(postcss@8.4.39)
       typescript: 5.4.5
 
-  svelte-writable-derived@3.1.0(svelte@5.0.0-next.196):
+  svelte-writable-derived@3.1.0(svelte@5.0.0-next.222):
     dependencies:
-      svelte: 5.0.0-next.196
+      svelte: 5.0.0-next.222
 
-  svelte2tsx@0.7.13(svelte@5.0.0-next.196)(typescript@5.4.5):
+  svelte2tsx@0.7.13(svelte@5.0.0-next.222)(typescript@5.4.5):
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
-      svelte: 5.0.0-next.196
+      svelte: 5.0.0-next.222
       typescript: 5.4.5
 
-  svelte@5.0.0-next.196:
+  svelte@5.0.0-next.222:
     dependencies:
       '@ampproject/remapping': 2.2.1
       '@jridgewell/sourcemap-codec': 1.4.15

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ catalogs:
       specifier: 2.5.22
       version: 2.5.22
     '@sveltejs/vite-plugin-svelte':
-      specifier: 4.0.0-next.6
-      version: 4.0.0-next.6
+      specifier: 3.1.1
+      version: 3.1.1
     svelte:
       specifier: 5.0.0-next.222
       version: 5.0.0-next.222
@@ -150,16 +150,16 @@ importers:
         version: 6.0.0(@codemirror/autocomplete@6.16.2(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1))(@codemirror/lang-css@6.2.1(@codemirror/view@6.26.3))(@codemirror/lang-html@6.4.9)(@codemirror/lang-javascript@6.2.2)(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/javascript@1.4.16)(@lezer/lr@1.4.1)
       '@sentry/sveltekit':
         specifier: ^8.9.2
-        version: 8.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.0)(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)
+        version: 8.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.0)(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)
       '@sveltejs/adapter-static':
         specifier: catalog:svelte
-        version: 3.0.4(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))
+        version: 3.0.4(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))
       '@sveltejs/kit':
         specifier: catalog:svelte
-        version: 2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))
+        version: 2.5.22(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))
       '@sveltejs/vite-plugin-svelte':
         specifier: catalog:svelte
-        version: 4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))
+        version: 3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))
       '@tauri-apps/api':
         specifier: ^1.6.0
         version: 1.6.0
@@ -276,7 +276,7 @@ importers:
     dependencies:
       '@sentry/sveltekit':
         specifier: ^8.9.2
-        version: 8.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.0)(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)
+        version: 8.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.0)(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)
     devDependencies:
       '@fontsource/fira-mono':
         specifier: ^4.5.10
@@ -289,13 +289,13 @@ importers:
         version: 1.0.0
       '@sveltejs/adapter-auto':
         specifier: ^3.0.0
-        version: 3.2.2(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))
+        version: 3.2.2(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))
       '@sveltejs/kit':
         specifier: catalog:svelte
-        version: 2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
+        version: 2.5.22(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
       '@sveltejs/vite-plugin-svelte':
         specifier: catalog:svelte
-        version: 4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
+        version: 3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
       svelte:
         specifier: catalog:svelte
         version: 5.0.0-next.222
@@ -328,19 +328,19 @@ importers:
         version: 8.2.7(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.222)
       '@storybook/sveltekit':
         specifier: ^8.2.7
-        version: 8.2.7(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.222)(typescript@5.4.5)(vite@5.2.13(@types/node@20.14.13))
+        version: 8.2.7(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.222)(typescript@5.4.5)(vite@5.2.13(@types/node@20.14.13))
       '@sveltejs/adapter-static':
         specifier: catalog:svelte
-        version: 3.0.4(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))
+        version: 3.0.4(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))
       '@sveltejs/kit':
         specifier: catalog:svelte
-        version: 2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
+        version: 2.5.22(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
       '@sveltejs/package':
         specifier: ^2.3.2
         version: 2.3.2(svelte@5.0.0-next.222)(typescript@5.4.5)
       '@sveltejs/vite-plugin-svelte':
         specifier: catalog:svelte
-        version: 4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
+        version: 3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
       '@terrazzo/cli':
         specifier: ^0.0.11
         version: 0.0.11
@@ -2094,19 +2094,19 @@ packages:
     peerDependencies:
       svelte: ^3.44.0 || ^4.0.0 || ^5.0.0-next.1
 
-  '@sveltejs/vite-plugin-svelte-inspector@3.0.0-next.3':
-    resolution: {integrity: sha512-kuGJ2CZ5lAw3gKF8Kw0AfKtUJWbwdlDHY14K413B0MCyrzvQvsKTorwmwZcky0+QqY6RnVIZ/5FttB9bQmkLXg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
+  '@sveltejs/vite-plugin-svelte-inspector@2.1.0':
+    resolution: {integrity: sha512-9QX28IymvBlSCqsCll5t0kQVxipsfhFFL+L2t3nTWfXnddYwxBuAEtTtlaVQpRz9c37BhJjltSeY4AJSC03SSg==}
+    engines: {node: ^18.0.0 || >=20}
     peerDependencies:
-      '@sveltejs/vite-plugin-svelte': ^4.0.0-next.0||^4.0.0
-      svelte: ^5.0.0-next.96 || ^5.0.0
+      '@sveltejs/vite-plugin-svelte': ^3.0.0
+      svelte: ^4.0.0 || ^5.0.0-next.0
       vite: ^5.0.0
 
-  '@sveltejs/vite-plugin-svelte@4.0.0-next.6':
-    resolution: {integrity: sha512-7+bEFN5F9pthG6nOEHNz9yioHxNXK6yl+0GnTy9WOfxN/SvPykkH/Hs6MqTGjo47a9G2q3QXQnzuxG5WXNX4Tg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
+  '@sveltejs/vite-plugin-svelte@3.1.1':
+    resolution: {integrity: sha512-rimpFEAboBBHIlzISibg94iP09k/KYdHgVhJlcsTfn7KMBhc70jFX/GRWkRdFCc2fdnk+4+Bdfej23cMDnJS6A==}
+    engines: {node: ^18.0.0 || >=20}
     peerDependencies:
-      svelte: ^5.0.0-next.96 || ^5.0.0
+      svelte: ^4.0.0 || ^5.0.0-next.0
       vite: ^5.0.0
 
   '@szmarczak/http-timer@5.0.1':
@@ -5797,6 +5797,12 @@ packages:
     peerDependencies:
       svelte: ^3.57.0 || ^4.0.0
 
+  svelte-hmr@0.16.0:
+    resolution: {integrity: sha512-Gyc7cOS3VJzLlfj7wKS0ZnzDVdv3Pn2IuVeJPk9m2skfhcu5bq3wtIZyQGggr7/Iim5rH5cncyQft/kRLupcnA==}
+    engines: {node: ^12.20 || ^14.13.1 || >= 16}
+    peerDependencies:
+      svelte: ^3.19.0 || ^4.0.0
+
   svelte-preprocess@5.1.3:
     resolution: {integrity: sha512-xxAkmxGHT+J/GourS5mVJeOXZzne1FR5ljeOUAMXUkfEhkLEllRreXpbl3dIYJlcJRfL1LO1uIAPpBpBfiqGPw==}
     engines: {node: '>= 16.0.0', pnpm: ^8.0.0}
@@ -8283,7 +8289,7 @@ snapshots:
       magic-string: 0.30.10
       svelte: 5.0.0-next.222
 
-  '@sentry/sveltekit@8.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.0)(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)':
+  '@sentry/sveltekit@8.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.0)(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)':
     dependencies:
       '@sentry/core': 8.9.2
       '@sentry/node': 8.9.2
@@ -8292,7 +8298,7 @@ snapshots:
       '@sentry/types': 8.9.2
       '@sentry/utils': 8.9.2
       '@sentry/vite-plugin': 2.18.0
-      '@sveltejs/kit': 2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
+      '@sveltejs/kit': 2.5.22(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
       magic-string: 0.30.7
       magicast: 0.2.8
       sorcery: 0.11.0
@@ -8306,7 +8312,7 @@ snapshots:
       - supports-color
       - svelte
 
-  '@sentry/sveltekit@8.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.0)(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)':
+  '@sentry/sveltekit@8.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.0)(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)':
     dependencies:
       '@sentry/core': 8.9.2
       '@sentry/node': 8.9.2
@@ -8315,7 +8321,7 @@ snapshots:
       '@sentry/types': 8.9.2
       '@sentry/utils': 8.9.2
       '@sentry/vite-plugin': 2.18.0
-      '@sveltejs/kit': 2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))
+      '@sveltejs/kit': 2.5.22(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))
       magic-string: 0.30.7
       magicast: 0.2.8
       sorcery: 0.11.0
@@ -8569,11 +8575,11 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7))
 
-  '@storybook/svelte-vite@8.2.7(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.222)(typescript@5.4.5)(vite@5.2.13(@types/node@20.14.13))':
+  '@storybook/svelte-vite@8.2.7(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.222)(typescript@5.4.5)(vite@5.2.13(@types/node@20.14.13))':
     dependencies:
       '@storybook/builder-vite': 8.2.7(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(typescript@5.4.5)(vite@5.2.13(@types/node@20.14.13))
       '@storybook/svelte': 8.2.7(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.222)
-      '@sveltejs/vite-plugin-svelte': 4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
+      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
       magic-string: 0.30.10
       storybook: 8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7))
       svelte: 5.0.0-next.222
@@ -8611,12 +8617,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/sveltekit@8.2.7(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.222)(typescript@5.4.5)(vite@5.2.13(@types/node@20.14.13))':
+  '@storybook/sveltekit@8.2.7(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.222)(typescript@5.4.5)(vite@5.2.13(@types/node@20.14.13))':
     dependencies:
       '@storybook/addon-actions': 8.2.7(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))
       '@storybook/builder-vite': 8.2.7(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(typescript@5.4.5)(vite@5.2.13(@types/node@20.14.13))
       '@storybook/svelte': 8.2.7(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.222)
-      '@storybook/svelte-vite': 8.2.7(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.222)(typescript@5.4.5)(vite@5.2.13(@types/node@20.14.13))
+      '@storybook/svelte-vite': 8.2.7(@babel/core@7.24.7)(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(storybook@8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7)))(svelte@5.0.0-next.222)(typescript@5.4.5)(vite@5.2.13(@types/node@20.14.13))
       storybook: 8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7))
       svelte: 5.0.0-next.222
       vite: 5.2.13(@types/node@20.14.13)
@@ -8640,29 +8646,29 @@ snapshots:
     dependencies:
       storybook: 8.2.7(@babel/preset-env@7.24.7(@babel/core@7.24.7))
 
-  '@sveltejs/adapter-auto@3.2.2(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))':
+  '@sveltejs/adapter-auto@3.2.2(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))':
     dependencies:
-      '@sveltejs/kit': 2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
+      '@sveltejs/kit': 2.5.22(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/adapter-static@3.0.4(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))':
+  '@sveltejs/adapter-static@3.0.4(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))':
     dependencies:
-      '@sveltejs/kit': 2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
+      '@sveltejs/kit': 2.5.22(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
 
-  '@sveltejs/adapter-static@3.0.4(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))':
+  '@sveltejs/adapter-static@3.0.4(@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))':
     dependencies:
-      '@sveltejs/kit': 2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))
+      '@sveltejs/kit': 2.5.22(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))
 
-  '@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))':
+  '@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
+      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.0.0
       esm-env: 1.0.0
       import-meta-resolve: 4.1.0
       kleur: 4.1.5
-      magic-string: 0.30.10
+      magic-string: 0.30.11
       mrmime: 2.0.0
       sade: 1.8.1
       set-cookie-parser: 2.6.0
@@ -8671,16 +8677,16 @@ snapshots:
       tiny-glob: 0.2.9
       vite: 5.2.13(@types/node@20.14.13)
 
-  '@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))':
+  '@sveltejs/kit@2.5.22(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))
+      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.0.0
       esm-env: 1.0.0
       import-meta-resolve: 4.1.0
       kleur: 4.1.5
-      magic-string: 0.30.10
+      magic-string: 0.30.11
       mrmime: 2.0.0
       sade: 1.8.1
       set-cookie-parser: 2.6.0
@@ -8700,45 +8706,47 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@sveltejs/vite-plugin-svelte-inspector@3.0.0-next.3(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))':
+  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
+      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
       debug: 4.3.6(supports-color@8.1.1)
       svelte: 5.0.0-next.222
       vite: 5.2.13(@types/node@20.14.13)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@3.0.0-next.3(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))':
+  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))
+      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))
       debug: 4.3.6(supports-color@8.1.1)
       svelte: 5.0.0-next.222
       vite: 5.2.13(@types/node@20.5.9)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))':
+  '@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 3.0.0-next.3(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
+      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.14.13))
       debug: 4.3.6(supports-color@8.1.1)
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.11
       svelte: 5.0.0-next.222
+      svelte-hmr: 0.16.0(svelte@5.0.0-next.222)
       vite: 5.2.13(@types/node@20.14.13)
       vitefu: 0.2.5(vite@5.2.13(@types/node@20.14.13))
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))':
+  '@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 3.0.0-next.3(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))
+      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9)))(svelte@5.0.0-next.222)(vite@5.2.13(@types/node@20.5.9))
       debug: 4.3.6(supports-color@8.1.1)
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.11
       svelte: 5.0.0-next.222
+      svelte-hmr: 0.16.0(svelte@5.0.0-next.222)
       vite: 5.2.13(@types/node@20.5.9)
       vitefu: 0.2.5(vite@5.2.13(@types/node@20.5.9))
     transitivePeerDependencies:
@@ -10602,7 +10610,7 @@ snapshots:
 
   esrap@1.2.2:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
       '@types/estree': 1.0.5
 
   esrecurse@4.3.0:
@@ -13045,6 +13053,10 @@ snapshots:
       svelte: 5.0.0-next.222
       svelte-writable-derived: 3.1.0(svelte@5.0.0-next.222)
 
+  svelte-hmr@0.16.0(svelte@5.0.0-next.222):
+    dependencies:
+      svelte: 5.0.0-next.222
+
   svelte-preprocess@5.1.3(@babel/core@7.24.7)(postcss-load-config@5.1.0(postcss@8.4.39))(postcss@8.4.39)(svelte@5.0.0-next.222)(typescript@5.4.5):
     dependencies:
       '@types/pug': 2.0.6
@@ -13073,7 +13085,7 @@ snapshots:
   svelte@5.0.0-next.222:
     dependencies:
       '@ampproject/remapping': 2.2.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
       '@types/estree': 1.0.5
       acorn: 8.12.0
       acorn-typescript: 1.4.13(acorn@8.12.0)
@@ -13083,7 +13095,7 @@ snapshots:
       esrap: 1.2.2
       is-reference: 3.0.2
       locate-character: 3.0.0
-      magic-string: 0.30.10
+      magic-string: 0.30.11
       zimmerframe: 1.1.2
 
   sveltedoc-parser@4.2.1:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,8 +6,8 @@ catalog:
   vite: 5.2.13
 catalogs:
   svelte:
-    svelte: 5.0.0-next.196
-    '@sveltejs/kit': 2.5.18
-    svelte-check: 3.8.4
-    '@sveltejs/vite-plugin-svelte': 3.1.1
-    '@sveltejs/adapter-static': 3.0.2
+    svelte: 5.0.0-next.222
+    '@sveltejs/kit': 2.5.22
+    svelte-check: 3.8.5
+    '@sveltejs/vite-plugin-svelte': 4.0.0-next.6
+    '@sveltejs/adapter-static': 3.0.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,5 +9,5 @@ catalogs:
     svelte: 5.0.0-next.222
     '@sveltejs/kit': 2.5.22
     svelte-check: 3.8.5
-    '@sveltejs/vite-plugin-svelte': 4.0.0-next.6
+    '@sveltejs/vite-plugin-svelte': 3.1.1
     '@sveltejs/adapter-static': 3.0.4


### PR DESCRIPTION
WIP - this has grown and grown, will split it apart later.

- Bump all svelte related dependencies across the board
	- `BranchHeader.svelte` wasn't showing contextMenu; Refactored to runes / svelte 5 syntax and fixed the binding. This required also updating `BranchLaneContextMenu.svelte`
- ~Minor `eslint.config` reorganisation~ #4704
	- ~Removed ignore on `e2e/*` files~
	- ~Renamed from `.mjs` -> `.js` since the root package.json already defines `type: "module"`, i.e. its assumed to be ESM by default~
- ~Noticed in the branch lane context menu (or any context menu really) when using tooltip's as helper text, for example, that the tooltip's would appear below the context menu. Fixed by adding some zIndex to the dynamically created tooltip element~ #4703