### PR TITLE
fix: tooltips when used in elevated contexts

### DIFF
--- a/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
@@ -130,7 +130,7 @@
 				slot="control"
 				bind:checked={allowRebasing}
 				on:click={toggleAllowRebasing}
-				help="Having this enabled permits commit amending and reordering after a branch has been pushed, which would subsequently require force pushing"
+				help="Allows changing commits after push (force push needed)"
 			/>
 		</ContextMenuItem>
 	</ContextMenuSection>

--- a/packages/ui/src/lib/utils/tooltip.ts
+++ b/packages/ui/src/lib/utils/tooltip.ts
@@ -54,6 +54,7 @@ export function tooltip(node: HTMLElement, optsOrString: ToolTipOptions | string
 		tooltip = document.createElement('div') as HTMLDivElement;
 		// TODO: Can we co-locate tooltip.js & tooltip.postcss?
 		tooltip.classList.add('tooltip', 'text-11'); // see tooltip.postcss
+		tooltip.style.zIndex = 'calc(infinity)';
 		if (noMaxWidth) tooltip.classList.add('no-max-width');
 		tooltip.innerText = text;
 		document.body.appendChild(tooltip);

--- a/packages/ui/src/lib/utils/tooltip.ts
+++ b/packages/ui/src/lib/utils/tooltip.ts
@@ -54,7 +54,6 @@ export function tooltip(node: HTMLElement, optsOrString: ToolTipOptions | string
 		tooltip = document.createElement('div') as HTMLDivElement;
 		// TODO: Can we co-locate tooltip.js & tooltip.postcss?
 		tooltip.classList.add('tooltip', 'text-11'); // see tooltip.postcss
-		tooltip.style.zIndex = 'calc(infinity)';
 		if (noMaxWidth) tooltip.classList.add('no-max-width');
 		tooltip.innerText = text;
 		document.body.appendChild(tooltip);

--- a/packages/ui/src/styles/components/tooltip.css
+++ b/packages/ui/src/styles/components/tooltip.css
@@ -6,7 +6,7 @@
 	color: var(--clr-core-ntrl-60);
 	display: inline-block;
 	padding: 6px 8px;
-	z-index: var(--z-tooltip);
+	z-index: var(--z-blocker);
 
 	max-width: 180px;
 	position: absolute;

--- a/packages/ui/src/styles/core/variables.css
+++ b/packages/ui/src/styles/core/variables.css
@@ -9,8 +9,7 @@
 	--z-lifted: 2;
 	--z-floating: 3;
 	--z-modal: 4;
-	--z-tooltip: 9;
-	--z-blocker: 10;
+	--z-blocker: calc(infinity);
 
 	/* TODO: add focus color */
 	--focus-color: var(--clr-scale-pop-50);


### PR DESCRIPTION
## Changes

- Tooltips used in elevated contexts, like contextMenu's would be rendered behind that context. With `calc(infinity)` nothing should be able to be on top of it, other than the newer `top-layer` stuff

### Before

![image](https://github.com/user-attachments/assets/cb08dbab-2344-4faf-9832-ac80429b904e)

### After

![image](https://github.com/user-attachments/assets/f7967287-d617-45c3-b33d-b81593d11dc5)
