### PR TITLE
fix: allow use of xdg-open binary to open links

### DIFF
--- a/crates/gitbutler-tauri/tauri.conf.nightly.json
+++ b/crates/gitbutler-tauri/tauri.conf.nightly.json
@@ -6,6 +6,11 @@
 		"productName": "GitButler Nightly"
 	},
 	"tauri": {
+		"allowlist": {
+			"shell": {
+				"open": "^((https://)|(http://)|(mailto:)|(vscode://)|(vscodium://)).+"
+			}
+    },
 		"bundle": {
 			"identifier": "com.gitbutler.app.nightly",
 			"icon": [

--- a/crates/gitbutler-tauri/tauri.conf.release.json
+++ b/crates/gitbutler-tauri/tauri.conf.release.json
@@ -6,6 +6,11 @@
 		"productName": "GitButler"
 	},
 	"tauri": {
+		"allowlist": {
+			"shell": {
+				"open": "^((https://)|(http://)|(mailto:)|(vscode://)|(vscodium://)).+"
+			}
+    },
 		"bundle": {
 			"identifier": "com.gitbutler.app",
 			"icon": [


### PR DESCRIPTION
- Unable to open URLs in Linux / AppImage builds
- This allows using the packaged-in `xdg-open` binary to open the whitelisted protocol types in both release / nightly builds.

Fixes: #2975 