### PR TITLE
Use gix for cloning repositories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2588,6 +2588,7 @@ dependencies = [
  "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-pathspec",
  "gix-prompt",
+ "gix-protocol",
  "gix-ref 0.45.0",
  "gix-refspec",
  "gix-revision",
@@ -2601,6 +2602,7 @@ dependencies = [
  "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-worktree 0.34.1 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-worktree-state",
  "once_cell",
  "smallvec",
  "thiserror",
@@ -3203,10 +3205,23 @@ dependencies = [
  "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-tempfile 14.0.1 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "memmap2",
+ "parking_lot 0.12.3",
  "smallvec",
  "thiserror",
  "uluru",
+]
+
+[[package]]
+name = "gix-packetline"
+version = "0.17.5"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "thiserror",
 ]
 
 [[package]]
@@ -3269,6 +3284,23 @@ dependencies = [
  "parking_lot 0.12.3",
  "rustix 0.38.34",
  "thiserror",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.45.2"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
+dependencies = [
+ "bstr",
+ "gix-credentials",
+ "gix-date 0.9.0",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-transport",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "maybe-async",
+ "thiserror",
+ "winnow 0.6.16",
 ]
 
 [[package]]
@@ -3491,6 +3523,21 @@ version = "0.1.9"
 source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
 
 [[package]]
+name = "gix-transport"
+version = "0.42.2"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-packetline",
+ "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-sec 0.10.7 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-url",
+ "thiserror",
+]
+
+[[package]]
 name = "gix-traverse"
 version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3610,6 +3657,25 @@ dependencies = [
  "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
  "gix-validate 0.8.5 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+]
+
+[[package]]
+name = "gix-worktree-state"
+version = "0.11.1"
+source = "git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af#d51f330e9d364c6f7b068116b59bf5c0160e47af"
+dependencies = [
+ "bstr",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-filter",
+ "gix-fs 0.11.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-glob 0.16.4 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-index 0.33.1 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-object 0.42.3 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-path 0.10.9 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "gix-worktree 0.34.1 (git+https://github.com/Byron/gitoxide?rev=d51f330e9d364c6f7b068116b59bf5c0160e47af)",
+ "io-close",
+ "thiserror",
 ]
 
 [[package]]
@@ -4693,6 +4759,17 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "maybe-async"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+]
 
 [[package]]
 name = "md5"

--- a/apps/desktop/src/lib/onboarding/CloneForm.svelte
+++ b/apps/desktop/src/lib/onboarding/CloneForm.svelte
@@ -68,18 +68,6 @@
 
 			const targetDir = await join(targetDirPath, remoteUrl.name);
 
-			if (remoteUrl.protocol) {
-				if (remoteUrl.protocol === 'ssh') {
-					posthog.capture('SSH Clone Attempted');
-				}
-				if (!['https', 'http'].includes(remoteUrl.protocol)) {
-					errors.push({
-						label: 'Only HTTP(S) Remote URLs allowed'
-					});
-					return;
-				}
-			}
-
 			await invoke('git_clone_repository', {
 				repositoryUrl,
 				targetDir

--- a/crates/gitbutler-tauri/src/repo.rs
+++ b/crates/gitbutler-tauri/src/repo.rs
@@ -1,10 +1,11 @@
 pub mod commands {
     use anyhow::{Context, Result};
-    use git2::{self};
     use gitbutler_project as projects;
     use gitbutler_project::ProjectId;
     use gitbutler_repo::RepoCommands;
+    use gix::progress::Discard;
     use std::path::Path;
+    use std::sync::atomic::AtomicBool;
     use tauri::State;
     use tracing::instrument;
 
@@ -45,7 +46,18 @@ pub mod commands {
 
     #[tauri::command(async)]
     pub fn git_clone_repository(repository_url: &str, target_dir: &Path) -> Result<(), Error> {
-        git2::Repository::clone(repository_url, target_dir).context("Cloning failed")?;
+        let url =
+            gix::url::parse(repository_url.into()).context("Failed to parse repository URL")?;
+        let should_interrupt = AtomicBool::new(false);
+        let mut prepared_clone =
+            gix::prepare_clone(url, target_dir).context("Failed to prepare clone")?;
+        let (mut prepared_checkout, _) = prepared_clone
+            .fetch_then_checkout(Discard, &should_interrupt)
+            .context("Failed to fetch")?;
+        let should_interrupt = AtomicBool::new(false);
+        prepared_checkout
+            .main_worktree(Discard, &should_interrupt)
+            .context("Failed to checkout main worktree")?;
         Ok(())
     }
 }

--- a/crates/gitbutler-watcher/Cargo.toml
+++ b/crates/gitbutler-watcher/Cargo.toml
@@ -17,7 +17,11 @@ anyhow = "1.0.86"
 tokio = { workspace = true, features = ["macros"] }
 tokio-util = "0.7.11"
 tracing = "0.1.40"
-gix = { workspace = true, features = ["excludes"] }
+gix = { workspace = true, features = [
+    "excludes",
+    "blocking-network-client",
+    "worktree-mutation",
+] }
 gitbutler-command-context.workspace = true
 gitbutler-project.workspace = true
 gitbutler-user.workspace = true


### PR DESCRIPTION
Looking through my emails this morning I saw this comment from @Byron on cloning azure devops https://github.com/gitbutlerapp/gitbutler/issues/2651#issuecomment-2293123466 (source gix issue: https://github.com/Byron/gitoxide/issues/1025) repositories not working through gix. It however made me think: Currently in GitButler, both cloning via SSH URLs and cloning private repositories doesn't work. It also got me wondering if switching to gix, despite the aforementioned issue, could be a quick and easy win that would resolve a large majority of the issues with the current setup. After trying it out, it works pretty much perfectly.

```diff
 
     #[tauri::command(async)]
     pub fn git_clone_repository(repository_url: &str, target_dir: &Path) -> Result<(), Error> {
-        git2::Repository::clone(repository_url, target_dir).context("Cloning failed")?;
+        let url =
+            gix::url::parse(repository_url.into()).context("Failed to parse repository URL")?;
+        let should_interrupt = AtomicBool::new(false);
+        let mut prepared_clone =
+            gix::prepare_clone(url, target_dir).context("Failed to prepare clone")?;
+        let (mut prepared_checkout, _) = prepared_clone
+            .fetch_then_checkout(Discard, &should_interrupt)
+            .context("Failed to fetch")?;
+        let should_interrupt = AtomicBool::new(false);
+        prepared_checkout
+            .main_worktree(Discard, &should_interrupt)
+            .context("Failed to checkout main worktree")?;
         Ok(())
     }
 }
```