### PR TITLE
Fix branch name deduplication

### DIFF
--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -662,6 +662,7 @@ pub fn update_branch(ctx: &CommandContext, branch_update: &BranchUpdateRequest) 
         branch.name = dedup(
             &all_virtual_branches
                 .iter()
+                .filter(|b| b.id != branch_update.id)
                 .map(|b| b.name.as_str())
                 .collect::<Vec<_>>(),
             name,


### PR DESCRIPTION
- do not include name of branch being updated when deduping