### PR TITLE
fix: `xdg-open`  test whitelisting externalBin

### DIFF
--- a/crates/gitbutler-tauri/.gitignore
+++ b/crates/gitbutler-tauri/.gitignore
@@ -1,1 +1,2 @@
-/gitbutler-git-*
+gitbutler-git-*
+xdg-open-*

--- a/crates/gitbutler-tauri/inject-git-binaries.sh
+++ b/crates/gitbutler-tauri/inject-git-binaries.sh
@@ -11,13 +11,16 @@ TRIPLE=${TRIPLE_OVERRIDE:-$(rustc -vV | sed -n 's|host: ||p')}
 TARGET_ROOT="$ROOT/target/${TRIPLE_OVERRIDE:-}/release"
 CRATE_ROOT="$ROOT/crates/gitbutler-tauri"
 
-cp "$(which xdg-open)" "$TARGET_ROOT/xdg-open"
-
 if [ -f "$TARGET_ROOT/gitbutler-git-askpass" ] && [ -f "$TARGET_ROOT/gitbutler-git-setsid" ]; then
     log injecting gitbutler-git binaries into crates/gitbutler-tauri "(TRIPLE=${TRIPLE})"
     cp -v "$TARGET_ROOT/gitbutler-git-askpass" "$CRATE_ROOT/gitbutler-git-askpass-${TRIPLE}"
     cp -v "$TARGET_ROOT/gitbutler-git-setsid" "$CRATE_ROOT/gitbutler-git-setsid-${TRIPLE}"
-    cp -v "$TARGET_ROOT/xdg-open" "$CRATE_ROOT/xdg-open-${TRIPLE}"
+
+    # Linux Only
+    XDG_OPEN_PATH=$(which xdg-open)
+    if [ -n "$XDG_OPEN_PATH" ]; then
+        cp -v "$XDG_OPEN_PATH" "$CRATE_ROOT/xdg-open-${TRIPLE}"
+    fi
 elif [ -f "$TARGET_ROOT/gitbutler-git-askpass.exe" ] && [ -f "$TARGET_ROOT/gitbutler-git-setsid.exe" ]; then
     log injecting gitbutler-git binaries into crates/gitbutler-tauri "(TRIPLE=${TRIPLE})"
     cp -v "$TARGET_ROOT/gitbutler-git-askpass.exe" "$CRATE_ROOT/gitbutler-git-askpass-${TRIPLE}.exe"

--- a/crates/gitbutler-tauri/inject-git-binaries.sh
+++ b/crates/gitbutler-tauri/inject-git-binaries.sh
@@ -11,7 +11,7 @@ TRIPLE=${TRIPLE_OVERRIDE:-$(rustc -vV | sed -n 's|host: ||p')}
 TARGET_ROOT="$ROOT/target/${TRIPLE_OVERRIDE:-}/release"
 CRATE_ROOT="$ROOT/crates/gitbutler-tauri"
 
-cp -v "$TARGET_ROOT/xdg-open" "$CRATE_ROOT/xdg-open-${TRIPLE}"
+cp "$(which xdg-open)" "$TARGET_ROOT/xdg-open"
 
 if [ -f "$TARGET_ROOT/gitbutler-git-askpass" ] && [ -f "$TARGET_ROOT/gitbutler-git-setsid" ]; then
     log injecting gitbutler-git binaries into crates/gitbutler-tauri "(TRIPLE=${TRIPLE})"

--- a/crates/gitbutler-tauri/inject-git-binaries.sh
+++ b/crates/gitbutler-tauri/inject-git-binaries.sh
@@ -11,10 +11,13 @@ TRIPLE=${TRIPLE_OVERRIDE:-$(rustc -vV | sed -n 's|host: ||p')}
 TARGET_ROOT="$ROOT/target/${TRIPLE_OVERRIDE:-}/release"
 CRATE_ROOT="$ROOT/crates/gitbutler-tauri"
 
+cp -v "$TARGET_ROOT/xdg-open" "$CRATE_ROOT/xdg-open-${TRIPLE}"
+
 if [ -f "$TARGET_ROOT/gitbutler-git-askpass" ] && [ -f "$TARGET_ROOT/gitbutler-git-setsid" ]; then
     log injecting gitbutler-git binaries into crates/gitbutler-tauri "(TRIPLE=${TRIPLE})"
     cp -v "$TARGET_ROOT/gitbutler-git-askpass" "$CRATE_ROOT/gitbutler-git-askpass-${TRIPLE}"
     cp -v "$TARGET_ROOT/gitbutler-git-setsid" "$CRATE_ROOT/gitbutler-git-setsid-${TRIPLE}"
+    cp -v "$TARGET_ROOT/xdg-open" "$CRATE_ROOT/xdg-open-${TRIPLE}"
 elif [ -f "$TARGET_ROOT/gitbutler-git-askpass.exe" ] && [ -f "$TARGET_ROOT/gitbutler-git-setsid.exe" ]; then
     log injecting gitbutler-git binaries into crates/gitbutler-tauri "(TRIPLE=${TRIPLE})"
     cp -v "$TARGET_ROOT/gitbutler-git-askpass.exe" "$CRATE_ROOT/gitbutler-git-askpass-${TRIPLE}.exe"

--- a/crates/gitbutler-tauri/tauri.conf.nightly.json
+++ b/crates/gitbutler-tauri/tauri.conf.nightly.json
@@ -8,7 +8,7 @@
 	"tauri": {
 		"allowlist": {
 			"shell": {
-				"open": "^((https://)|(http://)|(mailto:)|(vscode://)|(vscodium://)).+"
+				"open": "^((https?://)(mailto:)|(vscod(e|ium)://)).+"
 			}
     },
 		"bundle": {

--- a/crates/gitbutler-tauri/tauri.conf.nightly.json
+++ b/crates/gitbutler-tauri/tauri.conf.nightly.json
@@ -21,6 +21,7 @@
 				"icons/icon.ico"
 			],
 			"externalBin": [
+				"xdg-open",
 				"gitbutler-git-setsid",
 				"gitbutler-git-askpass"
 			],

--- a/crates/gitbutler-tauri/tauri.conf.nightly.json
+++ b/crates/gitbutler-tauri/tauri.conf.nightly.json
@@ -8,7 +8,7 @@
 	"tauri": {
 		"allowlist": {
 			"shell": {
-				"open": "^((https?://)(mailto:)|(vscod(e|ium)://)).+"
+				"open": "^((https://)|(http://)|(mailto:)|(vscode://)|(vscodium://)).+"
 			}
     },
 		"bundle": {

--- a/crates/gitbutler-tauri/tauri.conf.release.json
+++ b/crates/gitbutler-tauri/tauri.conf.release.json
@@ -8,7 +8,7 @@
 	"tauri": {
 		"allowlist": {
 			"shell": {
-				"open": "^((https://)|(http://)|(mailto:)|(vscode://)|(vscodium://)).+"
+				"open": "^((https?://)(mailto:)|(vscod(e|ium)://)).+"
 			}
     },
 		"bundle": {

--- a/crates/gitbutler-tauri/tauri.conf.release.json
+++ b/crates/gitbutler-tauri/tauri.conf.release.json
@@ -21,6 +21,7 @@
 				"icons/icon.ico"
 			],
 			"externalBin": [
+				"xdg-open",
 				"gitbutler-git-setsid",
 				"gitbutler-git-askpass"
 			],

--- a/crates/gitbutler-tauri/tauri.conf.release.json
+++ b/crates/gitbutler-tauri/tauri.conf.release.json
@@ -8,7 +8,7 @@
 	"tauri": {
 		"allowlist": {
 			"shell": {
-				"open": "^((https?://)(mailto:)|(vscod(e|ium)://)).+"
+				"open": "^((https://)|(http://)|(mailto:)|(vscode://)|(vscodium://)).+"
 			}
     },
 		"bundle": {

--- a/crates/gitbutler-tauri/tauri.conf.test.json
+++ b/crates/gitbutler-tauri/tauri.conf.test.json
@@ -13,7 +13,7 @@
 				"scope": ["$APPCACHE/archives/*", "$RESOURCE/_up_/scripts/*"]
 			},
 			"shell": {
-				"open": "^((https://)|(http://)|(mailto:)|(vscode://)|(vscodium://)).+"
+				"open": "^((https?://)(mailto:)|(vscod(e|ium)://)).+"
 			},
 			"dialog": {
 				"open": true

--- a/crates/gitbutler-tauri/tauri.conf.test.json
+++ b/crates/gitbutler-tauri/tauri.conf.test.json
@@ -13,7 +13,7 @@
 				"scope": ["$APPCACHE/archives/*", "$RESOURCE/_up_/scripts/*"]
 			},
 			"shell": {
-                "open": "^((https://)|(http://)|(mailto:)|(vscode://)|(vscodium://)).+"
+				"open": "^((https://)|(http://)|(mailto:)|(vscode://)|(vscodium://)).+"
 			},
 			"dialog": {
 				"open": true

--- a/crates/gitbutler-tauri/tauri.conf.test.json
+++ b/crates/gitbutler-tauri/tauri.conf.test.json
@@ -13,7 +13,7 @@
 				"scope": ["$APPCACHE/archives/*", "$RESOURCE/_up_/scripts/*"]
 			},
 			"shell": {
-				"open": "^((https?://)(mailto:)|(vscod(e|ium)://)).+"
+                "open": "^((https://)|(http://)|(mailto:)|(vscode://)|(vscodium://)).+"
 			},
 			"dialog": {
 				"open": true


### PR DESCRIPTION
Investigating `openExternalUrl` (i.e. `xdg-open`) (mis)behavior on Linux w/AppImage's

Findings:
- AppImage on Ubuntu 22.04 allows opening external links
- AppImage on NixOS does not allow opening external links

### 👷 Changes
- `xdg-open` still wasn't being executed correctly in nightly/release builds
- Test whitelisting it in included binaries, as that's where it ends up in an AppImage
![image](https://github.com/user-attachments/assets/775a8f8a-307c-4354-b45b-52f7f0112446)

### 📓 Notes
- Follow up to #4706 