### PR TITLE
fix: skip bundling AppImage updater tarball

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -196,6 +196,7 @@ if [ "$OS" = "macos" ]; then
 	info "	- $RELEASE_DIR/$(basename "$MACOS_UPDATER_SIG")"
 elif [ "$OS" = "linux" ]; then
 	APPIMAGE="$(find "$BUNDLE_DIR/appimage" -name \*.AppImage)"
+	# AppImage Updates will require the '*.AppImage.tar.gz' as well as '*.AppImage.tar.gz.sig'
 	DEB="$(find "$BUNDLE_DIR/deb" -name \*.deb)"
 	RPM="$(find "$BUNDLE_DIR/rpm" -name \*.rpm)"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -196,21 +196,15 @@ if [ "$OS" = "macos" ]; then
 	info "	- $RELEASE_DIR/$(basename "$MACOS_UPDATER_SIG")"
 elif [ "$OS" = "linux" ]; then
 	APPIMAGE="$(find "$BUNDLE_DIR/appimage" -name \*.AppImage)"
-	APPIMAGE_UPDATER="$(find "$BUNDLE_DIR/appimage" -name \*.AppImage.tar.gz)"
-	APPIMAGE_UPDATER_SIG="$(find "$BUNDLE_DIR/appimage" -name \*.AppImage.tar.gz.sig)"
 	DEB="$(find "$BUNDLE_DIR/deb" -name \*.deb)"
 	RPM="$(find "$BUNDLE_DIR/rpm" -name \*.rpm)"
 
 	cp "$APPIMAGE" "$RELEASE_DIR"
-	cp "$APPIMAGE_UPDATER" "$RELEASE_DIR"
-	cp "$APPIMAGE_UPDATER_SIG" "$RELEASE_DIR"
 	cp "$DEB" "$RELEASE_DIR"
 	cp "$RPM" "$RELEASE_DIR"
 
 	info "built:"
 	info "	- $RELEASE_DIR/$(basename "$APPIMAGE")"
-	info "	- $RELEASE_DIR/$(basename "$APPIMAGE_UPDATER")"
-	info "	- $RELEASE_DIR/$(basename "$APPIMAGE_UPDATER_SIG")"
 	info "	- $RELEASE_DIR/$(basename "$DEB")"
 	info "	- $RELEASE_DIR/$(basename "$RPM")"
 elif [ "$OS" = "windows" ]; then


### PR DESCRIPTION
- Reduce AppImage artifact size


### 👷 Changes

- Because we set the AppImage passphrase env var, `tauri build` generates a "raw" `git-butler.AppImage`, as well as the updater artifacts like a tarball of the identical AppImage (`git-butler.AppImage.tar.gz`) and a signature of that tarball (`git-butler.AppImage.tar.gz.sig`).
- The tarball and it's signature are deisgned to be used by the Tauri updater
- However, we currently don't support updating on Linux / with AppImages ([Error](https://docs.rs/tauri/latest/tauri/updater/enum.Error.html#variant.UnsupportedLinuxPackage))
- So I figure, until that changes, we can remove those two files (the tarball and its signature) from the resulting artifact that is uploaded to GitHub. 
- **This cuts the AppImage artifact size almost in half**

What do you all think? Fine to cut out for now?