### PR TITLE
fix: avatars from Google accounts via Auth0

### DIFF
--- a/apps/desktop/src/lib/shared/AccountLink.svelte
+++ b/apps/desktop/src/lib/shared/AccountLink.svelte
@@ -26,7 +26,7 @@
 		</span>
 	{/if}
 	{#if $user?.picture}
-		<img class="profile-picture" src={$user.picture} alt="Avatar" />
+		<img class="profile-picture" src={$user.picture} alt="Avatar" referrerpolicy="no-referrer" />
 	{:else}
 		<div class="anon-icon">
 			<Icon name="profile" />

--- a/apps/desktop/src/routes/settings/profile/+page.svelte
+++ b/apps/desktop/src/routes/settings/profile/+page.svelte
@@ -127,7 +127,7 @@
 					/>
 
 					{#if $user.picture}
-						<img class="profile-pic" src={userPicture} alt="" />
+						<img class="profile-pic" src={userPicture} alt="" referrerpolicy="no-referrer" />
 					{/if}
 
 					<span class="profile-pic__edit-label text-11 text-semibold">Edit</span>

--- a/apps/desktop/src/routes/settings/profile/+page.svelte
+++ b/apps/desktop/src/routes/settings/profile/+page.svelte
@@ -122,7 +122,7 @@
 						type="file"
 						id="picture"
 						name="picture"
-						accept={fileTypes.join('')}
+						accept={fileTypes.join(',')}
 						class="hidden-input"
 					/>
 

--- a/crates/gitbutler-tauri/tauri.conf.nightly.json
+++ b/crates/gitbutler-tauri/tauri.conf.nightly.json
@@ -31,7 +31,7 @@
 		"security": {
 			"csp": {
 				"default-src": "'self'",
-				"img-src": "'self' asset: https://asset.localhost data: tauri://localhost https://avatars.githubusercontent.com https://*.gitbutler.com  https://gitbutler-public.s3.amazonaws.com https://*.gravatar.com https://io.wp.com https://i0.wp.com https://i1.wp.com https://i2.wp.com https://i3.wp.com https://github.com",
+				"img-src": "'self' asset: https://asset.localhost data: tauri://localhost https://avatars.githubusercontent.com https://*.gitbutler.com  https://gitbutler-public.s3.amazonaws.com https://*.gravatar.com https://io.wp.com https://i0.wp.com https://i1.wp.com https://i2.wp.com https://i3.wp.com https://github.com https://lh*.googleusercontent.com",
 				"connect-src": "'self' https://eu.posthog.com https://eu.i.posthog.com https://app.gitbutler.com https://o4504644069687296.ingest.sentry.io ws://localhost:7703 https://github.com https://api.github.com https://api.openai.com",
 				"script-src": "'self' https://eu.posthog.com https://eu.i.posthog.com",
 				"style-src": "'self' 'unsafe-inline'"

--- a/crates/gitbutler-tauri/tauri.conf.release.json
+++ b/crates/gitbutler-tauri/tauri.conf.release.json
@@ -31,7 +31,7 @@
 		"security": {
 			"csp": {
 				"default-src": "'self'",
-				"img-src": "'self' asset: https://asset.localhost data: tauri://localhost https://avatars.githubusercontent.com https://*.gitbutler.com  https://gitbutler-public.s3.amazonaws.com https://*.gravatar.com https://io.wp.com https://i0.wp.com https://i1.wp.com https://i2.wp.com https://i3.wp.com https://github.com",
+				"img-src": "'self' asset: https://asset.localhost data: tauri://localhost https://avatars.githubusercontent.com https://*.gitbutler.com  https://gitbutler-public.s3.amazonaws.com https://*.gravatar.com https://io.wp.com https://i0.wp.com https://i1.wp.com https://i2.wp.com https://i3.wp.com https://github.com https://lh*.googleusercontent.com",
 				"connect-src": "'self' https://eu.posthog.com https://eu.i.posthog.com https://app.gitbutler.com https://o4504644069687296.ingest.sentry.io ws://localhost:7703 https://github.com https://api.github.com https://api.openai.com",
 				"script-src": "'self' https://eu.posthog.com https://eu.i.posthog.com",
 				"style-src": "'self' 'unsafe-inline'"


### PR DESCRIPTION
### Changes

- fix showing avatars from google accounts via Auth0
- Without the `referrerpolicy` attribute on the `img` tag Google would respond with a 403
- A quick bit of research seems to indicate that google only serves these from `lh3`, `lh4`, etc. subdomains of `googleusercontent.com`. But that may need to be expanded eventually. Wanted to start small.
