### PR TITLE
Rename gitbutler/integration -> gitbutler/workspace

### DIFF
--- a/apps/desktop/src/lib/components/NotOnGitButlerBranch.svelte
+++ b/apps/desktop/src/lib/components/NotOnGitButlerBranch.svelte
@@ -48,7 +48,7 @@
 			<ProjectNameLabel projectName={project?.title} />
 		</div>
 		<p class="switchrepo__title text-18 text-body text-bold">
-			Looks like you've switched away from <span class="code-string"> gitbutler/integration </span>
+			Looks like you've switched away from <span class="code-string"> gitbutler/workspace </span>
 		</p>
 
 		<p class="switchrepo__message text-13 text-body">
@@ -69,7 +69,7 @@
 					if (baseBranch) branchController.setTarget(baseBranch.branchName);
 				}}
 			>
-				Go back to gitbutler/integration
+				Go back to gitbutler/workspace
 			</Button>
 
 			{#if project}

--- a/crates/gitbutler-branch-actions/benches/branches.rs
+++ b/crates/gitbutler-branch-actions/benches/branches.rs
@@ -18,7 +18,7 @@ pub fn benchmark_list_branches(c: &mut Criterion) {
         (
             "list-branches[tiny repo]",
             3,
-            ("one-vbranch-on-integration-two-remotes", "for-listing.sh"),
+            ("one-vbranch-in-workspace-two-remotes", "for-listing.sh"),
         ),
         (
             "list-branches[many local branches [packed]]",
@@ -59,7 +59,7 @@ pub fn benchmark_branch_details(c: &mut Criterion) {
         (
             "branch-details [tiny no change]",
             (
-                "one-vbranch-on-integration-two-remotes",
+                "one-vbranch-in-workspace-two-remotes",
                 "main",
                 0,
                 "for-listing.sh",

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -17,7 +17,7 @@ use crate::{
     branch_manager::BranchManagerExt,
     conflicts::RepoConflictsExt,
     hunk::VirtualBranchHunk,
-    integration::update_gitbutler_integration,
+    integration::update_workspace_commit,
     remote::{commit_to_remote_commit, RemoteCommit},
     status::get_applied_status,
     VirtualBranchesExt,
@@ -105,7 +105,7 @@ fn go_back_to_integration(ctx: &CommandContext, default_target: &Target) -> Resu
         .context("failed to checkout tree")?;
 
     let base = target_to_base_branch(ctx, default_target)?;
-    update_gitbutler_integration(&vb_state, ctx)?;
+    update_workspace_commit(&vb_state, ctx)?;
     Ok(base)
 }
 
@@ -260,7 +260,7 @@ pub(crate) fn set_base_branch(
 
     set_exclude_decoration(ctx)?;
 
-    update_gitbutler_integration(&vb_state, ctx)?;
+    update_workspace_commit(&vb_state, ctx)?;
 
     let base = target_to_base_branch(ctx, &target)?;
     Ok(base)
@@ -549,7 +549,7 @@ pub(crate) fn update_base_branch(
     })?;
 
     // Rewriting the integration commit is necessary after changing target sha.
-    crate::integration::update_gitbutler_integration(&vb_state, ctx)?;
+    crate::integration::update_workspace_commit(&vb_state, ctx)?;
     Ok(unapplied_branch_names)
 }
 

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Context, Result};
 use git2::Index;
 use gitbutler_branch::{
     self, Branch, BranchId, BranchOwnershipClaims, Target, VirtualBranchesHandle,
-    GITBUTLER_INTEGRATION_REFERENCE,
+    GITBUTLER_WORKSPACE_REFERENCE,
 };
 use gitbutler_command_context::CommandContext;
 use gitbutler_error::error::Marker;
@@ -176,7 +176,7 @@ pub(crate) fn set_base_branch(
         .context("Failed to get HEAD reference name")?;
     if !head_name
         .to_string()
-        .eq(&GITBUTLER_INTEGRATION_REFERENCE.to_string())
+        .eq(&GITBUTLER_WORKSPACE_REFERENCE.to_string())
     {
         // if there are any commits on the head branch or uncommitted changes in the working directory, we need to
         // put them into a virtual branch

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -167,7 +167,7 @@ fn combine_branches(
         let Some(identity) = branch.identity(&remotes) else {
             continue;
         };
-        // Skip branches that should not be listed, e.g. the target 'main' or the gitbutler technical branches like 'gitbutler/integration'
+        // Skip branches that should not be listed, e.g. the target 'main' or the gitbutler technical branches like 'gitbutler/workspace'
         if !should_list_git_branch(&identity) {
             continue;
         }
@@ -358,7 +358,8 @@ impl GroupBranch<'_> {
 fn should_list_git_branch(identity: &BranchIdentity) -> bool {
     // Exclude gitbutler technical branches (not useful for the user)
     const TECHNICAL_IDENTITIES: &[&[u8]] = &[
-        b"gitbutler/integration",
+        b"gitbutler/workspace",
+        b"gitbutler/integration", // Remove me after transition.
         b"gitbutler/target",
         b"gitbutler/oplog",
         b"HEAD",

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -16,7 +16,7 @@ use crate::{
     conflicts::{self, RepoConflictsExt},
     ensure_selected_for_changes,
     hunk::VirtualBranchHunk,
-    integration::update_gitbutler_integration,
+    integration::update_workspace_commit,
     set_ownership, undo_commit, VirtualBranchesExt,
 };
 
@@ -514,7 +514,7 @@ impl BranchManager<'_> {
             }
         }
 
-        update_gitbutler_integration(&vb_state, self.ctx)?;
+        update_workspace_commit(&vb_state, self.ctx)?;
 
         Ok(branch.name)
     }

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
@@ -49,7 +49,7 @@ impl BranchManager<'_> {
         // Ensure we still have a default target
         ensure_selected_for_changes(&vb_state).context("failed to ensure selected for changes")?;
 
-        crate::integration::update_gitbutler_integration(&vb_state, self.ctx)?;
+        crate::integration::update_workspace_commit(&vb_state, self.ctx)?;
 
         real_branch.reference_name()
     }

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -19,6 +19,7 @@ use crate::{branch_manager::BranchManagerExt, conflicts, VirtualBranchesExt};
 
 const WORKSPACE_HEAD: &str = "Workspace Head";
 const GITBUTLER_INTEGRATION_COMMIT_TITLE: &str = "GitButler Integration Commit";
+const GITBUTLER_WORKSPACE_COMMIT_TITLE: &str = "GitButler Workspace Commit";
 
 /// Creates and returns a merge commit of all active branch heads.
 ///
@@ -330,11 +331,12 @@ fn verify_head_is_clean(ctx: &CommandContext, perm: &mut WorktreeWritePermission
     let integration_index = commits
         .iter()
         .position(|commit| {
-            commit
-                .message()
-                .is_some_and(|message| message.starts_with(GITBUTLER_INTEGRATION_COMMIT_TITLE))
+            commit.message().is_some_and(|message| {
+                message.starts_with(GITBUTLER_WORKSPACE_COMMIT_TITLE)
+                    || message.starts_with(GITBUTLER_INTEGRATION_COMMIT_TITLE)
+            })
         })
-        .context("GitButler integration commit not found")?;
+        .context("GitButler workspace commit not found")?;
     let integration_commit = &commits[integration_index];
     let mut extra_commits = commits[..integration_index].to_vec();
     extra_commits.reverse();

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -19,7 +19,7 @@ use crate::{branch_manager::BranchManagerExt, conflicts, VirtualBranchesExt};
 
 const WORKSPACE_HEAD: &str = "Workspace Head";
 const GITBUTLER_INTEGRATION_COMMIT_TITLE: &str = "GitButler Integration Commit";
-const GITBUTLER_WORKSPACE_COMMIT_TITLE: &str = "GitButler Workspace Commit";
+pub const GITBUTLER_WORKSPACE_COMMIT_TITLE: &str = "GitButler Workspace Commit";
 
 /// Creates and returns a merge commit of all active branch heads.
 ///

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -161,11 +161,14 @@ pub fn update_gitbutler_integration(
     let workspace_head = repo.find_commit(get_workspace_head(ctx)?)?;
 
     // message that says how to get back to where they were
-    let mut message = GITBUTLER_INTEGRATION_COMMIT_TITLE.to_string();
+    let mut message = GITBUTLER_WORKSPACE_COMMIT_TITLE.to_string();
     message.push_str("\n\n");
-    message.push_str(
-        "This is an integration commit for the virtual branches that GitButler is tracking.\n\n",
-    );
+    if !virtual_branches.is_empty() {
+        message.push_str("This is an merge commit the virtual branches in your workspace.\n\n");
+    } else {
+        message.push_str("This is placeholder commit and will be replaced by a merge of your");
+        message.push_str("virtual branches.\n\n");
+    }
     message.push_str(
         "Due to GitButler managing multiple virtual branches, you cannot switch back and\n",
     );
@@ -173,22 +176,24 @@ pub fn update_gitbutler_integration(
 
     message.push_str("If you switch to another branch, GitButler will need to be reinitialized.\n");
     message.push_str("If you commit on this branch, GitButler will throw it away.\n\n");
-    message.push_str("Here are the branches that are currently applied:\n");
-    for branch in &virtual_branches {
-        message.push_str(" - ");
-        message.push_str(branch.name.as_str());
-        message.push_str(format!(" ({})", &branch.refname()?).as_str());
-        message.push('\n');
+    if !virtual_branches.is_empty() {
+        message.push_str("Here are the branches that are currently applied:\n");
+        for branch in &virtual_branches {
+            message.push_str(" - ");
+            message.push_str(branch.name.as_str());
+            message.push_str(format!(" ({})", &branch.refname()?).as_str());
+            message.push('\n');
 
-        if branch.head != target.sha {
-            message.push_str("   branch head: ");
-            message.push_str(&branch.head.to_string());
-            message.push('\n');
-        }
-        for file in &branch.ownership.claims {
-            message.push_str("   - ");
-            message.push_str(&file.file_path.display().to_string());
-            message.push('\n');
+            if branch.head != target.sha {
+                message.push_str("   branch head: ");
+                message.push_str(&branch.head.to_string());
+                message.push('\n');
+            }
+            for file in &branch.ownership.claims {
+                message.push_str("   - ");
+                message.push_str(&file.file_path.display().to_string());
+                message.push('\n');
+            }
         }
     }
     if let Some(prev_branch) = prev_branch {

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -164,7 +164,7 @@ pub fn update_workspace_commit(
     let mut message = GITBUTLER_WORKSPACE_COMMIT_TITLE.to_string();
     message.push_str("\n\n");
     if !virtual_branches.is_empty() {
-        message.push_str("This is an merge commit the virtual branches in your workspace.\n\n");
+        message.push_str("This is a merge commit the virtual branches in your workspace.\n\n");
     } else {
         message.push_str("This is placeholder commit and will be replaced by a merge of your");
         message.push_str("virtual branches.\n\n");

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -44,3 +44,5 @@ pub use branch::{
     get_branch_listing_details, list_branches, Author, BranchListing, BranchListingDetails,
     BranchListingFilter,
 };
+
+pub use integration::GITBUTLER_WORKSPACE_COMMIT_TITLE;

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -12,7 +12,7 @@ mod base;
 pub use base::BaseBranch;
 
 mod integration;
-pub use integration::{update_gitbutler_integration, verify_branch};
+pub use integration::{update_workspace_commit, verify_branch};
 
 mod file;
 pub use file::{Get, RemoteBranchFile};

--- a/crates/gitbutler-branch-actions/src/remote.rs
+++ b/crates/gitbutler-branch-actions/src/remote.rs
@@ -83,12 +83,12 @@ pub fn list_local_branches(ctx: &CommandContext) -> Result<Vec<RemoteBranch>> {
                 continue;
             }
         };
-
         let branch_is_trunk = branch.name.branch() == Some(default_target.branch.branch())
             && branch.name.remote() == Some(default_target.branch.remote());
 
         if !branch_is_trunk
-            && branch.name.branch() != Some("gitbutler/integration")
+            && branch.name.branch() != Some("gitbutler/integration") // Remove after rename migration complete.
+            && branch.name.branch() != Some("gitbutler/workspace")
             && branch.name.branch() != Some("gitbutler/target")
         {
             remote_branches.push(branch);

--- a/crates/gitbutler-branch-actions/tests/extra/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/extra/mod.rs
@@ -1309,7 +1309,7 @@ fn detect_mergeable_branch() -> Result<()> {
     std::fs::remove_file(Path::new(&project.path).join(file_path3))?;
 
     ctx.repository()
-        .set_head("refs/heads/gitbutler/integration")?;
+        .set_head("refs/heads/gitbutler/workspace")?;
     ctx.repository()
         .checkout_head(Some(&mut git2::build::CheckoutBuilder::default().force()))?;
 
@@ -1986,7 +1986,7 @@ fn verify_branch_not_integration() -> Result<()> {
     assert!(verify_result.is_err());
     assert_eq!(
         format!("{:#}", verify_result.unwrap_err()),
-        "<verification-failed>: project is on refs/heads/master. Please checkout gitbutler/integration to continue"
+        "<verification-failed>: project is on refs/heads/master. Please checkout gitbutler/workspace to continue"
     );
 
     Ok(())

--- a/crates/gitbutler-branch-actions/tests/extra/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/extra/mod.rs
@@ -17,7 +17,7 @@ use gitbutler_branch::{
 };
 use gitbutler_branch_actions::{
     commit, get_applied_status, integrate_upstream_commits, is_remote_branch_mergeable,
-    list_virtual_branches, unapply_ownership, update_branch, update_gitbutler_integration,
+    list_virtual_branches, unapply_ownership, update_branch, update_workspace_commit,
     verify_branch, BranchManagerExt, Get,
 };
 use gitbutler_commit::{commit_ext::CommitExt, commit_headers::CommitHeadersV2};
@@ -814,8 +814,8 @@ fn merge_vbranch_upstream_clean_rebase() -> Result<()> {
     let file_path2 = Path::new("test2.txt");
     std::fs::write(Path::new(&project.path).join(file_path2), "file2\n")?;
 
-    // Update integration commit
-    update_gitbutler_integration(&vb_state, ctx)?;
+    // Update workspace commit
+    update_workspace_commit(&vb_state, ctx)?;
 
     let remote_branch: RemoteRefname = "refs/remotes/origin/master".parse().unwrap();
     let branch_manager = ctx.branch_manager();
@@ -973,7 +973,7 @@ fn merge_vbranch_upstream_conflict() -> Result<()> {
     )?;
 
     // make gb see the conflict resolution
-    gitbutler_branch_actions::update_gitbutler_integration(&vb_state, ctx)?;
+    update_workspace_commit(&vb_state, ctx)?;
     let (branches, _) = list_virtual_branches(ctx, guard.write_permission())?;
     assert!(branches[0].conflicted);
 
@@ -1409,7 +1409,7 @@ fn upstream_integrated_vbranch() -> Result<()> {
     })?;
     ctx.repository()
         .remote("origin", "http://origin.com/project")?;
-    update_gitbutler_integration(&vb_state, ctx)?;
+    update_workspace_commit(&vb_state, ctx)?;
 
     // create vbranches, one integrated, one not
     let branch_manager = ctx.branch_manager();
@@ -1940,7 +1940,7 @@ fn tree_to_entry_list(
 }
 
 #[test]
-fn verify_branch_commits_to_integration() -> Result<()> {
+fn verify_branch_commits_to_workspace() -> Result<()> {
     let suite = Suite::default();
     let Case { ctx, project, .. } = &suite.new_case();
 
@@ -1971,7 +1971,7 @@ fn verify_branch_commits_to_integration() -> Result<()> {
 }
 
 #[test]
-fn verify_branch_not_integration() -> Result<()> {
+fn verify_branch_not_workspace() -> Result<()> {
     let suite = Suite::default();
     let Case { ctx, project, .. } = &suite.new_case();
 

--- a/crates/gitbutler-branch-actions/tests/fixtures/branch-benches.sh
+++ b/crates/gitbutler-branch-actions/tests/fixtures/branch-benches.sh
@@ -9,7 +9,7 @@ git init remote
 )
 
 function init-virtual() {
-  $CLI project add --switch-to-integration "$(git rev-parse --symbolic-full-name @{u})"
+  $CLI project add --switch-to-workspace "$(git rev-parse --symbolic-full-name @{u})"
   $CLI branch create virtual
 }
 

--- a/crates/gitbutler-branch-actions/tests/fixtures/branch-details-benches.sh
+++ b/crates/gitbutler-branch-actions/tests/fixtures/branch-details-benches.sh
@@ -10018,7 +10018,7 @@ EOF
 
 git clone big-repo big-repo-clone
 (cd big-repo-clone
-  $CLI project add --switch-to-integration "$(git rev-parse --symbolic-full-name @{u})"
+  $CLI project add --switch-to-workspace "$(git rev-parse --symbolic-full-name @{u})"
   $CLI branch create no-change
 )
 
@@ -10032,7 +10032,7 @@ function change-all() {
 
 git clone big-repo big-repo-clone-one-commit-ahead
 (cd big-repo-clone-one-commit-ahead
-  $CLI project add --switch-to-integration "$(git rev-parse --symbolic-full-name @{u})"
+  $CLI project add --switch-to-workspace "$(git rev-parse --symbolic-full-name @{u})"
   $CLI branch create virtual
 
   change-all new-content
@@ -10061,7 +10061,7 @@ git clone remote revwalk-repo
   done
 
   git checkout main
-  $CLI project add --switch-to-integration "$local_tracking_ref"
+  $CLI project add --switch-to-workspace "$local_tracking_ref"
   for round in $(seq 10); do
     echo virtual-main >> file
     $CLI branch commit --message "virt-$round" main

--- a/crates/gitbutler-branch-actions/tests/fixtures/for-details.sh
+++ b/crates/gitbutler-branch-actions/tests/fixtures/for-details.sh
@@ -38,7 +38,7 @@ git clone remote complex-repo
   done
 
   git checkout main
-  $CLI project add --switch-to-integration "$local_tracking_ref"
+  $CLI project add --switch-to-workspace "$local_tracking_ref"
   for round in $(seq 10); do
     echo virtual-main >> file
     $CLI branch commit --message "virt-$round" main

--- a/crates/gitbutler-branch-actions/tests/fixtures/for-listing.sh
+++ b/crates/gitbutler-branch-actions/tests/fixtures/for-listing.sh
@@ -22,15 +22,15 @@ git init remote
 )
 
 export GITBUTLER_CLI_DATA_DIR=../user/gitbutler/app-data
-git clone remote one-vbranch-on-integration
-(cd one-vbranch-on-integration
-  $CLI project add --switch-to-integration "$(git rev-parse --symbolic-full-name @{u})"
+git clone remote one-vbranch-in-workspace
+(cd one-vbranch-in-workspace
+  $CLI project add --switch-to-workspace "$(git rev-parse --symbolic-full-name @{u})"
   $CLI branch create virtual
 )
 
-git clone remote one-vbranch-on-integration-one-commit
-(cd one-vbranch-on-integration-one-commit
-  $CLI project add --switch-to-integration "$(git rev-parse --symbolic-full-name @{u})"
+git clone remote one-vbranch-in-workspace-one-commit
+(cd one-vbranch-in-workspace-one-commit
+  $CLI project add --switch-to-workspace "$(git rev-parse --symbolic-full-name @{u})"
   $CLI branch create virtual
   echo change >> file
   echo in-index > new && git add new
@@ -38,9 +38,9 @@ git clone remote one-vbranch-on-integration-one-commit
   $CLI branch commit virtual -m "virtual branch change in index and worktree"
 )
 
-git clone remote two-vbranches-on-integration-one-applied
-(cd two-vbranches-on-integration-one-applied
-  $CLI project add --switch-to-integration "$(git rev-parse --symbolic-full-name @{u})"
+git clone remote two-vbranches-in-workspace-one-applied
+(cd two-vbranches-in-workspace-one-applied
+  $CLI project add --switch-to-workspace "$(git rev-parse --symbolic-full-name @{u})"
   $CLI branch create virtual
   echo change >> file
   echo in-index > new && git add new
@@ -54,7 +54,7 @@ git clone remote two-vbranches-on-integration-one-applied
 
 git clone remote a-vbranch-named-like-target-branch-short-name
 (cd a-vbranch-named-like-target-branch-short-name
-  $CLI project add --switch-to-integration "$(git rev-parse --symbolic-full-name @{u})"
+  $CLI project add --switch-to-workspace "$(git rev-parse --symbolic-full-name @{u})"
   $CLI branch create --set-default main
   echo change >> file
   echo in-index > new && git add new
@@ -62,9 +62,9 @@ git clone remote a-vbranch-named-like-target-branch-short-name
   $CLI branch commit main -m "virtual branch change in index and worktree"
 )
 
-git clone remote one-vbranch-on-integration-two-remotes
-(cd one-vbranch-on-integration-two-remotes
-  $CLI project add --switch-to-integration "$(git rev-parse --symbolic-full-name @{u})"
+git clone remote one-vbranch-in-workspace-two-remotes
+(cd one-vbranch-in-workspace-two-remotes
+  $CLI project add --switch-to-workspace "$(git rev-parse --symbolic-full-name @{u})"
   $CLI branch create main
 
   git remote add other-remote ../remote
@@ -80,5 +80,5 @@ git clone remote one-branch-one-commit-other-branch-without-commit
   git add . && git commit -m "change standard git feature branch"
 
   git checkout -b other-feature main
-  $CLI project add --switch-to-integration "$local_tracking_ref"
+  $CLI project add --switch-to-workspace "$local_tracking_ref"
 )

--- a/crates/gitbutler-branch-actions/tests/fixtures/for-workspace-migration.sh
+++ b/crates/gitbutler-branch-actions/tests/fixtures/for-workspace-migration.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+CLI=${1:?The first argument is the GitButler CLI}
+
+git init remote
+(cd remote
+  echo first > file
+  git add . && git commit -m "init"
+)
+
+export GITBUTLER_CLI_DATA_DIR=../user/gitbutler/app-data
+git clone remote workspace-migration
+(cd workspace-migration
+  $CLI project add --switch-to-workspace "$(git rev-parse --symbolic-full-name @{u})"
+  $CLI branch create virtual
+  # Start the test on the old integration branch.
+  git checkout -b gitbutler/integration
+)

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/convert_to_real_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/convert_to_real_branch.rs
@@ -100,7 +100,7 @@ fn conflicting() {
 
         let vb_state = VirtualBranchesHandle::new(project.gb_dir());
         let ctx = CommandContext::open(project).unwrap();
-        update_gitbutler_integration(&vb_state, &ctx).unwrap();
+        update_workspace_commit(&vb_state, &ctx).unwrap();
         let (branches, _) = controller.list_virtual_branches(project).unwrap();
 
         assert_eq!(branches.len(), 1);

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
@@ -68,7 +68,7 @@ fn integration() {
         std::fs::write(repository.path().join("another.txt"), "").unwrap();
         repository.commit_all("another");
         repository.push_branch(&"refs/heads/master".parse().unwrap());
-        repository.checkout(&"refs/heads/gitbutler/integration".parse().unwrap());
+        repository.checkout(&"refs/heads/gitbutler/workspace".parse().unwrap());
     }
 
     {

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/init.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/init.rs
@@ -31,7 +31,7 @@ fn twice() {
             .set_base_branch(&project, &"refs/remotes/origin/master".parse().unwrap())
             .unwrap();
 
-        // even though project is on gitbutler/integration, we should not import it
+        // even though project is on gitbutler/workspace, we should not import it
         assert!(controller
             .list_virtual_branches(&project)
             .unwrap()

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/list.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/list.rs
@@ -2,9 +2,9 @@ use anyhow::Result;
 use gitbutler_branch_actions::BranchListingFilter;
 
 #[test]
-fn one_vbranch_on_integration() -> Result<()> {
+fn one_vbranch_in_workspace() -> Result<()> {
     init_env();
-    let list = list_branches(&project_ctx("one-vbranch-on-integration")?, None)?;
+    let list = list_branches(&project_ctx("one-vbranch-in-workspace")?, None)?;
     assert_eq!(list.len(), 1);
 
     assert_equal(
@@ -22,9 +22,9 @@ fn one_vbranch_on_integration() -> Result<()> {
 }
 
 #[test]
-fn one_vbranch_on_integration_one_commit() -> Result<()> {
+fn one_vbranch_in_workspace_one_commit() -> Result<()> {
     init_env();
-    let ctx = project_ctx("one-vbranch-on-integration-one-commit")?;
+    let ctx = project_ctx("one-vbranch-in-workspace-one-commit")?;
     let list = list_branches(&ctx, None)?;
     assert_eq!(list.len(), 1);
 
@@ -43,9 +43,9 @@ fn one_vbranch_on_integration_one_commit() -> Result<()> {
 }
 
 #[test]
-fn two_vbranches_on_integration_one_commit() -> Result<()> {
+fn two_vbranches_in_workspace_one_commit() -> Result<()> {
     init_env();
-    let ctx = project_ctx("two-vbranches-on-integration-one-applied")?;
+    let ctx = project_ctx("two-vbranches-in-workspace-one-applied")?;
     let list = list_branches(
         &ctx,
         Some(BranchListingFilter {
@@ -89,7 +89,7 @@ fn two_vbranches_on_integration_one_commit() -> Result<()> {
 }
 
 #[test]
-fn one_feature_branch_and_one_vbranch_on_integration_one_commit() -> Result<()> {
+fn one_feature_branch_and_one_vbranch_in_workspace_one_commit() -> Result<()> {
     init_env();
     let ctx = project_ctx("a-vbranch-named-like-target-branch-short-name")?;
     let list = list_branches(&ctx, None)?;
@@ -115,9 +115,9 @@ fn one_feature_branch_and_one_vbranch_on_integration_one_commit() -> Result<()> 
 }
 
 #[test]
-fn one_branch_on_integration_multiple_remotes() -> Result<()> {
+fn one_branch_in_workspace_multiple_remotes() -> Result<()> {
     init_env();
-    let ctx = project_ctx("one-vbranch-on-integration-two-remotes")?;
+    let ctx = project_ctx("one-vbranch-in-workspace-two-remotes")?;
     let list = list_branches(&ctx, None)?;
     assert_eq!(list.len(), 1, "a single virtual branch");
 

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/list_details.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/list_details.rs
@@ -2,9 +2,9 @@ use crate::virtual_branches::list;
 use gitbutler_branch_actions::BranchListingDetails;
 
 #[test]
-fn one_vbranch_on_integration_empty_details() -> anyhow::Result<()> {
+fn one_vbranch_in_workspace_empty_details() -> anyhow::Result<()> {
     let list = branch_details(
-        &list::project_ctx("one-vbranch-on-integration")?,
+        &list::project_ctx("one-vbranch-in-workspace")?,
         Some("virtual"),
     )?;
     assert_eq!(list.len(), 1);
@@ -23,9 +23,9 @@ fn one_vbranch_on_integration_empty_details() -> anyhow::Result<()> {
 }
 
 #[test]
-fn one_vbranch_on_integration_single_commit() -> anyhow::Result<()> {
+fn one_vbranch_in_workspace_single_commit() -> anyhow::Result<()> {
     let list = branch_details(
-        &list::project_ctx("one-vbranch-on-integration-one-commit")?,
+        &list::project_ctx("one-vbranch-in-workspace-one-commit")?,
         Some("virtual"),
     )?;
     assert_eq!(list.len(), 1);

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/mod.rs
@@ -1,6 +1,7 @@
 use std::{fs, path, path::PathBuf, str::FromStr};
 
 use gitbutler_branch::{BranchCreateRequest, VirtualBranchesHandle};
+use gitbutler_branch_actions::GITBUTLER_WORKSPACE_COMMIT_TITLE;
 use gitbutler_branch_actions::{update_gitbutler_integration, VirtualBranchActions};
 use gitbutler_command_context::CommandContext;
 use gitbutler_error::error::Marker;

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/mod.rs
@@ -82,6 +82,7 @@ mod update_base_branch;
 mod update_commit_message;
 mod upstream;
 mod verify_branch;
+mod workspace_migration;
 
 #[test]
 fn resolve_conflict_flow() {

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/mod.rs
@@ -2,7 +2,7 @@ use std::{fs, path, path::PathBuf, str::FromStr};
 
 use gitbutler_branch::{BranchCreateRequest, VirtualBranchesHandle};
 use gitbutler_branch_actions::GITBUTLER_WORKSPACE_COMMIT_TITLE;
-use gitbutler_branch_actions::{update_gitbutler_integration, VirtualBranchActions};
+use gitbutler_branch_actions::{update_workspace_commit, VirtualBranchActions};
 use gitbutler_command_context::CommandContext;
 use gitbutler_error::error::Marker;
 use gitbutler_project::{self as projects, Project, ProjectId};
@@ -141,7 +141,7 @@ fn resolve_conflict_flow() {
 
         let vb_state = VirtualBranchesHandle::new(project.gb_dir());
         let ctx = CommandContext::open(project).unwrap();
-        update_gitbutler_integration(&vb_state, &ctx).unwrap();
+        update_workspace_commit(&vb_state, &ctx).unwrap();
         let (branches, _) = controller.list_virtual_branches(project).unwrap();
         assert_eq!(branches.len(), 1);
         assert!(branches[0].active);

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/oplog.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/oplog.rs
@@ -230,7 +230,7 @@ fn basic_oplog() -> anyhow::Result<()> {
 }
 
 #[test]
-fn restores_gitbutler_integration() -> anyhow::Result<()> {
+fn restores_gitbutler_workspace() -> anyhow::Result<()> {
     let Test {
         repository,
         controller,
@@ -260,7 +260,7 @@ fn restores_gitbutler_integration() -> anyhow::Result<()> {
 
     let repo = git2::Repository::open(&project.path)?;
 
-    // check the integration commit
+    // check the workspace commit
     let head = repo.head().expect("never unborn");
     let commit = &head.peel_to_commit()?;
     let commit1_id = commit.id();
@@ -271,7 +271,7 @@ fn restores_gitbutler_integration() -> anyhow::Result<()> {
     fs::write(repository.path().join("file.txt"), "changed content")?;
     let _commit2_id = controller.create_commit(project, branch_id, "commit two", None, false)?;
 
-    // check the integration commit changed
+    // check the workspace commit changed
     let head = repo.head().expect("never unborn");
     let commit = &head.peel_to_commit()?;
     let commit2_id = commit.id();

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/oplog.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/oplog.rs
@@ -265,7 +265,7 @@ fn restores_gitbutler_integration() -> anyhow::Result<()> {
     let commit = &head.peel_to_commit()?;
     let commit1_id = commit.id();
     let message = commit.summary().unwrap();
-    assert_eq!(message, "GitButler Integration Commit");
+    assert_eq!(message, GITBUTLER_WORKSPACE_COMMIT_TITLE);
 
     // create second commit
     fs::write(repository.path().join("file.txt"), "changed content")?;
@@ -276,7 +276,7 @@ fn restores_gitbutler_integration() -> anyhow::Result<()> {
     let commit = &head.peel_to_commit()?;
     let commit2_id = commit.id();
     let message = commit.summary().unwrap();
-    assert_eq!(message, "GitButler Integration Commit");
+    assert_eq!(message, GITBUTLER_WORKSPACE_COMMIT_TITLE);
     assert_ne!(commit1_id, commit2_id);
 
     // restore the first

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/set_base_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/set_base_branch.rs
@@ -39,7 +39,7 @@ mod error {
     }
 }
 
-mod go_back_to_integration {
+mod go_back_to_workspace {
     use gitbutler_branch::BranchCreateRequest;
     use pretty_assertions::assert_eq;
 

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/update_base_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/update_base_branch.rs
@@ -738,7 +738,7 @@ mod applied_branch {
 
             let vb_state = VirtualBranchesHandle::new(project.gb_dir());
             let ctx = CommandContext::open(project).unwrap();
-            update_gitbutler_integration(&vb_state, &ctx).unwrap();
+            update_workspace_commit(&vb_state, &ctx).unwrap();
             let (branches, _) = controller.list_virtual_branches(project).unwrap();
             assert_eq!(branches.len(), 1);
             assert!(branches[0].active);

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/verify_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/verify_branch.rs
@@ -2,7 +2,7 @@ use gitbutler_reference::LocalRefname;
 
 use super::*;
 
-// Ensures that `verify_branch` returns an error when not on the integration branch.
+// Ensures that `verify_branch` returns an error when not on the workspace branch.
 #[test]
 fn should_fail_on_incorrect_branch() {
     let Test {
@@ -19,6 +19,6 @@ fn should_fail_on_incorrect_branch() {
     let err = result.unwrap_err();
     assert_eq!(
         format!("{err:#}"),
-        "<verification-failed>: project is on refs/heads/somebranch. Please checkout gitbutler/integration to continue"
+        "<verification-failed>: project is on refs/heads/somebranch. Please checkout gitbutler/workspace to continue"
     );
 }

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/workspace_migration.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/workspace_migration.rs
@@ -1,6 +1,8 @@
 use gitbutler_branch::VirtualBranchesHandle;
-use gitbutler_branch_actions::{update_workspace_commit, verify_branch};
-use gitbutler_operating_modes::{INTEGRATION_BRANCH_REF, WORKSPACE_BRANCH_REF};
+use gitbutler_branch_actions::update_workspace_commit;
+use gitbutler_operating_modes::{
+    assure_open_workspace_mode, INTEGRATION_BRANCH_REF, WORKSPACE_BRANCH_REF,
+};
 
 /// Tests that "verify branch" won't complain if we are on the old integration
 /// branch, and that `update_workspace_commit` will put us back on the a branch
@@ -11,8 +13,6 @@ fn works_on_integration_branch() -> anyhow::Result<()> {
         "for-workspace-migration.sh",
         "workspace-migration",
     )?;
-    let mut guard = ctx.project().exclusive_worktree_access();
-    let perm = guard.write_permission();
 
     // Check that we are on the old `gitbutler/integration` branch.
     assert_eq!(
@@ -21,7 +21,7 @@ fn works_on_integration_branch() -> anyhow::Result<()> {
     );
 
     // Should not throw verification error until migration is complete.
-    let result = verify_branch(&ctx, perm);
+    let result = assure_open_workspace_mode(&ctx);
     assert!(result.is_ok());
 
     // Updating workspace commit should put us on the workspace branch.

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/workspace_migration.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/workspace_migration.rs
@@ -1,0 +1,31 @@
+use gitbutler_branch::VirtualBranchesHandle;
+use gitbutler_branch_actions::{update_workspace_commit, verify_branch};
+use gitbutler_operating_modes::{INTEGRATION_BRANCH_REF, WORKSPACE_BRANCH_REF};
+
+/// Tests that "verify branch" won't complain if we are on the old integration
+/// branch, and that `update_workspace_commit` will put us back on the a branch
+/// with the new name.
+#[test]
+fn works_on_integration_branch() -> anyhow::Result<()> {
+    let ctx = gitbutler_testsupport::read_only::fixture(
+        "for-workspace-migration.sh",
+        "workspace-migration",
+    )?;
+    let mut guard = ctx.project().exclusive_worktree_access();
+    let perm = guard.write_permission();
+
+    // Check that we are on the old `gitbutler/integration` branch.
+    assert_eq!(
+        ctx.repository().head()?.name(),
+        Some(INTEGRATION_BRANCH_REF)
+    );
+
+    // Should not throw verification error until migration is complete.
+    let result = verify_branch(&ctx, perm);
+    assert!(result.is_ok());
+
+    // Updating workspace commit should put us on the workspace branch.
+    update_workspace_commit(&VirtualBranchesHandle::new(ctx.project().gb_dir()), &ctx)?;
+    assert_eq!(ctx.repository().head()?.name(), Some(WORKSPACE_BRANCH_REF));
+    Ok(())
+}

--- a/crates/gitbutler-branch/src/lib.rs
+++ b/crates/gitbutler-branch/src/lib.rs
@@ -23,8 +23,8 @@ mod state;
 use lazy_static::lazy_static;
 pub use state::{VirtualBranches as VirtualBranchesState, VirtualBranchesHandle};
 lazy_static! {
-    pub static ref GITBUTLER_INTEGRATION_REFERENCE: gitbutler_reference::LocalRefname =
-        gitbutler_reference::LocalRefname::new("gitbutler/integration", None);
+    pub static ref GITBUTLER_WORKSPACE_REFERENCE: gitbutler_reference::LocalRefname =
+        gitbutler_reference::LocalRefname::new("gitbutler/workspace", None);
 }
 
 pub const GITBUTLER_COMMIT_AUTHOR_NAME: &str = "GitButler";

--- a/crates/gitbutler-cli/src/args.rs
+++ b/crates/gitbutler-cli/src/args.rs
@@ -108,13 +108,13 @@ pub mod project {
             /// The long name of the remote reference to track, like `refs/remotes/origin/main`,
             /// when switching to the workspace branch.
             #[clap(short = 's', long)]
-            switch_to_integration: Option<RemoteRefname>,
+            switch_to_workspace: Option<RemoteRefname>,
             /// The path at which the repository worktree is located.
             #[clap(default_value = ".", value_name = "REPOSITORY")]
             path: PathBuf,
         },
         /// Switch back to the workspace branch for use of virtual branches.
-        SwitchToIntegration {
+        SwitchToWorkspace {
             /// The long name of the remote reference to track, like `refs/remotes/origin/main`.
             remote_ref_name: RemoteRefname,
         },

--- a/crates/gitbutler-cli/src/args.rs
+++ b/crates/gitbutler-cli/src/args.rs
@@ -106,14 +106,14 @@ pub mod project {
         /// Add the given Git repository as project for use with GitButler.
         Add {
             /// The long name of the remote reference to track, like `refs/remotes/origin/main`,
-            /// when switching to the integration branch.
+            /// when switching to the workspace branch.
             #[clap(short = 's', long)]
             switch_to_integration: Option<RemoteRefname>,
             /// The path at which the repository worktree is located.
             #[clap(default_value = ".", value_name = "REPOSITORY")]
             path: PathBuf,
         },
-        /// Switch back to the integration branch for use of virtual branches.
+        /// Switch back to the workspace branch for use of virtual branches.
         SwitchToIntegration {
             /// The long name of the remote reference to track, like `refs/remotes/origin/main`.
             remote_ref_name: RemoteRefname,

--- a/crates/gitbutler-cli/src/command/project.rs
+++ b/crates/gitbutler-cli/src/command/project.rs
@@ -36,6 +36,6 @@ pub fn add(
     debug_print(project)
 }
 
-pub fn switch_to_integration(project: Project, refname: RemoteRefname) -> Result<()> {
+pub fn switch_to_workspace(project: Project, refname: RemoteRefname) -> Result<()> {
     debug_print(VirtualBranchActions.set_base_branch(&project, &refname)?)
 }

--- a/crates/gitbutler-cli/src/main.rs
+++ b/crates/gitbutler-cli/src/main.rs
@@ -49,16 +49,16 @@ fn main() -> Result<()> {
             app_suffix,
             cmd,
         }) => match cmd {
-            Some(project::SubCommands::SwitchToIntegration { remote_ref_name }) => {
+            Some(project::SubCommands::SwitchToWorkspace { remote_ref_name }) => {
                 let project = command::prepare::project_from_path(args.current_dir)?;
-                command::project::switch_to_integration(project, remote_ref_name)
+                command::project::switch_to_workspace(project, remote_ref_name)
             }
             Some(project::SubCommands::Add {
-                switch_to_integration,
+                switch_to_workspace,
                 path,
             }) => {
                 let ctrl = command::prepare::project_controller(app_suffix, app_data_dir)?;
-                command::project::add(ctrl, path, switch_to_integration)
+                command::project::add(ctrl, path, switch_to_workspace)
             }
             None => {
                 let ctrl = command::prepare::project_controller(app_suffix, app_data_dir)?;

--- a/crates/gitbutler-diff/src/diff.rs
+++ b/crates/gitbutler-diff/src/diff.rs
@@ -92,8 +92,9 @@ impl GitHunk {
 
 /// Comparison
 impl GitHunk {
-    /// workspace_intersects_unapplied is used to determine if a hunk from a diff between workspace and the trunk intersects with an unapplied hunk.
-    /// We want to use the new start/end for the integraiton hunk and the old start/end for the unapplied hunk.
+    /// workspace_intersects_unapplied is used to determine if a hunk from a diff between workspace
+    /// and the trunk intersects with an unapplied hunk. We want to use the new start/end for the
+    /// integration hunk and the old start/end for the unapplied hunk.
     pub fn workspace_intersects_unapplied(
         workspace_hunk: &GitHunk,
         unapplied_hunk: &GitHunk,

--- a/crates/gitbutler-diff/src/diff.rs
+++ b/crates/gitbutler-diff/src/diff.rs
@@ -92,17 +92,17 @@ impl GitHunk {
 
 /// Comparison
 impl GitHunk {
-    /// integration_intersects_unapplied is used to determine if a hunk from a diff between integration and the trunk intersects with an unapplied hunk.
+    /// workspace_intersects_unapplied is used to determine if a hunk from a diff between workspace and the trunk intersects with an unapplied hunk.
     /// We want to use the new start/end for the integraiton hunk and the old start/end for the unapplied hunk.
-    pub fn integration_intersects_unapplied(
-        integration_hunk: &GitHunk,
+    pub fn workspace_intersects_unapplied(
+        workspace_hunk: &GitHunk,
         unapplied_hunk: &GitHunk,
     ) -> bool {
         let unapplied_old_end = unapplied_hunk.old_start + unapplied_hunk.old_lines;
-        let integration_new_end = integration_hunk.new_start + integration_hunk.new_lines;
+        let workspace_new_end = workspace_hunk.new_start + workspace_hunk.new_lines;
 
-        unapplied_hunk.old_start <= integration_new_end
-            && integration_hunk.new_start <= unapplied_old_end
+        unapplied_hunk.old_start <= workspace_new_end
+            && workspace_hunk.new_start <= unapplied_old_end
     }
 }
 

--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -16,7 +16,7 @@ use gitbutler_commit::{
 use gitbutler_diff::hunks_by_filepath;
 use gitbutler_operating_modes::{
     operating_mode, read_edit_mode_metadata, write_edit_mode_metadata, EditModeMetadata,
-    OperatingMode, EDIT_BRANCH_REF, INTEGRATION_BRANCH_REF,
+    OperatingMode, EDIT_BRANCH_REF, WORKSPACE_BRANCH_REF,
 };
 use gitbutler_project::access::{WorktreeReadPermission, WorktreeWritePermission};
 use gitbutler_reference::{ReferenceName, Refname};
@@ -285,14 +285,14 @@ pub(crate) fn save_and_return_to_workspace(
         )
         .context("Failed to reference new commit branch head")?;
 
-    // Move back to gitbutler/integration and restore stashed changes
+    // Move back to gitbutler/workspace and restore stashed changes
     {
         repository
-            .set_head(INTEGRATION_BRANCH_REF)
+            .set_head(WORKSPACE_BRANCH_REF)
             .context("Failed to set head reference")?;
         repository
             .checkout_head(Some(CheckoutBuilder::new().force().remove_untracked(true)))
-            .context("Failed to checkout gitbutler/integration")?;
+            .context("Failed to checkout gitbutler/workspace")?;
 
         virtual_branch.head = new_branch_head;
         virtual_branch.updated_timestamp_ms = gitbutler_time::time::now_ms();

--- a/crates/gitbutler-operating-modes/src/lib.rs
+++ b/crates/gitbutler-operating-modes/src/lib.rs
@@ -17,7 +17,7 @@ const INTEGRATION_BRANCH_REF: &str = "refs/heads/gitbutler/integration";
 /// after upgrading to a version using the new gitbutler/workspace branch
 /// name we need some transition period during which both are accepted.
 /// The new branch will be checked out as soon as any modification is made
-/// that triggers `update_gitbutler_integration`.
+/// that triggers `update_workspace_commit`.
 pub const OPEN_WORKSPACE_REFS: [&str; 2] = [INTEGRATION_BRANCH_REF, WORKSPACE_BRANCH_REF];
 
 /// The reference the app will checkout when in edit mode

--- a/crates/gitbutler-operating-modes/src/lib.rs
+++ b/crates/gitbutler-operating-modes/src/lib.rs
@@ -11,7 +11,7 @@ pub mod commands;
 pub const WORKSPACE_BRANCH_REF: &str = "refs/heads/gitbutler/workspace";
 
 /// Previous workspace reference, delete after transition.
-const INTEGRATION_BRANCH_REF: &str = "refs/heads/gitbutler/integration";
+pub const INTEGRATION_BRANCH_REF: &str = "refs/heads/gitbutler/integration";
 
 /// To prevent clients hitting the "looks like you've moved away from..."
 /// after upgrading to a version using the new gitbutler/workspace branch

--- a/crates/gitbutler-operating-modes/src/lib.rs
+++ b/crates/gitbutler-operating-modes/src/lib.rs
@@ -11,7 +11,7 @@ pub mod commands;
 pub const WORKSPACE_BRANCH_REF: &str = "refs/heads/gitbutler/workspace";
 
 /// Previous workspace reference, delete after transition.
-pub const INTEGRATION_BRANCH_REF: &str = "refs/heads/gitbutler/integration";
+const INTEGRATION_BRANCH_REF: &str = "refs/heads/gitbutler/integration";
 
 /// To prevent clients hitting the "looks like you've moved away from..."
 /// after upgrading to a version using the new gitbutler/workspace branch

--- a/crates/gitbutler-operating-modes/tests/operating_modes.rs
+++ b/crates/gitbutler-operating-modes/tests/operating_modes.rs
@@ -36,7 +36,7 @@ mod operating_modes {
         use crate::create_and_checkout_branch;
 
         #[test]
-        fn in_open_workspace_mode_true_when_in_gitbutler_integration() {
+        fn in_open_workspace_mode_true_when_in_gitbutler_workspace() {
             let suite = Suite::default();
             let Case { ctx, .. } = &suite.new_case();
 
@@ -69,7 +69,7 @@ mod operating_modes {
         }
 
         #[test]
-        fn assure_open_workspace_mode_ok_when_on_gitbutler_integration() {
+        fn assure_open_workspace_mode_ok_when_on_gitbutler_workspace() {
             let suite = Suite::default();
             let Case { ctx, .. } = &suite.new_case();
 
@@ -129,7 +129,7 @@ mod operating_modes {
         }
 
         #[test]
-        fn in_outside_workspace_mode_false_when_on_gitbutler_integration() {
+        fn in_outside_workspace_mode_false_when_on_gitbutler_workspace() {
             let suite = Suite::default();
             let Case { ctx, .. } = &suite.new_case();
 
@@ -161,7 +161,7 @@ mod operating_modes {
         }
 
         #[test]
-        fn assure_outside_workspace_mode_err_when_on_gitbutler_integration() {
+        fn assure_outside_workspace_mode_err_when_on_gitbutler_workspace() {
             let suite = Suite::default();
             let Case { ctx, .. } = &suite.new_case();
 

--- a/crates/gitbutler-operating-modes/tests/operating_modes.rs
+++ b/crates/gitbutler-operating-modes/tests/operating_modes.rs
@@ -40,7 +40,7 @@ mod operating_modes {
             let suite = Suite::default();
             let Case { ctx, .. } = &suite.new_case();
 
-            create_and_checkout_branch(ctx, "gitbutler/integration");
+            create_and_checkout_branch(ctx, "gitbutler/workspace");
 
             let in_open_workspace = in_open_workspace_mode(ctx);
             assert!(in_open_workspace);
@@ -73,7 +73,7 @@ mod operating_modes {
             let suite = Suite::default();
             let Case { ctx, .. } = &suite.new_case();
 
-            create_and_checkout_branch(ctx, "gitbutler/integration");
+            create_and_checkout_branch(ctx, "gitbutler/workspace");
 
             assert!(assure_open_workspace_mode(ctx).is_ok());
         }
@@ -133,7 +133,7 @@ mod operating_modes {
             let suite = Suite::default();
             let Case { ctx, .. } = &suite.new_case();
 
-            create_and_checkout_branch(ctx, "gitbutler/integration");
+            create_and_checkout_branch(ctx, "gitbutler/workspace");
 
             let in_outside_worskpace = in_outside_workspace_mode(ctx);
             assert!(!in_outside_worskpace);
@@ -165,7 +165,7 @@ mod operating_modes {
             let suite = Suite::default();
             let Case { ctx, .. } = &suite.new_case();
 
-            create_and_checkout_branch(ctx, "gitbutler/integration");
+            create_and_checkout_branch(ctx, "gitbutler/workspace");
 
             assert!(assure_outside_workspace_mode(ctx).is_err());
         }

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -119,7 +119,7 @@ pub trait OplogExt {
     /// if this is 10s but the last snapshot was done 9s ago, no check if performed and the return value is `false`.
     ///
     /// This implementation returns `true` on the following conditions:
-    ///  - Head is pointing to the integration branch.
+    ///  - Head is pointing to the workspace branch.
     ///  - If it's been more than 5 minutes since the last snapshot,
     ///    check the sum of added and removed lines since the last snapshot, otherwise return `false`.
     ///      * If the sum of added and removed lines is greater than a configured threshold, return `true`, otherwise return `false`.
@@ -405,9 +405,9 @@ fn prepare_snapshot(ctx: &Project, _shared_access: &WorktreeReadPermission) -> R
         )?;
     }
 
-    // also add the gitbutler/integration commit to the branches tree
+    // also add the gitbutler/workspace commit to the branches tree
     let head = repo.head()?;
-    if head.name() == Some("refs/heads/gitbutler/integration") {
+    if head.name() == Some("refs/heads/gitbutler/workspace") {
         let head_commit = head.peel_to_commit()?;
         let head_tree = head_commit.tree()?;
 
@@ -545,13 +545,13 @@ fn restore_snapshot(
                     }
                 }
 
-                // if branch_name is 'integration', we need to create or update the gitbutler/integration branch
+                // if branch_name is 'integration', we need to create or update the gitbutler/workspace branch
                 if branch_name == Some("integration") {
                     // TODO(ST): with `gitoxide`, just update the branch without this dance,
                     //           similar to `git update-ref`.
-                    //           Then a missing integration branch also doesn't have to be
+                    //           Then a missing workspace branch also doesn't have to be
                     //           fatal, but we wouldn't want to `set_head()` if we are
-                    //           not already on the integration branch.
+                    //           not already on the workspace branch.
                     let mut integration_ref = repo.integration_ref_from_head()?;
 
                     // reset the branch if it's there, otherwise bail as we don't meddle with other branches
@@ -561,16 +561,16 @@ fn restore_snapshot(
 
                     // ok, now we set the branch to what it was and update HEAD
                     let integration_commit = repo.find_commit(commit_oid)?;
-                    repo.branch("gitbutler/integration", &integration_commit, true)?;
-                    // make sure head is gitbutler/integration
-                    repo.set_head("refs/heads/gitbutler/integration")?;
+                    repo.branch("gitbutler/workspace", &integration_commit, true)?;
+                    // make sure head is gitbutler/workspace
+                    repo.set_head("refs/heads/gitbutler/workspace")?;
                 }
             }
         }
     }
 
     repo.integration_ref_from_head().context(
-        "We will not change a worktree which for some reason isn't on the integration branch",
+        "We will not change a worktree which for some reason isn't on the workspace branch",
     )?;
 
     let workdir_tree_id = tree_from_applied_vbranches(&repo, snapshot_commit_id)?;

--- a/crates/gitbutler-reference/tests/reference.rs
+++ b/crates/gitbutler-reference/tests/reference.rs
@@ -48,10 +48,10 @@ mod normalize_branch_name {
         assert_eq!(normalize_branch_name("#[test]")?, "#-test]");
         assert_eq!(normalize_branch_name("foo#branch")?, "foo#branch");
         assert_eq!(normalize_branch_name("foo!branch")?, "foo!branch");
-        let input = r#"Revert "GitButler Integration Commit"
+        let input = r#"Revert "GitButler Workspace Commit"
 
 This reverts commit d6efa5fd96d36da445d5d1345b84163f05f5f229."#;
-        assert_eq!(normalize_branch_name(input)?, "Revert-\"GitButler-Integration-Commit\"-This-reverts-commit-d6efa5fd96d36da445d5d1345b84163f05f5f229");
+        assert_eq!(normalize_branch_name(input)?, "Revert-\"GitButler-Workspace-Commit\"-This-reverts-commit-d6efa5fd96d36da445d5d1345b84163f05f5f229");
         Ok(())
     }
 }

--- a/crates/gitbutler-repo/src/repository_ext.rs
+++ b/crates/gitbutler-repo/src/repository_ext.rs
@@ -35,8 +35,8 @@ pub trait RepositoryExt {
     /// disk when doing merges.
     /// Note that these written objects don't persist and will vanish with the returned instance.
     fn in_memory_repo(&self) -> Result<git2::Repository>;
-    /// Fetches the integration commit from the gitbutler/workspace branch
-    fn integration_commit(&self) -> Result<git2::Commit<'_>>;
+    /// Fetches the workspace commit from the gitbutler/workspace branch
+    fn workspace_commit(&self) -> Result<git2::Commit<'_>>;
     /// Takes a CommitBuffer and returns it after being signed by by your git signing configuration
     fn sign_buffer(&self, buffer: &CommitBuffer) -> Result<BString>;
 
@@ -49,10 +49,10 @@ pub trait RepositoryExt {
 
     /// Returns the `gitbutler/workspace` branch if the head currently points to it, or fail otherwise.
     /// Use it before any modification to the repository, or extra defensively each time the
-    /// integration is needed.
+    /// workspace is needed.
     ///
     /// This is for safety to assure the repository actually is in 'gitbutler mode'.
-    fn integration_ref_from_head(&self) -> Result<git2::Reference<'_>>;
+    fn workspace_ref_from_head(&self) -> Result<git2::Reference<'_>>;
 
     #[allow(clippy::too_many_arguments)]
     fn commit_with_signature(
@@ -151,7 +151,7 @@ impl RepositoryExt for git2::Repository {
         self.find_tree(oid).map(Into::into).map_err(Into::into)
     }
 
-    fn integration_ref_from_head(&self) -> Result<git2::Reference<'_>> {
+    fn workspace_ref_from_head(&self) -> Result<git2::Reference<'_>> {
         let head_ref = self.head().context("BUG: head must point to a reference")?;
         if head_ref.name_bytes() == b"refs/heads/gitbutler/workspace" {
             Ok(head_ref)
@@ -162,9 +162,9 @@ impl RepositoryExt for git2::Repository {
         }
     }
 
-    fn integration_commit(&self) -> Result<git2::Commit<'_>> {
-        let integration_ref = self.integration_ref_from_head()?;
-        Ok(integration_ref.peel_to_commit()?)
+    fn workspace_commit(&self) -> Result<git2::Commit<'_>> {
+        let workspace_ref = self.workspace_ref_from_head()?;
+        Ok(workspace_ref.peel_to_commit()?)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/gitbutler-repo/src/repository_ext.rs
+++ b/crates/gitbutler-repo/src/repository_ext.rs
@@ -35,7 +35,7 @@ pub trait RepositoryExt {
     /// disk when doing merges.
     /// Note that these written objects don't persist and will vanish with the returned instance.
     fn in_memory_repo(&self) -> Result<git2::Repository>;
-    /// Fetches the integration commit from the gitbutler/integration branch
+    /// Fetches the integration commit from the gitbutler/workspace branch
     fn integration_commit(&self) -> Result<git2::Commit<'_>>;
     /// Takes a CommitBuffer and returns it after being signed by by your git signing configuration
     fn sign_buffer(&self, buffer: &CommitBuffer) -> Result<BString>;
@@ -47,7 +47,7 @@ pub trait RepositoryExt {
     /// Based on the index, add all data similar to `git add .` and create a tree from it, which is returned.
     fn create_wd_tree(&self) -> Result<Tree>;
 
-    /// Returns the `gitbutler/integration` branch if the head currently points to it, or fail otherwise.
+    /// Returns the `gitbutler/workspace` branch if the head currently points to it, or fail otherwise.
     /// Use it before any modification to the repository, or extra defensively each time the
     /// integration is needed.
     ///
@@ -153,11 +153,11 @@ impl RepositoryExt for git2::Repository {
 
     fn integration_ref_from_head(&self) -> Result<git2::Reference<'_>> {
         let head_ref = self.head().context("BUG: head must point to a reference")?;
-        if head_ref.name_bytes() == b"refs/heads/gitbutler/integration" {
+        if head_ref.name_bytes() == b"refs/heads/gitbutler/workspace" {
             Ok(head_ref)
         } else {
             Err(anyhow!(
-                "Unexpected state: cannot perform operation on non-integration branch"
+                "Unexpected state: cannot perform operation on non-workspace branch"
             ))
         }
     }

--- a/crates/gitbutler-repo/tests/fixtures/stacking.sh
+++ b/crates/gitbutler-repo/tests/fixtures/stacking.sh
@@ -23,7 +23,7 @@ git init remote
 export GITBUTLER_CLI_DATA_DIR=../user/gitbutler/app-data
 git clone remote multiple-commits 
 (cd multiple-commits
-  $CLI project add --switch-to-integration "$(git rev-parse --symbolic-full-name @{u})"
+  $CLI project add --switch-to-workspace "$(git rev-parse --symbolic-full-name @{u})"
 
   $CLI branch create --set-default first_branch
   echo asdf >> foo

--- a/crates/gitbutler-testsupport/src/lib.rs
+++ b/crates/gitbutler-testsupport/src/lib.rs
@@ -41,8 +41,8 @@ pub mod virtual_branches {
             })
             .expect("failed to write target");
 
-        gitbutler_branch_actions::update_gitbutler_integration(&vb_state, ctx)
-            .expect("failed to update integration");
+        gitbutler_branch_actions::update_workspace_commit(&vb_state, ctx)
+            .expect("failed to update workspace");
 
         Ok(())
     }

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -201,11 +201,11 @@ impl Handler {
                     let ctx = CommandContext::open(&project)
                         .context("Failed to create a command context")?;
 
-                    // If the user has left gitbutler/integration, we want to delete the reference.
+                    // If the user has left gitbutler/workspace, we want to delete the reference.
                     // TODO: why do we want to do this?
                     if in_outside_workspace_mode(&ctx) {
                         let mut integration_reference = ctx.repository().find_reference(
-                            &Refname::from(LocalRefname::new("gitbutler/integration", None))
+                            &Refname::from(LocalRefname::new("gitbutler/workspace", None))
                                 .to_string(),
                         )?;
                         integration_reference.delete()?;

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -204,11 +204,11 @@ impl Handler {
                     // If the user has left gitbutler/workspace, we want to delete the reference.
                     // TODO: why do we want to do this?
                     if in_outside_workspace_mode(&ctx) {
-                        let mut integration_reference = ctx.repository().find_reference(
+                        let mut workspace_reference = ctx.repository().find_reference(
                             &Refname::from(LocalRefname::new("gitbutler/workspace", None))
                                 .to_string(),
                         )?;
-                        integration_reference.delete()?;
+                        workspace_reference.delete()?;
                     }
 
                     let head_ref = ctx.repository().head().context("failed to get head")?;


### PR DESCRIPTION
It makes it easier to communicate the meaning of the branch, a merge of all the commits in the virtual branches in your workspace.

warning: this pr will transition you from integration -> workspace, but unapplying it will not undo that transition. Clear your workspace first.