### PR TITLE
feat: use PR template when available

### DIFF
--- a/apps/desktop/src/lib/config/config.ts
+++ b/apps/desktop/src/lib/config/config.ts
@@ -49,3 +49,7 @@ export function projectLaneCollapsed(projectId: string, laneId: string): Persist
 export function persistedCommitMessage(projectId: string, branchId: string): Persisted<string> {
 	return persisted('', 'projectCurrentCommitMessage_' + projectId + '_' + branchId);
 }
+
+export function gitHostUsePullRequestTemplate(): Persisted<boolean> {
+	return persisted(false, 'gitHostUsePullRequestTemplate');
+}

--- a/apps/desktop/src/lib/gitHost/azure/azure.ts
+++ b/apps/desktop/src/lib/gitHost/azure/azure.ts
@@ -12,24 +12,24 @@ export const AZURE_DOMAIN = 'dev.azure.com';
  * https://github.com/gitbutlerapp/gitbutler/issues/2651
  */
 export class AzureDevOps implements GitHost {
-	url: string;
-	repo: RepoInfo;
+	private baseUrl: string;
+	private repo: RepoInfo;
 	private baseBranch: string;
 	private forkStr?: string;
 
 	constructor({ repo, baseBranch, forkStr }: GitHostArguments) {
-		this.url = `https://${AZURE_DOMAIN}/${repo.organization}/${repo.owner}/_git/${repo.name}`;
+		this.baseUrl = `https://${AZURE_DOMAIN}/${repo.organization}/${repo.owner}/_git/${repo.name}`;
 		this.repo = repo;
 		this.baseBranch = baseBranch;
 		this.forkStr = forkStr;
 	}
 
 	branch(name: string) {
-		return new AzureBranch(name, this.baseBranch, this.url, this.forkStr);
+		return new AzureBranch(name, this.baseBranch, this.baseUrl, this.forkStr);
 	}
 
 	commitUrl(id: string): string {
-		return `${this.url}/commit/${id}`;
+		return `${this.baseUrl}/commit/${id}`;
 	}
 
 	listService() {

--- a/apps/desktop/src/lib/gitHost/azure/azure.ts
+++ b/apps/desktop/src/lib/gitHost/azure/azure.ts
@@ -1,6 +1,7 @@
 import { AzureBranch } from './azureBranch';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import type { GitHost } from '../interface/gitHost';
+import type { GitHostArguments } from '../interface/types';
 
 export const AZURE_DOMAIN = 'dev.azure.com';
 
@@ -12,17 +13,19 @@ export const AZURE_DOMAIN = 'dev.azure.com';
  */
 export class AzureDevOps implements GitHost {
 	url: string;
+	repo: RepoInfo;
+	private baseBranch: string;
+	private forkStr?: string;
 
-	constructor(
-		repo: RepoInfo,
-		private baseBranch: string,
-		private fork?: string
-	) {
+	constructor({ repo, baseBranch, forkStr }: GitHostArguments) {
 		this.url = `https://${AZURE_DOMAIN}/${repo.organization}/${repo.owner}/_git/${repo.name}`;
+		this.repo = repo;
+		this.baseBranch = baseBranch;
+		this.forkStr = forkStr;
 	}
 
 	branch(name: string) {
-		return new AzureBranch(name, this.baseBranch, this.url, this.fork);
+		return new AzureBranch(name, this.baseBranch, this.url, this.forkStr);
 	}
 
 	commitUrl(id: string): string {

--- a/apps/desktop/src/lib/gitHost/bitbucket/bitbucket.ts
+++ b/apps/desktop/src/lib/gitHost/bitbucket/bitbucket.ts
@@ -1,7 +1,7 @@
 import { BitBucketBranch } from './bitbucketBranch';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import type { GitHost } from '../interface/gitHost';
-import type { DetailedPullRequest } from '../interface/types';
+import type { DetailedPullRequest, GitHostArguments } from '../interface/types';
 
 export type PrAction = 'creating_pr';
 export type PrState = { busy: boolean; branchId: string; action?: PrAction };
@@ -17,17 +17,19 @@ export const BITBUCKET_DOMAIN = 'bitbucket.org';
  */
 export class BitBucket implements GitHost {
 	webUrl: string;
+	repo: RepoInfo;
+	private baseBranch: string;
+	private forkStr?: string;
 
-	constructor(
-		repo: RepoInfo,
-		private baseBranch: string,
-		private fork?: string
-	) {
+	constructor({ repo, baseBranch, forkStr }: GitHostArguments) {
 		this.webUrl = `https://${BITBUCKET_DOMAIN}/${repo.owner}/${repo.name}`;
+		this.repo = repo;
+		this.baseBranch = baseBranch;
+		this.forkStr = forkStr;
 	}
 
 	branch(name: string) {
-		return new BitBucketBranch(name, this.baseBranch, this.webUrl, this.fork);
+		return new BitBucketBranch(name, this.baseBranch, this.webUrl, this.forkStr);
 	}
 
 	commitUrl(id: string): string {

--- a/apps/desktop/src/lib/gitHost/bitbucket/bitbucket.ts
+++ b/apps/desktop/src/lib/gitHost/bitbucket/bitbucket.ts
@@ -16,24 +16,24 @@ export const BITBUCKET_DOMAIN = 'bitbucket.org';
  * https://github.com/gitbutlerapp/gitbutler/issues/3252
  */
 export class BitBucket implements GitHost {
-	webUrl: string;
-	repo: RepoInfo;
+	private baseUrl: string;
+	private repo: RepoInfo;
 	private baseBranch: string;
 	private forkStr?: string;
 
 	constructor({ repo, baseBranch, forkStr }: GitHostArguments) {
-		this.webUrl = `https://${BITBUCKET_DOMAIN}/${repo.owner}/${repo.name}`;
+		this.baseUrl = `https://${BITBUCKET_DOMAIN}/${repo.owner}/${repo.name}`;
 		this.repo = repo;
 		this.baseBranch = baseBranch;
 		this.forkStr = forkStr;
 	}
 
 	branch(name: string) {
-		return new BitBucketBranch(name, this.baseBranch, this.webUrl, this.forkStr);
+		return new BitBucketBranch(name, this.baseBranch, this.baseUrl, this.forkStr);
 	}
 
 	commitUrl(id: string): string {
-		return `${this.webUrl}/commits/${id}`;
+		return `${this.baseUrl}/commits/${id}`;
 	}
 
 	listService() {

--- a/apps/desktop/src/lib/gitHost/gitHostFactory.ts
+++ b/apps/desktop/src/lib/gitHost/gitHostFactory.ts
@@ -3,11 +3,10 @@ import { BitBucket, BITBUCKET_DOMAIN } from './bitbucket/bitbucket';
 import { GitHub, GITHUB_DOMAIN } from './github/github';
 import { GitLab, GITLAB_DOMAIN } from './gitlab/gitlab';
 import { ProjectMetrics } from '$lib/metrics/projectMetrics';
-import type { Settings } from '$lib/settings/userSettings';
+import type { Persisted } from '$lib/persisted/persisted';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import type { GitHost } from './interface/gitHost';
 import type { Octokit } from '@octokit/rest';
-import type { Readable } from 'svelte/store';
 
 // Used on a branch level to acquire the right kind of merge request / checks
 // monitoring service.
@@ -18,7 +17,12 @@ export interface GitHostFactory {
 export class DefaultGitHostFactory implements GitHostFactory {
 	constructor(private octokit: Octokit | undefined) {}
 
-	build(repo: RepoInfo, baseBranch: string, fork?: RepoInfo, userSettings?: Readable<Settings>) {
+	build(
+		repo: RepoInfo,
+		baseBranch: string,
+		fork?: RepoInfo,
+		usePullRequestTemplate?: Persisted<boolean>
+	) {
 		const source = repo.source;
 		const forkStr = fork ? `${fork.owner}:${fork.name}` : undefined;
 
@@ -29,7 +33,7 @@ export class DefaultGitHostFactory implements GitHostFactory {
 				forkStr,
 				octokit: this.octokit,
 				projectMetrics: new ProjectMetrics(),
-				userSettings
+				usePullRequestTemplate
 			});
 		}
 		if (source.includes(GITLAB_DOMAIN)) {

--- a/apps/desktop/src/lib/gitHost/gitHostFactory.ts
+++ b/apps/desktop/src/lib/gitHost/gitHostFactory.ts
@@ -23,23 +23,23 @@ export class DefaultGitHostFactory implements GitHostFactory {
 		const forkStr = fork ? `${fork.owner}:${fork.name}` : undefined;
 
 		if (source.includes(GITHUB_DOMAIN)) {
-			return new GitHub(
+			return new GitHub({
 				repo,
 				baseBranch,
 				forkStr,
-				this.octokit,
-				new ProjectMetrics(),
+				octokit: this.octokit,
+				projectMetrics: new ProjectMetrics(),
 				userSettings
-			);
+			});
 		}
 		if (source.includes(GITLAB_DOMAIN)) {
-			return new GitLab(repo, baseBranch, forkStr);
+			return new GitLab({ repo, baseBranch, forkStr });
 		}
 		if (source.includes(BITBUCKET_DOMAIN)) {
-			return new BitBucket(repo, baseBranch, forkStr);
+			return new BitBucket({ repo, baseBranch, forkStr });
 		}
 		if (source.includes(AZURE_DOMAIN)) {
-			return new AzureDevOps(repo, baseBranch, forkStr);
+			return new AzureDevOps({ repo, baseBranch, forkStr });
 		}
 	}
 }

--- a/apps/desktop/src/lib/gitHost/gitHostFactory.ts
+++ b/apps/desktop/src/lib/gitHost/gitHostFactory.ts
@@ -3,9 +3,11 @@ import { BitBucket, BITBUCKET_DOMAIN } from './bitbucket/bitbucket';
 import { GitHub, GITHUB_DOMAIN } from './github/github';
 import { GitLab, GITLAB_DOMAIN } from './gitlab/gitlab';
 import { ProjectMetrics } from '$lib/metrics/projectMetrics';
+import type { Settings } from '$lib/settings/userSettings';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import type { GitHost } from './interface/gitHost';
 import type { Octokit } from '@octokit/rest';
+import type { Readable } from 'svelte/store';
 
 // Used on a branch level to acquire the right kind of merge request / checks
 // monitoring service.
@@ -16,11 +18,19 @@ export interface GitHostFactory {
 export class DefaultGitHostFactory implements GitHostFactory {
 	constructor(private octokit: Octokit | undefined) {}
 
-	build(repo: RepoInfo, baseBranch: string, fork?: RepoInfo) {
+	build(repo: RepoInfo, baseBranch: string, fork?: RepoInfo, userSettings?: Readable<Settings>) {
 		const source = repo.source;
 		const forkStr = fork ? `${fork.owner}:${fork.name}` : undefined;
+
 		if (source.includes(GITHUB_DOMAIN)) {
-			return new GitHub(repo, baseBranch, forkStr, this.octokit, new ProjectMetrics());
+			return new GitHub(
+				repo,
+				baseBranch,
+				forkStr,
+				this.octokit,
+				new ProjectMetrics(),
+				userSettings
+			);
 		}
 		if (source.includes(GITLAB_DOMAIN)) {
 			return new GitLab(repo, baseBranch, forkStr);

--- a/apps/desktop/src/lib/gitHost/github/github.test.ts
+++ b/apps/desktop/src/lib/gitHost/github/github.test.ts
@@ -10,7 +10,7 @@ describe.concurrent('GitHub', () => {
 	};
 
 	test('commit url', async () => {
-		const gh = new GitHub(repo);
+		const gh = new GitHub({ repo, baseBranch: id });
 		const url = gh.commitUrl(id);
 		expect(url).toMatch(new RegExp(`/${id}$`));
 	});

--- a/apps/desktop/src/lib/gitHost/github/github.ts
+++ b/apps/desktop/src/lib/gitHost/github/github.ts
@@ -13,7 +13,7 @@ import type { Readable } from 'svelte/store';
 export const GITHUB_DOMAIN = 'github.com';
 
 export class GitHub implements GitHost {
-	baseUrl: string;
+	private baseUrl: string;
 	private repo: RepoInfo;
 	private baseBranch: string;
 	private forkStr?: string;
@@ -34,7 +34,6 @@ export class GitHub implements GitHost {
 		userSettings?: Readable<Settings>;
 	}) {
 		this.baseUrl = `https://${GITHUB_DOMAIN}/${repo.owner}/${repo.name}`;
-
 		this.repo = repo;
 		this.baseBranch = baseBranch;
 		this.forkStr = forkStr;

--- a/apps/desktop/src/lib/gitHost/github/github.ts
+++ b/apps/desktop/src/lib/gitHost/github/github.ts
@@ -4,11 +4,10 @@ import { GitHubListingService } from './githubListingService';
 import { GitHubPrService } from './githubPrService';
 import { Octokit } from '@octokit/rest';
 import type { ProjectMetrics } from '$lib/metrics/projectMetrics';
-import type { Settings } from '$lib/settings/userSettings';
+import type { Persisted } from '$lib/persisted/persisted';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import type { GitHost } from '../interface/gitHost';
 import type { GitHostArguments } from '../interface/types';
-import type { Readable } from 'svelte/store';
 
 export const GITHUB_DOMAIN = 'github.com';
 
@@ -19,7 +18,7 @@ export class GitHub implements GitHost {
 	private forkStr?: string;
 	private octokit?: Octokit;
 	private projectMetrics?: ProjectMetrics;
-	private userSettings?: Readable<Settings>;
+	private usePullRequestTemplate?: Persisted<boolean>;
 
 	constructor({
 		repo,
@@ -27,11 +26,11 @@ export class GitHub implements GitHost {
 		forkStr,
 		octokit,
 		projectMetrics,
-		userSettings
+		usePullRequestTemplate
 	}: GitHostArguments & {
 		octokit?: Octokit;
 		projectMetrics?: ProjectMetrics;
-		userSettings?: Readable<Settings>;
+		usePullRequestTemplate?: Persisted<boolean>;
 	}) {
 		this.baseUrl = `https://${GITHUB_DOMAIN}/${repo.owner}/${repo.name}`;
 		this.repo = repo;
@@ -39,7 +38,7 @@ export class GitHub implements GitHost {
 		this.forkStr = forkStr;
 		this.octokit = octokit;
 		this.projectMetrics = projectMetrics;
-		this.userSettings = userSettings;
+		this.usePullRequestTemplate = usePullRequestTemplate;
 	}
 
 	listService() {
@@ -58,7 +57,7 @@ export class GitHub implements GitHost {
 			this.repo,
 			baseBranch,
 			upstreamName,
-			this.userSettings
+			this.usePullRequestTemplate
 		);
 	}
 

--- a/apps/desktop/src/lib/gitHost/github/github.ts
+++ b/apps/desktop/src/lib/gitHost/github/github.ts
@@ -4,8 +4,10 @@ import { GitHubListingService } from './githubListingService';
 import { GitHubPrService } from './githubPrService';
 import { Octokit } from '@octokit/rest';
 import type { ProjectMetrics } from '$lib/metrics/projectMetrics';
+import type { Settings } from '$lib/settings/userSettings';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import type { GitHost } from '../interface/gitHost';
+import type { Readable } from 'svelte/store';
 
 export const GITHUB_DOMAIN = 'github.com';
 
@@ -17,7 +19,8 @@ export class GitHub implements GitHost {
 		private baseBranch?: string,
 		private fork?: string,
 		private octokit?: Octokit,
-		private projectMetrics?: ProjectMetrics
+		private projectMetrics?: ProjectMetrics,
+		private userSettings?: Readable<Settings>
 	) {
 		this.baseUrl = `https://${GITHUB_DOMAIN}/${repo.owner}/${repo.name}`;
 	}
@@ -33,7 +36,13 @@ export class GitHub implements GitHost {
 		if (!this.octokit) {
 			return;
 		}
-		return new GitHubPrService(this.octokit, this.repo, baseBranch, upstreamName);
+		return new GitHubPrService(
+			this.octokit,
+			this.repo,
+			baseBranch,
+			upstreamName,
+			this.userSettings
+		);
 	}
 
 	checksMonitor(sourceBranch: string) {

--- a/apps/desktop/src/lib/gitHost/github/github.ts
+++ b/apps/desktop/src/lib/gitHost/github/github.ts
@@ -7,22 +7,40 @@ import type { ProjectMetrics } from '$lib/metrics/projectMetrics';
 import type { Settings } from '$lib/settings/userSettings';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import type { GitHost } from '../interface/gitHost';
+import type { GitHostArguments } from '../interface/types';
 import type { Readable } from 'svelte/store';
 
 export const GITHUB_DOMAIN = 'github.com';
 
 export class GitHub implements GitHost {
 	baseUrl: string;
+	private repo: RepoInfo;
+	private baseBranch: string;
+	private forkStr?: string;
+	private octokit?: Octokit;
+	private projectMetrics?: ProjectMetrics;
+	private userSettings?: Readable<Settings>;
 
-	constructor(
-		private repo: RepoInfo,
-		private baseBranch?: string,
-		private fork?: string,
-		private octokit?: Octokit,
-		private projectMetrics?: ProjectMetrics,
-		private userSettings?: Readable<Settings>
-	) {
+	constructor({
+		repo,
+		baseBranch,
+		forkStr,
+		octokit,
+		projectMetrics,
+		userSettings
+	}: GitHostArguments & {
+		octokit?: Octokit;
+		projectMetrics?: ProjectMetrics;
+		userSettings?: Readable<Settings>;
+	}) {
 		this.baseUrl = `https://${GITHUB_DOMAIN}/${repo.owner}/${repo.name}`;
+
+		this.repo = repo;
+		this.baseBranch = baseBranch;
+		this.forkStr = forkStr;
+		this.octokit = octokit;
+		this.projectMetrics = projectMetrics;
+		this.userSettings = userSettings;
 	}
 
 	listService() {
@@ -56,7 +74,7 @@ export class GitHub implements GitHost {
 		if (!this.baseBranch) {
 			return;
 		}
-		return new GitHubBranch(name, this.baseBranch, this.baseUrl, this.fork);
+		return new GitHubBranch(name, this.baseBranch, this.baseUrl, this.forkStr);
 	}
 
 	commitUrl(id: string): string {

--- a/apps/desktop/src/lib/gitHost/github/githubBranch.test.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubBranch.test.ts
@@ -4,7 +4,7 @@ import { expect, test, describe } from 'vitest';
 // TODO: Rewrite this proof-of-concept into something valuable.
 describe.concurrent('GitHubBranch', () => {
 	const name = 'some-branch';
-	const base = 'some-base';
+	const baseBranch = 'some-base';
 	const repo = {
 		source: 'github.com',
 		name: 'test-repo',
@@ -12,15 +12,15 @@ describe.concurrent('GitHubBranch', () => {
 	};
 
 	test('branch compare url', async () => {
-		const gh = new GitHub(repo, base);
+		const gh = new GitHub({ repo, baseBranch });
 		const branch = gh.branch(name);
 		expect(branch?.url).toMatch(new RegExp(`...${name}$`));
 	});
 
 	test('fork compare url', async () => {
-		const fork = `${repo.owner}:${repo.name}`;
-		const gh = new GitHub(repo, base, fork);
+		const forkStr = `${repo.owner}:${repo.name}`;
+		const gh = new GitHub({ repo, baseBranch, forkStr });
 		const branch = gh.branch(name);
-		expect(branch?.url).toMatch(new RegExp(`...${fork}:${name}$`));
+		expect(branch?.url).toMatch(new RegExp(`...${forkStr}:${name}$`));
 	});
 });

--- a/apps/desktop/src/lib/gitHost/github/githubChecksMonitor.test.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubChecksMonitor.test.ts
@@ -29,16 +29,15 @@ describe('GitHubChecksMonitor', () => {
 
 	beforeEach(() => {
 		octokit = new Octokit();
-		gh = new GitHub(
-			{
+		gh = new GitHub({
+			repo: {
 				source: 'github.com',
 				name: 'test-repo',
 				owner: 'test-owner'
 			},
-			undefined,
-			undefined,
+			baseBranch: 'test-branch',
 			octokit
-		);
+		});
 		monitor = gh.checksMonitor('upstream-branch');
 	});
 

--- a/apps/desktop/src/lib/gitHost/github/githubListingService.test.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubListingService.test.ts
@@ -31,7 +31,7 @@ describe.concurrent('GitHubListingService', () => {
 		octokit = new Octokit();
 		projectMetrics = new ProjectMetrics();
 
-		gh = new GitHub(repoInfo, 'some-base', undefined, octokit, projectMetrics);
+		gh = new GitHub({ repo: repoInfo, baseBranch: 'some-base', octokit, projectMetrics });
 		service = gh.listService();
 	});
 

--- a/apps/desktop/src/lib/gitHost/github/githubPrMonitor.test.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubPrMonitor.test.ts
@@ -21,16 +21,15 @@ describe.concurrent('GitHubPrMonitor', () => {
 
 	beforeEach(() => {
 		octokit = new Octokit();
-		gh = new GitHub(
-			{
+		gh = new GitHub({
+			repo: {
 				source: 'github.com',
 				name: 'test-repo',
 				owner: 'test-owner'
 			},
-			undefined,
-			undefined,
+			baseBranch: 'test-branch',
 			octokit
-		);
+		});
 		service = gh.prService('base-branch', 'upstream-branch');
 		monitor = service?.prMonitor(123);
 	});

--- a/apps/desktop/src/lib/gitHost/github/githubPrService.test.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubPrService.test.ts
@@ -11,16 +11,15 @@ describe.concurrent('GitHubPrService', () => {
 
 	beforeEach(() => {
 		octokit = new Octokit();
-		gh = new GitHub(
-			{
+		gh = new GitHub({
+			repo: {
 				source: 'github.com',
 				name: 'test-repo',
 				owner: 'test-owner'
 			},
-			'main',
-			undefined,
+			baseBranch: 'main',
 			octokit
-		);
+		});
 		service = gh.prService('base-branch', 'upstream-branch');
 	});
 

--- a/apps/desktop/src/lib/gitHost/github/githubPrService.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubPrService.ts
@@ -3,8 +3,8 @@ import { DEFAULT_HEADERS } from './headers';
 import { ghResponseToInstance, parseGitHubDetailedPullRequest } from './types';
 import { sleep } from '$lib/utils/sleep';
 import posthog from 'posthog-js';
-import { get, writable, type Readable } from 'svelte/store';
-import type { Settings } from '$lib/settings/userSettings';
+import { get, writable } from 'svelte/store';
+import type { Persisted } from '$lib/persisted/persisted';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import type { GitHostPrService } from '../interface/gitHostPrService';
 import type { DetailedPullRequest, MergeMethod, PullRequest } from '../interface/types';
@@ -20,7 +20,7 @@ export class GitHubPrService implements GitHostPrService {
 		private repo: RepoInfo,
 		private baseBranch: string,
 		private upstreamName: string,
-		private userSettings?: Readable<Settings>
+		private usePullRequestTemplate?: Persisted<boolean>
 	) {}
 
 	async createPr(title: string, body: string, draft: boolean): Promise<PullRequest> {
@@ -42,9 +42,7 @@ export class GitHubPrService implements GitHostPrService {
 		let lastError: any;
 		let pr: PullRequest | undefined;
 		let pullRequestTemplate: string | undefined;
-		const usePrTemplate = this.userSettings
-			? get(this.userSettings)?.gitHost.usePullRequestTemplate
-			: null;
+		const usePrTemplate = this.usePullRequestTemplate ? get(this.usePullRequestTemplate) : null;
 
 		if (!body && usePrTemplate) {
 			pullRequestTemplate = await this.fetchPrTemplate();

--- a/apps/desktop/src/lib/gitHost/github/githubPrService.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubPrService.ts
@@ -9,6 +9,8 @@ import type { GitHostPrService } from '../interface/gitHostPrService';
 import type { DetailedPullRequest, MergeMethod, PullRequest } from '../interface/types';
 import type { Octokit } from '@octokit/rest';
 
+const DEFAULT_PULL_REQUEST_TEMPLATE_PATH = '.github/PULL_REQUEST_TEMPLATE.md';
+
 export class GitHubPrService implements GitHostPrService {
 	loading = writable(false);
 
@@ -19,12 +21,7 @@ export class GitHubPrService implements GitHostPrService {
 		private upstreamName: string
 	) {}
 
-	async createPr(
-		title: string,
-		body: string,
-		draft: boolean,
-		templatePath: string = '.github/PULL_REQUEST_TEMPLATE.md'
-	): Promise<PullRequest> {
+	async createPr(title: string, body: string, draft: boolean): Promise<PullRequest> {
 		this.loading.set(true);
 		const request = async (pullRequestTemplate: string) => {
 			const resp = await this.octokit.rest.pulls.create({
@@ -49,7 +46,7 @@ export class GitHubPrService implements GitHostPrService {
 				const response = await this.octokit.rest.repos.getContent({
 					owner: this.repo.owner,
 					repo: this.repo.name,
-					path: templatePath
+					path: DEFAULT_PULL_REQUEST_TEMPLATE_PATH
 				});
 				const b64Content = (response.data as any)?.content;
 				if (b64Content) {

--- a/apps/desktop/src/lib/gitHost/github/githubPrService.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubPrService.ts
@@ -1,6 +1,7 @@
 import { GitHubPrMonitor } from './githubPrMonitor';
 import { DEFAULT_HEADERS } from './headers';
 import { ghResponseToInstance, parseGitHubDetailedPullRequest } from './types';
+import { showError } from '$lib/notifications/toasts';
 import { sleep } from '$lib/utils/sleep';
 import posthog from 'posthog-js';
 import { get, writable } from 'svelte/store';
@@ -76,8 +77,10 @@ export class GitHubPrService implements GitHostPrService {
 			if (b64Content) {
 				return decodeURIComponent(escape(atob(b64Content)));
 			}
-			// eslint-disable-next-line no-empty
-		} catch {}
+		} catch (err) {
+			console.error('Error fetching pull request template: ', err);
+			showError('Failed to fetch pull request template', err);
+		}
 	}
 
 	async get(prNumber: number): Promise<DetailedPullRequest> {

--- a/apps/desktop/src/lib/gitHost/github/githubPrService.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubPrService.ts
@@ -68,12 +68,12 @@ export class GitHubPrService implements GitHostPrService {
 		throw lastError;
 	}
 
-	async fetchPrTemplate(path?: string) {
+	async fetchPrTemplate() {
 		try {
 			const response = await this.octokit.rest.repos.getContent({
 				owner: this.repo.owner,
 				repo: this.repo.name,
-				path: path ?? DEFAULT_PULL_REQUEST_TEMPLATE_PATH
+				path: DEFAULT_PULL_REQUEST_TEMPLATE_PATH
 			});
 			const b64Content = (response.data as any)?.content;
 			if (b64Content) {

--- a/apps/desktop/src/lib/gitHost/gitlab/gitlab.ts
+++ b/apps/desktop/src/lib/gitHost/gitlab/gitlab.ts
@@ -1,7 +1,7 @@
 import { GitLabBranch } from './gitlabBranch';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import type { GitHost } from '../interface/gitHost';
-import type { DetailedPullRequest } from '../interface/types';
+import type { DetailedPullRequest, GitHostArguments } from '../interface/types';
 
 export type PrAction = 'creating_pr';
 export type PrState = { busy: boolean; branchId: string; action?: PrAction };
@@ -17,17 +17,19 @@ export const GITLAB_DOMAIN = 'gitlab.com';
  */
 export class GitLab implements GitHost {
 	webUrl: string;
+	repo: RepoInfo;
+	private baseBranch: string;
+	private forkStr?: string;
 
-	constructor(
-		repo: RepoInfo,
-		private baseBranch: string,
-		private fork?: string
-	) {
+	constructor({ repo, baseBranch, forkStr }: GitHostArguments) {
 		this.webUrl = `https://${GITLAB_DOMAIN}/${repo.owner}/${repo.name}`;
+		this.repo = repo;
+		this.baseBranch = baseBranch;
+		this.forkStr = forkStr;
 	}
 
 	branch(name: string) {
-		return new GitLabBranch(name, this.baseBranch, this.webUrl, this.fork);
+		return new GitLabBranch(name, this.baseBranch, this.webUrl, this.forkStr);
 	}
 
 	commitUrl(id: string): string {

--- a/apps/desktop/src/lib/gitHost/gitlab/gitlab.ts
+++ b/apps/desktop/src/lib/gitHost/gitlab/gitlab.ts
@@ -16,24 +16,24 @@ export const GITLAB_DOMAIN = 'gitlab.com';
  * https://github.com/gitbutlerapp/gitbutler/issues/2511
  */
 export class GitLab implements GitHost {
-	webUrl: string;
-	repo: RepoInfo;
+	private baseUrl: string;
+	private repo: RepoInfo;
 	private baseBranch: string;
 	private forkStr?: string;
 
 	constructor({ repo, baseBranch, forkStr }: GitHostArguments) {
-		this.webUrl = `https://${GITLAB_DOMAIN}/${repo.owner}/${repo.name}`;
+		this.baseUrl = `https://${GITLAB_DOMAIN}/${repo.owner}/${repo.name}`;
 		this.repo = repo;
 		this.baseBranch = baseBranch;
 		this.forkStr = forkStr;
 	}
 
 	branch(name: string) {
-		return new GitLabBranch(name, this.baseBranch, this.webUrl, this.forkStr);
+		return new GitLabBranch(name, this.baseBranch, this.baseUrl, this.forkStr);
 	}
 
 	commitUrl(id: string): string {
-		return `${this.webUrl}/-/commit/${id}`;
+		return `${this.baseUrl}/-/commit/${id}`;
 	}
 
 	listService() {

--- a/apps/desktop/src/lib/gitHost/interface/gitHostPrService.ts
+++ b/apps/desktop/src/lib/gitHost/interface/gitHostPrService.ts
@@ -11,6 +11,7 @@ export interface GitHostPrService {
 	loading: Writable<boolean>;
 	get(prNumber: number): Promise<DetailedPullRequest>;
 	createPr(title: string, body: string, draft: boolean): Promise<PullRequest>;
+	fetchPrTemplate(path?: string): Promise<string | undefined>;
 	merge(method: MergeMethod, prNumber: number): Promise<void>;
 	prMonitor(prNumber: number): GitHostPrMonitor;
 }

--- a/apps/desktop/src/lib/gitHost/interface/gitHostPrService.ts
+++ b/apps/desktop/src/lib/gitHost/interface/gitHostPrService.ts
@@ -10,12 +10,7 @@ export const [getGitHostPrService, createGitHostPrServiceStore] = buildContextSt
 export interface GitHostPrService {
 	loading: Writable<boolean>;
 	get(prNumber: number): Promise<DetailedPullRequest>;
-	createPr(
-		title: string,
-		body: string,
-		draft: boolean,
-		templatePath?: string
-	): Promise<PullRequest>;
+	createPr(title: string, body: string, draft: boolean): Promise<PullRequest>;
 	merge(method: MergeMethod, prNumber: number): Promise<void>;
 	prMonitor(prNumber: number): GitHostPrMonitor;
 }

--- a/apps/desktop/src/lib/gitHost/interface/gitHostPrService.ts
+++ b/apps/desktop/src/lib/gitHost/interface/gitHostPrService.ts
@@ -10,7 +10,12 @@ export const [getGitHostPrService, createGitHostPrServiceStore] = buildContextSt
 export interface GitHostPrService {
 	loading: Writable<boolean>;
 	get(prNumber: number): Promise<DetailedPullRequest>;
-	createPr(title: string, body: string, draft: boolean): Promise<PullRequest>;
+	createPr(
+		title: string,
+		body: string,
+		draft: boolean,
+		templatePath?: string
+	): Promise<PullRequest>;
 	merge(method: MergeMethod, prNumber: number): Promise<void>;
 	prMonitor(prNumber: number): GitHostPrMonitor;
 }

--- a/apps/desktop/src/lib/gitHost/interface/types.ts
+++ b/apps/desktop/src/lib/gitHost/interface/types.ts
@@ -1,3 +1,4 @@
+import type { RepoInfo } from '$lib/url/gitUrl';
 import type { Author } from '$lib/vbranches/types';
 
 export interface Label {
@@ -68,4 +69,10 @@ export type CheckSuite = {
 	name?: string;
 	count: number;
 	status: 'queued' | 'in_progress' | 'completed' | 'waiting' | 'requested' | 'pending' | null;
+};
+
+export type GitHostArguments = {
+	repo: RepoInfo;
+	baseBranch: string;
+	forkStr?: string;
 };

--- a/apps/desktop/src/lib/settings/GithubIntegration.svelte
+++ b/apps/desktop/src/lib/settings/GithubIntegration.svelte
@@ -2,12 +2,14 @@
 	import { checkAuthStatus, initDeviceOauth } from '$lib/backend/github';
 	import SectionCard from '$lib/components/SectionCard.svelte';
 	import { getGitHubUserServiceStore } from '$lib/gitHost/github/githubUserService';
+	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import { UserService } from '$lib/stores/user';
 	import { copyToClipboard } from '$lib/utils/clipboard';
-	import { getContext } from '$lib/utils/context';
+	import { getContext, getContextStoreBySymbol } from '$lib/utils/context';
 	import * as toasts from '$lib/utils/toasts';
 	import { openExternalUrl } from '$lib/utils/url';
 	import Button from '@gitbutler/ui/Button.svelte';
+	import Checkbox from '@gitbutler/ui/Checkbox.svelte';
 	import Icon from '@gitbutler/ui/Icon.svelte';
 	import Modal from '@gitbutler/ui/Modal.svelte';
 	import { fade } from 'svelte/transition';
@@ -15,6 +17,7 @@
 	export let minimal = false;
 	export let disabled = false;
 
+	const userSettings = getContextStoreBySymbol<Settings>(SETTINGS);
 	const githubUserService = getGitHubUserServiceStore();
 	const userService = getContext(UserService);
 	const user = userService.user;
@@ -103,6 +106,19 @@
 		{:else}
 			<Button style="pop" kind="solid" {disabled} onclick={gitHubStartOauth}>Authorize</Button>
 		{/if}
+	</SectionCard>
+	<SectionCard roundedBottom={false} orientation="row" labelFor="use-pull-request-template">
+		<svelte:fragment slot="title">Pull Request Template</svelte:fragment>
+		<svelte:fragment slot="caption">
+			Use Pull Request template when creating a PR through GitButler.
+		</svelte:fragment>
+		<svelte:fragment slot="actions">
+			<Checkbox
+				name="use-pull-request-template"
+				value="false"
+				bind:checked={$userSettings.gitHost.usePullRequestTemplate}
+			/>
+		</svelte:fragment>
 	</SectionCard>
 {/if}
 

--- a/apps/desktop/src/lib/settings/GithubIntegration.svelte
+++ b/apps/desktop/src/lib/settings/GithubIntegration.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import { checkAuthStatus, initDeviceOauth } from '$lib/backend/github';
 	import SectionCard from '$lib/components/SectionCard.svelte';
+	import { gitHostUsePullRequestTemplate } from '$lib/config/config';
 	import { getGitHubUserServiceStore } from '$lib/gitHost/github/githubUserService';
-	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import { UserService } from '$lib/stores/user';
 	import { copyToClipboard } from '$lib/utils/clipboard';
-	import { getContext, getContextStoreBySymbol } from '$lib/utils/context';
+	import { getContext } from '$lib/utils/context';
 	import * as toasts from '$lib/utils/toasts';
 	import { openExternalUrl } from '$lib/utils/url';
 	import Button from '@gitbutler/ui/Button.svelte';
@@ -17,7 +17,7 @@
 	export let minimal = false;
 	export let disabled = false;
 
-	const userSettings = getContextStoreBySymbol<Settings>(SETTINGS);
+	const usePullRequestTemplate = gitHostUsePullRequestTemplate();
 	const githubUserService = getGitHubUserServiceStore();
 	const userService = getContext(UserService);
 	const user = userService.user;
@@ -116,7 +116,7 @@
 			<Checkbox
 				name="use-pull-request-template"
 				value="false"
-				bind:checked={$userSettings.gitHost.usePullRequestTemplate}
+				bind:checked={$usePullRequestTemplate}
 			/>
 		</svelte:fragment>
 	</SectionCard>

--- a/apps/desktop/src/lib/settings/userSettings.ts
+++ b/apps/desktop/src/lib/settings/userSettings.ts
@@ -19,6 +19,9 @@ export interface Settings {
 	zoom: number;
 	scrollbarVisibilityState: ScrollbarVisilitySettings;
 	tabSize: number;
+	gitHost: {
+		usePullRequestTemplate: false;
+	};
 }
 
 const defaults: Settings = {
@@ -33,7 +36,10 @@ const defaults: Settings = {
 	stashedBranchesHeight: 150,
 	zoom: 1,
 	scrollbarVisibilityState: 'scroll',
-	tabSize: 4
+	tabSize: 4,
+	gitHost: {
+		usePullRequestTemplate: false
+	}
 };
 
 export function loadUserSettings(): Writable<Settings> {

--- a/apps/desktop/src/lib/settings/userSettings.ts
+++ b/apps/desktop/src/lib/settings/userSettings.ts
@@ -19,9 +19,6 @@ export interface Settings {
 	zoom: number;
 	scrollbarVisibilityState: ScrollbarVisilitySettings;
 	tabSize: number;
-	gitHost: {
-		usePullRequestTemplate: false;
-	};
 }
 
 const defaults: Settings = {
@@ -36,10 +33,7 @@ const defaults: Settings = {
 	stashedBranchesHeight: 150,
 	zoom: 1,
 	scrollbarVisibilityState: 'scroll',
-	tabSize: 4,
-	gitHost: {
-		usePullRequestTemplate: false
-	}
+	tabSize: 4
 };
 
 export function loadUserSettings(): Writable<Settings> {

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -13,6 +13,7 @@
 	import NoBaseBranch from '$lib/components/NoBaseBranch.svelte';
 	import NotOnGitButlerBranch from '$lib/components/NotOnGitButlerBranch.svelte';
 	import ProblemLoadingRepo from '$lib/components/ProblemLoadingRepo.svelte';
+	import { gitHostUsePullRequestTemplate } from '$lib/config/config';
 	import { ReorderDropzoneManagerFactory } from '$lib/dragging/reorderDropzoneManager';
 	import { DefaultGitHostFactory } from '$lib/gitHost/gitHostFactory';
 	import { octokitFromAccessToken } from '$lib/gitHost/github/octokit';
@@ -24,10 +25,8 @@
 	import { ModeService } from '$lib/modes/service';
 	import Navigation from '$lib/navigation/Navigation.svelte';
 	import { persisted } from '$lib/persisted/persisted';
-	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import { RemoteBranchService } from '$lib/stores/remoteBranches';
 	import { parseRemoteUrl } from '$lib/url/gitUrl';
-	import { getContextStoreBySymbol } from '$lib/utils/context';
 	import { debounce } from '$lib/utils/debounce';
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { VirtualBranchService } from '$lib/vbranches/virtualBranch';
@@ -79,8 +78,7 @@
 	let intervalId: any;
 
 	const showHistoryView = persisted(false, 'showHistoryView');
-
-	const userSettings = getContextStoreBySymbol<Settings>(SETTINGS);
+	const usePullRequestTemplate = gitHostUsePullRequestTemplate();
 	const octokit = $derived(accessToken ? octokitFromAccessToken(accessToken) : undefined);
 	const gitHostFactory = $derived(new DefaultGitHostFactory(octokit));
 	const repoInfo = $derived(remoteUrl ? parseRemoteUrl(remoteUrl) : undefined);
@@ -123,7 +121,7 @@
 	$effect.pre(() => {
 		const gitHost =
 			repoInfo && baseBranchName
-				? gitHostFactory.build(repoInfo, baseBranchName, forkInfo, userSettings)
+				? gitHostFactory.build(repoInfo, baseBranchName, forkInfo, usePullRequestTemplate)
 				: undefined;
 
 		const ghListService = gitHost?.listService();

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -24,8 +24,10 @@
 	import { ModeService } from '$lib/modes/service';
 	import Navigation from '$lib/navigation/Navigation.svelte';
 	import { persisted } from '$lib/persisted/persisted';
+	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import { RemoteBranchService } from '$lib/stores/remoteBranches';
 	import { parseRemoteUrl } from '$lib/url/gitUrl';
+	import { getContextStoreBySymbol } from '$lib/utils/context';
 	import { debounce } from '$lib/utils/debounce';
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { VirtualBranchService } from '$lib/vbranches/virtualBranch';
@@ -78,6 +80,7 @@
 
 	const showHistoryView = persisted(false, 'showHistoryView');
 
+	const userSettings = getContextStoreBySymbol<Settings>(SETTINGS);
 	const octokit = $derived(accessToken ? octokitFromAccessToken(accessToken) : undefined);
 	const gitHostFactory = $derived(new DefaultGitHostFactory(octokit));
 	const repoInfo = $derived(remoteUrl ? parseRemoteUrl(remoteUrl) : undefined);
@@ -120,7 +123,7 @@
 	$effect.pre(() => {
 		const gitHost =
 			repoInfo && baseBranchName
-				? gitHostFactory.build(repoInfo, baseBranchName, forkInfo)
+				? gitHostFactory.build(repoInfo, baseBranchName, forkInfo, userSettings)
 				: undefined;
 
 		const ghListService = gitHost?.listService();


### PR DESCRIPTION
### 👷 Changes

- Use a repositories default `.github/PULL_REQUEST_TEMPLATE.md` when available and no other `body` has been passed
	- Add optional `fetchPrTemplate` method to `GitHostPrService` class 
	- Implement this method in the GitHub PR Service
- GitHost's arguments were beginning to get too long, therefore refactored them into an object
	- Updated all relevant tests
- Harmonized various GitHost's property names and added shared type for constructor args

### 📓 Notes

Fixes: #3313 