### PR TITLE
fix: add linux dependencies to tauri.conf

### DIFF
--- a/crates/gitbutler-tauri/tauri.conf.nightly.json
+++ b/crates/gitbutler-tauri/tauri.conf.nightly.json
@@ -26,6 +26,17 @@
 			],
 			"windows": {
 				"certificateThumbprint": null
+			},
+			"rpm": {
+				"depends": [
+					"webkit2gtk4.0-devel"
+				]
+			},
+			"deb": {
+				"depends": [
+					"libwebkit2gtk-4.0-dev",
+					"libgtk-3-dev"
+				]
 			}
 		},
 		"security": {

--- a/crates/gitbutler-tauri/tauri.conf.release.json
+++ b/crates/gitbutler-tauri/tauri.conf.release.json
@@ -26,6 +26,17 @@
 			],
 			"windows": {
 				"certificateThumbprint": null
+			},
+			"rpm": {
+				"depends": [
+					"webkit2gtk4.0-devel"
+				]
+			},
+			"deb": {
+				"depends": [
+					"libwebkit2gtk-4.0-dev",
+					"libgtk-3-dev"
+				]
 			}
 		},
 		"security": {


### PR DESCRIPTION
- ~Testing~ Tested whether this will result in these dependencies automaticlaly being installed on the respective platforms via their package managers (apt/dpkg, rpm, etc.)
	- Update: It doesn't look like the two package managers I tested will _automatically_ install the dependencies, but it does warn everywhere you'd expect it to 

Ubuntu complains when you try to uninstall stuff we depend on:
> ![image](https://github.com/user-attachments/assets/940bbaeb-e4d1-4473-ab9f-48287b98282c)

It also complains when installing `git-butler-nightly` that pkgs are potentially missing:
>![image](https://github.com/user-attachments/assets/beb40b2f-2699-4276-816c-4e29a12f84d8)

And same goes for Fedora (rpm):
> ![image](https://github.com/user-attachments/assets/ee19bd90-6e6b-43d2-9841-b5c151048ab0)

Should result in a smoother experience overall for our linux users :pray: 