### PR TITLE
Exit edit mode without saving

### DIFF
--- a/apps/desktop/src/lib/components/EditMode.svelte
+++ b/apps/desktop/src/lib/components/EditMode.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import DecorativeSplitView from './DecorativeSplitView.svelte';
 	import ProjectNameLabel from '../shared/ProjectNameLabel.svelte';
-	import dzenPc from '$lib/assets/dzen-pc.svg?raw';
+	import newProjectSvg from '$lib/assets/illustrations/new-project.svg?raw';
 	import { Project } from '$lib/backend/projects';
 	import { ModeService, type EditModeMetadata } from '$lib/modes/service';
 	import { getContext } from '$lib/utils/context';
@@ -18,6 +18,14 @@
 
 	let modeServiceSaving = $state<'inert' | 'loading' | 'completed'>('inert');
 
+	async function abort() {
+		modeServiceSaving = 'loading';
+
+		await modeService.abortEditAndReturnToWorkspace();
+
+		modeServiceSaving = 'completed';
+	}
+
 	async function save() {
 		modeServiceSaving = 'loading';
 
@@ -27,7 +35,7 @@
 	}
 </script>
 
-<DecorativeSplitView img={dzenPc}>
+<DecorativeSplitView img={newProjectSvg}>
 	<div class="switchrepo">
 		<div class="project-name">
 			<ProjectNameLabel projectName={project?.title} />
@@ -39,20 +47,22 @@
 		</p>
 
 		<p class="switchrepo__message text-13 text-body">
-			Please do not make any commits whilst in edit mode. To leave edit mode, use the "save changes"
-			button.
+			Please do not make any commits whilst in edit mode. To leave edit mode, use the provided
+			actions.
 		</p>
 
 		<div class="switchrepo__actions">
+			<Button style="ghost" outline onclick={abort} loading={modeServiceSaving === 'loading'}>
+				Cancel changes
+			</Button>
 			<Button
 				style="pop"
 				kind="solid"
 				icon="undo-small"
-				reversedDirection
 				onclick={save}
 				loading={modeServiceSaving === 'loading'}
 			>
-				Save changes
+				Save and exit
 			</Button>
 		</div>
 	</div>
@@ -77,5 +87,6 @@
 		gap: 8px;
 		padding-bottom: 24px;
 		flex-wrap: wrap;
+		justify-content: flex-end;
 	}
 </style>

--- a/apps/desktop/src/lib/modes/service.ts
+++ b/apps/desktop/src/lib/modes/service.ts
@@ -49,6 +49,12 @@ export class ModeService {
 		});
 	}
 
+	async abortEditAndReturnToWorkspace() {
+		await invoke('abort_edit_and_return_to_workspace', {
+			projectId: this.projectId
+		});
+	}
+
 	async saveEditAndReturnToWorkspace() {
 		await invoke('save_edit_and_return_to_workspace', {
 			projectId: this.projectId

--- a/crates/gitbutler-edit-mode/src/commands.rs
+++ b/crates/gitbutler-edit-mode/src/commands.rs
@@ -52,6 +52,14 @@ pub fn save_and_return_to_workspace(project: &Project) -> Result<()> {
     crate::save_and_return_to_workspace(&ctx, guard.write_permission())
 }
 
+pub fn abort_and_return_to_workspace(project: &Project) -> Result<()> {
+    let (ctx, mut guard) = open_with_permission(project)?;
+
+    assure_edit_mode(&ctx).context("Edit mode may only be left while in edit mode")?;
+
+    crate::abort_and_return_to_workspace(&ctx, guard.write_permission())
+}
+
 fn open_with_permission(project: &Project) -> Result<(CommandContext, WriteWorkspaceGuard)> {
     let ctx = CommandContext::open(project)?;
     let guard = project.exclusive_worktree_access();

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -197,7 +197,8 @@ fn main() {
                     remotes::add_remote,
                     modes::operating_mode,
                     modes::enter_edit_mode,
-                    modes::save_edit_and_return_to_workspace
+                    modes::save_edit_and_return_to_workspace,
+                    modes::abort_edit_and_return_to_workspace
                 ])
                 .menu(menu::build(tauri_context.package_info()))
                 .on_menu_event(|event| menu::handle_event(&event))

--- a/crates/gitbutler-tauri/src/modes.rs
+++ b/crates/gitbutler-tauri/src/modes.rs
@@ -36,6 +36,17 @@ pub fn enter_edit_mode(
 
 #[tauri::command(async)]
 #[instrument(skip(projects), err(Debug))]
+pub fn abort_edit_and_return_to_workspace(
+    projects: State<'_, Controller>,
+    project_id: ProjectId,
+) -> Result<(), Error> {
+    let project = projects.get(project_id)?;
+
+    gitbutler_edit_mode::commands::abort_and_return_to_workspace(&project).map_err(Into::into)
+}
+
+#[tauri::command(async)]
+#[instrument(skip(projects), err(Debug))]
 pub fn save_edit_and_return_to_workspace(
     projects: State<'_, Controller>,
     project_id: ProjectId,


### PR DESCRIPTION
The main logic is found in this function:

```rs
pub(crate) fn abort_and_return_to_workspace(
    ctx: &CommandContext,
    _perm: &mut WorktreeWritePermission,
) -> Result<()> {
    let repository = ctx.repository();

    // Checkout gitbutler workspace branch
    {
        repository
            .set_head(INTEGRATION_BRANCH_REF)
            .context("Failed to set head reference")?;
        repository
            .checkout_head(Some(CheckoutBuilder::new().force().remove_untracked(true)))
            .context("Failed to checkout gitbutler/integration")?;
    }

    // Checkout any stashed changes.
    {
        let stashed_integration_changes_reference = repository
            .find_reference(EDIT_UNCOMMITED_FILES_REF)
            .context("Failed to find stashed integration changes")?;
        let stashed_integration_changes_commit = stashed_integration_changes_reference
            .peel_to_commit()
            .context("Failed to get stashed changes commit")?;

        repository
            .checkout_tree(
                stashed_integration_changes_commit.tree()?.as_object(),
                Some(CheckoutBuilder::new().force().remove_untracked(true)),
            )
            .context("Failed to checkout stashed changes tree")?;
    }

    Ok(())
}
```

This PR also includes some minor design tweaks which move towards Pavel's design.