### PR TITLE
Fix wdio and tsconfig errors

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -81,7 +81,8 @@
 		"tinykeys": "^2.1.0",
 		"ts-node": "^10.9.2",
 		"vite": "catalog:",
-		"vitest": "^2.0.5"
+		"vitest": "^2.0.5",
+		"@types/node": "^22.3.0"
 	},
 	"dependencies": {
 		"openai": "^4.47.3"

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -14,7 +14,7 @@
 		"sourceMap": true,
 		"strict": true,
 		"experimentalDecorators": true,
-		"types": ["node", "@wdio/globals/types", "@wdio/mocha-framework", "vitest/importMeta"]
+		"types": ["@wdio/globals/types", "@wdio/mocha-framework", "vitest/importMeta"]
 	},
 	"include": [
 		"vitest-setup.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
       '@types/marked':
         specifier: ^5.0.2
         version: 5.0.2
+      '@types/node':
+        specifier: ^22.3.0
+        version: 22.3.0
       '@types/postcss-pxtorem':
         specifier: ^6.0.3
         version: 6.0.3
@@ -7811,7 +7814,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.14.13
+      '@types/node': 22.3.0
       '@types/yargs': 17.0.32
       chalk: 4.1.2
 
@@ -8995,7 +8998,7 @@ snapshots:
 
   '@types/accepts@1.3.7':
     dependencies:
-      '@types/node': 20.14.13
+      '@types/node': 22.3.0
 
   '@types/aria-query@5.0.4': {}
 
@@ -9004,15 +9007,15 @@ snapshots:
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 20.14.13
+      '@types/node': 22.3.0
 
   '@types/connect@3.4.36':
     dependencies:
-      '@types/node': 20.14.13
+      '@types/node': 22.3.0
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 20.14.13
+      '@types/node': 22.3.0
 
   '@types/content-disposition@0.5.8': {}
 
@@ -9023,11 +9026,11 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/express': 4.17.21
       '@types/keygrip': 1.0.6
-      '@types/node': 20.14.13
+      '@types/node': 22.3.0
 
   '@types/cross-spawn@6.0.6':
     dependencies:
-      '@types/node': 20.14.13
+      '@types/node': 22.3.0
 
   '@types/culori@2.1.1': {}
 
@@ -9050,7 +9053,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.3':
     dependencies:
-      '@types/node': 20.14.13
+      '@types/node': 22.3.0
       '@types/qs': 6.9.15
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -9105,7 +9108,7 @@ snapshots:
       '@types/http-errors': 2.0.4
       '@types/keygrip': 1.0.6
       '@types/koa-compose': 3.2.8
-      '@types/node': 20.14.13
+      '@types/node': 22.3.0
 
   '@types/koa__router@12.0.3':
     dependencies:
@@ -9125,11 +9128,11 @@ snapshots:
 
   '@types/mysql@2.15.22':
     dependencies:
-      '@types/node': 20.14.13
+      '@types/node': 22.3.0
 
   '@types/node-fetch@2.6.11':
     dependencies:
-      '@types/node': 20.14.13
+      '@types/node': 22.3.0
       form-data: 4.0.0
 
   '@types/node@18.19.22':
@@ -9152,7 +9155,7 @@ snapshots:
 
   '@types/pg@8.6.1':
     dependencies:
-      '@types/node': 20.14.13
+      '@types/node': 22.3.0
       pg-protocol: 1.6.1
       pg-types: 2.2.0
 
@@ -9178,12 +9181,12 @@ snapshots:
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 20.14.13
+      '@types/node': 22.3.0
 
   '@types/serve-static@1.15.7':
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 20.14.13
+      '@types/node': 22.3.0
       '@types/send': 0.17.4
 
   '@types/shimmer@1.0.5': {}
@@ -9198,7 +9201,7 @@ snapshots:
 
   '@types/ws@8.5.12':
     dependencies:
-      '@types/node': 20.14.13
+      '@types/node': 22.3.0
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -9208,7 +9211,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 20.14.13
+      '@types/node': 22.3.0
     optional: true
 
   '@typescript-eslint/eslint-plugin@7.13.1(@typescript-eslint/parser@7.13.1(eslint@9.5.0)(typescript@5.4.5))(eslint@9.5.0)(typescript@5.4.5)':
@@ -11702,7 +11705,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.14.13
+      '@types/node': 22.3.0
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11


### PR DESCRIPTION
I was getting two errors. In the `wdio.conf.ts` I was getting errors about `process.stdout` and `process.stderr` having bad types. I was also having an error in my `apps/desktop/tsconfig.json` complaining that it couldn't find a package called "node".

As it so turns out, the `types` field in the `tsconfig.json` is for globally importing packages for their types. (packages called `@types/*` have their types globally imported by default). We never had a package called `node` so all hell was breaking loose.

```diff
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -81,7 +81,8 @@
 		"tinykeys": "^2.1.0",
 		"ts-node": "^10.9.2",
 		"vite": "catalog:",
-		"vitest": "^2.0.5"
+		"vitest": "^2.0.5",
+		"@types/node": "^22.3.0"
 	},
 	"dependencies": {
 		"openai": "^4.47.3"
```


```diff
--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -14,7 +14,7 @@
 		"sourceMap": true,
 		"strict": true,
 		"experimentalDecorators": true,
-		"types": ["node", "@wdio/globals/types", "@wdio/mocha-framework", "vitest/importMeta"]
+		"types": ["@wdio/globals/types", "@wdio/mocha-framework", "vitest/importMeta"]
 	},
 	"include": [
 		"vitest-setup.js",
```