### PR TITLE
Fix conflicting-branches list message

### DIFF
--- a/apps/desktop/src/lib/vbranches/branchController.ts
+++ b/apps/desktop/src/lib/vbranches/branchController.ts
@@ -4,6 +4,7 @@ import * as toasts from '$lib/utils/toasts';
 import posthog from 'posthog-js';
 import type { BaseBranchService } from '$lib/baseBranch/baseBranchService';
 import type { RemoteBranchService } from '$lib/stores/remoteBranches';
+import type { Hunk, LocalFile } from './types';
 import type { VirtualBranchService } from './virtualBranch';
 
 export class BranchController {

--- a/apps/desktop/src/lib/vbranches/branchController.ts
+++ b/apps/desktop/src/lib/vbranches/branchController.ts
@@ -4,7 +4,6 @@ import * as toasts from '$lib/utils/toasts';
 import posthog from 'posthog-js';
 import type { BaseBranchService } from '$lib/baseBranch/baseBranchService';
 import type { RemoteBranchService } from '$lib/stores/remoteBranches';
-import type { VirtualBranch, Hunk, LocalFile } from './types';
 import type { VirtualBranchService } from './virtualBranch';
 
 export class BranchController {
@@ -257,12 +256,13 @@ export class BranchController {
 
 	async updateBaseBranch(): Promise<string | undefined> {
 		try {
-			const stashedConflicting = await invoke<VirtualBranch[]>('update_base_branch', {
+			const stashedConflicting = await invoke<string[]>('update_base_branch', {
 				projectId: this.projectId
 			});
+			const branchRefPrefix = 'refs/heads/';
 			if (stashedConflicting.length > 0) {
 				return `The following branches were stashed due to a merge conflict during updating the workspace: \n\n \
-${stashedConflicting.map((branch) => branch.name).join('\n')} \n\n \
+${stashedConflicting.map((branch) => branch.split(branchRefPrefix)[1]).join('\n')} \n\n \
 You can find them in the 'Branches' sidebar in order to resolve conflicts.`;
 			} else {
 				return undefined;


### PR DESCRIPTION
## ☕️ Reasoning
- Currently no branches are listed in the error message when pulling changes and a merge conflict occurs
- The branches list returned by update_base_branch contains string, whereas when the error message is constructed it's assumed the objects in the list have a 'name' property.

## 🧢 Changes
- Use  the strings as they are to list the conflicting remote branch references (without the `refs/heads/` prefix)

## 🎫 Affected issues

Fixes: [4472](https://github.com/gitbutlerapp/gitbutler/issues/4472) 
Possibly also
Fixes: [4567](https://github.com/gitbutlerapp/gitbutler/issues/4567)

## 📌 Todos
- Consider displaying the prefix, to make it clear (?) that remote branches are listed
- Consider converting the remote ref to the local virtual branch name. This might be clearer, also in light of 4666 - after  a virtual branch get unnapplied during conflict, it loses its association with the remote branch (was also raised in [Discord](https://discord.com/channels/1060193121130000425/1073202153163857920/1275799343097577503))