### PR TITLE
Fix files selection

### DIFF
--- a/apps/desktop/src/lib/commit/CommitCard.svelte
+++ b/apps/desktop/src/lib/commit/CommitCard.svelte
@@ -31,6 +31,7 @@
 	export let branch: VirtualBranch | undefined = undefined;
 	export let commit: DetailedCommit | Commit;
 	export let commitUrl: string | undefined = undefined;
+	export let isPreview: boolean = false;
 	export let isHeadCommit: boolean = false;
 	export let isUnapplied = false;
 	export let first = false;
@@ -368,7 +369,12 @@
 				{/if}
 
 				<div class="files-container">
-					<BranchFilesList {files} {isUnapplied} readonly={type === 'remote'} />
+					<BranchFilesList
+						allowMultiple={!isPreview}
+						{files}
+						{isUnapplied}
+						readonly={type === 'remote' || isPreview}
+					/>
 				</div>
 			{/if}
 		</CommitDragItem>

--- a/apps/desktop/src/lib/commit/CommitCard.svelte
+++ b/apps/desktop/src/lib/commit/CommitCard.svelte
@@ -232,10 +232,12 @@
 					class:integrated={type === 'integrated'}
 				></div>
 
-				{#if type === 'local' || type === 'localAndRemote'}
-					<div class="commit__drag-icon">
-						<Icon name="draggable-narrow" />
-					</div>
+				{#if !isPreview}
+					{#if type === 'local' || type === 'localAndRemote'}
+						<div class="commit__drag-icon">
+							<Icon name="draggable-narrow" />
+						</div>
+					{/if}
 				{/if}
 
 				{#if first}

--- a/apps/desktop/src/lib/commit/CommitCard.svelte
+++ b/apps/desktop/src/lib/commit/CommitCard.svelte
@@ -371,7 +371,7 @@
 
 				<div class="files-container">
 					<BranchFilesList
-						allowMultiple={!isUnapplied}
+						allowMultiple={!isUnapplied && type !== 'remote'}
 						{files}
 						{isUnapplied}
 						readonly={type === 'remote' || isUnapplied}

--- a/apps/desktop/src/lib/commit/CommitCard.svelte
+++ b/apps/desktop/src/lib/commit/CommitCard.svelte
@@ -31,7 +31,6 @@
 	export let branch: VirtualBranch | undefined = undefined;
 	export let commit: DetailedCommit | Commit;
 	export let commitUrl: string | undefined = undefined;
-	export let isPreview: boolean = false;
 	export let isHeadCommit: boolean = false;
 	export let isUnapplied = false;
 	export let first = false;
@@ -232,7 +231,7 @@
 					class:integrated={type === 'integrated'}
 				></div>
 
-				{#if !isPreview}
+				{#if !isUnapplied}
 					{#if type === 'local' || type === 'localAndRemote'}
 						<div class="commit__drag-icon">
 							<Icon name="draggable-narrow" />
@@ -372,10 +371,10 @@
 
 				<div class="files-container">
 					<BranchFilesList
-						allowMultiple={!isPreview}
+						allowMultiple={!isUnapplied}
 						{files}
 						{isUnapplied}
-						readonly={type === 'remote' || isPreview}
+						readonly={type === 'remote' || isUnapplied}
 					/>
 				</div>
 			{/if}

--- a/apps/desktop/src/lib/components/BranchPreview.svelte
+++ b/apps/desktop/src/lib/components/BranchPreview.svelte
@@ -120,6 +120,7 @@
 						{#if remoteCommits}
 							{#each remoteCommits as commit, index (commit.id)}
 								<CommitCard
+									isPreview
 									first={index === 0}
 									last={index === remoteCommits.length - 1}
 									{commit}
@@ -135,6 +136,7 @@
 						{#if localCommits}
 							{#each localCommits as commit, index (commit.id)}
 								<CommitCard
+									isPreview
 									first={index === 0}
 									last={index === localCommits.length - 1}
 									{commit}
@@ -150,6 +152,7 @@
 						{#if localAndRemoteCommits}
 							{#each localAndRemoteCommits as commit, index (commit.id)}
 								<CommitCard
+									isPreview
 									first={index === 0}
 									last={index === localAndRemoteCommits.length - 1}
 									{commit}

--- a/apps/desktop/src/lib/components/BranchPreview.svelte
+++ b/apps/desktop/src/lib/components/BranchPreview.svelte
@@ -120,7 +120,7 @@
 						{#if remoteCommits}
 							{#each remoteCommits as commit, index (commit.id)}
 								<CommitCard
-									isPreview
+									isUnapplied
 									first={index === 0}
 									last={index === remoteCommits.length - 1}
 									{commit}
@@ -136,7 +136,7 @@
 						{#if localCommits}
 							{#each localCommits as commit, index (commit.id)}
 								<CommitCard
-									isPreview
+									isUnapplied
 									first={index === 0}
 									last={index === localCommits.length - 1}
 									{commit}
@@ -152,7 +152,7 @@
 						{#if localAndRemoteCommits}
 							{#each localAndRemoteCommits as commit, index (commit.id)}
 								<CommitCard
-									isPreview
+									isUnapplied
 									first={index === 0}
 									last={index === localAndRemoteCommits.length - 1}
 									{commit}

--- a/apps/desktop/src/lib/file/BranchFilesList.svelte
+++ b/apps/desktop/src/lib/file/BranchFilesList.svelte
@@ -103,7 +103,8 @@
 							file,
 							files: displayedFiles,
 							selectedFileIds: $fileIdSelection,
-							fileIdSelection
+							fileIdSelection,
+							commitId: $commit?.id
 						}
 					);
 

--- a/apps/desktop/src/lib/utils/selection.ts
+++ b/apps/desktop/src/lib/utils/selection.ts
@@ -8,8 +8,8 @@ import type { AnyFile } from '$lib/vbranches/types';
 
 export function getNextFile(files: AnyFile[], currentId: string): AnyFile | undefined {
 	const fileIndex = files.findIndex((f) => f.id === currentId);
-	const nextFile =
-		fileIndex !== -1 && fileIndex + 1 < files.length ? files[fileIndex + 1] : undefined;
+	const nextFile = fileIndex > 0 && fileIndex + 1 < files.length ? files[fileIndex + 1] : undefined;
+	console.log('nextFile', nextFile);
 	return nextFile;
 }
 

--- a/apps/desktop/src/lib/utils/selection.ts
+++ b/apps/desktop/src/lib/utils/selection.ts
@@ -8,12 +8,15 @@ import type { AnyFile } from '$lib/vbranches/types';
 
 export function getNextFile(files: AnyFile[], currentId: string): AnyFile | undefined {
 	const fileIndex = files.findIndex((f) => f.id === currentId);
-	return fileIndex !== -1 && fileIndex + 1 < files.length ? files[fileIndex + 1] : undefined;
+	const nextFile =
+		fileIndex !== -1 && fileIndex + 1 < files.length ? files[fileIndex + 1] : undefined;
+	return nextFile;
 }
 
 export function getPreviousFile(files: AnyFile[], currentId: string): AnyFile | undefined {
 	const fileIndex = files.findIndex((f) => f.id === currentId);
-	return fileIndex > 0 ? files[fileIndex - 1] : undefined;
+	const previousFile = fileIndex > 0 ? files[fileIndex - 1] : undefined;
+	return previousFile;
 }
 
 interface MoveSelectionParams {
@@ -25,6 +28,7 @@ interface MoveSelectionParams {
 	files: AnyFile[];
 	selectedFileIds: string[];
 	fileIdSelection: FileIdSelection;
+	commitId?: string;
 }
 
 export function maybeMoveSelection({
@@ -35,7 +39,8 @@ export function maybeMoveSelection({
 	file,
 	files,
 	selectedFileIds,
-	fileIdSelection
+	fileIdSelection,
+	commitId
 }: MoveSelectionParams) {
 	if (!selectedFileIds[0] || selectedFileIds.length === 0) return;
 
@@ -53,9 +58,10 @@ export function maybeMoveSelection({
 		const file = getFileFunc(files, id);
 		if (file) {
 			// if file is already selected, do nothing
-			if (selectedFileIds.includes(stringifyFileKey(file.id))) return;
 
-			fileIdSelection.add(file.id);
+			if (selectedFileIds.includes(stringifyFileKey(file.id, commitId))) return;
+
+			fileIdSelection.add(file.id, commitId);
 		}
 	}
 
@@ -64,9 +70,10 @@ export function maybeMoveSelection({
 		id: string
 	) {
 		const file = getFileFunc(files, id);
+
 		if (file) {
 			fileIdSelection.clear();
-			fileIdSelection.add(file.id);
+			fileIdSelection.add(file.id, commitId);
 		}
 	}
 
@@ -104,6 +111,7 @@ export function maybeMoveSelection({
 				} else if (selectionDirection === 'up') {
 					fileIdSelection.remove(lastFileId);
 				}
+
 				getAndAddFile(getNextFile, lastFileId);
 			} else {
 				// focus next file

--- a/apps/desktop/src/lib/utils/selection.ts
+++ b/apps/desktop/src/lib/utils/selection.ts
@@ -8,15 +8,12 @@ import type { AnyFile } from '$lib/vbranches/types';
 
 export function getNextFile(files: AnyFile[], currentId: string): AnyFile | undefined {
 	const fileIndex = files.findIndex((f) => f.id === currentId);
-	const nextFile =
-		fileIndex !== -1 && fileIndex + 1 < files.length ? files[fileIndex + 1] : undefined;
-	return nextFile;
+	return fileIndex !== -1 && fileIndex + 1 < files.length ? files[fileIndex + 1] : undefined;
 }
 
 export function getPreviousFile(files: AnyFile[], currentId: string): AnyFile | undefined {
 	const fileIndex = files.findIndex((f) => f.id === currentId);
-	const previousFile = fileIndex > 0 ? files[fileIndex - 1] : undefined;
-	return previousFile;
+	return fileIndex > 0 ? files[fileIndex - 1] : undefined;
 }
 
 interface MoveSelectionParams {

--- a/apps/desktop/src/lib/utils/selection.ts
+++ b/apps/desktop/src/lib/utils/selection.ts
@@ -8,8 +8,8 @@ import type { AnyFile } from '$lib/vbranches/types';
 
 export function getNextFile(files: AnyFile[], currentId: string): AnyFile | undefined {
 	const fileIndex = files.findIndex((f) => f.id === currentId);
-	const nextFile = fileIndex > 0 && fileIndex + 1 < files.length ? files[fileIndex + 1] : undefined;
-	console.log('nextFile', nextFile);
+	const nextFile =
+		fileIndex !== -1 && fileIndex + 1 < files.length ? files[fileIndex + 1] : undefined;
 	return nextFile;
 }
 

--- a/apps/desktop/src/lib/utils/selection.ts
+++ b/apps/desktop/src/lib/utils/selection.ts
@@ -72,8 +72,7 @@ export function maybeMoveSelection({
 		const file = getFileFunc(files, id);
 
 		if (file) {
-			fileIdSelection.clear();
-			fileIdSelection.add(file.id, commitId);
+			fileIdSelection.clearExcept(file.id, commitId);
 		}
 	}
 
@@ -85,7 +84,7 @@ export function maybeMoveSelection({
 				if (selectedFileIds.length === 1) {
 					selectionDirection = 'up';
 				} else if (selectionDirection === 'down') {
-					fileIdSelection.remove(lastFileId);
+					fileIdSelection.remove(lastFileId, commitId);
 				}
 				getAndAddFile(getPreviousFile, lastFileId);
 			} else {
@@ -109,7 +108,7 @@ export function maybeMoveSelection({
 				if (selectedFileIds.length === 1) {
 					selectionDirection = 'down';
 				} else if (selectionDirection === 'up') {
-					fileIdSelection.remove(lastFileId);
+					fileIdSelection.remove(lastFileId, commitId);
 				}
 
 				getAndAddFile(getNextFile, lastFileId);

--- a/apps/desktop/src/lib/vbranches/fileIdSelection.ts
+++ b/apps/desktop/src/lib/vbranches/fileIdSelection.ts
@@ -83,6 +83,11 @@ export class FileIdSelection {
 		this.emit();
 	}
 
+	clearExcept(fileId: string, commitId?: string) {
+		this.value = [stringifyFileKey(fileId, commitId)];
+		this.emit();
+	}
+
 	emit() {
 		for (const callback of this.callbacks) {
 			callback(this.value);


### PR DESCRIPTION
## ☕️ Reasoning

- The selection using arrow keys didn't work on commits. It's because we didn't provide the `commit id` and there wasn't any matches.
- Allow to select multiple files, except `remote` commits
 - disable `draggable` icon for unapplied commits

Result:

https://github.com/user-attachments/assets/3bfe924b-3ca7-41a7-9f51-767f977bed87

Related issue — https://github.com/gitbutlerapp/gitbutler/issues/4734#issuecomment-2307668787


