### PR TITLE
merge-base performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,32 +2629,32 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.66.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "gix-actor 0.32.0",
- "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-command",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-config",
  "gix-credentials",
  "gix-date 0.9.0",
  "gix-diff",
  "gix-dir",
  "gix-discover 0.35.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-filter",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-ignore 0.11.4 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-ignore 0.11.4 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-index 0.35.0",
- "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-negotiate",
  "gix-object 0.44.0",
  "gix-odb",
  "gix-pack",
- "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-pathspec",
  "gix-prompt",
  "gix-protocol",
@@ -2662,13 +2662,13 @@ dependencies = [
  "gix-refspec",
  "gix-revision",
  "gix-revwalk 0.15.0",
- "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-submodule",
- "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-traverse 0.41.0",
  "gix-url",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-validate 0.9.0",
  "gix-worktree 0.36.0",
  "gix-worktree-state",
@@ -2694,11 +2694,11 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.32.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
  "gix-date 0.9.0",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "itoa 1.0.11",
  "thiserror",
  "winnow 0.6.18",
@@ -2724,13 +2724,13 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.22.5"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "kstring",
  "smallvec",
  "thiserror",
@@ -2749,7 +2749,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.11"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "thiserror",
 ]
@@ -2766,7 +2766,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.8"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "thiserror",
 ]
@@ -2774,11 +2774,11 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.3.9"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
- "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "shell-words",
 ]
 
@@ -2799,12 +2799,12 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.24.3"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
- "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "memmap2",
  "thiserror",
 ]
@@ -2812,15 +2812,15 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.40.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-ref 0.47.0",
- "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "memchr",
  "once_cell",
  "smallvec",
@@ -2832,11 +2832,11 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.14.8"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "libc",
  "thiserror",
 ]
@@ -2844,15 +2844,15 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.24.5"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-config-value",
- "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-prompt",
- "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-url",
  "thiserror",
 ]
@@ -2872,7 +2872,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.9.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
  "itoa 1.0.11",
@@ -2883,17 +2883,17 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.46.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-filter",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-object 0.44.0",
- "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-worktree 0.36.0",
  "imara-diff",
  "thiserror",
@@ -2902,18 +2902,18 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.8.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
  "gix-discover 0.35.0",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-ignore 0.11.4 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-ignore 0.11.4 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-index 0.35.0",
  "gix-object 0.44.0",
- "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-pathspec",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-worktree 0.36.0",
  "thiserror",
 ]
@@ -2937,15 +2937,15 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.35.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
  "dunce",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-ref 0.47.0",
- "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "thiserror",
 ]
 
@@ -2967,14 +2967,14 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.38.2"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",
  "flate2",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "libc",
  "once_cell",
  "parking_lot 0.12.3",
@@ -2988,19 +2988,19 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.13.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
  "encoding_rs",
- "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-command",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-object 0.44.0",
  "gix-packetline-blocking",
- "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "smallvec",
  "thiserror",
 ]
@@ -3019,11 +3019,11 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.11.3"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "fastrand 2.1.1",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
 ]
 
 [[package]]
@@ -3041,12 +3041,12 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.16.5"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
 ]
 
 [[package]]
@@ -3062,7 +3062,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.14.2"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "faster-hex",
  "thiserror",
@@ -3082,9 +3082,9 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.5.2"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "hashbrown 0.14.5",
  "parking_lot 0.12.3",
 ]
@@ -3105,12 +3105,12 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.11.4"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "unicode-bom",
 ]
 
@@ -3145,20 +3145,20 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.35.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "filetime",
  "fnv",
- "gix-bitmap 0.2.11 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-bitmap 0.2.11 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-object 0.44.0",
  "gix-traverse 0.41.0",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-validate 0.9.0",
  "hashbrown 0.14.5",
  "itoa 1.0.11",
@@ -3183,22 +3183,22 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "14.0.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
- "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-negotiate"
 version = "0.15.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bitflags 2.6.0",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-object 0.44.0",
  "gix-revwalk 0.15.0",
  "smallvec",
@@ -3227,14 +3227,14 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.44.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
  "gix-actor 0.32.0",
  "gix-date 0.9.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-validate 0.9.0",
  "itoa 1.0.11",
  "smallvec",
@@ -3245,17 +3245,17 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.63.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "arc-swap",
  "gix-date 0.9.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-object 0.44.0",
  "gix-pack",
- "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "parking_lot 0.12.3",
  "tempfile",
  "thiserror",
@@ -3264,16 +3264,16 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.53.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "clru",
- "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-object 0.44.0",
- "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "memmap2",
  "parking_lot 0.12.3",
  "smallvec",
@@ -3284,22 +3284,22 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.17.6"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.17.5"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "thiserror",
 ]
 
@@ -3319,10 +3319,10 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.10"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "home",
  "once_cell",
  "thiserror",
@@ -3331,21 +3331,21 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.7.7"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-config-value",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-prompt"
 version = "0.8.7"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -3357,15 +3357,15 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.45.3"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
  "gix-credentials",
  "gix-date 0.9.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-transport",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "maybe-async",
  "thiserror",
  "winnow 0.6.18",
@@ -3385,10 +3385,10 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.4.12"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "thiserror",
 ]
 
@@ -3417,17 +3417,17 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.47.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "gix-actor 0.32.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-object 0.44.0",
- "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-validate 0.9.0",
  "memmap2",
  "thiserror",
@@ -3437,10 +3437,10 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.25.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-revision",
  "gix-validate 0.9.0",
  "smallvec",
@@ -3450,17 +3450,17 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.29.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-object 0.44.0",
  "gix-revwalk 0.15.0",
- "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "thiserror",
 ]
 
@@ -3482,12 +3482,12 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.15.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-object 0.44.0",
  "smallvec",
  "thiserror",
@@ -3508,10 +3508,10 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.10.8"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bitflags 2.6.0",
- "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -3519,11 +3519,11 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.14.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
  "gix-config",
- "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
@@ -3548,10 +3548,10 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "14.0.2"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "dashmap",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "libc",
  "once_cell",
  "parking_lot 0.12.3",
@@ -3593,7 +3593,7 @@ checksum = "f924267408915fddcd558e3f37295cc7d6a3e50f8bd8b606cee0808c3915157e"
 [[package]]
 name = "gix-trace"
 version = "0.1.9"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "tracing-core",
 ]
@@ -3601,14 +3601,14 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.42.3"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
  "gix-command",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-packetline",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-url",
  "thiserror",
 ]
@@ -3633,13 +3633,13 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.41.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bitflags 2.6.0",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-object 0.44.0",
  "gix-revwalk 0.15.0",
  "smallvec",
@@ -3649,11 +3649,11 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.27.5"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "thiserror",
  "url",
 ]
@@ -3671,7 +3671,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.1.12"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
  "fastrand 2.1.1",
@@ -3691,7 +3691,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.9.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
  "thiserror",
@@ -3719,35 +3719,35 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.36.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
- "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-ignore 0.11.4 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-ignore 0.11.4 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-index 0.35.0",
  "gix-object 0.44.0",
- "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-validate 0.9.0",
 ]
 
 [[package]]
 name = "gix-worktree-state"
 version = "0.13.0"
-source = "git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e#649f5882cbebadf1133fa5f310e09b4aab77217e"
+source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
  "bstr",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-filter",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-index 0.35.0",
  "gix-object 0.44.0",
- "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=649f5882cbebadf1133fa5f310e09b4aab77217e)",
+ "gix-path 0.10.10 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-worktree 0.36.0",
  "io-close",
  "thiserror",
@@ -8394,7 +8394,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ resolver = "2"
 [workspace.dependencies]
 bstr = "1.10.0"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
-gix = { git = "https://github.com/Byron/gitoxide", rev = "649f5882cbebadf1133fa5f310e09b4aab77217e", default-features = false, features = [] }
+gix = { git = "https://github.com/Byron/gitoxide", rev = "0fe5133598c6f843fb3172a4e0c4f58932405647", default-features = false, features = [] }
 git2 = { version = "0.18.3", features = [
     "vendored-openssl",
     "vendored-libgit2",

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -517,13 +517,14 @@ pub fn get_branch_listing_details(
                     let mut repo = repo.to_thread_local();
                     repo.object_cache_size_if_unset(50 * 1024 * 1024);
                     let cache = repo.commit_graph_if_enabled()?;
+                    let mut graph = repo.revision_graph(cache.as_ref());
                     for (other_branch_commit_id, branch_head) in all_other_branch_commit_ids {
                         let branch_head = git2_to_gix_object_id(branch_head);
                         let base = repo
-                            .merge_base_with_cache(
+                            .merge_base_with_graph(
                                 git2_to_gix_object_id(other_branch_commit_id),
                                 branch_head,
-                                cache.as_ref(),
+                                &mut graph,
                             )
                             .ok()
                             .map(gix::Id::detach);


### PR DESCRIPTION
Follow-up to #4757.

Get `merge-base` computation performance to be en-par with the cache-less variant in `git2`.
Prevously when there is no commit-graph cache, it was 7% slower than `git2` (which is just as fast as Git itself),
which is likely due to Git2 leveraging already parsed objects between multiple merge-base queries.

`gix` has to learn that to be en-par or faster, and I think it's not going to take long.

### Tasks

* [x] move rev-walking to the thread that deals with commits walks to leverage caches (from 6% slower to 4% slower)
* [x] performance comparison compared to the previous version that used `git2` for merge-bases. (from 6% slower to 8% faster)
* [x] use [latest version of `gix`](https://github.com/Byron/gitoxide/pull/1564) (that can re-use the existing commit-graph cache (with parsed objects)

### Performance

This was a win, as `gix` is now about 4% faster than Git (in one particular workload without commit-graph), and *8% faster* than `git2` thanks to greatly improved caching.
Memory consumption is still lower at 575MB compared to 617MB.

When a commit-graph is present (via `git commit-graph write --reachable`), then `gix` is 26% faster. Now it probably hits the boundary where diffing trees is the slowest operation, whereas merge-base computation is very quickly done (it's at least 10x faster then). Those who have repos big enough to use commit-graphs will certainly appreciate it.