### PR TITLE
fix: use ubuntu-22.04 to build app for release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -86,7 +86,7 @@ jobs:
         platform:
           - macos-13 # [macOs, x64]
           - macos-latest # [macOs, ARM64]
-          - ubuntu-20.04 # [linux, x64]
+          - ubuntu-22.04 # [linux, x64]
           - windows-latest # [windows, x64]
 
     runs-on: ${{ matrix.platform }}
@@ -256,7 +256,7 @@ jobs:
         platform:
           - macos-13 # [macOs, x64]
           - macos-latest # [macOs, ARM64]
-          - ubuntu-20.04 # [linux, x64]
+          - ubuntu-22.04 # [linux, x64]
           - windows-latest # [windows, x64]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## ☕️ Reasoning
- Use latest compatible Ubuntu to build Linux releases. This has the effect of using a newer version of `libwebkit2gtk-4.0`, which is bundled into the AppImage from the build environment and fixes a few obscure bugs. 
- Kicked off a nightly with this already as test build (https://github.com/gitbutlerapp/gitbutler/actions/runs/10576019661), works as intended on Linux :+1: 

For example, see the dropzone opacity/transform fail here in the previous nightly (built with Ubuntu 20.04):

> ![image](https://github.com/user-attachments/assets/bf55de8b-3c8a-4fda-88d4-53a9bbf6650c)

This now works in the AppImage as intended in the latest nightly built from this PR:

> ![image](https://github.com/user-attachments/assets/f0bd9749-1194-4fbc-902a-311b7bbf998c)


## 🧢 Changes
- Use Ubuntu 22.04 to build `.deb` and `AppImage` bundles for release


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
