### PR TITLE
list virtual branches performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,6 +2627,7 @@ dependencies = [
  "backoff",
  "gitbutler-branch-actions",
  "gitbutler-command-context",
+ "gitbutler-diff",
  "gitbutler-error",
  "gitbutler-notify-debouncer",
  "gitbutler-operating-modes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2565,6 +2565,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-appender",
+ "tracing-forest",
  "tracing-subscriber",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2211,6 +2211,7 @@ name = "gitbutler-command-context"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bstr",
  "git2",
  "gitbutler-project",
  "gix",
@@ -2374,6 +2375,7 @@ dependencies = [
  "anyhow",
  "git2",
  "gitbutler-branch",
+ "gitbutler-command-context",
  "gitbutler-diff",
  "gitbutler-fs",
  "gitbutler-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,3 +90,8 @@ codegen-units = 1 # Compile crates one after another so the compiler can optimiz
 lto = true        # Enables link to optimizations
 opt-level = "s"   # Optimize for binary size
 debug = true      # Enable debug symbols, for profiling
+
+[profile.bench]
+codegen-units = 256
+lto = false
+opt-level = 3

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -138,6 +138,23 @@ One can get performance log when launching the application locally as follows:
 GITBUTLER_PERFORMANCE_LOG=1 LOG_LEVEL=debug pnpm tauri dev
 ```
 
+For more realistic performance logging, use local release builds with `--release`.
+
+```bash
+GITBUTLER_PERFORMANCE_LOG=1 LOG_LEVEL=debug pnpm tauri dev --release
+```
+
+Since release builds are configured for public releases, they are very slow to compile.
+Speed them up by sourcing the following file.
+
+```bash
+export CARGO_PROFILE_RELEASE_DEBUG=0
+export CARGO_PROFILE_RELEASE_INCREMENTAL=false
+export CARGO_PROFILE_RELEASE_LTO=false
+export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=256
+export CARGO_PROFILE_RELEASE_OPT_LEVEL=2
+```
+
 ### Tokio
 
 We are also collecting tokio's runtime tracing information that could be viewed using [tokio-console](https://github.com/tokio-rs/console#tokio-console-prototypes):

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -132,6 +132,12 @@ The app writes logs into:
 1. `stdout` in development mode
 2. The Tauri [logs](https://tauri.app/v1/api/js/path/#platform-specific) directory
 
+One can get performance log when launching the application locally as follows:
+
+```bash
+GITBUTLER_PERFORMANCE_LOG=1 LOG_LEVEL=debug pnpm tauri dev
+```
+
 ### Tokio
 
 We are also collecting tokio's runtime tracing information that could be viewed using [tokio-console](https://github.com/tokio-rs/console#tokio-console-prototypes):

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -5,11 +5,11 @@ use core::fmt;
 use gitbutler_branch::{
     Branch as GitButlerBranch, BranchId, BranchIdentity, ReferenceExtGix, Target,
 };
-use gitbutler_command_context::{CommandContext, GixRepositoryExt};
+use gitbutler_command_context::CommandContext;
 use gitbutler_diff::DiffByPathMap;
 use gitbutler_project::access::WorktreeReadPermission;
 use gitbutler_reference::normalize_branch_name;
-use gitbutler_repo::RepositoryExt;
+use gitbutler_repo::{GixRepositoryExt, RepositoryExt};
 use gitbutler_serde::BStringForFrontend;
 use gix::object::tree::diff::Action;
 use gix::prelude::ObjectIdExt;

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -8,6 +8,7 @@ use gitbutler_branch::{
 use gitbutler_command_context::{CommandContext, GixRepositoryExt};
 use gitbutler_project::access::WorktreeReadPermission;
 use gitbutler_reference::normalize_branch_name;
+use gitbutler_repo::RepositoryExt;
 use gitbutler_serde::BStringForFrontend;
 use gix::object::tree::diff::Action;
 use gix::prelude::ObjectIdExt;
@@ -27,12 +28,7 @@ pub(crate) fn get_uncommited_files(
     _permission: &WorktreeReadPermission,
 ) -> Result<Vec<RemoteBranchFile>> {
     let repository = context.repository();
-    let head_commit = repository
-        .head()
-        .context("Failed to get head")?
-        .peel_to_commit()
-        .context("Failed to get head commit")?;
-
+    let head_commit = repository.head_commit()?;
     let files = gitbutler_diff::workdir(repository, &head_commit.id())
         .context("Failed to list uncommited files")?
         .into_iter()

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -454,7 +454,7 @@ impl BranchManager<'_> {
             vb_state.set_branch(branch.clone())?;
         }
 
-        let wd_tree = self.ctx.repository().get_wd_tree()?;
+        let wd_tree = self.ctx.repository().create_wd_tree()?;
 
         let branch_tree = repo
             .find_tree(branch.tree)

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -12,6 +12,7 @@ use gitbutler_commit::commit_ext::CommitExt;
 use gitbutler_error::error::Marker;
 use gitbutler_project::access::WorktreeWritePermission;
 use gitbutler_repo::{LogUntil, RepoActionsExt, RepositoryExt};
+use tracing::instrument;
 
 use crate::{branch_manager::BranchManagerExt, conflicts, VirtualBranchesExt};
 
@@ -22,6 +23,7 @@ const GITBUTLER_INTEGRATION_COMMIT_TITLE: &str = "GitButler Integration Commit";
 //
 // This is the base against which we diff the working directory to understand
 // what files have been modified.
+#[instrument(level = tracing::Level::DEBUG, skip(ctx))]
 pub(crate) fn get_workspace_head(ctx: &CommandContext) -> Result<git2::Oid> {
     let vb_state = ctx.project().virtual_branches();
     let target = vb_state

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -19,10 +19,14 @@ use crate::{branch_manager::BranchManagerExt, conflicts, VirtualBranchesExt};
 const WORKSPACE_HEAD: &str = "Workspace Head";
 const GITBUTLER_INTEGRATION_COMMIT_TITLE: &str = "GitButler Integration Commit";
 
-// Creates and returns a merge commit of all active branch heads.
-//
-// This is the base against which we diff the working directory to understand
-// what files have been modified.
+/// Creates and returns a merge commit of all active branch heads.
+///
+/// This is the base against which we diff the working directory to understand
+/// what files have been modified.
+///
+/// This should be used to update the `gitbutler/workspace` ref with, which is usually
+/// done from [`update_gitbutler_integration()`], after any of its input changes.
+/// This is namely the conflicting state, or any head of the virtual branches.
 #[instrument(level = tracing::Level::DEBUG, skip(ctx))]
 pub(crate) fn get_workspace_head(ctx: &CommandContext) -> Result<git2::Oid> {
     let vb_state = ctx.project().virtual_branches();

--- a/crates/gitbutler-branch-actions/src/status.rs
+++ b/crates/gitbutler-branch-actions/src/status.rs
@@ -47,16 +47,16 @@ pub fn get_applied_status_cached(
     worktree_changes: Option<gitbutler_diff::DiffByPathMap>,
 ) -> Result<VirtualBranchesStatus> {
     assure_open_workspace_mode(ctx).context("ng applied status requires open workspace mode")?;
-    // TODO(ST): this was `get_workspace_head()`, which is slow and ideally, we don't dynamically
-    //           calculate which should already be 'fixed' - why do we have the integration branch
-    //           if we can't assume it's in the right state? So ideally, we assure that the code
-    //           that affects the integration branch also updates it?
-    let integration_commit_id = ctx.repository().head_commit()?.id();
     let mut virtual_branches = ctx
         .project()
         .virtual_branches()
         .list_branches_in_workspace()?;
     let base_file_diffs = worktree_changes.map(Ok).unwrap_or_else(|| {
+        // TODO(ST): this was `get_workspace_head()`, which is slow and ideally, we don't dynamically
+        //           calculate which should already be 'fixed' - why do we have the integration branch
+        //           if we can't assume it's in the right state? So ideally, we assure that the code
+        //           that affects the integration branch also updates it?
+        let integration_commit_id = ctx.repository().head_commit()?.id();
         gitbutler_diff::workdir(ctx.repository(), &integration_commit_id.to_owned())
             .context("failed to diff workdir")
     })?;

--- a/crates/gitbutler-branch-actions/src/status.rs
+++ b/crates/gitbutler-branch-actions/src/status.rs
@@ -10,6 +10,7 @@ use gitbutler_command_context::CommandContext;
 use gitbutler_diff::{diff_files_into_hunks, GitHunk, Hunk, HunkHash};
 use gitbutler_operating_modes::assure_open_workspace_mode;
 use gitbutler_project::access::WorktreeWritePermission;
+use tracing::instrument;
 
 use crate::{
     conflicts::RepoConflictsExt,
@@ -30,6 +31,7 @@ pub struct VirtualBranchesStatus {
 /// Returns branches and their associated file changes, in addition to a list
 /// of skipped files.
 // TODO(kv): make this side effect free
+#[instrument(level = tracing::Level::DEBUG, skip(ctx, perm))]
 pub fn get_applied_status(
     ctx: &CommandContext,
     perm: Option<&mut WorktreeWritePermission>,

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -5,6 +5,17 @@ use std::{
     vec,
 };
 
+use crate::{
+    branch_manager::BranchManagerExt,
+    commit::{commit_to_vbranch_commit, VirtualBranchCommit},
+    conflicts::{self, RepoConflictsExt},
+    file::VirtualBranchFile,
+    hunk::VirtualBranchHunk,
+    integration::get_workspace_head,
+    remote::{branch_to_remote_branch, RemoteBranch},
+    status::get_applied_status,
+    Get, VirtualBranchesExt,
+};
 use anyhow::{anyhow, bail, Context, Result};
 use bstr::ByteSlice;
 use git2_hooks::HookResult;
@@ -27,18 +38,7 @@ use gitbutler_repo::{
 };
 use gitbutler_time::time::now_since_unix_epoch_ms;
 use serde::Serialize;
-
-use crate::{
-    branch_manager::BranchManagerExt,
-    commit::{commit_to_vbranch_commit, VirtualBranchCommit},
-    conflicts::{self, RepoConflictsExt},
-    file::VirtualBranchFile,
-    hunk::VirtualBranchHunk,
-    integration::get_workspace_head,
-    remote::{branch_to_remote_branch, RemoteBranch},
-    status::get_applied_status,
-    Get, VirtualBranchesExt,
-};
+use tracing::instrument;
 
 // this struct is a mapping to the view `Branch` type in Typescript
 // found in src-tauri/src/routes/repo/[project_id]/types.ts
@@ -255,6 +255,7 @@ fn resolve_old_applied_state(
     Ok(())
 }
 
+#[instrument(level = tracing::Level::DEBUG, skip(ctx, perm))]
 pub fn list_virtual_branches(
     ctx: &CommandContext,
     // TODO(ST): this should really only shared access, but there is some internals

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -578,7 +578,7 @@ pub fn integrate_upstream_commits(ctx: &CommandContext, branch_id: BranchId) -> 
     let new_head_tree = repo.find_commit(new_head)?.tree()?;
     let head_commit = repo.find_commit(new_head)?;
 
-    let wd_tree = ctx.repository().get_wd_tree()?;
+    let wd_tree = ctx.repository().create_wd_tree()?;
     let integration_tree = repo.find_commit(get_workspace_head(ctx)?)?.tree()?;
 
     let mut merge_index = repo.merge_trees(&integration_tree, &new_head_tree, &wd_tree, None)?;
@@ -616,7 +616,7 @@ pub(crate) fn integrate_with_merge(
     upstream_commit: &git2::Commit,
     merge_base: git2::Oid,
 ) -> Result<git2::Oid> {
-    let wd_tree = ctx.repository().get_wd_tree()?;
+    let wd_tree = ctx.repository().create_wd_tree()?;
     let repo = ctx.repository();
     let remote_tree = upstream_commit.tree().context("failed to get tree")?;
     let upstream_branch = branch.upstream.as_ref().context("upstream not found")?;
@@ -1171,7 +1171,7 @@ pub fn is_remote_branch_mergeable(
 
     let base_tree = find_base_tree(ctx.repository(), &branch_commit, &target_commit)?;
 
-    let wd_tree = ctx.repository().get_wd_tree()?;
+    let wd_tree = ctx.repository().create_wd_tree()?;
 
     let branch_tree = branch_commit.tree().context("failed to find branch tree")?;
     let mergeable = !ctx

--- a/crates/gitbutler-branch-actions/tests/extra/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/extra/mod.rs
@@ -759,7 +759,7 @@ fn commit_id_can_be_generated_or_specified() -> Result<()> {
 #[test]
 fn merge_vbranch_upstream_clean_rebase() -> Result<()> {
     let suite = Suite::default();
-    let Case { ctx, project, .. } = &suite.new_case();
+    let Case { ctx, project, .. } = &mut suite.new_case();
 
     // create a commit and set the target
     let file_path = Path::new("test.txt");
@@ -829,8 +829,14 @@ fn merge_vbranch_upstream_clean_rebase() -> Result<()> {
 
     // create the branch
     let (branches, _) = list_virtual_branches(ctx, guard.write_permission())?;
+    assert_eq!(branches.len(), 1);
     let branch1 = &branches[0];
-    assert_eq!(branch1.files.len(), 1);
+    assert_eq!(
+        branch1.files.len(),
+        1 + 1,
+        "'test' (modified compared to index) and 'test2' (untracked).\
+        This is actually correct when looking at the git repository"
+    );
     assert_eq!(branch1.commits.len(), 1);
     // assert_eq!(branch1.upstream.as_ref().unwrap().commits.len(), 1);
 

--- a/crates/gitbutler-branch-actions/tests/extra/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/extra/mod.rs
@@ -973,6 +973,7 @@ fn merge_vbranch_upstream_conflict() -> Result<()> {
     )?;
 
     // make gb see the conflict resolution
+    gitbutler_branch_actions::update_gitbutler_integration(&vb_state, ctx)?;
     let (branches, _) = list_virtual_branches(ctx, guard.write_permission())?;
     assert!(branches[0].conflicted);
 

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/convert_to_real_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/convert_to_real_branch.rs
@@ -61,15 +61,20 @@ fn conflicting() {
 
         let (branches, _) = controller.list_virtual_branches(project).unwrap();
         assert_eq!(branches.len(), 1);
-        assert!(branches[0].base_current);
-        assert!(branches[0].active);
+        let branch = &branches[0];
         assert_eq!(
-            branches[0].files[0].hunks[0].diff,
+            branch.name, "Virtual branch",
+            "the auto-created branch gets the default name"
+        );
+        assert!(branch.base_current);
+        assert!(branch.active);
+        assert_eq!(
+            branch.files[0].hunks[0].diff,
             "@@ -1 +1 @@\n-first\n\\ No newline at end of file\n+conflict\n\\ No newline at end of file\n"
         );
 
         let unapplied_branch = controller
-            .convert_to_real_branch(project, branches[0].id)
+            .convert_to_real_branch(project, branch.id)
             .unwrap();
 
         Refname::from_str(&unapplied_branch).unwrap()
@@ -100,7 +105,6 @@ fn conflicting() {
 
         assert_eq!(branches.len(), 1);
         let branch = &branches[0];
-        // assert!(!branch.base_current);
         assert!(branch.conflicted);
         assert_eq!(
             branch.files[0].hunks[0].diff,

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/convert_to_real_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/convert_to_real_branch.rs
@@ -1,6 +1,3 @@
-use gitbutler_branch::BranchCreateRequest;
-use gitbutler_reference::Refname;
-
 use super::*;
 
 #[test]
@@ -101,6 +98,9 @@ fn conflicting() {
             "<<<<<<< ours\nconflict\n=======\nsecond\n>>>>>>> theirs\n"
         );
 
+        let vb_state = VirtualBranchesHandle::new(project.gb_dir());
+        let ctx = CommandContext::open(project).unwrap();
+        update_gitbutler_integration(&vb_state, &ctx).unwrap();
         let (branches, _) = controller.list_virtual_branches(project).unwrap();
 
         assert_eq!(branches.len(), 1);

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/mod.rs
@@ -1,7 +1,8 @@
 use std::{fs, path, path::PathBuf, str::FromStr};
 
-use gitbutler_branch::BranchCreateRequest;
-use gitbutler_branch_actions::VirtualBranchActions;
+use gitbutler_branch::{BranchCreateRequest, VirtualBranchesHandle};
+use gitbutler_branch_actions::{update_gitbutler_integration, VirtualBranchActions};
+use gitbutler_command_context::CommandContext;
 use gitbutler_error::error::Marker;
 use gitbutler_project::{self as projects, Project, ProjectId};
 use gitbutler_reference::Refname;
@@ -137,6 +138,9 @@ fn resolve_conflict_flow() {
             .create_virtual_branch_from_branch(project, &unapplied_branch, None)
             .unwrap();
 
+        let vb_state = VirtualBranchesHandle::new(project.gb_dir());
+        let ctx = CommandContext::open(project).unwrap();
+        update_gitbutler_integration(&vb_state, &ctx).unwrap();
         let (branches, _) = controller.list_virtual_branches(project).unwrap();
         assert_eq!(branches.len(), 1);
         assert!(branches[0].active);

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/mod.rs
@@ -50,9 +50,8 @@ impl Test {
     /// Consume this instance and keep the temp directory that held the local repository, returning it.
     /// Best used inside a `dbg!(test.debug_local_repo())`
     #[allow(dead_code)]
-    pub fn debug_local_repo(mut self) -> PathBuf {
-        let repo = std::mem::take(&mut self.repository);
-        repo.debug_local_repo()
+    pub fn debug_local_repo(&mut self) -> Option<PathBuf> {
+        self.repository.debug_local_repo()
     }
 }
 

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/update_base_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/update_base_branch.rs
@@ -731,6 +731,9 @@ mod applied_branch {
                 )
                 .unwrap();
 
+            let vb_state = VirtualBranchesHandle::new(project.gb_dir());
+            let ctx = CommandContext::open(project).unwrap();
+            update_gitbutler_integration(&vb_state, &ctx).unwrap();
             let (branches, _) = controller.list_virtual_branches(project).unwrap();
             assert_eq!(branches.len(), 1);
             assert!(branches[0].active);

--- a/crates/gitbutler-cli/src/args.rs
+++ b/crates/gitbutler-cli/src/args.rs
@@ -38,6 +38,8 @@ pub mod vbranch {
 
     #[derive(Debug, clap::Subcommand)]
     pub enum SubCommands {
+        /// Provide the current state of all applied virtual branches.
+        Status,
         /// Make the named branch the default so all worktree or index changes are associated with it automatically.
         SetDefault {
             /// The name of the new default virtual branch.

--- a/crates/gitbutler-cli/src/command/vbranch.rs
+++ b/crates/gitbutler-cli/src/command/vbranch.rs
@@ -40,6 +40,10 @@ pub fn list(project: Project) -> Result<()> {
     Ok(())
 }
 
+pub fn status(project: Project) -> Result<()> {
+    debug_print(VirtualBranchActions.list_virtual_branches(&project)?)
+}
+
 pub fn unapply(project: Project, branch_name: String) -> Result<()> {
     let branch = branch_by_name(&project, &branch_name)?;
     debug_print(VirtualBranchActions.convert_to_real_branch(&project, branch.id)?)

--- a/crates/gitbutler-cli/src/main.rs
+++ b/crates/gitbutler-cli/src/main.rs
@@ -20,6 +20,7 @@ fn main() -> Result<()> {
         args::Subcommands::Branch(vbranch::Platform { cmd }) => {
             let project = command::prepare::project_from_path(args.current_dir)?;
             match cmd {
+                Some(vbranch::SubCommands::Status) => command::vbranch::status(project),
                 Some(vbranch::SubCommands::Unapply { name }) => {
                     command::vbranch::unapply(project, name)
                 }

--- a/crates/gitbutler-cli/src/main.rs
+++ b/crates/gitbutler-cli/src/main.rs
@@ -77,14 +77,19 @@ fn main() -> Result<()> {
 }
 
 mod trace {
+    use tracing::metadata::LevelFilter;
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
+    use tracing_subscriber::Layer;
 
     pub fn init() -> anyhow::Result<()> {
         tracing_subscriber::registry()
-            .with(tracing_forest::ForestLayer::from(
-                tracing_forest::printer::PrettyPrinter::new().writer(std::io::stderr),
-            ))
+            .with(
+                tracing_forest::ForestLayer::from(
+                    tracing_forest::printer::PrettyPrinter::new().writer(std::io::stderr),
+                )
+                .with_filter(LevelFilter::DEBUG),
+            )
             .init();
         Ok(())
     }

--- a/crates/gitbutler-command-context/Cargo.toml
+++ b/crates/gitbutler-command-context/Cargo.toml
@@ -12,3 +12,4 @@ gix.workspace = true
 tracing.workspace = true
 gitbutler-project.workspace = true
 itertools = "0.13"
+bstr = "1.10.0"

--- a/crates/gitbutler-command-context/src/lib.rs
+++ b/crates/gitbutler-command-context/src/lib.rs
@@ -98,3 +98,6 @@ impl CommandContext {
         )?)
     }
 }
+
+mod repository_ext;
+pub use repository_ext::RepositoryExtLite;

--- a/crates/gitbutler-command-context/src/lib.rs
+++ b/crates/gitbutler-command-context/src/lib.rs
@@ -98,18 +98,3 @@ impl CommandContext {
         )?)
     }
 }
-
-// TODO(ST): put this into `gix`, the logic seems good, add unit-test for number generation.
-pub trait GixRepositoryExt: Sized {
-    /// Configure the repository for diff operations between trees.
-    /// This means it needs an object cache relative to the amount of files in the repository.
-    fn for_tree_diffing(self) -> Result<Self>;
-}
-
-impl GixRepositoryExt for gix::Repository {
-    fn for_tree_diffing(mut self) -> anyhow::Result<Self> {
-        let bytes = self.compute_object_cache_size_for_tree_diffs(&***self.index_or_empty()?);
-        self.object_cache_size_if_unset(bytes);
-        Ok(self)
-    }
-}

--- a/crates/gitbutler-command-context/src/lib.rs
+++ b/crates/gitbutler-command-context/src/lib.rs
@@ -28,7 +28,7 @@ impl CommandContext {
                 Ok(false) => true,
                 Ok(true) => false,
                 Err(err) => {
-                    tracing::warn!(
+                    tracing::trace!(
                                 "failed to get gitbutler.didSetPrune for repository at {}; cannot disable gc: {}",
                                 project.path.display(),
                                 err

--- a/crates/gitbutler-command-context/src/repository_ext.rs
+++ b/crates/gitbutler-command-context/src/repository_ext.rs
@@ -1,0 +1,50 @@
+use anyhow::{Context, Result};
+use gix::bstr::{BString, ByteVec};
+use tracing::instrument;
+
+/// An extension trait that should avoid pulling in large amounts of dependency so it can be used
+/// in more places without causing cycles.
+/// `gitbutler_repo::RepositoryExt` may not be usable everywhere due to that.
+pub trait RepositoryExtLite {
+    /// Exclude files that are larger than `limit_in_bytes` (eg. database.sql which may never be intended to be committed)
+    /// so they don't show up in the next diff.
+    fn ignore_large_files_in_diffs(&self, limit_in_bytes: u64) -> Result<()>;
+}
+
+impl RepositoryExtLite for git2::Repository {
+    #[instrument(level = tracing::Level::DEBUG, skip(self), err(Debug))]
+    fn ignore_large_files_in_diffs(&self, limit_in_bytes: u64) -> Result<()> {
+        use gix::bstr::ByteSlice;
+        let repo = gix::open(self.path())?;
+        let worktree_dir = repo
+            .work_dir()
+            .context("All repos are expected to have a worktree")?;
+        let files_to_exclude: Vec<_> = repo
+            .dirwalk_iter(
+                repo.index_or_empty()?,
+                None::<BString>,
+                Default::default(),
+                repo.dirwalk_options()?
+                    .emit_ignored(None)
+                    .emit_pruned(false)
+                    .emit_untracked(gix::dir::walk::EmissionMode::Matching),
+            )?
+            .filter_map(Result::ok)
+            .filter_map(|item| {
+                let path = worktree_dir.join(gix::path::from_bstr(item.entry.rela_path.as_bstr()));
+                let file_is_too_large = path
+                    .metadata()
+                    .map_or(false, |md| md.is_file() && md.len() > limit_in_bytes);
+                file_is_too_large
+                    .then(|| Vec::from(item.entry.rela_path).into_string().ok())
+                    .flatten()
+            })
+            .collect();
+        // TODO(ST): refactor this to be path-safe and ' ' save - the returned list is space separated (!!)
+        //           Just make sure this isn't needed anymore.
+        let ignore_list = files_to_exclude.join(" ");
+        // In-memory, libgit2 internal ignore rule
+        self.add_ignore_rule(&ignore_list)?;
+        Ok(())
+    }
+}

--- a/crates/gitbutler-diff/src/diff.rs
+++ b/crates/gitbutler-diff/src/diff.rs
@@ -126,7 +126,7 @@ pub struct FileDiff {
     pub new_size_bytes: u64,
 }
 
-#[instrument(skip(repo))]
+#[instrument(level = tracing::Level::DEBUG, skip(repo))]
 pub fn workdir(repo: &git2::Repository, commit_oid: &git2::Oid) -> Result<DiffByPathMap> {
     let commit = repo
         .find_commit(*commit_oid)

--- a/crates/gitbutler-diff/src/diff.rs
+++ b/crates/gitbutler-diff/src/diff.rs
@@ -3,6 +3,7 @@ use std::{borrow::Cow, collections::HashMap, path::PathBuf, str};
 use anyhow::{Context, Result};
 use bstr::{BStr, BString, ByteSlice, ByteVec};
 use gitbutler_cherry_pick::RepositoryExt;
+use gitbutler_command_context::RepositoryExtLite;
 use gitbutler_serde::BStringForFrontend;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
@@ -155,8 +156,8 @@ pub fn workdir(repo: &git2::Repository, commit_oid: &git2::Oid) -> Result<DiffBy
     for conflict_path_to_resolve in paths_to_add {
         index.add_path(conflict_path_to_resolve.as_ref())?;
     }
+    repo.ignore_large_files_in_diffs(50_000_000)?;
     let diff = repo.diff_tree_to_workdir_with_index(Some(&old_tree), Some(&mut diff_opts))?;
-    // TODO(ST): bring back support for skipped (large) files.
     hunks_by_filepath(Some(repo), &diff)
 }
 

--- a/crates/gitbutler-diff/src/diff.rs
+++ b/crates/gitbutler-diff/src/diff.rs
@@ -1,9 +1,4 @@
-use std::{
-    borrow::Cow,
-    collections::HashMap,
-    path::{Path, PathBuf},
-    str,
-};
+use std::{borrow::Cow, collections::HashMap, path::PathBuf, str};
 
 use anyhow::{Context, Result};
 use bstr::{BStr, BString, ByteSlice, ByteVec};
@@ -133,34 +128,6 @@ pub fn workdir(repo: &git2::Repository, commit_oid: &git2::Oid) -> Result<DiffBy
         .context("failed to find commit")?;
     let old_tree = repo.find_real_tree(&commit, Default::default())?;
 
-    let mut workdir_index = repo.index()?;
-
-    let mut skipped_files = HashMap::new();
-    let cb = &mut |path: &Path, _matched_spec: &[u8]| -> i32 {
-        let file_size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
-        if file_size > 50_000_000 {
-            skipped_files.insert(
-                path.to_path_buf(),
-                FileDiff {
-                    old_path: None,
-                    new_path: None,
-                    hunks: Vec::new(),
-                    skipped: true,
-                    binary: true,
-                    old_size_bytes: 0,
-                    new_size_bytes: 0,
-                },
-            );
-            1 //skips the entry
-        } else {
-            0
-        }
-    };
-    workdir_index.add_all(["."], git2::IndexAddOption::DEFAULT, Some(cb))?;
-    let workdir_tree_id = workdir_index.write_tree()?;
-
-    let new_tree = repo.find_tree(workdir_tree_id)?;
-
     let mut diff_opts = git2::DiffOptions::new();
     diff_opts
         .recurse_untracked_dirs(true)
@@ -170,14 +137,27 @@ pub fn workdir(repo: &git2::Repository, commit_oid: &git2::Oid) -> Result<DiffBy
         .ignore_submodules(true)
         .context_lines(3);
 
-    let diff = repo.diff_tree_to_tree(Some(&old_tree), Some(&new_tree), Some(&mut diff_opts))?;
-    let diff_files = hunks_by_filepath(Some(repo), &diff);
-    diff_files.map(|mut df| {
-        for (key, value) in skipped_files {
-            df.insert(key, value);
-        }
-        df
-    })
+    let mut index = repo.index()?;
+    // Just a hack to resolve conflicts, which don't get diffed.
+    // Diffed conflicts are something we need though.
+    // For now, it seems easiest to resolve by adding the path forcefully,
+    // which will create objects for the diffs at least.
+    let paths_to_add: Vec<_> = index
+        .conflicts()?
+        .filter_map(Result::ok)
+        .filter_map(|c| {
+            c.our
+                .or(c.their)
+                .or(c.ancestor)
+                .and_then(|c| c.path.into_string().ok())
+        })
+        .collect();
+    for conflict_path_to_resolve in paths_to_add {
+        index.add_path(conflict_path_to_resolve.as_ref())?;
+    }
+    let diff = repo.diff_tree_to_workdir_with_index(Some(&old_tree), Some(&mut diff_opts))?;
+    // TODO(ST): bring back support for skipped (large) files.
+    hunks_by_filepath(Some(repo), &diff)
 }
 
 pub fn trees(
@@ -194,9 +174,10 @@ pub fn trees(
         .context_lines(3)
         .show_untracked_content(true);
 
+    // This is not a content-based diff, but also considers modification times apparently,
+    // maybe related to racy-git. This is why empty diffs have ot be filtered.
     let diff =
         repository.diff_tree_to_tree(Some(old_tree), Some(new_tree), Some(&mut diff_opts))?;
-
     hunks_by_filepath(None, &diff)
 }
 

--- a/crates/gitbutler-diff/src/lib.rs
+++ b/crates/gitbutler-diff/src/lib.rs
@@ -2,7 +2,7 @@ mod diff;
 mod hunk;
 pub mod write;
 pub use diff::{
-    diff_files_into_hunks, hunks_by_filepath, reverse_hunk, trees, workdir, ChangeType, FileDiff,
-    GitHunk,
+    diff_files_into_hunks, hunks_by_filepath, reverse_hunk, trees, workdir, ChangeType,
+    DiffByPathMap, FileDiff, GitHunk,
 };
 pub use hunk::{Hunk, HunkHash};

--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -34,17 +34,7 @@ fn save_uncommited_files(ctx: &CommandContext) -> Result<()> {
     let repository = ctx.repository();
 
     // Create a tree of all uncommited files
-    let mut index = repository.index().context("Failed to get index")?;
-    index
-        .add_all(["*"], git2::IndexAddOption::DEFAULT, None)
-        .context("Failed to add all to index")?;
-    index.write().context("Failed to write index")?;
-    let tree_oid = index
-        .write_tree()
-        .context("Failed to create tree from index")?;
-    let tree = repository
-        .find_tree(tree_oid)
-        .context("Failed to find tree")?;
+    let tree = repository.create_wd_tree()?;
 
     // Commit tree and reference it
     let author_signature =
@@ -134,10 +124,7 @@ fn checkout_edit_branch(ctx: &CommandContext, commit: &git2::Commit) -> Result<(
         ),
     )?;
 
-    let mut index = repository.index()?;
-    index.add_all(["*"], git2::IndexAddOption::DEFAULT, None)?;
-    let tree = index.write_tree()?;
-    let tree = repository.find_tree(tree)?;
+    let tree = repository.create_wd_tree()?;
 
     let author_signature = signature(SignaturePurpose::Author)?;
     let committer_signature = signature(SignaturePurpose::Committer)?;
@@ -265,17 +252,7 @@ pub(crate) fn save_and_return_to_workspace(
     };
 
     // Recommit commit
-    let mut index = repository.index().context("Failed to get index")?;
-    index
-        .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
-        .context("Failed to add all to index")?;
-    index.write().context("Failed to write index")?;
-    let tree_oid = index
-        .write_tree()
-        .context("Failed to create tree from index")?;
-    let tree = repository
-        .find_tree(tree_oid)
-        .context("Failed to find tree")?;
+    let tree = repository.create_wd_tree()?;
     let commit_headers = commit
         .gitbutler_headers()
         .map(|commit_headers| CommitHeadersV2 {

--- a/crates/gitbutler-oplog/Cargo.toml
+++ b/crates/gitbutler-oplog/Cargo.toml
@@ -15,6 +15,7 @@ strum = { version = "0.26", features = ["derive"] }
 tracing.workspace = true
 gix = { workspace = true, features = ["dirwalk", "credentials", "parallel"] }
 toml.workspace = true
+gitbutler-command-context.workspace = true
 gitbutler-project.workspace = true
 gitbutler-branch.workspace = true
 gitbutler-serde.workspace = true

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -260,6 +260,7 @@ impl OplogExt for Project {
         restore_snapshot(self, snapshot_commit_id, guard.write_permission())
     }
 
+    #[instrument(level = tracing::Level::DEBUG, skip(self), err(Debug))]
     fn should_auto_snapshot(&self, check_if_last_snapshot_older_than: Duration) -> Result<bool> {
         let last_snapshot_time = OplogHandle::new(&self.gb_dir()).modified_at()?;
         if last_snapshot_time.elapsed()? <= check_if_last_snapshot_older_than {
@@ -711,6 +712,7 @@ fn write_conflicts_tree(
 
 /// Exclude files that are larger than the limit (eg. database.sql which may never be intended to be committed)
 /// TODO(ST): refactor this to be path-safe and ' ' save - the returned list is space separated (!!)
+#[instrument(level = tracing::Level::DEBUG, skip(repo), err(Debug))]
 fn worktree_files_larger_than_limit_as_git2_ignore_rule(
     repo: &git2::Repository,
     worktree_dir: &Path,
@@ -765,6 +767,7 @@ fn lines_since_snapshot(project: &Project, repo: &git2::Repository) -> Result<us
     Ok(lines_changed)
 }
 
+#[instrument(level = tracing::Level::DEBUG, skip(branch, repo), err(Debug))]
 fn branch_lines_since_snapshot(
     branch: &Branch,
     repo: &git2::Repository,

--- a/crates/gitbutler-repo/src/lib.rs
+++ b/crates/gitbutler-repo/src/lib.rs
@@ -7,7 +7,7 @@ mod commands;
 pub use commands::RepoCommands;
 
 mod repository_ext;
-pub use repository_ext::RepositoryExt;
+pub use repository_ext::{GixRepositoryExt, RepositoryExt};
 
 pub mod credentials;
 

--- a/crates/gitbutler-repo/src/repository_ext.rs
+++ b/crates/gitbutler-repo/src/repository_ext.rs
@@ -17,6 +17,7 @@ use tracing::instrument;
 ///
 /// For now, it collects useful methods from `gitbutler-core::git::Repository`
 pub trait RepositoryExt {
+    fn head_commit(&self) -> Result<git2::Commit<'_>>;
     fn remote_branches(&self) -> Result<Vec<RemoteRefname>>;
     fn remotes_as_string(&self) -> Result<Vec<String>>;
     /// Open a new in-memory repository and executes the provided closure using it.
@@ -72,6 +73,13 @@ pub trait RepositoryExt {
 }
 
 impl RepositoryExt for git2::Repository {
+    fn head_commit(&self) -> Result<git2::Commit<'_>> {
+        self.head()
+            .context("Failed to get head")?
+            .peel_to_commit()
+            .context("Failed to get head commit")
+    }
+
     fn in_memory<T, F>(&self, f: F) -> Result<T>
     where
         F: FnOnce(&git2::Repository) -> Result<T>,

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -47,6 +47,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "parking_lot"] }
 tracing.workspace = true
 tracing-appender = "0.2.3"
 tracing-subscriber.workspace = true
+tracing-forest = { version = "0.1.6" }
 gitbutler-watcher.workspace = true
 gitbutler-branch-actions.workspace = true
 gitbutler-oplog.workspace = true

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -20,6 +20,7 @@ use tauri::{generate_context, Manager};
 use tauri_plugin_log::LogTarget;
 
 fn main() {
+    let performance_logging = std::env::var_os("GITBUTLER_PERFORMANCE_LOG").is_some();
     gitbutler_project::configure_git2();
     let tauri_context = generate_context!();
     gitbutler_secret::secret::set_application_namespace(
@@ -60,7 +61,7 @@ fn main() {
 
                     let app_handle = tauri_app.handle();
 
-                    logs::init(&app_handle);
+                    logs::init(&app_handle, performance_logging);
 
                     // On MacOS, in dev mode with debug assertions, we encounter popups each time
                     // the binary is rebuilt. To counter that, use a git-credential based implementation.

--- a/crates/gitbutler-testsupport/src/suite.rs
+++ b/crates/gitbutler-testsupport/src/suite.rs
@@ -92,7 +92,7 @@ pub struct Case {
     pub ctx: CommandContext,
     pub credentials: Helper,
     /// The directory containing the `ctx`
-    project_tmp: Option<TempDir>,
+    pub project_tmp: Option<TempDir>,
 }
 
 impl Drop for Case {

--- a/crates/gitbutler-testsupport/src/test_project.rs
+++ b/crates/gitbutler-testsupport/src/test_project.rs
@@ -19,8 +19,8 @@ pub struct TestProject {
 impl Drop for TestProject {
     fn drop(&mut self) {
         if std::env::var_os(VAR_NO_CLEANUP).is_some() {
-            let _ = self.local_tmp.take().unwrap().into_path();
-            let _ = self.remote_tmp.take().unwrap().into_path();
+            let _ = self.local_tmp.take().map(|tmp| tmp.into_path());
+            let _ = self.remote_tmp.take().map(|tmp| tmp.into_path());
         }
     }
 }
@@ -83,10 +83,11 @@ impl Default for TestProject {
 }
 
 impl TestProject {
-    /// Consume this instance and keep the temp directory that held the local repository, returning it.
+    /// Take the tmp directory holding the local repository and make sure it won't be deleted,
+    /// returning a path to it.
     /// Best used inside a `dbg!(test_project.debug_local_repo())`
-    pub fn debug_local_repo(mut self) -> PathBuf {
-        self.local_tmp.take().unwrap().into_path()
+    pub fn debug_local_repo(&mut self) -> Option<PathBuf> {
+        self.local_tmp.take().map(|tmp| tmp.into_path())
     }
     pub fn path(&self) -> &std::path::Path {
         self.local_repository.workdir().unwrap()

--- a/crates/gitbutler-watcher/Cargo.toml
+++ b/crates/gitbutler-watcher/Cargo.toml
@@ -24,6 +24,7 @@ gix = { workspace = true, features = [
 ] }
 gitbutler-command-context.workspace = true
 gitbutler-project.workspace = true
+gitbutler-diff.workspace = true
 gitbutler-user.workspace = true
 gitbutler-reference.workspace = true
 gitbutler-error.workspace = true


### PR DESCRIPTION
An early PR to capture the research and first steps towards making `list_virtual_branches` faster by introducing `gix`.
Refactoring might happen here as well.

### Tasks

* [x] `list_virtual_branches` for CLI
* [x] figure out the best target for `list_virtual_branches` by profiling: **gitbutler_diff:workdir()**
* [x] Can `diff::workdir()` be implemented without writing objects (but also, without skipping files probably?) in `git2`?
    - <img width="916" alt="Screenshot 2024-08-28 at 08 10 15" src="https://github.com/user-attachments/assets/6eb181b6-fd89-4d39-b2b2-3e153b371173">
    - It kind-of works as it's a bit faster, doesn't write objects. Also there is no control over big files, but that's more of a diff-API issue.
* [x] make 'big files check' faster (**1.9x**)
* [x] remove duplicate `diff::workdir()` call when responding to filesystem events (reuse the data instead) - makes it **800ms** faster
* [x] fix failing tests
* [x] bring big-file support back to read-only `diff::workdir()`
* [x] fix E2E test - maybe it's a sign that `get_workspace_head()` is required?
    - it was flaky

### Notes for the Reviewer

* ~~`recalculate_everything()` is about twice as fast in this PR as it is on Master.~~ I think I compared debug with release or something. This PR is merely equally fast for responses to filesystem changes, but will write much less to the ODB in the process as it avoids `index.add_all(*)`.
* `diff::workdir()` is read-only, but a little slower as it now has to find big files to skip first (in order to be mergeable). Overall it's still an improvement, but wants `gix` (in follow-up)

### Follow-Ups

* ❌`apply_branch` speedups
   - https://github.com/gitbutlerapp/gitbutler/pull/5899
   - Actually, everything changed, let's keep it as is.
* ✅`gix` for `get_worktree_head()` - merge-trees
    - https://github.com/Byron/gitoxide/pull/1566
    - https://github.com/Byron/gitoxide/pull/1585
    - https://github.com/Byron/gitoxide/pull/1611
    - https://github.com/Byron/gitoxide/pull/1612
    - https://github.com/GitoxideLabs/gitoxide/pull/1618
    - https://github.com/gitbutlerapp/gitbutler/pull/5411
    - https://github.com/gitbutlerapp/gitbutler/pull/5416
    - https://github.com/GitoxideLabs/gitoxide/pull/1658
    - https://github.com/GitoxideLabs/gitoxide/pull/1659
    - https://github.com/gitbutlerapp/gitbutler/pull/5490
    - https://github.com/GitoxideLabs/gitoxide/pull/1661
    - https://github.com/gitbutlerapp/gitbutler/issues/5558
    - https://github.com/GitoxideLabs/gitoxide/pull/1705
    - https://github.com/gitbutlerapp/gitbutler/pull/5722
* ✅`gix` for `create_wd_tree`
    - https://github.com/GitoxideLabs/gitoxide/pull/1410
    - https://github.com/GitoxideLabs/gitoxide/pull/1746
    - https://github.com/gitbutlerapp/gitbutler/pull/5889
* #4793

### Shortcomings of current implementation

- Current implementation creates objects that it isn't interested in, as a side-effect of `index::add(*)`

### Performance Results

Everything was taken from the GitLab repository, with a `--release` build.

#### workspace big files

**Before**

**731ms** with `git2`.

```
DEBUG       ┝━ should_auto_snapshot [ 778ms | 0.94% / 31.94% ] check_if_last_snapshot_older_than: 300s
DEBUG       │  ┝━ worktree_files_larger_than_limit_as_git2_ignore_rule [ 731ms | 30.01% ] worktree_dir: "/Users/byron/dev-gb/gitlab"
DEBUG       │  ┕━ branch_lines_since_snapshot [ 24.0ms | 0.98% ] head_sha: 
```

**After**

**389ms** for traversing 78k files, a **1.88x** improvement. It's faster as it won't have to do an actual status, it just finds untracked files. Of course, ideally one day there is no need to exclude untracked large files as untracked files as virtual branches won't 'soak up' the worktree like they do now.

```
DEBUG       ┝━ should_auto_snapshot [ 549ms | 0.96% / 25.52% ] check_if_last_snapshot_older_than: 300s
DEBUG       │  ┝━ worktree_files_larger_than_limit_as_git2_ignore_rule [ 389ms | 18.09% ] worktree_dir: "/Users/byron/dev-gb/gitlab"
DEBUG       │  ┕━ branch_lines_since_snapshot [ 139ms | 6.47% ] head_sha: 
```

#### duplicate workdir call

**Before**

```
INFO     handle [ 2.15s | 0.00% / 100.00% ] event: ProjectFileChange(d4abe90e-4fed-4d86-bb80-048e3740f003, bar)
INFO     ┕━ recalculate_everything [ 2.15s | 1.07% / 100.00% ] paths: 1
DEBUG       ┝━ workdir [ 698ms | 32.48% ] commit_oid: 1b885e82d93fe522a7c8a0128f57c61a12d2a4de
DEBUG       ┝━ should_auto_snapshot [ 570ms | 0.89% / 26.52% ] check_if_last_snapshot_older_than: 300s
DEBUG       │  ┝━ worktree_files_larger_than_limit_as_git2_ignore_rule [ 403ms | 18.75% ] worktree_dir: "/Users/byron/dev-gb/gitlab"
DEBUG       │  ┕━ branch_lines_since_snapshot [ 148ms | 6.87% ] head_sha: 1928e73219a69ead3324c7ad3d0d5ffeb18625fb
INFO        ┕━ calculate_virtual_branches [ 858ms | 1.34% / 39.93% ]
DEBUG          ┕━ list_virtual_branches [ 829ms | 5.39% / 38.58% ]
DEBUG             ┕━ get_applied_status [ 714ms | 1.06% / 33.20% ]
DEBUG                ┕━ workdir [ 691ms | 32.14% ] commit_oid: 1b885e82d93fe522a7c8a0128f57c61a12d2a4de
```

**After**

```
INFO     handle [ 1.65s | 0.00% / 100.00% ] event: ProjectFileChange(d4abe90e-4fed-4d86-bb80-048e3740f003, bar)
INFO     ┕━ recalculate_everything [ 1.65s | 1.55% / 100.00% ] paths: 1
DEBUG       ┝━ workdir [ 750ms | 45.48% ] commit_oid: 1b885e82d93fe522a7c8a0128f57c61a12d2a4de
DEBUG       ┝━ should_auto_snapshot [ 580ms | 1.20% / 35.22% ] check_if_last_snapshot_older_than: 300s
DEBUG       │  ┝━ worktree_files_larger_than_limit_as_git2_ignore_rule [ 420ms | 25.48% ] worktree_dir: "/Users/byron/dev-gb/gitlab"
DEBUG       │  ┕━ branch_lines_since_snapshot [ 141ms | 8.54% ] head_sha: 1928e73219a69ead3324c7ad3d0d5ffeb18625fb
INFO        ┕━ calculate_virtual_branches [ 293ms | 1.66% / 17.75% ]
DEBUG          ┕━ list_virtual_branches_cached [ 265ms | 7.54% / 16.09% ]
DEBUG             ┕━ get_applied_status_cached [ 141ms | 8.55% ]
```

#### Final Result

On `master`, unfortunately, this takes about 1,9s as well, which is largely due to `workdir` now actually being faster there. The overhead of doing the `ignore_large_files_in_diffs()` call is significant, and it eats up all wins.

```
2024-08-28T20:38:35.471023Z  INFO handle: crates/gitbutler-watcher/src/handler.rs:57: close time.busy=1.87s time.idle=7.54µs event=ProjectFileChange(a4dfef20-d58e-47d8-984d-9f78eb012c2a, that)
```

However, this is the basis `gix` to come in and do a status much faster, which is when everything will be consistently faster once again.

```
INFO     handle [ 1.91s | 0.00% / 100.00% ] event: ProjectFileChange(d4abe90e-4fed-4d86-bb80-048e3740f003, bar)
INFO     ┕━ recalculate_everything [ 1.91s | 1.23% / 100.00% ] paths: 1
DEBUG       ┝━ workdir [ 1.07s | 35.45% / 55.88% ] commit_oid: 1b885e82d93fe522a7c8a0128f57c61a12d2a4de
DEBUG       │  ┕━ ignore_large_files_in_diffs [ 390ms | 20.43% ] limit_in_bytes: 50000000
DEBUG       ┝━ should_auto_snapshot [ 549ms | 0.98% / 28.78% ] check_if_last_snapshot_older_than: 300s
DEBUG       │  ┝━ ignore_large_files_in_diffs [ 396ms | 20.75% ] limit_in_bytes: 33554432
DEBUG       │  ┕━ branch_lines_since_snapshot [ 134ms | 7.05% ] head_sha: 1928e73219a69ead3324c7ad3d0d5ffeb18625fb
INFO        ┕━ calculate_virtual_branches [ 269ms | 1.25% / 14.11% ]
DEBUG          ┕━ list_virtual_branches_cached [ 245ms | 6.02% / 12.86% ]
DEBUG             ┕━ get_applied_status_cached [ 131ms | 6.84% ]
```

It's notable though that technically, `diff::workdir` is now **25% slower** at least, and all that so it won't add everything to the worktree.
And I am quite aware that there are many locations that call `create_wd_tree()` which does exactly that, but I suppose it has to start somewhere.

### Performance 

* `list_virual_branches()` on the GitLab repo takes 1.16s, of which 802ms are spent on the workdir diff.
* `worktree::add(*)` is most time-consuming, but it's the dirwalk that really takes time. <img width="556" alt="Screenshot 2024-08-27 at 15 44 07" src="https://github.com/user-attachments/assets/858a7789-ca88-4346-a79c-d69612b50f66">
