### PR TITLE
fix: reenable tipsy hover on branch empty-state

### DIFF
--- a/apps/desktop/src/lib/components/Board.svelte
+++ b/apps/desktop/src/lib/components/Board.svelte
@@ -325,6 +325,7 @@
 			border-radius: 100%;
 			background-color: var(--clr-illustration-outline);
 			opacity: 0.1;
+        animation: shadow-scale 5.5s infinite ease-in-out;
 			animation-delay: 3s;
 		}
 	}
@@ -335,6 +336,33 @@
 		left: 50%;
 		transform: translate(-50%, -66%) translateZ(0);
 		width: 212px;
+    animation: hovering 5.5s infinite ease-in-out;
+		animation-delay: 3s;
+	}
+	@keyframes hovering {
+		0% {
+			transform: translate(-50%, -70%) translateZ(0);
+		}
+		50% {
+			transform: translate(-50%, -65%) translateZ(0);
+		}
+		100% {
+			transform: translate(-50%, -70%) translateZ(0);
+		}
+	}
+	@keyframes shadow-scale {
+		0% {
+			opacity: 0.08;
+			transform: translateX(-50%) scale(1.15);
+		}
+		50% {
+			opacity: 0.12;
+			transform: translateX(-50%) scale(1);
+		}
+		100% {
+			opacity: 0.08;
+			transform: translateX(-50%) scale(1.15);
+		}
 	}
 
 	.empty-board__about {

--- a/apps/desktop/src/lib/components/Board.svelte
+++ b/apps/desktop/src/lib/components/Board.svelte
@@ -325,7 +325,7 @@
 			border-radius: 100%;
 			background-color: var(--clr-illustration-outline);
 			opacity: 0.1;
-        animation: shadow-scale 5.5s infinite ease-in-out;
+			animation: shadow-scale 5.5s infinite ease-in-out;
 			animation-delay: 3s;
 		}
 	}
@@ -336,7 +336,7 @@
 		left: 50%;
 		transform: translate(-50%, -66%) translateZ(0);
 		width: 212px;
-    animation: hovering 5.5s infinite ease-in-out;
+		animation: hovering 5.5s infinite ease-in-out;
 		animation-delay: 3s;
 	}
 	@keyframes hovering {


### PR DESCRIPTION
## ☕️ Reasoning

- Now that [we're shipping the latest](https://github.com/gitbutlerapp/gitbutler/pull/4767) `libwebkit2gtk-4.0` on Linux the css performance penalty is very small. The same as (for example) the animation on the "Update now" button on the updater modal in the bottom left.
- I'm happy to re-add this if you are @PavelLaptev :)

## 🧢 Changes

- Add back hover / bob animations on Tipsy in Board empty state, i.e.:

> ![image](https://github.com/user-attachments/assets/4d837874-5884-41f0-b6a1-c675ea25be12)


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
