### PR TITLE
Set gitHostFactory for gitlab self hosted instances

### DIFF
--- a/apps/desktop/src/lib/gitHost/gitHostFactory.test.ts
+++ b/apps/desktop/src/lib/gitHost/gitHostFactory.test.ts
@@ -1,5 +1,6 @@
 import { DefaultGitHostFactory } from './gitHostFactory';
 import { GitHub } from './github/github';
+import { GitLab } from './gitlab/gitlab';
 import { Octokit } from '@octokit/rest';
 import { expect, test, describe } from 'vitest';
 
@@ -16,5 +17,34 @@ describe.concurrent('DefaultgitHostFactory', () => {
 				'some-base'
 			)
 		).instanceOf(GitHub);
+	});
+
+	test('Create self hosted Gitlab service', async () => {
+		const monitorFactory = new DefaultGitHostFactory(new Octokit());
+		expect(
+			monitorFactory.build(
+				{
+					source: 'domain.com',
+					name: 'test-repo',
+					owner: 'test-owner',
+					resource: 'gitlab.domain.com'
+				},
+				'some-base'
+			)
+		).instanceOf(GitLab);
+	});
+
+	test('Create Gitlab service', async () => {
+		const monitorFactory = new DefaultGitHostFactory(new Octokit());
+		expect(
+			monitorFactory.build(
+				{
+					source: 'gitlab.com',
+					name: 'test-repo',
+					owner: 'test-owner'
+				},
+				'some-base'
+			)
+		).instanceOf(GitLab);
 	});
 });

--- a/apps/desktop/src/lib/gitHost/gitHostFactory.test.ts
+++ b/apps/desktop/src/lib/gitHost/gitHostFactory.test.ts
@@ -10,10 +10,9 @@ describe.concurrent('DefaultgitHostFactory', () => {
 		expect(
 			monitorFactory.build(
 				{
-					source: 'github.com',
+					domain: 'github.com',
 					name: 'test-repo',
-					owner: 'test-owner',
-					resource: 'test-resource'
+					owner: 'test-owner'
 				},
 				'some-base'
 			)
@@ -25,10 +24,9 @@ describe.concurrent('DefaultgitHostFactory', () => {
 		expect(
 			monitorFactory.build(
 				{
-					source: 'domain.com',
+					domain: 'gitlab.domain.com',
 					name: 'test-repo',
-					owner: 'test-owner',
-					resource: 'gitlab.domain.com'
+					owner: 'test-owner'
 				},
 				'some-base'
 			)
@@ -40,10 +38,9 @@ describe.concurrent('DefaultgitHostFactory', () => {
 		expect(
 			monitorFactory.build(
 				{
-					source: 'gitlab.com',
+					domain: 'gitlab.com',
 					name: 'test-repo',
-					owner: 'test-owner',
-					resource: 'test-resource'
+					owner: 'test-owner'
 				},
 				'some-base'
 			)

--- a/apps/desktop/src/lib/gitHost/gitHostFactory.test.ts
+++ b/apps/desktop/src/lib/gitHost/gitHostFactory.test.ts
@@ -12,7 +12,8 @@ describe.concurrent('DefaultgitHostFactory', () => {
 				{
 					source: 'github.com',
 					name: 'test-repo',
-					owner: 'test-owner'
+					owner: 'test-owner',
+					resource: 'test-resource'
 				},
 				'some-base'
 			)
@@ -41,7 +42,8 @@ describe.concurrent('DefaultgitHostFactory', () => {
 				{
 					source: 'gitlab.com',
 					name: 'test-repo',
-					owner: 'test-owner'
+					owner: 'test-owner',
+					resource: 'test-resource'
 				},
 				'some-base'
 			)

--- a/apps/desktop/src/lib/gitHost/gitHostFactory.ts
+++ b/apps/desktop/src/lib/gitHost/gitHostFactory.ts
@@ -23,11 +23,10 @@ export class DefaultGitHostFactory implements GitHostFactory {
 		fork?: RepoInfo,
 		usePullRequestTemplate?: Persisted<boolean>
 	) {
-		const source = repo.source;
-		const resource = repo.resource;
+		const domain = repo.domain;
 		const forkStr = fork ? `${fork.owner}:${fork.name}` : undefined;
 
-		if (source.includes(GITHUB_DOMAIN)) {
+		if (domain.includes(GITHUB_DOMAIN)) {
 			return new GitHub({
 				repo,
 				baseBranch,
@@ -37,13 +36,13 @@ export class DefaultGitHostFactory implements GitHostFactory {
 				usePullRequestTemplate
 			});
 		}
-		if (source === GITLAB_DOMAIN || resource.startsWith(GITLAB_SUB_DOMAIN + '.')) {
+		if (domain === GITLAB_DOMAIN || domain.startsWith(GITLAB_SUB_DOMAIN + '.')) {
 			return new GitLab({ repo, baseBranch, forkStr });
 		}
-		if (source.includes(BITBUCKET_DOMAIN)) {
+		if (domain.includes(BITBUCKET_DOMAIN)) {
 			return new BitBucket({ repo, baseBranch, forkStr });
 		}
-		if (source.includes(AZURE_DOMAIN)) {
+		if (domain.includes(AZURE_DOMAIN)) {
 			return new AzureDevOps({ repo, baseBranch, forkStr });
 		}
 	}

--- a/apps/desktop/src/lib/gitHost/gitHostFactory.ts
+++ b/apps/desktop/src/lib/gitHost/gitHostFactory.ts
@@ -37,7 +37,7 @@ export class DefaultGitHostFactory implements GitHostFactory {
 				usePullRequestTemplate
 			});
 		}
-		if (source === GITLAB_DOMAIN || resource.startsWith(GITLAB_SUB_DOMAIN + ".")) {
+		if (source === GITLAB_DOMAIN || resource.startsWith(GITLAB_SUB_DOMAIN + '.')) {
 			return new GitLab({ repo, baseBranch, forkStr });
 		}
 		if (source.includes(BITBUCKET_DOMAIN)) {

--- a/apps/desktop/src/lib/gitHost/gitHostFactory.ts
+++ b/apps/desktop/src/lib/gitHost/gitHostFactory.ts
@@ -1,7 +1,7 @@
 import { AZURE_DOMAIN, AzureDevOps } from './azure/azure';
 import { BitBucket, BITBUCKET_DOMAIN } from './bitbucket/bitbucket';
 import { GitHub, GITHUB_DOMAIN } from './github/github';
-import { GitLab, GITLAB_DOMAIN } from './gitlab/gitlab';
+import { GitLab, GITLAB_DOMAIN, GITLAB_SUB_DOMAIN } from './gitlab/gitlab';
 import { ProjectMetrics } from '$lib/metrics/projectMetrics';
 import type { Persisted } from '$lib/persisted/persisted';
 import type { RepoInfo } from '$lib/url/gitUrl';
@@ -24,6 +24,7 @@ export class DefaultGitHostFactory implements GitHostFactory {
 		usePullRequestTemplate?: Persisted<boolean>
 	) {
 		const source = repo.source;
+		const resource = repo.resource;
 		const forkStr = fork ? `${fork.owner}:${fork.name}` : undefined;
 
 		if (source.includes(GITHUB_DOMAIN)) {
@@ -36,7 +37,7 @@ export class DefaultGitHostFactory implements GitHostFactory {
 				usePullRequestTemplate
 			});
 		}
-		if (source.includes(GITLAB_DOMAIN)) {
+		if (source.includes(GITLAB_DOMAIN) || resource.includes(GITLAB_SUB_DOMAIN)) {
 			return new GitLab({ repo, baseBranch, forkStr });
 		}
 		if (source.includes(BITBUCKET_DOMAIN)) {

--- a/apps/desktop/src/lib/gitHost/gitHostFactory.ts
+++ b/apps/desktop/src/lib/gitHost/gitHostFactory.ts
@@ -37,7 +37,7 @@ export class DefaultGitHostFactory implements GitHostFactory {
 				usePullRequestTemplate
 			});
 		}
-		if (source.includes(GITLAB_DOMAIN) || resource.includes(GITLAB_SUB_DOMAIN)) {
+		if (source === GITLAB_DOMAIN || resource.startsWith(GITLAB_SUB_DOMAIN + ".")) {
 			return new GitLab({ repo, baseBranch, forkStr });
 		}
 		if (source.includes(BITBUCKET_DOMAIN)) {

--- a/apps/desktop/src/lib/gitHost/github/github.test.ts
+++ b/apps/desktop/src/lib/gitHost/github/github.test.ts
@@ -4,10 +4,9 @@ import { expect, test, describe } from 'vitest';
 describe.concurrent('GitHub', () => {
 	const id = 'some-branch';
 	const repo = {
-		source: 'github.com',
+		domain: 'github.com',
 		name: 'test-repo',
-		owner: 'test-owner',
-		resource: 'test-resource'
+		owner: 'test-owner'
 	};
 
 	test('commit url', async () => {

--- a/apps/desktop/src/lib/gitHost/github/github.test.ts
+++ b/apps/desktop/src/lib/gitHost/github/github.test.ts
@@ -6,7 +6,8 @@ describe.concurrent('GitHub', () => {
 	const repo = {
 		source: 'github.com',
 		name: 'test-repo',
-		owner: 'test-owner'
+		owner: 'test-owner',
+		resource: 'test-resource'
 	};
 
 	test('commit url', async () => {

--- a/apps/desktop/src/lib/gitHost/github/githubBranch.test.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubBranch.test.ts
@@ -6,10 +6,9 @@ describe.concurrent('GitHubBranch', () => {
 	const name = 'some-branch';
 	const baseBranch = 'some-base';
 	const repo = {
-		source: 'github.com',
+		domain: 'github.com',
 		name: 'test-repo',
-		owner: 'test-owner',
-		resource: 'test-resource'
+		owner: 'test-owner'
 	};
 
 	test('branch compare url', async () => {

--- a/apps/desktop/src/lib/gitHost/github/githubBranch.test.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubBranch.test.ts
@@ -8,7 +8,8 @@ describe.concurrent('GitHubBranch', () => {
 	const repo = {
 		source: 'github.com',
 		name: 'test-repo',
-		owner: 'test-owner'
+		owner: 'test-owner',
+		resource: 'test-resource'
 	};
 
 	test('branch compare url', async () => {

--- a/apps/desktop/src/lib/gitHost/github/githubChecksMonitor.test.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubChecksMonitor.test.ts
@@ -31,10 +31,9 @@ describe('GitHubChecksMonitor', () => {
 		octokit = new Octokit();
 		gh = new GitHub({
 			repo: {
-				source: 'github.com',
+				domain: 'github.com',
 				name: 'test-repo',
-				owner: 'test-owner',
-				resource: 'test-resource'
+				owner: 'test-owner'
 			},
 			baseBranch: 'test-branch',
 			octokit

--- a/apps/desktop/src/lib/gitHost/github/githubChecksMonitor.test.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubChecksMonitor.test.ts
@@ -33,7 +33,8 @@ describe('GitHubChecksMonitor', () => {
 			repo: {
 				source: 'github.com',
 				name: 'test-repo',
-				owner: 'test-owner'
+				owner: 'test-owner',
+				resource: 'test-resource'
 			},
 			baseBranch: 'test-branch',
 			octokit

--- a/apps/desktop/src/lib/gitHost/github/githubListingService.test.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubListingService.test.ts
@@ -9,10 +9,9 @@ type PrListResponse = RestEndpointMethodTypes['pulls']['list']['response'];
 
 describe.concurrent('GitHubListingService', () => {
 	const repoInfo = {
-		source: 'github.com',
+		domain: 'github.com',
 		name: 'test-repo',
-		owner: 'test-owner',
-		resource: 'test-resource'
+		owner: 'test-owner'
 	};
 
 	let octokit: Octokit;

--- a/apps/desktop/src/lib/gitHost/github/githubListingService.test.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubListingService.test.ts
@@ -11,7 +11,8 @@ describe.concurrent('GitHubListingService', () => {
 	const repoInfo = {
 		source: 'github.com',
 		name: 'test-repo',
-		owner: 'test-owner'
+		owner: 'test-owner',
+		resource: 'test-resource'
 	};
 
 	let octokit: Octokit;

--- a/apps/desktop/src/lib/gitHost/github/githubPrMonitor.test.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubPrMonitor.test.ts
@@ -23,10 +23,9 @@ describe.concurrent('GitHubPrMonitor', () => {
 		octokit = new Octokit();
 		gh = new GitHub({
 			repo: {
-				source: 'github.com',
+				domain: 'github.com',
 				name: 'test-repo',
-				owner: 'test-owner',
-				resource: 'test-resource'
+				owner: 'test-owner'
 			},
 			baseBranch: 'test-branch',
 			octokit

--- a/apps/desktop/src/lib/gitHost/github/githubPrMonitor.test.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubPrMonitor.test.ts
@@ -25,7 +25,8 @@ describe.concurrent('GitHubPrMonitor', () => {
 			repo: {
 				source: 'github.com',
 				name: 'test-repo',
-				owner: 'test-owner'
+				owner: 'test-owner',
+				resource: 'test-resource'
 			},
 			baseBranch: 'test-branch',
 			octokit

--- a/apps/desktop/src/lib/gitHost/github/githubPrService.test.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubPrService.test.ts
@@ -13,10 +13,9 @@ describe.concurrent('GitHubPrService', () => {
 		octokit = new Octokit();
 		gh = new GitHub({
 			repo: {
-				source: 'github.com',
+				domain: 'github.com',
 				name: 'test-repo',
-				owner: 'test-owner',
-				resource: 'test-resource'
+				owner: 'test-owner'
 			},
 			baseBranch: 'main',
 			octokit

--- a/apps/desktop/src/lib/gitHost/github/githubPrService.test.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubPrService.test.ts
@@ -15,7 +15,8 @@ describe.concurrent('GitHubPrService', () => {
 			repo: {
 				source: 'github.com',
 				name: 'test-repo',
-				owner: 'test-owner'
+				owner: 'test-owner',
+				resource: 'test-resource'
 			},
 			baseBranch: 'main',
 			octokit

--- a/apps/desktop/src/lib/gitHost/gitlab/gitlab.ts
+++ b/apps/desktop/src/lib/gitHost/gitlab/gitlab.ts
@@ -1,7 +1,7 @@
+import { GitLabBranch } from './gitlabBranch';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import type { GitHost } from '../interface/gitHost';
 import type { DetailedPullRequest, GitHostArguments } from '../interface/types';
-import { GitLabBranch } from './gitlabBranch';
 
 export type PrAction = 'creating_pr';
 export type PrState = { busy: boolean; branchId: string; action?: PrAction };
@@ -23,7 +23,7 @@ export class GitLab implements GitHost {
 	private forkStr?: string;
 
 	constructor({ repo, baseBranch, forkStr }: GitHostArguments) {
-		this.baseUrl = `https://${repo.resource}/${repo.owner}/${repo.name}`;
+		this.baseUrl = `https://${repo.domain}/${repo.owner}/${repo.name}`;
 		this.repo = repo;
 		this.baseBranch = baseBranch;
 		this.forkStr = forkStr;

--- a/apps/desktop/src/lib/gitHost/gitlab/gitlab.ts
+++ b/apps/desktop/src/lib/gitHost/gitlab/gitlab.ts
@@ -1,13 +1,14 @@
-import { GitLabBranch } from './gitlabBranch';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import type { GitHost } from '../interface/gitHost';
 import type { DetailedPullRequest, GitHostArguments } from '../interface/types';
+import { GitLabBranch } from './gitlabBranch';
 
 export type PrAction = 'creating_pr';
 export type PrState = { busy: boolean; branchId: string; action?: PrAction };
 export type PrCacheKey = { value: DetailedPullRequest | undefined; fetchedAt: Date };
 
 export const GITLAB_DOMAIN = 'gitlab.com';
+export const GITLAB_SUB_DOMAIN = 'gitlab'; // For self hosted instance of Gitlab
 
 /**
  * PR support is pending OAuth support in the rust code.
@@ -22,7 +23,7 @@ export class GitLab implements GitHost {
 	private forkStr?: string;
 
 	constructor({ repo, baseBranch, forkStr }: GitHostArguments) {
-		this.baseUrl = `https://${GITLAB_DOMAIN}/${repo.owner}/${repo.name}`;
+		this.baseUrl = `https://${repo.resource}/${repo.owner}/${repo.name}`;
 		this.repo = repo;
 		this.baseBranch = baseBranch;
 		this.forkStr = forkStr;

--- a/apps/desktop/src/lib/url/gitUrl.ts
+++ b/apps/desktop/src/lib/url/gitUrl.ts
@@ -1,25 +1,23 @@
 import gitUrlParse from 'git-url-parse';
 
 export type RepoInfo = {
-	source: string;
+	domain: string;
 	name: string;
 	owner: string;
-	resource: string;
 	organization?: string;
 	protocol?: string;
 };
 
 export function parseRemoteUrl(url: string): RepoInfo | undefined {
 	try {
-		const { protocol, source, name, owner, organization, resource } = gitUrlParse(url);
+		const { protocol, name, owner, organization, resource } = gitUrlParse(url);
 
 		return {
 			protocol,
-			source,
+			domain: resource,
 			name,
 			owner,
-			organization,
-			resource
+			organization
 		};
 	} catch {
 		return undefined;

--- a/apps/desktop/src/lib/url/gitUrl.ts
+++ b/apps/desktop/src/lib/url/gitUrl.ts
@@ -4,20 +4,22 @@ export type RepoInfo = {
 	source: string;
 	name: string;
 	owner: string;
+	resource: string;
 	organization?: string;
 	protocol?: string;
 };
 
 export function parseRemoteUrl(url: string): RepoInfo | undefined {
 	try {
-		const { protocol, source, name, owner, organization } = gitUrlParse(url);
+		const { protocol, source, name, owner, organization, resource } = gitUrlParse(url);
 
 		return {
 			protocol,
 			source,
 			name,
 			owner,
-			organization
+			organization,
+			resource
 		};
 	} catch {
 		return undefined;


### PR DESCRIPTION
## ☕️ Reasoning
The `DefaultGitHostFactory` class assumes that gitlab domain is always `gitlab.com`, which is not correct for self hosted instances of gitlab, and leads to branch link buttons to be unusable. 

## 🧢 Changes
- Adds `resource` to `RepoInfo` type to be used for adding the correct `baseUrl`
- Checks `resource` for gitlab subdomain to initialize the `gitHostFactory` with a Gitlab class


## 🎫 Affected issues

Fixes: https://github.com/gitbutlerapp/gitbutler/issues/4558#issuecomment-2293337474


## Things to consider
Self hosted instance might not have `gitlab` in their subdomain, which will result in the same issue.
