### PR TITLE
Assure HTTPS support is compiled into `gix` using `curl`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,6 +1253,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "curl"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e2161dd6eba090ff1594084e95fd67aeccf04382ffea77999ea94ed42ec67b6"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2 0.5.7",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.74+curl-8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8af10b986114528fcdc4b63b6f5f021b7057618411046a4de2ba0f0149a097bf"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2682,6 +2712,7 @@ dependencies = [
  "gix-submodule",
  "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-trace 0.1.9 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-transport",
  "gix-traverse 0.41.0",
  "gix-url",
  "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
@@ -2985,6 +3016,7 @@ name = "gix-features"
 version = "0.38.2"
 source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
+ "bytes",
  "crc32fast",
  "crossbeam-channel",
  "flate2",
@@ -3619,8 +3651,11 @@ name = "gix-transport"
 version = "0.42.3"
 source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
 dependencies = [
+ "base64 0.22.1",
  "bstr",
+ "curl",
  "gix-command",
+ "gix-credentials",
  "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
  "gix-packetline",
  "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -29,7 +29,7 @@ dirs = "5.0.1"
 fslock.workspace = true
 futures.workspace = true
 git2.workspace = true
-gix = { workspace = true, features = ["max-performance"] }
+gix = { workspace = true, features = ["max-performance", "blocking-http-transport-curl"] }
 once_cell = "1.19"
 reqwest = { version = "0.12.4", features = ["json"] }
 serde.workspace = true


### PR DESCRIPTION
Fixes #4778.

### Tasks

* [x] enable CURL for HTTPS support
* [x] Validate HTTPS is working


### Notes for the Reviewer

As this now pulls in more C-dependencies, compilation might be more prone to failure, particularly on Windows.
It's probably good to make a test-release to validate it works.
