### PR TITLE
Remove unnecessary `gix` features from `watcher` and add them to `tauri`

### DIFF
--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -29,7 +29,7 @@ dirs = "5.0.1"
 fslock.workspace = true
 futures.workspace = true
 git2.workspace = true
-gix = { workspace = true, features = ["max-performance", "blocking-http-transport-curl"] }
+gix = { workspace = true, features = ["max-performance", "blocking-http-transport-curl", "worktree-mutation"] }
 once_cell = "1.19"
 reqwest = { version = "0.12.4", features = ["json"] }
 serde.workspace = true

--- a/crates/gitbutler-watcher/Cargo.toml
+++ b/crates/gitbutler-watcher/Cargo.toml
@@ -17,11 +17,7 @@ anyhow = "1.0.86"
 tokio = { workspace = true, features = ["macros"] }
 tokio-util = "0.7.11"
 tracing.workspace = true
-gix = { workspace = true, features = [
-    "excludes",
-    "blocking-network-client",
-    "worktree-mutation",
-] }
+gix = { workspace = true, features = ["excludes"] }
 gitbutler-command-context.workspace = true
 gitbutler-project.workspace = true
 gitbutler-user.workspace = true


### PR DESCRIPTION
This is a follow-up to [a comment](https://github.com/gitbutlerapp/gitbutler/issues/4778#issuecomment-2315949363) that indicated that some feature-flags were put into the wrong crate.
