### PR TITLE
performance improvements and bug fixes

### DIFF
--- a/apps/desktop/src/lib/stores/remoteBranches.ts
+++ b/apps/desktop/src/lib/stores/remoteBranches.ts
@@ -21,7 +21,7 @@ export class RemoteBranchService {
 		try {
 			const remoteBranches = plainToInstance(
 				Branch,
-				await invoke<any[]>('list_remote_branches', { projectId: this.projectId })
+				await invoke<any[]>('list_local_branches', { projectId: this.projectId })
 			);
 			this.projectMetrics?.setMetric('normal_branch_count', remoteBranches.length);
 			this.branches.set(remoteBranches);

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -8,7 +8,7 @@ use crate::{
     branch::get_uncommited_files,
     branch_manager::BranchManagerExt,
     file::RemoteBranchFile,
-    remote::{get_branch_data, list_remote_branches, RemoteBranch, RemoteBranchData},
+    remote::{get_branch_data, list_local_branches, RemoteBranch, RemoteBranchData},
     VirtualBranchesExt,
 };
 use anyhow::{Context, Result};
@@ -474,9 +474,9 @@ impl VirtualBranchActions {
         branch::push(&ctx, branch_id, with_force, &helper, askpass)
     }
 
-    pub fn list_remote_branches(project: Project) -> Result<Vec<RemoteBranch>> {
+    pub fn list_local_branches(project: Project) -> Result<Vec<RemoteBranch>> {
         let ctx = CommandContext::open(&project)?;
-        list_remote_branches(&ctx)
+        list_local_branches(&ctx)
     }
 
     pub fn get_remote_branch_data(

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -570,6 +570,7 @@ impl VirtualBranchActions {
         branch::move_commit(&ctx, target_branch_id, commit_oid).map_err(Into::into)
     }
 
+    #[instrument(level = tracing::Level::DEBUG, skip(self, project), err(Debug))]
     pub fn create_virtual_branch_from_branch(
         &self,
         project: &Project,

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -181,7 +181,7 @@ pub(crate) fn set_base_branch(
         // if there are any commits on the head branch or uncommitted changes in the working directory, we need to
         // put them into a virtual branch
 
-        let wd_diff = gitbutler_diff::workdir(repo, &current_head_commit.id())?;
+        let wd_diff = gitbutler_diff::workdir(repo, current_head_commit.id())?;
         if !wd_diff.is_empty() || current_head_commit.id() != target.sha {
             // assign ownership to the branch
             let ownership = wd_diff.iter().fold(

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -1,3 +1,4 @@
+use crate::integration::get_workspace_head;
 use crate::{RemoteBranchFile, VirtualBranchesExt};
 use anyhow::{bail, Context, Result};
 use bstr::{BStr, ByteSlice};
@@ -9,7 +10,7 @@ use gitbutler_command_context::CommandContext;
 use gitbutler_diff::DiffByPathMap;
 use gitbutler_project::access::WorktreeReadPermission;
 use gitbutler_reference::normalize_branch_name;
-use gitbutler_repo::{GixRepositoryExt, RepositoryExt};
+use gitbutler_repo::GixRepositoryExt;
 use gitbutler_serde::BStringForFrontend;
 use gix::object::tree::diff::Action;
 use gix::prelude::ObjectIdExt;
@@ -25,12 +26,10 @@ use std::{
 };
 
 pub(crate) fn get_uncommited_files_raw(
-    context: &CommandContext,
+    ctx: &CommandContext,
     _permission: &WorktreeReadPermission,
 ) -> Result<DiffByPathMap> {
-    let repository = context.repository();
-    let head_commit = repository.head_commit()?;
-    gitbutler_diff::workdir(repository, &head_commit.id())
+    gitbutler_diff::workdir(ctx.repository(), get_workspace_head(ctx)?)
         .context("Failed to list uncommited files")
 }
 

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -24,7 +24,9 @@ use std::{
     fmt::Debug,
     vec,
 };
+use tracing::instrument;
 
+#[instrument(level = tracing::Level::DEBUG, skip(ctx, _permission))]
 pub(crate) fn get_uncommited_files_raw(
     ctx: &CommandContext,
     _permission: &WorktreeReadPermission,

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
@@ -102,7 +102,7 @@ impl BranchManager<'_> {
                         .map(|file| (file.path, file.hunks))
                         .collect::<Vec<(PathBuf, Vec<VirtualBranchHunk>)>>();
                     let tree_oid =
-                        gitbutler_diff::write::hunks_onto_oid(self.ctx, &branch.head, files)?;
+                        gitbutler_diff::write::hunks_onto_oid(self.ctx, branch.head, files)?;
                     let branch_tree = repo.find_tree(tree_oid)?;
                     let mut result =
                         repo.merge_trees(&base_tree, &final_tree, &branch_tree, None)?;

--- a/crates/gitbutler-branch-actions/src/commit.rs
+++ b/crates/gitbutler-branch-actions/src/commit.rs
@@ -36,6 +36,11 @@ pub struct VirtualBranchCommit {
     pub change_id: Option<String>,
     pub is_signed: bool,
     pub conflicted: bool,
+    /// The id of the remote commit from which this one was copied, as identified by
+    /// having equal author, committer, and commit message.
+    /// This is used by the frontend similar to the `change_id` to group matching commits.
+    #[serde(with = "gitbutler_serde::oid_opt")]
+    pub copied_from_remote_id: Option<git2::Oid>,
     pub remote_ref: Option<ReferenceName>,
 }
 
@@ -45,6 +50,7 @@ pub(crate) fn commit_to_vbranch_commit(
     commit: &git2::Commit,
     is_integrated: bool,
     is_remote: bool,
+    copied_from_remote_id: Option<git2::Oid>,
 ) -> Result<VirtualBranchCommit> {
     let timestamp = u128::try_from(commit.time().seconds())?;
     let message = commit.message_bstr().to_owned();
@@ -81,6 +87,7 @@ pub(crate) fn commit_to_vbranch_commit(
         change_id: commit.change_id(),
         is_signed: commit.is_signed(),
         conflicted: commit.is_conflicted(),
+        copied_from_remote_id,
         remote_ref,
     };
 

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -122,6 +122,7 @@ fn write_integration_file(head: &git2::Reference, path: PathBuf) -> Result<()> {
     std::fs::write(path, format!(":{}", sha))?;
     Ok(())
 }
+#[instrument(level = tracing::Level::DEBUG, skip(vb_state, ctx), err(Debug))]
 pub fn update_gitbutler_integration(
     vb_state: &VirtualBranchesHandle,
     ctx: &CommandContext,

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -18,7 +18,7 @@ mod file;
 pub use file::{Get, RemoteBranchFile};
 
 mod remote;
-pub use remote::{list_remote_branches, RemoteBranch, RemoteBranchData, RemoteCommit};
+pub use remote::{list_local_branches, RemoteBranch, RemoteBranchData, RemoteCommit};
 
 pub mod conflicts;
 

--- a/crates/gitbutler-branch-actions/src/remote.rs
+++ b/crates/gitbutler-branch-actions/src/remote.rs
@@ -68,24 +68,30 @@ pub fn list_local_branches(ctx: &CommandContext) -> Result<Vec<RemoteBranch>> {
     let default_target = default_target(&ctx.project().gb_dir())?;
 
     let mut remote_branches = vec![];
+    let remotes = ctx.repository().remotes()?;
     for (branch, _) in ctx
         .repository()
         .branches(None)
         .context("failed to list remote branches")?
         .flatten()
     {
-        let branch = branch_to_remote_branch(ctx, &branch);
-
-        if let Some(branch) = branch {
-            let branch_is_trunk = branch.name.branch() == Some(default_target.branch.branch())
-                && branch.name.remote() == Some(default_target.branch.remote());
-
-            if !branch_is_trunk
-                && branch.name.branch() != Some("gitbutler/integration")
-                && branch.name.branch() != Some("gitbutler/target")
-            {
-                remote_branches.push(branch);
+        let branch = match branch_to_remote_branch(&branch, &remotes) {
+            Ok(Some(b)) => b,
+            Ok(None) => continue,
+            Err(err) => {
+                tracing::warn!(?err, "Ignoring branch");
+                continue;
             }
+        };
+
+        let branch_is_trunk = branch.name.branch() == Some(default_target.branch.branch())
+            && branch.name.remote() == Some(default_target.branch.remote());
+
+        if !branch_is_trunk
+            && branch.name.branch() != Some("gitbutler/integration")
+            && branch.name.branch() != Some("gitbutler/target")
+        {
+            remote_branches.push(branch);
         }
     }
     Ok(remote_branches)
@@ -104,30 +110,15 @@ pub(crate) fn get_branch_data(ctx: &CommandContext, refname: &Refname) -> Result
 }
 
 pub(crate) fn branch_to_remote_branch(
-    ctx: &CommandContext,
-    branch: &git2::Branch,
-) -> Option<RemoteBranch> {
-    let commit = match branch.get().peel_to_commit() {
-        Ok(c) => c,
-        Err(err) => {
-            tracing::warn!(
-                ?err,
-                "ignoring branch {:?} as peeling failed",
-                branch.name()
-            );
-            return None;
-        }
-    };
-    let name = Refname::try_from(branch)
-        .context("could not get branch name")
-        .ok()?;
+    branch: &git2::Branch<'_>,
+    remotes: &git2::string_array::StringArray,
+) -> Result<Option<RemoteBranch>> {
+    let commit = branch.get().peel_to_commit()?;
+    let name = Refname::try_from(branch).context("could not get branch name")?;
 
-    let given_name = branch
-        .get()
-        .given_name(&ctx.repository().remotes().ok()?)
-        .ok()?;
+    let given_name = branch.get().given_name(remotes)?;
 
-    branch.get().target().map(|sha| RemoteBranch {
+    Ok(branch.get().target().map(|sha| RemoteBranch {
         sha,
         upstream: if let Refname::Local(local_name) = &name {
             local_name.remote().cloned()
@@ -144,7 +135,7 @@ pub(crate) fn branch_to_remote_branch(
             .ok(),
         last_commit_author: commit.author().name().map(std::string::ToString::to_string),
         is_remote: branch.get().is_remote(),
-    })
+    }))
 }
 
 pub(crate) fn branch_to_remote_branch_data(

--- a/crates/gitbutler-branch-actions/src/remote.rs
+++ b/crates/gitbutler-branch-actions/src/remote.rs
@@ -10,15 +10,15 @@ use gitbutler_repo::{LogUntil, RepoActionsExt, RepositoryExt};
 use gitbutler_serde::BStringForFrontend;
 use serde::Serialize;
 
-// this struct is a mapping to the view `RemoteBranch` type in Typescript
-// found in src-tauri/src/routes/repo/[project_id]/types.ts
-//
-// it holds data calculated for presentation purposes of one Git branch
-// with comparison data to the Target commit, determining if it is mergeable,
-// and how far ahead or behind the Target it is.
-// an array of them can be requested from the frontend to show in the sidebar
-// Tray and should only contain branches that have not been converted into
-// virtual branches yet (ie, we have no `Branch` struct persisted in our data.
+/// this struct is a mapping to the view `RemoteBranch` type in Typescript
+/// found in src-tauri/src/routes/repo/[project_id]/types.ts
+///
+/// it holds data calculated for presentation purposes of one Git branch
+/// with comparison data to the Target commit, determining if it is mergeable,
+/// and how far ahead or behind the Target it is.
+/// an array of them can be requested from the frontend to show in the sidebar
+/// Tray and should only contain branches that have not been converted into
+/// virtual branches yet (ie, we have no `Branch` struct persisted in our data.
 #[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct RemoteBranch {
@@ -57,9 +57,14 @@ pub struct RemoteCommit {
     pub parent_ids: Vec<git2::Oid>,
 }
 
-// for legacy purposes, this is still named "remote" branches, but it's actually
-// a list of all the normal (non-gitbutler) git branches.
-pub fn list_remote_branches(ctx: &CommandContext) -> Result<Vec<RemoteBranch>> {
+/// Return information on all local branches, while skipping gitbutler-specific branches in `refs/heads`.
+///
+/// Note to be confused with `list_branches()`, which is used for the new branch listing.
+///
+/// # Previous notes
+/// For legacy purposes, this is still named "remote" branches, but it's actually
+/// a list of all the normal (non-gitbutler) git branches.
+pub fn list_local_branches(ctx: &CommandContext) -> Result<Vec<RemoteBranch>> {
     let default_target = default_target(&ctx.project().gb_dir())?;
 
     let mut remote_branches = vec![];

--- a/crates/gitbutler-branch-actions/src/status.rs
+++ b/crates/gitbutler-branch-actions/src/status.rs
@@ -213,7 +213,7 @@ pub fn get_applied_status_cached(
     // write updated state if not resolving
     if !ctx.is_resolving() {
         for (vbranch, files) in &mut hunks_by_branch {
-            vbranch.tree = gitbutler_diff::write::hunks_onto_oid(ctx, &vbranch.head, files)?;
+            vbranch.tree = gitbutler_diff::write::hunks_onto_oid(ctx, vbranch.head, files)?;
             vb_state
                 .set_branch(vbranch.clone())
                 .context(format!("failed to write virtual branch {}", vbranch.name))?;

--- a/crates/gitbutler-branch-actions/src/status.rs
+++ b/crates/gitbutler-branch-actions/src/status.rs
@@ -56,7 +56,7 @@ pub fn get_applied_status_cached(
         //           any of its inputs will update the intragration commit right away.
         //           It's for another day though - right now the integration commit may be slightly stale.
         let integration_commit_id = get_workspace_head(ctx)?;
-        gitbutler_diff::workdir(ctx.repository(), &integration_commit_id.to_owned())
+        gitbutler_diff::workdir(ctx.repository(), integration_commit_id.to_owned())
             .context("failed to diff workdir")
     })?;
 

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -1215,7 +1215,7 @@ pub(crate) fn move_commit_file(
     let mut upstream_commits = ctx.l(target_branch.head, LogUntil::Commit(amend_commit.id()))?;
 
     // get a list of all the diffs across all the virtual branches
-    let base_file_diffs = gitbutler_diff::workdir(ctx.repository(), &default_target.sha)
+    let base_file_diffs = gitbutler_diff::workdir(ctx.repository(), default_target.sha)
         .context("failed to diff workdir")?;
 
     // filter base_file_diffs to HashMap<filepath, Vec<GitHunk>> only for hunks in target_ownership

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -354,8 +354,10 @@ pub fn list_virtual_branches_cached(
             .context("failed to find merge base")?;
         let base_current = true;
 
-        let upstream = upstream_branch
-            .and_then(|upstream_branch| branch_to_remote_branch(ctx, &upstream_branch));
+        let upstream = upstream_branch.and_then(|upstream_branch| {
+            let remotes = repo.remotes().ok()?;
+            branch_to_remote_branch(&upstream_branch, &remotes).ok()?
+        });
 
         let path_claim_positions: HashMap<&PathBuf, usize> = branch
             .ownership

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -158,7 +158,7 @@ pub fn unapply_ownership(
                 .map(|file| (file.path, file.hunks))
                 .collect::<Vec<(PathBuf, Vec<VirtualBranchHunk>)>>();
             let tree_oid =
-                gitbutler_diff::write::hunks_onto_oid(ctx, &integration_commit_id, files)?;
+                gitbutler_diff::write::hunks_onto_oid(ctx, integration_commit_id, files)?;
             let branch_tree = repo.find_tree(tree_oid)?;
             let mut result = repo.merge_trees(&base_tree, &final_tree, &branch_tree, None)?;
             let final_tree_oid = result.write_tree_to(ctx.repository())?;
@@ -1043,7 +1043,7 @@ pub(crate) fn push(
     };
 
     ctx.push(
-        &vbranch.head,
+        vbranch.head,
         &remote_branch,
         with_force,
         credentials,

--- a/crates/gitbutler-branch-actions/tests/extra/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/extra/mod.rs
@@ -1345,7 +1345,7 @@ fn detect_mergeable_branch() -> Result<()> {
     vb_state.set_branch(branch4.clone())?;
 
     let remotes =
-        gitbutler_branch_actions::list_remote_branches(ctx).expect("failed to list remotes");
+        gitbutler_branch_actions::list_local_branches(ctx).expect("failed to list remotes");
     let _remote1 = &remotes
         .iter()
         .find(|b| b.name.to_string() == "refs/remotes/origin/remote_branch")

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/update_base_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/update_base_branch.rs
@@ -415,6 +415,11 @@ mod applied_branch {
                 assert_eq!(branches[0].files.len(), 1);
                 assert_eq!(branches[0].commits.len(), 1);
                 assert!(!branches[0].commits[0].is_remote);
+                assert!(
+                    branches[0].commits[0].copied_from_remote_id.is_some(),
+                    "it's copied, which displays things differently in the \
+                     UI which knows what remote commit it relates to"
+                );
                 assert!(!branches[0].commits[0].is_integrated);
             }
         }

--- a/crates/gitbutler-cli/src/args.rs
+++ b/crates/gitbutler-cli/src/args.rs
@@ -38,6 +38,8 @@ pub mod vbranch {
 
     #[derive(Debug, clap::Subcommand)]
     pub enum SubCommands {
+        /// List all local branches that aren't GitButler specific.
+        ListLocal,
         /// Provide the current state of all applied virtual branches.
         Status,
         /// Make the named branch the default so all worktree or index changes are associated with it automatically.

--- a/crates/gitbutler-cli/src/command/vbranch.rs
+++ b/crates/gitbutler-cli/src/command/vbranch.rs
@@ -18,6 +18,10 @@ pub fn list_all(project: Project) -> Result<()> {
     debug_print(list_branches(&ctx, None, None)?)
 }
 
+pub fn list_local(project: Project) -> Result<()> {
+    debug_print(VirtualBranchActions::list_local_branches(project)?)
+}
+
 pub fn details(project: Project, branch_names: Vec<BranchIdentity>) -> Result<()> {
     let ctx = CommandContext::open(&project)?;
     debug_print(get_branch_listing_details(&ctx, branch_names)?)

--- a/crates/gitbutler-cli/src/main.rs
+++ b/crates/gitbutler-cli/src/main.rs
@@ -20,6 +20,7 @@ fn main() -> Result<()> {
         args::Subcommands::Branch(vbranch::Platform { cmd }) => {
             let project = command::prepare::project_from_path(args.current_dir)?;
             match cmd {
+                Some(vbranch::SubCommands::ListLocal) => command::vbranch::list_local(project),
                 Some(vbranch::SubCommands::Status) => command::vbranch::status(project),
                 Some(vbranch::SubCommands::Unapply { name }) => {
                     command::vbranch::unapply(project, name)

--- a/crates/gitbutler-diff/src/diff.rs
+++ b/crates/gitbutler-diff/src/diff.rs
@@ -162,7 +162,7 @@ pub fn workdir(repo: &git2::Repository, commit_oid: git2::Oid) -> Result<DiffByP
 }
 
 pub fn trees(
-    repository: &git2::Repository,
+    repo: &git2::Repository,
     old_tree: &git2::Tree,
     new_tree: &git2::Tree,
 ) -> Result<DiffByPathMap> {
@@ -175,10 +175,7 @@ pub fn trees(
         .context_lines(3)
         .show_untracked_content(true);
 
-    // This is not a content-based diff, but also considers modification times apparently,
-    // maybe related to racy-git. This is why empty diffs have ot be filtered.
-    let diff =
-        repository.diff_tree_to_tree(Some(old_tree), Some(new_tree), Some(&mut diff_opts))?;
+    let diff = repo.diff_tree_to_tree(Some(old_tree), Some(new_tree), Some(&mut diff_opts))?;
     hunks_by_filepath(None, &diff)
 }
 

--- a/crates/gitbutler-diff/src/diff.rs
+++ b/crates/gitbutler-diff/src/diff.rs
@@ -123,9 +123,9 @@ pub struct FileDiff {
 }
 
 #[instrument(level = tracing::Level::DEBUG, skip(repo))]
-pub fn workdir(repo: &git2::Repository, commit_oid: &git2::Oid) -> Result<DiffByPathMap> {
+pub fn workdir(repo: &git2::Repository, commit_oid: git2::Oid) -> Result<DiffByPathMap> {
     let commit = repo
-        .find_commit(*commit_oid)
+        .find_commit(commit_oid)
         .context("failed to find commit")?;
     let old_tree = repo.find_real_tree(&commit, Default::default())?;
 

--- a/crates/gitbutler-diff/src/write.rs
+++ b/crates/gitbutler-diff/src/write.rs
@@ -15,13 +15,13 @@ use crate::GitHunk;
 // and writes it as a new tree for storage
 pub fn hunks_onto_oid<T>(
     ctx: &CommandContext,
-    target: &git2::Oid,
+    target: git2::Oid,
     files: impl IntoIterator<Item = (impl Borrow<PathBuf>, impl Borrow<Vec<T>>)>,
 ) -> Result<git2::Oid>
 where
     T: Into<GitHunk> + Clone,
 {
-    hunks_onto_commit(ctx, *target, files)
+    hunks_onto_commit(ctx, target, files)
 }
 
 pub fn hunks_onto_commit<T>(

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -148,7 +148,7 @@ impl OplogExt for Project {
         commit_snapshot(self, snapshot_tree_id, details, perm)
     }
 
-    #[instrument(skip(details, perm), err(Debug))]
+    #[instrument(skip(self, details, perm), err(Debug))]
     fn create_snapshot(
         &self,
         details: SnapshotDetails,
@@ -158,6 +158,7 @@ impl OplogExt for Project {
         commit_snapshot(self, tree_id, details, perm)
     }
 
+    #[instrument(skip(self), err(Debug))]
     fn list_snapshots(
         &self,
         limit: usize,

--- a/crates/gitbutler-repo/src/change_reference.rs
+++ b/crates/gitbutler-repo/src/change_reference.rs
@@ -146,7 +146,7 @@ pub fn push_change_reference(
     let commit =
         commit_by_branch_id_and_change_id(ctx, &vbranch, &handle, reference.change_id.clone())?;
     ctx.push(
-        &commit.id(),
+        commit.id(),
         &upstream_refname,
         with_force,
         credentials,

--- a/crates/gitbutler-repo/src/repository.rs
+++ b/crates/gitbutler-repo/src/repository.rs
@@ -14,7 +14,7 @@ pub trait RepoActionsExt {
         -> Result<()>;
     fn push(
         &self,
-        head: &git2::Oid,
+        head: git2::Oid,
         branch: &RemoteRefname,
         with_force: bool,
         credentials: &Helper,
@@ -67,14 +67,14 @@ impl RepoActionsExt for CommandContext {
         let refname =
             RemoteRefname::from_str(&format!("refs/remotes/{remote_name}/{branch_name}",))?;
 
-        match self.push(&commit_id, &refname, false, credentials, None, askpass) {
+        match self.push(commit_id, &refname, false, credentials, None, askpass) {
             Ok(()) => Ok(()),
             Err(e) => Err(anyhow::anyhow!(e.to_string())),
         }?;
 
         let empty_refspec = Some(format!(":refs/heads/{}", branch_name));
         match self.push(
-            &commit_id,
+            commit_id,
             &refname,
             false,
             credentials,
@@ -254,7 +254,7 @@ impl RepoActionsExt for CommandContext {
 
     fn push(
         &self,
-        head: &git2::Oid,
+        head: git2::Oid,
         branch: &RemoteRefname,
         with_force: bool,
         credentials: &Helper,

--- a/crates/gitbutler-repo/src/repository_ext.rs
+++ b/crates/gitbutler-repo/src/repository_ext.rs
@@ -17,6 +17,10 @@ use tracing::instrument;
 ///
 /// For now, it collects useful methods from `gitbutler-core::git::Repository`
 pub trait RepositoryExt {
+    /// Return `HEAD^{commit}` - ideal for obtaining the integration branch commit in open-workspace mode
+    /// when it's clear that it's representing the current state.
+    ///
+    /// Ideally, this is used in places of `get_workspace_head()`.
     fn head_commit(&self) -> Result<git2::Commit<'_>>;
     fn remote_branches(&self) -> Result<Vec<RemoteRefname>>;
     fn remotes_as_string(&self) -> Result<Vec<String>>;

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -177,7 +177,7 @@ fn main() {
                     virtual_branches::commands::push_change_reference,
                     virtual_branches::commands::reorder_commit,
                     virtual_branches::commands::update_commit_message,
-                    virtual_branches::commands::list_remote_branches,
+                    virtual_branches::commands::list_local_branches,
                     virtual_branches::commands::list_branches,
                     virtual_branches::commands::get_branch_listing_details,
                     virtual_branches::commands::get_remote_branch_data,

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -447,12 +447,12 @@ pub mod commands {
 
     #[tauri::command(async)]
     #[instrument(skip(projects), err(Debug))]
-    pub fn list_remote_branches(
+    pub fn list_local_branches(
         projects: State<'_, projects::Controller>,
         project_id: ProjectId,
     ) -> Result<Vec<RemoteBranch>, Error> {
         let project = projects.get(project_id)?;
-        let branches = VirtualBranchActions::list_remote_branches(project)?;
+        let branches = VirtualBranchActions::list_local_branches(project)?;
         Ok(branches)
     }
 


### PR DESCRIPTION
This PR is planned as follow-up to #4771, even though it chooses to pick other low-hanging fruit first.

This means, adding more instrumentation to find long-running functions or functions that run more than once in the same operation.
From there, one can avoid duplication, and optimize specific cases while keeping `git2`, at least at first.

Probably this will lead to this PR being merged early as it aims to deliver more small improvements while guiding the way towards
bigger improvements that would require `gix`, along with some upgrades to it which may take more time.

### Tasks

* [x] 2x performance (according to profiler) for `list_remote_branches()` (now `list_local_branches()`)
* [x] Fix #4795 
   From 
   <img width="367" alt="Screenshot 2024-08-29 at 22 34 04" src="https://github.com/user-attachments/assets/16a9d96f-ff5b-4599-b71e-efc4f72a8e25">
   To 
   <img width="346" alt="Screenshot 2024-08-29 at 22 34 53" src="https://github.com/user-attachments/assets/e971b2de-1c2b-481d-ab77-ad1ae9a5f73b">

### Notes for the reviewer

* It's not actually a perfect fix, as I saw this while testing:
  <img width="352" alt="Screenshot 2024-08-29 at 22 50 43" src="https://github.com/user-attachments/assets/6bdcdbbf-1286-4a31-a19f-99cdfc62c426">
   And actually, it turned out that this is a similar looking, but different, commit, so it's correct after all.
* After unapplying, I saw that there are two duplicate commits which seem exactly the same (but have different patches). It was strange that the UI didn't show them combined anymore, maybe intentionally? Or maybe it's another implementation? It seems like it, so I didn't touch it.
   <img width="454" alt="Screenshot 2024-08-29 at 22 52 34" src="https://github.com/user-attachments/assets/a5caf62a-5813-4fd0-ae1c-8454a98918b1">

### Follow-Up

* accelerate `is_commit_integrated()` - octopus merge with trees as results
    <img width="992" alt="Screenshot 2024-08-29 at 18 48 46" src="https://github.com/user-attachments/assets/b0f59a3d-7e79-42d5-bb42-eef8b44ce37e">

### Notes

* When applying a branch in GitLab, it runs into the write-lock and operations block each other, with the last recalculation taking 20.4s (most of the time is waiting). Overall, this cascade of events seems very suboptimal.
    - I feel a lot of compute could be saved if the operation itself would emit whatever the UI needs, instead of relying on the watcher. The watcher could be deactivated/told to ignore what happens while the alteration is running. However, this also seems very complicated so it's probably better for now to make everything faster.
* It seems like `list_local_branches()` (formerly `list_remote_branches()`) is used to build a combined branches view, similar what the new `list_branches` does. It's hard for me to see how it's used, and it am surprised this information is still used anywhere as the side-bar definitely uses the new `branch_listing` now.
* It's clear that my tests of creating a vbranch from a local branch cause particularly bad performance when listing virtual branches due to their integration-commit checks.

### Issues

These issues where created while processing this PR.

* #4794
* #4795

### References

* https://www.figma.com/design/FbeLt0yjY9RiNn8MXUXsYs/Client-design?node-id=2907-112917&node-type=CANVAS - branch states