### PR TITLE
fix: do not allow pressing branch delete btn multiple times

### DIFF
--- a/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
@@ -38,6 +38,7 @@
 	let aiConfigurationValid = $state(false);
 	let newRemoteName = $state('');
 	let allowRebasing = $state<boolean>();
+	let loadingDelete = $state(false);
 
 	const branch = $derived($branchStore);
 	const commits = $derived(branch.commits);
@@ -187,8 +188,13 @@
 	title="Delete branch"
 	bind:this={deleteBranchModal}
 	onSubmit={async (close) => {
-		await branchController.deleteBranch(branch.id);
-		close();
+		try {
+			loadingDelete = true;
+			await branchController.deleteBranch(branch.id);
+			close();
+		} finally {
+			loadingDelete = false;
+		}
 	}}
 >
 	{#snippet children(branch)}
@@ -196,6 +202,6 @@
 	{/snippet}
 	{#snippet controls(close)}
 		<Button style="ghost" outline onclick={close}>Cancel</Button>
-		<Button style="error" kind="solid" type="submit">Delete</Button>
+		<Button style="error" kind="solid" type="submit" loading={loadingDelete}>Delete</Button>
 	{/snippet}
 </Modal>

--- a/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
@@ -38,7 +38,7 @@
 	let aiConfigurationValid = $state(false);
 	let newRemoteName = $state('');
 	let allowRebasing = $state<boolean>();
-	let loadingDelete = $state(false);
+	let isDeleting = $state(false);
 
 	const branch = $derived($branchStore);
 	const commits = $derived(branch.commits);
@@ -189,11 +189,11 @@
 	bind:this={deleteBranchModal}
 	onSubmit={async (close) => {
 		try {
-			loadingDelete = true;
+			isDeleting = true;
 			await branchController.deleteBranch(branch.id);
 			close();
 		} finally {
-			loadingDelete = false;
+			isDeleting = false;
 		}
 	}}
 >
@@ -202,6 +202,6 @@
 	{/snippet}
 	{#snippet controls(close)}
 		<Button style="ghost" outline onclick={close}>Cancel</Button>
-		<Button style="error" kind="solid" type="submit" loading={loadingDelete}>Delete</Button>
+		<Button style="error" kind="solid" type="submit" loading={isDeleting}>Delete</Button>
 	{/snippet}
 </Modal>

--- a/apps/desktop/src/lib/branch/BranchPreviewHeader.svelte
+++ b/apps/desktop/src/lib/branch/BranchPreviewHeader.svelte
@@ -144,6 +144,7 @@
 	bind:this={deleteBranchModal}
 	onSubmit={async (close) => {
 		try {
+			isDeleting = true;
 			await branchController.deleteLocalBranch(branch.name, branch.givenName);
 		} catch (e) {
 			const err = 'Failed to delete local branch';
@@ -161,7 +162,7 @@
 	{/snippet}
 	{#snippet controls(close)}
 		<Button style="ghost" outline onclick={close}>Cancel</Button>
-		<Button style="error" type="submit" kind="solid">Delete</Button>
+		<Button style="error" type="submit" kind="solid" loading={isDeleting}>Delete</Button>
 	{/snippet}
 </Modal>
 

--- a/apps/desktop/src/lib/branch/BranchPreviewHeader.svelte
+++ b/apps/desktop/src/lib/branch/BranchPreviewHeader.svelte
@@ -126,7 +126,6 @@
 					disabled={!localBranch}
 					onclick={async () => {
 						if (localBranch) {
-							console.log(JSON.stringify(localBranch));
 							deleteBranchModal.show(branch);
 						}
 					}}


### PR DESCRIPTION
## ☕️ Reasoning

- Delete branch actoin can be triggered multiple times on the Rust side

## 🧢 Changes

- Add a `loading` attribute to the delete fn, which when true will disable the btn, among other things.
- Fix `loading={isDeleting}` attribute in the `BranchPreviewHeader.svelte` as well.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

Fixes: #4794 

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
