### PR TITLE
fix: revert modal `transition` back to `animation`

### DIFF
--- a/packages/ui/src/lib/Modal.svelte
+++ b/packages/ui/src/lib/Modal.svelte
@@ -80,7 +80,6 @@
 	dialog {
 		display: none;
 		outline: none;
-		--overlay-bg: var(--clr-overlay-bg);
 	}
 
 	dialog[open] {
@@ -88,7 +87,11 @@
 	}
 
 	dialog[open]::backdrop {
-		background-color: var(--overlay-bg);
+		background-color: color(srgb 0 0 0 / 0.34901960784313724);
+	}
+
+	html.dark dialog[open]::backdrop {
+		background-color: color(srgb 0.8392156862745098 0.8392156862745098 0.8392156862745098 / 0.4);
 	}
 
 	.modal-container[open]::backdrop {

--- a/packages/ui/src/lib/Modal.svelte
+++ b/packages/ui/src/lib/Modal.svelte
@@ -36,7 +36,7 @@
 
 <dialog
 	bind:this={dialogElement}
-	class="modal-content"
+	class="modal-container"
 	class:default={width === 'default'}
 	class:large={width === 'large'}
 	class:small={width === 'small'}
@@ -80,35 +80,26 @@
 	dialog {
 		display: none;
 		outline: none;
-		transform: scale(0.95);
-		transition: transform 250ms cubic-bezier(0.34, 1.35, 0.7, 1);
-	}
-
-	dialog::backdrop {
-		transition: opacity 150ms ease-in;
-		background-color: rgb(0 0 0 / 0%);
+		--overlay-bg: var(--clr-overlay-bg);
 	}
 
 	dialog[open] {
 		display: flex;
-		transform: scale(1);
 	}
 
 	dialog[open]::backdrop {
-		background-color: var(--clr-overlay-bg);
-		opacity: 1;
+		background-color: var(--overlay-bg);
 	}
 
-	@starting-style {
-		dialog[open] {
-			transform: scale(0.95);
-		}
-		dialog[open]::backdrop {
-			opacity: 0;
-		}
+	.modal-container[open]::backdrop {
+		animation: dialog-fade 0.15s ease-in;
 	}
 
-	.modal-content {
+	.modal-container[open] {
+		animation: dialog-zoom 0.25s cubic-bezier(0.34, 1.35, 0.7, 1);
+	}
+
+	.modal-container {
 		flex-direction: column;
 
 		max-height: calc(100vh - 80px);
@@ -116,6 +107,7 @@
 		background-color: var(--clr-bg-1);
 		box-shadow: var(--fx-shadow-l);
 	}
+
 	dialog[open] {
 		border: 1px solid var(--clr-border-2);
 	}
@@ -148,20 +140,38 @@
 		background-color: var(--clr-bg-1);
 	}
 
+	@keyframes dialog-zoom {
+		from {
+			transform: scale(0.95);
+		}
+		to {
+			transform: scale(1);
+		}
+	}
+
+	@keyframes dialog-fade {
+		from {
+			opacity: 0;
+		}
+		to {
+			opacity: 1;
+		}
+	}
+
 	/* MODIFIERS */
-	.modal-content.default {
+	.modal-container.default {
 		width: 580px;
 	}
 
-	.modal-content.large {
+	.modal-container.large {
 		width: 840px;
 	}
 
-	.modal-content.small {
+	.modal-container.small {
 		width: 380px;
 	}
 
-	.modal-content.xsmall {
+	.modal-container.xsmall {
 		width: 310px;
 	}
 </style>

--- a/packages/ui/src/lib/Modal.svelte
+++ b/packages/ui/src/lib/Modal.svelte
@@ -87,10 +87,12 @@
 	}
 
 	dialog[open]::backdrop {
+		/* NOTE: temporarily hardcoded var(--clr-overlay-bg); */
 		background-color: color(srgb 0 0 0 / 0.34901960784313724);
 	}
 
 	html.dark dialog[open]::backdrop {
+		/* NOTE: temporarily hardcoded dark var(--clr-overlay-bg); */
 		background-color: color(srgb 0.8392156862745098 0.8392156862745098 0.8392156862745098 / 0.4);
 	}
 


### PR DESCRIPTION
## ☕️ Reasoning

- Revert `animation` -> `transition` changes
- The `transition`'s didn't work on Mac OS :( 

## 🧢 Changes

- Hardcode the `::backdrop` `background-color`'s because `::backdrop` doesn't inherit CSS custom properties from anywhere (see: https://kilianvalkhof.com/2023/css-html/backdrop-doesnt-inherit-from-anywhere/). This bug is fixed in the very latest Chrome/Firefox/Safari, but not webkitgtk yet

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
