### PR TITLE
Trace the `git` binary path (#3601)

### DIFF
--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -62,6 +62,10 @@ fn main() {
                     let app_handle = tauri_app.handle();
 
                     logs::init(&app_handle, performance_logging);
+                    tracing::info!(
+                        "system git executable for fetch/push: {git:?}",
+                        git = gix::path::env::exe_invocation(),
+                    );
 
                     // On MacOS, in dev mode with debug assertions, we encounter popups each time
                     // the binary is rebuilt. To counter that, use a git-credential based implementation.


### PR DESCRIPTION
This should help in cases the binary can't be found nonetheless, for yet to be clarified reason.

Should help debugging #3601.
