### PR TITLE
Fix `copiedFromRemoteId` bug

### DIFF
--- a/apps/desktop/src/lib/vbranches/types.ts
+++ b/apps/desktop/src/lib/vbranches/types.ts
@@ -188,10 +188,7 @@ export class DetailedCommit {
 
 	get status(): CommitStatus {
 		if (this.isIntegrated) return 'integrated';
-		if (
-			(this.isRemote && (!this.relatedTo || this.id === this.relatedTo.id)) ||
-			(this.copiedFromRemoteId && this.relatedTo && this.copiedFromRemoteId === this.relatedTo.id)
-		)
+		if (this.isRemote && (!this.relatedTo || this.id === this.relatedTo.id))
 			return 'localAndRemote';
 		return 'local';
 	}


### PR DESCRIPTION
- correctly shows commits as rebased when changeId is missing
- setting relatedTo is sufficient, no need to touch `get status()`

For testing I applied this branch by Pavel:
<img width="481" alt="image" src="https://github.com/user-attachments/assets/22c10816-e81f-4a47-933c-b027ce65daf5">
