### PR TITLE
feat: add support for custom pull request template paths

### DIFF
--- a/apps/desktop/src/lib/config/config.ts
+++ b/apps/desktop/src/lib/config/config.ts
@@ -53,3 +53,7 @@ export function persistedCommitMessage(projectId: string, branchId: string): Per
 export function gitHostUsePullRequestTemplate(): Persisted<boolean> {
 	return persisted(false, 'gitHostUsePullRequestTemplate');
 }
+
+export function gitHostPullRequestTemplatePath(): Persisted<string> {
+	return persisted('', 'gitHostPullRequestTemplatePath');
+}

--- a/apps/desktop/src/lib/gitHost/gitHostFactory.ts
+++ b/apps/desktop/src/lib/gitHost/gitHostFactory.ts
@@ -21,7 +21,8 @@ export class DefaultGitHostFactory implements GitHostFactory {
 		repo: RepoInfo,
 		baseBranch: string,
 		fork?: RepoInfo,
-		usePullRequestTemplate?: Persisted<boolean>
+		usePullRequestTemplate?: Persisted<boolean>,
+		pullRequestTemplatePath?: Persisted<string>
 	) {
 		const domain = repo.domain;
 		const forkStr = fork ? `${fork.owner}:${fork.name}` : undefined;
@@ -33,7 +34,8 @@ export class DefaultGitHostFactory implements GitHostFactory {
 				forkStr,
 				octokit: this.octokit,
 				projectMetrics: new ProjectMetrics(),
-				usePullRequestTemplate
+				usePullRequestTemplate,
+				pullRequestTemplatePath
 			});
 		}
 		if (domain === GITLAB_DOMAIN || domain.startsWith(GITLAB_SUB_DOMAIN + '.')) {

--- a/apps/desktop/src/lib/gitHost/github/github.ts
+++ b/apps/desktop/src/lib/gitHost/github/github.ts
@@ -19,6 +19,7 @@ export class GitHub implements GitHost {
 	private octokit?: Octokit;
 	private projectMetrics?: ProjectMetrics;
 	private usePullRequestTemplate?: Persisted<boolean>;
+	private pullRequestTemplatePath?: Persisted<string>;
 
 	constructor({
 		repo,
@@ -26,11 +27,13 @@ export class GitHub implements GitHost {
 		forkStr,
 		octokit,
 		projectMetrics,
-		usePullRequestTemplate
+		usePullRequestTemplate,
+		pullRequestTemplatePath
 	}: GitHostArguments & {
 		octokit?: Octokit;
 		projectMetrics?: ProjectMetrics;
 		usePullRequestTemplate?: Persisted<boolean>;
+		pullRequestTemplatePath?: Persisted<string>;
 	}) {
 		this.baseUrl = `https://${GITHUB_DOMAIN}/${repo.owner}/${repo.name}`;
 		this.repo = repo;
@@ -39,6 +42,7 @@ export class GitHub implements GitHost {
 		this.octokit = octokit;
 		this.projectMetrics = projectMetrics;
 		this.usePullRequestTemplate = usePullRequestTemplate;
+		this.pullRequestTemplatePath = pullRequestTemplatePath;
 	}
 
 	listService() {
@@ -57,7 +61,8 @@ export class GitHub implements GitHost {
 			this.repo,
 			baseBranch,
 			upstreamName,
-			this.usePullRequestTemplate
+			this.usePullRequestTemplate,
+			this.pullRequestTemplatePath
 		);
 	}
 

--- a/apps/desktop/src/lib/gitHost/github/githubPrService.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubPrService.ts
@@ -68,25 +68,26 @@ export class GitHubPrService implements GitHostPrService {
 	}
 
 	async fetchPrTemplate() {
-		const prPath = this.pullRequestTemplatePath
+		const path = this.pullRequestTemplatePath
 			? get(this.pullRequestTemplatePath)
 			: DEFAULT_PULL_REQUEST_TEMPLATE_PATH;
+
 		try {
 			const response = await this.octokit.rest.repos.getContent({
 				owner: this.repo.owner,
 				repo: this.repo.name,
-				path: prPath
+				path
 			});
 			const b64Content = (response.data as any)?.content;
 			if (b64Content) {
 				return decodeURIComponent(escape(atob(b64Content)));
 			}
 		} catch (err) {
-			console.error(`Error fetching pull request template at path: ${prPath}`, err);
+			console.error(`Error fetching pull request template at path: ${path}`, err);
 
 			showToast({
 				title: 'Failed to fetch pull request template',
-				message: `Template not found at path: <code>${prPath}</code>.`,
+				message: `Template not found at path: <code>${path}</code>.`,
 				style: 'neutral'
 			});
 		}

--- a/apps/desktop/src/lib/gitHost/github/githubPrService.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubPrService.ts
@@ -1,7 +1,7 @@
 import { GitHubPrMonitor } from './githubPrMonitor';
 import { DEFAULT_HEADERS } from './headers';
 import { ghResponseToInstance, parseGitHubDetailedPullRequest } from './types';
-import { showError, showToast } from '$lib/notifications/toasts';
+import { showError } from '$lib/notifications/toasts';
 import { sleep } from '$lib/utils/sleep';
 import posthog from 'posthog-js';
 import { get, writable } from 'svelte/store';
@@ -84,15 +84,10 @@ export class GitHubPrService implements GitHostPrService {
 		} catch (err) {
 			console.error(`Error fetching pull request template at path: ${prPath}`, err);
 
-			showToast({
-				title: 'Failed to fetch pull request template',
-				error: `Couldn't find template at path: \n\n${prPath}\n\nPull Request created without template.`,
-				style: 'error'
-			});
-			// showError(
-			// 	`Failed to fetch pull request template at path \n\n${prPath}\n\nPull Request created without template.`,
-			// 	err
-			// );
+			showError(
+				`Failed to fetch pull request template at path \n\n${prPath}\n\nPull Request created without template.`,
+				err
+			);
 		}
 	}
 

--- a/apps/desktop/src/lib/gitHost/github/githubPrService.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubPrService.ts
@@ -1,7 +1,7 @@
 import { GitHubPrMonitor } from './githubPrMonitor';
 import { DEFAULT_HEADERS } from './headers';
 import { ghResponseToInstance, parseGitHubDetailedPullRequest } from './types';
-import { showError } from '$lib/notifications/toasts';
+import { showError, showToast } from '$lib/notifications/toasts';
 import { sleep } from '$lib/utils/sleep';
 import posthog from 'posthog-js';
 import { get, writable } from 'svelte/store';
@@ -21,7 +21,8 @@ export class GitHubPrService implements GitHostPrService {
 		private repo: RepoInfo,
 		private baseBranch: string,
 		private upstreamName: string,
-		private usePullRequestTemplate?: Persisted<boolean>
+		private usePullRequestTemplate?: Persisted<boolean>,
+		private pullRequestTemplatePath?: Persisted<string>
 	) {}
 
 	async createPr(title: string, body: string, draft: boolean): Promise<PullRequest> {
@@ -67,19 +68,31 @@ export class GitHubPrService implements GitHostPrService {
 	}
 
 	async fetchPrTemplate() {
+		const prPath = this.pullRequestTemplatePath
+			? get(this.pullRequestTemplatePath)
+			: DEFAULT_PULL_REQUEST_TEMPLATE_PATH;
 		try {
 			const response = await this.octokit.rest.repos.getContent({
 				owner: this.repo.owner,
 				repo: this.repo.name,
-				path: DEFAULT_PULL_REQUEST_TEMPLATE_PATH
+				path: prPath
 			});
 			const b64Content = (response.data as any)?.content;
 			if (b64Content) {
 				return decodeURIComponent(escape(atob(b64Content)));
 			}
 		} catch (err) {
-			console.error('Error fetching pull request template: ', err);
-			showError('Failed to fetch pull request template', err);
+			console.error(`Error fetching pull request template at path: ${prPath}`, err);
+
+			showToast({
+				title: 'Failed to fetch pull request template',
+				error: `Couldn't find template at path: \n\n${prPath}\n\nPull Request created without template.`,
+				style: 'error'
+			});
+			// showError(
+			// 	`Failed to fetch pull request template at path \n\n${prPath}\n\nPull Request created without template.`,
+			// 	err
+			// );
 		}
 	}
 

--- a/apps/desktop/src/lib/gitHost/github/githubPrService.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubPrService.ts
@@ -1,7 +1,7 @@
 import { GitHubPrMonitor } from './githubPrMonitor';
 import { DEFAULT_HEADERS } from './headers';
 import { ghResponseToInstance, parseGitHubDetailedPullRequest } from './types';
-import { showError } from '$lib/notifications/toasts';
+import { showToast } from '$lib/notifications/toasts';
 import { sleep } from '$lib/utils/sleep';
 import posthog from 'posthog-js';
 import { get, writable } from 'svelte/store';
@@ -84,10 +84,11 @@ export class GitHubPrService implements GitHostPrService {
 		} catch (err) {
 			console.error(`Error fetching pull request template at path: ${prPath}`, err);
 
-			showError(
-				`Failed to fetch pull request template at path \n\n${prPath}\n\nPull Request created without template.`,
-				err
-			);
+			showToast({
+				title: 'Failed to fetch pull request template',
+				message: `Template not found at path: <code>${prPath}</code>.`,
+				style: 'neutral'
+			});
 		}
 	}
 

--- a/apps/desktop/src/lib/settings/GitHostForm.svelte
+++ b/apps/desktop/src/lib/settings/GitHostForm.svelte
@@ -34,8 +34,8 @@
 				/>
 			</svelte:fragment>
 			<svelte:fragment slot="caption">
-				If enabled, we will use the path below to set the body of any pull requested created through
-				GitButler.
+				If enabled, we will use the path below to set the initial body of any pull requested created
+				on this project through GitButler.
 			</svelte:fragment>
 		</SectionCard>
 		<SectionCard roundedTop={false} orientation="row" labelFor="use-pull-request-template-path">

--- a/apps/desktop/src/lib/settings/GitHostForm.svelte
+++ b/apps/desktop/src/lib/settings/GitHostForm.svelte
@@ -1,78 +1,57 @@
 <script lang="ts">
-	import { Project, ProjectService } from '$lib/backend/projects';
 	import SectionCard from '$lib/components/SectionCard.svelte';
 	import {
 		gitHostPullRequestTemplatePath,
 		gitHostUsePullRequestTemplate
 	} from '$lib/config/config';
+	import Section from '$lib/settings/Section.svelte';
 	import Spacer from '$lib/shared/Spacer.svelte';
-	import TextArea from '$lib/shared/TextArea.svelte';
 	import TextBox from '$lib/shared/TextBox.svelte';
 	import Toggle from '$lib/shared/Toggle.svelte';
-	import { User } from '$lib/stores/user';
-	import { getContext, getContextStore } from '$lib/utils/context';
 
 	const usePullRequestTemplate = gitHostUsePullRequestTemplate();
 	const pullRequestTemplatePath = gitHostPullRequestTemplatePath();
-
-	const project = getContext(Project);
-	const user = getContextStore(User);
-	const projectService = getContext(ProjectService);
-
-	let title = project?.title;
-	let description = project?.description;
-
-	async function saveProject() {
-		const api =
-			$user && project.api
-				? await projectService.updateCloudProject($user?.access_token, project.api.repository_id, {
-						name: project.title,
-						description: project.description
-					})
-				: undefined;
-		project.api = api ? { ...api, sync: false, sync_code: undefined } : undefined;
-		projectService.updateProject(project);
-	}
 </script>
 
-<div>
-	<SectionCard roundedBottom={false} orientation="row" labelFor="use-pull-request-template">
-		<svelte:fragment slot="title">Pull Request Template</svelte:fragment>
-		<svelte:fragment slot="caption">
-			Use Pull Request template when creating a Pull Requests.
-		</svelte:fragment>
-		<svelte:fragment slot="actions">
-			<Toggle id="use-pull-request-template" value="false" bind:checked={$usePullRequestTemplate} />
-		</svelte:fragment>
-	</SectionCard>
-	<SectionCard roundedTop={false} orientation="row" labelFor="pull-request-template-path">
-		<svelte:fragment slot="title">Pull Request Template Path</svelte:fragment>
-		<svelte:fragment slot="caption">
-			<div class="pr-path--label">Path to your Pull Request template in your repository.</div>
-			<TextBox
-				id="pull-request-template-path"
-				bind:value={$pullRequestTemplatePath}
-				placeholder=".github/pull_request_template.md"
-			/>
-		</svelte:fragment>
-	</SectionCard>
-</div>
+<Section>
+	<svelte:fragment slot="title">Pull Request Template</svelte:fragment>
+	<svelte:fragment slot="description">
+		Use Pull Request template when creating a Pull Requests.
+	</svelte:fragment>
+
+	<div>
+		<SectionCard
+			roundedBottom={false}
+			orientation="row"
+			labelFor="use-pull-request-template-boolean"
+		>
+			<svelte:fragment slot="title">Enable Pull Request Templates</svelte:fragment>
+			<svelte:fragment slot="actions">
+				<Toggle
+					id="use-pull-request-template-boolean"
+					value="false"
+					bind:checked={$usePullRequestTemplate}
+				/>
+			</svelte:fragment>
+			<svelte:fragment slot="caption">
+				If enabled, we will use the path below to set the body of any pull requested created through
+				GitButler.
+			</svelte:fragment>
+		</SectionCard>
+		<SectionCard roundedTop={false} orientation="row" labelFor="use-pull-request-template-path">
+			<svelte:fragment slot="caption">
+				<form>
+					<fieldset class="fields-wrapper">
+						<TextBox
+							label="Pull request template path"
+							id="use-pull-request-template-path"
+							bind:value={$pullRequestTemplatePath}
+							placeholder=".github/pull_request_template.md"
+						/>
+					</fieldset>
+				</form>
+			</svelte:fragment>
+		</SectionCard>
+	</div>
+</Section>
 <Spacer />
-
-<style>
-	.fields-wrapper {
-		display: flex;
-		flex-direction: column;
-		gap: 16px;
-	}
-
-	.description-wrapper {
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
-	}
-
-	.pr-path--label {
-		margin-bottom: 0.75rem;
-	}
-</style>

--- a/apps/desktop/src/lib/settings/GitHostForm.svelte
+++ b/apps/desktop/src/lib/settings/GitHostForm.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+	import { Project, ProjectService } from '$lib/backend/projects';
+	import SectionCard from '$lib/components/SectionCard.svelte';
+	import {
+		gitHostPullRequestTemplatePath,
+		gitHostUsePullRequestTemplate
+	} from '$lib/config/config';
+	import Spacer from '$lib/shared/Spacer.svelte';
+	import TextArea from '$lib/shared/TextArea.svelte';
+	import TextBox from '$lib/shared/TextBox.svelte';
+	import Toggle from '$lib/shared/Toggle.svelte';
+	import { User } from '$lib/stores/user';
+	import { getContext, getContextStore } from '$lib/utils/context';
+
+	const usePullRequestTemplate = gitHostUsePullRequestTemplate();
+	const pullRequestTemplatePath = gitHostPullRequestTemplatePath();
+
+	const project = getContext(Project);
+	const user = getContextStore(User);
+	const projectService = getContext(ProjectService);
+
+	let title = project?.title;
+	let description = project?.description;
+
+	async function saveProject() {
+		const api =
+			$user && project.api
+				? await projectService.updateCloudProject($user?.access_token, project.api.repository_id, {
+						name: project.title,
+						description: project.description
+					})
+				: undefined;
+		project.api = api ? { ...api, sync: false, sync_code: undefined } : undefined;
+		projectService.updateProject(project);
+	}
+</script>
+
+<div>
+	<SectionCard roundedBottom={false} orientation="row" labelFor="use-pull-request-template">
+		<svelte:fragment slot="title">Pull Request Template</svelte:fragment>
+		<svelte:fragment slot="caption">
+			Use Pull Request template when creating a Pull Requests.
+		</svelte:fragment>
+		<svelte:fragment slot="actions">
+			<Toggle id="use-pull-request-template" value="false" bind:checked={$usePullRequestTemplate} />
+		</svelte:fragment>
+	</SectionCard>
+	<SectionCard roundedTop={false} orientation="row" labelFor="pull-request-template-path">
+		<svelte:fragment slot="title">Pull Request Template Path</svelte:fragment>
+		<svelte:fragment slot="caption">
+			<div class="pr-path--label">Path to your Pull Request template in your repository.</div>
+			<TextBox
+				id="pull-request-template-path"
+				bind:value={$pullRequestTemplatePath}
+				placeholder=".github/pull_request_template.md"
+			/>
+		</svelte:fragment>
+	</SectionCard>
+</div>
+<Spacer />
+
+<style>
+	.fields-wrapper {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+	}
+
+	.description-wrapper {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.pr-path--label {
+		margin-bottom: 0.75rem;
+	}
+</style>

--- a/apps/desktop/src/lib/settings/GithubIntegration.svelte
+++ b/apps/desktop/src/lib/settings/GithubIntegration.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
 	import { checkAuthStatus, initDeviceOauth } from '$lib/backend/github';
 	import SectionCard from '$lib/components/SectionCard.svelte';
-	import { gitHostUsePullRequestTemplate } from '$lib/config/config';
+	import {
+		gitHostPullRequestTemplatePath,
+		gitHostUsePullRequestTemplate
+	} from '$lib/config/config';
 	import { getGitHubUserServiceStore } from '$lib/gitHost/github/githubUserService';
+	import TextBox from '$lib/shared/TextBox.svelte';
 	import Toggle from '$lib/shared/Toggle.svelte';
 	import { UserService } from '$lib/stores/user';
 	import { copyToClipboard } from '$lib/utils/clipboard';
@@ -18,6 +22,7 @@
 	export let disabled = false;
 
 	const usePullRequestTemplate = gitHostUsePullRequestTemplate();
+	const pullRequestTemplatePath = gitHostPullRequestTemplatePath();
 	const githubUserService = getGitHubUserServiceStore();
 	const userService = getContext(UserService);
 	const user = userService.user;
@@ -98,22 +103,39 @@
 		<svelte:fragment slot="title">GitHub</svelte:fragment>
 		<svelte:fragment slot="caption">Allows you to view and create Pull Requests.</svelte:fragment>
 		{#if $user?.github_access_token}
-			<Button style="ghost" outline {disabled} icon="bin-small" onclick={forgetGitHub}
-				>Forget</Button
-			>
+			<Button style="ghost" outline {disabled} icon="bin-small" onclick={forgetGitHub}>
+				Forget
+			</Button>
 		{:else}
 			<Button style="pop" kind="solid" {disabled} onclick={gitHubStartOauth}>Authorize</Button>
 		{/if}
 	</SectionCard>
-	<SectionCard roundedBottom={false} orientation="row" labelFor="use-pull-request-template">
-		<svelte:fragment slot="title">Pull Request Template</svelte:fragment>
-		<svelte:fragment slot="caption"
-			>Use Pull Request template when creating a Pull Requests.</svelte:fragment
-		>
-		<svelte:fragment slot="actions">
-			<Toggle id="use-pull-request-template" value="false" bind:checked={$usePullRequestTemplate} />
-		</svelte:fragment>
-	</SectionCard>
+	<div>
+		<SectionCard roundedBottom={false} orientation="row" labelFor="use-pull-request-template">
+			<svelte:fragment slot="title">Pull Request Template</svelte:fragment>
+			<svelte:fragment slot="caption">
+				Use Pull Request template when creating a Pull Requests.
+			</svelte:fragment>
+			<svelte:fragment slot="actions">
+				<Toggle
+					id="use-pull-request-template"
+					value="false"
+					bind:checked={$usePullRequestTemplate}
+				/>
+			</svelte:fragment>
+		</SectionCard>
+		<SectionCard roundedTop={false} orientation="row" labelFor="pull-request-template-path">
+			<svelte:fragment slot="title">Pull Request Template Path</svelte:fragment>
+			<svelte:fragment slot="caption">
+				<div class="pr-path--label">Path to your Pull Request template in your repository.</div>
+				<TextBox
+					id="pull-request-template-path"
+					bind:value={$pullRequestTemplatePath}
+					placeholder=".github/pull_request_template.md"
+				/>
+			</svelte:fragment>
+		</SectionCard>
+	</div>
 {/if}
 
 <Modal
@@ -286,7 +308,9 @@
 		}
 	}
 
-	/*  */
+	.pr-path--label {
+		margin-bottom: 0.75rem;
+	}
 
 	.icon-wrapper {
 		align-self: flex-start;

--- a/apps/desktop/src/lib/settings/GithubIntegration.svelte
+++ b/apps/desktop/src/lib/settings/GithubIntegration.svelte
@@ -1,13 +1,7 @@
 <script lang="ts">
 	import { checkAuthStatus, initDeviceOauth } from '$lib/backend/github';
 	import SectionCard from '$lib/components/SectionCard.svelte';
-	import {
-		gitHostPullRequestTemplatePath,
-		gitHostUsePullRequestTemplate
-	} from '$lib/config/config';
 	import { getGitHubUserServiceStore } from '$lib/gitHost/github/githubUserService';
-	import TextBox from '$lib/shared/TextBox.svelte';
-	import Toggle from '$lib/shared/Toggle.svelte';
 	import { UserService } from '$lib/stores/user';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { getContext } from '$lib/utils/context';
@@ -21,8 +15,6 @@
 	export let minimal = false;
 	export let disabled = false;
 
-	const usePullRequestTemplate = gitHostUsePullRequestTemplate();
-	const pullRequestTemplatePath = gitHostPullRequestTemplatePath();
 	const githubUserService = getGitHubUserServiceStore();
 	const userService = getContext(UserService);
 	const user = userService.user;
@@ -110,32 +102,6 @@
 			<Button style="pop" kind="solid" {disabled} onclick={gitHubStartOauth}>Authorize</Button>
 		{/if}
 	</SectionCard>
-	<div>
-		<SectionCard roundedBottom={false} orientation="row" labelFor="use-pull-request-template">
-			<svelte:fragment slot="title">Pull Request Template</svelte:fragment>
-			<svelte:fragment slot="caption">
-				Use Pull Request template when creating a Pull Requests.
-			</svelte:fragment>
-			<svelte:fragment slot="actions">
-				<Toggle
-					id="use-pull-request-template"
-					value="false"
-					bind:checked={$usePullRequestTemplate}
-				/>
-			</svelte:fragment>
-		</SectionCard>
-		<SectionCard roundedTop={false} orientation="row" labelFor="pull-request-template-path">
-			<svelte:fragment slot="title">Pull Request Template Path</svelte:fragment>
-			<svelte:fragment slot="caption">
-				<div class="pr-path--label">Path to your Pull Request template in your repository.</div>
-				<TextBox
-					id="pull-request-template-path"
-					bind:value={$pullRequestTemplatePath}
-					placeholder=".github/pull_request_template.md"
-				/>
-			</svelte:fragment>
-		</SectionCard>
-	</div>
 {/if}
 
 <Modal
@@ -306,10 +272,6 @@
 		&::before {
 			top: 30px;
 		}
-	}
-
-	.pr-path--label {
-		margin-bottom: 0.75rem;
 	}
 
 	.icon-wrapper {

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -12,7 +12,10 @@
 	import NoBaseBranch from '$lib/components/NoBaseBranch.svelte';
 	import NotOnGitButlerBranch from '$lib/components/NotOnGitButlerBranch.svelte';
 	import ProblemLoadingRepo from '$lib/components/ProblemLoadingRepo.svelte';
-	import { gitHostUsePullRequestTemplate } from '$lib/config/config';
+	import {
+		gitHostPullRequestTemplatePath,
+		gitHostUsePullRequestTemplate
+	} from '$lib/config/config';
 	import { ReorderDropzoneManagerFactory } from '$lib/dragging/reorderDropzoneManager';
 	import { DefaultGitHostFactory } from '$lib/gitHost/gitHostFactory';
 	import { octokitFromAccessToken } from '$lib/gitHost/github/octokit';
@@ -80,6 +83,7 @@
 
 	const showHistoryView = persisted(false, 'showHistoryView');
 	const usePullRequestTemplate = gitHostUsePullRequestTemplate();
+	const pullRequestTemplatePath = gitHostPullRequestTemplatePath();
 	const octokit = $derived(accessToken ? octokitFromAccessToken(accessToken) : undefined);
 	const gitHostFactory = $derived(new DefaultGitHostFactory(octokit));
 	const repoInfo = $derived(remoteUrl ? parseRemoteUrl(remoteUrl) : undefined);
@@ -122,7 +126,13 @@
 	$effect.pre(() => {
 		const gitHost =
 			repoInfo && baseBranchName
-				? gitHostFactory.build(repoInfo, baseBranchName, forkInfo, usePullRequestTemplate)
+				? gitHostFactory.build(
+						repoInfo,
+						baseBranchName,
+						forkInfo,
+						usePullRequestTemplate,
+						pullRequestTemplatePath
+					)
 				: undefined;
 
 		const ghListService = gitHost?.listService();

--- a/apps/desktop/src/routes/[projectId]/settings/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/settings/+page.svelte
@@ -13,6 +13,7 @@
 	import KeysForm from '$lib/settings/KeysForm.svelte';
 	import PreferencesForm from '$lib/settings/PreferencesForm.svelte';
 	import Spacer from '$lib/shared/Spacer.svelte';
+	import { UserService } from '$lib/stores/user';
 	import { getContext } from '$lib/utils/context';
 	import * as toasts from '$lib/utils/toasts';
 	import { goto } from '$app/navigation';
@@ -20,6 +21,8 @@
 	const baseBranchSwitching = featureBaseBranchSwitching();
 	const projectService = getContext(ProjectService);
 	const project = getContext(Project);
+	const userService = getContext(UserService);
+	const user = userService.user;
 
 	let deleteConfirmationModal: RemoveProjectButton;
 	let isDeleting = false;
@@ -46,7 +49,9 @@
 	{/if}
 	<CloudForm />
 	<DetailsForm />
-	<GitHostForm />
+	{#if $user?.github_access_token}
+		<GitHostForm />
+	{/if}
 	{#if $platformName !== 'win32'}
 		<KeysForm showProjectName={false} />
 		<Spacer />

--- a/apps/desktop/src/routes/[projectId]/settings/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/settings/+page.svelte
@@ -9,6 +9,7 @@
 	import { platformName } from '$lib/platform/platform';
 	import CloudForm from '$lib/settings/CloudForm.svelte';
 	import DetailsForm from '$lib/settings/DetailsForm.svelte';
+	import GitHostForm from '$lib/settings/GitHostForm.svelte';
 	import KeysForm from '$lib/settings/KeysForm.svelte';
 	import PreferencesForm from '$lib/settings/PreferencesForm.svelte';
 	import Spacer from '$lib/shared/Spacer.svelte';
@@ -45,6 +46,7 @@
 	{/if}
 	<CloudForm />
 	<DetailsForm />
+	<GitHostForm />
 	{#if $platformName !== 'win32'}
 		<KeysForm showProjectName={false} />
 		<Spacer />


### PR DESCRIPTION
## ☕️ Reasoning

- After a user comment on discord and some research, it turns out that folks put their PR templates at both `.github/PULL_REQUEST_TEMPLATE.md` and `.github/pull_request_template.md` about 50/50. There is also technically an option for folks to put their template anywhere under `.github/PULL_REQUEST_TEMPLATE/*.md`
- Therefore, adding a settings path for folks to customize which PR template they want to be used. 


## 🧢 Changes

- The PR template enable boolean and PR template path (new) are now in the project preferences.
- This section is hidden if the user is not logged into GitHub


## 📺 Screenshots

![image](https://github.com/user-attachments/assets/9c5b2a4c-6788-4110-8b0b-50c9857ff1e3)


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
