### PR TITLE
fix: Zen PC hover animation

### DIFF
--- a/apps/desktop/src/lib/components/BoardEmptyState.svelte
+++ b/apps/desktop/src/lib/components/BoardEmptyState.svelte
@@ -154,7 +154,7 @@
 			transform: translateX(-50%) scale(1.15);
 			border-radius: 100%;
 			background-color: var(--clr-illustration-outline);
-			opacity: 0.1;
+			opacity: 0.09;
 			animation: shadow-scale 5.5s infinite ease-in-out;
 			animation-delay: 3s;
 		}
@@ -164,7 +164,7 @@
 		position: absolute;
 		top: 50%;
 		left: 50%;
-		transform: translate(-50%, -66%) translateZ(0);
+		transform: translate(-50%, -70%) translateZ(0);
 		width: 212px;
 		animation: hovering 5.5s infinite ease-in-out;
 		animation-delay: 3s;
@@ -182,7 +182,7 @@
 	}
 	@keyframes shadow-scale {
 		0% {
-			opacity: 0.08;
+			opacity: 0.09;
 			transform: translateX(-50%) scale(1.15);
 		}
 		50% {
@@ -190,7 +190,7 @@
 			transform: translateX(-50%) scale(1);
 		}
 		100% {
-			opacity: 0.08;
+			opacity: 0.09;
 			transform: translateX(-50%) scale(1.15);
 		}
 	}


### PR DESCRIPTION
## ☕️ Reasoning

There was a seam between two states — when the Zen PC is not moving and when the animation starts to play.


https://github.com/user-attachments/assets/d693c54b-d526-4570-82e9-ef8270834b31



## 🧢 Changes


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
