### PR TITLE
Only discard the files changes inside the lane

### DIFF
--- a/apps/desktop/src/lib/file/FileContextMenu.svelte
+++ b/apps/desktop/src/lib/file/FileContextMenu.svelte
@@ -14,6 +14,7 @@
 	import { join } from '@tauri-apps/api/path';
 	import { open as openFile } from '@tauri-apps/api/shell';
 
+	export let branchId: string | undefined;
 	export let target: HTMLElement | undefined;
 	export let isUnapplied;
 
@@ -115,7 +116,12 @@
 			style="error"
 			kind="solid"
 			onclick={() => {
-				branchController.unapplyFiles(item.files);
+				if (!branchId) {
+					console.error('Branch ID is not set');
+					toasts.error('Failed to discard changes');
+					return;
+				}
+				branchController.unapplyFiles(branchId, item.files);
 				close();
 			}}
 		>

--- a/apps/desktop/src/lib/file/FileListItem.svelte
+++ b/apps/desktop/src/lib/file/FileListItem.svelte
@@ -85,7 +85,12 @@
 	});
 </script>
 
-<FileContextMenu bind:this={contextMenu} target={draggableEl} {isUnapplied} />
+<FileContextMenu
+	bind:this={contextMenu}
+	target={draggableEl}
+	{isUnapplied}
+	branchId={$branch?.id}
+/>
 
 <FileListItem
 	id={`file-${file.id}`}

--- a/apps/desktop/src/lib/vbranches/branchController.ts
+++ b/apps/desktop/src/lib/vbranches/branchController.ts
@@ -226,11 +226,12 @@ export class BranchController {
 		}
 	}
 
-	async unapplyFiles(files: LocalFile[]) {
+	async unapplyFiles(branchId: string, files: LocalFile[]) {
 		try {
 			await invoke<void>('reset_files', {
 				projectId: this.projectId,
-				files: files.flatMap((f) => f.path).join('\n')
+				branchId,
+				files: files.flatMap((f) => f.path)
 			});
 		} catch (err) {
 			showError('Failed to unapply file changes', err);

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -285,7 +285,12 @@ impl VirtualBranchActions {
         branch::unapply_ownership(&ctx, ownership, guard.write_permission()).map_err(Into::into)
     }
 
-    pub fn reset_files(&self, project: &Project, files: &Vec<String>) -> Result<()> {
+    pub fn reset_files(
+        &self,
+        project: &Project,
+        branch_id: BranchId,
+        files: &[String],
+    ) -> Result<()> {
         let ctx = open_with_verify(project)?;
         assure_open_workspace_mode(&ctx)
             .context("Resetting a file requires open workspace mode")?;
@@ -294,7 +299,7 @@ impl VirtualBranchActions {
             SnapshotDetails::new(OperationKind::DiscardFile),
             guard.write_permission(),
         );
-        branch::reset_files(&ctx, files).map_err(Into::into)
+        branch::reset_files(&ctx, branch_id, files, guard.write_permission()).map_err(Into::into)
     }
 
     pub fn amend(

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -25,6 +25,7 @@ use gitbutler_oplog::{
 use gitbutler_project::{FetchResult, Project};
 use gitbutler_reference::{ReferenceName, Refname, RemoteRefname};
 use gitbutler_repo::{credentials::Helper, RepoActionsExt, RepositoryExt};
+use std::path::PathBuf;
 use tracing::instrument;
 
 #[derive(Clone, Copy, Default)]
@@ -289,7 +290,7 @@ impl VirtualBranchActions {
         &self,
         project: &Project,
         branch_id: BranchId,
-        files: &[String],
+        files: &[PathBuf],
     ) -> Result<()> {
         let ctx = open_with_verify(project)?;
         assure_open_workspace_mode(&ctx)

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -14,6 +14,7 @@ pub mod commands {
     use gitbutler_reference::{
         normalize_branch_name as normalize_name, ReferenceName, Refname, RemoteRefname,
     };
+    use std::path::PathBuf;
     use tauri::State;
     use tracing::instrument;
 
@@ -251,14 +252,9 @@ pub mod commands {
         projects: State<'_, projects::Controller>,
         project_id: ProjectId,
         branch_id: BranchId,
-        files: &str,
+        files: Vec<PathBuf>,
     ) -> Result<(), Error> {
         let project = projects.get(project_id)?;
-        // convert files to Vec<String>
-        let files = files
-            .split('\n')
-            .map(std::string::ToString::to_string)
-            .collect::<Vec<String>>();
         VirtualBranchActions.reset_files(&project, branch_id, &files)?;
         emit_vbranches(&windows, project_id);
         Ok(())

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -250,6 +250,7 @@ pub mod commands {
         windows: State<'_, WindowState>,
         projects: State<'_, projects::Controller>,
         project_id: ProjectId,
+        branch_id: BranchId,
         files: &str,
     ) -> Result<(), Error> {
         let project = projects.get(project_id)?;
@@ -258,7 +259,7 @@ pub mod commands {
             .split('\n')
             .map(std::string::ToString::to_string)
             .collect::<Vec<String>>();
-        VirtualBranchActions.reset_files(&project, &files)?;
+        VirtualBranchActions.reset_files(&project, branch_id, &files)?;
         emit_vbranches(&windows, project_id);
         Ok(())
     }


### PR DESCRIPTION
### Problem
When using the file context menu inside a given lane to discard the changes, all changes to that file across all lanes are discarded.
This is either weird or unexpected behavior.

### Solution
Only discard the changes inside the lane that the context menu was opened from.

### Issues
This fixes issue https://github.com/gitbutlerapp/gitbutler/issues/4137