### PR TITLE
Fancy fast forward

### DIFF
--- a/crates/gitbutler-repo/src/rebase.rs
+++ b/crates/gitbutler-repo/src/rebase.rs
@@ -7,6 +7,7 @@ use gitbutler_commit::{
     commit_headers::{CommitHeadersV2, HasCommitHeaders},
 };
 use gitbutler_error::error::Marker;
+use itertools::Itertools;
 
 use crate::{LogUntil, RepoActionsExt};
 
@@ -60,6 +61,10 @@ pub fn cherry_rebase_group(
                 .context("failed to find new commit"),
             |head, to_rebase| {
                 let head = head?;
+
+                if to_rebase.parent_ids().len() == 1 && head.id() == to_rebase.parent_id(0)? {
+                    return Ok(to_rebase);
+                };
 
                 let cherrypick_index = repository
                     .cherry_pick_gitbutler(&head, &to_rebase, None)


### PR DESCRIPTION
We're occasionally re-basing commits when we don't need to. This causes strange or unexpected behavior when integrating upstream changes, when a fast forward merge or "git reset --hard" would have sufficed.
<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
