### PR TITLE
Improve the commit text content experience

### DIFF
--- a/apps/desktop/src/lib/utils/string.ts
+++ b/apps/desktop/src/lib/utils/string.ts
@@ -19,3 +19,7 @@ export function isChar(char: string) {
 export function isStr(s: unknown): s is string {
 	return typeof s === 'string';
 }
+
+export function isWhiteSpaceString(s: string) {
+	return s.trim() === '';
+}


### PR DESCRIPTION
### As seen on issue 
https://github.com/gitbutlerapp/gitbutler/issues/4790

### Problem
Pressing the 'Enter' key on the commit message text area will only focus the description text area, but not move the text down.

### Expected behavior 
1. Move everything right of the cursor into the description text area
2. Delete all of the selected text

### Solved
Pressing enter from the title will behave in the expected way, pushing down the content into the description box and deleting any selected text

### Visuals
![text-area-update](https://github.com/user-attachments/assets/19875fd7-4967-45f8-8d6f-7635c1c73ce2)
