### PR TITLE
fix: Disable the PR button if there is no GitHub integration

### DIFF
--- a/apps/desktop/src/lib/branch/BranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/BranchHeader.svelte
@@ -241,8 +241,10 @@
 						{#if !$pr}
 							<PullRequestButton
 								click={async ({ draft }) => await createPr({ draft })}
-								disabled={branch.commits.length === 0 || !$gitHost}
-								tooltip={!$gitHost ? 'You can enable git host integration in the settings' : ''}
+								disabled={branch.commits.length === 0 || !$gitHost || !$prService}
+								tooltip={!$gitHost || !$prService
+									? 'You can enable git host integration in the settings'
+									: ''}
 								loading={isLoading}
 							/>
 						{/if}


### PR DESCRIPTION
If there is no GitHub integration, correctly disable the create PR button

### Issue
Even if there was no GitHub integration configured by the user, the button would still be enabled.
Clicking 'Create PR' would then push the branch and then fail to create the PR.

### Changes
Check whether there is both a GitHost **and** a PR service available, before enabling the PR creation button
**No design changes included in this PR**