### PR TITLE
Clean-up: Remove anti-pattern from the Select component

### DIFF
--- a/apps/desktop/src/lib/select/SearchItem.svelte
+++ b/apps/desktop/src/lib/select/SearchItem.svelte
@@ -1,42 +1,27 @@
 <script lang="ts">
-	import { type SelectItem } from './Select.svelte';
 	import Icon from '@gitbutler/ui/Icon.svelte';
 
 	interface Props {
+		searchValue: string;
 		placeholder?: string;
-		items: SelectItem[];
-		onSort?: (items: SelectItem[]) => void;
 	}
 
-	const { placeholder = 'Search…', items, onSort }: Props = $props();
-
-	let value = $state('');
-	let filteredItems = $state(items);
+	let { placeholder = 'Search…', searchValue = $bindable() }: Props = $props();
 
 	let inputEl: HTMLInputElement;
 
-	function handleFilter() {
-		filteredItems = items.filter((item) => item.label.toLowerCase().includes(value.toLowerCase()));
-	}
-
 	function resetFilter() {
-		value = '';
-		handleFilter();
+		searchValue = '';
 		inputEl.focus();
 	}
 
 	function handleInput(event: Event) {
-		value = (event.target as HTMLInputElement).value;
-		handleFilter();
+		searchValue = (event.target as HTMLInputElement).value;
 	}
-
-	$effect(() => {
-		onSort?.(filteredItems);
-	});
 </script>
 
 <div class="container">
-	{#if !value}
+	{#if !searchValue}
 		<i class="icon search-icon">
 			<Icon name="search" />
 		</i>
@@ -51,7 +36,7 @@
 		class="text-13 search-input"
 		type="text"
 		{placeholder}
-		bind:value
+		bind:value={searchValue}
 		oninput={handleInput}
 		autocorrect="off"
 		autocomplete="off"

--- a/apps/desktop/src/lib/select/Select.svelte
+++ b/apps/desktop/src/lib/select/Select.svelte
@@ -50,14 +50,13 @@
 	let selectWrapperEl: HTMLElement;
 
 	let highlightedIndex: number | undefined = $state(undefined);
-	let filteredOptions = $state(options);
+	let searchValue = $state('');
+	let filteredOptions = $derived(
+		options.filter((item) => item.label.toLowerCase().includes(searchValue.toLowerCase()))
+	);
 	let maxHeightState = $state(maxHeight);
 	let listOpen = $state(false);
 	let inputBoundingRect = $state<DOMRect>();
-
-	$effect(() => {
-		filteredOptions = options;
-	});
 
 	const maxBottomPadding = 20;
 
@@ -187,12 +186,7 @@
 			>
 				<ScrollableContainer initiallyVisible>
 					{#if searchable && options.length > 5}
-						<SearchItem
-							items={options}
-							onSort={(filtered) => {
-								filteredOptions = filtered;
-							}}
-						/>
+						<SearchItem bind:searchValue />
 					{/if}
 					<OptionsGroup>
 						{#if filteredOptions.length === 0}


### PR DESCRIPTION
Instead of updating the state through an effect, factor out the `searchValue` state variable into the parent component, and only derive the filtered options from it

I ended up following the approach suggested by @Caleb-T-Owens [here](https://github.com/gitbutlerapp/gitbutler/pull/4821#issuecomment-2328924429)

The only "compromise" is that now the search value state variable is now a bindable prop managed by the parent, and so concerns are not "fully" separated. But it's a fair price for removing an anti-pattern