### PR TITLE
fix: Project Not Found page

### DIFF
--- a/apps/desktop/src/lib/backend/projects.ts
+++ b/apps/desktop/src/lib/backend/projects.ts
@@ -97,7 +97,8 @@ export class ProjectService {
 	}
 
 	async deleteProject(id: string) {
-		return await invoke('delete_project', { id });
+		await invoke('delete_project', { id });
+		await this.reload();
 	}
 
 	async promptForDirectory(): Promise<string | undefined> {


### PR DESCRIPTION
### Issue
- Project not found page doesn't display the status message correctly after choosing to delete the project
- The list of projects was not correctly updated

### Solution
After successfully un-tracking the missing project, display the correct messages (whether the success or failure to un-track).
Also, update the projects list accordingly

### Visuals

**Before**
(After successfully deleting project *gpt*)
<img width="740" alt="before" src="https://github.com/user-attachments/assets/9727f2c8-9eec-47fa-9fcd-da81860e9f11">

**After**
(After successfully deleting project *gpt_2*)
<img width="740" alt="after" src="https://github.com/user-attachments/assets/ed65e1bc-1016-406f-aed3-f252a45078f8">

