### PR TITLE
Commit List: Allow force push when removing commits

### DIFF
--- a/apps/desktop/src/lib/commit/CommitList.svelte
+++ b/apps/desktop/src/lib/commit/CommitList.svelte
@@ -137,8 +137,6 @@
 			$listingService?.refresh();
 			$prMonitor?.refresh();
 			$checksMonitor?.update();
-		} catch (e) {
-			console.error(e);
 		} finally {
 			isPushingCommits = false;
 		}

--- a/apps/desktop/src/lib/commit/CommitList.svelte
+++ b/apps/desktop/src/lib/commit/CommitList.svelte
@@ -49,20 +49,30 @@
 	const reorderDropzoneManagerFactory = getContext(ReorderDropzoneManagerFactory);
 	const gitHost = getGitHost();
 
+	enum LineSpacer {
+		Remote = 'remote-spacer',
+		Local = 'local-spacer',
+		LocalAndRemote = 'local-and-remote-spacer'
+	}
+
 	$: mappedRemoteCommits =
 		$remoteCommits.length > 0
-			? [...$remoteCommits.map(transformAnyCommit), { id: 'remote-spacer' }]
+			? [...$remoteCommits.map(transformAnyCommit), { id: LineSpacer.Remote }]
 			: [];
 	$: mappedLocalCommits =
 		$localCommits.length > 0
-			? [...$localCommits.map(transformAnyCommit), { id: 'local-spacer' }]
+			? [...$localCommits.map(transformAnyCommit), { id: LineSpacer.Local }]
+			: [];
+	$: mappedLocalAndRemoteCommits =
+		$localAndRemoteCommits.length > 0
+			? [...$localAndRemoteCommits.map(transformAnyCommit), { id: LineSpacer.LocalAndRemote }]
 			: [];
 
 	$: lineManager = lineManagerFactory.build(
 		{
 			remoteCommits: mappedRemoteCommits,
 			localCommits: mappedLocalCommits,
-			localAndRemoteCommits: $localAndRemoteCommits.map(transformAnyCommit),
+			localAndRemoteCommits: mappedLocalAndRemoteCommits,
 			integratedCommits: $integratedCommits.map(transformAnyCommit)
 		},
 		!isRebased
@@ -118,6 +128,21 @@
 	}
 
 	$: localCommitsConflicted = $localCommits.some((commit) => commit.conflicted);
+	$: localAndRemoteCommitsConflicted = $localAndRemoteCommits.some((commit) => commit.conflicted);
+
+	async function push() {
+		isPushingCommits = true;
+		try {
+			await branchController.pushBranch($branch.id, $branch.requiresForce);
+			$listingService?.refresh();
+			$prMonitor?.refresh();
+			$checksMonitor?.update();
+		} catch (e) {
+			console.error(e);
+		} finally {
+			isPushingCommits = false;
+		}
+	}
 </script>
 
 {#snippet reorderDropzone(dropzone: ReorderDropzone, yOffsetPx: number)}
@@ -154,7 +179,7 @@
 
 				<CommitAction>
 					{#snippet lines()}
-						<LineGroup lineGroup={lineManager.get('remote-spacer')} topHeightPx={0} />
+						<LineGroup lineGroup={lineManager.get(LineSpacer.Remote)} topHeightPx={0} />
 					{/snippet}
 					{#snippet action()}
 						<Button
@@ -217,10 +242,11 @@
 					/>
 				{/each}
 
-				<CommitAction bottomBorder={hasRemoteCommits}>
-					{#snippet lines()}
-						<LineGroup lineGroup={lineManager.get('local-spacer')} topHeightPx={0} />
-					{/snippet}
+				{#snippet lines()}
+					<LineGroup lineGroup={lineManager.get(LineSpacer.Local)} topHeightPx={0} />
+				{/snippet}
+
+				<CommitAction bottomBorder={hasRemoteCommits} {lines}>
 					{#snippet action()}
 						<Button
 							style="pop"
@@ -231,19 +257,7 @@
 							tooltip={localCommitsConflicted
 								? 'In order to push, please resolve any conflicted commits.'
 								: undefined}
-							onclick={async () => {
-								isPushingCommits = true;
-								try {
-									await branchController.pushBranch($branch.id, $branch.requiresForce);
-									$listingService?.refresh();
-									$prMonitor?.refresh();
-									$checksMonitor?.update();
-								} catch (e) {
-									console.error(e);
-								} finally {
-									isPushingCommits = false;
-								}
-							}}
+							onclick={push}
 						>
 							{$branch.requiresForce ? 'Force push' : 'Push'}
 						</Button>
@@ -281,6 +295,29 @@
 						on:click={() => insertBlankCommit(commit.id, 'below')}
 					/>
 				{/each}
+
+				{#if $remoteCommits.length > 0 && $localCommits.length === 0}
+					<CommitAction>
+						{#snippet lines()}
+							<LineGroup lineGroup={lineManager.get(LineSpacer.LocalAndRemote)} topHeightPx={0} />
+						{/snippet}
+						{#snippet action()}
+							<Button
+								style="pop"
+								kind="solid"
+								wide
+								loading={isPushingCommits}
+								disabled={localAndRemoteCommitsConflicted}
+								tooltip={localAndRemoteCommitsConflicted
+									? 'In order to push, please resolve any conflicted commits.'
+									: undefined}
+								onclick={push}
+							>
+								{$branch.requiresForce ? 'Force push' : 'Push'}
+							</Button>
+						{/snippet}
+					</CommitAction>
+				{/if}
 			</div>
 		{/if}
 

--- a/apps/desktop/src/lib/vbranches/branchController.ts
+++ b/apps/desktop/src/lib/vbranches/branchController.ts
@@ -272,6 +272,7 @@ export class BranchController {
 			await this.vbranchService.refresh();
 		} catch (err: any) {
 			posthog.capture('Push Failed', { error: err });
+			console.error(err);
 			if (err.code === 'errors.git.authentication') {
 				showToast({
 					title: 'Git push failed',


### PR DESCRIPTION
### Issue
As described in
https://github.com/gitbutlerapp/gitbutler/issues/4791

It seems that we only display the force-push button when local-only commits are present.
This is a bit annoying if you just want to e.g. get rid of the last commit of the branch by undoing it.
That would result in a list of local-and-remote commits and a remote-only commit,.

### Changes
Display the force-push action button under local-and-remote section if there are any remote-only commits.
This would mean that there is a set of commits that are only remotely available, and so the user has the option to force-push that

<img width="385" alt="Screenshot 2024-09-06 at 17 26 08" src="https://github.com/user-attachments/assets/c8a89d27-795a-4ca8-b6e0-22289fe2435b">
