### PR TITLE
feat: Display binary image and size

### DIFF
--- a/apps/desktop/src/lib/utils/filePath.ts
+++ b/apps/desktop/src/lib/utils/filePath.ts
@@ -9,3 +9,11 @@ export function splitFilePath(filepath: string): { filename: string; path: strin
 
 	return { filename, path };
 }
+
+export function getFileExtension(filepath: string): string {
+	const { filename } = splitFilePath(filepath);
+	if (!filename) return '';
+	
+	const parts = filename.split('.');
+	return parts.length > 1 ? parts[parts.length - 1]!.toLowerCase() : '';
+}

--- a/apps/desktop/src/lib/utils/filePath.ts
+++ b/apps/desktop/src/lib/utils/filePath.ts
@@ -13,7 +13,7 @@ export function splitFilePath(filepath: string): { filename: string; path: strin
 export function getFileExtension(filepath: string): string {
 	const { filename } = splitFilePath(filepath);
 	if (!filename) return '';
-	
+
 	const parts = filename.split('.');
 	return parts.length > 1 ? parts[parts.length - 1]!.toLowerCase() : '';
 }

--- a/apps/desktop/src/lib/utils/fileSize.ts
+++ b/apps/desktop/src/lib/utils/fileSize.ts
@@ -1,0 +1,23 @@
+import { readBinaryFile } from '@tauri-apps/api/fs';
+
+export async function getBinFileSize(path: string): Promise<string> {
+	try {
+		const contents = await readBinaryFile(path);
+		const sizeInBytes = contents.length;
+		return formatFileSize(sizeInBytes);
+	} catch (error) {
+		console.error('Failed to get file size:', error);
+		return 'Unknown size';
+	}
+}
+
+const KB = 1024;
+const MB = 1024 * 1024;
+const GB = 1024 * 1024 * 1024;
+
+function formatFileSize(bytes: number): string {
+	if (bytes < KB) return bytes + ' B';
+	else if (bytes < MB) return (bytes / KB).toFixed(1) + ' KB';
+	else if (bytes < GB) return (bytes / MB).toFixed(1) + ' MB';
+	else return (bytes / GB).toFixed(1) + ' GB';
+}

--- a/crates/gitbutler-tauri/tauri.conf.json
+++ b/crates/gitbutler-tauri/tauri.conf.json
@@ -13,7 +13,7 @@
 		"allowlist": {
 			"fs": {
 				"readFile": true,
-				"scope": ["$APPCACHE/archives/*", "$RESOURCE/_up_/scripts/*"]
+				"scope": ["$APPCACHE/archives/*", "$RESOURCE/_up_/scripts/*", "$HOME/**"]
 			},
 			"dialog": {
 				"open": true
@@ -23,7 +23,7 @@
 			},
 			"protocol": {
 				"asset": true,
-				"assetScope": ["$APPCACHE/images/*", "**"]
+				"assetScope": ["$APPCACHE/images/*", "$HOME/**"]
 			},
 			"process": {
 				"relaunch": true

--- a/crates/gitbutler-tauri/tauri.conf.json
+++ b/crates/gitbutler-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
 			},
 			"protocol": {
 				"asset": true,
-				"assetScope": ["$APPCACHE/images/*"]
+				"assetScope": ["$APPCACHE/images/*", "**"]
 			},
 			"process": {
 				"relaunch": true


### PR DESCRIPTION
Hello team! First, I want to express my gratitude for this fantastic app. 
I've been using it regularly, and it's been incredibly helpful in my workflow.

I've prepared this pull request after reviewing issues #2752 and #3093.

## ☕️ Reasoning

The current implementation doesn't provide image previews and file sizes for binary files, especially image files.

This PR aims to implement image previews for binary files, particularly images, in the FileDiff component and display file sizes for binary files.

## 🧢 Changes

- Binary file handling and information improvement:
   - Implemented image display for image files in the FileDiff component 
   - Implemented `getBinFileSize` to retrieve binary file sizes and updated the FileDiff component accordingly
   - Modified Tauri configuration to allow file access in user's home directory

### Image Preview

<img width="1138" alt="스크린샷 2024-09-08 오후 10 05 19" src="https://github.com/user-attachments/assets/5eae4477-c2aa-44ca-80d6-befba55cde5d">

### Binary File Size

![file-size](https://github.com/user-attachments/assets/95d8fe25-9207-4665-a05f-9c868e5411ab)

## 🎫 Affected issues

Fixes: #2752
Fixes: #3093
