### PR TITLE
IpcNameNormalizationService: Add timed cache

### DIFF
--- a/apps/desktop/src/lib/branches/nameNormalizationService.ts
+++ b/apps/desktop/src/lib/branches/nameNormalizationService.ts
@@ -1,15 +1,39 @@
 import { invoke as ipcInvoke } from '$lib/backend/ipc';
 import { buildContext } from '$lib/utils/context';
+import { isStr } from '$lib/utils/string';
+
+const CACHE_STALE_TIME = 1000 * 60 * 5;
 
 export interface NameNormalizationService {
 	normalize(branchName: string): Promise<string>;
 }
 
+interface TimestampedBranchName {
+	name: string;
+	timestamp: number;
+}
+
 export class IpcNameNormalizationService implements NameNormalizationService {
-	constructor(private invoke: typeof ipcInvoke) {}
+	private cache: Map<string, TimestampedBranchName>;
+
+	constructor(private invoke: typeof ipcInvoke) {
+		this.cache = new Map();
+	}
 
 	async normalize(branchName: string): Promise<string> {
-		return await this.invoke('normalize_branch_name', { name: branchName });
+		const now = Date.now();
+		const cached = this.cache.get(branchName);
+		if (cached && now - cached.timestamp < CACHE_STALE_TIME) {
+			return cached.name;
+		}
+		const result = await this.invoke('normalize_branch_name', { name: branchName });
+
+		if (!isStr(result)) {
+			throw new Error('Branch name normalization failed');
+		}
+
+		this.cache.set(branchName, { name: result, timestamp: now });
+		return result;
 	}
 }
 


### PR DESCRIPTION
Cache the branch name normalization responses with a stale time of 5 minutes

Motivation behind it is that I think the returned values are simple and consistent enough to deserve some front-end caching. What do you think?