### PR TITLE
feat: add e2e runner container and GHA to build and publish

### DIFF
--- a/.github/workflows/publish-e2e-img.yml
+++ b/.github/workflows/publish-e2e-img.yml
@@ -1,10 +1,13 @@
 name: Build and Publish E2E Container
 on:
+  pull_request:
+    branches:
+      - master
   push:
     branches:
       - master
-    paths:
-      - 'apps/desktop/e2e/Dockerfile'
+    # paths:
+    #   - 'apps/desktop/e2e/Dockerfile'
 
 jobs:
   docker_publish:

--- a/.github/workflows/publish-e2e-img.yml
+++ b/.github/workflows/publish-e2e-img.yml
@@ -1,0 +1,27 @@
+name: Build and Publish E2E Container
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'apps/desktop/e2e/Dockerfile'
+
+jobs:
+  docker_publish:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push container image
+        uses: docker/build-push-action@v6
+        with:
+          context: "apps/desktop/e2e"
+          push: true
+          tags: ghcr.io/gitbutler/e2e-runner:latest

--- a/.github/workflows/publish-e2e-img.yml
+++ b/.github/workflows/publish-e2e-img.yml
@@ -1,13 +1,10 @@
 name: Build and Publish E2E Container
 on:
-  pull_request:
-    branches:
-      - master
   push:
     branches:
       - master
-    # paths:
-    #   - 'apps/desktop/e2e/Dockerfile'
+    paths:
+      - 'apps/desktop/e2e/Dockerfile'
 
 jobs:
   docker_publish:

--- a/.github/workflows/publish-e2e-img.yml
+++ b/.github/workflows/publish-e2e-img.yml
@@ -24,4 +24,4 @@ jobs:
         with:
           context: "apps/desktop/e2e"
           push: true
-          tags: ghcr.io/gitbutler/e2e-runner:latest
+          tags: ghcr.io/gitbutlerapp/e2e-runner:latest

--- a/.github/workflows/publish-e2e-img.yml
+++ b/.github/workflows/publish-e2e-img.yml
@@ -1,5 +1,8 @@
 name: Build and Publish E2E Container
 on:
+  pull_request:
+    branches:
+      - master
   push:
     branches:
       - master

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -13,6 +13,8 @@ jobs:
   test:
     name: Run WebdriverIO Tests
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/gitbutlerapp/e2e-runner:latest
     env:
       CARGO_TERM_COLOR: always
     steps:
@@ -22,44 +24,12 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
           ref: ${{ github.event.inputs.sha }}
-      - name: Install Tauri OS dependencies
-        run: |
-          sudo apt update && sudo apt install -y \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            libwebkit2gtk-4.0-dev \
-            webkit2gtk-driver \
-            ffmpeg \
-            xvfb
-      - name: Setup rust-toolchain stable
-        id: rust-toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: cargo-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-
-      - name: Setup node environment
-        uses: ./.github/actions/init-env-node
       - name: Build CLI
         run: cargo build -p gitbutler-cli
       - name: Build SvelteKit
         run: pnpm build:desktop -- --mode development
       - name: Build Tauri
         run: pnpm build:test
-      - name: Install tauri-driver
-        run: |
-          if [ ! -e "$HOME/.cargo/bin/tauri-driver" ]; then
-            cargo install tauri-driver@0.1.3
-          fi
-
-      # Run it through `xvfb-run` to have a fake display server which allows our
-      # application to run headless without any changes to the code
       - name: WebdriverIO
         run: xvfb-run pnpm test:e2e
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Build CLI
         run: cargo build -p gitbutler-cli
       - name: Build SvelteKit
-        run: pnpm build:desktop -- --mode development
+        run: |
+          pnpm install
+          pnpm build:desktop -- --mode development
       - name: Build Tauri
         run: pnpm build:test
       - name: WebdriverIO

--- a/apps/desktop/e2e/Dockerfile
+++ b/apps/desktop/e2e/Dockerfile
@@ -83,6 +83,9 @@ RUN pnpm add --global turbo && \
   cargo install tauri-driver && \
   # Make `tauri-driver` more widely available
   ln -s /root/.cargo/bin/tauri-driver /usr/local/bin/tauri-driver && \
+  # Copy tauri-driver to where GHA expects it
+  mkdir -p /github/home/.cargo/bin && \
+  ln -s /root/.cargo/bin/tauri-driver /github/home/.cargo/bin/tauri-driver && \
   # vi bindings on by default.
   echo "set -o vi" >> /root/.bashrc
 

--- a/apps/desktop/e2e/Dockerfile
+++ b/apps/desktop/e2e/Dockerfile
@@ -84,5 +84,4 @@ RUN pnpm add --global turbo && \
   # vi bindings on by default.
   echo "set -o vi" >> /root/.bashrc
 
-# Run SSH server in foreground.
-CMD ["service", "ssh", "start", "-D"]
+WORKDIR /root

--- a/apps/desktop/e2e/Dockerfile
+++ b/apps/desktop/e2e/Dockerfile
@@ -16,37 +16,37 @@ FROM ubuntu:22.04
 
 RUN apt update && \
   apt install -y \
-    build-essential \
-    curl \
-    git \
-    pkg-config \
-    psmisc \
-    vim && \
-    # Clean up
-    apt -y autoremove && apt -y clean
+  build-essential \
+  curl \
+  git \
+  pkg-config \
+  psmisc \
+  vim && \
+  # Clean up
+  apt -y autoremove && apt -y clean
 
 # Install Tauri dependencies
 # v1: https://v1.tauri.app/v1/guides/getting-started/prerequisites#setting-up-linux
 # v2: https://v2.tauri.app/start/prerequisites/#linux
 RUN apt install -y \
-    libwebkit2gtk-4.0-dev \
-    build-essential \
-    curl \
-    wget \
-    libssl-dev \
-    libgtk-3-dev \
-    libayatana-appindicator3-dev \
-    librsvg2-dev && \
-    # Clean up
-    apt -y autoremove && apt -y clean
+  libwebkit2gtk-4.0-dev \
+  build-essential \
+  curl \
+  wget \
+  libssl-dev \
+  libgtk-3-dev \
+  libayatana-appindicator3-dev \
+  librsvg2-dev && \
+  # Clean up
+  apt -y autoremove && apt -y clean
 
 # Install tauri-driver dependencies
 RUN apt install -y \
-    dbus-x11 \
-    webkit2gtk-driver \
-    xvfb && \
-    # Clean up
-    apt -y autoremove && apt -y clean
+  dbus-x11 \
+  webkit2gtk-driver \
+  xvfb && \
+  # Clean up
+  apt -y autoremove && apt -y clean
 
 # Install ssh server for X11 forwarding
 RUN apt install -y openssh-server && \
@@ -81,5 +81,9 @@ RUN pnpm setup
 RUN pnpm add --global turbo && \
   # Used as a proxy for communicating with WebKitWebDriver.
   cargo install tauri-driver && \
+  # Make `tauri-driver` more widely available
+  ln -s /root/.cargo/bin/tauri-driver /usr/local/bin/tauri-driver \
   # vi bindings on by default.
   echo "set -o vi" >> /root/.bashrc
+
+CMD ["/bin/bash"]

--- a/apps/desktop/e2e/Dockerfile
+++ b/apps/desktop/e2e/Dockerfile
@@ -83,9 +83,6 @@ RUN pnpm add --global turbo && \
   cargo install tauri-driver && \
   # Make `tauri-driver` more widely available
   ln -s /root/.cargo/bin/tauri-driver /usr/local/bin/tauri-driver && \
-  # Copy tauri-driver to where GHA expects it
-  mkdir -p /github/home/.cargo/bin && \
-  ln -s /root/.cargo/bin/tauri-driver /github/home/.cargo/bin/tauri-driver && \
   # vi bindings on by default.
   echo "set -o vi" >> /root/.bashrc
 

--- a/apps/desktop/e2e/Dockerfile
+++ b/apps/desktop/e2e/Dockerfile
@@ -82,7 +82,7 @@ RUN pnpm add --global turbo && \
   # Used as a proxy for communicating with WebKitWebDriver.
   cargo install tauri-driver && \
   # Make `tauri-driver` more widely available
-  ln -s /root/.cargo/bin/tauri-driver /usr/local/bin/tauri-driver \
+  ln -s /root/.cargo/bin/tauri-driver /usr/local/bin/tauri-driver && \
   # vi bindings on by default.
   echo "set -o vi" >> /root/.bashrc
 

--- a/apps/desktop/e2e/Dockerfile
+++ b/apps/desktop/e2e/Dockerfile
@@ -83,5 +83,3 @@ RUN pnpm add --global turbo && \
   cargo install tauri-driver && \
   # vi bindings on by default.
   echo "set -o vi" >> /root/.bashrc
-
-WORKDIR /root

--- a/apps/desktop/e2e/Dockerfile
+++ b/apps/desktop/e2e/Dockerfile
@@ -1,0 +1,88 @@
+# Container for running E2E tests on MacOS
+#
+# 1. docker build --tag gitbutler/e2e:latest
+# 2. docker run --name e2e-agent --detach -p 2222:22 -v $GITBUTLER_REPO:/root/gitbutler \
+#     -v /tmp/e2e-pnpm-store:/tmp/pnpm-store gitbutler/e2e:latest
+# 3. docker cp -a ~/.ssh/id_ed25519.pub e2e-agent:/root/.ssh/authorized_keys
+# 4. ssh -p 2222 -Y root@localhost
+# The rest is run inside the container in your SSH session:
+# 5. cd /root/gitbutler
+# 6. pnpm install && cargo build
+# 7. cargo build -p gitbutler-git && cargo build -p gitbutler-cli
+# 8. pnpm build:test
+# 9. pnpm test:e2e
+
+FROM ubuntu:22.04
+
+RUN apt update && \
+  apt install -y \
+    build-essential \
+    curl \
+    git \
+    pkg-config \
+    psmisc \
+    vim && \
+    # Clean up
+    apt -y autoremove && apt -y clean
+
+# Install Tauri dependencies
+# v1: https://v1.tauri.app/v1/guides/getting-started/prerequisites#setting-up-linux
+# v2: https://v2.tauri.app/start/prerequisites/#linux
+RUN apt install -y \
+    libwebkit2gtk-4.0-dev \
+    build-essential \
+    curl \
+    wget \
+    libssl-dev \
+    libgtk-3-dev \
+    libayatana-appindicator3-dev \
+    librsvg2-dev && \
+    # Clean up
+    apt -y autoremove && apt -y clean
+
+# Install tauri-driver dependencies
+RUN apt install -y \
+    dbus-x11 \
+    webkit2gtk-driver \
+    xvfb && \
+    # Clean up
+    apt -y autoremove && apt -y clean
+
+# Install ssh server for X11 forwarding
+RUN apt install -y openssh-server && \
+  # Needed for recording test execution.
+  apt install -y ffmpeg && \
+  # Install gitbutler dependencies
+  apt install -y cmake && \
+  # Clean up
+  apt -y autoremove && apt -y clean
+
+# Needed by at least pnpm.
+ENV SHELL=bash
+
+# Install rust.
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install node.
+RUN curl -fsSL "https://deb.nodesource.com/setup_20.x" | bash - && \
+  apt install -y nodejs && \
+  corepack enable
+
+# Install pnpm and configure store directory.
+ENV PNPM_HOME=/tmp/.pnpm
+RUN wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.bashrc" SHELL="$(which bash)" bash -
+# Home/store dir should be mounted from the host.
+RUN pnpm config set store-dir /tmp/.pnpm
+ENV PATH="/tmp/.pnpm:${PATH}"
+RUN pnpm setup
+
+# Used to manage build dependencies between packages.
+RUN pnpm add --global turbo && \
+  # Used as a proxy for communicating with WebKitWebDriver.
+  cargo install tauri-driver && \
+  # vi bindings on by default.
+  echo "set -o vi" >> /root/.bashrc
+
+# Run SSH server in foreground.
+CMD ["service", "ssh", "start", "-D"]

--- a/apps/desktop/src/lib/vbranches/branchController.ts
+++ b/apps/desktop/src/lib/vbranches/branchController.ts
@@ -324,7 +324,7 @@ export class BranchController {
 			if (stashedConflicting.length > 0) {
 				return `The following branches were stashed due to a merge conflict during updating the workspace: \n\n \
 ${stashedConflicting.map((branch) => branch.split(branchRefPrefix)[1]).join('\n')} \n\n \
-You can find them in the "Branches" sidebar in order to resolve conflicts.`;
+You can find them in the 'Branches' sidebar in order to resolve conflicts.`;
 			} else {
 				return undefined;
 			}

--- a/apps/desktop/src/lib/vbranches/branchController.ts
+++ b/apps/desktop/src/lib/vbranches/branchController.ts
@@ -324,7 +324,7 @@ export class BranchController {
 			if (stashedConflicting.length > 0) {
 				return `The following branches were stashed due to a merge conflict during updating the workspace: \n\n \
 ${stashedConflicting.map((branch) => branch.split(branchRefPrefix)[1]).join('\n')} \n\n \
-You can find them in the 'Branches' sidebar in order to resolve conflicts.`;
+You can find them in the "Branches" sidebar in order to resolve conflicts.`;
 			} else {
 				return undefined;
 			}

--- a/apps/desktop/wdio.conf.ts
+++ b/apps/desktop/wdio.conf.ts
@@ -49,10 +49,14 @@ export const config: Options.WebdriverIO = {
 	},
 
 	// ensure we are running `tauri-driver` before the session starts so that we can proxy the webdriver requests
-	beforeSession: () =>
-		(tauriDriver = spawn(path.resolve(os.homedir(), '.cargo', 'bin', 'tauri-driver'), [], {
+	beforeSession: () => {
+		const tauriDriverPath = process.env.CI
+			? path.resolve('usr', 'local', 'bin', 'tauri-driver')
+			: path.resolve(os.homedir(), '.cargo', 'bin', 'tauri-driver');
+		tauriDriver = spawn(tauriDriverPath, [], {
 			stdio: [null, process.stdout, process.stderr]
-		})),
+		});
+	},
 
 	afterSession: () => {
 		tauriDriver.kill();

--- a/apps/desktop/wdio.conf.ts
+++ b/apps/desktop/wdio.conf.ts
@@ -51,7 +51,7 @@ export const config: Options.WebdriverIO = {
 	// ensure we are running `tauri-driver` before the session starts so that we can proxy the webdriver requests
 	beforeSession: () => {
 		const tauriDriverPath = process.env.CI
-			? path.resolve('usr', 'local', 'bin', 'tauri-driver')
+			? '/usr/local/bin/tauri-driver'
 			: path.resolve(os.homedir(), '.cargo', 'bin', 'tauri-driver');
 		tauriDriver = spawn(tauriDriverPath, [], {
 			stdio: [null, process.stdout, process.stderr]


### PR DESCRIPTION
## ☕️ Reasoning

- Since we've put Tauri v2 on hold for a bit, I decided to move this e2e testing Dockerfile and the GHA to build and publish it into its own PR here. 
- Backported for Tuari v2 / `libwebkitgtk4.0-dev`

## 🧢 Changes

- Add `apps/desktop/e2e/Dockerfile`
- Add GHA to build and publish that Dockerfile (`ghcr.io/gitbutlerapp/e2e-runner:latest`)
- Use that `e2e-runner:latest` image to run the `test-e2e.yml` GHA

### Notes

- Using a custom `Dockerfile` in GHA: https://docs.github.com/en/actions/sharing-automations/creating-actions/dockerfile-support-for-github-actions

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
