### PR TITLE
fix: A bug with Wayland display (Error 71) in WSL

### DIFF
--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -118,7 +118,7 @@ fn main() {
 
                     Ok(())
                 })
-                .plugin(tauri_plugin_window_state::Builder::default().build())
+                //.plugin(tauri_plugin_window_state::Builder::default().build())
                 .plugin(tauri_plugin_single_instance::init(|_, _, _| {}))
                 .plugin(tauri_plugin_context_menu::init())
                 .plugin(tauri_plugin_store::Builder::default().build())

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -38,7 +38,7 @@ fn main() {
                 .target(LogTarget::LogDir)
                 .level(log::LevelFilter::Error);
 
-            tauri::Builder::default()
+            let builder = tauri::Builder::default()
                 .setup(move |tauri_app| {
                     let window = gitbutler_tauri::window::create(
                         &tauri_app.handle(),
@@ -118,7 +118,6 @@ fn main() {
 
                     Ok(())
                 })
-                //.plugin(tauri_plugin_window_state::Builder::default().build())
                 .plugin(tauri_plugin_single_instance::init(|_, _, _| {}))
                 .plugin(tauri_plugin_context_menu::init())
                 .plugin(tauri_plugin_store::Builder::default().build())
@@ -239,7 +238,12 @@ fn main() {
                         }
                         _ => {}
                     }
-                })
+                });
+
+            #[cfg(not(target_os = "linux"))]
+            let builder = builder.plugin(tauri_plugin_window_state::Builder::default().build());
+
+            builder
                 .build(tauri_context)
                 .expect("Failed to build tauri app")
                 .run(|app_handle, event| {


### PR DESCRIPTION
## ☕️ Reasoning

Hello Team! This PR has been created after reviewing issue #4039.

```
`wl_display@1.error(xdg_wm_base@20, 4, "xdg_surface buffer (1160 x 757) does not match the configured maximized state (0 x 0)"

[3521097-278] -> xdg_toplevel@22.set._maximized()
[3521097.300] -> xdg_toplevel@22.unset_fullscreen()
[3521098.399] xdg_toplevel@22.configure(0, 0, array[4])
[3521098.410] xdg_surface@21.configure (900)
[3521101.5681] → xdg_toplevel@22.set_min_size(900, 587)
[3521101.586] -> xdg_toplevel@22.set_max_size (3840, 2160)
[3521101.617] -> xdg_surface@21.set_window_geometry(0, 0, 1160, 757)
```

After running the command `WAYLAND_DEBUG=1 pnpm run dev:desktop`, I reviewed the logs and noticed the issue occurs when the window tries to maximize and then revert to its original size.

It seems that the `tauri_plugin_window_state` plugin conflicts with the maximized state in Wayland while attempting to restore the previously saved window size.

In fact, by removing the `tauri_plugin_window_state` plugin in `gitbutler-tauri/src/main.rs`, I confirmed that the application works in WSL.

Additionally, after removing the plugin, I verified that the application still opens correctly on other OS (Windows, macOS).
Although there would be a temporary loss of window state saving functionality, would it be a good idea to temporarily comment out the plugin as a workaround until the issue is fully resolved?

**Before and after commenting out the plugin**

![comment-out-before-after](https://github.com/user-attachments/assets/55c4c159-d2cc-4f76-ad9b-7331b426087b)

**Retesting after commenting out**

![tauri-window-plugin-remove](https://github.com/user-attachments/assets/c7e1c814-92c7-4bff-a614-c35b4a704d5d)

## 🧢 Changes

- Temporarily disabled the `tauri_plugin_window_state` plugin in `gitbutler-tauri/src/main.rs` to resolve compatibility issues with WSL.

## 🎫 Affected issues

Fixes: #4039 
