### PR TITLE
Fix janky generics

### DIFF
--- a/apps/desktop/src/lib/navigation/ChunkyList.svelte
+++ b/apps/desktop/src/lib/navigation/ChunkyList.svelte
@@ -1,8 +1,3 @@
-<script lang="ts" module>
-	// If this is not present, eslint complains that T is not defined below
-	type T = unknown;
-</script>
-
 <script lang="ts" generics="T">
 	/**
 	 * Lazily renders a list of many many items. This is intended to be used

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -49,7 +49,10 @@ export default tsEslint.config(
 			parser: svelteParser,
 			parserOptions: {
 				parser: tsParser,
-				extraFileExtensions: ['.svelte']
+				extraFileExtensions: ['.svelte'],
+				svelteFeatures: {
+					experimentalGenerics: true
+				}
 			}
 		}
 	},


### PR DESCRIPTION
Correctly inform eslint about svelte generics

```diff
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -49,7 +49,10 @@ export default tsEslint.config(
 			parser: svelteParser,
 			parserOptions: {
 				parser: tsParser,
-				extraFileExtensions: ['.svelte']
+				extraFileExtensions: ['.svelte'],
+				svelteFeatures: {
+					experimentalGenerics: true
+				}
 			}
 		}
 	},

```

From the svelte discord: https://discord.com/channels/457912077277855764/1153350350158450758/1283426193340891158
