### PR TITLE
fix: improve deeply nested token rendering

### DIFF
--- a/apps/desktop/src/lib/components/MarkdownContent.svelte
+++ b/apps/desktop/src/lib/components/MarkdownContent.svelte
@@ -18,32 +18,32 @@
 
 	let { type, ...rest }: Props = $props();
 
-	// @ts-expect-error indexing on string union is having trouble
-	const CurrentComponent = renderers[type as Props['type']];
+	// @ts-expect-error todo: map cannot be indexed on a union of string literals apparently
+	const CurrentComponent = renderers[type];
 </script>
 
-{#if type && CurrentComponent}
+{#if (!type || type === 'init') && 'tokens' in rest && rest.tokens}
+	{#each rest.tokens as token}
+		<svelte:self {...token} />
+	{/each}
+{:else if renderers[type as Extract<Props, 'type'>]}
 	{#if type === 'list'}
 		{@const listItems = (rest as Extract<Props, { type: typeof type }>).items}
 		<CurrentComponent {...rest}>
 			{#each listItems as item}
 				{@const ChildComponent = renderers[item.type]}
 				<ChildComponent {...item}>
-					<svelte:self tokens={item.tokens} {renderers} />
+					<svelte:self tokens={item.tokens} />
 				</ChildComponent>
 			{/each}
 		</CurrentComponent>
 	{:else}
-		<CurrentComponent {...rest}>
-			{#if 'tokens' in rest}
+		<CurrentComponent this={renderers[type as Extract<Props, 'type'>]} {...rest}>
+			{#if 'tokens' in rest && rest.tokens}
 				<svelte:self tokens={rest.tokens} />
+			{:else if 'raw' in rest}
+				{rest.raw}
 			{/if}
 		</CurrentComponent>
 	{/if}
-{:else if 'tokens' in rest && rest.tokens}
-	{#each rest.tokens as token}
-		<svelte:self {...token} />
-	{/each}
-{:else if 'raw' in rest}
-	{@html rest.raw?.replaceAll('\n', '') ?? ''}
 {/if}

--- a/apps/desktop/src/lib/components/MarkdownContent.svelte
+++ b/apps/desktop/src/lib/components/MarkdownContent.svelte
@@ -3,6 +3,7 @@
 	/* - Required because spreading in prop destructuring still throws eslint errors */
 	import { renderers } from '$lib/utils/markdownRenderers';
 	import type { Tokens, Token } from 'marked';
+	import type { Component } from 'svelte';
 
 	type Props =
 		| { type: 'init'; tokens: Token[] }
@@ -17,9 +18,9 @@
 		| Tokens.ListItem
 		| Tokens.List;
 
-	let { type, ...rest }: Props = $props();
+	const { type, ...rest }: Props = $props();
 
-	const CurrentComponent = renderers[type];
+	const CurrentComponent = renderers[type] as Component<Props>;
 </script>
 
 {#if (!type || type === 'init') && 'tokens' in rest && rest.tokens}

--- a/apps/desktop/src/lib/components/MarkdownContent.svelte
+++ b/apps/desktop/src/lib/components/MarkdownContent.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	/* eslint svelte/valid-compile: "off" */
+	/* - Required because spreading in prop destructuring still throws eslint errors */
 	import { renderers } from '$lib/utils/markdownRenderers';
 	import type { Tokens, Token } from 'marked';
 
@@ -18,7 +19,6 @@
 
 	let { type, ...rest }: Props = $props();
 
-	// @ts-expect-error todo: map cannot be indexed on a union of string literals apparently
 	const CurrentComponent = renderers[type];
 </script>
 
@@ -26,9 +26,9 @@
 	{#each rest.tokens as token}
 		<svelte:self {...token} />
 	{/each}
-{:else if renderers[type as Extract<Props, 'type'>]}
+{:else if renderers[type]}
 	{#if type === 'list'}
-		{@const listItems = (rest as Extract<Props, { type: typeof type }>).items}
+		{@const listItems = (rest as Extract<Props, { type: 'list' }>).items}
 		<CurrentComponent {...rest}>
 			{#each listItems as item}
 				{@const ChildComponent = renderers[item.type]}
@@ -38,7 +38,7 @@
 			{/each}
 		</CurrentComponent>
 	{:else}
-		<CurrentComponent this={renderers[type as Extract<Props, 'type'>]} {...rest}>
+		<CurrentComponent this={renderers[type]} {...rest}>
 			{#if 'tokens' in rest && rest.tokens}
 				<svelte:self tokens={rest.tokens} />
 			{:else if 'raw' in rest}

--- a/apps/desktop/src/lib/components/markdownRenderers/Html.svelte
+++ b/apps/desktop/src/lib/components/markdownRenderers/Html.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	interface Props {
+		raw: string;
+	}
+
+	const { raw }: Props = $props();
+</script>
+
+{@html raw}

--- a/apps/desktop/src/lib/components/markdownRenderers/Text.svelte
+++ b/apps/desktop/src/lib/components/markdownRenderers/Text.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
+	import { type Snippet } from 'svelte';
+
 	interface Props {
-		text: string;
+		children: Snippet;
 	}
 
-	const { text }: Props = $props();
+	const { children }: Props = $props();
 </script>
 
 <span>
-	{text}
+	{@render children()}
 </span>

--- a/apps/desktop/src/lib/utils/markdownRenderers.ts
+++ b/apps/desktop/src/lib/utils/markdownRenderers.ts
@@ -2,6 +2,7 @@ import Blockquote from '$lib/components/markdownRenderers/Blockquote.svelte';
 import Code from '$lib/components/markdownRenderers/Code.svelte';
 import Codespan from '$lib/components/markdownRenderers/Codespan.svelte';
 import Heading from '$lib/components/markdownRenderers/Heading.svelte';
+import Html from '$lib/components/markdownRenderers/Html.svelte';
 import Image from '$lib/components/markdownRenderers/Image.svelte';
 import List from '$lib/components/markdownRenderers/List.svelte';
 import ListItem from '$lib/components/markdownRenderers/ListItem.svelte';
@@ -16,6 +17,7 @@ export const renderers = {
 	code: Code,
 	codespan: Codespan,
 	text: Text,
+	html: Html,
 	list: List,
 	list_item: ListItem,
 	heading: Heading,

--- a/apps/desktop/src/lib/utils/markdownRenderers.ts
+++ b/apps/desktop/src/lib/utils/markdownRenderers.ts
@@ -9,8 +9,11 @@ import ListItem from '$lib/components/markdownRenderers/ListItem.svelte';
 import Paragraph from '$lib/components/markdownRenderers/Paragraph.svelte';
 import Text from '$lib/components/markdownRenderers/Text.svelte';
 import Link from '$lib/shared/Link.svelte';
+import type { ComponentType } from 'svelte';
 
-export const renderers = {
+type Renderers = Record<string, ComponentType>;
+
+export const renderers: Renderers = {
 	link: Link,
 	image: Image,
 	blockquote: Blockquote,

--- a/apps/desktop/src/lib/utils/markdownRenderers.ts
+++ b/apps/desktop/src/lib/utils/markdownRenderers.ts
@@ -9,9 +9,9 @@ import ListItem from '$lib/components/markdownRenderers/ListItem.svelte';
 import Paragraph from '$lib/components/markdownRenderers/Paragraph.svelte';
 import Text from '$lib/components/markdownRenderers/Text.svelte';
 import Link from '$lib/shared/Link.svelte';
-import type { ComponentType } from 'svelte';
+import type { Component } from 'svelte';
 
-type Renderers = Record<string, ComponentType>;
+type Renderers = Record<string, Component>;
 
 export const renderers: Renderers = {
 	link: Link,

--- a/apps/desktop/src/lib/utils/markdownRenderers.ts
+++ b/apps/desktop/src/lib/utils/markdownRenderers.ts
@@ -9,11 +9,8 @@ import ListItem from '$lib/components/markdownRenderers/ListItem.svelte';
 import Paragraph from '$lib/components/markdownRenderers/Paragraph.svelte';
 import Text from '$lib/components/markdownRenderers/Text.svelte';
 import Link from '$lib/shared/Link.svelte';
-import type { Component } from 'svelte';
 
-type Renderers = Record<string, Component>;
-
-export const renderers: Renderers = {
+export const renderers = {
 	link: Link,
 	image: Image,
 	blockquote: Blockquote,
@@ -24,7 +21,8 @@ export const renderers: Renderers = {
 	list: List,
 	list_item: ListItem,
 	heading: Heading,
-	paragraph: Paragraph
+	paragraph: Paragraph,
+	init: null
 };
 
 export const options = {


### PR DESCRIPTION
## ☕️ Reasoning

- Rendering other items inside nested items (such as `List` -> `ListItem` -> `Link`) wasn't working

## 🧢 Changes

### Before

> ![image](https://github.com/user-attachments/assets/ca6bafb4-e66c-4e3e-a720-7e72c942167e)

### After

> ![image](https://github.com/user-attachments/assets/da751a05-2ac7-4729-a016-b5e2a9e33283)



<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
