### PR TITLE
fix discarding of deleted and created files

### DIFF
--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -159,7 +159,7 @@ pub fn unapply_ownership(
         },
     )?;
 
-    let final_tree_oid = gitbutler_diff::write::hunks_onto_tree(ctx, &final_tree, diff)?;
+    let final_tree_oid = gitbutler_diff::write::hunks_onto_tree(ctx, &final_tree, diff, true)?;
     let final_tree = repo
         .find_tree(final_tree_oid)
         .context("failed to find tree")?;

--- a/crates/gitbutler-diff/src/diff.rs
+++ b/crates/gitbutler-diff/src/diff.rs
@@ -78,7 +78,7 @@ impl GitHunk {
             new_lines: 0,
             diff_lines: Default::default(),
             binary: false,
-            change_type: ChangeType::Modified,
+            change_type: ChangeType::Added,
         }
     }
 }

--- a/crates/gitbutler-diff/src/diff.rs
+++ b/crates/gitbutler-diff/src/diff.rs
@@ -387,6 +387,11 @@ fn reverse_patch(patch: &BStr) -> Option<BString> {
 
 // returns `None` if the reversal failed
 pub fn reverse_hunk(hunk: &GitHunk) -> Option<GitHunk> {
+    let new_change_type = match hunk.change_type {
+        ChangeType::Added => ChangeType::Deleted,
+        ChangeType::Deleted => ChangeType::Added,
+        ChangeType::Modified => ChangeType::Modified,
+    };
     if hunk.binary {
         None
     } else {
@@ -397,7 +402,7 @@ pub fn reverse_hunk(hunk: &GitHunk) -> Option<GitHunk> {
             new_lines: hunk.old_lines,
             diff_lines: diff.into(),
             binary: hunk.binary,
-            change_type: hunk.change_type,
+            change_type: new_change_type,
         })
     }
 }

--- a/crates/gitbutler-diff/src/write.rs
+++ b/crates/gitbutler-diff/src/write.rs
@@ -69,7 +69,13 @@ where
             if discard_hunk.map_or(false, |hunk| hunk.change_type == crate::ChangeType::Deleted) {
                 // File was created but now that hunk is being discarded with an inversed hunk
                 builder.remove(rel_path);
-                fs::remove_file(full_path.clone())?;
+                fs::remove_file(full_path.clone()).or_else(|err| {
+                    if err.kind() == std::io::ErrorKind::NotFound {
+                        Ok(())
+                    } else {
+                        Err(err)
+                    }
+                })?;
                 continue;
             }
             // if file is executable, use 755, otherwise 644

--- a/crates/gitbutler-diff/src/write.rs
+++ b/crates/gitbutler-diff/src/write.rs
@@ -63,7 +63,13 @@ where
             && hunks[0].diff_lines.contains_str(b"Subproject commit");
 
         // if file exists
-        if full_path.exists() {
+        if full_path.exists() || allow_new_file {
+            if hunks.len() == 1 && hunks[0].change_type == crate::ChangeType::Deleted {
+                // File was created but now that hunk is being discarded with an inversed hunk
+                builder.remove(rel_path);
+                fs::remove_file(full_path.clone())?;
+                continue;
+            }
             // if file is executable, use 755, otherwise 644
             let mut filemode = git2::FileMode::Blob;
             // check if full_path file is executable


### PR DESCRIPTION
This fixes 3 issues:
- new files that are empty are incorrectly shown as modified (should be added)
- discarding a newly added file did not work
- discarding file deletions did not work