### PR TITLE
UI for stacked branches

### DIFF
--- a/apps/desktop/src/lib/branch/BranchCard.svelte
+++ b/apps/desktop/src/lib/branch/BranchCard.svelte
@@ -113,6 +113,9 @@
 
 	let isPushingCommits = $state(false);
 	const localCommitsConflicted = $derived($localCommits.some((commit) => commit.conflicted));
+	const localAndRemoteCommitsConflicted = $derived(
+		$localAndRemoteCommits.some((commit) => commit.conflicted)
+	);
 
 	const listingService = getGitHostListingService();
 	const prMonitor = getGitHostPrMonitor();
@@ -214,6 +217,21 @@
 							</Dropzones>
 						{/if}
 
+						{#snippet pushButton({disabled}: {disabled: boolean})}
+							<Button
+								style="pop"
+								kind="solid"
+								wide
+								loading={isPushingCommits}
+								{disabled}
+								tooltip={localCommitsConflicted
+									? 'In order to push, please resolve any conflicted commits.'
+									: undefined}
+								onclick={push}
+							>
+								{branch.requiresForce ? 'Force push' : 'Push'}
+							</Button>
+						{/snippet}
 						{#if $stackingFeature}
 							{@const groups = groupCommitsByRef(branch.commits)}
 							{#each groups as group (group.ref)}
@@ -223,9 +241,8 @@
 									integratedCommits={group.integratedCommits}
 									remoteCommits={[]}
 									isUnapplied={false}
-									{isPushingCommits}
 									{localCommitsConflicted}
-									{push}
+									{localAndRemoteCommitsConflicted}
 								/>
 							{/each}
 						{:else}
@@ -235,24 +252,16 @@
 								integratedCommits={$integratedCommits}
 								remoteCommits={$remoteCommits}
 								isUnapplied={false}
-								{isPushingCommits}
 								{localCommitsConflicted}
-								{push}
+								{localAndRemoteCommitsConflicted}
+								{pushButton}
 							/>
 						{/if}
-						<Button
-							style="pop"
-							kind="solid"
-							wide
-							loading={isPushingCommits}
-							disabled={localCommitsConflicted}
-							tooltip={localCommitsConflicted
-								? 'In order to push, please resolve any conflicted commits.'
-								: undefined}
-							onclick={push}
-						>
-							{branch.requiresForce ? 'Force push' : 'Push'}
-						</Button>
+						{#if $stackingFeature}
+							{@render pushButton({
+								disabled: localCommitsConflicted || localAndRemoteCommitsConflicted
+							})}
+						{/if}
 					</div>
 				</div>
 			</ScrollableContainer>

--- a/apps/desktop/src/lib/branch/BranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/BranchHeader.svelte
@@ -7,7 +7,7 @@
 	import { BaseBranch } from '$lib/baseBranch/baseBranch';
 	import { BaseBranchService } from '$lib/baseBranch/baseBranchService';
 	import ContextMenu from '$lib/components/contextmenu/ContextMenu.svelte';
-	import { featureBranchStacking } from '$lib/config/uiFeatureFlags';
+	import { stackingFeature } from '$lib/config/uiFeatureFlags';
 	import { mapErrorToToast } from '$lib/gitHost/github/errorMap';
 	import { getGitHost } from '$lib/gitHost/interface/gitHost';
 	import { getGitHostListingService } from '$lib/gitHost/interface/gitHostListingService';
@@ -45,8 +45,6 @@
 	const baseBranchName = $derived($baseBranch.shortName);
 	const branch = $derived($branchStore);
 	const pr = $derived($prMonitor?.pr);
-
-	const branchStacking = featureBranchStacking();
 
 	let contextMenu = $state<ContextMenu>();
 	let meatballButtonEl = $state<HTMLDivElement>();
@@ -212,9 +210,9 @@
 					<Icon name="draggable" />
 				</div>
 
-				<div class:header__info={!branchStacking} class:stacking-header__info={branchStacking}>
+				<div class:header__info={!$stackingFeature} class:stacking-header__info={$stackingFeature}>
 					<BranchLabel name={branch.name} onChange={(name) => handleBranchNameChange(name)} />
-					{#if branchStacking}
+					{#if stackingFeature}
 						<span class="button-group">
 							<DefaultTargetButton
 								selectedForChanges={branch.selectedForChanges}
@@ -264,7 +262,7 @@
 				</div>
 			</div>
 
-			{#if !branchStacking}
+			{#if !$stackingFeature}
 				<div class="header__actions">
 					<div class="header__buttons">
 						<DefaultTargetButton

--- a/apps/desktop/src/lib/branch/BranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/BranchHeader.svelte
@@ -2,10 +2,12 @@
 	import ActiveBranchStatus from './ActiveBranchStatus.svelte';
 	import BranchLabel from './BranchLabel.svelte';
 	import BranchLaneContextMenu from './BranchLaneContextMenu.svelte';
+	import DefaultTargetButton from './DefaultTargetButton.svelte';
 	import PullRequestButton from '../pr/PullRequestButton.svelte';
 	import { BaseBranch } from '$lib/baseBranch/baseBranch';
 	import { BaseBranchService } from '$lib/baseBranch/baseBranchService';
 	import ContextMenu from '$lib/components/contextmenu/ContextMenu.svelte';
+	import { featureBranchStacking } from '$lib/config/uiFeatureFlags';
 	import { mapErrorToToast } from '$lib/gitHost/github/errorMap';
 	import { getGitHost } from '$lib/gitHost/interface/gitHost';
 	import { getGitHostListingService } from '$lib/gitHost/interface/gitHostListingService';
@@ -43,6 +45,8 @@
 	const baseBranchName = $derived($baseBranch.shortName);
 	const branch = $derived($branchStore);
 	const pr = $derived($prMonitor?.pr);
+
+	const branchStacking = featureBranchStacking();
 
 	let contextMenu = $state<ContextMenu>();
 	let meatballButtonEl = $state<HTMLDivElement>();
@@ -208,90 +212,101 @@
 					<Icon name="draggable" />
 				</div>
 
-				<div class="header__info">
+				<div class:header__info={!branchStacking} class:stacking-header__info={branchStacking}>
 					<BranchLabel name={branch.name} onChange={(name) => handleBranchNameChange(name)} />
-					<div class="header__remote-branch">
-						<ActiveBranchStatus
-							{hasIntegratedCommits}
-							remoteExists={!!branch.upstream}
-							isLaneCollapsed={$isLaneCollapsed}
-						/>
+					{#if branchStacking}
+						<span class="button-group">
+							<DefaultTargetButton
+								selectedForChanges={branch.selectedForChanges}
+								onclick={async () => {
+									isTargetBranchAnimated = true;
+									await branchController.setSelectedForChanges(branch.id);
+								}}
+							/>
+							<Button
+								bind:el={meatballButtonEl}
+								style="ghost"
+								icon="kebab"
+								onclick={() => {
+									contextMenu?.toggle();
+								}}
+							/>
+							<BranchLaneContextMenu
+								bind:contextMenuEl={contextMenu}
+								target={meatballButtonEl}
+								onCollapse={collapseLane}
+								{onGenerateBranchName}
+							/>
+						</span>
+					{:else}
+						<div class="header__remote-branch">
+							<ActiveBranchStatus
+								{hasIntegratedCommits}
+								remoteExists={!!branch.upstream}
+								isLaneCollapsed={$isLaneCollapsed}
+							/>
 
-						{#await branch.isMergeable then isMergeable}
-							{#if !isMergeable}
-								<Button
-									size="tag"
-									clickable={false}
-									icon="locked-small"
-									style="warning"
-									tooltip="Applying this branch will add merge conflict markers that you will have to resolve"
-								>
-									Conflict
-								</Button>
-							{/if}
-						{/await}
-					</div>
+							{#await branch.isMergeable then isMergeable}
+								{#if !isMergeable}
+									<Button
+										size="tag"
+										clickable={false}
+										icon="locked-small"
+										style="warning"
+										tooltip="Applying this branch will add merge conflict markers that you will have to resolve"
+									>
+										Conflict
+									</Button>
+								{/if}
+							{/await}
+						</div>
+					{/if}
 				</div>
 			</div>
 
-			<div class="header__actions">
-				<div class="header__buttons">
-					{#if branch.selectedForChanges}
-						<Button
-							style="pop"
-							kind="soft"
-							tooltip="New changes will land here"
-							icon="target"
-							clickable={false}
-						>
-							Default branch
-						</Button>
-					{:else}
-						<Button
-							style="ghost"
-							outline
-							tooltip="When selected, new changes land here"
-							icon="target"
+			{#if !branchStacking}
+				<div class="header__actions">
+					<div class="header__buttons">
+						<DefaultTargetButton
+							selectedForChanges={branch.selectedForChanges}
 							onclick={async () => {
 								isTargetBranchAnimated = true;
 								await branchController.setSelectedForChanges(branch.id);
 							}}
-						>
-							Set as default
-						</Button>
-					{/if}
-				</div>
-
-				<div class="relative">
-					<div class="header__buttons">
-						{#if !$pr}
-							<PullRequestButton
-								click={async ({ draft }) => await createPr({ draft })}
-								disabled={branch.commits.length === 0 || !$gitHost || !$prService}
-								tooltip={!$gitHost || !$prService
-									? 'You can enable git host integration in the settings'
-									: ''}
-								loading={isLoading}
-							/>
-						{/if}
-						<Button
-							bind:el={meatballButtonEl}
-							style="ghost"
-							outline
-							icon="kebab"
-							onclick={() => {
-								contextMenu?.toggle();
-							}}
-						/>
-						<BranchLaneContextMenu
-							bind:contextMenuEl={contextMenu}
-							target={meatballButtonEl}
-							onCollapse={collapseLane}
-							{onGenerateBranchName}
 						/>
 					</div>
+
+					<div class="relative">
+						<div class="header__buttons">
+							{#if !$pr}
+								<PullRequestButton
+									click={async ({ draft }) => await createPr({ draft })}
+									disabled={branch.commits.length === 0 || !$gitHost || !$prService}
+									tooltip={!$gitHost || !$prService
+										? 'You can enable git host integration in the settings'
+										: ''}
+									loading={isLoading}
+								/>
+							{/if}
+							<Button
+								bind:el={meatballButtonEl}
+								style="ghost"
+								outline
+								icon="kebab"
+								onclick={() => {
+									contextMenu?.toggle();
+								}}
+							/>
+							<BranchLaneContextMenu
+								bind:contextMenuEl={contextMenu}
+								target={meatballButtonEl}
+								onCollapse={collapseLane}
+								{onGenerateBranchName}
+							/>
+						</div>
+					</div>
 				</div>
-			</div>
+			{/if}
 		</div>
 		<div class="header__top-overlay" data-remove-from-draggable data-tauri-drag-region></div>
 	</div>
@@ -360,6 +375,20 @@
 		display: flex;
 		flex-direction: column;
 		overflow: hidden;
+		gap: 10px;
+	}
+	/* TODO: Remove me after stacking feature toggle has been removed. */
+	.stacking-header__info {
+		flex: 1;
+		display: flex;
+		overflow: hidden;
+		justify-content: space-between;
+		align-items: center;
+		gap: 10px;
+	}
+	.button-group {
+		display: flex;
+		align-items: center;
 		gap: 10px;
 	}
 	.header__actions {

--- a/apps/desktop/src/lib/branch/BranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/BranchHeader.svelte
@@ -212,7 +212,7 @@
 
 				<div class:header__info={!$stackingFeature} class:stacking-header__info={$stackingFeature}>
 					<BranchLabel name={branch.name} onChange={(name) => handleBranchNameChange(name)} />
-					{#if stackingFeature}
+					{#if $stackingFeature}
 						<span class="button-group">
 							<DefaultTargetButton
 								selectedForChanges={branch.selectedForChanges}

--- a/apps/desktop/src/lib/branch/DefaultTargetButton.svelte
+++ b/apps/desktop/src/lib/branch/DefaultTargetButton.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import Button from '@gitbutler/ui/Button.svelte';
+
+	interface Props {
+		selectedForChanges: boolean;
+		onclick: () => void;
+	}
+
+	const { selectedForChanges }: Props = $props();
+</script>
+
+{#if selectedForChanges}
+	<Button
+		style="pop"
+		kind="soft"
+		tooltip="New changes will land here"
+		icon="target"
+		size="tag"
+		clickable={false}
+	>
+		Default branch
+	</Button>
+{:else}
+	<Button
+		style="ghost"
+		outline
+		tooltip="When selected, new changes land here"
+		icon="target"
+		size="tag"
+		{onclick}
+	>
+		Set as default
+	</Button>
+{/if}

--- a/apps/desktop/src/lib/branch/StackedBranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackedBranchHeader.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import { getGitHostListingService } from '$lib/gitHost/interface/gitHostListingService';
+	import { getGitHostPrService } from '$lib/gitHost/interface/gitHostPrService';
+	import PullRequestButton from '$lib/pr/PullRequestButton.svelte';
+
+	interface Props {
+		upstreamName: string | undefined;
+	}
+
+	const { upstreamName }: Props = $props();
+
+	const hostedListingServiceStore = getGitHostListingService();
+	const prStore = $derived($hostedListingServiceStore?.prs);
+	const prs = $derived(prStore ? $prStore : undefined);
+
+	const listedPr = $derived(prs?.find((pr) => pr.sourceBranch === upstreamName));
+	const prNumber = $derived(listedPr?.number);
+
+	const prService = getGitHostPrService();
+	const prMonitor = $derived(prNumber ? $prService?.prMonitor(prNumber) : undefined);
+
+	const pr = $derived(prMonitor?.pr);
+
+	let loading = $state(false);
+</script>
+
+<div class="branch-info">
+	<div class="branch-name text-14 text-bold">
+		<span class="remote-name">origin/</span>{upstreamName}
+	</div>
+	{#if !pr}
+		<PullRequestButton {loading} click={() => {}} />
+	{/if}
+</div>
+
+<style lang="postcss">
+	.branch-info {
+		padding: 14px 16px;
+		display: flex;
+		border-bottom: 1px solid var(--clr-border-2);
+		user-select: text;
+		cursor: text;
+		display: flex;
+		flex-direction: column;
+		gap: 14px;
+	}
+
+	.branch-name {
+	}
+	.remote-name {
+		color: var(--clr-scale-ntrl-60);
+	}
+</style>

--- a/apps/desktop/src/lib/commit/CommitCard.svelte
+++ b/apps/desktop/src/lib/commit/CommitCard.svelte
@@ -347,18 +347,8 @@
 								</div>
 							</button>
 						{/if}
-
 						<span class="commit__subtitle-divider">•</span>
-
 						<span>{getTimeAndAuthor()}</span>
-
-						{#if $stackingFeature && commit instanceof DetailedCommit}
-							<div
-								style="background-color:var(--clr-core-pop-80); border-radius: 3px; padding: 2px;"
-							>
-								{commit?.remoteRef}
-							</div>
-						{/if}
 					</div>
 				{/if}
 			</div>

--- a/apps/desktop/src/lib/commit/CommitCard.svelte
+++ b/apps/desktop/src/lib/commit/CommitCard.svelte
@@ -4,7 +4,7 @@
 	import { BaseBranch } from '$lib/baseBranch/baseBranch';
 	import CommitMessageInput from '$lib/commit/CommitMessageInput.svelte';
 	import { persistedCommitMessage } from '$lib/config/config';
-	import { featureBranchStacking } from '$lib/config/uiFeatureFlags';
+	import { stackingFeature } from '$lib/config/uiFeatureFlags';
 	import { draggableCommit } from '$lib/dragging/draggable';
 	import { DraggableCommit, nonDraggable } from '$lib/dragging/draggables';
 	import BranchFilesList from '$lib/file/BranchFilesList.svelte';
@@ -49,8 +49,6 @@
 	$: commitStore.set(commit);
 
 	const currentCommitMessage = persistedCommitMessage(project.id, branch?.id || '');
-
-	const branchStacking = featureBranchStacking();
 
 	let draggableCommitElement: HTMLElement | null = null;
 	let files: RemoteFile[] = [];
@@ -354,7 +352,7 @@
 
 						<span>{getTimeAndAuthor()}</span>
 
-						{#if $branchStacking && commit instanceof DetailedCommit}
+						{#if $stackingFeature && commit instanceof DetailedCommit}
 							<div
 								style="background-color:var(--clr-core-pop-80); border-radius: 3px; padding: 2px;"
 							>
@@ -399,7 +397,7 @@
 										icon="edit-small"
 										onclick={openCommitMessageModal}>Edit message</Button
 									>
-									{#if $branchStacking && commit instanceof DetailedCommit && !commit.remoteRef}
+									{#if $stackingFeature && commit instanceof DetailedCommit && !commit.remoteRef}
 										<Button
 											size="tag"
 											style="ghost"
@@ -408,7 +406,7 @@
 											onclick={(e: Event) => {openCreateRefModal(e, commit)}}>Create ref</Button
 										>
 									{/if}
-									{#if $branchStacking && commit instanceof DetailedCommit && commit.remoteRef}
+									{#if $stackingFeature && commit instanceof DetailedCommit && commit.remoteRef}
 										<Button
 											size="tag"
 											style="ghost"

--- a/apps/desktop/src/lib/commit/CommitList.svelte
+++ b/apps/desktop/src/lib/commit/CommitList.svelte
@@ -148,7 +148,7 @@
 {/snippet}
 
 {#if hasCommits || hasRemoteCommits}
-	<div class="commits">
+	<div class="commits" class:stacked={$stackingFeature}>
 		<!-- UPSTREAM COMMITS -->
 
 		{#if remoteCommits.length > 0}
@@ -363,6 +363,10 @@
 
 		--avatar-first-top: 50px;
 		--avatar-top: 16px;
+	}
+
+	.commits.stacked {
+		border-top: none;
 	}
 
 	/* BASE ROW */

--- a/apps/desktop/src/lib/components/Board.svelte
+++ b/apps/desktop/src/lib/components/Board.svelte
@@ -3,9 +3,11 @@
 	import FullviewLoading from './FullviewLoading.svelte';
 	import BranchDropzone from '$lib/branch/BranchDropzone.svelte';
 	import BranchLane from '$lib/branch/BranchLane.svelte';
+	import { stackingFeature } from '$lib/config/uiFeatureFlags';
 	import { cloneElement } from '$lib/dragging/draggable';
 	import { persisted } from '$lib/persisted/persisted';
 	import { getContext } from '$lib/utils/context';
+	import { createKeybind } from '$lib/utils/hotkeys';
 	import { throttle } from '$lib/utils/misc';
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { VirtualBranchService } from '$lib/vbranches/virtualBranch';
@@ -62,8 +64,15 @@
 			sortedBranches = sortedBranches; // Redraws #each loop.
 		}
 	}, 200);
+
+	const handleKeyDown = createKeybind({
+		's t a c k': async () => {
+			$stackingFeature = !$stackingFeature;
+		}
+	});
 </script>
 
+<svelte:window on:keydown={handleKeyDown} />
 {#if $error}
 	<div class="p-4" data-tauri-drag-region>Something went wrong...</div>
 {:else if !$branches}

--- a/apps/desktop/src/lib/config/uiFeatureFlags.ts
+++ b/apps/desktop/src/lib/config/uiFeatureFlags.ts
@@ -16,10 +16,7 @@ export function featureInlineUnifiedDiffs(): Persisted<boolean> {
 	return persisted(false, key);
 }
 
-export function featureBranchStacking(): Persisted<boolean> {
-	const key = 'branchStacking';
-	return persisted(false, key);
-}
+export const stackingFeature = persisted(false, 'stackingFeature');
 
 export function featureTopics(): Persisted<boolean> {
 	const key = 'feature--topics';

--- a/apps/desktop/src/lib/pr/PullRequestButton.svelte
+++ b/apps/desktop/src/lib/pr/PullRequestButton.svelte
@@ -16,8 +16,8 @@
 
 	type Props = {
 		loading: boolean;
-		disabled: boolean;
-		tooltip: string;
+		disabled?: boolean;
+		tooltip?: string;
 		click: (opts: { draft: boolean }) => void;
 	};
 	const { loading, disabled, tooltip, click }: Props = $props();

--- a/apps/desktop/src/lib/vbranches/commitGroups.test.ts
+++ b/apps/desktop/src/lib/vbranches/commitGroups.test.ts
@@ -1,0 +1,35 @@
+import { groupCommitsByRef } from './commitGroups';
+import { DetailedCommit } from './types';
+import { expect, test } from 'vitest';
+
+test('group commits correctly by remote ref', () => {
+	const commits = [
+		{ id: '1', remoteRef: 'a' },
+		{ id: '2', remoteRef: 'b' },
+		{ id: '3' },
+		{ id: '4' },
+		{ id: '5', remoteRef: 'c' },
+		{ id: '6' }
+	] as DetailedCommit[];
+
+	const groups = groupCommitsByRef(commits);
+	expect(groups.length).toEqual(3);
+
+	const [groupA, groupB, groupC] = groups;
+	expect(groupA?.ref).toEqual('a');
+	expect(groupB?.ref).toEqual('b');
+	expect(groupC?.ref).toEqual('c');
+	expect(groupA?.commits.length).toEqual(1);
+	expect(groupB?.commits.length).toEqual(3);
+	expect(groupC?.commits.length).toEqual(2);
+});
+
+test('group commits with undefined head ref', () => {
+	const commits = [{ id: '1' }, { id: '2', remoteRef: 'b' }] as DetailedCommit[];
+	const groups = groupCommitsByRef(commits);
+	expect(groups.length).toEqual(2);
+
+	const [groupA, groupB] = groups;
+	expect(groupA?.ref).toBeUndefined();
+	expect(groupB?.ref).toEqual('b');
+});

--- a/apps/desktop/src/lib/vbranches/commitGroups.ts
+++ b/apps/desktop/src/lib/vbranches/commitGroups.ts
@@ -1,0 +1,39 @@
+import { DetailedCommit } from './types';
+
+class CommitGroup {
+	commits: DetailedCommit[];
+
+	constructor(readonly ref?: string | undefined) {
+		this.commits = [];
+	}
+
+	get localCommits() {
+		return this.commits.filter((c) => c.status === 'local');
+	}
+
+	get remoteCommits() {
+		return this.commits.filter((c) => c.status === 'localAndRemote');
+	}
+
+	get integratedCommits() {
+		return this.commits.filter((c) => c.status === 'integrated');
+	}
+
+	get branchName() {
+		return this.ref?.replace('refs/remotes/origin/', '');
+	}
+}
+
+export function groupCommitsByRef(arr: DetailedCommit[]): CommitGroup[] {
+	const groups: CommitGroup[] = [];
+	let currentGroup: CommitGroup | undefined;
+
+	for (const item of arr) {
+		if (item.remoteRef || currentGroup === undefined) {
+			currentGroup = new CommitGroup(item.remoteRef);
+			groups.push(currentGroup);
+		}
+		currentGroup.commits.push(item);
+	}
+	return groups;
+}

--- a/apps/desktop/src/routes/settings/experimental/+page.svelte
+++ b/apps/desktop/src/routes/settings/experimental/+page.svelte
@@ -3,7 +3,7 @@
 	import {
 		featureBaseBranchSwitching,
 		featureInlineUnifiedDiffs,
-		featureBranchStacking,
+		stackingFeature,
 		featureTopics
 	} from '$lib/config/uiFeatureFlags';
 	import SettingsPage from '$lib/layout/SettingsPage.svelte';
@@ -11,7 +11,6 @@
 
 	const baseBranchSwitching = featureBaseBranchSwitching();
 	const inlineUnifiedDiffs = featureInlineUnifiedDiffs();
-	const branchStacking = featureBranchStacking();
 	const topicsEnabled = featureTopics();
 </script>
 
@@ -49,16 +48,16 @@
 			/>
 		</svelte:fragment>
 	</SectionCard>
-	<SectionCard labelFor="branchStacking" orientation="row">
+	<SectionCard labelFor="stackingFeature" orientation="row">
 		<svelte:fragment slot="title">Branch stacking</svelte:fragment>
 		<svelte:fragment slot="caption">
 			Allows for branch / pull request stacking. The user interface for this is still very crude.
 		</svelte:fragment>
 		<svelte:fragment slot="actions">
 			<Toggle
-				id="branchStacking"
-				checked={$branchStacking}
-				on:click={() => ($branchStacking = !$branchStacking)}
+				id="stackingFeature"
+				checked={$stackingFeature}
+				on:click={() => ($stackingFeature = !$stackingFeature)}
 			/>
 		</svelte:fragment>
 	</SectionCard>


### PR DESCRIPTION
Note that this is work in progress (e.g. some buttons don't even work), and hidden behind a feature toggle. It changes the way we render commits based on earlier work that enables branch creation for individual commits.
- [x] transform commit list to grouped list by reference
- [x] render pr card for groups that have a pr
