### PR TITLE
fix: rm unnecessary extra markdown wrapping class

### DIFF
--- a/apps/desktop/src/lib/components/AIPromptEdit/DialogBubble.svelte
+++ b/apps/desktop/src/lib/components/AIPromptEdit/DialogBubble.svelte
@@ -70,7 +70,7 @@
 				}}
 			></textarea>
 		{:else}
-			<div class="markdown bubble-message scrollbar text-13 text-body">
+			<div class="bubble-message scrollbar text-13 text-body">
 				<Markdown content={promptMessage.content} />
 			</div>
 		{/if}

--- a/apps/desktop/src/lib/components/BranchPreview.svelte
+++ b/apps/desktop/src/lib/components/BranchPreview.svelte
@@ -108,7 +108,7 @@
 						<div class="card">
 							<div class="card__header text-14 text-body text-semibold">{pr.title}</div>
 							{#if pr.body}
-								<div class="markdown card__content text-13 text-body">
+								<div class="card__content text-13 text-body">
 									<Markdown content={pr.body} />
 								</div>
 							{/if}

--- a/apps/desktop/src/lib/components/Markdown.svelte
+++ b/apps/desktop/src/lib/components/Markdown.svelte
@@ -15,14 +15,8 @@
 	});
 </script>
 
-<div class="markdown-content">
+<div class="markdown">
 	{#if tokens}
 		<MarkdownContent type="init" {tokens} />
 	{/if}
 </div>
-
-<style>
-	.markdown-content {
-		display: inline;
-	}
-</style>

--- a/apps/desktop/src/lib/components/PullRequestPreview.svelte
+++ b/apps/desktop/src/lib/components/PullRequestPreview.svelte
@@ -127,9 +127,7 @@
 				</span>
 			</div>
 			{#if pullrequest.body}
-				<div class="markdown">
-					<Markdown content={pullrequest.body} />
-				</div>
+				<Markdown content={pullrequest.body} />
 			{/if}
 		</div>
 		<div class="card__footer">


### PR DESCRIPTION
## ☕️ Reasoning

- Move wrapping `markdown` class to inside the new `<Markdown />` component


## 🧢 Changes

- Move `markdown` from outside `<Markdown />` to inside, where we wrap `<MarkdownContent />`


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
