### PR TITLE
Base branch: Safely handle divergence

### DIFF
--- a/apps/desktop/src/lib/baseBranch/baseBranch.ts
+++ b/apps/desktop/src/lib/baseBranch/baseBranch.ts
@@ -17,6 +17,7 @@ export class BaseBranch {
 	@Type(() => Commit)
 	recentCommits!: Commit[];
 	lastFetchedMs?: number;
+	conflicted!: boolean;
 	diverged!: boolean;
 	divergedAhead!: string[];
 	divergedBehind!: string[];

--- a/apps/desktop/src/lib/baseBranch/baseBranch.ts
+++ b/apps/desktop/src/lib/baseBranch/baseBranch.ts
@@ -17,6 +17,9 @@ export class BaseBranch {
 	@Type(() => Commit)
 	recentCommits!: Commit[];
 	lastFetchedMs?: number;
+	diverged!: boolean;
+	divergedAhead!: string[];
+	divergedBehind!: string[];
 
 	actualPushRemoteName(): string {
 		return this.pushRemoteName || this.remoteName;

--- a/apps/desktop/src/lib/baseBranch/baseBranchService.ts
+++ b/apps/desktop/src/lib/baseBranch/baseBranchService.ts
@@ -67,6 +67,27 @@ export class BaseBranchService {
 		});
 		await this.fetchFromRemotes();
 	}
+
+	async push(withForce?: boolean) {
+		this.loading.set(true);
+		try {
+			await invoke<void>('push_base_branch', {
+				projectId: this.projectId,
+				withForce
+			});
+		} catch (err: any) {
+			if (err.code === Code.DefaultTargetNotFound) {
+				// Swallow this error since user should be taken to project setup page
+				return;
+			} else if (err.code === Code.ProjectsGitAuth) {
+				showError('Failed to authenticate', err);
+			} else {
+				showError('Failed to push', err);
+			}
+			console.error(err);
+		}
+		await this.fetchFromRemotes();
+	}
 }
 
 export async function getRemoteBranches(

--- a/apps/desktop/src/lib/commit/CommitAction.svelte
+++ b/apps/desktop/src/lib/commit/CommitAction.svelte
@@ -4,11 +4,12 @@
 
 	interface Props {
 		bottomBorder?: boolean;
+		backgroundColor?: boolean;
 		lines: Snippet;
 		action: Snippet;
 	}
 
-	const { bottomBorder = true, lines, action }: Props = $props();
+	const { bottomBorder = true, backgroundColor = true, lines, action }: Props = $props();
 
 	let isNotInViewport = $state(false);
 </script>
@@ -18,6 +19,7 @@
 	class:not-in-viewport={!isNotInViewport}
 	class:sticky-z-index={!isNotInViewport}
 	class:bottom-border={bottomBorder}
+	class:background-color={backgroundColor}
 	use:intersectionObserver={{
 		callback: (entry) => {
 			if (entry?.isIntersecting) {
@@ -46,10 +48,13 @@
 		position: relative;
 		display: flex;
 
-		background-color: var(--clr-bg-2);
 		overflow: hidden;
 
 		transition: border-top var(--transition-fast);
+	}
+
+	.background-color {
+		background-color: var(--clr-bg-2);
 	}
 
 	.action {

--- a/apps/desktop/src/lib/commit/CommitCard.svelte
+++ b/apps/desktop/src/lib/commit/CommitCard.svelte
@@ -142,7 +142,7 @@
 		modeService!.enterEditMode(commit.id, branch!.refname);
 	}
 
-	$: conflicted = commit instanceof DetailedCommit && commit.conflicted;
+	$: conflicted = commit.conflicted;
 </script>
 
 <Modal bind:this={commitMessageModal} width="small" onSubmit={submitCommitMessageModal}>

--- a/apps/desktop/src/lib/commit/CommitList.svelte
+++ b/apps/desktop/src/lib/commit/CommitList.svelte
@@ -18,7 +18,7 @@
 	import { Commit, DetailedCommit, VirtualBranch } from '$lib/vbranches/types';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import LineGroup from '@gitbutler/ui/commitLines/LineGroup.svelte';
-	import { LineManagerFactory } from '@gitbutler/ui/commitLines/lineManager';
+	import { LineManagerFactory, LineSpacer } from '@gitbutler/ui/commitLines/lineManager';
 	import type { Snippet } from 'svelte';
 	import { goto } from '$app/navigation';
 
@@ -51,14 +51,6 @@
 
 	const reorderDropzoneManagerFactory = getContext(ReorderDropzoneManagerFactory);
 	const gitHost = getGitHost();
-
-	// TODO: Why does eslint-svelte-plugin complain about enum?
-	// eslint-disable-next-line svelte/valid-compile
-	enum LineSpacer {
-		Remote = 'remote-spacer',
-		Local = 'local-spacer',
-		LocalAndRemote = 'local-and-remote-spacer'
-	}
 
 	const mappedRemoteCommits = $derived(
 		remoteCommits.length > 0

--- a/apps/desktop/src/lib/components/BaseBranch.svelte
+++ b/apps/desktop/src/lib/components/BaseBranch.svelte
@@ -66,6 +66,7 @@
 	);
 
 	let baseBranchIsUpdating = $state<boolean>(false);
+	const baseBranchConflicted = $derived(base.conflicted);
 	let updateTargetModal = $state<Modal>();
 	let resetBaseStrategy = $state<ResetBaseStrategy | undefined>(undefined);
 	let confirmResetModal = $state<Modal>();
@@ -73,6 +74,12 @@
 	let integrateUpstreamModal = $state<IntegrateUpstreamModal>();
 	const integrateUpstreamModalOpen = $derived(!!integrateUpstreamModal?.imports.open);
 	let mergeUpstreamWarningDismissedCheckbox = $state<boolean>(false);
+
+	const pushButtonTooltip = $derived.by(() => {
+		if (onlyLocalAhead) return 'Push your local changes to upstream';
+		if (base.conflicted) return 'Cannot push while there are conflicts';
+		return resetBaseTo.local.tooltip;
+	});
 
 	const multiple = $derived(
 		base ? base.upstreamCommits.length > 1 || base.upstreamCommits.length === 0 : false
@@ -296,13 +303,12 @@
 						style={resetBaseTo.local.color}
 						icon={onlyLocalAhead ? undefined : 'warning'}
 						kind="solid"
-						tooltip={onlyLocalAhead
-							? 'Push your local changes to upstream'
-							: resetBaseTo.local.tooltip}
+						tooltip={pushButtonTooltip}
 						loading={baseBranchIsUpdating || confirmResetModalOpen}
 						disabled={$mode?.type !== 'OpenWorkspace' ||
 							baseBranchIsUpdating ||
-							confirmResetModalOpen}
+							confirmResetModalOpen ||
+							baseBranchConflicted}
 						onclick={resetBaseTo.local.handler}
 					>
 						{onlyLocalAhead ? 'Push' : resetBaseTo.local.title}

--- a/apps/desktop/src/lib/components/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/lib/components/IntegrateUpstreamModal.svelte
@@ -225,8 +225,8 @@
 										onselect={(value) => {
 											const result = results.get(branch.id)!;
 
-										results.set(branch.id, {...result, approach: { type: value }})
-									}}
+											results.set(branch.id, { ...result, approach: { type: value } });
+										}}
 										options={[
 											{ label: 'Rebase', value: 'rebase' },
 											{ label: 'Merge', value: 'merge' },

--- a/apps/desktop/src/lib/components/UpdateBaseButton.svelte
+++ b/apps/desktop/src/lib/components/UpdateBaseButton.svelte
@@ -15,7 +15,8 @@
 
 	const displayButton = $derived.by(() => {
 		const hasUpstreamCommits = ($base?.upstreamCommits?.length ?? 0) > 0;
-		return hasUpstreamCommits;
+		const diverged = $base?.diverged ?? true;
+		return hasUpstreamCommits && !diverged;
 	});
 
 	let modal = $state<IntegrateUpstreamModal>();

--- a/apps/desktop/src/lib/navigation/TargetCard.svelte
+++ b/apps/desktop/src/lib/navigation/TargetCard.svelte
@@ -18,6 +18,10 @@
 	const base = baseBranchService.base;
 	$: selected = $page.url.href.endsWith('/base');
 	$: baseBranchDiverged = !!$base?.diverged;
+	$: baseBranchAheadOnly = baseBranchDiverged && !!$base?.divergedBehind?.length === false;
+	$: divergenceTooltip = baseBranchAheadOnly
+		? 'Your local target branch is ahead of its upstream'
+		: 'Your local target branch has diverged from its upstream';
 </script>
 
 <DomainButton
@@ -48,9 +52,12 @@
 					</Tooltip>
 				{/if}
 				{#if baseBranchDiverged}
-					<Tooltip text="Your branch has diverged from the target branch">
+					<Tooltip text={divergenceTooltip}>
 						<div>
-							<Icon name="warning" color="warning" />
+							<Icon
+								name={baseBranchAheadOnly ? 'info' : 'warning'}
+								color={baseBranchAheadOnly ? undefined : 'warning'}
+							/>
 						</div>
 					</Tooltip>
 				{/if}

--- a/apps/desktop/src/lib/navigation/TargetCard.svelte
+++ b/apps/desktop/src/lib/navigation/TargetCard.svelte
@@ -17,6 +17,7 @@
 
 	const base = baseBranchService.base;
 	$: selected = $page.url.href.endsWith('/base');
+	$: baseBranchDiverged = !!$base?.diverged;
 </script>
 
 <DomainButton
@@ -41,9 +42,16 @@
 				<Tooltip text="The branch your Workspace branches are based on and merge into.">
 					<span class="text-14 text-semibold trunk-label">Target</span>
 				</Tooltip>
-				{#if ($base?.behind || 0) > 0}
+				{#if ($base?.behind || 0) > 0 && !baseBranchDiverged}
 					<Tooltip text="Unmerged upstream commits">
 						<Badge label={$base?.behind || 0} />
+					</Tooltip>
+				{/if}
+				{#if baseBranchDiverged}
+					<Tooltip text="Your branch has diverged from the target branch">
+						<div>
+							<Icon name="warning" color="warning" />
+						</div>
 					</Tooltip>
 				{/if}
 				<SyncButton />

--- a/apps/desktop/src/lib/utils/array.ts
+++ b/apps/desktop/src/lib/utils/array.ts
@@ -1,6 +1,8 @@
+type Predicate<T> = (item: T) => boolean;
+
 type ItemsSatisfyResult = 'all' | 'some' | 'none';
 
-export function itemsSatisfy<T>(arr: T[], predicate: (item: T) => boolean): ItemsSatisfyResult {
+export function itemsSatisfy<T>(arr: T[], predicate: Predicate<T>): ItemsSatisfyResult {
 	let satisfyCount = 0;
 	let offenseCount = 0;
 	for (const item of arr) {
@@ -29,6 +31,23 @@ export function chunk<T>(arr: T[], size: number) {
 	);
 }
 
-export function unique<T>(arr: T[]): T[] {
-	return Array.from(new Set(arr));
+interface GroupByResult<T> {
+	satisfied: T[];
+	rest: T[];
+}
+
+export function groupByCondition<T>(arr: T[], predicate: Predicate<T>): GroupByResult<T> {
+	const satisfied: T[] = [];
+	const rest: T[] = [];
+
+	for (const item of arr) {
+		if (predicate(item)) {
+			satisfied.push(item);
+			continue;
+		}
+
+		rest.push(item);
+	}
+
+	return { satisfied, rest };
 }

--- a/apps/desktop/src/lib/utils/array.ts
+++ b/apps/desktop/src/lib/utils/array.ts
@@ -51,3 +51,7 @@ export function groupByCondition<T>(arr: T[], predicate: Predicate<T>): GroupByR
 
 	return { satisfied, rest };
 }
+
+export function unique<T>(arr: T[]): T[] {
+	return Array.from(new Set(arr));
+}

--- a/apps/desktop/src/lib/vbranches/types.ts
+++ b/apps/desktop/src/lib/vbranches/types.ts
@@ -228,6 +228,7 @@ export class Commit {
 	changeId!: string;
 	isSigned!: boolean;
 	parentIds!: string[];
+	conflicted!: boolean;
 
 	prev?: Commit;
 	next?: Commit;

--- a/apps/desktop/src/lib/vbranches/upstreamIntegrationService.ts
+++ b/apps/desktop/src/lib/vbranches/upstreamIntegrationService.ts
@@ -37,6 +37,8 @@ export type Resolution = {
 	approach: ResolutionApproach;
 };
 
+export type BaseBranchResolutionApproach = 'rebase' | 'merge' | 'hardReset';
+
 export function getResolutionApproach(statusInfo: BranchStatusInfo): ResolutionApproach {
 	if (statusInfo.status.type === 'fullyIntegrated') {
 		return { type: 'delete' };
@@ -79,7 +81,7 @@ export class UpstreamIntegrationService {
 		private virtualBranchService: VirtualBranchService
 	) {}
 
-	upstreamStatuses(): Readable<BranchStatusesWithBranches | undefined> {
+	upstreamStatuses(_targetId?: string): Readable<BranchStatusesWithBranches | undefined> {
 		const branchStatuses = readable<BranchStatusesResponse | undefined>(undefined, (set) => {
 			invoke<BranchStatusesResponse>('upstream_integration_statuses', {
 				projectId: this.project.id
@@ -115,5 +117,12 @@ export class UpstreamIntegrationService {
 
 	async integrateUpstream(resolutions: Resolution[]) {
 		return await invoke('integrate_upstream', { projectId: this.project.id, resolutions });
+	}
+
+	async resolveUpstreamIntegration(type: BaseBranchResolutionApproach) {
+		return await invoke<string>('resolve_upstream_integration', {
+			projectId: this.project.id,
+			resolutionApproach: { type }
+		});
 	}
 }

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -158,6 +158,11 @@ pub fn set_target_push_remote(project: &Project, push_remote: &str) -> Result<()
     base::set_target_push_remote(&ctx, push_remote)
 }
 
+pub fn push_base_branch(project: &Project, with_force: bool) -> Result<()> {
+    let ctx = CommandContext::open(project)?;
+    base::push(&ctx, with_force)
+}
+
 pub fn integrate_upstream_commits(project: &Project, branch_id: BranchId) -> Result<()> {
     let ctx = open_with_verify(project)?;
     assure_open_workspace_mode(&ctx)

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -1,5 +1,9 @@
 use super::r#virtual as vbranch;
-use crate::upstream_integration::{self, BranchStatuses, Resolution, UpstreamIntegrationContext};
+use crate::move_commits;
+use crate::reorder_commits;
+use crate::upstream_integration::{
+    self, BaseBranchResolutionApproach, BranchStatuses, Resolution, UpstreamIntegrationContext,
+};
 use crate::{
     base,
     base::BaseBranch,
@@ -9,7 +13,6 @@ use crate::{
     remote::{RemoteBranch, RemoteBranchData, RemoteCommit},
     VirtualBranchesExt,
 };
-use crate::{move_commits, reorder_commits};
 use anyhow::{Context, Result};
 use gitbutler_branch::{BranchCreateRequest, BranchId, BranchOwnershipClaims, BranchUpdateRequest};
 use gitbutler_command_context::CommandContext;
@@ -540,6 +543,20 @@ pub fn integrate_upstream(project: &Project, resolutions: &[Resolution]) -> Resu
     upstream_integration::integrate_upstream(
         &command_context,
         resolutions,
+        guard.write_permission(),
+    )
+}
+
+pub fn resolve_upstream_integration(
+    project: &Project,
+    resolution_approach: BaseBranchResolutionApproach,
+) -> Result<git2::Oid> {
+    let command_context = CommandContext::open(project)?;
+    let mut guard = project.exclusive_worktree_access();
+
+    upstream_integration::resolve_upstream_integration(
+        &command_context,
+        resolution_approach,
         guard.write_permission(),
     )
 }

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -647,3 +647,10 @@ pub(crate) fn target_to_base_branch(ctx: &CommandContext, target: &Target) -> Re
 fn default_target(base_path: &Path) -> Result<Target> {
     VirtualBranchesHandle::new(base_path).get_default_target()
 }
+
+pub(crate) fn push(ctx: &CommandContext, with_force: bool) -> Result<()> {
+    ctx.assure_resolved()?;
+    let target = default_target(&ctx.project().gb_dir())?;
+    let _ = ctx.push(target.sha, &target.branch, with_force, None, None);
+    Ok(())
+}

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -8,7 +8,7 @@ pub use actions::{
     get_uncommited_files_reusable, insert_blank_commit, integrate_upstream,
     integrate_upstream_commits, list_local_branches, list_remote_commit_files,
     list_virtual_branches, list_virtual_branches_cached, move_commit, move_commit_file,
-    push_virtual_branch, reorder_commit, reset_files, reset_virtual_branch,
+    push_base_branch, push_virtual_branch, reorder_commit, reset_files, reset_virtual_branch,
     save_and_unapply_virutal_branch, set_base_branch, set_target_push_remote, squash,
     unapply_ownership, unapply_without_saving_virtual_branch, undo_commit, update_base_branch,
     update_branch_order, update_commit_message, update_virtual_branch,

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -9,10 +9,10 @@ pub use actions::{
     integrate_upstream_commits, list_local_branches, list_remote_commit_files,
     list_virtual_branches, list_virtual_branches_cached, move_commit, move_commit_file,
     push_base_branch, push_virtual_branch, reorder_commit, reset_files, reset_virtual_branch,
-    save_and_unapply_virutal_branch, set_base_branch, set_target_push_remote, squash,
-    unapply_ownership, unapply_without_saving_virtual_branch, undo_commit, update_base_branch,
-    update_branch_order, update_commit_message, update_virtual_branch,
-    upstream_integration_statuses,
+    resolve_upstream_integration, save_and_unapply_virutal_branch, set_base_branch,
+    set_target_push_remote, squash, unapply_ownership, unapply_without_saving_virtual_branch,
+    undo_commit, update_base_branch, update_branch_order, update_commit_message,
+    update_virtual_branch, upstream_integration_statuses,
 };
 
 mod r#virtual;

--- a/crates/gitbutler-branch-actions/src/remote.rs
+++ b/crates/gitbutler-branch-actions/src/remote.rs
@@ -55,6 +55,7 @@ pub struct RemoteCommit {
     pub change_id: Option<String>,
     #[serde(with = "gitbutler_serde::oid_vec")]
     pub parent_ids: Vec<git2::Oid>,
+    pub conflicted: bool,
 }
 
 /// Return information on all local branches, while skipping gitbutler-specific branches in `refs/heads`.
@@ -206,6 +207,7 @@ pub(crate) fn commit_to_remote_commit(commit: &git2::Commit) -> RemoteCommit {
         author: commit.author().into(),
         change_id: commit.change_id(),
         parent_ids,
+        conflicted: commit.is_conflicted(),
     }
 }
 

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
@@ -436,7 +436,7 @@ mod conflict_cases {
             )
             .unwrap();
 
-        gitbutler_branch_actions::integrate_upstream(&project, &[]).unwrap();
+        gitbutler_branch_actions::integrate_upstream(&project, &[], None).unwrap();
 
         // Apply B
 
@@ -535,7 +535,7 @@ mod conflict_cases {
             )
             .unwrap();
 
-        gitbutler_branch_actions::integrate_upstream(&project, &[]).unwrap();
+        gitbutler_branch_actions::integrate_upstream(&project, &[], None).unwrap();
 
         // Apply B
 

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -159,6 +159,7 @@ fn main() {
                     virtual_branches::commands::get_base_branch_data,
                     virtual_branches::commands::set_base_branch,
                     virtual_branches::commands::update_base_branch,
+                    virtual_branches::commands::push_base_branch,
                     virtual_branches::commands::integrate_upstream_commits,
                     virtual_branches::commands::update_virtual_branch,
                     virtual_branches::commands::update_branch_order,

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -188,6 +188,7 @@ fn main() {
                     virtual_branches::commands::normalize_branch_name,
                     virtual_branches::commands::upstream_integration_statuses,
                     virtual_branches::commands::integrate_upstream,
+                    virtual_branches::commands::resolve_upstream_integration,
                     virtual_branches::commands::find_commit,
                     stack::create_series,
                     stack::remove_series,

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -176,6 +176,20 @@ pub mod commands {
 
     #[tauri::command(async)]
     #[instrument(skip(projects, windows), err(Debug))]
+    pub fn push_base_branch(
+        windows: State<'_, WindowState>,
+        projects: State<'_, projects::Controller>,
+        project_id: ProjectId,
+        with_force: bool,
+    ) -> Result<(), Error> {
+        let project = projects.get(project_id)?;
+        gitbutler_branch_actions::push_base_branch(&project, with_force)?;
+        emit_vbranches(&windows, project_id);
+        Ok(())
+    }
+
+    #[tauri::command(async)]
+    #[instrument(skip(projects, windows), err(Debug))]
     pub fn update_virtual_branch(
         windows: State<'_, WindowState>,
         projects: State<'_, projects::Controller>,

--- a/packages/ui/src/lib/commitLines/lineManager.ts
+++ b/packages/ui/src/lib/commitLines/lineManager.ts
@@ -1,5 +1,11 @@
 import type { CommitData, LineGroupData, LineData, Color } from '$lib/commitLines/types';
 
+export enum LineSpacer {
+	Remote = 'remote-spacer',
+	Local = 'local-spacer',
+	LocalAndRemote = 'local-and-remote-spacer'
+}
+
 interface Commits {
 	remoteCommits: CommitData[];
 	localCommits: CommitData[];


### PR DESCRIPTION
## ☕️ Reasoning
The application doesn't display any kind of information related to base branch divergence.
It should detect this, raise this to the user and present alternative actions to address this.

### Scenario
1. I open a repository on GitButler.
2. A team-mate of mine makes some changes, and mistakenly pushes a commit with sensitive information.
3. I merge the changes into the local base branch of GitButler. I can see the mistaken commit.
4. They decide to force-push the commit away.
5. I reload the application, but the state is the same as in step 3.

Expected behavior would be to have some information about this and the ability to restore the application to the latest version of the target upstream.

## 🧢 Changes
1. Detect whether the base-branch has diverged with its upstream.
2. Display the information to the user in a way that makes it clear if and which changes will be lost, if any action is taken.
3. Allow the user to decide how to resolve said conflict through the **Integrate Upstream Changes** modal.
4. Detect whether the base-branch has conflicts (e.g. after rebasing your local base-branch changes into the upstream) and display that.

## 📋 TODO
### Allow the user to use edit mode on a base-branch conflict
Since we're allowing the user to rebase or merge changes into the base-branch, we can end up with conflicted commits there.
We already display and signal it, but we need to enable edit mode on base-branch conflicts.