### PR TITLE
ignore lock-errors on filesystems that lack support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2555,7 +2555,6 @@ dependencies = [
  "backtrace",
  "console-subscriber",
  "dirs 5.0.1",
- "fslock",
  "futures",
  "git2",
  "gitbutler-branch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ thiserror = "1.0.63"
 tokio = { version = "1.40.0", default-features = false }
 keyring = "2.3.3"
 anyhow = "1.0.86"
-fslock = "0.2.1"
 parking_lot = "0.12.3"
 futures = "0.3.30"
 toml = "0.8.13"

--- a/crates/gitbutler-project/Cargo.toml
+++ b/crates/gitbutler-project/Cargo.toml
@@ -21,7 +21,7 @@ tracing.workspace = true
 resolve-path = "0.1.0"
 
 # for locking
-fslock.workspace = true
+fslock = "0.2.1"
 
 [[test]]
 name="project"

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -26,7 +26,6 @@ anyhow = "1.0.86"
 backtrace = { version = "0.3.72", optional = true }
 console-subscriber = "0.4.0"
 dirs = "5.0.1"
-fslock.workspace = true
 futures.workspace = true
 git2.workspace = true
 gix = { workspace = true, features = ["max-performance", "blocking-http-transport-curl", "worktree-mutation"] }

--- a/crates/gitbutler-tauri/src/window.rs
+++ b/crates/gitbutler-tauri/src/window.rs
@@ -79,7 +79,7 @@ pub(super) mod state {
         /// The watcher of the currently active project.
         watcher: gitbutler_watcher::WatcherHandle,
         /// An active lock to signal that the entire project is locked for the Window this state belongs to.
-        exclusive_access: fslock::LockFile,
+        exclusive_access: gitbutler_project::access::LockFile,
     }
 
     impl Drop for State {


### PR DESCRIPTION
The same seems to be done in `cargo`.

Fixes #4895

### Tasks

* [x] research
* [x] implementation
* [x] validation - see that it still works

### Notes for the Reviewer

I didn't test it on linux or on btrfs, but assume it will work there. My suggestion is to merge it and have a nightly for testing by @azzamsa .
