### PR TITLE
feat: Add onclick prop to DefaultTargetButton

### DIFF
--- a/apps/desktop/src/lib/branch/DefaultTargetButton.svelte
+++ b/apps/desktop/src/lib/branch/DefaultTargetButton.svelte
@@ -6,7 +6,7 @@
 		onclick: () => void;
 	}
 
-	const { selectedForChanges }: Props = $props();
+	const { selectedForChanges, onclick }: Props = $props();
 </script>
 
 {#if selectedForChanges}


### PR DESCRIPTION
Add onclick prop to DefaultTargetButton component to enable
button functionality. This change allows the component to handle
click events and perform specified actions when the button is
clicked.