### PR TITLE
Improve applying branches

### DIFF
--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -297,7 +297,9 @@ pub fn undo_commit(project: &Project, branch_id: BranchId, commit_oid: git2::Oid
     assure_open_workspace_mode(&ctx).context("Undoing a commit requires open workspace mode")?;
     let mut guard = project.exclusive_worktree_access();
     let snapshot_tree = ctx.project().prepare_snapshot(guard.read_permission());
-    let result: Result<()> = vbranch::undo_commit(&ctx, branch_id, commit_oid).map_err(Into::into);
+    let result: Result<()> = vbranch::undo_commit(&ctx, branch_id, commit_oid)
+        .map(|_| ())
+        .map_err(Into::into);
     let _ = snapshot_tree.and_then(|snapshot_tree| {
         ctx.project().snapshot_commit_undo(
             snapshot_tree,

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -1782,7 +1782,7 @@ pub(crate) fn undo_commit(
     ctx: &CommandContext,
     branch_id: BranchId,
     commit_oid: git2::Oid,
-) -> Result<()> {
+) -> Result<Branch> {
     let vb_state = ctx.project().virtual_branches();
 
     let mut branch = vb_state.get_branch_in_workspace(branch_id)?;
@@ -1824,7 +1824,7 @@ pub(crate) fn undo_commit(
             .context("failed to update gitbutler workspace")?;
     }
 
-    Ok(())
+    Ok(branch)
 }
 
 /// squashes a commit from a virtual branch into its parent.

--- a/crates/gitbutler-branch-actions/tests/extra/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/extra/mod.rs
@@ -1125,8 +1125,7 @@ fn unapply_branch() -> Result<()> {
 
     let (branches, _) = internal::list_virtual_branches(ctx, guard.write_permission())?;
     let branch = &branches.iter().find(|b| b.id == branch1_id).unwrap();
-    // TODO: expect there to be 0 branches
-    assert_eq!(branch.files.len(), 0);
+    assert_eq!(branch.files.len(), 1);
     assert!(branch.active);
 
     Ok(())

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/apply_virtual_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/apply_virtual_branch.rs
@@ -199,10 +199,8 @@ fn rebase_work() {
         let (branches, _) = gitbutler_branch_actions::list_virtual_branches(project).unwrap();
         assert_eq!(branches.len(), 1);
         assert_eq!(branches[0].id, branch1_id);
-        // TODO: Should be 1
-        assert_eq!(branches[0].files.len(), 0);
-        // TODO: Should be 0
-        assert_eq!(branches[0].commits.len(), 1);
+        assert_eq!(branches[0].files.len(), 1);
+        assert_eq!(branches[0].commits.len(), 0);
         assert!(branches[0].active);
         assert!(!branches[0].conflicted);
 

--- a/crates/gitbutler-commit/src/commit_headers.rs
+++ b/crates/gitbutler-commit/src/commit_headers.rs
@@ -70,7 +70,7 @@ impl HasCommitHeaders for git2::Commit<'_> {
 
                 let conflicted = match self.header_field_bytes(V2_CONFLICTED_HEADER) {
                     Ok(value) => {
-                        let value = dbg!(value.as_str())?;
+                        let value = value.as_str()?;
 
                         value.parse::<u64>().ok()
                     }


### PR DESCRIPTION
Applying branches now uses the never-conflicting logic if fearless rebasing is enabled.