### PR TITLE
create a worktree-tree without an intermediate index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2716,6 +2716,7 @@ dependencies = [
  "gix-revision",
  "gix-revwalk 0.15.0",
  "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-status",
  "gix-submodule",
  "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
@@ -3571,6 +3572,28 @@ dependencies = [
  "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "gix-status"
+version = "0.13.0"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-diff",
+ "gix-dir",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-filter",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-index 0.35.0",
+ "gix-object 0.44.0",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-pathspec",
+ "gix-worktree 0.36.0",
+ "portable-atomic",
+ "thiserror",
 ]
 
 [[package]]
@@ -5826,6 +5849,12 @@ dependencies = [
  "tracing",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
 name = "powerfmt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,7 +2345,7 @@ version = "0.0.0"
 dependencies = [
  "assert_cmd",
  "futures",
- "gix-path 0.10.11",
+ "gix-path 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.29.0",
  "rand 0.8.5",
  "serde",
@@ -2682,32 +2682,32 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.66.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "gix-actor 0.32.0",
- "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-command",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-config",
  "gix-credentials",
  "gix-date 0.9.0",
  "gix-diff",
  "gix-dir",
  "gix-discover 0.35.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-filter",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-ignore 0.11.4 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-ignore 0.11.4 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-index 0.35.0",
- "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-negotiate",
  "gix-object 0.44.0",
  "gix-odb",
  "gix-pack",
- "gix-path 0.10.10",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-pathspec",
  "gix-prompt",
  "gix-protocol",
@@ -2715,14 +2715,14 @@ dependencies = [
  "gix-refspec",
  "gix-revision",
  "gix-revwalk 0.15.0",
- "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-submodule",
- "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-trace 0.1.9",
+ "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-transport",
  "gix-traverse 0.41.0",
  "gix-url",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-validate 0.9.0",
  "gix-worktree 0.36.0",
  "gix-worktree-state",
@@ -2748,11 +2748,11 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.32.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
  "gix-date 0.9.0",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "itoa 1.0.11",
  "thiserror",
  "winnow 0.6.18",
@@ -2766,9 +2766,9 @@ checksum = "ebccbf25aa4a973dd352564a9000af69edca90623e8a16dad9cbc03713131311"
 dependencies = [
  "bstr",
  "gix-glob 0.16.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.10.11",
+ "gix-path 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "gix-quote 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-trace 0.1.10",
+ "gix-trace 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "kstring",
  "smallvec",
  "thiserror",
@@ -2778,13 +2778,13 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.22.5"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-path 0.10.10",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-trace 0.1.9",
+ "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "kstring",
  "smallvec",
  "thiserror",
@@ -2803,7 +2803,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.11"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "thiserror",
 ]
@@ -2820,7 +2820,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.8"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "thiserror",
 ]
@@ -2828,11 +2828,11 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.3.9"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
- "gix-path 0.10.10",
- "gix-trace 0.1.9",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "shell-words",
 ]
 
@@ -2853,12 +2853,12 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.24.3"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
- "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "memmap2",
  "thiserror",
 ]
@@ -2866,15 +2866,15 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.40.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-path 0.10.10",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-ref 0.47.0",
- "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "memchr",
  "once_cell",
  "smallvec",
@@ -2886,11 +2886,11 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.14.8"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-path 0.10.10",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "libc",
  "thiserror",
 ]
@@ -2898,15 +2898,15 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.24.5"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-config-value",
- "gix-path 0.10.10",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-prompt",
- "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-trace 0.1.9",
+ "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-url",
  "thiserror",
 ]
@@ -2926,7 +2926,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.9.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
  "itoa 1.0.11",
@@ -2937,17 +2937,17 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.46.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-filter",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-object 0.44.0",
- "gix-path 0.10.10",
- "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-trace 0.1.9",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-worktree 0.36.0",
  "imara-diff",
  "thiserror",
@@ -2956,18 +2956,18 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.8.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
  "gix-discover 0.35.0",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-ignore 0.11.4 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-ignore 0.11.4 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-index 0.35.0",
  "gix-object 0.44.0",
- "gix-path 0.10.10",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-pathspec",
- "gix-trace 0.1.9",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-worktree 0.36.0",
  "thiserror",
 ]
@@ -2982,7 +2982,7 @@ dependencies = [
  "dunce",
  "gix-fs 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gix-hash 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.10.11",
+ "gix-path 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "gix-ref 0.44.1",
  "gix-sec 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
@@ -2991,15 +2991,15 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.35.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
  "dunce",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-path 0.10.10",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-ref 0.47.0",
- "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "thiserror",
 ]
 
@@ -3010,7 +3010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac7045ac9fe5f9c727f38799d002a7ed3583cd777e3322a7c4b43e3cf437dc69"
 dependencies = [
  "gix-hash 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-trace 0.1.10",
+ "gix-trace 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "gix-utils 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
  "prodash 28.0.0",
@@ -3021,15 +3021,15 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.38.2"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bytes",
  "crc32fast",
  "crossbeam-channel",
  "flate2",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-trace 0.1.9",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "libc",
  "once_cell",
  "parking_lot 0.12.3",
@@ -3043,19 +3043,19 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.13.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
  "encoding_rs",
- "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-command",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-object 0.44.0",
  "gix-packetline-blocking",
- "gix-path 0.10.10",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-trace 0.1.9",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "smallvec",
  "thiserror",
 ]
@@ -3074,11 +3074,11 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.11.3"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "fastrand 2.1.1",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
 ]
 
 [[package]]
@@ -3090,18 +3090,18 @@ dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "gix-features 0.38.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.10.11",
+ "gix-path 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gix-glob"
 version = "0.16.5"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-path 0.10.10",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
 ]
 
 [[package]]
@@ -3117,7 +3117,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.14.2"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "faster-hex",
  "thiserror",
@@ -3137,9 +3137,9 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.5.2"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "hashbrown 0.14.5",
  "parking_lot 0.12.3",
 ]
@@ -3152,20 +3152,20 @@ checksum = "e447cd96598460f5906a0f6c75e950a39f98c2705fc755ad2f2020c9e937fab7"
 dependencies = [
  "bstr",
  "gix-glob 0.16.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.10.11",
- "gix-trace 0.1.10",
+ "gix-path 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-trace 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-bom",
 ]
 
 [[package]]
 name = "gix-ignore"
 version = "0.11.4"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-path 0.10.10",
- "gix-trace 0.1.9",
+ "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "unicode-bom",
 ]
 
@@ -3200,20 +3200,20 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.35.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "filetime",
  "fnv",
- "gix-bitmap 0.2.11 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-bitmap 0.2.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-object 0.44.0",
  "gix-traverse 0.41.0",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-validate 0.9.0",
  "hashbrown 0.14.5",
  "itoa 1.0.11",
@@ -3238,22 +3238,22 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "14.0.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
- "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-negotiate"
 version = "0.15.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bitflags 2.6.0",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-object 0.44.0",
  "gix-revwalk 0.15.0",
  "smallvec",
@@ -3282,14 +3282,15 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.44.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
  "gix-actor 0.32.0",
  "gix-date 0.9.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-validate 0.9.0",
  "itoa 1.0.11",
  "smallvec",
@@ -3300,17 +3301,18 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.63.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "arc-swap",
  "gix-date 0.9.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-object 0.44.0",
  "gix-pack",
- "gix-path 0.10.10",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "parking_lot 0.12.3",
  "tempfile",
  "thiserror",
@@ -3319,16 +3321,16 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.53.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "clru",
- "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-object 0.44.0",
- "gix-path 0.10.10",
- "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "memmap2",
  "parking_lot 0.12.3",
  "smallvec",
@@ -3339,34 +3341,22 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.17.6"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.9",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.17.5"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.9",
- "thiserror",
-]
-
-[[package]]
-name = "gix-path"
-version = "0.10.10"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
-dependencies = [
- "bstr",
- "gix-trace 0.1.9",
- "home",
- "once_cell",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "thiserror",
 ]
 
@@ -3377,7 +3367,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebfc4febd088abdcbc9f1246896e57e37b7a34f6909840045a1767c6dafac7af"
 dependencies = [
  "bstr",
- "gix-trace 0.1.10",
+ "gix-trace 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "home",
+ "once_cell",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.10.11"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
+dependencies = [
+ "bstr",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "home",
  "once_cell",
  "thiserror",
@@ -3386,21 +3388,21 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.7.7"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-config-value",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-path 0.10.10",
+ "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-prompt"
 version = "0.8.7"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -3412,15 +3414,15 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.45.3"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
  "gix-credentials",
  "gix-date 0.9.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-transport",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "maybe-async",
  "thiserror",
  "winnow 0.6.18",
@@ -3440,10 +3442,10 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.4.12"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "thiserror",
 ]
 
@@ -3460,7 +3462,7 @@ dependencies = [
  "gix-hash 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gix-lock 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gix-object 0.42.3",
- "gix-path 0.10.11",
+ "gix-path 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "gix-tempfile 14.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gix-utils 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "gix-validate 0.8.5",
@@ -3472,17 +3474,17 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.47.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "gix-actor 0.32.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-object 0.44.0",
- "gix-path 0.10.10",
- "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-validate 0.9.0",
  "memmap2",
  "thiserror",
@@ -3492,10 +3494,10 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.25.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-revision",
  "gix-validate 0.9.0",
  "smallvec",
@@ -3505,17 +3507,17 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.29.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-object 0.44.0",
  "gix-revwalk 0.15.0",
- "gix-trace 0.1.9",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "thiserror",
 ]
 
@@ -3537,12 +3539,12 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.15.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-object 0.44.0",
  "smallvec",
  "thiserror",
@@ -3555,7 +3557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fe4d52f30a737bbece5276fab5d3a8b276dc2650df963e293d0673be34e7a5f"
 dependencies = [
  "bitflags 2.6.0",
- "gix-path 0.10.11",
+ "gix-path 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -3563,10 +3565,10 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.10.8"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bitflags 2.6.0",
- "gix-path 0.10.10",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -3574,11 +3576,11 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.14.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
  "gix-config",
- "gix-path 0.10.10",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
@@ -3603,10 +3605,10 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "14.0.2"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "dashmap",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "libc",
  "once_cell",
  "parking_lot 0.12.3",
@@ -3641,32 +3643,32 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.9"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
-dependencies = [
- "tracing-core",
-]
-
-[[package]]
-name = "gix-trace"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cae0e8661c3ff92688ce1c8b8058b3efb312aba9492bbe93661a21705ab431b"
 
 [[package]]
+name = "gix-trace"
+version = "0.1.10"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
+dependencies = [
+ "tracing-core",
+]
+
+[[package]]
 name = "gix-transport"
 version = "0.42.3"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "base64 0.22.1",
  "bstr",
  "curl",
  "gix-command",
  "gix-credentials",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-packetline",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-url",
  "thiserror",
 ]
@@ -3691,13 +3693,13 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.41.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bitflags 2.6.0",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-object 0.44.0",
  "gix-revwalk 0.15.0",
  "smallvec",
@@ -3707,11 +3709,11 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.27.5"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-path 0.10.10",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "thiserror",
  "url",
 ]
@@ -3729,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.1.12"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
  "fastrand 2.1.1",
@@ -3749,7 +3751,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.9.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
  "thiserror",
@@ -3770,42 +3772,42 @@ dependencies = [
  "gix-ignore 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "gix-index 0.33.1",
  "gix-object 0.42.3",
- "gix-path 0.10.11",
+ "gix-path 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "gix-validate 0.8.5",
 ]
 
 [[package]]
 name = "gix-worktree"
 version = "0.36.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
- "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-ignore 0.11.4 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-ignore 0.11.4 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-index 0.35.0",
  "gix-object 0.44.0",
- "gix-path 0.10.10",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-validate 0.9.0",
 ]
 
 [[package]]
 name = "gix-worktree-state"
 version = "0.13.0"
-source = "git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647#0fe5133598c6f843fb3172a4e0c4f58932405647"
+source = "git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a#72daa46bad9d397ef2cc48a3cffda23f414ccd8a"
 dependencies = [
  "bstr",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-filter",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=0fe5133598c6f843fb3172a4e0c4f58932405647)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-index 0.35.0",
  "gix-object 0.44.0",
- "gix-path 0.10.10",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=72daa46bad9d397ef2cc48a3cffda23f414ccd8a)",
  "gix-worktree 0.36.0",
  "io-close",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ resolver = "2"
 [workspace.dependencies]
 bstr = "1.10.0"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
-gix = { git = "https://github.com/Byron/gitoxide", rev = "0fe5133598c6f843fb3172a4e0c4f58932405647", default-features = false, features = [] }
+gix = { git = "https://github.com/Byron/gitoxide", rev = "72daa46bad9d397ef2cc48a3cffda23f414ccd8a", default-features = false, features = [] }
 git2 = { version = "0.18.3", features = [
     "vendored-openssl",
     "vendored-libgit2",

--- a/crates/gitbutler-repo/Cargo.toml
+++ b/crates/gitbutler-repo/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 git2.workspace = true
-gix.workspace = true
+gix = { workspace = true, features = ["status", "tree-editor"] }
 anyhow = "1.0.86"
 bstr.workspace = true
 tokio = { workspace = true, features = [


### PR DESCRIPTION
Initially I didn't know where it would be beneficial to use `gitoxide` tree editing capabilities, but now found `create_wd_tree()` as candidate.

Despite not exactly knowing why it's needed when applying a branch, it's easy for me to trigger it this way, while noting that it's also used
in many other places.

### Baseline

735ms as baseline in the `GitLab` repository is quite respectable!

```
INFO     create_virtual_branch_from_branch [ 2.05s | 0.02% / 100.00% ] project_id: d4abe90e-4fed-4d86-bb80-048e3740f003 | branch: Local(Refname { branch: "Virtual-branch", remote: None }) | remote: None
DEBUG    ┕━ create_virtual_branch_from_branch [ 2.05s | 9.48% / 99.98% ] branch: Local(Refname { branch: "Virtual-branch", remote: None }) | remote: None
INFO        ┝━ create_snapshot [ 102ms | 4.97% ]
DEBUG       ┕━ apply_branch [ 1.75s | 0.02% / 85.53% ] branch_id: a5d78a15-5777-471f-be76-a8dcfe578d9c
DEBUG          ┕━ finalize [ 1.75s | 36.14% / 85.51% ]
DEBUG             ┝━ create_wd_tree [ 735ms | 35.84% ]     <-------------------- Before
DEBUG             ┕━ update_workspace_commit [ 277ms | 5.58% / 13.52% ]
DEBUG                ┕━ get_workspace_head [ 163ms | 7.95% ]
```

### After

**Now it runs slightly faster at 549ms for a 33% speedup.** However, the is likely going to be faster once it actually has to add objects, as these are now added in the main thread, while another thread is producing the status information.

```
INFO     create_virtual_branch_from_branch [ 1.88s | 0.03% / 100.00% ] project_id: d4abe90e-4fed-4d86-bb80-048e3740f003 | branch: Local(Refname { branch: "Virtual-branch", remote: None }) | remote: None
DEBUG    ┕━ create_virtual_branch_from_branch [ 1.88s | 10.48% / 99.97% ] branch: Local(Refname { branch: "Virtual-branch", remote: None }) | remote: None
INFO        ┝━ create_snapshot [ 99.4ms | 5.30% ]
DEBUG       ┕━ apply_branch [ 1.58s | 0.02% / 84.19% ] branch_id: 1f725f79-8a3c-4c8b-a2ce-cd5a7f8fd15a
DEBUG          ┕━ finalize [ 1.58s | 39.59% / 84.17% ]
DEBUG             ┝━ create_wd_tree [ 549ms | 29.29% ]  <------------------- After
DEBUG             ┕━ update_workspace_commit [ 287ms | 6.31% / 15.30% ]
DEBUG                ┕━ get_workspace_head [ 169ms | 8.99% ]
```

### Tasks

* [x] use `gix`
* [x] remeasure performance

### Notes for the Reviewer

* This PR adds a lot of complexity to what was 4 lines of code previously. In return, one gets performance, more even when it's actually adding objects, and control over every aspect of the operation, an operation that essentially is a manual `index.add_all()`. The 'control' part is particularly interesting as eventually, I'd really hope it's possible to avoid adding worktree files without user request.
* My intuition here is that it probably should skip large files right away, but for now I left it like it was to keep the PR focussed.
* Should IO errors be ignored to make this method more resilient? I don't know what that means for correctness though.