### PR TITLE
fix: Only allow hunk selection in uncommited files

### DIFF
--- a/apps/desktop/src/lib/branch/BranchLane.svelte
+++ b/apps/desktop/src/lib/branch/BranchLane.svelte
@@ -122,7 +122,7 @@
 					conflicted={selected.conflicted}
 					file={selected}
 					readonly={selected instanceof RemoteFile}
-					selectable={$commitBoxOpen}
+					selectable={$commitBoxOpen && commitId === undefined}
 					{commitId}
 					on:close={() => {
 						fileIdSelection.clear();


### PR DESCRIPTION
Files hunks from the commits should not be selectable