### PR TITLE
fix: actions initialization for CommitDragItem

### DIFF
--- a/apps/desktop/src/lib/commit/CommitDragItem.svelte
+++ b/apps/desktop/src/lib/commit/CommitDragItem.svelte
@@ -17,12 +17,9 @@
 
 	const branch = maybeGetContextStore(VirtualBranch);
 
-	let actions = $state<CommitDragActions>();
-	$effect.pre(() => {
-		if (!$branch) return;
-
-		actions = commitDragActionsFactory.build($branch, commit);
-	});
+	const actions = $derived<CommitDragActions | undefined>(
+		$branch && commitDragActionsFactory.build($branch, commit)
+	);
 </script>
 
 <div class="dropzone-wrapper">


### PR DESCRIPTION
Use a derived store to compute actions based on the branch and commit, 
removing the need for a side effect. This enhances readability and 
ensures that actions are updated reactively whenever dependencies change.