### PR TITLE
fix: rm `effect.pre` used only to avoid previous bug

### DIFF
--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -116,8 +116,7 @@
 	// Refresh base branch if git fetch event is detected.
 	const mode = $derived(modeService.mode);
 	const head = $derived(modeService.head);
-	// We end up with a `state_unsafe_mutation` when switching projects if we
-	// don't use $effect.pre here.
+
 	// TODO: can we eliminate the need to debounce?
 	const fetch = $derived(fetchSignal.event);
 	const debouncedBaseBranchRefresh = debounce(() => baseBranchService.refresh(), 500);

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -120,18 +120,18 @@
 	// don't use $effect.pre here.
 	// TODO: can we eliminate the need to debounce?
 	const fetch = $derived(fetchSignal.event);
-	const debouncedBaseBranchResfresh = debounce(() => baseBranchService.refresh(), 500);
-	$effect.pre(() => {
-		if ($fetch || $head) debouncedBaseBranchResfresh();
+	const debouncedBaseBranchRefresh = debounce(() => baseBranchService.refresh(), 500);
+	$effect(() => {
+		if ($fetch || $head) debouncedBaseBranchRefresh();
 	});
 
 	// TODO: can we eliminate the need to debounce?
 	const debouncedRemoteBranchRefresh = debounce(() => remoteBranchService.refresh(), 500);
-	$effect.pre(() => {
+	$effect(() => {
 		if ($baseBranch || $head || $fetch) debouncedRemoteBranchRefresh();
 	});
 
-	$effect.pre(() => {
+	$effect(() => {
 		const gitHost =
 			repoInfo && baseBranchName
 				? gitHostFactory.build(repoInfo, baseBranchName, forkInfo)


### PR DESCRIPTION
- Remove `$effect.pre` usage in `+layout.svelte` where we were using it to avoid a previous bug