### PR TITLE
HunkDiff: Display a lock if needed

### DIFF
--- a/apps/desktop/src/lib/hunk/HunkDiff.svelte
+++ b/apps/desktop/src/lib/hunk/HunkDiff.svelte
@@ -360,6 +360,9 @@
 									}}
 								/>
 							{/if}
+							{#if hunk.locked}
+								<Icon name="locked-small" color="warning" />
+							{/if}
 						</div>
 						<div
 							class="table__title-content"
@@ -481,6 +484,7 @@
 	.table__checkbox {
 		padding: 4px 6px;
 		display: flex;
+		justify-content: space-between;
 		align-items: center;
 	}
 


### PR DESCRIPTION
Show a lock icon if the hunk in question is locked to this lane:

<img width="482" alt="Screenshot 2024-09-17 at 15 20 26" src="https://github.com/user-attachments/assets/1afa03b1-ffdc-4942-97eb-87c6ee658f49">
