### PR TITLE
refactor: Improve label for unapplying changes in BranchLaneContextMenu

### DIFF
--- a/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
@@ -99,7 +99,7 @@
 		/>
 
 		<ContextMenuItem
-			label="Drop changes and unapply"
+			label="Unapply and drop changes"
 			on:click={async () => {
 				if (
 					branch.name.toLowerCase().includes('virtual branch') &&


### PR DESCRIPTION
Small copy update: I moved 'Unapply' to the first position in 'Drop changes and unapply' because it's consistent and easier to read as 'Unapply and drop changes.' It starts with the previous action ('unapply') and then adds more detail, making it easier to find this line in the list.

![image](https://github.com/user-attachments/assets/56a849e9-1614-43fd-983c-355ad7fff3c3)
