### PR TITLE
fix: Calculate the right file tree when resolving

### DIFF
--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -267,7 +267,11 @@ pub(crate) fn save_and_return_to_workspace(
     let parents = commit.parents().collect::<Vec<_>>();
 
     // Recommit commit
-    let tree = repository.create_wd_tree()?;
+    let mut index = repository.index()?;
+    index.add_all(["*"], git2::IndexAddOption::DEFAULT, None)?;
+    let tree = index.write_tree()?;
+    let tree = repository.find_tree(tree)?;
+
     let commit_headers = commit
         .gitbutler_headers()
         .map(|commit_headers| CommitHeadersV2 {


### PR DESCRIPTION
Get the correct file tree when resolving a conflict