### PR TITLE
The edit branch should not be listed in the side bar

### DIFF
--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -357,6 +357,7 @@ impl GroupBranch<'_> {
 fn should_list_git_branch(identity: &BranchIdentity) -> bool {
     // Exclude gitbutler technical branches (not useful for the user)
     const TECHNICAL_IDENTITIES: &[&[u8]] = &[
+        b"gitbutler/edit",
         b"gitbutler/workspace",
         b"gitbutler/integration", // Remove me after transition.
         b"gitbutler/target",

--- a/crates/gitbutler-branch-actions/src/remote.rs
+++ b/crates/gitbutler-branch-actions/src/remote.rs
@@ -89,6 +89,7 @@ pub fn list_local_branches(ctx: &CommandContext) -> Result<Vec<RemoteBranch>> {
         if !branch_is_trunk
             && branch.name.branch() != Some("gitbutler/integration") // Remove after rename migration complete.
             && branch.name.branch() != Some("gitbutler/workspace")
+            && branch.name.branch() != Some("gitbutler/edit")
             && branch.name.branch() != Some("gitbutler/target")
         {
             remote_branches.push(branch);


### PR DESCRIPTION
The `gitbutler/edit` branch should not be listed in the side bar of the application