### PR TITLE
fix: submit commit title/desc with `ctrl+Enter` everywhere

### DIFF
--- a/apps/desktop/src/lib/commit/CommitCard.svelte
+++ b/apps/desktop/src/lib/commit/CommitCard.svelte
@@ -165,6 +165,7 @@
 			bind:valid={commitMessageValid}
 			isExpanded={true}
 			cancel={close}
+			commit={submitCommitMessageModal}
 		/>
 	{/snippet}
 	{#snippet controls(close)}

--- a/apps/desktop/src/lib/commit/CommitMessageInput.svelte
+++ b/apps/desktop/src/lib/commit/CommitMessageInput.svelte
@@ -133,6 +133,8 @@
 			return;
 		}
 
+		if (commit && (e.ctrlKey || e.metaKey) && e.key === KeyName.Enter) commit();
+
 		if (e.key === KeyName.Delete && value.length === 0) {
 			e.preventDefault();
 			if (titleTextArea) {


### PR DESCRIPTION
## ☕️ Reasoning

- Feature request from Support
- Also submit the `CommitMessageInput` form in commit edit modal/dialog, just like in the "normal" create commit form. 

## 🧢 Changes

- Pass `commit` prop for submitting commit message modal to the commit card in **edit** modal, just like in **create** commit form.
- Ensure `commit()` is also called when pressing `ctrl + Enter` from the `description` textarea, not just the `summary` (title) textarea


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
