### PR TITLE
Fix state for file selections not propagating

### DIFF
--- a/apps/desktop/src/lib/branch/BranchLane.svelte
+++ b/apps/desktop/src/lib/branch/BranchLane.svelte
@@ -84,7 +84,9 @@
 
 	const project = getContext(Project);
 	const fileIdSelection = new FileIdSelection(project.id, branchFiles);
-	const selectedFile = $derived(fileIdSelection.selectedFile);
+	const selectedFile = fileIdSelection.selectedFile;
+	const commitId = $derived($selectedFile?.[0]);
+	const selected = $derived($selectedFile?.[1]);
 	setContext(FileIdSelection, fileIdSelection);
 
 	const userSettings = getContextStoreBySymbol<Settings>(SETTINGS);
@@ -109,39 +111,37 @@
 <div class="wrapper" data-tauri-drag-region>
 	<BranchCard {commitBoxOpen} {isLaneCollapsed} />
 
-	{#await $selectedFile then [commitId, selected]}
-		{#if selected}
-			<div
-				class="file-preview"
-				bind:this={rsViewport}
-				in:slide={{ duration: 180, easing: quintOut, axis: 'x' }}
-				style:width={`${fileWidth || $defaultFileWidthRem}rem`}
-			>
-				<FileCard
-					isUnapplied={false}
-					conflicted={selected.conflicted}
-					file={selected}
-					readonly={selected instanceof RemoteFile}
-					selectable={$commitBoxOpen && commitId === undefined}
-					{commitId}
-					on:close={() => {
-						fileIdSelection.clear();
-					}}
-				/>
-				<Resizer
-					viewport={rsViewport}
-					direction="right"
-					minWidth={400}
-					defaultLineColor="var(--clr-border-2)"
-					on:width={(e) => {
-						fileWidth = e.detail / (16 * $userSettings.zoom);
-						lscache.set(fileWidthKey + branch.id, fileWidth, 7 * 1440); // 7 day ttl
-						$defaultFileWidthRem = fileWidth;
-					}}
-				/>
-			</div>
-		{/if}
-	{/await}
+	{#if selected}
+		<div
+			class="file-preview"
+			bind:this={rsViewport}
+			in:slide={{ duration: 180, easing: quintOut, axis: 'x' }}
+			style:width={`${fileWidth || $defaultFileWidthRem}rem`}
+		>
+			<FileCard
+				isUnapplied={false}
+				conflicted={selected.conflicted}
+				file={selected}
+				readonly={selected instanceof RemoteFile}
+				selectable={$commitBoxOpen && commitId === undefined}
+				{commitId}
+				on:close={() => {
+					fileIdSelection.clear();
+				}}
+			/>
+			<Resizer
+				viewport={rsViewport}
+				direction="right"
+				minWidth={400}
+				defaultLineColor="var(--clr-border-2)"
+				on:width={(e) => {
+					fileWidth = e.detail / (16 * $userSettings.zoom);
+					lscache.set(fileWidthKey + branch.id, fileWidth, 7 * 1440); // 7 day ttl
+					$defaultFileWidthRem = fileWidth;
+				}}
+			/>
+		</div>
+	{/if}
 </div>
 
 <style lang="postcss">

--- a/apps/desktop/src/lib/components/BranchPreview.svelte
+++ b/apps/desktop/src/lib/components/BranchPreview.svelte
@@ -31,8 +31,9 @@
 	const fileIdSelection = new FileIdSelection(project.id, writable([]));
 	setContext(FileIdSelection, fileIdSelection);
 
-	// eslint-disable-next-line svelte/valid-compile
-	$: selectedFile = fileIdSelection.selectedFile;
+	const selectedFile = fileIdSelection.selectedFile;
+	$: commitId = $selectedFile?.[0];
+	$: selected = $selectedFile?.[1];
 
 	const defaultBranchWidthRem = 30;
 	const laneWidthKey = 'branchPreviewLaneWidth';
@@ -177,20 +178,18 @@
 			/>
 		</div>
 		<div class="base__right">
-			{#await $selectedFile then [commitId, selected]}
-				{#if selected}
-					<FileCard
-						conflicted={selected.conflicted}
-						file={selected}
-						isUnapplied={false}
-						readonly={true}
-						{commitId}
-						on:close={() => {
-							fileIdSelection.clear();
-						}}
-					/>
-				{/if}
-			{/await}
+			{#if selected}
+				<FileCard
+					conflicted={selected.conflicted}
+					file={selected}
+					isUnapplied={false}
+					readonly={true}
+					{commitId}
+					on:close={() => {
+						fileIdSelection.clear();
+					}}
+				/>
+			{/if}
 		</div>
 	</div>
 {:else}

--- a/apps/desktop/src/lib/navigation/Branches.svelte
+++ b/apps/desktop/src/lib/navigation/Branches.svelte
@@ -299,12 +299,6 @@
 	}
 
 	/* BRANCHES LIST */
-
-	.scroll-container {
-		display: flex;
-		flex-direction: column;
-	}
-
 	.group {
 		display: flex;
 		flex-direction: column;

--- a/apps/desktop/src/lib/navigation/Navigation.svelte
+++ b/apps/desktop/src/lib/navigation/Navigation.svelte
@@ -30,8 +30,7 @@
 	let isResizerHovered = false;
 	let isResizerDragging = false;
 
-	// eslint-disable-next-line svelte/valid-compile
-	$: isNavCollapsed = persisted<boolean>(false, 'projectNavCollapsed_' + project.id);
+	const isNavCollapsed = persisted<boolean>(false, 'projectNavCollapsed_' + project.id);
 
 	function toggleNavCollapse() {
 		$isNavCollapsed = !$isNavCollapsed;

--- a/apps/desktop/src/lib/navigation/TargetCard.svelte
+++ b/apps/desktop/src/lib/navigation/TargetCard.svelte
@@ -15,8 +15,7 @@
 	const baseBranchService = getContext(BaseBranchService);
 	const project = getContext(Project);
 
-	// eslint-disable-next-line svelte/valid-compile
-	$: base = baseBranchService.base;
+	const base = baseBranchService.base;
 	$: selected = $page.url.href.endsWith('/base');
 </script>
 

--- a/apps/desktop/src/lib/utils/flattenPromises.ts
+++ b/apps/desktop/src/lib/utils/flattenPromises.ts
@@ -1,0 +1,17 @@
+import { derived, type Readable } from 'svelte/store';
+
+export function flattenPromises<T>(readable: Readable<Promise<T>>): Readable<T | undefined> {
+	return derived(readable, (value, set) => {
+		let discarded = false;
+
+		value.then((value) => {
+			// Don't try to set after the readable has been disposed of
+			if (discarded) return;
+			set(value);
+		});
+
+		return () => {
+			discarded = true;
+		};
+	});
+}

--- a/apps/desktop/src/lib/utils/selectFilesInList.ts
+++ b/apps/desktop/src/lib/utils/selectFilesInList.ts
@@ -22,6 +22,7 @@ export function selectFilesInList(
 			fileIdSelection.add(file.id, commit?.id);
 		}
 	} else if (e.shiftKey && allowMultiple) {
+		// TODO(CTO): Not sure that this is accurate.
 		const initiallySelectedIndex = sortedFiles.findIndex(
 			(f) => f.id === fileIdSelection.only()?.fileId
 		);

--- a/apps/desktop/src/lib/vbranches/fileIdSelection.ts
+++ b/apps/desktop/src/lib/vbranches/fileIdSelection.ts
@@ -33,7 +33,7 @@ export type SelectedFile = {
 
 type CallBack = (value: string[]) => void;
 
-export class FileIdSelection {
+export class FileIdSelection implements Readable<string[]> {
 	private value: string[];
 	private callbacks: CallBack[];
 
@@ -52,7 +52,7 @@ export class FileIdSelection {
 		return () => this.unsubscribe(callback);
 	}
 
-	unsubscribe(callback: CallBack) {
+	private unsubscribe(callback: CallBack) {
 		this.callbacks = this.callbacks.filter((cb) => cb !== callback);
 	}
 
@@ -73,10 +73,6 @@ export class FileIdSelection {
 		this.emit();
 	}
 
-	map<T>(callback: (fileId: string) => T) {
-		return this.value.map((fileKey) => callback(fileKey));
-	}
-
 	set(values: string[]) {
 		this.value = values;
 		this.emit();
@@ -92,7 +88,7 @@ export class FileIdSelection {
 		this.emit();
 	}
 
-	emit() {
+	private emit() {
 		for (const callback of this.callbacks) {
 			callback(this.value);
 		}
@@ -145,10 +141,6 @@ export class FileIdSelection {
 		this.#files = flattenPromises(files);
 
 		return this.#files;
-	}
-
-	get length() {
-		return this.value.length;
 	}
 }
 

--- a/apps/desktop/src/routes/[projectId]/base/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/base/+page.svelte
@@ -24,14 +24,15 @@
 	const fileIdSelection = new FileIdSelection(project.id, writable([]));
 	setContext(FileIdSelection, fileIdSelection);
 
-	// eslint-disable-next-line svelte/valid-compile
-	$: selectedFile = fileIdSelection.selectedFile;
+	const selectedFile = fileIdSelection.selectedFile;
+
+	$: commitId = $selectedFile?.[0];
+	$: selected = $selectedFile?.[1];
 
 	let rsViewport: HTMLDivElement;
 	let laneWidth: number;
 
-	// eslint-disable-next-line svelte/valid-compile
-	$: error = baseBranchService.error;
+	const error = baseBranchService.error;
 
 	onMount(() => {
 		laneWidth = lscache.get(laneWidthKey);
@@ -65,20 +66,18 @@
 			/>
 		</div>
 		<div class="base__right">
-			{#await $selectedFile then [commitId, selected]}
-				{#if selected}
-					<FileCard
-						conflicted={selected.conflicted}
-						file={selected}
-						isUnapplied={false}
-						readonly={true}
-						{commitId}
-						on:close={() => {
-							fileIdSelection.clear();
-						}}
-					/>
-				{/if}
-			{/await}
+			{#if selected}
+				<FileCard
+					conflicted={selected.conflicted}
+					file={selected}
+					isUnapplied={false}
+					readonly={true}
+					{commitId}
+					on:close={() => {
+						fileIdSelection.clear();
+					}}
+				/>
+			{/if}
 		</div>
 	</div>
 {/if}

--- a/apps/desktop/src/routes/[projectId]/board/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/board/+page.svelte
@@ -38,11 +38,13 @@
 	const modeService = getContext(ModeService);
 	const mode = modeService.mode;
 
-	$: {
-		if ($mode?.type === 'Edit') {
-			// eslint-disable-next-line svelte/valid-compile
-			goto(`/${project.id}/edit`);
-		}
+	function gotoEdit() {
+		goto(`/${project.id}/edit`);
+	}
+
+	$: if ($mode?.type === 'Edit') {
+		// That was causing an incorrect linting error when project.id was accessed inside the reactive block
+		gotoEdit();
 	}
 </script>
 


### PR DESCRIPTION
Please could the reviewer pay extra attention to the changes made in the files `apps/desktop/src/lib/file/FileListItem.svelte` and `apps/desktop/src/lib/vbranches/fileIdSelection.ts`.

This pr closes the issue about dragging some hunks and then the remaining file, but there seems to still be some problems related to the file selection which I'd like to resolve tomorrow in a separate PR.
* Closes https://github.com/gitbutlerapp/gitbutler/issues/4934

I've noticed that there is a strange behavior where:
- If you select a file/s
- Drag the file/s to another lane
- Drag the file/s back

The files will retain their selected state. Ideally this state should be cleared after a drag as its holding a selected state for files that no longer exist in that lane. This potentially could cause a problematic state, if you dragged two files to the other branch, and then only dragged on back.



