### PR TITLE
fix: Test for integrateUpstreamModal being undefined

### DIFF
--- a/apps/desktop/src/lib/components/BaseBranch.svelte
+++ b/apps/desktop/src/lib/components/BaseBranch.svelte
@@ -67,8 +67,8 @@
 			style="pop"
 			kind="solid"
 			tooltip={`Merges the commits from ${base.branchName} into the base of all applied virtual branches`}
-			disabled={$mode?.type !== 'OpenWorkspace' || integrateUpstreamModal.imports.open}
-			loading={integrateUpstreamModal.imports.open}
+			disabled={$mode?.type !== 'OpenWorkspace' || integrateUpstreamModal?.imports.open}
+			loading={integrateUpstreamModal?.imports.open}
 			onclick={mergeUpstream}
 		>
 			Merge into common base


### PR DESCRIPTION
Don't try to read a property from the integration modal if it's undefined

Weirdly this wasn't caught by eslint at all