### PR TITLE
fix: simplify crates/package.json setup

### DIFF
--- a/crates/gitbutler-tauri/tauri.conf.json
+++ b/crates/gitbutler-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"build": {
-		"beforeDevCommand": "cd ../ && pnpm dev:internal-tauri",
-		"beforeBuildCommand": "[ $CI = true ] || cd ../ && pnpm build:desktop -- --mode development",
+		"beforeDevCommand": "pnpm dev:internal-tauri",
+		"beforeBuildCommand": "[ $CI = true ] || pnpm build:desktop -- --mode development",
 		"devPath": "http://localhost:1420",
 		"distDir": "../../apps/desktop/build",
 		"withGlobalTauri": false

--- a/crates/package.json
+++ b/crates/package.json
@@ -1,4 +1,9 @@
 {
-	"name": "crates",
-	"description": "Required for Vercel / pnpm-workspace CI"
+	"name": "@gitbutler/crates",
+	"description": "Required for Vercel / pnpm-workspace CI",
+	"scripts": {
+		"build:desktop": "pnpm --workspace-root build:desktop",
+		"dev:internal-tauri": "pnpm --workspace-root dev:internal-tauri"
+	},
+	"packageManager": "pnpm@9.5.0"
 }


### PR DESCRIPTION
- Remove `cd ../` from the 1 `tauri.conf.json`
- Support running `build:desktop` and `dev:internal-tauri` from anything inside of `crates/*`
- Add the required npm scripts to the `crates/package.json` and just forward the script to the `--workspace-root` `package.json` basically