### PR TITLE
Add tests for reordering commits

### DIFF
--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -1,4 +1,5 @@
 use super::r#virtual as vbranch;
+use crate::reorder_commits;
 use crate::upstream_integration::{self, BranchStatuses, Resolution, UpstreamIntegrationContext};
 use crate::{
     base,
@@ -372,7 +373,14 @@ pub fn reorder_commit(
         SnapshotDetails::new(OperationKind::ReorderCommit),
         guard.write_permission(),
     );
-    vbranch::reorder_commit(&ctx, branch_id, commit_oid, offset).map_err(Into::into)
+    reorder_commits::reorder_commit(
+        &ctx,
+        branch_id,
+        commit_oid,
+        offset,
+        guard.write_permission(),
+    )
+    .map_err(Into::into)
 }
 
 pub fn reset_virtual_branch(

--- a/crates/gitbutler-branch-actions/src/branch_trees.rs
+++ b/crates/gitbutler-branch-actions/src/branch_trees.rs
@@ -5,6 +5,9 @@ use gitbutler_repo::RepositoryExt as _;
 
 use crate::VirtualBranchesExt as _;
 
+/// Checks out the combined trees of all branches in the workspace.
+///
+/// This function will fail if the applied branches conflict with each other.
 pub(crate) fn checkout_branch_trees<'a>(
     ctx: &'a CommandContext,
     _perm: &mut WorktreeWritePermission,

--- a/crates/gitbutler-branch-actions/src/branch_trees.rs
+++ b/crates/gitbutler-branch-actions/src/branch_trees.rs
@@ -1,0 +1,59 @@
+use anyhow::{bail, Result};
+use gitbutler_command_context::CommandContext;
+use gitbutler_project::access::WorktreeWritePermission;
+use gitbutler_repo::RepositoryExt as _;
+
+use crate::VirtualBranchesExt as _;
+
+pub(crate) fn checkout_branch_trees<'a>(
+    ctx: &'a CommandContext,
+    _perm: &mut WorktreeWritePermission,
+) -> Result<git2::Tree<'a>> {
+    let repository = ctx.repository();
+    let vb_state = ctx.project().virtual_branches();
+    let branches = vb_state.list_branches_in_workspace()?;
+
+    if branches.is_empty() {
+        // If there are no applied branches, then return the current uncommtied state
+        return repository.create_wd_tree();
+    };
+
+    if branches.len() == 1 {
+        let tree = repository.find_tree(branches[0].tree)?;
+        repository
+            .checkout_tree_builder(&tree)
+            .force()
+            .remove_untracked()
+            .checkout()?;
+
+        Ok(tree)
+    } else {
+        let merge_base =
+            repository.merge_base_many(&branches.iter().map(|b| b.head).collect::<Vec<_>>())?;
+
+        let merge_base_tree = repository.find_commit(merge_base)?.tree()?;
+
+        let mut final_tree = merge_base_tree.clone();
+
+        for branch in branches {
+            let theirs = repository.find_tree(branch.tree)?;
+            let mut merge_index =
+                repository.merge_trees(&merge_base_tree, &final_tree, &theirs, None)?;
+
+            if merge_index.has_conflicts() {
+                bail!("There appears to be conflicts between the virtual branches");
+            };
+
+            let tree_oid = merge_index.write_tree_to(repository)?;
+            final_tree = repository.find_tree(tree_oid)?;
+        }
+
+        repository
+            .checkout_tree_builder(&final_tree)
+            .force()
+            .remove_untracked()
+            .checkout()?;
+
+        Ok(final_tree)
+    }
+}

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -43,6 +43,7 @@ pub use remote::{RemoteBranch, RemoteBranchData, RemoteCommit};
 
 pub mod conflicts;
 
+mod branch_trees;
 mod reorder_commits;
 
 mod author;

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -43,6 +43,8 @@ pub use remote::{RemoteBranch, RemoteBranchData, RemoteCommit};
 
 pub mod conflicts;
 
+mod reorder_commits;
+
 mod author;
 mod status;
 use gitbutler_branch::VirtualBranchesHandle;

--- a/crates/gitbutler-branch-actions/src/reorder_commits.rs
+++ b/crates/gitbutler-branch-actions/src/reorder_commits.rs
@@ -6,7 +6,7 @@ use gitbutler_commit::commit_ext::CommitExt as _;
 use gitbutler_project::access::WorktreeWritePermission;
 use gitbutler_repo::{rebase::cherry_rebase_group, LogUntil, RepositoryExt as _};
 
-use crate::VirtualBranchesExt as _;
+use crate::{branch_trees::checkout_branch_trees, VirtualBranchesExt as _};
 
 ///
 /// Presume we had the stack:
@@ -47,7 +47,7 @@ pub(crate) fn reorder_commit(
     branch_id: BranchId,
     subject_commit_oid: git2::Oid,
     offset: i32,
-    _perm: &mut WorktreeWritePermission,
+    perm: &mut WorktreeWritePermission,
 ) -> Result<()> {
     let repository = ctx.repository();
     let vb_state = ctx.project().virtual_branches();
@@ -74,6 +74,8 @@ pub(crate) fn reorder_commit(
 
     branch.updated_timestamp_ms = gitbutler_time::time::now_ms();
     vb_state.set_branch(branch.clone())?;
+
+    checkout_branch_trees(ctx, perm)?;
 
     crate::integration::update_workspace_commit(&vb_state, ctx)
         .context("failed to update gitbutler workspace")?;

--- a/crates/gitbutler-branch-actions/src/reorder_commits.rs
+++ b/crates/gitbutler-branch-actions/src/reorder_commits.rs
@@ -1,0 +1,609 @@
+use anyhow::{bail, Context as _, Result};
+use gitbutler_branch::{signature, BranchId, SignaturePurpose};
+use gitbutler_cherry_pick::RepositoryExt as _;
+use gitbutler_command_context::CommandContext;
+use gitbutler_commit::commit_ext::CommitExt as _;
+use gitbutler_project::access::WorktreeWritePermission;
+use gitbutler_repo::{rebase::cherry_rebase_group, LogUntil, RepositoryExt as _};
+
+use crate::VirtualBranchesExt as _;
+
+///
+/// Presume we had the stack:
+///
+/// A
+/// B
+/// C
+/// D
+///
+/// If C was the subject, and the offset was -1, we would expect:
+///
+/// A
+/// C
+/// B
+/// D
+///
+/// Presume we had the stack:
+///
+/// A
+/// B
+/// C
+/// D
+///
+/// If B was the subject, and the offset was 1, we would expect:
+///
+/// A
+/// C
+/// B
+/// D
+///
+
+// move a given commit in a branch up one or down one
+// if the offset is positive, move the commit down one
+// if the offset is negative, move the commit up one
+// rewrites the branch head to the new head commit
+pub(crate) fn reorder_commit(
+    ctx: &CommandContext,
+    branch_id: BranchId,
+    subject_commit_oid: git2::Oid,
+    offset: i32,
+    _perm: &mut WorktreeWritePermission,
+) -> Result<()> {
+    let repository = ctx.repository();
+    let vb_state = ctx.project().virtual_branches();
+    let default_target = vb_state.get_default_target()?;
+    let default_target_commit = repository
+        .find_reference(&default_target.branch.to_string())?
+        .peel_to_commit()?;
+    let merge_base = repository.merge_base(default_target_commit.id(), subject_commit_oid)?;
+
+    let mut branch = vb_state.get_branch_in_workspace(branch_id)?;
+
+    let ReorderResult { tree, head } = inner_reorder_commit(
+        repository,
+        merge_base,
+        subject_commit_oid,
+        offset,
+        &repository.l(branch.head, LogUntil::Commit(merge_base))?,
+        &repository.find_tree(branch.tree)?,
+        ctx.project().succeeding_rebases,
+    )?;
+
+    branch.tree = tree;
+    branch.head = head;
+
+    branch.updated_timestamp_ms = gitbutler_time::time::now_ms();
+    vb_state.set_branch(branch.clone())?;
+
+    crate::integration::update_workspace_commit(&vb_state, ctx)
+        .context("failed to update gitbutler workspace")?;
+
+    Ok(())
+}
+
+struct ReorderResult {
+    tree: git2::Oid,
+    head: git2::Oid,
+}
+
+/// Commit reordering implemented with libgit2 primatives
+///
+/// This returns a new head commit and tree for the branch.
+///
+/// If the tree ends up in a conflicted state when rebasing the head commit
+/// will actually be the commited tree in a conflicted state, and the tree
+/// will be the auto-resolved tree.
+///
+/// After usage (which should only be in `reorder_commit`), its important to
+/// re-merge all the branch trees together and check that out, as otherwise
+/// the tree writes will be lost.
+///
+/// * `base_commit`: The merge base of the branch head and trunk
+/// * `subject_commit`: The commit to be moved
+/// * `offset`: The offset to move the subject commit by, where
+///     negative is up (towards the branch head) and positive is down
+/// * `branch_commits`: The commits all the commits in the branch.
+/// * `branch_tree`: The tree of the branch
+fn inner_reorder_commit(
+    repository: &git2::Repository,
+    base_commit: git2::Oid,
+    subject_commit: git2::Oid,
+    offset: i32,
+    branch_commits: &[git2::Oid],
+    branch_tree: &git2::Tree,
+    succeeding_rebases: bool,
+) -> Result<ReorderResult> {
+    if branch_commits.len() < 2 {
+        bail!("Cannot re-order less than two commits");
+    };
+
+    if offset == 0 {
+        return Ok(ReorderResult {
+            tree: branch_tree.id(),
+            head: branch_commits[0],
+        });
+    };
+
+    ensure_offset_within_bounds(subject_commit, offset, branch_commits)?;
+
+    let author = signature(SignaturePurpose::Author)?;
+    let committer = signature(SignaturePurpose::Committer)?;
+    let tree_commit = repository.commit(
+        None,
+        &author,
+        &committer,
+        "Uncommited changes",
+        branch_tree,
+        &[&repository.find_commit(branch_commits[0])?],
+    )?;
+
+    let branch_commits = reorder_commit_list(subject_commit, offset, branch_commits)?;
+
+    // Rebase branch commits
+    // We are passing all the commits to the cherry_rebase_group funcion, but
+    // this is not a concern as it will verbaitm copy any commits that have
+    // not had their parents changed.
+    let new_head_oid =
+        cherry_rebase_group(repository, base_commit, &branch_commits, succeeding_rebases)?;
+
+    // Rebase branch tree on top of new stack
+    let new_tree_commit =
+        cherry_rebase_group(repository, new_head_oid, &[tree_commit], succeeding_rebases)?;
+    let new_tree_commit = repository.find_commit(new_tree_commit)?;
+
+    if new_tree_commit.is_conflicted() {
+        Ok(ReorderResult {
+            tree: repository
+                .find_real_tree(&new_tree_commit, Default::default())?
+                .id(),
+            head: new_tree_commit.id(),
+        })
+    } else {
+        Ok(ReorderResult {
+            tree: new_tree_commit.tree_id(),
+            head: new_head_oid,
+        })
+    }
+}
+
+fn reorder_commit_list(
+    subject_commit: git2::Oid,
+    offset: i32,
+    branch_commits: &[git2::Oid],
+) -> Result<Vec<git2::Oid>> {
+    let subject_index = branch_commits
+        .iter()
+        .position(|c| *c == subject_commit)
+        .ok_or(anyhow::anyhow!(
+            "Subject commit not found in branch commits"
+        ))?;
+
+    let mut output = branch_commits.to_owned();
+
+    output.remove(subject_index);
+    output.insert(((subject_index as i32) + offset) as usize, subject_commit);
+
+    Ok(output)
+}
+
+/// Presume we had the stack:
+///
+/// A
+/// B
+/// C // idx 2 // 2 + -1 = 1; 1 < 0 => All good
+/// D
+///
+/// If C was the subject, and the offset was -1, we would expect:
+///
+/// A
+/// C
+/// B
+/// D
+///
+/// Presume we had the stack:
+///
+/// A
+/// B // idx 1 // 1 + 1 = 2; 2 >= 4 => All good
+/// C
+/// D
+///
+/// If B was the subject, and the offset was 1, we would expect:
+///
+/// A
+/// C
+/// B
+/// D
+fn ensure_offset_within_bounds(
+    subject_commit: git2::Oid,
+    offset: i32,
+    branch_commits: &[git2::Oid],
+) -> Result<()> {
+    let subject_index = branch_commits
+        .iter()
+        .position(|c| *c == subject_commit)
+        .ok_or(anyhow::anyhow!(
+            "Subject commit not found in branch commits"
+        ))?;
+
+    if subject_index as i32 + offset < 0 {
+        bail!("Offset is out of bounds");
+    }
+
+    if subject_index as i32 + offset >= branch_commits.len() as i32 {
+        bail!("Offset is out of bounds");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    #[cfg(test)]
+    mod inner_reorder_commit {
+        use gitbutler_cherry_pick::RepositoryExt as _;
+        use gitbutler_commit::commit_ext::CommitExt as _;
+        use gitbutler_repo::LogUntil;
+        use gitbutler_repo::RepositoryExt as _;
+        use gitbutler_testsupport::testing_repository::{assert_tree_matches, TestingRepository};
+
+        #[test]
+        fn less_than_two_commits_is_an_error() {
+            let test_repository = TestingRepository::open();
+
+            let merge_base = test_repository.commit_tree(None, &[("foo.txt", "a")]);
+            let b = test_repository.commit_tree(Some(&merge_base), &[("foo.txt", "b")]);
+
+            let result = crate::reorder_commits::inner_reorder_commit(
+                &test_repository.repository,
+                merge_base.id(),
+                b.id(),
+                0,
+                &[b.id()],
+                &b.tree().unwrap(),
+                true,
+            );
+
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn unconflicting_reorder() {
+            let test_repository = TestingRepository::open();
+
+            let merge_base = test_repository.commit_tree(None, &[("foo.txt", "a")]);
+            // Commit A adds file bar
+            let a = test_repository
+                .commit_tree(Some(&merge_base), &[("foo.txt", "a"), ("bar.txt", "a")]);
+            // Commit B adds file baz
+            let b = test_repository.commit_tree(
+                Some(&a),
+                &[("foo.txt", "a"), ("bar.txt", "a"), ("baz.txt", "a")],
+            );
+
+            dbg!(merge_base.tree_id(), a.tree_id(), b.tree_id());
+
+            let result = crate::reorder_commits::inner_reorder_commit(
+                &test_repository.repository,
+                merge_base.id(),
+                a.id(),
+                -1,
+                &[b.id(), a.id()],
+                &b.tree().unwrap(),
+                true,
+            )
+            .unwrap();
+
+            let a_prime: git2::Commit =
+                test_repository.repository.find_commit(result.head).unwrap();
+            assert!(!a_prime.is_conflicted());
+
+            assert_tree_matches(
+                &test_repository.repository,
+                &a_prime,
+                &[("foo.txt", b"a"), ("bar.txt", b"a"), ("baz.txt", b"a")],
+            );
+
+            let b_prime: git2::Commit = a_prime.parent(0).unwrap();
+            assert!(!b_prime.is_conflicted());
+
+            assert_tree_matches(
+                &test_repository.repository,
+                &b_prime,
+                &[("foo.txt", b"a"), ("baz.txt", b"a")],
+            );
+            assert!(b_prime.tree().unwrap().get_name("bar.txt").is_none());
+
+            // In this case, the tree should be the same as a_prime, as there
+            // were no uncommited files
+            assert_eq!(result.tree, a_prime.tree_id());
+        }
+
+        #[test]
+        fn conflicting_reorder() {
+            let test_repository = TestingRepository::open();
+
+            let merge_base = test_repository.commit_tree(None, &[("foo.txt", "a")]);
+            let a = test_repository.commit_tree(Some(&merge_base), &[("foo.txt", "x")]);
+            let b = test_repository.commit_tree(Some(&a), &[("foo.txt", "y")]);
+
+            // When we re-order a and b, they will conflict.
+            //
+            // Setup:  : Step 1:  : Step 2:  :
+            // B: y    :          : A': x    :
+            // |       :          :          :
+            // A: x    : B': a    : B': a    : <- B' is the auto-resolved tree
+            // |       :          :          :
+            // MB: a   : MB: a    : MB: a    :
+            //
+            // Reorder step 1:
+            // Cherry pick B on top of Merge Base:
+            // Merge trees: Bt and MBt, with base At. The theirs and ours sides
+            // both have changes compared to the base so it conflicts.
+            // We auto resolve to have the content of MBt: "a"
+            //
+            // Reorder step 2:
+            // Cherry pick A on top of B':
+            // Merge trees: At and B't, with base MBt. MBt is unchange relative
+            // to the base, so it merges cleanly to "x".
+
+            let result = crate::reorder_commits::inner_reorder_commit(
+                &test_repository.repository,
+                merge_base.id(),
+                a.id(),
+                -1,
+                &[b.id(), a.id()],
+                &b.tree().unwrap(),
+                true,
+            )
+            .unwrap();
+
+            let a_prime: git2::Commit =
+                test_repository.repository.find_commit(result.head).unwrap();
+            assert!(!a_prime.is_conflicted());
+
+            assert_tree_matches(&test_repository.repository, &a_prime, &[("foo.txt", b"x")]);
+
+            let b_prime: git2::Commit = a_prime.parent(0).unwrap();
+            assert!(b_prime.is_conflicted());
+
+            assert_tree_matches(
+                &test_repository.repository,
+                &b_prime,
+                &[
+                    (".auto-resolution/foo.txt", b"a"),
+                    (".conflict-base-0/foo.txt", b"x"),
+                    (".conflict-side-0/foo.txt", b"a"),
+                    (".conflict-side-1/foo.txt", b"y"),
+                ],
+            );
+
+            // In this case, the tree should be the same as a_prime, as there
+            // were no uncommited files
+            assert_eq!(result.tree, a_prime.tree_id());
+
+            // We should now be able to re-order the commits back back to their
+            // original order and the tree should be the same as the original.
+
+            // When we re-order A' and B', they become unconflicted
+            //
+            // Setup:  : Step 1:  : Step 2:  :
+            // A': y   :          : B'': x   :
+            // |       :          :          :
+            // B': a   : A'': y   : A'': y   : <- B' is the auto-resolved tree
+            // |       :          :          :
+            // MB: a   : MB: a    : MB: a    :
+            //
+            // Reorder step 1:
+            // Cherry pick A'' on top of Merge Base:
+            // Merge trees: A't and MBt, with base B't (auto-resolution. MBt is
+            // unchanged relative to the base, so it merges cleanly to "x".
+            //
+            // Reorder step 2:
+            // Cherry pick B' on top of A'':
+            // Merge trees: A''t and B't (ours == Bt), with base At.
+            // A''t is y, B't is a, and At is y. This is a clean merge.
+
+            let result = crate::reorder_commits::inner_reorder_commit(
+                &test_repository.repository,
+                merge_base.id(),
+                b_prime.id(),
+                -1,
+                &[a_prime.id(), b_prime.id()],
+                &a_prime.tree().unwrap(),
+                true,
+            )
+            .unwrap();
+
+            let b_double_prime: git2::Commit =
+                test_repository.repository.find_commit(result.head).unwrap();
+
+            assert!(!b_double_prime.is_conflicted());
+            assert_eq!(b_double_prime.tree_id(), b.tree_id());
+
+            let a_double_prime: git2::Commit = b_double_prime.parent(0).unwrap();
+
+            assert!(!a_double_prime.is_conflicted());
+            assert_eq!(a_double_prime.tree_id(), a.tree_id());
+        }
+
+        #[test]
+        fn conflicting_tree() {
+            let test_repository = TestingRepository::open();
+
+            let merge_base = test_repository.commit_tree(None, &[("foo.txt", "a")]);
+            let a = test_repository.commit_tree(Some(&merge_base), &[("foo.txt", "x")]);
+            let b = test_repository.commit_tree(Some(&a), &[("foo.txt", "y")]);
+            let tree = test_repository.commit_tree(Some(&b), &[("foo.txt", "z")]);
+
+            let result = crate::reorder_commits::inner_reorder_commit(
+                &test_repository.repository,
+                merge_base.id(),
+                a.id(),
+                -1,
+                &[b.id(), a.id()],
+                &tree.tree().unwrap(),
+                true,
+            )
+            .unwrap();
+
+            let commits: Vec<git2::Commit> = test_repository
+                .repository
+                .log(result.head, LogUntil::Commit(merge_base.id()))
+                .unwrap();
+
+            assert_eq!(
+                commits.len(),
+                3,
+                "The conflicted tree should be come a commit"
+            );
+
+            let tree_commit = &commits[0];
+            let a_prime = &commits[1];
+            let b_prime = &commits[2];
+
+            assert!(tree_commit.is_conflicted());
+            assert!(!a_prime.is_conflicted());
+            assert!(b_prime.is_conflicted());
+
+            assert_eq!(
+                test_repository
+                    .repository
+                    .find_real_tree(tree_commit, Default::default())
+                    .unwrap()
+                    .id(),
+                result.tree,
+                "The tree should be the auto-resolved tree of the tree commit"
+            );
+
+            // Order the commits back to their initial order and all should be
+            // resolved
+            let result = crate::reorder_commits::inner_reorder_commit(
+                &test_repository.repository,
+                merge_base.id(),
+                b_prime.id(),
+                -1,
+                &[tree_commit.id(), a_prime.id(), b_prime.id()],
+                &tree.tree().unwrap(),
+                true,
+            )
+            .unwrap();
+
+            let commits: Vec<git2::Commit> = test_repository
+                .repository
+                .log(result.head, LogUntil::Commit(merge_base.id()))
+                .unwrap();
+
+            assert_eq!(commits.len(), 3);
+
+            let tree_commit = &commits[0];
+            let b_double_prime = &commits[1];
+            let a_double_prime = &commits[2];
+
+            assert!(!tree_commit.is_conflicted());
+            assert!(!b_double_prime.is_conflicted());
+            assert!(!a_double_prime.is_conflicted());
+
+            assert_eq!(tree_commit.tree_id(), result.tree);
+        }
+    }
+
+    #[cfg(test)]
+    mod reorder_commit_list {
+        use gitbutler_testsupport::testing_repository::TestingRepository;
+
+        use crate::reorder_commits::reorder_commit_list;
+
+        #[test]
+        fn move_commit_up() {
+            let test_repository = TestingRepository::open();
+
+            let a = test_repository.commit_tree(None, &[("foo.txt", "a")]).id();
+            let b = test_repository.commit_tree(None, &[("foo.txt", "b")]).id();
+            let c = test_repository.commit_tree(None, &[("foo.txt", "c")]).id();
+            let d = test_repository.commit_tree(None, &[("foo.txt", "d")]).id();
+
+            let branch_commits = reorder_commit_list(c, -1, &[a, b, c, d]).unwrap();
+
+            assert_eq!(branch_commits, &[a, c, b, d]);
+        }
+
+        #[test]
+        fn move_commit_up_to_top() {
+            let test_repository = TestingRepository::open();
+
+            let a = test_repository.commit_tree(None, &[("foo.txt", "a")]).id();
+            let b = test_repository.commit_tree(None, &[("foo.txt", "b")]).id();
+            let c = test_repository.commit_tree(None, &[("foo.txt", "c")]).id();
+            let d = test_repository.commit_tree(None, &[("foo.txt", "d")]).id();
+
+            let branch_commits = reorder_commit_list(c, -2, &[a, b, c, d]).unwrap();
+
+            assert_eq!(branch_commits, &[c, a, b, d]);
+        }
+
+        #[test]
+        fn move_nowhere() {
+            let test_repository = TestingRepository::open();
+
+            let a = test_repository.commit_tree(None, &[("foo.txt", "a")]).id();
+            let b = test_repository.commit_tree(None, &[("foo.txt", "b")]).id();
+            let c = test_repository.commit_tree(None, &[("foo.txt", "c")]).id();
+            let d = test_repository.commit_tree(None, &[("foo.txt", "d")]).id();
+
+            let branch_commits = reorder_commit_list(b, 0, &[a, b, c, d]).unwrap();
+
+            assert_eq!(branch_commits, &[a, b, c, d]);
+        }
+
+        #[test]
+        fn move_commit_down() {
+            let test_repository = TestingRepository::open();
+
+            let a = test_repository.commit_tree(None, &[("foo.txt", "a")]).id();
+            let b = test_repository.commit_tree(None, &[("foo.txt", "b")]).id();
+            let c = test_repository.commit_tree(None, &[("foo.txt", "c")]).id();
+            let d = test_repository.commit_tree(None, &[("foo.txt", "d")]).id();
+
+            let branch_commits = reorder_commit_list(b, 1, &[a, b, c, d]).unwrap();
+
+            assert_eq!(branch_commits, &[a, c, b, d]);
+        }
+
+        #[test]
+        fn move_commit_down_two() {
+            let test_repository = TestingRepository::open();
+
+            let a = test_repository.commit_tree(None, &[("foo.txt", "a")]).id();
+            let b = test_repository.commit_tree(None, &[("foo.txt", "b")]).id();
+            let c = test_repository.commit_tree(None, &[("foo.txt", "c")]).id();
+            let d = test_repository.commit_tree(None, &[("foo.txt", "d")]).id();
+
+            let branch_commits = reorder_commit_list(b, 2, &[a, b, c, d]).unwrap();
+
+            assert_eq!(branch_commits, &[a, c, d, b]);
+        }
+    }
+
+    #[cfg(test)]
+    mod ensure_offset_within_bounds {
+        use crate::reorder_commits::ensure_offset_within_bounds;
+        use gitbutler_testsupport::testing_repository::TestingRepository;
+
+        #[test]
+        fn test() {
+            let test_repository = TestingRepository::open();
+
+            let a = test_repository.commit_tree(None, &[("foo.txt", "a")]).id();
+            let b = test_repository.commit_tree(None, &[("foo.txt", "b")]).id();
+            let c = test_repository.commit_tree(None, &[("foo.txt", "c")]).id();
+            let d = test_repository.commit_tree(None, &[("foo.txt", "d")]).id();
+
+            assert!(ensure_offset_within_bounds(b, -2, &[a, b, c, d]).is_err());
+            assert!(ensure_offset_within_bounds(b, -1, &[a, b, c, d]).is_ok());
+            assert!(ensure_offset_within_bounds(b, 0, &[a, b, c, d]).is_ok());
+            assert!(ensure_offset_within_bounds(b, 1, &[a, b, c, d]).is_ok());
+            assert!(ensure_offset_within_bounds(b, 2, &[a, b, c, d]).is_ok());
+            assert!(ensure_offset_within_bounds(b, 3, &[a, b, c, d]).is_err());
+        }
+    }
+}

--- a/crates/gitbutler-cherry-pick/src/lib.rs
+++ b/crates/gitbutler-cherry-pick/src/lib.rs
@@ -66,18 +66,18 @@ impl RepositoryExt for git2::Repository {
     ) -> Result<git2::Index, anyhow::Error> {
         // we need to do a manual 3-way patch merge
         // find the base, which is the parent of to_rebase
-        let base = if to_rebase.is_conflicted() {
+        let base = dbg!(if to_rebase.is_conflicted() {
             // Use to_rebase's recorded base
             self.find_real_tree(to_rebase, ConflictedTreeKey::Base)?
         } else {
             let base_commit = to_rebase.parent(0)?;
             // Use the parent's auto-resolution
             self.find_real_tree(&base_commit, Default::default())?
-        };
+        });
         // Get the auto-resolution
-        let ours = self.find_real_tree(head, Default::default())?;
+        let ours = dbg!(self.find_real_tree(head, Default::default())?);
         // Get the original theirs
-        let thiers = self.find_real_tree(to_rebase, ConflictedTreeKey::Theirs)?;
+        let thiers = dbg!(self.find_real_tree(to_rebase, ConflictedTreeKey::Theirs)?);
 
         self.merge_trees(&base, &ours, &thiers, merge_options)
             .context("failed to merge trees for cherry pick")

--- a/crates/gitbutler-diff/src/write.rs
+++ b/crates/gitbutler-diff/src/write.rs
@@ -5,6 +5,7 @@ use std::{borrow::Borrow, fs, path::PathBuf};
 use anyhow::{anyhow, Context, Result};
 use bstr::{BString, ByteSlice, ByteVec};
 use diffy::{apply_bytes as diffy_apply, Line, Patch};
+use gitbutler_cherry_pick::RepositoryExt as _;
 use gitbutler_command_context::CommandContext;
 use hex::ToHex;
 
@@ -36,7 +37,7 @@ where
     let git_repository: &git2::Repository = ctx.repository();
 
     let head_commit = git_repository.find_commit(commit_oid)?;
-    let base_tree = head_commit.tree()?;
+    let base_tree = git_repository.find_real_tree(&head_commit, Default::default())?;
 
     hunks_onto_tree(ctx, &base_tree, files, false)
 }

--- a/crates/gitbutler-repo/src/rebase.rs
+++ b/crates/gitbutler-repo/src/rebase.rs
@@ -421,36 +421,11 @@ fn resolve_index(
 
 #[cfg(test)]
 mod test {
-    use std::path::Path;
-
-    use bstr::ByteSlice;
-
-    fn assert_tree_matches(
-        repository: &git2::Repository,
-        commit: &git2::Commit,
-        files: &[(&str, &[u8])],
-    ) {
-        let tree = commit.tree().unwrap();
-
-        for (path, content) in files {
-            let blob = tree.get_path(Path::new(path)).unwrap().id();
-            let blob: git2::Blob = repository.find_blob(blob).unwrap();
-            assert_eq!(
-                blob.content(),
-                *content,
-                "{}: expect {} == {}",
-                path,
-                blob.content().to_str_lossy(),
-                content.to_str_lossy()
-            );
-        }
-    }
-
     #[cfg(test)]
     mod cherry_rebase_group {
-        use crate::{rebase::test::assert_tree_matches, repository_ext::RepositoryExt as _};
+        use crate::repository_ext::RepositoryExt as _;
         use gitbutler_commit::commit_ext::CommitExt;
-        use gitbutler_testsupport::testing_repository::TestingRepository;
+        use gitbutler_testsupport::testing_repository::{assert_tree_matches, TestingRepository};
 
         use crate::{rebase::cherry_rebase_group, LogUntil};
 
@@ -651,9 +626,9 @@ mod test {
 
     #[cfg(test)]
     mod gitbutler_merge_commits {
-        use crate::rebase::{gitbutler_merge_commits, test::assert_tree_matches};
+        use crate::rebase::gitbutler_merge_commits;
         use gitbutler_commit::commit_ext::CommitExt as _;
-        use gitbutler_testsupport::testing_repository::TestingRepository;
+        use gitbutler_testsupport::testing_repository::{assert_tree_matches, TestingRepository};
 
         #[test]
         fn unconflicting_merge() {

--- a/crates/gitbutler-repo/src/rebase.rs
+++ b/crates/gitbutler-repo/src/rebase.rs
@@ -425,7 +425,9 @@ mod test {
     mod cherry_rebase_group {
         use crate::repository_ext::RepositoryExt as _;
         use gitbutler_commit::commit_ext::CommitExt;
-        use gitbutler_testsupport::testing_repository::{assert_tree_matches, TestingRepository};
+        use gitbutler_testsupport::testing_repository::{
+            assert_commit_tree_matches, TestingRepository,
+        };
 
         use crate::{rebase::cherry_rebase_group, LogUntil};
 
@@ -452,7 +454,7 @@ mod test {
 
             assert!(commits.into_iter().all(|commit| !commit.is_conflicted()));
 
-            assert_tree_matches(
+            assert_commit_tree_matches(
                 &test_repository.repository,
                 &commit,
                 &[("foo.txt", b"c"), ("bar.txt", b"x")],
@@ -475,7 +477,7 @@ mod test {
 
             assert!(commit.is_conflicted());
 
-            assert_tree_matches(
+            assert_commit_tree_matches(
                 &test_repository.repository,
                 &commit,
                 &[
@@ -508,7 +510,7 @@ mod test {
 
             assert!(commit.is_conflicted());
 
-            assert_tree_matches(
+            assert_commit_tree_matches(
                 &test_repository.repository,
                 &commit,
                 &[
@@ -537,7 +539,7 @@ mod test {
             let commit: git2::Commit = test_repository.repository.find_commit(result).unwrap();
             assert!(commit.is_conflicted());
 
-            assert_tree_matches(
+            assert_commit_tree_matches(
                 &test_repository.repository,
                 &commit,
                 &[
@@ -555,7 +557,7 @@ mod test {
             let commit: git2::Commit = test_repository.repository.find_commit(result).unwrap();
             assert!(commit.is_conflicted());
 
-            assert_tree_matches(
+            assert_commit_tree_matches(
                 &test_repository.repository,
                 &commit,
                 &[
@@ -591,7 +593,7 @@ mod test {
             assert!(commits.iter().all(|commit| commit.is_conflicted()));
 
             // Rebased version of B (B')
-            assert_tree_matches(
+            assert_commit_tree_matches(
                 &test_repository.repository,
                 &commits[1],
                 &[
@@ -607,7 +609,7 @@ mod test {
             );
 
             // Rebased version of C
-            assert_tree_matches(
+            assert_commit_tree_matches(
                 &test_repository.repository,
                 &commits[0],
                 &[
@@ -628,7 +630,9 @@ mod test {
     mod gitbutler_merge_commits {
         use crate::rebase::gitbutler_merge_commits;
         use gitbutler_commit::commit_ext::CommitExt as _;
-        use gitbutler_testsupport::testing_repository::{assert_tree_matches, TestingRepository};
+        use gitbutler_testsupport::testing_repository::{
+            assert_commit_tree_matches, TestingRepository,
+        };
 
         #[test]
         fn unconflicting_merge() {
@@ -645,7 +649,7 @@ mod test {
 
             assert!(!result.is_conflicted());
 
-            assert_tree_matches(
+            assert_commit_tree_matches(
                 &test_repository.repository,
                 &result,
                 &[("foo.txt", b"b"), ("bar.txt", b"a")],
@@ -667,7 +671,7 @@ mod test {
 
             assert!(result.is_conflicted());
 
-            assert_tree_matches(
+            assert_commit_tree_matches(
                 &test_repository.repository,
                 &result,
                 &[
@@ -711,7 +715,7 @@ mod test {
 
             assert!(!result.is_conflicted());
 
-            assert_tree_matches(
+            assert_commit_tree_matches(
                 &test_repository.repository,
                 &result,
                 &[("foo.txt", b"c"), ("bar.txt", b"a")],
@@ -760,7 +764,7 @@ mod test {
 
             assert!(!result.is_conflicted());
 
-            assert_tree_matches(
+            assert_commit_tree_matches(
                 &test_repository.repository,
                 &result,
                 &[("foo.txt", b"c"), ("bar.txt", b"c")],
@@ -808,7 +812,7 @@ mod test {
 
             assert!(result.is_conflicted());
 
-            assert_tree_matches(
+            assert_commit_tree_matches(
                 &test_repository.repository,
                 &result,
                 &[

--- a/crates/gitbutler-testsupport/src/testing_repository.rs
+++ b/crates/gitbutler-testsupport/src/testing_repository.rs
@@ -81,13 +81,19 @@ impl TestingRepository {
     }
 }
 
-pub fn assert_tree_matches<'a>(
+pub fn assert_commit_tree_matches<'a>(
     repository: &'a git2::Repository,
     commit: &git2::Commit<'a>,
     files: &[(&str, &[u8])],
 ) {
-    let tree = commit.tree().unwrap();
+    assert_tree_matches(repository, &commit.tree().unwrap(), files);
+}
 
+pub fn assert_tree_matches<'a>(
+    repository: &'a git2::Repository,
+    tree: &git2::Tree<'a>,
+    files: &[(&str, &[u8])],
+) {
     for (path, content) in files {
         let blob = tree.get_path(Path::new(path)).unwrap().id();
         let blob: git2::Blob<'a> = repository.find_blob(blob).unwrap();


### PR DESCRIPTION
## ☕️ Reasoning

This moves all the logic for reordering commits in to a `reordering_commits.rs` file. This re-implements reordering with an `inner` function which operates using only libgit2 primitives. As such it should be reasonably easy to re-implement in gix.

It also adds a `checkout_branch_trees` function which merges all the trees of the applied branches and checks them out. This is currently untested as the tests depend on `create_wd_tree` behaving correctly.

## 🧢 Changes


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
