### PR TITLE
fix: migrate Icon.svelte to svelte 5 syntax

### DIFF
--- a/packages/ui/src/lib/Icon.svelte
+++ b/packages/ui/src/lib/Icon.svelte
@@ -15,13 +15,7 @@
 		size?: number;
 	}
 
-	let {
-		name,
-		color = undefined,
-		opacity = 1,
-		spinnerRadius = 5,
-		size = 16
-	}: Props = $props();
+	let { name, color = undefined, opacity = 1, spinnerRadius = 5, size = 16 }: Props = $props();
 </script>
 
 <svg

--- a/packages/ui/src/lib/Icon.svelte
+++ b/packages/ui/src/lib/Icon.svelte
@@ -7,11 +7,21 @@
 	import iconsJson from '$lib/data/icons.json';
 	import type { ComponentColor } from '$lib/utils/colorTypes';
 
-	export let name: keyof typeof iconsJson;
-	export let color: IconColor = undefined;
-	export let opacity: number | undefined = 1;
-	export let spinnerRadius: number | undefined = 5;
-	export let size = 16;
+	interface Props {
+		name: keyof typeof iconsJson;
+		color?: IconColor;
+		opacity?: number | undefined;
+		spinnerRadius?: number | undefined;
+		size?: number;
+	}
+
+	let {
+		name,
+		color = undefined,
+		opacity = 1,
+		spinnerRadius = 5,
+		size = 16
+	}: Props = $props();
 </script>
 
 <svg


### PR DESCRIPTION
## ☕️ Reasoning

- Follow up svelte-5 migration (see: #4989) for the `@gitbutler/ui` package contents 
- Seems only the `Icon.svelte` component wasn't already in Svelte 5/runes syntax

## 🧢 Changes

- Migrate `Icon.svelte` to Svelte 5 runes syntax

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
