### PR TITLE
Custom font support for displaying diffs

### DIFF
--- a/apps/desktop/src/lib/config/uiFeatureFlags.ts
+++ b/apps/desktop/src/lib/config/uiFeatureFlags.ts
@@ -11,11 +11,6 @@ export function featureBaseBranchSwitching(): Persisted<boolean> {
 	return persisted(false, key);
 }
 
-export function featureInlineUnifiedDiffs(): Persisted<boolean> {
-	const key = 'inlineUnifiedDiffs';
-	return persisted(false, key);
-}
-
 export const stackingFeature = persisted(false, 'stackingFeature');
 
 export function featureTopics(): Persisted<boolean> {

--- a/apps/desktop/src/lib/hunk/HunkDiff.svelte
+++ b/apps/desktop/src/lib/hunk/HunkDiff.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { type Row, Operation, type DiffRows } from './types';
-	import { featureInlineUnifiedDiffs } from '$lib/config/uiFeatureFlags';
 	import ScrollableContainer from '$lib/scroll/ScrollableContainer.svelte';
 	import { create } from '$lib/utils/codeHighlight';
 	import { maybeGetContextStore } from '$lib/utils/context';
@@ -27,6 +26,7 @@
 		tabSize: number;
 		diffFont: string;
 		diffLigatures: boolean;
+		inlineUnifiedDiffs: boolean;
 		minWidth: number;
 		draggingDisabled: boolean;
 		onclick: () => void;
@@ -53,6 +53,7 @@
 		tabSize,
 		diffFont,
 		diffLigatures,
+		inlineUnifiedDiffs,
 		minWidth,
 		draggingDisabled = false,
 		onclick,
@@ -73,8 +74,6 @@
 
 	const selected = $derived($selectedOwnership?.isSelected(hunk.filePath, hunk.id) ?? false);
 	let isSelected = $derived(selectable && selected);
-
-	const inlineUnifiedDiffs = featureInlineUnifiedDiffs();
 
 	function charDiff(text1: string, text2: string): { 0: number; 1: string }[] {
 		const differ = new diff_match_patch();
@@ -254,7 +253,7 @@
 				return acc;
 			}
 
-			if ($inlineUnifiedDiffs) {
+			if (inlineUnifiedDiffs) {
 				const rows = computeInlineWordDiff(prevSection, nextSection);
 
 				acc.splice(-prevSection.lines.length);

--- a/apps/desktop/src/lib/hunk/HunkDiff.svelte
+++ b/apps/desktop/src/lib/hunk/HunkDiff.svelte
@@ -25,6 +25,7 @@
 		selectable: boolean;
 		subsections: ContentSection[];
 		tabSize: number;
+		diffFont: string;
 		minWidth: number;
 		draggingDisabled: boolean;
 		onclick: () => void;
@@ -49,12 +50,15 @@
 		selectable,
 		subsections,
 		tabSize,
+		diffFont,
 		minWidth,
 		draggingDisabled = false,
 		onclick,
 		handleSelected,
 		handleLineContextMenu
 	}: Props = $props();
+
+	console.log(minWidth);
 
 	const WHITESPACE_REGEX = /\s/;
 	const NUMBER_COLUMN_WIDTH_PX = minWidth * 20;
@@ -335,11 +339,11 @@
 	bind:clientWidth={tableWidth}
 	bind:clientHeight={tableHeight}
 	class="table__wrapper hide-native-scrollbar"
-	style="--tab-size: {tabSize}"
+	style="--tab-size: {tabSize}; --diff-font: {diffFont};"
 >
 	<ScrollableContainer horz padding={{ left: NUMBER_COLUMN_WIDTH_PX * 2 + 2 }}>
 		<table data-hunk-id={hunk.id} class="table__section">
-			<thead class="table__title">
+			<thead class="table__title" class:draggable={!draggingDisabled}>
 				<tr
 					onclick={() => {
 						selectable && handleSelected(hunk, !isSelected);
@@ -442,7 +446,7 @@
 	table,
 	.table__section {
 		width: 100%;
-		font-family: var(--mono-font-family);
+		font-family: var(--diff-font);
 		border-collapse: separate;
 		border-spacing: 0;
 	}
@@ -494,8 +498,11 @@
 	}
 
 	.table__title {
-		cursor: grab;
 		user-select: none;
+	}
+
+	.draggable {
+		cursor: grab;
 	}
 
 	.table__drag-handle {
@@ -552,7 +559,6 @@
 		width: calc(var(--table-width) - var(--number-col-width));
 		height: calc(100% + var(--border-width) * 2);
 		box-sizing: border-box;
-		font-family: var(--mono-font-family);
 		font-weight: 400;
 		font-size: 12px;
 		padding: 4px 6px;

--- a/apps/desktop/src/lib/hunk/HunkDiff.svelte
+++ b/apps/desktop/src/lib/hunk/HunkDiff.svelte
@@ -26,6 +26,7 @@
 		subsections: ContentSection[];
 		tabSize: number;
 		diffFont: string;
+		diffLigatures: boolean;
 		minWidth: number;
 		draggingDisabled: boolean;
 		onclick: () => void;
@@ -51,6 +52,7 @@
 		subsections,
 		tabSize,
 		diffFont,
+		diffLigatures,
 		minWidth,
 		draggingDisabled = false,
 		onclick,
@@ -340,6 +342,7 @@
 	bind:clientHeight={tableHeight}
 	class="table__wrapper hide-native-scrollbar"
 	style="--tab-size: {tabSize}; --diff-font: {diffFont};"
+	style:font-variant-ligatures={diffLigatures ? 'common-ligatures' : 'none'}
 >
 	<ScrollableContainer horz padding={{ left: NUMBER_COLUMN_WIDTH_PX * 2 + 2 }}>
 		<table data-hunk-id={hunk.id} class="table__section">

--- a/apps/desktop/src/lib/hunk/HunkDiff.svelte
+++ b/apps/desktop/src/lib/hunk/HunkDiff.svelte
@@ -60,8 +60,6 @@
 		handleLineContextMenu
 	}: Props = $props();
 
-	console.log(minWidth);
-
 	const WHITESPACE_REGEX = /\s/;
 	const NUMBER_COLUMN_WIDTH_PX = minWidth * 20;
 	const BORDER_WIDTH = 1;

--- a/apps/desktop/src/lib/hunk/HunkViewer.svelte
+++ b/apps/desktop/src/lib/hunk/HunkViewer.svelte
@@ -93,6 +93,7 @@
 				{draggingDisabled}
 				tabSize={$userSettings.tabSize}
 				diffFont={$userSettings.diffFont}
+				diffLigatures={$userSettings.diffLigatures}
 				hunk={section.hunk}
 				onclick={() => {
 					contextMenu?.close();

--- a/apps/desktop/src/lib/hunk/HunkViewer.svelte
+++ b/apps/desktop/src/lib/hunk/HunkViewer.svelte
@@ -92,6 +92,7 @@
 				{selectable}
 				{draggingDisabled}
 				tabSize={$userSettings.tabSize}
+				diffFont={$userSettings.diffFont}
 				hunk={section.hunk}
 				onclick={() => {
 					contextMenu?.close();

--- a/apps/desktop/src/lib/hunk/HunkViewer.svelte
+++ b/apps/desktop/src/lib/hunk/HunkViewer.svelte
@@ -94,6 +94,7 @@
 				tabSize={$userSettings.tabSize}
 				diffFont={$userSettings.diffFont}
 				diffLigatures={$userSettings.diffLigatures}
+				inlineUnifiedDiffs={$userSettings.inlineUnifiedDiffs}
 				hunk={section.hunk}
 				onclick={() => {
 					contextMenu?.close();

--- a/apps/desktop/src/lib/navigation/ProjectAvatar.svelte
+++ b/apps/desktop/src/lib/navigation/ProjectAvatar.svelte
@@ -36,7 +36,7 @@
 	}
 
 	.avatar-letter text {
-		font-family: 'Inter', sans-serif;
+		font-family: var(--base-font-family);
 		font-weight: 800;
 		font-size: 16px;
 		line-height: 1;

--- a/apps/desktop/src/lib/settings/userSettings.ts
+++ b/apps/desktop/src/lib/settings/userSettings.ts
@@ -20,6 +20,7 @@ export interface Settings {
 	scrollbarVisibilityState: ScrollbarVisilitySettings;
 	tabSize: number;
 	diffFont: string;
+	diffLigatures: boolean;
 }
 
 const defaults: Settings = {
@@ -35,7 +36,8 @@ const defaults: Settings = {
 	zoom: 1,
 	scrollbarVisibilityState: 'scroll',
 	tabSize: 4,
-	diffFont: 'Geist Mono, Menlo, monospace'
+	diffFont: 'Geist Mono, Menlo, monospace',
+	diffLigatures: false
 };
 
 export function loadUserSettings(): Writable<Settings> {

--- a/apps/desktop/src/lib/settings/userSettings.ts
+++ b/apps/desktop/src/lib/settings/userSettings.ts
@@ -21,6 +21,7 @@ export interface Settings {
 	tabSize: number;
 	diffFont: string;
 	diffLigatures: boolean;
+	inlineUnifiedDiffs: boolean;
 }
 
 const defaults: Settings = {
@@ -37,7 +38,8 @@ const defaults: Settings = {
 	scrollbarVisibilityState: 'scroll',
 	tabSize: 4,
 	diffFont: 'Geist Mono, Menlo, monospace',
-	diffLigatures: false
+	diffLigatures: false,
+	inlineUnifiedDiffs: false
 };
 
 export function loadUserSettings(): Writable<Settings> {

--- a/apps/desktop/src/lib/settings/userSettings.ts
+++ b/apps/desktop/src/lib/settings/userSettings.ts
@@ -19,6 +19,7 @@ export interface Settings {
 	zoom: number;
 	scrollbarVisibilityState: ScrollbarVisilitySettings;
 	tabSize: number;
+	diffFont: string;
 }
 
 const defaults: Settings = {
@@ -33,7 +34,8 @@ const defaults: Settings = {
 	stashedBranchesHeight: 150,
 	zoom: 1,
 	scrollbarVisibilityState: 'scroll',
-	tabSize: 4
+	tabSize: 4,
+	diffFont: 'Geist Mono, Menlo, monospace'
 };
 
 export function loadUserSettings(): Writable<Settings> {

--- a/apps/desktop/src/routes/settings/appearance/+page.svelte
+++ b/apps/desktop/src/routes/settings/appearance/+page.svelte
@@ -99,7 +99,9 @@
 
 	<SectionCard centerAlign>
 		<svelte:fragment slot="title">Diff font</svelte:fragment>
-		<svelte:fragment slot="caption">Controls the font size of the diff view.</svelte:fragment>
+		<svelte:fragment slot="caption"
+			>Sets the font size for the diff view. The first font is the default, others are fallbacks.
+		</svelte:fragment>
 
 		<div class="diff-preview">
 			<TextBox

--- a/apps/desktop/src/routes/settings/appearance/+page.svelte
+++ b/apps/desktop/src/routes/settings/appearance/+page.svelte
@@ -27,16 +27,7 @@
 		binary: false,
 		poisoned: false,
 		changeType: 'modified',
-		diff: `@@ -59,7 +59,7 @@ (HunkDiff.svelte, line 141)
- 			on:branchSelected={async (e) => {
- 				selectedBranch = e.detail;
- 				// TODO: Temporary solution to forcing Windows to use system executable
--				if ($platformName === 'win32') {
-+				if ($platformName === 'wsin32') {
- 					setTarget();
- 				}
- 			}}
-		`,
+		diff: '',
 		filePath: 'test',
 		new_start: 59,
 		new_lines: 7
@@ -44,11 +35,11 @@
 
 	// prettier-ignore
 	const hunkSubsections = [
+		{expanded: true, lines: [{beforeLineNumber: 56, afterLineNumber: 56, content: "\t\t\t// Diff example"}], sectionType: 2, maxLineNumber: 55},
 		{expanded: true, lines: [{beforeLineNumber: 57, afterLineNumber: 57, content: "\t\t\tprojectName={project.title}"}, {beforeLineNumber: 58, afterLineNumber: 58, content: "\t\t\t{remoteBranches}"}, {beforeLineNumber: 59, afterLineNumber: 59, content: "\t\t\ton:branchSelected={async (e) => {"}], sectionType: 2, maxLineNumber: 59},
-		{expanded: true, lines: [{beforeLineNumber: 60, afterLineNumber: undefined, content: "\t\t\t\tselectedBranch = e.detail;"}], sectionType: 1, maxLineNumber: 60},
-		{expanded: true, lines: [{beforeLineNumber: 61, afterLineNumber: 60, content: "\t\t\t\t// TODO: Temporary solution to forcing Windows to use system executable"}], sectionType: 2, maxLineNumber: 61},
-		{expanded: true, lines: [{beforeLineNumber: 62, afterLineNumber: undefined, content: "\t\t\t\tif ($platformName === 'win32') {"}], sectionType: 1, maxLineNumber: 62},
-		{expanded: true, lines: [{beforeLineNumber: undefined, afterLineNumber: 61, content: "\t\t\t\tif ($platformName === 'wsin32') {"}], sectionType: 0, maxLineNumber: 61},
+		{expanded: true, lines: [{beforeLineNumber: 61, afterLineNumber: undefined, content: "\t\t\t\tselectedBranch = e.detail;"}], sectionType: 0, maxLineNumber: 60},
+		{expanded: true, lines: [{beforeLineNumber: 62, afterLineNumber: undefined, content: "\t\t\t\tif ($platformName === 'win32') {"}], sectionType: 2, maxLineNumber: 61},
+		{expanded: true, lines: [{beforeLineNumber: undefined, afterLineNumber: 61, content: "\t\t\t\tif ($platformName === 'wsin64') {"}], sectionType: 1, maxLineNumber: 61},
 		{expanded: true, lines: [{beforeLineNumber: 63, afterLineNumber: 62, content: "\t\t\t\t\tsetTarget();"}, {beforeLineNumber: 64, afterLineNumber: 63, content: "\t\t\t\t}"}, {beforeLineNumber: 65, afterLineNumber: 64, content: "\t\t\t}}"}], sectionType: 2, maxLineNumber: 65}
 	];
 

--- a/apps/desktop/src/routes/settings/appearance/+page.svelte
+++ b/apps/desktop/src/routes/settings/appearance/+page.svelte
@@ -39,7 +39,7 @@
 		{expanded: true, lines: [{beforeLineNumber: 57, afterLineNumber: 57, content: "\t\t\tprojectName={project.title}"}, {beforeLineNumber: 58, afterLineNumber: 58, content: "\t\t\t{remoteBranches}"}, {beforeLineNumber: 59, afterLineNumber: 59, content: "\t\t\ton:branchSelected={async (e) => {"}], sectionType: 2, maxLineNumber: 59},
 		{expanded: true, lines: [{beforeLineNumber: 61, afterLineNumber: undefined, content: "\t\t\t\tselectedBranch = e.detail;"}], sectionType: 0, maxLineNumber: 60},
 		{expanded: true, lines: [{beforeLineNumber: 62, afterLineNumber: undefined, content: "\t\t\t\tif ($platformName === 'win32') {"}], sectionType: 2, maxLineNumber: 61},
-		{expanded: true, lines: [{beforeLineNumber: undefined, afterLineNumber: 61, content: "\t\t\t\tif ($platformName === 'wsin64') {"}], sectionType: 1, maxLineNumber: 61},
+		{expanded: true, lines: [{beforeLineNumber: undefined, afterLineNumber: 61, content: "\t\t\t\tif ($platformName === 'win64') {"}], sectionType: 1, maxLineNumber: 61},
 		{expanded: true, lines: [{beforeLineNumber: 63, afterLineNumber: 62, content: "\t\t\t\t\tsetTarget();"}, {beforeLineNumber: 64, afterLineNumber: 63, content: "\t\t\t\t}"}, {beforeLineNumber: 65, afterLineNumber: 64, content: "\t\t\t}}"}], sectionType: 2, maxLineNumber: 65}
 	];
 

--- a/apps/desktop/src/routes/settings/appearance/+page.svelte
+++ b/apps/desktop/src/routes/settings/appearance/+page.svelte
@@ -64,12 +64,31 @@
 
 	<div class="stack-v">
 		<SectionCard centerAlign roundedBottom={false}>
-			<svelte:fragment slot="title">Diff font</svelte:fragment>
+			<svelte:fragment slot="title">Diff preview</svelte:fragment>
+
+			<HunkDiff
+				readonly
+				filePath="test.tsx"
+				minWidth={1.25}
+				selectable={false}
+				draggingDisabled
+				tabSize={$userSettings.tabSize}
+				diffFont={$userSettings.diffFont}
+				diffLigatures={$userSettings.diffLigatures}
+				hunk={testHunk}
+				subsections={hunkSubsections}
+				onclick={() => {}}
+				handleSelected={() => {}}
+				handleLineContextMenu={() => {}}
+			/>
+		</SectionCard>
+
+		<SectionCard orientation="column" roundedTop={false} roundedBottom={false}>
+			<svelte:fragment slot="title">Font family</svelte:fragment>
 			<svelte:fragment slot="caption"
 				>Sets the font for the diff view. The first font name is the default, others are fallbacks.
 			</svelte:fragment>
-
-			<div class="diff-preview">
+			<svelte:fragment slot="actions">
 				<TextBox
 					wide
 					bind:value={$userSettings.diffFont}
@@ -81,23 +100,7 @@
 						}));
 					}}
 				/>
-
-				<HunkDiff
-					readonly
-					filePath="test.tsx"
-					minWidth={1.25}
-					selectable={false}
-					draggingDisabled
-					tabSize={$userSettings.tabSize}
-					diffFont={$userSettings.diffFont}
-					diffLigatures={$userSettings.diffLigatures}
-					hunk={testHunk}
-					subsections={hunkSubsections}
-					onclick={() => {}}
-					handleSelected={() => {}}
-					handleLineContextMenu={() => {}}
-				/>
-			</div>
+			</svelte:fragment>
 		</SectionCard>
 
 		<SectionCard
@@ -212,11 +215,3 @@
 		</svelte:fragment>
 	</SectionCard>
 </SettingsPage>
-
-<style>
-	.diff-preview {
-		display: flex;
-		flex-direction: column;
-		gap: 10px;
-	}
-</style>

--- a/apps/desktop/src/routes/settings/appearance/+page.svelte
+++ b/apps/desktop/src/routes/settings/appearance/+page.svelte
@@ -100,7 +100,7 @@
 	<SectionCard centerAlign>
 		<svelte:fragment slot="title">Diff font</svelte:fragment>
 		<svelte:fragment slot="caption"
-			>Sets the font size for the diff view. The first font is the default, others are fallbacks.
+			>Sets the font for the diff view. The first font name is the default, others are fallbacks.
 		</svelte:fragment>
 
 		<div class="diff-preview">

--- a/apps/desktop/src/routes/settings/appearance/+page.svelte
+++ b/apps/desktop/src/routes/settings/appearance/+page.svelte
@@ -71,69 +71,93 @@
 		<ThemeSelector {userSettings} />
 	</SectionCard>
 
-	<SectionCard orientation="row" centerAlign>
-		<svelte:fragment slot="title">Tab size</svelte:fragment>
-		<svelte:fragment slot="caption">
-			The number of spaces a tab is equal to when previewing code changes.
-		</svelte:fragment>
+	<div class="stack-v">
+		<SectionCard centerAlign roundedBottom={false}>
+			<svelte:fragment slot="title">Diff font</svelte:fragment>
+			<svelte:fragment slot="caption"
+				>Sets the font for the diff view. The first font name is the default, others are fallbacks.
+			</svelte:fragment>
 
-		<svelte:fragment slot="actions">
-			<TextBox
-				type="number"
-				width={100}
-				textAlign="center"
-				value={$userSettings.tabSize.toString()}
-				minVal={1}
-				maxVal={8}
-				showCountActions
-				on:change={(e) => {
-					userSettings.update((s) => ({
-						...s,
-						tabSize: parseInt(e.detail) || $userSettings.tabSize
-					}));
-				}}
-				placeholder={$userSettings.tabSize.toString()}
-			/>
-		</svelte:fragment>
-	</SectionCard>
+			<div class="diff-preview">
+				<TextBox
+					wide
+					bind:value={$userSettings.diffFont}
+					required
+					on:change={(e) => {
+						userSettings.update((s) => ({
+							...s,
+							diffFont: e.detail
+						}));
+					}}
+				/>
 
-	<SectionCard centerAlign>
-		<svelte:fragment slot="title">Diff font</svelte:fragment>
-		<svelte:fragment slot="caption"
-			>Sets the font for the diff view. The first font name is the default, others are fallbacks.
-		</svelte:fragment>
+				<HunkDiff
+					readonly
+					filePath="test.tsx"
+					minWidth={1.25}
+					selectable={false}
+					draggingDisabled
+					tabSize={$userSettings.tabSize}
+					diffFont={$userSettings.diffFont}
+					diffLigatures={$userSettings.diffLigatures}
+					hunk={testHunk}
+					subsections={hunkSubsections}
+					onclick={() => {}}
+					handleSelected={() => {}}
+					handleLineContextMenu={() => {}}
+				/>
+			</div>
+		</SectionCard>
 
-		<div class="diff-preview">
-			<TextBox
-				wide
-				bind:value={$userSettings.diffFont}
-				required
-				on:change={(e) => {
-					userSettings.update((s) => ({
-						...s,
-						diffFont: e.detail
-					}));
-				}}
-			/>
+		<SectionCard
+			labelFor="allowDiffLigatures"
+			orientation="row"
+			roundedTop={false}
+			roundedBottom={false}
+		>
+			<svelte:fragment slot="title">Allow font ligatures</svelte:fragment>
+			<svelte:fragment slot="actions">
+				<Toggle
+					id="allowDiffLigatures"
+					checked={$userSettings.diffLigatures}
+					on:click={() => {
+						userSettings.update((s) => ({
+							...s,
+							diffLigatures: !$userSettings.diffLigatures
+						}));
+					}}
+				/>
+			</svelte:fragment>
+		</SectionCard>
 
-			<HunkDiff
-				readonly
-				filePath="test.tsx"
-				minWidth={1.25}
-				selectable={false}
-				draggingDisabled
-				tabSize={$userSettings.tabSize}
-				diffFont={$userSettings.diffFont}
-				hunk={testHunk}
-				subsections={hunkSubsections}
-				onclick={() => {}}
-				handleSelected={() => {}}
-				handleLineContextMenu={() => {}}
-			/>
-		</div>
-	</SectionCard>
+		<SectionCard orientation="row" centerAlign roundedTop={false}>
+			<svelte:fragment slot="title">Tab size</svelte:fragment>
+			<svelte:fragment slot="caption">
+				The number of spaces a tab is equal to when previewing code changes.
+			</svelte:fragment>
 
-	<form on:change={(e) => onScrollbarFormChange(e.currentTarget)}>
+			<svelte:fragment slot="actions">
+				<TextBox
+					type="number"
+					width={100}
+					textAlign="center"
+					value={$userSettings.tabSize.toString()}
+					minVal={1}
+					maxVal={8}
+					showCountActions
+					on:change={(e) => {
+						userSettings.update((s) => ({
+							...s,
+							tabSize: parseInt(e.detail) || $userSettings.tabSize
+						}));
+					}}
+					placeholder={$userSettings.tabSize.toString()}
+				/>
+			</svelte:fragment>
+		</SectionCard>
+	</div>
+
+	<form class="stack-v" on:change={(e) => onScrollbarFormChange(e.currentTarget)}>
 		<SectionCard roundedBottom={false} orientation="row" labelFor="scrollbar-on-scroll">
 			<svelte:fragment slot="title">Scrollbar-On-Scroll</svelte:fragment>
 			<svelte:fragment slot="caption">

--- a/apps/desktop/src/routes/settings/appearance/+page.svelte
+++ b/apps/desktop/src/routes/settings/appearance/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import SectionCard from '$lib/components/SectionCard.svelte';
 	import { autoSelectBranchNameFeature } from '$lib/config/uiFeatureFlags';
+	import HunkDiff from '$lib/hunk/HunkDiff.svelte';
 	import SettingsPage from '$lib/layout/SettingsPage.svelte';
 	import ThemeSelector from '$lib/settings/ThemeSelector.svelte';
 	import {
@@ -12,9 +13,44 @@
 	import TextBox from '$lib/shared/TextBox.svelte';
 	import Toggle from '$lib/shared/Toggle.svelte';
 	import { getContextStoreBySymbol } from '$lib/utils/context';
+	import { type Hunk } from '$lib/vbranches/types';
 	import type { Writable } from 'svelte/store';
 
 	const userSettings = getContextStoreBySymbol<Settings, Writable<Settings>>(SETTINGS);
+
+	const testHunk = {
+		id: '59-66',
+		hash: 'test',
+		modifiedAt: new Date(),
+		lockedTo: [],
+		locked: false,
+		binary: false,
+		poisoned: false,
+		changeType: 'modified',
+		diff: `@@ -59,7 +59,7 @@ (HunkDiff.svelte, line 141)
+ 			on:branchSelected={async (e) => {
+ 				selectedBranch = e.detail;
+ 				// TODO: Temporary solution to forcing Windows to use system executable
+-				if ($platformName === 'win32') {
++				if ($platformName === 'wsin32') {
+ 					setTarget();
+ 				}
+ 			}}
+		`,
+		filePath: 'test',
+		new_start: 59,
+		new_lines: 7
+	} as Hunk;
+
+	// prettier-ignore
+	const hunkSubsections = [
+		{expanded: true, lines: [{beforeLineNumber: 57, afterLineNumber: 57, content: "\t\t\tprojectName={project.title}"}, {beforeLineNumber: 58, afterLineNumber: 58, content: "\t\t\t{remoteBranches}"}, {beforeLineNumber: 59, afterLineNumber: 59, content: "\t\t\ton:branchSelected={async (e) => {"}], sectionType: 2, maxLineNumber: 59},
+		{expanded: true, lines: [{beforeLineNumber: 60, afterLineNumber: undefined, content: "\t\t\t\tselectedBranch = e.detail;"}], sectionType: 1, maxLineNumber: 60},
+		{expanded: true, lines: [{beforeLineNumber: 61, afterLineNumber: 60, content: "\t\t\t\t// TODO: Temporary solution to forcing Windows to use system executable"}], sectionType: 2, maxLineNumber: 61},
+		{expanded: true, lines: [{beforeLineNumber: 62, afterLineNumber: undefined, content: "\t\t\t\tif ($platformName === 'win32') {"}], sectionType: 1, maxLineNumber: 62},
+		{expanded: true, lines: [{beforeLineNumber: undefined, afterLineNumber: 61, content: "\t\t\t\tif ($platformName === 'wsin32') {"}], sectionType: 0, maxLineNumber: 61},
+		{expanded: true, lines: [{beforeLineNumber: 63, afterLineNumber: 62, content: "\t\t\t\t\tsetTarget();"}, {beforeLineNumber: 64, afterLineNumber: 63, content: "\t\t\t\t}"}, {beforeLineNumber: 65, afterLineNumber: 64, content: "\t\t\t}}"}], sectionType: 2, maxLineNumber: 65}
+	];
 
 	function onScrollbarFormChange(form: HTMLFormElement) {
 		const formData = new FormData(form);
@@ -59,6 +95,40 @@
 				placeholder={$userSettings.tabSize.toString()}
 			/>
 		</svelte:fragment>
+	</SectionCard>
+
+	<SectionCard centerAlign>
+		<svelte:fragment slot="title">Diff font</svelte:fragment>
+		<svelte:fragment slot="caption">Controls the font size of the diff view.</svelte:fragment>
+
+		<div class="diff-preview">
+			<TextBox
+				wide
+				bind:value={$userSettings.diffFont}
+				required
+				on:change={(e) => {
+					userSettings.update((s) => ({
+						...s,
+						diffFont: e.detail
+					}));
+				}}
+			/>
+
+			<HunkDiff
+				readonly
+				filePath="test.tsx"
+				minWidth={1.25}
+				selectable={false}
+				draggingDisabled
+				tabSize={$userSettings.tabSize}
+				diffFont={$userSettings.diffFont}
+				hunk={testHunk}
+				subsections={hunkSubsections}
+				onclick={() => {}}
+				handleSelected={() => {}}
+				handleLineContextMenu={() => {}}
+			/>
+		</div>
 	</SectionCard>
 
 	<form on:change={(e) => onScrollbarFormChange(e.currentTarget)}>
@@ -125,3 +195,11 @@
 		</svelte:fragment>
 	</SectionCard>
 </SettingsPage>
+
+<style>
+	.diff-preview {
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+	}
+</style>

--- a/apps/desktop/src/routes/settings/appearance/+page.svelte
+++ b/apps/desktop/src/routes/settings/appearance/+page.svelte
@@ -14,31 +14,31 @@
 	import Toggle from '$lib/shared/Toggle.svelte';
 	import { getContextStoreBySymbol } from '$lib/utils/context';
 	import { type Hunk } from '$lib/vbranches/types';
+	import type { ContentSection } from '$lib/utils/fileSections';
 	import type { Writable } from 'svelte/store';
 
 	const userSettings = getContextStoreBySymbol<Settings, Writable<Settings>>(SETTINGS);
 
-	const testHunk = {
+	const testHunk: Hunk = {
 		id: '59-66',
 		hash: 'test',
 		modifiedAt: new Date(),
 		lockedTo: [],
 		locked: false,
-		binary: false,
 		poisoned: false,
 		changeType: 'modified',
 		diff: '',
 		filePath: 'test',
 		new_start: 59,
 		new_lines: 7
-	} as Hunk;
+	};
 
 	// prettier-ignore
-	const hunkSubsections = [
+	const hunkSubsections: ContentSection[] = [
 		{expanded: true, lines: [{beforeLineNumber: 56, afterLineNumber: 56, content: "\t\t\t// Diff example"}], sectionType: 2, maxLineNumber: 55},
 		{expanded: true, lines: [{beforeLineNumber: 57, afterLineNumber: 57, content: "\t\t\tprojectName={project.title}"}, {beforeLineNumber: 58, afterLineNumber: 58, content: "\t\t\t{remoteBranches}"}, {beforeLineNumber: 59, afterLineNumber: 59, content: "\t\t\ton:branchSelected={async (e) => {"}], sectionType: 2, maxLineNumber: 59},
-		{expanded: true, lines: [{beforeLineNumber: 61, afterLineNumber: undefined, content: "\t\t\t\tselectedBranch = e.detail;"}], sectionType: 0, maxLineNumber: 60},
-		{expanded: true, lines: [{beforeLineNumber: 62, afterLineNumber: undefined, content: "\t\t\t\tif ($platformName === 'win32') {"}], sectionType: 2, maxLineNumber: 61},
+		{expanded: true, lines: [{beforeLineNumber: 61, afterLineNumber: undefined, content: "\t\t\t\tselectedBranch = e.detail;"}], sectionType: 2, maxLineNumber: 60},
+		{expanded: true, lines: [{beforeLineNumber: 62, afterLineNumber: undefined, content: "\t\t\t\tif ($platformName === 'win32') {"}], sectionType: 0, maxLineNumber: 61},
 		{expanded: true, lines: [{beforeLineNumber: undefined, afterLineNumber: 61, content: "\t\t\t\tif ($platformName === 'win64') {"}], sectionType: 1, maxLineNumber: 61},
 		{expanded: true, lines: [{beforeLineNumber: 63, afterLineNumber: 62, content: "\t\t\t\t\tsetTarget();"}, {beforeLineNumber: 64, afterLineNumber: 63, content: "\t\t\t\t}"}, {beforeLineNumber: 65, afterLineNumber: 64, content: "\t\t\t}}"}], sectionType: 2, maxLineNumber: 65}
 	];
@@ -75,6 +75,7 @@
 				tabSize={$userSettings.tabSize}
 				diffFont={$userSettings.diffFont}
 				diffLigatures={$userSettings.diffLigatures}
+				inlineUnifiedDiffs={$userSettings.inlineUnifiedDiffs}
 				hunk={testHunk}
 				subsections={hunkSubsections}
 				onclick={() => {}}
@@ -124,7 +125,7 @@
 			</svelte:fragment>
 		</SectionCard>
 
-		<SectionCard orientation="row" centerAlign roundedTop={false}>
+		<SectionCard orientation="row" centerAlign roundedTop={false} roundedBottom={false}>
 			<svelte:fragment slot="title">Tab size</svelte:fragment>
 			<svelte:fragment slot="caption">
 				The number of spaces a tab is equal to when previewing code changes.
@@ -146,6 +147,26 @@
 						}));
 					}}
 					placeholder={$userSettings.tabSize.toString()}
+				/>
+			</svelte:fragment>
+		</SectionCard>
+
+		<SectionCard labelFor="inlineUnifiedDiffs" orientation="row" roundedTop={false}>
+			<svelte:fragment slot="title">Display word diffs inline</svelte:fragment>
+			<svelte:fragment slot="caption">
+				Instead of separate lines for removals and additions, this feature shows a single line with
+				both added and removed words highlighted.
+			</svelte:fragment>
+			<svelte:fragment slot="actions">
+				<Toggle
+					id="inlineUnifiedDiffs"
+					checked={$userSettings.inlineUnifiedDiffs}
+					on:click={() => {
+						userSettings.update((s) => ({
+							...s,
+							inlineUnifiedDiffs: !s.inlineUnifiedDiffs
+						}));
+					}}
 				/>
 			</svelte:fragment>
 		</SectionCard>

--- a/apps/desktop/src/routes/settings/experimental/+page.svelte
+++ b/apps/desktop/src/routes/settings/experimental/+page.svelte
@@ -2,7 +2,6 @@
 	import SectionCard from '$lib/components/SectionCard.svelte';
 	import {
 		featureBaseBranchSwitching,
-		featureInlineUnifiedDiffs,
 		stackingFeature,
 		featureTopics
 	} from '$lib/config/uiFeatureFlags';
@@ -10,7 +9,6 @@
 	import Toggle from '$lib/shared/Toggle.svelte';
 
 	const baseBranchSwitching = featureBaseBranchSwitching();
-	const inlineUnifiedDiffs = featureInlineUnifiedDiffs();
 	const topicsEnabled = featureTopics();
 </script>
 
@@ -30,21 +28,6 @@
 				id="baseBranchSwitching"
 				checked={$baseBranchSwitching}
 				on:click={() => ($baseBranchSwitching = !$baseBranchSwitching)}
-			/>
-		</svelte:fragment>
-	</SectionCard>
-	<SectionCard labelFor="inlineUnifiedDiffs" orientation="row">
-		<svelte:fragment slot="title">Display word diffs inline</svelte:fragment>
-		<svelte:fragment slot="caption">
-			Rather than showing one line which is the all the removals and another line which is all the
-			additions, with the specific words emboldened. With the feature flag enabled, only one line
-			with both the words added and removed is displayed.
-		</svelte:fragment>
-		<svelte:fragment slot="actions">
-			<Toggle
-				id="inlineUnifiedDiffs"
-				checked={$inlineUnifiedDiffs}
-				on:click={() => ($inlineUnifiedDiffs = !$inlineUnifiedDiffs)}
 			/>
 		</svelte:fragment>
 	</SectionCard>

--- a/packages/ui/src/styles/core/reset.css
+++ b/packages/ui/src/styles/core/reset.css
@@ -14,7 +14,7 @@
 	}
 
 	body {
-		font-family: 'Inter', sans-serif;
+		font-family: var(--base-font-family);
 		line-height: inherit;
 		padding: 0;
 		margin: 0;

--- a/packages/ui/src/styles/utility/helpers.css
+++ b/packages/ui/src/styles/utility/helpers.css
@@ -37,6 +37,16 @@ pre {
 	}
 }
 
+.stack-v {
+	display: flex;
+	flex-direction: column;
+}
+
+.stack-h {
+	display: flex;
+	flex-direction: row;
+}
+
 .truncate {
 	overflow: hidden;
 	text-overflow: ellipsis;


### PR DESCRIPTION
## ☕️ Reasoning
Allowing users to choose a font tailored to their preferences improves code clarity, reduces eye strain, and offers a more accessible and personalized diff view.

<img width="626" alt="image" src="https://github.com/user-attachments/assets/cf931dc9-d537-4f47-aa21-46b3c2f4615a">


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
