### PR TITLE
chore: Bump `git2-hooks`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,9 +2126,9 @@ dependencies = [
 
 [[package]]
 name = "git2-hooks"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e010ee9804b082020b3aa9e39a32b11595e7b46185b55b509948217e847203f"
+checksum = "2f930f5fe956eb55418c0da7e40736636e3fe80b577d8b60d9e54da0fc038619"
 dependencies = [
  "git2",
  "log",

--- a/crates/gitbutler-branch-actions/Cargo.toml
+++ b/crates/gitbutler-branch-actions/Cargo.toml
@@ -32,7 +32,7 @@ bstr.workspace = true
 diffy = "0.4.0"
 hex = "0.4.3"
 regex = "1.10"
-git2-hooks = "0.3"
+git2-hooks = "0.4"
 url = { version = "2.5.2", features = ["serde"] }
 md5 = "0.7.0"
 itertools = "0.13"


### PR DESCRIPTION
## ☕️ Reasoning

I fixed an upstream issue in `git2-hooks` where executing Git hooks would cause extra windows to spawn on Windows. This PR makes GitButler use those changes.

## 🧢 Changes

- Bump `git2-hooks` to version `0.4`.

## 🎫 Affected issues

Fixes: #4982 
