### PR TITLE
Edit mode: Open the conflicted files in the IDE

### DIFF
--- a/apps/desktop/src/lib/file/FileContextMenu.svelte
+++ b/apps/desktop/src/lib/file/FileContextMenu.svelte
@@ -9,7 +9,7 @@
 	import * as toasts from '$lib/utils/toasts';
 	import { openExternalUrl } from '$lib/utils/url';
 	import { BranchController } from '$lib/vbranches/branchController';
-	import { LocalFile, type AnyFile } from '$lib/vbranches/types';
+	import { isAnyFile, LocalFile } from '$lib/vbranches/types';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import Modal from '@gitbutler/ui/Modal.svelte';
 	import { join } from '@tauri-apps/api/path';
@@ -25,7 +25,12 @@
 	let contextMenu: ContextMenu;
 
 	function isDeleted(item: any): boolean {
-		return item.files.some((f: AnyFile) => computeFileStatus(f) === 'D');
+		if (!item.files || !Array.isArray(item.files)) return false;
+
+		return item.files.some((f: unknown) => {
+			if (!isAnyFile(f)) return false;
+			computeFileStatus(f) === 'D';
+		});
 	}
 
 	export function open(e: MouseEvent, item: any) {

--- a/apps/desktop/src/lib/vbranches/types.ts
+++ b/apps/desktop/src/lib/vbranches/types.ts
@@ -39,6 +39,10 @@ export class HunkLock {
 
 export type AnyFile = LocalFile | RemoteFile;
 
+export function isAnyFile(something: unknown): something is AnyFile {
+	return something instanceof LocalFile || something instanceof RemoteFile;
+}
+
 export class LocalFile {
 	id!: string;
 	path!: string;


### PR DESCRIPTION
Add the ability to right-click a file in the list to open it in the selected IDE.
Also add a button that opens all the conflicted files automatically.

<img width="604" alt="Screenshot 2024-09-30 at 19 09 41" src="https://github.com/user-attachments/assets/bd638d06-7125-4ad7-9243-65ccfea4a0b5">
