### PR TITLE
Factor out the `move_commit` function

### DIFF
--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -1,5 +1,4 @@
 use super::r#virtual as vbranch;
-use crate::reorder_commits;
 use crate::upstream_integration::{self, BranchStatuses, Resolution, UpstreamIntegrationContext};
 use crate::{
     base,
@@ -10,6 +9,7 @@ use crate::{
     remote::{RemoteBranch, RemoteBranchData, RemoteCommit},
     VirtualBranchesExt,
 };
+use crate::{move_commits, reorder_commits};
 use anyhow::{Context, Result};
 use gitbutler_branch::{
     BranchCreateRequest, BranchId, BranchOwnershipClaims, BranchUpdateRequest, ChangeReference,
@@ -513,7 +513,8 @@ pub fn move_commit(
         SnapshotDetails::new(OperationKind::MoveCommit),
         guard.write_permission(),
     );
-    vbranch::move_commit(&ctx, target_branch_id, commit_oid).map_err(Into::into)
+    move_commits::move_commit(&ctx, target_branch_id, commit_oid, guard.write_permission())
+        .map_err(Into::into)
 }
 
 #[instrument(level = tracing::Level::DEBUG, skip(project), err(Debug))]

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -44,6 +44,7 @@ pub use remote::{RemoteBranch, RemoteBranchData, RemoteCommit};
 pub mod conflicts;
 
 mod branch_trees;
+mod move_commits;
 mod reorder_commits;
 mod undo_commit;
 

--- a/crates/gitbutler-branch-actions/src/move_commits.rs
+++ b/crates/gitbutler-branch-actions/src/move_commits.rs
@@ -1,0 +1,311 @@
+use crate::{
+    branch_trees::checkout_branch_trees, conflicts::RepoConflictsExt, status::get_applied_status,
+    VirtualBranchesExt,
+};
+use anyhow::{anyhow, bail, Context, Result};
+use bstr::ByteSlice;
+use gitbutler_branch::{BranchId, OwnershipClaim};
+use gitbutler_command_context::CommandContext;
+use gitbutler_commit::{commit_ext::CommitExt, commit_headers::HasCommitHeaders};
+use gitbutler_project::access::WorktreeWritePermission;
+use gitbutler_repo::RepoActionsExt;
+use std::collections::HashMap;
+
+/// moves commit from the branch it's in to the top of the target branch
+pub(crate) fn move_commit(
+    ctx: &CommandContext,
+    target_branch_id: BranchId,
+    commit_id: git2::Oid,
+    perm: &mut WorktreeWritePermission,
+) -> Result<()> {
+    ctx.assure_resolved()?;
+    let vb_state = ctx.project().virtual_branches();
+
+    let applied_branches = vb_state
+        .list_branches_in_workspace()
+        .context("failed to read virtual branches")?;
+
+    if !applied_branches.iter().any(|b| b.id == target_branch_id) {
+        bail!("branch {target_branch_id} is not among applied branches")
+    }
+
+    let mut applied_statuses = get_applied_status(ctx, None)?.branches;
+
+    let (ref mut source_branch, source_status) = applied_statuses
+        .iter_mut()
+        .find(|(b, _)| b.head == commit_id)
+        .ok_or_else(|| anyhow!("commit {commit_id} to be moved could not be found"))?;
+
+    let source_branch_non_comitted_files = source_status;
+
+    let source_commit = ctx
+        .repository()
+        .find_commit(commit_id)
+        .context("failed to find commit")?;
+
+    if source_commit.is_conflicted() {
+        bail!("Can not move conflicted commits");
+    }
+
+    let source_branch_head_parent = source_commit
+        .parent(0)
+        .context("failed to get parent commit")?;
+    let source_branch_head_tree = source_commit
+        .tree()
+        .context("failed to get commit tree")?;
+    let source_branch_head_parent_tree = source_branch_head_parent
+        .tree()
+        .context("failed to get parent tree")?;
+    let branch_head_diff = gitbutler_diff::trees(
+        ctx.repository(),
+        &source_branch_head_parent_tree,
+        &source_branch_head_tree,
+    )?;
+
+    let branch_head_diff: HashMap<_, _> =
+        gitbutler_diff::diff_files_into_hunks(branch_head_diff).collect();
+    let is_source_locked = check_source_lock(source_branch_non_comitted_files, &branch_head_diff);
+
+    if is_source_locked {
+        bail!("the source branch contains hunks locked to the target commit")
+    }
+
+    // move files ownerships from source branch to the destination branch
+
+    let ownerships_to_transfer = branch_head_diff
+        .iter()
+        .map(|(file_path, hunks)| {
+            (
+                file_path.clone(),
+                hunks.iter().map(Into::into).collect::<Vec<_>>(),
+            )
+        })
+        .map(|(file_path, hunks)| OwnershipClaim { file_path, hunks })
+        .flat_map(|file_ownership| source_branch.ownership.take(&file_ownership))
+        .collect::<Vec<_>>();
+
+    // reset the source branch to the parent commit
+    {
+        source_branch.head = source_branch_head_parent.id();
+        vb_state.set_branch(source_branch.clone())?;
+    }
+
+    // move the commit to destination branch target branch
+    {
+        let mut destination_branch = vb_state.get_branch_in_workspace(target_branch_id)?;
+
+        for ownership in ownerships_to_transfer {
+            destination_branch.ownership.put(ownership);
+        }
+
+        let new_destination_tree_oid = gitbutler_diff::write::hunks_onto_commit(
+            ctx,
+            destination_branch.head,
+            branch_head_diff,
+        )
+        .context("failed to write tree onto commit")?;
+
+        let new_destination_tree = ctx
+            .repository()
+            .find_tree(new_destination_tree_oid)
+            .context("failed to find tree")?;
+
+        let new_destination_head_oid = ctx
+            .commit(
+                &source_commit.message_bstr().to_str_lossy(),
+                &new_destination_tree,
+                &[&ctx
+                    .repository()
+                    .find_commit(destination_branch.head)
+                    .context("failed to get dst branch head commit")?],
+                source_commit.gitbutler_headers(),
+            )
+            .context("failed to commit")?;
+
+        destination_branch.head = new_destination_head_oid;
+        vb_state.set_branch(destination_branch.clone())?;
+    }
+
+    checkout_branch_trees(ctx, perm)?;
+
+    crate::integration::update_workspace_commit(&vb_state, ctx)
+        .context("failed to update gitbutler workspace")?;
+
+    Ok(())
+}
+
+/// determines if the uncommitted files are locked to commit
+fn check_source_lock(
+    source_branch_non_comitted_files: &[crate::file::VirtualBranchFile],
+    source_commit_diff: &HashMap<std::path::PathBuf, Vec<gitbutler_diff::GitHunk>>,
+) -> bool {
+    let is_source_locked = source_branch_non_comitted_files.iter().any(|file| {
+        source_commit_diff
+            .get(&file.path)
+            .map_or(false, |head_diff_hunks| {
+                file.hunks.iter().any(|hunk| {
+                    let hunk: gitbutler_diff::GitHunk = hunk.clone().into();
+                    head_diff_hunks.iter().any(|head_hunk| {
+                        lines_overlap(
+                            head_hunk.new_start,
+                            head_hunk.new_start + head_hunk.new_lines,
+                            hunk.new_start,
+                            hunk.new_start + hunk.new_lines,
+                        )
+                    })
+                })
+            })
+    });
+    is_source_locked
+}
+
+fn lines_overlap(start_a: u32, end_a: u32, start_b: u32, end_b: u32) -> bool {
+    ((start_a >= start_b && start_a <= end_b) || (end_a >= start_b && end_a <= end_b))
+        || ((start_b >= start_a && start_b <= end_a) || (end_b >= start_a && end_b <= end_a))
+}
+
+#[cfg(test)]
+mod tests {
+    use gitbutler_diff::Hunk;
+
+    use crate::hunk::VirtualBranchHunk;
+
+    use super::*;
+
+    fn create_virtual_branch_files(
+        path: &str,
+        start: u32,
+        end: u32,
+    ) -> Vec<crate::file::VirtualBranchFile> {
+        let source_branch_non_comitted_files = vec![crate::file::VirtualBranchFile {
+            id: path.to_string(),
+            path: path.into(),
+            hunks: vec![VirtualBranchHunk {
+                id: "1-2".into(),
+                diff: "".into(),
+                modified_at: 0,
+                file_path: path.into(),
+                old_start: 0,
+                old_lines: 0,
+                start,
+                end,
+                binary: false,
+                hash: Hunk::hash_diff("".as_bytes()),
+                locked: false,
+                locked_to: None,
+                change_type: gitbutler_diff::ChangeType::Modified,
+                poisoned: false,
+            }],
+            modified_at: 0,
+            conflicted: false,
+            binary: false,
+            large: false,
+        }];
+        source_branch_non_comitted_files
+    }
+
+    fn create_source_commit_diff(
+        path: &str,
+        new_start: u32,
+        new_lines: u32,
+    ) -> HashMap<std::path::PathBuf, Vec<gitbutler_diff::GitHunk>> {
+        let source_commit_diff: HashMap<_, _> = vec![(
+            path.into(),
+            vec![gitbutler_diff::GitHunk {
+                old_start: 0,
+                old_lines: 0,
+                new_start,
+                new_lines,
+                diff_lines: "".into(),
+                binary: false,
+                change_type: gitbutler_diff::ChangeType::Modified,
+            }],
+        )]
+        .into_iter()
+        .collect();
+        source_commit_diff
+    }
+
+    #[test]
+    fn lines_overlap_test() {
+        assert!(!lines_overlap(1, 2, 3, 4));
+        assert!(lines_overlap(1, 4, 2, 3));
+        assert!(lines_overlap(2, 3, 1, 4));
+        assert!(!lines_overlap(3, 4, 1, 2));
+
+        assert!(lines_overlap(1, 2, 2, 3));
+        assert!(lines_overlap(1, 3, 2, 3));
+        assert!(lines_overlap(2, 3, 1, 2));
+
+        assert!(!lines_overlap(1, 1, 2, 2));
+        assert!(lines_overlap(1, 1, 1, 1));
+        assert!(lines_overlap(1, 1, 1, 2));
+        assert!(lines_overlap(1, 2, 2, 2));
+    }
+
+    #[test]
+    fn check_source_lock_test_not_locked_same_file() {
+        let path: &str = "foo.txt";
+
+        let source_branch_non_comitted_files = create_virtual_branch_files(path, 1, 2);
+        let source_commit_diff = create_source_commit_diff(path, 3, 1);
+
+        assert!(!check_source_lock(
+            &source_branch_non_comitted_files,
+            &source_commit_diff
+        ));
+    }
+
+    #[test]
+    fn check_source_lock_test_not_locked_different_file() {
+        let path_1: &str = "foo.txt";
+        let path_2: &str = "bar.txt";
+
+        let source_branch_non_comitted_files = create_virtual_branch_files(path_1, 1, 2);
+        let source_commit_diff = create_source_commit_diff(path_2, 1, 1);
+
+        assert!(!check_source_lock(
+            &source_branch_non_comitted_files,
+            &source_commit_diff
+        ));
+    }
+
+    #[test]
+    fn check_source_lock_test_locked_exact_lines() {
+        let path: &str = "foo.txt";
+
+        let source_branch_non_comitted_files = create_virtual_branch_files(path, 1, 2);
+        let source_commit_diff = create_source_commit_diff(path, 1, 1);
+
+        assert!(check_source_lock(
+            &source_branch_non_comitted_files,
+            &source_commit_diff
+        ));
+    }
+
+    #[test]
+    fn check_source_lock_test_locked_overlapping_files() {
+        let path: &str = "foo.txt";
+
+        let source_branch_non_comitted_files = create_virtual_branch_files(path, 1, 4);
+        let source_commit_diff = create_source_commit_diff(path, 3, 4);
+
+        assert!(check_source_lock(
+            &source_branch_non_comitted_files,
+            &source_commit_diff
+        ));
+    }
+
+    #[test]
+    fn check_source_lock_test_locked_containing_lines() {
+        let path: &str = "foo.txt";
+
+        let source_branch_non_comitted_files = create_virtual_branch_files(path, 1, 4);
+        let source_commit_diff = create_source_commit_diff(path, 1, 2);
+
+        assert!(check_source_lock(
+            &source_branch_non_comitted_files,
+            &source_commit_diff
+        ));
+    }
+}

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/move_commit_to_vbranch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/move_commit_to_vbranch.rs
@@ -1,4 +1,6 @@
+use bstr::ByteSlice;
 use gitbutler_branch::{BranchCreateRequest, BranchId};
+use std::{path::PathBuf, str::FromStr};
 
 use super::Test;
 
@@ -51,6 +53,194 @@ fn no_diffs() {
     assert_eq!(destination_branch.files.len(), 0);
     assert_eq!(source_branch.commits.len(), 0);
     assert_eq!(source_branch.files.len(), 0);
+}
+
+#[test]
+fn multiple_commits() {
+    let Test {
+        repository,
+        project,
+        ..
+    } = &Test::default();
+
+    gitbutler_branch_actions::set_base_branch(
+        project,
+        &"refs/remotes/origin/master".parse().unwrap(),
+    )
+    .unwrap();
+
+    std::fs::write(repository.path().join("a.txt"), "This is a").unwrap();
+
+    let (branches, _) = gitbutler_branch_actions::list_virtual_branches(project).unwrap();
+    assert_eq!(branches.len(), 1);
+
+    let source_branch_id = branches[0].id;
+
+    // Create a commit on the source branch
+    gitbutler_branch_actions::create_commit(project, source_branch_id, "Add a", None, false)
+        .unwrap();
+
+    std::fs::write(repository.path().join("b.txt"), "This is b").unwrap();
+
+    // Create as second commit on the source branch, to be moved
+    let commit_oid =
+        gitbutler_branch_actions::create_commit(project, source_branch_id, "Add b", None, false)
+            .unwrap();
+
+    let target_branch_id = gitbutler_branch_actions::create_virtual_branch(
+        project,
+        &BranchCreateRequest {
+            selected_for_changes: Some(true),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    std::fs::write(repository.path().join("c.txt"), "This is c").unwrap();
+
+    // Create a commit on the destination branch
+    gitbutler_branch_actions::create_commit(project, target_branch_id, "Add c", None, false)
+        .unwrap();
+
+    // Move the top commit from the source branch to the destination branch
+    gitbutler_branch_actions::move_commit(project, target_branch_id, commit_oid).unwrap();
+
+    let (branches, _) = gitbutler_branch_actions::list_virtual_branches(project).unwrap();
+    let source_branch = branches.iter().find(|b| b.id == source_branch_id).unwrap();
+    let destination_branch = branches.iter().find(|b| b.id == target_branch_id).unwrap();
+
+    assert_eq!(destination_branch.commits.len(), 2);
+    assert_eq!(destination_branch.files.len(), 0);
+    assert_eq!(
+        destination_branch
+            .commits
+            .clone()
+            .into_iter()
+            .map(|c| c.description.to_str_lossy().into_owned())
+            .collect::<Vec<_>>(),
+        vec!["Add b", "Add c"]
+    );
+
+    assert_eq!(source_branch.commits.len(), 1);
+    assert_eq!(source_branch.files.len(), 0);
+    assert_eq!(source_branch.commits[0].description.to_str_lossy(), "Add a");
+}
+
+#[test]
+fn multiple_commits_with_diffs() {
+    let Test {
+        repository,
+        project,
+        ..
+    } = &Test::default();
+
+    gitbutler_branch_actions::set_base_branch(
+        project,
+        &"refs/remotes/origin/master".parse().unwrap(),
+    )
+    .unwrap();
+
+    std::fs::write(repository.path().join("a.txt"), "This is a").unwrap();
+
+    let (branches, _) = gitbutler_branch_actions::list_virtual_branches(project).unwrap();
+    assert_eq!(branches.len(), 1);
+
+    let source_branch_id = branches[0].id;
+
+    // Create a commit on the source branch
+    gitbutler_branch_actions::create_commit(project, source_branch_id, "Add a", None, false)
+        .unwrap();
+
+    std::fs::write(repository.path().join("b.txt"), "This is b").unwrap();
+
+    // Create as second commit on the source branch, to be moved
+    let commit_oid =
+        gitbutler_branch_actions::create_commit(project, source_branch_id, "Add b", None, false)
+            .unwrap();
+
+    // Uncommitted changes on the source branch
+    std::fs::write(repository.path().join("c.txt"), "This is c").unwrap();
+
+    let source_branch = gitbutler_branch_actions::list_virtual_branches(project)
+        .unwrap()
+        .0
+        .into_iter()
+        .find(|b| b.id == source_branch_id)
+        .unwrap();
+
+    // State of source branch after the two commits
+    assert_eq!(source_branch.commits.len(), 2);
+    assert_eq!(source_branch.files.len(), 1);
+
+    let target_branch_id = gitbutler_branch_actions::create_virtual_branch(
+        project,
+        &BranchCreateRequest {
+            selected_for_changes: Some(true),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    std::fs::write(repository.path().join("d.txt"), "This is d").unwrap();
+
+    // Create a commit on the destination branch
+    gitbutler_branch_actions::create_commit(project, target_branch_id, "Add d", None, false)
+        .unwrap();
+
+    // Uncommitted changes on the destination branch
+    std::fs::write(repository.path().join("e.txt"), "This is e").unwrap();
+
+    let destination_branch = gitbutler_branch_actions::list_virtual_branches(project)
+        .unwrap()
+        .0
+        .into_iter()
+        .find(|b| b.id == target_branch_id)
+        .unwrap();
+
+    // State of destination branch before the commit is moved
+    assert_eq!(destination_branch.commits.len(), 1);
+    assert_eq!(destination_branch.files.len(), 1);
+
+    // Move the top commit from the source branch to the destination branch
+    gitbutler_branch_actions::move_commit(project, target_branch_id, commit_oid).unwrap();
+
+    let (branches, _) = gitbutler_branch_actions::list_virtual_branches(project).unwrap();
+    let source_branch = branches.iter().find(|b| b.id == source_branch_id).unwrap();
+    let destination_branch = branches.iter().find(|b| b.id == target_branch_id).unwrap();
+
+    assert_eq!(destination_branch.commits.len(), 2);
+    assert_eq!(destination_branch.files.len(), 1);
+    assert_eq!(
+        destination_branch
+            .commits
+            .clone()
+            .into_iter()
+            .map(|c| c.description.to_str_lossy().into_owned())
+            .collect::<Vec<_>>(),
+        vec!["Add b", "Add d"]
+    );
+    assert_eq!(
+        destination_branch.files[0].path,
+        PathBuf::from_str("e.txt").unwrap()
+    );
+    assert_eq!(destination_branch.files[0].hunks.len(), 1);
+    assert_eq!(
+        destination_branch.files[0].hunks[0].diff.to_str_lossy(),
+        "@@ -0,0 +1 @@\n+This is e\n\\ No newline at end of file\n"
+    );
+
+    assert_eq!(source_branch.commits.len(), 1);
+    assert_eq!(source_branch.files.len(), 1);
+    assert_eq!(source_branch.commits[0].description.to_str_lossy(), "Add a");
+    assert_eq!(
+        source_branch.files[0].path,
+        PathBuf::from_str("c.txt").unwrap()
+    );
+    assert_eq!(source_branch.files[0].hunks.len(), 1);
+    assert_eq!(
+        source_branch.files[0].hunks[0].diff.to_str_lossy(),
+        "@@ -0,0 +1 @@\n+This is c\n\\ No newline at end of file\n"
+    );
 }
 
 #[test]
@@ -108,6 +298,15 @@ fn diffs_on_source_branch() {
     assert_eq!(destination_branch.files.len(), 0);
     assert_eq!(source_branch.commits.len(), 0);
     assert_eq!(source_branch.files.len(), 1);
+    assert_eq!(
+        source_branch.files[0].path,
+        PathBuf::from_str("another file.txt").unwrap()
+    );
+    assert_eq!(source_branch.files[0].hunks.len(), 1);
+    assert_eq!(
+        source_branch.files[0].hunks[0].diff.to_str_lossy(),
+        "@@ -0,0 +1 @@\n+another content\n\\ No newline at end of file\n"
+    );
 }
 
 #[test]
@@ -168,8 +367,137 @@ fn diffs_on_target_branch() {
 
     assert_eq!(destination_branch.commits.len(), 1);
     assert_eq!(destination_branch.files.len(), 1);
+    assert_eq!(
+        destination_branch.files[0].path,
+        PathBuf::from_str("another file.txt").unwrap()
+    );
+    assert_eq!(destination_branch.files[0].hunks.len(), 1);
+    assert_eq!(
+        destination_branch.files[0].hunks[0].diff.to_str_lossy(),
+        "@@ -0,0 +1 @@\n+another content\n\\ No newline at end of file\n"
+    );
     assert_eq!(source_branch.commits.len(), 0);
     assert_eq!(source_branch.files.len(), 0);
+}
+
+#[test]
+fn diffs_on_both_branches() {
+    let Test {
+        repository,
+        project,
+        ..
+    } = &Test::default();
+
+    gitbutler_branch_actions::set_base_branch(
+        project,
+        &"refs/remotes/origin/master".parse().unwrap(),
+    )
+    .unwrap();
+
+    std::fs::write(repository.path().join("file.txt"), "content").unwrap();
+
+    let (branches, _) = gitbutler_branch_actions::list_virtual_branches(project).unwrap();
+    assert_eq!(branches.len(), 1);
+
+    let source_branch_id = branches[0].id;
+
+    let commit_oid =
+        gitbutler_branch_actions::create_commit(project, source_branch_id, "commit", None, false)
+            .unwrap();
+
+    // Uncommitted changes on the source branch
+    std::fs::write(
+        repository.path().join("another file.txt"),
+        "another content",
+    )
+    .unwrap();
+
+    // Note: Calling `list_virtual_branches` actually is *needed* to correctly update the state of the virtual branches.
+    let source_branch = gitbutler_branch_actions::list_virtual_branches(project)
+        .unwrap()
+        .0
+        .into_iter()
+        .find(|b| b.id == source_branch_id)
+        .unwrap();
+
+    // State of source branch after the first commit
+    assert_eq!(source_branch.commits.len(), 1);
+    assert_eq!(source_branch.files.len(), 1);
+    assert_eq!(
+        source_branch.files[0].path,
+        PathBuf::from_str("another file.txt").unwrap()
+    );
+    assert_eq!(source_branch.files[0].hunks.len(), 1);
+    assert_eq!(
+        source_branch.files[0].hunks[0].diff.to_str_lossy(),
+        "@@ -0,0 +1 @@\n+another content\n\\ No newline at end of file\n"
+    );
+
+    let target_branch_id = gitbutler_branch_actions::create_virtual_branch(
+        project,
+        &BranchCreateRequest {
+            selected_for_changes: Some(true),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    // Uncommitted changes on the destination branch
+    std::fs::write(
+        repository.path().join("yet another file.txt"),
+        "yet another content",
+    )
+    .unwrap();
+
+    let destination_branch = gitbutler_branch_actions::list_virtual_branches(project)
+        .unwrap()
+        .0
+        .into_iter()
+        .find(|b| b.id == target_branch_id)
+        .unwrap();
+
+    // State of the destination branch before the commit is moved
+    assert_eq!(destination_branch.commits.len(), 0);
+    assert_eq!(destination_branch.files.len(), 1);
+    assert_eq!(
+        destination_branch.files[0].path,
+        PathBuf::from_str("yet another file.txt").unwrap()
+    );
+    assert_eq!(destination_branch.files[0].hunks.len(), 1);
+    assert_eq!(
+        destination_branch.files[0].hunks[0].diff.to_str_lossy(),
+        "@@ -0,0 +1 @@\n+yet another content\n\\ No newline at end of file\n"
+    );
+
+    gitbutler_branch_actions::move_commit(project, target_branch_id, commit_oid).unwrap();
+
+    let (branches, _) = gitbutler_branch_actions::list_virtual_branches(project).unwrap();
+    let source_branch = branches.iter().find(|b| b.id == source_branch_id).unwrap();
+    let destination_branch = branches.iter().find(|b| b.id == target_branch_id).unwrap();
+
+    assert_eq!(destination_branch.commits.len(), 1);
+    assert_eq!(destination_branch.files.len(), 1);
+    assert_eq!(
+        destination_branch.files[0].path,
+        PathBuf::from_str("yet another file.txt").unwrap()
+    );
+    assert_eq!(destination_branch.files[0].hunks.len(), 1);
+    assert_eq!(
+        destination_branch.files[0].hunks[0].diff.to_str_lossy(),
+        "@@ -0,0 +1 @@\n+yet another content\n\\ No newline at end of file\n"
+    );
+
+    assert_eq!(source_branch.commits.len(), 0);
+    assert_eq!(source_branch.files.len(), 1);
+    assert_eq!(
+        source_branch.files[0].path,
+        PathBuf::from_str("another file.txt").unwrap()
+    );
+    assert_eq!(source_branch.files[0].hunks.len(), 1);
+    assert_eq!(
+        source_branch.files[0].hunks[0].diff.to_str_lossy(),
+        "@@ -0,0 +1 @@\n+another content\n\\ No newline at end of file\n"
+    );
 }
 
 #[test]

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/move_commit_to_vbranch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/move_commit_to_vbranch.rs
@@ -501,6 +501,54 @@ fn diffs_on_both_branches() {
 }
 
 #[test]
+fn target_commit_locked_to_ancestors() {
+    let Test {
+        repository,
+        project,
+        ..
+    } = &Test::default();
+
+    gitbutler_branch_actions::set_base_branch(
+        project,
+        &"refs/remotes/origin/master".parse().unwrap(),
+    )
+    .unwrap();
+
+    std::fs::write(repository.path().join("a.txt"), "This is a").unwrap();
+
+    let (branches, _) = gitbutler_branch_actions::list_virtual_branches(project).unwrap();
+    assert_eq!(branches.len(), 1);
+
+    let source_branch_id = branches[0].id;
+
+    gitbutler_branch_actions::create_commit(project, source_branch_id, "Add a", None, false)
+        .unwrap();
+
+    std::fs::write(repository.path().join("a.txt"), "This is a \n\n Updated").unwrap();
+    std::fs::write(repository.path().join("b.txt"), "This is b").unwrap();
+
+    let commit_oid = gitbutler_branch_actions::create_commit(
+        project,
+        source_branch_id,
+        "Add b and update b",
+        None,
+        false,
+    )
+    .unwrap();
+
+    let target_branch_id =
+        gitbutler_branch_actions::create_virtual_branch(project, &BranchCreateRequest::default())
+            .unwrap();
+
+    let result = gitbutler_branch_actions::move_commit(project, target_branch_id, commit_oid);
+
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        "the source branch contains hunks locked to the target commit ancestors"
+    );
+}
+
+#[test]
 fn locked_hunks_on_source_branch() {
     let Test {
         repository,


### PR DESCRIPTION
### Motivation
Make more maintainable and testable the logic behind the `move_commit`.

### Changes
- Move the `move_commit` function to a separate module.
- Prefer using the `cherry_rebase_group` instead of calculating the commit out of the hunks to be moved on top of the destination branch.
- ⚠️ Bug fix: Stop the commit transferal if locked to any ancestor commit.
- Add some unit tests for testing whether the commit is locked.
- Add some more integration tests (rust-end only) for more scenarios of moving commits in between virtual branches

