### PR TITLE
Fix bind:this={} for Svelte5 components

### DIFF
--- a/apps/desktop/src/lib/branch/BranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/BranchHeader.svelte
@@ -48,7 +48,7 @@
 	const branch = $derived($branchStore);
 	const pr = $derived($prMonitor?.pr);
 
-	let contextMenu = $state<ContextMenu>();
+	let contextMenu = $state<ReturnType<typeof ContextMenu>>();
 	let meatballButtonEl = $state<HTMLDivElement>();
 	let isLoading = $state(false);
 	let isTargetBranchAnimated = $state(false);

--- a/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
@@ -17,7 +17,7 @@
 	import Tooltip from '@gitbutler/ui/Tooltip.svelte';
 
 	interface Props {
-		contextMenuEl?: ContextMenu;
+		contextMenuEl?: ReturnType<typeof ContextMenu>;
 		target?: HTMLElement;
 		onCollapse: () => void;
 		onGenerateBranchName: () => void;

--- a/apps/desktop/src/lib/commit/CommitContextMenu.svelte
+++ b/apps/desktop/src/lib/commit/CommitContextMenu.svelte
@@ -16,7 +16,7 @@
 
 	const target = $derived(targetElement ?? undefined);
 
-	let contextMenu = $state<ContextMenu>();
+	let contextMenu = $state<ReturnType<typeof ContextMenu>>();
 
 	export function open(e: MouseEvent) {
 		e.preventDefault();

--- a/apps/desktop/src/lib/commit/StackingCommitCard.svelte
+++ b/apps/desktop/src/lib/commit/StackingCommitCard.svelte
@@ -66,7 +66,7 @@
 	const currentCommitMessage = persistedCommitMessage(project.id, branch?.id || '');
 
 	let draggableCommitElement = $state<HTMLElement>();
-	let contextMenu = $state<CommitContextMenu>();
+	let contextMenu = $state<ReturnType<typeof CommitContextMenu>>();
 	let files = $state<RemoteFile[]>([]);
 	let showDetails = $state(false);
 

--- a/apps/desktop/src/lib/components/FilterBranchesButton.svelte
+++ b/apps/desktop/src/lib/components/FilterBranchesButton.svelte
@@ -16,7 +16,7 @@
 	export let hideInactive: Writable<boolean | undefined>;
 
 	let target: HTMLElement;
-	let contextMenu: ContextMenu;
+	let contextMenu: ReturnType<typeof ContextMenu>;
 
 	export function onFilterClick() {
 		contextMenu.toggle();

--- a/apps/desktop/src/lib/file/FileContextMenu.svelte
+++ b/apps/desktop/src/lib/file/FileContextMenu.svelte
@@ -22,7 +22,7 @@
 	const project = getContext(Project);
 
 	let confirmationModal: Modal;
-	let contextMenu: ContextMenu;
+	let contextMenu: ReturnType<typeof ContextMenu>;
 
 	function isDeleted(item: any): boolean {
 		if (!item.files || !Array.isArray(item.files)) return false;

--- a/apps/desktop/src/lib/hunk/HunkContextMenu.svelte
+++ b/apps/desktop/src/lib/hunk/HunkContextMenu.svelte
@@ -18,7 +18,7 @@
 
 	const branchController = getContext(BranchController);
 
-	let contextMenu: ContextMenu;
+	let contextMenu: ReturnType<typeof ContextMenu>;
 
 	export function open(e: MouseEvent, item: any) {
 		contextMenu.open(e, item);

--- a/apps/desktop/src/lib/hunk/HunkViewer.svelte
+++ b/apps/desktop/src/lib/hunk/HunkViewer.svelte
@@ -44,7 +44,7 @@
 
 	let alwaysShow = $state(false);
 	let viewport = $state<HTMLDivElement>();
-	let contextMenu = $state<HunkContextMenu>();
+	let contextMenu = $state<ReturnType<typeof HunkContextMenu>>();
 	const draggingDisabled = $derived(isUnapplied);
 
 	function onHunkSelected(hunk: Hunk, isSelected: boolean) {

--- a/apps/desktop/src/lib/pr/CopyLinkContextMenu.svelte
+++ b/apps/desktop/src/lib/pr/CopyLinkContextMenu.svelte
@@ -6,7 +6,7 @@
 
 	const { target, url }: { target: HTMLElement | undefined; url: string } = $props();
 
-	let menu: ContextMenu;
+	let menu: ReturnType<typeof ContextMenu>;
 
 	export function openByMouse(e: MouseEvent) {
 		menu.open(e);

--- a/apps/desktop/src/lib/shared/DropDownButton.svelte
+++ b/apps/desktop/src/lib/shared/DropDownButton.svelte
@@ -36,7 +36,7 @@
 		onclick
 	}: DropDownButtonProps = $props();
 
-	let contextMenu = $state<ContextMenu>();
+	let contextMenu = $state<ReturnType<typeof ContextMenu>>();
 	let iconEl = $state<HTMLElement>();
 	let visible = $state(false);
 


### PR DESCRIPTION
- needs `ReturnType` and `typeof` to work correctly
- svelte-check does not recognise this type bug yet
- vscode svelte plugin started complaining a week ago