### PR TITLE
fix: upstream commits accordion and cards

### DIFF
--- a/apps/desktop/src/lib/commit/StackingCommitCard.svelte
+++ b/apps/desktop/src/lib/commit/StackingCommitCard.svelte
@@ -75,7 +75,8 @@
 		files = await listRemoteCommitFiles(project.id, commit.id);
 	}
 
-	function toggleFiles() {
+	function toggleFiles(e?: MouseEvent) {
+		e?.stopPropagation();
 		if (!filesToggleable) return;
 		showDetails = !showDetails;
 

--- a/packages/ui/src/lib/commitLinesStacking/lineManager.ts
+++ b/packages/ui/src/lib/commitLinesStacking/lineManager.ts
@@ -27,46 +27,10 @@ function generateLineData({
 		line.commitNode = { type: 'Upstream', commit };
 	});
 
-	let localCommitWithChangeIdFound = false;
 	localBranchGroups.forEach(({ commit, line }) => {
 		line.top.type = 'Local';
 		line.bottom.type = 'Local';
 		line.commitNode = { type: 'Local', commit };
-
-		if (localCommitWithChangeIdFound) {
-			// If a commit with a change ID has been found above this commit, use the leftStyle
-			line.top.type = 'LocalShadow';
-			line.bottom.type = 'LocalShadow';
-
-			if (commit.relatedRemoteCommit) {
-				line.commitNode = {
-					type: 'LocalShadow',
-					commit
-				};
-			}
-		} else {
-			if (commit.relatedRemoteCommit) {
-				// For the first commit with a change ID found, only set the top if there are any remote commits
-				if (remoteBranchGroups.length > 0) {
-					line.top.type = 'LocalShadow';
-				}
-
-				line.commitNode = {
-					type: 'LocalShadow',
-					commit
-				};
-				line.bottom.type = 'LocalShadow';
-
-				localCommitWithChangeIdFound = true;
-			} else {
-				// If there are any remote commits, continue the line
-				if (remoteBranchGroups.length > 0) {
-					line.top.type = 'LocalRemote';
-					line.bottom.type = 'LocalRemote';
-					line.commitNode.type = 'LocalRemote';
-				}
-			}
-		}
 	});
 
 	localAndRemoteBranchGroups.forEach(({ commit, line }) => {

--- a/packages/ui/src/lib/commitLinesStacking/lineManager.ts
+++ b/packages/ui/src/lib/commitLinesStacking/lineManager.ts
@@ -25,15 +25,6 @@ function generateLineData({
 		line.top.type = 'Upstream';
 		line.bottom.type = 'Upstream';
 		line.commitNode = { type: 'Upstream', commit };
-
-		// If there are local commits we want to fill in a local dashed line
-		if (localBranchGroups.length > 0) {
-			line.commitNode.type = 'Local';
-			line.top.type = 'Local';
-			line.bottom.type = 'Local';
-			line.top.style = 'dashed';
-			line.bottom.style = 'dashed';
-		}
 	});
 
 	let localCommitWithChangeIdFound = false;


### PR DESCRIPTION
## ☕️ Reasoning

- Fix Upstream-only commit lines coloring
- Fix clicking on one of those upstream `CommitCard`s. It would previously propagate the click event on so that the `toggle` would be triggered on the upstream commits accordion, instead of loading the files of the commitcard

## 🧢 Changes

### Before

![image](https://github.com/user-attachments/assets/b2e2c271-f464-41f7-b41f-3c860fa2178c)


### After

![image](https://github.com/user-attachments/assets/5ba6fc16-46d5-4fcb-801d-9bb660a31ec2)


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
