### PR TITLE
Stacking: fix upstream handling

### DIFF
--- a/crates/gitbutler-patch-reference/src/lib.rs
+++ b/crates/gitbutler-patch-reference/src/lib.rs
@@ -45,7 +45,7 @@ impl PatchReference {
 
     /// Returns `true` if the reference is pushed to the provided remote
     pub fn pushed(&self, remote: &str, ctx: &CommandContext) -> Result<bool> {
-        let remote_ref = self.remote_reference(remote)?;
+        let remote_ref = self.remote_reference(remote)?; // todo: this should probably just return false
         Ok(ctx.repository().find_reference(&remote_ref).is_ok())
     }
 }

--- a/crates/gitbutler-stack/src/series.rs
+++ b/crates/gitbutler-stack/src/series.rs
@@ -20,3 +20,25 @@ pub struct Series {
     /// Topologically ordered, the first entry is the newest in the series.
     pub remote_commits: Vec<CommitOrChangeId>,
 }
+
+impl Series {
+    /// Returns `true` if the provided patch is part of the remote commits in this series (i.e. has been pushed).
+    pub fn remote(&self, patch: &CommitOrChangeId) -> bool {
+        self.remote_commits.contains(patch)
+    }
+    /// Returns a list of patches that are only in the upstream (remote) and not in the local commits,
+    /// as determined by the commit ID or change ID.
+    /// This comparison is peformed against the full stack of series.
+    pub fn upstream_only(&self, stack_series: &[Series]) -> Vec<CommitOrChangeId> {
+        let mut upstream_only = vec![];
+        for commit in &self.remote_commits {
+            if !stack_series
+                .iter()
+                .any(|s| s.local_commits.contains(commit))
+            {
+                upstream_only.push(commit.clone());
+            }
+        }
+        upstream_only
+    }
+}


### PR DESCRIPTION
- Correctly detect commits that have been pushed
- Return the list of upstream only commits on the list_virtual_branches response