### PR TITLE
[#4889] feat: allow moving any commit from a stack into another lane

### DIFF
--- a/apps/desktop/src/lib/branches/dragActions.ts
+++ b/apps/desktop/src/lib/branches/dragActions.ts
@@ -11,15 +11,12 @@ class BranchDragActions {
 
 	acceptMoveCommit(data: any) {
 		return (
-			data instanceof DraggableCommit &&
-			data.branchId !== this.branch.id &&
-			data.isHeadCommit &&
-			!data.commit.conflicted
+			data instanceof DraggableCommit && data.branchId !== this.branch.id && !data.commit.conflicted
 		);
 	}
 
 	onMoveCommit(data: DraggableCommit) {
-		this.branchController.moveCommit(this.branch.id, data.commit.id);
+		this.branchController.moveCommit(this.branch.id, data.commit.id, data.commit.branchId);
 	}
 
 	acceptBranchDrop(data: any) {

--- a/apps/desktop/src/lib/vbranches/branchController.ts
+++ b/apps/desktop/src/lib/vbranches/branchController.ts
@@ -534,12 +534,13 @@ export class BranchController {
 		}
 	}
 
-	async moveCommit(targetBranchId: string, commitOid: string) {
+	async moveCommit(targetBranchId: string, commitOid: string, sourceBranchId: string) {
 		try {
 			await invoke<void>('move_commit', {
 				projectId: this.projectId,
 				targetBranchId,
-				commitOid
+				commitOid,
+				sourceBranchId
 			});
 		} catch (err: any) {
 			// TODO: Probably we wanna have error code checking in a more generic way

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -476,6 +476,7 @@ pub fn move_commit(
     project: &Project,
     target_branch_id: StackId,
     commit_oid: git2::Oid,
+    source_branch_id: StackId,
 ) -> Result<()> {
     let ctx = open_with_verify(project)?;
     assure_open_workspace_mode(&ctx).context("Moving a commit requires open workspace mode")?;
@@ -484,8 +485,14 @@ pub fn move_commit(
         SnapshotDetails::new(OperationKind::MoveCommit),
         guard.write_permission(),
     );
-    move_commits::move_commit(&ctx, target_branch_id, commit_oid, guard.write_permission())
-        .map_err(Into::into)
+    move_commits::move_commit(
+        &ctx,
+        target_branch_id,
+        commit_oid,
+        guard.write_permission(),
+        source_branch_id,
+    )
+    .map_err(Into::into)
 }
 
 #[instrument(level = tracing::Level::DEBUG, skip(project), err(Debug))]

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/move_commit_to_vbranch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/move_commit_to_vbranch.rs
@@ -34,7 +34,8 @@ fn no_diffs() {
         gitbutler_branch_actions::create_virtual_branch(project, &BranchCreateRequest::default())
             .unwrap();
 
-    gitbutler_branch_actions::move_commit(project, target_branch_id, commit_oid).unwrap();
+    gitbutler_branch_actions::move_commit(project, target_branch_id, commit_oid, source_branch_id)
+        .unwrap();
 
     let destination_branch = gitbutler_branch_actions::list_virtual_branches(project)
         .unwrap()
@@ -104,7 +105,8 @@ fn multiple_commits() {
         .unwrap();
 
     // Move the top commit from the source branch to the destination branch
-    gitbutler_branch_actions::move_commit(project, target_branch_id, commit_oid).unwrap();
+    gitbutler_branch_actions::move_commit(project, target_branch_id, commit_oid, source_branch_id)
+        .unwrap();
 
     let (branches, _) = gitbutler_branch_actions::list_virtual_branches(project).unwrap();
     let source_branch = branches.iter().find(|b| b.id == source_branch_id).unwrap();
@@ -203,7 +205,8 @@ fn multiple_commits_with_diffs() {
     assert_eq!(destination_branch.files.len(), 1);
 
     // Move the top commit from the source branch to the destination branch
-    gitbutler_branch_actions::move_commit(project, target_branch_id, commit_oid).unwrap();
+    gitbutler_branch_actions::move_commit(project, target_branch_id, commit_oid, source_branch_id)
+        .unwrap();
 
     let (branches, _) = gitbutler_branch_actions::list_virtual_branches(project).unwrap();
     let source_branch = branches.iter().find(|b| b.id == source_branch_id).unwrap();
@@ -279,7 +282,8 @@ fn diffs_on_source_branch() {
         gitbutler_branch_actions::create_virtual_branch(project, &BranchCreateRequest::default())
             .unwrap();
 
-    gitbutler_branch_actions::move_commit(project, target_branch_id, commit_oid).unwrap();
+    gitbutler_branch_actions::move_commit(project, target_branch_id, commit_oid, source_branch_id)
+        .unwrap();
 
     let destination_branch = gitbutler_branch_actions::list_virtual_branches(project)
         .unwrap()
@@ -350,7 +354,8 @@ fn diffs_on_target_branch() {
     )
     .unwrap();
 
-    gitbutler_branch_actions::move_commit(project, target_branch_id, commit_oid).unwrap();
+    gitbutler_branch_actions::move_commit(project, target_branch_id, commit_oid, source_branch_id)
+        .unwrap();
 
     let destination_branch = gitbutler_branch_actions::list_virtual_branches(project)
         .unwrap()
@@ -470,7 +475,8 @@ fn diffs_on_both_branches() {
         "@@ -0,0 +1 @@\n+yet another content\n\\ No newline at end of file\n"
     );
 
-    gitbutler_branch_actions::move_commit(project, target_branch_id, commit_oid).unwrap();
+    gitbutler_branch_actions::move_commit(project, target_branch_id, commit_oid, source_branch_id)
+        .unwrap();
 
     let (branches, _) = gitbutler_branch_actions::list_virtual_branches(project).unwrap();
     let source_branch = branches.iter().find(|b| b.id == source_branch_id).unwrap();
@@ -541,7 +547,12 @@ fn target_commit_locked_to_ancestors() {
         gitbutler_branch_actions::create_virtual_branch(project, &BranchCreateRequest::default())
             .unwrap();
 
-    let result = gitbutler_branch_actions::move_commit(project, target_branch_id, commit_oid);
+    let result = gitbutler_branch_actions::move_commit(
+        project,
+        target_branch_id,
+        commit_oid,
+        source_branch_id,
+    );
 
     assert_eq!(
         result.unwrap_err().to_string(),
@@ -581,9 +592,14 @@ fn locked_hunks_on_source_branch() {
             .unwrap();
 
     assert_eq!(
-        gitbutler_branch_actions::move_commit(project, target_branch_id, commit_oid)
-            .unwrap_err()
-            .to_string(),
+        gitbutler_branch_actions::move_commit(
+            project,
+            target_branch_id,
+            commit_oid,
+            source_branch_id
+        )
+        .unwrap_err()
+        .to_string(),
         "the source branch contains hunks locked to the target commit"
     );
 }
@@ -621,7 +637,8 @@ fn no_commit() {
         gitbutler_branch_actions::move_commit(
             project,
             target_branch_id,
-            git2::Oid::from_str(commit_id_hex).unwrap()
+            git2::Oid::from_str(commit_id_hex).unwrap(),
+            source_branch_id,
         )
         .unwrap_err()
         .to_string(),
@@ -656,7 +673,7 @@ fn no_branch() {
 
     let id = StackId::generate();
     assert_eq!(
-        gitbutler_branch_actions::move_commit(project, id, commit_oid)
+        gitbutler_branch_actions::move_commit(project, id, commit_oid, source_branch_id)
             .unwrap_err()
             .to_string(),
         format!("branch {id} is not among applied branches")

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -517,10 +517,16 @@ pub mod commands {
         project_id: ProjectId,
         commit_oid: String,
         target_branch_id: StackId,
+        source_branch_id: StackId,
     ) -> Result<(), Error> {
         let project = projects.get(project_id)?;
         let commit_oid = git2::Oid::from_str(&commit_oid).map_err(|e| anyhow!(e))?;
-        gitbutler_branch_actions::move_commit(&project, target_branch_id, commit_oid)?;
+        gitbutler_branch_actions::move_commit(
+            &project,
+            target_branch_id,
+            commit_oid,
+            source_branch_id,
+        )?;
         emit_vbranches(&windows, project_id);
         Ok(())
     }


### PR DESCRIPTION
## ☕️ Reasoning
Currently we only allow moving the top commit of a stack between lanes. This PR now also allows the user to move a non-head commit to the top of a different lane ( provided that the commit is not locked to its ancestors & children )

## 🧢 Changes
- Remove the UI check preventing the movement of a non-top commit to a different lane
- Propogate the source commit branch to the `move_commit` func. This is now required as there is no way to determine which branch a commit belongs to given just the commitId
- Perform the actual commit move
    - Add a check to ensure that none of the commits which occur after the source commit are locked to it
    - Apart from rebasing the source commit onto the new lane, now we also need to rebase the commits above the source commit to the parent of the source commit
    - Update the head of source branch ( destination branch head is already updated )
- To make the above change easier, we also update the `check_source_lock_to_ancestors` func to `check_source_lock_to_commits` and make it work without taking ownership of the commitIds to check for.

## 🎫 Affected issues

Fixes: #4889

## 🔬 Tests
_WIP_
<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
