### PR TITLE
improvement: Allow for string error toasts

### DIFF
--- a/apps/desktop/src/lib/notifications/ToastController.svelte
+++ b/apps/desktop/src/lib/notifications/ToastController.svelte
@@ -6,7 +6,6 @@
 </script>
 
 <div class="toast-controller hide-native-scrollbar">
-	<!-- eslint-disable-next-line svelte/valid-compile -->
 	{#each $toastStore as toast (toast.id)}
 		<div transition:slide={{ duration: 170 }}>
 			<InfoMessage

--- a/apps/desktop/src/lib/notifications/toasts.ts
+++ b/apps/desktop/src/lib/notifications/toasts.ts
@@ -1,3 +1,4 @@
+import { isStr } from '$lib/utils/string';
 import { writable, type Writable } from 'svelte/store';
 import type { MessageStyle } from '$lib/shared/InfoMessage.svelte';
 
@@ -34,6 +35,10 @@ export function showError(title: string, error: unknown) {
 			return;
 		const message = 'message' in error ? error.message : String(error);
 		showToast({ title, error: message, style: 'error' });
+	}
+
+	if (isStr(error)) {
+		showToast({ title, error, style: 'error' });
 	}
 }
 


### PR DESCRIPTION
Passing a string as the error to be displayed in the toast will display it as is