### PR TITLE
Refactor Branch to abstract setting and getting the `head` property

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2151,6 +2151,7 @@ dependencies = [
  "gitbutler-patch-reference",
  "gitbutler-reference",
  "gitbutler-serde",
+ "gitbutler-time",
  "gix",
  "hex",
  "itertools 0.13.0",

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -3,7 +3,7 @@ use std::{path::Path, time};
 use anyhow::{anyhow, Context, Result};
 use git2::Index;
 use gitbutler_branch::{
-    self, Branch, BranchId, BranchOwnershipClaims, Target, VirtualBranchesHandle,
+    self, Branch, BranchOwnershipClaims, Target, VirtualBranchesHandle,
     GITBUTLER_WORKSPACE_REFERENCE,
 };
 use gitbutler_command_context::CommandContext;
@@ -208,8 +208,6 @@ pub(crate) fn set_base_branch(
                 },
             );
 
-            let now_ms = gitbutler_time::time::now_ms();
-
             let (upstream, upstream_head) = if let Refname::Local(head_name) = &head_name {
                 let upstream_name = target_branch_ref.with_branch(head_name.branch());
                 if upstream_name.eq(target_branch_ref) {
@@ -235,29 +233,22 @@ pub(crate) fn set_base_branch(
                 (None, None)
             };
 
-            let branch = Branch {
-                id: BranchId::generate(),
-                name: head_name.to_string().replace("refs/heads/", ""),
-                notes: String::new(),
-                source_refname: Some(head_name),
+            let mut branch = Branch::new(
+                head_name.to_string().replace("refs/heads/", ""),
+                Some(head_name),
                 upstream,
                 upstream_head,
-                created_timestamp_ms: now_ms,
-                updated_timestamp_ms: now_ms,
-                head: current_head_commit.id(),
-                tree: gitbutler_diff::write::hunks_onto_commit(
+                gitbutler_diff::write::hunks_onto_commit(
                     ctx,
                     current_head_commit.id(),
                     gitbutler_diff::diff_files_into_hunks(wd_diff),
                 )?,
-                ownership,
-                order: 0,
-                selected_for_changes: None,
-                allow_rebasing: ctx.project().ok_with_force_push.into(),
-                in_workspace: true,
-                not_in_workspace_wip_change_id: None,
-                heads: Default::default(),
-            };
+                current_head_commit.id(),
+                0,
+                None,
+                ctx.project().ok_with_force_push.into(),
+            );
+            branch.ownership = ownership;
 
             vb_state.set_branch(branch)?;
         }
@@ -384,7 +375,7 @@ pub(crate) fn update_base_branch(
                 // branch head tree is the same as the new target tree.
                 // meaning we can safely use the new target commit as the branch head.
 
-                branch.head = new_target_commit.id();
+                branch.set_head(new_target_commit.id());
 
                 // it also means that the branch is fully integrated into the target.
                 // disconnect it from the upstream
@@ -433,7 +424,7 @@ pub(crate) fn update_base_branch(
 
             if branch.head() == target.sha {
                 // there are no commits on the branch, so we can just update the head to the new target and calculate the new tree
-                branch.head = new_target_commit.id();
+                branch.set_head(new_target_commit.id());
                 branch.tree = branch_merge_index_tree_oid;
                 vb_state.set_branch(branch.clone())?;
                 return Ok(Some(branch));
@@ -488,7 +479,7 @@ pub(crate) fn update_base_branch(
                     )
                     .context("failed to commit merge")?;
 
-                branch.head = new_target_head;
+                branch.set_head(new_target_head);
                 branch.tree = branch_merge_index_tree_oid;
                 vb_state.set_branch(branch.clone())?;
                 Ok(Some(branch))
@@ -513,7 +504,7 @@ pub(crate) fn update_base_branch(
 
             if let Some(rebased_head_oid) = rebased_head_oid? {
                 // rebase worked out, rewrite the branch head
-                branch.head = rebased_head_oid;
+                branch.set_head(rebased_head_oid);
                 branch.tree = branch_merge_index_tree_oid;
                 vb_state.set_branch(branch.clone())?;
                 return Ok(Some(branch));

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -86,7 +86,7 @@ fn go_back_to_integration(ctx: &CommandContext, default_target: &Target) -> Resu
         // merge this branches tree with our tree
         let branch_head = ctx
             .repository()
-            .find_commit(branch.head)
+            .find_commit(branch.head())
             .context("failed to find branch head")?;
         let branch_tree = branch_head
             .tree()
@@ -369,13 +369,15 @@ pub(crate) fn update_base_branch(
         .map(|(mut branch, _)| -> Result<Option<Branch>> {
             let branch_tree = repo.find_tree(branch.tree)?;
 
-            let branch_head_commit = repo.find_commit(branch.head).context(format!(
+            let branch_head_commit = repo.find_commit(branch.head()).context(format!(
                 "failed to find commit {} for branch {}",
-                branch.head, branch.id
+                branch.head(),
+                branch.id
             ))?;
             let branch_head_tree = branch_head_commit.tree().context(format!(
                 "failed to find tree for commit {} for branch {}",
-                branch.head, branch.id
+                branch.head(),
+                branch.id
             ))?;
 
             let result_integrated_detected = |mut branch: Branch| -> Result<Option<Branch>> {
@@ -429,7 +431,7 @@ pub(crate) fn update_base_branch(
                 return result_integrated_detected(branch);
             }
 
-            if branch.head == target.sha {
+            if branch.head() == target.sha {
                 // there are no commits on the branch, so we can just update the head to the new target and calculate the new tree
                 branch.head = new_target_commit.id();
                 branch.tree = branch_merge_index_tree_oid;
@@ -501,7 +503,7 @@ pub(crate) fn update_base_branch(
                 ctx,
                 new_target_commit.id(),
                 new_target_commit.id(),
-                branch.head,
+                branch.head(),
             );
 
             // rebase failed, just do the merge

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -261,7 +261,7 @@ fn branch_group_to_branch(
     // If there is a virtual branch let's get it's head. Alternatively, pick the first local branch and use it's head.
     // If there are no local branches, pick the first remote branch.
     let head_commit = if let Some(vbranch) = virtual_branch {
-        Some(git2_to_gix_object_id(vbranch.head).attach(repo))
+        Some(git2_to_gix_object_id(vbranch.head()).attach(repo))
     } else if let Some(mut branch) = local_branches.into_iter().next() {
         branch.peel_to_id_in_place_packed(packed).ok()
     } else if let Some(mut branch) = remote_branches.into_iter().next() {

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -98,27 +98,17 @@ impl BranchManager<'_> {
             }
         }
 
-        let now = gitbutler_time::time::now_ms();
-
-        let mut branch = Branch {
-            id: BranchId::generate(),
-            name: name.clone(),
-            notes: String::new(),
-            upstream: None,
-            upstream_head: None,
-            tree: tree.id(),
-            head: default_target.sha,
-            created_timestamp_ms: now,
-            updated_timestamp_ms: now,
-            ownership: BranchOwnershipClaims::default(),
+        let mut branch = Branch::new(
+            name.clone(),
+            None,
+            None,
+            None,
+            tree.id(),
+            default_target.sha,
             order,
             selected_for_changes,
-            allow_rebasing: self.ctx.project().ok_with_force_push.into(),
-            in_workspace: true,
-            not_in_workspace_wip_change_id: None,
-            source_refname: None,
-            heads: Default::default(),
-        };
+            self.ctx.project().ok_with_force_push.into(),
+        );
 
         if let Some(ownership) = &create.ownership {
             vbranch::set_ownership(&vb_state, &mut branch, ownership)
@@ -199,8 +189,6 @@ impl BranchManager<'_> {
             .any(|b| b.selected_for_changes.is_some()))
         .then_some(now_since_unix_epoch_ms());
 
-        let now = gitbutler_time::time::now_ms();
-
         // add file ownership based off the diff
         let target_commit = repo.find_commit(default_target.sha)?;
         let merge_base_oid = repo.merge_base(target_commit.id(), head_commit.id())?;
@@ -235,7 +223,7 @@ impl BranchManager<'_> {
             branch.upstream_head = upstream_branch.is_some().then_some(head_commit.id());
             branch.upstream = upstream_branch;
             branch.tree = head_commit_tree.id();
-            branch.head = head_commit.id();
+            branch.set_head(head_commit.id());
             branch.ownership = ownership;
             branch.order = order;
             branch.selected_for_changes = selected_for_changes;
@@ -244,25 +232,18 @@ impl BranchManager<'_> {
 
             branch
         } else {
-            Branch {
-                id: BranchId::generate(),
-                name: branch_name.clone(),
-                notes: String::new(),
-                source_refname: Some(target.clone()),
-                upstream_head: upstream_branch.is_some().then_some(head_commit.id()),
-                upstream: upstream_branch,
-                tree: head_commit_tree.id(),
-                head: head_commit.id(),
-                created_timestamp_ms: now,
-                updated_timestamp_ms: now,
-                ownership,
+            let upstream_head = upstream_branch.is_some().then_some(head_commit.id());
+            Branch::new(
+                branch_name.clone(),
+                Some(target.clone()),
+                upstream_branch,
+                upstream_head,
+                head_commit_tree.id(),
+                head_commit.id(),
                 order,
                 selected_for_changes,
-                allow_rebasing: self.ctx.project().ok_with_force_push.into(),
-                in_workspace: true,
-                not_in_workspace_wip_change_id: None,
-                heads: Default::default(),
-            }
+                self.ctx.project().ok_with_force_push.into(),
+            )
         };
 
         vb_state.set_branch(branch.clone())?;
@@ -433,7 +414,7 @@ impl BranchManager<'_> {
                 )?
             };
 
-            branch.head = new_head.id();
+            branch.set_head(new_head.id());
             branch.tree = repo.find_real_tree(&new_head, Default::default())?.id();
 
             vb_state.set_branch(branch.clone())?;

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
@@ -108,7 +108,7 @@ impl BranchManager<'_> {
                             .map(|file| (file.path, file.hunks))
                             .collect::<Vec<(PathBuf, Vec<VirtualBranchHunk>)>>();
                         let tree_oid =
-                            gitbutler_diff::write::hunks_onto_oid(self.ctx, branch.head, files)?;
+                            gitbutler_diff::write::hunks_onto_oid(self.ctx, branch.head(), files)?;
                         let branch_tree = repo.find_tree(tree_oid)?;
                         let mut result =
                             repo.merge_trees(&base_tree, &final_tree, &branch_tree, None)?;
@@ -147,7 +147,7 @@ impl BranchManager<'_> {
     #[instrument(level = tracing::Level::DEBUG, skip(self, vbranch), err(Debug))]
     fn build_real_branch(&self, vbranch: &mut Branch) -> Result<git2::Branch<'_>> {
         let repo = self.ctx.repository();
-        let target_commit = repo.find_commit(vbranch.head)?;
+        let target_commit = repo.find_commit(vbranch.head())?;
         let branch_name = vbranch.name.clone();
         let branch_name = normalize_branch_name(&branch_name)?;
 
@@ -170,7 +170,7 @@ impl BranchManager<'_> {
 
         // Build wip tree as either any uncommitted changes or an empty tree
         let vbranch_wip_tree = repo.find_tree(vbranch.tree)?;
-        let vbranch_head_tree = repo.find_commit(vbranch.head)?.tree()?;
+        let vbranch_head_tree = repo.find_commit(vbranch.head())?.tree()?;
 
         let tree = if vbranch_head_tree.id() != vbranch_wip_tree.id() {
             vbranch_wip_tree

--- a/crates/gitbutler-branch-actions/src/branch_trees.rs
+++ b/crates/gitbutler-branch-actions/src/branch_trees.rs
@@ -36,7 +36,7 @@ pub fn checkout_branch_trees<'a>(
         Ok(tree)
     } else {
         let merge_base = repository
-            .merge_base_octopussy(&branches.iter().map(|b| b.head).collect::<Vec<_>>())?;
+            .merge_base_octopussy(&branches.iter().map(|b| b.head()).collect::<Vec<_>>())?;
 
         let merge_base_tree = repository.find_commit(merge_base)?.tree()?;
 
@@ -92,7 +92,7 @@ pub fn compute_updated_branch_head(
 ) -> Result<BranchHeadAndTree> {
     compute_updated_branch_head_for_commits(
         repository,
-        branch.head,
+        branch.head(),
         branch.tree,
         new_head,
         fearless_rebasing,

--- a/crates/gitbutler-branch-actions/src/move_commits.rs
+++ b/crates/gitbutler-branch-actions/src/move_commits.rs
@@ -32,7 +32,7 @@ pub(crate) fn move_commit(
 
     let (ref mut source_branch, source_status) = applied_statuses
         .iter_mut()
-        .find(|(b, _)| b.head == commit_id)
+        .find(|(b, _)| b.head() == commit_id)
         .ok_or_else(|| anyhow!("commit {commit_id} to be moved could not be found"))?;
 
     let source_branch_non_comitted_files = source_status;
@@ -116,17 +116,17 @@ pub(crate) fn move_commit(
 
     let new_destination_head_oid = cherry_rebase_group(
         ctx.repository(),
-        destination_branch.head,
+        destination_branch.head(),
         &[source_commit.id()],
         true,
     )?;
 
     // reset the source branch to the parent commit
     // and update the destination branch head
-    source_branch.head = source_branch_head_parent.id();
+    source_branch.set_head(source_branch_head_parent.id());
     vb_state.set_branch(source_branch.clone())?;
 
-    destination_branch.head = new_destination_head_oid;
+    destination_branch.set_head(new_destination_head_oid);
     vb_state.set_branch(destination_branch.clone())?;
 
     checkout_branch_trees(ctx, perm)?;

--- a/crates/gitbutler-branch-actions/src/reorder_commits.rs
+++ b/crates/gitbutler-branch-actions/src/reorder_commits.rs
@@ -58,13 +58,13 @@ pub(crate) fn reorder_commit(
         merge_base,
         subject_commit_oid,
         offset,
-        &repository.l(branch.head, LogUntil::Commit(merge_base))?,
+        &repository.l(branch.head(), LogUntil::Commit(merge_base))?,
         &repository.find_tree(branch.tree)?,
         ctx.project().succeeding_rebases,
     )?;
 
     branch.tree = tree;
-    branch.head = head;
+    branch.set_head(head);
 
     branch.updated_timestamp_ms = gitbutler_time::time::now_ms();
     vb_state.set_branch(branch.clone())?;

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -122,7 +122,7 @@ pub fn push_stack(project: &Project, branch_id: BranchId, with_force: bool) -> R
 
     let repo = ctx.repository();
     let merge_base =
-        repo.find_commit(repo.merge_base(stack.head, state.get_default_target()?.sha)?)?;
+        repo.find_commit(repo.merge_base(stack.head(), state.get_default_target()?.sha)?)?;
     let merge_base = if let Some(change_id) = merge_base.change_id() {
         CommitOrChangeId::ChangeId(change_id)
     } else {

--- a/crates/gitbutler-branch-actions/src/status.rs
+++ b/crates/gitbutler-branch-actions/src/status.rs
@@ -218,7 +218,7 @@ pub fn get_applied_status_cached(
     // write updated state if not resolving
     if !ctx.is_resolving() {
         for (vbranch, files) in &mut hunks_by_branch {
-            vbranch.tree = gitbutler_diff::write::hunks_onto_oid(ctx, vbranch.head, files)?;
+            vbranch.tree = gitbutler_diff::write::hunks_onto_oid(ctx, vbranch.head(), files)?;
             vb_state
                 .set_branch(vbranch.clone())
                 .context(format!("failed to write virtual branch {}", vbranch.name))?;
@@ -261,7 +261,7 @@ fn compute_locks(
     let branch_path_diffs = virtual_branches
         .iter()
         .filter_map(|branch| {
-            let commit = repository.find_commit(branch.head).ok()?;
+            let commit = repository.find_commit(branch.head()).ok()?;
             let tree = repository
                 .find_real_tree(&commit, Default::default())
                 .ok()?;
@@ -319,7 +319,7 @@ fn compute_locks(
                 .iter()
                 .map(|b| HunkLock {
                     branch_id: b.id,
-                    commit_id: b.head,
+                    commit_id: b.head(),
                 })
                 .collect::<Vec<_>>();
 

--- a/crates/gitbutler-branch-actions/src/undo_commit.rs
+++ b/crates/gitbutler-branch-actions/src/undo_commit.rs
@@ -29,12 +29,12 @@ pub(crate) fn undo_commit(
 
     let new_head_commit = inner_undo_commit(
         ctx.repository(),
-        branch.head,
+        branch.head(),
         commit_oid,
         succeeding_rebases,
     )?;
 
-    branch.head = new_head_commit;
+    branch.set_head(new_head_commit);
     branch.updated_timestamp_ms = gitbutler_time::time::now_ms();
     vb_state.set_branch(branch.clone())?;
 

--- a/crates/gitbutler-branch-actions/tests/extra/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/extra/mod.rs
@@ -845,7 +845,7 @@ fn merge_vbranch_upstream_clean_rebase() -> Result<()> {
         .expect("failed to create virtual branch");
 
     branch.upstream = Some(remote_branch.clone());
-    branch.head = last_push;
+    branch.set_head(last_push);
     vb_state.set_branch(branch.clone())?;
 
     // create the branch
@@ -970,7 +970,7 @@ fn merge_vbranch_upstream_conflict() -> Result<()> {
         .create_virtual_branch(&BranchCreateRequest::default(), guard.write_permission())
         .expect("failed to create virtual branch");
     branch.upstream = Some(remote_branch.clone());
-    branch.head = last_push;
+    branch.set_head(last_push);
     vb_state.set_branch(branch.clone())?;
 
     internal::update_branch(

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/branch_trees.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/branch_trees.rs
@@ -1,30 +1,25 @@
-use gitbutler_branch::{Branch, BranchOwnershipClaims};
-use uuid::Uuid;
+use gitbutler_branch::Branch;
 
 /// Makes a Branch struct with a bunch of default values.
 ///
 /// This assumes that the only relevant properties for your test are the head
 /// and tree Oids.
 fn make_branch(head: git2::Oid, tree: git2::Oid) -> Branch {
-    Branch {
-        id: Uuid::new_v4().into(),
-        name: "branchy branch".into(),
-        notes: "bla bla bla".into(),
-        source_refname: None,
-        upstream: None,
-        upstream_head: None,
-        created_timestamp_ms: 69420,
-        updated_timestamp_ms: 69420,
+    let mut branch = Branch::new(
+        "branchy branch".into(),
+        None,
+        None,
+        None,
         tree,
         head,
-        ownership: BranchOwnershipClaims::default(),
-        order: 0,
-        selected_for_changes: None,
-        allow_rebasing: true,
-        in_workspace: true,
-        not_in_workspace_wip_change_id: None,
-        heads: Default::default(),
-    }
+        0,
+        None,
+        true,
+    );
+    branch.created_timestamp_ms = 69420;
+    branch.updated_timestamp_ms = 69420;
+    branch.notes = "bla bla bla".into();
+    branch
 }
 
 #[cfg(test)]
@@ -52,7 +47,7 @@ mod compute_updated_branch_head {
             compute_updated_branch_head(&test_repository.repository, &branch, head.id(), true)
                 .unwrap();
 
-        assert_eq!(head, branch.head);
+        assert_eq!(head, branch.head());
         assert_eq!(tree, branch.tree);
     }
 

--- a/crates/gitbutler-branch/Cargo.toml
+++ b/crates/gitbutler-branch/Cargo.toml
@@ -17,6 +17,7 @@ gitbutler-fs.workspace = true
 gitbutler-diff.workspace = true
 gitbutler-oxidize.workspace = true
 gitbutler-patch-reference.workspace = true
+gitbutler-time.workspace = true
 itertools = "0.13"
 toml.workspace = true
 serde = { workspace = true, features = ["std"] }

--- a/crates/gitbutler-branch/src/branch.rs
+++ b/crates/gitbutler-branch/src/branch.rs
@@ -44,7 +44,7 @@ pub struct Branch {
     pub tree: git2::Oid,
     /// head is id of the last "virtual" commit in this branch
     #[serde(with = "gitbutler_serde::oid")]
-    pub head: git2::Oid,
+    head: git2::Oid,
     pub ownership: BranchOwnershipClaims,
     // order is the number by which UI should sort branches
     pub order: usize,
@@ -86,12 +86,51 @@ where
 }
 
 impl Branch {
+    /// Creates a new `Branch` with the given name. The `in_workspace` flag is set to `true`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        name: String,
+        source_refname: Option<Refname>,
+        upstream: Option<RemoteRefname>,
+        upstream_head: Option<git2::Oid>,
+        tree: git2::Oid,
+        head: git2::Oid,
+        order: usize,
+        selected_for_changes: Option<i64>,
+        allow_rebasing: bool,
+    ) -> Self {
+        let now = gitbutler_time::time::now_ms();
+        Self {
+            id: BranchId::generate(),
+            name,
+            notes: String::new(),
+            source_refname,
+            upstream,
+            upstream_head,
+            created_timestamp_ms: now,
+            updated_timestamp_ms: now,
+            tree,
+            head,
+            ownership: BranchOwnershipClaims::default(),
+            order,
+            selected_for_changes,
+            allow_rebasing,
+            in_workspace: true,
+            not_in_workspace_wip_change_id: None,
+            heads: Default::default(),
+        }
+    }
+
     pub fn refname(&self) -> anyhow::Result<VirtualRefname> {
         self.try_into()
     }
 
     pub fn head(&self) -> git2::Oid {
         self.head
+    }
+
+    pub fn set_head(&mut self, head: git2::Oid) {
+        self.head = head;
     }
 }
 

--- a/crates/gitbutler-branch/src/branch.rs
+++ b/crates/gitbutler-branch/src/branch.rs
@@ -89,6 +89,10 @@ impl Branch {
     pub fn refname(&self) -> anyhow::Result<VirtualRefname> {
         self.try_into()
     }
+
+    pub fn head(&self) -> git2::Oid {
+        self.head
+    }
 }
 
 impl TryFrom<&Branch> for VirtualRefname {

--- a/crates/gitbutler-branch/src/ownership.rs
+++ b/crates/gitbutler-branch/src/ownership.rs
@@ -119,14 +119,12 @@ pub fn reconcile_claims(
         });
     }
 
+    let mut updated_branch = claiming_branch.clone();
+    updated_branch.ownership.claims = new_claims.to_owned();
+
     // Add the claiming branch to the list of outcomes
     claim_outcomes.push(ClaimOutcome {
-        updated_branch: Branch {
-            ownership: BranchOwnershipClaims {
-                claims: new_claims.to_owned(),
-            },
-            ..claiming_branch.clone()
-        },
+        updated_branch,
         removed_claims: Vec::new(),
     });
 

--- a/crates/gitbutler-branch/tests/ownership.rs
+++ b/crates/gitbutler-branch/tests/ownership.rs
@@ -1,73 +1,65 @@
 use std::{path::PathBuf, vec};
 
-use gitbutler_branch::{reconcile_claims, Branch, BranchId, BranchOwnershipClaims, OwnershipClaim};
+use gitbutler_branch::{reconcile_claims, Branch, BranchOwnershipClaims, OwnershipClaim};
 use gitbutler_diff::Hunk;
 
 #[test]
 fn reconcile_ownership_simple() {
-    let branch_a = Branch {
-        name: "a".to_string(),
-        ownership: BranchOwnershipClaims {
-            claims: vec![OwnershipClaim {
-                file_path: PathBuf::from("foo"),
-                hunks: vec![
-                    Hunk {
-                        start: 1,
-                        end: 3,
-                        hash: Some(Hunk::hash("1,3")),
-                    },
-                    Hunk {
-                        start: 4,
-                        end: 6,
-                        hash: Some(Hunk::hash("4,6")),
-                    },
-                ],
-            }],
-        },
-        tree: git2::Oid::zero(),
-        head: git2::Oid::zero(),
-        id: BranchId::default(),
-        notes: String::default(),
-        upstream: None,
-        upstream_head: None,
-        created_timestamp_ms: u128::default(),
-        updated_timestamp_ms: u128::default(),
-        order: usize::default(),
-        selected_for_changes: None,
-        allow_rebasing: true,
-        in_workspace: true,
-        not_in_workspace_wip_change_id: None,
-        source_refname: None,
-        heads: Default::default(),
+    let mut branch_a = Branch::new(
+        "a".to_string(),
+        None,
+        None,
+        None,
+        git2::Oid::zero(),
+        git2::Oid::zero(),
+        usize::default(),
+        None,
+        true,
+    );
+    branch_a.ownership = BranchOwnershipClaims {
+        claims: vec![OwnershipClaim {
+            file_path: PathBuf::from("foo"),
+            hunks: vec![
+                Hunk {
+                    start: 1,
+                    end: 3,
+                    hash: Some(Hunk::hash("1,3")),
+                },
+                Hunk {
+                    start: 4,
+                    end: 6,
+                    hash: Some(Hunk::hash("4,6")),
+                },
+            ],
+        }],
     };
-    let branch_b = Branch {
-        name: "b".to_string(),
-        ownership: BranchOwnershipClaims {
-            claims: vec![OwnershipClaim {
-                file_path: PathBuf::from("foo"),
-                hunks: vec![Hunk {
-                    start: 7,
-                    end: 9,
-                    hash: Some(Hunk::hash("7,9")),
-                }],
+    branch_a.created_timestamp_ms = u128::default();
+    branch_a.updated_timestamp_ms = u128::default();
+
+    let mut branch_b = Branch::new(
+        "b".to_string(),
+        None,
+        None,
+        None,
+        git2::Oid::zero(),
+        git2::Oid::zero(),
+        usize::default(),
+        None,
+        true,
+    );
+    branch_b.ownership = BranchOwnershipClaims {
+        claims: vec![OwnershipClaim {
+            file_path: PathBuf::from("foo"),
+            hunks: vec![Hunk {
+                start: 7,
+                end: 9,
+                hash: Some(Hunk::hash("7,9")),
             }],
-        },
-        tree: git2::Oid::zero(),
-        head: git2::Oid::zero(),
-        id: BranchId::default(),
-        notes: String::default(),
-        upstream: None,
-        upstream_head: None,
-        created_timestamp_ms: u128::default(),
-        updated_timestamp_ms: u128::default(),
-        order: usize::default(),
-        selected_for_changes: None,
-        allow_rebasing: true,
-        in_workspace: true,
-        not_in_workspace_wip_change_id: None,
-        source_refname: None,
-        heads: Default::default(),
+        }],
     };
+    branch_b.created_timestamp_ms = u128::default();
+    branch_b.updated_timestamp_ms = u128::default();
+
     let all_branches: Vec<Branch> = vec![branch_a.clone(), branch_b.clone()];
     let claim: Vec<OwnershipClaim> = vec![OwnershipClaim {
         file_path: PathBuf::from("foo"),

--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -216,7 +216,7 @@ pub(crate) fn save_and_return_to_workspace(
         .context("Failed to commit new commit")?;
 
     // Rebase all all commits on top of the new commit and update reference
-    let new_branch_head = cherry_rebase(ctx, new_commit_oid, commit.id(), virtual_branch.head)
+    let new_branch_head = cherry_rebase(ctx, new_commit_oid, commit.id(), virtual_branch.head())
         .context("Failed to rebase commits onto new commit")?
         .unwrap_or(new_commit_oid);
 
@@ -232,7 +232,7 @@ pub(crate) fn save_and_return_to_workspace(
         fearless_rebasing,
     )?;
 
-    virtual_branch.head = new_branch_head;
+    virtual_branch.set_head(new_branch_head);
     virtual_branch.tree = new_branch_tree;
     virtual_branch.updated_timestamp_ms = gitbutler_time::time::now_ms();
     vb_state

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -372,7 +372,7 @@ fn prepare_snapshot(ctx: &Project, _shared_access: &WorktreeReadPermission) -> R
 
         // let's get all the commits between the branch head and the target
         let mut revwalk = repo.revwalk()?;
-        revwalk.push(branch.head)?;
+        revwalk.push(branch.head())?;
         revwalk.hide(default_target_commit.id())?;
 
         let mut commits_tree_builder = repo.treebuilder(None)?;

--- a/crates/gitbutler-repo/src/repository.rs
+++ b/crates/gitbutler-repo/src/repository.rs
@@ -79,7 +79,7 @@ impl RepoActionsExt for CommandContext {
             .find_reference(&branch.refname()?.to_string())
         {
             Ok(reference) => match reference.target() {
-                Some(head_oid) => Ok((head_oid != branch.head, true)),
+                Some(head_oid) => Ok((head_oid != branch.head(), true)),
                 None => Ok((true, true)),
             },
             Err(err) => match err.code() {
@@ -93,7 +93,7 @@ impl RepoActionsExt for CommandContext {
             self.repository()
                 .reference(
                     &branch.refname()?.to_string(),
-                    branch.head,
+                    branch.head(),
                     with_force,
                     "new vbranch",
                 )

--- a/crates/gitbutler-stack/tests/mod.rs
+++ b/crates/gitbutler-stack/tests/mod.rs
@@ -22,7 +22,7 @@ fn init_success() -> Result<()> {
         branch.heads[0].target,
         CommitOrChangeId::ChangeId(
             ctx.repository()
-                .find_commit(branch.head)?
+                .find_commit(branch.head())?
                 .change_id()
                 .unwrap()
         )
@@ -101,7 +101,7 @@ fn add_series_top_base() -> Result<()> {
     test_ctx.branch.initialize(&ctx)?;
     let merge_base = ctx.repository().find_commit(
         ctx.repository()
-            .merge_base(test_ctx.branch.head, test_ctx.default_target.sha)?,
+            .merge_base(test_ctx.branch.head(), test_ctx.default_target.sha)?,
     )?;
     let reference = PatchReference {
         name: "asdf".into(),
@@ -772,11 +772,11 @@ fn test_ctx(ctx: &CommandContext) -> Result<TestContext> {
     let target = handle.get_default_target()?;
     let mut branch_commits = ctx
         .repository()
-        .log(branch.head, LogUntil::Commit(target.sha))?;
+        .log(branch.head(), LogUntil::Commit(target.sha))?;
     branch_commits.reverse();
     let mut other_commits = ctx
         .repository()
-        .log(other_branch.head, LogUntil::Commit(target.sha))?;
+        .log(other_branch.head(), LogUntil::Commit(target.sha))?;
     other_commits.reverse();
     Ok(TestContext {
         branch: branch.clone(),


### PR DESCRIPTION
This pull request refactors the Branch class to abstract setting and getting the `head` property. It introduces a `head()` method, and implements `set_head()` while making the field private. This change paves the way for a potential migration to the `heads` field.

Functionality wise this should be a noop - just sets the stage for controlling the behavior better