### PR TITLE
fix: stackingCommitList reorder-dropzone and "add empty commit" btn rendering

### DIFF
--- a/apps/desktop/src/lib/commit/CommitList.svelte
+++ b/apps/desktop/src/lib/commit/CommitList.svelte
@@ -188,10 +188,7 @@
 		<!-- LOCAL COMMITS -->
 		{#if localCommits.length > 0}
 			<div class="commits-group">
-				<InsertEmptyCommitAction
-					isFirst
-					on:click={() => insertBlankCommit($branch.head, 'above')}
-				/>
+				<InsertEmptyCommitAction isFirst onclick={() => insertBlankCommit($branch.head, 'above')} />
 				{@render reorderDropzone(
 					reorderDropzoneManager.topDropzone,
 					getReorderDropzoneOffset({ isFirst: true })
@@ -221,7 +218,7 @@
 
 					<InsertEmptyCommitAction
 						isLast={idx + 1 === localCommits.length}
-						on:click={() => insertBlankCommit(commit.id, 'below')}
+						onclick={() => insertBlankCommit(commit.id, 'below')}
 					/>
 				{/each}
 				{#if pushButton}
@@ -263,7 +260,7 @@
 					)}
 					<InsertEmptyCommitAction
 						isLast={idx + 1 === localAndRemoteCommits.length}
-						on:click={() => insertBlankCommit(commit.id, 'below')}
+						onclick={() => insertBlankCommit(commit.id, 'below')}
 					/>
 				{/each}
 

--- a/apps/desktop/src/lib/commit/StackingCommitList.svelte
+++ b/apps/desktop/src/lib/commit/StackingCommitList.svelte
@@ -284,7 +284,6 @@
 		flex-direction: column;
 		background-color: var(--clr-bg-2);
 		border-radius: 0 0 var(--radius-m) var(--radius-m);
-		overflow: hidden;
 	}
 
 	.commits-group {

--- a/apps/desktop/src/lib/commit/StackingCommitList.svelte
+++ b/apps/desktop/src/lib/commit/StackingCommitList.svelte
@@ -155,10 +155,7 @@
 		<!-- LOCAL COMMITS -->
 		{#if localCommits.length > 0}
 			<div class="commits-group">
-				<InsertEmptyCommitAction
-					isFirst
-					on:click={() => insertBlankCommit($branch.head, 'above')}
-				/>
+				<InsertEmptyCommitAction isFirst onclick={() => insertBlankCommit($branch.head, 'above')} />
 
 				{@render reorderDropzone(reorderDropzoneManager.topDropzone)}
 
@@ -182,7 +179,7 @@
 
 					<InsertEmptyCommitAction
 						isLast={idx + 1 === localCommits.length}
-						on:click={() => insertBlankCommit(commit.id, 'below')}
+						onclick={() => insertBlankCommit(commit.id, 'below')}
 					/>
 				{/each}
 			</div>
@@ -194,7 +191,7 @@
 				{#if localCommits.length === 0}
 					<InsertEmptyCommitAction
 						isFirst
-						on:click={() => insertBlankCommit($branch.head, 'above')}
+						onclick={() => insertBlankCommit($branch.head, 'above')}
 					/>
 
 					{@render reorderDropzone(reorderDropzoneManager.topDropzone)}
@@ -220,7 +217,7 @@
 
 					<InsertEmptyCommitAction
 						isLast={idx + 1 === localAndRemoteCommits.length}
-						on:click={() => insertBlankCommit(commit.id, 'below')}
+						onclick={() => insertBlankCommit(commit.id, 'below')}
 					/>
 				{/each}
 

--- a/apps/desktop/src/lib/commit/StackingCommitList.svelte
+++ b/apps/desktop/src/lib/commit/StackingCommitList.svelte
@@ -98,27 +98,12 @@
 		}
 		branchController.insertBlankCommit($branch.id, commitId, location === 'above' ? -1 : 1);
 	}
-
-	function getReorderDropzoneOffset({
-		isFirst = false,
-		isMiddle = false,
-		isLast = false
-	}: {
-		isFirst?: boolean;
-		isMiddle?: boolean;
-		isLast?: boolean;
-	}) {
-		if (isFirst) return 12;
-		if (isMiddle) return 6;
-		if (isLast) return 0;
-		return 0;
-	}
 </script>
 
-{#snippet reorderDropzone(dropzone: ReorderDropzone, yOffsetPx: number)}
+{#snippet reorderDropzone(dropzone: ReorderDropzone)}
 	<Dropzone accepts={dropzone.accepts.bind(dropzone)} ondrop={dropzone.onDrop.bind(dropzone)}>
 		{#snippet overlay({ hovered, activated })}
-			<LineOverlay {hovered} {activated} {yOffsetPx} />
+			<LineOverlay {hovered} {activated} />
 		{/snippet}
 	</Dropzone>
 {/snippet}
@@ -174,10 +159,9 @@
 					isFirst
 					on:click={() => insertBlankCommit($branch.head, 'above')}
 				/>
-				{@render reorderDropzone(
-					reorderDropzoneManager.topDropzone,
-					getReorderDropzoneOffset({ isFirst: true })
-				)}
+
+				{@render reorderDropzone(reorderDropzoneManager.topDropzone)}
+
 				{#each localCommits as commit, idx (commit.id)}
 					<StackingCommitDragItem {commit}>
 						<StackingCommitCard
@@ -194,13 +178,7 @@
 						</StackingCommitCard>
 					</StackingCommitDragItem>
 
-					{@render reorderDropzone(
-						reorderDropzoneManager.dropzoneBelowCommit(commit.id),
-						getReorderDropzoneOffset({
-							isLast: idx + 1 === localCommits.length,
-							isMiddle: idx + 1 === localCommits.length
-						})
-					)}
+					{@render reorderDropzone(reorderDropzoneManager.dropzoneBelowCommit(commit.id))}
 
 					<InsertEmptyCommitAction
 						isLast={idx + 1 === localCommits.length}
@@ -213,6 +191,14 @@
 		<!-- LOCAL AND REMOTE COMMITS -->
 		{#if localAndRemoteCommits.length > 0}
 			<div class="commits-group">
+				{#if localCommits.length === 0}
+					<InsertEmptyCommitAction
+						isFirst
+						on:click={() => insertBlankCommit($branch.head, 'above')}
+					/>
+
+					{@render reorderDropzone(reorderDropzoneManager.topDropzone)}
+				{/if}
 				{#each localAndRemoteCommits as commit, idx (commit.id)}
 					<StackingCommitDragItem {commit}>
 						<StackingCommitCard
@@ -229,12 +215,9 @@
 							{/snippet}
 						</StackingCommitCard>
 					</StackingCommitDragItem>
-					{@render reorderDropzone(
-						reorderDropzoneManager.dropzoneBelowCommit(commit.id),
-						getReorderDropzoneOffset({
-							isMiddle: idx + 1 === localAndRemoteCommits.length
-						})
-					)}
+
+					{@render reorderDropzone(reorderDropzoneManager.dropzoneBelowCommit(commit.id))}
+
 					<InsertEmptyCommitAction
 						isLast={idx + 1 === localAndRemoteCommits.length}
 						on:click={() => insertBlankCommit(commit.id, 'below')}

--- a/apps/desktop/src/lib/components/InsertEmptyCommitAction.svelte
+++ b/apps/desktop/src/lib/components/InsertEmptyCommitAction.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
-	import Button from '@gitbutler/ui/Button.svelte';
 	import { stackingFeature } from '$lib/config/uiFeatureFlags';
-	import { createEventDispatcher } from 'svelte';
+	import Button from '@gitbutler/ui/Button.svelte';
 
-	export let isLast = false;
-	export let isFirst = false;
+	interface Props {
+		isLast?: boolean;
+		isFirst?: boolean;
+		onclick?: () => void;
+	}
 
-	const dispatch = createEventDispatcher<{ click: void }>();
+	const { isLast = false, isFirst = false, onclick }: Props = $props();
 </script>
 
 <div
@@ -25,7 +27,7 @@
 			width={26}
 			tooltip="Insert empty commit"
 			helpShowDelay={500}
-			onclick={() => dispatch('click')}
+			onclick={onclick?.()}
 		/>
 	</div>
 </div>

--- a/apps/desktop/src/lib/components/InsertEmptyCommitAction.svelte
+++ b/apps/desktop/src/lib/components/InsertEmptyCommitAction.svelte
@@ -93,13 +93,8 @@
 	}
 
 	/* MODIFIERS */
-
 	.line-container.is-last {
 		transform: translateY(-4px);
-	}
-
-	.line-container.is-first {
-		transform: translateY(16px);
 	}
 
 	.line-container.is-middle {

--- a/apps/desktop/src/lib/components/InsertEmptyCommitAction.svelte
+++ b/apps/desktop/src/lib/components/InsertEmptyCommitAction.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import Button from '@gitbutler/ui/Button.svelte';
+	import { stackingFeature } from '$lib/config/uiFeatureFlags';
 	import { createEventDispatcher } from 'svelte';
 
 	export let isLast = false;
 	export let isFirst = false;
-	export let isMiddle = false;
 
 	const dispatch = createEventDispatcher<{ click: void }>();
 </script>
@@ -13,7 +13,7 @@
 	class="line-container"
 	class:is-last={isLast}
 	class:is-first={isFirst}
-	class:is-middle={isMiddle}
+	class:not-stacking={!$stackingFeature}
 >
 	<div class="hover-target">
 		<Button
@@ -93,11 +93,11 @@
 	}
 
 	/* MODIFIERS */
-	.line-container.is-last {
-		transform: translateY(-4px);
+	.line-container.not-stacking.is-first {
+		transform: translateY(16px);
 	}
 
-	.line-container.is-middle {
-		transform: translateY(6px);
+	.line-container.not-stacking.is-last {
+		transform: translateY(-4px);
 	}
 </style>

--- a/apps/desktop/src/lib/stack/StackSeries.svelte
+++ b/apps/desktop/src/lib/stack/StackSeries.svelte
@@ -59,6 +59,9 @@
 		border: 1px solid var(--clr-border-2);
 		border-radius: var(--radius-m);
 		background: var(--clr-bg-1);
-		overflow: hidden;
+
+		&:last-child {
+			margin-bottom: 12px;
+		}
 	}
 </style>


### PR DESCRIPTION
## ☕️ Reasoning

- `StackingCommitList` "Insert Empty Commit" buttons were misplaced
- Dropzone line was rendering in the wrong place
- Converted `InsertEmptyCommitAction` to runes syntax

## 🧢 Changes

![image](https://github.com/user-attachments/assets/90f56cbd-a12a-44a4-92b7-ce92b49faefb)

![image](https://github.com/user-attachments/assets/20cd149f-5f4c-4cd8-a219-cd6af2bf1b18)


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
