### PR TITLE
fix: stacking header tweaks

### DIFF
--- a/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
@@ -103,6 +103,7 @@
 				bind:contextMenuEl={contextMenu}
 				target={meatballButtonEl}
 				headName={name}
+				seriesCount={branch.series?.length ?? 0}
 				{addDescription}
 			/>
 		</div>

--- a/apps/desktop/src/lib/branch/StackingBranchHeaderContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/StackingBranchHeaderContextMenu.svelte
@@ -13,10 +13,17 @@
 		contextMenuEl?: ReturnType<typeof ContextMenu>;
 		target?: HTMLElement;
 		headName: string;
+		seriesCount: number;
 		addDescription: () => void;
 	}
 
-	let { contextMenuEl = $bindable(), target, headName, addDescription }: Props = $props();
+	let {
+		contextMenuEl = $bindable(),
+		target,
+		seriesCount,
+		headName,
+		addDescription
+	}: Props = $props();
 
 	const branchStore = getContextStore(VirtualBranch);
 	const branchController = getContext(BranchController);
@@ -48,6 +55,7 @@
 		/>
 		<ContextMenuItem
 			label="Delete"
+			disabled={seriesCount <= 1}
 			on:click={() => {
 				deleteSeriesModal.show(branch);
 				contextMenuEl?.close();

--- a/apps/desktop/src/lib/branch/StackingNewStackCard.svelte
+++ b/apps/desktop/src/lib/branch/StackingNewStackCard.svelte
@@ -73,8 +73,8 @@
 		<TextBox placeholder="New branch name" id="newRemoteName" bind:value={createRefName} focus />
 	{/snippet}
 	{#snippet controls(close)}
-		<Button style="pop" kind="solid">Ok</Button>
 		<Button style="ghost" outline type="reset" onclick={close}>Cancel</Button>
+		<Button style="pop" kind="solid">Ok</Button>
 	{/snippet}
 </Modal>
 

--- a/apps/desktop/src/lib/commit/StackingCommitCard.svelte
+++ b/apps/desktop/src/lib/commit/StackingCommitCard.svelte
@@ -205,8 +205,8 @@
 		<TextBox placeholder="New branch name" id="newRemoteName" bind:value={createRefName} focus />
 	{/snippet}
 	{#snippet controls(close)}
-		<Button style="pop" kind="solid">Ok</Button>
 		<Button style="ghost" outline type="reset" onclick={close}>Cancel</Button>
+		<Button style="pop" kind="solid">Ok</Button>
 	{/snippet}
 </Modal>
 


### PR DESCRIPTION
## ☕️ Reasoning

- Disable "Delete (Series)" button when there is only 1 series
- Reorient the primary and secondary btns in the "create new series in stack" naming modal

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
