### PR TITLE
User: Make email optional

### DIFF
--- a/apps/desktop/src/lib/stores/user.ts
+++ b/apps/desktop/src/lib/stores/user.ts
@@ -137,9 +137,9 @@ export class User {
 	name: string | undefined;
 	given_name: string | undefined;
 	family_name: string | undefined;
-	email!: string;
+	email!: string | undefined;
 	picture!: string;
-	locale!: string;
+	locale!: string | undefined;
 	created_at!: string;
 	updated_at!: string;
 	access_token!: string;

--- a/crates/gitbutler-tauri/src/users.rs
+++ b/crates/gitbutler-tauri/src/users.rs
@@ -41,7 +41,7 @@ pub mod commands {
         name: Option<String>,
         given_name: Option<String>,
         family_name: Option<String>,
-        email: String,
+        email: Option<String>,
         picture: String,
         locale: Option<String>,
         created_at: String,

--- a/crates/gitbutler-user/src/user.rs
+++ b/crates/gitbutler-user/src/user.rs
@@ -10,7 +10,7 @@ pub struct User {
     pub name: Option<String>,
     pub given_name: Option<String>,
     pub family_name: Option<String>,
-    pub email: String,
+    pub email: Option<String>,
     pub picture: String,
     pub locale: Option<String>,
     pub created_at: String,


### PR DESCRIPTION
When authenticating with some IdPs, sharing the email is optional.
In that case, trying to authenticate would just throw a Rust-end error to the privacy-minded user.
This fixes that