### PR TITLE
fix: do not group commits by type when rendering and harmonize commit color keys

### DIFF
--- a/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
@@ -39,17 +39,16 @@
 	let prDetailsModal = $state<ReturnType<typeof PrDetailsModal>>();
 	let meatballButtonEl = $state<HTMLDivElement>();
 
+	// TODO: Simplify figuring out if shadow color is needed
 	const currentSeries = $derived(branch.series?.find((series) => series.name === upstreamName));
 	const topPatch = $derived(currentSeries?.patches[0]);
 	const hasShadow = $derived.by(() => {
 		if (!topPatch || !topPatch.remoteCommitId) return false;
-
 		if (topPatch.remoteCommitId !== topPatch.id) return true;
-
 		return false;
 	});
 	const branchColorType = $derived<CommitStatus | 'localAndShadow'>(
-		hasShadow ? 'localAndShadow' : (topPatch?.status ?? 'local')
+		hasShadow ? 'localAndShadow' : topPatch?.status ?? 'local'
 	);
 	const lineColor = $derived(getColorFromBranchType(branchColorType));
 
@@ -154,6 +153,7 @@
 		border-bottom: 1px solid var(--clr-border-2);
 		display: flex;
 		flex-direction: column;
+		overflow: hidden;
 	}
 
 	.branch-info {

--- a/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
@@ -39,7 +39,8 @@
 	let prDetailsModal = $state<ReturnType<typeof PrDetailsModal>>();
 	let meatballButtonEl = $state<HTMLDivElement>();
 
-	const branchColorType = $derived<CommitStatus>(branch.commits?.[0]?.status ?? 'local');
+	const currentSeries = $derived(branch.series?.find((series) => series.name === upstreamName));
+	const branchColorType = $derived<CommitStatus>(currentSeries?.patches[0]?.status ?? 'local');
 	const lineColor = $derived(getColorFromBranchType(branchColorType));
 
 	// Pretty cumbersome way of getting the PR number, would be great if we can

--- a/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
@@ -40,7 +40,17 @@
 	let meatballButtonEl = $state<HTMLDivElement>();
 
 	const currentSeries = $derived(branch.series?.find((series) => series.name === upstreamName));
-	const branchColorType = $derived<CommitStatus>(currentSeries?.patches[0]?.status ?? 'local');
+	const topPatch = $derived(currentSeries?.patches[0]);
+	const hasShadow = $derived.by(() => {
+		if (!topPatch || !topPatch.remoteCommitId) return false;
+
+		if (topPatch.remoteCommitId !== topPatch.id) return true;
+
+		return false;
+	});
+	const branchColorType = $derived<CommitStatus | 'localAndShadow'>(
+		hasShadow ? 'localAndShadow' : (topPatch?.status ?? 'local')
+	);
 	const lineColor = $derived(getColorFromBranchType(branchColorType));
 
 	// Pretty cumbersome way of getting the PR number, would be great if we can

--- a/apps/desktop/src/lib/branch/stackingUtils.ts
+++ b/apps/desktop/src/lib/branch/stackingUtils.ts
@@ -1,3 +1,5 @@
+import type { CellType } from '@gitbutler/ui/commitLinesStacking/types';
+
 const colorMap = {
 	local: 'var(--clr-commit-local)',
 	localAndRemote: 'var(--clr-commit-remote)',
@@ -6,6 +8,6 @@ const colorMap = {
 	integrated: 'var(--clr-commit-integrated)'
 };
 
-export function getColorFromBranchType(type: keyof typeof colorMap): string {
+export function getColorFromBranchType(type: CellType): string {
 	return colorMap[type];
 }

--- a/apps/desktop/src/lib/branch/stackingUtils.ts
+++ b/apps/desktop/src/lib/branch/stackingUtils.ts
@@ -2,7 +2,7 @@ import type { CommitStatus } from '$lib/vbranches/types';
 
 const colorMap = {
 	local: 'var(--clr-commit-local)',
-	localAndRemote: 'var(--clr-commit-shadow)',
+	localAndRemote: 'var(--clr-commit-remote)',
 	remote: 'var(--clr-commit-remote)',
 	integrated: 'var(--clr-commit-integrated)'
 };

--- a/apps/desktop/src/lib/branch/stackingUtils.ts
+++ b/apps/desktop/src/lib/branch/stackingUtils.ts
@@ -1,12 +1,11 @@
-import type { CommitStatus } from '$lib/vbranches/types';
-
 const colorMap = {
 	local: 'var(--clr-commit-local)',
 	localAndRemote: 'var(--clr-commit-remote)',
+	localAndShadow: 'var(--clr-commit-local)',
 	remote: 'var(--clr-commit-remote)',
 	integrated: 'var(--clr-commit-integrated)'
 };
 
-export function getColorFromBranchType(type: CommitStatus) {
+export function getColorFromBranchType(type: keyof typeof colorMap): string {
 	return colorMap[type];
 }

--- a/apps/desktop/src/lib/commit/StackingCommitCard.svelte
+++ b/apps/desktop/src/lib/commit/StackingCommitCard.svelte
@@ -8,10 +8,8 @@
 	import { DraggableCommit, nonDraggable } from '$lib/dragging/draggables';
 	import BranchFilesList from '$lib/file/BranchFilesList.svelte';
 	import { ModeService } from '$lib/modes/service';
-	import TextBox from '$lib/shared/TextBox.svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { getContext, getContextStore, maybeGetContext } from '$lib/utils/context';
-	import { error } from '$lib/utils/toasts';
 	import { openExternalUrl } from '$lib/utils/url';
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { createCommitStore } from '$lib/vbranches/contexts';
@@ -103,24 +101,6 @@
 	let commitMessageValid = $state(false);
 	let description = $state('');
 
-	let createRefModal: Modal;
-	let createRefName: string | undefined = $state();
-	let createRefTargetCommit: DetailedCommit | Commit | undefined;
-
-	function openCreateRefModal(e: Event) {
-		e.stopPropagation();
-		if (createRefTargetCommit) {
-			createRefModal.show(createRefTargetCommit);
-		}
-		createRefTargetCommit = undefined;
-	}
-
-	function pushCommitRef(commit: DetailedCommit) {
-		if (branch && commit.remoteRef) {
-			branchController.pushChangeReference(branch.id, commit.remoteRef);
-		}
-	}
-
 	function openCommitMessageModal(e: Event) {
 		e.stopPropagation();
 
@@ -177,36 +157,6 @@
 		<Button style="neutral" type="submit" kind="solid" grow disabled={!commitMessageValid}>
 			Submit
 		</Button>
-	{/snippet}
-</Modal>
-
-<Modal
-	bind:this={createRefModal}
-	title="Add branch to the stack"
-	width="small"
-	onSubmit={() => {
-		if (!createRefName) {
-			error('No branch name provided');
-			createRefModal.close();
-			return;
-		}
-		if (!branch) {
-			return;
-		}
-		branchController.createPatchSeries(
-			branch.id,
-			createRefName,
-			commit.changeId ? { ChangeId: commit.changeId } : { CommitId: commit.id }
-		);
-		createRefModal.close();
-	}}
->
-	{#snippet children()}
-		<TextBox placeholder="New branch name" id="newRemoteName" bind:value={createRefName} focus />
-	{/snippet}
-	{#snippet controls(close)}
-		<Button style="ghost" outline type="reset" onclick={close}>Cancel</Button>
-		<Button style="pop" kind="solid">Ok</Button>
 	{/snippet}
 </Modal>
 
@@ -401,31 +351,6 @@
 									icon="edit-small"
 									onclick={openCommitMessageModal}>Edit message</Button
 								>
-								{#if commit instanceof DetailedCommit && !commit.remoteRef}
-									<Button
-										size="tag"
-										style="ghost"
-										outline
-										icon="virtual-branch-small"
-										onclick={(e: Event) => {
-											createRefTargetCommit = commit;
-											openCreateRefModal(e);
-										}}
-									>
-										Add branch
-									</Button>
-								{/if}
-								{#if commit instanceof DetailedCommit && commit.remoteRef}
-									<Button
-										size="tag"
-										style="ghost"
-										outline
-										icon="remote"
-										onclick={() => {
-											pushCommitRef(commit);
-										}}>Push ref</Button
-									>
-								{/if}
 							{/if}
 							{#if canEdit()}
 								<Button size="tag" style="ghost" outline onclick={editPatch}>

--- a/apps/desktop/src/lib/commit/StackingCommitList.svelte
+++ b/apps/desktop/src/lib/commit/StackingCommitList.svelte
@@ -4,7 +4,6 @@
 	import StackingCommitDragItem from './StackingCommitDragItem.svelte';
 	import StackingUpstreamCommitsAccordion from './StackingUpstreamCommitsAccordion.svelte';
 	import { BaseBranch } from '$lib/baseBranch/baseBranch';
-	import { transformAnyCommit } from '$lib/commitLines/transformers';
 	import InsertEmptyCommitAction from '$lib/components/InsertEmptyCommitAction.svelte';
 	import {
 		ReorderDropzoneManager,
@@ -16,17 +15,16 @@
 	import { getContext } from '$lib/utils/context';
 	import { getContextStore } from '$lib/utils/context';
 	import { BranchController } from '$lib/vbranches/branchController';
-	import { Commit, DetailedCommit, VirtualBranch } from '$lib/vbranches/types';
+	import { DetailedCommit, VirtualBranch } from '$lib/vbranches/types';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import Line from '@gitbutler/ui/commitLinesStacking/Line.svelte';
 	import { LineManagerFactory } from '@gitbutler/ui/commitLinesStacking/lineManager';
 	import type { Snippet } from 'svelte';
 
 	interface Props {
-		localCommits: DetailedCommit[];
-		localAndRemoteCommits: DetailedCommit[];
-		integratedCommits: DetailedCommit[];
-		remoteCommits: Commit[];
+		remoteOnlyPatches: DetailedCommit[];
+		// Remaining patches that aren't remote-only
+		patches: DetailedCommit[];
 		isUnapplied: boolean;
 		pushButton?: Snippet<[{ disabled: boolean }]>;
 		localCommitsConflicted: boolean;
@@ -34,10 +32,8 @@
 		reorderDropzoneManager: ReorderDropzoneManager;
 	}
 	const {
-		localCommits,
-		localAndRemoteCommits,
-		integratedCommits,
-		remoteCommits,
+		remoteOnlyPatches,
+		patches,
 		isUnapplied,
 		pushButton,
 		localAndRemoteCommitsConflicted,
@@ -51,43 +47,26 @@
 
 	const gitHost = getGitHost();
 
-	// TODO: Why does eslint-svelte-plugin complain about enum?
-	// eslint-disable-next-line svelte/valid-compile
-	enum LineSpacer {
-		Remote = 'remote-spacer',
-		Local = 'local-spacer',
-		LocalAndRemote = 'local-and-remote-spacer'
-	}
+	const LineSpacer = {
+		Remote: 'remote-spacer',
+		Local: 'local-spacer',
+		LocalAndRemote: 'local-and-remote-spacer'
+	};
 
-	const mappedRemoteCommits = $derived(
-		remoteCommits.length > 0
-			? [...remoteCommits.map(transformAnyCommit), { id: LineSpacer.Remote }]
-			: []
-	);
-	const mappedLocalCommits = $derived(
-		localCommits.length > 0
-			? [...localCommits.map(transformAnyCommit), { id: LineSpacer.Local }]
-			: []
-	);
-	const mappedLocalAndRemoteCommits = $derived(
-		localAndRemoteCommits.length > 0
-			? [...localAndRemoteCommits.map(transformAnyCommit), { id: LineSpacer.LocalAndRemote }]
-			: []
-	);
-
+	// TODO: Refactor out lineManager; unnecessary in stacking context
 	const lineManager = $derived(
 		lineManagerFactory.build({
-			remoteCommits: mappedRemoteCommits,
-			localCommits: mappedLocalCommits,
-			localAndRemoteCommits: mappedLocalAndRemoteCommits,
-			integratedCommits: integratedCommits.map(transformAnyCommit)
+			remoteCommits: remoteOnlyPatches,
+			localCommits: patches.filter((patch) => !patch.isRemote),
+			localAndRemoteCommits: patches.filter((patch) => patch.remoteCommitId),
+			integratedCommits: patches.filter((patch) => patch.isIntegrated)
 		})
 	);
 
 	const hasCommits = $derived($branch.commits && $branch.commits.length > 0);
 	const headCommit = $derived($branch.commits.at(0));
 
-	const hasRemoteCommits = $derived(remoteCommits.length > 0);
+	const hasRemoteCommits = $derived(remoteOnlyPatches.length > 0);
 
 	let isIntegratingCommits = $state(false);
 
@@ -110,17 +89,16 @@
 
 {#if hasCommits || hasRemoteCommits}
 	<div class="commits">
-		<!-- UPSTREAM COMMITS -->
-
+		<!-- UPSTREAM ONLY COMMITS -->
 		{#if hasRemoteCommits}
-			<StackingUpstreamCommitsAccordion count={Math.min(remoteCommits.length, 3)}>
-				{#each remoteCommits as commit, idx (commit.id)}
+			<StackingUpstreamCommitsAccordion count={Math.min(remoteOnlyPatches.length, 3)}>
+				{#each remoteOnlyPatches as commit, idx (commit.id)}
 					<StackingCommitCard
 						type="remote"
 						branch={$branch}
 						{commit}
 						{isUnapplied}
-						last={idx === remoteCommits.length - 1}
+						last={idx === remoteOnlyPatches.length - 1}
 						commitUrl={$gitHost?.commitUrl(commit.id)}
 						isHeadCommit={commit.id === headCommit?.id}
 					>
@@ -152,58 +130,21 @@
 			</StackingUpstreamCommitsAccordion>
 		{/if}
 
-		<!-- LOCAL COMMITS -->
-		{#if localCommits.length > 0}
+		<!-- REMAINING LOCAL, LOCALANDREMOTE, AND INTEGRATED COMMITS -->
+		{#if patches.length > 0}
 			<div class="commits-group">
 				<InsertEmptyCommitAction isFirst onclick={() => insertBlankCommit($branch.head, 'above')} />
 
 				{@render reorderDropzone(reorderDropzoneManager.topDropzone)}
 
-				{#each localCommits as commit, idx (commit.id)}
+				{#each patches as commit, idx (commit.id)}
 					<StackingCommitDragItem {commit}>
 						<StackingCommitCard
+							type={commit.status}
+							branch={$branch}
 							{commit}
 							{isUnapplied}
-							type="local"
-							branch={$branch}
-							last={idx === localCommits.length - 1}
-							isHeadCommit={commit.id === headCommit?.id}
-						>
-							{#snippet lines()}
-								<Line line={lineManager.get(commit.id)} />
-							{/snippet}
-						</StackingCommitCard>
-					</StackingCommitDragItem>
-
-					{@render reorderDropzone(reorderDropzoneManager.dropzoneBelowCommit(commit.id))}
-
-					<InsertEmptyCommitAction
-						isLast={idx + 1 === localCommits.length}
-						onclick={() => insertBlankCommit(commit.id, 'below')}
-					/>
-				{/each}
-			</div>
-		{/if}
-
-		<!-- LOCAL AND REMOTE COMMITS -->
-		{#if localAndRemoteCommits.length > 0}
-			<div class="commits-group">
-				{#if localCommits.length === 0}
-					<InsertEmptyCommitAction
-						isFirst
-						onclick={() => insertBlankCommit($branch.head, 'above')}
-					/>
-
-					{@render reorderDropzone(reorderDropzoneManager.topDropzone)}
-				{/if}
-				{#each localAndRemoteCommits as commit, idx (commit.id)}
-					<StackingCommitDragItem {commit}>
-						<StackingCommitCard
-							{commit}
-							{isUnapplied}
-							type="localAndRemote"
-							branch={$branch}
-							last={idx === localAndRemoteCommits.length - 1}
+							last={idx === patches.length - 1}
 							isHeadCommit={commit.id === headCommit?.id}
 							commitUrl={$gitHost?.commitUrl(commit.id)}
 						>
@@ -216,43 +157,22 @@
 					{@render reorderDropzone(reorderDropzoneManager.dropzoneBelowCommit(commit.id))}
 
 					<InsertEmptyCommitAction
-						isLast={idx + 1 === localAndRemoteCommits.length}
+						isLast={idx + 1 === patches.length}
 						onclick={() => insertBlankCommit(commit.id, 'below')}
 					/>
 				{/each}
-
-				{#if remoteCommits.length > 0 && localCommits.length === 0 && pushButton}
-					<CommitAction>
-						{#snippet lines()}
-							<Line line={lineManager.get(LineSpacer.LocalAndRemote)} />
-						{/snippet}
-						{#snippet action()}
-							{@render pushButton({ disabled: localAndRemoteCommitsConflicted })}
-						{/snippet}
-					</CommitAction>
-				{/if}
 			</div>
 		{/if}
-
-		<!-- INTEGRATED COMMITS -->
-		{#if integratedCommits.length > 0}
-			<div class="commits-group">
-				{#each integratedCommits as commit, idx (commit.id)}
-					<StackingCommitCard
-						{commit}
-						{isUnapplied}
-						type="integrated"
-						branch={$branch}
-						isHeadCommit={commit.id === headCommit?.id}
-						last={idx === integratedCommits.length - 1}
-						commitUrl={$gitHost?.commitUrl(commit.id)}
-					>
-						{#snippet lines()}
-							<Line line={lineManager.get(commit.id)} />
-						{/snippet}
-					</StackingCommitCard>
-				{/each}
-			</div>
+		<!-- {#if remoteCommits.length > 0 && localCommits.length === 0 && pushButton} -->
+		{#if remoteOnlyPatches.length > 0 && patches.length === 0 && pushButton}
+			<CommitAction>
+				{#snippet lines()}
+					<Line line={lineManager.get(LineSpacer.LocalAndRemote)} />
+				{/snippet}
+				{#snippet action()}
+					{@render pushButton({ disabled: localAndRemoteCommitsConflicted })}
+				{/snippet}
+			</CommitAction>
 		{/if}
 	</div>
 {/if}

--- a/apps/desktop/src/lib/commit/StackingCommitList.svelte
+++ b/apps/desktop/src/lib/commit/StackingCommitList.svelte
@@ -23,7 +23,6 @@
 
 	interface Props {
 		remoteOnlyPatches: DetailedCommit[];
-		// Remaining patches that aren't remote-only
 		patches: DetailedCommit[];
 		isUnapplied: boolean;
 		pushButton?: Snippet<[{ disabled: boolean }]>;
@@ -57,7 +56,7 @@
 	const lineManager = $derived(
 		lineManagerFactory.build({
 			remoteCommits: remoteOnlyPatches,
-			localCommits: patches.filter((patch) => !patch.isRemote),
+			localCommits: patches.filter((patch) => !patch.remoteCommitId),
 			localAndRemoteCommits: patches.filter((patch) => patch.remoteCommitId),
 			integratedCommits: patches.filter((patch) => patch.isIntegrated)
 		})
@@ -163,7 +162,6 @@
 				{/each}
 			</div>
 		{/if}
-		<!-- {#if remoteCommits.length > 0 && localCommits.length === 0 && pushButton} -->
 		{#if remoteOnlyPatches.length > 0 && patches.length === 0 && pushButton}
 			<CommitAction>
 				{#snippet lines()}

--- a/apps/desktop/src/lib/dragging/reorderDropzoneManager.ts
+++ b/apps/desktop/src/lib/dragging/reorderDropzoneManager.ts
@@ -80,7 +80,6 @@ class Indexer {
 	}
 
 	private getIndex(key: string) {
-		// console.log('reorderDzManager.getIndex.key', key, this.dropzoneIndexes);
 		if (key === 'top') {
 			return this.dropzoneIndexes.get(key) ?? 0;
 		} else {
@@ -121,6 +120,8 @@ class Entry {
 		const index = this.commitIndexes.get(commitId);
 
 		// TODO: Handle updated commitIds after rebasing in `commitIndexes`
+		// Reordering works, but it throws errors for old commitIds that it can't find
+		// anymore after rebasing, for example.
 		// if (index === undefined) {
 		// 	throw new Error(`Commit ${commitId} not found in commitIndexes`);
 		// }

--- a/apps/desktop/src/lib/dragging/reorderDropzoneManager.ts
+++ b/apps/desktop/src/lib/dragging/reorderDropzoneManager.ts
@@ -59,7 +59,7 @@ export class ReorderDropzoneManagerFactory {
 	}
 }
 
-// Private classes used to calculate distances between commtis
+// Private classes used to calculate distances between commits
 class Indexer {
 	private dropzoneIndexes = new Map<string, number>();
 	private commitIndexes = new Map<string, number>();
@@ -80,6 +80,7 @@ class Indexer {
 	}
 
 	private getIndex(key: string) {
+		// console.log('reorderDzManager.getIndex.key', key, this.dropzoneIndexes);
 		if (key === 'top') {
 			return this.dropzoneIndexes.get(key) ?? 0;
 		} else {
@@ -105,6 +106,7 @@ class Entry {
 	 */
 	distanceToOtherCommit(commitId: string) {
 		const commitIndex = this.commitIndex(commitId);
+		if (!commitIndex) return 0;
 
 		const offset = this.index - commitIndex;
 
@@ -118,9 +120,10 @@ class Entry {
 	private commitIndex(commitId: string) {
 		const index = this.commitIndexes.get(commitId);
 
-		if (index === undefined) {
-			throw new Error(`Commit ${commitId} not found in commitIndexes`);
-		}
+		// TODO: Handle updated commitIds after rebasing in `commitIndexes`
+		// if (index === undefined) {
+		// 	throw new Error(`Commit ${commitId} not found in commitIndexes`);
+		// }
 
 		return index;
 	}

--- a/apps/desktop/src/lib/stack/Stack.svelte
+++ b/apps/desktop/src/lib/stack/Stack.svelte
@@ -114,6 +114,7 @@
 	async function push() {
 		isPushingCommits = true;
 		try {
+			// TODO: Ensure requiresForce is bubbled up from each series to the stack here
 			await branchController.pushBranch(branch.id, branch.requiresForce, true);
 			$listingService?.refresh();
 			$prMonitor?.refresh();

--- a/apps/desktop/src/lib/stack/Stack.svelte
+++ b/apps/desktop/src/lib/stack/Stack.svelte
@@ -114,7 +114,6 @@
 	async function push() {
 		isPushingCommits = true;
 		try {
-			// TODO: Ensure requiresForce is bubbled up from each series to the stack here
 			await branchController.pushBranch(branch.id, branch.requiresForce, true);
 			$listingService?.refresh();
 			$prMonitor?.refresh();

--- a/apps/desktop/src/lib/stack/StackSeries.svelte
+++ b/apps/desktop/src/lib/stack/StackSeries.svelte
@@ -3,11 +3,7 @@
 	import StackingCommitList from '$lib/commit/StackingCommitList.svelte';
 	import { ReorderDropzoneManagerFactory } from '$lib/dragging/reorderDropzoneManager';
 	import { getContext } from '$lib/utils/context';
-	import {
-		getLocalAndRemoteCommits,
-		getLocalCommits,
-		getRemoteCommits
-	} from '$lib/vbranches/contexts';
+	import { getLocalAndRemoteCommits, getLocalCommits } from '$lib/vbranches/contexts';
 	import type { VirtualBranch } from '$lib/vbranches/types';
 	// import type { Series } from './types';
 
@@ -20,7 +16,6 @@
 
 	const localCommits = getLocalCommits();
 	const localAndRemoteCommits = getLocalAndRemoteCommits();
-	const remoteCommits = getRemoteCommits();
 
 	const localCommitsConflicted = $derived($localCommits.some((commit) => commit.conflicted));
 	const localAndRemoteCommitsConflicted = $derived(

--- a/apps/desktop/src/lib/stack/StackSeries.svelte
+++ b/apps/desktop/src/lib/stack/StackSeries.svelte
@@ -42,10 +42,8 @@
 			upstreamName={currentSeries.name}
 		/>
 		<StackingCommitList
-			localCommits={currentSeries.localCommits}
-			localAndRemoteCommits={currentSeries.remoteCommits}
-			integratedCommits={currentSeries.integratedCommits}
-			remoteCommits={$remoteCommits}
+			remoteOnlyPatches={currentSeries.upstreamPatches}
+			patches={currentSeries.patches}
 			isUnapplied={false}
 			{reorderDropzoneManager}
 			{localCommitsConflicted}

--- a/apps/desktop/src/lib/vbranches/types.ts
+++ b/apps/desktop/src/lib/vbranches/types.ts
@@ -234,8 +234,7 @@ export class DetailedCommit {
 
 	get status(): CommitStatus {
 		if (this.isIntegrated) return 'integrated';
-		if (this.isRemote && (!this.relatedTo || this.id === this.relatedTo.id))
-			return 'localAndRemote';
+		if (this.remoteCommitId) return 'localAndRemote';
 		return 'local';
 	}
 

--- a/packages/ui/src/lib/commitLinesStacking/Cell.svelte
+++ b/packages/ui/src/lib/commitLinesStacking/Cell.svelte
@@ -11,11 +11,11 @@
 
 <div
 	class="commit-line stacked"
-	class:local={cell.type === 'Local'}
-	class:remote={cell.type === 'LocalRemote'}
-	class:local-shadow={cell.type === 'LocalShadow'}
-	class:upstream={cell.type === 'Upstream'}
-	class:integrated={cell.type === 'Integrated'}
+	class:local={cell.type === 'local'}
+	class:remote={cell.type === 'localAndRemote'}
+	class:local-shadow={cell.type === 'localAndShadow'}
+	class:upstream={cell.type === 'remote'}
+	class:integrated={cell.type === 'integrated'}
 	class:dashed={cell.style === 'dashed' || isBottom}
 ></div>
 

--- a/packages/ui/src/lib/commitLinesStacking/CommitNode.svelte
+++ b/packages/ui/src/lib/commitLinesStacking/CommitNode.svelte
@@ -21,7 +21,7 @@
 	);
 
 	const hoverTextShadow = $derived.by(() => {
-		return commitNode.type === 'LocalShadow'
+		return commitNode.type === 'localAndShadow'
 			? [
 					commitNode.commit?.relatedRemoteCommit?.author?.name,
 					commitNode.commit?.relatedRemoteCommit?.title,
@@ -34,7 +34,7 @@
 </script>
 
 <div class="container">
-	{#if type === 'Local'}
+	{#if type === 'local'}
 		<Tooltip text={hoverText}>
 			<svg
 				class="local-commit-dot"
@@ -47,7 +47,7 @@
 				<rect width="10" height="10" rx="5" />
 			</svg>
 		</Tooltip>
-	{:else if type === 'LocalShadow'}
+	{:else if type === 'localAndShadow'}
 		<div class="local-shadow-commit-dot">
 			<Tooltip text={hoverTextShadow}>
 				<svg
@@ -82,9 +82,9 @@
 		<Tooltip text={hoverText}>
 			<svg
 				class="generic-commit-dot"
-				class:remote={type === 'LocalRemote'}
-				class:upstream={type === 'Upstream'}
-				class:integrated={type === 'Integrated'}
+				class:remote={type === 'localAndRemote'}
+				class:upstream={type === 'remote'}
+				class:integrated={type === 'integrated'}
 				width="11"
 				height="12"
 				viewBox="0 0 11 12"

--- a/packages/ui/src/lib/commitLinesStacking/Line.svelte
+++ b/packages/ui/src/lib/commitLinesStacking/Line.svelte
@@ -16,7 +16,7 @@
 		<Cell cell={line.top} />
 	</div>
 	{#if line.commitNode}
-		<CommitNode commitNode={line.commitNode} type={line.commitNode.type ?? 'Local'} />
+		<CommitNode commitNode={line.commitNode} type={line.commitNode.type ?? 'local'} />
 	{/if}
 	<div class="line-bottom">
 		<Cell cell={line.bottom} {isBottom} />

--- a/packages/ui/src/lib/commitLinesStacking/lineManager.ts
+++ b/packages/ui/src/lib/commitLinesStacking/lineManager.ts
@@ -22,27 +22,33 @@ function generateLineData({
 	const integratedBranchGroups = mapToCommitLineGroupPair(integratedCommits);
 
 	remoteBranchGroups.forEach(({ commit, line }) => {
-		line.top.type = 'Upstream';
-		line.bottom.type = 'Upstream';
-		line.commitNode = { type: 'Upstream', commit };
+		line.top.type = 'remote';
+		line.bottom.type = 'remote';
+		line.commitNode = { type: 'remote', commit };
 	});
 
 	localBranchGroups.forEach(({ commit, line }) => {
-		line.top.type = 'Local';
-		line.bottom.type = 'Local';
-		line.commitNode = { type: 'Local', commit };
+		line.top.type = 'local';
+		line.bottom.type = 'local';
+		line.commitNode = { type: 'local', commit };
 	});
 
 	localAndRemoteBranchGroups.forEach(({ commit, line }) => {
-		line.top.type = 'LocalRemote';
-		line.bottom.type = 'LocalRemote';
-		line.commitNode = { type: 'LocalRemote', commit };
+		if (line.commitNode.commit.remoteCommitId !== line.commitNode.commit.id) {
+			line.commitNode = { type: 'localAndShadow', commit };
+			line.top.type = 'localAndShadow';
+			line.bottom.type = 'localAndShadow';
+		} else {
+			line.commitNode = { type: 'localAndRemote', commit };
+			line.top.type = 'localAndRemote';
+			line.bottom.type = 'localAndRemote';
+		}
 	});
 
 	integratedBranchGroups.forEach(({ commit, line }) => {
-		line.top.type = 'Integrated';
-		line.bottom.type = 'Integrated';
-		line.commitNode = { type: 'Integrated', commit };
+		line.top.type = 'integrated';
+		line.bottom.type = 'integrated';
+		line.commitNode = { type: 'integrated', commit };
 	});
 
 	const data = new Map<string, LineData>([
@@ -71,22 +77,15 @@ function mapToCommitLineGroupPair(commits: CommitData[]) {
 	const groupings = commits.map((commit) => ({
 		commit,
 		line: {
-			top: { type: 'Local' as CellType, style: 'solid' as Style },
-			bottom: { type: 'Local' as CellType, style: 'solid' as Style },
-			commitNode: { type: 'Local' as CellType, commit }
+			top: { type: 'local' as CellType, style: 'solid' as Style },
+			bottom: { type: 'local' as CellType, style: 'solid' as Style },
+			commitNode: { type: 'local' as CellType, commit }
 		}
 	}));
 
 	return groupings;
 }
 
-/**
- * The Line Manager assumes that the groups of commits will be in the following order:
- * 1. Remote Commits (Commits you don't have in your branch)
- * 2. Local Commits (Commits that you have changed locally)
- * 3. LocalAndRemote Commits (Commits that exist locally and on the remote and have the same hash)
- * 4. Integrated Commits (Commits that exist locally and perhaps on the remote that are in the trunk)
- */
 export class LineManager {
 	private data: Map<string, LineData>;
 

--- a/packages/ui/src/lib/commitLinesStacking/types.ts
+++ b/packages/ui/src/lib/commitLinesStacking/types.ts
@@ -30,6 +30,7 @@ export interface CommitData {
 	// If an author is not provided, a commit node will not be drawn
 	author?: Author;
 	relatedRemoteCommit?: CommitData;
+	remoteCommitId?: string;
 }
 
-export type CellType = 'Local' | 'LocalRemote' | 'Integrated' | 'Upstream' | 'LocalShadow';
+export type CellType = 'local' | 'localAndRemote' | 'integrated' | 'remote' | 'localAndShadow';


### PR DESCRIPTION
## ☕️ Reasoning

- When rendering, do not group the commits together in Remote, LocalAndRemote, etc. groups
	- Instead, render `remotePatches` (i.e. remote only) into the yellow accordion
	- Render the rest of the `patches` through 1 `#each` block
- Ensure that the commitStatus and color key's are harmonized and we're rendering the correct color for the commitCard lines and branchHeader lines
- Remove the "Create Branch" / "Push Ref" buttons from the stacking commit card

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
