### PR TITLE
Conflict Resolution: Add a confirmation modal

### DIFF
--- a/apps/desktop/src/lib/vbranches/types.ts
+++ b/apps/desktop/src/lib/vbranches/types.ts
@@ -161,6 +161,14 @@ export class VirtualBranch {
 
 		return this.upstreamName || this.name;
 	}
+
+	get ancestorMostConflictedCommit(): DetailedCommit | undefined {
+		if (this.commits.length === 0) return undefined;
+		for (let i = this.commits.length - 1; i >= 0; i--) {
+			const commit = this.commits[i];
+			if (commit?.conflicted) return commit;
+		}
+	}
 }
 
 // Used for dependency injection


### PR DESCRIPTION
If attempting to resolve conflicts on non-acestor-most commits, the user will be prompted to confirm whether they actually want that or not.

### Visuals
<img width="930" alt="Screenshot 2024-10-10 at 10 27 14" src="https://github.com/user-attachments/assets/ed79eaf4-e488-41bd-a2b8-d42889020934">
