### PR TITLE
fix: hide upstream related btns if stack/series hasn't been pushed yet

### DIFF
--- a/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
@@ -95,17 +95,19 @@
 		<div class="text-14 text-bold branch-info__name">
 			<span class="remote-name">{$baseBranch.remoteName ?? 'origin'}/</span>
 			<BranchLabel {name} onChange={(name) => editTitle(name)} />
-			<Button
-				size="tag"
-				icon="open-link"
-				style="ghost"
-				onclick={(e: MouseEvent) => {
-					const url = gitHostBranch?.url;
-					if (url) openExternalUrl(url);
-					e.preventDefault();
-					e.stopPropagation();
-				}}
-			></Button>
+			{#if gitHostBranch}
+				<Button
+					size="tag"
+					icon="open-link"
+					style="ghost"
+					onclick={(e: MouseEvent) => {
+						const url = gitHostBranch?.url;
+						if (url) openExternalUrl(url);
+						e.preventDefault();
+						e.stopPropagation();
+					}}
+				></Button>
+			{/if}
 		</div>
 		<div class="branch-info__btns">
 			<Button
@@ -135,22 +137,24 @@
 			/>
 		</div>
 	{/if}
-	<div class="branch-action">
-		<div class="branch-action__line" style:--bg-color={lineColor}></div>
-		<div class="branch-action__body">
-			{#if $pr}
-				<StackingPullRequestCard pr={$pr} {prMonitor} sourceBranch={$pr.sourceBranch} />
-			{:else}
-				<Button
-					style="ghost"
-					wide
-					outline
-					disabled={commits.length === 0 || !$gitHost || !$prService}
-					onclick={handleOpenPR}>Create pull request</Button
-				>
-			{/if}
+	{#if gitHostBranch}
+		<div class="branch-action">
+			<div class="branch-action__line" style:--bg-color={lineColor}></div>
+			<div class="branch-action__body">
+				{#if $pr}
+					<StackingPullRequestCard pr={$pr} {prMonitor} sourceBranch={$pr.sourceBranch} />
+				{:else}
+					<Button
+						style="ghost"
+						wide
+						outline
+						disabled={commits.length === 0 || !$gitHost || !$prService}
+						onclick={handleOpenPR}>Create pull request</Button
+					>
+				{/if}
+			</div>
 		</div>
-	</div>
+	{/if}
 </div>
 
 <PrDetailsModal bind:this={prDetailsModal} type="preview-series" {upstreamName} {name} {commits} />

--- a/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
@@ -155,17 +155,25 @@
 			</div>
 		</div>
 	{/if}
+	<PrDetailsModal
+		bind:this={prDetailsModal}
+		type="preview-series"
+		{upstreamName}
+		{name}
+		{commits}
+	/>
 </div>
-
-<PrDetailsModal bind:this={prDetailsModal} type="preview-series" {upstreamName} {name} {commits} />
 
 <style lang="postcss">
 	.branch-header {
 		display: flex;
-		border-bottom: 1px solid var(--clr-border-2);
 		display: flex;
 		flex-direction: column;
 		overflow: hidden;
+
+		&:not(:last-child) {
+			border-bottom: 1px solid var(--clr-border-2);
+		}
 	}
 
 	.branch-info {

--- a/apps/desktop/src/lib/stack/StackSeries.svelte
+++ b/apps/desktop/src/lib/stack/StackSeries.svelte
@@ -34,7 +34,7 @@
 		<StackingBranchHeader
 			commits={currentSeries.patches}
 			name={currentSeries.branchName}
-			upstreamName={currentSeries.name}
+			upstreamName={currentSeries.upstreamReference}
 		/>
 		<StackingCommitList
 			remoteOnlyPatches={currentSeries.upstreamPatches}

--- a/apps/desktop/src/lib/stack/StackSeries.svelte
+++ b/apps/desktop/src/lib/stack/StackSeries.svelte
@@ -34,7 +34,7 @@
 		<StackingBranchHeader
 			commits={currentSeries.patches}
 			name={currentSeries.branchName}
-			upstreamName={currentSeries.upstreamReference}
+			upstreamName={currentSeries.upstreamReference ? currentSeries.name : undefined}
 		/>
 		<StackingCommitList
 			remoteOnlyPatches={currentSeries.upstreamPatches}


### PR DESCRIPTION
## ☕️ Reasoning

- Hide upstream related btns on series header (i.e. "open in browser" and "create PR") if the stack hasn't been pushed yet.

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
