### PR TITLE
feat: add global ctrl+z keyboard shortcut

### DIFF
--- a/apps/desktop/src/lib/history/History.svelte
+++ b/apps/desktop/src/lib/history/History.svelte
@@ -19,13 +19,13 @@
 
 	const project = getContext(Project);
 	const historyService = getContext(HistoryService);
-	const snapshots = historyService.snapshots;
+	const snapshots = $derived(historyService.snapshots);
 	const dispatch = createEventDispatcher<{ hide: any }>();
 
 	const loading = historyService.loading;
 	const isAllLoaded = historyService.isAllLoaded;
 
-	let currentFilePreview: RemoteFile | undefined = undefined;
+	let currentFilePreview = $state<RemoteFile>();
 
 	function findRestorationRanges(snapshots: Snapshot[]) {
 		if (snapshots.length === 0) return [];
@@ -74,7 +74,7 @@
 	let snapshotFilesTempStore:
 		| { entryId: string; diffs: { [key: string]: SnapshotDiff } }
 		| undefined = undefined;
-	let selectedFile: { entryId: string; path: string } | undefined = undefined;
+	let selectedFile = $state<{ entryId: string; path: string }>();
 </script>
 
 <svelte:window


### PR DESCRIPTION
## ☕️ Reasoning

- Add a `$history - 1` keyboard shortcut

## 🧢 Changes

- Update `Board.svelte` to runes syntax

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
