### PR TITLE
fix: check stackingFeature to determine which checks to use for assigning 'localAndRemote' commit status

### DIFF
--- a/apps/desktop/src/lib/vbranches/types.ts
+++ b/apps/desktop/src/lib/vbranches/types.ts
@@ -1,9 +1,11 @@
 import 'reflect-metadata';
+import { stackingFeature } from '$lib/config/uiFeatureFlags';
 import { emptyConflictEntryPresence, type ConflictEntryPresence } from '$lib/conflictEntryPresence';
 import { splitMessage } from '$lib/utils/commitMessage';
 import { hashCode } from '$lib/utils/string';
 import { isDefined, notNull } from '@gitbutler/ui/utils/typeguards';
 import { Type, Transform } from 'class-transformer';
+import { get } from 'svelte/store';
 import type { PullRequest } from '$lib/gitHost/interface/types';
 
 export type ChangeType =
@@ -242,7 +244,12 @@ export class DetailedCommit {
 
 	get status(): CommitStatus {
 		if (this.isIntegrated) return 'integrated';
-		if (this.remoteCommitId) return 'localAndRemote';
+		if (get(stackingFeature)) {
+			if (this.remoteCommitId) return 'localAndRemote';
+		} else {
+			if (this.isRemote && (!this.relatedTo || this.id === this.relatedTo.id))
+				return 'localAndRemote';
+		}
 		return 'local';
 	}
 


### PR DESCRIPTION
## ☕️ Reasoning

- Check `$stackingFeature` to determine which checks to use for assigning 'localAndRemote' commit status


![image](https://github.com/user-attachments/assets/224508da-2d3d-4805-8538-6aa7ffdaa82a)


## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
