### PR TITLE
"unnaply and drop changes" update copy, update modals UI and layout

### DIFF
--- a/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
@@ -180,7 +180,6 @@
 
 <Modal
 	width="small"
-	title="Delete branch"
 	bind:this={deleteBranchModal}
 	onSubmit={async (close) => {
 		try {
@@ -193,10 +192,12 @@
 	}}
 >
 	{#snippet children(branch)}
-		Are you sure you want to delete <code class="code-string">{branch.name}</code>?
+		Are you sure you want to unapply and drop changes in branch <strong>{branch.name}</strong>?
 	{/snippet}
 	{#snippet controls(close)}
 		<Button style="ghost" outline onclick={close}>Cancel</Button>
-		<Button style="error" kind="solid" type="submit" loading={isDeleting}>Delete</Button>
+		<Button style="error" kind="solid" type="submit" loading={isDeleting}
+			>Unapply and drop changes</Button
+		>
 	{/snippet}
 </Modal>

--- a/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
@@ -192,7 +192,7 @@
 	}}
 >
 	{#snippet children(branch)}
-		Are you sure you want to unapply and drop changes in branch <strong>{branch.name}</strong>?
+		All changes will be lost for <strong>{branch.name}</strong>. Are you sure you want to continue?
 	{/snippet}
 	{#snippet controls(close)}
 		<Button style="ghost" outline onclick={close}>Cancel</Button>

--- a/apps/desktop/src/lib/branch/BranchPreviewHeader.svelte
+++ b/apps/desktop/src/lib/branch/BranchPreviewHeader.svelte
@@ -148,7 +148,6 @@
 
 <Modal
 	width="small"
-	title="Delete branch"
 	bind:this={deleteBranchModal}
 	onSubmit={async (close) => {
 		try {

--- a/apps/desktop/src/lib/stack/StackHeader.svelte
+++ b/apps/desktop/src/lib/stack/StackHeader.svelte
@@ -122,6 +122,7 @@
 						<Button
 							bind:el={meatballButtonEl}
 							style="ghost"
+							size="tag"
 							icon="kebab"
 							onclick={() => {
 								contextMenu?.toggle();
@@ -150,7 +151,6 @@
 			height: auto;
 		}
 	}
-
 	.header.card {
 		border-bottom-right-radius: 0px;
 		border-bottom-left-radius: 0px;
@@ -205,7 +205,7 @@
 	.header__info-wrapper {
 		display: flex;
 		gap: 2px;
-		padding: 10px;
+		padding: 12px;
 	}
 	.header__info {
 		flex: 1;
@@ -218,7 +218,7 @@
 	.button-group {
 		display: flex;
 		align-items: center;
-		gap: 10px;
+		gap: 6px;
 	}
 
 	.draggable {


### PR DESCRIPTION
## ☕️ Reasoning

Inconsistency between modal and the action copy. 

New version:

<img width="541" alt="image" src="https://github.com/user-attachments/assets/ce0233ca-4397-43f2-86ea-5168265e95bb">


## 🎫 Affected issues

https://github.com/gitbutlerapp/gitbutler/issues/5088

## Changes
- Copy updated
- Remove modals headers because there were three places with the almost same copy
- Series header "kebab" button size updated

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:


-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
