### PR TITLE
fix: refactor `showHistoryView` and add `ctrl+z` shortcut alias

### DIFF
--- a/apps/desktop/src/lib/barmenuActions/ProjectSettingsMenuAction.svelte
+++ b/apps/desktop/src/lib/barmenuActions/ProjectSettingsMenuAction.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { listen } from '$lib/backend/ipc';
 	import { Project } from '$lib/backend/projects';
+	import { showHistoryView } from '$lib/config/config';
 	import { editor } from '$lib/editorLink/editorLink';
 	import * as events from '$lib/utils/events';
-	import { createKeybind } from '$lib/utils/hotkeys';
 	import { unsubscribe } from '$lib/utils/unsubscribe';
 	import { openExternalUrl } from '$lib/utils/url';
 	import { getContext } from '@gitbutler/shared/context';
@@ -11,14 +11,6 @@
 	import { goto } from '$app/navigation';
 
 	const project = getContext(Project);
-
-	interface Props {
-		showHistory: boolean;
-		onHistoryShow: (show: boolean) => void;
-	}
-
-	const { showHistory, onHistoryShow }: Props = $props();
-	let showHistoryState = $state(showHistory);
 
 	onMount(() => {
 		const unsubscribeSettings = listen<string>('menu://project/settings/clicked', () => {
@@ -34,12 +26,12 @@
 		);
 
 		const unsubscribeHistory = listen<string>('menu://project/history/clicked', () => {
-			showHistoryState = true;
+			$showHistoryView = true;
 		});
 
 		const unsubscribeHistoryButton = unsubscribe(
 			events.on('openHistory', () => {
-				showHistoryState = true;
+				$showHistoryView = true;
 			})
 		);
 
@@ -50,20 +42,4 @@
 			unsubscribeHistoryButton();
 		};
 	});
-
-	const handleKeyDown = createKeybind({
-		'$mod+Shift+H': () => {
-			showHistoryState = !showHistoryState;
-		}
-	});
-
-	$effect(() => {
-		onHistoryShow(showHistoryState);
-	});
-
-	$effect(() => {
-		showHistoryState = showHistory;
-	});
 </script>
-
-<svelte:window on:keydown={handleKeyDown} />

--- a/apps/desktop/src/lib/components/Board.svelte
+++ b/apps/desktop/src/lib/components/Board.svelte
@@ -3,9 +3,9 @@
 	import FullviewLoading from './FullviewLoading.svelte';
 	import BranchDropzone from '$lib/branch/BranchDropzone.svelte';
 	import BranchLane from '$lib/branch/BranchLane.svelte';
+	import { showHistoryView } from '$lib/config/config';
 	import { stackingFeature } from '$lib/config/uiFeatureFlags';
 	import { cloneElement } from '$lib/dragging/draggable';
-	import { persisted } from '$lib/persisted/persisted';
 	import { createKeybind } from '$lib/utils/hotkeys';
 	import { throttle } from '$lib/utils/misc';
 	import { BranchController } from '$lib/vbranches/branchController';
@@ -17,7 +17,6 @@
 	const branchController = getContext(BranchController);
 	const error = vbranchService.error;
 	const branches = vbranchService.branches;
-	const showHistoryView = persisted(false, 'showHistoryView');
 
 	let dragged: HTMLDivElement | undefined;
 	let dropZone: HTMLDivElement;
@@ -66,8 +65,14 @@
 	}, 200);
 
 	const handleKeyDown = createKeybind({
-		's t a c k': async () => {
+		's t a c k': () => {
 			$stackingFeature = !$stackingFeature;
+		},
+		'$mod+Shift+H': () => {
+			$showHistoryView = !$showHistoryView;
+		},
+		'$mod+z': () => {
+			$showHistoryView = !$showHistoryView;
 		}
 	});
 </script>

--- a/apps/desktop/src/lib/config/config.ts
+++ b/apps/desktop/src/lib/config/config.ts
@@ -46,3 +46,5 @@ export function persistedCommitMessage(projectId: string, branchId: string): Per
 }
 
 export const showStackingCardDetails = persisted(false, 'showStackingCardDetails');
+
+export const showHistoryView = persisted(false, 'showHistoryView');

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -11,6 +11,7 @@
 	import NoBaseBranch from '$lib/components/NoBaseBranch.svelte';
 	import NotOnGitButlerBranch from '$lib/components/NotOnGitButlerBranch.svelte';
 	import ProblemLoadingRepo from '$lib/components/ProblemLoadingRepo.svelte';
+	import { showHistoryView } from '$lib/config/config';
 	import { featureTopics } from '$lib/config/uiFeatureFlags';
 	import { ReorderDropzoneManagerFactory } from '$lib/dragging/reorderDropzoneManager';
 	import { DefaultGitHostFactory } from '$lib/gitHost/gitHostFactory';
@@ -22,7 +23,6 @@
 	import MetricsReporter from '$lib/metrics/MetricsReporter.svelte';
 	import { ModeService } from '$lib/modes/service';
 	import Navigation from '$lib/navigation/Navigation.svelte';
-	import { persisted } from '$lib/persisted/persisted';
 	import { RemoteBranchService } from '$lib/stores/remoteBranches';
 	import CreateIssueModal from '$lib/topics/CreateIssueModal.svelte';
 	import CreateTopicModal from '$lib/topics/CreateTopicModal.svelte';
@@ -82,7 +82,6 @@
 
 	let intervalId: any;
 
-	const showHistoryView = persisted(false, 'showHistoryView');
 	const octokit = $derived(accessToken ? octokitFromAccessToken(accessToken) : undefined);
 	const gitHostFactory = $derived(new DefaultGitHostFactory(octokit));
 	const repoInfo = $derived(remoteUrl ? parseRemoteUrl(remoteUrl) : undefined);
@@ -180,10 +179,7 @@
 
 <!-- forces components to be recreated when projectId changes -->
 {#key projectId}
-	<ProjectSettingsMenuAction
-		showHistory={$showHistoryView}
-		onHistoryShow={(show) => ($showHistoryView = show)}
-	/>
+	<ProjectSettingsMenuAction />
 	<FileMenuAction />
 
 	{#if !project}


### PR DESCRIPTION
## ☕️ Reasoning

- Cleanup `showHistoryView` and add alias shortcut

## 🧢 Changes

- Refactor persisted `$showHistoryView` a bit
- add `ctrl + z` shortcut alias in addition to the pre-existing one, `ctrl + shift + H`

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
