### PR TITLE
Ensure stack initialized when re-applying branch

### DIFF
--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -228,6 +228,7 @@ impl BranchManager<'_> {
             branch.allow_rebasing = self.ctx.project().ok_with_force_push.into();
             branch.in_workspace = true;
 
+            branch.initialize(self.ctx)?;
             branch
         } else {
             let upstream_head = upstream_branch.is_some().then_some(head_commit.id());


### PR DESCRIPTION
- set_stack_head throws if not initialized
- nolith reported this breakage on discord