### PR TITLE
fix: update stacking CommitCard tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"dev:web": "turbo run --filter @gitbutler/web dev --no-daemon",
 		"dev:desktop": "pnpm tauri dev",
 		"dev:internal-tauri": "turbo watch --filter @gitbutler/desktop dev",
+		"package": "turbo run package",
 		"test": "turbo run test --no-daemon",
 		"test:watch": "pnpm --filter @gitbutler/desktop run test:watch",
 		"test:e2e": "pnpm --filter @gitbutler/desktop run test:e2e",

--- a/packages/ui/src/lib/commitLinesStacking/CommitNode.svelte
+++ b/packages/ui/src/lib/commitLinesStacking/CommitNode.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Tooltip from '$lib/Tooltip.svelte';
-	import { isDefined } from '$lib/utils/typeguards';
+	import { camelCaseToTitleCase } from '$lib/utils/string';
 	import type { CellType, CommitNodeData } from '$lib/commitLinesStacking/types';
 
 	interface Props {
@@ -10,32 +10,12 @@
 
 	const { commitNode, type }: Props = $props();
 
-	const hoverText = $derived(
-		[
-			commitNode.commit?.author?.name,
-			commitNode.commit?.title,
-			commitNode.commit?.id.substring(0, 7)
-		]
-			.filter(isDefined)
-			.join('\n')
-	);
-
-	const hoverTextShadow = $derived.by(() => {
-		return commitNode.type === 'localAndShadow'
-			? [
-					commitNode.commit?.relatedRemoteCommit?.author?.name,
-					commitNode.commit?.relatedRemoteCommit?.title,
-					commitNode.commit?.relatedRemoteCommit?.id.substring(0, 7)
-				]
-					.filter(isDefined)
-					.join('\n')
-			: undefined;
-	});
+	const tooltipText = $derived(camelCaseToTitleCase(commitNode.type ?? 'local'));
 </script>
 
 <div class="container">
 	{#if type === 'local'}
-		<Tooltip text={hoverText}>
+		<Tooltip text={tooltipText}>
 			<svg
 				class="local-commit-dot"
 				width="10"
@@ -49,7 +29,7 @@
 		</Tooltip>
 	{:else if type === 'localAndShadow'}
 		<div class="local-shadow-commit-dot">
-			<Tooltip text={hoverTextShadow}>
+			<Tooltip text="Diverged">
 				<svg
 					class="shadow-dot"
 					width="10"
@@ -62,7 +42,7 @@
 					/>
 				</svg>
 			</Tooltip>
-			<Tooltip text={hoverText}>
+			<Tooltip text={tooltipText}>
 				<svg
 					class="local-dot"
 					width="11"
@@ -79,7 +59,7 @@
 			</Tooltip>
 		</div>
 	{:else}
-		<Tooltip text={hoverText}>
+		<Tooltip text={tooltipText}>
 			<svg
 				class="generic-commit-dot"
 				class:remote={type === 'localAndRemote'}

--- a/packages/ui/src/lib/utils/string.ts
+++ b/packages/ui/src/lib/utils/string.ts
@@ -1,0 +1,8 @@
+export function camelCaseToTitleCase(input: string) {
+	return input
+		.split(/(?<![A-Z])(?=[A-Z])/)
+		.map(function (word: string) {
+			return word.charAt(0).toUpperCase() + word.slice(1);
+		})
+		.join(' ');
+}


### PR DESCRIPTION
## ☕️ Reasoning

- Teach user about commitList icon colors / types

## 🧢 Changes

- Update tooltip content from commit sha / author name (both of which are available on the commit card right next to the tooltip) to the label of the commit type, i.e. what the color means
- Add a `package` npm script to the root `package.json` to `package` both the `packages/ui` and `packages/shared` packages.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
