### PR TITLE
fix: always show gap on stackingstatusicon and use border radius css variable

### DIFF
--- a/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
@@ -89,7 +89,6 @@
 			icon={branchType === 'integrated' ? 'tick-small' : 'remote-branch-small'}
 			iconColor="#fff"
 			color={lineColor}
-			gap={false}
 			lineTop
 		/>
 		<div class="text-14 text-bold branch-info__name">

--- a/apps/desktop/src/lib/branch/StackingNewStackCard.svelte
+++ b/apps/desktop/src/lib/branch/StackingNewStackCard.svelte
@@ -56,7 +56,7 @@
 		<Spacer />
 	{/if}
 	<section class="card__action" class:showDetails={!$showStackingCardDetails}>
-		<StackingStatusIcon icon="plus-small" gap={true} />
+		<StackingStatusIcon icon="plus-small" />
 		<Button grow style="neutral" {loading} onclick={() => createRefModal.show()}>
 			Add a branch to the stack
 		</Button>

--- a/apps/desktop/src/lib/branch/StackingStatusIcon.svelte
+++ b/apps/desktop/src/lib/branch/StackingStatusIcon.svelte
@@ -7,14 +7,13 @@
 		icon: 'plus-small' | 'tick-small' | 'remote-branch-small';
 		iconColor?: string;
 		color?: string;
-		gap?: boolean;
 		lineTop?: boolean;
 	}
 
-	const { icon, iconColor, color = FALLBACK_COLOR, gap = false, lineTop = false }: Props = $props();
+	const { icon, iconColor, color = FALLBACK_COLOR, lineTop = false }: Props = $props();
 </script>
 
-<div class="stack__status gap" class:gap>
+<div class="stack__status gap">
 	{#if lineTop}
 		<div class="stack__status--bar" style:--bg-color={color}></div>
 	{/if}
@@ -30,10 +29,7 @@
 		flex-direction: column;
 		justify-content: center;
 		align-items: center;
-
-		&.gap {
-			gap: 0.25rem;
-		}
+		gap: 0.25rem;
 
 		& .stack__status--icon {
 			display: flex;
@@ -41,7 +37,7 @@
 			justify-content: center;
 			width: 21px;
 			height: 28px;
-			border-radius: 30%;
+			border-radius: var(--radius-m);
 			background-color: var(--bg-color);
 			color: var(--icon-color, var(--clr-text-1));
 		}


### PR DESCRIPTION
## ☕️ Reasoning

- Always show gap around `StackingStatusIcon` and use `border-radius: var(--radius-m);`

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
