### PR TITLE
fix: History lazy loading

### DIFF
--- a/apps/desktop/src/lib/history/History.svelte
+++ b/apps/desktop/src/lib/history/History.svelte
@@ -75,6 +75,8 @@
 		| { entryId: string; diffs: { [key: string]: SnapshotDiff } }
 		| undefined = undefined;
 	let selectedFile: { entryId: string; path: string } | undefined = undefined;
+
+	$: withinRestoreItems = findRestorationRanges($snapshots);
 </script>
 
 <svelte:window
@@ -150,12 +152,10 @@
 						<LazyloadContainer
 							minTriggerCount={30}
 							ontrigger={() => {
-								console.log('load more snapshots…');
 								onLastInView();
 							}}
 						>
 							{#each $snapshots as entry, idx (entry.id)}
-								{@const withinRestoreItems = findRestorationRanges($snapshots)}
 								{#if idx === 0 || createdOnDay(entry.createdAt) !== createdOnDay($snapshots[idx - 1]?.createdAt ?? new Date())}
 									<div class="sideview__date-header">
 										<h4 class="text-13 text-semibold">

--- a/apps/desktop/src/lib/history/history.ts
+++ b/apps/desktop/src/lib/history/history.ts
@@ -15,7 +15,7 @@ export class HistoryService {
 			// Clear store when component last subscriber unsubscribes.
 			set([]);
 			this.cursor = undefined;
-			this.isAllLoaded.set(true);
+			this.isAllLoaded.set(false);
 		};
 	});
 

--- a/apps/desktop/src/lib/shared/LazyloadContainer.svelte
+++ b/apps/desktop/src/lib/shared/LazyloadContainer.svelte
@@ -12,13 +12,14 @@
 
 	let { children, minTriggerCount, role, ontrigger, onkeydown }: Props = $props();
 
-	let lazyContainerEl: HTMLDivElement;
+	let lazyContainerEl: HTMLDivElement | undefined;
 
 	const mutuationObserver = new MutationObserver(attachIntersectionObserver);
 	$effect(() => {
 		if (lazyContainerEl) {
 			mutuationObserver.disconnect();
 			mutuationObserver.observe(lazyContainerEl, { childList: true });
+			attachIntersectionObserver();
 		}
 	});
 	const intersectionObserver = new IntersectionObserver((entries) => {
@@ -33,11 +34,15 @@
 	function attachIntersectionObserver() {
 		// unattach all intersection observers
 		intersectionObserver.disconnect();
+		if (!lazyContainerEl) return;
 
 		const containerChildren = lazyContainerEl.children;
 		if (containerChildren.length < minTriggerCount) return;
 
-		intersectionObserver.observe(containerChildren[containerChildren.length - 1] as HTMLElement);
+		const lastChild = containerChildren[containerChildren.length - 1];
+		if (!lastChild) return;
+
+		intersectionObserver.observe(lastChild);
 	}
 
 	onMount(() => {


### PR DESCRIPTION
Lazy loading the history side bar list items wouldn't paginate correctly.
There seems to have been two issues that caused this:
1. The intersection observer would was not initially set correctly
2. The "all loaded" flag was incorrectly set to true when clearing the history snapshots store. It should have been set to false.

Will fix the weird loading animation on another PR