### PR TITLE
Probably fix #5096

### DIFF
--- a/crates/gitbutler-project/src/controller.rs
+++ b/crates/gitbutler-project/src/controller.rs
@@ -72,7 +72,7 @@ impl Controller {
         let project = Project {
             id: ProjectId::generate(),
             title,
-            path: path.to_path_buf(),
+            path: gix::path::realpath(path)?,
             api: None,
             ..Default::default()
         };

--- a/crates/gitbutler-testsupport/src/testing_repository.rs
+++ b/crates/gitbutler-testsupport/src/testing_repository.rs
@@ -1,5 +1,6 @@
 use std::fs;
 
+use crate::init_opts;
 use gitbutler_oxidize::git2_to_gix_object_id;
 use gix_testtools::bstr::ByteSlice as _;
 use tempfile::{tempdir, TempDir};
@@ -13,7 +14,7 @@ pub struct TestingRepository {
 impl TestingRepository {
     pub fn open() -> Self {
         let tempdir = tempdir().unwrap();
-        let repository = git2::Repository::init(tempdir.path()).unwrap();
+        let repository = git2::Repository::init_opts(tempdir.path(), &init_opts()).unwrap();
 
         let config = repository.config().unwrap();
         match config.open_level(git2::ConfigLevel::Local) {


### PR DESCRIPTION
When testing paths for prefix-matches it's important they are all normalized in the same fashion.

`canonicalize()` is very particular about canonicalizing Windows paths, which makes it easy for these paths to not be compatible to other absolute-looking paths.

The difficulty here is to get the right trade-off between performance and safety, e.g. we wouldn't want these canonicalized Windows paths to be used anywhere as they are very uncommon (and don't even work everywhere).

### Notes for the Reviewer

* I didn't actually validate this on Windows, but am quite confident that this will fix the issue.
* This PR touches `read_file_from_workspace()` which needs work, I just did the bare minimum here. More context is [here](https://github.com/gitbutlerapp/gitbutler/pull/5089#discussion_r1797379253).

Related to #5096 .
