### PR TITLE
style: Update design token for shadow commit

### DIFF
--- a/packages/ui/src/lib/data/design-tokens.json
+++ b/packages/ui/src/lib/data/design-tokens.json
@@ -3514,12 +3514,12 @@
 			},
 			"shadow": {
 				"$type": "color",
-				"$value": "{clr-core.ntrl.60}",
+				"$value": "{clr-core.pop.60}",
 				"$description": "",
 				"$extensions": {
 					"mode": {
-						"light": "{clr-core.ntrl.60}",
-						"dark": "{clr-core.ntrl.40}"
+						"light": "{clr-core.pop.60}",
+						"dark": "{clr-core.pop.30}"
 					},
 					"figma": {
 						"variableId": "VariableID:3172:9430",
@@ -4237,7 +4237,7 @@
 			"useDTCGKeys": true,
 			"colorMode": "hex",
 			"variableCollections": ["clr-core", "clr", "size", "radius"],
-			"createdAt": "2024-10-09T14:46:18.350Z"
+			"createdAt": "2024-10-13T22:48:55.998Z"
 		}
 	}
 }

--- a/packages/ui/src/styles/core/design-tokens.css
+++ b/packages/ui/src/styles/core/design-tokens.css
@@ -196,7 +196,7 @@
 	--clr-commit-upstream: var(--clr-core-warn-50);
 	--clr-commit-local: var(--clr-core-ntrl-50);
 	--clr-commit-remote: var(--clr-core-pop-50);
-	--clr-commit-shadow: var(--clr-core-ntrl-60);
+	--clr-commit-shadow: var(--clr-core-pop-60);
 	--clr-commit-integrated: var(--clr-core-purp-50);
 	--clr-text-1: var(--clr-core-ntrl-5);
 	--clr-text-2: var(--clr-core-ntrl-50);
@@ -379,7 +379,7 @@
 	--clr-commit-upstream: var(--clr-core-warn-50);
 	--clr-commit-local: var(--clr-core-ntrl-50);
 	--clr-commit-remote: var(--clr-core-pop-50);
-	--clr-commit-shadow: var(--clr-core-ntrl-40);
+	--clr-commit-shadow: var(--clr-core-pop-30);
 	--clr-commit-integrated: var(--clr-core-purp-40);
 	--clr-text-1: var(--clr-core-ntrl-95);
 	--clr-text-2: var(--clr-core-ntrl-60);


### PR DESCRIPTION
## Description
This pull request updates the design token for the "shadow" commit in the project. The new color is a lighter variation of the "remote" color.

### Changes Made
- Revised the design token for shadow to ensure consistency and adherence to the project's design guidelines.

---

Current one-branch per lane:

<img width="458" alt="image" src="https://github.com/user-attachments/assets/eb896060-2d36-4b75-8e23-e5520ef5966e">

Stacking design:

<img width="395" alt="image" src="https://github.com/user-attachments/assets/99a27c5d-a9cb-4f48-847c-ac2fcdc6ae93">
