### PR TITLE
fix: Title state update for the PR modal

### DIFF
--- a/apps/desktop/src/lib/pr/PrDetailsModal.svelte
+++ b/apps/desktop/src/lib/pr/PrDetailsModal.svelte
@@ -129,7 +129,12 @@
 
 	// Fetch PR template content
 	$effect(() => {
-		if ($prService && pullRequestTemplateBody === undefined && prTemplatePath) {
+		if (
+			modal?.imports.open &&
+			$prService &&
+			pullRequestTemplateBody === undefined &&
+			prTemplatePath
+		) {
 			$prService.pullRequestTemplateContent(prTemplatePath, project.id).then((template) => {
 				pullRequestTemplateBody = template;
 			});
@@ -358,7 +363,7 @@
 						placeholder="PR title"
 						value={actualTitle}
 						readonly={!isEditing || isPreviewOnly}
-						on:change={(e) => {
+						on:input={(e) => {
 							inputTitle = e.detail;
 						}}
 					/>


### PR DESCRIPTION
The PR modals title would only be correctly updated on blur, because it was using the 'onchange' listener.
Using the 'oninput' listener fixed that.
Also: 
Only fetch the pull-request body if the modal is open