### PR TITLE
Tidy grammar and inaccuracies

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug.yml
@@ -16,7 +16,7 @@ body:
       label: Operating System
       description: What OS are you using GitButler on?
       options:
-        - MacOS
+        - macOS
         - Windows
         - Linux
       default: 0

--- a/.github/ISSUE_TEMPLATE/1_bug.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug.yml
@@ -16,7 +16,7 @@ body:
       label: Operating System
       description: What OS are you using GitButler on?
       options:
-        - Mac OS X
+        - MacOS
         - Windows
         - Linux
       default: 0
@@ -39,7 +39,7 @@ body:
   - type: textarea
     attributes:
       label: Describe the issue
-      description: Describe us what the issue is and what have you tried so far to fix it. Add any extra useful information in this section. Feel free to use screenshots over a picture of your code) or a video explanation.
+      description: Describe for us what the issue is and what you have tried so far to fix it. Add any extra useful information in this section. Feel free to use screenshots over a picture of your code) or a video explanation.
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
## ☕️ Reasoning

I raised an issue earlier today, and spotted a few (minor!) issues in the template.

## 🧢 Changes

- Mac OS X => macOS
- Tidy grammar for readability; note that there's another sentence in there that doesn't really make any sense, but it's not clear to me what it's intended to say, so there wasn't really a way to fix it:

> Feel free to use screenshots over a picture of your code) or a video explanation.
