### PR TITLE
fix: show diverged commitId in diverged state

### DIFF
--- a/packages/ui/src/lib/commitLinesStacking/CommitNode.svelte
+++ b/packages/ui/src/lib/commitLinesStacking/CommitNode.svelte
@@ -29,7 +29,7 @@
 		</Tooltip>
 	{:else if type === 'localAndShadow'}
 		<div class="local-shadow-commit-dot">
-			<Tooltip text="Diverged">
+			<Tooltip text={commitNode.commit?.remoteCommitId ?? 'Diverged'}>
 				<svg
 					class="shadow-dot"
 					width="10"
@@ -42,7 +42,7 @@
 					/>
 				</svg>
 			</Tooltip>
-			<Tooltip text={tooltipText}>
+			<Tooltip text="Diverged">
 				<svg
 					class="local-dot"
 					width="11"


### PR DESCRIPTION
## ☕️ Reasoning

- Diverged commit line node (dual icon) should show "Diverged" + the diverged remote commit id. The local commit Id is already on th ecommit card right next to the icon

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
