### PR TITLE
feat: Remove tabindex attribute from Navigation menu

### DIFF
--- a/apps/desktop/src/lib/navigation/Navigation.svelte
+++ b/apps/desktop/src/lib/navigation/Navigation.svelte
@@ -107,7 +107,6 @@
 		style:width={$defaultTrayWidthRem && !$isNavCollapsed ? $defaultTrayWidthRem + 'rem' : null}
 		bind:this={viewport}
 		role="menu"
-		tabindex="0"
 	>
 		<!-- condition prevents split second UI shift -->
 		{#if $platformName || env.PUBLIC_TESTING}

--- a/apps/desktop/src/lib/pr/PrDetailsModal.svelte
+++ b/apps/desktop/src/lib/pr/PrDetailsModal.svelte
@@ -253,6 +253,7 @@
 
 		inputBody = descriptionResult.value;
 		aiIsLoading = false;
+		aiDescriptionDirective = undefined;
 		await tick();
 	}
 


### PR DESCRIPTION
### Description
Fixed a bug where closing a Modal component would shift focus to the sidebar, which is not the intended behavior. Removed the `tabIndex` attribute from the sidebar wrapper to prevent this issue from occurring.


https://github.com/user-attachments/assets/a30ba9fd-fa6f-488f-893f-75c90bd56092


