### PR TITLE
fix: change stacking header line alignment

### DIFF
--- a/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
@@ -234,8 +234,9 @@
 	}
 
 	.branch-action__line {
-		margin: 0 22px 0 22.5px;
-		border-left: 2px solid var(--bg-color, var(--clr-border-3));
+		width: 2px;
+		margin: 0 22px;
+		background-color: var(--bg-color, var(--clr-border-3));
 	}
 
 	.branch-emptystate {

--- a/apps/desktop/src/lib/branch/StackingStatusIcon.svelte
+++ b/apps/desktop/src/lib/branch/StackingStatusIcon.svelte
@@ -56,7 +56,7 @@
 		& .stack__status--bar {
 			width: 2px;
 			height: 10px;
-			margin: 0 22px 0 22px;
+			margin: 0 22px;
 			background: var(--bg-color);
 		}
 	}

--- a/apps/desktop/src/lib/commit/StackingUpstreamCommitsAccordion.svelte
+++ b/apps/desktop/src/lib/commit/StackingUpstreamCommitsAccordion.svelte
@@ -93,8 +93,9 @@
 		}
 
 		& .accordion-row__line {
-			margin: 0 10px 0 22.5px;
-			border-right: 2px solid var(--clr-commit-upstream);
+			width: 2px;
+			margin: 0 22px;
+			background-color: var(--clr-commit-upstream);
 
 			&.dots {
 				place-items: center;

--- a/packages/ui/src/lib/commitLinesStacking/Cell.svelte
+++ b/packages/ui/src/lib/commitLinesStacking/Cell.svelte
@@ -21,6 +21,8 @@
 
 <style lang="postcss">
 	.commit-line {
-		border-right: 2px var(--border-style) var(--border-color);
+		width: 2px;
+		margin: 0 22px;
+		background: var(--border-color);
 	}
 </style>

--- a/packages/ui/src/lib/commitLinesStacking/CommitNode.svelte
+++ b/packages/ui/src/lib/commitLinesStacking/CommitNode.svelte
@@ -90,7 +90,7 @@
 	}
 
 	.generic-commit-dot {
-		transform: translateX(5px);
+		transform: translateX(4px);
 
 		&.remote {
 			fill: var(--clr-commit-remote);


### PR DESCRIPTION
## ☕️ Reasoning

- Align all commit lines better by using widht + margin instead of borders

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
