### PR TITLE
fix: dont allow changing series name once pushed

### DIFF
--- a/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
@@ -95,7 +95,7 @@
 		/>
 		<div class="text-14 text-bold branch-info__name">
 			<span class="remote-name">{$baseBranch.remoteName ?? 'origin'}/</span>
-			<BranchLabel {name} onChange={(name) => editTitle(name)} />
+			<BranchLabel {name} onChange={(name) => editTitle(name)} disabled={!!gitHostBranch} />
 			{#if gitHostBranch}
 				<Button
 					size="tag"


### PR DESCRIPTION
## ☕️ Reasoning

- Series/branches that have been pushed can no longer be renamed, therefore we shouldn't even allow the user to input here any more once thats happened

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
