### PR TITLE
fix: do not show upstream label when branch has not been pushed yet

### DIFF
--- a/apps/desktop/src/lib/branch/BranchLabel.svelte
+++ b/apps/desktop/src/lib/branch/BranchLabel.svelte
@@ -61,7 +61,7 @@
 	.branch-name-input {
 		min-width: 44px;
 		height: 20px;
-		padding: 2px 4px;
+		padding: 2px 3px;
 		border: 1px solid transparent;
 	}
 	.branch-name-measure-el {

--- a/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
@@ -94,7 +94,9 @@
 			lineBottom={commits.length > 0}
 		/>
 		<div class="text-14 text-bold branch-info__name">
-			<span class="remote-name">{$baseBranch.remoteName ?? 'origin'}/</span>
+			<span class:no-upstream={!gitHostBranch} class="remote-name">
+				{$baseBranch.remoteName ?? 'origin'}/
+			</span>
 			<BranchLabel {name} onChange={(name) => editTitle(name)} disabled={!!gitHostBranch} />
 			{#if gitHostBranch}
 				<Button
@@ -210,6 +212,11 @@
 		.remote-name {
 			margin-top: 3px;
 			color: var(--clr-scale-ntrl-60);
+
+			&.no-upstream {
+				width: 0px;
+				margin-right: -5px;
+			}
 		}
 	}
 


### PR DESCRIPTION
## ☕️ Reasoning

- When branch is local only, do not show `origin /` prefix in series / branch header

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
