### PR TITLE
fix: hide commitList if there are no commits

### DIFF
--- a/apps/desktop/src/lib/stack/StackSeries.svelte
+++ b/apps/desktop/src/lib/stack/StackSeries.svelte
@@ -36,14 +36,16 @@
 			name={currentSeries.branchName}
 			upstreamName={currentSeries.upstreamReference ? currentSeries.name : undefined}
 		/>
-		<StackingCommitList
-			remoteOnlyPatches={currentSeries.upstreamPatches}
-			patches={currentSeries.patches}
-			isUnapplied={false}
-			{reorderDropzoneManager}
-			{localCommitsConflicted}
-			{localAndRemoteCommitsConflicted}
-		/>
+		{#if currentSeries.upstreamPatches.length > 0 || currentSeries.patches.length > 0}
+			<StackingCommitList
+				remoteOnlyPatches={currentSeries.upstreamPatches}
+				patches={currentSeries.patches}
+				isUnapplied={false}
+				{reorderDropzoneManager}
+				{localCommitsConflicted}
+				{localAndRemoteCommitsConflicted}
+			/>
+		{/if}
 	</div>
 {/each}
 


### PR DESCRIPTION
## ☕️ Reasoning

- StackingHeader was adding an additional `border-bottom` when it was unwanted

## 🧢 Changes

- Do not render the `StackingCommitList` when there are no commits, so that the stacking header is the last-child when it is supposed to be

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
