### PR TITLE
fix: dont show 'set remote branch name' option in stack header contextMenu

### DIFF
--- a/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
@@ -6,6 +6,7 @@
 	import ContextMenuItem from '$lib/components/contextmenu/ContextMenuItem.svelte';
 	import ContextMenuSection from '$lib/components/contextmenu/ContextMenuSection.svelte';
 	import { projectAiGenEnabled } from '$lib/config/config';
+	import { stackingFeature } from '$lib/config/uiFeatureFlags';
 	import TextBox from '$lib/shared/TextBox.svelte';
 	import Toggle from '$lib/shared/Toggle.svelte';
 	import { User } from '$lib/stores/user';
@@ -124,16 +125,18 @@
 		/>
 	</ContextMenuSection>
 
-	<ContextMenuSection>
-		<ContextMenuItem
-			label="Set remote branch name"
-			on:click={() => {
-				newRemoteName = branch.upstreamName || normalizedBranchName || '';
-				renameRemoteModal.show(branch);
-				contextMenuEl?.close();
-			}}
-		/>
-	</ContextMenuSection>
+	{#if !$stackingFeature}
+		<ContextMenuSection>
+			<ContextMenuItem
+				label="Set remote branch name"
+				on:click={() => {
+					newRemoteName = branch.upstreamName || normalizedBranchName || '';
+					renameRemoteModal.show(branch);
+					contextMenuEl?.close();
+				}}
+			/>
+		</ContextMenuSection>
+	{/if}
 
 	<ContextMenuSection>
 		<ContextMenuItem label="Allow rebasing" on:click={toggleAllowRebasing}>


### PR DESCRIPTION
## ☕️ Reasoning

- "Set remote branch name" doesn't apply in stacking context to stack/lane header

## 🧢 Changes

- Hide option in context menu when featureflag is enabled

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
