### PR TITLE
feat: add support for default code editor (Zed)

### DIFF
--- a/apps/desktop/src/lib/barmenuActions/ProjectSettingsMenuAction.svelte
+++ b/apps/desktop/src/lib/barmenuActions/ProjectSettingsMenuAction.svelte
@@ -23,7 +23,7 @@
 		const unsubscribeopenInEditor = listen<string>(
 			'menu://project/open-in-vscode/clicked',
 			async () => {
-				const path = `${$userSettings.defaultCodeEditor}://file${project.vscodePath}?windowId=_blank`;
+				const path = `${$userSettings.defaultCodeEditor.schemeIdentifer}://file${project.vscodePath}?windowId=_blank`;
 				openExternalUrl(path);
 			}
 		);

--- a/apps/desktop/src/lib/barmenuActions/ProjectSettingsMenuAction.svelte
+++ b/apps/desktop/src/lib/barmenuActions/ProjectSettingsMenuAction.svelte
@@ -20,7 +20,7 @@
 			goto(`/${project.id}/settings/`);
 		});
 
-		const unsubscribeOpenInVSCode = listen<string>(
+		const unsubscribeopenInEditor = listen<string>(
 			'menu://project/open-in-vscode/clicked',
 			async () => {
 				const path = `${$userSettings.defaultCodeEditor}://file${project.vscodePath}?windowId=_blank`;
@@ -40,7 +40,7 @@
 
 		return () => {
 			unsubscribeSettings();
-			unsubscribeOpenInVSCode();
+			unsubscribeopenInEditor();
 			unsubscribeHistory();
 			unsubscribeHistoryButton();
 		};

--- a/apps/desktop/src/lib/barmenuActions/ProjectSettingsMenuAction.svelte
+++ b/apps/desktop/src/lib/barmenuActions/ProjectSettingsMenuAction.svelte
@@ -2,15 +2,15 @@
 	import { listen } from '$lib/backend/ipc';
 	import { Project } from '$lib/backend/projects';
 	import { showHistoryView } from '$lib/config/config';
-	import { getContextStoreBySymbol } from '@gitbutler/shared/context';
 	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import * as events from '$lib/utils/events';
 	import { unsubscribe } from '$lib/utils/unsubscribe';
 	import { openExternalUrl } from '$lib/utils/url';
+	import { getContextStoreBySymbol } from '@gitbutler/shared/context';
 	import { getContext } from '@gitbutler/shared/context';
 	import { onMount } from 'svelte';
-	import { goto } from '$app/navigation';
 	import type { Writable } from 'svelte/store';
+	import { goto } from '$app/navigation';
 
 	const project = getContext(Project);
 	const userSettings = getContextStoreBySymbol<Settings, Writable<Settings>>(SETTINGS);

--- a/apps/desktop/src/lib/barmenuActions/ProjectSettingsMenuAction.svelte
+++ b/apps/desktop/src/lib/barmenuActions/ProjectSettingsMenuAction.svelte
@@ -2,15 +2,18 @@
 	import { listen } from '$lib/backend/ipc';
 	import { Project } from '$lib/backend/projects';
 	import { showHistoryView } from '$lib/config/config';
-	import { editor } from '$lib/editorLink/editorLink';
+	import { getContextStoreBySymbol } from '@gitbutler/shared/context';
+	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import * as events from '$lib/utils/events';
 	import { unsubscribe } from '$lib/utils/unsubscribe';
 	import { openExternalUrl } from '$lib/utils/url';
 	import { getContext } from '@gitbutler/shared/context';
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
+	import type { Writable } from 'svelte/store';
 
 	const project = getContext(Project);
+	const userSettings = getContextStoreBySymbol<Settings, Writable<Settings>>(SETTINGS);
 
 	onMount(() => {
 		const unsubscribeSettings = listen<string>('menu://project/settings/clicked', () => {
@@ -20,7 +23,7 @@
 		const unsubscribeOpenInVSCode = listen<string>(
 			'menu://project/open-in-vscode/clicked',
 			async () => {
-				const path = `${$editor}://file${project.vscodePath}?windowId=_blank`;
+				const path = `${$userSettings.defaultCodeEditor}://file${project.vscodePath}?windowId=_blank`;
 				openExternalUrl(path);
 			}
 		);

--- a/apps/desktop/src/lib/components/BoardEmptyState.svelte
+++ b/apps/desktop/src/lib/components/BoardEmptyState.svelte
@@ -6,11 +6,7 @@
 	import { getGitHost } from '$lib/gitHost/interface/gitHost';
 	import { openExternalUrl } from '$lib/utils/url';
 	import { BranchController } from '$lib/vbranches/branchController';
-	import {
-		getContext,
-		getContextStore,
-		getContextStoreBySymbol
-	} from '@gitbutler/shared/context';
+	import { getContext, getContextStore, getContextStoreBySymbol } from '@gitbutler/shared/context';
 	import Icon from '@gitbutler/ui/Icon.svelte';
 	import type { Writable } from 'svelte/store';
 
@@ -21,7 +17,7 @@
 
 	const project = getContext(Project);
 
-	async function openInVSCode() {
+	async function openInEditor() {
 		openExternalUrl(
 			`${$userSettings.defaultCodeEditor}://file${project.vscodePath}/?windowId=_blank`
 		);
@@ -58,8 +54,7 @@
 						</div>
 						<button
 							class="empty-board__suggestions__link"
-							on:click={async () =>
-								await openExternalUrl('https://docs.gitbutler.com')}
+							on:click={async () => await openExternalUrl('https://docs.gitbutler.com')}
 						>
 							<div class="empty-board__suggestions__link__icon">
 								<Icon name="docs" />
@@ -69,8 +64,8 @@
 						</button>
 						<button
 							class="empty-board__suggestions__link"
-							on:keypress={async () => await openInVSCode()}
-							on:click={async () => await openInVSCode()}
+							on:keypress={async () => await openInEditor()}
+							on:click={async () => await openInEditor()}
 						>
 							<div class="empty-board__suggestions__link__icon">
 								<Icon name="vscode" />

--- a/apps/desktop/src/lib/components/BoardEmptyState.svelte
+++ b/apps/desktop/src/lib/components/BoardEmptyState.svelte
@@ -2,8 +2,8 @@
 	import zenSvg from '$lib/assets/dzen-pc.svg?raw';
 	import { Project } from '$lib/backend/projects';
 	import { BaseBranch } from '$lib/baseBranch/baseBranch';
-	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import { getGitHost } from '$lib/gitHost/interface/gitHost';
+	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import { openExternalUrl } from '$lib/utils/url';
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { getContext, getContextStore, getContextStoreBySymbol } from '@gitbutler/shared/context';

--- a/apps/desktop/src/lib/components/BoardEmptyState.svelte
+++ b/apps/desktop/src/lib/components/BoardEmptyState.svelte
@@ -19,7 +19,7 @@
 
 	async function openInEditor() {
 		openExternalUrl(
-			`${$userSettings.defaultCodeEditor}://file${project.vscodePath}/?windowId=_blank`
+			`${$userSettings.defaultCodeEditor.schemeIdentifer}://file${project.vscodePath}/?windowId=_blank`
 		);
 	}
 </script>
@@ -70,7 +70,7 @@
 							<div class="empty-board__suggestions__link__icon">
 								<Icon name="vscode" />
 							</div>
-							<span class="text-12">Open in Editor</span>
+							<span class="text-12">`Open in {$userSettings.defaultCodeEditor.displayName}`</span>
 						</button>
 					</div>
 				</div>

--- a/apps/desktop/src/lib/components/BoardEmptyState.svelte
+++ b/apps/desktop/src/lib/components/BoardEmptyState.svelte
@@ -2,21 +2,29 @@
 	import zenSvg from '$lib/assets/dzen-pc.svg?raw';
 	import { Project } from '$lib/backend/projects';
 	import { BaseBranch } from '$lib/baseBranch/baseBranch';
-	import { editor } from '$lib/editorLink/editorLink';
+	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import { getGitHost } from '$lib/gitHost/interface/gitHost';
 	import { openExternalUrl } from '$lib/utils/url';
 	import { BranchController } from '$lib/vbranches/branchController';
-	import { getContext, getContextStore } from '@gitbutler/shared/context';
+	import {
+		getContext,
+		getContextStore,
+		getContextStoreBySymbol
+	} from '@gitbutler/shared/context';
 	import Icon from '@gitbutler/ui/Icon.svelte';
+	import type { Writable } from 'svelte/store';
 
 	const gitHost = getGitHost();
 	const baseBranch = getContextStore(BaseBranch);
 	const branchController = getContext(BranchController);
+	const userSettings = getContextStoreBySymbol<Settings, Writable<Settings>>(SETTINGS);
 
 	const project = getContext(Project);
 
 	async function openInVSCode() {
-		openExternalUrl(`${$editor}://file${project.vscodePath}/?windowId=_blank`);
+		openExternalUrl(
+			`${$userSettings.defaultCodeEditor}://file${project.vscodePath}/?windowId=_blank`
+		);
 	}
 </script>
 
@@ -50,7 +58,8 @@
 						</div>
 						<button
 							class="empty-board__suggestions__link"
-							on:click={async () => await openExternalUrl('https://docs.gitbutler.com')}
+							on:click={async () =>
+								await openExternalUrl('https://docs.gitbutler.com')}
 						>
 							<div class="empty-board__suggestions__link__icon">
 								<Icon name="docs" />
@@ -66,7 +75,7 @@
 							<div class="empty-board__suggestions__link__icon">
 								<Icon name="vscode" />
 							</div>
-							<span class="text-12">Open in VSCode</span>
+							<span class="text-12">Open in Editor</span>
 						</button>
 					</div>
 				</div>

--- a/apps/desktop/src/lib/components/EditMode.svelte
+++ b/apps/desktop/src/lib/components/EditMode.svelte
@@ -2,7 +2,9 @@
 	import { Project } from '$lib/backend/projects';
 	import { CommitService } from '$lib/commits/service';
 	import { conflictEntryHint, type ConflictEntryPresence } from '$lib/conflictEntryPresence';
-	import { editor } from '$lib/editorLink/editorLink';
+	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
+	import { getContextStoreBySymbol } from '@gitbutler/shared/context';
+
 	import FileContextMenu from '$lib/file/FileContextMenu.svelte';
 	import { ModeService, type EditModeMetadata } from '$lib/modes/service';
 	import ScrollableContainer from '$lib/scroll/ScrollableContainer.svelte';
@@ -17,6 +19,7 @@
 	import FileListItem from '@gitbutler/ui/file/FileListItem.svelte';
 	import { join } from '@tauri-apps/api/path';
 	import type { FileStatus } from '@gitbutler/ui/file/types';
+	import type { Writable } from 'svelte/store';
 
 	interface Props {
 		editModeMetadata: EditModeMetadata;
@@ -28,6 +31,7 @@
 	const remoteCommitService = getContext(CommitService);
 	const uncommitedFileWatcher = getContext(UncommitedFilesWatcher);
 	const modeService = getContext(ModeService);
+	const userSettings = getContextStoreBySymbol<Settings, Writable<Settings>>(SETTINGS);
 
 	const uncommitedFiles = uncommitedFileWatcher.uncommitedFiles;
 
@@ -162,7 +166,7 @@
 	async function openAllConflictedFiles() {
 		for (const file of conflictedFiles) {
 			const absPath = await join(project.vscodePath, file.path);
-			openExternalUrl(`${$editor}://file${absPath}`);
+			openExternalUrl(`${$userSettings.defaultCodeEditor}://file${absPath}`);
 		}
 	}
 </script>
@@ -173,8 +177,8 @@
 			{editModeMetadata.commitOid.slice(0, 7)}
 		</span>
 		<InfoButton title="Edit Mode">
-			Edit Mode lets you modify an existing commit in isolation or resolve conflicts. Any changes
-			made, including new files, will be added to the selected commit.
+			Edit Mode lets you modify an existing commit in isolation or resolve conflicts. Any
+			changes made, including new files, will be added to the selected commit.
 		</InfoButton>
 	</h2>
 

--- a/apps/desktop/src/lib/components/EditMode.svelte
+++ b/apps/desktop/src/lib/components/EditMode.svelte
@@ -2,15 +2,14 @@
 	import { Project } from '$lib/backend/projects';
 	import { CommitService } from '$lib/commits/service';
 	import { conflictEntryHint, type ConflictEntryPresence } from '$lib/conflictEntryPresence';
-	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
-	import { getContextStoreBySymbol } from '@gitbutler/shared/context';
-
 	import FileContextMenu from '$lib/file/FileContextMenu.svelte';
 	import { ModeService, type EditModeMetadata } from '$lib/modes/service';
 	import ScrollableContainer from '$lib/scroll/ScrollableContainer.svelte';
+	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import { UncommitedFilesWatcher } from '$lib/uncommitedFiles/watcher';
 	import { openExternalUrl } from '$lib/utils/url';
 	import { Commit, type RemoteFile } from '$lib/vbranches/types';
+	import { getContextStoreBySymbol } from '@gitbutler/shared/context';
 	import { getContext } from '@gitbutler/shared/context';
 	import Badge from '@gitbutler/ui/Badge.svelte';
 	import Button from '@gitbutler/ui/Button.svelte';

--- a/apps/desktop/src/lib/components/EditMode.svelte
+++ b/apps/desktop/src/lib/components/EditMode.svelte
@@ -166,7 +166,7 @@
 	async function openAllConflictedFiles() {
 		for (const file of conflictedFiles) {
 			const absPath = await join(project.vscodePath, file.path);
-			openExternalUrl(`${$userSettings.defaultCodeEditor}://file${absPath}`);
+			openExternalUrl(`${$userSettings.defaultCodeEditor.schemeIdentifer}://file${absPath}`);
 		}
 	}
 </script>
@@ -177,8 +177,8 @@
 			{editModeMetadata.commitOid.slice(0, 7)}
 		</span>
 		<InfoButton title="Edit Mode">
-			Edit Mode lets you modify an existing commit in isolation or resolve conflicts. Any
-			changes made, including new files, will be added to the selected commit.
+			Edit Mode lets you modify an existing commit in isolation or resolve conflicts. Any changes
+			made, including new files, will be added to the selected commit.
 		</InfoButton>
 	</h2>
 

--- a/apps/desktop/src/lib/file/FileContextMenu.svelte
+++ b/apps/desktop/src/lib/file/FileContextMenu.svelte
@@ -3,7 +3,9 @@
 	import ContextMenu from '$lib/components/contextmenu/ContextMenu.svelte';
 	import ContextMenuItem from '$lib/components/contextmenu/ContextMenuItem.svelte';
 	import ContextMenuSection from '$lib/components/contextmenu/ContextMenuSection.svelte';
-	import { editor } from '$lib/editorLink/editorLink';
+	import { getContextStoreBySymbol } from '@gitbutler/shared/context';
+	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
+
 	import { computeFileStatus } from '$lib/utils/fileStatus';
 	import * as toasts from '$lib/utils/toasts';
 	import { openExternalUrl } from '$lib/utils/url';
@@ -13,6 +15,7 @@
 	import Button from '@gitbutler/ui/Button.svelte';
 	import Modal from '@gitbutler/ui/Modal.svelte';
 	import { join } from '@tauri-apps/api/path';
+	import type { Writable } from 'svelte/store';
 
 	export let branchId: string | undefined;
 	export let target: HTMLElement | undefined;
@@ -20,6 +23,7 @@
 
 	const branchController = getContext(BranchController);
 	const project = getContext(Project);
+	const userSettings = getContextStoreBySymbol<Settings, Writable<Settings>>(SETTINGS);
 
 	let confirmationModal: Modal;
 	let contextMenu: ReturnType<typeof ContextMenu>;
@@ -90,12 +94,12 @@
 							if (!project) return;
 							for (let file of item.files) {
 								const absPath = await join(project.vscodePath, file.path);
-								openExternalUrl(`${$editor}://file${absPath}`);
+								openExternalUrl(`${$userSettings.defaultCodeEditor}://file${absPath}`);
 							}
 							contextMenu.close();
 						} catch {
-							console.error('Failed to open in VSCode');
-							toasts.error('Failed to open in VSCode');
+							console.error('Failed to open in editor');
+							toasts.error('Failed to open in editor');
 						}
 					}}
 				/>

--- a/apps/desktop/src/lib/file/FileContextMenu.svelte
+++ b/apps/desktop/src/lib/file/FileContextMenu.svelte
@@ -87,14 +87,16 @@
 					/>
 				{/if}
 				<ContextMenuItem
-					label="Open in Editor"
+					label="Open in {$userSettings.defaultCodeEditor.displayName}"
 					disabled={isDeleted(item)}
 					on:click={async () => {
 						try {
 							if (!project) return;
 							for (let file of item.files) {
 								const absPath = await join(project.vscodePath, file.path);
-								openExternalUrl(`${$userSettings.defaultCodeEditor}://file${absPath}`);
+								openExternalUrl(
+									`${$userSettings.defaultCodeEditor.schemeIdentifer}://file${absPath}`
+								);
 							}
 							contextMenu.close();
 						} catch {

--- a/apps/desktop/src/lib/file/FileContextMenu.svelte
+++ b/apps/desktop/src/lib/file/FileContextMenu.svelte
@@ -3,14 +3,13 @@
 	import ContextMenu from '$lib/components/contextmenu/ContextMenu.svelte';
 	import ContextMenuItem from '$lib/components/contextmenu/ContextMenuItem.svelte';
 	import ContextMenuSection from '$lib/components/contextmenu/ContextMenuSection.svelte';
-	import { getContextStoreBySymbol } from '@gitbutler/shared/context';
 	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
-
 	import { computeFileStatus } from '$lib/utils/fileStatus';
 	import * as toasts from '$lib/utils/toasts';
 	import { openExternalUrl } from '$lib/utils/url';
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { isAnyFile, LocalFile } from '$lib/vbranches/types';
+	import { getContextStoreBySymbol } from '@gitbutler/shared/context';
 	import { getContext } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import Modal from '@gitbutler/ui/Modal.svelte';

--- a/apps/desktop/src/lib/file/FileContextMenu.svelte
+++ b/apps/desktop/src/lib/file/FileContextMenu.svelte
@@ -87,7 +87,7 @@
 					/>
 				{/if}
 				<ContextMenuItem
-					label="Open in VSCode"
+					label="Open in Editor"
 					disabled={isDeleted(item)}
 					on:click={async () => {
 						try {

--- a/apps/desktop/src/lib/hunk/HunkContextMenu.svelte
+++ b/apps/desktop/src/lib/hunk/HunkContextMenu.svelte
@@ -3,9 +3,9 @@
 	import ContextMenuItem from '$lib/components/contextmenu/ContextMenuItem.svelte';
 	import ContextMenuSection from '$lib/components/contextmenu/ContextMenuSection.svelte';
 	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
-	import { getContextStoreBySymbol } from '@gitbutler/shared/context';
 	import { openExternalUrl } from '$lib/utils/url';
 	import { BranchController } from '$lib/vbranches/branchController';
+	import { getContextStoreBySymbol } from '@gitbutler/shared/context';
 	import { getContext } from '@gitbutler/shared/context';
 	import type { Writable } from 'svelte/store';
 

--- a/apps/desktop/src/lib/hunk/HunkContextMenu.svelte
+++ b/apps/desktop/src/lib/hunk/HunkContextMenu.svelte
@@ -2,10 +2,12 @@
 	import ContextMenu from '$lib/components/contextmenu/ContextMenu.svelte';
 	import ContextMenuItem from '$lib/components/contextmenu/ContextMenuItem.svelte';
 	import ContextMenuSection from '$lib/components/contextmenu/ContextMenuSection.svelte';
-	import { editor } from '$lib/editorLink/editorLink';
+	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
+	import { getContextStoreBySymbol } from '@gitbutler/shared/context';
 	import { openExternalUrl } from '$lib/utils/url';
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { getContext } from '@gitbutler/shared/context';
+	import type { Writable } from 'svelte/store';
 
 	interface Props {
 		target: HTMLElement | undefined;
@@ -17,6 +19,7 @@
 	let { target, filePath, projectPath, readonly }: Props = $props();
 
 	const branchController = getContext(BranchController);
+	const userSettings = getContextStoreBySymbol<Settings, Writable<Settings>>(SETTINGS);
 
 	let contextMenu: ReturnType<typeof ContextMenu>;
 
@@ -43,10 +46,12 @@
 			{/if}
 			{#if item.lineNumber}
 				<ContextMenuItem
-					label="Open in VSCode"
+					label="Open in Editor"
 					on:click={() => {
 						projectPath &&
-							openExternalUrl(`${$editor}://file${projectPath}/${filePath}:${item.lineNumber}`);
+							openExternalUrl(
+								`${$userSettings.defaultCodeEditor}://file${projectPath}/${filePath}:${item.lineNumber}`
+							);
 						contextMenu.close();
 					}}
 				/>

--- a/apps/desktop/src/lib/hunk/HunkContextMenu.svelte
+++ b/apps/desktop/src/lib/hunk/HunkContextMenu.svelte
@@ -46,11 +46,11 @@
 			{/if}
 			{#if item.lineNumber}
 				<ContextMenuItem
-					label="Open in Editor"
+					label="Open in {$userSettings.defaultCodeEditor.displayName}"
 					on:click={() => {
 						projectPath &&
 							openExternalUrl(
-								`${$userSettings.defaultCodeEditor}://file${projectPath}/${filePath}:${item.lineNumber}`
+								`${$userSettings.defaultCodeEditor.schemeIdentifer}://file${projectPath}/${filePath}:${item.lineNumber}`
 							);
 						contextMenu.close();
 					}}

--- a/apps/desktop/src/lib/settings/userSettings.ts
+++ b/apps/desktop/src/lib/settings/userSettings.ts
@@ -4,6 +4,10 @@ const SETTINGS_KEY = 'settings-json';
 export const SETTINGS = Symbol('Settings');
 
 export type ScrollbarVisilitySettings = 'scroll' | 'hover' | 'always';
+export type CodeEditorSettings = {
+	schemeIdentifer: string;
+	displayName: string;
+};
 
 export interface Settings {
 	aiSummariesEnabled?: boolean;
@@ -22,7 +26,7 @@ export interface Settings {
 	diffFont: string;
 	diffLigatures: boolean;
 	inlineUnifiedDiffs: boolean;
-	defaultCodeEditor: string;
+	defaultCodeEditor: CodeEditorSettings;
 }
 
 const defaults: Settings = {
@@ -41,7 +45,7 @@ const defaults: Settings = {
 	diffFont: 'Geist Mono, Menlo, monospace',
 	diffLigatures: false,
 	inlineUnifiedDiffs: false,
-	defaultCodeEditor: 'vscode'
+	defaultCodeEditor: { schemeIdentifer: 'vscode', displayName: 'VSCode' }
 };
 
 export function loadUserSettings(): Writable<Settings> {

--- a/apps/desktop/src/lib/settings/userSettings.ts
+++ b/apps/desktop/src/lib/settings/userSettings.ts
@@ -22,6 +22,7 @@ export interface Settings {
 	diffFont: string;
 	diffLigatures: boolean;
 	inlineUnifiedDiffs: boolean;
+	defaultCodeEditor: string;
 }
 
 const defaults: Settings = {
@@ -39,7 +40,8 @@ const defaults: Settings = {
 	tabSize: 4,
 	diffFont: 'Geist Mono, Menlo, monospace',
 	diffLigatures: false,
-	inlineUnifiedDiffs: false
+	inlineUnifiedDiffs: false,
+	defaultCodeEditor: 'vscode'
 };
 
 export function loadUserSettings(): Writable<Settings> {

--- a/apps/desktop/src/routes/settings/appearance/+page.svelte
+++ b/apps/desktop/src/routes/settings/appearance/+page.svelte
@@ -7,7 +7,8 @@
 	import {
 		SETTINGS,
 		type Settings,
-		type ScrollbarVisilitySettings
+		type ScrollbarVisilitySettings,
+		type CodeEditorSettings
 	} from '$lib/settings/userSettings';
 	import RadioButton from '$lib/shared/RadioButton.svelte';
 	import TextBox from '$lib/shared/TextBox.svelte';
@@ -19,10 +20,14 @@
 	import Select from '$lib/select/Select.svelte';
 	import SelectItem from '$lib/select/SelectItem.svelte';
 
-	const editorOptions = [
-		{ label: 'VSCode', value: 'vscode' },
-		{ label: 'Zed', value: 'zed' }
+	const editorOptions: CodeEditorSettings[] = [
+		{ schemeIdentifer: 'vscode', displayName: 'VSCode' },
+		{ schemeIdentifer: 'zed', displayName: 'Zed' }
 	];
+	const editorOptionsForSelect = editorOptions.map((option) => ({
+		label: option.displayName,
+		value: option.schemeIdentifer
+	}));
 
 	const userSettings = getContextStoreBySymbol<Settings, Writable<Settings>>(SETTINGS);
 
@@ -73,15 +78,20 @@
 		<svelte:fragment slot="caption">Select your preferred default code editor.</svelte:fragment>
 		<svelte:fragment slot="actions">
 			<Select
-				value={$userSettings.defaultCodeEditor}
-				options={editorOptions}
+				value={$userSettings.defaultCodeEditor.schemeIdentifer}
+				options={editorOptionsForSelect}
 				onselect={(value) => {
-					userSettings.update((s) => ({ ...s, defaultCodeEditor: value }));
-					console.log('userSettings', $userSettings.defaultCodeEditor);
+					const selected = editorOptions.find((option) => option.schemeIdentifer === value);
+					if (selected) {
+						userSettings.update((s) => ({ ...s, defaultCodeEditor: selected }));
+					}
 				}}
 			>
 				{#snippet itemSnippet({ item, highlighted })}
-					<SelectItem selected={item.value === $userSettings.defaultCodeEditor} {highlighted}>
+					<SelectItem
+						selected={item.value === $userSettings.defaultCodeEditor.schemeIdentifer}
+						{highlighted}
+					>
 						{item.label}
 					</SelectItem>
 				{/snippet}

--- a/apps/desktop/src/routes/settings/appearance/+page.svelte
+++ b/apps/desktop/src/routes/settings/appearance/+page.svelte
@@ -246,4 +246,19 @@
 			</svelte:fragment>
 		</SectionCard>
 	</form>
+
+	<SectionCard labelFor="branchLaneContents" orientation="row">
+		<svelte:fragment slot="title">Auto-highlight Branch Lane Contents</svelte:fragment>
+		<svelte:fragment slot="caption">
+			An experimental UI toggle to highlight the contents of the branch lane input fields when
+			clicking into them.
+		</svelte:fragment>
+		<svelte:fragment slot="actions">
+			<Toggle
+				id="branchLaneContents"
+				checked={$autoSelectBranchNameFeature}
+				on:click={() => ($autoSelectBranchNameFeature = !$autoSelectBranchNameFeature)}
+			/>
+		</svelte:fragment>
+	</SectionCard>
 </SettingsPage>

--- a/apps/desktop/src/routes/settings/appearance/+page.svelte
+++ b/apps/desktop/src/routes/settings/appearance/+page.svelte
@@ -3,6 +3,8 @@
 	import { autoSelectBranchNameFeature } from '$lib/config/uiFeatureFlags';
 	import HunkDiff from '$lib/hunk/HunkDiff.svelte';
 	import SettingsPage from '$lib/layout/SettingsPage.svelte';
+	import Select from '$lib/select/Select.svelte';
+	import SelectItem from '$lib/select/SelectItem.svelte';
 	import ThemeSelector from '$lib/settings/ThemeSelector.svelte';
 	import {
 		SETTINGS,
@@ -17,8 +19,6 @@
 	import { getContextStoreBySymbol } from '@gitbutler/shared/context';
 	import type { ContentSection } from '$lib/utils/fileSections';
 	import type { Writable } from 'svelte/store';
-	import Select from '$lib/select/Select.svelte';
-	import SelectItem from '$lib/select/SelectItem.svelte';
 
 	const editorOptions: CodeEditorSettings[] = [
 		{ schemeIdentifer: 'vscode', displayName: 'VSCode' },

--- a/apps/desktop/src/routes/settings/appearance/+page.svelte
+++ b/apps/desktop/src/routes/settings/appearance/+page.svelte
@@ -16,6 +16,13 @@
 	import { getContextStoreBySymbol } from '@gitbutler/shared/context';
 	import type { ContentSection } from '$lib/utils/fileSections';
 	import type { Writable } from 'svelte/store';
+	import Select from '$lib/select/Select.svelte';
+	import SelectItem from '$lib/select/SelectItem.svelte';
+
+	const editorOptions = [
+		{ label: 'VSCode', value: 'vscode' },
+		{ label: 'Zed', value: 'zed' }
+	];
 
 	const userSettings = getContextStoreBySymbol<Settings, Writable<Settings>>(SETTINGS);
 
@@ -61,7 +68,26 @@
 		<svelte:fragment slot="title">Theme</svelte:fragment>
 		<ThemeSelector {userSettings} />
 	</SectionCard>
-
+	<SectionCard labelFor="defaultCodeEditor" orientation="row">
+		<svelte:fragment slot="title">Default Code Editor</svelte:fragment>
+		<svelte:fragment slot="caption">Select your preferred default code editor.</svelte:fragment>
+		<svelte:fragment slot="actions">
+			<Select
+				value={$userSettings.defaultCodeEditor}
+				options={editorOptions}
+				onselect={(value) => {
+					userSettings.update((s) => ({ ...s, defaultCodeEditor: value }));
+					console.log('userSettings', $userSettings.defaultCodeEditor);
+				}}
+			>
+				{#snippet itemSnippet({ item, highlighted })}
+					<SelectItem selected={item.value === $userSettings.defaultCodeEditor} {highlighted}>
+						{item.label}
+					</SelectItem>
+				{/snippet}
+			</Select>
+		</svelte:fragment>
+	</SectionCard>
 	<div class="stack-v">
 		<SectionCard centerAlign roundedBottom={false}>
 			<svelte:fragment slot="title">Diff preview</svelte:fragment>
@@ -220,19 +246,4 @@
 			</svelte:fragment>
 		</SectionCard>
 	</form>
-
-	<SectionCard labelFor="branchLaneContents" orientation="row">
-		<svelte:fragment slot="title">Auto-highlight Branch Lane Contents</svelte:fragment>
-		<svelte:fragment slot="caption">
-			An experimental UI toggle to highlight the contents of the branch lane input fields when
-			clicking into them.
-		</svelte:fragment>
-		<svelte:fragment slot="actions">
-			<Toggle
-				id="branchLaneContents"
-				checked={$autoSelectBranchNameFeature}
-				on:click={() => ($autoSelectBranchNameFeature = !$autoSelectBranchNameFeature)}
-			/>
-		</svelte:fragment>
-	</SectionCard>
 </SettingsPage>

--- a/crates/gitbutler-tauri/src/open.rs
+++ b/crates/gitbutler-tauri/src/open.rs
@@ -6,7 +6,7 @@ use url::Url;
 
 pub(crate) fn open_that(path: &str) -> anyhow::Result<()> {
     let target_url = Url::parse(path).with_context(|| format!("Invalid path format: '{path}'"))?;
-    if !["http", "https", "mailto", "vscode", "vscodium"].contains(&target_url.scheme()) {
+    if !["http", "https", "mailto", "vscode", "vscodium", "zed"].contains(&target_url.scheme()) {
         bail!("Invalid path scheme: {}", target_url.scheme());
     }
 


### PR DESCRIPTION
Implemented the ability to select default code editor #5038. This currently works for both VSCode & Zed.

## ☕️ Reasoning
Centralized the editor logic (effectively nullifying the use of `editor` store in favor of `userSettings`. 

This can be extended to allow GitButler to select a default code editor. This is a global setting which can be found in `Appearance -> Default Code Editor`

Can be used to extend to other default editors, so long as the file path matches that of VSCode

## 🧢 Changes
- Editor defaults to `userSettings` option 
- `userSettings.defaultCodeEditor` selectable in `Appearance -> Default Code Editor`
- Refactored UI to read as generic code editor, replacing the default `Open in VSCode`
- Added Zed url scheme in `open.rs`

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues #5038

Fixes: #5038 #4169

-->

<!--
## 📌 Todos
- Find permanent place for the editor select.
- Ensure other editors follow the `://file${project.vscodePath}/?windowId=_blank` scheme

-->

https://github.com/user-attachments/assets/6a70e4a6-fdea-4fcd-a262-86d577f96759