### PR TITLE
Revert dialog modal implementation

### DIFF
--- a/apps/desktop/src/lib/pr/PrDetailsModal.svelte
+++ b/apps/desktop/src/lib/pr/PrDetailsModal.svelte
@@ -325,7 +325,7 @@
 	const isPreviewOnly = props.type === 'display';
 </script>
 
-<Modal bind:this={modal} width="default" noPadding {onClose} onKeyDown={handleModalKeydown}>
+<Modal bind:this={modal} width={580} noPadding {onClose} onKeyDown={handleModalKeydown}>
 	<div class="pr-header">
 		{#if !isPreviewOnly}
 			<h3 class="text-14 text-semibold pr-title">

--- a/apps/desktop/src/lib/select/Select.svelte
+++ b/apps/desktop/src/lib/select/Select.svelte
@@ -12,6 +12,7 @@
 	import TextBox from '../shared/TextBox.svelte';
 	import ScrollableContainer from '$lib/scroll/ScrollableContainer.svelte';
 	import { KeyName } from '$lib/utils/hotkeys';
+	import { portal } from '@gitbutler/ui/utils/portal';
 	import { resizeObserver } from '@gitbutler/ui/utils/resizeObserver';
 	import { type Snippet } from 'svelte';
 
@@ -171,6 +172,7 @@
 			role="presentation"
 			class="overlay-wrapper"
 			onclick={clickOutside}
+			use:portal={'body'}
 			use:resizeObserver={() => {
 				getInputBoundingRect();
 				setMaxHeight();
@@ -231,7 +233,7 @@
 		left: 0;
 		width: 100%;
 		height: 100%;
-		/* background-color: rgba(0, 0, 0, 0.1); */
+		/* background-color: rgba(0, 0, 0, 0.1);  */
 	}
 
 	.options {

--- a/packages/ui/src/lib/Modal.svelte
+++ b/packages/ui/src/lib/Modal.svelte
@@ -34,7 +34,6 @@
 
 	let open = $state(false);
 	let item = $state<any>();
-	let dialogElement = $state<HTMLDivElement>();
 	let isClosing = $state(false);
 
 	function handleKeyDown(event: KeyboardEvent) {
@@ -51,6 +50,7 @@
 	export function show(newItem?: any) {
 		item = newItem;
 		open = true;
+
 		window.addEventListener('keydown', handleKeyDown);
 	}
 
@@ -72,12 +72,7 @@
 </script>
 
 {#if open}
-	<div
-		use:portal={'body'}
-		class="modal-container {isClosing ? 'closing' : 'open'}"
-		class:open
-		bind:this={dialogElement}
-	>
+	<div use:portal={'body'} class="modal-container {isClosing ? 'closing' : 'open'}" class:open>
 		<div
 			use:focusTrap
 			use:clickOutside={{

--- a/packages/ui/src/lib/Modal.svelte
+++ b/packages/ui/src/lib/Modal.svelte
@@ -77,14 +77,11 @@
 		class="modal-container {isClosing ? 'closing' : 'open'}"
 		class:open
 		onclick={(e) => {
-			console.log(e.target);
 			e.stopPropagation();
 
 			if (e.target === e.currentTarget) {
 				close();
 			}
-
-			// close();
 		}}
 		onkeydown={onKeyDown}
 	>

--- a/packages/ui/src/lib/Modal.svelte
+++ b/packages/ui/src/lib/Modal.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 	import Icon from '$lib/Icon.svelte';
 	import { clickOutside } from '$lib/utils/clickOutside';
+	import { focusTrap } from '$lib/utils/focusTrap';
+	import { portal } from '$lib/utils/portal';
 	import { pxToRem } from '$lib/utils/pxToRem';
+	import { onDestroy } from 'svelte';
 	import type iconsJson from '$lib/data/icons.json';
 	import type { Snippet } from 'svelte';
 
@@ -31,19 +34,34 @@
 
 	let open = $state(false);
 	let item = $state<any>();
-	let dialogElement = $state<HTMLDialogElement>();
+	let dialogElement = $state<HTMLDivElement>();
+	let isClosing = $state(false);
+
+	function handleKeyDown(event: KeyboardEvent) {
+		if (event.key === 'Escape') {
+			close();
+		}
+	}
+
+	// Clean up event listener if component is destroyed (in case modal is open)
+	onDestroy(() => {
+		window.removeEventListener('keydown', handleKeyDown);
+	});
 
 	export function show(newItem?: any) {
 		item = newItem;
 		open = true;
-		dialogElement?.showModal();
+		window.addEventListener('keydown', handleKeyDown);
 	}
 
 	export function close() {
-		item = undefined;
-		open = false;
-		onClose?.();
-		dialogElement?.close();
+		isClosing = true;
+		setTimeout(() => {
+			item = undefined;
+			open = false;
+			isClosing = false;
+			onClose?.();
+		}, 100); // This should match the duration of the closing animation
 	}
 
 	export const imports = {
@@ -53,105 +71,100 @@
 	};
 </script>
 
-<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-<dialog
-	tabindex="0"
-	onkeydown={onKeyDown}
-	bind:this={dialogElement}
-	class:medium={width === 'medium'}
-	class:large={width === 'large'}
-	class:small={width === 'small'}
-	class:xsmall={width === 'xsmall'}
-	style:width={typeof width === 'number' ? pxToRem(width) : undefined}
->
-	{#if open}
-		<form
+{#if open}
+	<div
+		use:portal={'body'}
+		class="modal-container {isClosing ? 'closing' : 'open'}"
+		class:open
+		bind:this={dialogElement}
+	>
+		<div
+			use:focusTrap
 			use:clickOutside={{
 				handler: close
 			}}
-			onsubmit={(e) => {
-				e.preventDefault();
-				onSubmit?.(close);
-			}}
+			class="modal-content"
+			role="presentation"
+			onkeydown={onKeyDown}
+			class:medium={width === 'medium'}
+			class:large={width === 'large'}
+			class:small={width === 'small'}
+			class:xsmall={width === 'xsmall'}
+			style:width={typeof width === 'number' ? pxToRem(width) : undefined}
 		>
-			{#if title}
-				<div class="modal__header">
-					{#if icon}
-						<Icon name={icon} />
-					{/if}
-					<h2 class="text-14 text-semibold">
-						{title}
-					</h2>
-				</div>
-			{/if}
+			<form
+				onsubmit={(e) => {
+					e.preventDefault();
+					onSubmit?.(close);
+				}}
+			>
+				{#if title}
+					<div class="modal__header">
+						{#if icon}
+							<Icon name={icon} />
+						{/if}
+						<h2 class="text-14 text-semibold">
+							{title}
+						</h2>
+					</div>
+				{/if}
 
-			<div class="modal__body custom-scrollbar text-13 text-body" class:no-padding={noPadding}>
-				{@render children(item, close)}
-			</div>
-
-			{#if controls}
-				<div class="modal__footer">
-					{@render controls(close, item)}
+				<div class="modal__body custom-scrollbar text-13 text-body" class:no-padding={noPadding}>
+					{@render children(item, close)}
 				</div>
-			{/if}
-		</form>
-	{/if}
-</dialog>
+
+				{#if controls}
+					<div class="modal__footer">
+						{@render controls(close, item)}
+					</div>
+				{/if}
+			</form>
+		</div>
+	</div>
+{/if}
 
 <style lang="postcss">
-	dialog {
-		display: none;
-		outline: none;
+	.modal-container {
+		z-index: var(--z-modal);
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+
+		display: flex;
+		justify-content: center;
+		align-items: center;
+
+		background-color: var(--clr-overlay-bg);
 	}
 
-	dialog[open] {
+	.modal-container.open {
+		animation: dialog-fade-in 0.15s ease-out forwards;
+
+		& .modal-content {
+			animation: dialog-zoom-in 0.25s cubic-bezier(0.34, 1.35, 0.7, 1) forwards;
+		}
+	}
+
+	.modal-container.closing {
+		animation: dialog-fade-out 0.05s ease-out forwards;
+
+		& .modal-content {
+			animation: dialog-zoom-out 0.1s cubic-bezier(0.34, 1.35, 0.7, 1) forwards;
+		}
+	}
+
+	.modal-content {
 		display: flex;
-
-		border: 1px solid var(--clr-border-2);
-
 		flex-direction: column;
 
 		max-height: calc(100vh - 80px);
-		overflow: hidden;
 		border-radius: var(--radius-l);
 		background-color: var(--clr-bg-1);
+		border: 1px solid var(--clr-border-2);
 		box-shadow: var(--fx-shadow-l);
-
-		/* fix for the native dialog "inherit" issue */
-		text-align: left;
-
-		animation: dialog-zoom 0.25s cubic-bezier(0.34, 1.35, 0.7, 1);
-
-		/* MODIFIERS */
-		&.medium {
-			width: 580px;
-		}
-
-		&.large {
-			width: 840px;
-		}
-
-		&.small {
-			width: 380px;
-		}
-
-		&.xsmall {
-			width: 310px;
-		}
-	}
-
-	/* backdrop global */
-	/* NOTE: temporarily hardcoded var(--clr-overlay-bg); */
-	:global(dialog[open]::backdrop) {
-		background-color: rgba(214, 214, 214, 0.4);
-		animation: dialog-fade 0.15s ease-in;
-	}
-
-	/* backdrop dark */
-	/* NOTE: temporarily hardcoded dark var(--clr-overlay-bg); */
-	:global(html.dark dialog[open]::backdrop) {
-		background-color: rgba(0, 0, 0, 0.35);
+		overflow: hidden;
 	}
 
 	.modal__header {
@@ -186,7 +199,9 @@
 		background-color: var(--clr-bg-1);
 	}
 
-	@keyframes dialog-zoom {
+	/* ANIMATION */
+
+	@keyframes dialog-zoom-in {
 		from {
 			transform: scale(0.95);
 		}
@@ -195,12 +210,48 @@
 		}
 	}
 
-	@keyframes dialog-fade {
+	@keyframes dialog-zoom-out {
+		from {
+			transform: scale(1);
+		}
+		to {
+			transform: scale(0.95);
+		}
+	}
+
+	@keyframes dialog-fade-in {
 		from {
 			opacity: 0;
 		}
 		to {
 			opacity: 1;
 		}
+	}
+
+	@keyframes dialog-fade-out {
+		from {
+			opacity: 1;
+		}
+		to {
+			opacity: 0;
+		}
+	}
+
+	/* MODIFIERS */
+
+	.modal-content.medium {
+		width: 580px;
+	}
+
+	.modal-content.large {
+		width: 840px;
+	}
+
+	.modal-content.small {
+		width: 380px;
+	}
+
+	.modal-content.xsmall {
+		width: 310px;
 	}
 </style>

--- a/packages/ui/src/lib/Modal.svelte
+++ b/packages/ui/src/lib/Modal.svelte
@@ -6,7 +6,7 @@
 	import type { Snippet } from 'svelte';
 
 	interface Props {
-		width?: 'default' | 'medium-large' | 'large' | 'small' | 'xsmall' | number;
+		width?: 'medium' | 'large' | 'small' | 'xsmall' | number;
 		title?: string;
 		icon?: keyof typeof iconsJson;
 		noPadding?: boolean;
@@ -18,7 +18,7 @@
 	}
 
 	const {
-		width = 'default',
+		width = 'medium',
 		title,
 		icon,
 		onClose,
@@ -59,8 +59,7 @@
 	tabindex="0"
 	onkeydown={onKeyDown}
 	bind:this={dialogElement}
-	class:default={width === 'default'}
-	class:medium-large={width === 'medium-large'}
+	class:medium={width === 'medium'}
 	class:large={width === 'large'}
 	class:small={width === 'small'}
 	class:xsmall={width === 'xsmall'}
@@ -125,12 +124,8 @@
 		animation: dialog-zoom 0.25s cubic-bezier(0.34, 1.35, 0.7, 1);
 
 		/* MODIFIERS */
-		&.default {
+		&.medium {
 			width: 580px;
-		}
-
-		&.medium-large {
-			width: 640px;
 		}
 
 		&.large {

--- a/packages/ui/src/lib/Modal.svelte
+++ b/packages/ui/src/lib/Modal.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import Icon from '$lib/Icon.svelte';
-	import { clickOutside } from '$lib/utils/clickOutside';
 	import { focusTrap } from '$lib/utils/focusTrap';
 	import { portal } from '$lib/utils/portal';
 	import { pxToRem } from '$lib/utils/pxToRem';
@@ -72,15 +71,26 @@
 </script>
 
 {#if open}
-	<div use:portal={'body'} class="modal-container {isClosing ? 'closing' : 'open'}" class:open>
+	<div
+		role="presentation"
+		use:portal={'body'}
+		class="modal-container {isClosing ? 'closing' : 'open'}"
+		class:open
+		onclick={(e) => {
+			console.log(e.target);
+			e.stopPropagation();
+
+			if (e.target === e.currentTarget) {
+				close();
+			}
+
+			// close();
+		}}
+		onkeydown={onKeyDown}
+	>
 		<div
 			use:focusTrap
-			use:clickOutside={{
-				handler: close
-			}}
 			class="modal-content"
-			role="presentation"
-			onkeydown={onKeyDown}
 			class:medium={width === 'medium'}
 			class:large={width === 'large'}
 			class:small={width === 'small'}

--- a/packages/ui/src/lib/utils/focusTrap.ts
+++ b/packages/ui/src/lib/utils/focusTrap.ts
@@ -1,0 +1,48 @@
+let trapFocusList: HTMLElement[] = [];
+
+if (typeof window !== 'undefined') {
+	function isNext(event: KeyboardEvent): boolean {
+		return event.key === 'Tab' && !event.shiftKey;
+	}
+	function isPrevious(event: KeyboardEvent): boolean {
+		return event.key === 'Tab' && event.shiftKey;
+	}
+	function trapFocusListener(event: KeyboardEvent) {
+		if (event.target === window) {
+			return;
+		}
+
+		const eventTarget = event.target as Node;
+
+		const parentNode = trapFocusList.find((node) => node.contains(eventTarget));
+		if (!parentNode) {
+			return;
+		}
+
+		// List inspired by https://github.com/nico3333fr/van11y-accessible-modal-tooltip-aria/blob/master/src/van11y-accessible-modal-tooltip-aria.es6.js#L47C17-L47C17
+		const focusable: NodeListOf<HTMLElement> = parentNode.querySelectorAll(
+			'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, *[tabindex], *[contenteditable]'
+		);
+		const first = focusable[0];
+		const last = focusable[focusable.length - 1];
+
+		if (isNext(event) && event.target === last) {
+			event.preventDefault();
+			first.focus();
+		} else if (isPrevious(event) && event.target === first) {
+			event.preventDefault();
+			last.focus();
+		}
+	}
+
+	document.addEventListener('keydown', trapFocusListener);
+}
+
+export function focusTrap(node: HTMLElement) {
+	trapFocusList.push(node);
+	return {
+		destroy() {
+			trapFocusList = trapFocusList.filter((element) => element !== node);
+		}
+	};
+}

--- a/packages/ui/src/lib/utils/focusTrap.ts
+++ b/packages/ui/src/lib/utils/focusTrap.ts
@@ -1,5 +1,13 @@
 let trapFocusList: HTMLElement[] = [];
 
+function getFocusableElements(node: HTMLElement): HTMLElement[] {
+	return Array.from(
+		node.querySelectorAll<HTMLElement>(
+			'a, button, input, textarea, select, details,[tabindex]:not([tabindex="-1"]):not([tabindex="0"])'
+		)
+	);
+}
+
 if (typeof window !== 'undefined') {
 	function isNext(event: KeyboardEvent): boolean {
 		return event.key === 'Tab' && !event.shiftKey;
@@ -20,9 +28,7 @@ if (typeof window !== 'undefined') {
 		}
 
 		// List inspired by https://github.com/nico3333fr/van11y-accessible-modal-tooltip-aria/blob/master/src/van11y-accessible-modal-tooltip-aria.es6.js#L47C17-L47C17
-		const focusable: NodeListOf<HTMLElement> = parentNode.querySelectorAll(
-			'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, *[tabindex], *[contenteditable]'
-		);
+		const focusable = getFocusableElements(parentNode);
 		const first = focusable[0];
 		const last = focusable[focusable.length - 1];
 
@@ -38,7 +44,15 @@ if (typeof window !== 'undefined') {
 	document.addEventListener('keydown', trapFocusListener);
 }
 
-export function focusTrap(node: HTMLElement) {
+export function focusTrap(node: HTMLElement, focusOnFirst = true) {
+	// focus on the first focusable element
+	if (focusOnFirst) {
+		const focusable = getFocusableElements(node);
+		if (focusable.length) {
+			focusable[0].focus();
+		}
+	}
+
 	trapFocusList.push(node);
 	return {
 		destroy() {

--- a/packages/ui/src/lib/utils/focusTrap.ts
+++ b/packages/ui/src/lib/utils/focusTrap.ts
@@ -3,6 +3,7 @@ let trapFocusList: HTMLElement[] = [];
 function getFocusableElements(node: HTMLElement): HTMLElement[] {
 	return Array.from(
 		node.querySelectorAll<HTMLElement>(
+			// List inspired by https://github.com/nico3333fr/van11y-accessible-modal-tooltip-aria/blob/master/src/van11y-accessible-modal-tooltip-aria.es6.js#L47C17-L47C17
 			'a, button, input, textarea, select, details,[tabindex]:not([tabindex="-1"]):not([tabindex="0"])'
 		)
 	);
@@ -27,7 +28,6 @@ if (typeof window !== 'undefined') {
 			return;
 		}
 
-		// List inspired by https://github.com/nico3333fr/van11y-accessible-modal-tooltip-aria/blob/master/src/van11y-accessible-modal-tooltip-aria.es6.js#L47C17-L47C17
 		const focusable = getFocusableElements(parentNode);
 		const first = focusable[0];
 		const last = focusable[focusable.length - 1];
@@ -44,13 +44,18 @@ if (typeof window !== 'undefined') {
 	document.addEventListener('keydown', trapFocusListener);
 }
 
-export function focusTrap(node: HTMLElement, focusOnFirst = true) {
+export function focusTrap(node: HTMLElement, focusOnFirst = true, focusOnElement?: HTMLElement) {
 	// focus on the first focusable element
-	if (focusOnFirst) {
+	if (focusOnFirst && !focusOnElement) {
 		const focusable = getFocusableElements(node);
 		if (focusable.length) {
 			focusable[0].focus();
 		}
+	}
+
+	// focus on the specified element
+	if (focusOnElement) {
+		focusOnElement.focus();
 	}
 
 	trapFocusList.push(node);

--- a/packages/ui/src/stories/modal/DemoModal.svelte
+++ b/packages/ui/src/stories/modal/DemoModal.svelte
@@ -2,16 +2,17 @@
 	import iconsJson from '$lib/data/icons.json';
 	import Button from '$lib/Button.svelte';
 	import Modal from '$lib/Modal.svelte';
+	import { type SvelteComponent } from 'svelte';
 
 	interface Props {
-		width?: 'default' | 'small' | 'large';
+		width?: 'small' | 'large' | 'medium' | 'xsmall' | number;
 		title?: string;
 		icon?: keyof typeof iconsJson;
 	}
 
 	const { ...args }: Props = $props();
 
-	let modal = $state<Modal>();
+	let modal: SvelteComponent<Props>;
 </script>
 
 <Button

--- a/packages/ui/src/stories/modal/DemoModal.svelte
+++ b/packages/ui/src/stories/modal/DemoModal.svelte
@@ -24,5 +24,8 @@
 
 	{#snippet controls(close)}
 		<Button onclick={() => close()}>Close</Button>
+		<Button style="pop" kind="solid" type="submit" onclick={() => console.log('Submit clicked')}
+			>Submit</Button
+		>
 	{/snippet}
 </Modal>


### PR DESCRIPTION
## ☕️ Reasoning

The native `<dialog>` element has several critical bugs, making it less reliable. This update reverts to a more stable implementation.

## 🧢 Changes

- Reverted `<dialog>` to `<div>`
- Added a custom backdrop layer using CSS variables
- Added `Esc` key support to close the modal
- Autofocus now targets the first focusable element in the modal
- Implemented a focus trap hook for improved accessibility
- Added an optional `focusOnElement` option in the `focusTrap` hook to allow specifying the initial focus element
- Modified `clickoutside` behavior to only trigger when clicking on the backdrop, preventing issues with components like `Select`
