### PR TITLE
fix: Move any commit from branch to branch 

### DIFF
--- a/crates/gitbutler-branch-actions/src/move_commits.rs
+++ b/crates/gitbutler-branch-actions/src/move_commits.rs
@@ -104,9 +104,10 @@ pub(crate) fn move_commit(
     if let Some(commits_to_check) = descendant_commits.as_mut() {
         // we append the source commit so that we can create the diff between
         // the source commit and its first descendant
+        let mut commits_to_check = commits_to_check.clone();
         commits_to_check.push(source_commit.clone());
         let is_descendant_locked =
-            check_source_lock_to_commits(ctx.repository(), commits_to_check, &source_commit_diff);
+            check_source_lock_to_commits(ctx.repository(), &commits_to_check, &source_commit_diff);
 
         if is_descendant_locked {
             bail!("the target commit contains hunks locked to its descendants")

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/move_commit_to_vbranch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/move_commit_to_vbranch.rs
@@ -84,10 +84,17 @@ fn multiple_commits() {
 
     std::fs::write(repository.path().join("b.txt"), "This is b").unwrap();
 
-    // Create as second commit on the source branch, to be moved
+    // Create a second commit on the source branch, to be moved
     let commit_oid =
         gitbutler_branch_actions::create_commit(project, source_branch_id, "Add b", None, false)
             .unwrap();
+
+    std::fs::write(repository.path().join("c.txt"), "This is c").unwrap();
+
+    // Create a third commit on the source branch
+
+    gitbutler_branch_actions::create_commit(project, source_branch_id, "Add c", None, false)
+        .unwrap();
 
     let target_branch_id = gitbutler_branch_actions::create_virtual_branch(
         project,
@@ -98,10 +105,10 @@ fn multiple_commits() {
     )
     .unwrap();
 
-    std::fs::write(repository.path().join("c.txt"), "This is c").unwrap();
+    std::fs::write(repository.path().join("d.txt"), "This is d").unwrap();
 
     // Create a commit on the destination branch
-    gitbutler_branch_actions::create_commit(project, target_branch_id, "Add c", None, false)
+    gitbutler_branch_actions::create_commit(project, target_branch_id, "Add d", None, false)
         .unwrap();
 
     // Move the top commit from the source branch to the destination branch
@@ -121,12 +128,20 @@ fn multiple_commits() {
             .into_iter()
             .map(|c| c.description.to_str_lossy().into_owned())
             .collect::<Vec<_>>(),
-        vec!["Add b", "Add c"]
+        vec!["Add b", "Add d"]
     );
 
-    assert_eq!(source_branch.commits.len(), 1);
+    assert_eq!(source_branch.commits.len(), 2);
     assert_eq!(source_branch.files.len(), 0);
-    assert_eq!(source_branch.commits[0].description.to_str_lossy(), "Add a");
+    assert_eq!(
+        source_branch
+            .commits
+            .clone()
+            .into_iter()
+            .map(|c| c.description.to_str_lossy().into_owned())
+            .collect::<Vec<_>>(),
+        vec!["Add c", "Add a"]
+    );
 }
 
 #[test]


### PR DESCRIPTION
Move any commit won't duplicate the commit in both virtual branches.
Also:
- Also add tests to catch this