### PR TITLE
fix(ui): Change onmousedown to onclick in Segment.svelte

### DIFF
--- a/packages/ui/src/lib/segmentControl/Segment.svelte
+++ b/packages/ui/src/lib/segmentControl/Segment.svelte
@@ -42,7 +42,7 @@
 	{disabled}
 	tabindex={isSelected || unfocusable ? -1 : 0}
 	aria-selected={isSelected}
-	onmousedown={() => {
+	onclick={() => {
 		if (index !== $selectedSegmentIndex) {
 			context.setSelected({
 				index,


### PR DESCRIPTION
This pull request resolves a UI issue by updating the event listener from `onmousedown` to `onclick` in the `Segment.svelte` file. The previous usage of `onmousedown` was causing overlapping interactions with `onClick` when used within a `Modal`, leading to immediate triggering of actions and interfering with the `clickOutside` modal functionality.

See the issue below:


https://github.com/user-attachments/assets/b440f521-d3ce-4207-9c7c-279a1eddb91d

