### PR TITLE
Branch entries cleanup

### DIFF
--- a/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
@@ -91,8 +91,12 @@
 	<ContextMenuSection>
 		<ContextMenuItem
 			label="Unapply"
-			on:click={() => {
-				saveAndUnapply();
+			on:click={async () => {
+				if (commits.length === 0 && branch.files?.length === 0) {
+					await branchController.unapplyWithoutSaving(branch.id);
+				} else {
+					saveAndUnapply();
+				}
 				contextMenuEl?.close();
 			}}
 		/>

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -472,6 +472,9 @@ pub fn fetch_from_remotes(project: &Project, askpass: Option<String>) -> Result<
             error: fetch_errors.join("\n"),
         }
     };
+    let state = ctx.project().virtual_branches();
+
+    state.garbage_collect(ctx.repository())?;
 
     Ok(project_data_last_fetched)
 }


### PR DESCRIPTION
- Correctly cleanup upon "unapply and drop changes"
- Unapply will also cleanup if the lane was empty
- Implements a GC mechanism collecting entries that:
  - Do not have a WIP commit
  - Have no regular commits
  - Have head pointing to an invalid old