### PR TITLE
fix: show only stack push btn when necessary

### DIFF
--- a/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
@@ -240,7 +240,7 @@
 	}
 
 	.branch-action__line {
-		width: 2px;
+		min-width: 2px;
 		margin: 0 22px;
 		background-color: var(--bg-color, var(--clr-border-3));
 	}

--- a/apps/desktop/src/lib/stack/Stack.svelte
+++ b/apps/desktop/src/lib/stack/Stack.svelte
@@ -105,6 +105,15 @@
 		$localAndRemoteCommits.some((commit) => commit.conflicted)
 	);
 
+	const branchUpstreamPatches = $derived(branch.series.flatMap((s) => s.upstreamPatches));
+	const branchPatches = $derived(branch.series.flatMap((s) => s.patches));
+
+	let canPush = $derived.by(() => {
+		if (branchUpstreamPatches.length > 0) return true;
+		if (branchPatches.find((p) => p.status !== 'localAndRemote')) return true;
+		return false;
+	});
+
 	const listingService = getGitHostListingService();
 	const prMonitor = getGitHostPrMonitor();
 	const checksMonitor = getGitHostChecksMonitor();
@@ -228,21 +237,23 @@
 						</div>
 					</div>
 				</div>
-				<div class="lane-branches__action" class:scroll-end-visible={scrollEndVisible}>
-					<Button
-						style="neutral"
-						kind="solid"
-						wide
-						loading={isPushingCommits}
-						disabled={localCommitsConflicted || localAndRemoteCommitsConflicted}
-						tooltip={localCommitsConflicted
-							? 'In order to push, please resolve any conflicted commits.'
-							: undefined}
-						onclick={push}
-					>
-						{branch.requiresForce ? 'Force push' : 'Push'}
-					</Button>
-				</div>
+				{#if canPush}
+					<div class="lane-branches__action" class:scroll-end-visible={scrollEndVisible}>
+						<Button
+							style="neutral"
+							kind="solid"
+							wide
+							loading={isPushingCommits}
+							disabled={localCommitsConflicted || localAndRemoteCommitsConflicted}
+							tooltip={localCommitsConflicted
+								? 'In order to push, please resolve any conflicted commits.'
+								: undefined}
+							onclick={push}
+						>
+							{branch.requiresForce ? 'Force push' : 'Push'}
+						</Button>
+					</div>
+				{/if}
 			</ScrollableContainer>
 			<div class="divider-line">
 				{#if rsViewport}


### PR DESCRIPTION
## ☕️ Reasoning

- Don't always show "Push" / "Force Push" btn at bottom of stack

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
