### PR TITLE
fix: upstream label slash bug

### DIFF
--- a/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
@@ -95,7 +95,7 @@
 		/>
 		<div class="text-14 text-bold branch-info__name">
 			<span class:no-upstream={!gitHostBranch} class="remote-name">
-				{$baseBranch.remoteName ?? 'origin'}/
+				{$baseBranch.remoteName ? `${$baseBranch.remoteName} /` : 'origin /'}
 			</span>
 			<BranchLabel {name} onChange={(name) => editTitle(name)} disabled={!!gitHostBranch} />
 			{#if gitHostBranch}
@@ -211,10 +211,18 @@
 
 		.remote-name {
 			margin-top: 3px;
+			min-width: max-content;
 			color: var(--clr-scale-ntrl-60);
 
 			&.no-upstream {
-				width: 0px;
+				/**
+				 * Element is requird to still be there, so we can use
+				 * it to wiggle 5px to the left to align the BranchLabel 
+				 * Input/Label component.
+				 */
+				visibility: hidden;
+				max-width: 0px;
+				max-height: 0px;
 				margin-right: -5px;
 			}
 		}


### PR DESCRIPTION
## ☕️ Reasoning

- Fix bug with `/` character poking through

## 🧢 Changes

### Before
![image](https://github.com/user-attachments/assets/c4e1079e-fda7-49a0-a7e1-f46c67705ee7)


### After

![image](https://github.com/user-attachments/assets/73b56678-d3d1-43ce-8f3f-d2ecea7ba9d4)



<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
