### PR TITLE
fix: don't fail if the file isn't there anymore after discarding hunk

### DIFF
--- a/apps/desktop/src/lib/vbranches/branchController.ts
+++ b/apps/desktop/src/lib/vbranches/branchController.ts
@@ -277,7 +277,7 @@ export class BranchController {
 			await invoke<void>('reset_files', {
 				projectId: this.projectId,
 				branchId,
-				files: files.flatMap((f) => f.path)
+				files: files?.flatMap((f) => f.path) ?? []
 			});
 		} catch (err) {
 			showError('Failed to unapply file changes', err);


### PR DESCRIPTION
## ☕️ Reasoning

- Resolve edge case
- When discarding a hunk from a newly added file, and that file exists only of that hunk; the `files` would be empty after discarding and we would throw on this `files.flatMap()` call\

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
