### PR TITLE
fix: do not allow user to generate series name after branch has been pushed

### DIFF
--- a/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingBranchHeader.svelte
@@ -164,6 +164,7 @@
 				seriesCount={branch.series?.length ?? 0}
 				{addDescription}
 				onGenerateBranchName={generateBranchName}
+				disableTitleEdit={!!gitHostBranch}
 			/>
 		</div>
 	</div>

--- a/apps/desktop/src/lib/branch/StackingBranchHeaderContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/StackingBranchHeaderContextMenu.svelte
@@ -17,6 +17,7 @@
 		target?: HTMLElement;
 		headName: string;
 		seriesCount: number;
+		disableTitleEdit: boolean;
 		addDescription: () => void;
 		onGenerateBranchName: () => void;
 	}
@@ -25,6 +26,7 @@
 		contextMenuEl = $bindable(),
 		target,
 		seriesCount,
+		disableTitleEdit,
 		headName,
 		addDescription,
 		onGenerateBranchName
@@ -69,7 +71,7 @@
 				onGenerateBranchName();
 				contextMenuEl?.close();
 			}}
-			disabled={!($aiGenEnabled && aiConfigurationValid)}
+			disabled={!($aiGenEnabled && aiConfigurationValid) || disableTitleEdit}
 		/>
 		<ContextMenuItem
 			label="Rename"


### PR DESCRIPTION
## ☕️ Reasoning

- Already not allowed to manually edit title; also disable AI generated series title updates after the series (branch) has been pushed.

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
