### PR TITLE
Some improvements on top of #5089

### DIFF
--- a/apps/desktop/src/lib/file/FileDiff.svelte
+++ b/apps/desktop/src/lib/file/FileDiff.svelte
@@ -15,7 +15,6 @@
 		name?: string;
 		mimeType?: string;
 		size?: number;
-		status: 'normal' | 'deleted';
 	}
 
 	interface Props {
@@ -77,8 +76,7 @@
 		content: '',
 		name: undefined,
 		mimeType: undefined,
-		size: 0,
-		status: 'normal'
+		size: 0
 	});
 
 	async function fetchBlobInfo() {
@@ -104,7 +102,7 @@
 		{#if fileInfo.mimeType && fileInfo.content}
 			<img src="data:{fileInfo.mimeType};base64,{fileInfo.content}" alt={fileInfo.name} />
 		{/if}
-		{#if fileInfo.status === 'deleted'}
+		{#if fileInfo.size === undefined}
 			<p>File has been deleted</p>
 		{:else}
 			<p>Size: {formatFileSize(fileInfo.size || 0)}</p>

--- a/crates/gitbutler-tauri/src/repo.rs
+++ b/crates/gitbutler-tauri/src/repo.rs
@@ -1,6 +1,6 @@
 pub mod commands {
     use crate::error::{Error, UnmarkedError};
-    use anyhow::Result;
+    use anyhow::{Context, Result};
     use git2::Oid;
     use gitbutler_branch_actions::RemoteBranchFile;
     use gitbutler_project as projects;
@@ -78,7 +78,9 @@ pub mod commands {
         let project = projects.get(project_id)?;
         let file_info = project.read_file_from_workspace(None, relative_path)?;
 
-        Ok(file_info.content)
+        Ok(file_info
+            .content
+            .context("PR template was not valid UTF-8")?)
     }
 
     #[tauri::command(async)]


### PR DESCRIPTION
Follow-up of #5089

The PR was merged earlier to not hold it after a passed review, yet I personally feel strongly enough about the backend portions to give it another round of polish.

### Tasks

* [x] document the current behaviour of the backend methods and refactor
* ~~turn the 'variable type' `FileInfo` into an enum to be type-safe in the frontend as well~~ - probably that would make the frontend code more complicated, at least I wouldn't want to do it.


### Notes for the Reviewer

* I think the frontend should always use relative path, and never pass or store absolute paths. Even though the backend is defensive towards absolute paths, I can imagine issues to show up once repositories are renamed on disk.
* I did test it with a PNG file and went through all the states with it, i.e. in worktree, deleted, and deleted from index, and it all worked as one would expect.