### PR TITLE
fix: binary image filePreview

### DIFF
--- a/apps/desktop/src/lib/file/FileContextMenu.svelte
+++ b/apps/desktop/src/lib/file/FileContextMenu.svelte
@@ -17,9 +17,14 @@
 	import { join } from '@tauri-apps/api/path';
 	import type { Writable } from 'svelte/store';
 
-	export let branchId: string | undefined;
-	export let target: HTMLElement | undefined;
-	export let isUnapplied;
+	interface Props {
+		isUnapplied: boolean;
+		branchId?: string;
+		target?: HTMLElement;
+		isBinary?: boolean;
+	}
+
+	const { branchId, target, isUnapplied, isBinary = false }: Props = $props();
 
 	const branchController = getContext(BranchController);
 	const project = getContext(Project);
@@ -57,7 +62,7 @@
 		<ContextMenuSection>
 			{#if item.files && item.files.length > 0}
 				{@const files = item.files}
-				{#if files[0] instanceof LocalFile && !isUnapplied}
+				{#if files[0] instanceof LocalFile && !isUnapplied && !isBinary}
 					<ContextMenuItem
 						label="Discard changes"
 						on:click={() => {

--- a/apps/desktop/src/lib/file/FileDiff.svelte
+++ b/apps/desktop/src/lib/file/FileDiff.svelte
@@ -102,12 +102,16 @@
 <div class="hunks">
 	{#if isBinary}
 		{#if fileInfo.mimeType && fileInfo.content}
-			<img src="data:{fileInfo.mimeType};base64,{fileInfo.content}" alt={fileInfo.name} />
+			<img
+				class="hunk-image"
+				src="data:{fileInfo.mimeType};base64,{fileInfo.content}"
+				alt={fileInfo.name}
+			/>
 		{/if}
 		{#if fileInfo.status === 'deleted'}
 			<p>File has been deleted</p>
 		{:else}
-			<p>Size: {formatFileSize(fileInfo.size || 0)}</p>
+			<p class="hunk-label__size">{formatFileSize(fileInfo.size || 0)}</p>
 		{/if}
 	{:else if isLarge}
 		Diff too large to be shown
@@ -169,6 +173,18 @@
 		padding: 14px;
 		gap: 16px;
 	}
+
+	.hunk-image {
+		border: 1px solid var(--clr-border-2);
+		border-radius: var(--radius-m);
+	}
+
+	.hunk-label__size {
+		align-self: flex-start;
+		font-size: 12px;
+		color: var(--clr-text-3);
+	}
+
 	.hunk-wrapper {
 		display: flex;
 		flex-direction: column;

--- a/apps/desktop/src/lib/file/FileDiff.svelte
+++ b/apps/desktop/src/lib/file/FileDiff.svelte
@@ -89,6 +89,11 @@
 				commitId
 			});
 			fileInfo = fetchedFileInfo;
+
+			// If file.size > 5mb; don't render it
+			if (fileInfo.size && fileInfo.size > 5 * 1024 * 1024) {
+				isLarge = true;
+			}
 		} catch (error) {
 			console.error(error);
 		}
@@ -100,7 +105,9 @@
 </script>
 
 <div class="hunks">
-	{#if isBinary}
+	{#if isLarge}
+		Change too large to be shown
+	{:else if isBinary}
 		{#if fileInfo.mimeType && fileInfo.content}
 			<img
 				class="hunk-image"
@@ -116,8 +123,6 @@
 		{:else}
 			<p class="hunk-label__size">{formatFileSize(fileInfo.size || 0)}</p>
 		{/if}
-	{:else if isLarge}
-		Diff too large to be shown
 	{:else if sections.length > 50 && !alwaysShow}
 		<LargeDiffMessage
 			showFrame

--- a/apps/desktop/src/lib/file/FileDiff.svelte
+++ b/apps/desktop/src/lib/file/FileDiff.svelte
@@ -105,6 +105,9 @@
 			<img
 				class="hunk-image"
 				src="data:{fileInfo.mimeType};base64,{fileInfo.content}"
+				oncontextmenu={(e) => {
+					e.preventDefault();
+				}}
 				alt={fileInfo.name}
 			/>
 		{/if}
@@ -132,16 +135,16 @@
 						<div class="indicators text-11 text-semibold">
 							{#if isHunkLocked}
 								<InfoMessage filled outlined={false} style="warning" icon="locked">
-									<svelte:fragment slot="content"
-										>{getLockText(section.hunk.lockedTo, commits)}</svelte:fragment
-									>
+									<svelte:fragment slot="content">
+										{getLockText(section.hunk.lockedTo, commits)}
+									</svelte:fragment>
 								</InfoMessage>
 							{/if}
 							{#if section.hunk.poisoned}
 								<InfoMessage filled outlined={false}>
-									<svelte:fragment slot="content"
-										>Can not manage this hunk because it depends on changes from multiple branches</svelte:fragment
-									>
+									<svelte:fragment slot="content">
+										Can not manage this hunk because it depends on changes from multiple branches
+									</svelte:fragment>
 								</InfoMessage>
 							{/if}
 						</div>

--- a/apps/desktop/src/lib/file/FileListItem.svelte
+++ b/apps/desktop/src/lib/file/FileListItem.svelte
@@ -127,6 +127,7 @@
 	target={draggableEl}
 	{isUnapplied}
 	branchId={$branch?.id}
+	isBinary={file.binary}
 />
 
 <FileListItem


### PR DESCRIPTION
## ☕️ Reasoning

- Little tweak for the newly shipped binary file preview
- Removed "Discard" from file context menu as we cannot discard a binary file atm, all our code expects a text file
- Tweak the display of the image and its "Size: ..." label
- Don't render image if `5mb+` in size

## 🧢 Changes

### Before
![image](https://github.com/user-attachments/assets/916abffd-81e0-4254-9ed6-19ecdc845391)


### After

![image](https://github.com/user-attachments/assets/341149c5-7801-439d-8f9b-e993f1e4b5b3)
![image](https://github.com/user-attachments/assets/9763a3c3-8880-4426-911a-9e02ac8f94d9)


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
