### PR TITLE
fix: Swallow the default target not found

### DIFF
--- a/apps/desktop/src/lib/branches/branchListing.ts
+++ b/apps/desktop/src/lib/branches/branchListing.ts
@@ -1,7 +1,7 @@
 // Class transformers will bust a gut if this isn't imported first
 import 'reflect-metadata';
 
-import { invoke } from '$lib/backend/ipc';
+import { Code, invoke } from '$lib/backend/ipc';
 import {
 	getEntryName,
 	getEntryUpdatedDate,
@@ -33,8 +33,15 @@ export class BranchListingService {
 	}
 
 	private async list(filter: BranchListingFilter | undefined = undefined) {
-		const entries = await invoke<any[]>('list_branches', { projectId: this.projectId, filter });
-		return plainToInstance(BranchListing, entries);
+		try {
+			const entries = await invoke<any[]>('list_branches', { projectId: this.projectId, filter });
+			return plainToInstance(BranchListing, entries);
+		} catch (error: any) {
+			if (error.code === Code.DefaultTargetNotFound) {
+				// Swallow this error since user should be taken to project setup page
+				return undefined;
+			}
+		}
 	}
 
 	private branchListingDetails = new Map<string, Writable<BranchListingDetails | undefined>>();

--- a/apps/desktop/src/lib/stores/remoteBranches.ts
+++ b/apps/desktop/src/lib/stores/remoteBranches.ts
@@ -1,4 +1,4 @@
-import { invoke } from '$lib/backend/ipc';
+import { Code, invoke } from '$lib/backend/ipc';
 import { Branch, BranchData } from '$lib/vbranches/types';
 import { plainToInstance } from 'class-transformer';
 import { writable } from 'svelte/store';
@@ -26,6 +26,10 @@ export class RemoteBranchService {
 			this.projectMetrics?.setMetric('normal_branch_count', remoteBranches.length);
 			this.branches.set(remoteBranches);
 		} catch (err: any) {
+			if (err.code === Code.DefaultTargetNotFound) {
+				// Swallow this error since user should be taken to project setup page
+				return;
+			}
 			this.error.set(err);
 		} finally {
 			this.branchListingService.refresh();


### PR DESCRIPTION
Don't surface the default target not found. This already is caught at the top level and the user is taken to the 'target not found' page.

### Issue
As seen in https://github.com/gitbutlerapp/gitbutler/issues/5113