### PR TITLE
fix: do not allow commit editing for upstream-only commits

### DIFF
--- a/apps/desktop/src/lib/commit/StackingCommitCard.svelte
+++ b/apps/desktop/src/lib/commit/StackingCommitCard.svelte
@@ -95,7 +95,7 @@
 		branchController.undoCommit(branch.id, commit.id);
 	}
 
-	let isUndoable = commit instanceof DetailedCommit;
+	let isUndoable = commit instanceof DetailedCommit && type !== 'remote';
 
 	let commitMessageModal: Modal;
 	let commitMessageValid = $state(false);


### PR DESCRIPTION
## ☕️ Reasoning

- Do not allow undoable actions when commit is upstream only

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
