### PR TITLE
fix: Get the right PR source branch

### DIFF
--- a/apps/desktop/src/lib/gitHost/github/types.ts
+++ b/apps/desktop/src/lib/gitHost/github/types.ts
@@ -11,7 +11,7 @@ export function parseGitHubDetailedPullRequest(
 		number: data.number,
 		title: data.title,
 		body: data.body ?? undefined,
-		sourceBranch: data.base?.ref,
+		sourceBranch: data.head?.ref,
 		draft: data.draft,
 		htmlUrl: data.html_url,
 		createdAt: new Date(data.created_at),


### PR DESCRIPTION
Proposed PR Description:

## ☕️ Reasoning

This PR fixes an issue where the PR source branch was being set incorrectly.

## 🧢 Changes

The commit in this PR ensures that the PR source branch is set correctly, instead of setting the base branch (e.g. main or master) as the source branch.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->