### PR TITLE
fix: ensure commit-lines.css works for both stacking/original lanes

### DIFF
--- a/packages/ui/src/styles/components/commit-lines.css
+++ b/packages/ui/src/styles/components/commit-lines.css
@@ -3,41 +3,42 @@
 	width: 100%;
 	height: 100%;
 
-	--background-color: var(--clr-commit-shadow);
+	--border-color: var(--clr-commit-shadow);
+	--border-style: solid;
 
 	&.none {
-		--background-color: transparent;
+		--border-color: transparent;
 	}
 
 	&.remote {
-		--background-color: var(--clr-commit-remote);
+		--border-color: var(--clr-commit-remote);
 	}
 
 	&.local {
-		--background-color: var(--clr-commit-local);
+		--border-color: var(--clr-commit-local);
 	}
 
 	&.local-and-remote {
-		--background-color: var(--clr-commit-remote);
+		--border-color: var(--clr-commit-remote);
 	}
 
 	&.local-shadow {
-		--background-color: var(--clr-commit-local);
+		--border-color: var(--clr-commit-local);
 	}
 
 	&.shadow {
-		--background-color: var(--clr-commit-shadow);
+		--border-color: var(--clr-commit-shadow);
 	}
 
 	&.upstream {
-		--background-color: var(--clr-commit-upstream);
+		--border-color: var(--clr-commit-upstream);
 	}
 
 	&.integrated {
-		--background-color: var(--clr-commit-shadow);
+		--border-color: var(--clr-commit-shadow);
 
 		&.stacked {
-			--background-color: var(--clr-commit-integrated);
+			--border-color: var(--clr-commit-integrated);
 		}
 	}
 
@@ -48,18 +49,23 @@
 		right: 0;
 		width: 2px;
 		height: 100%;
-		background: var(--background-color);
+	}
+
+	&.stacked:before {
+		background: var(--border-color);
 	}
 
 	&.dashed {
+		--border-style: none;
+
 		&:before {
 			height: calc(100% + 1px);
 			background: repeating-linear-gradient(
 				0,
 				transparent,
 				transparent 2px,
-				var(--background-color) 2px,
-				var(--background-color) 4px
+				var(--border-color) 2px,
+				var(--border-color) 4px
 			);
 		}
 	}


### PR DESCRIPTION
## ☕️ Reasoning

- Ensure `commit-lines.css` classes work for both original and stacking lanes / commit card lines

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
