### PR TITLE
fix: stacking dont show PR cards/btns if no service exists

### DIFF
--- a/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
@@ -189,7 +189,7 @@
 			/>
 		</div>
 	{/if}
-	{#if gitHostBranch}
+	{#if gitHostBranch && $prService}
 		<div class="branch-action">
 			<div class="branch-action__line" style:--bg-color={lineColor}></div>
 			<div class="branch-action__body">


### PR DESCRIPTION
## ☕️ Reasoning

- Don't show PR btns if no prService has been initialized

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
