### PR TITLE
fix: also disable series 'rename' via contextMenu once pushed

### DIFF
--- a/apps/desktop/src/lib/branch/StackingSeriesHeaderContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeaderContextMenu.svelte
@@ -81,6 +81,7 @@
 		/>
 		<ContextMenuItem
 			label="Rename"
+			disabled={disableTitleEdit}
 			on:click={async () => {
 				renameSeriesModal.show(branch);
 				contextMenuEl?.close();


### PR DESCRIPTION
## ☕️ Reasoning

- Ensure all methods for renaming are disabled once the series/branch has been pushed

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
