### PR TITLE
fix: in series delete confirmation modal, show correct series name

### DIFF
--- a/apps/desktop/src/lib/branch/StackingSeriesHeaderContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeaderContextMenu.svelte
@@ -149,8 +149,8 @@
 		}
 	}}
 >
-	{#snippet children(branch)}
-		Are you sure you want to delete <code class="code-string">{branch.name}</code>?
+	{#snippet children()}
+		Are you sure you want to delete <code class="code-string">{headName}</code>?
 	{/snippet}
 	{#snippet controls(close)}
 		<Button style="ghost" outline onclick={close}>Cancel</Button>


### PR DESCRIPTION
## ☕️ Reasoning

- We were showing the `branch.name` still in the "Are you sure you want to delete this **series**" modal

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
