### PR TITLE
feat: hide contextMenu items that cant be activated and convert ContextMenuItem to runes

### DIFF
--- a/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
@@ -14,6 +14,7 @@
 	import { getContext, getContextStore } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import Modal from '@gitbutler/ui/Modal.svelte';
+	import Tooltip from '@gitbutler/ui/Tooltip.svelte';
 
 	interface Props {
 		hasPr: boolean;
@@ -153,13 +154,11 @@
 	{/if}
 
 	<ContextMenuSection>
-		<ContextMenuItem
-			label="Allow rebasing"
-			onclick={toggleAllowRebasing}
-			tooltip="Allows changing commits after push (force push needed)"
-		>
+		<ContextMenuItem label="Allow rebasing" onclick={toggleAllowRebasing}>
 			{#snippet control()}
-				<Toggle small bind:checked={allowRebasing} on:click={toggleAllowRebasing} />
+				<Tooltip text={'Allows changing commits after push\n(force push needed)'}>
+					<Toggle small bind:checked={allowRebasing} on:click={toggleAllowRebasing} />
+				</Tooltip>
 			{/snippet}
 		</ContextMenuItem>
 	</ContextMenuSection>

--- a/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
@@ -14,7 +14,6 @@
 	import { getContext, getContextStore } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import Modal from '@gitbutler/ui/Modal.svelte';
-	import Tooltip from '@gitbutler/ui/Tooltip.svelte';
 
 	interface Props {
 		hasPr: boolean;
@@ -93,7 +92,7 @@
 	<ContextMenuSection>
 		<ContextMenuItem
 			label="Collapse lane"
-			on:click={() => {
+			onclick={() => {
 				onCollapse();
 				contextMenuEl?.close();
 			}}
@@ -102,7 +101,7 @@
 	<ContextMenuSection>
 		<ContextMenuItem
 			label="Unapply"
-			on:click={async () => {
+			onclick={async () => {
 				if (commits.length === 0 && branch.files?.length === 0) {
 					await branchController.unapplyWithoutSaving(branch.id);
 				} else {
@@ -114,7 +113,7 @@
 
 		<ContextMenuItem
 			label="Unapply and drop changes"
-			on:click={async () => {
+			onclick={async () => {
 				if (
 					branch.name.toLowerCase().includes('virtual branch') &&
 					commits.length === 0 &&
@@ -131,7 +130,7 @@
 		{#if !$stackingFeature}
 			<ContextMenuItem
 				label="Generate branch name"
-				on:click={() => {
+				onclick={() => {
 					onGenerateBranchName?.();
 					contextMenuEl?.close();
 				}}
@@ -144,7 +143,7 @@
 		<ContextMenuSection>
 			<ContextMenuItem
 				label="Set remote branch name"
-				on:click={() => {
+				onclick={() => {
 					newRemoteName = branch.upstreamName || normalizedBranchName || '';
 					renameRemoteModal.show(branch);
 					contextMenuEl?.close();
@@ -154,10 +153,14 @@
 	{/if}
 
 	<ContextMenuSection>
-		<ContextMenuItem label="Allow rebasing" on:click={toggleAllowRebasing}>
-			<Tooltip slot="control" text={'Allows changing commits after push\n(force push needed)'}>
+		<ContextMenuItem
+			label="Allow rebasing"
+			onclick={toggleAllowRebasing}
+			tooltip="Allows changing commits after push (force push needed)"
+		>
+			{#snippet control()}
 				<Toggle small bind:checked={allowRebasing} on:click={toggleAllowRebasing} />
-			</Tooltip>
+			{/snippet}
 		</ContextMenuItem>
 	</ContextMenuSection>
 
@@ -165,14 +168,14 @@
 		<ContextMenuSection>
 			<ContextMenuItem
 				label="PR details"
-				on:click={() => {
+				onclick={() => {
 					openPrDetailsModal?.();
 					contextMenuEl?.close();
 				}}
 			/>
 			<ContextMenuItem
 				label="Refetch PR status"
-				on:click={() => {
+				onclick={() => {
 					reloadPR?.();
 					contextMenuEl?.close();
 				}}
@@ -183,7 +186,7 @@
 	<ContextMenuSection>
 		<ContextMenuItem
 			label={`Create ${$stackingFeature ? 'stack' : 'branch'} to the left`}
-			on:click={() => {
+			onclick={() => {
 				branchController.createBranch({ order: branch.order });
 				contextMenuEl?.close();
 			}}
@@ -191,7 +194,7 @@
 
 		<ContextMenuItem
 			label={`Create ${$stackingFeature ? 'stack' : 'branch'} to the right`}
-			on:click={() => {
+			onclick={() => {
 				branchController.createBranch({ order: branch.order + 1 });
 				contextMenuEl?.close();
 			}}

--- a/apps/desktop/src/lib/branch/StackingSeriesHeaderContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeaderContextMenu.svelte
@@ -66,23 +66,27 @@
 		<ContextMenuItem
 			disabled
 			label="Add description"
-			on:click={() => {
+			onclick={() => {
 				addDescription();
 				contextMenuEl?.close();
 			}}
 		/>
 		<ContextMenuItem
 			label="Generate series name"
-			on:click={() => {
+			onclick={() => {
 				onGenerateBranchName();
 				contextMenuEl?.close();
 			}}
+			tooltip={!($aiGenEnabled && aiConfigurationValid) || disableTitleEdit
+				? 'Series name change disabled once branch has been pushed'
+				: ''}
 			disabled={!($aiGenEnabled && aiConfigurationValid) || disableTitleEdit}
 		/>
 		<ContextMenuItem
 			label="Rename"
 			disabled={disableTitleEdit}
-			on:click={async () => {
+			tooltip={disableTitleEdit ? 'Series name change disabled once branch has been pushed' : ''}
+			onclick={async () => {
 				renameSeriesModal.show(branch);
 				contextMenuEl?.close();
 			}}
@@ -90,7 +94,10 @@
 		<ContextMenuItem
 			label="Delete"
 			disabled={seriesCount <= 1}
-			on:click={() => {
+			tooltip={seriesCount <= 1
+				? 'Delete disabled if this is the only series. Please use stack delete instead.'
+				: ''}
+			onclick={() => {
 				deleteSeriesModal.show(branch);
 				contextMenuEl?.close();
 			}}
@@ -100,14 +107,14 @@
 		<ContextMenuSection>
 			<ContextMenuItem
 				label="PR details"
-				on:click={() => {
+				onclick={() => {
 					openPrDetailsModal();
 					contextMenuEl?.close();
 				}}
 			/>
 			<ContextMenuItem
 				label="Refetch PR status"
-				on:click={() => {
+				onclick={() => {
 					reloadPR();
 					contextMenuEl?.close();
 				}}

--- a/apps/desktop/src/lib/branch/StackingSeriesHeaderContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeaderContextMenu.svelte
@@ -71,37 +71,33 @@
 				contextMenuEl?.close();
 			}}
 		/>
-		<ContextMenuItem
-			label="Generate series name"
-			onclick={() => {
-				onGenerateBranchName();
-				contextMenuEl?.close();
-			}}
-			tooltip={!($aiGenEnabled && aiConfigurationValid) || disableTitleEdit
-				? 'Series name change disabled once branch has been pushed'
-				: ''}
-			disabled={!($aiGenEnabled && aiConfigurationValid) || disableTitleEdit}
-		/>
-		<ContextMenuItem
-			label="Rename"
-			disabled={disableTitleEdit}
-			tooltip={disableTitleEdit ? 'Series name change disabled once branch has been pushed' : ''}
-			onclick={async () => {
-				renameSeriesModal.show(branch);
-				contextMenuEl?.close();
-			}}
-		/>
-		<ContextMenuItem
-			label="Delete"
-			disabled={seriesCount <= 1}
-			tooltip={seriesCount <= 1
-				? 'Delete disabled if this is the only series. Please use stack delete instead.'
-				: ''}
-			onclick={() => {
-				deleteSeriesModal.show(branch);
-				contextMenuEl?.close();
-			}}
-		/>
+		{#if $aiGenEnabled && aiConfigurationValid && !disableTitleEdit}
+			<ContextMenuItem
+				label="Generate series name"
+				onclick={() => {
+					onGenerateBranchName();
+					contextMenuEl?.close();
+				}}
+			/>
+		{/if}
+		{#if !disableTitleEdit}
+			<ContextMenuItem
+				label="Rename"
+				onclick={async () => {
+					renameSeriesModal.show(branch);
+					contextMenuEl?.close();
+				}}
+			/>
+		{/if}
+		{#if seriesCount > 1}
+			<ContextMenuItem
+				label="Delete"
+				onclick={() => {
+					deleteSeriesModal.show(branch);
+					contextMenuEl?.close();
+				}}
+			/>
+		{/if}
 	</ContextMenuSection>
 	{#if hasPr}
 		<ContextMenuSection>

--- a/apps/desktop/src/lib/commit/CommitContextMenu.svelte
+++ b/apps/desktop/src/lib/commit/CommitContextMenu.svelte
@@ -42,10 +42,10 @@
 
 <ContextMenu bind:this={contextMenu} {target} openByMouse>
 	<ContextMenuSection>
-		<ContextMenuItem label="Copy SHA" on:click={copySha} />
+		<ContextMenuItem label="Copy SHA" onclick={copySha} />
 		{#if commitUrl}
-			<ContextMenuItem label="Open in browser" on:click={openInBrowser} />
+			<ContextMenuItem label="Open in browser" onclick={openInBrowser} />
 		{/if}
-		<ContextMenuItem label="Copy commit message" on:click={copyCommitMessage} />
+		<ContextMenuItem label="Copy commit message" onclick={copyCommitMessage} />
 	</ContextMenuSection>
 </ContextMenu>

--- a/apps/desktop/src/lib/commit/CommitMessageInput.svelte
+++ b/apps/desktop/src/lib/commit/CommitMessageInput.svelte
@@ -261,16 +261,20 @@
 						<ContextMenuSection>
 							<ContextMenuItem
 								label="Extra concise"
-								on:click={() => ($commitGenerationExtraConcise = !$commitGenerationExtraConcise)}
+								onclick={() => ($commitGenerationExtraConcise = !$commitGenerationExtraConcise)}
 							>
-								<Checkbox small slot="control" bind:checked={$commitGenerationExtraConcise} />
+								{#snippet control()}
+									<Checkbox small bind:checked={$commitGenerationExtraConcise} />
+								{/snippet}
 							</ContextMenuItem>
 
 							<ContextMenuItem
 								label="Use emojis 😎"
-								on:click={() => ($commitGenerationUseEmojis = !$commitGenerationUseEmojis)}
+								onclick={() => ($commitGenerationUseEmojis = !$commitGenerationUseEmojis)}
 							>
-								<Checkbox small slot="control" bind:checked={$commitGenerationUseEmojis} />
+								{#snippet control()}
+									<Checkbox small bind:checked={$commitGenerationUseEmojis} />
+								{/snippet}
 							</ContextMenuItem>
 						</ContextMenuSection>
 					{/snippet}

--- a/apps/desktop/src/lib/components/FilterBranchesButton.svelte
+++ b/apps/desktop/src/lib/components/FilterBranchesButton.svelte
@@ -36,21 +36,29 @@
 	<ContextMenu bind:this={contextMenu} {target}>
 		<ContextMenuSection>
 			{#if showPrCheckbox}
-				<ContextMenuItem label="Pull requests" on:click={() => ($includePrs = !$includePrs)}>
-					<Checkbox small bind:checked={$includePrs} slot="control" />
+				<ContextMenuItem label="Pull requests" onclick={() => ($includePrs = !$includePrs)}>
+					{#snippet control()}
+						<Checkbox small bind:checked={$includePrs} />
+					{/snippet}
 				</ContextMenuItem>
 			{/if}
-			<ContextMenuItem label="Branches" on:click={() => ($includeRemote = !$includeRemote)}>
-				<Checkbox small bind:checked={$includeRemote} slot="control" />
+			<ContextMenuItem label="Branches" onclick={() => ($includeRemote = !$includeRemote)}>
+				{#snippet control()}
+					<Checkbox small bind:checked={$includeRemote} />
+				{/snippet}
 			</ContextMenuItem>
 		</ContextMenuSection>
 
 		<ContextMenuSection>
-			<ContextMenuItem label="Hide bots" on:click={() => ($hideBots = !$hideBots)}>
-				<Toggle small slot="control" bind:checked={$hideBots} />
+			<ContextMenuItem label="Hide bots" onclick={() => ($hideBots = !$hideBots)}>
+				{#snippet control()}
+					<Toggle small bind:checked={$hideBots} />
+				{/snippet}
 			</ContextMenuItem>
-			<ContextMenuItem label="Hide inactive" on:click={() => ($hideInactive = !$hideInactive)}>
-				<Toggle small slot="control" bind:checked={$hideInactive} />
+			<ContextMenuItem label="Hide inactive" onclick={() => ($hideInactive = !$hideInactive)}>
+				{#snippet control()}
+					<Toggle small bind:checked={$hideInactive} />
+				{/snippet}
 			</ContextMenuItem>
 		</ContextMenuSection>
 	</ContextMenu>

--- a/apps/desktop/src/lib/components/contextmenu/ContextMenuItem.svelte
+++ b/apps/desktop/src/lib/components/contextmenu/ContextMenuItem.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import Icon from '@gitbutler/ui/Icon.svelte';
-	import Tooltip from '@gitbutler/ui/Tooltip.svelte';
 	import type iconsJson from '@gitbutler/ui/data/icons.json';
 	import type { Snippet } from 'svelte';
 
@@ -9,11 +8,10 @@
 		label: string;
 		disabled?: boolean;
 		control?: Snippet;
-		tooltip?: string;
 		onclick: () => void;
 	}
 
-	const { onclick, icon = undefined, label, disabled, control, tooltip = '' }: Props = $props();
+	const { onclick, icon = undefined, label, disabled, control }: Props = $props();
 </script>
 
 <button class="menu-item" class:disabled {disabled} {onclick}>
@@ -21,11 +19,9 @@
 		<Icon name={icon} />
 	{/if}
 
-	<Tooltip text={tooltip}>
-		<span class="label text-12">
-			{label}
-		</span>
-	</Tooltip>
+	<span class="label text-12">
+		{label}
+	</span>
 	{#if control}
 		{@render control()}
 	{/if}

--- a/apps/desktop/src/lib/components/contextmenu/ContextMenuItem.svelte
+++ b/apps/desktop/src/lib/components/contextmenu/ContextMenuItem.svelte
@@ -1,21 +1,34 @@
 <script lang="ts">
 	import Icon from '@gitbutler/ui/Icon.svelte';
+	import Tooltip from '@gitbutler/ui/Tooltip.svelte';
 	import type iconsJson from '@gitbutler/ui/data/icons.json';
+	import type { Snippet } from 'svelte';
 
-	export let icon: keyof typeof iconsJson | undefined = undefined;
-	export let label: string;
-	export let disabled = false;
+	interface Props {
+		icon?: keyof typeof iconsJson | undefined;
+		label: string;
+		disabled?: boolean;
+		control?: Snippet;
+		tooltip?: string;
+		onclick: () => void;
+	}
+
+	const { onclick, icon = undefined, label, disabled, control, tooltip = '' }: Props = $props();
 </script>
 
-<button class="menu-item" class:disabled {disabled} on:click>
+<button class="menu-item" class:disabled {disabled} {onclick}>
 	{#if icon}
 		<Icon name={icon} />
 	{/if}
 
-	<span class="label text-12">
-		{label}
-	</span>
-	<slot name="control" />
+	<Tooltip text={tooltip}>
+		<span class="label text-12">
+			{label}
+		</span>
+	</Tooltip>
+	{#if control}
+		{@render control()}
+	{/if}
 </button>
 
 <style lang="postcss">

--- a/apps/desktop/src/lib/file/FileContextMenu.svelte
+++ b/apps/desktop/src/lib/file/FileContextMenu.svelte
@@ -65,7 +65,7 @@
 				{#if files[0] instanceof LocalFile && !isUnapplied && !isBinary}
 					<ContextMenuItem
 						label="Discard changes"
-						on:click={() => {
+						onclick={() => {
 							confirmationModal.show(item);
 							contextMenu.close();
 						}}
@@ -74,7 +74,7 @@
 				{#if files.length === 1}
 					<ContextMenuItem
 						label="Copy Path"
-						on:click={async () => {
+						onclick={async () => {
 							try {
 								if (!project) return;
 								const absPath = await join(project.path, item.files[0].path);
@@ -89,7 +89,7 @@
 					/>
 					<ContextMenuItem
 						label="Copy Relative Path"
-						on:click={() => {
+						onclick={() => {
 							try {
 								if (!project) return;
 								navigator.clipboard.writeText(item.files[0].path);
@@ -104,7 +104,7 @@
 				<ContextMenuItem
 					label="Open in {$userSettings.defaultCodeEditor.displayName}"
 					disabled={isDeleted(item)}
-					on:click={async () => {
+					onclick={async () => {
 						try {
 							if (!project) return;
 							for (let file of item.files) {

--- a/apps/desktop/src/lib/hunk/HunkContextMenu.svelte
+++ b/apps/desktop/src/lib/hunk/HunkContextMenu.svelte
@@ -38,7 +38,7 @@
 			{#if item.hunk !== undefined && !readonly}
 				<ContextMenuItem
 					label="Discard"
-					on:click={() => {
+					onclick={() => {
 						branchController.unapplyHunk(item.hunk);
 						contextMenu.close();
 					}}
@@ -47,7 +47,7 @@
 			{#if item.lineNumber}
 				<ContextMenuItem
 					label="Open in {$userSettings.defaultCodeEditor.displayName}"
-					on:click={() => {
+					onclick={() => {
 						projectPath &&
 							openExternalUrl(
 								`${$userSettings.defaultCodeEditor.schemeIdentifer}://file${projectPath}/${filePath}:${item.lineNumber}`

--- a/apps/desktop/src/lib/pr/CopyLinkContextMenu.svelte
+++ b/apps/desktop/src/lib/pr/CopyLinkContextMenu.svelte
@@ -17,7 +17,7 @@
 	<ContextMenuSection>
 		<ContextMenuItem
 			label="Copy to Clipbaord"
-			on:click={() => {
+			onclick={() => {
 				copyToClipboard(url);
 				menu.close();
 			}}

--- a/apps/desktop/src/lib/pr/MergeButton.svelte
+++ b/apps/desktop/src/lib/pr/MergeButton.svelte
@@ -47,7 +47,7 @@
 			{#each Object.values(MergeMethod) as method}
 				<ContextMenuItem
 					label={labels[method]}
-					on:click={() => {
+					onclick={() => {
 						$action = method;
 						dropDown.close();
 					}}

--- a/apps/desktop/src/lib/pr/PullRequestButton.svelte
+++ b/apps/desktop/src/lib/pr/PullRequestButton.svelte
@@ -31,7 +31,7 @@
 			{#each prActions as method}
 				<ContextMenuItem
 					label={PRActionLabels[method]}
-					on:click={() => {
+					onclick={() => {
 						preferredAction.set(method);
 						dropDown?.close();
 					}}


### PR DESCRIPTION
## ☕️ Reasoning

- Hide series context menu items that would normally be disabled

## 🧢 Changes

- Convert ContextMenuItem to runes
- Update all uses of `ContextMenuItem`


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
