### PR TITLE
fix: update push label to 'Push All' when there are multiple series

### DIFF
--- a/apps/desktop/src/lib/stack/Stack.svelte
+++ b/apps/desktop/src/lib/stack/Stack.svelte
@@ -224,7 +224,7 @@
 								: undefined}
 							onclick={push}
 						>
-							{branch.requiresForce ? 'Force push' : 'Push'}
+							{branch.requiresForce ? 'Force push' : branch.series.length > 1 ? 'Push All' : 'Push'}
 						</Button>
 					</div>
 				{/if}


### PR DESCRIPTION
## ☕️ Reasoning

- Pushing when there are multiple series in a lane pushes all the series (branches), therefore updating the label accurately communicates to the user what is actually going to happen when that button is pressed.

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
