### PR TITLE
feat: add token for `branch_name` in commit message custom prompt

### DIFF
--- a/apps/desktop/src/lib/ai/service.ts
+++ b/apps/desktop/src/lib/ai/service.ts
@@ -58,6 +58,7 @@ interface SummarizeCommitOpts extends BaseAIServiceOpts {
 	useEmojiStyle?: boolean;
 	useBriefStyle?: boolean;
 	commitTemplate?: Prompt;
+	branchName?: string;
 }
 
 interface SummarizeBranchOpts extends BaseAIServiceOpts {
@@ -267,7 +268,8 @@ export class AIService {
 		useEmojiStyle = false,
 		useBriefStyle = false,
 		commitTemplate,
-		onToken
+		onToken,
+		branchName
 	}: SummarizeCommitOpts): Promise<Result<string, Error>> {
 		const aiClientResult = await this.buildClient();
 		if (isFailure(aiClientResult)) return aiClientResult;
@@ -292,6 +294,10 @@ export class AIService {
 				? 'Make use of GitMoji in the title prefix.'
 				: "Don't use any emoji.";
 			content = content.replaceAll('%{emoji_style}', emojiPart);
+
+			if (branchName) {
+				content = content.replaceAll('%{branch_name}', branchName);
+			}
 
 			return {
 				role: MessageRole.User,

--- a/apps/desktop/src/lib/commit/CommitMessageInput.svelte
+++ b/apps/desktop/src/lib/commit/CommitMessageInput.svelte
@@ -89,7 +89,8 @@
 			hunks,
 			useEmojiStyle: $commitGenerationUseEmojis,
 			useBriefStyle: $commitGenerationExtraConcise,
-			commitTemplate: prompt
+			commitTemplate: prompt,
+			branchName: $branch.name
 		});
 
 		if (isFailure(generatedMessageResult)) {


### PR DESCRIPTION
## ☕️ Reasoning

- User feature request from Discord

## 🧢 Changes

- Add `%{branch_name}` token that can be used in the "Commit Message" generation custom prompts

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
