### PR TITLE
New crate for calculating hunk dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,6 +2181,7 @@ dependencies = [
  "gitbutler-error",
  "gitbutler-fs",
  "gitbutler-git",
+ "gitbutler-hunk-dependency",
  "gitbutler-id",
  "gitbutler-operating-modes",
  "gitbutler-oplog",
@@ -2374,6 +2375,25 @@ dependencies = [
  "tokio",
  "uuid",
  "windows 0.58.0",
+]
+
+[[package]]
+name = "gitbutler-hunk-dependency"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "bstr",
+ "git2",
+ "gitbutler-diff",
+ "gitbutler-id",
+ "gitbutler-reference",
+ "gitbutler-serde",
+ "gitbutler-stack",
+ "gix",
+ "itertools 0.13.0",
+ "serde",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "crates/gitbutler-oxidize",
     "crates/gitbutler-stack",
     "crates/gitbutler-patch-reference",
+    "crates/gitbutler-hunk-dependency",
 ]
 resolver = "2"
 
@@ -93,6 +94,7 @@ gitbutler-oxidize = { path = "crates/gitbutler-oxidize" }
 gitbutler-stack = { path = "crates/gitbutler-stack" }
 gitbutler-patch-reference = { path = "crates/gitbutler-patch-reference" }
 gitbutler-forge = { path = "crates/gitbutler-forge" }
+gitbutler-hunk-dependency = { path = "crates/gitbutler-hunk-dependency" }
 
 [profile.release]
 codegen-units = 1 # Compile crates one after another so the compiler can optimize better

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -150,7 +150,7 @@ fn matches_all(branch: &BranchListing, filter: BranchListingFilter) -> bool {
     if let Some(local) = filter.local {
         conditions.push((branch.has_local || branch.virtual_branch.is_some()) && local);
     }
-    return conditions.iter().all(|&x| x);
+    conditions.iter().all(|&x| x)
 }
 
 fn combine_branches(

--- a/crates/gitbutler-branch/src/branch_ext.rs
+++ b/crates/gitbutler-branch/src/branch_ext.rs
@@ -5,7 +5,7 @@ pub trait BranchExt {
     fn reference_name(&self) -> Result<ReferenceName>;
 }
 
-impl<'repo> BranchExt for git2::Branch<'repo> {
+impl BranchExt for git2::Branch<'_> {
     fn reference_name(&self) -> Result<ReferenceName> {
         let name = self.get().name().context("Failed to get branch name")?;
 

--- a/crates/gitbutler-branch/src/reference_ext.rs
+++ b/crates/gitbutler-branch/src/reference_ext.rs
@@ -31,7 +31,7 @@ pub trait ReferenceExtGix {
     fn identity(&self, remotes: &BTreeSet<Cow<'_, BStr>>) -> Result<BranchIdentity>;
 }
 
-impl<'repo> ReferenceExt for git2::Reference<'repo> {
+impl ReferenceExt for git2::Reference<'_> {
     fn given_name(&self, remotes: &git2::string_array::StringArray) -> Result<String> {
         if self.is_remote() {
             let shorthand_name = self

--- a/crates/gitbutler-commit/src/commit_ext.rs
+++ b/crates/gitbutler-commit/src/commit_ext.rs
@@ -13,7 +13,7 @@ pub trait CommitExt {
     fn is_conflicted(&self) -> bool;
 }
 
-impl<'repo> CommitExt for git2::Commit<'repo> {
+impl CommitExt for git2::Commit<'_> {
     fn message_bstr(&self) -> &BStr {
         self.message_bytes().as_ref()
     }

--- a/crates/gitbutler-hunk-dependency/Cargo.toml
+++ b/crates/gitbutler-hunk-dependency/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "gitbutler-hunk-dependency"
+version = "0.0.0"
+edition = "2021"
+authors = ["GitButler <gitbutler@gitbutler.com>"]
+publish = false
+
+[dependencies]
+anyhow = "1.0.86"
+git2.workspace = true
+gix = { workspace = true, features = [] }
+gitbutler-diff.workspace = true
+gitbutler-reference.workspace = true
+gitbutler-serde.workspace = true
+gitbutler-stack.workspace = true
+gitbutler-id.workspace = true
+itertools = "0.13"
+serde = { workspace = true, features = ["std"] }
+bstr.workspace = true
+tokio.workspace = true
+uuid = { workspace = true, features = ["v4", "fast-rng"] }

--- a/crates/gitbutler-hunk-dependency/src/hunk.rs
+++ b/crates/gitbutler-hunk-dependency/src/hunk.rs
@@ -1,0 +1,25 @@
+use gitbutler_stack::StackId;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct HunkRange {
+    pub stack_id: StackId,
+    pub commit_id: git2::Oid,
+    pub start: u32,
+    pub lines: u32,
+    pub line_shift: i32,
+}
+
+impl HunkRange {
+    pub fn intersects(&self, start: u32, lines: u32) -> bool {
+        if self.lines == 0 {
+            // Special case for checking if a point is inside a range, happens
+            // when a change contains only deletions.
+            return self.start >= start && self.start < start + lines;
+        }
+        self.start < start + lines && self.start + self.lines > start
+    }
+
+    pub fn contains(&self, start: u32, lines: u32) -> bool {
+        start > self.start && start + lines <= self.start + self.lines
+    }
+}

--- a/crates/gitbutler-hunk-dependency/src/input.rs
+++ b/crates/gitbutler-hunk-dependency/src/input.rs
@@ -1,0 +1,144 @@
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Context};
+use gitbutler_stack::StackId;
+
+pub struct InputStack {
+    pub stack_id: StackId,
+    pub commits: Vec<InputCommit>,
+}
+
+pub struct InputCommit {
+    pub commit_id: git2::Oid,
+    pub files: Vec<InputFile>,
+}
+
+pub struct InputFile {
+    pub path: PathBuf,
+    pub diffs: Vec<InputDiff>,
+}
+
+/// Please note that the From conversions and parsing of diffs exists to facilitate
+/// testing, in the client code we get the line numbers from elsewhere.
+#[derive(Debug, PartialEq, Clone)]
+pub struct InputDiff {
+    pub old_start: u32,
+    pub old_lines: u32,
+    pub new_start: u32,
+    pub new_lines: u32,
+}
+
+impl InputDiff {
+    pub fn net_lines(&self) -> anyhow::Result<i32> {
+        self.new_lines
+            .checked_signed_diff(self.old_lines)
+            .ok_or(anyhow!("u32 -> i32 conversion overflow"))
+    }
+}
+
+fn count_context_lines<I, S>(iter: I) -> u32
+where
+    I: Iterator<Item = S>,
+    S: AsRef<str>,
+{
+    iter.take_while(|line| {
+        let line_ref = line.as_ref(); // Convert to &str
+        !line_ref.starts_with('-') && !line_ref.starts_with('+')
+    })
+    .fold(0u32, |acc, _| acc + 1)
+}
+
+impl TryFrom<String> for InputDiff {
+    fn try_from(value: String) -> Result<Self, anyhow::Error> {
+        parse_diff(value)
+    }
+
+    type Error = anyhow::Error;
+}
+
+impl TryFrom<&str> for InputDiff {
+    fn try_from(value: &str) -> Result<Self, anyhow::Error> {
+        parse_diff(value)
+    }
+
+    type Error = anyhow::Error;
+}
+
+fn parse_diff(value: impl AsRef<str>) -> Result<InputDiff, anyhow::Error> {
+    let value = value.as_ref();
+    let header = value.lines().next().context("No header found")?;
+    if !header.starts_with("@@") {
+        return Err(anyhow!("Malformed undiff"));
+    }
+    let parts: Vec<&str> = header.split_whitespace().collect();
+    let (old_start, old_lines) = parse_header(parts[1]);
+    let (new_start, new_lines) = parse_header(parts[2]);
+    let head_context_lines = count_context_lines(value.lines().skip(1).take(3));
+    let tail_context_lines = count_context_lines(value.rsplit_terminator('\n').take(3));
+    let context_lines = head_context_lines + tail_context_lines;
+
+    Ok(InputDiff {
+        old_start: old_start + head_context_lines,
+        old_lines: old_lines - context_lines,
+        new_start: new_start + head_context_lines,
+        new_lines: new_lines - context_lines,
+    })
+}
+
+fn parse_header(hunk_info: &str) -> (u32, u32) {
+    let hunk_info = hunk_info.trim_start_matches(&['-', '+'][..]); // Remove the leading '-' or '+'
+    let parts: Vec<&str> = hunk_info.split(',').collect();
+    let start = parts[0].parse().unwrap();
+    let lines = if parts.len() > 1 {
+        parts[1].parse().unwrap()
+    } else {
+        1
+    };
+    (start, lines)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diff_simple() -> anyhow::Result<()> {
+        let header = InputDiff::try_from(
+            "@@ -1,6 +1,7 @@
+1
+2
+3
++4
+5
+6
+7
+",
+        )?;
+        assert_eq!(header.old_start, 4);
+        assert_eq!(header.old_lines, 0);
+        assert_eq!(header.new_start, 4);
+        assert_eq!(header.new_lines, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn diff_complex() -> anyhow::Result<()> {
+        let header = InputDiff::try_from(
+            "@@ -5,7 +5,6 @@
+5
+6
+7
+-8
+-9
++a
+10
+11
+",
+        )?;
+        assert_eq!(header.old_start, 8);
+        assert_eq!(header.old_lines, 2);
+        assert_eq!(header.new_start, 8);
+        assert_eq!(header.new_lines, 1);
+        Ok(())
+    }
+}

--- a/crates/gitbutler-hunk-dependency/src/lib.rs
+++ b/crates/gitbutler-hunk-dependency/src/lib.rs
@@ -1,0 +1,16 @@
+#![feature(unsigned_signed_diff)]
+pub(crate) mod hunk;
+pub mod input;
+pub mod locks;
+pub(crate) mod path;
+pub(crate) mod stack;
+pub(crate) mod workspace;
+
+pub use {
+    hunk::HunkRange,
+    input::{InputCommit, InputDiff, InputFile, InputStack},
+    locks::{compute_hunk_locks, HunkDependencyOptions, HunkLock},
+    path::PathRanges,
+    stack::StackRanges,
+    workspace::WorkspaceRanges,
+};

--- a/crates/gitbutler-hunk-dependency/src/locks.rs
+++ b/crates/gitbutler-hunk-dependency/src/locks.rs
@@ -1,0 +1,69 @@
+use std::{collections::HashMap, path::PathBuf};
+
+use gitbutler_diff::{Hunk, HunkHash};
+use gitbutler_stack::StackId;
+use itertools::Itertools;
+use serde::Serialize;
+
+use crate::{InputStack, WorkspaceRanges};
+
+// Type defined in gitbutler-branch-actions and can't be imported here.
+type BranchStatus = HashMap<PathBuf, Vec<gitbutler_diff::GitHunk>>;
+
+// A hunk is locked when it depends on changes in commits that are in your
+// workspace. A hunk can be locked to more than one branch if it overlaps
+// with more than one committed hunk.
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Copy)]
+#[serde(rename_all = "camelCase")]
+pub struct HunkLock {
+    // TODO: Rename this stack_id.
+    pub branch_id: StackId,
+    #[serde(with = "gitbutler_serde::oid")]
+    pub commit_id: git2::Oid,
+}
+
+pub struct HunkDependencyOptions<'a> {
+    // Uncommitted changes in workspace.
+    pub workdir: &'a BranchStatus,
+
+    /// A nested map of committed diffs per stack, commit, and path.
+    pub stacks: Vec<InputStack>,
+}
+
+/// Returns a map from hunk hash to hunk locks.
+///
+/// To understand if any uncommitted changes depend on (intersect) any existing
+/// changes we first transform the branch specific line numbers to global ones,
+/// then look for places they intersect.
+///
+/// TODO: Change terminology to talk about dependencies instead of locks.
+pub fn compute_hunk_locks(
+    options: HunkDependencyOptions,
+) -> anyhow::Result<HashMap<HunkHash, Vec<HunkLock>>> {
+    let HunkDependencyOptions { workdir, stacks } = options;
+
+    // Transforms local line numbers to global line numbers.
+    let workspace_ranges = WorkspaceRanges::create(stacks)?;
+
+    let mut result = HashMap::new();
+
+    for (path, workspace_hunks) in workdir {
+        for hunk in workspace_hunks {
+            let hunk_dependencies =
+                workspace_ranges.intersection(path, hunk.old_start, hunk.old_lines);
+            let hash = Hunk::hash_diff(&hunk.diff_lines);
+            let locks = hunk_dependencies
+                .iter()
+                .map(|dependency| HunkLock {
+                    commit_id: dependency.commit_id,
+                    branch_id: dependency.stack_id,
+                })
+                .collect_vec();
+
+            if !locks.is_empty() {
+                result.insert(hash, locks);
+            }
+        }
+    }
+    Ok(result)
+}

--- a/crates/gitbutler-hunk-dependency/src/path.rs
+++ b/crates/gitbutler-hunk-dependency/src/path.rs
@@ -1,0 +1,518 @@
+use std::collections::HashSet;
+
+use anyhow::bail;
+use gitbutler_stack::StackId;
+
+use crate::{HunkRange, InputDiff};
+
+/// Adds sequential diffs from sequential commits for a specific path, and
+/// shifts line numbers with additions and deletions. It is expected that
+/// diffs are added one commit at a time, each time merging the already added
+/// diffs with the new ones being added.
+///
+/// When combining old and new diffs we process them in turn of their start
+/// line, lowest first. With each addition it is possible that we conflict
+/// with previous ranges (we only know start line is higher, line count can
+/// be very different), but it is important to note that old ranges will
+/// not conflict with old ranges, and new ranges cannot conflict with new
+/// ranges.
+///
+/// Therefore, a) if we are processing a new diff we know it overwrites
+/// anything it conflicts with, b) when processing an old diff we e.g.
+/// omit it if has been overwritten.
+#[derive(Debug, Default, PartialEq, Clone)]
+pub struct PathRanges {
+    pub hunks: Vec<HunkRange>,
+    commit_ids: HashSet<git2::Oid>,
+}
+
+impl PathRanges {
+    pub fn add(
+        &mut self,
+        stack_id: StackId,
+        commit_id: git2::Oid,
+        diffs: Vec<InputDiff>,
+    ) -> anyhow::Result<()> {
+        if !self.commit_ids.insert(commit_id) {
+            bail!("Commit ID already in stack: {}", commit_id)
+        }
+
+        // Cumulative count of net line change, used to update start lines.
+        let mut net_lines = 0;
+        let mut new_hunks: Vec<HunkRange> = vec![];
+        let mut last_hunk: Option<HunkRange> = None;
+
+        // Two pointers for iterating over two arrays.
+        let [mut i, mut j] = [0, 0];
+
+        while i < diffs.len() || j < self.hunks.len() {
+            // If the old start is smaller than existing new_start, or if only have
+            // new diffs left to process.
+            let mut hunks = if (i < diffs.len()
+                && j < self.hunks.len()
+                && diffs[i].old_start < self.hunks[j].start)
+                || (i < diffs.len() && j >= self.hunks.len())
+            {
+                i += 1;
+                net_lines += diffs[i - 1].net_lines()?;
+                add_new(&diffs[i - 1], last_hunk, stack_id, commit_id)?
+            } else {
+                j += 1;
+                add_existing(&self.hunks[j - 1], last_hunk, net_lines)
+            };
+            // Last node is needed when adding new one, so we delay inserting it.
+            last_hunk = hunks.pop();
+            new_hunks.extend(hunks);
+        }
+
+        if let Some(last_hunk) = last_hunk {
+            new_hunks.push(last_hunk);
+        };
+
+        self.hunks = new_hunks;
+        Ok(())
+    }
+
+    pub fn intersection(&mut self, start: u32, lines: u32) -> Vec<&mut HunkRange> {
+        self.hunks
+            .iter_mut()
+            .filter(|hunk| hunk.intersects(start, lines))
+            .collect()
+    }
+}
+
+/// Determines how to add new diff given the previous one.
+fn add_new(
+    new_diff: &InputDiff,
+    last_hunk: Option<HunkRange>,
+    stack_id: StackId,
+    commit_id: git2::Oid,
+) -> anyhow::Result<Vec<HunkRange>> {
+    // If we have nothing to compare against we just return the new diff.
+    if last_hunk.is_none() {
+        return Ok(vec![HunkRange {
+            stack_id,
+            commit_id,
+            start: new_diff.new_start,
+            lines: new_diff.new_lines,
+            line_shift: new_diff.net_lines()?,
+        }]);
+    }
+    let last_hunk = last_hunk.unwrap();
+
+    if last_hunk.start + last_hunk.lines < new_diff.old_start {
+        // Diffs do not overlap so we return them in order.
+        Ok(vec![
+            last_hunk.clone(),
+            HunkRange {
+                commit_id,
+                stack_id,
+                start: new_diff.new_start,
+                lines: new_diff.new_lines,
+                line_shift: new_diff.net_lines()?,
+            },
+        ])
+    } else if last_hunk.contains(new_diff.old_start, new_diff.old_lines) {
+        // Since the diff being added is from the current commit it overwrites the
+        // preceding one, but we need to split it in two and retain the tail.
+        Ok(vec![
+            HunkRange {
+                commit_id: last_hunk.commit_id,
+                stack_id: last_hunk.stack_id,
+                start: last_hunk.start,
+                lines: new_diff.new_start - last_hunk.start,
+                line_shift: 0,
+            },
+            HunkRange {
+                commit_id,
+                stack_id,
+                start: new_diff.new_start,
+                lines: new_diff.new_lines,
+                line_shift: new_diff.net_lines()?,
+            },
+            HunkRange {
+                commit_id: last_hunk.commit_id,
+                stack_id: last_hunk.stack_id,
+                start: new_diff.new_start + new_diff.new_lines,
+                lines: last_hunk.lines
+                    - new_diff.old_lines
+                    - (new_diff.old_start - last_hunk.start),
+                line_shift: last_hunk.line_shift,
+            },
+        ])
+    } else {
+        // Overwrite the tail of the previous diff.
+        Ok(vec![
+            HunkRange {
+                commit_id: last_hunk.commit_id,
+                stack_id: last_hunk.stack_id,
+                start: last_hunk.start,
+                lines: new_diff.new_start - last_hunk.start,
+                line_shift: last_hunk.line_shift,
+            },
+            HunkRange {
+                commit_id,
+                stack_id,
+                start: new_diff.new_start,
+                lines: new_diff.new_lines,
+                line_shift: new_diff.net_lines()?,
+            },
+        ])
+    }
+}
+
+/// Determines how existing diff given the previous one.
+fn add_existing(hunk: &HunkRange, last_hunk: Option<HunkRange>, shift: i32) -> Vec<HunkRange> {
+    if last_hunk.is_none() {
+        return vec![hunk.clone()];
+    };
+    let last_hunk = last_hunk.unwrap();
+
+    if hunk.start.saturating_add_signed(shift) > last_hunk.start + last_hunk.lines {
+        vec![
+            last_hunk.clone(),
+            HunkRange {
+                commit_id: hunk.commit_id,
+                stack_id: hunk.stack_id,
+                start: hunk.start.saturating_add_signed(shift),
+                lines: hunk.lines,
+                line_shift: hunk.line_shift,
+            },
+        ]
+    } else if last_hunk.contains(hunk.start.saturating_add_signed(shift), hunk.lines) {
+        vec![last_hunk.clone()]
+    } else {
+        vec![
+            last_hunk.clone(),
+            HunkRange {
+                commit_id: hunk.commit_id,
+                stack_id: hunk.stack_id,
+                start: hunk.start.saturating_add_signed(shift),
+                lines: hunk.lines - (last_hunk.start + last_hunk.lines - hunk.start),
+                line_shift: hunk.line_shift,
+            },
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stack_simple() -> anyhow::Result<()> {
+        let diff = InputDiff::try_from(
+            "@@ -1,6 +1,7 @@
+1
+2
+3
++4
+5
+6
+7
+",
+        )?;
+        let stack_ranges = &mut PathRanges::default();
+        let stack_id = StackId::generate();
+        let commit_id = git2::Oid::from_str("a")?;
+
+        stack_ranges.add(stack_id, commit_id, vec![diff])?;
+
+        let intersection = stack_ranges.intersection(4, 1);
+        assert_eq!(intersection.len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn stack_complex() -> anyhow::Result<()> {
+        let diff_1 = InputDiff::try_from(
+            "@@ -1,6 +1,7 @@
+1
+2
+3
++4
+5
+6
+7
+",
+        )?;
+        let diff_2 = InputDiff::try_from(
+            "@@ -2,6 +2,7 @@
+2
+3
+4
++4.5
+5
+6
+7
+",
+        )?;
+
+        let stack_ranges = &mut PathRanges::default();
+        let stack_id = StackId::generate();
+
+        let commit_id = git2::Oid::from_str("a")?;
+        stack_ranges.add(stack_id, commit_id, vec![diff_1])?;
+
+        let commit_id = git2::Oid::from_str("b")?;
+        stack_ranges.add(stack_id, commit_id, vec![diff_2])?;
+
+        let intersection = stack_ranges.intersection(4, 1);
+        assert_eq!(intersection.len(), 1);
+
+        let intersection = stack_ranges.intersection(5, 1);
+        assert_eq!(intersection.len(), 1);
+
+        let intersection = stack_ranges.intersection(4, 2);
+        assert_eq!(intersection.len(), 2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn stack_basic_line_shift() -> anyhow::Result<()> {
+        let diff_1 = InputDiff::try_from(
+            "@@ -1,4 +1,5 @@
+a
++b
+a
+a
+a
+",
+        )?;
+        let diff_2 = InputDiff::try_from(
+            "@@ -1,3 +1,4 @@
++c
+a
+b
+a
+",
+        )?;
+
+        let stack_ranges = &mut PathRanges::default();
+        let stack_id = StackId::generate();
+
+        let commit_id = git2::Oid::from_str("a")?;
+        stack_ranges.add(stack_id, commit_id, vec![diff_1])?;
+
+        let commit_id = git2::Oid::from_str("b")?;
+        stack_ranges.add(stack_id, commit_id, vec![diff_2])?;
+
+        let result = stack_ranges.intersection(1, 1);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].commit_id, commit_id);
+
+        Ok(())
+    }
+
+    #[test]
+    fn stack_complex_line_shift() -> anyhow::Result<()> {
+        let stack_ranges = &mut PathRanges::default();
+        let stack_id = StackId::generate();
+
+        let commit1_id = git2::Oid::from_str("a")?;
+        let diff1 = InputDiff::try_from(
+            "@@ -1,4 +1,5 @@
+a
++b
+a
+a
+a
+",
+        )?;
+        stack_ranges.add(stack_id, commit1_id, vec![diff1])?;
+
+        let commit2_id = git2::Oid::from_str("b")?;
+        let diff2 = InputDiff::try_from(
+            "@@ -1,3 +1,4 @@
++c
+a
+b
+a
+",
+        )?;
+
+        stack_ranges.add(stack_id, commit2_id, vec![diff2])?;
+
+        let result = stack_ranges.intersection(1, 1);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].commit_id, commit2_id);
+
+        let result = stack_ranges.intersection(2, 1);
+        assert_eq!(result.len(), 0);
+
+        let result = stack_ranges.intersection(3, 1);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].commit_id, commit1_id);
+
+        Ok(())
+    }
+
+    #[test]
+    fn stack_multiple_overwrites() -> anyhow::Result<()> {
+        let stack_ranges = &mut PathRanges::default();
+        let stack_id = StackId::generate();
+
+        let commit1_id = git2::Oid::from_str("a")?;
+        let diff_1 = InputDiff::try_from(
+            "@@ -1,0 +1,7 @@
++a
++a
++a
++a
++a
++a
++a
+",
+        )?;
+        stack_ranges.add(stack_id, commit1_id, vec![diff_1])?;
+
+        let commit2_id = git2::Oid::from_str("b")?;
+        let diff2 = InputDiff::try_from(
+            "@@ -1,5 +1,5 @@
+a
+-a
++b
+a
+a
+a
+",
+        )?;
+        stack_ranges.add(stack_id, commit2_id, vec![diff2])?;
+
+        let commit3_id = git2::Oid::from_str("c")?;
+        let diff3 = InputDiff::try_from(
+            "@@ -1,7 +1,7 @@
+a
+b
+a
+-a
++b
+a
+a
+a
+",
+        )?;
+        stack_ranges.add(stack_id, commit3_id, vec![diff3])?;
+
+        let commit4_id = git2::Oid::from_str("d")?;
+        let diff4 = InputDiff::try_from(
+            "@@ -3,5 +3,5 @@
+a
+b
+a
+-a
++b
+a
+",
+        )?;
+        stack_ranges.add(stack_id, commit4_id, vec![diff4])?;
+
+        let result = stack_ranges.intersection(1, 1);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].commit_id, commit1_id);
+
+        let result = stack_ranges.intersection(2, 1);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].commit_id, commit2_id);
+
+        let result = stack_ranges.intersection(4, 1);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].commit_id, commit3_id);
+
+        let result = stack_ranges.intersection(6, 1);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].commit_id, commit4_id);
+
+        Ok(())
+    }
+
+    #[test]
+    fn stack_detect_deletion() -> anyhow::Result<()> {
+        let stack_ranges = &mut PathRanges::default();
+        let stack_id = StackId::generate();
+
+        let commit1_id = git2::Oid::from_str("a")?;
+        let diff_1 = InputDiff::try_from(
+            "@@ -1,7 +1,6 @@
+a
+a
+a
+-a
+a
+a
+a
+",
+        )?;
+        stack_ranges.add(stack_id, commit1_id, vec![diff_1])?;
+
+        let result = stack_ranges.intersection(3, 2);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].commit_id, commit1_id);
+
+        Ok(())
+    }
+
+    #[test]
+    fn stack_offset_and_split() -> anyhow::Result<()> {
+        let stack_ranges = &mut PathRanges::default();
+        let stack_id = StackId::generate();
+
+        let commit1_id = git2::Oid::from_str("a")?;
+        let diff_1 = InputDiff::try_from(
+            "@@ -10,6 +10,9 @@
+a
+a
+a
++b
++b
++b
+a
+a
+a
+",
+        )?;
+        stack_ranges.add(stack_id, commit1_id, vec![diff_1])?;
+
+        let commit2_id = git2::Oid::from_str("b")?;
+        let diff_2 = InputDiff::try_from(
+            "@@ -1,6 +1,9 @@
+a
+a
+a
++c
++c
++c
+a
+a
+a
+",
+        )?;
+        stack_ranges.add(stack_id, commit2_id, vec![diff_2])?;
+
+        let commit3_id = git2::Oid::from_str("c")?;
+        let diff_3 = InputDiff::try_from(
+            "@@ -14,7 +14,7 @@
+a
+a
+b
+-b
++d
+b
+a
+a
+",
+        )?;
+        stack_ranges.add(stack_id, commit3_id, vec![diff_3])?;
+
+        assert_eq!(stack_ranges.intersection(4, 3)[0].commit_id, commit2_id);
+        assert_eq!(stack_ranges.intersection(15, 1).len(), 0);
+        assert_eq!(stack_ranges.intersection(16, 1)[0].commit_id, commit1_id);
+        assert_eq!(stack_ranges.intersection(17, 1)[0].commit_id, commit3_id);
+        assert_eq!(stack_ranges.intersection(18, 1)[0].commit_id, commit1_id);
+        assert_eq!(stack_ranges.intersection(19, 1).len(), 0);
+
+        Ok(())
+    }
+}

--- a/crates/gitbutler-hunk-dependency/src/stack.rs
+++ b/crates/gitbutler-hunk-dependency/src/stack.rs
@@ -1,0 +1,48 @@
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+};
+
+use gitbutler_stack::StackId;
+use itertools::Itertools;
+
+use crate::{HunkRange, InputDiff, PathRanges};
+
+#[derive(Debug, Default, PartialEq, Clone)]
+pub struct StackRanges {
+    pub paths: HashMap<PathBuf, PathRanges>,
+}
+
+impl StackRanges {
+    pub fn add(
+        &mut self,
+        stack_id: StackId,
+        commit_id: git2::Oid,
+        path: &PathBuf,
+        diffs: Vec<InputDiff>,
+    ) -> anyhow::Result<()> {
+        if let Some(deps_path) = self.paths.get_mut(path) {
+            deps_path.add(stack_id, commit_id, diffs)?;
+        } else {
+            let mut path_deps = PathRanges::default();
+            path_deps.add(stack_id, commit_id, diffs)?;
+            self.paths.insert(path.clone(), path_deps);
+        };
+        Ok(())
+    }
+
+    pub fn unique_paths(&self) -> HashSet<PathBuf> {
+        self.paths
+            .keys()
+            .unique()
+            .map(|path| path.to_owned())
+            .collect::<HashSet<PathBuf>>()
+    }
+
+    pub fn intersection(&mut self, path: &PathBuf, start: u32, lines: u32) -> Vec<&mut HunkRange> {
+        if let Some(deps_path) = self.paths.get_mut(path) {
+            return deps_path.intersection(start, lines);
+        }
+        vec![]
+    }
+}

--- a/crates/gitbutler-hunk-dependency/src/workspace.rs
+++ b/crates/gitbutler-hunk-dependency/src/workspace.rs
@@ -1,0 +1,190 @@
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+use itertools::Itertools;
+
+use crate::{HunkRange, InputCommit, InputStack, StackRanges};
+
+#[derive(Debug, Default, PartialEq, Clone)]
+pub struct WorkspaceRanges {
+    paths: HashMap<PathBuf, Vec<HunkRange>>,
+}
+
+/// Provides blame-like functionality for looking up what commit(s) have
+/// touched a specific line number range for a given path.
+///
+/// First it combines changes per branch sequentially by commit, allowing
+/// for dependent changes where one commit introduces changes that overwrites
+/// previous changes.
+///
+/// It then combines the changes per branch into a single vector with line
+/// numbers that should match the workspace commit. These per branch changes
+/// are assumed and required to be independent without overlap.
+impl WorkspaceRanges {
+    pub fn create(input_stacks: Vec<InputStack>) -> anyhow::Result<WorkspaceRanges> {
+        let mut stacks = vec![];
+        for input_stack in input_stacks {
+            let mut stack = StackRanges::default();
+            let InputStack { stack_id, commits } = input_stack;
+            for commit in commits {
+                let InputCommit { commit_id, files } = commit;
+                for file in files {
+                    stack.add(stack_id, commit_id, &file.path, file.diffs)?;
+                }
+            }
+            stacks.push(stack);
+        }
+        let paths = stacks
+            .iter()
+            .flat_map(StackRanges::unique_paths)
+            .collect_vec();
+
+        Ok(WorkspaceRanges {
+            paths: paths
+                .iter()
+                .map(|path| (path.clone(), combine_path_ranges(path, &stacks)))
+                .collect(),
+        })
+    }
+
+    /// Finds commits that intersect with a given path and range combination.
+    pub fn intersection(&self, path: &Path, start: u32, lines: u32) -> Vec<HunkRange> {
+        if let Some(stack_hunks) = self.paths.get(path) {
+            return stack_hunks
+                .iter()
+                .filter(|hunk| hunk.intersects(start, lines))
+                .map(|x| x.to_owned())
+                .collect_vec();
+        }
+        vec![]
+    }
+}
+
+/// Combines ranges from muiltiple branches/stacks into a single vector
+/// with adjusted line numbers. For this to work it is required that changes
+/// between stacks are not overlapping, which is already a hard requirement.
+fn combine_path_ranges(path: &Path, stacks: &[StackRanges]) -> Vec<HunkRange> {
+    let mut result: Vec<HunkRange> = vec![];
+
+    // Only process stacks that contain the path.
+    let filtered_paths = stacks
+        .iter()
+        .filter_map(|stack| stack.paths.get(path))
+        .collect_vec();
+
+    // Tracks the cumulative lines added/removed.
+    let mut line_shift: i32 = 0;
+
+    // Next hunk to consider for each branch containing path.
+    let mut hunk_indexes: Vec<usize> = vec![0; filtered_paths.len()];
+
+    loop {
+        let start_lines = filtered_paths
+            .iter()
+            .enumerate()
+            .map(|(i, path_dep)| path_dep.hunks.get(hunk_indexes[i]))
+            .map(|hunk| hunk.map(|hunk_dep| hunk_dep.start))
+            .collect_vec();
+
+        // Find the index of the dependency path with the lowest start line.
+        let next_index = start_lines
+            .iter()
+            .enumerate() // We want to filter out None values, but keep their index.
+            .filter(|(_, start_line)| start_line.is_some())
+            .min_by_key(|&(index, &start_line)| {
+                start_line.unwrap() + start_lines[index].unwrap_or(0)
+            })
+            .map(|(index, _)| index);
+
+        if next_index.is_none() {
+            break; // No more items to process.
+        }
+        let next_index = next_index.unwrap();
+
+        let hunk_index = hunk_indexes[next_index];
+        hunk_indexes[next_index] += 1;
+
+        // Get the path with the lowest next start line.
+        let path_dep = &filtered_paths[next_index];
+
+        let hunk_dep = &path_dep.hunks[hunk_index];
+
+        result.push(HunkRange {
+            start: hunk_dep.start.saturating_add_signed(line_shift),
+            ..hunk_dep.clone()
+        });
+        line_shift += hunk_dep.line_shift;
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use gitbutler_stack::StackId;
+
+    use crate::input::{InputDiff, InputFile};
+
+    use super::*;
+
+    #[test]
+    fn workspace_simple() -> anyhow::Result<()> {
+        let path = PathBuf::from_str("/test.txt")?;
+
+        let commit1_id = git2::Oid::from_str("a")?;
+        let stack1_id = StackId::generate();
+
+        let commit2_id = git2::Oid::from_str("b")?;
+        let stack2_id = StackId::generate();
+
+        let workspace_ranges = WorkspaceRanges::create(vec![
+            InputStack {
+                stack_id: stack1_id,
+                commits: vec![InputCommit {
+                    commit_id: commit1_id,
+                    files: vec![InputFile {
+                        path: path.to_owned(),
+                        diffs: vec![InputDiff::try_from(
+                            "@@ -1,6 +1,7 @@
+1
+2
+3
++4
+5
+6
+7
+",
+                        )?],
+                    }],
+                }],
+            },
+            InputStack {
+                stack_id: stack2_id,
+                commits: vec![InputCommit {
+                    commit_id: commit2_id,
+                    files: vec![InputFile {
+                        path: path.to_owned(),
+                        diffs: vec![InputDiff::try_from(
+                            "@@ -1,5 +1,3 @@
+-1
+-2
+3
+5
+6
+",
+                        )?],
+                    }],
+                }],
+            },
+        ])?;
+
+        let dependencies = workspace_ranges.intersection(&path, 2, 1);
+        assert_eq!(dependencies.len(), 1);
+        assert_eq!(dependencies[0].commit_id, commit1_id);
+        assert_eq!(dependencies[0].stack_id, stack1_id);
+        Ok(())
+    }
+}

--- a/crates/gitbutler-repo-actions/src/askpass.rs
+++ b/crates/gitbutler-repo-actions/src/askpass.rs
@@ -14,6 +14,7 @@ static mut GLOBAL_ASKPASS_BROKER: Option<AskpassBroker> = None;
 /// before any other function from this module is called. **Calls to [`get_broker`] before [`init`] will panic.**
 ///
 /// This function is **NOT** thread safe.
+#[allow(static_mut_refs)]
 pub unsafe fn init(submit_prompt: impl Fn(PromptEvent<Context>) + Send + Sync + 'static) {
     GLOBAL_ASKPASS_BROKER.replace(AskpassBroker::init(submit_prompt));
 }
@@ -22,6 +23,7 @@ pub unsafe fn init(submit_prompt: impl Fn(PromptEvent<Context>) + Send + Sync + 
 ///
 /// # Panics
 /// Will panic if [`init`] was not called before this function.
+#[allow(static_mut_refs)]
 pub fn get_broker() -> &'static AskpassBroker {
     unsafe {
         GLOBAL_ASKPASS_BROKER

--- a/crates/gitbutler-repo/src/repository_ext.rs
+++ b/crates/gitbutler-repo/src/repository_ext.rs
@@ -67,9 +67,10 @@ pub trait RepositoryExt {
     /// Returns the computed signature.
     fn sign_buffer(&self, buffer: &[u8]) -> Result<BString>;
 
-    fn checkout_index_builder<'a>(&'a self, index: &'a mut git2::Index) -> CheckoutIndexBuilder;
+    fn checkout_index_builder<'a>(&'a self, index: &'a mut git2::Index)
+        -> CheckoutIndexBuilder<'a>;
     fn checkout_index_path_builder<P: AsRef<Path>>(&self, path: P) -> Result<()>;
-    fn checkout_tree_builder<'a>(&'a self, tree: &'a git2::Tree<'a>) -> CheckoutTreeBuidler;
+    fn checkout_tree_builder<'a>(&'a self, tree: &'a git2::Tree<'a>) -> CheckoutTreeBuidler<'a>;
     fn maybe_find_branch_by_refname(&self, name: &Refname) -> Result<Option<git2::Branch>>;
     /// Based on the index, add all data similar to `git add .` and create a tree from it, which is returned.
     fn create_wd_tree(&self) -> Result<Tree>;
@@ -124,7 +125,10 @@ impl RepositoryExt for git2::Repository {
         Ok(repo)
     }
 
-    fn checkout_index_builder<'a>(&'a self, index: &'a mut git2::Index) -> CheckoutIndexBuilder {
+    fn checkout_index_builder<'a>(
+        &'a self,
+        index: &'a mut git2::Index,
+    ) -> CheckoutIndexBuilder<'a> {
         CheckoutIndexBuilder {
             index,
             repo: self,
@@ -142,7 +146,7 @@ impl RepositoryExt for git2::Repository {
 
         Ok(())
     }
-    fn checkout_tree_builder<'a>(&'a self, tree: &'a git2::Tree<'a>) -> CheckoutTreeBuidler {
+    fn checkout_tree_builder<'a>(&'a self, tree: &'a git2::Tree<'a>) -> CheckoutTreeBuidler<'a> {
         CheckoutTreeBuidler {
             tree,
             repo: self,

--- a/crates/gitbutler-url/src/convert.rs
+++ b/crates/gitbutler-url/src/convert.rs
@@ -19,7 +19,7 @@ pub(crate) fn to_https_url(url: &Url) -> Result<Url, ConvertError> {
             scheme: Scheme::Https,
             user: None,
             serialize_alternative_form: true,
-            path: if url.path.starts_with(&[b'/']) {
+            path: if url.path.starts_with(b"/") {
                 url.path.clone()
             } else {
                 format!("/{}", url.path.to_str().unwrap()).into()
@@ -40,7 +40,7 @@ pub(crate) fn to_ssh_url(url: &Url) -> Result<Url, ConvertError> {
             scheme: Scheme::Ssh,
             user: Some("git".to_string()),
             serialize_alternative_form: true,
-            path: if url.path.starts_with(&[b'/']) {
+            path: if url.path.starts_with(b"/") {
                 url.path.trim_start_with(|c| c == '/').into()
             } else {
                 url.path.clone()

--- a/crates/gitbutler-url/src/parse.rs
+++ b/crates/gitbutler-url/src/parse.rs
@@ -94,7 +94,7 @@ pub fn parse(input: &BStr) -> Result<Url, Error> {
         }
         let input_starts_with_file_protocol = input.starts_with(b"file://");
         if input_starts_with_file_protocol {
-            let wanted = &[b'/'];
+            let wanted = b"/";
             if !wanted.iter().any(|w| path.contains(w)) {
                 return Err(Error::MissingRepositoryPath);
             }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,10 @@
 [toolchain]
-channel = "nightly-2024-07-01"
-components = [ "rustfmt", "rustc-dev", "clippy", "rust-src", "llvm-tools-preview" ]
+channel = "nightly-2024-10-22"
+components = [
+    "rustfmt",
+    "rustc-dev",
+    "clippy",
+    "rust-src",
+    "llvm-tools-preview",
+]
 profile = "minimal"


### PR DESCRIPTION
Adds new crate with code for calculating dependencies between workspace changes and workspace commits. What we ultimately want to understand is: given an uncommitted change, do the old line numbers intersect with anything committed in the workspace?

The problem we have to overcome is that we the workspace changes are produced by diffing the working directory against the workspace commit. It means changes from one stack can offset line numbers in changes from a different stack. The most intuitive way of checking if they touch the same lines is to use regular git blame, but it suffers from two problems, 1) speed and 2) lack of --reverse flag in git2. The latter means we can't detect intersections with deleted lines.

If we don't calculate these dependencies correctly it means a user might be able to move a hunk into a stack where it cannot be committed. So the solution here is that we build up the same information we would get from blame by adding diffs together.

Follow-up PR for integration this code: https://github.com/gitbutlerapp/gitbutler/pull/5252