### PR TITLE
fix - stack / requires force

### DIFF
--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -236,6 +236,9 @@ pub(crate) fn stack_series(
             }
         }
         upstream_patches.reverse();
+        if !upstream_patches.is_empty() {
+            requires_force = true;
+        }
         api_series.push(PatchSeries {
             name: series.head.name,
             description: series.head.description,


### PR DESCRIPTION
Toggle on 'requires force push' if there are upstream only patches (so that they can be overriden)