### PR TITLE
Series UI: update copy to speak about branches

### DIFF
--- a/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
@@ -221,10 +221,10 @@
 		<div class="branch-emptystate">
 			<EmptyStatePlaceholder bottomMargin={10}>
 				{#snippet title()}
-					This is an empty series
+					This is an empty branch
 				{/snippet}
 				{#snippet caption()}
-					All your commits will land here
+					Create or drag and drop commits here
 				{/snippet}
 			</EmptyStatePlaceholder>
 		</div>

--- a/apps/desktop/src/lib/branch/StackingSeriesHeaderContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeaderContextMenu.svelte
@@ -73,7 +73,7 @@
 		/>
 		{#if $aiGenEnabled && aiConfigurationValid && !disableTitleEdit}
 			<ContextMenuItem
-				label="Generate series name"
+				label="Generate branch name"
 				onclick={() => {
 					onGenerateBranchName();
 					contextMenuEl?.close();
@@ -121,7 +121,7 @@
 
 <Modal
 	width="small"
-	title="Rename series"
+	title="Rename branch"
 	bind:this={renameSeriesModal}
 	onSubmit={(close) => {
 		if (newHeadName && newHeadName !== headName) {
@@ -140,7 +140,7 @@
 
 <Modal
 	width="small"
-	title="Delete series"
+	title="Delete branch"
 	bind:this={deleteSeriesModal}
 	onSubmit={async (close) => {
 		try {


### PR DESCRIPTION
At least for now, its more familiar terminology

Also update the empty state copy:
Before:
<img width="503" alt="image" src="https://github.com/user-attachments/assets/a67955f7-2252-4bce-9d57-e0c9c30c93b4">

After:
<img width="464" alt="image" src="https://github.com/user-attachments/assets/009ade9e-5e60-492c-9d02-8768edfb8d2c">
