### PR TITLE
Refactor the "PR template path" fetch logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2340,6 +2340,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gitbutler-forge"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "gitbutler-fs",
+ "serde",
+]
+
+[[package]]
 name = "gitbutler-fs"
 version = "0.0.0"
 dependencies = [
@@ -2464,6 +2473,7 @@ dependencies = [
  "fslock",
  "git2",
  "gitbutler-error",
+ "gitbutler-forge",
  "gitbutler-id",
  "gitbutler-serde",
  "gitbutler-storage",
@@ -2648,6 +2658,7 @@ dependencies = [
  "gitbutler-edit-mode",
  "gitbutler-error",
  "gitbutler-feedback",
+ "gitbutler-forge",
  "gitbutler-fs",
  "gitbutler-id",
  "gitbutler-operating-modes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ gitbutler-oxidize = { path = "crates/gitbutler-oxidize" }
 gitbutler-stack-api = { path = "crates/gitbutler-stack-api" }
 gitbutler-stack = { path = "crates/gitbutler-stack" }
 gitbutler-patch-reference = { path = "crates/gitbutler-patch-reference" }
+gitbutler-forge = { path = "crates/gitbutler-forge" }
 
 [profile.release]
 codegen-units = 1 # Compile crates one after another so the compiler can optimize better

--- a/apps/desktop/src/lib/backend/forge.ts
+++ b/apps/desktop/src/lib/backend/forge.ts
@@ -1,0 +1,15 @@
+import { invoke } from './ipc';
+
+export type ForgeType = 'github' | 'gitlab' | 'bitbucket' | 'azure';
+
+export class ForgeService {
+	constructor(private projectId: string) {}
+
+	async getAvailableReviewTemplates(): Promise<string[]> {
+		const templates = await invoke<string[]>('get_available_review_templates', {
+			projectId: this.projectId
+		});
+
+		return templates;
+	}
+}

--- a/apps/desktop/src/lib/gitHost/azure/azure.ts
+++ b/apps/desktop/src/lib/gitHost/azure/azure.ts
@@ -1,4 +1,5 @@
 import { AzureBranch } from './azureBranch';
+import type { ForgeType } from '$lib/backend/forge';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import type { GitHost } from '../interface/gitHost';
 import type { GitHostArguments } from '../interface/types';
@@ -12,6 +13,7 @@ export const AZURE_DOMAIN = 'dev.azure.com';
  * https://github.com/gitbutlerapp/gitbutler/issues/2651
  */
 export class AzureDevOps implements GitHost {
+	readonly type: ForgeType = 'azure';
 	private baseUrl: string;
 	private repo: RepoInfo;
 	private baseBranch: string;
@@ -45,11 +47,6 @@ export class AzureDevOps implements GitHost {
 	}
 
 	checksMonitor(_sourceBranch: string) {
-		return undefined;
-	}
-
-	async availablePullRequestTemplates(_path?: string) {
-		// See: https://learn.microsoft.com/en-us/azure/devops/repos/git/pull-request-templates?view=azure-devops#default-pull-request-templates
 		return undefined;
 	}
 

--- a/apps/desktop/src/lib/gitHost/bitbucket/bitbucket.ts
+++ b/apps/desktop/src/lib/gitHost/bitbucket/bitbucket.ts
@@ -1,4 +1,5 @@
 import { BitBucketBranch } from './bitbucketBranch';
+import type { ForgeType } from '$lib/backend/forge';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import type { GitHost } from '../interface/gitHost';
 import type { DetailedPullRequest, GitHostArguments } from '../interface/types';
@@ -16,6 +17,7 @@ export const BITBUCKET_DOMAIN = 'bitbucket.org';
  * https://github.com/gitbutlerapp/gitbutler/issues/3252
  */
 export class BitBucket implements GitHost {
+	readonly type: ForgeType = 'bitbucket';
 	private baseUrl: string;
 	private repo: RepoInfo;
 	private baseBranch: string;
@@ -49,11 +51,6 @@ export class BitBucket implements GitHost {
 	}
 
 	checksMonitor(_sourceBranch: string) {
-		return undefined;
-	}
-
-	async availablePullRequestTemplates(_path?: string) {
-		// See: https://confluence.atlassian.com/bitbucketserver/create-a-pull-request-808488431.html#Createapullrequest-templatePullrequestdescriptiontemplates
 		return undefined;
 	}
 

--- a/apps/desktop/src/lib/gitHost/github/github.ts
+++ b/apps/desktop/src/lib/gitHost/github/github.ts
@@ -4,6 +4,7 @@ import { GitHubListingService } from './githubListingService';
 import { GitHubPrService } from './githubPrService';
 import { GitHubIssueService } from '$lib/gitHost/github/issueService';
 import { Octokit } from '@octokit/rest';
+import type { ForgeType } from '$lib/backend/forge';
 import type { ProjectMetrics } from '$lib/metrics/projectMetrics';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import type { GitHost } from '../interface/gitHost';
@@ -12,6 +13,7 @@ import type { GitHostArguments } from '../interface/types';
 export const GITHUB_DOMAIN = 'github.com';
 
 export class GitHub implements GitHost {
+	readonly type: ForgeType = 'github';
 	private baseUrl: string;
 	private repo: RepoInfo;
 	private baseBranch: string;

--- a/apps/desktop/src/lib/gitHost/github/githubPrService.ts
+++ b/apps/desktop/src/lib/gitHost/github/githubPrService.ts
@@ -107,18 +107,4 @@ export class GitHubPrService implements GitHostPrService {
 			});
 		}
 	}
-
-	async availablePullRequestTemplates(path: string): Promise<string[] | undefined> {
-		// TODO: Find a workaround to avoid this dynamic import
-		// https://github.com/sveltejs/kit/issues/905
-		const { join } = await import('@tauri-apps/api/path');
-		const targetPath = await join(path, '.github');
-
-		const availableTemplates: string[] | undefined = await invoke(
-			'available_pull_request_templates',
-			{ rootPath: targetPath }
-		);
-
-		return availableTemplates;
-	}
 }

--- a/apps/desktop/src/lib/gitHost/gitlab/gitlab.ts
+++ b/apps/desktop/src/lib/gitHost/gitlab/gitlab.ts
@@ -1,4 +1,5 @@
 import { GitLabBranch } from './gitlabBranch';
+import type { ForgeType } from '$lib/backend/forge';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import type { GitHost } from '../interface/gitHost';
 import type { DetailedPullRequest, GitHostArguments } from '../interface/types';
@@ -17,6 +18,7 @@ export const GITLAB_SUB_DOMAIN = 'gitlab'; // For self hosted instance of Gitlab
  * https://github.com/gitbutlerapp/gitbutler/issues/2511
  */
 export class GitLab implements GitHost {
+	readonly type: ForgeType = 'gitlab';
 	private baseUrl: string;
 	private repo: RepoInfo;
 	private baseBranch: string;
@@ -50,11 +52,6 @@ export class GitLab implements GitHost {
 	}
 
 	checksMonitor(_sourceBranch: string) {
-		return undefined;
-	}
-
-	async availablePullRequestTemplates(_path?: string) {
-		// See: https://docs.gitlab.com/ee/user/project/description_templates.html
 		return undefined;
 	}
 

--- a/apps/desktop/src/lib/gitHost/interface/gitHost.ts
+++ b/apps/desktop/src/lib/gitHost/interface/gitHost.ts
@@ -1,4 +1,5 @@
 import { buildContextStore } from '@gitbutler/shared/context';
+import type { ForgeType } from '$lib/backend/forge';
 import type { GitHostIssueService } from '$lib/gitHost/interface/gitHostIssueService';
 import type { GitHostBranch } from './gitHostBranch';
 import type { GitHostChecksMonitor } from './gitHostChecksMonitor';
@@ -6,6 +7,7 @@ import type { GitHostListingService } from './gitHostListingService';
 import type { GitHostPrService } from './gitHostPrService';
 
 export interface GitHost {
+	readonly type: ForgeType;
 	// Lists PRs for the repo.
 	listService(): GitHostListingService | undefined;
 

--- a/apps/desktop/src/lib/gitHost/interface/gitHostPrService.ts
+++ b/apps/desktop/src/lib/gitHost/interface/gitHostPrService.ts
@@ -17,7 +17,6 @@ export interface GitHostPrService {
 		baseBranchName,
 		upstreamName
 	}: CreatePullRequestArgs): Promise<PullRequest>;
-	availablePullRequestTemplates(path: string): Promise<string[] | undefined>;
 	pullRequestTemplateContent(path: string, projectId: string): Promise<string | undefined>;
 	merge(method: MergeMethod, prNumber: number): Promise<void>;
 	prMonitor(prNumber: number): GitHostPrMonitor;

--- a/apps/desktop/src/lib/pr/PrDetailsModal.svelte
+++ b/apps/desktop/src/lib/pr/PrDetailsModal.svelte
@@ -82,7 +82,7 @@
 		props.type === 'preview-series' ? props.upstreamName : branch.upstreamName
 	);
 	const baseBranchName = $derived($baseBranch.shortName);
-	const prTemplatePath = $derived(project.git_host.pullRequestTemplatePath);
+	const prTemplatePath = $derived(project.git_host.reviewTemplatePath);
 	let isDraft = $state<boolean>($preferredPRAction === PRAction.CreateDraft);
 
 	let modal = $state<ReturnType<typeof Modal>>();

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { ForgeService } from '$lib/backend/forge';
 	import { Project, ProjectService } from '$lib/backend/projects';
 	import FileMenuAction from '$lib/barmenuActions/FileMenuAction.svelte';
 	import ProjectSettingsMenuAction from '$lib/barmenuActions/ProjectSettingsMenuAction.svelte';
@@ -71,6 +72,7 @@
 		setContext(BranchController, data.branchController);
 		setContext(BaseBranchService, data.baseBranchService);
 		setContext(CommitService, data.commitService);
+		setContext(ForgeService, data.forgeService);
 		setContext(BaseBranch, baseBranch);
 		setContext(Project, project);
 		setContext(BranchDragActionsFactory, data.branchDragActionsFactory);
@@ -145,6 +147,8 @@
 				: undefined;
 
 		const ghListService = gitHost?.listService();
+
+		if (gitHost) projectsService.setGitHostType(project, gitHost.type);
 
 		listServiceStore.set(ghListService);
 		gitHostStore.set(gitHost);

--- a/apps/desktop/src/routes/[projectId]/+layout.ts
+++ b/apps/desktop/src/routes/[projectId]/+layout.ts
@@ -1,3 +1,4 @@
+import { ForgeService } from '$lib/backend/forge';
 import { getUserErrorCode, invoke } from '$lib/backend/ipc';
 import { ProjectService, type Project } from '$lib/backend/projects';
 import { BaseBranchService } from '$lib/baseBranch/baseBranchService';
@@ -61,6 +62,7 @@ export const load: LayoutLoad = async ({ params, parent }) => {
 	const historyService = new HistoryService(projectId);
 	const baseBranchService = new BaseBranchService(projectId);
 	const commitService = new CommitService(projectId);
+	const forgeService = new ForgeService(projectId);
 
 	const branchListingService = new BranchListingService(projectId);
 	const remoteBranchService = new RemoteBranchService(
@@ -108,6 +110,7 @@ export const load: LayoutLoad = async ({ params, parent }) => {
 		authService,
 		baseBranchService,
 		commitService,
+		forgeService,
 		branchController,
 		historyService,
 		projectId,

--- a/crates/gitbutler-forge/Cargo.toml
+++ b/crates/gitbutler-forge/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "gitbutler-forge"
+version = "0.0.0"
+edition = "2021"
+authors = ["GitButler <gitbutler@gitbutler.com>"]
+publish = false
+
+[dependencies]
+serde = { workspace = true, features = ["std"] }
+anyhow = "1.0.86"
+gitbutler-fs.workspace = true

--- a/crates/gitbutler-forge/src/forge.rs
+++ b/crates/gitbutler-forge/src/forge.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[serde(tag = "type", rename_all = "lowercase")]
+/// Supported git forge types
+pub enum ForgeType {
+    GitHub,
+    GitLab,
+    Bitbucket,
+    Azure,
+}

--- a/crates/gitbutler-forge/src/lib.rs
+++ b/crates/gitbutler-forge/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod forge;
+pub mod review;

--- a/crates/gitbutler-forge/src/review.rs
+++ b/crates/gitbutler-forge/src/review.rs
@@ -1,0 +1,103 @@
+use std::path;
+
+use gitbutler_fs::list_files;
+
+use crate::forge::ForgeType;
+
+/// Get a list of available review template paths for a project
+///
+/// The paths are relative to the root path
+pub fn available_review_templates(root_path: &path::Path, forge_type: &ForgeType) -> Vec<String> {
+    let (is_review_template, get_root) = match forge_type {
+        ForgeType::GitHub => (
+            is_review_template_github as fn(&str) -> bool,
+            get_github_directory_path as fn(&path::Path) -> path::PathBuf,
+        ),
+        ForgeType::GitLab => (
+            is_review_template_gitlab as fn(&str) -> bool,
+            get_gitlab_directory_path as fn(&path::Path) -> path::PathBuf,
+        ),
+        ForgeType::Bitbucket => (
+            is_review_template_bitbucket as fn(&str) -> bool,
+            get_bitbucket_directory_path as fn(&path::Path) -> path::PathBuf,
+        ),
+        ForgeType::Azure => (
+            is_review_template_azure as fn(&str) -> bool,
+            get_azure_directory_path as fn(&path::Path) -> path::PathBuf,
+        ),
+    };
+
+    let forge_root_path = get_root(root_path);
+    let forge_root_path = forge_root_path.as_path();
+
+    let walked_paths = list_files(forge_root_path, &[forge_root_path]).unwrap_or_default();
+
+    let mut available_paths = Vec::new();
+    for entry in walked_paths {
+        let path_entry = entry.as_path();
+        let path_str = path_entry.to_string_lossy();
+
+        if is_review_template(&path_str) {
+            if let Ok(template_path) = forge_root_path.join(path_entry).strip_prefix(root_path) {
+                available_paths.push(template_path.to_string_lossy().to_string());
+            }
+        }
+    }
+
+    available_paths
+}
+
+fn get_github_directory_path(root_path: &path::Path) -> path::PathBuf {
+    let mut path = root_path.to_path_buf();
+    path.push(".github");
+    path
+}
+
+fn is_review_template_github(path_str: &str) -> bool {
+    path_str == "PULL_REQUEST_TEMPLATE.md"
+        || path_str == "pull_request_template.md"
+        || path_str.contains("PULL_REQUEST_TEMPLATE/")
+}
+
+fn get_gitlab_directory_path(root_path: &path::Path) -> path::PathBuf {
+    // TODO: implement
+    root_path.to_path_buf()
+}
+
+fn is_review_template_gitlab(_path_str: &str) -> bool {
+    // TODO: implement
+    false
+}
+
+fn get_bitbucket_directory_path(root_path: &path::Path) -> path::PathBuf {
+    // TODO: implement
+    root_path.to_path_buf()
+}
+
+fn is_review_template_bitbucket(_path_str: &str) -> bool {
+    // TODO: implement
+    false
+}
+
+fn get_azure_directory_path(root_path: &path::Path) -> path::PathBuf {
+    // TODO: implement
+    root_path.to_path_buf()
+}
+
+fn is_review_template_azure(_path_str: &str) -> bool {
+    // TODO: implement
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_review_template_github() {
+        assert!(is_review_template_github("PULL_REQUEST_TEMPLATE.md"));
+        assert!(is_review_template_github("pull_request_template.md"));
+        assert!(is_review_template_github("PULL_REQUEST_TEMPLATE/"));
+        assert!(!is_review_template_github("README.md"));
+    }
+}

--- a/crates/gitbutler-project/Cargo.toml
+++ b/crates/gitbutler-project/Cargo.toml
@@ -14,6 +14,7 @@ gitbutler-error.workspace = true
 gitbutler-serde.workspace = true
 gitbutler-id.workspace = true
 gitbutler-storage.workspace = true
+gitbutler-forge.workspace = true
 git2.workspace = true
 gix = { workspace = true, features = ["dirwalk", "credentials", "parallel"] }
 uuid.workspace = true

--- a/crates/gitbutler-project/src/project.rs
+++ b/crates/gitbutler-project/src/project.rs
@@ -1,8 +1,9 @@
 use std::{
-    path::{self, PathBuf},
+    path::{self, Path, PathBuf},
     time,
 };
 
+use gitbutler_forge::{forge::ForgeType, review::available_review_templates};
 use gitbutler_id::id::Id;
 use serde::{Deserialize, Serialize};
 
@@ -102,9 +103,21 @@ pub struct Project {
 #[serde(rename_all = "camelCase")]
 pub struct GitHostSettings {
     #[serde(default)]
-    pub host_type: Option<String>,
+    pub host_type: Option<ForgeType>,
     #[serde(default)]
-    pub pull_request_template_path: Option<String>,
+    pub review_template_path: Option<String>,
+}
+
+impl GitHostSettings {
+    pub fn init(&mut self, project_path: &Path) {
+        if let Some(forge_type) = &self.host_type {
+            if self.review_template_path.is_none() {
+                self.review_template_path = available_review_templates(project_path, forge_type)
+                    .first()
+                    .cloned();
+            }
+        }
+    }
 }
 
 impl Project {

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -73,6 +73,7 @@ gitbutler-diff.workspace = true
 gitbutler-operating-modes.workspace = true
 gitbutler-edit-mode.workspace = true
 gitbutler-sync.workspace = true
+gitbutler-forge.workspace = true
 open = "5"
 url = "2.5.2"
 

--- a/crates/gitbutler-tauri/src/forge.rs
+++ b/crates/gitbutler-tauri/src/forge.rs
@@ -1,0 +1,24 @@
+pub mod commands {
+    use gitbutler_forge::review::available_review_templates;
+    use gitbutler_project::{Controller, ProjectId};
+    use tauri::State;
+    use tracing::instrument;
+
+    use crate::error::Error;
+
+    #[tauri::command(async)]
+    #[instrument(skip(projects), err(Debug))]
+    pub fn get_available_review_templates(
+        projects: State<'_, Controller>,
+        project_id: ProjectId,
+    ) -> Result<Vec<String>, Error> {
+        let project = projects.get_validated(project_id)?;
+        let root_path = &project.path;
+        let forge_type = project.git_host.host_type;
+
+        let review_templates = forge_type
+            .map(|forge_type| available_review_templates(root_path, &forge_type))
+            .unwrap_or_default();
+        Ok(review_templates)
+    }
+}

--- a/crates/gitbutler-tauri/src/github.rs
+++ b/crates/gitbutler-tauri/src/github.rs
@@ -1,8 +1,7 @@
 pub mod commands {
-    use std::{collections::HashMap, path};
+    use std::collections::HashMap;
 
     use anyhow::{Context, Result};
-    use gitbutler_fs::list_files;
     use serde::{Deserialize, Serialize};
     use tracing::instrument;
 
@@ -79,29 +78,5 @@ pub mod commands {
             .map(|rsp_body| rsp_body.access_token)
             .context("Failed to parse response body")
             .map_err(Into::into)
-    }
-
-    #[tauri::command(async)]
-    #[instrument]
-    pub fn available_pull_request_templates(root_path: &path::Path) -> Result<Vec<String>, Error> {
-        let walked_paths = list_files(root_path, &[root_path])?;
-
-        let mut available_paths = Vec::new();
-        for entry in walked_paths {
-            let path_entry = entry.as_path();
-            let path_str = path_entry.to_string_lossy();
-            // TODO: Refactor these paths out in the future to something like a common
-            // gitHosts.pullRequestTemplatePaths map, an entry for each gitHost type and
-            // their valid files / directories. So that this 'get_available_templates'
-            // can be more generic and we can add / modify paths more easily for all supported githost types
-            if path_str == "PULL_REQUEST_TEMPLATE.md"
-                || path_str == "pull_request_template.md"
-                || path_str.contains("PULL_REQUEST_TEMPLATE/")
-            {
-                available_paths.push(root_path.join(path_entry).to_string_lossy().to_string());
-            }
-        }
-
-        Ok(available_paths)
     }
 }

--- a/crates/gitbutler-tauri/src/lib.rs
+++ b/crates/gitbutler-tauri/src/lib.rs
@@ -24,6 +24,7 @@ pub use window::state::WindowState;
 pub mod askpass;
 pub mod config;
 pub mod error;
+pub mod forge;
 pub mod github;
 pub mod modes;
 pub mod open;

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -12,8 +12,8 @@
 )]
 
 use gitbutler_tauri::{
-    askpass, commands, config, github, logs, menu, modes, open, projects, remotes, repo, secret,
-    stack, undo, users, virtual_branches, zip, App, WindowState,
+    askpass, commands, config, forge, github, logs, menu, modes, open, projects, remotes, repo,
+    secret, stack, undo, users, virtual_branches, zip, App, WindowState,
 };
 use tauri::{generate_context, Manager};
 use tauri_plugin_log::LogTarget;
@@ -146,6 +146,7 @@ fn main() {
                     projects::commands::list_projects,
                     projects::commands::set_project_active,
                     projects::commands::open_project_in_window,
+                    projects::commands::update_project_git_host,
                     repo::commands::git_get_local_config,
                     repo::commands::git_set_local_config,
                     repo::commands::check_signing_settings,
@@ -207,7 +208,6 @@ fn main() {
                     menu::get_editor_link_scheme,
                     github::commands::init_device_oauth,
                     github::commands::check_auth_status,
-                    github::commands::available_pull_request_templates,
                     askpass::commands::submit_prompt_response,
                     remotes::list_remotes,
                     remotes::add_remote,
@@ -216,7 +216,8 @@ fn main() {
                     modes::save_edit_and_return_to_workspace,
                     modes::abort_edit_and_return_to_workspace,
                     modes::edit_initial_index_state,
-                    open::open_url
+                    open::open_url,
+                    forge::commands::get_available_review_templates,
                 ])
                 .menu(menu::build(tauri_context.package_info()))
                 .on_menu_event(|event| menu::handle_event(&event))


### PR DESCRIPTION
This pull request moves the logic for fetching PR template paths out of the main application and into a centralized crate called `gitbulter-forge`. This allows the PR template functionality to be provider-agnostic, making it easier to support different git hosting platforms in the future.

The key changes include:
1. Moved the logic for fetching PR templates from the main application into the `gitbulter-forge` crate.
2. The FE sets the type of git forge in the Rust-end, and the Rust end picks a default PR template if found.

By default, the PR template will be used, unless the user explicitly disables that