### PR TITLE
fix: calculating dropzone distance when commitIndex 0

### DIFF
--- a/apps/desktop/src/lib/dragging/reorderDropzoneManager.ts
+++ b/apps/desktop/src/lib/dragging/reorderDropzoneManager.ts
@@ -105,7 +105,7 @@ class Entry {
 	 */
 	distanceToOtherCommit(commitId: string) {
 		const commitIndex = this.commitIndex(commitId);
-		if (!commitIndex) return 0;
+		if (commitIndex === undefined) return 0;
 
 		const offset = this.index - commitIndex;
 


### PR DESCRIPTION
## ☕️ Reasoning

- When calculating distance from `commitIndex: 0` we'd early return accidentally, causing the top commit to not be able to be reordered downward at all

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
