### PR TITLE
fix: status icon line on series header

### DIFF
--- a/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
@@ -28,9 +28,10 @@
 
 	interface Props {
 		currentSeries: PatchSeries;
+		isTopSeries: boolean;
 	}
 
-	const { currentSeries }: Props = $props();
+	const { currentSeries, isTopSeries }: Props = $props();
 
 	let descriptionVisible = $state(false);
 
@@ -137,7 +138,7 @@
 
 	<div class="branch-info">
 		<StackingStatusIcon
-			lineTop={false}
+			lineTop={isTopSeries ? false : true}
 			icon={branchType === 'integrated' ? 'tick-small' : 'remote-branch-small'}
 			iconColor="#fff"
 			color={lineColor}

--- a/apps/desktop/src/lib/stack/StackSeries.svelte
+++ b/apps/desktop/src/lib/stack/StackSeries.svelte
@@ -28,11 +28,12 @@
 </script>
 
 {#each branch.series as currentSeries, idx (currentSeries.name)}
-	{#if idx !== 0}
+	{@const isTopSeries = idx === 0}
+	{#if !isTopSeries}
 		<StackSeriesDividerLine {currentSeries} />
 	{/if}
 	<div class="branch-group">
-		<StackingSeriesHeader {currentSeries} />
+		<StackingSeriesHeader {currentSeries} {isTopSeries} />
 		{#if currentSeries.upstreamPatches.length > 0 || currentSeries.patches.length > 0}
 			<StackingCommitList
 				remoteOnlyPatches={currentSeries.upstreamPatches}


### PR DESCRIPTION
## ☕️ Reasoning

- Series header status icon was missing anchor line in certain cases

## 🧢 Changes

![image](https://github.com/user-attachments/assets/943b0ece-f182-49d8-b81f-2d8dd3cad2ea)


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
