### PR TITLE
small-fix: Remove extra quote in add series modal

### DIFF
--- a/apps/desktop/src/lib/branch/StackingAddSeriesButton.svelte
+++ b/apps/desktop/src/lib/branch/StackingAddSeriesButton.svelte
@@ -57,7 +57,7 @@
 			id="newRemoteName"
 			bind:value={createRefName}
 			focus
-			helperText={generatedNameDiverges ? `Will be created as '${slugifiedRefName}''` : undefined}
+			helperText={generatedNameDiverges ? `Will be created as '${slugifiedRefName}'` : undefined}
 		/>
 
 		<p class="text-12 text-body helper-text">


### PR DESCRIPTION
Minor issue in the add series modal where there was an extra quote

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
