### PR TITLE
UI fix default editor select

### DIFF
--- a/apps/desktop/src/lib/select/Select.svelte
+++ b/apps/desktop/src/lib/select/Select.svelte
@@ -219,6 +219,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: 6px;
+		height: fit-content;
 	}
 
 	.select__label {

--- a/apps/desktop/src/routes/settings/appearance/+page.svelte
+++ b/apps/desktop/src/routes/settings/appearance/+page.svelte
@@ -75,9 +75,8 @@
 		<svelte:fragment slot="title">Theme</svelte:fragment>
 		<ThemeSelector {userSettings} />
 	</SectionCard>
-	<SectionCard labelFor="defaultCodeEditor" orientation="row">
-		<svelte:fragment slot="title">Default Code Editor</svelte:fragment>
-		<svelte:fragment slot="caption">Select your preferred default code editor.</svelte:fragment>
+	<SectionCard orientation="row" centerAlign>
+		<svelte:fragment slot="title">Default code editor</svelte:fragment>
 		<svelte:fragment slot="actions">
 			<Select
 				value={$userSettings.defaultCodeEditor.schemeIdentifer}


### PR DESCRIPTION
## ☕️ Reasoning

- there was a large gap between elements in some cases

![image](https://github.com/user-attachments/assets/06774605-93dd-4875-bc8a-43b1ccaf8536)

- removed the copy that basically duplicate the title


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
