### PR TITLE
Double click to edit branch name

### DIFF
--- a/apps/desktop/src/lib/branch/BranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/BranchHeader.svelte
@@ -45,6 +45,7 @@
 	const patchStack = $derived(cloudPatchStacksService.patchStackForBranchId(branch.id));
 	const showCreatePatchStack = $derived($patchStack.state === 'not-found');
 
+	let branchNameComponent = $state<ReturnType<typeof BranchLabel>>();
 	let contextMenu = $state<ReturnType<typeof ContextMenu>>();
 	let prDetailsModal = $state<ReturnType<typeof PrDetailsModal>>();
 	let meatballButtonEl = $state<HTMLDivElement>();
@@ -140,7 +141,11 @@
 				</div>
 
 				<div class="header__info">
-					<BranchLabel name={branch.name} onChange={(name) => handleBranchNameChange(name)} />
+					<BranchLabel
+						bind:this={branchNameComponent}
+						name={branch.name}
+						onChange={(name) => handleBranchNameChange(name)}
+					/>
 					<div class="header__remote-branch">
 						<ActiveBranchStatus
 							{hasIntegratedCommits}
@@ -211,6 +216,9 @@
 							target={meatballButtonEl}
 							onCollapse={collapseLane}
 							{onGenerateBranchName}
+							onRenameLane={() => {
+								branchNameComponent?.focusInput();
+							}}
 							hasPr={!!$pr}
 							openPrDetailsModal={handleOpenPR}
 							reloadPR={handleReloadPR}

--- a/apps/desktop/src/lib/branch/BranchLabel.svelte
+++ b/apps/desktop/src/lib/branch/BranchLabel.svelte
@@ -5,9 +5,10 @@
 		name: string;
 		disabled?: boolean;
 		onChange?: (value: string) => void;
+		onBlur?: () => void;
 	}
 
-	let { name, disabled = false, onChange }: Props = $props();
+	let { name, disabled = false, onChange, onBlur }: Props = $props();
 
 	let inputEl: HTMLInputElement | undefined = $state();
 	let labelEl: HTMLSpanElement | undefined = $state();
@@ -15,7 +16,7 @@
 	let inputVisible = $state(false);
 	let inputWidth = $state('');
 
-	function handleFocusInput() {
+	export function focusInput() {
 		if (disabled) return;
 		inputVisible = true;
 		setTimeout(() => {
@@ -26,6 +27,7 @@
 	function handleBlurInput() {
 		if (name === '') name = initialName;
 		inputVisible = false;
+		onBlur?.();
 		setTimeout(() => {
 			labelEl?.focus();
 		});
@@ -48,10 +50,10 @@
 			tabindex={disabled ? undefined : 0}
 			class="branch-name-label text-14 text-bold"
 			class:disabled
-			ondblclick={handleFocusInput}
+			ondblclick={focusInput}
 			onkeydown={(e) => {
 				if (e.key === 'Enter') {
-					handleFocusInput();
+					focusInput();
 				}
 			}}
 		>
@@ -94,13 +96,8 @@
 		white-space: nowrap;
 		overflow: hidden;
 
-		/* &:hover,
-		&:focus {
-			background-color: var(--clr-bg-2);
-		} */
-
 		&:not(.disabled):hover,
-		&:not(.disabled):focus {
+		&:not(.disabled):focus-visible {
 			background-color: var(--clr-bg-2);
 		}
 	}

--- a/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
@@ -22,6 +22,7 @@
 		target?: HTMLElement;
 		onCollapse: () => void;
 		onGenerateBranchName?: () => void;
+		onRenameLane?: () => void;
 		openPrDetailsModal?: () => void;
 		reloadPR?: () => void;
 	}
@@ -31,6 +32,7 @@
 		target,
 		onCollapse,
 		onGenerateBranchName,
+		onRenameLane,
 		hasPr,
 		openPrDetailsModal,
 		reloadPR
@@ -95,6 +97,13 @@
 			label="Collapse lane"
 			onclick={() => {
 				onCollapse();
+				contextMenuEl?.close();
+			}}
+		/>
+		<ContextMenuItem
+			label="Rename lane"
+			onclick={() => {
+				onRenameLane?.();
 				contextMenuEl?.close();
 			}}
 		/>

--- a/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
@@ -50,6 +50,7 @@
 	const gitHostBranch = $derived(upstreamName ? $gitHost?.branch(upstreamName) : undefined);
 	const branch = $derived($branchStore);
 
+	let branchNameEl = $state<ReturnType<typeof BranchLabel>>();
 	let contextMenu = $state<ReturnType<typeof ContextMenu>>();
 	let prDetailsModal = $state<ReturnType<typeof PrDetailsModal>>();
 	let meatballButtonEl = $state<HTMLDivElement>();
@@ -127,8 +128,6 @@
 			branchController.updateSeriesName(branch.id, currentSeries.name, slugify(message));
 		}
 	}
-
-	console.log('$baseBranch.remoteName', $baseBranch.remoteName);
 </script>
 
 <div class="branch-header">
@@ -153,6 +152,7 @@
 				</span>
 			{/if}
 			<BranchLabel
+				bind:this={branchNameEl}
 				name={currentSeries.name}
 				onChange={(name) => editTitle(name)}
 				disabled={!!gitHostBranch}
@@ -188,6 +188,7 @@
 				seriesCount={branch.series?.length ?? 0}
 				{addDescription}
 				onGenerateBranchName={generateBranchName}
+				onRenameBranch={() => branchNameEl?.focusInput()}
 				disableTitleEdit={!!gitHostBranch}
 				hasPr={!!$pr}
 				openPrDetailsModal={handleOpenPR}

--- a/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
@@ -127,6 +127,8 @@
 			branchController.updateSeriesName(branch.id, currentSeries.name, slugify(message));
 		}
 	}
+
+	console.log('$baseBranch.remoteName', $baseBranch.remoteName);
 </script>
 
 <div class="branch-header">
@@ -145,9 +147,11 @@
 			lineBottom={currentSeries.patches.length > 0}
 		/>
 		<div class="text-14 text-bold branch-info__name">
-			<span class:no-upstream={!gitHostBranch} class="remote-name">
-				{$baseBranch.remoteName ? `${$baseBranch.remoteName} /` : 'origin /'}
-			</span>
+			{#if gitHostBranch}
+				<span class="remote-name">
+					{$baseBranch.remoteName ? `${$baseBranch.remoteName} /` : 'origin /'}
+				</span>
+			{/if}
 			<BranchLabel
 				name={currentSeries.name}
 				onChange={(name) => editTitle(name)}
@@ -276,6 +280,7 @@
 			display: flex;
 			align-items: center;
 			justify-content: flex-start;
+			overflow: hidden;
 			min-width: 0;
 			flex-grow: 1;
 		}
@@ -287,18 +292,6 @@
 		.remote-name {
 			min-width: max-content;
 			color: var(--clr-scale-ntrl-60);
-
-			&.no-upstream {
-				/**
-				 * Element is requird to still be there, so we can use
-				 * it to wiggle 5px to the left to align the BranchLabel
-				 * Input/Label component.
-				 */
-				visibility: hidden;
-				max-width: 0px;
-				max-height: 0px;
-				margin-right: -5px;
-			}
 		}
 	}
 

--- a/apps/desktop/src/lib/branch/StackingSeriesHeaderContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeaderContextMenu.svelte
@@ -65,14 +65,6 @@
 
 <ContextMenu bind:this={contextMenuEl} {target}>
 	<ContextMenuSection>
-		<ContextMenuItem
-			disabled
-			label="Add description"
-			onclick={() => {
-				addDescription();
-				contextMenuEl?.close();
-			}}
-		/>
 		{#if $aiGenEnabled && aiConfigurationValid && !disableTitleEdit}
 			<ContextMenuItem
 				label="Rename branch"
@@ -89,6 +81,14 @@
 				}}
 			/>
 		{/if}
+		<ContextMenuItem
+			disabled
+			label="Add description"
+			onclick={() => {
+				addDescription();
+				contextMenuEl?.close();
+			}}
+		/>
 		{#if !disableTitleEdit}
 			<ContextMenuItem
 				label="Rename"

--- a/apps/desktop/src/lib/branch/StackingSeriesHeaderContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeaderContextMenu.svelte
@@ -21,6 +21,7 @@
 		hasPr: boolean;
 		addDescription: () => void;
 		onGenerateBranchName: () => void;
+		onRenameBranch: () => void;
 		openPrDetailsModal: () => void;
 		reloadPR: () => void;
 	}
@@ -35,6 +36,7 @@
 		addDescription,
 		onGenerateBranchName,
 		openPrDetailsModal,
+		onRenameBranch,
 		reloadPR
 	}: Props = $props();
 
@@ -72,6 +74,13 @@
 			}}
 		/>
 		{#if $aiGenEnabled && aiConfigurationValid && !disableTitleEdit}
+			<ContextMenuItem
+				label="Rename branch"
+				onclick={() => {
+					onRenameBranch?.();
+					contextMenuEl?.close();
+				}}
+			/>
 			<ContextMenuItem
 				label="Generate branch name"
 				onclick={() => {

--- a/apps/desktop/src/lib/config/uiFeatureFlags.ts
+++ b/apps/desktop/src/lib/config/uiFeatureFlags.ts
@@ -19,5 +19,3 @@ export function featureTopics(): Persisted<boolean> {
 	const key = 'feature--topics';
 	return persisted(false, key);
 }
-
-export const autoSelectBranchNameFeature = persisted(false, 'autoSelectBranchLaneContentsFeature');

--- a/apps/desktop/src/lib/stack/StackHeader.svelte
+++ b/apps/desktop/src/lib/stack/StackHeader.svelte
@@ -23,6 +23,7 @@
 	const branchStore = getContextStore(VirtualBranch);
 	const branch = $derived($branchStore);
 
+	let branchNameComponent = $state<ReturnType<typeof BranchLabel>>();
 	let contextMenu = $state<ReturnType<typeof ContextMenu>>();
 	let meatballButtonEl = $state<HTMLDivElement>();
 	let isTargetBranchAnimated = $state(false);
@@ -110,7 +111,11 @@
 
 				<div class="header__info">
 					<div class="header__info-row spread">
-						<BranchLabel name={branch.name} onChange={(name) => handleBranchNameChange(name)} />
+						<BranchLabel
+							bind:this={branchNameComponent}
+							name={branch.name}
+							onChange={(name) => handleBranchNameChange(name)}
+						/>
 						<Button
 							bind:el={meatballButtonEl}
 							style="ghost"
@@ -123,6 +128,9 @@
 							bind:contextMenuEl={contextMenu}
 							target={meatballButtonEl}
 							onCollapse={collapseLane}
+							onRenameLane={() => {
+								branchNameComponent?.focusInput();
+							}}
 							hasPr={false}
 						/>
 					</div>

--- a/apps/desktop/src/routes/settings/appearance/+page.svelte
+++ b/apps/desktop/src/routes/settings/appearance/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import SectionCard from '$lib/components/SectionCard.svelte';
-	import { autoSelectBranchNameFeature } from '$lib/config/uiFeatureFlags';
 	import HunkDiff from '$lib/hunk/HunkDiff.svelte';
 	import SettingsPage from '$lib/layout/SettingsPage.svelte';
 	import Select from '$lib/select/Select.svelte';
@@ -278,19 +277,4 @@
 			</svelte:fragment>
 		</SectionCard>
 	</form>
-
-	<SectionCard labelFor="branchLaneContents" orientation="row">
-		<svelte:fragment slot="title">Auto-highlight Branch Lane Contents</svelte:fragment>
-		<svelte:fragment slot="caption">
-			An experimental UI toggle to highlight the contents of the branch lane input fields when
-			clicking into them.
-		</svelte:fragment>
-		<svelte:fragment slot="actions">
-			<Toggle
-				id="branchLaneContents"
-				checked={$autoSelectBranchNameFeature}
-				on:click={() => ($autoSelectBranchNameFeature = !$autoSelectBranchNameFeature)}
-			/>
-		</svelte:fragment>
-	</SectionCard>
 </SettingsPage>


### PR DESCRIPTION
## 🧢 Changes

- Rename lanes/branches on double-click instead of single-click
- Add "Rename lane/branch" option to the context menu

## ☕️ Reasoning

- Prevent users from accidentally triggering the rename function
- Align with the common renaming pattern in native apps (via double-click)

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
