### PR TITLE
fixes a bug in handling the remote name

### DIFF
--- a/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
@@ -30,9 +30,7 @@ pub fn integrate_upstream_commits_for_series(
     let all_series = branch.list_series(ctx)?;
 
     let default_target = vb_state.get_default_target()?;
-    let remote = default_target.clone().push_remote_name.ok_or(anyhow!(
-        "No remote has been configured for the target branch"
-    ))?;
+    let remote = default_target.push_remote_name();
 
     let subject_series = all_series
         .iter()

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -164,13 +164,12 @@ pub(crate) fn stack_series(
         .repository()
         .merge_base(branch.head(), default_target.sha)?;
     for series in stack_series.clone() {
-        let upstream_reference = default_target.push_remote_name.as_ref().and_then(|remote| {
-            if series.head.pushed(remote.as_str(), ctx).ok()? {
-                series.head.remote_reference(remote.as_str()).ok()
-            } else {
-                None
-            }
-        });
+        let remote = default_target.push_remote_name();
+        let upstream_reference = if series.head.pushed(remote.as_str(), ctx)? {
+            series.head.remote_reference(remote.as_str()).ok()
+        } else {
+            None
+        };
         let mut patches: Vec<VirtualBranchCommit> = vec![];
         for patch in series.clone().local_commits {
             let commit =

--- a/crates/gitbutler-stack-api/tests/mod.rs
+++ b/crates/gitbutler-stack-api/tests/mod.rs
@@ -582,21 +582,6 @@ fn update_series_target_success() -> Result<()> {
 }
 
 #[test]
-fn push_series_no_remote() -> Result<()> {
-    let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
-    let mut test_ctx = test_ctx(&ctx)?;
-    test_ctx.branch.initialize(&ctx)?;
-    let result = test_ctx
-        .branch
-        .push_series(&ctx, "a-branch-2".into(), false);
-    assert_eq!(
-        result.err().unwrap().to_string(),
-        "No remote has been configured for the target branch"
-    );
-    Ok(())
-}
-
-#[test]
 fn push_series_success() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;

--- a/crates/gitbutler-stack/src/target.rs
+++ b/crates/gitbutler-stack/src/target.rs
@@ -23,6 +23,16 @@ pub struct Target {
     pub push_remote_name: Option<String>,
 }
 
+impl Target {
+    pub fn push_remote_name(&self) -> String {
+        let upstream_remote = match &self.push_remote_name {
+            Some(remote) => remote.clone(),
+            None => self.branch.remote().to_owned(),
+        };
+        upstream_remote
+    }
+}
+
 impl Serialize for Target {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
Seems like projects that were created long time ago do not have the push_remote_name field set up. Add correct handling for all those situations