### PR TITLE
mention ref-name when reference isn't found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2782,32 +2782,32 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.66.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "gix-actor 0.32.0",
- "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-command",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-config",
  "gix-credentials",
  "gix-date 0.9.0",
  "gix-diff",
  "gix-dir",
  "gix-discover 0.35.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-filter",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-ignore 0.11.4 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-ignore 0.11.4 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-index 0.35.0",
- "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-negotiate",
  "gix-object 0.44.0",
  "gix-odb",
  "gix-pack",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-pathspec",
  "gix-prompt",
  "gix-protocol",
@@ -2815,15 +2815,15 @@ dependencies = [
  "gix-refspec",
  "gix-revision",
  "gix-revwalk 0.15.0",
- "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-status",
  "gix-submodule",
- "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-transport",
  "gix-traverse 0.41.0",
  "gix-url",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-validate 0.9.0",
  "gix-worktree 0.36.0",
  "gix-worktree-state",
@@ -2849,11 +2849,11 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.32.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
  "gix-date 0.9.0",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "itoa 1.0.11",
  "thiserror",
  "winnow 0.6.18",
@@ -2879,13 +2879,13 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.22.5"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "kstring",
  "smallvec",
  "thiserror",
@@ -2904,7 +2904,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.11"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "thiserror",
 ]
@@ -2921,7 +2921,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.8"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "thiserror",
 ]
@@ -2929,11 +2929,11 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.3.9"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "shell-words",
 ]
 
@@ -2954,12 +2954,12 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.24.3"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
- "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "memmap2",
  "thiserror",
 ]
@@ -2967,15 +2967,15 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.40.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-ref 0.47.0",
- "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "memchr",
  "once_cell",
  "smallvec",
@@ -2987,11 +2987,11 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.14.8"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "libc",
  "thiserror",
 ]
@@ -2999,15 +2999,15 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.24.5"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-config-value",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-prompt",
- "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-url",
  "thiserror",
 ]
@@ -3027,7 +3027,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.9.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
  "itoa 1.0.11",
@@ -3038,17 +3038,17 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.46.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-filter",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-object 0.44.0",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-traverse 0.41.0",
  "gix-worktree 0.36.0",
  "imara-diff",
@@ -3058,18 +3058,18 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.8.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
  "gix-discover 0.35.0",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-ignore 0.11.4 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-ignore 0.11.4 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-index 0.35.0",
  "gix-object 0.44.0",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-pathspec",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-worktree 0.36.0",
  "thiserror",
 ]
@@ -3093,15 +3093,15 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.35.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
  "dunce",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-ref 0.47.0",
- "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "thiserror",
 ]
 
@@ -3123,15 +3123,15 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.38.2"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bytes",
  "crc32fast",
  "crossbeam-channel",
  "flate2",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "libc",
  "once_cell",
  "parking_lot 0.12.3",
@@ -3145,19 +3145,19 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.13.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
  "encoding_rs",
- "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-command",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-object 0.44.0",
  "gix-packetline-blocking",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "smallvec",
  "thiserror",
 ]
@@ -3176,11 +3176,11 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.11.3"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "fastrand 2.1.1",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
 ]
 
 [[package]]
@@ -3198,12 +3198,12 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.16.5"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
 ]
 
 [[package]]
@@ -3219,7 +3219,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.14.2"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "faster-hex",
  "thiserror",
@@ -3239,9 +3239,9 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.5.2"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "hashbrown 0.14.5",
  "parking_lot 0.12.3",
 ]
@@ -3262,12 +3262,12 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.11.4"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "unicode-bom",
 ]
 
@@ -3302,20 +3302,20 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.35.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "filetime",
  "fnv",
- "gix-bitmap 0.2.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-bitmap 0.2.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-object 0.44.0",
  "gix-traverse 0.41.0",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-validate 0.9.0",
  "hashbrown 0.14.5",
  "itoa 1.0.11",
@@ -3340,22 +3340,22 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "14.0.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
- "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-negotiate"
 version = "0.15.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bitflags 2.6.0",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-object 0.44.0",
  "gix-revwalk 0.15.0",
  "smallvec",
@@ -3384,15 +3384,15 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.44.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
  "gix-actor 0.32.0",
  "gix-date 0.9.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-validate 0.9.0",
  "itoa 1.0.11",
  "smallvec",
@@ -3403,18 +3403,18 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.63.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "arc-swap",
  "gix-date 0.9.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-object 0.44.0",
  "gix-pack",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "parking_lot 0.12.3",
  "tempfile",
  "thiserror",
@@ -3423,16 +3423,16 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.53.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "clru",
- "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-object 0.44.0",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "memmap2",
  "parking_lot 0.12.3",
  "smallvec",
@@ -3443,22 +3443,22 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.17.6"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.17.5"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "thiserror",
 ]
 
@@ -3478,10 +3478,10 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.11"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "home",
  "once_cell",
  "thiserror",
@@ -3490,21 +3490,21 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.7.7"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-config-value",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-prompt"
 version = "0.8.7"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -3516,15 +3516,15 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.45.3"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
  "gix-credentials",
  "gix-date 0.9.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-transport",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "maybe-async",
  "thiserror",
  "winnow 0.6.18",
@@ -3544,10 +3544,10 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.4.12"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "thiserror",
 ]
 
@@ -3576,17 +3576,17 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.47.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "gix-actor 0.32.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-object 0.44.0",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-validate 0.9.0",
  "memmap2",
  "thiserror",
@@ -3596,10 +3596,10 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.25.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-revision",
  "gix-validate 0.9.0",
  "smallvec",
@@ -3609,17 +3609,17 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.29.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-object 0.44.0",
  "gix-revwalk 0.15.0",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "thiserror",
 ]
 
@@ -3641,12 +3641,12 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.15.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-object 0.44.0",
  "smallvec",
  "thiserror",
@@ -3667,10 +3667,10 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.10.8"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bitflags 2.6.0",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -3678,19 +3678,19 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.13.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
  "filetime",
  "gix-diff",
  "gix-dir",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-filter",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-index 0.35.0",
  "gix-object 0.44.0",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-pathspec",
  "gix-worktree 0.36.0",
  "portable-atomic",
@@ -3700,11 +3700,11 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.14.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
  "gix-config",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
@@ -3729,10 +3729,10 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "14.0.2"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "dashmap",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "libc",
  "once_cell",
  "parking_lot 0.12.3",
@@ -3774,7 +3774,7 @@ checksum = "6cae0e8661c3ff92688ce1c8b8058b3efb312aba9492bbe93661a21705ab431b"
 [[package]]
 name = "gix-trace"
 version = "0.1.10"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "tracing-core",
 ]
@@ -3782,17 +3782,17 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.42.3"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "base64 0.22.1",
  "bstr",
  "curl",
  "gix-command",
  "gix-credentials",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-packetline",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-url",
  "thiserror",
 ]
@@ -3817,13 +3817,13 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.41.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bitflags 2.6.0",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-object 0.44.0",
  "gix-revwalk 0.15.0",
  "smallvec",
@@ -3833,11 +3833,11 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.27.5"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "thiserror",
  "url",
 ]
@@ -3855,7 +3855,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.1.12"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
  "fastrand 2.1.1",
@@ -3875,7 +3875,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.9.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
  "thiserror",
@@ -3903,35 +3903,35 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.36.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
- "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-ignore 0.11.4 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-ignore 0.11.4 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-index 0.35.0",
  "gix-object 0.44.0",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-validate 0.9.0",
 ]
 
 [[package]]
 name = "gix-worktree-state"
 version = "0.13.0"
-source = "git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c#64872690e60efdd9267d517f4d9971eecd3b875c"
+source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
 dependencies = [
  "bstr",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-filter",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-index 0.35.0",
  "gix-object 0.44.0",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=64872690e60efdd9267d517f4d9971eecd3b875c)",
+ "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
  "gix-worktree 0.36.0",
  "io-close",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ resolver = "2"
 [workspace.dependencies]
 bstr = "1.10.0"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
-gix = { git = "https://github.com/Byron/gitoxide", rev = "64872690e60efdd9267d517f4d9971eecd3b875c", default-features = false, features = [
+gix = { git = "https://github.com/Byron/gitoxide", rev = "b36d7efb9743766338ac7bb7fb2399a06fae5e60", default-features = false, features = [
 ] }
 git2 = { version = "0.19.0", features = [
     "vendored-openssl",


### PR DESCRIPTION
Now it will include the name of the reference that wasn't found, which should help with debugging.

Related to #5229 and various others.

