### PR TITLE
Template branch names - ensure initials generation handles utf8 chars correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2599,6 +2599,7 @@ dependencies = [
  "gitbutler-testsupport",
  "gitbutler-time",
  "gix",
+ "gix-utils 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.13.0",
  "rand 0.8.5",
  "serde",
@@ -8225,9 +8226,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "untrusted"

--- a/crates/gitbutler-stack-api/Cargo.toml
+++ b/crates/gitbutler-stack-api/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 anyhow = "1.0.86"
 itertools = "0.13"
 rand = "0.8.5"
+gix-utils = "0.1.12"
 serde = { workspace = true, features = ["std"] }
 git2.workspace = true
 gix.workspace = true


### PR DESCRIPTION
Refactors the branch generation by moving it to a function and ensures that when generating initials, accents and other special characters are handled correctly. Additionally, the PR fixes an issue where the branch name needs to be in ASCII format.