### PR TITLE
fix: do not error on empty `dropzoneIndexes`

### DIFF
--- a/apps/desktop/src/lib/dragging/reorderDropzoneManager.ts
+++ b/apps/desktop/src/lib/dragging/reorderDropzoneManager.ts
@@ -80,6 +80,11 @@ class Indexer {
 	}
 
 	private getIndex(key: string) {
+		// Not 0, because 'top' will always be in the map
+		if (this.dropzoneIndexes.size === 1) {
+			return 0;
+		}
+
 		if (key === 'top') {
 			return this.dropzoneIndexes.get(key) ?? 0;
 		} else {


### PR DESCRIPTION
## ☕️ Reasoning

- When there were listed commits, but the dropzoneIndexes were empty, like in the case where there are only "integrated" commits, errors would be thrown for not beign able to find the commitId in the dropzoneIndexes map

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
