### PR TITLE
fix: stacking remove pseudo dropzone line overlay

### DIFF
--- a/apps/desktop/src/lib/commit/StackingCommitCard.svelte
+++ b/apps/desktop/src/lib/commit/StackingCommitCard.svelte
@@ -124,9 +124,6 @@
 
 	const commitShortSha = commit.id.substring(0, 7);
 
-	let dragDirection: 'up' | 'down' | undefined = $state();
-	let isDragTargeted = $state(false);
-
 	function canEdit() {
 		if (isUnapplied) return false;
 		if (!modeService) return false;
@@ -200,25 +197,6 @@
 	onkeyup={onKeyup}
 	role="button"
 	tabindex="0"
-	ondragenter={() => {
-		isDragTargeted = true;
-	}}
-	ondragleave={() => {
-		isDragTargeted = false;
-	}}
-	ondrop={() => {
-		isDragTargeted = false;
-	}}
-	ondrag={(e) => {
-		const target = e.target as HTMLElement;
-		const targetHeight = target.offsetHeight;
-		const targetTop = target.getBoundingClientRect().top;
-		const mouseY = e.clientY;
-
-		const isTop = mouseY < targetTop + targetHeight / 2;
-
-		dragDirection = isTop ? 'up' : 'down';
-	}}
 	use:draggableCommit={commit instanceof DetailedCommit && !isUnapplied && type !== 'integrated'
 		? {
 				label: commit.descriptionTitle,
@@ -231,15 +209,6 @@
 			}
 		: nonDraggable()}
 >
-	{#if dragDirection && isDragTargeted}
-		<div
-			class="pseudo-reorder-zone"
-			class:top={dragDirection === 'up'}
-			class:bottom={dragDirection === 'down'}
-			class:is-last={last}
-		></div>
-	{/if}
-
 	{#if lines}
 		<div>
 			{@render lines()}

--- a/apps/desktop/src/lib/dropzone/LineOverlay.svelte
+++ b/apps/desktop/src/lib/dropzone/LineOverlay.svelte
@@ -22,7 +22,7 @@
 <style lang="postcss">
 	.container {
 		--dropzone-overlap: calc(var(--dropzone-height) / 2);
-		--dropzone-height: 16px;
+		--dropzone-height: 24px;
 
 		position: absolute;
 		top: var(--y-offset);
@@ -55,7 +55,7 @@
 
 	.indicator {
 		width: 100%;
-		height: 2px;
+		height: 3px;
 		margin-top: 1px;
 		transition: opacity 0.1s;
 		background-color: transparent;


### PR DESCRIPTION
## ☕️ Reasoning

- Remove pseudo dropzone in stacking cards to hide no-op dropzones on hover around commit that's being dragged
- Increase droptarget area and height of dropzone line overlay to be a bit more visible / easy to drop on

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
