### PR TITLE
fix: eslint monorepo svelte 5 setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ build
 package
 !.env.example
 vite.config.ts.timestamp-*
+tsconfig.tsbuildinfo
 
 # Written to disk when using `act`
 .pnpm-store

--- a/apps/desktop/src/lib/ai/service.test.ts
+++ b/apps/desktop/src/lib/ai/service.test.ts
@@ -353,6 +353,6 @@ describe.concurrent('buildDiff', () => {
 			buildDiff([hunk1, hunk1], 10000)
 		);
 
-		expect(outputMatchesExpectedValue).toBeTruthy;
+		expect(outputMatchesExpectedValue).toBeTruthy();
 	});
 });

--- a/apps/desktop/src/lib/ai/service.test.ts
+++ b/apps/desktop/src/lib/ai/service.test.ts
@@ -353,6 +353,6 @@ describe.concurrent('buildDiff', () => {
 			buildDiff([hunk1, hunk1], 10000)
 		);
 
-		expect(outputMatchesExpectedValue).toBeTruthy();
+		expect(outputMatchesExpectedValue).toBeFalsy();
 	});
 });

--- a/apps/desktop/src/lib/ai/service.test.ts
+++ b/apps/desktop/src/lib/ai/service.test.ts
@@ -350,9 +350,9 @@ describe.concurrent('buildDiff', () => {
 		const expectedOutput2 = `${hunk2.filePath} - ${hunk2.diff}\n${hunk1.filePath} - ${hunk1.diff}`;
 
 		const outputMatchesExpectedValue = [expectedOutput1, expectedOutput2].includes(
-			buildDiff([hunk1, hunk1], 10000)
+			buildDiff([hunk1, hunk2], 10000)
 		);
 
-		expect(outputMatchesExpectedValue).toBeFalsy();
+		expect(outputMatchesExpectedValue).toBeTruthy();
 	});
 });

--- a/apps/desktop/src/lib/analytics/analytics.ts
+++ b/apps/desktop/src/lib/analytics/analytics.ts
@@ -25,9 +25,11 @@ export function initAnalyticsIfEnabled() {
 			appNonAnonMetricsEnabled()
 				.onDisk()
 				.then((enabled) => {
-					enabled
-						? posthog.capture('nonAnonMetricsEnabled')
-						: posthog.capture('nonAnonMetricsDisabled');
+					if (enabled) {
+						posthog.capture('nonAnonMetricsEnabled');
+					} else {
+						posthog.capture('nonAnonMetricsDisabled');
+					}
 				});
 		}
 	});

--- a/apps/desktop/src/lib/commit/CommitList.svelte
+++ b/apps/desktop/src/lib/commit/CommitList.svelte
@@ -88,6 +88,7 @@
 	// Force the "base" commit lines to update when $branch updates.
 	let tsKey = $state<number | undefined>(undefined);
 	$effect(() => {
+		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 		$branch;
 		tsKey = Date.now();
 	});

--- a/apps/desktop/src/lib/components/ProjectNotFound.svelte
+++ b/apps/desktop/src/lib/components/ProjectNotFound.svelte
@@ -23,7 +23,7 @@
 		deleteProject: {
 			try {
 				await projectsService.deleteProject(id);
-			} catch (e) {
+			} catch {
 				deleteSucceeded = false;
 				break deleteProject;
 			}

--- a/apps/desktop/src/lib/components/contextmenu/ContextMenu.svelte
+++ b/apps/desktop/src/lib/components/contextmenu/ContextMenu.svelte
@@ -34,7 +34,9 @@
 
 	export function close() {
 		isVisible = false;
-		onclose && onclose();
+		if (onclose) {
+			onclose();
+		}
 	}
 
 	export function open(e?: MouseEvent, newItem?: any) {

--- a/apps/desktop/src/lib/config/appSettings.ts
+++ b/apps/desktop/src/lib/config/appSettings.ts
@@ -86,7 +86,7 @@ function persisted<T>(initial: T, key: string): Writable<T> & { onDisk: () => Pr
 async function storeValueWithDefault<T>(initial: T, key: string): Promise<T> {
 	try {
 		await store.load();
-	} catch (e) {
+	} catch {
 		// If file does not exist, reset it
 		store.reset();
 	}

--- a/apps/desktop/src/lib/file/FileContextMenu.svelte
+++ b/apps/desktop/src/lib/file/FileContextMenu.svelte
@@ -38,7 +38,7 @@
 
 		return item.files.some((f: unknown) => {
 			if (!isAnyFile(f)) return false;
-			computeFileStatus(f) === 'D';
+			return computeFileStatus(f) === 'D';
 		});
 	}
 

--- a/apps/desktop/src/lib/history/History.svelte
+++ b/apps/desktop/src/lib/history/History.svelte
@@ -81,7 +81,9 @@
 
 <svelte:window
 	on:keydown={(e) => {
-		e.key === 'Escape' && dispatch('hide');
+		if (e.key === 'Escape') {
+			dispatch('hide');
+		}
 	}}
 />
 

--- a/apps/desktop/src/lib/hunk/HunkContextMenu.svelte
+++ b/apps/desktop/src/lib/hunk/HunkContextMenu.svelte
@@ -48,10 +48,11 @@
 				<ContextMenuItem
 					label="Open in {$userSettings.defaultCodeEditor.displayName}"
 					onclick={() => {
-						projectPath &&
+						if (projectPath) {
 							openExternalUrl(
 								`${$userSettings.defaultCodeEditor.schemeIdentifer}://file${projectPath}/${filePath}:${item.lineNumber}`
 							);
+						}
 						contextMenu?.close();
 					}}
 				/>

--- a/apps/desktop/src/lib/hunk/HunkDiff.svelte
+++ b/apps/desktop/src/lib/hunk/HunkDiff.svelte
@@ -329,7 +329,9 @@
 		class:is-before={side === CountColumnSide.Before}
 		class:selected={isSelected}
 		onclick={() => {
-			selectable && handleSelected(hunk, !isSelected);
+			if (selectable) {
+				handleSelected(hunk, !isSelected);
+			}
 		}}
 	>
 		{side === CountColumnSide.Before ? row.beforeLineNumber : row.afterLineNumber}
@@ -348,7 +350,9 @@
 			<thead class="table__title" class:draggable={!draggingDisabled}>
 				<tr
 					onclick={() => {
-						selectable && handleSelected(hunk, !isSelected);
+						if (selectable) {
+							handleSelected(hunk, !isSelected);
+						}
 					}}
 				>
 					<th
@@ -364,7 +368,9 @@
 									checked={isSelected}
 									small
 									onclick={() => {
-										selectable && handleSelected(hunk, !isSelected);
+										if (selectable) {
+											handleSelected(hunk, !isSelected);
+										}
 									}}
 								/>
 							{/if}

--- a/apps/desktop/src/lib/navigation/ChunkyList.svelte
+++ b/apps/desktop/src/lib/navigation/ChunkyList.svelte
@@ -1,3 +1,7 @@
+<script lang="ts" module>
+	type T = any;
+</script>
+
 <script lang="ts" generics="T">
 	/**
 	 * Lazily renders a list of many many items. This is intended to be used

--- a/apps/desktop/src/lib/select/Select.svelte
+++ b/apps/desktop/src/lib/select/Select.svelte
@@ -1,4 +1,6 @@
 <script lang="ts" module>
+	type T = string;
+
 	export type SelectItem<T extends string = string> = {
 		label: string;
 		value: T;

--- a/apps/desktop/src/lib/stores/user.ts
+++ b/apps/desktop/src/lib/stores/user.ts
@@ -37,7 +37,10 @@ export class UserService {
 		this.user.set(undefined);
 	}
 	readonly accessToken$ = derived(this.user, (user) => {
-		user?.github_access_token;
+		if (user?.github_access_token) {
+			return user.github_access_token;
+		}
+		return undefined;
 	});
 
 	constructor(

--- a/apps/web/src/lib/components/Navigation.svelte
+++ b/apps/web/src/lib/components/Navigation.svelte
@@ -37,7 +37,11 @@
 		<button
 			class="nav__right--button"
 			onclick={() => {
-				$token ? logout() : login();
+				if ($token) {
+					logout();
+				} else {
+					login();
+				}
 			}}
 		>
 			{$token ? 'Log Out' : 'Log In'}

--- a/apps/web/src/lib/user/userService.ts
+++ b/apps/web/src/lib/user/userService.ts
@@ -12,7 +12,7 @@ export interface User {
 }
 
 export class UserService {
-	user = writable<User | undefined>(undefined, (set) => {
+	user: Writable<User | undefined> = writable<User | undefined>(undefined, (set) => {
 		this.fetchUser()
 			.then((data) => {
 				this.error.set(undefined);

--- a/apps/web/src/lib/user/userService.ts
+++ b/apps/web/src/lib/user/userService.ts
@@ -1,5 +1,5 @@
 import { setSentryUser } from '$lib/analytics/sentry';
-import { writable } from 'svelte/store';
+import { writable, type Writable } from 'svelte/store';
 import type { HttpClient } from '@gitbutler/shared/httpClient';
 
 export interface User {

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -11,7 +11,10 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
-		"experimentalDecorators": true
+		"experimentalDecorators": true,
+		"declaration": true,
+		"composite": true,
+		"declarationMap": true
 	}
 	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
 	// except $lib which is handled by https://kit.svelte.dev/docs/configuration#files

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -125,7 +125,9 @@ export default ts.config(
 			'!.storybook',
 			'target/',
 			'crates/',
-			'packages/ui/storybook-static'
+			'packages/ui/storybook-static',
+			// Storybook Meta type wrapper
+			'packages/ui/src/stories/**/*.stories.ts'
 		]
 	}
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,8 +2,8 @@ import prettier from 'eslint-config-prettier';
 import js from '@eslint/js';
 import svelte from 'eslint-plugin-svelte';
 import globals from 'globals';
-import pluginImportX from 'eslint-plugin-import-x';
 import ts from 'typescript-eslint';
+import pluginImportX from 'eslint-plugin-import-x';
 
 export default ts.config(
 	js.configs.recommended,
@@ -16,14 +16,24 @@ export default ts.config(
 			globals: {
 				...globals.browser,
 				...globals.node
-			},
-			parserOptions: {
-				projectService: true,
-				allowDefaultProject: ['*.svelte'],
-				extraFileExtensions: ['.svelte']
 			}
 		},
 		rules: {
+			'@typescript-eslint/no-namespace': 'off',
+			'@typescript-eslint/no-empty-function': 'off',
+			'@typescript-eslint/no-explicit-any': 'off',
+			'@typescript-eslint/no-unused-vars': [
+				'error',
+				{
+					argsIgnorePattern: '^_',
+					varsIgnorePattern: '^_',
+					caughtErrorsIgnorePattern: '^_'
+				}
+			],
+			// '@typescript-eslint/return-await': ['error', 'always'],
+			// '@typescript-eslint/promise-function-async': 'error',
+			// '@typescript-eslint/await-thenable': 'error',
+
 			eqeqeq: ['error', 'always'],
 			'import-x/no-cycle': 'error',
 			'import-x/order': [
@@ -34,7 +44,6 @@ export default ts.config(
 						orderImportKind: 'asc',
 						caseInsensitive: false
 					},
-
 					groups: [
 						'index',
 						'sibling',
@@ -45,37 +54,18 @@ export default ts.config(
 						'object',
 						'type'
 					],
-
 					'newlines-between': 'never'
 				}
 			],
-
 			'import-x/no-unresolved': [
 				'error',
 				{
 					ignore: ['^\\$app', '^\\$env']
 				}
 			],
-
 			'import-x/no-relative-packages': 'error', // Don't allow packages to have relative imports between each other
 			'func-style': [2, 'declaration'],
-			'@typescript-eslint/no-namespace': 'off',
-			'@typescript-eslint/no-empty-function': 'off',
-			'@typescript-eslint/no-explicit-any': 'off',
-
-			'@typescript-eslint/no-unused-vars': [
-				'error',
-				{
-					argsIgnorePattern: '^_',
-					varsIgnorePattern: '^_',
-					caughtErrorsIgnorePattern: '^_'
-				}
-			],
-
 			'no-return-await': 'off',
-			'@typescript-eslint/return-await': ['error', 'always'],
-			'@typescript-eslint/promise-function-async': 'error',
-			'@typescript-eslint/await-thenable': 'error',
 			'svelte/no-at-html-tags': 'off'
 		},
 		settings: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,105 +1,31 @@
+import prettier from 'eslint-config-prettier';
 import js from '@eslint/js';
-import tsParser from '@typescript-eslint/parser';
-import eslintConfigPrettier from 'eslint-config-prettier';
-import eslintPluginSvelte from 'eslint-plugin-svelte';
+import svelte from 'eslint-plugin-svelte';
 import globals from 'globals';
-import tsEslint from 'typescript-eslint';
 import pluginImportX from 'eslint-plugin-import-x';
-// Flat config support: https://github.com/storybookjs/eslint-plugin-storybook/pull/156
-import storybook from 'eslint-plugin-storybook';
-import svelteParser from 'svelte-eslint-parser';
+import ts from 'typescript-eslint';
 
-export default tsEslint.config(
+export default ts.config(
 	js.configs.recommended,
-	...storybook.configs['flat/recommended'],
-	...tsEslint.configs.recommended,
-	...eslintPluginSvelte.configs['flat/recommended'],
-	eslintConfigPrettier,
-	...eslintPluginSvelte.configs['flat/prettier'],
+	...ts.configs.recommended,
+	...svelte.configs['flat/recommended'],
+	prettier,
+	...svelte.configs['flat/prettier'],
 	{
-		files: ['apps/desktop/e2e/**'],
 		languageOptions: {
-			ecmaVersion: 2021,
-			sourceType: 'module',
 			globals: {
-				...globals.node,
 				...globals.browser,
-				...globals.mocha,
-				...globals.chai,
-				$: false
-			}
-		}
-	},
-	{
-		files: ['**/*.svelte'],
-		languageOptions: {
-			ecmaVersion: 2021,
-			sourceType: 'module',
-			globals: {
-				...globals.node,
-				...globals.browser,
-				$state: 'readonly',
-				$derived: 'readonly',
-				$props: 'readonly',
-				$bindable: 'readonly',
-				$inspect: 'readonly',
-				$host: 'readonly',
-				$effect: 'readonly'
+				...globals.node
 			},
-			parser: svelteParser,
 			parserOptions: {
-				parser: tsParser,
-				extraFileExtensions: ['.svelte'],
-				svelteFeatures: {
-					experimentalGenerics: true
-				}
-			}
-		}
-	},
-	{
-		ignores: [
-			'**/.*', // dotfiles aren't ignored by default in FlatConfig
-			'.*', // dotfiles aren't ignored by default in FlatConfig
-			'**/.DS_Store',
-			'**/node_modules',
-			'**/butler/target',
-			'**/build',
-			'**/dist',
-			'.svelte-kit',
-			'**/package',
-			'**/.env',
-			'**/.env.*',
-			'!**/.env.example',
-			'**/pnpm-lock.yaml',
-			'**/package-lock.json',
-			'**/yarn.lock',
-			'.github',
-			'.vscode',
-			'src-tauri',
-			'**/eslint.config.js',
-			'**/svelte.config.js',
-			'**/.pnpm-store',
-			'**/vite.config.ts.timestamp-*',
-			'!.storybook',
-			'target/',
-			'crates/',
-			'packages/ui/storybook-static',
-			// We're having issues parsing splat syntax in svelte components
-			'packages/ui/src/stories/**/*.svelte'
-		]
-	},
-	{
-		languageOptions: {
-			parserOptions: {
-				parser: tsEslint.parser,
-				project: ['./packages/**/tsconfig.json', './apps/**/tsconfig.json'],
+				projectService: true,
+				allowDefaultProject: ['*.svelte'],
 				extraFileExtensions: ['.svelte']
 			}
 		},
 		rules: {
 			eqeqeq: ['error', 'always'],
 			'import-x/no-cycle': 'error',
-
 			'import-x/order': [
 				'error',
 				{
@@ -165,7 +91,8 @@ export default tsEslint.config(
 						'./apps/web/tsconfig.json',
 						'./apps/web/.svelte-kit/tsconfig.json',
 						'./packages/**/tsconfig.json',
-						'./packages/ui/.svelte-kit/tsconfig.json'
+						'./packages/ui/.svelte-kit/tsconfig.json',
+						'./packages/shared/.svelte-kit/tsconfig.json'
 					]
 				}
 			}
@@ -173,5 +100,42 @@ export default tsEslint.config(
 		plugins: {
 			'import-x': pluginImportX
 		}
+	},
+	{
+		files: ['**/*.svelte'],
+		languageOptions: {
+			parserOptions: {
+				parser: ts.parser
+			}
+		}
+	},
+	{
+		ignores: [
+			'**/.*', // dotfiles aren't ignored by default in FlatConfig
+			'.*', // dotfiles aren't ignored by default in FlatConfig
+			'**/.DS_Store',
+			'**/node_modules',
+			'**/butler/target',
+			'**/build',
+			'**/dist',
+			'.svelte-kit',
+			'**/package',
+			'**/.env',
+			'**/.env.*',
+			'!**/.env.example',
+			'**/pnpm-lock.yaml',
+			'**/package-lock.json',
+			'**/yarn.lock',
+			'.github',
+			'.vscode',
+			'**/eslint.config.js',
+			'**/svelte.config.js',
+			'**/.pnpm-store',
+			'**/vite.config.ts.timestamp-*',
+			'!.storybook',
+			'target/',
+			'crates/',
+			'packages/ui/storybook-static'
+		]
 	}
 );

--- a/package.json
+++ b/package.json
@@ -32,21 +32,22 @@
 	"devDependencies": {
 		"@eslint/js": "^9.5.0",
 		"@tauri-apps/cli": "^1.6.2",
+		"@types/eslint": "9.6.0",
 		"@types/eslint__js": "^8.42.3",
 		"@types/node": "^22.3.0",
 		"@typescript-eslint/parser": "^7.13.1",
-		"eslint": "^9.5.0",
+		"eslint": "^9.13.0",
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-import-resolver-typescript": "^3.6.1",
 		"eslint-plugin-import-x": "^0.5.1",
 		"eslint-plugin-storybook": "0.9.0--canary.156.ed236ca.0",
-		"eslint-plugin-svelte": "2.44.1",
+		"eslint-plugin-svelte": "2.46.0",
 		"globals": "^15.6.0",
 		"prettier": "^3.3.2",
 		"prettier-plugin-svelte": "^3.2.7",
 		"svelte-eslint-parser": "^0.41.1",
-		"turbo": "2.1.1",
+		"turbo": "2.2.1",
 		"typescript": "5.4.5",
-		"typescript-eslint": "^7.13.1"
+		"typescript-eslint": "^8.10.0"
 	}
 }

--- a/packages/shared/svelte.config.js
+++ b/packages/shared/svelte.config.js
@@ -15,7 +15,8 @@ const config = {
 	},
 	compilerOptions: {
 		css: 'injected',
-		enableSourcemap: true
+		enableSourcemap: true,
+		runes: true
 	}
 };
 

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -12,7 +12,9 @@
 		"sourceMap": true,
 		"strict": true,
 		"experimentalDecorators": true,
-		"declaration": true
+		"declaration": true,
+		"composite": true,
+		"declarationMap": true
 	},
 	"include": [
 		".svelte-kit/ambient.d.ts",

--- a/packages/ui/src/lib/BorderlessTextarea.svelte
+++ b/packages/ui/src/lib/BorderlessTextarea.svelte
@@ -56,6 +56,7 @@
 		if (ref) {
 			// reference the value to trigger
 			// the effect when it changes
+			// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 			value;
 			autoHeight(ref);
 		}

--- a/packages/ui/src/lib/commitLines/types.ts
+++ b/packages/ui/src/lib/commitLines/types.ts
@@ -12,7 +12,7 @@ export interface CommitNodeData {
 	commit?: CommitData;
 }
 
-export interface BaseNodeData {}
+export type BaseNodeData = object;
 
 export interface LineData {
 	top: CellData;

--- a/packages/ui/src/lib/segmentControl/Segment.svelte
+++ b/packages/ui/src/lib/segmentControl/Segment.svelte
@@ -21,7 +21,9 @@
 	let isSelected = $state(false);
 
 	$effect(() => {
-		elRef && isFocused && elRef.focus();
+		if (elRef && isFocused) {
+			elRef.focus();
+		}
 	});
 
 	$effect(() => {
@@ -47,7 +49,9 @@
 				index,
 				id
 			});
-			onselect && onselect(id);
+			if (onselect) {
+				onselect(id);
+			}
 		}
 	}}
 	onkeydown={({ key }) => {
@@ -57,7 +61,9 @@
 					index,
 					id
 				});
-				onselect && onselect(id);
+				if (onselect) {
+					onselect(id);
+				}
 			}
 		}
 	}}

--- a/packages/ui/src/lib/segmentControl/SegmentControl.svelte
+++ b/packages/ui/src/lib/segmentControl/SegmentControl.svelte
@@ -30,7 +30,9 @@
 		setSelected: ({ index: segmentIndex, id }) => {
 			if (segmentIndex >= 0 && segmentIndex < segments.length) {
 				$selectedSegmentIndex = segmentIndex;
-				onselect && onselect(id);
+				if (onselect) {
+					onselect(id);
+				}
 			}
 		}
 	};

--- a/packages/ui/src/lib/utils/convertToBase64.ts
+++ b/packages/ui/src/lib/utils/convertToBase64.ts
@@ -1,7 +1,7 @@
 export function convertToBase64(iconString: string) {
 	try {
 		return btoa(iconString);
-	} catch (err) {
+	} catch {
 		return Buffer.from(iconString).toString('base64');
 	}
 }

--- a/packages/ui/src/lib/utils/portal.ts
+++ b/packages/ui/src/lib/utils/portal.ts
@@ -1,6 +1,8 @@
 export function portal(node: HTMLElement, to: string) {
 	const target = document.querySelector(to);
-	target && target.appendChild(node);
+	if (target) {
+		target.appendChild(node);
+	}
 	return {
 		destroy() {
 			if (node.isConnected) node.remove();

--- a/packages/ui/src/stories/button/DemoAllButtons.svelte
+++ b/packages/ui/src/stories/button/DemoAllButtons.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import type { ComponentColor } from '$lib/utils/colorTypes';
 	import Button from '$lib/Button.svelte';
+	import type { ComponentColor } from '$lib/utils/colorTypes';
 
 	interface Props {
 		label: string;

--- a/packages/ui/src/stories/modal/DemoModal.svelte
+++ b/packages/ui/src/stories/modal/DemoModal.svelte
@@ -2,9 +2,9 @@
 	import Button from '$lib/Button.svelte';
 	import Modal from '$lib/Modal.svelte';
 
-	const { ...args }: typeof Modal = $props();
+	const { ...args }: ReturnType<typeof Modal> = $props();
 
-	let modal: Modal;
+	let modal: ReturnType<typeof Modal>;
 </script>
 
 <Button
@@ -18,8 +18,8 @@
 
 	{#snippet controls(close)}
 		<Button style="ghost" outline onclick={() => close()}>Cancel</Button>
-		<Button style="pop" kind="solid" type="submit" onclick={() => console.log('clicked')}
-			>Merge</Button
-		>
+		<Button style="pop" kind="solid" type="submit" onclick={() => console.log('clicked')}>
+			Merge
+		</Button>
 	{/snippet}
 </Modal>

--- a/packages/ui/src/stories/modal/DemoModal.svelte
+++ b/packages/ui/src/stories/modal/DemoModal.svelte
@@ -10,8 +10,10 @@
 <Button
 	onclick={() => {
 		modal?.show();
-	}}>Show</Button
+	}}
 >
+	Show
+</Button>
 <Modal bind:this={modal} {...args} onSubmit={() => console.log('submitted')}>
 	A branch with the same name already exists. Do you want to merge this branch into the current
 	branch?

--- a/packages/ui/src/stories/sidebarEntry/DemoSidebarEntry.svelte
+++ b/packages/ui/src/stories/sidebarEntry/DemoSidebarEntry.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import AvatarGroup from '$lib/avatar/AvatarGroup.svelte';
 	import SidebarEntry from '$lib/SidebarEntry.svelte';
+	import AvatarGroup from '$lib/avatar/AvatarGroup.svelte';
 
 	interface Props {
 		selected?: boolean;

--- a/packages/ui/svelte.config.js
+++ b/packages/ui/svelte.config.js
@@ -15,8 +15,7 @@ const config = {
 	},
 	compilerOptions: {
 		css: 'injected',
-		enableSourcemap: true,
-		runes: true
+		enableSourcemap: true
 	}
 };
 

--- a/packages/ui/svelte.config.js
+++ b/packages/ui/svelte.config.js
@@ -15,7 +15,8 @@ const config = {
 	},
 	compilerOptions: {
 		css: 'injected',
-		enableSourcemap: true
+		enableSourcemap: true,
+		runes: true
 	}
 };
 

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -31,5 +31,12 @@
 		"tests/**/*.js",
 		"tests/**/*.ts",
 		"tests/**/*.svelte"
+	],
+	"exclude": [
+		"node_modules/**",
+		"src/service-worker.js",
+		"src/service-worker.ts",
+		"src/service-worker.d.ts",
+		"src/stories/**/*.stories.ts"
 	]
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -11,7 +11,10 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
-		"experimentalDecorators": true
+		"experimentalDecorators": true,
+		"declaration": true,
+		"composite": true,
+		"declarationMap": true
 	},
 	"include": [
 		".svelte-kit/ambient.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@tauri-apps/cli':
         specifier: ^1.6.2
         version: 1.6.2
+      '@types/eslint':
+        specifier: 9.6.0
+        version: 9.6.0
       '@types/eslint__js':
         specifier: ^8.42.3
         version: 8.42.3
@@ -44,25 +47,25 @@ importers:
         version: 22.3.0
       '@typescript-eslint/parser':
         specifier: ^7.13.1
-        version: 7.13.1(eslint@9.5.0)(typescript@5.4.5)
+        version: 7.13.1(eslint@9.13.0)(typescript@5.4.5)
       eslint:
-        specifier: ^9.5.0
-        version: 9.5.0
+        specifier: ^9.13.0
+        version: 9.13.0
       eslint-config-prettier:
         specifier: ^9.1.0
-        version: 9.1.0(eslint@9.5.0)
+        version: 9.1.0(eslint@9.13.0)
       eslint-import-resolver-typescript:
         specifier: ^3.6.1
-        version: 3.6.1(@typescript-eslint/parser@7.13.1(eslint@9.5.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@9.5.0)
+        version: 3.6.1(@typescript-eslint/parser@7.13.1(eslint@9.13.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@9.13.0)
       eslint-plugin-import-x:
         specifier: ^0.5.1
-        version: 0.5.1(eslint@9.5.0)(typescript@5.4.5)
+        version: 0.5.1(eslint@9.13.0)(typescript@5.4.5)
       eslint-plugin-storybook:
         specifier: 0.9.0--canary.156.ed236ca.0
-        version: 0.9.0--canary.156.ed236ca.0(eslint@9.5.0)(typescript@5.4.5)
+        version: 0.9.0--canary.156.ed236ca.0(eslint@9.13.0)(typescript@5.4.5)
       eslint-plugin-svelte:
-        specifier: 2.44.1
-        version: 2.44.1(eslint@9.5.0)(svelte@5.0.0-next.243)(ts-node@10.9.2(@types/node@22.3.0)(typescript@5.4.5))
+        specifier: 2.46.0
+        version: 2.46.0(eslint@9.13.0)(svelte@5.0.0-next.243)(ts-node@10.9.2(@types/node@22.3.0)(typescript@5.4.5))
       globals:
         specifier: ^15.6.0
         version: 15.6.0
@@ -76,14 +79,14 @@ importers:
         specifier: ^0.41.1
         version: 0.41.1(svelte@5.0.0-next.243)
       turbo:
-        specifier: 2.1.1
-        version: 2.1.1
+        specifier: 2.2.1
+        version: 2.2.1
       typescript:
         specifier: 5.4.5
         version: 5.4.5
       typescript-eslint:
-        specifier: ^7.13.1
-        version: 7.13.1(eslint@9.5.0)(typescript@5.4.5)
+        specifier: ^8.10.0
+        version: 8.10.0(eslint@9.13.0)(typescript@5.4.5)
 
   apps/desktop:
     dependencies:
@@ -879,12 +882,16 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
-  '@eslint-community/regexpp@4.10.0':
-    resolution: {integrity: sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==}
+  '@eslint-community/regexpp@4.11.1':
+    resolution: {integrity: sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint/config-array@0.16.0':
-    resolution: {integrity: sha512-/jmuSd74i4Czf1XXn7wGRWZCuyaUZ330NH1Bek0Pplatt4Sy1S5haN21SCLLdbeKslQ+S0wEJ+++v5YibSi+Lg==}
+  '@eslint/config-array@0.18.0':
+    resolution: {integrity: sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.7.0':
+    resolution: {integrity: sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/eslintrc@1.4.1':
@@ -895,6 +902,10 @@ packages:
     resolution: {integrity: sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/js@9.13.0':
+    resolution: {integrity: sha512-IFLyoY4d72Z5y/6o/BazFBezupzI/taV8sGumxTAVw3lXG9A6md1Dc34T9s1FoD/an9pJH8RHbAxsaEbBed9lA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/js@9.5.0':
     resolution: {integrity: sha512-A7+AOT2ICkodvtsWnxZP4Xxk3NbZ3VMHd8oihydLRGrJgqqdEz1qSeEgXYyT/Cu8h1TWWsQRejIx48mtjZ5y1w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -903,8 +914,20 @@ packages:
     resolution: {integrity: sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/plugin-kit@0.2.1':
+    resolution: {integrity: sha512-HFZ4Mp26nbWk9d/BpvP0YNL6W4UoZF0VFcTw/aPPA8RpOxeFQgK+ClABGgAUXs9Y/RGX/l1vOmrqz1MQt9MNuw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@fontsource/fira-mono@4.5.10':
     resolution: {integrity: sha512-bxUnRP8xptGRo8YXeY073DSpfK74XpSb0ZyRNpHV9WvLnJ7TwPOjZll8hTMin7zLC6iOp59pDZ8EQDj1gzgAQQ==}
+
+  '@humanfs/core@0.19.0':
+    resolution: {integrity: sha512-2cbWIHbZVEweE853g8jymffCA+NCMiuqeECeBBLm8dg2oFdjuGJhgN4UAbI+6v0CKbbhvtXA4qV8YR5Ji86nmw==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.5':
+    resolution: {integrity: sha512-KSPA4umqSG4LHYRodq31VDwKAvaTF4xmVlzM8Aeh4PlU1JQ3IG0wiA8C25d3RQ9nJyM3mBHyI53K06VVL/oFFg==}
+    engines: {node: '>=18.18.0'}
 
   '@humanwhocodes/config-array@0.9.5':
     resolution: {integrity: sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==}
@@ -923,8 +946,8 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     deprecated: Use @eslint/object-schema instead
 
-  '@humanwhocodes/retry@0.3.0':
-    resolution: {integrity: sha512-d2CGZR2o7fS6sWB7DG/3a95bGKQyHMACZ5aW8qGkkqQpUoZV6C0X7Pc7l4ZNMZkfNBf4VWNe9E1jRsf0G146Ew==}
+  '@humanwhocodes/retry@0.3.1':
+    resolution: {integrity: sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==}
     engines: {node: '>=18.18'}
 
   '@inquirer/confirm@3.1.22':
@@ -970,9 +993,6 @@ packages:
   '@jridgewell/set-array@1.2.1':
     resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
-
-  '@jridgewell/sourcemap-codec@1.4.15':
-    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
 
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
@@ -1931,14 +1951,17 @@ packages:
   '@types/diff-match-patch@1.0.36':
     resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
 
-  '@types/eslint@8.56.10':
-    resolution: {integrity: sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==}
+  '@types/eslint@9.6.0':
+    resolution: {integrity: sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==}
 
   '@types/eslint__js@8.42.3':
     resolution: {integrity: sha512-alfG737uhmPdnvkrLdZLcEKJ/B8s9Y4hrZ+YAdzUeoArBlSUERA2E87ROfOaS4jd/C45fzOoZzidLc1IPwLqOw==}
 
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
+
+  '@types/estree@1.0.6':
+    resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
   '@types/express-serve-static-core@4.19.3':
     resolution: {integrity: sha512-KOzM7MhcBFlmnlr/fzISFF5vGWVSvN6fTd4T+ExOt08bA/dA5kpSzY52nMsI1KDFmUREpJelPYyuslLRSjjgCg==}
@@ -2096,12 +2119,12 @@ packages:
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
-  '@typescript-eslint/eslint-plugin@7.13.1':
-    resolution: {integrity: sha512-kZqi+WZQaZfPKnsflLJQCz6Ze9FFSMfXrrIOcyargekQxG37ES7DJNpJUE9Q/X5n3yTIP/WPutVNzgknQ7biLg==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  '@typescript-eslint/eslint-plugin@8.10.0':
+    resolution: {integrity: sha512-phuB3hoP7FFKbRXxjl+DRlQDuJqhpOnm5MmtROXyWi3uS/Xg2ZXqiQfcG2BJHiN4QKyzdOJi3NEn/qTnjUlkmQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^7.0.0
-      eslint: ^8.56.0
+      '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
+      eslint: ^8.57.0 || ^9.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -2117,6 +2140,16 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/parser@8.10.0':
+    resolution: {integrity: sha512-E24l90SxuJhytWJ0pTQydFT46Nk0Z+bsLKo/L8rtQSL93rQ6byd1V/QbDpHUTdLPOMsBCcYXZweADNCfOCmOAg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@typescript-eslint/scope-manager@7.13.1':
     resolution: {integrity: sha512-adbXNVEs6GmbzaCpymHQ0MB6E4TqoiVbC0iqG3uijR8ZYfpAXMGttouQzF4Oat3P2GxDVIrg7bMI/P65LiQZdg==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -2125,11 +2158,14 @@ packages:
     resolution: {integrity: sha512-8gVv3kW6n01Q6TrI1cmTZ9YMFi3ucDT7i7aI5lEikk2ebk1AEjrwX8MDTdaX5D7fPXMBLvnsaa0IFTAu+jcfOw==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
-  '@typescript-eslint/type-utils@7.13.1':
-    resolution: {integrity: sha512-aWDbLu1s9bmgPGXSzNCxELu+0+HQOapV/y+60gPXafR8e2g1Bifxzevaa+4L2ytCWm+CHqpELq4CSoN9ELiwCg==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  '@typescript-eslint/scope-manager@8.10.0':
+    resolution: {integrity: sha512-AgCaEjhfql9MDKjMUxWvH7HjLeBqMCBfIaBbzzIcBbQPZE7CPh1m6FF+L75NUMJFMLYhCywJXIDEMa3//1A0dw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/type-utils@8.10.0':
+    resolution: {integrity: sha512-PCpUOpyQSpxBn230yIcK+LeCQaXuxrgCm2Zk1S+PTIRJsEfU6nJ0TtwyH8pIwPK/vJoA+7TZtzyAJSGBz+s/dg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.56.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -2142,6 +2178,10 @@ packages:
   '@typescript-eslint/types@7.16.0':
     resolution: {integrity: sha512-fecuH15Y+TzlUutvUl9Cc2XJxqdLr7+93SQIbcZfd4XRGGKoxyljK27b+kxKamjRkU7FYC6RrbSCg0ALcZn/xw==}
     engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/types@8.10.0':
+    resolution: {integrity: sha512-k/E48uzsfJCRRbGLapdZgrX52csmWJ2rcowwPvOZ8lwPUv3xW6CcFeJAXgx4uJm+Ge4+a4tFOkdYvSpxhRhg1w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@7.13.1':
     resolution: {integrity: sha512-uxNr51CMV7npU1BxZzYjoVz9iyjckBduFBP0S5sLlh1tXYzHzgZ3BR9SVsNed+LmwKrmnqN3Kdl5t7eZ5TS1Yw==}
@@ -2161,6 +2201,15 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/typescript-estree@8.10.0':
+    resolution: {integrity: sha512-3OE0nlcOHaMvQ8Xu5gAfME3/tWVDpb/HxtpUZ1WeOAksZ/h/gwrBzCklaGzwZT97/lBbbxJ16dMA98JMEngW4w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@typescript-eslint/utils@7.13.1':
     resolution: {integrity: sha512-h5MzFBD5a/Gh/fvNdp9pTfqJAbuQC4sCN2WzuXme71lqFJsZtLbjxfSk4r3p02WIArOF9N94pdsLiGutpDbrXQ==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -2173,6 +2222,12 @@ packages:
     peerDependencies:
       eslint: ^8.56.0
 
+  '@typescript-eslint/utils@8.10.0':
+    resolution: {integrity: sha512-Oq4uZ7JFr9d1ZunE/QKy5egcDRXT/FrS2z/nlxzPua2VHFtmMvFNDvpq1m/hq0ra+T52aUezfcjGRIB7vNJF9w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+
   '@typescript-eslint/visitor-keys@7.13.1':
     resolution: {integrity: sha512-k/Bfne7lrP7hcb7m9zSsgcBmo+8eicqqfNAJ7uUY+jkTFpKeH2FSkWpFRtimBxgkyvqfu9jTPRbYOvud6isdXA==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -2180,6 +2235,10 @@ packages:
   '@typescript-eslint/visitor-keys@7.16.0':
     resolution: {integrity: sha512-rMo01uPy9C7XxG7AFsxa8zLnWXTF8N3PYclekWSrurvhwiw1eW88mrKiAYe6s53AUY57nTRz8dJsuuXdkAhzCg==}
     engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/visitor-keys@8.10.0':
+    resolution: {integrity: sha512-k8nekgqwr7FadWk548Lfph6V3r9OVqjzAIVskE7orMZR23cGJjAOVazsZSJW+ElyjfTM4wx/1g88Mi70DDtG9A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
@@ -3185,12 +3244,12 @@ packages:
     peerDependencies:
       eslint: '>=6'
 
-  eslint-plugin-svelte@2.44.1:
-    resolution: {integrity: sha512-w6wkoJPw1FJKFtM/2oln21rlu5+HTd2CSkkzhm32A+trNoW2EYQqTQAbDTU6k2GI/6Vh64rBHYQejqEgDld7fw==}
+  eslint-plugin-svelte@2.46.0:
+    resolution: {integrity: sha512-1A7iEMkzmCZ9/Iz+EAfOGYL8IoIG6zeKEq1SmpxGeM5SXmoQq+ZNnCpXFVJpsxPWYx8jIVGMerQMzX20cqUl0g==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0-0 || ^9.0.0-0
-      svelte: ^3.37.0 || ^4.0.0 || ^5.0.0-next.191
+      svelte: ^3.37.0 || ^4.0.0 || ^5.0.0
     peerDependenciesMeta:
       svelte:
         optional: true
@@ -3199,8 +3258,8 @@ packages:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  eslint-scope@8.0.1:
-    resolution: {integrity: sha512-pL8XjgP4ZOmmwfFE8mEhSxA7ZY4C+LWyqjQ3o4yWkkmD0qcMT9kkW3zWHOczhWcjTSgqycYAgwSlXvZltv65og==}
+  eslint-scope@8.1.0:
+    resolution: {integrity: sha512-14dSvlhaVhKKsa9Fx1l8A17s7ah7Ef7wCakJ10LYk6+GYmP9yDti2oq2SEwcyndt6knfcZyhyxwY3i9yL78EQw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint-utils@3.0.0:
@@ -3217,25 +3276,31 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  eslint-visitor-keys@4.0.0:
-    resolution: {integrity: sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==}
+  eslint-visitor-keys@4.1.0:
+    resolution: {integrity: sha512-Q7lok0mqMUSf5a/AdAZkA5a/gHcO6snwQClVNNvFKCAVlxXucdU8pKydU5ZVZjBx5xr37vGbFFWtLQYreLzrZg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint@8.4.1:
     resolution: {integrity: sha512-TxU/p7LB1KxQ6+7aztTnO7K0i+h0tDi81YRY9VzB6Id71kNz+fFYnf5HD5UOQmxkzcoa0TlVZf9dpMtUv0GpWg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
-  eslint@9.5.0:
-    resolution: {integrity: sha512-+NAOZFrW/jFTS3dASCGBxX1pkFD0/fsO+hfAkJ4TyYKwgsXZbqzrw+seCYFCcPCYXvnD67tAnglU7GQTz6kcVw==}
+  eslint@9.13.0:
+    resolution: {integrity: sha512-EYZK6SX6zjFHST/HRytOdA/zE72Cq/bfw45LSyuwrdvcclb/gqV8RRQxywOBEWO2+WDpva6UZa4CcDeJKzUCFA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
 
   esm-env@1.0.0:
     resolution: {integrity: sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==}
 
-  espree@10.1.0:
-    resolution: {integrity: sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==}
+  espree@10.2.0:
+    resolution: {integrity: sha512-upbkBJbckcCNBDBDXEbuhjbP68n+scUd3k/U2EkyM9nw+I/jPiL4cLF/Al06CF96wRltFda16sxDFrxsI1v0/g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@9.2.0:
@@ -3895,10 +3960,6 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
-  is-path-inside@3.0.3:
-    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
-    engines: {node: '>=8'}
-
   is-plain-obj@2.1.0:
     resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
     engines: {node: '>=8'}
@@ -4091,8 +4152,8 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
-  known-css-properties@0.34.0:
-    resolution: {integrity: sha512-tBECoUqNFbyAY4RrbqsBQqDFpGXAEbdD5QKr8kACx3+rnArmuuR22nKQWKazvp07N9yjTyDZaw/20UIH8tL9DQ==}
+  known-css-properties@0.35.0:
+    resolution: {integrity: sha512-a/RAk2BfKk+WFGhhOCAYqSiFLc34k8Mt/6NWRI4joER0EYUzXIcFivjjnoD3+XU1DggLn/tZc3DOAgke7l8a4A==}
 
   ky@0.33.3:
     resolution: {integrity: sha512-CasD9OCEQSFIam2U8efFK81Yeg8vNMTBUqtMOHlrcWQHqUX3HeCl9Dr31u4toV7emlH8Mymk5+9p0lL6mKb/Xw==}
@@ -5391,6 +5452,15 @@ packages:
       svelte:
         optional: true
 
+  svelte-eslint-parser@0.43.0:
+    resolution: {integrity: sha512-GpU52uPKKcVnh8tKN5P4UZpJ/fUDndmq7wfsvoVXsyP+aY0anol7Yqo01fyrlaWGMFfm4av5DyrjlaXdLRJvGA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      svelte: ^3.37.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+
   svelte-french-toast@1.2.0:
     resolution: {integrity: sha512-5PW+6RFX3xQPbR44CngYAP1Sd9oCq9P2FOox4FZffzJuZI2mHOB7q5gJBVnOiLF5y3moVGZ7u2bYt7+yPAgcEQ==}
     peerDependencies:
@@ -5576,38 +5646,38 @@ packages:
   tslib@2.6.3:
     resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
 
-  turbo-darwin-64@2.1.1:
-    resolution: {integrity: sha512-aYNuJpZlCoi0Htd79fl/2DywpewGKijdXeOfg9KzNuPVKzSMYlAXuAlNGh0MKjiOcyqxQGL7Mq9LFhwA0VpDpQ==}
+  turbo-darwin-64@2.2.1:
+    resolution: {integrity: sha512-jltMdSQ+7rQDVaorjW729PCw6fwAn1MgZSdoa0Gil7GZCOF3SnR/ok0uJw6G5mdm6F5XM8ZTlz+mdGzBLuBRaA==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.1.1:
-    resolution: {integrity: sha512-tifJKD8yHY48rHXPMcM8o1jI/Jk2KCaXiNjTKvvy9Zsim61BZksNVLelIbrRoCGwAN6PUBZO2lGU5iL/TQJ5Pw==}
+  turbo-darwin-arm64@2.2.1:
+    resolution: {integrity: sha512-RHW0c1NonsJXXlutlZeunmhLanf0/WbeizFfYgWuTEaJE4MbbhyD/RG4Fm/7iob5kxQ4Es2TzfDPqyMqpIO0GA==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.1.1:
-    resolution: {integrity: sha512-Js6d/bSQe9DuV9c7ITXYpsU/ADzFHABdz1UIHa7Oqjj9VOEbFeA9WpAn0c+mdJrVD+IXJFbbDZUjN7VYssmtcg==}
+  turbo-linux-64@2.2.1:
+    resolution: {integrity: sha512-RasrjV+i2B90hoR8r6B2Btf2/ebNT5MJbhkpY0G1EN06E1IkjCKfAXj/1Dwmjy9+Zo0NC2r69L3HxRrtpar8jQ==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.1.1:
-    resolution: {integrity: sha512-LidzTCq0yvQ+N8w8Qub9FmhQ/mmEIeoqFi7DSupekEV2EjvE9jw/zYc9Pk67X+g7dHVfgOnvVzmrjChdxpFePw==}
+  turbo-linux-arm64@2.2.1:
+    resolution: {integrity: sha512-LNkUUJuu1gNkhlo7Ky/zilXEiajLoGlWLiKT1XV5neEf+x1s+aU9Hzd/+HhSVMiyI8l7z6zLbrM1a6+v4co/SQ==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.1.1:
-    resolution: {integrity: sha512-GKc9ZywKwy4xLDhwXd6H07yzl0TB52HjXMrFLyHGhCVnf/w0oq4sLJv2sjbvuarPjsyx4xnCBJ3m3oyL2XmFtA==}
+  turbo-windows-64@2.2.1:
+    resolution: {integrity: sha512-Mn5tlFrLzlQ6tW6wTWNlyT1osXuDUg0VT1VAjRpmRXlK2Zi3oKVVG0rs0nkkq4rmuheryD1xyuGPN9nFKbAn/A==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.1.1:
-    resolution: {integrity: sha512-oFKkMj11KKUv3xSK9/fhAEQTxLUp1Ol1EOktwc32+SFtEU0uls7kosAz0b+qe8k3pJGEMFdDPdqoEjyJidbxtQ==}
+  turbo-windows-arm64@2.2.1:
+    resolution: {integrity: sha512-bvYOJ3SMN00yiem+uAqwRMbUMau/KiMzJYxnD0YkFo6INc08z8gZi5g0GLZAR7g/L3JegktX3UQW2cJvryjvLg==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.1.1:
-    resolution: {integrity: sha512-u9gUDkmR9dFS8b5kAYqIETK4OnzsS4l2ragJ0+soSMHh6VEeNHjTfSjk1tKxCqLyziCrPogadxP680J+v6yGHw==}
+  turbo@2.2.1:
+    resolution: {integrity: sha512-clZFkh6U6NpsLKBVZYRjlZjRTfju1Z5STqvFVaOGu5443uM75alJe1nCYH9pQ9YJoiOvXAqA2rDHWN5kLS9JMg==}
     hasBin: true
 
   type-check@0.4.0:
@@ -5658,11 +5728,10 @@ packages:
     resolution: {integrity: sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==}
     engines: {node: '>= 0.4'}
 
-  typescript-eslint@7.13.1:
-    resolution: {integrity: sha512-pvLEuRs8iS9s3Cnp/Wt//hpK8nKc8hVa3cLljHqzaJJQYP8oys8GUyIFqtlev+2lT/fqMPcyQko+HJ6iYK3nFA==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  typescript-eslint@8.10.0:
+    resolution: {integrity: sha512-YIu230PeN7z9zpu/EtqCIuRVHPs4iSlqW6TEvjbyDAE3MZsSl2RXBo+5ag+lbABCG8sFM1WVKEXhlQ8Ml8A3Fw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.56.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -6471,20 +6540,22 @@ snapshots:
   '@esbuild/win32-x64@0.20.2':
     optional: true
 
-  '@eslint-community/eslint-utils@4.4.0(eslint@9.5.0)':
+  '@eslint-community/eslint-utils@4.4.0(eslint@9.13.0)':
     dependencies:
-      eslint: 9.5.0
+      eslint: 9.13.0
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/regexpp@4.10.0': {}
+  '@eslint-community/regexpp@4.11.1': {}
 
-  '@eslint/config-array@0.16.0':
+  '@eslint/config-array@0.18.0':
     dependencies:
       '@eslint/object-schema': 2.1.4
-      debug: 4.3.4
+      debug: 4.3.6(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
+
+  '@eslint/core@0.7.0': {}
 
   '@eslint/eslintrc@1.4.1':
     dependencies:
@@ -6503,8 +6574,8 @@ snapshots:
   '@eslint/eslintrc@3.1.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
-      espree: 10.1.0
+      debug: 4.3.6(supports-color@8.1.1)
+      espree: 10.2.0
       globals: 14.0.0
       ignore: 5.3.1
       import-fresh: 3.3.0
@@ -6514,11 +6585,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@eslint/js@9.13.0': {}
+
   '@eslint/js@9.5.0': {}
 
   '@eslint/object-schema@2.1.4': {}
 
+  '@eslint/plugin-kit@0.2.1':
+    dependencies:
+      levn: 0.4.1
+
   '@fontsource/fira-mono@4.5.10': {}
+
+  '@humanfs/core@0.19.0': {}
+
+  '@humanfs/node@0.16.5':
+    dependencies:
+      '@humanfs/core': 0.19.0
+      '@humanwhocodes/retry': 0.3.1
 
   '@humanwhocodes/config-array@0.9.5':
     dependencies:
@@ -6534,7 +6618,7 @@ snapshots:
 
   '@humanwhocodes/object-schema@1.2.1': {}
 
-  '@humanwhocodes/retry@0.3.0': {}
+  '@humanwhocodes/retry@0.3.1': {}
 
   '@inquirer/confirm@3.1.22':
     dependencies:
@@ -6599,8 +6683,6 @@ snapshots:
 
   '@jridgewell/set-array@1.2.1': {}
 
-  '@jridgewell/sourcemap-codec@1.4.15': {}
-
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@jridgewell/trace-mapping@0.3.25':
@@ -6611,7 +6693,7 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   '@lezer/common@1.2.1': {}
 
@@ -7822,16 +7904,18 @@ snapshots:
 
   '@types/diff-match-patch@1.0.36': {}
 
-  '@types/eslint@8.56.10':
+  '@types/eslint@9.6.0':
     dependencies:
       '@types/estree': 1.0.5
       '@types/json-schema': 7.0.15
 
   '@types/eslint__js@8.42.3':
     dependencies:
-      '@types/eslint': 8.56.10
+      '@types/eslint': 9.6.0
 
   '@types/estree@1.0.5': {}
+
+  '@types/estree@1.0.6': {}
 
   '@types/express-serve-static-core@4.19.3':
     dependencies:
@@ -8004,15 +8088,15 @@ snapshots:
       '@types/node': 22.3.0
     optional: true
 
-  '@typescript-eslint/eslint-plugin@7.13.1(@typescript-eslint/parser@7.13.1(eslint@9.5.0)(typescript@5.4.5))(eslint@9.5.0)(typescript@5.4.5)':
+  '@typescript-eslint/eslint-plugin@8.10.0(@typescript-eslint/parser@8.10.0(eslint@9.13.0)(typescript@5.4.5))(eslint@9.13.0)(typescript@5.4.5)':
     dependencies:
-      '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 7.13.1(eslint@9.5.0)(typescript@5.4.5)
-      '@typescript-eslint/scope-manager': 7.13.1
-      '@typescript-eslint/type-utils': 7.13.1(eslint@9.5.0)(typescript@5.4.5)
-      '@typescript-eslint/utils': 7.13.1(eslint@9.5.0)(typescript@5.4.5)
-      '@typescript-eslint/visitor-keys': 7.13.1
-      eslint: 9.5.0
+      '@eslint-community/regexpp': 4.11.1
+      '@typescript-eslint/parser': 8.10.0(eslint@9.13.0)(typescript@5.4.5)
+      '@typescript-eslint/scope-manager': 8.10.0
+      '@typescript-eslint/type-utils': 8.10.0(eslint@9.13.0)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.10.0(eslint@9.13.0)(typescript@5.4.5)
+      '@typescript-eslint/visitor-keys': 8.10.0
+      eslint: 9.13.0
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
@@ -8022,14 +8106,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.13.1(eslint@9.5.0)(typescript@5.4.5)':
+  '@typescript-eslint/parser@7.13.1(eslint@9.13.0)(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.13.1
       '@typescript-eslint/types': 7.13.1
       '@typescript-eslint/typescript-estree': 7.13.1(typescript@5.4.5)
       '@typescript-eslint/visitor-keys': 7.13.1
       debug: 4.3.4
-      eslint: 9.5.0
+      eslint: 9.13.0
+    optionalDependencies:
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.10.0(eslint@9.13.0)(typescript@5.4.5)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.10.0
+      '@typescript-eslint/types': 8.10.0
+      '@typescript-eslint/typescript-estree': 8.10.0(typescript@5.4.5)
+      '@typescript-eslint/visitor-keys': 8.10.0
+      debug: 4.3.6(supports-color@8.1.1)
+      eslint: 9.13.0
     optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -8045,27 +8142,34 @@ snapshots:
       '@typescript-eslint/types': 7.16.0
       '@typescript-eslint/visitor-keys': 7.16.0
 
-  '@typescript-eslint/type-utils@7.13.1(eslint@9.5.0)(typescript@5.4.5)':
+  '@typescript-eslint/scope-manager@8.10.0':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.13.1(typescript@5.4.5)
-      '@typescript-eslint/utils': 7.13.1(eslint@9.5.0)(typescript@5.4.5)
+      '@typescript-eslint/types': 8.10.0
+      '@typescript-eslint/visitor-keys': 8.10.0
+
+  '@typescript-eslint/type-utils@8.10.0(eslint@9.13.0)(typescript@5.4.5)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 8.10.0(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.10.0(eslint@9.13.0)(typescript@5.4.5)
       debug: 4.3.6(supports-color@8.1.1)
-      eslint: 9.5.0
       ts-api-utils: 1.3.0(typescript@5.4.5)
     optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
+      - eslint
       - supports-color
 
   '@typescript-eslint/types@7.13.1': {}
 
   '@typescript-eslint/types@7.16.0': {}
 
+  '@typescript-eslint/types@8.10.0': {}
+
   '@typescript-eslint/typescript-estree@7.13.1(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/types': 7.13.1
       '@typescript-eslint/visitor-keys': 7.13.1
-      debug: 4.3.4
+      debug: 4.3.6(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.4
@@ -8091,24 +8195,50 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@7.13.1(eslint@9.5.0)(typescript@5.4.5)':
+  '@typescript-eslint/typescript-estree@8.10.0(typescript@5.4.5)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.5.0)
+      '@typescript-eslint/types': 8.10.0
+      '@typescript-eslint/visitor-keys': 8.10.0
+      debug: 4.3.6(supports-color@8.1.1)
+      fast-glob: 3.3.2
+      is-glob: 4.0.3
+      minimatch: 9.0.4
+      semver: 7.6.2
+      ts-api-utils: 1.3.0(typescript@5.4.5)
+    optionalDependencies:
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@7.13.1(eslint@9.13.0)(typescript@5.4.5)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.13.0)
       '@typescript-eslint/scope-manager': 7.13.1
       '@typescript-eslint/types': 7.13.1
       '@typescript-eslint/typescript-estree': 7.13.1(typescript@5.4.5)
-      eslint: 9.5.0
+      eslint: 9.13.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@7.16.0(eslint@9.5.0)(typescript@5.4.5)':
+  '@typescript-eslint/utils@7.16.0(eslint@9.13.0)(typescript@5.4.5)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.5.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.13.0)
       '@typescript-eslint/scope-manager': 7.16.0
       '@typescript-eslint/types': 7.16.0
       '@typescript-eslint/typescript-estree': 7.16.0(typescript@5.4.5)
-      eslint: 9.5.0
+      eslint: 9.13.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@typescript-eslint/utils@8.10.0(eslint@9.13.0)(typescript@5.4.5)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.13.0)
+      '@typescript-eslint/scope-manager': 8.10.0
+      '@typescript-eslint/types': 8.10.0
+      '@typescript-eslint/typescript-estree': 8.10.0(typescript@5.4.5)
+      eslint: 9.13.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -8121,6 +8251,11 @@ snapshots:
   '@typescript-eslint/visitor-keys@7.16.0':
     dependencies:
       '@typescript-eslint/types': 7.16.0
+      eslint-visitor-keys: 3.4.3
+
+  '@typescript-eslint/visitor-keys@8.10.0':
+    dependencies:
+      '@typescript-eslint/types': 8.10.0
       eslint-visitor-keys: 3.4.3
 
   '@ungap/structured-clone@1.2.0': {}
@@ -8368,10 +8503,6 @@ snapshots:
   acorn-import-attributes@1.9.5(acorn@8.12.1):
     dependencies:
       acorn: 8.12.1
-
-  acorn-jsx@5.3.2(acorn@8.12.0):
-    dependencies:
-      acorn: 8.12.0
 
   acorn-jsx@5.3.2(acorn@8.12.1):
     dependencies:
@@ -9270,14 +9401,14 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-compat-utils@0.5.1(eslint@9.5.0):
+  eslint-compat-utils@0.5.1(eslint@9.13.0):
     dependencies:
-      eslint: 9.5.0
+      eslint: 9.13.0
       semver: 7.6.2
 
-  eslint-config-prettier@9.1.0(eslint@9.5.0):
+  eslint-config-prettier@9.1.0(eslint@9.13.0):
     dependencies:
-      eslint: 9.5.0
+      eslint: 9.13.0
 
   eslint-import-resolver-node@0.3.9:
     dependencies:
@@ -9287,13 +9418,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.13.1(eslint@9.5.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@9.5.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.13.1(eslint@9.13.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@9.13.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.17.0
-      eslint: 9.5.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.13.1(eslint@9.5.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.13.1(eslint@9.5.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@9.5.0))(eslint@9.5.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.13.1(eslint@9.5.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@9.5.0)
+      eslint: 9.13.0
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.13.1(eslint@9.13.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.13.1(eslint@9.13.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@9.13.0))(eslint@9.13.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.13.1(eslint@9.13.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@9.13.0)
       fast-glob: 3.3.1
       get-tsconfig: 4.7.5
       is-core-module: 2.13.1
@@ -9304,23 +9435,23 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.13.1(eslint@9.5.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.13.1(eslint@9.5.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@9.5.0))(eslint@9.5.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.13.1(eslint@9.13.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.13.1(eslint@9.13.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@9.13.0))(eslint@9.13.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 7.13.1(eslint@9.5.0)(typescript@5.4.5)
-      eslint: 9.5.0
+      '@typescript-eslint/parser': 7.13.1(eslint@9.13.0)(typescript@5.4.5)
+      eslint: 9.13.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.13.1(eslint@9.5.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@9.5.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.13.1(eslint@9.13.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@9.13.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import-x@0.5.1(eslint@9.5.0)(typescript@5.4.5):
+  eslint-plugin-import-x@0.5.1(eslint@9.13.0)(typescript@5.4.5):
     dependencies:
-      '@typescript-eslint/utils': 7.13.1(eslint@9.5.0)(typescript@5.4.5)
+      '@typescript-eslint/utils': 7.13.1(eslint@9.13.0)(typescript@5.4.5)
       debug: 4.3.4
       doctrine: 3.0.0
-      eslint: 9.5.0
+      eslint: 9.13.0
       eslint-import-resolver-node: 0.3.9
       get-tsconfig: 4.7.5
       is-glob: 4.0.3
@@ -9331,7 +9462,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.13.1(eslint@9.5.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@9.5.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.13.1(eslint@9.13.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@9.13.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -9339,9 +9470,9 @@ snapshots:
       array.prototype.flatmap: 1.3.2
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.5.0
+      eslint: 9.13.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.13.1(eslint@9.5.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.13.1(eslint@9.5.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@9.5.0))(eslint@9.5.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.13.1(eslint@9.13.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.13.1(eslint@9.13.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@9.13.0))(eslint@9.13.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -9352,36 +9483,36 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 7.13.1(eslint@9.5.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 7.13.1(eslint@9.13.0)(typescript@5.4.5)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-storybook@0.9.0--canary.156.ed236ca.0(eslint@9.5.0)(typescript@5.4.5):
+  eslint-plugin-storybook@0.9.0--canary.156.ed236ca.0(eslint@9.13.0)(typescript@5.4.5):
     dependencies:
       '@storybook/csf': 0.0.1
-      '@typescript-eslint/utils': 7.16.0(eslint@9.5.0)(typescript@5.4.5)
-      eslint: 9.5.0
+      '@typescript-eslint/utils': 7.16.0(eslint@9.13.0)(typescript@5.4.5)
+      eslint: 9.13.0
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-svelte@2.44.1(eslint@9.5.0)(svelte@5.0.0-next.243)(ts-node@10.9.2(@types/node@22.3.0)(typescript@5.4.5)):
+  eslint-plugin-svelte@2.46.0(eslint@9.13.0)(svelte@5.0.0-next.243)(ts-node@10.9.2(@types/node@22.3.0)(typescript@5.4.5)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.5.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.13.0)
       '@jridgewell/sourcemap-codec': 1.5.0
-      eslint: 9.5.0
-      eslint-compat-utils: 0.5.1(eslint@9.5.0)
+      eslint: 9.13.0
+      eslint-compat-utils: 0.5.1(eslint@9.13.0)
       esutils: 2.0.3
-      known-css-properties: 0.34.0
+      known-css-properties: 0.35.0
       postcss: 8.4.39
       postcss-load-config: 3.1.4(postcss@8.4.39)(ts-node@10.9.2(@types/node@22.3.0)(typescript@5.4.5))
       postcss-safe-parser: 6.0.0(postcss@8.4.39)
       postcss-selector-parser: 6.1.0
       semver: 7.6.2
-      svelte-eslint-parser: 0.41.1(svelte@5.0.0-next.243)
+      svelte-eslint-parser: 0.43.0(svelte@5.0.0-next.243)
     optionalDependencies:
       svelte: 5.0.0-next.243
     transitivePeerDependencies:
@@ -9392,7 +9523,7 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
-  eslint-scope@8.0.1:
+  eslint-scope@8.1.0:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
@@ -9406,7 +9537,7 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
-  eslint-visitor-keys@4.0.0: {}
+  eslint-visitor-keys@4.1.0: {}
 
   eslint@8.4.1:
     dependencies:
@@ -9451,24 +9582,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint@9.5.0:
+  eslint@9.13.0:
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.5.0)
-      '@eslint-community/regexpp': 4.10.0
-      '@eslint/config-array': 0.16.0
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.13.0)
+      '@eslint-community/regexpp': 4.11.1
+      '@eslint/config-array': 0.18.0
+      '@eslint/core': 0.7.0
       '@eslint/eslintrc': 3.1.0
-      '@eslint/js': 9.5.0
+      '@eslint/js': 9.13.0
+      '@eslint/plugin-kit': 0.2.1
+      '@humanfs/node': 0.16.5
       '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.3.0
-      '@nodelib/fs.walk': 1.2.8
+      '@humanwhocodes/retry': 0.3.1
+      '@types/estree': 1.0.6
+      '@types/json-schema': 7.0.15
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4
+      debug: 4.3.6(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
-      eslint-scope: 8.0.1
-      eslint-visitor-keys: 4.0.0
-      espree: 10.1.0
+      eslint-scope: 8.1.0
+      eslint-visitor-keys: 4.1.0
+      espree: 10.2.0
       esquery: 1.5.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
@@ -9478,25 +9613,22 @@ snapshots:
       ignore: 5.3.1
       imurmurhash: 0.1.4
       is-glob: 4.0.3
-      is-path-inside: 3.0.3
       json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
       lodash.merge: 4.6.2
       minimatch: 3.1.2
       natural-compare: 1.4.0
       optionator: 0.9.3
-      strip-ansi: 6.0.1
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
 
   esm-env@1.0.0: {}
 
-  espree@10.1.0:
+  espree@10.2.0:
     dependencies:
-      acorn: 8.12.0
-      acorn-jsx: 5.3.2(acorn@8.12.0)
-      eslint-visitor-keys: 4.0.0
+      acorn: 8.12.1
+      acorn-jsx: 5.3.2(acorn@8.12.1)
+      eslint-visitor-keys: 4.1.0
 
   espree@9.2.0:
     dependencies:
@@ -10278,8 +10410,6 @@ snapshots:
 
   is-number@7.0.0: {}
 
-  is-path-inside@3.0.3: {}
-
   is-plain-obj@2.1.0: {}
 
   is-plain-obj@4.1.0: {}
@@ -10483,7 +10613,7 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  known-css-properties@0.34.0: {}
+  known-css-properties@0.35.0: {}
 
   ky@0.33.3: {}
 
@@ -10581,7 +10711,7 @@ snapshots:
 
   magic-string@0.30.10:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   magic-string@0.30.11:
     dependencies:
@@ -10589,7 +10719,7 @@ snapshots:
 
   magic-string@0.30.7:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   magic-string@0.30.8:
     dependencies:
@@ -11642,7 +11772,7 @@ snapshots:
 
   sorcery@0.11.0:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
       buffer-crc32: 0.2.13
       minimist: 1.2.8
       sander: 0.5.1
@@ -11808,6 +11938,16 @@ snapshots:
       - picomatch
 
   svelte-eslint-parser@0.41.1(svelte@5.0.0-next.243):
+    dependencies:
+      eslint-scope: 7.2.2
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      postcss: 8.4.39
+      postcss-scss: 4.0.9(postcss@8.4.39)
+    optionalDependencies:
+      svelte: 5.0.0-next.243
+
+  svelte-eslint-parser@0.43.0(svelte@5.0.0-next.243):
     dependencies:
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -11994,32 +12134,32 @@ snapshots:
 
   tslib@2.6.3: {}
 
-  turbo-darwin-64@2.1.1:
+  turbo-darwin-64@2.2.1:
     optional: true
 
-  turbo-darwin-arm64@2.1.1:
+  turbo-darwin-arm64@2.2.1:
     optional: true
 
-  turbo-linux-64@2.1.1:
+  turbo-linux-64@2.2.1:
     optional: true
 
-  turbo-linux-arm64@2.1.1:
+  turbo-linux-arm64@2.2.1:
     optional: true
 
-  turbo-windows-64@2.1.1:
+  turbo-windows-64@2.2.1:
     optional: true
 
-  turbo-windows-arm64@2.1.1:
+  turbo-windows-arm64@2.2.1:
     optional: true
 
-  turbo@2.1.1:
+  turbo@2.2.1:
     optionalDependencies:
-      turbo-darwin-64: 2.1.1
-      turbo-darwin-arm64: 2.1.1
-      turbo-linux-64: 2.1.1
-      turbo-linux-arm64: 2.1.1
-      turbo-windows-64: 2.1.1
-      turbo-windows-arm64: 2.1.1
+      turbo-darwin-64: 2.2.1
+      turbo-darwin-arm64: 2.2.1
+      turbo-linux-64: 2.2.1
+      turbo-linux-arm64: 2.2.1
+      turbo-windows-64: 2.2.1
+      turbo-windows-arm64: 2.2.1
 
   type-check@0.4.0:
     dependencies:
@@ -12074,15 +12214,15 @@ snapshots:
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
 
-  typescript-eslint@7.13.1(eslint@9.5.0)(typescript@5.4.5):
+  typescript-eslint@8.10.0(eslint@9.13.0)(typescript@5.4.5):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.13.1(@typescript-eslint/parser@7.13.1(eslint@9.5.0)(typescript@5.4.5))(eslint@9.5.0)(typescript@5.4.5)
-      '@typescript-eslint/parser': 7.13.1(eslint@9.5.0)(typescript@5.4.5)
-      '@typescript-eslint/utils': 7.13.1(eslint@9.5.0)(typescript@5.4.5)
-      eslint: 9.5.0
+      '@typescript-eslint/eslint-plugin': 8.10.0(@typescript-eslint/parser@8.10.0(eslint@9.13.0)(typescript@5.4.5))(eslint@9.13.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 8.10.0(eslint@9.13.0)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.10.0(eslint@9.13.0)(typescript@5.4.5)
     optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
+      - eslint
       - supports-color
 
   typescript@5.4.5: {}
@@ -12130,7 +12270,7 @@ snapshots:
 
   unplugin@1.0.1:
     dependencies:
-      acorn: 8.12.0
+      acorn: 8.12.1
       chokidar: 3.6.0
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.5.0
@@ -12156,7 +12296,7 @@ snapshots:
 
   uri-js@4.4.1:
     dependencies:
-      punycode: 2.3.0
+      punycode: 2.3.1
 
   url-parse@1.5.10:
     dependencies:


### PR DESCRIPTION
## ☕️ Reasoning

- Fix eslint issue where first character of .svelte files was throwing errors where spreading of props was taking place.
- In addition, we weren't checking a few eslint rules previously, which we are now. i.e. `@typescript-eslint/no-unused-expression`
- Enable helpful monorepo tsconfig rules for child packages

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
