### PR TITLE
fix: stack header z-index

### DIFF
--- a/apps/desktop/src/lib/stack/StackHeader.svelte
+++ b/apps/desktop/src/lib/stack/StackHeader.svelte
@@ -165,7 +165,7 @@
 
 <style>
 	.header__wrapper {
-		z-index: var(--z-lifted);
+		z-index: var(--z-floating);
 		top: 12px;
 		padding-bottom: unset !important;
 		position: sticky;


### PR DESCRIPTION
## ☕️ Reasoning

- Dropzone line containers would render over StackHeader
## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
