### PR TITLE
Fixes a bug where the UI may freeze due to incorrectly processed duplicate changeID

### DIFF
--- a/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
@@ -45,7 +45,8 @@ pub fn integrate_upstream_commits_for_series(
         repo,
         remote_head.id(),
         stack_merge_base,
-    )?;
+    )?
+    .head;
 
     let do_rebease = branch.allow_rebasing || Some(subject_series) != all_series.first();
     let integrate_upstream_context = IntegrateUpstreamContext {

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -215,6 +215,9 @@ pub(crate) fn stack_series(
             )?;
             patches.push(vcommit);
         }
+        // There should be no duplicates, but dedup because the UI cant handle duplicates
+        patches.dedup_by(|a, b| a.id == b.id);
+
         let mut upstream_patches = vec![];
         if let Some(upstream_reference) = upstream_reference.clone() {
             let remote_head = ctx
@@ -244,6 +247,9 @@ pub(crate) fn stack_series(
             }
         }
         upstream_patches.reverse();
+        // There should be no duplicates, but dedup because the UI cant handle duplicates
+        upstream_patches.dedup_by(|a, b| a.id == b.id);
+
         if !upstream_patches.is_empty() {
             requires_force = true;
         }

--- a/crates/gitbutler-stack-api/src/lib.rs
+++ b/crates/gitbutler-stack-api/src/lib.rs
@@ -2,4 +2,6 @@ mod heads;
 mod series;
 mod stack_ext;
 pub use series::Series;
-pub use stack_ext::{commit_by_oid_or_change_id, PatchReferenceUpdate, StackExt, TargetUpdate};
+pub use stack_ext::{
+    commit_by_oid_or_change_id, CommitsForId, PatchReferenceUpdate, StackExt, TargetUpdate,
+};

--- a/crates/gitbutler-stack-api/tests/mod.rs
+++ b/crates/gitbutler-stack-api/tests/mod.rs
@@ -291,7 +291,7 @@ fn add_series_target_change_id_doesnt_exist() -> Result<()> {
     let result = test_ctx.branch.add_series(&ctx, reference.clone(), None);
     assert_eq!(
         result.err().unwrap().to_string(),
-        "Commit with change id does-not-exist not found"
+        "No commit with change id does-not-exist found",
     );
     Ok(())
 }


### PR DESCRIPTION
If a branch/stack has more than one commit with the same change ID - well that breaks the UI.
While a change ID being duplicated in the branch/stack is a bad state to be in, it is possible to be achieved. And if the app finds itself in that condition, it needs to handle it.

This PR removes that assumption that there would be only one commit with a given changeID in branch.

This issue was initially reported on Discord: https://discord.com/channels/1060193121130000425/1297929207329984542
Once this occurs, the UI is unable to handle key duplication and freezes up entirely, with no error logs entries anywhere. 

### How is it possible to end up with duplicate change IDs?
Here are at least to scenarios, curtesy of Caleb:

**Rebase on GitHub**
- Make branch A with a commit
- Push branch A
- Use GitHub to rebase branch A (because we know this preserves commit ids)
- Click "integrate upstream", which creates the commits `A -> A'`

**Using the undo history in-app**
- Make a branch A with commit which modifies file foo.txt
- Unapply branch A
- Use history to restore before the unapply (we now have A' applied)
- Drag commit to different branch B
- Modify commit such that it no longer modifies foo.txt, and now modifies bar.txt
- Drop changes and unapply branch A'
- Apply branch A
- Drag commit from branch A into branch B, or vise versa