### PR TITLE
fix: allow renaming already pushed branches

### DIFF
--- a/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
@@ -176,7 +176,7 @@
 				seriesCount={branch.series?.length ?? 0}
 				{addDescription}
 				onGenerateBranchName={generateBranchName}
-				disableTitleEdit={!!gitHostBranch}
+				hasGitHostBranch={!!gitHostBranch}
 				hasPr={!!$pr}
 				openPrDetailsModal={handleOpenPR}
 				reloadPR={handleReloadPR}

--- a/apps/desktop/src/lib/branch/StackingSeriesHeaderContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeaderContextMenu.svelte
@@ -17,7 +17,7 @@
 		target?: HTMLElement;
 		headName: string;
 		seriesCount: number;
-		disableTitleEdit: boolean;
+		hasGitHostBranch: boolean;
 		hasPr: boolean;
 		addDescription: () => void;
 		onGenerateBranchName: () => void;
@@ -29,7 +29,7 @@
 		contextMenuEl = $bindable(),
 		target,
 		seriesCount,
-		disableTitleEdit,
+		hasGitHostBranch,
 		headName,
 		hasPr,
 		addDescription,
@@ -71,7 +71,7 @@
 				contextMenuEl?.close();
 			}}
 		/>
-		{#if $aiGenEnabled && aiConfigurationValid && !disableTitleEdit}
+		{#if $aiGenEnabled && aiConfigurationValid && !hasGitHostBranch}
 			<ContextMenuItem
 				label="Generate branch name"
 				onclick={() => {
@@ -80,15 +80,13 @@
 				}}
 			/>
 		{/if}
-		{#if !disableTitleEdit}
-			<ContextMenuItem
-				label="Rename"
-				onclick={async () => {
-					renameSeriesModal.show(branch);
-					contextMenuEl?.close();
-				}}
-			/>
-		{/if}
+		<ContextMenuItem
+			label="Rename"
+			onclick={async () => {
+				renameSeriesModal.show(branch);
+				contextMenuEl?.close();
+			}}
+		/>
 		{#if seriesCount > 1}
 			<ContextMenuItem
 				label="Delete"
@@ -121,7 +119,8 @@
 
 <Modal
 	width="small"
-	title="Rename branch"
+	title={hasGitHostBranch ? 'Branch has already been pushed' : 'Rename branch'}
+	type={hasGitHostBranch ? 'warning' : 'info'}
 	bind:this={renameSeriesModal}
 	onSubmit={(close) => {
 		if (newHeadName && newHeadName !== headName) {
@@ -131,6 +130,13 @@
 	}}
 >
 	<TextBox placeholder="New name" id="newSeriesName" bind:value={newHeadName} focus />
+
+	{#if hasGitHostBranch}
+		<div class="text-12 text-light helper-text">
+			Renaming a branch that has already been pushed will create a new branch at the remote. The old
+			one will remain untouched but will be disassociated from this branch.
+		</div>
+	{/if}
 
 	{#snippet controls(close)}
 		<Button style="ghost" outline type="reset" onclick={close}>Cancel</Button>
@@ -160,3 +166,11 @@
 		<Button style="error" kind="solid" type="submit" loading={isDeleting}>Delete</Button>
 	{/snippet}
 </Modal>
+
+<style>
+	.helper-text {
+		margin-top: 1rem;
+		color: var(--clr-scale-ntrl-50);
+		line-height: 1.5;
+	}
+</style>

--- a/crates/gitbutler-stack-api/src/stack_ext.rs
+++ b/crates/gitbutler-stack-api/src/stack_ext.rs
@@ -367,14 +367,6 @@ impl StackExt for Stack {
                 .iter_mut()
                 .find(|h: &&mut PatchReference| h.name == branch_name);
             if let Some(head) = head {
-                // ensure that the head has not been pushed to a remote yet
-                let default_target = branch_state(ctx).get_default_target()?;
-                if reference_exists(
-                    ctx,
-                    &head.remote_reference(&default_target.push_remote_name())?,
-                )? {
-                    bail!("Cannot update the name of a head that has been pushed to a remote");
-                }
                 head.name = name;
                 validate_name(head, ctx, &state, self.upstream.clone())?;
             }

--- a/crates/gitbutler-stack-api/tests/mod.rs
+++ b/crates/gitbutler-stack-api/tests/mod.rs
@@ -625,11 +625,8 @@ fn update_name_after_push() -> Result<()> {
             ..Default::default()
         },
     );
-    assert!(result.is_err());
-    assert_eq!(
-        result.err().unwrap().to_string(),
-        "Cannot update the name of a head that has been pushed to a remote"
-    );
+
+    assert!(result.is_ok());
     Ok(())
 }
 


### PR DESCRIPTION
## ☕️ Reasoning

- Allow renaming an already pushed branch/series

## 🧢 Changes

- When attempting to rename an already pushed branch/series, show the user a warning 
- Update tests

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
