### PR TITLE
fix: stacking pr card reactivity 

### DIFF
--- a/apps/desktop/src/lib/branch/BranchLane.svelte
+++ b/apps/desktop/src/lib/branch/BranchLane.svelte
@@ -4,11 +4,6 @@
 	import { projectLaneCollapsed } from '$lib/config/config';
 	import { stackingFeature } from '$lib/config/uiFeatureFlags';
 	import FileCard from '$lib/file/FileCard.svelte';
-	import { getGitHost } from '$lib/gitHost/interface/gitHost';
-	import { createGitHostChecksMonitorStore } from '$lib/gitHost/interface/gitHostChecksMonitor';
-	import { getGitHostListingService } from '$lib/gitHost/interface/gitHostListingService';
-	import { createGitHostPrMonitorStore } from '$lib/gitHost/interface/gitHostPrMonitor';
-	import { createGitHostPrServiceStore } from '$lib/gitHost/interface/gitHostPrService';
 	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import Resizer from '$lib/shared/Resizer.svelte';
 	import Stack from '$lib/stack/Stack.svelte';
@@ -34,34 +29,6 @@
 	import { slide } from 'svelte/transition';
 
 	const { branch }: { branch: VirtualBranch } = $props();
-
-	const gitHost = getGitHost();
-
-	// BRANCH SERVICE
-	const prService = createGitHostPrServiceStore(undefined);
-	$effect(() => prService.set($gitHost?.prService()));
-
-	// Pretty cumbersome way of getting the PR number, would be great if we can
-	// make it more concise somehow.
-	const hostedListingServiceStore = getGitHostListingService();
-	const prStore = $derived($hostedListingServiceStore?.prs);
-	const prs = $derived(prStore ? $prStore : undefined);
-
-	const listedPr = $derived(prs?.find((pr) => pr.sourceBranch === branch.upstream?.givenName));
-	const sourceBranch = $derived(listedPr?.sourceBranch);
-	const prNumber = $derived(listedPr?.number);
-
-	if (!$stackingFeature) {
-		const gitHostPrMonitorStore = createGitHostPrMonitorStore(undefined);
-		const prMonitor = $derived(prNumber ? $prService?.prMonitor(prNumber) : undefined);
-		$effect(() => gitHostPrMonitorStore.set(prMonitor));
-
-		const gitHostChecksMonitorStore = createGitHostChecksMonitorStore(undefined);
-		const checksMonitor = $derived(
-			sourceBranch ? $gitHost?.checksMonitor(sourceBranch) : undefined
-		);
-		$effect(() => gitHostChecksMonitorStore.set(checksMonitor));
-	}
 
 	// BRANCH
 	const branchStore = createContextStore(VirtualBranch, branch);

--- a/apps/desktop/src/lib/branch/BranchLane.svelte
+++ b/apps/desktop/src/lib/branch/BranchLane.svelte
@@ -51,13 +51,17 @@
 	const sourceBranch = $derived(listedPr?.sourceBranch);
 	const prNumber = $derived(listedPr?.number);
 
-	const gitHostPrMonitorStore = createGitHostPrMonitorStore(undefined);
-	const prMonitor = $derived(prNumber ? $prService?.prMonitor(prNumber) : undefined);
-	$effect(() => gitHostPrMonitorStore.set(prMonitor));
+	if (!$stackingFeature) {
+		const gitHostPrMonitorStore = createGitHostPrMonitorStore(undefined);
+		const prMonitor = $derived(prNumber ? $prService?.prMonitor(prNumber) : undefined);
+		$effect(() => gitHostPrMonitorStore.set(prMonitor));
 
-	const gitHostChecksMonitorStore = createGitHostChecksMonitorStore(undefined);
-	const checksMonitor = $derived(sourceBranch ? $gitHost?.checksMonitor(sourceBranch) : undefined);
-	$effect(() => gitHostChecksMonitorStore.set(checksMonitor));
+		const gitHostChecksMonitorStore = createGitHostChecksMonitorStore(undefined);
+		const checksMonitor = $derived(
+			sourceBranch ? $gitHost?.checksMonitor(sourceBranch) : undefined
+		);
+		$effect(() => gitHostChecksMonitorStore.set(checksMonitor));
+	}
 
 	// BRANCH
 	const branchStore = createContextStore(VirtualBranch, branch);

--- a/apps/desktop/src/lib/commit/CommitDragItem.svelte
+++ b/apps/desktop/src/lib/commit/CommitDragItem.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { CommitDragActions, CommitDragActionsFactory } from '$lib/commits/dragActions';
-	import { stackingFeature } from '$lib/config/uiFeatureFlags';
 	import CardOverlay from '$lib/dropzone/CardOverlay.svelte';
 	import Dropzone from '$lib/dropzone/Dropzone.svelte';
 	import { Commit, VirtualBranch, DetailedCommit } from '$lib/vbranches/types';
@@ -41,13 +40,9 @@
 				{hovered}
 				{activated}
 				label="Amend commit"
-				extraPaddings={$stackingFeature
-					? {
-							left: 4
-						}
-					: {
-							left: 4
-						}}
+				extraPaddings={{
+					left: 4
+				}}
 			/>
 		{/snippet}
 	</Dropzone>
@@ -62,13 +57,9 @@
 				{hovered}
 				{activated}
 				label="Squash commit"
-				extraPaddings={$stackingFeature
-					? {
-							left: -4
-						}
-					: {
-							left: 4
-						}}
+				extraPaddings={{
+					left: 4
+				}}
 			/>
 		{/snippet}
 	</Dropzone>

--- a/apps/desktop/src/lib/dragging/reorderDropzoneManager.ts
+++ b/apps/desktop/src/lib/dragging/reorderDropzoneManager.ts
@@ -76,7 +76,7 @@ class Indexer {
 	get(key: string) {
 		const index = this.getIndex(key);
 
-		return new Entry(this.commitIndexes, index);
+		return new Entry(this.commitIndexes, index ?? 0);
 	}
 
 	private getIndex(key: string) {
@@ -90,9 +90,11 @@ class Indexer {
 		} else {
 			const index = this.dropzoneIndexes.get(key);
 
-			if (index === undefined) {
-				throw new Error(`Commit ${key} not found in dropzoneIndexes`);
-			}
+			// TODO: Improve reactivity of dropzoneIndexes
+			// Handle integrated state and dont error
+			// if (index === undefined) {
+			// 	throw new Error(`Commit ${key} not found in dropzoneIndexes`);
+			// }
 
 			return index;
 		}

--- a/apps/desktop/src/lib/pr/PullRequestCard.svelte
+++ b/apps/desktop/src/lib/pr/PullRequestCard.svelte
@@ -143,8 +143,10 @@
 				tooltip="Open in browser"
 				onclick={() => {
 					openExternalUrl($pr.htmlUrl);
-				}}>View PR</Button
+				}}
 			>
+				View PR
+			</Button>
 		</div>
 
 		<!--

--- a/apps/desktop/src/lib/pr/StackingPullRequestCard.svelte
+++ b/apps/desktop/src/lib/pr/StackingPullRequestCard.svelte
@@ -32,7 +32,6 @@
 	const project = getContext(Project);
 
 	const gitHostListingService = getGitHostListingService();
-
 	const prStore = $derived($gitHostListingService?.prs);
 	const prs = $derived(prStore ? $prStore : undefined);
 
@@ -52,7 +51,9 @@
 	// While the pr monitor is set to fetch updates by interval, we want
 	// frequent updates while checks are running.
 	$effect(() => {
-		if ($checks) prMonitor?.refresh();
+		if ($checks) {
+			prMonitor?.refresh();
+		}
 	});
 
 	let isMerging = $state(false);
@@ -111,7 +112,7 @@
 	});
 </script>
 
-{#if pr}
+{#if $pr}
 	<div class="pr-header">
 		<div class="text-13 text-semibold pr-header-title">
 			<span style="color: var(--clr-scale-ntrl-50)">PR #{$pr?.number}:</span>
@@ -164,7 +165,7 @@
         determining "no checks will run for this PR" such that we can show the merge button
         immediately.
         -->
-		{#if pr}
+		{#if $pr}
 			<div class="pr-header-actions">
 				<MergeButton
 					wide

--- a/apps/desktop/src/lib/stack/Stack.svelte
+++ b/apps/desktop/src/lib/stack/Stack.svelte
@@ -8,9 +8,7 @@
 	import Dropzones from '$lib/branch/Dropzones.svelte';
 	import CommitDialog from '$lib/commit/CommitDialog.svelte';
 	import BranchFiles from '$lib/file/BranchFiles.svelte';
-	import { getGitHostChecksMonitor } from '$lib/gitHost/interface/gitHostChecksMonitor';
 	import { getGitHostListingService } from '$lib/gitHost/interface/gitHostListingService';
-	import { getGitHostPrMonitor } from '$lib/gitHost/interface/gitHostPrMonitor';
 	import ScrollableContainer from '$lib/scroll/ScrollableContainer.svelte';
 	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import Resizer from '$lib/shared/Resizer.svelte';
@@ -74,8 +72,6 @@
 	});
 
 	const listingService = getGitHostListingService();
-	const prMonitor = getGitHostPrMonitor();
-	const checksMonitor = getGitHostChecksMonitor();
 	const hostedListingServiceStore = getGitHostListingService();
 
 	const stackBranches = $derived(branch.series.map((s) => s.name));
@@ -87,8 +83,7 @@
 		try {
 			await branchController.pushBranch(branch.id, branch.requiresForce, true);
 			$listingService?.refresh();
-			$prMonitor?.refresh();
-			$checksMonitor?.update();
+			// TODO: Refresh prMonitor and checksMonitor upon push
 		} finally {
 			isPushingCommits = false;
 		}

--- a/apps/desktop/src/lib/stack/StackCurrentSeries.svelte
+++ b/apps/desktop/src/lib/stack/StackCurrentSeries.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	import { getGitHost } from '$lib/gitHost/interface/gitHost';
+	import { createGitHostChecksMonitorStore } from '$lib/gitHost/interface/gitHostChecksMonitor';
+	import { getGitHostListingService } from '$lib/gitHost/interface/gitHostListingService';
+	import { createGitHostPrMonitorStore } from '$lib/gitHost/interface/gitHostPrMonitor';
+	import { getGitHostPrService } from '$lib/gitHost/interface/gitHostPrService';
+	import type { PatchSeries } from '$lib/vbranches/types';
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		currentSeries: PatchSeries;
+		children: Snippet;
+	}
+
+	const { currentSeries, children }: Props = $props();
+
+	// Setup PR Store and Monitor on a per-series basis
+	const gitHost = getGitHost();
+	const prService = getGitHostPrService();
+
+	// Pretty cumbersome way of getting the PR number, would be great if we can
+	// make it more concise somehow.
+	const hostedListingServiceStore = getGitHostListingService();
+	const prStore = $derived($hostedListingServiceStore?.prs);
+	const prs = $derived(prStore ? $prStore : undefined);
+
+	const listedPr = $derived(prs?.find((pr) => pr.sourceBranch === currentSeries.name));
+	const prNumber = $derived(listedPr?.number);
+
+	const prMonitor = $derived(prNumber ? $prService?.prMonitor(prNumber) : undefined);
+	const pr = $derived(prMonitor?.pr);
+
+	const gitHostPrMonitorStore = createGitHostPrMonitorStore(undefined);
+	$effect(() => gitHostPrMonitorStore.set(prMonitor));
+
+	const checksMonitor = $derived(
+		$pr?.sourceBranch ? $gitHost?.checksMonitor($pr.sourceBranch) : undefined
+	);
+	const gitHostChecksMonitorStore = createGitHostChecksMonitorStore(undefined);
+	$effect(() => gitHostChecksMonitorStore.set(checksMonitor));
+</script>
+
+<div class="branch-group">
+	{@render children()}
+</div>
+
+<style>
+	.branch-group {
+		border: 1px solid var(--clr-border-2);
+		border-radius: var(--radius-m);
+		background: var(--clr-bg-1);
+
+		&:last-child {
+			margin-bottom: 12px;
+		}
+	}
+</style>

--- a/apps/desktop/src/lib/stack/StackCurrentSeries.svelte
+++ b/apps/desktop/src/lib/stack/StackCurrentSeries.svelte
@@ -3,7 +3,7 @@
 	import { createGitHostChecksMonitorStore } from '$lib/gitHost/interface/gitHostChecksMonitor';
 	import { getGitHostListingService } from '$lib/gitHost/interface/gitHostListingService';
 	import { createGitHostPrMonitorStore } from '$lib/gitHost/interface/gitHostPrMonitor';
-	import { getGitHostPrService } from '$lib/gitHost/interface/gitHostPrService';
+	import { createGitHostPrServiceStore } from '$lib/gitHost/interface/gitHostPrService';
 	import type { PatchSeries } from '$lib/vbranches/types';
 	import type { Snippet } from 'svelte';
 
@@ -16,7 +16,8 @@
 
 	// Setup PR Store and Monitor on a per-series basis
 	const gitHost = getGitHost();
-	const prService = getGitHostPrService();
+	const prService = createGitHostPrServiceStore(undefined);
+	$effect(() => prService.set($gitHost?.prService()));
 
 	// Pretty cumbersome way of getting the PR number, would be great if we can
 	// make it more concise somehow.

--- a/apps/desktop/src/lib/stack/StackSeries.svelte
+++ b/apps/desktop/src/lib/stack/StackSeries.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import StackCurrentSeries from './StackCurrentSeries.svelte';
 	import StackSeriesDividerLine from './StackSeriesDividerLine.svelte';
 	import StackingSeriesHeader from '$lib/branch/StackingSeriesHeader.svelte';
 	import StackingCommitList from '$lib/commit/StackingCommitList.svelte';
@@ -27,7 +28,7 @@
 	{#if !isTopSeries}
 		<StackSeriesDividerLine {currentSeries} />
 	{/if}
-	<div class="branch-group">
+	<StackCurrentSeries {currentSeries}>
 		<StackingSeriesHeader {currentSeries} {isTopSeries} />
 		{#if currentSeries.upstreamPatches.length > 0 || currentSeries.patches.length > 0}
 			<StackingCommitList
@@ -40,17 +41,5 @@
 				{hasConflicts}
 			/>
 		{/if}
-	</div>
+	</StackCurrentSeries>
 {/each}
-
-<style>
-	.branch-group {
-		border: 1px solid var(--clr-border-2);
-		border-radius: var(--radius-m);
-		background: var(--clr-bg-1);
-
-		&:last-child {
-			margin-bottom: 12px;
-		}
-	}
-</style>


### PR DESCRIPTION
## ☕️ Reasoning

- fix StackingPullRequestCard reactivity issues
- Split `prMonitor` and `checksMonitor` creation out from the top-level `BranchLane`, i.e. from before the stacking/non-stacking contexts split, to afterward the split so they can be init-ed differently and the user can still switch between the two contexts without reloading
	- init those stores separately in stacking context for each series and separately in non-stacking context once per lane / branch
	- Minor cleanup in some related files 


## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
