### PR TITLE
style: Fix the history container z-index

### DIFF
--- a/apps/desktop/src/lib/history/History.svelte
+++ b/apps/desktop/src/lib/history/History.svelte
@@ -231,7 +231,7 @@
 
 <style lang="postcss">
 	.sideview-container {
-		z-index: var(--z-floating);
+		z-index: var(--z-modal);
 		position: fixed;
 		top: 0;
 		right: 0;


### PR DESCRIPTION
Fix the side-view container so that it is rendered above the lane headers