### PR TITLE
fix: show commit fileList when there are only conflictedFiles

### DIFF
--- a/apps/desktop/src/lib/file/BranchFilesList.svelte
+++ b/apps/desktop/src/lib/file/BranchFilesList.svelte
@@ -126,7 +126,7 @@
 	</div>
 {/if}
 
-{#if displayedFiles.length > 0}
+{#if displayedFiles.length > 0 || (conflictedFiles?.entries.size || 0) > 0}
 	<!-- Maximum amount for initial render is 100 files
 	`minTriggerCount` set to 80 in order to start the loading a bit earlier. -->
 


### PR DESCRIPTION
## ☕️ Reasoning

- Conflicted files were hidden if the commit contained **only** conflicted files

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
