### PR TITLE
fix: enable "push and create PR"

### DIFF
--- a/apps/desktop/src/lib/branch/BranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/BranchHeader.svelte
@@ -73,7 +73,7 @@
 	}
 
 	function handleOpenPR() {
-		prDetailsModal?.show({ pushAndCreatePr: false });
+		prDetailsModal?.show(false);
 	}
 </script>
 

--- a/apps/desktop/src/lib/branch/BranchHeader.svelte
+++ b/apps/desktop/src/lib/branch/BranchHeader.svelte
@@ -73,7 +73,7 @@
 	}
 
 	function handleOpenPR() {
-		prDetailsModal?.show();
+		prDetailsModal?.show({ pushAndCreatePr: false });
 	}
 </script>
 

--- a/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
@@ -231,13 +231,7 @@
 	{#if $pr}
 		<PrDetailsModal bind:this={prDetailsModal} type="display" pr={$pr} />
 	{:else}
-		<PrDetailsModal
-			bind:this={prDetailsModal}
-			type="preview-series"
-			{upstreamName}
-			name={currentSeries.name}
-			commits={currentSeries.patches}
-		/>
+		<PrDetailsModal bind:this={prDetailsModal} type="preview-series" {currentSeries} />
 	{/if}
 </div>
 

--- a/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
@@ -80,8 +80,8 @@
 		await Promise.allSettled([prMonitor?.refresh(), checksMonitor?.update()]);
 	}
 
-	function handleOpenPR(pushAndCreatePr: boolean = false) {
-		prDetailsModal?.show(pushAndCreatePr);
+	function handleOpenPR(pushBeforeCreate: boolean = false) {
+		prDetailsModal?.show(pushBeforeCreate);
 	}
 
 	function editTitle(title: string) {

--- a/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
@@ -81,7 +81,7 @@
 	}
 
 	function handleOpenPR(pushAndCreatePr: boolean = false) {
-		prDetailsModal?.show({ pushAndCreatePr, name: currentSeries.name });
+		prDetailsModal?.show(pushAndCreatePr);
 	}
 
 	function editTitle(title: string) {

--- a/apps/desktop/src/lib/pr/PrDetailsModal.svelte
+++ b/apps/desktop/src/lib/pr/PrDetailsModal.svelte
@@ -98,7 +98,7 @@
 	let aiConfigurationValid = $state<boolean>(false);
 	let aiDescriptionDirective = $state<string | undefined>(undefined);
 	let showAiBox = $state<boolean>(false);
-	let pushBeforeCreatePr = $state(false);
+	let pushBeforeCreate = $state(false);
 
 	async function handleToggleUseTemplate() {
 		if (!templateSelector) return;
@@ -155,7 +155,7 @@
 		try {
 			let upstreamBranchName = upstreamName;
 
-			if (pushBeforeCreatePr || commits.some((c) => !c.isRemote)) {
+			if (pushBeforeCreate || commits.some((c) => !c.isRemote)) {
 				const firstPush = !branch.upstream;
 				const pushResult = await branchController.pushBranch(
 					branch.id,
@@ -307,7 +307,7 @@
 	 * @param {boolean} pushAndCreate - Whether or not the commits need pushed before opening a PR
 	 */
 	export function show(pushAndCreate = false) {
-		pushBeforeCreatePr = pushAndCreate;
+		pushBeforeCreate = pushAndCreate;
 		modal?.show();
 	}
 
@@ -443,7 +443,7 @@
 				type="submit"
 				onclick={async () => await handleCreatePR(close)}
 			>
-				{pushBeforeCreatePr ? 'Push and ' : ''}
+				{pushBeforeCreate ? 'Push and ' : ''}
 				{isDraft ? 'Create pull request draft' : `Create pull request`}
 
 				{#snippet contextMenuSlot()}

--- a/apps/desktop/src/lib/pr/PrDetailsModal.svelte
+++ b/apps/desktop/src/lib/pr/PrDetailsModal.svelte
@@ -33,7 +33,7 @@
 	import { error } from '$lib/utils/toasts';
 	import { openExternalUrl } from '$lib/utils/url';
 	import { BranchController } from '$lib/vbranches/branchController';
-	import { DetailedCommit, VirtualBranch } from '$lib/vbranches/types';
+	import { PatchSeries, VirtualBranch } from '$lib/vbranches/types';
 	import { getContext, getContextStore } from '@gitbutler/shared/context';
 	import BorderlessTextarea from '@gitbutler/ui/BorderlessTextarea.svelte';
 	import Button from '@gitbutler/ui/Button.svelte';
@@ -57,9 +57,8 @@
 
 	interface PreviewSeriesProps {
 		type: 'preview-series';
-		name: string;
 		upstreamName?: string;
-		commits: DetailedCommit[];
+		currentSeries: PatchSeries;
 	}
 
 	type Props = DisplayProps | PreviewProps | PreviewSeriesProps;
@@ -79,10 +78,14 @@
 	const preferredPRAction = getPreferredPRAction();
 
 	const branch = $derived($branchStore);
-	const branchName = $derived(props.type === 'preview-series' ? props.name : branch.name);
-	const commits = $derived(props.type === 'preview-series' ? props.commits : branch.commits);
+	const branchName = $derived(
+		props.type === 'preview-series' ? props.currentSeries.name : branch.name
+	);
+	const commits = $derived(
+		props.type === 'preview-series' ? props.currentSeries.patches : branch.commits
+	);
 	const upstreamName = $derived(
-		props.type === 'preview-series' ? props.upstreamName : branch.upstreamName
+		props.type === 'preview-series' ? props.currentSeries.name : branch.upstreamName
 	);
 	const baseBranchName = $derived($baseBranch.shortName);
 


### PR DESCRIPTION
## ☕️ Reasoning

- Add "Push and Create PR" funcitonality back

## 🧢 Changes

- Works by showing the "Create Pull Request" button in the series header early (i.e. before series has been pushed).
	- If the user presses it, the `PrDetailsModal` opens as normal, but the options there are then "Push and Create Pull Request" / "Push and Create Draft Pull Request", which upon clicking then does what it says on the tin.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
