### PR TITLE
Update StackingUpstreamCommitsAccordion.svelte

### DIFF
--- a/apps/desktop/src/lib/commit/StackingUpstreamCommitsAccordion.svelte
+++ b/apps/desktop/src/lib/commit/StackingUpstreamCommitsAccordion.svelte
@@ -17,9 +17,9 @@
 	}
 </script>
 
-<button class="accordion" onclick={toggle}>
+<div class="accordion">
 	{#if count !== 1}
-		<div class="accordion-row header">
+		<button class="accordion-row header" onclick={toggle}>
 			<div class="accordion-row__line">
 				<div class="dots">
 					{#if !isOpen}
@@ -48,7 +48,7 @@
 				<h5 class="text-13 text-body text-semibold title">Upstream commits</h5>
 				<Icon name={isOpen ? 'chevron-up' : 'chevron-down'} />
 			</div>
-		</div>
+		</button>
 	{/if}
 	{#if isOpen}
 		<div class="accordion-children">
@@ -62,7 +62,7 @@
 			</div>
 		</div>
 	{/if}
-</button>
+</div>
 
 <style>
 	.accordion {


### PR DESCRIPTION
## ☕️ Reasoning

It was impossible to unfold the commit card because it was blocked by the action on top. Only the header of the accordion should be clickable.

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
