### PR TITLE
fix(nix): use stable flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,9 +18,26 @@
         "type": "github"
       }
     },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1729449015,
+        "narHash": "sha256-Gf04dXB0n4q0A9G5nTGH3zuMGr6jtJppqdeljxua1fo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "89172919243df199fe237ba0f776c3e3e3d72367",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay",
         "unstablePkgs": "unstablePkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,6 @@
 {
   inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
     unstablePkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay = {
@@ -9,7 +10,7 @@
       };
     };
   };
-  outputs = { self, unstablePkgs, flake-utils, rust-overlay }:
+  outputs = { self, unstablePkgs, nixpkgs, flake-utils, rust-overlay }:
     flake-utils.lib.eachDefaultSystem
       (system:
         let
@@ -17,10 +18,13 @@
           unstable = import unstablePkgs {
             inherit system overlays;
           };
+          pkgs = import nixpkgs {
+            inherit system overlays;
+          };
 
           rustToolchain = unstable.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
 
-          common = with unstable; [
+          common = with pkgs; [
             gtk3
             glib
             glib-networking
@@ -37,7 +41,7 @@
           ];
 
           # runtime Deps
-          libraries = with unstable;[
+          libraries = with pkgs; [
             cairo
             pango
             harfbuzz
@@ -45,7 +49,7 @@
           ] ++ common;
 
           # compile-time deps
-          packages = with unstable; [
+          packages = with pkgs; [
             curl
             wget
             pkg-config


### PR DESCRIPTION
## ☕️ Reasoning

- Update flake.nix inputs to use stable 24.05 inputs instead of from unstable branch

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
