### PR TITLE
feat: add contextMenu to checks and pr btns in StackingPullRequestCard

### DIFF
--- a/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
@@ -210,7 +210,7 @@
 			<div class="branch-action__line" style:--bg-color={lineColor}></div>
 			<div class="branch-action__body">
 				{#if $pr}
-					<StackingPullRequestCard upstreamName={currentSeries.name} />
+					<StackingPullRequestCard upstreamName={currentSeries.name} reloadPR={handleReloadPR} />
 				{:else}
 					<Button
 						style="ghost"

--- a/apps/desktop/src/lib/pr/StackingPullRequestCard.svelte
+++ b/apps/desktop/src/lib/pr/StackingPullRequestCard.svelte
@@ -162,12 +162,14 @@
 							label="Open checks"
 							onclick={() => {
 								openExternalUrl(`${$pr.htmlUrl}/checks`);
+								checksContextMenuEl?.close();
 							}}
 						/>
 						<ContextMenuItem
 							label="Copy Checks"
 							onclick={() => {
 								copyToClipboard(`${$pr.htmlUrl}/checks`);
+								checksContextMenuEl?.close();
 							}}
 						/>
 					</ContextMenuSection>
@@ -199,6 +201,7 @@
 							label="Copy PR Link"
 							onclick={() => {
 								copyToClipboard($pr.htmlUrl);
+								prContextMenuEl?.close();
 							}}
 						/>
 					</ContextMenuSection>

--- a/apps/desktop/src/lib/pr/StackingPullRequestCard.svelte
+++ b/apps/desktop/src/lib/pr/StackingPullRequestCard.svelte
@@ -93,7 +93,7 @@
 			return { style, icon, text };
 		}
 		if ($checksLoading) {
-			return { style: 'neutral', icon: 'spinner', text: ' Checks' };
+			return { style: 'neutral', icon: 'spinner', text: 'Checks' };
 		}
 
 		return { style: 'neutral', icon: undefined, text: 'No PR checks' };
@@ -145,23 +145,25 @@
 				}}
 			/>
 		</ContextMenuSection>
-		{#if checksTagInfo && checksTagInfo.text !== 'No PR checks' && checksTagInfo.text === 'Checks'}
-			<ContextMenuSection>
-				<ContextMenuItem
-					label="Open checks"
-					onclick={() => {
-						openExternalUrl(`${$pr.htmlUrl}/checks`);
-						contextMenuEl?.close();
-					}}
-				/>
-				<ContextMenuItem
-					label="Copy checks"
-					onclick={() => {
-						copyToClipboard(`${$pr.htmlUrl}/checks`);
-						contextMenuEl?.close();
-					}}
-				/>
-			</ContextMenuSection>
+		{#if checksTagInfo}
+			{#if checksTagInfo.text !== 'No PR checks' && checksTagInfo.text !== 'Checks'}
+				<ContextMenuSection>
+					<ContextMenuItem
+						label="Open checks"
+						onclick={() => {
+							openExternalUrl(`${$pr.htmlUrl}/checks`);
+							contextMenuEl?.close();
+						}}
+					/>
+					<ContextMenuItem
+						label="Copy checks"
+						onclick={() => {
+							copyToClipboard(`${$pr.htmlUrl}/checks`);
+							contextMenuEl?.close();
+						}}
+					/>
+				</ContextMenuSection>
+			{/if}
 		{/if}
 	</ContextMenu>
 

--- a/apps/desktop/src/lib/pr/StackingPullRequestCard.svelte
+++ b/apps/desktop/src/lib/pr/StackingPullRequestCard.svelte
@@ -31,10 +31,8 @@
 		messageStyle?: MessageStyle;
 	};
 
-	let checksContextMenuEl = $state<ReturnType<typeof ContextMenu>>();
-	let prContextMenuEl = $state<ReturnType<typeof ContextMenu>>();
-	let checksContextMenuTarget = $state<HTMLElement>();
-	let prContextMenuTarget = $state<HTMLElement>();
+	let contextMenuEl = $state<ReturnType<typeof ContextMenu>>();
+	let contextMenuTarget = $state<HTMLElement>();
 
 	const vbranchService = getContext(VirtualBranchService);
 	const baseBranchService = getContext(BaseBranchService);
@@ -122,7 +120,52 @@
 </script>
 
 {#if $pr}
-	<div class="pr-header">
+	<ContextMenu bind:this={contextMenuEl} target={contextMenuTarget} openByMouse>
+		<ContextMenuSection>
+			<ContextMenuItem
+				label="Open PR in browser"
+				onclick={() => {
+					openExternalUrl($pr.htmlUrl);
+					contextMenuEl?.close();
+				}}
+			/>
+			<ContextMenuItem
+				label="Copy PR link"
+				onclick={() => {
+					copyToClipboard($pr.htmlUrl);
+					contextMenuEl?.close();
+				}}
+			/>
+		</ContextMenuSection>
+		{#if checksTagInfo && checksTagInfo.text !== 'No PR checks' && checksTagInfo.text === 'Checks'}
+			<ContextMenuSection>
+				<ContextMenuItem
+					label="Open checks"
+					onclick={() => {
+						openExternalUrl(`${$pr.htmlUrl}/checks`);
+						contextMenuEl?.close();
+					}}
+				/>
+				<ContextMenuItem
+					label="Copy checks"
+					onclick={() => {
+						copyToClipboard(`${$pr.htmlUrl}/checks`);
+						contextMenuEl?.close();
+					}}
+				/>
+			</ContextMenuSection>
+		{/if}
+	</ContextMenu>
+
+	<div
+		bind:this={contextMenuTarget}
+		role="article"
+		class="pr-header"
+		oncontextmenu={(e: MouseEvent) => {
+			e.preventDefault();
+			contextMenuEl?.open(e);
+		}}
+	>
 		<div class="text-13 text-semibold pr-header-title">
 			<span style="color: var(--clr-scale-ntrl-50)">PR #{$pr?.number}:</span>
 			<span>{$pr?.title}</span>
@@ -140,72 +183,29 @@
 				{prStatusInfo.text}
 			</Button>
 			{#if !$pr?.closedAt && checksTagInfo}
-				<div bind:this={checksContextMenuTarget}>
-					<Button
-						size="tag"
-						clickable={false}
-						icon={checksTagInfo.icon}
-						style={checksTagInfo.style}
-						kind={checksTagInfo.icon === 'success-small' ? 'solid' : 'soft'}
-						oncontextmenu={(e: MouseEvent) => {
-							e.preventDefault();
-							checksContextMenuEl?.open();
-						}}
-					>
-						{checksTagInfo.text}
-					</Button>
-				</div>
-
-				<ContextMenu bind:this={checksContextMenuEl} target={checksContextMenuTarget}>
-					<ContextMenuSection>
-						<ContextMenuItem
-							label="Open checks"
-							onclick={() => {
-								openExternalUrl(`${$pr.htmlUrl}/checks`);
-								checksContextMenuEl?.close();
-							}}
-						/>
-						<ContextMenuItem
-							label="Copy Checks"
-							onclick={() => {
-								copyToClipboard(`${$pr.htmlUrl}/checks`);
-								checksContextMenuEl?.close();
-							}}
-						/>
-					</ContextMenuSection>
-				</ContextMenu>
+				<Button
+					size="tag"
+					clickable={false}
+					icon={checksTagInfo.icon}
+					style={checksTagInfo.style}
+					kind={checksTagInfo.icon === 'success-small' ? 'solid' : 'soft'}
+				>
+					{checksTagInfo.text}
+				</Button>
 			{/if}
 			{#if $pr?.htmlUrl}
-				<div bind:this={prContextMenuTarget}>
-					<Button
-						icon="open-link"
-						size="tag"
-						style="ghost"
-						outline
-						tooltip="Open in browser"
-						onclick={() => {
-							openExternalUrl($pr.htmlUrl);
-						}}
-						oncontextmenu={(e: MouseEvent) => {
-							e.preventDefault();
-							prContextMenuEl?.open();
-						}}
-					>
-						View PR
-					</Button>
-				</div>
-
-				<ContextMenu bind:this={prContextMenuEl} target={prContextMenuTarget}>
-					<ContextMenuSection>
-						<ContextMenuItem
-							label="Copy PR Link"
-							onclick={() => {
-								copyToClipboard($pr.htmlUrl);
-								prContextMenuEl?.close();
-							}}
-						/>
-					</ContextMenuSection>
-				</ContextMenu>
+				<Button
+					icon="open-link"
+					size="tag"
+					style="ghost"
+					outline
+					tooltip="Open in browser"
+					onclick={() => {
+						openExternalUrl($pr.htmlUrl);
+					}}
+				>
+					View PR
+				</Button>
 			{/if}
 		</div>
 

--- a/apps/desktop/src/lib/pr/StackingPullRequestCard.svelte
+++ b/apps/desktop/src/lib/pr/StackingPullRequestCard.svelte
@@ -20,9 +20,10 @@
 
 	interface Props {
 		upstreamName: string;
+		reloadPR?: () => void;
 	}
 
-	const { upstreamName }: Props = $props();
+	const { upstreamName, reloadPR }: Props = $props();
 
 	type StatusInfo = {
 		text: string;
@@ -133,6 +134,13 @@
 				label="Copy PR link"
 				onclick={() => {
 					copyToClipboard($pr.htmlUrl);
+					contextMenuEl?.close();
+				}}
+			/>
+			<ContextMenuItem
+				label="Refetch PR status"
+				onclick={() => {
+					reloadPR?.();
 					contextMenuEl?.close();
 				}}
 			/>

--- a/apps/desktop/src/lib/shared/DropDownButton.svelte
+++ b/apps/desktop/src/lib/shared/DropDownButton.svelte
@@ -42,6 +42,11 @@
 	let iconEl = $state<HTMLElement>();
 	let visible = $state(false);
 
+	function preventContextMenu(e: MouseEvent) {
+		e.preventDefault();
+		e.stopPropagation();
+	}
+
 	export function show() {
 		visible = true;
 		contextMenu?.open();
@@ -66,6 +71,7 @@
 				disabled={disabled || loading}
 				dropdownChild
 				{onclick}
+				oncontextmenu={preventContextMenu}
 			>
 				{@render children()}
 			</Button>
@@ -82,6 +88,7 @@
 					visible = !visible;
 					contextMenu?.toggle();
 				}}
+				oncontextmenu={preventContextMenu}
 			/>
 		</div>
 		<ContextMenu


### PR DESCRIPTION
## ☕️ Reasoning

- Add contextMenu's to PR Card btns

## 🧢 Changes

- The checks tag can be right-clicked to reveal "Copy URL" or "Open URL" to jump directly to the checks on GitHub
- The PR tag can be right-clicked to reveal a "Copy PR Link" option

CC: @PavelLaptev feel free to tweak :+1: 

![image](https://github.com/user-attachments/assets/9c2fa023-4321-4b8d-81bb-74484ff180ed)
![image](https://github.com/user-attachments/assets/dab03113-88f9-44fd-ab8c-f060dc1b3c70)


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
