### PR TITLE
Context menu fixes

### DIFF
--- a/apps/desktop/src/lib/commit/StackingCommitCard.svelte
+++ b/apps/desktop/src/lib/commit/StackingCommitCard.svelte
@@ -226,6 +226,7 @@
 <div
 	class="commit-row"
 	class:is-commit-open={showDetails}
+	class:commit-card-activated={isKebabContextMenuOpen}
 	class:is-last={last}
 	onclick={(e) => {
 		e.preventDefault();
@@ -264,7 +265,7 @@
 			tooltip="More options"
 			thin
 			onclick={(e) => {
-				kebabContextMenu?.open(e);
+				kebabContextMenu?.toggle(e);
 			}}
 		/>
 	</PopoverActionsContainer>
@@ -272,6 +273,10 @@
 	<div class="commit-card" class:is-last={last}>
 		<!-- GENERAL INFO -->
 		<div bind:this={draggableCommitElement} class="commit__header" role="button" tabindex="-1">
+			<div class="commit__drag-icon">
+				<Icon name="draggable" />
+			</div>
+
 			{#if isUndoable && !commit.descriptionTitle}
 				<span class="text-13 text-body text-semibold commit__empty-title">empty commit message</span
 				>
@@ -431,6 +436,10 @@
 		&:not(.is-commit-open) {
 			&:hover {
 				background-color: var(--clr-bg-1-muted);
+
+				& .commit__drag-icon {
+					opacity: 1;
+				}
 			}
 		}
 
@@ -441,6 +450,10 @@
 		&.is-last {
 			border-radius: 0 0 var(--radius-m) var(--radius-m);
 		}
+	}
+
+	.commit-card-activated {
+		background-color: var(--clr-bg-1-muted);
 	}
 
 	.commit-card {
@@ -455,35 +468,29 @@
 		display: flex;
 		align-items: center;
 		gap: 4px;
-
 		color: var(--clr-core-err-40);
 	}
 
 	/* HEADER */
 	.commit__header {
+		position: relative;
 		display: flex;
 		flex-direction: column;
 		gap: 6px;
 		padding: 14px 14px 14px 0;
-
-		/* &:hover {
-			& .commit__drag-icon {
-				opacity: 1;
-			}
-		} */
 	}
 
-	/* .commit__drag-icon {
-		pointer-events: none;
+	.commit__drag-icon {
+		cursor: grab;
 		position: absolute;
 		display: flex;
-		top: 4px;
-		right: 2px;
+		bottom: 10px;
+		right: 6px;
 		color: var(--clr-text-3);
 
 		opacity: 0;
 		transition: opacity var(--transition-fast);
-	} */
+	}
 
 	.commit__title {
 		flex: 1;

--- a/apps/desktop/src/lib/components/contextmenu/ContextMenu.svelte
+++ b/apps/desktop/src/lib/components/contextmenu/ContextMenu.svelte
@@ -42,12 +42,14 @@
 	}
 
 	function setHorizontalAlign(targetBoundingRect: DOMRect) {
+		const correction = 2;
+
 		if (horizontalAlign === 'left') {
 			return targetBoundingRect?.left ? targetBoundingRect.left : 0;
 		}
 
 		return targetBoundingRect?.left
-			? targetBoundingRect.left + targetBoundingRect.width - contextMenuWidth
+			? targetBoundingRect.left + targetBoundingRect.width - contextMenuWidth - correction
 			: 0;
 	}
 
@@ -56,12 +58,12 @@
 
 		let newMenuPosition = { x: e.clientX, y: e.clientY };
 
-		const menuOffset = 20;
+		const menuWindowEdgesOffset = 20;
 
 		// Check if the menu exceeds the window's right edge
 		const exceedsRight = newMenuPosition.x + contextMenuWidth > window.innerWidth;
 		if (exceedsRight) {
-			newMenuPosition.x = window.innerWidth - contextMenuWidth - menuOffset;
+			newMenuPosition.x = window.innerWidth - contextMenuWidth - menuWindowEdgesOffset;
 		}
 
 		// Check if the menu exceeds the window's left edge
@@ -73,7 +75,7 @@
 		// Check if the menu exceeds the window's bottom edge
 		const exceedsBottom = newMenuPosition.y + contextMenuHeight > window.innerHeight;
 		if (exceedsBottom) {
-			newMenuPosition.y = window.innerHeight - contextMenuHeight - menuOffset;
+			newMenuPosition.y = window.innerHeight - contextMenuHeight - menuWindowEdgesOffset;
 		}
 
 		// Check if the menu exceeds the window's top edge
@@ -213,6 +215,7 @@
 		tabindex="-1"
 		use:focusTrap
 		use:clickOutside={{
+			excludeElement: target,
 			handler: () => close()
 		}}
 		bind:clientHeight={contextMenuHeight}
@@ -231,29 +234,13 @@
 
 {#if isVisible}
 	<div class="portal-wrap" use:portal={'body'}>
-		{#if openByMouse}
-			{@render contextMenu()}
-		{:else}
-			<div class="overlay-wrapper">
-				{@render contextMenu()}
-			</div>
-		{/if}
+		{@render contextMenu()}
 	</div>
 {/if}
 
 <style lang="postcss">
 	.portal-wrap {
 		display: contents;
-	}
-
-	.overlay-wrapper {
-		z-index: var(--z-blocker);
-		position: fixed;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100%;
-		/* background-color: rgba(0, 0, 0, 0.1); */
 	}
 
 	.top-oriented {

--- a/packages/ui/src/lib/Tooltip.svelte
+++ b/packages/ui/src/lib/Tooltip.svelte
@@ -12,12 +12,13 @@
 	interface Props {
 		text?: string;
 		delay?: number;
+		disabled?: boolean;
 		align?: TooltipAlign;
 		position?: TooltipPosition;
 		children: Snippet;
 	}
 
-	const { text, delay = 700, align, position, children }: Props = $props();
+	const { text, delay = 700, disabled, align, position, children }: Props = $props();
 
 	let targetEl: HTMLElement | undefined = $state();
 
@@ -27,6 +28,7 @@
 	const isTextEmpty = $derived(!text || text === '');
 
 	function handleMouseEnter() {
+		if (disabled) return;
 		timeoutId = setTimeout(() => {
 			show = true;
 			// console.log('showing tooltip');

--- a/packages/ui/src/lib/popoverActions/PopoverActionsItem.svelte
+++ b/packages/ui/src/lib/popoverActions/PopoverActionsItem.svelte
@@ -15,7 +15,7 @@
 	let { el = $bindable(), icon, tooltip, thin, activated, onclick }: Props = $props();
 </script>
 
-<Tooltip text={tooltip} position="top" delay={200}>
+<Tooltip disabled={activated} text={tooltip} position="top" delay={200}>
 	<button
 		bind:this={el}
 		data-clickable="true"


### PR DESCRIPTION
## ☕️ Reasoning

- added "disabled" prop to Tooltip
- don't show tooltips when the context menu is activated
- correct context menu positioning
- remove popover actions flickering on context menu close in commit cards
- fixes: menu toggling, hold the active card state when the ctx menu is opened

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
