### PR TITLE
fix: Compare branches to the remote target branch

### DIFF
--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -462,18 +462,12 @@ pub fn get_branch_listing_details(
             .virtual_branches()
             .get_default_target()
             .context("failed to get default target")?;
-        let local_branch = repo.find_reference(target.branch.branch())?;
-        let local_tracking_ref_name = local_branch
-            .remote_tracking_ref_name(gix::remote::Direction::Fetch)
-            .with_context(|| {
-                format!(
-                    "Branch {} did not have a remote tracking branch",
-                    local_branch.name().as_bstr()
-                )
-            })??;
-        let mut local_tracking_ref = repo.find_reference(local_tracking_ref_name.as_ref())?;
+        let target_branch_name = format!("{}/{}", &target.branch.remote(), &target.branch.branch());
+        let target_branch_name = target_branch_name.as_str();
+        let mut target_branch = repo.find_reference(target_branch_name)?;
+
         (
-            gix_to_git2_oid(local_tracking_ref.peel_to_commit()?.id),
+            gix_to_git2_oid(target_branch.peel_to_commit()?.id),
             target.sha,
         )
     };


### PR DESCRIPTION
When getting the branch listings, compare the branches to the remote target branch.
This is necessary because of two reasons:
- GitButler doesn't really care about what your local target branch (e.g. main) does, and also doesn't update it as we merge upstream (e.g. origin/main).
- In some cases, a repository might not have a local branch pusgin to the remote target branch (especially in the cases in which branches are merged through a forge)

### Issue
As seen in: https://github.com/gitbutlerapp/gitbutler/issues/5229

### A bunch more context if anyone is interested :)
I think this is why the sometimes the branch listings in the side-bar were a bit broken (in some cases).

There are key parts to this:
- The remote target (e.g. origin/main)
- The local "target" branch (e.g. main)
- The GitButler workspace branch (gitbutler/workspace)

Whenever we integrate upstream, what GB does is to effectively move `gitbutler/workspace` to the tip of `origin/main`.
The local "target" will never be updated and that's why comparing to it would sometimes show multiple commits and authors on the side-bar listings.

To fix that we need to compare against the tip of `origin/main` for the branches not on the workspace and against `gitbulter/workspace` (`target.sha`) for the ones that are.