### PR TITLE
fix: type all buttons

### DIFF
--- a/apps/desktop/src/lib/commit/CommitCard.svelte
+++ b/apps/desktop/src/lib/commit/CommitCard.svelte
@@ -331,6 +331,7 @@
 						{/if}
 
 						<button
+							type="button"
 							class="commit__subtitle-btn commit__subtitle-btn_dashed"
 							on:click|stopPropagation={() => copyToClipboard(commit.id)}
 						>
@@ -345,6 +346,7 @@
 							<span class="commit__subtitle-divider">•</span>
 
 							<button
+								type="button"
 								class="commit__subtitle-btn"
 								on:click|stopPropagation={() => {
 									if (commitUrl) openExternalUrl(commitUrl);

--- a/apps/desktop/src/lib/commit/CommitList.svelte
+++ b/apps/desktop/src/lib/commit/CommitList.svelte
@@ -321,6 +321,7 @@
 					<span class="text-11 base-row__text">
 						Base commit
 						<button
+							type="button"
 							class="base-row__commit-link"
 							onclick={async () => await goto(`/${project.id}/base`)}
 						>

--- a/apps/desktop/src/lib/commit/StackingCommitCard.svelte
+++ b/apps/desktop/src/lib/commit/StackingCommitCard.svelte
@@ -317,6 +317,7 @@
 					<span class="commit__subtitle-divider">•</span>
 
 					<button
+						type="button"
 						class="commit__subtitle-btn commit__subtitle-btn_dashed"
 						onclick={(e) => {
 							e.stopPropagation();
@@ -334,6 +335,7 @@
 						<span class="commit__subtitle-divider">•</span>
 
 						<button
+							type="button"
 							class="commit__subtitle-btn"
 							onclick={(e) => {
 								e.stopPropagation();

--- a/apps/desktop/src/lib/commit/StackingUpstreamCommitsAccordion.svelte
+++ b/apps/desktop/src/lib/commit/StackingUpstreamCommitsAccordion.svelte
@@ -19,7 +19,7 @@
 
 <div class="accordion">
 	{#if count !== 1}
-		<button class="accordion-row header" onclick={toggle}>
+		<button type="button" class="accordion-row header" onclick={toggle}>
 			<div class="accordion-row__line">
 				<div class="dots">
 					{#if !isOpen}

--- a/apps/desktop/src/lib/components/BoardEmptyState.svelte
+++ b/apps/desktop/src/lib/components/BoardEmptyState.svelte
@@ -53,6 +53,7 @@
 							<span class="text-12">Create a new branch</span>
 						</div>
 						<button
+							type="button"
 							class="empty-board__suggestions__link"
 							on:click={async () => await openExternalUrl('https://docs.gitbutler.com')}
 						>
@@ -63,6 +64,7 @@
 							<span class="text-12">GitButler Docs</span>
 						</button>
 						<button
+							type="button"
 							class="empty-board__suggestions__link"
 							on:keypress={async () => await openInEditor()}
 							on:click={async () => await openInEditor()}

--- a/apps/desktop/src/lib/components/DecorativeSplitView.svelte
+++ b/apps/desktop/src/lib/components/DecorativeSplitView.svelte
@@ -70,6 +70,7 @@
 					<div class="right-side__meta">
 						<div class="right-side__links">
 							<button
+								type="button"
 								class="right-side__link"
 								onclick={async () => await openExternalUrl('https://docs.gitbutler.com/')}
 							>
@@ -77,6 +78,7 @@
 								<span class="text-14 text-semibold">GitButler docs</span>
 							</button>
 							<button
+								type="button"
 								class="right-side__link"
 								onclick={async () => await openExternalUrl('https://discord.com/invite/MmFkmaJ42D')}
 							>

--- a/apps/desktop/src/lib/components/ProjectNotFound.svelte
+++ b/apps/desktop/src/lib/components/ProjectNotFound.svelte
@@ -61,7 +61,9 @@
 						Sorry, we can't find the project you're looking for.
 						<br />
 						It might have been removed or doesn't exist.
-						<button class="check-again-btn" onclick={() => location.reload()}>Click here</button>
+						<button type="button" class="check-again-btn" onclick={() => location.reload()}
+							>Click here</button
+						>
 						to check again.
 						<br />
 						The current project path: <span class="code-string">{project.path}</span>

--- a/apps/desktop/src/lib/components/WelcomeAction.svelte
+++ b/apps/desktop/src/lib/components/WelcomeAction.svelte
@@ -28,6 +28,7 @@
 </script>
 
 <button
+	type="button"
 	class="action__wrapper"
 	class:loading
 	class:row

--- a/apps/desktop/src/lib/components/contextmenu/ContextMenuItem.svelte
+++ b/apps/desktop/src/lib/components/contextmenu/ContextMenuItem.svelte
@@ -14,7 +14,7 @@
 	const { onclick, icon = undefined, label, disabled, control }: Props = $props();
 </script>
 
-<button class="menu-item" class:disabled {disabled} {onclick}>
+<button type="button" class="menu-item" class:disabled {disabled} {onclick}>
 	{#if icon}
 		<Icon name={icon} />
 	{/if}

--- a/apps/desktop/src/lib/components/tabs/TabTrigger.svelte
+++ b/apps/desktop/src/lib/components/tabs/TabTrigger.svelte
@@ -20,6 +20,7 @@
 </script>
 
 <button
+	type="button"
 	role="tab"
 	tabindex={isActive ? -1 : 0}
 	aria-selected={isActive}

--- a/apps/desktop/src/lib/file/FileCard.svelte
+++ b/apps/desktop/src/lib/file/FileCard.svelte
@@ -51,6 +51,7 @@
 	{#if conflicted}
 		<div class="file-card__resolved-btn">
 			<button
+				type="button"
 				class="font-bold text-white"
 				onclick={async () => await branchController.markResolved(file.path)}
 			>

--- a/apps/desktop/src/lib/history/SnapshotAttachment.svelte
+++ b/apps/desktop/src/lib/history/SnapshotAttachment.svelte
@@ -44,6 +44,7 @@
 	</div>
 	{#if foldable}
 		<button
+			type="button"
 			class="toggle-btn"
 			on:click={() => {
 				isOpen = !isOpen;

--- a/apps/desktop/src/lib/history/SnapshotCard.svelte
+++ b/apps/desktop/src/lib/history/SnapshotCard.svelte
@@ -215,6 +215,7 @@
 				<div class="files-attacment">
 					{#each entry.filesChanged as filePath}
 						<button
+							type="button"
 							class="files-attacment__file"
 							class:file-selected={selectedFile?.path === filePath &&
 								selectedFile?.entryId === entry.id}

--- a/apps/desktop/src/lib/navigation/Branches.svelte
+++ b/apps/desktop/src/lib/navigation/Branches.svelte
@@ -110,7 +110,12 @@
 			</div>
 
 			<div class="search-container" class:show-search={searching}>
-				<button tabindex={searching ? -1 : 0} class="search-button" onclick={toggleSearch}>
+				<button
+					type="button"
+					tabindex={searching ? -1 : 0}
+					class="search-button"
+					onclick={toggleSearch}
+				>
 					<Icon name={searching ? 'cross' : 'search'} />
 				</button>
 

--- a/apps/desktop/src/lib/navigation/DomainButton.svelte
+++ b/apps/desktop/src/lib/navigation/DomainButton.svelte
@@ -23,6 +23,7 @@
 
 <Tooltip text={isNavCollapsed ? tooltipLabel : ''} align="start">
 	<button
+		type="button"
 		{onmousedown}
 		class="domain-button text-14 text-semibold"
 		class:selected={isSelected}

--- a/apps/desktop/src/lib/navigation/Navigation.svelte
+++ b/apps/desktop/src/lib/navigation/Navigation.svelte
@@ -90,6 +90,7 @@
 		/>
 
 		<button
+			type="button"
 			class="folding-button"
 			class:resizer-hovered={isResizerHovered || isResizerDragging}
 			on:mousedown={toggleNavCollapse}

--- a/apps/desktop/src/lib/navigation/ProjectSelector.svelte
+++ b/apps/desktop/src/lib/navigation/ProjectSelector.svelte
@@ -6,22 +6,27 @@
 	import Icon from '@gitbutler/ui/Icon.svelte';
 	import Tooltip from '@gitbutler/ui/Tooltip.svelte';
 
-	export let isNavCollapsed: boolean;
+	interface Props {
+		isNavCollapsed: boolean;
+	}
 
-	let buttonTrigger: HTMLButtonElement;
+	let { isNavCollapsed }: Props = $props();
+
 	const project = getContext(Project);
 
-	let popup: ProjectsPopup;
+	let buttonTrigger = $state<HTMLButtonElement>();
+	let popup = $state<ReturnType<typeof ProjectsPopup>>();
 </script>
 
 <div class="wrapper">
 	<Tooltip text={isNavCollapsed ? project?.title : ''} align="start">
 		<button
+			type="button"
 			bind:this={buttonTrigger}
 			class="text-input button"
-			on:mousedown={(e) => {
+			onmousedown={(e) => {
 				e.preventDefault();
-				popup.toggle();
+				popup?.toggle();
 			}}
 		>
 			<ProjectAvatar name={project?.title} />

--- a/apps/desktop/src/lib/navigation/ProjectsPopup.svelte
+++ b/apps/desktop/src/lib/navigation/ProjectsPopup.svelte
@@ -64,6 +64,7 @@
 
 {#snippet itemSnippet(props: ItemSnippetProps)}
 	<button
+		type="button"
 		disabled={props.selected}
 		class="list-item"
 		class:selected={props.selected}

--- a/apps/desktop/src/lib/select/SearchItem.svelte
+++ b/apps/desktop/src/lib/select/SearchItem.svelte
@@ -26,7 +26,7 @@
 			<Icon name="search" />
 		</i>
 	{:else}
-		<button class="icon" onclick={resetFilter}>
+		<button type="button" class="icon" onclick={resetFilter}>
 			<Icon name="clear-input" />
 		</button>
 	{/if}

--- a/apps/desktop/src/lib/select/SelectItem.svelte
+++ b/apps/desktop/src/lib/select/SelectItem.svelte
@@ -14,6 +14,7 @@
 </script>
 
 <button
+	type="button"
 	{disabled}
 	class="button"
 	class:selected

--- a/apps/desktop/src/lib/settings/Sidebar.svelte
+++ b/apps/desktop/src/lib/settings/Sidebar.svelte
@@ -45,6 +45,7 @@
 			<ul class="profile-sidebar__menu">
 				<li>
 					<button
+						type="button"
 						class="profile-sidebar__menu-item"
 						class:item_selected={currentSection === 'profile'}
 						on:mousedown={() => onMenuClick('profile')}
@@ -55,6 +56,7 @@
 				</li>
 				<li>
 					<button
+						type="button"
 						class="profile-sidebar__menu-item"
 						class:item_selected={currentSection === 'appearance'}
 						on:mousedown={() => onMenuClick('appearance')}
@@ -65,6 +67,7 @@
 				</li>
 				<li>
 					<button
+						type="button"
 						class="profile-sidebar__menu-item"
 						class:item_selected={currentSection === 'git'}
 						on:mousedown={() => onMenuClick('git')}
@@ -76,6 +79,7 @@
 
 				<li>
 					<button
+						type="button"
 						class="profile-sidebar__menu-item"
 						class:item_selected={currentSection === 'integrations'}
 						on:mousedown={() => onMenuClick('integrations')}
@@ -86,6 +90,7 @@
 				</li>
 				<li>
 					<button
+						type="button"
 						class="profile-sidebar__menu-item"
 						class:item_selected={currentSection === 'ai'}
 						on:mousedown={() => onMenuClick('ai')}
@@ -96,6 +101,7 @@
 				</li>
 				<li>
 					<button
+						type="button"
 						class="profile-sidebar__menu-item"
 						class:item_selected={currentSection === 'telemetry'}
 						on:mousedown={() => onMenuClick('telemetry')}
@@ -106,6 +112,7 @@
 				</li>
 				<li>
 					<button
+						type="button"
 						class="profile-sidebar__menu-item"
 						class:item_selected={currentSection === 'experimental'}
 						on:mousedown={() => onMenuClick('experimental')}
@@ -121,6 +128,7 @@
 	<section class="profile-sidebar__bottom">
 		<div class="social-banners">
 			<button
+				type="button"
 				class="social-banner"
 				on:click={async () =>
 					await openExternalUrl('mailto:hello@gitbutler.com?subject=Feedback or question!')}
@@ -129,6 +137,7 @@
 				<Icon name="mail" />
 			</button>
 			<button
+				type="button"
 				class="social-banner"
 				on:click={async () => await openExternalUrl('https://discord.gg/MmFkmaJ42D')}
 			>

--- a/apps/desktop/src/lib/settings/SupportersBanner.svelte
+++ b/apps/desktop/src/lib/settings/SupportersBanner.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <button
+	type="button"
 	class="banner"
 	on:click={async () => await openExternalUrl('https://docs.gitbutler.com/community/supporters')}
 >

--- a/apps/desktop/src/lib/shared/AccountLink.svelte
+++ b/apps/desktop/src/lib/shared/AccountLink.svelte
@@ -11,6 +11,7 @@
 </script>
 
 <button
+	type="button"
 	class="btn"
 	class:pop
 	on:click={async () => await goto('/settings/')}

--- a/apps/desktop/src/lib/shared/IconLink.svelte
+++ b/apps/desktop/src/lib/shared/IconLink.svelte
@@ -13,7 +13,7 @@
 	const { href, icon, children }: Props = $props();
 </script>
 
-<button class="link" onclick={async () => await openExternalUrl(href)}>
+<button type="button" class="link" onclick={async () => await openExternalUrl(href)}>
 	<Icon name={icon} />
 	<span class="text-12">
 		{@render children()}

--- a/apps/desktop/src/lib/shared/ListItem.svelte
+++ b/apps/desktop/src/lib/shared/ListItem.svelte
@@ -10,7 +10,13 @@
 	const dispatch = createEventDispatcher<{ click: void }>();
 </script>
 
-<button disabled={selected} class="button" class:selected on:click={() => dispatch('click')}>
+<button
+	type="button"
+	disabled={selected}
+	class="button"
+	class:selected
+	on:click={() => dispatch('click')}
+>
 	<div class="label text-14 text-bold">
 		<slot />
 	</div>

--- a/apps/desktop/src/lib/shared/TextBox.svelte
+++ b/apps/desktop/src/lib/shared/TextBox.svelte
@@ -107,6 +107,7 @@
 		{#if type === 'number' && showCountActions}
 			<div class="textbox__count-actions">
 				<button
+					type="button"
 					class="textbox__count-btn"
 					on:click={() => {
 						htmlInput.stepDown();
@@ -119,6 +120,7 @@
 					<Icon name="minus-small" />
 				</button>
 				<button
+					type="button"
 					class="textbox__count-btn"
 					on:click={() => {
 						htmlInput.stepUp();
@@ -135,6 +137,7 @@
 
 		{#if type === 'password'}
 			<button
+				type="button"
 				class="textbox__show-hide-icon"
 				on:click={() => {
 					showPassword = !showPassword;

--- a/apps/desktop/src/routes/settings/ai/+page.svelte
+++ b/apps/desktop/src/routes/settings/ai/+page.svelte
@@ -342,6 +342,7 @@
 		<svelte:fragment slot="description">
 			GitButler's AI assistant generates commit messages and branch names. Use default prompts or
 			create your own. Assign prompts in the <button
+				type="button"
 				class="link"
 				on:click={() => console.log('got to project settings')}>project settings</button
 			>.

--- a/apps/web/src/lib/components/Navigation.svelte
+++ b/apps/web/src/lib/components/Navigation.svelte
@@ -35,6 +35,7 @@
 	</div>
 	<div class="nav__right">
 		<button
+			type="button"
 			class="nav__right--button"
 			onclick={() => {
 				if ($token) {

--- a/apps/web/src/routes/projects/[projectId]/+page.svelte
+++ b/apps/web/src/routes/projects/[projectId]/+page.svelte
@@ -121,7 +121,7 @@
 						{#each Object.keys(event.files) as branch}
 							{#if event.branch_data.branches[branch]}
 								<h3>Branch {event.branch_data.branches[branch].name}</h3>
-								<button on:click={() => createPatchStack(branch, event.sha)}
+								<button type="button" on:click={() => createPatchStack(branch, event.sha)}
 									>Create Patch Stack</button
 								>
 								{#each Object.keys(event.files[branch]) as file}

--- a/apps/web/src/routes/projects/[projectId]/branches/[branchId]/stack/[changeId]/+page.svelte
+++ b/apps/web/src/routes/projects/[projectId]/branches/[branchId]/stack/[changeId]/+page.svelte
@@ -278,12 +278,18 @@
 					<div id="section-{section.id}">
 						{#if section.section_type === 'diff'}
 							<div class="right">
-								<button class="action" on:click={() => addSection(section.position)}>add</button>
-								[<button class="action" on:click={() => moveSection(section.position, -1)}
-									>up</button
+								<button type="button" class="action" on:click={() => addSection(section.position)}
+									>add</button
 								>
-								<button class="action" on:click={() => moveSection(section.position, 1)}
-									>down</button
+								[<button
+									type="button"
+									class="action"
+									on:click={() => moveSection(section.position, -1)}>up</button
+								>
+								<button
+									type="button"
+									class="action"
+									on:click={() => moveSection(section.position, 1)}>down</button
 								>]
 							</div>
 							<div>
@@ -292,27 +298,40 @@
 							<div><pre><code>{section.diff_patch}</code></pre></div>
 						{:else}
 							<div class="right">
-								<button class="action" on:click={() => addSection(section.position)}>add</button>
-								[
-								<button class="action" on:click={() => editSection(section.code)}>edit</button>] [
-								<button class="action" on:click={() => deleteSection(section.code)}>del</button>] [
-								<button class="action" on:click={() => moveSection(section.position, -1)}>up</button
+								<button type="button" class="action" on:click={() => addSection(section.position)}
+									>add</button
 								>
-								<button class="action" on:click={() => moveSection(section.position, 1)}
-									>down</button
+								[
+								<button type="button" class="action" on:click={() => editSection(section.code)}
+									>edit</button
+								>] [
+								<button type="button" class="action" on:click={() => deleteSection(section.code)}
+									>del</button
+								>] [
+								<button
+									type="button"
+									class="action"
+									on:click={() => moveSection(section.position, -1)}>up</button
+								>
+								<button
+									type="button"
+									class="action"
+									on:click={() => moveSection(section.position, 1)}>down</button
 								>
 								]
 							</div>
 							<div class="editor edit-{section.code}">
 								<textarea class="editing">{section.data.text}</textarea>
-								<button on:click={() => saveSection(section.code)}>Save</button>
+								<button type="button" on:click={() => saveSection(section.code)}>Save</button>
 							</div>
 							<div class="markdown display-{section.code}">{section.data.text}</div>
 						{/if}
 					</div>
 				{/each}
 				<div class="right">
-					<button class="action" on:click={() => addSection(patch.sections.length)}>add</button>
+					<button type="button" class="action" on:click={() => addSection(patch.sections.length)}
+						>add</button
+					>
 				</div>
 			</div>
 		</div>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -66,7 +66,15 @@ export default ts.config(
 			'import-x/no-relative-packages': 'error', // Don't allow packages to have relative imports between each other
 			'func-style': [2, 'declaration'],
 			'no-return-await': 'off',
-			'svelte/no-at-html-tags': 'off'
+			'svelte/no-at-html-tags': 'off',
+			'svelte/button-has-type': [
+				'error',
+				{
+					button: true,
+					submit: true,
+					reset: true
+				}
+			]
 		},
 		settings: {
 			'import-x/extensions': ['.ts'],

--- a/packages/ui/src/lib/LinkButton.svelte
+++ b/packages/ui/src/lib/LinkButton.svelte
@@ -13,6 +13,7 @@
 </script>
 
 <button
+	type="button"
 	class="link-button"
 	onclick={(e) => {
 		e.stopPropagation();

--- a/packages/ui/src/lib/SidebarEntry.svelte
+++ b/packages/ui/src/lib/SidebarEntry.svelte
@@ -55,7 +55,13 @@
 	});
 </script>
 
-<button class="branch" class:selected onmousedown={onMouseDown} bind:this={intersectionTarget}>
+<button
+	type="button"
+	class="branch"
+	class:selected
+	onmousedown={onMouseDown}
+	bind:this={intersectionTarget}
+>
 	<h4 class="text-13 text-semibold branch-name">
 		{title}
 	</h4>

--- a/packages/ui/src/lib/SimpleCommitRow.svelte
+++ b/packages/ui/src/lib/SimpleCommitRow.svelte
@@ -24,12 +24,12 @@
 			{title}
 		</span>
 		<div class="details text-11">
-			<button class="details-btn copy-btn" onclick={onCopy}>
+			<button type="button" class="details-btn copy-btn" onclick={onCopy}>
 				<span>{sha.substring(0, 7)}</span>
 				<Icon name="copy-small" />
 			</button>
 			<span class="details-divider">•</span>
-			<button class="details-btn link-btn" onclick={onUrlOpen}>
+			<button type="button" class="details-btn link-btn" onclick={onUrlOpen}>
 				<span>Open</span>
 				<Icon name="open-link" />
 			</button>

--- a/packages/ui/src/lib/popoverActions/PopoverActionsItem.svelte
+++ b/packages/ui/src/lib/popoverActions/PopoverActionsItem.svelte
@@ -17,6 +17,7 @@
 
 <Tooltip disabled={activated} text={tooltip} position="top" delay={200}>
 	<button
+		type="button"
 		bind:this={el}
 		data-clickable="true"
 		class="overflow-actions-btn focus-state"

--- a/packages/ui/src/lib/segmentControl/Segment.svelte
+++ b/packages/ui/src/lib/segmentControl/Segment.svelte
@@ -36,6 +36,7 @@
 </script>
 
 <button
+	type="button"
 	bind:this={elRef}
 	{id}
 	class="segment-control-item"


### PR DESCRIPTION
Apparently buttons without a type inside a form default to `submit`.
Example: Inside the Integrate Upstream modal, in order to open the links in the commit list and not trigger the upstream to be integrated, we need to set the type of the button to `button`

More info on the button.type: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#type