### PR TITLE
fix: force GHA to use older libwebkit2gtk for Linux builds

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -157,7 +157,6 @@ jobs:
         run: |
           sudo apt update;
           sudo apt install -y \
-            libwebkit2gtk-4.0-dev \
             build-essential \
             curl \
             wget \
@@ -166,6 +165,13 @@ jobs:
             libgtk-3-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev;
+          sudo apt install -y \
+            libwebkit2gtk-4.0-37=2.36.0-2ubuntu1 \
+            libwebkit2gtk-4.0-dev=2.36.0-2ubuntu1 \
+            libjavascriptcoregtk-4.0-18=2.36.0-2ubuntu1 \
+            libjavascriptcoregtk-4.0-dev=2.36.0-2ubuntu1 \
+            gir1.2-javascriptcoregtk-4.0=2.36.0-2ubuntu1 \
+            gir1.2-webkit2-4.0=2.36.0-2ubuntu1;
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## ☕️ Reasoning

- GHA builder bumped to `libwebkit2gtk@2.46.1` silently ~2 days ago, so I pinned it and its dependencies to the previously available version.
	- Tested with nightly release, seems to work on my machine at least :tm: 

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

-->

## 🎫 Affected issues

Fixes: #5282


<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
