### PR TITLE
minor fixes

### DIFF
--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -353,8 +353,7 @@ impl GroupBranch<'_> {
     /// Determines if the branch is a remote branch by ref name
     fn is_remote_branch(&self, ref_name: &RemoteRefname) -> bool {
         if let GroupBranch::Remote(branch) = self {
-            let branch_name = branch.name().as_bstr();
-            ref_name == branch_name
+            ref_name == branch.name()
         } else {
             false
         }

--- a/crates/gitbutler-reference/Cargo.toml
+++ b/crates/gitbutler-reference/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 authors = ["GitButler <gitbutler@gitbutler.com>"]
 publish = false
 
+[lib]
+doctest = false
+
+
 [dependencies]
 anyhow.workspace = true
 git2.workspace = true

--- a/crates/gitbutler-reference/src/refname/remote.rs
+++ b/crates/gitbutler-reference/src/refname/remote.rs
@@ -1,9 +1,7 @@
-use std::{fmt, str::FromStr};
-
-use gix::bstr::BStr;
-use serde::{Deserialize, Serialize};
-
 use super::error::Error;
+use gix::refs::FullNameRef;
+use serde::{Deserialize, Serialize};
+use std::{fmt, str::FromStr};
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct Refname {
@@ -100,8 +98,17 @@ impl TryFrom<&git2::Branch<'_>> for Refname {
     }
 }
 
-impl PartialEq<BStr> for Refname {
-    fn eq(&self, other: &BStr) -> bool {
-        format!("refs/remotes/{}/{}", self.remote, self.branch) == *other
+impl PartialEq<FullNameRef> for Refname {
+    fn eq(&self, other: &FullNameRef) -> bool {
+        let Some((category, shortname)) = other.category_and_short_name() else {
+            return false;
+        };
+        if !matches!(category, gix::reference::Category::RemoteBranch) {
+            return false;
+        }
+        shortname
+            .strip_prefix(self.remote.as_bytes())
+            .and_then(|rest| rest.strip_suffix(self.branch.as_bytes()))
+            .map_or(false, |rest| rest == b"/")
     }
 }

--- a/crates/gitbutler-reference/tests/reference.rs
+++ b/crates/gitbutler-reference/tests/reference.rs
@@ -55,3 +55,33 @@ This reverts commit d6efa5fd96d36da445d5d1345b84163f05f5f229."#;
         Ok(())
     }
 }
+
+mod remote_refname {
+    mod eq_fullname_ref {
+        use gitbutler_reference::RemoteRefname;
+        use gix::refs::FullNameRef;
+
+        fn fullname_ref(fullname: &str) -> &FullNameRef {
+            fullname.try_into().expect("known to be valid")
+        }
+
+        #[test]
+        fn comparison() {
+            let origin_main = RemoteRefname::new("origin", "main");
+            assert_eq!(origin_main, *fullname_ref("refs/remotes/origin/main"));
+
+            assert_ne!(origin_main, *fullname_ref("refs/remotes/origin2/main"));
+            assert_ne!(origin_main, *fullname_ref("refs/remotes/origim/main"));
+            assert_ne!(origin_main, *fullname_ref("refs/remotes/origin/maim"));
+            assert_ne!(origin_main, *fullname_ref("refs/abcdefg/origin/main"));
+
+            assert_ne!(origin_main, *fullname_ref("refs/heads/origin/main"));
+            assert_ne!(origin_main, *fullname_ref("refs/heads/main"));
+            assert_ne!(origin_main, *fullname_ref("refs/remotes/origin"));
+            assert_ne!(origin_main, *fullname_ref("refs/remotes/main"));
+
+            let multi_slash = RemoteRefname::new("my/one", "feature");
+            assert_eq!(multi_slash, *fullname_ref("refs/remotes/my/one/feature"));
+        }
+    }
+}


### PR DESCRIPTION
This adds code-complexity (and tests) to avoid allocating when making a comparison.
The PR also adds type-safety for the comparison.

Follow-up of #5289 .
