### PR TITLE
fix: overlapping context menus

### DIFF
--- a/packages/ui/src/lib/file/FileListItem.svelte
+++ b/packages/ui/src/lib/file/FileListItem.svelte
@@ -79,6 +79,7 @@
 	oncontextmenu={(e) => {
 		if (oncontextmenu) {
 			e.preventDefault();
+			e.stopPropagation();
 			oncontextmenu(e);
 		}
 	}}


### PR DESCRIPTION
## ☕️ Reasoning

- The file and commitCard contextMenus were both being triggered when right clicking on the file in the expanded commit file list

![image](https://github.com/user-attachments/assets/c7a36679-89d8-4f6d-a724-7fdb9800d64a)


## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
