### PR TITLE
CLI: add the ability to create series for a stack

### DIFF
--- a/crates/gitbutler-cli/src/args.rs
+++ b/crates/gitbutler-cli/src/args.rs
@@ -60,6 +60,14 @@ pub mod vbranch {
             /// The name of the virtual to commit all staged and unstaged changes to.
             name: String,
         },
+        /// Create a new series on top of the stack.
+        Series {
+            /// The name of the series to create on top of the stack.
+            #[clap(short = 's', long)]
+            series_name: String,
+            /// The name of the stack to create new series for.
+            name: String,
+        },
         /// Create a new virtual branch
         Create {
             /// Also make this branch the default branch, so it is considered the owner of new edits.

--- a/crates/gitbutler-cli/src/command/vbranch.rs
+++ b/crates/gitbutler-cli/src/command/vbranch.rs
@@ -89,6 +89,13 @@ fn set_default_branch(project: &Project, branch: &Stack) -> Result<()> {
     )
 }
 
+pub fn series(project: Project, stack_name: String, new_series_name: String) -> Result<()> {
+    let mut stack = branch_by_name(&project, &stack_name)?;
+    let ctx = CommandContext::open(&project)?;
+    stack.add_series_top_of_stack(&ctx, new_series_name, None)?;
+    Ok(())
+}
+
 pub fn commit(project: Project, branch_name: String, message: String) -> Result<()> {
     let branch = branch_by_name(&project, &branch_name)?;
     let (info, skipped) = gitbutler_branch_actions::list_virtual_branches(&project)?;

--- a/crates/gitbutler-cli/src/main.rs
+++ b/crates/gitbutler-cli/src/main.rs
@@ -31,6 +31,9 @@ fn main() -> Result<()> {
                 Some(vbranch::SubCommands::Commit { message, name }) => {
                     command::vbranch::commit(project, name, message)
                 }
+                Some(vbranch::SubCommands::Series { name, series_name }) => {
+                    command::vbranch::series(project, name, series_name)
+                }
                 Some(vbranch::SubCommands::Create { set_default, name }) => {
                     command::vbranch::create(project, name, set_default)
                 }


### PR DESCRIPTION
This makes it very easy to create test fixtures with multiple series in the same stack, e.g. 
```
$CLI branch series my_stack -s "top-series"
```