### PR TITLE
feat: add e2e testing setup for web app

### DIFF
--- a/.github/workflows/test-e2e-playwright.yml
+++ b/.github/workflows/test-e2e-playwright.yml
@@ -1,0 +1,35 @@
+name: E2E Tests Playwright
+on:
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+    inputs:
+      sha:
+        type: string
+        required: false
+        description: Target SHA
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4
+      if: ${{ github.event_name != 'workflow_dispatch' }}
+    - uses: actions/checkout@v4
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      with:
+        ref: ${{ github.event.inputs.sha }}
+    - name: Setup node environment
+      uses: ./.github/actions/init-env-node
+    - name: Install Playwright Browsers
+      run: cd apps/web && pnpm exec playwright install --with-deps
+    - name: Run Playwright tests
+      run: pnpm exec turbo run test:e2e:playwright
+    - uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/.github/workflows/test-e2e-playwright.yml
+++ b/.github/workflows/test-e2e-playwright.yml
@@ -1,7 +1,7 @@
 name: E2E Tests Playwright
 on:
   pull_request:
-    branches: [ master ]
+    branches: [master]
   workflow_dispatch:
     inputs:
       sha:
@@ -15,21 +15,32 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v4
-      if: ${{ github.event_name != 'workflow_dispatch' }}
-    - uses: actions/checkout@v4
-      if: ${{ github.event_name == 'workflow_dispatch' }}
-      with:
-        ref: ${{ github.event.inputs.sha }}
-    - name: Setup node environment
-      uses: ./.github/actions/init-env-node
-    - name: Install Playwright Browsers
-      run: cd apps/web && pnpm exec playwright install --with-deps
-    - name: Run Playwright tests
-      run: pnpm exec turbo run test:e2e:playwright
-    - uses: actions/upload-artifact@v4
-      if: ${{ !cancelled() }}
-      with:
-        name: playwright-report
-        path: playwright-report/
-        retention-days: 30
+      - uses: actions/checkout@v4
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+      - uses: actions/checkout@v4
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        with:
+          ref: ${{ github.event.inputs.sha }}
+      - name: Setup node environment
+        uses: ./.github/actions/init-env-node
+
+      - id: get_playwright_version
+        uses: eviden-actions/get-playwright-version@v1
+      - name: Cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.get_playwright_version.outputs.playwright-version }}
+      - if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: cd apps/web && pnpm exec playwright install --with-deps
+
+      - name: Run Playwright tests
+        run: pnpm exec turbo run test:e2e:web
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/test-e2e-webdriver.yml
+++ b/.github/workflows/test-e2e-webdriver.yml
@@ -1,4 +1,4 @@
-name: E2E Tests
+name: E2E Tests Webdriver
 on:
   pull_request:
     branches: [master]
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    name: Run WebdriverIO Tests
+    name: Run Tests
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,7 @@
 		"prepare": "svelte-kit sync",
 		"check": "svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
-		"test:e2e": "playwright test"
+		"test:e2e:playwright": "playwright test"
 	},
 	"devDependencies": {
 		"@fontsource/fira-mono": "^4.5.10",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,16 +9,19 @@
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync",
 		"check": "svelte-check --tsconfig ./tsconfig.json",
-		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch"
+		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
+		"test:e2e": "playwright test"
 	},
 	"devDependencies": {
 		"@fontsource/fira-mono": "^4.5.10",
 		"@gitbutler/shared": "workspace:*",
 		"@gitbutler/ui": "workspace:*",
 		"@neoconfetti/svelte": "^1.0.0",
+		"@playwright/test": "^1.47.0",
 		"@sveltejs/adapter-auto": "^3.0.0",
 		"@sveltejs/kit": "catalog:svelte",
 		"@sveltejs/vite-plugin-svelte": "catalog:svelte",
+		"@types/node": "^22.3.0",
 		"svelte": "catalog:svelte",
 		"svelte-check": "catalog:svelte",
 		"vite": "catalog:"

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+	testDir: './tests',
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: 'html',
+	use: {
+		baseURL: 'http://localhost:5173',
+		trace: 'on-first-retry'
+	},
+
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] }
+		}
+	],
+
+	webServer: {
+		command: 'pnpm dev',
+		url: 'http://localhost:5173',
+		reuseExistingServer: !process.env.CI
+	}
+});

--- a/apps/web/tests/init.spec.ts
+++ b/apps/web/tests/init.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('has title', async ({ page }) => {
+	await page.goto('/');
+
+	await expect(page).toHaveTitle(/Home/);
+});
+
+test('downloads load', async ({ page }) => {
+	await page.goto('/');
+
+	await page.getByRole('link', { name: 'Downloads' }).click();
+
+	await expect(page.getByRole('heading', { name: 'Stable Release' })).toBeVisible();
+	await expect(page.getByRole('heading', { name: 'Nightly Release' })).toBeVisible();
+});

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -15,10 +15,21 @@
 		"declaration": true,
 		"composite": true,
 		"declarationMap": true
-	}
+	},
 	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
 	// except $lib which is handled by https://kit.svelte.dev/docs/configuration#files
-	//
-	// If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
-	// from the referenced tsconfig.json - TypeScript does not merge them in
+	"include": [
+		".svelte-kit/ambient.d.ts",
+		".svelte-kit/non-ambient.d.ts",
+		".svelte-kit/types/**/$types.d.ts",
+		"vite.config.js",
+		"vite.config.ts",
+		"playwright.config.ts",
+		"src/**/*.js",
+		"src/**/*.ts",
+		"src/**/*.svelte",
+		"tests/**/*.js",
+		"tests/**/*.ts",
+		"tests/**/*.svelte"
+	]
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"package": "turbo run package",
 		"test": "turbo run test --no-daemon",
 		"test:watch": "pnpm --filter @gitbutler/desktop run test:watch",
+		"test:e2e:web": "turbo run test:e2e:web",
 		"test:e2e": "pnpm --filter @gitbutler/desktop run test:e2e",
 		"act:test:e2e": "act -j test -W .github/workflows/test-e2e.yml -P catthehacker/ubuntu:act-22.04",
 		"build": "turbo run build --no-daemon",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -52,7 +52,6 @@
 		"autoprefixer": "^10.4.19",
 		"cpy-cli": "^5.0.0",
 		"dayjs": "^1.11.13",
-		"playwright": "^1.46.1",
 		"postcss": "^8.4.38",
 		"postcss-cli": "^11.0.0",
 		"postcss-minify": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,6 +323,9 @@ importers:
       '@neoconfetti/svelte':
         specifier: ^1.0.0
         version: 1.0.0
+      '@playwright/test':
+        specifier: ^1.47.0
+        version: 1.48.2
       '@sveltejs/adapter-auto':
         specifier: ^3.0.0
         version: 3.2.2(@sveltejs/kit@2.5.25(@sveltejs/vite-plugin-svelte@4.0.0-next.6(svelte@5.0.0-next.243)(vite@5.2.13(@types/node@22.3.0)))(svelte@5.0.0-next.243)(vite@5.2.13(@types/node@22.3.0)))
@@ -332,6 +335,9 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: catalog:svelte
         version: 4.0.0-next.6(svelte@5.0.0-next.243)(vite@5.2.13(@types/node@22.3.0))
+      '@types/node':
+        specifier: ^22.3.0
+        version: 22.3.0
       svelte:
         specifier: catalog:svelte
         version: 5.0.0-next.243
@@ -373,7 +379,7 @@ importers:
         version: 6.0.3
       '@vitest/browser':
         specifier: ^2.0.5
-        version: 2.0.5(playwright@1.46.1)(typescript@5.4.5)(vitest@2.0.5)(webdriverio@8.40.2)
+        version: 2.0.5(playwright@1.48.2)(typescript@5.4.5)(vitest@2.0.5)(webdriverio@8.40.2)
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.19(postcss@8.4.39)
@@ -1299,6 +1305,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.48.2':
+    resolution: {integrity: sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.25':
     resolution: {integrity: sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==}
@@ -4760,8 +4771,18 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  playwright-core@1.48.2:
+    resolution: {integrity: sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   playwright@1.46.1:
     resolution: {integrity: sha512-oPcr1yqoXLCkgKtD5eNUPLiN40rYEM39odNpIb6VE6S7/15gJmA1NzVv6zJYusV0e7tzvkU/utBFNa/Kpxmwng==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.48.2:
+    resolution: {integrity: sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -7069,6 +7090,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.48.2':
+    dependencies:
+      playwright: 1.48.2
+
   '@polka/url@1.0.0-next.25': {}
 
   '@prisma/instrumentation@5.15.0':
@@ -8242,6 +8267,25 @@ snapshots:
       ws: 8.18.0
     optionalDependencies:
       playwright: 1.46.1
+      webdriverio: 8.40.2
+    transitivePeerDependencies:
+      - bufferutil
+      - graphql
+      - typescript
+      - utf-8-validate
+
+  '@vitest/browser@2.0.5(playwright@1.48.2)(typescript@5.4.5)(vitest@2.0.5)(webdriverio@8.40.2)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+      '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
+      '@vitest/utils': 2.0.5
+      magic-string: 0.30.10
+      msw: 2.4.1(typescript@5.4.5)
+      sirv: 2.0.4
+      vitest: 2.0.5(@types/node@22.3.0)(@vitest/browser@2.0.5)(@vitest/ui@2.0.5)(happy-dom@14.12.3)(jsdom@24.1.1)
+      ws: 8.18.0
+    optionalDependencies:
+      playwright: 1.48.2
       webdriverio: 8.40.2
     transitivePeerDependencies:
       - bufferutil
@@ -11155,9 +11199,17 @@ snapshots:
 
   playwright-core@1.46.1: {}
 
+  playwright-core@1.48.2: {}
+
   playwright@1.46.1:
     dependencies:
       playwright-core: 1.46.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  playwright@1.48.2:
+    dependencies:
+      playwright-core: 1.48.2
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,9 +383,6 @@ importers:
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
-      playwright:
-        specifier: ^1.46.1
-        version: 1.46.1
       postcss:
         specifier: ^8.4.38
         version: 8.4.39
@@ -9611,7 +9608,7 @@ snapshots:
   esrap@1.2.2:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   esrecurse@4.3.0:
     dependencies:
@@ -10380,7 +10377,7 @@ snapshots:
 
   is-reference@3.0.2:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   is-regex@1.1.4:
     dependencies:
@@ -11949,7 +11946,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       acorn: 8.12.1
       acorn-typescript: 1.4.13(acorn@8.12.1)
       aria-query: 5.3.0

--- a/turbo.json
+++ b/turbo.json
@@ -29,6 +29,9 @@
 		"test": {
 			"dependsOn": ["package", "playwright:install"]
 		},
+		"test:e2e:web": {
+			"dependsOn": ["package"]
+		},
 		"//#globallint": {
 			"dependsOn": ["@gitbutler/ui#package", "@gitbutler/shared#package"]
 		}


### PR DESCRIPTION
## ☕️ Reasoning

- Goal: Have good e2e testing setup available early as we dev on the web application
- This being a normal web app, should be muchhh easier than e2e testing the Tauri application

## 🧢 Changes

- Add `test-e2e-playwright.yml` GHA
	- Rename existing webdriver `test-e2e.yml` to `test-e2e-webdriver.yml` to differentiate between the two separate e2e tests in the monorepo
	- Caches playwright browser installs 
	- Runs in ~50s when pulling browsers from said cache
- Add `@plyawright/test` setup to `apps/web`
	- Add initial simple test
- Add root `test:e2e:web` npm script to run the web e2e playwrihgt tests
- GHA [passes with 2/2](https://github.com/gitbutlerapp/gitbutler/actions/runs/11532103494/job/32103539626?pr=5319) :heavy_check_mark: 

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
