### PR TITLE
fix: renable type-aware linting rules

### DIFF
--- a/apps/desktop/src/lib/components/MarkdownContent.svelte
+++ b/apps/desktop/src/lib/components/MarkdownContent.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	/* eslint svelte/valid-compile: "off" */
-	/* - Required because spreading in prop destructuring still throws eslint errors */
 	import { renderers } from '$lib/utils/markdownRenderers';
 	import type { Tokens, Token } from 'marked';
 	import type { Component } from 'svelte';

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,9 @@ export default ts.config(
 			globals: {
 				...globals.browser,
 				...globals.node
+			},
+			parserOptions: {
+				projectService: true
 			}
 		},
 		rules: {
@@ -30,9 +33,9 @@ export default ts.config(
 					caughtErrorsIgnorePattern: '^_'
 				}
 			],
-			// '@typescript-eslint/return-await': ['error', 'always'],
-			// '@typescript-eslint/promise-function-async': 'error',
-			// '@typescript-eslint/await-thenable': 'error',
+			'@typescript-eslint/return-await': ['error', 'always'],
+			'@typescript-eslint/promise-function-async': 'error',
+			'@typescript-eslint/await-thenable': 'error',
 
 			eqeqeq: ['error', 'always'],
 			'import-x/no-cycle': 'error',
@@ -98,6 +101,10 @@ export default ts.config(
 		plugins: {
 			'import-x': pluginImportX
 		}
+	},
+	{
+		files: ['**/*.svelte'],
+		...ts.configs.disableTypeChecked
 	},
 	{
 		files: ['**/*.svelte'],


### PR DESCRIPTION
## ☕️ Reasoning

- Re-enable type-aware linting rules for `.ts` files.

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
