### PR TITLE
fix(nix): flake dev env environment variables

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,13 +60,15 @@
           ] ++ common;
         in
         {
-          devShells.default = unstable.mkShell {
+          devShells.default = pkgs.mkShell {
             nativeBuildInputs = packages;
             buildInputs = libraries;
             shellHook = ''
-              LD_LIBRARY_PATH=${unstable.lib.makeLibraryPath libraries}:$LD_LIBRARY_PATH
-              XDG_DATA_DIRS=${unstable.gsettings-desktop-schemas}/share/gsettings-schemas/${unstable.gsettings-desktop-schemas.name}:${unstable.gtk3}/share/gsettings-schemas/${unstable.gtk3.name}:$XDG_DATA_DIRS
-              GIO_MODULE_DIR=${unstable.glib-networking}/lib/gio/modules/
+              LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath libraries}:$LD_LIBRARY_PATH
+              XDG_DATA_DIRS=${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}:${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}:$XDG_DATA_DIRS
+              GIO_MODULE_DIR=${pkgs.glib-networking.out}/lib/gio/modules/
+              GIO_EXTRA_MODULES=${pkgs.glib-networking.out}/lib/gio/modules/
+
               PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-browsers_v1_47_0}
               PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
               PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true


### PR DESCRIPTION
## ☕️ Reasoning

- Add `GLIB_EXTRA_MODULES` `glib-networking` related env var to enable tls in dev environment

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
