### PR TITLE
fix: Modal closes on mouse down outside

### DIFF
--- a/packages/ui/src/lib/Modal.svelte
+++ b/packages/ui/src/lib/Modal.svelte
@@ -96,7 +96,7 @@
 		use:portal={'body'}
 		class="modal-container {isClosing ? 'closing' : 'open'}"
 		class:open
-		onclick={(e) => {
+		onmousedown={(e) => {
 			e.stopPropagation();
 
 			if (e.target === e.currentTarget) {


### PR DESCRIPTION
## ☕️ Reasoning
The modal was unintentionally closing when a user clicked down inside the modal and released the mouse outside. This pull request addresses this behavior to only close the modal when the user clicks down outside the modal.

## 🧢 Changes
- Updated the functionality to close the modal only on clicking down outside the modal.