### PR TITLE
Show correct remote name in branch header

### DIFF
--- a/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
@@ -201,7 +201,7 @@
 		/>
 		<div class="text-14 text-bold branch-info__name">
 			<span class:no-upstream={!gitHostBranch} class="remote-name">
-				{$baseBranch.remoteName ? `${$baseBranch.remoteName} /` : 'origin /'}
+				{$baseBranch.pushRemoteName ? `${$baseBranch.pushRemoteName} /` : 'origin /'}
 			</span>
 			<BranchLabel
 				name={currentSeries.name}


### PR DESCRIPTION
User might have a push remote set where we create branches on a different remote than the target branch.