### PR TITLE
fix: Open files on editor in Windows

### DIFF
--- a/apps/desktop/src/lib/barmenuActions/ProjectSettingsMenuAction.svelte
+++ b/apps/desktop/src/lib/barmenuActions/ProjectSettingsMenuAction.svelte
@@ -5,7 +5,7 @@
 	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import * as events from '$lib/utils/events';
 	import { unsubscribe } from '$lib/utils/unsubscribe';
-	import { openExternalUrl } from '$lib/utils/url';
+	import { getEditorUri, openExternalUrl } from '$lib/utils/url';
 	import { getContextStoreBySymbol } from '@gitbutler/shared/context';
 	import { getContext } from '@gitbutler/shared/context';
 	import { onMount } from 'svelte';
@@ -23,7 +23,11 @@
 		const unsubscribeopenInEditor = listen<string>(
 			'menu://project/open-in-vscode/clicked',
 			async () => {
-				const path = `${$userSettings.defaultCodeEditor.schemeIdentifer}://file${project.vscodePath}?windowId=_blank`;
+				const path = getEditorUri({
+					schemeId: $userSettings.defaultCodeEditor.schemeIdentifer,
+					path: [project.vscodePath],
+					searchParams: { windowId: '_blank' }
+				});
 				openExternalUrl(path);
 			}
 		);

--- a/apps/desktop/src/lib/components/BoardEmptyState.svelte
+++ b/apps/desktop/src/lib/components/BoardEmptyState.svelte
@@ -4,7 +4,7 @@
 	import { BaseBranch } from '$lib/baseBranch/baseBranch';
 	import { getGitHost } from '$lib/gitHost/interface/gitHost';
 	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
-	import { openExternalUrl } from '$lib/utils/url';
+	import { getEditorUri, openExternalUrl } from '$lib/utils/url';
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { getContext, getContextStore, getContextStoreBySymbol } from '@gitbutler/shared/context';
 	import Icon from '@gitbutler/ui/Icon.svelte';
@@ -18,9 +18,12 @@
 	const project = getContext(Project);
 
 	async function openInEditor() {
-		openExternalUrl(
-			`${$userSettings.defaultCodeEditor.schemeIdentifer}://file${project.vscodePath}/?windowId=_blank`
-		);
+		const path = getEditorUri({
+			schemeId: $userSettings.defaultCodeEditor.schemeIdentifer,
+			path: [project.vscodePath],
+			searchParams: { windowId: '_blank' }
+		});
+		openExternalUrl(path);
 	}
 </script>
 

--- a/apps/desktop/src/lib/components/EditMode.svelte
+++ b/apps/desktop/src/lib/components/EditMode.svelte
@@ -7,7 +7,7 @@
 	import ScrollableContainer from '$lib/scroll/ScrollableContainer.svelte';
 	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import { UncommitedFilesWatcher } from '$lib/uncommitedFiles/watcher';
-	import { openExternalUrl } from '$lib/utils/url';
+	import { getEditorUri, openExternalUrl } from '$lib/utils/url';
 	import { Commit, type RemoteFile } from '$lib/vbranches/types';
 	import { getContextStoreBySymbol } from '@gitbutler/shared/context';
 	import { getContext } from '@gitbutler/shared/context';
@@ -16,7 +16,6 @@
 	import InfoButton from '@gitbutler/ui/InfoButton.svelte';
 	import Avatar from '@gitbutler/ui/avatar/Avatar.svelte';
 	import FileListItem from '@gitbutler/ui/file/FileListItem.svelte';
-	import { join } from '@tauri-apps/api/path';
 	import type { FileStatus } from '@gitbutler/ui/file/types';
 	import type { Writable } from 'svelte/store';
 
@@ -164,8 +163,11 @@
 
 	async function openAllConflictedFiles() {
 		for (const file of conflictedFiles) {
-			const absPath = await join(project.vscodePath, file.path);
-			openExternalUrl(`${$userSettings.defaultCodeEditor.schemeIdentifer}://file${absPath}`);
+			const path = getEditorUri({
+				schemeId: $userSettings.defaultCodeEditor.schemeIdentifer,
+				path: [project.vscodePath, file.path]
+			});
+			openExternalUrl(path);
 		}
 	}
 </script>

--- a/apps/desktop/src/lib/file/FileContextMenu.svelte
+++ b/apps/desktop/src/lib/file/FileContextMenu.svelte
@@ -6,7 +6,7 @@
 	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import { computeFileStatus } from '$lib/utils/fileStatus';
 	import * as toasts from '$lib/utils/toasts';
-	import { openExternalUrl } from '$lib/utils/url';
+	import { getEditorUri, openExternalUrl } from '$lib/utils/url';
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { isAnyFile, LocalFile } from '$lib/vbranches/types';
 	import { getContextStoreBySymbol } from '@gitbutler/shared/context';
@@ -108,10 +108,11 @@
 						try {
 							if (!project) return;
 							for (let file of item.files) {
-								const absPath = await join(project.vscodePath, file.path);
-								openExternalUrl(
-									`${$userSettings.defaultCodeEditor.schemeIdentifer}://file${absPath}`
-								);
+								const path = getEditorUri({
+									schemeId: $userSettings.defaultCodeEditor.schemeIdentifer,
+									path: [project.vscodePath, file.path]
+								});
+								openExternalUrl(path);
 							}
 							contextMenu.close();
 						} catch {

--- a/apps/desktop/src/lib/hunk/HunkContextMenu.svelte
+++ b/apps/desktop/src/lib/hunk/HunkContextMenu.svelte
@@ -3,7 +3,7 @@
 	import ContextMenuItem from '$lib/components/contextmenu/ContextMenuItem.svelte';
 	import ContextMenuSection from '$lib/components/contextmenu/ContextMenuSection.svelte';
 	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
-	import { openExternalUrl } from '$lib/utils/url';
+	import { getEditorUri, openExternalUrl } from '$lib/utils/url';
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { getContextStoreBySymbol } from '@gitbutler/shared/context';
 	import { getContext } from '@gitbutler/shared/context';
@@ -49,9 +49,12 @@
 					label="Open in {$userSettings.defaultCodeEditor.displayName}"
 					onclick={() => {
 						if (projectPath) {
-							openExternalUrl(
-								`${$userSettings.defaultCodeEditor.schemeIdentifer}://file${projectPath}/${filePath}:${item.lineNumber}`
-							);
+							const path = getEditorUri({
+								schemeId: $userSettings.defaultCodeEditor.schemeIdentifer,
+								path: [projectPath, filePath],
+								line: item.lineNumber
+							});
+							openExternalUrl(path);
 						}
 						contextMenu?.close();
 					}}

--- a/apps/desktop/src/lib/utils/url.test.ts
+++ b/apps/desktop/src/lib/utils/url.test.ts
@@ -1,4 +1,4 @@
-import { remoteUrlIsHttp, convertRemoteToWebUrl } from '$lib/utils/url';
+import { remoteUrlIsHttp, convertRemoteToWebUrl, getEditorUri } from '$lib/utils/url';
 import { describe, expect, test } from 'vitest';
 
 describe.concurrent('cleanUrl', () => {
@@ -40,5 +40,73 @@ describe.concurrent('cleanUrl', () => {
 
 	test.each(nonHttpRemoteUrls)('Non HTTP Remote - %s', (remoteUrl) => {
 		expect(remoteUrlIsHttp(remoteUrl)).toBe(false);
+	});
+});
+
+describe.concurrent('getEditorUri', () => {
+	test('it should handle editor path with no search params', () => {
+		expect(getEditorUri({ schemeId: 'vscode', path: ['/path', 'to', 'file'] })).toEqual(
+			'vscode://file/path/to/file'
+		);
+	});
+
+	test('it should handle editor path with search params', () => {
+		expect(
+			getEditorUri({
+				schemeId: 'vscode',
+				path: ['/path', 'to', 'file'],
+				searchParams: { something: 'cool' }
+			})
+		).toEqual('vscode://file/path/to/file?something=cool');
+	});
+
+	test('it should handle editor path with search params with special characters', () => {
+		expect(
+			getEditorUri({
+				schemeId: 'vscode',
+				path: ['/path', 'to', 'file'],
+				searchParams: {
+					search: 'hello world',
+					what: 'bye-&*%*\\ded-yeah'
+				}
+			})
+		).toEqual('vscode://file/path/to/file?search=hello+world&what=bye-%26*%25*%5Cded-yeah');
+	});
+
+	test('it should handle editor path with search params with line number', () => {
+		expect(
+			getEditorUri({
+				schemeId: 'vscode',
+				path: ['/path', 'to', 'file'],
+				line: 10
+			})
+		).toEqual('vscode://file/path/to/file:10');
+	});
+
+	test('it should handle editor path with search params with line and column number', () => {
+		expect(
+			getEditorUri({
+				schemeId: 'vscode',
+				path: ['/path', 'to', 'file'],
+				searchParams: {
+					another: 'thing'
+				},
+				line: 10,
+				column: 20
+			})
+		).toEqual('vscode://file/path/to/file:10:20?another=thing');
+	});
+
+	test('it should ignore the column if there is no line number', () => {
+		expect(
+			getEditorUri({
+				schemeId: 'vscode',
+				path: ['/path', 'to', 'file'],
+				searchParams: {
+					another: 'thing'
+				},
+				column: 20
+			})
+		).toEqual('vscode://file/path/to/file?another=thing');
 	});
 });


### PR DESCRIPTION
## ☕️ Reasoning
The changes in this pull request fix the issue related to opening files on the editor in Windows. Previously, there was an issue with the path formatting when opening files using the editor URL on Windows.

More on the formatting of VSCode URLs: https://code.visualstudio.com/docs/editor/command-line#_opening-vs-code-with-urls

## 🧢 Changes
This pull request ensures that forward slashes are used for the path when opening files with the editor URL on Windows.

## Issue
As seen in: https://github.com/gitbutlerapp/gitbutler/issues/5307

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
