### PR TITLE
fix: test using color-mix instead of oklch for better legacy support

### DIFF
--- a/apps/desktop/src/lib/branch/BranchDropzone.svelte
+++ b/apps/desktop/src/lib/branch/BranchDropzone.svelte
@@ -168,7 +168,7 @@
 		left: 35px;
 		width: 77px;
 		height: 83px;
-		background-color: oklch(from var(--clr-scale-ntrl-60) l c h / 0.2);
+		background-color: color-mix(in srgb, var(--clr-scale-ntrl-60), transparent 80%);
 		border-radius: 12px;
 	}
 
@@ -214,8 +214,8 @@
 	/* DRAGZONE MODIEFIERS */
 	.activated {
 		&.new-virtual-branch {
-			background-color: oklch(from var(--clr-scale-pop-70) l c h / 0.1);
-			border: 1px dashed oklch(from var(--clr-scale-pop-40) l c h / 0.8);
+			background-color: color-mix(in srgb, var(--clr-scale-pop-70), transparent 90%);
+			border: 1px dashed color-mix(in srgb, var(--clr-scale-pop-40), transparent 20%);
 			color: var(--clr-scale-pop-50);
 		}
 

--- a/apps/desktop/src/lib/commit/CommitMessageInput.svelte
+++ b/apps/desktop/src/lib/commit/CommitMessageInput.svelte
@@ -324,7 +324,7 @@
 		}
 
 		&::placeholder {
-			color: oklch(from var(--clr-scale-ntrl-30) l c h / 0.4);
+			color: var(--clr-text-3);
 		}
 	}
 

--- a/apps/desktop/src/lib/components/DecorativeSplitView.svelte
+++ b/apps/desktop/src/lib/components/DecorativeSplitView.svelte
@@ -242,7 +242,7 @@
 		transition: background-color var(--transition-fast);
 
 		&:hover {
-			background-color: oklch(from var(--clr-scale-pop-60) l c h / 0.3);
+			background-color: color-mix(in srgb, var(--clr-scale-pop-60), transparent 70%);
 		}
 	}
 </style>

--- a/apps/desktop/src/lib/dropzone/CardOverlay.svelte
+++ b/apps/desktop/src/lib/dropzone/CardOverlay.svelte
@@ -91,7 +91,7 @@
 			transform: scale(1.01);
 
 			.animated-rectangle rect {
-				fill: oklch(from var(--clr-scale-pop-50) l c h / 0.16);
+				fill: color-mix(in srgb, var(--clr-scale-pop-50), transparent 84%);
 			}
 
 			.dropzone-label {
@@ -152,7 +152,7 @@
 		height: 100%;
 
 		& rect {
-			fill: oklch(from var(--clr-scale-pop-50) l c h / 0.1);
+			fill: color-mix(in srgb, var(--clr-scale-pop-50), transparent 90%);
 			stroke: var(--clr-scale-pop-50);
 
 			stroke-width: 2px;

--- a/apps/desktop/src/lib/shared/AccountLink.svelte
+++ b/apps/desktop/src/lib/shared/AccountLink.svelte
@@ -60,7 +60,7 @@
 
 			&:hover {
 				color: var(--clr-scale-pop-10);
-				background: oklch(from var(--clr-scale-pop-70) calc(l - 0.03) c h);
+				background-color: color-mix(in srgb, var(--clr-scale-pop-60), transparent 60%);
 			}
 		}
 

--- a/apps/desktop/src/lib/shared/IconLink.svelte
+++ b/apps/desktop/src/lib/shared/IconLink.svelte
@@ -36,7 +36,7 @@
 
 		&:hover {
 			color: var(--clr-text-1);
-			background-color: oklch(from var(--clr-scale-ntrl-0) l c h / 0.05);
+			background-color: color-mix(in srgb, var(--clr-scale-ntrl-0), transparent 50%);
 		}
 	}
 </style>

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -94,7 +94,7 @@ body {
 }
 
 .locked-file-animation {
-	--locked-color: oklch(from var(--clr-scale-warn-50) l c h / 0.2);
+	--locked-color: color-mix(in srgb, var(--clr-scale-warn-50), transparent 80%);
 	border: 1px solid var(--clr-bg-1);
 	animation: locked-file-animation 1.4s ease-out forwards;
 }


### PR DESCRIPTION
## ☕️ Reasoning

- Test PR
- AppImages running older versions of libwebkit2gtk would result in dropzone backgrounds being black holes, for example. 

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
