### PR TITLE
feat: show RenameSeries modal on BranchLabel dblClick

### DIFF
--- a/apps/desktop/src/lib/branch/BranchLabel.svelte
+++ b/apps/desktop/src/lib/branch/BranchLabel.svelte
@@ -5,10 +5,12 @@
 	interface Props {
 		name: string;
 		disabled?: boolean;
+		readonly?: boolean;
 		onChange?: (value: string) => void;
+		onDblClick?: () => void;
 	}
 
-	let { name, disabled = false, onChange }: Props = $props();
+	let { name, disabled = false, readonly = false, onChange, onDblClick }: Props = $props();
 
 	let inputEl: HTMLInputElement;
 	let initialName = name;
@@ -26,12 +28,18 @@
 <input
 	type="text"
 	{disabled}
+	{readonly}
 	bind:this={inputEl}
 	bind:value={name}
 	onchange={(e) => onChange?.(e.currentTarget.value.trim())}
 	title={name}
 	class="branch-name-input text-14 text-bold"
-	ondblclick={(e) => e.stopPropagation()}
+	ondblclick={(e) => {
+		e.stopPropagation();
+		if (readonly) {
+			onDblClick?.();
+		}
+	}}
 	oncontextmenu={(e) => {
 		e.stopPropagation();
 	}}
@@ -90,14 +98,18 @@
 		outline: none;
 
 		/* not readonly */
-		&:not([disabled]):hover {
+		&:not([readonly]):not([disabled]):hover {
 			background-color: var(--clr-bg-2);
 		}
 
-		&:not([disabled]):focus {
+		&:not([readonly]):not([disabled]):focus {
 			outline: none;
 			background-color: var(--clr-bg-2);
 			border-color: var(--clr-border-2);
 		}
+	}
+	.branch-name-input[readonly] {
+		pointer: normal;
+		user-select: none;
 	}
 </style>

--- a/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
@@ -56,6 +56,7 @@
 	let stackingAddSeriesModal = $state<ReturnType<typeof StackingAddSeriesModal>>();
 	let prDetailsModal = $state<ReturnType<typeof PrDetailsModal>>();
 	let kebabContextMenu = $state<ReturnType<typeof ContextMenu>>();
+	let stackingContextMenu = $state<ReturnType<typeof StackingSeriesHeaderContextMenu>>();
 	let kebabContextMenuTrigger = $state<HTMLButtonElement>();
 
 	let contextMenuOpened = $state(false);
@@ -145,6 +146,7 @@
 <StackingAddSeriesModal bind:this={stackingAddSeriesModal} parentSeriesName={currentSeries.name} />
 
 <StackingSeriesHeaderContextMenu
+	bind:this={stackingContextMenu}
 	bind:contextMenuEl={kebabContextMenu}
 	target={kebabContextMenuTrigger}
 	headName={currentSeries.name}
@@ -207,7 +209,10 @@
 				<BranchLabel
 					name={currentSeries.name}
 					onChange={(name) => editTitle(name)}
-					disabled={!!gitHostBranch}
+					readonly={!!gitHostBranch}
+					onDblClick={() => {
+						stackingContextMenu?.showSeriesRenameModal?.();
+					}}
 				/>
 			</div>
 		</div>

--- a/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
@@ -159,6 +159,7 @@
 	reloadPR={handleReloadPR}
 	onopen={() => (contextMenuOpened = true)}
 	onclose={() => (contextMenuOpened = false)}
+	{branchType}
 />
 
 <div role="article" class="branch-header" oncontextmenu={(e) => e.preventDefault()}>
@@ -211,7 +212,9 @@
 					onChange={(name) => editTitle(name)}
 					readonly={!!gitHostBranch}
 					onDblClick={() => {
-						stackingContextMenu?.showSeriesRenameModal?.();
+						if (branchType !== 'integrated') {
+							stackingContextMenu?.showSeriesRenameModal?.();
+						}
 					}}
 				/>
 			</div>

--- a/apps/desktop/src/lib/branch/StackingSeriesHeaderContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeaderContextMenu.svelte
@@ -7,7 +7,7 @@
 	import { projectAiGenEnabled } from '$lib/config/config';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { BranchController } from '$lib/vbranches/branchController';
-	import { VirtualBranch } from '$lib/vbranches/types';
+	import { VirtualBranch, type CommitStatus } from '$lib/vbranches/types';
 	import { getContext, getContextStore } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import Modal from '@gitbutler/ui/Modal.svelte';
@@ -20,6 +20,7 @@
 		seriesCount: number;
 		hasGitHostBranch: boolean;
 		prUrl?: string;
+		branchType: CommitStatus;
 		addDescription: () => void;
 		onGenerateBranchName: () => void;
 		openPrDetailsModal: () => void;
@@ -35,6 +36,7 @@
 		hasGitHostBranch,
 		headName,
 		prUrl,
+		branchType,
 		addDescription,
 		onGenerateBranchName,
 		openPrDetailsModal,
@@ -91,6 +93,7 @@
 		{/if}
 		<ContextMenuItem
 			label="Rename"
+			disabled={branchType === 'integrated'}
 			onclick={async () => {
 				renameSeriesModal.show(branch);
 				contextMenuEl?.close();

--- a/apps/desktop/src/lib/branch/StackingSeriesHeaderContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeaderContextMenu.svelte
@@ -64,6 +64,10 @@
 	}
 
 	const branch = $derived($branchStore);
+
+	export function showSeriesRenameModal() {
+		renameSeriesModal.show(branch);
+	}
 </script>
 
 <ContextMenu bind:this={contextMenuEl} {target} {onopen} {onclose}>


### PR DESCRIPTION
## ☕️ Reasoning

- Double clicking on branch name used to allow renaming it

## 🧢 Changes

- Doublbe clicking on "disabled" (now "readonly" since disabled inputs don't trigger click events) opens the "Rename Branch" modal, just like the "Rename" context menu entry

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
