### PR TITLE
fix: series name normalization

### DIFF
--- a/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
@@ -28,7 +28,6 @@
 	import Button from '@gitbutler/ui/Button.svelte';
 	import PopoverActionsContainer from '@gitbutler/ui/popoverActions/PopoverActionsContainer.svelte';
 	import PopoverActionsItem from '@gitbutler/ui/popoverActions/PopoverActionsItem.svelte';
-	import { slugify } from '@gitbutler/ui/utils/string';
 
 	interface Props {
 		currentSeries: PatchSeries;
@@ -105,7 +104,7 @@
 
 	function editTitle(title: string) {
 		if (currentSeries?.name && title !== currentSeries.name) {
-			branchController.updateSeriesName(branch.id, currentSeries.name, slugify(title));
+			branchController.updateSeriesName(branch.id, currentSeries.name, title);
 		}
 	}
 
@@ -138,7 +137,7 @@
 		const message = messageResult.value;
 
 		if (message && message !== currentSeries.name) {
-			branchController.updateSeriesName(branch.id, currentSeries.name, slugify(message));
+			branchController.updateSeriesName(branch.id, currentSeries.name, message);
 		}
 	}
 </script>

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -5,6 +5,7 @@ use gitbutler_command_context::CommandContext;
 use gitbutler_commit::commit_ext::CommitExt;
 use gitbutler_patch_reference::{CommitOrChangeId, ForgeIdentifier, PatchReference};
 use gitbutler_project::Project;
+use gitbutler_reference::normalize_branch_name;
 use gitbutler_repo_actions::RepoActionsExt;
 use gitbutler_stack::{PatchReferenceUpdate, Series};
 use gitbutler_stack::{Stack, StackId, Target};
@@ -92,11 +93,12 @@ pub fn update_series_name(
     let ctx = &open_with_verify(project)?;
     assure_open_workspace_mode(ctx).context("Requires an open workspace mode")?;
     let mut stack = ctx.project().virtual_branches().get_branch(branch_id)?;
+    let normalized_head_name = normalize_branch_name(&new_head_name)?;
     stack.update_series(
         ctx,
         head_name,
         &PatchReferenceUpdate {
-            name: Some(new_head_name),
+            name: Some(normalized_head_name),
             ..Default::default()
         },
     )

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -38,13 +38,14 @@ pub fn create_series(
     let ctx = &open_with_verify(project)?;
     assure_open_workspace_mode(ctx).context("Requires an open workspace mode")?;
     let mut stack = ctx.project().virtual_branches().get_branch(branch_id)?;
+    let normalized_head_name = normalize_branch_name(&req.name)?;
     // If target_patch is None, create a new head that points to the top of the stack (most recent patch)
     if let Some(target_patch) = req.target_patch {
         stack.add_series(
             ctx,
             PatchReference {
                 target: target_patch,
-                name: req.name,
+                name: normalized_head_name,
                 description: req.description,
                 forge_id: Default::default(),
                 archived: Default::default(),

--- a/packages/ui/src/lib/utils/string.test.ts
+++ b/packages/ui/src/lib/utils/string.test.ts
@@ -39,6 +39,10 @@ describe.concurrent('branch slugify with valid characters', () => {
 	test('underscores are fine', () => {
 		expect(slugify('my_branch')).toEqual('my_branch');
 	});
+
+	test('periods are fine', () => {
+		expect(slugify('my.branch')).toEqual('my.branch');
+	});
 });
 
 describe.concurrent('branch slugify with replaced characters', () => {

--- a/packages/ui/src/lib/utils/string.ts
+++ b/packages/ui/src/lib/utils/string.ts
@@ -44,7 +44,7 @@ export function slugify(input: string) {
 		.normalize('NFKD')
 		.replace(/[\u0300-\u036f]/g, '')
 		.trim()
-		.replace(/[^A-Za-z0-9_/ -]/g, '')
+		.replace(/[^A-Za-z0-9._/ -]/g, '')
 		.replace(/\s+/g, '-')
 		.replace(/-+/g, '-');
 }


### PR DESCRIPTION
## ☕️ Reasoning

- Periods (`.`) are supposed to allowed in branch names

## 🧢 Changes

- Allow period character through our `slugify` fn used for branch names/titles
- Where possible, use `gix`'s `normalize_branch_name` fn on the rust side to handle this instead

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
