### PR TITLE
fix: do not cutoff traversals by date for branch details (#1650).

### DIFF
--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -571,6 +571,7 @@ pub fn get_branch_listing_details(
                                 let revwalk = repo
                                     .rev_walk(Some(branch_head))
                                     .with_pruned(Some(base))
+                                    .sorting(gix::revision::walk::Sorting::BreadthFirst)
                                     .all()?;
                                 for commit_info in revwalk {
                                     let commit_info = commit_info?;


### PR DESCRIPTION
We already found the merge-base and know that this will naturally be the end of the traversal. Thus there is no need to additionally set a cut-off date, which is the documented default.

With such a cutoff, it's very possible that certain operations on the branches change the date of the base to lie in the future, which is when no traversal would be able to happen anymore.

Fixes #1650.

### Tasks

* [x] initial fix
* [x] safe fix

### Notes for the reviewer

* The implementation is a bit more complex to be sure that the cutoff is still used where possible. The GitLab repository for instance has such complex graphs that somehow... the first mergebase often isn't enough to cancel the traversal.

<img width="298" alt="Screenshot 2024-10-30 at 16 02 28" src="https://github.com/user-attachments/assets/e5903e2d-ad7d-486d-8ec9-018bda7da01d">
