### PR TITLE
Align gravatar images and refresh the branch listing on commit changes

### DIFF
--- a/apps/desktop/src/lib/branches/branchListing.ts
+++ b/apps/desktop/src/lib/branches/branchListing.ts
@@ -63,6 +63,18 @@ export class BranchListingService {
 		return store;
 	}
 
+	/**
+	 * Refresh the information for a particular branch.
+	 *
+	 * Will only fetch the information if the branch is already being tracked.
+	 */
+	refreshBranchListingDetails(branchName: string) {
+		if (!this.branchListingDetails.has(branchName)) {
+			return;
+		}
+		this.updateBranchListing(branchName);
+	}
+
 	private accumulatedBranchListings: string[] = [];
 	private updateBranchListingTimeout: ReturnType<typeof setTimeout> | undefined;
 	// Accumulates multiple update calls
@@ -341,6 +353,8 @@ export class Author {
 	name?: string | undefined;
 	/** The email of the author as configured in the git config */
 	email?: string | undefined;
+	/** The gravatar id of the author */
+	gravatarUrl?: string | undefined;
 }
 
 /** Represents a fat struct with all the data associated with a branch */

--- a/apps/desktop/src/lib/commit/CommitCard.svelte
+++ b/apps/desktop/src/lib/commit/CommitCard.svelte
@@ -104,7 +104,7 @@
 			console.error('Unable to undo commit');
 			return;
 		}
-		branchController.undoCommit(branch.id, commit.id);
+		branchController.undoCommit(branch.id, branch.name, commit.id);
 	}
 
 	let isUndoable = commit instanceof DetailedCommit && type !== 'remote';

--- a/apps/desktop/src/lib/commit/CommitDialog.svelte
+++ b/apps/desktop/src/lib/commit/CommitDialog.svelte
@@ -33,6 +33,7 @@
 		try {
 			await branchController.commitBranch(
 				$branch.id,
+				$branch.name,
 				message.trim(),
 				$selectedOwnership.toString(),
 				$runCommitHooks

--- a/apps/desktop/src/lib/commit/StackingCommitCard.svelte
+++ b/apps/desktop/src/lib/commit/StackingCommitCard.svelte
@@ -104,7 +104,7 @@
 			console.error('Unable to undo commit');
 			return;
 		}
-		branchController.undoCommit(branch.id, commit.id);
+		branchController.undoCommit(branch.id, branch.name, commit.id);
 	}
 
 	let isUndoable = commit instanceof DetailedCommit && type !== 'remote';

--- a/apps/desktop/src/lib/navigation/BranchListingSidebarEntry.svelte
+++ b/apps/desktop/src/lib/navigation/BranchListingSidebarEntry.svelte
@@ -100,7 +100,7 @@
 				branchListingDetails.authors.map(async (author) => {
 					return {
 						name: author.name || unknownName,
-						srcUrl: await gravatarUrlFromEmail(author.email || unknownEmail)
+						srcUrl: author.gravatarUrl ?? (await gravatarUrlFromEmail(author.email || unknownEmail))
 					};
 				})
 			);

--- a/apps/desktop/src/routes/[projectId]/+layout.ts
+++ b/apps/desktop/src/routes/[projectId]/+layout.ts
@@ -79,7 +79,8 @@ export const load: LayoutLoad = async ({ params, parent }) => {
 		projectId,
 		vbranchService,
 		remoteBranchService,
-		baseBranchService
+		baseBranchService,
+		branchListingService
 	);
 
 	const branchDragActionsFactory = new BranchDragActionsFactory(branchController);

--- a/crates/gitbutler-branch-actions/src/gravatar.rs
+++ b/crates/gitbutler-branch-actions/src/gravatar.rs
@@ -1,0 +1,9 @@
+use anyhow::Result;
+
+pub fn gravatar_url_from_email(email: &str) -> Result<url::Url> {
+    let gravatar_url = format!(
+        "https://www.gravatar.com/avatar/{:x}?s=100&r=g&d=retro",
+        md5::compute(email.to_lowercase())
+    );
+    url::Url::parse(gravatar_url.as_str()).map_err(Into::into)
+}

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -52,6 +52,7 @@ pub use reorder::{SeriesOrder, StackOrder};
 mod undo_commit;
 
 mod author;
+mod gravatar;
 mod status;
 use gitbutler_stack::VirtualBranchesHandle;
 pub use status::get_applied_status;

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/list_details.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/list_details.rs
@@ -93,6 +93,7 @@ mod util {
         Author {
             name: Some("author".into()),
             email: Some("author@example.com".into()),
+            gravatar_url: Some("https://www.gravatar.com/avatar/5c1e6d6e64e12aca17657581a48005d1?s=100&r=g&d=retro".into()),
         }
     }
 


### PR DESCRIPTION
## ☕️ Reasoning
This pull request includes changes related to displaying the author information and gravatar URL in branch listings.
The branch author's gravatar now shares the same URL as the one in the commits.

## 🧢 Changes
- Added the gravatar URL for the author in branches
- Display the gravatar image in the branch listings if present
- Implemented logic to refresh the branch listing on every commit done to or undone from it

## Issue
As seen in: https://github.com/gitbutlerapp/gitbutler/issues/5359