### PR TITLE
Store forgeId after creating a new pull request

### DIFF
--- a/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
@@ -78,7 +78,7 @@
 	const prs = $derived(prStore ? $prStore : undefined);
 
 	const listedPr = $derived(prs?.find((pr) => pr.sourceBranch === upstreamName));
-	const prNumber = $derived(listedPr?.number);
+	const prNumber = $derived(currentSeries.forgeId?.subject.prNumber || listedPr?.number);
 
 	const prMonitor = $derived(prNumber ? $prService?.prMonitor(prNumber) : undefined);
 	const pr = $derived(prMonitor?.pr);
@@ -288,7 +288,12 @@
 		{#if $pr}
 			<PrDetailsModal bind:this={prDetailsModal} type="display" pr={$pr} />
 		{:else}
-			<PrDetailsModal bind:this={prDetailsModal} type="preview-series" {currentSeries} />
+			<PrDetailsModal
+				bind:this={prDetailsModal}
+				type="preview-series"
+				{currentSeries}
+				stackId={branch.id}
+			/>
 		{/if}
 	</Dropzones>
 </div>

--- a/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeader.svelte
@@ -106,6 +106,14 @@
 		prDetailsModal?.show(pushBeforeCreate);
 	}
 
+	async function handleReopenPr() {
+		if (!$pr) {
+			return;
+		}
+		await $prService?.reopen($pr?.number);
+		await Promise.allSettled([prMonitor?.refresh(), checksMonitor?.update()]);
+	}
+
 	function editTitle(title: string) {
 		if (currentSeries?.name && title !== currentSeries.name) {
 			branchController.updateSeriesName(branch.id, currentSeries.name, title);
@@ -255,6 +263,7 @@
 							<StackingPullRequestCard
 								upstreamName={currentSeries.name}
 								reloadPR={handleReloadPR}
+								reopenPr={handleReopenPr}
 								pr={$pr}
 								{checksMonitor}
 							/>

--- a/apps/desktop/src/lib/forge/github/githubPrService.ts
+++ b/apps/desktop/src/lib/forge/github/githubPrService.ts
@@ -84,6 +84,15 @@ export class GitHubPrService implements ForgePrService {
 		});
 	}
 
+	async reopen(prNumber: number) {
+		await this.octokit.pulls.update({
+			owner: this.repo.owner,
+			repo: this.repo.name,
+			pull_number: prNumber,
+			state: 'open'
+		});
+	}
+
 	prMonitor(prNumber: number): GitHubPrMonitor {
 		return new GitHubPrMonitor(this, prNumber);
 	}

--- a/apps/desktop/src/lib/forge/github/types.ts
+++ b/apps/desktop/src/lib/forge/github/types.ts
@@ -20,7 +20,8 @@ export function parseGitHubDetailedPullRequest(
 		mergeable: !!data.mergeable,
 		mergeableState: data.mergeable_state,
 		rebaseable: !!data.rebaseable,
-		squashable: !!data.mergeable // Enabled whenever merge is enabled
+		squashable: !!data.mergeable, // Enabled whenever merge is enabled
+		state: data.state
 	};
 }
 

--- a/apps/desktop/src/lib/forge/interface/forgePrService.ts
+++ b/apps/desktop/src/lib/forge/interface/forgePrService.ts
@@ -18,5 +18,6 @@ export interface ForgePrService {
 		upstreamName
 	}: CreatePullRequestArgs): Promise<PullRequest>;
 	merge(method: MergeMethod, prNumber: number): Promise<void>;
+	reopen(prNumber: number): Promise<void>;
 	prMonitor(prNumber: number): ForgePrMonitor;
 }

--- a/apps/desktop/src/lib/forge/interface/types.ts
+++ b/apps/desktop/src/lib/forge/interface/types.ts
@@ -42,6 +42,7 @@ export interface DetailedPullRequest {
 	mergeableState: string;
 	rebaseable: boolean;
 	squashable: boolean;
+	state: 'open' | 'closed';
 }
 
 export type ChecksStatus = {


### PR DESCRIPTION
With this id persisted we do not need to match prs and branches by their names. Since pull requests will now be visible after being closed I also add a button for reopening it.