### PR TITLE
Prevent escape from closing "create pull request" modal that contains changes

### DIFF
--- a/crates/gitbutler-tauri/capabilities/main.json
+++ b/crates/gitbutler-tauri/capabilities/main.json
@@ -8,6 +8,7 @@
 		"core:default",
 		"core:window:allow-start-dragging",
 		"core:window:default",
+		"dialog:allow-confirm",
 		"dialog:allow-open",
 		"fs:allow-read-file",
 		"fs:allow-cache-read-recursive",


### PR DESCRIPTION
## ☕️ Reasoning

After carefully crafting a pull request description for 10 minutes, the last thing you expect is for an accidental press of escape to close the dialog and destroy your stuff.

## 🧢 Changes

If title or body has been changed, prompt the user to confirm before closing dialog.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
