### PR TITLE
fix: Hunk dependencies - Pass the commits in application order

### DIFF
--- a/crates/gitbutler-branch-actions/src/status.rs
+++ b/crates/gitbutler-branch-actions/src/status.rs
@@ -293,7 +293,14 @@ fn compute_locks(
     let mut stacks_input: Vec<InputStack> = vec![];
     for stack in stacks {
         let mut commits_input: Vec<InputCommit> = vec![];
-        let commit_ids = repo.l(stack.head(), LogUntil::Commit(*target_sha), false)?;
+        // Commit IDs in application order
+        let commit_ids = repo
+            .l(stack.head(), LogUntil::Commit(*target_sha), false)
+            .context("failed to list commits")?
+            .into_iter()
+            .rev()
+            .collect_vec();
+
         for commit_id in commit_ids {
             let mut files_input: Vec<InputFile> = vec![];
             let commit = repo.find_commit(commit_id)?;

--- a/crates/gitbutler-hunk-dependency/src/input.rs
+++ b/crates/gitbutler-hunk-dependency/src/input.rs
@@ -6,6 +6,9 @@ use gitbutler_stack::StackId;
 #[derive(Debug, Clone)]
 pub struct InputStack {
     pub stack_id: StackId,
+    /// The commits in the stack.
+    ///
+    /// The commits are ordered from the base to the top of the stack (application order).
     pub commits: Vec<InputCommit>,
 }
 


### PR DESCRIPTION
Pass the commits in application order when calculating the hunk diffs