### PR TITLE
Introduce gitbutler-settings crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2837,6 +2837,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "gitbutler-settings"
+version = "0.0.0"
+
+[[package]]
 name = "gitbutler-stack"
 version = "0.0.0"
 dependencies = [
@@ -2928,6 +2932,7 @@ dependencies = [
  "gitbutler-repo",
  "gitbutler-repo-actions",
  "gitbutler-secret",
+ "gitbutler-settings",
  "gitbutler-stack",
  "gitbutler-storage",
  "gitbutler-sync",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "crates/gitbutler-stack",
     "crates/gitbutler-patch-reference",
     "crates/gitbutler-hunk-dependency",
+    "crates/gitbutler-settings",
 ]
 resolver = "2"
 
@@ -95,6 +96,7 @@ gitbutler-stack = { path = "crates/gitbutler-stack" }
 gitbutler-patch-reference = { path = "crates/gitbutler-patch-reference" }
 gitbutler-forge = { path = "crates/gitbutler-forge" }
 gitbutler-hunk-dependency = { path = "crates/gitbutler-hunk-dependency" }
+gitbutler-settings = { path = "crates/gitbutler-settings" }
 
 [profile.release]
 codegen-units = 1 # Compile crates one after another so the compiler can optimize better

--- a/crates/gitbutler-settings/Cargo.toml
+++ b/crates/gitbutler-settings/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "gitbutler-settings"
+version = "0.0.0"
+edition = "2021"
+authors = ["GitButler <gitbutler@gitbutler.com>"]
+publish = false
+
+[dependencies]

--- a/crates/gitbutler-settings/src/lib.rs
+++ b/crates/gitbutler-settings/src/lib.rs
@@ -1,0 +1,9 @@
+/// Application settings
+/// Constructed via the `tauri_plugin_store::Store` from `settings.json`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AppSettings {
+    pub app_metrics_enabled: Option<bool>,
+    pub app_error_reporting_enabled: Option<bool>,
+    pub app_non_anon_metrics_enabled: Option<bool>,
+    pub app_analytics_confirmed: Option<bool>,
+}

--- a/crates/gitbutler-settings/src/lib.rs
+++ b/crates/gitbutler-settings/src/lib.rs
@@ -6,4 +6,6 @@ pub struct AppSettings {
     pub app_error_reporting_enabled: Option<bool>,
     pub app_non_anon_metrics_enabled: Option<bool>,
     pub app_analytics_confirmed: Option<bool>,
+    /// Client ID for the GitHub OAuth application
+    pub github_oauth_client_id: Option<String>,
 }

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -83,6 +83,7 @@ gitbutler-operating-modes.workspace = true
 gitbutler-edit-mode.workspace = true
 gitbutler-sync.workspace = true
 gitbutler-forge.workspace = true
+gitbutler-settings.workspace = true
 open = "5"
 url = "2.5.2"
 

--- a/crates/gitbutler-tauri/src/lib.rs
+++ b/crates/gitbutler-tauri/src/lib.rs
@@ -36,5 +36,6 @@ pub mod undo;
 pub mod users;
 pub mod virtual_branches;
 
+pub mod settings;
 pub mod stack;
 pub mod zip;

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -11,6 +11,7 @@
     clippy::too_many_lines
 )]
 
+use gitbutler_tauri::settings::SettingsStore;
 use gitbutler_tauri::{
     askpass, commands, config, forge, github, logs, menu, modes, open, projects, remotes, repo,
     secret, stack, undo, users, virtual_branches, zip, App, WindowState,
@@ -18,6 +19,7 @@ use gitbutler_tauri::{
 use tauri::Emitter;
 use tauri::{generate_context, Manager};
 use tauri_plugin_log::{Target, TargetKind};
+use tauri_plugin_store::StoreExt;
 
 fn main() {
     let performance_logging = std::env::var_os("GITBUTLER_PERFORMANCE_LOG").is_some();
@@ -104,6 +106,8 @@ fn main() {
                     };
                     app_handle.manage(app.users());
                     app_handle.manage(app.projects());
+                    let settings_store: SettingsStore = tauri_app.store("settings.json")?.into();
+                    app_handle.manage(settings_store);
 
                     app_handle.manage(gitbutler_feedback::Archival {
                         cache_dir: app_cache_dir,

--- a/crates/gitbutler-tauri/src/settings.rs
+++ b/crates/gitbutler-tauri/src/settings.rs
@@ -20,10 +20,17 @@ impl SettingsStore {
             app_error_reporting_enabled: self.get_bool("appErrorReportingEnabled"),
             app_non_anon_metrics_enabled: self.get_bool("appNonAnonMetricsEnabled"),
             app_analytics_confirmed: self.get_bool("appAnalyticsConfirmed"),
+            github_oauth_client_id: self.get_string("githubOauthClientId"),
         }
     }
 
     fn get_bool(&self, value: &str) -> Option<bool> {
         self.store.get(value).and_then(|v| v.as_bool())
+    }
+
+    fn get_string(&self, value: &str) -> Option<String> {
+        self.store
+            .get(value)
+            .and_then(|v| v.as_str().map(|s| s.to_string()))
     }
 }

--- a/crates/gitbutler-tauri/src/settings.rs
+++ b/crates/gitbutler-tauri/src/settings.rs
@@ -1,0 +1,29 @@
+use gitbutler_settings::AppSettings;
+use std::sync::Arc;
+use tauri::Wry;
+use tauri_plugin_store::Store;
+
+pub struct SettingsStore {
+    store: Arc<Store<Wry>>,
+}
+
+impl From<Arc<Store<Wry>>> for SettingsStore {
+    fn from(store: Arc<Store<Wry>>) -> Self {
+        Self { store }
+    }
+}
+
+impl SettingsStore {
+    pub fn app_settings(&self) -> AppSettings {
+        AppSettings {
+            app_metrics_enabled: self.get_bool("appMetricsEnabled"),
+            app_error_reporting_enabled: self.get_bool("appErrorReportingEnabled"),
+            app_non_anon_metrics_enabled: self.get_bool("appNonAnonMetricsEnabled"),
+            app_analytics_confirmed: self.get_bool("appAnalyticsConfirmed"),
+        }
+    }
+
+    fn get_bool(&self, value: &str) -> Option<bool> {
+        self.store.get(value).and_then(|v| v.as_bool())
+    }
+}


### PR DESCRIPTION
This PR adds 2 things:
- A crate/struct/mechanism for accessing application settings in various commands (using tauri_plugin_store but not tied to it)
- First usage of the new settings mechanism for optionally configuring githubOauthClientId (there are rare use cases where it is helpful for people to set their own client ID)