### PR TITLE
fix: PR modal: Disable the generate button if so configured

### DIFF
--- a/apps/desktop/src/lib/pr/PrDetailsModal.svelte
+++ b/apps/desktop/src/lib/pr/PrDetailsModal.svelte
@@ -114,9 +114,7 @@
 		}
 	}
 
-	const canUseAI = $derived.by(() => {
-		return aiConfigurationValid || $aiGenEnabled;
-	});
+	const canUseAI = $derived(aiConfigurationValid && $aiGenEnabled);
 	const defaultTitle: string = $derived.by(() => {
 		if (props.type === 'display') return props.pr.title;
 


### PR DESCRIPTION
If the AI generation is disabled in the project settings, disable the button in the  'generate message' button in the PR Modal as well