### PR TITLE
use gitoxide for merging trees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3059,6 +3059,7 @@ dependencies = [
  "gix-ignore 0.12.0",
  "gix-index 0.36.0",
  "gix-lock 15.0.0",
+ "gix-merge",
  "gix-negotiate",
  "gix-object 0.45.0",
  "gix-odb",
@@ -3600,6 +3601,29 @@ source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c16
 dependencies = [
  "gix-tempfile 15.0.0",
  "gix-utils 0.1.13",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-merge"
+version = "0.0.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-diff",
+ "gix-filter",
+ "gix-fs 0.12.0",
+ "gix-hash 0.15.0",
+ "gix-object 0.45.0",
+ "gix-path 0.10.12",
+ "gix-quote 0.4.13",
+ "gix-revision",
+ "gix-revwalk 0.16.0",
+ "gix-tempfile 15.0.0",
+ "gix-trace 0.1.11",
+ "gix-worktree 0.37.0",
+ "imara-diff",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2604,7 +2604,7 @@ version = "0.0.0"
 dependencies = [
  "assert_cmd",
  "futures",
- "gix-path 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-path 0.10.11",
  "nix 0.29.0",
  "rand 0.8.5",
  "serde",
@@ -2847,7 +2847,7 @@ dependencies = [
  "gitbutler-testsupport",
  "gitbutler-time",
  "gix",
- "gix-utils 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-utils 0.1.12",
  "itertools 0.13.0",
  "serde",
  "tempfile",
@@ -3037,51 +3037,51 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.66.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.67.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
- "gix-actor 0.32.0",
- "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-actor 0.33.0",
+ "gix-attributes 0.23.0",
  "gix-command",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-commitgraph 0.25.0",
  "gix-config",
  "gix-credentials",
- "gix-date 0.9.0",
+ "gix-date 0.9.1",
  "gix-diff",
  "gix-dir",
- "gix-discover 0.35.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-discover 0.36.0",
+ "gix-features 0.39.0",
  "gix-filter",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-ignore 0.11.4 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-index 0.35.0",
- "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-fs 0.12.0",
+ "gix-glob 0.17.0",
+ "gix-hash 0.15.0",
+ "gix-hashtable 0.6.0",
+ "gix-ignore 0.12.0",
+ "gix-index 0.36.0",
+ "gix-lock 15.0.0",
  "gix-negotiate",
- "gix-object 0.44.0",
+ "gix-object 0.45.0",
  "gix-odb",
  "gix-pack",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-path 0.10.12",
  "gix-pathspec",
  "gix-prompt",
  "gix-protocol",
- "gix-ref 0.47.0",
+ "gix-ref 0.48.0",
  "gix-refspec",
  "gix-revision",
- "gix-revwalk 0.15.0",
- "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-revwalk 0.16.0",
+ "gix-sec 0.10.9",
  "gix-status",
  "gix-submodule",
- "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-tempfile 15.0.0",
+ "gix-trace 0.1.11",
  "gix-transport",
- "gix-traverse 0.41.0",
+ "gix-traverse 0.42.0",
  "gix-url",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-validate 0.9.0",
- "gix-worktree 0.36.0",
+ "gix-utils 0.1.13",
+ "gix-validate 0.9.1",
+ "gix-worktree 0.37.0",
  "gix-worktree-state",
  "once_cell",
  "smallvec",
@@ -3096,7 +3096,7 @@ checksum = "a0e454357e34b833cc3a00b6efbbd3dd4d18b24b9fb0c023876ec2645e8aa3f2"
 dependencies = [
  "bstr",
  "gix-date 0.8.7",
- "gix-utils 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-utils 0.1.12",
  "itoa 1.0.11",
  "thiserror",
  "winnow 0.6.20",
@@ -3104,12 +3104,12 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.32.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.33.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
- "gix-date 0.9.0",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-date 0.9.1",
+ "gix-utils 0.1.13",
  "itoa 1.0.11",
  "thiserror",
  "winnow 0.6.20",
@@ -3122,10 +3122,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebccbf25aa4a973dd352564a9000af69edca90623e8a16dad9cbc03713131311"
 dependencies = [
  "bstr",
- "gix-glob 0.16.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-quote 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-trace 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-glob 0.16.5",
+ "gix-path 0.10.11",
+ "gix-quote 0.4.12",
+ "gix-trace 0.1.10",
  "kstring",
  "smallvec",
  "thiserror",
@@ -3134,14 +3134,14 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.22.5"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.23.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-glob 0.17.0",
+ "gix-path 0.10.12",
+ "gix-quote 0.4.13",
+ "gix-trace 0.1.11",
  "kstring",
  "smallvec",
  "thiserror",
@@ -3159,8 +3159,8 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.2.11"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.2.12"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "thiserror",
 ]
@@ -3176,20 +3176,20 @@ dependencies = [
 
 [[package]]
 name = "gix-chunk"
-version = "0.4.8"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.4.9"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "gix-command"
-version = "0.3.9"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.3.10"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-path 0.10.12",
+ "gix-trace 0.1.11",
  "shell-words",
 ]
 
@@ -3200,38 +3200,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "133b06f67f565836ec0c473e2116a60fb74f80b6435e21d88013ac0e3c60fc78"
 dependencies = [
  "bstr",
- "gix-chunk 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-features 0.38.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-chunk 0.4.8",
+ "gix-features 0.38.2",
+ "gix-hash 0.14.2",
  "memmap2",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.24.3"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.25.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
- "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-chunk 0.4.9",
+ "gix-features 0.39.0",
+ "gix-hash 0.15.0",
  "memmap2",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-config"
-version = "0.40.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.41.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-ref 0.47.0",
- "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-features 0.39.0",
+ "gix-glob 0.17.0",
+ "gix-path 0.10.12",
+ "gix-ref 0.48.0",
+ "gix-sec 0.10.9",
  "memchr",
  "once_cell",
  "smallvec",
@@ -3242,28 +3242,28 @@ dependencies = [
 
 [[package]]
 name = "gix-config-value"
-version = "0.14.8"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.14.9"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-path 0.10.12",
  "libc",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-credentials"
-version = "0.24.5"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.25.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-config-value",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-path 0.10.12",
  "gix-prompt",
- "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-sec 0.10.9",
+ "gix-trace 0.1.11",
  "gix-url",
  "thiserror",
 ]
@@ -3282,8 +3282,8 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.9.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.9.1"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
  "itoa 1.0.11",
@@ -3293,40 +3293,40 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.46.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.47.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-filter",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-object 0.44.0",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-traverse 0.41.0",
- "gix-worktree 0.36.0",
+ "gix-fs 0.12.0",
+ "gix-hash 0.15.0",
+ "gix-object 0.45.0",
+ "gix-path 0.10.12",
+ "gix-tempfile 15.0.0",
+ "gix-trace 0.1.11",
+ "gix-traverse 0.42.0",
+ "gix-worktree 0.37.0",
  "imara-diff",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-dir"
-version = "0.8.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.9.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
- "gix-discover 0.35.0",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-ignore 0.11.4 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-index 0.35.0",
- "gix-object 0.44.0",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-discover 0.36.0",
+ "gix-fs 0.12.0",
+ "gix-ignore 0.12.0",
+ "gix-index 0.36.0",
+ "gix-object 0.45.0",
+ "gix-path 0.10.12",
  "gix-pathspec",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-worktree 0.36.0",
+ "gix-trace 0.1.11",
+ "gix-utils 0.1.13",
+ "gix-worktree 0.37.0",
  "thiserror",
 ]
 
@@ -3338,26 +3338,26 @@ checksum = "fc27c699b63da66b50d50c00668bc0b7e90c3a382ef302865e891559935f3dbf"
 dependencies = [
  "bstr",
  "dunce",
- "gix-fs 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-fs 0.11.3",
+ "gix-hash 0.14.2",
+ "gix-path 0.10.11",
  "gix-ref 0.44.1",
- "gix-sec 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-sec 0.10.8",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-discover"
-version = "0.35.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.36.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
  "dunce",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-ref 0.47.0",
- "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-fs 0.12.0",
+ "gix-hash 0.15.0",
+ "gix-path 0.10.12",
+ "gix-ref 0.48.0",
+ "gix-sec 0.10.9",
  "thiserror",
 ]
 
@@ -3367,9 +3367,9 @@ version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac7045ac9fe5f9c727f38799d002a7ed3583cd777e3322a7c4b43e3cf437dc69"
 dependencies = [
- "gix-hash 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-trace 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-utils 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-hash 0.14.2",
+ "gix-trace 0.1.10",
+ "gix-utils 0.1.12",
  "libc",
  "prodash 28.0.0",
  "sha1_smol",
@@ -3378,16 +3378,16 @@ dependencies = [
 
 [[package]]
 name = "gix-features"
-version = "0.38.2"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.39.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bytes",
  "crc32fast",
  "crossbeam-channel",
  "flate2",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hash 0.15.0",
+ "gix-trace 0.1.11",
+ "gix-utils 0.1.13",
  "libc",
  "once_cell",
  "parking_lot",
@@ -3400,20 +3400,20 @@ dependencies = [
 
 [[package]]
 name = "gix-filter"
-version = "0.13.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.14.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
  "encoding_rs",
- "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-attributes 0.23.0",
  "gix-command",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-object 0.44.0",
+ "gix-hash 0.15.0",
+ "gix-object 0.45.0",
  "gix-packetline-blocking",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-path 0.10.12",
+ "gix-quote 0.4.13",
+ "gix-trace 0.1.11",
+ "gix-utils 0.1.13",
  "smallvec",
  "thiserror",
 ]
@@ -3425,18 +3425,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2bfe6249cfea6d0c0e0990d5226a4cb36f030444ba9e35e0639275db8f98575"
 dependencies = [
  "fastrand 2.1.1",
- "gix-features 0.38.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-utils 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-features 0.38.2",
+ "gix-utils 0.1.12",
 ]
 
 [[package]]
 name = "gix-fs"
-version = "0.11.3"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.12.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "fastrand 2.1.1",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-features 0.39.0",
+ "gix-utils 0.1.13",
 ]
 
 [[package]]
@@ -3447,19 +3447,19 @@ checksum = "74908b4bbc0a0a40852737e5d7889f676f081e340d5451a16e5b4c50d592f111"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-features 0.38.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-features 0.38.2",
+ "gix-path 0.10.11",
 ]
 
 [[package]]
 name = "gix-glob"
-version = "0.16.5"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.17.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-features 0.39.0",
+ "gix-path 0.10.12",
 ]
 
 [[package]]
@@ -3474,8 +3474,8 @@ dependencies = [
 
 [[package]]
 name = "gix-hash"
-version = "0.14.2"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.15.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "faster-hex",
  "thiserror",
@@ -3487,17 +3487,17 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddf80e16f3c19ac06ce415a38b8591993d3f73aede049cb561becb5b3a8e242"
 dependencies = [
- "gix-hash 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-hash 0.14.2",
  "hashbrown 0.14.5",
  "parking_lot",
 ]
 
 [[package]]
 name = "gix-hashtable"
-version = "0.5.2"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.6.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hash 0.15.0",
  "hashbrown 0.14.5",
  "parking_lot",
 ]
@@ -3509,21 +3509,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e447cd96598460f5906a0f6c75e950a39f98c2705fc755ad2f2020c9e937fab7"
 dependencies = [
  "bstr",
- "gix-glob 0.16.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-trace 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-glob 0.16.5",
+ "gix-path 0.10.11",
+ "gix-trace 0.1.10",
  "unicode-bom",
 ]
 
 [[package]]
 name = "gix-ignore"
-version = "0.11.4"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.12.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-glob 0.17.0",
+ "gix-path 0.10.12",
+ "gix-trace 0.1.11",
  "unicode-bom",
 ]
 
@@ -3537,14 +3537,14 @@ dependencies = [
  "bstr",
  "filetime",
  "fnv",
- "gix-bitmap 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-features 0.38.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-fs 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-lock 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-bitmap 0.2.11",
+ "gix-features 0.38.2",
+ "gix-fs 0.11.3",
+ "gix-hash 0.14.2",
+ "gix-lock 14.0.0",
  "gix-object 0.42.3",
  "gix-traverse 0.39.2",
- "gix-utils 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-utils 0.1.12",
  "gix-validate 0.8.5",
  "hashbrown 0.14.5",
  "itoa 1.0.11",
@@ -3557,22 +3557,22 @@ dependencies = [
 
 [[package]]
 name = "gix-index"
-version = "0.35.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.36.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "filetime",
  "fnv",
- "gix-bitmap 0.2.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-object 0.44.0",
- "gix-traverse 0.41.0",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-validate 0.9.0",
+ "gix-bitmap 0.2.12",
+ "gix-features 0.39.0",
+ "gix-fs 0.12.0",
+ "gix-hash 0.15.0",
+ "gix-lock 15.0.0",
+ "gix-object 0.45.0",
+ "gix-traverse 0.42.0",
+ "gix-utils 0.1.13",
+ "gix-validate 0.9.1",
  "hashbrown 0.14.5",
  "itoa 1.0.11",
  "libc",
@@ -3588,32 +3588,32 @@ version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bc7fe297f1f4614774989c00ec8b1add59571dc9b024b4c00acb7dedd4e19d"
 dependencies = [
- "gix-tempfile 14.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-utils 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-tempfile 14.0.2",
+ "gix-utils 0.1.12",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-lock"
-version = "14.0.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "15.0.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
- "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-tempfile 15.0.0",
+ "gix-utils 0.1.13",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-negotiate"
-version = "0.15.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.16.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bitflags 2.6.0",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-object 0.44.0",
- "gix-revwalk 0.15.0",
+ "gix-commitgraph 0.25.0",
+ "gix-date 0.9.1",
+ "gix-hash 0.15.0",
+ "gix-object 0.45.0",
+ "gix-revwalk 0.16.0",
  "smallvec",
  "thiserror",
 ]
@@ -3627,9 +3627,9 @@ dependencies = [
  "bstr",
  "gix-actor 0.31.5",
  "gix-date 0.8.7",
- "gix-features 0.38.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-utils 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-features 0.38.2",
+ "gix-hash 0.14.2",
+ "gix-utils 0.1.12",
  "gix-validate 0.8.5",
  "itoa 1.0.11",
  "smallvec",
@@ -3639,17 +3639,17 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.44.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.45.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
- "gix-actor 0.32.0",
- "gix-date 0.9.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-validate 0.9.0",
+ "gix-actor 0.33.0",
+ "gix-date 0.9.1",
+ "gix-features 0.39.0",
+ "gix-hash 0.15.0",
+ "gix-hashtable 0.6.0",
+ "gix-utils 0.1.13",
+ "gix-validate 0.9.1",
  "itoa 1.0.11",
  "smallvec",
  "thiserror",
@@ -3658,19 +3658,19 @@ dependencies = [
 
 [[package]]
 name = "gix-odb"
-version = "0.63.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.64.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "arc-swap",
- "gix-date 0.9.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-object 0.44.0",
+ "gix-date 0.9.1",
+ "gix-features 0.39.0",
+ "gix-fs 0.12.0",
+ "gix-hash 0.15.0",
+ "gix-hashtable 0.6.0",
+ "gix-object 0.45.0",
  "gix-pack",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-path 0.10.12",
+ "gix-quote 0.4.13",
  "parking_lot",
  "tempfile",
  "thiserror",
@@ -3678,17 +3678,17 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.53.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.54.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "clru",
- "gix-chunk 0.4.8 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-object 0.44.0",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-chunk 0.4.9",
+ "gix-features 0.39.0",
+ "gix-hash 0.15.0",
+ "gix-hashtable 0.6.0",
+ "gix-object 0.45.0",
+ "gix-path 0.10.12",
+ "gix-tempfile 15.0.0",
  "memmap2",
  "parking_lot",
  "smallvec",
@@ -3698,23 +3698,23 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline"
-version = "0.17.6"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.18.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-trace 0.1.11",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-packetline-blocking"
-version = "0.17.5"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.18.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-trace 0.1.11",
  "thiserror",
 ]
 
@@ -3725,7 +3725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebfc4febd088abdcbc9f1246896e57e37b7a34f6909840045a1767c6dafac7af"
 dependencies = [
  "bstr",
- "gix-trace 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-trace 0.1.10",
  "home",
  "once_cell",
  "thiserror",
@@ -3733,11 +3733,11 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.10.11"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.10.12"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-trace 0.1.11",
  "home",
  "once_cell",
  "thiserror",
@@ -3745,22 +3745,22 @@ dependencies = [
 
 [[package]]
 name = "gix-pathspec"
-version = "0.7.7"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.8.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-attributes 0.23.0",
  "gix-config-value",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-glob 0.17.0",
+ "gix-path 0.10.12",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-prompt"
-version = "0.8.7"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.8.8"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -3771,16 +3771,16 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.45.3"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.46.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
  "gix-credentials",
- "gix-date 0.9.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-date 0.9.1",
+ "gix-features 0.39.0",
+ "gix-hash 0.15.0",
  "gix-transport",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-utils 0.1.13",
  "maybe-async",
  "thiserror",
  "winnow 0.6.20",
@@ -3793,17 +3793,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbff4f9b9ea3fa7a25a70ee62f545143abef624ac6aa5884344e70c8b0a1d9ff"
 dependencies = [
  "bstr",
- "gix-utils 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-utils 0.1.12",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-quote"
-version = "0.4.12"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.4.13"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-utils 0.1.13",
  "thiserror",
 ]
 
@@ -3815,14 +3815,14 @@ checksum = "3394a2997e5bc6b22ebc1e1a87b41eeefbcfcff3dbfa7c4bd73cb0ac8f1f3e2e"
 dependencies = [
  "gix-actor 0.31.5",
  "gix-date 0.8.7",
- "gix-features 0.38.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-fs 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-lock 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-features 0.38.2",
+ "gix-fs 0.11.3",
+ "gix-hash 0.14.2",
+ "gix-lock 14.0.0",
  "gix-object 0.42.3",
- "gix-path 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-tempfile 14.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-utils 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-path 0.10.11",
+ "gix-tempfile 14.0.2",
+ "gix-utils 0.1.12",
  "gix-validate 0.8.5",
  "memmap2",
  "thiserror",
@@ -3831,19 +3831,19 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.47.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.48.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
- "gix-actor 0.32.0",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-lock 14.0.0 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-object 0.44.0",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-tempfile 14.0.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-utils 0.1.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-validate 0.9.0",
+ "gix-actor 0.33.0",
+ "gix-features 0.39.0",
+ "gix-fs 0.12.0",
+ "gix-hash 0.15.0",
+ "gix-lock 15.0.0",
+ "gix-object 0.45.0",
+ "gix-path 0.10.12",
+ "gix-tempfile 15.0.0",
+ "gix-utils 0.1.13",
+ "gix-validate 0.9.1",
  "memmap2",
  "thiserror",
  "winnow 0.6.20",
@@ -3851,31 +3851,31 @@ dependencies = [
 
 [[package]]
 name = "gix-refspec"
-version = "0.25.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.26.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-hash 0.15.0",
  "gix-revision",
- "gix-validate 0.9.0",
+ "gix-validate 0.9.1",
  "smallvec",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-revision"
-version = "0.29.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.30.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-object 0.44.0",
- "gix-revwalk 0.15.0",
- "gix-trace 0.1.10 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-commitgraph 0.25.0",
+ "gix-date 0.9.1",
+ "gix-hash 0.15.0",
+ "gix-hashtable 0.6.0",
+ "gix-object 0.45.0",
+ "gix-revwalk 0.16.0",
+ "gix-trace 0.1.11",
  "thiserror",
 ]
 
@@ -3885,10 +3885,10 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b030ccaab71af141f537e0225f19b9e74f25fefdba0372246b844491cab43e0"
 dependencies = [
- "gix-commitgraph 0.24.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-commitgraph 0.24.3",
  "gix-date 0.8.7",
- "gix-hash 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hashtable 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-hash 0.14.2",
+ "gix-hashtable 0.5.2",
  "gix-object 0.42.3",
  "smallvec",
  "thiserror",
@@ -3896,14 +3896,14 @@ dependencies = [
 
 [[package]]
 name = "gix-revwalk"
-version = "0.15.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.16.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-object 0.44.0",
+ "gix-commitgraph 0.25.0",
+ "gix-date 0.9.1",
+ "gix-hash 0.15.0",
+ "gix-hashtable 0.6.0",
+ "gix-object 0.45.0",
  "smallvec",
  "thiserror",
 ]
@@ -3915,52 +3915,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fe4d52f30a737bbece5276fab5d3a8b276dc2650df963e293d0673be34e7a5f"
 dependencies = [
  "bitflags 2.6.0",
- "gix-path 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-path 0.10.11",
  "libc",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "gix-sec"
-version = "0.10.8"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.10.9"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bitflags 2.6.0",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-path 0.10.12",
  "libc",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "gix-status"
-version = "0.13.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.14.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
  "filetime",
  "gix-diff",
  "gix-dir",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-features 0.39.0",
  "gix-filter",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-index 0.35.0",
- "gix-object 0.44.0",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-fs 0.12.0",
+ "gix-hash 0.15.0",
+ "gix-index 0.36.0",
+ "gix-object 0.45.0",
+ "gix-path 0.10.12",
  "gix-pathspec",
- "gix-worktree 0.36.0",
+ "gix-worktree 0.37.0",
  "portable-atomic",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-submodule"
-version = "0.14.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.15.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
  "gix-config",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-path 0.10.12",
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
@@ -3973,7 +3973,7 @@ version = "14.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046b4927969fa816a150a0cda2e62c80016fe11fb3c3184e4dddf4e542f108aa"
 dependencies = [
- "gix-fs 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-fs 0.11.3",
  "libc",
  "once_cell",
  "parking_lot",
@@ -3984,11 +3984,11 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "14.0.2"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "15.0.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "dashmap",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-fs 0.12.0",
  "libc",
  "once_cell",
  "parking_lot",
@@ -4006,11 +4006,11 @@ dependencies = [
  "fastrand 2.1.1",
  "fs_extra",
  "gix-discover 0.32.0",
- "gix-fs 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-ignore 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-fs 0.11.3",
+ "gix-ignore 0.11.4",
  "gix-index 0.33.1",
- "gix-lock 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-tempfile 14.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-lock 14.0.0",
+ "gix-tempfile 14.0.2",
  "gix-worktree 0.34.1",
  "io-close",
  "is_ci",
@@ -4029,26 +4029,26 @@ checksum = "6cae0e8661c3ff92688ce1c8b8058b3efb312aba9492bbe93661a21705ab431b"
 
 [[package]]
 name = "gix-trace"
-version = "0.1.10"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.1.11"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "tracing-core",
 ]
 
 [[package]]
 name = "gix-transport"
-version = "0.42.3"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.43.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "base64 0.22.1",
  "bstr",
  "curl",
  "gix-command",
  "gix-credentials",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-features 0.39.0",
  "gix-packetline",
- "gix-quote 0.4.12 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-sec 0.10.8 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-quote 0.4.13",
+ "gix-sec 0.10.9",
  "gix-url",
  "thiserror",
 ]
@@ -4060,10 +4060,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e499a18c511e71cf4a20413b743b9f5bcf64b3d9e81e9c3c6cd399eae55a8840"
 dependencies = [
  "bitflags 2.6.0",
- "gix-commitgraph 0.24.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-commitgraph 0.24.3",
  "gix-date 0.8.7",
- "gix-hash 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hashtable 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-hash 0.14.2",
+ "gix-hashtable 0.5.2",
  "gix-object 0.42.3",
  "gix-revwalk 0.13.2",
  "smallvec",
@@ -4072,28 +4072,28 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.41.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.42.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bitflags 2.6.0",
- "gix-commitgraph 0.24.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-date 0.9.0",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-hashtable 0.5.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-object 0.44.0",
- "gix-revwalk 0.15.0",
+ "gix-commitgraph 0.25.0",
+ "gix-date 0.9.1",
+ "gix-hash 0.15.0",
+ "gix-hashtable 0.6.0",
+ "gix-object 0.45.0",
+ "gix-revwalk 0.16.0",
  "smallvec",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-url"
-version = "0.27.5"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.28.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-features 0.39.0",
+ "gix-path 0.10.12",
  "thiserror",
  "url",
 ]
@@ -4110,8 +4110,8 @@ dependencies = [
 
 [[package]]
 name = "gix-utils"
-version = "0.1.12"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.1.13"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
  "fastrand 2.1.1",
@@ -4130,8 +4130,8 @@ dependencies = [
 
 [[package]]
 name = "gix-validate"
-version = "0.9.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.9.1"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
  "thiserror",
@@ -4144,51 +4144,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26f7326ebe0b9172220694ea69d344c536009a9b98fb0f9de092c440f3efe7a6"
 dependencies = [
  "bstr",
- "gix-attributes 0.22.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-features 0.38.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-fs 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-glob 0.16.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-ignore 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-attributes 0.22.5",
+ "gix-features 0.38.2",
+ "gix-fs 0.11.3",
+ "gix-glob 0.16.5",
+ "gix-hash 0.14.2",
+ "gix-ignore 0.11.4",
  "gix-index 0.33.1",
  "gix-object 0.42.3",
- "gix-path 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-path 0.10.11",
  "gix-validate 0.8.5",
 ]
 
 [[package]]
 name = "gix-worktree"
-version = "0.36.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.37.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
- "gix-attributes 0.22.5 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-ignore 0.11.4 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-index 0.35.0",
- "gix-object 0.44.0",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-validate 0.9.0",
+ "gix-attributes 0.23.0",
+ "gix-features 0.39.0",
+ "gix-fs 0.12.0",
+ "gix-glob 0.17.0",
+ "gix-hash 0.15.0",
+ "gix-ignore 0.12.0",
+ "gix-index 0.36.0",
+ "gix-object 0.45.0",
+ "gix-path 0.10.12",
+ "gix-validate 0.9.1",
 ]
 
 [[package]]
 name = "gix-worktree-state"
-version = "0.13.0"
-source = "git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60#b36d7efb9743766338ac7bb7fb2399a06fae5e60"
+version = "0.14.0"
+source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
 dependencies = [
  "bstr",
- "gix-features 0.38.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
+ "gix-features 0.39.0",
  "gix-filter",
- "gix-fs 0.11.3 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-glob 0.16.5 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-hash 0.14.2 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-index 0.35.0",
- "gix-object 0.44.0",
- "gix-path 0.10.11 (git+https://github.com/Byron/gitoxide?rev=b36d7efb9743766338ac7bb7fb2399a06fae5e60)",
- "gix-worktree 0.36.0",
+ "gix-fs 0.12.0",
+ "gix-glob 0.17.0",
+ "gix-hash 0.15.0",
+ "gix-index 0.36.0",
+ "gix-object 0.45.0",
+ "gix-path 0.10.12",
+ "gix-worktree 0.37.0",
  "io-close",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ git2 = { version = "0.19.0", features = [
     "vendored-openssl",
     "vendored-libgit2",
 ] }
-uuid = { version = "1.11.0", features = ["serde"] }
+uuid = { version = "1.11.0", features = ["v4", "serde"] }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.66"
 tokio = { version = "1.41.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ resolver = "2"
 [workspace.dependencies]
 bstr = "1.10.0"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
-gix = { git = "https://github.com/Byron/gitoxide", rev = "b36d7efb9743766338ac7bb7fb2399a06fae5e60", default-features = false, features = [
+gix = { git = "https://github.com/Byron/gitoxide", rev = "3fb989be21c739bbfeac93953c1685e7c6cd2106", default-features = false, features = [
 ] }
 git2 = { version = "0.19.0", features = [
     "vendored-openssl",

--- a/crates/gitbutler-branch-actions/Cargo.toml
+++ b/crates/gitbutler-branch-actions/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 tracing.workspace = true
 anyhow = "1.0.92"
 git2.workspace = true
-gix = { workspace = true, features = ["blob-diff", "revision"] }
+gix = { workspace = true, features = ["blob-diff", "revision", "blob-merge"] }
 tokio.workspace = true
 gitbutler-oplog.workspace = true
 gitbutler-repo.workspace = true

--- a/crates/gitbutler-branch-actions/src/status.rs
+++ b/crates/gitbutler-branch-actions/src/status.rs
@@ -131,9 +131,7 @@ pub fn get_applied_status_cached(
                     .filter_map(|claimed_hunk| {
                         // if any of the current hunks intersects with the owned hunk, we want to keep it
                         for (i, git_diff_hunk) in git_diff_hunks.iter().enumerate() {
-                            if claimed_hunk == &Hunk::from(git_diff_hunk)
-                                || claimed_hunk.intersects(git_diff_hunk)
-                            {
+                            if claimed_hunk.intersects(git_diff_hunk) {
                                 let hash = Hunk::hash_diff(&git_diff_hunk.diff_lines);
                                 if locks.contains_key(&hash) {
                                     return None; // Defer allocation to unclaimed hunks processing

--- a/crates/gitbutler-diff/src/diff.rs
+++ b/crates/gitbutler-diff/src/diff.rs
@@ -174,12 +174,9 @@ pub fn trees(
         false => 0,
     };
     diff_opts
-        .recurse_untracked_dirs(true)
-        .include_untracked(true)
         .show_binary(true)
         .ignore_submodules(true)
-        .context_lines(context_lines)
-        .show_untracked_content(true);
+        .context_lines(context_lines);
 
     let diff = repo.diff_tree_to_tree(Some(old_tree), Some(new_tree), Some(&mut diff_opts))?;
     hunks_by_filepath(None, &diff)

--- a/crates/gitbutler-git/Cargo.toml
+++ b/crates/gitbutler-git/Cargo.toml
@@ -31,13 +31,13 @@ benches = []
 thiserror.workspace = true
 serde = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = [
-  "process",
-  "time",
-  "io-util",
-  "net",
-  "fs",
+    "process",
+    "time",
+    "io-util",
+    "net",
+    "fs",
 ] }
-uuid = { workspace = true, features = ["v4", "fast-rng"] }
+uuid = { workspace = true, features = ["fast-rng"] }
 rand = "0.8.5"
 futures.workspace = true
 sysinfo = "0.32.0"
@@ -48,14 +48,14 @@ nix = { version = "0.29.0", features = ["process", "socket", "user"] }
 
 [target."cfg(windows)".dependencies]
 windows = { version = "0.58.0", features = [
-  "Win32",
-  "Win32_System",
-  "Win32_System_Pipes",
-  "Win32_Storage",
-  "Win32_Storage_FileSystem",
-  "Win32_Security",
-  "Win32_System_IO",
-  "Win32_System_Threading",
+    "Win32",
+    "Win32_System",
+    "Win32_System_Pipes",
+    "Win32_Storage",
+    "Win32_Storage_FileSystem",
+    "Win32_Security",
+    "Win32_System_IO",
+    "Win32_System_Threading",
 ] }
 tokio = { workspace = true, optional = true, features = ["sync"] }
 

--- a/crates/gitbutler-hunk-dependency/Cargo.toml
+++ b/crates/gitbutler-hunk-dependency/Cargo.toml
@@ -18,4 +18,4 @@ itertools = "0.13"
 serde = { workspace = true, features = ["std"] }
 bstr.workspace = true
 tokio.workspace = true
-uuid = { workspace = true, features = ["v4", "fast-rng"] }
+uuid = { workspace = true, features = ["fast-rng"] }


### PR DESCRIPTION
An attempt to improve performance by integrating `gix::Repository::merge_trees()`.

In a single sample that didn't actually have merge conflicts, it was 1.8x of merge-ORT.

```
❯ hyperfine -w3 -N 'git merge-tree --write-tree diff-to-suggestion-spike master' '/Users/byron/dev/github.com/Byron/gitoxide/target/release/gix merge tree diff-to-suggestion-spike master master'
Benchmark 1: git merge-tree --write-tree diff-to-suggestion-spike master
  Time (mean ± σ):     287.7 ms ±   3.8 ms    [User: 255.3 ms, System: 27.3 ms]
  Range (min … max):   282.5 ms … 294.4 ms    10 runs

Benchmark 2: /Users/byron/dev/github.com/Byron/gitoxide/target/release/gix merge tree diff-to-suggestion-spike master master
  Time (mean ± σ):     158.7 ms ±   3.1 ms    [User: 130.6 ms, System: 30.5 ms]
  Range (min … max):   153.1 ms … 164.6 ms    18 runs

Summary
  /Users/byron/dev/github.com/Byron/gitoxide/target/release/gix merge tree diff-to-suggestion-spike master master ran
    1.81 ± 0.04 times faster than git merge-tree --write-tree diff-to-suggestion-spike master
```

GitHub wrote about changing rebases from `git2` to `git` with `merge-ORT`:

> Extrapolating those numbers out to 100%, if we had done all rebases during that interval with merge-ort, it would have taken us 2,000 minutes, or about 33 hours. That same work done with libgit2 would have taken 512 hours!
Merge-ORT seems to be 15.5x faster for GitHub in average - they mention rebases, but merges certainly apply similarly.

So in theory, we could see a 15x * 1.8x = ~28x speedup in a best-case scenario.

~~However, this much improvement is probably not going to happen... let's see.~~ - Actually it did happen, 28x on the first day, but it took a little tuning.

Related to #5163. 

### Tasks

* [x] use `gitoxide` for `is_integrated()`
* [x] evaluate performance results.
* [x] try to get better.
* [x] try to get even better

### As follow-up

* ~~try to remove duplication of work in `stack_series()`.~~ - This will happen naturally as the other path is deprecated.
* [ ] use `merge_trees` in remaining places
    - but try to assure there is a test-case for it to be able to profile it a little.

### Data so far

* **86min** baseline
* **65min** the same with gitoxide
* **4min36s** by stopping immediately when the commit fails.
* **4min16s** by avoiding some more duplicate work (but it's also the first run purely through instruments.
* **3min7s** by avoiding unnecessary hashing in a tight loop

### Stuff that could still be faster

* Can the stack-series work be omitted somehow?
    - I don't understand where these commits are coming from. Are they truly 'new'? Or is it checking different integration targets? These seem potentially different, but the `IsIntegrated` state isn't adjusted.
    - Should this not be free given that my repo has no stacks at all?
* `list_virtual_commit_files()` could be using `gitoxide` to get faster tree-diffing and faster hunk generation. This needs time though as it's basically rewriting a core of GB, so should be its own PR.

### Performance Data

#### Performance log before any change

List virtual branches takes 86 minutes!

```
INFO     ｉ [info]: system git executable for fetch/push: "git"
INFO     ｉ [info]: starting app | version: 0.13.8 | name: GitButler
2024-11-02 15:32:36.824 GitButler[55418:10356652] +[IMKClient subclass]: chose IMKClient_Modern
INFO     list_projects [ 328µs | 100.00% ]
2024-11-02 15:32:36.892 GitButler[55418:10356652] +[IMKInputSession subclass]: chose IMKInputSession_Modern
INFO     get_user [ 42.1ms | 100.00% ]
INFO     get_project [ 840µs | 100.00% ] id: a4dfef20-d58e-47d8-984d-9f78eb012c2a | no_validation: None
INFO     git_head [ 1.42ms | 100.00% ] project_id: a4dfef20-d58e-47d8-984d-9f78eb012c2a
INFO     operating_mode [ 462µs | 100.00% ] project_id: a4dfef20-d58e-47d8-984d-9f78eb012c2a
INFO     list_branches [ 216ms | 100.00% ] project_id: a4dfef20-d58e-47d8-984d-9f78eb012c2a | filter: Some(BranchListingFilter { local: None, applied: None })
INFO     get_base_branch_data [ 386ms | 0.03% / 100.00% ] project_id: a4dfef20-d58e-47d8-984d-9f78eb012c2a
INFO     ┕━ get_base_branch_data [ 386ms | 99.97% ]
INFO     list_projects [ 119µs | 100.00% ]
INFO     get_base_branch_data [ 408ms | 0.04% / 100.00% ] project_id: a4dfef20-d58e-47d8-984d-9f78eb012c2a
INFO     ┕━ get_base_branch_data [ 408ms | 99.96% ]
INFO     list_local_branches [ 129ms | 100.00% ] project_id: a4dfef20-d58e-47d8-984d-9f78eb012c2a
INFO     list_branches [ 233ms | 100.00% ] project_id: a4dfef20-d58e-47d8-984d-9f78eb012c2a | filter: Some(BranchListingFilter { local: None, applied: None })
INFO     fetch_from_remotes [ 2.95s | 85.34% / 100.00% ] project_id: a4dfef20-d58e-47d8-984d-9f78eb012c2a | action: Some("auto")
INFO     ┕━ get_base_branch_data [ 432ms | 14.66% ]
INFO     get_branch_listing_details [ 2.46s | 100.00% ] project_id: a4dfef20-d58e-47d8-984d-9f78eb012c2a | branch_names: ["Virtual-branch", "requeue-milestone-releases-backfill", "vr-aigw-service-class", "lw/488887-allow-disabling-sidekiq-workers-via-configuration"]
INFO     handle [ 150µs | 100.00% ] event: GitFileChange(a4dfef20-d58e-47d8-984d-9f78eb012c2a, FETCH_HEAD)
INFO     get_base_branch_data [ 383ms | 0.04% / 100.00% ] project_id: a4dfef20-d58e-47d8-984d-9f78eb012c2a
INFO     ┕━ get_base_branch_data [ 383ms | 99.96% ]
[..]
INFO     fetch_from_remotes [ 2.90s | 86.93% / 100.00% ] project_id: a4dfef20-d58e-47d8-984d-9f78eb012c2a | action: Some("auto")
INFO     ┕━ get_base_branch_data [ 380ms | 13.07% ]
[..]
INFO     list_virtual_branches [ 5169s | 100.00% ] project_id: a4dfef20-d58e-47d8-984d-9f78eb012c2a
INFO     list_branches [ 255ms | 100.00% ] project_id: a4dfef20-d58e-47d8-984d-9f78eb012c2a | filter: Some(BranchListingFilter { local: None, applied: None })
```

Here we see that it takes 3m15s to get the applied status, but the rest of the time is taken to do a lot of merges. In the screenshot, I stopped the trace after about an hour.

<img width="932" alt="Screenshot 2024-11-02 at 16 52 58" src="https://github.com/user-attachments/assets/9e8f7519-27d9-4e5a-b9f3-9d3ceacc098d">

#### Performance after the change

TBD … but one thing is for sure - it's not 28 times faster (saying this with the CLI running for 16 minutes already with everything configured correctly, I think).

It clocked in at **1h5m** which is still an improvement.

A partial profile I took while it was running reveals that the reason for the incredible increase in time consumption is also that the commit-integration check is now **run twice: Once for the stack, once in the previous context**. However, I didn't investigate if it's doing something new or if it's a repetition.

<img width="1203" alt="Screenshot 2024-11-02 at 18 33 36" src="https://github.com/user-attachments/assets/91d2da60-47cd-40b4-96c4-a021caefeb04">

When it comes to the time spent on the actual merges, we see that only about 1/30th is spent on diffing trees and performing tree-edits.

<img width="937" alt="Screenshot 2024-11-02 at 18 39 07" src="https://github.com/user-attachments/assets/e64110cd-008a-4bce-882d-0591dd3e0e4f">

The rest goes into blob-merges, where half the time is used to read blobs from the ODB, the other half is spent on diffing them. Once again, it only takes about 1/30th of the time to actually perform the merge.

<img width="975" alt="Screenshot 2024-11-02 at 18 44 09" src="https://github.com/user-attachments/assets/82569059-2156-4d36-bb34-294e38beab0b">


Another fun-fact: one merge operation takes about **3.5s**!

#### The best work is the work you don't have to do ;)

This time we told the merge operation to stop as soon as there is an unresolved conflict. This saves tremendous amounts of work and the total time is now down to **4m36s**!

Now we have the commit-integrated checks times 2 like before, each of them costing nearly 2m, with 1m for getting the status.

<img width="937" alt="Screenshot 2024-11-02 at 18 59 31" src="https://github.com/user-attachments/assets/4896bb43-ff9b-4ae7-8892-ea7b2f3fa378">

And there we see that it's mostly hunk conversions and the computation of an MD5 hash.

<img width="920" alt="Screenshot 2024-11-02 at 19 04 13" src="https://github.com/user-attachments/assets/568d39ff-9aac-4974-af3e-675e6c035b4b">

Unfortunately the trace is cut-off so, as the hunks have to be computed as well.

#### Try to re-use 'is-integrated' work

Under the assumption that in my case, the stacks should not be anything new, then the commits it finds should mostly (?) be coming from the existing branches. We now try to avoid an actual integration check by looking up the commit (non-optimized) in a list of pre-computed virtual commits.

<img width="871" alt="Screenshot 2024-11-02 at 19 29 53" src="https://github.com/user-attachments/assets/e8cf72b2-88f4-4b31-8a70-a5edda47c01f">

This brings down the time to **4m08** in total, and 1m12s for the stack series function. Note that this value also looks better because there is no tracing, and the output is faster, but it still takes 16s to debug print a huge structure.

#### Avoid hashing in favor of intersecting first

From my possibly flawed logic, it should be enough to roughly prune out hunks by intersections, and then do the expensive hashing. This cut down the time by another minute to **3m 7s**.

<img width="974" alt="Screenshot 2024-11-02 at 20 25 17" src="https://github.com/user-attachments/assets/b4b8a52c-ed43-4154-9d11-16fe15506e8f">

Now the time to run the `is_integrated()` checks is down to just 24s, but the most time, 1m10s times 2, is spent listing virtual commit files and diffing trees. This can probably be done faster, while trying to avoid the duplication in the stack-series more.