### PR TITLE
Refactor pull request id handling

### DIFF
--- a/apps/desktop/src/lib/backend/templateService.ts
+++ b/apps/desktop/src/lib/backend/templateService.ts
@@ -1,9 +1,10 @@
 import { invoke } from './ipc';
+import type { ForgeName } from '$lib/forge/interface/types';
 
 export class TemplateService {
 	constructor(private projectId: string) {}
 
-	async getAvailable(forgeName: string): Promise<string[]> {
+	async getAvailable(forgeName: ForgeName): Promise<string[]> {
 		return await invoke<string[]>('get_available_review_templates', {
 			projectId: this.projectId,
 			forge: { name: forgeName }

--- a/apps/desktop/src/lib/branch/BranchPreviewHeader.svelte
+++ b/apps/desktop/src/lib/branch/BranchPreviewHeader.svelte
@@ -2,6 +2,7 @@
 	import BranchLabel from './BranchLabel.svelte';
 	import { Project } from '$lib/backend/projects';
 	import { getForge } from '$lib/forge/interface/forge';
+	import { type PullRequest } from '$lib/forge/interface/types';
 	import { ModeService } from '$lib/modes/service';
 	import { error } from '$lib/utils/toasts';
 	import { openExternalUrl } from '$lib/utils/url';
@@ -11,8 +12,7 @@
 	import Icon from '@gitbutler/ui/Icon.svelte';
 	import Modal from '@gitbutler/ui/Modal.svelte';
 	import Tooltip from '@gitbutler/ui/Tooltip.svelte';
-	import type { PullRequest } from '$lib/forge/interface/types';
-	import type { Branch, ForgeIdentifier } from '$lib/vbranches/types';
+	import type { Branch } from '$lib/vbranches/types';
 	import { goto } from '$app/navigation';
 
 	export let localBranch: Branch | undefined;
@@ -111,13 +111,10 @@
 									remoteBranch?.name
 								);
 							} else {
-								let forgeId: ForgeIdentifier | undefined = pr
-									? { type: 'GitHub', subject: { prNumber: pr.number } }
-									: undefined;
 								await branchController.createvBranchFromBranch(
 									remoteBranch!.name,
 									undefined,
-									forgeId
+									pr?.id
 								);
 							}
 							goto(`/${project.id}/board`);

--- a/apps/desktop/src/lib/components/PullRequestPreview.svelte
+++ b/apps/desktop/src/lib/components/PullRequestPreview.svelte
@@ -3,6 +3,7 @@
 	import { Project } from '$lib/backend/projects';
 	import { BaseBranchService } from '$lib/baseBranch/baseBranchService';
 	import Markdown from '$lib/components/Markdown.svelte';
+	import { ForgeName, type PullRequest } from '$lib/forge/interface/types';
 	import { RemotesService } from '$lib/remotes/service';
 	import Link from '$lib/shared/Link.svelte';
 	import * as toasts from '$lib/utils/toasts';
@@ -14,7 +15,6 @@
 	import Modal from '@gitbutler/ui/Modal.svelte';
 	import Textbox from '@gitbutler/ui/Textbox.svelte';
 	import { get } from 'svelte/store';
-	import type { PullRequest } from '$lib/forge/interface/types';
 	import { goto } from '$app/navigation';
 
 	export let pullrequest: PullRequest;
@@ -69,7 +69,7 @@
 			await branchController.createvBranchFromBranch(
 				`refs/remotes/${remoteName}/${pullrequest.sourceBranch}`,
 				undefined,
-				{ type: 'GitHub', subject: { prNumber: pullrequest.number } }
+				pullrequest.id
 			);
 			await virtualBranchService.refresh();
 
@@ -101,7 +101,9 @@
 				{pullrequest.title}
 				<span class="card__title-pr">
 					<Link target="_blank" rel="noreferrer" href={pullrequest.htmlUrl}>
-						#{pullrequest.number}
+						{#if pullrequest.id.type === ForgeName.GitHub}
+							#{pullrequest.id.subject.prNumber}:
+						{/if}
 					</Link>
 				</span>
 			</h2>

--- a/apps/desktop/src/lib/forge/azure/azure.ts
+++ b/apps/desktop/src/lib/forge/azure/azure.ts
@@ -1,7 +1,7 @@
 import { AzureBranch } from './azureBranch';
+import { type Forge } from '$lib/forge/interface/forge';
+import { ForgeName, type ForgeArguments } from '$lib/forge/interface/types';
 import type { RepoInfo } from '$lib/url/gitUrl';
-import type { Forge, ForgeName } from '../interface/forge';
-import type { ForgeArguments } from '../interface/types';
 
 export const AZURE_DOMAIN = 'dev.azure.com';
 
@@ -12,7 +12,7 @@ export const AZURE_DOMAIN = 'dev.azure.com';
  * https://github.com/gitbutlerapp/gitbutler/issues/2651
  */
 export class AzureDevOps implements Forge {
-	readonly name: ForgeName = 'azure';
+	readonly name = ForgeName.Azure;
 	private baseUrl: string;
 	private repo: RepoInfo;
 	private baseBranch: string;

--- a/apps/desktop/src/lib/forge/bitbucket/bitbucket.ts
+++ b/apps/desktop/src/lib/forge/bitbucket/bitbucket.ts
@@ -1,7 +1,11 @@
 import { BitBucketBranch } from './bitbucketBranch';
+import { type Forge } from '$lib/forge/interface/forge';
+import {
+	ForgeName,
+	type DetailedPullRequest,
+	type ForgeArguments
+} from '$lib/forge/interface/types';
 import type { RepoInfo } from '$lib/url/gitUrl';
-import type { Forge, ForgeName } from '../interface/forge';
-import type { DetailedPullRequest, ForgeArguments } from '../interface/types';
 
 export type PrAction = 'creating_pr';
 export type PrState = { busy: boolean; branchId: string; action?: PrAction };
@@ -16,7 +20,7 @@ export const BITBUCKET_DOMAIN = 'bitbucket.org';
  * https://github.com/gitbutlerapp/gitbutler/issues/3252
  */
 export class BitBucket implements Forge {
-	readonly name: ForgeName = 'bitbucket';
+	readonly name = ForgeName.BitBucket;
 	private baseUrl: string;
 	private repo: RepoInfo;
 	private baseBranch: string;

--- a/apps/desktop/src/lib/forge/github/github.ts
+++ b/apps/desktop/src/lib/forge/github/github.ts
@@ -2,17 +2,17 @@ import { GitHubBranch } from './githubBranch';
 import { GitHubChecksMonitor } from './githubChecksMonitor';
 import { GitHubListingService } from './githubListingService';
 import { GitHubPrService } from './githubPrService';
+import { type Forge } from '../interface/forge';
 import { GitHubIssueService } from '$lib/forge/github/issueService';
+import { ForgeName, type ForgeArguments } from '$lib/forge/interface/types';
 import { Octokit } from '@octokit/rest';
 import type { ProjectMetrics } from '$lib/metrics/projectMetrics';
 import type { RepoInfo } from '$lib/url/gitUrl';
-import type { Forge, ForgeName } from '../interface/forge';
-import type { ForgeArguments } from '../interface/types';
 
 export const GITHUB_DOMAIN = 'github.com';
 
 export class GitHub implements Forge {
-	readonly name: ForgeName = 'github';
+	readonly name = ForgeName.GitHub;
 	private baseUrl: string;
 	private repo: RepoInfo;
 	private baseBranch: string;

--- a/apps/desktop/src/lib/forge/github/githubListingService.ts
+++ b/apps/desktop/src/lib/forge/github/githubListingService.ts
@@ -1,10 +1,10 @@
 import { DEFAULT_HEADERS } from './headers';
 import { ghResponseToInstance } from './types';
 import { writable } from 'svelte/store';
+import type { PullRequest } from '$lib/forge/interface/types';
 import type { ProjectMetrics } from '$lib/metrics/projectMetrics';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import type { ForgeListingService } from '../interface/forgeListingService';
-import type { PullRequest } from '../interface/types';
 import type { Octokit } from '@octokit/rest';
 
 export class GitHubListingService implements ForgeListingService {

--- a/apps/desktop/src/lib/forge/github/githubPrMonitor.test.ts
+++ b/apps/desktop/src/lib/forge/github/githubPrMonitor.test.ts
@@ -1,4 +1,5 @@
 import { GitHub } from './github';
+import { ForgeName } from '../interface/types';
 import { Octokit, type RestEndpointMethodTypes } from '@octokit/rest';
 import { expect, test, describe, vi, beforeEach, afterEach } from 'vitest';
 import type { ForgePrMonitor } from '../interface/forgePrMonitor';
@@ -31,7 +32,7 @@ describe.concurrent('GitHubPrMonitor', () => {
 			octokit
 		});
 		service = gh.prService();
-		monitor = service?.prMonitor(123);
+		monitor = service?.prMonitor({ type: ForgeName.GitHub, subject: { prNumber: 123 } });
 	});
 
 	test('should run on set interval', async () => {

--- a/apps/desktop/src/lib/forge/github/githubPrMonitor.ts
+++ b/apps/desktop/src/lib/forge/github/githubPrMonitor.ts
@@ -1,4 +1,4 @@
-import { type DetailedPullRequest } from '$lib/forge/interface/types';
+import { type DetailedPullRequest, type PullRequestId } from '$lib/forge/interface/types';
 import { sleep } from '$lib/utils/sleep';
 import { derived, writable } from 'svelte/store';
 import type { GitHubPrService } from './githubPrService';
@@ -24,7 +24,7 @@ export class GitHubPrMonitor implements ForgePrMonitor {
 
 	constructor(
 		private prService: GitHubPrService,
-		private prNumber: number
+		private prId: PullRequestId
 	) {}
 
 	private start() {
@@ -46,7 +46,7 @@ export class GitHubPrMonitor implements ForgePrMonitor {
 		this.error.set(undefined);
 		this.loading.set(true);
 		try {
-			this.pr.set(await this.getPrWithRetries(this.prNumber));
+			this.pr.set(await this.getPrWithRetries(this.prId));
 			this.lastFetch.set(new Date());
 		} catch (err: any) {
 			this.error.set(err);
@@ -57,8 +57,8 @@ export class GitHubPrMonitor implements ForgePrMonitor {
 	}
 
 	// Right after pushing GitHub will respond with status 422, necessatating retries.
-	private async getPrWithRetries(prNumber: number): Promise<DetailedPullRequest> {
-		const request = async () => await this.prService.get(prNumber);
+	private async getPrWithRetries(prId: PullRequestId): Promise<DetailedPullRequest> {
+		const request = async () => await this.prService.get(prId);
 		let lastError: any;
 		let attempt = 0;
 		while (attempt < 3) {

--- a/apps/desktop/src/lib/forge/github/githubPrService.test.ts
+++ b/apps/desktop/src/lib/forge/github/githubPrService.test.ts
@@ -1,4 +1,5 @@
 import { GitHub } from './github';
+import { ForgeName } from '$lib/forge/interface/types';
 import { Octokit, type RestEndpointMethodTypes } from '@octokit/rest';
 import { expect, test, describe, vi, beforeEach } from 'vitest';
 import type { ForgePrService as GitHubPrService } from '../interface/forgePrService';
@@ -30,7 +31,7 @@ describe.concurrent('GitHubPrService', () => {
 				data: { title }
 			} as RestEndpointMethodTypes['pulls']['get']['response'])
 		);
-		const pr = await service?.get(123);
+		const pr = await service?.get({ type: ForgeName.GitHub, subject: { prNumber: 123 } });
 		expect(pr?.title).equal(title);
 	});
 });

--- a/apps/desktop/src/lib/forge/github/githubPrService.ts
+++ b/apps/desktop/src/lib/forge/github/githubPrService.ts
@@ -1,18 +1,26 @@
 import { GitHubPrMonitor } from './githubPrMonitor';
 import { DEFAULT_HEADERS } from './headers';
-import { ghResponseToInstance, parseGitHubDetailedPullRequest } from './types';
+import {
+	ghResponseToInstance,
+	parseGitHubDetailedPullRequest,
+	type GitHubPullRequestId
+} from './types';
+import {
+	ForgeName,
+	type CreatePullRequestArgs,
+	type DetailedPullRequest,
+	type PullRequestId,
+	type MergeMethod,
+	type PullRequest
+} from '$lib/forge/interface/types';
 import { sleep } from '$lib/utils/sleep';
 import posthog from 'posthog-js';
 import { writable } from 'svelte/store';
 import type { ForgePrService } from '$lib/forge/interface/forgePrService';
 import type { RepoInfo } from '$lib/url/gitUrl';
-import type {
-	CreatePullRequestArgs,
-	DetailedPullRequest,
-	MergeMethod,
-	PullRequest
-} from '../interface/types';
 import type { Octokit } from '@octokit/rest';
+
+const INVALID_PR_TYPE = new Error(`Forge name mismatch, expected 'GitHub'`);
 
 export class GitHubPrService implements ForgePrService {
 	loading = writable(false);
@@ -65,35 +73,45 @@ export class GitHubPrService implements ForgePrService {
 		throw lastError;
 	}
 
-	async get(prNumber: number): Promise<DetailedPullRequest> {
+	async get(id: PullRequestId): Promise<DetailedPullRequest> {
+		if (!isGitHubPr(id)) throw INVALID_PR_TYPE;
 		const resp = await this.octokit.pulls.get({
 			headers: DEFAULT_HEADERS,
 			owner: this.repo.owner,
 			repo: this.repo.name,
-			pull_number: prNumber
+			pull_number: id.subject.prNumber
 		});
 		return parseGitHubDetailedPullRequest(resp.data);
 	}
 
-	async merge(method: MergeMethod, prNumber: number) {
+	async merge(method: MergeMethod, id: PullRequestId) {
+		if (!isGitHubPr(id)) throw INVALID_PR_TYPE;
 		await this.octokit.pulls.merge({
 			owner: this.repo.owner,
 			repo: this.repo.name,
-			pull_number: prNumber,
+			pull_number: id.subject.prNumber,
 			merge_method: method
 		});
 	}
 
-	async reopen(prNumber: number) {
+	async reopen(id: PullRequestId) {
+		if (!isGitHubPr(id)) throw INVALID_PR_TYPE;
 		await this.octokit.pulls.update({
 			owner: this.repo.owner,
 			repo: this.repo.name,
-			pull_number: prNumber,
+			pull_number: id.subject.prNumber,
 			state: 'open'
 		});
 	}
 
-	prMonitor(prNumber: number): GitHubPrMonitor {
-		return new GitHubPrMonitor(this, prNumber);
+	prMonitor(id: PullRequestId): GitHubPrMonitor {
+		if (!isGitHubPr(id)) throw INVALID_PR_TYPE;
+		return new GitHubPrMonitor(this, id);
 	}
+}
+
+function isGitHubPr(
+	id: PullRequestId
+): id is { type: ForgeName.GitHub; subject: GitHubPullRequestId } {
+	return id.type === ForgeName.GitHub;
 }

--- a/apps/desktop/src/lib/forge/github/types.ts
+++ b/apps/desktop/src/lib/forge/github/types.ts
@@ -1,14 +1,26 @@
-import type { CheckSuite, DetailedPullRequest, Label, PullRequest } from '../interface/types';
+import {
+	ForgeName,
+	type CheckSuite,
+	type DetailedPullRequest,
+	type Label,
+	type PullRequest
+} from '$lib/forge/interface/types';
 import type { RestEndpointMethodTypes } from '@octokit/rest';
 
-export type DetailedGitHubPullRequest = RestEndpointMethodTypes['pulls']['get']['response']['data'];
+type DetailedGitHubPullRequest = RestEndpointMethodTypes['pulls']['get']['response']['data'];
+
+/**
+ * Represents a GitHub pull request identifier.
+ */
+export interface GitHubPullRequestId {
+	prNumber: number;
+}
 
 export function parseGitHubDetailedPullRequest(
 	data: DetailedGitHubPullRequest
 ): DetailedPullRequest {
 	return {
-		id: data.id,
-		number: data.number,
+		id: { type: ForgeName.GitHub, subject: { prNumber: data.number } },
 		title: data.title,
 		body: data.body ?? undefined,
 		sourceBranch: data.head?.ref,
@@ -37,8 +49,8 @@ export function ghResponseToInstance(
 	}));
 
 	return {
+		id: { type: ForgeName.GitHub, subject: { prNumber: pr.number } },
 		htmlUrl: pr.html_url,
-		number: pr.number,
 		title: pr.title,
 		body: pr.body || undefined,
 		author: pr.user

--- a/apps/desktop/src/lib/forge/gitlab/gitlab.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlab.ts
@@ -1,7 +1,11 @@
 import { GitLabBranch } from './gitlabBranch';
+import { type Forge } from '$lib/forge/interface/forge';
+import {
+	ForgeName,
+	type DetailedPullRequest,
+	type ForgeArguments
+} from '$lib/forge/interface/types';
 import type { RepoInfo } from '$lib/url/gitUrl';
-import type { Forge, ForgeName } from '../interface/forge';
-import type { DetailedPullRequest, ForgeArguments } from '../interface/types';
 
 export type PrAction = 'creating_pr';
 export type PrState = { busy: boolean; branchId: string; action?: PrAction };
@@ -17,7 +21,7 @@ export const GITLAB_SUB_DOMAIN = 'gitlab'; // For self hosted instance of Gitlab
  * https://github.com/gitbutlerapp/gitbutler/issues/2511
  */
 export class GitLab implements Forge {
-	readonly name: ForgeName = 'gitlab';
+	readonly name = ForgeName.GitLab;
 	private baseUrl: string;
 	private repo: RepoInfo;
 	private baseBranch: string;

--- a/apps/desktop/src/lib/forge/interface/forge.ts
+++ b/apps/desktop/src/lib/forge/interface/forge.ts
@@ -4,8 +4,7 @@ import type { ForgeBranch } from './forgeBranch';
 import type { ForgeChecksMonitor } from './forgeChecksMonitor';
 import type { ForgeListingService } from './forgeListingService';
 import type { ForgePrService } from './forgePrService';
-
-export type ForgeName = 'github' | 'gitlab' | 'bitbucket' | 'azure';
+import type { ForgeName } from './types';
 
 export interface Forge {
 	readonly name: ForgeName;

--- a/apps/desktop/src/lib/forge/interface/forgePrService.ts
+++ b/apps/desktop/src/lib/forge/interface/forgePrService.ts
@@ -1,15 +1,21 @@
 import { buildContextStore } from '@gitbutler/shared/context';
 import type { ForgePrMonitor } from './forgePrMonitor';
-import type { CreatePullRequestArgs, DetailedPullRequest, MergeMethod, PullRequest } from './types';
+import type {
+	CreatePullRequestArgs,
+	DetailedPullRequest,
+	PullRequestId,
+	MergeMethod,
+	PullRequest
+} from './types';
 import type { Writable } from 'svelte/store';
 
 export const [getForgePrService, createForgePrServiceStore] = buildContextStore<
 	ForgePrService | undefined
->('gitBranchService');
+>('forgePrService');
 
 export interface ForgePrService {
 	loading: Writable<boolean>;
-	get(prNumber: number): Promise<DetailedPullRequest>;
+	get(id: PullRequestId): Promise<DetailedPullRequest>;
 	createPr({
 		title,
 		body,
@@ -17,7 +23,7 @@ export interface ForgePrService {
 		baseBranchName,
 		upstreamName
 	}: CreatePullRequestArgs): Promise<PullRequest>;
-	merge(method: MergeMethod, prNumber: number): Promise<void>;
-	reopen(prNumber: number): Promise<void>;
-	prMonitor(prNumber: number): ForgePrMonitor;
+	merge(method: MergeMethod, id: PullRequestId): Promise<void>;
+	reopen(id: PullRequestId): Promise<void>;
+	prMonitor(id: PullRequestId): ForgePrMonitor;
 }

--- a/apps/desktop/src/lib/forge/interface/types.ts
+++ b/apps/desktop/src/lib/forge/interface/types.ts
@@ -1,5 +1,6 @@
 import type { RepoInfo } from '$lib/url/gitUrl';
 import type { Author } from '$lib/vbranches/types';
+import type { GitHubPullRequestId } from '../github/types';
 
 export interface Label {
 	name: string;
@@ -8,8 +9,8 @@ export interface Label {
 }
 
 export interface PullRequest {
+	id: PullRequestId;
 	htmlUrl: string;
-	number: number;
 	title: string;
 	body: string | undefined;
 	author: Author | null;
@@ -28,10 +29,9 @@ export interface PullRequest {
 }
 
 export interface DetailedPullRequest {
-	id: number;
+	id: PullRequestId;
 	title: string;
 	body: string | undefined;
-	number: number;
 	sourceBranch: string;
 	draft?: boolean;
 	createdAt: Date;
@@ -86,3 +86,19 @@ export type CreatePullRequestArgs = {
 	baseBranchName: string;
 	upstreamName: string;
 };
+
+export enum ForgeName {
+	GitHub = 'GitHub',
+	GitLab = 'GitLab',
+	BitBucket = 'BitBucket',
+	Azure = 'Azure'
+}
+
+/**
+ * Represents an identifier for the series at possible forges, e.g. a GitHub PR number.
+ */
+export type PullRequestId =
+	| { type: ForgeName.GitHub; subject: GitHubPullRequestId }
+	| { type: ForgeName.GitLab; subject: void }
+	| { type: ForgeName.Azure; subject: void }
+	| { type: ForgeName.BitBucket; subject: void };

--- a/apps/desktop/src/lib/forge/shared/pullRequestId.ts
+++ b/apps/desktop/src/lib/forge/shared/pullRequestId.ts
@@ -1,0 +1,15 @@
+import { ForgeName, type PullRequestId } from '$lib/forge/interface/types';
+
+/**
+ * TODO: Can this be expressed in a better way?
+ *
+ * @returns True if both pull request ids are the same.
+ */
+export function equalPrId(left: PullRequestId, right: PullRequestId): boolean {
+	if (left.type !== right.type) {
+		return false;
+	} else if (left.type === ForgeName.GitHub && right.type === ForgeName.GitHub) {
+		return left.subject.prNumber === right.subject.prNumber;
+	}
+	throw 'Not implemented';
+}

--- a/apps/desktop/src/lib/navigation/PullRequestSidebarEntry.svelte
+++ b/apps/desktop/src/lib/navigation/PullRequestSidebarEntry.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { Project } from '$lib/backend/projects';
+	import { ForgeName, type PullRequest, type PullRequestId } from '$lib/forge/interface/types';
 	import { getContext } from '@gitbutler/shared/context';
 	import SidebarEntry from '@gitbutler/ui/SidebarEntry.svelte';
 	import AvatarGroup from '@gitbutler/ui/avatar/AvatarGroup.svelte';
-	import type { PullRequest } from '$lib/forge/interface/types';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
 
@@ -16,16 +16,17 @@
 	const project = getContext(Project);
 
 	function onMouseDown() {
-		goto(formatPullRequestURL(project, pullRequest.number));
+		goto(formatPullRequestURL(project, pullRequest.id));
 	}
 
-	function formatPullRequestURL(project: Project, pullRequestNumber: number) {
-		return `/${project.id}/pull/${pullRequestNumber}`;
+	function formatPullRequestURL(project: Project, id: PullRequestId) {
+		if (id.type === ForgeName.GitHub) {
+			return `/${project.id}/pull/${id.subject.prNumber}`;
+		}
+		throw `Forge ${id.type} not supported`;
 	}
 
-	const selected = $derived(
-		$page.url.pathname === formatPullRequestURL(project, pullRequest.number)
-	);
+	const selected = $derived($page.url.pathname === formatPullRequestURL(project, pullRequest.id));
 </script>
 
 <SidebarEntry

--- a/apps/desktop/src/lib/pr/PrDetailsModal.svelte
+++ b/apps/desktop/src/lib/pr/PrDetailsModal.svelte
@@ -21,6 +21,7 @@
 	import { mapErrorToToast } from '$lib/forge/github/errorMap';
 	import { getForge } from '$lib/forge/interface/forge';
 	import { getForgePrService } from '$lib/forge/interface/forgePrService';
+	import { type DetailedPullRequest, type PullRequest } from '$lib/forge/interface/types';
 	import { showError, showToast } from '$lib/notifications/toasts';
 	import { isFailure } from '$lib/result';
 	import ScrollableContainer from '$lib/scroll/ScrollableContainer.svelte';
@@ -40,7 +41,6 @@
 	import Textbox from '@gitbutler/ui/Textbox.svelte';
 	import ToggleButton from '@gitbutler/ui/ToggleButton.svelte';
 	import { tick } from 'svelte';
-	import type { DetailedPullRequest, PullRequest } from '$lib/forge/interface/types';
 
 	interface BaseProps {
 		type: 'display' | 'preview' | 'preview-series';
@@ -211,10 +211,7 @@
 				upstreamName: upstreamBranchName
 			});
 			if (props.type === 'preview-series') {
-				await branchController.updateSeriesForgeId(props.stackId, props.currentSeries.name, {
-					type: 'GitHub',
-					subject: { prNumber: pr.number }
-				});
+				await branchController.updateSeriesForgeId(props.stackId, props.currentSeries.name, pr.id);
 			}
 		} catch (err: any) {
 			console.error(err);

--- a/apps/desktop/src/lib/pr/PullRequestCard.svelte
+++ b/apps/desktop/src/lib/pr/PullRequestCard.svelte
@@ -5,6 +5,7 @@
 	import { getForgeChecksMonitor } from '$lib/forge/interface/forgeChecksMonitor';
 	import { getForgeListingService } from '$lib/forge/interface/forgeListingService';
 	import { getForgePrService } from '$lib/forge/interface/forgePrService';
+	import { ForgeName } from '$lib/forge/interface/types';
 	import * as toasts from '$lib/utils/toasts';
 	import { openExternalUrl } from '$lib/utils/url';
 	import { VirtualBranchService } from '$lib/vbranches/virtualBranch';
@@ -36,10 +37,10 @@
 	const prs = $derived(prStore ? $prStore : undefined);
 
 	const listedPr = $derived(prs?.find((pr) => pr.sourceBranch === upstreamName));
-	const prNumber = $derived(listedPr?.number);
+	const prId = $derived(listedPr?.id);
 
 	const prService = getForgePrService();
-	const prMonitor = $derived(prNumber ? $prService?.prMonitor(prNumber) : undefined);
+	const prMonitor = $derived(prId ? $prService?.prMonitor(prId) : undefined);
 
 	// This PR has been loaded on demand, and contains more details than the version
 	// obtained when listing them.
@@ -109,7 +110,11 @@
 {#if $pr}
 	<div class="card pr-card">
 		<div class="pr-title text-13 text-semibold">
-			<span style="color: var(--clr-scale-ntrl-50)">PR #{$pr?.number}:</span>
+			<span style="color: var(--clr-scale-ntrl-50)">
+				{#if $pr.id.type === ForgeName.GitHub}
+					PR #{$pr.id.subject.prNumber}:
+				{/if}
+			</span>
 			<span>{$pr.title}</span>
 		</div>
 		<div class="pr-tags">
@@ -173,7 +178,7 @@
 						isMerging = true;
 						const method = e.detail.method;
 						try {
-							await $prService?.merge(method, $pr.number);
+							await $prService?.merge(method, $pr.id);
 							await baseBranchService.fetchFromRemotes();
 							await Promise.all([
 								prMonitor?.refresh(),

--- a/apps/desktop/src/lib/pr/StackingPullRequestCard.svelte
+++ b/apps/desktop/src/lib/pr/StackingPullRequestCard.svelte
@@ -8,6 +8,7 @@
 	import { type ForgeChecksMonitor } from '$lib/forge/interface/forgeChecksMonitor';
 	import { getForgeListingService } from '$lib/forge/interface/forgeListingService';
 	import { getForgePrService } from '$lib/forge/interface/forgePrService';
+	import { ForgeName, type DetailedPullRequest } from '$lib/forge/interface/types';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import * as toasts from '$lib/utils/toasts';
 	import { openExternalUrl } from '$lib/utils/url';
@@ -15,7 +16,6 @@
 	import { getContext } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import { type ComponentColor } from '@gitbutler/ui/utils/colorTypes';
-	import type { DetailedPullRequest } from '$lib/forge/interface/types';
 	import type { MessageStyle } from '$lib/shared/InfoMessage.svelte';
 	import type iconsJson from '@gitbutler/ui/data/icons.json';
 
@@ -50,10 +50,10 @@
 	const prs = $derived(prStore ? $prStore : undefined);
 
 	const listedPr = $derived(prs?.find((pr) => pr.sourceBranch === upstreamName));
-	const prNumber = $derived(listedPr?.number);
+	const prId = $derived(listedPr?.id);
 
 	const prService = getForgePrService();
-	const prMonitor = $derived(prNumber ? $prService?.prMonitor(prNumber) : undefined);
+	const prMonitor = $derived(prId ? $prService?.prMonitor(prId) : undefined);
 
 	const checks = $derived(checksMonitor?.status);
 
@@ -186,8 +186,12 @@
 		}}
 	>
 		<div class="text-13 text-semibold pr-header-title">
-			<span style="color: var(--clr-scale-ntrl-50)">PR #{pr?.number}:</span>
-			<span>{pr?.title}</span>
+			<span style="color: var(--clr-scale-ntrl-50)">
+				{#if pr.id.type === ForgeName.GitHub}
+					PR #{pr.id.subject.prNumber}:
+				{/if}
+				<span>{pr?.title}</span>
+			</span>
 		</div>
 		<div class="pr-header-tags">
 			<Button
@@ -252,7 +256,7 @@
 						isMerging = true;
 						const method = e.detail.method;
 						try {
-							await $prService?.merge(method, pr.number);
+							await $prService?.merge(method, pr.id);
 							await baseBranchService.fetchFromRemotes();
 							await Promise.all([
 								prMonitor?.refresh(),

--- a/apps/desktop/src/lib/stack/Stack.svelte
+++ b/apps/desktop/src/lib/stack/Stack.svelte
@@ -83,7 +83,6 @@
 		try {
 			await branchController.pushBranch(branch.id, branch.requiresForce, true);
 			$listingService?.refresh();
-			// TODO: Refresh prMonitor and checksMonitor upon push
 		} finally {
 			isPushingCommits = false;
 		}

--- a/apps/desktop/src/lib/stack/StackCurrentSeries.svelte
+++ b/apps/desktop/src/lib/stack/StackCurrentSeries.svelte
@@ -3,7 +3,7 @@
 	import { createForgeChecksMonitorStore } from '$lib/forge/interface/forgeChecksMonitor';
 	import { getForgeListingService } from '$lib/forge/interface/forgeListingService';
 	import { createForgePrMonitorStore } from '$lib/forge/interface/forgePrMonitor';
-	import { createForgePrServiceStore } from '$lib/forge/interface/forgePrService';
+	import { getForgePrService } from '$lib/forge/interface/forgePrService';
 	import type { PatchSeries } from '$lib/vbranches/types';
 	import type { Snippet } from 'svelte';
 
@@ -13,11 +13,8 @@
 	}
 
 	const { currentSeries, children }: Props = $props();
-
-	// Setup PR Store and Monitor on a per-series basis
+	const prService = getForgePrService();
 	const forge = getForge();
-	const prService = createForgePrServiceStore(undefined);
-	$effect(() => prService.set($forge?.prService()));
 
 	// Pretty cumbersome way of getting the PR number, would be great if we can
 	// make it more concise somehow.
@@ -26,9 +23,9 @@
 	const prs = $derived(prStore ? $prStore : undefined);
 
 	const listedPr = $derived(prs?.find((pr) => pr.sourceBranch === currentSeries.name));
-	const prNumber = $derived(listedPr?.number);
+	const prId = $derived(listedPr?.id);
 
-	const prMonitor = $derived(prNumber ? $prService?.prMonitor(prNumber) : undefined);
+	const prMonitor = $derived(prId ? $prService?.prMonitor(prId) : undefined);
 	const pr = $derived(prMonitor?.pr);
 
 	const forgePrMonitorStore = createForgePrMonitorStore(undefined);

--- a/apps/desktop/src/lib/vbranches/branchController.ts
+++ b/apps/desktop/src/lib/vbranches/branchController.ts
@@ -3,8 +3,9 @@ import { showError, showToast } from '$lib/notifications/toasts';
 import * as toasts from '$lib/utils/toasts';
 import posthog from 'posthog-js';
 import type { BaseBranchService } from '$lib/baseBranch/baseBranchService';
+import type { PullRequestId } from '$lib/forge/interface/types';
 import type { RemoteBranchService } from '$lib/stores/remoteBranches';
-import type { BranchPushResult, ForgeIdentifier, Hunk, LocalFile, StackOrder } from './types';
+import type { BranchPushResult, Hunk, LocalFile, StackOrder } from './types';
 import type { VirtualBranchService } from './virtualBranch';
 
 export type CommitIdOrChangeId = { CommitId: string } | { ChangeId: string };
@@ -164,11 +165,7 @@ export class BranchController {
 	 * @param headName The branch name to update.
 	 * @param forgeId New forge id to be set for the branch (overrides current state). Setting to undefined will remove the forge id.
 	 */
-	async updateSeriesForgeId(
-		stackId: string,
-		headName: string,
-		forgeId: ForgeIdentifier | undefined
-	) {
+	async updateSeriesForgeId(stackId: string, headName: string, forgeId: PullRequestId | undefined) {
 		try {
 			await invoke<void>('update_series_forge_id', {
 				projectId: this.projectId,
@@ -450,7 +447,7 @@ export class BranchController {
 	async createvBranchFromBranch(
 		branch: string,
 		remote: string | undefined = undefined,
-		forgeId: ForgeIdentifier | undefined = undefined
+		forgeId: PullRequestId | undefined = undefined
 	) {
 		try {
 			await invoke<string>('create_virtual_branch_from_branch', {

--- a/apps/desktop/src/lib/vbranches/types.ts
+++ b/apps/desktop/src/lib/vbranches/types.ts
@@ -2,9 +2,9 @@ import 'reflect-metadata';
 import { emptyConflictEntryPresence, type ConflictEntryPresence } from '$lib/conflictEntryPresence';
 import { splitMessage } from '$lib/utils/commitMessage';
 import { hashCode } from '@gitbutler/ui/utils/string';
-import { isDefined, notNull } from '@gitbutler/ui/utils/typeguards';
+import { isDefined } from '@gitbutler/ui/utils/typeguards';
 import { Type, Transform } from 'class-transformer';
-import type { PullRequest } from '$lib/forge/interface/types';
+import type { PullRequest, PullRequestId } from '$lib/forge/interface/types';
 
 export type ChangeType =
 	/// Entry does not exist in old version
@@ -80,10 +80,7 @@ export class LocalFile {
 	}
 
 	get lockedIds(): HunkLock[] {
-		return this.hunks
-			.flatMap((hunk) => hunk.lockedTo)
-			.filter(notNull)
-			.filter(isDefined);
+		return this.hunks.flatMap((hunk) => hunk.lockedTo).filter(isDefined);
 	}
 }
 
@@ -439,7 +436,7 @@ export class PatchSeries {
 	 * A list of identifiers for the review unit at possible forges (eg. Pull Request).
 	 * The list is empty if there is no review units, eg. no Pull Request has been created.
 	 */
-	forgeId?: ForgeIdentifier | undefined;
+	forgeId?: PullRequestId | undefined | null;
 	/**
 	 * Archived represents the state when series/branch has been integrated and is below the merge base of the branch.
 	 * This would occur when the branch has been merged at the remote and the workspace has been updated with that change.

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -19,6 +19,7 @@
 	import { octokitFromAccessToken } from '$lib/forge/github/octokit';
 	import { createForgeStore } from '$lib/forge/interface/forge';
 	import { createForgeListingServiceStore } from '$lib/forge/interface/forgeListingService';
+	import { createForgePrServiceStore } from '$lib/forge/interface/forgePrService';
 	import History from '$lib/history/History.svelte';
 	import { HistoryService } from '$lib/history/history';
 	import { SyncedSnapshotService } from '$lib/history/syncedSnapshotService';
@@ -135,6 +136,8 @@
 		if ($baseBranch || $head || $fetch) debouncedRemoteBranchRefresh();
 	});
 
+	const prService = createForgePrServiceStore(undefined);
+
 	$effect(() => {
 		const forge =
 			repoInfo && baseBranchName
@@ -143,6 +146,7 @@
 		const ghListService = forge?.listService();
 		listServiceStore.set(ghListService);
 		forgeStore.set(forge);
+		prService.set(forge ? forge.prService() : undefined);
 	});
 
 	// Once on load and every time the project id changes

--- a/apps/desktop/src/routes/[projectId]/pull/[number]/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/pull/[number]/+page.svelte
@@ -7,14 +7,18 @@
 	import FullviewLoading from '$lib/components/FullviewLoading.svelte';
 	import PullRequestPreview from '$lib/components/PullRequestPreview.svelte';
 	import { getForgeListingService } from '$lib/forge/interface/forgeListingService';
-	import type { PullRequest } from '$lib/forge/interface/types';
+	import { ForgeName, type PullRequest } from '$lib/forge/interface/types';
 	import type { Readable } from 'svelte/store';
 	import { page } from '$app/stores';
 
 	const forgeListing = getForgeListingService();
 	let prs = $derived<Readable<PullRequest[]> | undefined>($forgeListing?.prs);
 	let pr = $derived<PullRequest | undefined>(
-		$prs?.find((b) => b.number.toString() === $page.params.number)
+		$prs?.find((b) => {
+			return (
+				b.id.type === ForgeName.GitHub && b.id.subject.prNumber.toString() === $page.params.number
+			);
+		})
 	);
 </script>
 

--- a/crates/gitbutler-forge/src/forge.rs
+++ b/crates/gitbutler-forge/src/forge.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-#[serde(tag = "name", rename_all = "lowercase")]
+#[serde(tag = "name")]
 /// Supported git forge types
 pub enum ForgeName {
     GitHub,

--- a/packages/ui/src/lib/utils/typeguards.ts
+++ b/packages/ui/src/lib/utils/typeguards.ts
@@ -1,9 +1,5 @@
 export function isDefined<T>(file: T | undefined | null): file is T {
-	return file !== undefined;
-}
-
-export function notNull<T>(file: T | undefined | null): file is T {
-	return file !== null;
+	return file !== undefined && file !== null;
 }
 
 export type UnknownObject = Record<string, unknown>;


### PR DESCRIPTION
Uses `PullRequestId` instead of just a pr number in Forge interfaces.
<!-- GitButler Footer Boundary -->

| # | PR |
| --- | --- |
| 2 | #5413 |
| **1** | **#5412** |
