### PR TITLE
fix(stack): branch_base takes commit id directly

### DIFF
--- a/crates/gitbutler-stack/src/stack.rs
+++ b/crates/gitbutler-stack/src/stack.rs
@@ -547,7 +547,7 @@ impl Stack {
             .map(|head| head.target.clone());
         Ok(match previous_head {
             Some(previous_head) => previous_head,
-            None => self.merge_base(ctx)?.into(),
+            None => CommitOrChangeId::CommitId(self.merge_base(ctx)?.id().to_string()),
         })
     }
 


### PR DESCRIPTION
Using change ID for the merge base is not relevant