### PR TITLE
Replace `merge-tree` in more places

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,7 +3039,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.67.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "gix-actor 0.33.0",
  "gix-attributes 0.23.0",
@@ -3107,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.33.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "gix-date 0.9.1",
@@ -3137,7 +3137,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.23.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "gix-glob 0.17.0",
@@ -3162,7 +3162,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.12"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "thiserror",
 ]
@@ -3179,7 +3179,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.9"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "thiserror",
 ]
@@ -3187,7 +3187,7 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.3.10"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "gix-path 0.10.12",
@@ -3212,7 +3212,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.25.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "gix-chunk 0.4.9",
@@ -3225,7 +3225,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.41.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -3245,7 +3245,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.14.9"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -3257,7 +3257,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.25.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3285,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.9.1"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "itoa 1.0.11",
@@ -3296,7 +3296,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.47.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3316,7 +3316,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.9.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "gix-discover 0.36.0",
@@ -3351,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.36.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "dunce",
@@ -3381,7 +3381,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.39.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -3403,7 +3403,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.14.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -3434,7 +3434,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.12.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "fastrand 2.1.1",
  "gix-features 0.39.0",
@@ -3456,7 +3456,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.17.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -3477,7 +3477,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.15.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "faster-hex",
  "thiserror",
@@ -3497,7 +3497,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.6.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "gix-hash 0.15.0",
  "hashbrown 0.14.5",
@@ -3520,7 +3520,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.12.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "gix-glob 0.17.0",
@@ -3560,7 +3560,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.36.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -3598,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "15.0.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "gix-tempfile 15.0.0",
  "gix-utils 0.1.13",
@@ -3608,7 +3608,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.0.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3631,7 +3631,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.16.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bitflags 2.6.0",
  "gix-commitgraph 0.25.0",
@@ -3665,7 +3665,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.45.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "gix-actor 0.33.0",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.64.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "arc-swap",
  "gix-date 0.9.1",
@@ -3704,7 +3704,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.54.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "clru",
  "gix-chunk 0.4.9",
@@ -3724,7 +3724,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.18.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -3735,7 +3735,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.18.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -3759,7 +3759,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.12"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "gix-trace 0.1.11",
@@ -3771,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.8.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -3785,7 +3785,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.8.8"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.46.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.4.13"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "gix-utils 0.1.13",
@@ -3857,7 +3857,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.48.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "gix-actor 0.33.0",
  "gix-features 0.39.0",
@@ -3877,7 +3877,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.26.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "gix-hash 0.15.0",
@@ -3890,7 +3890,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.30.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -3922,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.16.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "gix-commitgraph 0.25.0",
  "gix-date 0.9.1",
@@ -3948,7 +3948,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.10.9"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bitflags 2.6.0",
  "gix-path 0.10.12",
@@ -3959,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.14.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "filetime",
@@ -3981,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.15.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "gix-config",
@@ -4010,7 +4010,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "15.0.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "dashmap",
  "gix-fs 0.12.0",
@@ -4055,7 +4055,7 @@ checksum = "6cae0e8661c3ff92688ce1c8b8058b3efb312aba9492bbe93661a21705ab431b"
 [[package]]
 name = "gix-trace"
 version = "0.1.11"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "tracing-core",
 ]
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.43.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -4098,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.42.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bitflags 2.6.0",
  "gix-commitgraph 0.25.0",
@@ -4114,7 +4114,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.28.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "gix-features 0.39.0",
@@ -4136,7 +4136,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.1.13"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "fastrand 2.1.1",
@@ -4156,7 +4156,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.9.1"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "thiserror",
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.37.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "gix-attributes 0.23.0",
@@ -4202,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.14.0"
-source = "git+https://github.com/Byron/gitoxide?rev=3fb989be21c739bbfeac93953c1685e7c6cd2106#3fb989be21c739bbfeac93953c1685e7c6cd2106"
+source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
 dependencies = [
  "bstr",
  "gix-features 0.39.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2687,6 +2687,7 @@ dependencies = [
  "gitbutler-command-context",
  "gitbutler-diff",
  "gitbutler-fs",
+ "gitbutler-oxidize",
  "gitbutler-project",
  "gitbutler-reference",
  "gitbutler-repo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ resolver = "2"
 [workspace.dependencies]
 bstr = "1.10.0"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
-gix = { git = "https://github.com/Byron/gitoxide", rev = "3fb989be21c739bbfeac93953c1685e7c6cd2106", default-features = false, features = [
+gix = { git = "https://github.com/Byron/gitoxide", rev = "a8765330fc16997dee275866b18a128dec1c5d55", default-features = false, features = [
 ] }
 git2 = { version = "0.19.0", features = [
     "vendored-openssl",

--- a/crates/gitbutler-branch-actions/Cargo.toml
+++ b/crates/gitbutler-branch-actions/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 tracing.workspace = true
 anyhow = "1.0.92"
 git2.workspace = true
-gix = { workspace = true, features = ["blob-diff", "revision", "blob-merge"] }
+gix = { workspace = true, features = ["blob-diff", "revision", "merge"] }
 tokio.workspace = true
 gitbutler-oplog.workspace = true
 gitbutler-repo.workspace = true

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -17,7 +17,6 @@ use gitbutler_reference::{Refname, RemoteRefname};
 use gitbutler_repo::{GixRepositoryExt, LogUntil, RepositoryExt};
 use gitbutler_repo_actions::RepoActionsExt;
 use gitbutler_stack::{BranchOwnershipClaims, Stack, Target, VirtualBranchesHandle};
-use gix::prelude::Write;
 use serde::Serialize;
 
 #[derive(Debug, Serialize, PartialEq, Clone)]
@@ -93,10 +92,7 @@ fn go_back_to_integration(ctx: &CommandContext, default_target: &Target) -> Resu
         if merge.has_unresolved_conflicts(conflict_kind) {
             bail!("Merge failed with conflicts");
         }
-        final_tree_id = merge
-            .tree
-            .write(|tree| gix_repo.write(tree))
-            .map_err(|err| anyhow!("failed to write tree: {err}"))?;
+        final_tree_id = merge.tree.write()?.detach();
     }
 
     let final_tree = repo.find_tree(gix_to_git2_oid(final_tree_id))?;

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
@@ -14,7 +14,6 @@ use gitbutler_repo::RepositoryExt;
 use gitbutler_repo::SignaturePurpose;
 use gitbutler_repo_actions::RepoActionsExt;
 use gitbutler_stack::{Stack, StackId};
-use gix::objs::Write;
 use tracing::instrument;
 
 use super::BranchManager;
@@ -128,10 +127,7 @@ impl BranchManager<'_> {
                             gix_repo.default_merge_labels(),
                             merge_options.clone(),
                         )?;
-                        let final_tree_id = merge
-                            .tree
-                            .write(|tree| gix_repo.write(tree))
-                            .map_err(|err| anyhow::anyhow!("Could not write merged tree: {err}"))?;
+                        let final_tree_id = merge.tree.write()?.detach();
                         Ok(final_tree_id)
                     },
                 )?;

--- a/crates/gitbutler-branch-actions/src/branch_trees.rs
+++ b/crates/gitbutler-branch-actions/src/branch_trees.rs
@@ -1,5 +1,5 @@
 use crate::VirtualBranchesExt as _;
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use gitbutler_cherry_pick::RepositoryExt;
 use gitbutler_command_context::CommandContext;
 use gitbutler_commit::commit_ext::CommitExt as _;
@@ -8,7 +8,6 @@ use gitbutler_project::access::WorktreeWritePermission;
 use gitbutler_repo::rebase::cherry_rebase_group;
 use gitbutler_repo::{GixRepositoryExt, RepositoryExt as _};
 use gitbutler_stack::Stack;
-use gix::prelude::Write;
 use tracing::instrument;
 
 /// Checks out the combined trees of all branches in the workspace.
@@ -61,10 +60,7 @@ pub fn checkout_branch_trees<'a>(
                 bail!("There appears to be conflicts between the virtual branches");
             };
 
-            final_tree_id = merge
-                .tree
-                .write(|tree| gix_repo.write(tree))
-                .map_err(|err| anyhow!("{err}"))?;
+            final_tree_id = merge.tree.write()?.detach();
         }
 
         let final_tree = repository.find_tree(gix_to_git2_oid(final_tree_id))?;

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -53,9 +53,7 @@ pub(crate) fn get_workspace_head(ctx: &CommandContext) -> Result<git2::Oid> {
         workspace_tree = repo.find_commit(merge_base)?.tree()?;
     } else {
         let gix_repo = ctx.gix_repository_for_merging()?;
-        let mut merge_options_fail_fast = gix_repo.tree_merge_options()?;
-        let conflict_kind = gix::merge::tree::UnresolvedConflict::Renames;
-        merge_options_fail_fast.fail_on_conflict = Some(conflict_kind);
+        let (merge_options_fail_fast, conflict_kind) = gix_repo.merge_options_fail_fast()?;
         let merge_tree_id = git2_to_gix_object_id(repo.find_commit(target.sha)?.tree_id());
         for branch in virtual_branches.iter_mut() {
             let branch_head = repo.find_commit(branch.head())?;

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -9,10 +9,12 @@ use gitbutler_command_context::CommandContext;
 use gitbutler_commit::commit_ext::CommitExt;
 use gitbutler_error::error::Marker;
 use gitbutler_operating_modes::OPEN_WORKSPACE_REFS;
+use gitbutler_oxidize::{git2_to_gix_object_id, gix_to_git2_oid};
 use gitbutler_project::access::WorktreeWritePermission;
-use gitbutler_repo::SignaturePurpose;
+use gitbutler_repo::{GixRepositoryExt, SignaturePurpose};
 use gitbutler_repo::{LogUntil, RepositoryExt};
 use gitbutler_stack::{Stack, VirtualBranchesHandle};
+use gix::objs::Write;
 use tracing::instrument;
 
 use crate::{branch_manager::BranchManagerExt, conflicts, VirtualBranchesExt};
@@ -41,6 +43,7 @@ pub(crate) fn get_workspace_head(ctx: &CommandContext) -> Result<git2::Oid> {
 
     let target_commit = repo.find_commit(target.sha)?;
     let mut workspace_tree = repo.find_real_tree(&target_commit, Default::default())?;
+    let mut workspace_tree_id = git2_to_gix_object_id(workspace_tree.id());
 
     if conflicts::is_conflicting(ctx, None)? {
         let merge_parent = conflicts::merge_parent(ctx)?.ok_or(anyhow!("No merge parent"))?;
@@ -49,15 +52,29 @@ pub(crate) fn get_workspace_head(ctx: &CommandContext) -> Result<git2::Oid> {
         let merge_base = repo.merge_base(first_branch.head(), merge_parent)?;
         workspace_tree = repo.find_commit(merge_base)?.tree()?;
     } else {
+        let gix_repo = ctx.gix_repository_for_merging()?;
+        let mut merge_options_fail_fast = gix_repo.tree_merge_options()?;
+        let conflict_kind = gix::merge::tree::UnresolvedConflict::Renames;
+        merge_options_fail_fast.fail_on_conflict = Some(conflict_kind);
+        let merge_tree_id = git2_to_gix_object_id(repo.find_commit(target.sha)?.tree_id());
         for branch in virtual_branches.iter_mut() {
-            let merge_tree = repo.find_commit(target.sha)?.tree()?;
-            let branch_tree = repo.find_commit(branch.head())?;
-            let branch_tree = repo.find_real_tree(&branch_tree, Default::default())?;
+            let branch_head = repo.find_commit(branch.head())?;
+            let branch_tree_id =
+                git2_to_gix_object_id(repo.find_real_tree(&branch_head, Default::default())?.id());
 
-            let mut index = repo.merge_trees(&merge_tree, &workspace_tree, &branch_tree, None)?;
+            let mut merge = gix_repo.merge_trees(
+                merge_tree_id,
+                workspace_tree_id,
+                branch_tree_id,
+                gix_repo.default_merge_labels(),
+                merge_options_fail_fast.clone(),
+            )?;
 
-            if !index.has_conflicts() {
-                workspace_tree = repo.find_tree(index.write_tree_to(repo)?)?;
+            if !merge.has_unresolved_conflicts(conflict_kind) {
+                workspace_tree_id = merge
+                    .tree
+                    .write(|tree| gix_repo.write(tree))
+                    .map_err(|err| anyhow!("{err}"))?;
             } else {
                 // This branch should have already been unapplied during the "update" command but for some reason that failed
                 tracing::warn!("Merge conflict between base and {:?}", branch.name);
@@ -65,6 +82,7 @@ pub(crate) fn get_workspace_head(ctx: &CommandContext) -> Result<git2::Oid> {
                 vb_state.set_branch(branch.clone())?;
             }
         }
+        workspace_tree = repo.find_tree(gix_to_git2_oid(workspace_tree_id))?;
     }
 
     let committer = gitbutler_repo::signature(SignaturePurpose::Committer)?;

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -14,7 +14,6 @@ use gitbutler_project::access::WorktreeWritePermission;
 use gitbutler_repo::{GixRepositoryExt, SignaturePurpose};
 use gitbutler_repo::{LogUntil, RepositoryExt};
 use gitbutler_stack::{Stack, VirtualBranchesHandle};
-use gix::objs::Write;
 use tracing::instrument;
 
 use crate::{branch_manager::BranchManagerExt, conflicts, VirtualBranchesExt};
@@ -69,10 +68,7 @@ pub(crate) fn get_workspace_head(ctx: &CommandContext) -> Result<git2::Oid> {
             )?;
 
             if !merge.has_unresolved_conflicts(conflict_kind) {
-                workspace_tree_id = merge
-                    .tree
-                    .write(|tree| gix_repo.write(tree))
-                    .map_err(|err| anyhow!("{err}"))?;
+                workspace_tree_id = merge.tree.write()?.detach();
             } else {
                 // This branch should have already been unapplied during the "update" command but for some reason that failed
                 tracing::warn!("Merge conflict between base and {:?}", branch.name);

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -7,7 +7,6 @@ use gitbutler_oplog::entry::{OperationKind, SnapshotDetails};
 use gitbutler_oplog::{OplogExt, SnapshotExt};
 use gitbutler_project::Project;
 use gitbutler_reference::normalize_branch_name;
-use gitbutler_repo::GixRepositoryExt;
 use gitbutler_repo_actions::RepoActionsExt;
 use gitbutler_stack::{
     CommitOrChangeId, ForgeIdentifier, PatchReference, PatchReferenceUpdate, Series,
@@ -192,10 +191,7 @@ pub fn push_stack(project: &Project, branch_id: StackId, with_force: bool) -> Re
 
     // First fetch, because we dont want to push integrated series
     ctx.fetch(&default_target.push_remote_name(), None)?;
-    let gix_repo = ctx
-        .gix_repository()?
-        .for_tree_diffing()?
-        .with_object_memory();
+    let gix_repo = ctx.gix_repository_for_merging_non_persisting()?;
     let cache = gix_repo.commit_graph_if_enabled()?;
     let mut graph = gix_repo.revision_graph(cache.as_ref());
     let mut check_commit = IsCommitIntegrated::new(ctx, &default_target, &gix_repo, &mut graph)?;

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -1,19 +1,20 @@
-use anyhow::{anyhow, bail, Result};
-use gitbutler_cherry_pick::RepositoryExt as _;
-use gitbutler_command_context::CommandContext;
-use gitbutler_project::access::WorktreeWritePermission;
-use gitbutler_repo::{
-    rebase::{cherry_rebase_group, gitbutler_merge_commits},
-    LogUntil, RepositoryExt as _,
-};
-use gitbutler_repo_actions::RepoActionsExt as _;
-use gitbutler_stack::{Stack, StackId, Target, VirtualBranchesHandle};
-use serde::{Deserialize, Serialize};
-
 use crate::{
     branch_trees::{checkout_branch_trees, compute_updated_branch_head, BranchHeadAndTree},
     BranchManagerExt, VirtualBranchesExt as _,
 };
+use anyhow::{anyhow, bail, Result};
+use gitbutler_cherry_pick::RepositoryExt as _;
+use gitbutler_command_context::CommandContext;
+use gitbutler_oxidize::git2_to_gix_object_id;
+use gitbutler_project::access::WorktreeWritePermission;
+use gitbutler_repo::{
+    rebase::{cherry_rebase_group, gitbutler_merge_commits},
+    GixRepositoryExt, LogUntil, RepositoryExt as _,
+};
+use gitbutler_repo_actions::RepoActionsExt as _;
+use gitbutler_stack::{Stack, StackId, Target, VirtualBranchesHandle};
+use gix::prelude::Write;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, PartialEq, Debug)]
 #[serde(tag = "type", content = "subject", rename_all = "camelCase")]
@@ -140,8 +141,19 @@ pub fn upstream_integration_statuses(
         ..
     } = context;
     // look up the target and see if there is a new oid
-    let old_target_tree = repository.find_real_tree(old_target, Default::default())?;
-    let new_target_tree = repository.find_real_tree(new_target, Default::default())?;
+    let old_target_tree_id = git2_to_gix_object_id(
+        repository
+            .find_real_tree(old_target, Default::default())?
+            .id(),
+    );
+    let new_target_tree_id = git2_to_gix_object_id(
+        repository
+            .find_real_tree(new_target, Default::default())?
+            .id(),
+    );
+    let gix_repo = gitbutler_command_context::gix_repository_for_merging(repository.path())?;
+    let gix_repo_in_memory = gix_repo.clone().with_object_memory();
+    let (merge_options_fail_fast, conflict_kind) = gix_repo.merge_options_fail_fast()?;
 
     if new_target.id() == old_target.id() {
         return Ok(BranchStatuses::UpToDate);
@@ -151,8 +163,10 @@ pub fn upstream_integration_statuses(
         .iter()
         .map(|virtual_branch| {
             let tree = repository.find_tree(virtual_branch.tree)?;
+            let tree_id = git2_to_gix_object_id(tree.id());
             let head = repository.find_commit(virtual_branch.head())?;
             let head_tree = repository.find_real_tree(&head, Default::default())?;
+            let head_tree_id = git2_to_gix_object_id(head_tree.id());
 
             // Try cherry pick the branch's head commit onto the target to
             // see if it conflics. This is equivalent to doing a merge
@@ -168,25 +182,33 @@ pub fn upstream_integration_statuses(
                 };
             }
 
-            let head_merge_index =
-                repository.merge_trees(&old_target_tree, &new_target_tree, &head_tree, None)?;
-            let mut tree_merge_index =
-                repository.merge_trees(&old_target_tree, &new_target_tree, &tree, None)?;
+            let mut tree_merge = gix_repo.merge_trees(
+                old_target_tree_id,
+                new_target_tree_id,
+                tree_id,
+                gix_repo.default_merge_labels(),
+                merge_options_fail_fast.clone(),
+            )?;
 
             // Is the branch conflicted?
             // A branch can't be integrated if its conflicted
             {
-                let commits_conflicted = head_merge_index.has_conflicts();
+                let commits_conflicted = gix_repo_in_memory
+                    .merge_trees(
+                        old_target_tree_id,
+                        new_target_tree_id,
+                        head_tree_id,
+                        Default::default(),
+                        merge_options_fail_fast.clone(),
+                    )?
+                    .has_unresolved_conflicts(conflict_kind);
+                gix_repo_in_memory.objects.reset_object_memory();
 
                 // See whether uncommited changes are potentially conflicted
                 let potentially_conflicted_uncommited_changes = if has_uncommited_changes {
                     // If the commits are conflicted, we can guarentee that the
                     // tree will be conflicted.
-                    if commits_conflicted {
-                        true
-                    } else {
-                        tree_merge_index.has_conflicts()
-                    }
+                    commits_conflicted || tree_merge.has_unresolved_conflicts(conflict_kind)
                 } else {
                     // If there are no uncommited changes, then there can't be
                     // any conflicts.
@@ -205,13 +227,20 @@ pub fn upstream_integration_statuses(
 
             // Is the branch fully integrated?
             {
+                if tree_merge.has_unresolved_conflicts(conflict_kind) {
+                    bail!(
+                        "Merge result unexpectedly has conflicts between base, ours, theirs: {old_target_tree_id}, {new_target_tree_id}, {tree_id}"
+                    )
+                }
                 // We're safe to write the tree as we've ensured it's
                 // unconflicted in the previous test.
-                let tree_merge_index_tree = tree_merge_index.write_tree_to(repository)?;
+                let tree_merge_index_tree_id = tree_merge
+                    .tree
+                    .write(|tree| gix_repo.write(tree))
+                    .map_err(|err| anyhow!("{err}"))?;
 
-                // Identical trees will have the same Oid so we can compare
-                // the two
-                if tree_merge_index_tree == new_target_tree.id() {
+                // Identical trees will have the same Oid so we can compare the two
+                if tree_merge_index_tree_id == new_target_tree_id {
                     return Ok((virtual_branch.id, BranchStatus::FullyIntegrated));
                 }
             }

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -41,9 +41,9 @@ pub enum BaseBranchResolutionApproach {
     HardReset,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 #[serde(tag = "type", content = "subject", rename_all = "camelCase")]
-enum ResolutionApproach {
+pub enum ResolutionApproach {
     Rebase,
     Merge,
     Unapply,
@@ -75,11 +75,11 @@ impl BranchStatus {
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Resolution {
-    branch_id: StackId,
+    pub branch_id: StackId,
     /// Used to ensure a given branch hasn't changed since the UI issued the command.
     #[serde(with = "gitbutler_serde::oid")]
-    branch_tree: git2::Oid,
-    approach: ResolutionApproach,
+    pub branch_tree: git2::Oid,
+    pub approach: ResolutionApproach,
 }
 
 enum IntegrationResult {

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -13,7 +13,6 @@ use gitbutler_repo::{
 };
 use gitbutler_repo_actions::RepoActionsExt as _;
 use gitbutler_stack::{Stack, StackId, Target, VirtualBranchesHandle};
-use gix::prelude::Write;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, PartialEq, Debug)]
@@ -229,15 +228,13 @@ pub fn upstream_integration_statuses(
             {
                 if tree_merge.has_unresolved_conflicts(conflict_kind) {
                     bail!(
-                        "Merge result unexpectedly has conflicts between base, ours, theirs: {old_target_tree_id}, {new_target_tree_id}, {tree_id}"
+                        "Merge result unexpectedly has conflicts between base, \
+                         ours, theirs: {old_target_tree_id}, {new_target_tree_id}, {tree_id}"
                     )
                 }
                 // We're safe to write the tree as we've ensured it's
                 // unconflicted in the previous test.
-                let tree_merge_index_tree_id = tree_merge
-                    .tree
-                    .write(|tree| gix_repo.write(tree))
-                    .map_err(|err| anyhow!("{err}"))?;
+                let tree_merge_index_tree_id = tree_merge.tree.write()?.detach();
 
                 // Identical trees will have the same Oid so we can compare the two
                 if tree_merge_index_tree_id == new_target_tree_id {

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -25,7 +25,7 @@ use gitbutler_project::access::WorktreeWritePermission;
 use gitbutler_reference::{normalize_branch_name, Refname, RemoteRefname};
 use gitbutler_repo::{
     rebase::{cherry_rebase, cherry_rebase_group},
-    GixRepositoryExt, LogUntil, RepositoryExt,
+    LogUntil, RepositoryExt,
 };
 use gitbutler_repo_actions::RepoActionsExt;
 use gitbutler_stack::{
@@ -302,10 +302,7 @@ pub fn list_virtual_branches_cached(
     let branches_span =
         tracing::debug_span!("handle branches", num_branches = status.branches.len()).entered();
     let repo = ctx.repository();
-    let gix_repo = ctx
-        .gix_repository()?
-        .for_tree_diffing()?
-        .with_object_memory();
+    let gix_repo = ctx.gix_repository_for_merging_non_persisting()?;
     // We will perform virtual merges, no need to write them to the ODB.
     let cache = gix_repo.commit_graph_if_enabled()?;
     let mut graph = gix_repo.revision_graph(cache.as_ref());

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -33,7 +33,6 @@ use gitbutler_stack::{
     VirtualBranchesHandle,
 };
 use gitbutler_time::time::now_since_unix_epoch_ms;
-use gix::objs::Write;
 use serde::Serialize;
 use std::collections::HashSet;
 use std::{collections::HashMap, path::PathBuf, vec};
@@ -203,10 +202,7 @@ pub fn unapply_ownership(
             if merge.has_unresolved_conflicts(conflict_kind) {
                 bail!("Tree has conflicts after merge")
             }
-            merge
-                .tree
-                .write(|tree| gix_repo.write(tree))
-                .map_err(|err| anyhow!("Could not write merged tree: {err}"))
+            Ok(merge.tree.write()?.detach())
         },
     )?;
 
@@ -1063,10 +1059,7 @@ impl IsCommitIntegrated<'_, '_, '_> {
             return Ok(false);
         }
 
-        let merge_tree_id = merge_output
-            .tree
-            .write(|tree| self.gix_repo.write(tree))
-            .map_err(|err| anyhow!("failed to write tree: {err}"))?;
+        let merge_tree_id = merge_output.tree.write()?.detach();
 
         // if the merge_tree is the same as the new_target_tree and there are no files (uncommitted changes)
         // then the vbranch is fully merged

--- a/crates/gitbutler-cli/src/args.rs
+++ b/crates/gitbutler-cli/src/args.rs
@@ -51,6 +51,11 @@ pub mod vbranch {
         ListLocal,
         /// Provide the current state of all applied virtual branches.
         Status,
+        /// Switch to the GitButler workspace.
+        SetBase {
+            /// The name of the remote branch to integrate with, like `origin/main`.
+            short_tracking_branch_name: String,
+        },
         /// Make the named branch the default so all worktree or index changes are associated with it automatically.
         SetDefault {
             /// The name of the new default virtual branch.

--- a/crates/gitbutler-cli/src/args.rs
+++ b/crates/gitbutler-cli/src/args.rs
@@ -52,6 +52,11 @@ pub mod vbranch {
             /// The name of the virtual branch to unapply.
             name: String,
         },
+        /// Add a branch to the workspace.
+        Apply {
+            /// The name of the virtual branch to apply.
+            name: String,
+        },
         /// Create a new commit to named virtual branch with all changes currently in the worktree or staging area assigned to it.
         Commit {
             /// The commit message

--- a/crates/gitbutler-cli/src/args.rs
+++ b/crates/gitbutler-cli/src/args.rs
@@ -16,6 +16,15 @@ pub struct Args {
 
 #[derive(Debug, clap::Subcommand)]
 pub enum Subcommands {
+    /// Unapply the given ownership claim.
+    UnapplyOwnership {
+        /// The path to remove the claim from.
+        filepath: PathBuf,
+        /// The first line of hunks that should be removed.
+        from_line: u32,
+        /// The last line of hunks that should be removed.
+        to_line: u32,
+    },
     /// List and manipulate virtual branches.
     #[clap(visible_alias = "branches")]
     Branch(vbranch::Platform),

--- a/crates/gitbutler-cli/src/args.rs
+++ b/crates/gitbutler-cli/src/args.rs
@@ -160,6 +160,11 @@ pub mod snapshot {
             /// The snapshot to restore
             snapshot_id: String,
         },
+        /// Show what is stored in a given snapshot.
+        Diff {
+            /// The hex-hash of the commit-id of the snapshot.
+            snapshot_id: String,
+        },
     }
 }
 

--- a/crates/gitbutler-cli/src/args.rs
+++ b/crates/gitbutler-cli/src/args.rs
@@ -14,6 +14,14 @@ pub struct Args {
     pub cmd: Subcommands,
 }
 
+#[derive(Debug, Clone, clap::ValueEnum)]
+pub enum UpdateMode {
+    Rebase,
+    Merge,
+    Unapply,
+    Delete,
+}
+
 #[derive(Debug, clap::Subcommand)]
 pub enum Subcommands {
     /// Unapply the given ownership claim.
@@ -24,6 +32,12 @@ pub enum Subcommands {
         from_line: u32,
         /// The last line of hunks that should be removed.
         to_line: u32,
+    },
+    /// Update the local workspace against an updated remote or target branch.
+    IntegrateUpstream {
+        /// Specify how all branches should be merged in.
+        #[clap(value_enum)]
+        mode: UpdateMode,
     },
     /// List and manipulate virtual branches.
     #[clap(visible_alias = "branches")]

--- a/crates/gitbutler-cli/src/command/mod.rs
+++ b/crates/gitbutler-cli/src/command/mod.rs
@@ -1,7 +1,6 @@
 pub mod prepare;
 pub mod project;
 pub mod vbranch;
-
 pub mod snapshot {
     use anyhow::Result;
     use gitbutler_oplog::OplogExt;
@@ -29,4 +28,30 @@ pub mod snapshot {
 fn debug_print(this: impl std::fmt::Debug) -> anyhow::Result<()> {
     println!("{:#?}", this);
     Ok(())
+}
+
+pub mod ownership {
+    use gitbutler_diff::Hunk;
+    use gitbutler_project::Project;
+    use gitbutler_stack::{BranchOwnershipClaims, OwnershipClaim};
+    use std::path::PathBuf;
+
+    pub fn unapply(
+        project: Project,
+        file_path: PathBuf,
+        from_line: u32,
+        to_line: u32,
+    ) -> anyhow::Result<()> {
+        let claims = BranchOwnershipClaims {
+            claims: vec![OwnershipClaim {
+                file_path,
+                hunks: vec![Hunk {
+                    hash: None,
+                    start: from_line,
+                    end: to_line,
+                }],
+            }],
+        };
+        gitbutler_branch_actions::unapply_ownership(&project, &claims)
+    }
 }

--- a/crates/gitbutler-cli/src/command/mod.rs
+++ b/crates/gitbutler-cli/src/command/mod.rs
@@ -2,6 +2,7 @@ pub mod prepare;
 pub mod project;
 pub mod vbranch;
 pub mod snapshot {
+    use crate::command::debug_print;
     use anyhow::Result;
     use gitbutler_oplog::OplogExt;
     use gitbutler_project::Project;
@@ -22,6 +23,10 @@ pub mod snapshot {
         let _guard = project.try_exclusive_access()?;
         project.restore_snapshot(snapshot_id.parse()?)?;
         Ok(())
+    }
+
+    pub fn diff(project: Project, snapshot_id: String) -> Result<()> {
+        debug_print(project.snapshot_diff(snapshot_id.parse()?))
     }
 }
 

--- a/crates/gitbutler-cli/src/command/vbranch.rs
+++ b/crates/gitbutler-cli/src/command/vbranch.rs
@@ -1,6 +1,6 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use gitbutler_branch::{BranchCreateRequest, BranchIdentity, BranchUpdateRequest};
-use gitbutler_branch_actions::{get_branch_listing_details, list_branches};
+use gitbutler_branch_actions::{get_branch_listing_details, list_branches, BranchManagerExt};
 use gitbutler_command_context::CommandContext;
 use gitbutler_project::Project;
 use gitbutler_stack::{Stack, VirtualBranchesHandle};
@@ -51,6 +51,23 @@ pub fn unapply(project: Project, branch_name: String) -> Result<()> {
     debug_print(gitbutler_branch_actions::save_and_unapply_virutal_branch(
         &project, branch.id,
     )?)
+}
+
+pub fn apply(project: Project, branch_name: String) -> Result<()> {
+    let branch = branch_by_name(&project, &branch_name)?;
+    let ctx = CommandContext::open(&project)?;
+    let mut guard = project.exclusive_worktree_access();
+    debug_print(
+        ctx.branch_manager().create_virtual_branch_from_branch(
+            branch
+                .source_refname
+                .as_ref()
+                .context("local reference name was missing")?,
+            None,
+            None,
+            guard.write_permission(),
+        )?,
+    )
 }
 
 pub fn create(project: Project, branch_name: String, set_default: bool) -> Result<()> {

--- a/crates/gitbutler-cli/src/command/vbranch.rs
+++ b/crates/gitbutler-cli/src/command/vbranch.rs
@@ -7,6 +7,16 @@ use gitbutler_stack::{Stack, VirtualBranchesHandle};
 
 use crate::command::debug_print;
 
+pub fn set_base(project: Project, short_tracking_branch_name: String) -> Result<()> {
+    let branch_name = format!("refs/remotes/{}", short_tracking_branch_name)
+        .parse()
+        .context("Invalid branch name")?;
+    debug_print(gitbutler_branch_actions::set_base_branch(
+        &project,
+        &branch_name,
+    )?)
+}
+
 pub fn list_all(project: Project) -> Result<()> {
     let ctx = CommandContext::open(&project)?;
     debug_print(list_branches(&ctx, None, None)?)

--- a/crates/gitbutler-cli/src/main.rs
+++ b/crates/gitbutler-cli/src/main.rs
@@ -85,6 +85,9 @@ fn main() -> Result<()> {
                 Some(snapshot::SubCommands::Restore { snapshot_id }) => {
                     command::snapshot::restore(project, snapshot_id)
                 }
+                Some(snapshot::SubCommands::Diff { snapshot_id }) => {
+                    command::snapshot::diff(project, snapshot_id)
+                }
                 None => command::snapshot::list(project),
             }
         }

--- a/crates/gitbutler-cli/src/main.rs
+++ b/crates/gitbutler-cli/src/main.rs
@@ -17,6 +17,14 @@ fn main() -> Result<()> {
     let _op_span = tracing::info_span!("cli-op").entered();
 
     match args.cmd {
+        args::Subcommands::UnapplyOwnership {
+            filepath,
+            from_line,
+            to_line,
+        } => {
+            let project = command::prepare::project_from_path(args.current_dir)?;
+            command::ownership::unapply(project, filepath, from_line, to_line)
+        }
         args::Subcommands::Branch(vbranch::Platform { cmd }) => {
             let project = command::prepare::project_from_path(args.current_dir)?;
             match cmd {

--- a/crates/gitbutler-cli/src/main.rs
+++ b/crates/gitbutler-cli/src/main.rs
@@ -28,6 +28,9 @@ fn main() -> Result<()> {
         args::Subcommands::Branch(vbranch::Platform { cmd }) => {
             let project = command::prepare::project_from_path(args.current_dir)?;
             match cmd {
+                Some(vbranch::SubCommands::SetBase {
+                    short_tracking_branch_name,
+                }) => command::vbranch::set_base(project, short_tracking_branch_name),
                 Some(vbranch::SubCommands::ListLocal) => command::vbranch::list_local(project),
                 Some(vbranch::SubCommands::Status) => command::vbranch::status(project),
                 Some(vbranch::SubCommands::Unapply { name }) => {

--- a/crates/gitbutler-cli/src/main.rs
+++ b/crates/gitbutler-cli/src/main.rs
@@ -17,6 +17,10 @@ fn main() -> Result<()> {
     let _op_span = tracing::info_span!("cli-op").entered();
 
     match args.cmd {
+        args::Subcommands::IntegrateUpstream { mode } => {
+            let project = command::prepare::project_from_path(args.current_dir)?;
+            command::workspace::update(project, mode)
+        }
         args::Subcommands::UnapplyOwnership {
             filepath,
             from_line,

--- a/crates/gitbutler-cli/src/main.rs
+++ b/crates/gitbutler-cli/src/main.rs
@@ -25,6 +25,9 @@ fn main() -> Result<()> {
                 Some(vbranch::SubCommands::Unapply { name }) => {
                     command::vbranch::unapply(project, name)
                 }
+                Some(vbranch::SubCommands::Apply { name }) => {
+                    command::vbranch::apply(project, name)
+                }
                 Some(vbranch::SubCommands::SetDefault { name }) => {
                     command::vbranch::set_default(project, name)
                 }

--- a/crates/gitbutler-command-context/src/lib.rs
+++ b/crates/gitbutler-command-context/src/lib.rs
@@ -86,6 +86,26 @@ impl CommandContext {
         Ok(gix::open(self.repository().path())?)
     }
 
+    /// Return a newly opened `gitoxide` repository, with all configuration available
+    /// to correctly figure out author and committer names (i.e. with most global configuration loaded),
+    /// *and* which will perform diffs quickly thanks to an adequate object cache.
+    pub fn gix_repository_for_merging(&self) -> Result<gix::Repository> {
+        let mut repo = gix::open(self.repository().path())?;
+        let bytes = repo.compute_object_cache_size_for_tree_diffs(&***repo.index_or_empty()?);
+        repo.object_cache_size_if_unset(bytes);
+        Ok(repo)
+    }
+
+    /// Return a newly opened `gitoxide` repository, with all configuration available
+    /// to correctly figure out author and committer names (i.e. with most global configuration loaded),
+    /// *and* which will perform diffs quickly thanks to an adequate object cache, *and*
+    /// which **writes all objects into memory**.
+    ///
+    /// This means *changes are non-persisting*.
+    pub fn gix_repository_for_merging_non_persisting(&self) -> Result<gix::Repository> {
+        Ok(self.gix_repository_for_merging()?.with_object_memory())
+    }
+
     /// Return a newly opened `gitoxide` repository with only the repository-local configuration
     /// available. This is a little faster as it has to open less files upon startup.
     ///

--- a/crates/gitbutler-command-context/src/lib.rs
+++ b/crates/gitbutler-command-context/src/lib.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use gitbutler_project::Project;
+use std::path::Path;
 
 pub struct CommandContext {
     /// The git repository of the `project` itself.
@@ -90,10 +91,7 @@ impl CommandContext {
     /// to correctly figure out author and committer names (i.e. with most global configuration loaded),
     /// *and* which will perform diffs quickly thanks to an adequate object cache.
     pub fn gix_repository_for_merging(&self) -> Result<gix::Repository> {
-        let mut repo = gix::open(self.repository().path())?;
-        let bytes = repo.compute_object_cache_size_for_tree_diffs(&***repo.index_or_empty()?);
-        repo.object_cache_size_if_unset(bytes);
-        Ok(repo)
+        gix_repository_for_merging(self.repository().path())
     }
 
     /// Return a newly opened `gitoxide` repository, with all configuration available
@@ -117,6 +115,16 @@ impl CommandContext {
             gix::open::Options::isolated(),
         )?)
     }
+}
+
+/// Return a newly opened `gitoxide` repository, with all configuration available
+/// to correctly figure out author and committer names (i.e. with most global configuration loaded),
+/// *and* which will perform diffs quickly thanks to an adequate object cache.
+pub fn gix_repository_for_merging(worktree_or_git_dir: &Path) -> Result<gix::Repository> {
+    let mut repo = gix::open(worktree_or_git_dir)?;
+    let bytes = repo.compute_object_cache_size_for_tree_diffs(&***repo.index_or_empty()?);
+    repo.object_cache_size_if_unset(bytes);
+    Ok(repo)
 }
 
 mod repository_ext;

--- a/crates/gitbutler-oplog/Cargo.toml
+++ b/crates/gitbutler-oplog/Cargo.toml
@@ -17,6 +17,7 @@ gix = { workspace = true, features = ["dirwalk", "credentials", "parallel"] }
 toml.workspace = true
 gitbutler-command-context.workspace = true
 gitbutler-project.workspace = true
+gitbutler-oxidize.workspace = true
 gitbutler-branch.workspace = true
 gitbutler-serde.workspace = true
 gitbutler-fs.workspace = true

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -25,7 +25,7 @@ use gitbutler_repo::{GixRepositoryExt, RepositoryExt};
 use gitbutler_stack::{Stack, VirtualBranchesHandle, VirtualBranchesState};
 use gix::bstr::ByteSlice;
 use gix::object::tree::diff::Change;
-use gix::prelude::{ObjectIdExt, Write};
+use gix::prelude::ObjectIdExt;
 use tracing::instrument;
 
 const SNAPSHOT_FILE_LIMIT_BYTES: u64 = 32 * 1024 * 1024;
@@ -860,10 +860,7 @@ fn tree_from_applied_vbranches(
         if merge.has_unresolved_conflicts(conflict_kind) {
             tracing::warn!("Failed to merge tree {branch_id} - this branch is probably applied at a time when it should not be");
         } else {
-            let id = merge
-                .tree
-                .write(|tree| repo.write(tree))
-                .map_err(|err| anyhow!("{err}"))?;
+            let id = merge.tree.write()?.detach();
             workdir_tree_id = id;
             current_ours_id = id;
         }

--- a/crates/gitbutler-oxidize/src/lib.rs
+++ b/crates/gitbutler-oxidize/src/lib.rs
@@ -4,6 +4,10 @@ use anyhow::Context;
 use gix::bstr::ByteSlice;
 use std::borrow::Borrow;
 
+pub fn gix_time_to_git2(time: gix::date::Time) -> git2::Time {
+    git2::Time::new(time.seconds, time.offset)
+}
+
 pub fn git2_to_gix_object_id(id: git2::Oid) -> gix::ObjectId {
     gix::ObjectId::try_from(id.as_bytes()).expect("git2 oid is always valid")
 }

--- a/crates/gitbutler-repo/Cargo.toml
+++ b/crates/gitbutler-repo/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 git2.workspace = true
-gix = { workspace = true, features = ["blob-merge", "status", "tree-editor"] }
+gix = { workspace = true, features = ["merge", "status", "tree-editor"] }
 anyhow = "1.0.92"
 bstr.workspace = true
 tracing.workspace = true

--- a/crates/gitbutler-repo/Cargo.toml
+++ b/crates/gitbutler-repo/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 git2.workspace = true
-gix = { workspace = true, features = ["status", "tree-editor"] }
+gix = { workspace = true, features = ["blob-merge", "status", "tree-editor"] }
 anyhow = "1.0.92"
 bstr.workspace = true
 tracing.workspace = true

--- a/crates/gitbutler-repo/src/repository_ext.rs
+++ b/crates/gitbutler-repo/src/repository_ext.rs
@@ -783,9 +783,10 @@ impl GixRepositoryExt for gix::Repository {
     }
 
     fn merge_options_fail_fast(&self) -> Result<(Options, UnresolvedConflict)> {
-        let mut options = self.tree_merge_options()?;
         let conflict_kind = gix::merge::tree::UnresolvedConflict::Renames;
-        options.fail_on_conflict = Some(conflict_kind);
+        let options = self
+            .tree_merge_options()?
+            .with_fail_on_conflict(Some(conflict_kind));
         Ok((options, conflict_kind))
     }
 }

--- a/crates/gitbutler-repo/src/repository_ext.rs
+++ b/crates/gitbutler-repo/src/repository_ext.rs
@@ -699,6 +699,38 @@ pub trait GixRepositoryExt: Sized {
     /// Configure the repository for diff operations between trees.
     /// This means it needs an object cache relative to the amount of files in the repository.
     fn for_tree_diffing(self) -> Result<Self>;
+
+    /// Returns `true` if the merge between `our_tree` and `their_tree` is free of conflicts.
+    /// Conflicts entail content merges with conflict markers, or anything else that doesn't merge cleanly in the tree.
+    ///
+    /// # Important
+    ///
+    /// Make sure the repository is configured [`with_object_memory()`](gix::Repository::with_object_memory()).
+    fn merges_cleanly_compat(
+        &self,
+        ancestor_tree: git2::Oid,
+        our_tree: git2::Oid,
+        their_tree: git2::Oid,
+    ) -> Result<bool>;
+
+    /// Just like the above, but with `gix` types.
+    fn merges_cleanly(
+        &self,
+        ancestor_tree: gix::ObjectId,
+        our_tree: gix::ObjectId,
+        their_tree: gix::ObjectId,
+    ) -> Result<bool>;
+
+    /// Return default lable names when merging trees.
+    ///
+    /// Note that these should probably rather be branch names, but that's for another day.
+    fn default_merge_labels(&self) -> gix::merge::blob::builtin_driver::text::Labels<'static> {
+        gix::merge::blob::builtin_driver::text::Labels {
+            ancestor: Some("base".into()),
+            current: Some("ours".into()),
+            other: Some("theirs".into()),
+        }
+    }
 }
 
 impl GixRepositoryExt for gix::Repository {
@@ -706,6 +738,40 @@ impl GixRepositoryExt for gix::Repository {
         let bytes = self.compute_object_cache_size_for_tree_diffs(&***self.index_or_empty()?);
         self.object_cache_size_if_unset(bytes);
         Ok(self)
+    }
+
+    fn merges_cleanly_compat(
+        &self,
+        ancestor_tree: git2::Oid,
+        our_tree: git2::Oid,
+        their_tree: git2::Oid,
+    ) -> Result<bool> {
+        self.merges_cleanly(
+            git2_to_gix_object_id(ancestor_tree),
+            git2_to_gix_object_id(our_tree),
+            git2_to_gix_object_id(their_tree),
+        )
+    }
+
+    fn merges_cleanly(
+        &self,
+        ancestor_tree: gix::ObjectId,
+        our_tree: gix::ObjectId,
+        their_tree: gix::ObjectId,
+    ) -> Result<bool> {
+        let mut options = self.tree_merge_options()?;
+        let conflict_kind = gix::merge::tree::UnresolvedConflict::Renames;
+        options.fail_on_conflict = Some(conflict_kind);
+        let merge_outcome = self
+            .merge_trees(
+                ancestor_tree,
+                our_tree,
+                their_tree,
+                Default::default(),
+                options,
+            )
+            .context("failed to merge trees")?;
+        Ok(!merge_outcome.has_unresolved_conflicts(conflict_kind))
     }
 }
 

--- a/crates/gitbutler-repo/tests/create_wd_tree.rs
+++ b/crates/gitbutler-repo/tests/create_wd_tree.rs
@@ -29,13 +29,7 @@ mod head_upsert_truthtable {
     // | add                | delete            | no-action |
     #[test]
     fn index_new_worktree_delete() {
-        let test_repository = TestingRepository::open();
-
-        let commit = test_repository.commit_tree(None, &[]);
-        test_repository
-            .repository
-            .branch("master", &commit, true)
-            .unwrap();
+        let test_repository = TestingRepository::open_with_initial_commit(&[]);
 
         std::fs::write(test_repository.tempdir.path().join("file1.txt"), "content1").unwrap();
 
@@ -53,13 +47,8 @@ mod head_upsert_truthtable {
     // | modify             | delete            | remove    |
     #[test]
     fn index_modify_worktree_delete() {
-        let test_repository = TestingRepository::open();
-
-        let commit = test_repository.commit_tree(None, &[("file1.txt", "content1")]);
-        test_repository
-            .repository
-            .branch("master", &commit, true)
-            .unwrap();
+        let test_repository =
+            TestingRepository::open_with_initial_commit(&[("file1.txt", "content1")]);
 
         std::fs::write(test_repository.tempdir.path().join("file1.txt"), "content2").unwrap();
 
@@ -77,13 +66,8 @@ mod head_upsert_truthtable {
     // |                    | delete            | remove    |
     #[test]
     fn worktree_delete() {
-        let test_repository = TestingRepository::open();
-
-        let commit = test_repository.commit_tree(None, &[("file1.txt", "content1")]);
-        test_repository
-            .repository
-            .branch("master", &commit, true)
-            .unwrap();
+        let test_repository =
+            TestingRepository::open_with_initial_commit(&[("file1.txt", "content1")]);
 
         std::fs::remove_file(test_repository.tempdir.path().join("file1.txt")).unwrap();
 
@@ -95,13 +79,8 @@ mod head_upsert_truthtable {
     // | delete             |                   | remove    |
     #[test]
     fn index_delete() {
-        let test_repository = TestingRepository::open();
-
-        let commit = test_repository.commit_tree(None, &[("file1.txt", "content1")]);
-        test_repository
-            .repository
-            .branch("master", &commit, true)
-            .unwrap();
+        let test_repository =
+            TestingRepository::open_with_initial_commit(&[("file1.txt", "content1")]);
 
         let mut index = test_repository.repository.index().unwrap();
         index.remove_all(["*"], None).unwrap();
@@ -120,13 +99,8 @@ mod head_upsert_truthtable {
     // | delete             | add               | upsert    |
     #[test]
     fn index_delete_worktree_add() {
-        let test_repository = TestingRepository::open();
-
-        let commit = test_repository.commit_tree(None, &[("file1.txt", "content1")]);
-        test_repository
-            .repository
-            .branch("master", &commit, true)
-            .unwrap();
+        let test_repository =
+            TestingRepository::open_with_initial_commit(&[("file1.txt", "content1")]);
 
         let mut index = test_repository.repository.index().unwrap();
         index.remove_all(["*"], None).unwrap();
@@ -147,13 +121,7 @@ mod head_upsert_truthtable {
     // | add                |                   | upsert    |
     #[test]
     fn index_add() {
-        let test_repository = TestingRepository::open();
-
-        let commit = test_repository.commit_tree(None, &[]);
-        test_repository
-            .repository
-            .branch("master", &commit, true)
-            .unwrap();
+        let test_repository = TestingRepository::open_with_initial_commit(&[]);
 
         std::fs::write(test_repository.tempdir.path().join("file1.txt"), "content2").unwrap();
 
@@ -174,13 +142,7 @@ mod head_upsert_truthtable {
     // |                    | add               | upsert    |
     #[test]
     fn worktree_add() {
-        let test_repository = TestingRepository::open();
-
-        let commit = test_repository.commit_tree(None, &[]);
-        test_repository
-            .repository
-            .branch("master", &commit, true)
-            .unwrap();
+        let test_repository = TestingRepository::open_with_initial_commit(&[]);
 
         std::fs::write(test_repository.tempdir.path().join("file1.txt"), "content2").unwrap();
 
@@ -197,13 +159,7 @@ mod head_upsert_truthtable {
     // | add                | modify            | upsert    |
     #[test]
     fn index_add_worktree_modify() {
-        let test_repository = TestingRepository::open();
-
-        let commit = test_repository.commit_tree(None, &[]);
-        test_repository
-            .repository
-            .branch("master", &commit, true)
-            .unwrap();
+        let test_repository = TestingRepository::open_with_initial_commit(&[]);
 
         std::fs::write(test_repository.tempdir.path().join("file1.txt"), "content1").unwrap();
 
@@ -226,13 +182,8 @@ mod head_upsert_truthtable {
     // | modify             | modify            | upsert    |
     #[test]
     fn index_modify_worktree_modify() {
-        let test_repository = TestingRepository::open();
-
-        let commit = test_repository.commit_tree(None, &[("file1.txt", "content1")]);
-        test_repository
-            .repository
-            .branch("master", &commit, true)
-            .unwrap();
+        let test_repository =
+            TestingRepository::open_with_initial_commit(&[("file1.txt", "content1")]);
 
         std::fs::write(test_repository.tempdir.path().join("file1.txt"), "content2").unwrap();
 
@@ -255,16 +206,7 @@ mod head_upsert_truthtable {
 
 #[test]
 fn lists_uncommited_changes() {
-    let test_repository = TestingRepository::open();
-
-    // Initial commit
-    // Create wd tree requires the HEAD branch to exist and for there
-    // to be at least one commit on that branch.
-    let commit = test_repository.commit_tree(None, &[]);
-    test_repository
-        .repository
-        .branch("master", &commit, true)
-        .unwrap();
+    let test_repository = TestingRepository::open_with_initial_commit(&[]);
 
     std::fs::write(test_repository.tempdir.path().join("file1.txt"), "content1").unwrap();
     std::fs::write(test_repository.tempdir.path().join("file2.txt"), "content2").unwrap();
@@ -280,16 +222,7 @@ fn lists_uncommited_changes() {
 
 #[test]
 fn does_not_include_staged_but_deleted_files() {
-    let test_repository = TestingRepository::open();
-
-    // Initial commit
-    // Create wd tree requires the HEAD branch to exist and for there
-    // to be at least one commit on that branch.
-    let commit = test_repository.commit_tree(None, &[]);
-    test_repository
-        .repository
-        .branch("master", &commit, true)
-        .unwrap();
+    let test_repository = TestingRepository::open_with_initial_commit(&[]);
 
     std::fs::write(test_repository.tempdir.path().join("file1.txt"), "content1").unwrap();
     std::fs::write(test_repository.tempdir.path().join("file2.txt"), "content2").unwrap();
@@ -312,16 +245,10 @@ fn does_not_include_staged_but_deleted_files() {
 
 #[test]
 fn should_be_empty_after_checking_out_empty_tree() {
-    let test_repository = TestingRepository::open();
-
-    let commit = test_repository.commit_tree(
-        None,
-        &[("file1.txt", "content1"), ("file2.txt", "content2")],
-    );
-    test_repository
-        .repository
-        .branch("master", &commit, true)
-        .unwrap();
+    let test_repository = TestingRepository::open_with_initial_commit(&[
+        ("file1.txt", "content1"),
+        ("file2.txt", "content2"),
+    ]);
 
     // Checkout an empty tree
     {
@@ -353,16 +280,10 @@ fn should_be_empty_after_checking_out_empty_tree() {
 
 #[test]
 fn should_track_deleted_files() {
-    let test_repository = TestingRepository::open();
-
-    let commit = test_repository.commit_tree(
-        None,
-        &[("file1.txt", "content1"), ("file2.txt", "content2")],
-    );
-    test_repository
-        .repository
-        .branch("master", &commit, true)
-        .unwrap();
+    let test_repository = TestingRepository::open_with_initial_commit(&[
+        ("file1.txt", "content1"),
+        ("file2.txt", "content2"),
+    ]);
 
     // Make sure the index is empty, perhaps the user did this action
     let mut index: git2::Index = test_repository.repository.index().unwrap();
@@ -384,13 +305,7 @@ fn should_track_deleted_files() {
 
 #[test]
 fn should_not_change_index() {
-    let test_repository = TestingRepository::open();
-
-    let commit = test_repository.commit_tree(None, &[("file1.txt", "content1")]);
-    test_repository
-        .repository
-        .branch("master", &commit, true)
-        .unwrap();
+    let test_repository = TestingRepository::open_with_initial_commit(&[("file1.txt", "content1")]);
 
     let mut index = test_repository.repository.index().unwrap();
     index.remove_all(["*"], None).unwrap();
@@ -417,20 +332,10 @@ fn should_not_change_index() {
 
 #[test]
 fn tree_behavior() {
-    let test_repository = TestingRepository::open();
-
-    let commit = test_repository.commit_tree(
-        None,
-        &[
-            ("dir1/file1.txt", "content1"),
-            ("dir2/file2.txt", "content2"),
-        ],
-    );
-
-    test_repository
-        .repository
-        .branch("master", &commit, true)
-        .unwrap();
+    let test_repository = TestingRepository::open_with_initial_commit(&[
+        ("dir1/file1.txt", "content1"),
+        ("dir2/file2.txt", "content2"),
+    ]);
 
     // Update a file in a directory
     std::fs::write(
@@ -464,13 +369,7 @@ fn tree_behavior() {
 fn executable_blobs() {
     use std::{io::Write, os::unix::fs::PermissionsExt as _};
 
-    let test_repository = TestingRepository::open();
-
-    let commit = test_repository.commit_tree(None, &[]);
-    test_repository
-        .repository
-        .branch("master", &commit, true)
-        .unwrap();
+    let test_repository = TestingRepository::open_with_initial_commit(&[]);
 
     let mut file = File::create(test_repository.tempdir.path().join("file1.txt")).unwrap();
     file.set_permissions(Permissions::from_mode(0o755)).unwrap();
@@ -492,13 +391,7 @@ fn executable_blobs() {
 #[cfg(unix)]
 #[test]
 fn links() {
-    let test_repository = TestingRepository::open();
-
-    let commit = test_repository.commit_tree(None, &[("target", "helloworld")]);
-    test_repository
-        .repository
-        .branch("master", &commit, true)
-        .unwrap();
+    let test_repository = TestingRepository::open_with_initial_commit(&[("target", "helloworld")]);
 
     std::os::unix::fs::symlink("target", test_repository.tempdir.path().join("link1.txt")).unwrap();
 

--- a/crates/gitbutler-testsupport/src/testing_repository.rs
+++ b/crates/gitbutler-testsupport/src/testing_repository.rs
@@ -15,6 +15,22 @@ impl TestingRepository {
     pub fn open() -> Self {
         let tempdir = tempdir().unwrap();
         let repository = git2::Repository::init_opts(tempdir.path(), &init_opts()).unwrap();
+        // TODO(ST): remove this once `gix::Repository::index_or_load_from_tree_or_empty()`
+        //           is available and used to get merge/diff resource caches. Also: name this
+        //          `open_unborn()` to make it clear.
+        // For now we need a resemblance of an initialized repo.
+        let signature = git2::Signature::now("Caleb", "caleb@gitbutler.com").unwrap();
+        let empty_tree_id = repository.treebuilder(None).unwrap().write().unwrap();
+        repository
+            .commit(
+                Some("refs/heads/master"),
+                &signature,
+                &signature,
+                "init to prevent load index failure",
+                &repository.find_tree(empty_tree_id).unwrap(),
+                &[],
+            )
+            .unwrap();
 
         let config = repository.config().unwrap();
         match config.open_level(git2::ConfigLevel::Local) {
@@ -34,9 +50,39 @@ impl TestingRepository {
         }
     }
 
+    pub fn open_with_initial_commit(files: &[(&str, &str)]) -> Self {
+        let tempdir = tempdir().unwrap();
+        let repository = git2::Repository::init_opts(tempdir.path(), &init_opts()).unwrap();
+
+        let config = repository.config().unwrap();
+        match config.open_level(git2::ConfigLevel::Local) {
+            Ok(mut local) => {
+                local.set_str("commit.gpgsign", "false").unwrap();
+                local.set_str("user.name", "gitbutler-test").unwrap();
+                local
+                    .set_str("user.email", "gitbutler-test@example.com")
+                    .unwrap();
+            }
+            Err(err) => panic!("{}", err),
+        }
+
+        let repository = Self {
+            tempdir,
+            repository,
+        };
+        {
+            let commit = repository.commit_tree(None, files);
+            repository
+                .repository
+                .branch("master", &commit, true)
+                .unwrap();
+        }
+        repository
+    }
+
     pub fn commit_tree<'a>(
         &'a self,
-        parent: Option<&git2::Commit<'a>>,
+        parent: Option<&git2::Commit<'_>>,
         files: &[(&str, &str)],
     ) -> git2::Commit<'a> {
         self.commit_tree_with_message(parent, &Uuid::new_v4().to_string(), files)
@@ -44,7 +90,7 @@ impl TestingRepository {
 
     pub fn commit_tree_with_message<'a>(
         &'a self,
-        parent: Option<&git2::Commit<'a>>,
+        parent: Option<&git2::Commit<'_>>,
         message: &str,
         files: &[(&str, &str)],
     ) -> git2::Commit<'a> {


### PR DESCRIPTION
The `gitoxide` merge-tree implementation is faster and better in quality, so it should be used where applicable. This PR attempts to find these places and make the switch.

The goal is also to provide performance metrics, even though it's not expected we will see great numbers here as merge-tree is a smaller portion of the total work to be done.

Follow-up on #5411 .

### Tasks

Use `merge-tree` in…

* [x] Apply and Unapply branch
* [x] unapply ownership
* [x] back to integration
* [x] Oplog Listing (3x faster, 3,5x for merge-trees)
* [x] checkout branch trees
* [x] upstream integration statuses
* [x] use latest `gix` for nicer API
* [x] be sure to switch `gix` to the one from `main`

### Notes for the Reviewer

* All uses that deal with `resolve_index()` have been postponed for now, as it's probably easiest to implement this directly in the `gitoxide` merge tree function, for achieving the best possible quality. In theory, it might already work doing a post-process on the conflict entries, but that would be harder to get right.
* There are a couple of other uses in `gitbutler-cherry-pick` and `gitbutler-edit-mode` that rely on the index quite a bit, and even checkout an index. But it *seems* that [it doesn't rely on the index to show merge-conflicts](https://github.com/gitbutlerapp/gitbutler/blob/068833059d6dbaad32b6aebe4d6863ad55333a38/crates/gitbutler-edit-mode/src/lib.rs#L102).

### Follow-Up

* Improve `gix` merge trees APIs, see https://github.com/GitoxideLabs/gitoxide/pull/1651
* Use `gix-merge` in all the remaining places for performance and merge-quality

### Apply and Unapply

#### Before

When *applying*, merge-trees takes a whopping **72ms**. It's clearly not the bottleneck, with a lot of time being spent in checkout.

<img width="944" alt="Screenshot 2024-11-03 at 14 22 36" src="https://github.com/user-attachments/assets/57399569-333c-480b-846e-6102c97da2cf">

When *unapplying*, it now clocks in at **139ms**, so once again isn't going to change anything when replaced. Checking out files takes a long time, comparatively.

<img width="950" alt="Screenshot 2024-11-03 at 14 24 46" src="https://github.com/user-attachments/assets/5c85dfd9-5427-4654-a3ba-71c9c6251ec8">


#### After

Like expected, there isn't much of a relevant change, with both merges during unapply and apply clocking in to ~90ms. Yes, it *seems*  a bit faster, but is still far from flexing any muscle.

<img width="920" alt="Screenshot 2024-11-03 at 16 05 34" src="https://github.com/user-attachments/assets/e0c74971-37da-4c85-b570-81aa9dcf3e3a">

### Unapply Ownership

#### Before 

A tiny portion of 66ms of the 4s runtime is related to merging trees. Since it's the same repository  (GitLab) the after should look very similar.

<img width="953" alt="Screenshot 2024-11-03 at 17 38 25" src="https://github.com/user-attachments/assets/84f77d17-0336-44fd-8606-222c9bb44777">


#### After

It's basically the same at 64ms.

<img width="940" alt="Screenshot 2024-11-03 at 17 38 59" src="https://github.com/user-attachments/assets/c81f2c71-7318-43a6-b11b-365804b1d19b">''

### Set Base Branch / Back to Integration

#### Before

**112ms**

<img width="935" alt="Screenshot 2024-11-03 at 19 30 17" src="https://github.com/user-attachments/assets/98f56c64-afcb-44a9-80ce-1d4b3b00eb0b">

#### After

**93ms**

<img width="938" alt="Screenshot 2024-11-03 at 19 34 21" src="https://github.com/user-attachments/assets/9b5d0348-7239-41b4-8e0b-0bcb8f8b3815">

### Oplog Listing

#### Before

Listing takes 22s, and one full diff takes 7s, which is duplicated for an additional stats. Merging of trees takes **1.93s**.

<img width="946" alt="Screenshot 2024-11-03 at 19 52 45" src="https://github.com/user-attachments/assets/f94bef9b-63d9-45e4-8746-cdbe464ac8d2">

#### After replacing merge-trees

Merging trees now take **585ms**,  3.3x of what was before.

<img width="939" alt="Screenshot 2024-11-03 at 20 28 31" src="https://github.com/user-attachments/assets/63d59962-3f73-48c1-9790-2ac68a3f5a78">

#### After using `gitoxide` for the diffing

The whole operation is down to 7.3s, a 3x improvement! This is also due to not duplicating work.

<img width="946" alt="Screenshot 2024-11-04 at 08 14 31" src="https://github.com/user-attachments/assets/d1c6f3d0-fbfd-4a0c-86b6-630d827b98b5">


It's noticeable how the TOML deserialisation takes 2s, which is a lot in comparison to the total runtime. But like I mentioned on Discord, I think there is ways to speed this up by not precomputing everything, instead of parallelising.

### Checkout Branch Trees

#### Before

Merging in total takes about **300ms** with two trivial branches. Like noticed before, writing the index to a tree is very expensive.

<img width="958" alt="Screenshot 2024-11-04 at 11 04 06" src="https://github.com/user-attachments/assets/16eb6cd4-3ad6-4cc5-8302-62516b43cdd7">

#### After

Now the same task takes **140ms** for merging and writing the tree. Notably, writing the tree now takes 6ms , 29x faster than having to write a whole index.

<img width="956" alt="Screenshot 2024-11-04 at 12 13 51" src="https://github.com/user-attachments/assets/b7977933-9d60-449e-9197-73a2419ad1cd">


### Upstream Integration Statuses

#### Before

As often, most time is spent elsewhere (and duplicated in `stack_series()`), but that aside we are looking at **1.09s** for merging trees in that function.

<img width="935" alt="Screenshot 2024-11-04 at 16 11 10" src="https://github.com/user-attachments/assets/850dc143-4161-4f43-ac26-314f352b6434">

#### After

Now it clocks in at 640ms, at 1.7x.

<img width="969" alt="Screenshot 2024-11-04 at 19 21 50" src="https://github.com/user-attachments/assets/7ad0c403-e9e4-4dfb-ae79-5ba729be875d">

