### PR TITLE
fix: ensure error message text wraps

### DIFF
--- a/apps/desktop/src/lib/settings/userPreferences/CommitSigningForm.svelte
+++ b/apps/desktop/src/lib/settings/userPreferences/CommitSigningForm.svelte
@@ -52,6 +52,7 @@
 	let errorMessage = '';
 
 	async function checkSigning() {
+		errorMessage = '';
 		checked = true;
 		loading = true;
 		await invoke('check_signing_settings', { id: project.id })
@@ -159,8 +160,11 @@
 							<p>Signing is working correctly</p>
 						{:else}
 							<p>Signing is not working correctly</p>
-							<pre>{errorMessage}</pre>
 						{/if}
+					</svelte:fragment>
+
+					<svelte:fragment slot="content">
+						{errorMessage}
 					</svelte:fragment>
 				</InfoMessage>
 			{/if}

--- a/apps/desktop/src/lib/settings/userPreferences/CommitSigningForm.svelte
+++ b/apps/desktop/src/lib/settings/userPreferences/CommitSigningForm.svelte
@@ -164,7 +164,7 @@
 					</svelte:fragment>
 
 					<svelte:fragment slot="content">
-						{errorMessage}
+						<pre>{errorMessage}</pre>
 					</svelte:fragment>
 				</InfoMessage>
 			{/if}

--- a/apps/desktop/src/lib/shared/InfoMessage.svelte
+++ b/apps/desktop/src/lib/shared/InfoMessage.svelte
@@ -128,6 +128,10 @@
 		}
 	}
 
+	.info-message__text :global(pre) {
+		white-space: pre-wrap;
+	}
+
 	/* MODIFIERS */
 	.neutral {
 		border: 0 solid var(--clr-border-2);


### PR DESCRIPTION
## ☕️ Reasoning

The error message is not fully visible when a commit signing test fails.

## 🧢 Changes

I moved the error message into the `content` slot, because that seems to be more in-line with how the `InfoMessage` component is used throughout the codebase. I also had to make sure the errorMessage was re-set when a new signing test was initiated. And then i added some styles to ensure that a `pre` in the content slot would always have text wrapping.

If y'all would prefer a different approach, just let me know!

## 📸 Screenshots

|Before|After|
|-----|-----|
|<img width="593" alt="prod_before" src="https://github.com/user-attachments/assets/280bcd45-d96e-4f31-b58f-671780244a6d">|<img width="627" alt="Screenshot 2024-11-04 at 8 24 37 AM" src="https://github.com/user-attachments/assets/bf771f71-9c65-4826-814c-1feb5ac6b6a3">|



<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
