### PR TITLE
feat: remove CommitCard usage from BranchPreview and BaseBranch view

### DIFF
--- a/apps/desktop/src/lib/commit/StackingCommitCard.svelte
+++ b/apps/desktop/src/lib/commit/StackingCommitCard.svelte
@@ -39,9 +39,10 @@
 		isUnapplied?: boolean;
 		last?: boolean;
 		type: CommitStatus;
-		lines?: Snippet | undefined;
+		lines?: Snippet<[topHeightPx?: number]> | undefined;
 		filesToggleable?: boolean;
 		seriesName?: string;
+		disableCommitActions?: boolean;
 	}
 
 	const {
@@ -54,7 +55,8 @@
 		type,
 		lines = undefined,
 		filesToggleable = true,
-		seriesName = ''
+		seriesName = '',
+		disableCommitActions = false
 	}: Props = $props();
 
 	const branchController = getContext(BranchController);
@@ -207,13 +209,13 @@
 	{/if}
 {/snippet}
 
-{#if draggableCommitElement}
+{#if draggableCommitElement && !disableCommitActions}
 	<ContextMenu bind:this={contextMenu} target={draggableCommitElement} openByMouse>
 		{@render commitContextMenuSnippet(contextMenu)}
 	</ContextMenu>
 {/if}
 
-{#if kebabMenuTrigger}
+{#if kebabMenuTrigger && !disableCommitActions}
 	<ContextMenu
 		bind:this={kebabContextMenu}
 		target={kebabMenuTrigger}
@@ -258,25 +260,29 @@
 		</div>
 	{/if}
 
-	<PopoverActionsContainer class="commit-actions-menu" thin stayOpen={isKebabContextMenuOpen}>
-		<PopoverActionsItem
-			bind:el={kebabMenuTrigger}
-			activated={isKebabContextMenuOpen}
-			icon="kebab"
-			tooltip="More options"
-			thin
-			onclick={(e) => {
-				kebabContextMenu?.toggle(e);
-			}}
-		/>
-	</PopoverActionsContainer>
+	{#if !disableCommitActions}
+		<PopoverActionsContainer class="commit-actions-menu" thin stayOpen={isKebabContextMenuOpen}>
+			<PopoverActionsItem
+				bind:el={kebabMenuTrigger}
+				activated={isKebabContextMenuOpen}
+				icon="kebab"
+				tooltip="More options"
+				thin
+				onclick={(e) => {
+					kebabContextMenu?.toggle(e);
+				}}
+			/>
+		</PopoverActionsContainer>
+	{/if}
 
 	<div class="commit-card" class:is-last={last}>
 		<!-- GENERAL INFO -->
 		<div bind:this={draggableCommitElement} class="commit__header" role="button" tabindex="-1">
-			<div class="commit__drag-icon">
-				<Icon name="draggable" />
-			</div>
+			{#if !disableCommitActions}
+				<div class="commit__drag-icon">
+					<Icon name="draggable" />
+				</div>
+			{/if}
 
 			{#if isUndoable && !commit.descriptionTitle}
 				<span class="text-13 text-body text-semibold commit__empty-title">empty commit message</span

--- a/apps/desktop/src/lib/components/BaseBranch.svelte
+++ b/apps/desktop/src/lib/components/BaseBranch.svelte
@@ -2,7 +2,7 @@
 	import IntegrateUpstreamModal from './IntegrateUpstreamModal.svelte';
 	import { BaseBranchService } from '$lib/baseBranch/baseBranchService';
 	import CommitAction from '$lib/commit/CommitAction.svelte';
-	import CommitCard from '$lib/commit/CommitCard.svelte';
+	import StackingCommitCard from '$lib/commit/StackingCommitCard.svelte';
 	import { transformAnyCommit } from '$lib/commitLines/transformers';
 	import { getForge } from '$lib/forge/interface/forge';
 	import { ModeService } from '$lib/modes/service';
@@ -210,18 +210,18 @@
 	{#if base.upstreamCommits?.length > 0}
 		<div>
 			{#each base.upstreamCommits as commit, index}
-				<CommitCard
+				<StackingCommitCard
 					{commit}
-					first={index === 0}
 					last={index === base.upstreamCommits.length - 1}
 					isUnapplied={true}
 					commitUrl={$forge?.commitUrl(commit.id)}
 					type="remote"
+					disableCommitActions={true}
 				>
 					{#snippet lines(topHeightPx)}
 						<LineGroup lineGroup={lineManager.get(commit.id)} {topHeightPx} />
 					{/snippet}
-				</CommitCard>
+				</StackingCommitCard>
 			{/each}
 		</div>
 
@@ -254,18 +254,18 @@
 	{#if commitsAhead.length > 0}
 		<div>
 			{#each commitsAhead as commit, index}
-				<CommitCard
+				<StackingCommitCard
 					{commit}
-					first={index === 0}
 					last={index === commitsAhead.length - 1}
 					isUnapplied={true}
 					commitUrl={$forge?.commitUrl(commit.id)}
 					type="local"
+					disableCommitActions={true}
 				>
 					{#snippet lines(topHeightPx)}
 						<LineGroup lineGroup={lineManager.get(commit.id)} {topHeightPx} />
 					{/snippet}
-				</CommitCard>
+				</StackingCommitCard>
 			{/each}
 		</div>
 
@@ -313,18 +313,18 @@
 	<!-- LOCAL AND REMOTE COMMITS -->
 	<div>
 		{#each localAndRemoteCommits as commit, index}
-			<CommitCard
+			<StackingCommitCard
 				{commit}
-				first={index === 0}
 				last={index === localAndRemoteCommits.length - 1}
 				isUnapplied={true}
 				commitUrl={$forge?.commitUrl(commit.id)}
 				type="localAndRemote"
+				disableCommitActions={true}
 			>
 				{#snippet lines(topHeightPx)}
 					<LineGroup lineGroup={lineManager.get(commit.id)} {topHeightPx} />
 				{/snippet}
-			</CommitCard>
+			</StackingCommitCard>
 		{/each}
 	</div>
 </div>

--- a/apps/desktop/src/lib/components/BranchPreview.svelte
+++ b/apps/desktop/src/lib/components/BranchPreview.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import BranchPreviewHeader from '../branch/BranchPreviewHeader.svelte';
 	import Resizer from '../shared/Resizer.svelte';
+	import StackingCommitCard from '$lib/commit/StackingCommitCard.svelte';
 	import { transformAnyCommit } from '$lib/commitLines/transformers';
 	import Markdown from '$lib/components/Markdown.svelte';
 	import FileCard from '$lib/file/FileCard.svelte';
@@ -17,7 +18,6 @@
 	import { onMount, setContext } from 'svelte';
 	import { writable } from 'svelte/store';
 	import type { PullRequest } from '$lib/forge/interface/types';
-	import StackingCommitCard from '$lib/commit/StackingCommitCommitCard.svelte';
 
 	export let localBranch: Branch | undefined = undefined;
 	export let remoteBranch: Branch | undefined = undefined;

--- a/apps/desktop/src/lib/components/BranchPreview.svelte
+++ b/apps/desktop/src/lib/components/BranchPreview.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import BranchPreviewHeader from '../branch/BranchPreviewHeader.svelte';
 	import Resizer from '../shared/Resizer.svelte';
-	import CommitCard from '$lib/commit/CommitCard.svelte';
 	import { transformAnyCommit } from '$lib/commitLines/transformers';
 	import Markdown from '$lib/components/Markdown.svelte';
 	import FileCard from '$lib/file/FileCard.svelte';
@@ -18,6 +17,7 @@
 	import { onMount, setContext } from 'svelte';
 	import { writable } from 'svelte/store';
 	import type { PullRequest } from '$lib/forge/interface/types';
+	import StackingCommitCard from '$lib/commit/StackingCommitCommitCard.svelte';
 
 	export let localBranch: Branch | undefined = undefined;
 	export let remoteBranch: Branch | undefined = undefined;
@@ -113,53 +113,53 @@
 							{/if}
 						</div>
 					{/if}
-					<div>
+					<div class="branch-group">
 						{#if remoteCommits}
 							{#each remoteCommits as commit, index (commit.id)}
-								<CommitCard
+								<StackingCommitCard
 									isUnapplied
-									first={index === 0}
 									last={index === remoteCommits.length - 1}
 									{commit}
 									commitUrl={$forge?.commitUrl(commit.id)}
 									type="remote"
+									disableCommitActions={true}
 								>
 									{#snippet lines(topHeightPx)}
 										<LineGroup lineGroup={lineManager.get(commit.id)} {topHeightPx} />
 									{/snippet}
-								</CommitCard>
+								</StackingCommitCard>
 							{/each}
 						{/if}
 						{#if localCommits}
 							{#each localCommits as commit, index (commit.id)}
-								<CommitCard
+								<StackingCommitCard
 									isUnapplied
-									first={index === 0}
 									last={index === localCommits.length - 1}
 									{commit}
 									commitUrl={$forge?.commitUrl(commit.id)}
 									type="local"
+									disableCommitActions={true}
 								>
 									{#snippet lines(topHeightPx)}
 										<LineGroup lineGroup={lineManager.get(commit.id)} {topHeightPx} />
 									{/snippet}
-								</CommitCard>
+								</StackingCommitCard>
 							{/each}
 						{/if}
 						{#if localAndRemoteCommits}
 							{#each localAndRemoteCommits as commit, index (commit.id)}
-								<CommitCard
+								<StackingCommitCard
 									isUnapplied
-									first={index === 0}
 									last={index === localAndRemoteCommits.length - 1}
 									{commit}
 									commitUrl={$forge?.commitUrl(commit.id)}
 									type="localAndRemote"
+									disableCommitActions={true}
 								>
 									{#snippet lines(topHeightPx)}
 										<LineGroup lineGroup={lineManager.get(commit.id)} {topHeightPx} />
 									{/snippet}
-								</CommitCard>
+								</StackingCommitCard>
 							{/each}
 						{/if}
 					</div>
@@ -224,5 +224,19 @@
 
 	.card__content {
 		color: var(--clr-scale-ntrl-30);
+	}
+
+	.branch-group {
+		border: 1px solid var(--clr-border-2);
+		border-radius: var(--radius-m);
+		background: var(--clr-bg-1);
+
+		&:last-child {
+			margin-bottom: 12px;
+		}
+
+		& :global(.commit-row):first-child {
+			border-radius: var(--radius-m) var(--radius-m) 0 0;
+		}
 	}
 </style>

--- a/apps/desktop/src/routes/[projectId]/base/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/base/+page.svelte
@@ -102,6 +102,9 @@
 	}
 	.card {
 		margin: 12px 6px 12px 12px;
-		padding: 16px;
+
+		& :global(.commit-row):first-child {
+			border-radius: var(--radius-m) var(--radius-m) 0 0;
+		}
 	}
 </style>


### PR DESCRIPTION
Branch 1/2

- #5426
- You are here --> #5425

## ☕️ Reasoning

- Remove all usage of `CommitCard.svelte` in order to drop more legacy code from the stacking/non-stacking split

## 🧢 Changes

- Migrate `BaseBranch.svelte` and `BranchPreview.svelte` to use the new `StackingCommitCard.svelte`

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->