### PR TITLE
fix: Tauri v2 listed linux dependencies

### DIFF
--- a/crates/gitbutler-tauri/tauri.conf.json
+++ b/crates/gitbutler-tauri/tauri.conf.json
@@ -25,10 +25,10 @@
 		},
 		"linux": {
 			"rpm": {
-				"depends": ["webkit2gtk4.1-devel"]
+				"depends": ["webkit2gtk4.1"]
 			},
 			"deb": {
-				"depends": ["libwebkit2gtk-4.1-dev", "libgtk-3-dev"]
+				"depends": ["libwebkit2gtk-4.1", "libgtk-3-0"]
 			}
 		}
 	},


### PR DESCRIPTION
## ☕️ Reasoning

- These are the dependencies our users will have to have installed, so it's not actually the `-dev` variants of the package, which is what we need to compile, but the normal variants which are required in order to execute.
- See: https://tauri.app/distribute/debian/#debian

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->