### PR TITLE
refactor: enable no-explicit-any rule in ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,7 +24,6 @@ export default ts.config(
 		rules: {
 			'@typescript-eslint/no-namespace': 'off',
 			'@typescript-eslint/no-empty-function': 'off',
-			'@typescript-eslint/no-explicit-any': 'off',
 			'@typescript-eslint/no-unused-vars': [
 				'error',
 				{


### PR DESCRIPTION
Let's see in how many places we do `any`