### PR TITLE
Bring back the "Copy PR link" to the context menu

### DIFF
--- a/apps/desktop/src/lib/branch/StackingSeriesHeaderContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/StackingSeriesHeaderContextMenu.svelte
@@ -5,6 +5,7 @@
 	import ContextMenuItem from '$lib/components/contextmenu/ContextMenuItem.svelte';
 	import ContextMenuSection from '$lib/components/contextmenu/ContextMenuSection.svelte';
 	import { projectAiGenEnabled } from '$lib/config/config';
+	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { openExternalUrl } from '$lib/utils/url';
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { VirtualBranch, type CommitStatus } from '$lib/vbranches/types';
@@ -116,6 +117,13 @@
 				label="Open PR in browser"
 				onclick={() => {
 					openExternalUrl(prUrl);
+					contextMenuEl?.close();
+				}}
+			/>
+			<ContextMenuItem
+				label="Copy PR link"
+				onclick={() => {
+					copyToClipboard(prUrl);
 					contextMenuEl?.close();
 				}}
 			/>


### PR DESCRIPTION
## ☕️ Reasoning
<img width="385" alt="image" src="https://github.com/user-attachments/assets/752798ac-f6b2-48c6-85fd-a16fa76d082a">

There was a user request on Discord. Design-wise, this feature doesn’t cost anything, so we can add it: https://discord.com/channels/1060193121130000425/1224366824305463337/1303283057817681954

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
