### PR TITLE
Expose `stackBranches` on VirtualBranchReference in the UI

### DIFF
--- a/apps/desktop/src/lib/branches/branchListing.ts
+++ b/apps/desktop/src/lib/branches/branchListing.ts
@@ -328,6 +328,11 @@ export class VirtualBranchReference {
 	id!: string;
 	/** Determines if the virtual branch is applied in the workspace */
 	inWorkspace!: boolean;
+	/**
+   List of branch names that are part of the stack
+   Ordered from newest to oldest (the most recent branch is first in the list)
+    */
+	stackBranches!: string[];
 }
 
 /** Represents a "commit author" or "signature", based on the data from ther git history */


### PR DESCRIPTION
To be used for rendering the updated design that shows the top-of-stack branch