### PR TITLE
fix: add tauri localhost entries to font-src CSP rules

### DIFF
--- a/crates/gitbutler-tauri/tauri.conf.json
+++ b/crates/gitbutler-tauri/tauri.conf.json
@@ -47,6 +47,7 @@
 			"csp": {
 				"default-src": "'self'",
 				"img-src": "'self' asset: https://asset.localhost data: tauri://localhost https://avatars.githubusercontent.com https://*.gitbutler.com  https://gitbutler-public.s3.amazonaws.com https://*.gravatar.com https://io.wp.com https://i0.wp.com https://i1.wp.com https://i2.wp.com https://i3.wp.com https://github.com https://*.googleusercontent.com",
+				"font-src": "'self' tauri://localhost http://tauri.localhost",
 				"connect-src": "'self' ipc: https://eu.posthog.com https://eu.i.posthog.com https://app.gitbutler.com https://o4504644069687296.ingest.sentry.io ws://localhost:7703 https://github.com https://api.github.com https://api.openai.com",
 				"script-src": "'self' https://eu.posthog.com https://eu.i.posthog.com",
 				"style-src": "'self' 'unsafe-inline'"


### PR DESCRIPTION
## ☕️ Reasoning

- TEST: Branch to test build on windows
- Windows fails loading Inter fonts

![image](https://github.com/user-attachments/assets/b311cbae-787f-466d-96b4-8297d297d94c)


## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->