### PR TITLE
fix: dont show push btn if all series have been integrated

### DIFF
--- a/apps/desktop/src/lib/stack/Stack.svelte
+++ b/apps/desktop/src/lib/stack/Stack.svelte
@@ -66,9 +66,14 @@
 	const branchPatches = $derived(branch.series.flatMap((s) => s.patches));
 
 	let canPush = $derived.by(() => {
+		// If all branches have status 'integrated', dont show push button
+		const allTopPatches = branch.series.map((s) => s.patches[0]).filter(Boolean);
+		if (!allTopPatches.some((patch) => patch?.status !== 'integrated')) return false;
+
 		if (branchUpstreamPatches.length > 0) return true;
 		if (branchPatches.some((p) => p.status !== 'localAndRemote')) return true;
 		if (branchPatches.some((p) => p.remoteCommitId !== p.id)) return true;
+
 		return false;
 	});
 


### PR DESCRIPTION
## ☕️ Reasoning

- Hide "Push" btn if all series have been integrated/merged
- Refactor to avoid 2/3 back-to-back `branch.series.map`'s

## 🧢 Changes

![image](https://github.com/user-attachments/assets/5b871464-e4af-475d-8ba0-3f67a68ab366)


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->