### PR TITLE
fix: BaseBranch commitLine colors

### DIFF
--- a/apps/desktop/src/lib/components/BaseBranch.svelte
+++ b/apps/desktop/src/lib/components/BaseBranch.svelte
@@ -311,7 +311,7 @@
 			disableCommitActions={true}
 		>
 			{#snippet lines()}
-				<Line line={lineManager.get(commit.id)} />
+				<Line type="local" line={lineManager.get(commit.id)} />
 			{/snippet}
 		</CommitCard>
 	{/each}

--- a/packages/ui/src/lib/commitLines/Line.svelte
+++ b/packages/ui/src/lib/commitLines/Line.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
 	import Cell from '$lib/commitLines/Cell.svelte';
 	import CommitNode from '$lib/commitLines/CommitNode.svelte';
-	import type { LineData } from '$lib/commitLines/types';
+	import type { CellType, LineData } from '$lib/commitLines/types';
 
 	interface Props {
 		line: LineData;
 		isBottom?: boolean;
+		type?: CellType;
 	}
 
-	const { line, isBottom = false }: Props = $props();
+	const { line, isBottom = false, type }: Props = $props();
 </script>
 
 <div class="line">
@@ -16,7 +17,7 @@
 		<Cell cell={line.top} />
 	</div>
 	{#if line.commitNode}
-		<CommitNode commitNode={line.commitNode} type={line.commitNode.type ?? 'local'} />
+		<CommitNode commitNode={line.commitNode} type={type ?? line.commitNode.type ?? 'local'} />
 	{/if}
 	<div class="line-bottom">
 		<Cell cell={line.bottom} {isBottom} />


### PR DESCRIPTION
## ☕️ Reasoning

- BaseBranch commits shouldn't have the default `localAndRemote` diverged line color / styling

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->