### PR TITLE
fix issue dealing with submodules in repositories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,7 +3039,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.67.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "gix-actor 0.33.0",
  "gix-attributes 0.23.0",
@@ -3107,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.33.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "gix-date 0.9.1",
@@ -3137,7 +3137,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.23.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "gix-glob 0.17.0",
@@ -3162,7 +3162,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.12"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "thiserror",
 ]
@@ -3179,7 +3179,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.9"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "thiserror",
 ]
@@ -3187,7 +3187,7 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.3.10"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "gix-path 0.10.12",
@@ -3212,7 +3212,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.25.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "gix-chunk 0.4.9",
@@ -3225,7 +3225,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.41.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -3245,7 +3245,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.14.9"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -3257,7 +3257,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.25.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3285,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.9.1"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "itoa 1.0.11",
@@ -3296,7 +3296,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.47.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3316,7 +3316,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.9.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "gix-discover 0.36.0",
@@ -3351,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.36.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "dunce",
@@ -3381,7 +3381,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.39.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -3403,7 +3403,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.14.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -3434,7 +3434,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.12.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "fastrand 2.1.1",
  "gix-features 0.39.0",
@@ -3456,7 +3456,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.17.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -3477,7 +3477,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.15.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "faster-hex",
  "thiserror",
@@ -3497,7 +3497,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.6.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "gix-hash 0.15.0",
  "hashbrown 0.14.5",
@@ -3520,7 +3520,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.12.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "gix-glob 0.17.0",
@@ -3560,7 +3560,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.36.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -3598,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "15.0.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "gix-tempfile 15.0.0",
  "gix-utils 0.1.13",
@@ -3608,7 +3608,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.0.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3631,7 +3631,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.16.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bitflags 2.6.0",
  "gix-commitgraph 0.25.0",
@@ -3665,7 +3665,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.45.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "gix-actor 0.33.0",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.64.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "arc-swap",
  "gix-date 0.9.1",
@@ -3704,7 +3704,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.54.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "clru",
  "gix-chunk 0.4.9",
@@ -3724,7 +3724,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.18.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -3735,7 +3735,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.18.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -3759,7 +3759,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.12"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "gix-trace 0.1.11",
@@ -3771,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.8.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -3785,7 +3785,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.8.8"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.46.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.4.13"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "gix-utils 0.1.13",
@@ -3857,7 +3857,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.48.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "gix-actor 0.33.0",
  "gix-features 0.39.0",
@@ -3877,7 +3877,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.26.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "gix-hash 0.15.0",
@@ -3890,7 +3890,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.30.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -3922,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.16.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "gix-commitgraph 0.25.0",
  "gix-date 0.9.1",
@@ -3948,7 +3948,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.10.9"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bitflags 2.6.0",
  "gix-path 0.10.12",
@@ -3959,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.14.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "filetime",
@@ -3981,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.15.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "gix-config",
@@ -4010,7 +4010,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "15.0.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "dashmap",
  "gix-fs 0.12.0",
@@ -4055,7 +4055,7 @@ checksum = "6cae0e8661c3ff92688ce1c8b8058b3efb312aba9492bbe93661a21705ab431b"
 [[package]]
 name = "gix-trace"
 version = "0.1.11"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "tracing-core",
 ]
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.43.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -4098,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.42.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bitflags 2.6.0",
  "gix-commitgraph 0.25.0",
@@ -4114,7 +4114,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.28.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "gix-features 0.39.0",
@@ -4136,7 +4136,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.1.13"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "fastrand 2.1.1",
@@ -4156,7 +4156,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.9.1"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "thiserror",
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.37.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "gix-attributes 0.23.0",
@@ -4202,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.14.0"
-source = "git+https://github.com/Byron/gitoxide?rev=a8765330fc16997dee275866b18a128dec1c5d55#a8765330fc16997dee275866b18a128dec1c5d55"
+source = "git+https://github.com/Byron/gitoxide?rev=697a6320c7664845590e3e8251015085b6cc5d81#697a6320c7664845590e3e8251015085b6cc5d81"
 dependencies = [
  "bstr",
  "gix-features 0.39.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ resolver = "2"
 [workspace.dependencies]
 bstr = "1.10.0"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
-gix = { git = "https://github.com/Byron/gitoxide", rev = "a8765330fc16997dee275866b18a128dec1c5d55", default-features = false, features = [
+gix = { git = "https://github.com/Byron/gitoxide", rev = "697a6320c7664845590e3e8251015085b6cc5d81", default-features = false, features = [
 ] }
 git2 = { version = "0.19.0", features = [
     "vendored-openssl",


### PR DESCRIPTION
With the merge of #5416, which made it into the latest release somehow, there was also the introduction of a more convenient API for writing trees. This API, however, also added validation for everything that was about to be written to ensure the tree-entry names are valid *and* the objects they point to exist.

Unfortunately, a test for submodules was missing, whose objects never exist in the parent repository as they refer to the HEAD commit in the submodule.
This object-exists check would cause errors like `The object d12a68fc4930062c0bed26447a6b5245697e77c1 (160000) at 'suite' could not be found`.

As this runs as part of most merges now, this also means that no repository with submodules will work.

This PR updates `gitoxide` to the latest version which [implements a test and fix](https://github.com/GitoxideLabs/gitoxide/pull/1653).

It's definitely recommended to release an update soon after.

Fixes #5459 .

### Tasks

* [x] update `gitoxide` to latest version on `main`
