### PR TITLE
fix: update linux dependencies

### DIFF
--- a/crates/gitbutler-tauri/tauri.conf.json
+++ b/crates/gitbutler-tauri/tauri.conf.json
@@ -28,7 +28,7 @@
 				"depends": ["webkit2gtk4.1"]
 			},
 			"deb": {
-				"depends": ["libwebkit2gtk-4.1", "libgtk-3-0"]
+				"depends": ["libwebkit2gtk-4.1-0", "libgtk-3-0"]
 			}
 		}
 	},


### PR DESCRIPTION
## ☕️ Reasoning

- Cleanup linux deps listing in tauri.conf.json
- `libwebkit2gtk-4.1` pkg doesn't technically exist
	- `libwebkit2gtk-4.1-0` does
	- https://packages.ubuntu.com/noble/libwebkit2gtk-4.1-0
	- https://packages.ubuntu.com/jammy/libwebkit2gtk-4.1-0

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->