### PR TITLE
fix: remove extra spacing on InfoMessage

### DIFF
--- a/apps/desktop/src/lib/settings/userPreferences/CommitSigningForm.svelte
+++ b/apps/desktop/src/lib/settings/userPreferences/CommitSigningForm.svelte
@@ -164,7 +164,9 @@
 					</svelte:fragment>
 
 					<svelte:fragment slot="content">
-						<pre>{errorMessage}</pre>
+						{#if errorMessage}
+							<pre>{errorMessage}</pre>
+						{/if}
 					</svelte:fragment>
 				</InfoMessage>
 			{/if}


### PR DESCRIPTION
## ☕️ Reasoning

In #5418 I made some changes to this `InfoMessage` to render the error message properly.
However, I introduced a scenario where the `content` slot could be rendered to the DOM with a `pre` element, but no text content. 

Ordinarily the content element would hide itself if empty, but the `pre` element prevents that. The parent container also uses `gap` to add space between the `title` and `content` slots, resulting in asymmetric spacing

## 🧢 Changes

- Don't render the `pre` if there's no error message

## 📸 Screenshots

|BEFORE|AFTER|
|-----|-----|
|<img width="515" alt="before_checked" src="https://github.com/user-attachments/assets/21df1072-c62d-4920-b1f3-f5453b746f4f">|<img width="511" alt="after_checked" src="https://github.com/user-attachments/assets/4ec51662-2fdb-4a2b-bbe2-3cdcf2589047">|
|<img width="515" alt="before_success" src="https://github.com/user-attachments/assets/17a56401-22d7-4f47-bdeb-6ed144d69d09">|<img width="512" alt="after_signed" src="https://github.com/user-attachments/assets/e5fd1b91-5ed4-406b-8009-3e50d7d058b9">|
|<img width="518" alt="before_error" src="https://github.com/user-attachments/assets/631f2209-8233-4cf5-a656-125938c86c8b">|<img width="515" alt="after_error" src="https://github.com/user-attachments/assets/f50becbf-7601-48db-abe0-3b096ef4c2b2">|









<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
