### PR TITLE
Push empty stacks, skip archived stacks.

### DIFF
--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -195,7 +195,7 @@ pub fn push_stack(project: &Project, branch_id: StackId, with_force: bool) -> Re
     let mut check_commit = IsCommitIntegrated::new(ctx, &default_target, &gix_repo, &mut graph)?;
     let stack_series = stack.list_series(ctx)?;
     for series in stack_series {
-        if series.local_commits.is_empty() {
+        if series.archived {
             // Nothing to push for this one
             continue;
         }


### PR DESCRIPTION
If a stack is archived (which means it was previously recognised as being integrated and that the workspace has been moved past it), then there should be no need to push it.

If a stack is empty, we should however still push it, because it may have previously contained commits, and if we don't push the head, it could leave some PRs in a confusing state