### PR TITLE
Move branch_trees modeule to workspace crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,6 +2435,7 @@ dependencies = [
  "gitbutler-time",
  "gitbutler-url",
  "gitbutler-user",
+ "gitbutler-workspace",
  "gix",
  "glob",
  "hex",
@@ -2555,6 +2556,7 @@ dependencies = [
  "gitbutler-repo",
  "gitbutler-stack",
  "gitbutler-time",
+ "gitbutler-workspace",
  "serde",
 ]
 
@@ -3033,6 +3035,26 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "gitbutler-workspace"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "git2",
+ "gitbutler-branch",
+ "gitbutler-branch-actions",
+ "gitbutler-cherry-pick",
+ "gitbutler-command-context",
+ "gitbutler-commit",
+ "gitbutler-oxidize",
+ "gitbutler-project",
+ "gitbutler-repo",
+ "gitbutler-stack",
+ "gitbutler-testsupport",
+ "gitbutler-workspace",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "crates/gitbutler-stack",
     "crates/gitbutler-hunk-dependency",
     "crates/gitbutler-settings",
+    "crates/gitbutler-workspace",
 ]
 resolver = "2"
 
@@ -95,6 +96,7 @@ gitbutler-stack = { path = "crates/gitbutler-stack" }
 gitbutler-forge = { path = "crates/gitbutler-forge" }
 gitbutler-hunk-dependency = { path = "crates/gitbutler-hunk-dependency" }
 gitbutler-settings = { path = "crates/gitbutler-settings" }
+gitbutler-workspace = { path = "crates/gitbutler-workspace" }
 
 [profile.release]
 codegen-units = 1 # Compile crates one after another so the compiler can optimize better

--- a/crates/gitbutler-branch-actions/Cargo.toml
+++ b/crates/gitbutler-branch-actions/Cargo.toml
@@ -30,6 +30,7 @@ gitbutler-cherry-pick.workspace = true
 gitbutler-oxidize.workspace = true
 gitbutler-stack.workspace = true
 gitbutler-hunk-dependency.workspace = true
+gitbutler-workspace.workspace = true
 serde = { workspace = true, features = ["std"] }
 bstr.workspace = true
 diffy = "0.4.0"
@@ -49,6 +50,7 @@ toml.workspace = true
 once_cell = "1.20"
 pretty_assertions = "1.4"
 gitbutler-testsupport.workspace = true
+gitbutler-workspace.workspace = true
 gix = { workspace = true, features = ["max-performance"] }
 gitbutler-git = { workspace = true, features = ["test-askpass-path"] }
 glob = "0.3.1"

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -1,4 +1,4 @@
-use crate::{branch_trees::checkout_branch_trees, r#virtual as vbranch};
+use crate::r#virtual as vbranch;
 use anyhow::{anyhow, bail, Context, Result};
 use gitbutler_branch::BranchCreateRequest;
 use gitbutler_branch::{self, dedup};
@@ -16,6 +16,7 @@ use gitbutler_repo::{
 use gitbutler_repo_actions::RepoActionsExt;
 use gitbutler_stack::{BranchOwnershipClaims, Stack, StackId};
 use gitbutler_time::time::now_since_unix_epoch_ms;
+use gitbutler_workspace::checkout_branch_trees;
 use tracing::instrument;
 
 use super::BranchManager;

--- a/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
@@ -7,13 +7,11 @@ use gitbutler_repo::{
 };
 use gitbutler_stack::commit_by_oid_or_change_id;
 use gitbutler_stack::StackId;
-
-use crate::{
-    branch_trees::{
-        checkout_branch_trees, compute_updated_branch_head_for_commits, BranchHeadAndTree,
-    },
-    conflicts, VirtualBranchesExt as _,
+use gitbutler_workspace::{
+    checkout_branch_trees, compute_updated_branch_head_for_commits, BranchHeadAndTree,
 };
+
+use crate::{conflicts, VirtualBranchesExt as _};
 
 pub fn integrate_upstream_commits_for_series(
     ctx: &CommandContext,
@@ -308,8 +306,7 @@ mod test {
         use gitbutler_commit::commit_ext::CommitExt as _;
         use gitbutler_repo::LogUntil;
         use gitbutler_repo::RepositoryExt as _;
-
-        use crate::branch_trees::BranchHeadAndTree;
+        use gitbutler_workspace::BranchHeadAndTree;
 
         use super::*;
 

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -44,7 +44,6 @@ pub use remote::{RemoteBranch, RemoteBranchData, RemoteCommit};
 
 pub mod conflicts;
 
-pub mod branch_trees;
 pub mod branch_upstream_integration;
 mod move_commits;
 pub mod reorder;

--- a/crates/gitbutler-branch-actions/src/move_commits.rs
+++ b/crates/gitbutler-branch-actions/src/move_commits.rs
@@ -1,13 +1,11 @@
-use crate::{
-    branch_trees::checkout_branch_trees, conflicts::RepoConflictsExt, status::get_applied_status,
-    VirtualBranchesExt,
-};
+use crate::{conflicts::RepoConflictsExt, status::get_applied_status, VirtualBranchesExt};
 use anyhow::{anyhow, bail, Context, Result};
 use gitbutler_command_context::CommandContext;
 use gitbutler_commit::commit_ext::CommitExt;
 use gitbutler_project::access::WorktreeWritePermission;
 use gitbutler_repo::{rebase::cherry_rebase_group, LogUntil, RepositoryExt};
 use gitbutler_stack::{OwnershipClaim, StackId};
+use gitbutler_workspace::checkout_branch_trees;
 use std::collections::HashMap;
 
 /// moves commit from the branch it's in to the top of the target branch

--- a/crates/gitbutler-branch-actions/src/reorder.rs
+++ b/crates/gitbutler-branch-actions/src/reorder.rs
@@ -7,15 +7,13 @@ use gitbutler_project::access::WorktreeWritePermission;
 use gitbutler_repo::rebase::cherry_rebase_group;
 use gitbutler_stack::{Series, StackId};
 
+use gitbutler_workspace::{
+    checkout_branch_trees, compute_updated_branch_head_for_commits, BranchHeadAndTree,
+};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    branch_trees::{
-        checkout_branch_trees, compute_updated_branch_head_for_commits, BranchHeadAndTree,
-    },
-    VirtualBranchesExt,
-};
+use crate::VirtualBranchesExt;
 
 /// This API allows the client to reorder commits in a stack.
 /// Commits may be moved within the same series or between different series.

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -1,7 +1,4 @@
-use crate::{
-    branch_trees::{checkout_branch_trees, compute_updated_branch_head, BranchHeadAndTree},
-    BranchManagerExt, VirtualBranchesExt as _,
-};
+use crate::{BranchManagerExt, VirtualBranchesExt as _};
 use anyhow::{anyhow, bail, Result};
 use gitbutler_cherry_pick::RepositoryExt as _;
 use gitbutler_command_context::CommandContext;
@@ -13,6 +10,7 @@ use gitbutler_repo::{
 };
 use gitbutler_repo_actions::RepoActionsExt as _;
 use gitbutler_stack::{Stack, StackId, Target, VirtualBranchesHandle};
+use gitbutler_workspace::{checkout_branch_trees, compute_updated_branch_head, BranchHeadAndTree};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, PartialEq, Debug)]

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/mod.rs
@@ -57,7 +57,6 @@ impl Test {
 
 mod amend;
 mod apply_virtual_branch;
-mod branch_trees;
 mod create_commit;
 mod create_virtual_branch_from_branch;
 mod init;

--- a/crates/gitbutler-edit-mode/Cargo.toml
+++ b/crates/gitbutler-edit-mode/Cargo.toml
@@ -22,4 +22,5 @@ gitbutler-oplog.workspace = true
 gitbutler-diff.workspace = true
 gitbutler-stack.workspace = true
 gitbutler-cherry-pick.workspace = true
+gitbutler-workspace.workspace = true
 serde.workspace = true

--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -5,9 +5,6 @@ use std::str::FromStr;
 use anyhow::{bail, Context, Result};
 use bstr::ByteSlice;
 use git2::build::CheckoutBuilder;
-use gitbutler_branch_actions::branch_trees::{
-    checkout_branch_trees, compute_updated_branch_head, BranchHeadAndTree,
-};
 use gitbutler_branch_actions::internal::list_virtual_branches;
 use gitbutler_branch_actions::{update_workspace_commit, RemoteBranchFile};
 use gitbutler_cherry_pick::{ConflictedTreeKey, RepositoryExt as _};
@@ -26,6 +23,7 @@ use gitbutler_reference::{ReferenceName, Refname};
 use gitbutler_repo::{rebase::cherry_rebase, RepositoryExt};
 use gitbutler_repo::{signature, SignaturePurpose};
 use gitbutler_stack::{Stack, VirtualBranchesHandle};
+use gitbutler_workspace::{checkout_branch_trees, compute_updated_branch_head, BranchHeadAndTree};
 use serde::Serialize;
 
 pub mod commands;

--- a/crates/gitbutler-workspace/Cargo.toml
+++ b/crates/gitbutler-workspace/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "gitbutler-workspace"
+version = "0.0.0"
+edition = "2021"
+authors = ["GitButler <gitbutler@gitbutler.com>"]
+publish = false
+
+[dependencies]
+anyhow.workspace = true
+tracing.workspace = true
+git2.workspace = true
+gitbutler-stack.workspace = true
+gitbutler-repo.workspace = true
+gitbutler-project.workspace = true
+gitbutler-commit.workspace = true
+gitbutler-oxidize.workspace = true
+gitbutler-command-context.workspace = true
+gitbutler-cherry-pick.workspace = true
+
+
+[[test]]
+name = "workspace"
+path = "tests/mod.rs"
+
+[dev-dependencies]
+gitbutler-testsupport.workspace = true
+gitbutler-branch.workspace = true
+gitbutler-branch-actions.workspace = true
+gitbutler-workspace.workspace = true

--- a/crates/gitbutler-workspace/src/branch_trees.rs
+++ b/crates/gitbutler-workspace/src/branch_trees.rs
@@ -1,4 +1,3 @@
-use crate::VirtualBranchesExt as _;
 use anyhow::{bail, Result};
 use gitbutler_cherry_pick::RepositoryExt;
 use gitbutler_command_context::CommandContext;
@@ -7,7 +6,7 @@ use gitbutler_oxidize::{git2_to_gix_object_id, gix_to_git2_oid};
 use gitbutler_project::access::WorktreeWritePermission;
 use gitbutler_repo::rebase::cherry_rebase_group;
 use gitbutler_repo::{GixRepositoryExt, RepositoryExt as _};
-use gitbutler_stack::Stack;
+use gitbutler_stack::{Stack, VirtualBranchesHandle};
 use tracing::instrument;
 
 /// Checks out the combined trees of all branches in the workspace.
@@ -19,7 +18,7 @@ pub fn checkout_branch_trees<'a>(
     _perm: &mut WorktreeWritePermission,
 ) -> Result<git2::Tree<'a>> {
     let repository = ctx.repository();
-    let vb_state = ctx.project().virtual_branches();
+    let vb_state = VirtualBranchesHandle::new(ctx.project().gb_dir());
     let branches = vb_state.list_branches_in_workspace()?;
 
     if branches.is_empty() {
@@ -147,100 +146,5 @@ pub fn compute_updated_branch_head_for_commits(
             head: new_head,
             tree: rebased_tree.tree_id(),
         })
-    }
-}
-
-// These possibly could be considered more "integration" tests, but there is no
-// need for `checkout_branch_trees` to be public, so it is tested here.
-#[cfg(test)]
-mod test {
-    use std::fs;
-
-    use gitbutler_branch::BranchCreateRequest;
-    use gitbutler_command_context::CommandContext;
-    use gitbutler_repo::RepositoryExt as _;
-    use gitbutler_testsupport::{paths, testing_repository::assert_tree_matches, TestProject};
-
-    #[test]
-    fn checkout_with_two_branches() {
-        let test_project = &TestProject::default();
-
-        let data_dir = paths::data_dir();
-        let projects = gitbutler_project::Controller::from_path(data_dir.path());
-
-        let project = projects
-            .add(test_project.path())
-            .expect("failed to add project");
-
-        crate::set_base_branch(&project, &"refs/remotes/origin/master".parse().unwrap()).unwrap();
-
-        let branch_1 =
-            crate::create_virtual_branch(&project, &BranchCreateRequest::default()).unwrap();
-
-        fs::write(test_project.path().join("foo.txt"), "content").unwrap();
-
-        crate::create_commit(&project, branch_1, "commit one", None, false).unwrap();
-
-        let branch_2 =
-            crate::create_virtual_branch(&project, &BranchCreateRequest::default()).unwrap();
-
-        fs::write(test_project.path().join("bar.txt"), "content").unwrap();
-
-        crate::create_commit(&project, branch_2, "commit two", None, false).unwrap();
-
-        let tree = test_project.local_repository.create_wd_tree().unwrap();
-
-        // Assert original state
-        assert_tree_matches(
-            &test_project.local_repository,
-            &tree,
-            &[("foo.txt", b"content"), ("bar.txt", b"content")],
-        );
-        assert_eq!(tree.len(), 2);
-
-        // Checkout an empty tree
-        {
-            let tree_oid = test_project
-                .local_repository
-                .treebuilder(None)
-                .unwrap()
-                .write()
-                .unwrap();
-            let tree = test_project.local_repository.find_tree(tree_oid).unwrap();
-            test_project
-                .local_repository
-                .checkout_tree_builder(&tree)
-                .force()
-                .remove_untracked()
-                .checkout()
-                .unwrap();
-        }
-
-        // Assert tree is indeed empty
-        {
-            let tree: git2::Tree = test_project.local_repository.create_wd_tree().unwrap();
-
-            // Tree should be empty
-            assert_eq!(
-                tree.len(),
-                0,
-                "Should be empty after checking out an empty tree"
-            );
-        }
-
-        let ctx = CommandContext::open(&project).unwrap();
-        let mut guard = project.exclusive_worktree_access();
-
-        super::checkout_branch_trees(&ctx, guard.write_permission()).unwrap();
-
-        let tree = test_project.local_repository.create_wd_tree().unwrap();
-
-        // Should be back to original state
-        assert_tree_matches(
-            &test_project.local_repository,
-            &tree,
-            &[("foo.txt", b"content"), ("bar.txt", b"content")],
-        );
-        assert_eq!(tree.len(), 2, "Should match original state");
     }
 }

--- a/crates/gitbutler-workspace/src/lib.rs
+++ b/crates/gitbutler-workspace/src/lib.rs
@@ -1,0 +1,6 @@
+mod branch_trees;
+
+pub use branch_trees::{
+    checkout_branch_trees, compute_updated_branch_head, compute_updated_branch_head_for_commits,
+    BranchHeadAndTree,
+};

--- a/crates/gitbutler-workspace/tests/branch_trees.rs
+++ b/crates/gitbutler-workspace/tests/branch_trees.rs
@@ -26,12 +26,12 @@ fn make_branch(head: git2::Oid, tree: git2::Oid) -> Stack {
 #[cfg(test)]
 mod compute_updated_branch_head {
     use super::*;
-    use gitbutler_branch_actions::branch_trees::{compute_updated_branch_head, BranchHeadAndTree};
     use gitbutler_cherry_pick::RepositoryExt as _;
     use gitbutler_commit::commit_ext::CommitExt;
     use gitbutler_testsupport::testing_repository::{
         assert_commit_tree_matches, assert_tree_matches, TestingRepository,
     };
+    use gitbutler_workspace::{compute_updated_branch_head, BranchHeadAndTree};
 
     /// When the head ID is the same as the branch ID, we should return the same Oids.
     #[test]

--- a/crates/gitbutler-workspace/tests/mod.rs
+++ b/crates/gitbutler-workspace/tests/mod.rs
@@ -1,0 +1,99 @@
+mod branch_trees;
+
+#[cfg(test)]
+mod test {
+    use std::fs;
+
+    use gitbutler_branch::BranchCreateRequest;
+    use gitbutler_branch_actions as branch_actions;
+    use gitbutler_command_context::CommandContext;
+    use gitbutler_repo::RepositoryExt as _;
+    use gitbutler_testsupport::{paths, testing_repository::assert_tree_matches, TestProject};
+    use gitbutler_workspace::checkout_branch_trees;
+
+    #[test]
+    fn checkout_with_two_branches() {
+        let test_project = &TestProject::default();
+
+        let data_dir = paths::data_dir();
+        let projects = gitbutler_project::Controller::from_path(data_dir.path());
+
+        let project = projects
+            .add(test_project.path())
+            .expect("failed to add project");
+
+        branch_actions::set_base_branch(&project, &"refs/remotes/origin/master".parse().unwrap())
+            .unwrap();
+
+        let branch_1 =
+            branch_actions::create_virtual_branch(&project, &BranchCreateRequest::default())
+                .unwrap();
+
+        fs::write(test_project.path().join("foo.txt"), "content").unwrap();
+
+        branch_actions::create_commit(&project, branch_1, "commit one", None, false).unwrap();
+
+        let branch_2 =
+            branch_actions::create_virtual_branch(&project, &BranchCreateRequest::default())
+                .unwrap();
+
+        fs::write(test_project.path().join("bar.txt"), "content").unwrap();
+
+        branch_actions::create_commit(&project, branch_2, "commit two", None, false).unwrap();
+
+        let tree = test_project.local_repository.create_wd_tree().unwrap();
+
+        // Assert original state
+        assert_tree_matches(
+            &test_project.local_repository,
+            &tree,
+            &[("foo.txt", b"content"), ("bar.txt", b"content")],
+        );
+        assert_eq!(tree.len(), 2);
+
+        // Checkout an empty tree
+        {
+            let tree_oid = test_project
+                .local_repository
+                .treebuilder(None)
+                .unwrap()
+                .write()
+                .unwrap();
+            let tree = test_project.local_repository.find_tree(tree_oid).unwrap();
+            test_project
+                .local_repository
+                .checkout_tree_builder(&tree)
+                .force()
+                .remove_untracked()
+                .checkout()
+                .unwrap();
+        }
+
+        // Assert tree is indeed empty
+        {
+            let tree: git2::Tree = test_project.local_repository.create_wd_tree().unwrap();
+
+            // Tree should be empty
+            assert_eq!(
+                tree.len(),
+                0,
+                "Should be empty after checking out an empty tree"
+            );
+        }
+
+        let ctx = CommandContext::open(&project).unwrap();
+        let mut guard = project.exclusive_worktree_access();
+
+        checkout_branch_trees(&ctx, guard.write_permission()).unwrap();
+
+        let tree = test_project.local_repository.create_wd_tree().unwrap();
+
+        // Should be back to original state
+        assert_tree_matches(
+            &test_project.local_repository,
+            &tree,
+            &[("foo.txt", b"content"), ("bar.txt", b"content")],
+        );
+        assert_eq!(tree.len(), 2, "Should match original state");
+    }
+}


### PR DESCRIPTION
This allows us to further break up gitbutler-branch-actions