### PR TITLE
test conflict handling when commit reordering

### DIFF
--- a/crates/gitbutler-branch-actions/tests/fixtures/reorder.sh
+++ b/crates/gitbutler-branch-actions/tests/fixtures/reorder.sh
@@ -2,6 +2,16 @@
 set -eu -o pipefail
 CLI=${1:?The first argument is the GitButler CLI}
 
+function tick () {
+  if test -z "${tick+set}"; then
+    tick=1675176957
+  else
+    tick=$(($tick + 60))
+  fi
+  GIT_COMMITTER_DATE="$tick +0100"
+  GIT_AUTHOR_DATE="$tick +0100"
+  export GIT_COMMITTER_DATE GIT_AUTHOR_DATE
+}
 
 git init remote
 (cd remote
@@ -80,6 +90,7 @@ git clone remote multiple-commits-empty-top
 )
 
 git clone remote overlapping-commits
+tick
 (cd overlapping-commits
   git config user.name "Author"
   git config user.email "author@example.com"
@@ -94,6 +105,7 @@ git clone remote overlapping-commits
   $CLI branch create --set-default my_stack
   echo x > file
   $CLI branch commit my_stack -m "commit 1"
+  tick
   echo y > file
   $CLI branch commit my_stack -m "commit 2"
 

--- a/crates/gitbutler-branch-actions/tests/fixtures/reorder.sh
+++ b/crates/gitbutler-branch-actions/tests/fixtures/reorder.sh
@@ -5,7 +5,7 @@ CLI=${1:?The first argument is the GitButler CLI}
 
 git init remote
 (cd remote
-  echo first > file
+  echo a > file
   git add . && git commit -m "init"
 )
 
@@ -75,6 +75,27 @@ git clone remote multiple-commits-empty-top
   $CLI branch create --set-default my_stack
   echo change1 >> file
   $CLI branch commit my_stack -m "commit 1"
+
+  $CLI branch series my_stack -s "top-series"
+)
+
+git clone remote overlapping-commits
+(cd overlapping-commits
+  git config user.name "Author"
+  git config user.email "author@example.com"
+  
+  git branch existing-branch
+  $CLI project add --switch-to-workspace "$(git rev-parse --symbolic-full-name @{u})"
+
+  $CLI branch create --set-default other_stack
+  echo change0 >> other_file
+  $CLI branch commit other_stack -m "commit 0"
+
+  $CLI branch create --set-default my_stack
+  echo x > file
+  $CLI branch commit my_stack -m "commit 1"
+  echo y > file
+  $CLI branch commit my_stack -m "commit 2"
 
   $CLI branch series my_stack -s "top-series"
 )


### PR DESCRIPTION
Porting this test https://github.com/gitbutlerapp/gitbutler/blob/e627b95e7412df1b566e40ea33c8361fec3b2362/crates/gitbutler-branch-actions/src/reorder_commits.rs#L317 as an integration test exercising the currently used `reorder_stack` endpoint.

Resolves https://github.com/gitbutlerapp/gitbutler/issues/5503