### PR TITLE
UI smaller empty branch state

### DIFF
--- a/apps/desktop/src/lib/file/FileContextMenu.svelte
+++ b/apps/desktop/src/lib/file/FileContextMenu.svelte
@@ -164,7 +164,7 @@
 		padding: 4px 0;
 		border-radius: var(--radius-m);
 		overflow: hidden;
-		border: 1px solid var(--clr-border-2);
+		background-color: var(--clr-bg-2);
 		margin-top: 12px;
 	}
 </style>

--- a/apps/desktop/src/lib/stack/SeriesList.svelte
+++ b/apps/desktop/src/lib/stack/SeriesList.svelte
@@ -65,12 +65,11 @@
 					{#snippet overlay({ hovered, activated })}
 						<CardOverlay {hovered} {activated} label="Move here" />
 					{/snippet}
-					<EmptyStatePlaceholder bottomMargin={10}>
-						{#snippet title()}
-							This is an empty branch
-						{/snippet}
+					<EmptyStatePlaceholder bottomMargin={8} topBottomPadding={28}>
 						{#snippet caption()}
-							Create or drag and drop commits here
+							This is an empty branch.
+							<br />
+							Create or drag & drop commits here
 						{/snippet}
 					</EmptyStatePlaceholder>
 				</Dropzone>

--- a/packages/ui/src/lib/EmptyStatePlaceholder.svelte
+++ b/packages/ui/src/lib/EmptyStatePlaceholder.svelte
@@ -1,17 +1,17 @@
 <script lang="ts" module>
 	export interface Props {
+		title?: Snippet;
+		caption?: Snippet;
 		image?: string;
 		width?: number;
 		bottomMargin?: number;
 		topBottomPadding?: number;
 		leftRightPadding?: number;
-		title?: Snippet;
-		caption?: Snippet;
 	}
 </script>
 
 <script lang="ts">
-	import { pxToRem } from '@gitbutler/ui/utils/pxToRem';
+	import { pxToRem } from '$lib/utils/pxToRem';
 	import type { Snippet } from 'svelte';
 	const {
 		image,

--- a/packages/ui/src/lib/EmptyStatePlaceholder.svelte
+++ b/packages/ui/src/lib/EmptyStatePlaceholder.svelte
@@ -80,7 +80,7 @@
 	.empty-state__content {
 		display: flex;
 		flex-direction: column;
-		gap: 8px;
+		gap: 6px;
 	}
 
 	.empty-state__title {

--- a/packages/ui/src/stories/badge/Badge.stories.ts
+++ b/packages/ui/src/stories/badge/Badge.stories.ts
@@ -2,7 +2,7 @@ import DemoBadge from './DemoBadge.svelte';
 import type { Meta, StoryObj } from '@storybook/svelte';
 
 const meta = {
-	title: 'Elements / Badge',
+	title: 'Basic / Badge',
 	component: DemoBadge
 } satisfies Meta<DemoBadge>;
 

--- a/packages/ui/src/stories/fileIcon/FileIcon.stories.ts
+++ b/packages/ui/src/stories/fileIcon/FileIcon.stories.ts
@@ -2,7 +2,7 @@ import FileIcon from '$lib/file/FileIcon.svelte';
 import type { Meta, StoryObj } from '@storybook/svelte';
 
 const meta = {
-	title: 'Elements / File Icon',
+	title: 'Basic / File Icon',
 	component: FileIcon
 } satisfies Meta<FileIcon>;
 

--- a/packages/ui/src/stories/icon/AllIcon.stories.ts
+++ b/packages/ui/src/stories/icon/AllIcon.stories.ts
@@ -2,7 +2,7 @@ import allIcons from './AllIcons.svelte';
 import type { Meta, StoryObj } from '@storybook/svelte';
 
 const meta = {
-	title: 'Elements / Icon / All icons',
+	title: 'Basic / Icon / All icons',
 	component: allIcons
 } satisfies Meta<allIcons>;
 

--- a/packages/ui/src/stories/icon/Icon.stories.ts
+++ b/packages/ui/src/stories/icon/Icon.stories.ts
@@ -3,7 +3,7 @@ import iconsJson from '$lib/data/icons.json';
 import type { Meta, StoryObj } from '@storybook/svelte';
 
 const meta = {
-	title: 'Elements / Icon',
+	title: 'Basic / Icon',
 	component: Icon
 } satisfies Meta<Icon>;
 

--- a/packages/ui/src/stories/seriesLabelsRow/SeriesLabelsRow.stories.ts
+++ b/packages/ui/src/stories/seriesLabelsRow/SeriesLabelsRow.stories.ts
@@ -2,7 +2,7 @@ import DemoSeriesLabelsRow from './DemoSeriesLabelsRow.svelte';
 import type { Meta, StoryObj } from '@storybook/svelte';
 
 const meta = {
-	title: 'Labels / Series Labels Row',
+	title: 'Basic / Series Labels Row',
 	component: DemoSeriesLabelsRow
 } satisfies Meta<DemoSeriesLabelsRow>;
 

--- a/packages/ui/src/stories/spacer/Spacer.stories.ts
+++ b/packages/ui/src/stories/spacer/Spacer.stories.ts
@@ -2,7 +2,7 @@ import SpacerDemo from './SpacerDemo.svelte';
 import type { Meta, StoryObj } from '@storybook/svelte';
 
 const meta = {
-	title: 'Elements / Spacer',
+	title: 'Basic / Spacer',
 	component: SpacerDemo
 } satisfies Meta<SpacerDemo>;
 

--- a/packages/ui/src/stories/timeAgo/TimeAgo.stories.ts
+++ b/packages/ui/src/stories/timeAgo/TimeAgo.stories.ts
@@ -2,7 +2,7 @@ import DemoTimeAgo from './DemoTimeAgo.svelte';
 import type { Meta, StoryObj } from '@storybook/svelte';
 
 const meta = {
-	title: 'Elements / Time Ago',
+	title: 'Basic / Time Ago',
 	component: DemoTimeAgo,
 	argTypes: {
 		date: {


### PR DESCRIPTION
## ☕️ Reasoning

Made them a bit smaller, but we shouldn’t make them too small, as the drop zone needs to be large enough for dropping files.

Before:
<img width="446" alt="image" src="https://github.com/user-attachments/assets/da88657e-fc44-4198-b66d-d6a6c697096b">

After:
<img width="387" alt="image" src="https://github.com/user-attachments/assets/7b565329-6dd6-4d93-84ab-e9fdd83a2edb">


## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
