### PR TITLE
Fix: Series description field

### DIFF
--- a/apps/desktop/src/lib/branch/SeriesDescription.svelte
+++ b/apps/desktop/src/lib/branch/SeriesDescription.svelte
@@ -39,10 +39,6 @@
 		onkeydown={(e: KeyboardEvent & { currentTarget: EventTarget & HTMLTextAreaElement }) => {
 			if (e.key === 'Escape') {
 				textAreaEl?.blur();
-
-				if (e.currentTarget.value === '') {
-					onEmpty?.();
-				}
 			}
 		}}
 	/>

--- a/apps/desktop/src/lib/branch/SeriesDescription.svelte
+++ b/apps/desktop/src/lib/branch/SeriesDescription.svelte
@@ -26,7 +26,7 @@
 		{disabled}
 		flex="1"
 		fontSize={12}
-		placeholder="Series description"
+		placeholder="Branch description"
 		unstyled
 		padding={{ top: 0, right: 0, bottom: 0, left: 0 }}
 		onblur={(e: FocusEvent & { currentTarget: EventTarget & HTMLTextAreaElement }) => {


### PR DESCRIPTION
Oi, 'ere's a right proper pull request for ya! 

We’ve gone and made a couple of nifty tweaks to the series description, innit? First off, we’ve fixed it so that when ya hit the `Escape` key, it blurs the input, makin' it all nice and tidy. Then, we’ve updated the placeholder text to keep it all consistent-like, so it don’t look all muddled. 

Take a butcher's and let us know what ya reckon! Cheers!