### PR TITLE
Refactor CommandContext out of various stack functions

### DIFF
--- a/crates/gitbutler-branch-actions/src/commit.rs
+++ b/crates/gitbutler-branch-actions/src/commit.rs
@@ -2,7 +2,6 @@ use crate::author::Author;
 use anyhow::{anyhow, Result};
 use bstr::ByteSlice as _;
 use gitbutler_cherry_pick::ConflictedTreeKey;
-use gitbutler_command_context::CommandContext;
 use gitbutler_commit::commit_ext::CommitExt;
 use gitbutler_repo::rebase::ConflictEntries;
 use gitbutler_serde::BStringForFrontend;
@@ -53,7 +52,7 @@ pub struct VirtualBranchCommit {
 }
 
 pub(crate) fn commit_to_vbranch_commit(
-    ctx: &CommandContext,
+    repository: &git2::Repository,
     stack: &Stack,
     commit: &git2::Commit,
     is_integrated: bool,
@@ -71,8 +70,6 @@ pub(crate) fn commit_to_vbranch_commit(
             c
         })
         .collect::<Vec<_>>();
-
-    let repository = ctx.repository();
 
     let conflicted_files = if commit.is_conflicted() {
         let conflict_files_string = commit.tree()?;

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -424,7 +424,7 @@ pub fn list_virtual_branches_cached(
                         .and_then(|data| remote_commit_data.get(&data).copied());
 
                     commit_to_vbranch_commit(
-                        ctx,
+                        repo,
                         &branch,
                         commit,
                         is_integrated,

--- a/crates/gitbutler-branch-actions/tests/reorder.rs
+++ b/crates/gitbutler-branch-actions/tests/reorder.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use git2::Oid;
 use gitbutler_branch_actions::{list_virtual_branches, reorder_stack, SeriesOrder, StackOrder};
 use gitbutler_command_context::CommandContext;
-use gitbutler_stack::VirtualBranchesHandle;
+use gitbutler_stack::{stack_context::CommandContextExt as _, VirtualBranchesHandle};
 use gitbutler_testsupport::testing_repository::assert_commit_tree_matches;
 use itertools::Itertools;
 use tempfile::TempDir;
@@ -469,14 +469,15 @@ fn test_ctx(ctx: &CommandContext) -> Result<TestContext> {
     let stack = stacks.iter().find(|b| b.name == "my_stack").unwrap();
 
     let branches = stack.branches();
+    let stack_context = ctx.to_stack_context()?;
     let top_commits: HashMap<String, git2::Oid> = branches[1]
-        .commits(ctx, stack)?
+        .commits(&stack_context, stack)?
         .local_commits
         .iter()
         .map(|c| (c.message().unwrap().to_string(), c.id()))
         .collect();
     let bottom_commits: HashMap<String, git2::Oid> = branches[0]
-        .commits(ctx, stack)?
+        .commits(&stack_context, stack)?
         .local_commits
         .iter()
         .map(|c| (c.message().unwrap().to_string(), c.id()))

--- a/crates/gitbutler-stack/src/lib.rs
+++ b/crates/gitbutler-stack/src/lib.rs
@@ -2,6 +2,7 @@
 mod file_ownership;
 mod ownership;
 mod stack;
+pub mod stack_context;
 mod state;
 mod target;
 

--- a/crates/gitbutler-stack/src/stack_context.rs
+++ b/crates/gitbutler-stack/src/stack_context.rs
@@ -1,0 +1,35 @@
+use anyhow::Result;
+use gitbutler_command_context::CommandContext;
+
+use crate::{Target, VirtualBranchesHandle};
+
+pub struct StackContext<'repositroy> {
+    repository: &'repositroy git2::Repository,
+    target: Target,
+}
+
+impl<'repository> StackContext<'repository> {
+    pub fn repository(&self) -> &'repository git2::Repository {
+        self.repository
+    }
+
+    pub fn target(&self) -> &Target {
+        &self.target
+    }
+}
+
+pub trait CommandContextExt {
+    fn to_stack_context(&self) -> Result<StackContext>;
+}
+
+impl CommandContextExt for CommandContext {
+    fn to_stack_context(&self) -> Result<StackContext> {
+        let virtual_branch_state = VirtualBranchesHandle::new(self.project().gb_dir());
+        let default_target = virtual_branch_state.get_default_target()?;
+
+        Ok(StackContext {
+            repository: self.repository(),
+            target: default_target,
+        })
+    }
+}

--- a/crates/gitbutler-stack/tests/mod.rs
+++ b/crates/gitbutler-stack/tests/mod.rs
@@ -7,6 +7,7 @@ use gitbutler_commit::commit_ext::CommitExt;
 use gitbutler_reference::RemoteRefname;
 use gitbutler_repo::{LogUntil, RepositoryExt as _};
 use gitbutler_repo_actions::RepoActionsExt;
+use gitbutler_stack::stack_context::CommandContextExt;
 use gitbutler_stack::{CommitOrChangeId, StackBranch, VirtualBranchesHandle};
 use gitbutler_stack::{PatchReferenceUpdate, TargetUpdate};
 use itertools::Itertools;
@@ -640,7 +641,7 @@ fn list_series_default_head() -> Result<()> {
     assert_eq!(branches[0].name, "a-branch-2");
     assert_eq!(
         branches[0]
-            .commits(&ctx, &test_ctx.stack)?
+            .commits(&ctx.to_stack_context()?, &test_ctx.stack)?
             .local_commits
             .iter()
             .map(|c| c.id())
@@ -670,9 +671,11 @@ fn list_series_two_heads_same_commit() -> Result<()> {
     // the number of series matches the number of heads
     assert_eq!(branches.len(), test_ctx.stack.heads.len());
 
+    let stack_context = ctx.to_stack_context()?;
+
     assert_eq!(
         branches[0]
-            .commits(&ctx, &test_ctx.stack)?
+            .commits(&stack_context, &test_ctx.stack)?
             .local_commits
             .iter()
             .map(|c| c.id())
@@ -682,7 +685,7 @@ fn list_series_two_heads_same_commit() -> Result<()> {
     assert_eq!(branches[0].name, "head_before");
     assert_eq!(
         branches[1]
-            .commits(&ctx, &test_ctx.stack)?
+            .commits(&stack_context, &test_ctx.stack)?
             .local_commits
             .iter()
             .map(|c| c.id())
@@ -705,6 +708,9 @@ fn list_series_two_heads_different_commit() -> Result<()> {
         pr_number: Default::default(),
         archived: Default::default(),
     };
+
+    let stack_context = ctx.to_stack_context()?;
+
     // add `head_before` before the initial head
     let result = test_ctx.stack.add_series(&ctx, head_before, None);
     assert!(result.is_ok());
@@ -714,7 +720,7 @@ fn list_series_two_heads_different_commit() -> Result<()> {
     let mut expected_patches = test_ctx.commits.iter().map(|c| c.id()).collect_vec();
     assert_eq!(
         branches[0]
-            .commits(&ctx, &test_ctx.stack)?
+            .commits(&stack_context, &test_ctx.stack)?
             .local_commits
             .iter()
             .map(|c| c.id())
@@ -725,7 +731,7 @@ fn list_series_two_heads_different_commit() -> Result<()> {
     assert_eq!(expected_patches.len(), 2);
     assert_eq!(
         branches[1]
-            .commits(&ctx, &test_ctx.stack)?
+            .commits(&stack_context, &test_ctx.stack)?
             .local_commits
             .iter()
             .map(|c| c.id())


### PR DESCRIPTION
The rational behind this is as follows:

Passing the CommandContext around everywhere as kind of global "god" object, is a very heavy handed thing to do - and makes unit testing harder. As well as exposing a large amount of state everywhere. In the upstream integration logic, it is written without a command context, making it very easy to test. I've gone and removed the CommandContext for everywhere reasonably can in order to enable me to call the required methods from upstream_integration.

In general, we should try to avoid CommandContext where possible, in favor of smaller Contexts or by passing around the objects directly, where appropriate.