### PR TITLE
Fix stale checks results

### DIFF
--- a/apps/desktop/src/lib/stack/CurrentSeries.svelte
+++ b/apps/desktop/src/lib/stack/CurrentSeries.svelte
@@ -1,10 +1,5 @@
 <script lang="ts">
 	import { getColorFromBranchType } from '$lib/branch/stackingUtils';
-	import { getForge } from '$lib/forge/interface/forge';
-	import { createForgeChecksMonitorStore } from '$lib/forge/interface/forgeChecksMonitor';
-	import { getForgeListingService } from '$lib/forge/interface/forgeListingService';
-	import { createForgePrMonitorStore } from '$lib/forge/interface/forgePrMonitor';
-	import { getForgePrService } from '$lib/forge/interface/forgePrService';
 	import type { PatchSeries } from '$lib/vbranches/types';
 	import type { Snippet } from 'svelte';
 
@@ -14,31 +9,6 @@
 	}
 
 	const { currentSeries, children }: Props = $props();
-
-	// Setup PR Store and Monitor on a per-series basis
-	const forge = getForge();
-	const prService = getForgePrService();
-
-	// Pretty cumbersome way of getting the PR number, would be great if we can
-	// make it more concise somehow.
-	const hostedListingServiceStore = getForgeListingService();
-	const prStore = $derived($hostedListingServiceStore?.prs);
-	const prs = $derived(prStore ? $prStore : undefined);
-
-	const listedPr = $derived(prs?.find((pr) => pr.sourceBranch === currentSeries.name));
-	const prNumber = $derived(listedPr?.number);
-
-	const prMonitor = $derived(prNumber ? $prService?.prMonitor(prNumber) : undefined);
-	const pr = $derived(prMonitor?.pr);
-
-	const forgePrMonitorStore = createForgePrMonitorStore(undefined);
-	$effect(() => forgePrMonitorStore.set(prMonitor));
-
-	const checksMonitor = $derived(
-		$pr?.sourceBranch ? $forge?.checksMonitor($pr.sourceBranch) : undefined
-	);
-	const forgeChecksMonitorStore = createForgeChecksMonitorStore(undefined);
-	$effect(() => forgeChecksMonitorStore.set(checksMonitor));
 
 	const seriesType = currentSeries.patches[0] ? currentSeries.patches[0].status : 'local';
 </script>

--- a/apps/desktop/src/lib/stack/SeriesList.svelte
+++ b/apps/desktop/src/lib/stack/SeriesList.svelte
@@ -14,12 +14,14 @@
 	import { PatchSeries, type VirtualBranch } from '$lib/vbranches/types';
 	import { getContext } from '@gitbutler/shared/context';
 	import EmptyStatePlaceholder from '@gitbutler/ui/EmptyStatePlaceholder.svelte';
+	import type { Writable } from 'svelte/store';
 
 	interface Props {
 		branch: VirtualBranch;
+		lastPush: Writable<Date | undefined>;
 	}
 
-	const { branch }: Props = $props();
+	const { branch, lastPush }: Props = $props();
 
 	const branchController = getContext(BranchController);
 	const hasConflicts = $derived(
@@ -57,7 +59,7 @@
 		<SeriesDividerLine {currentSeries} />
 	{/if}
 	<CurrentSeries {currentSeries}>
-		<SeriesHeader {currentSeries} {isTopSeries} />
+		<SeriesHeader {currentSeries} {isTopSeries} {lastPush} />
 
 		{#if currentSeries.upstreamPatches.length === 0 && currentSeries.patches.length === 0}
 			<div class="branch-emptystate">

--- a/apps/desktop/src/lib/stack/Stack.svelte
+++ b/apps/desktop/src/lib/stack/Stack.svelte
@@ -24,7 +24,7 @@
 	import Spacer from '@gitbutler/ui/Spacer.svelte';
 	import lscache from 'lscache';
 	import { onMount } from 'svelte';
-	import type { Writable } from 'svelte/store';
+	import { writable, type Writable } from 'svelte/store';
 
 	const {
 		isLaneCollapsed,
@@ -40,6 +40,7 @@
 	const userSettings = getContextStoreBySymbol<Settings>(SETTINGS);
 	const defaultBranchWidthRem = persisted<number>(24, 'defaulBranchWidth' + project.id);
 	const laneWidthKey = 'laneWidth_';
+	const lastPush = writable<Date | undefined>();
 
 	let laneWidth: number | undefined = $state();
 
@@ -94,7 +95,7 @@
 		try {
 			await branchController.pushBranch(branch.id, branch.requiresForce);
 			$listingService?.refresh();
-			// TODO: Refresh prMonitor and checksMonitor upon push
+			lastPush.set(new Date());
 		} finally {
 			isPushingCommits = false;
 		}
@@ -189,7 +190,7 @@
 						{/if}
 						<Spacer dotted />
 						<div class="lane-branches">
-							<SeriesList {branch} />
+							<SeriesList {branch} {lastPush} />
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
- removes seemingly duplicated pr monitor and checks monitor
- adds writable that can trigger refetching checks and statuses