### PR TITLE
Ability to discard single lines

### DIFF
--- a/apps/desktop/src/lib/history/SnapshotCard.svelte
+++ b/apps/desktop/src/lib/history/SnapshotCard.svelte
@@ -132,6 +132,8 @@
 					text: `Move hunk to "${entry.details?.trailers.find((t) => t.key === 'name')?.value}"`,
 					icon: 'item-move'
 				};
+			case 'DiscardLines':
+				return { text: 'Discard lines', icon: 'item-cross' };
 			case 'DiscardHunk':
 				return { text: 'Discard hunk', icon: 'item-cross' };
 			case 'DiscardFile':

--- a/apps/desktop/src/lib/history/types.ts
+++ b/apps/desktop/src/lib/history/types.ts
@@ -16,6 +16,7 @@ export type Operation =
 	| 'GenericBranchUpdate'
 	| 'DeleteBranch'
 	| 'ApplyBranch'
+	| 'DiscardLines'
 	| 'DiscardHunk'
 	| 'DiscardFile'
 	| 'AmendCommit'

--- a/apps/desktop/src/lib/hunk/HunkDiff.svelte
+++ b/apps/desktop/src/lib/hunk/HunkDiff.svelte
@@ -17,6 +17,14 @@
 	import diff_match_patch from 'diff-match-patch';
 	import type { Writable } from 'svelte/store';
 
+	interface ContextMenuParams {
+		event: MouseEvent;
+		beforeLineNumber: number | undefined;
+		afterLineNumber: number | undefined;
+		hunk: Hunk;
+		subsection: ContentSection;
+	}
+
 	interface Props {
 		hunk: Hunk;
 		readonly: boolean;
@@ -32,17 +40,7 @@
 		draggingDisabled: boolean;
 		onclick: () => void;
 		handleSelected: (hunk: Hunk, isSelected: boolean) => void;
-		handleLineContextMenu: ({
-			event,
-			lineNumber,
-			hunk,
-			subsection
-		}: {
-			event: MouseEvent;
-			lineNumber: number;
-			hunk: Hunk;
-			subsection: ContentSection;
-		}) => void;
+		handleLineContextMenu: (params: ContextMenuParams) => void;
 	}
 
 	const {
@@ -420,13 +418,11 @@
 							class:diff-line-addition={row.type === SectionType.AddedLines}
 							class:is-last={row.isLast}
 							oncontextmenu={(event) => {
-								const lineNumber = (
-									row.beforeLineNumber ? row.beforeLineNumber : row.afterLineNumber
-								) as number;
 								handleLineContextMenu({
 									event,
 									hunk,
-									lineNumber,
+									beforeLineNumber: row.beforeLineNumber,
+									afterLineNumber: row.afterLineNumber,
 									subsection: subsections[0] as ContentSection
 								});
 							}}

--- a/apps/desktop/src/lib/hunk/HunkViewer.svelte
+++ b/apps/desktop/src/lib/hunk/HunkViewer.svelte
@@ -106,11 +106,12 @@
 				}}
 				subsections={section.subSections}
 				handleSelected={(hunk, isSelected) => onHunkSelected(hunk, isSelected)}
-				handleLineContextMenu={({ event, lineNumber, hunk, subsection }) => {
+				handleLineContextMenu={({ event, beforeLineNumber, afterLineNumber, hunk, subsection }) => {
 					contextMenu?.open(event, {
 						hunk,
 						section: subsection,
-						lineNumber: lineNumber
+						beforeLineNumber,
+						afterLineNumber
 					});
 				}}
 			/>

--- a/apps/desktop/src/lib/vbranches/branchController.ts
+++ b/apps/desktop/src/lib/vbranches/branchController.ts
@@ -330,6 +330,18 @@ export class BranchController {
 		}
 	}
 
+	async unapplyLines(hunk: Hunk, linesToUnapply: { old?: number; new?: number }[]) {
+		const ownership = `${hunk.filePath}:${hunk.id}-${hunk.hash}`;
+		const lines = {
+			[hunk.id]: linesToUnapply
+		};
+		try {
+			await invoke<void>('unapply_lines', { projectId: this.projectId, ownership, lines });
+		} catch (err) {
+			showError('Failed to unapply lines', err);
+		}
+	}
+
 	async unapplyHunk(hunk: Hunk) {
 		const ownership = `${hunk.filePath}:${hunk.id}-${hunk.hash}`;
 		try {

--- a/crates/gitbutler-branch-actions/src/hunk.rs
+++ b/crates/gitbutler-branch-actions/src/hunk.rs
@@ -10,7 +10,7 @@ use gitbutler_hunk_dependency::locks::HunkLock;
 use gitbutler_serde::BStringForFrontend;
 use itertools::Itertools;
 use md5::Digest;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 // this struct is a mapping to the view `Hunk` type in Typescript
 // found in src-tauri/src/routes/repo/[project_id]/types.ts
@@ -153,3 +153,13 @@ impl MTimeCache {
         mtime
     }
 }
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct VirtualBranchHunkRange {
+    /// The old line number, if any.
+    pub old: Option<u32>,
+    /// The new line number, if any.
+    pub new: Option<u32>,
+}
+
+pub type VirtualBranchHunkRangeMap = HashMap<String, Vec<VirtualBranchHunkRange>>;

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -10,9 +10,9 @@ pub use actions::{
     list_virtual_branches_cached, move_commit, move_commit_file, push_base_branch,
     push_virtual_branch, reorder_stack, reset_files, reset_virtual_branch,
     resolve_upstream_integration, save_and_unapply_virutal_branch, set_base_branch,
-    set_target_push_remote, squash, unapply_ownership, unapply_without_saving_virtual_branch,
-    undo_commit, update_branch_order, update_commit_message, update_virtual_branch,
-    upstream_integration_statuses,
+    set_target_push_remote, squash, unapply_lines, unapply_ownership,
+    unapply_without_saving_virtual_branch, undo_commit, update_branch_order, update_commit_message,
+    update_virtual_branch, upstream_integration_statuses,
 };
 
 mod r#virtual;
@@ -68,6 +68,7 @@ impl VirtualBranchesExt for gitbutler_project::Project {
 mod branch;
 mod commit;
 mod hunk;
+pub use hunk::{VirtualBranchHunkRange, VirtualBranchHunkRangeMap};
 
 pub use branch::{
     get_branch_listing_details, list_branches, Author, BranchListing, BranchListingDetails,

--- a/crates/gitbutler-branch-actions/tests/extra/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/extra/mod.rs
@@ -1050,6 +1050,7 @@ fn unapply_ownership_partial() -> Result<()> {
     internal::unapply_ownership(
         ctx,
         &"test.txt:2-6".parse().unwrap(),
+        None,
         guard.write_permission(),
     )
     .unwrap();

--- a/crates/gitbutler-diff/src/lib.rs
+++ b/crates/gitbutler-diff/src/lib.rs
@@ -2,7 +2,7 @@ mod diff;
 mod hunk;
 pub mod write;
 pub use diff::{
-    diff_files_into_hunks, hunks_by_filepath, reverse_hunk, trees, workdir, ChangeType,
-    DiffByPathMap, FileDiff, GitHunk,
+    diff_files_into_hunks, hunks_by_filepath, reverse_hunk, reverse_hunk_lines, trees, workdir,
+    ChangeType, DiffByPathMap, FileDiff, GitHunk,
 };
 pub use hunk::{Hunk, HunkHash};

--- a/crates/gitbutler-oplog/src/entry.rs
+++ b/crates/gitbutler-oplog/src/entry.rs
@@ -141,6 +141,7 @@ pub enum OperationKind {
     GenericBranchUpdate,
     DeleteBranch,
     ApplyBranch,
+    DiscardLines,
     DiscardHunk,
     DiscardFile,
     AmendCommit,

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -173,6 +173,7 @@ fn main() {
                     virtual_branches::commands::update_branch_order,
                     virtual_branches::commands::unapply_without_saving_virtual_branch,
                     virtual_branches::commands::save_and_unapply_virtual_branch,
+                    virtual_branches::commands::unapply_lines,
                     virtual_branches::commands::unapply_ownership,
                     virtual_branches::commands::reset_files,
                     virtual_branches::commands::push_virtual_branch,

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -7,7 +7,8 @@ pub mod commands {
     };
     use gitbutler_branch_actions::{
         BaseBranch, BranchListing, BranchListingDetails, BranchListingFilter, RemoteBranch,
-        RemoteBranchData, RemoteBranchFile, RemoteCommit, StackOrder, VirtualBranches,
+        RemoteBranchData, RemoteBranchFile, RemoteCommit, StackOrder, VirtualBranchHunkRangeMap,
+        VirtualBranches,
     };
     use gitbutler_command_context::CommandContext;
     use gitbutler_project as projects;
@@ -244,6 +245,21 @@ pub mod commands {
     ) -> Result<(), Error> {
         let project = projects.get(project_id)?;
         gitbutler_branch_actions::unapply_ownership(&project, &ownership)?;
+        emit_vbranches(&windows, project_id);
+        Ok(())
+    }
+
+    #[tauri::command(async)]
+    #[instrument(skip(projects, windows), err(Debug))]
+    pub fn unapply_lines(
+        windows: State<'_, WindowState>,
+        projects: State<'_, projects::Controller>,
+        project_id: ProjectId,
+        ownership: BranchOwnershipClaims,
+        lines: VirtualBranchHunkRangeMap,
+    ) -> Result<(), Error> {
+        let project = projects.get(project_id)?;
+        gitbutler_branch_actions::unapply_lines(&project, &ownership, lines)?;
         emit_vbranches(&windows, project_id);
         Ok(())
     }


### PR DESCRIPTION
## ☕️ Reasoning

This pull request adds the ability to discard single lines in the file hunk context menu. This feature allows users to selectively remove individual lines from the changes, providing more granular control over the commit process.

## 🧢 Changes

- Added a method to unapply ownership lines, enabling the determination of a subset of hunk lines to be discarded.
- Implemented the option to discard single lines in the file hunk context menu.