### PR TITLE
Address janky stacky

### DIFF
--- a/apps/desktop/src/lib/stack/SeriesList.svelte
+++ b/apps/desktop/src/lib/stack/SeriesList.svelte
@@ -53,41 +53,43 @@
 	}
 </script>
 
-{#each nonArchivedSeries as currentSeries, idx}
-	{@const isTopSeries = idx === 0}
-	{#if !isTopSeries}
-		<SeriesDividerLine {currentSeries} />
-	{/if}
-	<CurrentSeries {currentSeries}>
-		<SeriesHeader {currentSeries} {isTopSeries} {lastPush} />
+{#key nonArchivedSeries}
+	{#each nonArchivedSeries as currentSeries, idx (currentSeries.name)}
+		{@const isTopSeries = idx === 0}
+		{#if !isTopSeries}
+			<SeriesDividerLine {currentSeries} />
+		{/if}
+		<CurrentSeries {currentSeries}>
+			<SeriesHeader {currentSeries} {isTopSeries} {lastPush} />
 
-		{#if currentSeries.upstreamPatches.length === 0 && currentSeries.patches.length === 0}
-			<div class="branch-emptystate">
-				<Dropzone {accepts} ondrop={(data) => onDrop(data, nonArchivedSeries, currentSeries)}>
-					{#snippet overlay({ hovered, activated })}
-						<CardOverlay {hovered} {activated} label="Move here" />
-					{/snippet}
-					<EmptyStatePlaceholder bottomMargin={8} topBottomPadding={28}>
-						{#snippet caption()}
-							This is an empty branch.
-							<br />
-							Create or drag & drop commits here
+			{#if currentSeries.upstreamPatches.length === 0 && currentSeries.patches.length === 0}
+				<div class="branch-emptystate">
+					<Dropzone {accepts} ondrop={(data) => onDrop(data, nonArchivedSeries, currentSeries)}>
+						{#snippet overlay({ hovered, activated })}
+							<CardOverlay {hovered} {activated} label="Move here" />
 						{/snippet}
-					</EmptyStatePlaceholder>
-				</Dropzone>
-			</div>
-		{/if}
+						<EmptyStatePlaceholder bottomMargin={8} topBottomPadding={28}>
+							{#snippet caption()}
+								This is an empty branch.
+								<br />
+								Create or drag & drop commits here
+							{/snippet}
+						</EmptyStatePlaceholder>
+					</Dropzone>
+				</div>
+			{/if}
 
-		{#if currentSeries.upstreamPatches.length > 0 || currentSeries.patches.length > 0}
-			<CommitList
-				remoteOnlyPatches={currentSeries.upstreamPatches}
-				patches={currentSeries.patches}
-				seriesName={currentSeries.name}
-				isUnapplied={false}
-				isBottom={idx === branch.series.length - 1}
-				{stackingReorderDropzoneManager}
-				{hasConflicts}
-			/>
-		{/if}
-	</CurrentSeries>
-{/each}
+			{#if currentSeries.upstreamPatches.length > 0 || currentSeries.patches.length > 0}
+				<CommitList
+					remoteOnlyPatches={currentSeries.upstreamPatches}
+					patches={currentSeries.patches}
+					seriesName={currentSeries.name}
+					isUnapplied={false}
+					isBottom={idx === branch.series.length - 1}
+					{stackingReorderDropzoneManager}
+					{hasConflicts}
+				/>
+			{/if}
+		</CurrentSeries>
+	{/each}
+{/key}

--- a/apps/desktop/src/lib/stack/UncommittedChanges.svelte
+++ b/apps/desktop/src/lib/stack/UncommittedChanges.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	import { Project } from '$lib/backend/projects';
+	import Dropzones from '$lib/branch/Dropzones.svelte';
+	import CommitDialog from '$lib/commit/CommitDialog.svelte';
+	import BranchFiles from '$lib/file/BranchFiles.svelte';
+	import InfoMessage from '$lib/shared/InfoMessage.svelte';
+	import { VirtualBranch } from '$lib/vbranches/types';
+	import { getContext, getContextStore } from '@gitbutler/shared/context';
+	import type { Writable } from 'svelte/store';
+
+	interface Props {
+		commitBoxOpen: Writable<boolean>;
+	}
+
+	let { commitBoxOpen }: Props = $props();
+
+	const project = getContext(Project);
+	const branchStore = getContextStore(VirtualBranch);
+
+	const branch = $derived($branchStore);
+
+	let commitDialog = $state<ReturnType<typeof CommitDialog>>();
+</script>
+
+<div class="branch-card__files">
+	<Dropzones type="file">
+		<BranchFiles
+			isUnapplied={false}
+			files={branch.files}
+			showCheckboxes={$commitBoxOpen}
+			allowMultiple
+			commitDialogExpanded={commitBoxOpen}
+			focusCommitDialog={() => commitDialog?.focus()}
+		/>
+		{#if branch.conflicted}
+			<div class="card-notifications">
+				<InfoMessage filled outlined={false} style="error">
+					<svelte:fragment slot="title">
+						{#if branch.files.some((f) => f.conflicted)}
+							This virtual branch conflicts with upstream changes. Please resolve all conflicts and
+							commit before you can continue.
+						{:else}
+							Please commit your resolved conflicts to continue.
+						{/if}
+					</svelte:fragment>
+				</InfoMessage>
+			</div>
+		{/if}
+	</Dropzones>
+
+	<CommitDialog
+		bind:this={commitDialog}
+		projectId={project.id}
+		expanded={commitBoxOpen}
+		hasSectionsAfter={branch.commits.length > 0}
+	/>
+</div>
+
+<style>
+	.branch-card__files {
+		border-radius: 0 0 var(--radius-m) var(--radius-m) !important;
+		border: 1px solid var(--clr-border-2);
+		border-top-width: 0;
+		background: var(--clr-bg-1);
+
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+		height: 100%;
+	}
+
+	.card-notifications {
+		display: flex;
+		flex-direction: column;
+		padding: 12px;
+	}
+</style>


### PR DESCRIPTION
## ☕️ Reasoning

This pull request addresses the "janky stacky" issue, which refers to the problematic behavior of the stack component in the application.

## 🧢 Changes

The changes made in this pull request include:

1. Addressing the jank in the stack component by correctly re-rendering the file list component based on the state of the stack (e.g., has uncommitted files, has no commits, etc.).
2. Extracting the components for uncommitted stack files into a dedicated component to improve the overall code organization and maintainability.
3. Improving the series list component to re-render the entire list whenever it changes, in order to avoid the "janky layout shift" issue.

These changes should help improve the overall user experience and stability of the application.

### Before
<img height="400" alt="Screenshot 2024-11-13 at 11 48 32" src="https://github.com/user-attachments/assets/8995a152-ae27-4150-8c5b-5868a670538f">

Notice how both the commit input (old state) and the empty component (new state) is rendered together for a second

https://github.com/user-attachments/assets/b8ea6261-b505-4795-97ab-74832630c4e0

### After
https://github.com/user-attachments/assets/29aef958-43c0-4812-bc1d-854aa65b6123


