### PR TITLE
Improvement: Don't rerender blocks unnecessarily

### DIFF
--- a/apps/desktop/src/lib/dropzone/CardOverlay.svelte
+++ b/apps/desktop/src/lib/dropzone/CardOverlay.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { pxToRem } from '@gitbutler/ui/utils/pxToRem';
-	import { scale } from 'svelte/transition';
 
 	interface Props {
 		hovered: boolean;
@@ -24,7 +23,6 @@
 </script>
 
 <div
-	transition:scale={{ duration: 200, start: 0.9 }}
 	class="dropzone-target dropzone-wrapper"
 	class:activated
 	class:hovered

--- a/apps/desktop/src/lib/dropzone/Dropzone.svelte
+++ b/apps/desktop/src/lib/dropzone/Dropzone.svelte
@@ -7,7 +7,7 @@
 		fillHeight?: boolean;
 		accepts: (data: any) => boolean;
 		ondrop: (data: any) => Promise<void> | void;
-		overlay: Snippet<[{ hovered: boolean; activated: boolean }]>;
+		overlay?: Snippet<[{ hovered: boolean; activated: boolean }]>;
 		children?: Snippet;
 	}
 
@@ -55,7 +55,9 @@
 	class:fill-height={fillHeight}
 	class="dropzone-container"
 >
-	{@render overlay({ hovered, activated })}
+	{#if overlay}
+		{@render overlay({ hovered, activated })}
+	{/if}
 
 	{#if children}
 		{@render children()}

--- a/apps/desktop/src/lib/stack/SeriesList.svelte
+++ b/apps/desktop/src/lib/stack/SeriesList.svelte
@@ -53,43 +53,42 @@
 	}
 </script>
 
-{#key nonArchivedSeries}
-	{#each nonArchivedSeries as currentSeries, idx (currentSeries.name)}
-		{@const isTopSeries = idx === 0}
-		{#if !isTopSeries}
-			<SeriesDividerLine {currentSeries} />
-		{/if}
-		<CurrentSeries {currentSeries}>
-			<SeriesHeader {currentSeries} {isTopSeries} {lastPush} />
+{#each nonArchivedSeries as currentSeries, idx (currentSeries.name)}
+	{@const isTopSeries = idx === 0}
+	{#if !isTopSeries}
+		<SeriesDividerLine {currentSeries} />
+	{/if}
 
-			{#if currentSeries.upstreamPatches.length === 0 && currentSeries.patches.length === 0}
-				<div class="branch-emptystate">
-					<Dropzone {accepts} ondrop={(data) => onDrop(data, nonArchivedSeries, currentSeries)}>
-						{#snippet overlay({ hovered, activated })}
-							<CardOverlay {hovered} {activated} label="Move here" />
+	<CurrentSeries {currentSeries}>
+		<SeriesHeader {currentSeries} {isTopSeries} {lastPush} />
+
+		{#if currentSeries.upstreamPatches.length === 0 && currentSeries.patches.length === 0}
+			<div class="branch-emptystate">
+				<Dropzone {accepts} ondrop={(data) => onDrop(data, nonArchivedSeries, currentSeries)}>
+					{#snippet overlay({ hovered, activated })}
+						<CardOverlay {hovered} {activated} label="Move here" />
+					{/snippet}
+					<EmptyStatePlaceholder bottomMargin={8} topBottomPadding={28}>
+						{#snippet caption()}
+							This is an empty branch.
+							<br />
+							Create or drag & drop commits here
 						{/snippet}
-						<EmptyStatePlaceholder bottomMargin={8} topBottomPadding={28}>
-							{#snippet caption()}
-								This is an empty branch.
-								<br />
-								Create or drag & drop commits here
-							{/snippet}
-						</EmptyStatePlaceholder>
-					</Dropzone>
-				</div>
-			{/if}
+					</EmptyStatePlaceholder>
+				</Dropzone>
+			</div>
+		{/if}
 
-			{#if currentSeries.upstreamPatches.length > 0 || currentSeries.patches.length > 0}
-				<CommitList
-					remoteOnlyPatches={currentSeries.upstreamPatches}
-					patches={currentSeries.patches}
-					seriesName={currentSeries.name}
-					isUnapplied={false}
-					isBottom={idx === branch.series.length - 1}
-					{stackingReorderDropzoneManager}
-					{hasConflicts}
-				/>
-			{/if}
-		</CurrentSeries>
-	{/each}
-{/key}
+		{#if currentSeries.upstreamPatches.length > 0 || currentSeries.patches.length > 0}
+			<CommitList
+				remoteOnlyPatches={currentSeries.upstreamPatches}
+				patches={currentSeries.patches}
+				seriesName={currentSeries.name}
+				isUnapplied={false}
+				isBottom={idx === branch.series.length - 1}
+				{stackingReorderDropzoneManager}
+				{hasConflicts}
+			/>
+		{/if}
+	</CurrentSeries>
+{/each}

--- a/apps/desktop/src/lib/stack/Stack.svelte
+++ b/apps/desktop/src/lib/stack/Stack.svelte
@@ -129,34 +129,32 @@
 						}}
 					/>
 					<div class="card-stacking">
-						{#key branch}
-							{#if branchHasFiles}
-								<UncommittedChanges {commitBoxOpen} />
-							{:else if branchHasNoCommits}
-								<Dropzones type="file">
-									<div class="new-branch">
-										<EmptyStatePlaceholder image={laneNewSvg} width={180} bottomMargin={48}>
-											{#snippet title()}
-												This is a new lane
-											{/snippet}
-											{#snippet caption()}
-												You can drag and drop files<br />or parts of files here.
-											{/snippet}
-										</EmptyStatePlaceholder>
-									</div>
-								</Dropzones>
-							{:else}
-								<Dropzones type="file">
-									<div class="no-changes">
-										<EmptyStatePlaceholder image={noChangesSvg} width={180}>
-											{#snippet caption()}
-												No uncommitted<br />changes on this lane
-											{/snippet}
-										</EmptyStatePlaceholder>
-									</div>
-								</Dropzones>
-							{/if}
-						{/key}
+						{#if branchHasFiles}
+							<UncommittedChanges {commitBoxOpen} />
+						{:else if branchHasNoCommits}
+							<Dropzones type="file">
+								<div class="new-branch">
+									<EmptyStatePlaceholder image={laneNewSvg} width={180} bottomMargin={48}>
+										{#snippet title()}
+											This is a new lane
+										{/snippet}
+										{#snippet caption()}
+											You can drag and drop files<br />or parts of files here.
+										{/snippet}
+									</EmptyStatePlaceholder>
+								</div>
+							</Dropzones>
+						{:else}
+							<Dropzones type="file">
+								<div class="no-changes">
+									<EmptyStatePlaceholder image={noChangesSvg} width={180}>
+										{#snippet caption()}
+											No uncommitted<br />changes on this lane
+										{/snippet}
+									</EmptyStatePlaceholder>
+								</div>
+							</Dropzones>
+						{/if}
 						<Spacer dotted />
 						<div class="lane-branches">
 							<SeriesList {branch} {lastPush} />


### PR DESCRIPTION
> When a block (such as an {#if ...} block) is transitioning out, all elements inside it, including those that do not have their own transitions, are kept in the DOM until every transition in the block has been completed.

From the transition docs: https://svelte.dev/docs/svelte/transition

