### PR TITLE
fix: PR status polling

### DIFF
--- a/apps/desktop/src/lib/branch/SeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/SeriesHeader.svelte
@@ -96,9 +96,16 @@
 		}
 	});
 
+	async function handleReloadPR() {
+		await Promise.allSettled([
+			prMonitor?.refresh(),
+			checksMonitor?.update(),
+			$hostedListingServiceStore?.refresh()
+		]);
+	}
+
 	function updateStatusAndChecks() {
-		prMonitor?.refresh();
-		checksMonitor?.update();
+		handleReloadPR();
 	}
 
 	const projectService = getContext(ProjectService);
@@ -130,10 +137,6 @@
 		}
 	});
 
-	async function handleReloadPR() {
-		await Promise.allSettled([prMonitor?.refresh(), checksMonitor?.update()]);
-	}
-
 	function handleOpenPR(pushBeforeCreate: boolean = false) {
 		prDetailsModal?.show(pushBeforeCreate);
 	}
@@ -143,7 +146,7 @@
 			return;
 		}
 		await $prService?.reopen($pr?.number);
-		await Promise.allSettled([prMonitor?.refresh(), checksMonitor?.update()]);
+		await handleReloadPR();
 	}
 
 	function editTitle(title: string) {

--- a/apps/desktop/src/lib/pr/PrDetailsModal.svelte
+++ b/apps/desktop/src/lib/pr/PrDetailsModal.svelte
@@ -19,6 +19,7 @@
 	import { projectAiGenEnabled } from '$lib/config/config';
 	import { mapErrorToToast } from '$lib/forge/github/errorMap';
 	import { getForge } from '$lib/forge/interface/forge';
+	import { getForgeListingService } from '$lib/forge/interface/forgeListingService';
 	import { getForgePrService } from '$lib/forge/interface/forgePrService';
 	import { type DetailedPullRequest, type PullRequest } from '$lib/forge/interface/types';
 	import { updatePrDescriptionTables as updatePrStackInfo } from '$lib/forge/shared/prFooter';
@@ -74,6 +75,7 @@
 	const aiService = getContext(AIService);
 	const aiGenEnabled = projectAiGenEnabled(project.id);
 	const forge = getForge();
+	const forgeListingService = getForgeListingService();
 	const templateService = getContext(TemplateService);
 
 	const branch = $derived($branchStore);
@@ -234,6 +236,9 @@
 			if (priorIds.length > 0) {
 				updatePrStackInfo($prService, priorIds.concat([pr.number]));
 			}
+
+			// Refresh store
+			$forgeListingService?.refresh();
 		} catch (err: any) {
 			console.error(err);
 			const toast = mapErrorToToast(err);


### PR DESCRIPTION
- When creating or reopening a PR, refresh the listing service
- Poll for the mergeability status if it's `unknown`