### PR TITLE
Dependencies: Follow ups

### DIFF
--- a/crates/gitbutler-branch-actions/src/dependencies.rs
+++ b/crates/gitbutler-branch-actions/src/dependencies.rs
@@ -28,7 +28,7 @@ pub fn compute_workspace_dependencies(
     let mut stacks_input: Vec<InputStack> = vec![];
     for stack in stacks {
         let mut commits_input: Vec<InputCommit> = vec![];
-        // The commit id's must be ordered from order they get applied.
+        // The commit id's must be in the order they get applied (parents first).
         let commit_ids = repo
             .l(stack.head(), LogUntil::Commit(*target_sha), false)
             .context("failed to list commits")?

--- a/crates/gitbutler-hunk-dependency/src/lib.rs
+++ b/crates/gitbutler-hunk-dependency/src/lib.rs
@@ -8,7 +8,7 @@ pub(crate) mod workspace;
 
 pub use {
     hunk::HunkRange,
-    input::{InputCommit, InputDiff, InputFile, InputStack},
+    input::{parse_diff_from_string, InputCommit, InputDiff, InputFile, InputStack},
     locks::{calculate_hunk_dependencies, HunkDependencyOptions, HunkLock},
     path::PathRanges,
     stack::StackRanges,

--- a/crates/gitbutler-hunk-dependency/src/workspace.rs
+++ b/crates/gitbutler-hunk-dependency/src/workspace.rs
@@ -174,7 +174,7 @@ mod tests {
 
     use gitbutler_stack::StackId;
 
-    use crate::input::{InputDiff, InputFile};
+    use crate::{input::InputFile, parse_diff_from_string};
 
     use super::*;
 
@@ -444,7 +444,7 @@ mod tests {
                     commit_id: commit1_id,
                     files: vec![InputFile {
                         path: path.to_owned(),
-                        diffs: vec![InputDiff::try_from((
+                        diffs: vec![parse_diff_from_string(
                             "@@ -1,6 +1,7 @@
 1
 2
@@ -455,7 +455,7 @@ mod tests {
 7
 ",
                             gitbutler_diff::ChangeType::Modified,
-                        ))?],
+                        )?],
                     }],
                 }],
             },
@@ -466,7 +466,7 @@ mod tests {
                     files: vec![InputFile {
                         path: path.to_owned(),
                         diffs: vec![
-                            InputDiff::try_from((
+                            parse_diff_from_string(
                                 "@@ -1,5 +1,3 @@
 -1
 -2
@@ -475,8 +475,8 @@ mod tests {
 6
 ",
                                 gitbutler_diff::ChangeType::Modified,
-                            ))?,
-                            InputDiff::try_from((
+                            )?,
+                            parse_diff_from_string(
                                 "@@ -10,6 +8,7 @@
 10
 11
@@ -487,7 +487,7 @@ mod tests {
 16
 ",
                                 gitbutler_diff::ChangeType::Modified,
-                            ))?,
+                            )?,
                         ],
                     }],
                 }],

--- a/crates/gitbutler-hunk-dependency/tests/path.rs
+++ b/crates/gitbutler-hunk-dependency/tests/path.rs
@@ -1,9 +1,9 @@
-use gitbutler_hunk_dependency::{HunkRange, InputDiff, PathRanges};
+use gitbutler_hunk_dependency::{parse_diff_from_string, HunkRange, InputDiff, PathRanges};
 use gitbutler_stack::StackId;
 
 #[test]
 fn stack_simple() -> anyhow::Result<()> {
-    let diff = InputDiff::try_from((
+    let diff = parse_diff_from_string(
         "@@ -1,6 +1,7 @@
 1
 2
@@ -14,7 +14,7 @@ fn stack_simple() -> anyhow::Result<()> {
 7
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     let stack_ranges = &mut PathRanges::default();
     let stack_id = StackId::generate();
     let commit_id = git2::Oid::from_str("a")?;
@@ -29,7 +29,7 @@ fn stack_simple() -> anyhow::Result<()> {
 
 #[test]
 fn stack_simple_update() -> anyhow::Result<()> {
-    let diff = InputDiff::try_from((
+    let diff = parse_diff_from_string(
         "@@ -1,6 +1,6 @@
 1
 2
@@ -41,7 +41,7 @@ fn stack_simple_update() -> anyhow::Result<()> {
 7
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     let stack_ranges = &mut PathRanges::default();
     let stack_id = StackId::generate();
     let commit_id = git2::Oid::from_str("a")?;
@@ -57,7 +57,7 @@ fn stack_simple_update() -> anyhow::Result<()> {
 
 #[test]
 fn stack_delete_file() -> anyhow::Result<()> {
-    let diff_1 = InputDiff::try_from((
+    let diff_1 = parse_diff_from_string(
         "@@ -0,0 +1,7 @@
 +a
 +a
@@ -68,8 +68,8 @@ fn stack_delete_file() -> anyhow::Result<()> {
 +a
 ",
         gitbutler_diff::ChangeType::Added,
-    ))?;
-    let diff_2 = InputDiff::try_from((
+    )?;
+    let diff_2 = parse_diff_from_string(
         "@@ -1,7 +1,7 @@
 a
 a
@@ -81,8 +81,8 @@ a
 a
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
-    let diff_3 = InputDiff::try_from((
+    )?;
+    let diff_3 = parse_diff_from_string(
         "@@ -1,7 +0,0 @@
 -a
 -a
@@ -93,7 +93,7 @@ a
 -a
 ",
         gitbutler_diff::ChangeType::Deleted,
-    ))?;
+    )?;
     let stack_ranges = &mut PathRanges::default();
     let stack_id = StackId::generate();
     let commit_a_id = git2::Oid::from_str("a")?;
@@ -174,7 +174,7 @@ a
 
 #[test]
 fn stack_delete_and_recreate_file() -> anyhow::Result<()> {
-    let diff_1 = InputDiff::try_from((
+    let diff_1 = parse_diff_from_string(
         "@@ -0,0 +1,7 @@
 +a
 +a
@@ -185,8 +185,8 @@ fn stack_delete_and_recreate_file() -> anyhow::Result<()> {
 +a
 ",
         gitbutler_diff::ChangeType::Added,
-    ))?;
-    let diff_2 = InputDiff::try_from((
+    )?;
+    let diff_2 = parse_diff_from_string(
         "@@ -1,7 +1,7 @@
 a
 a
@@ -198,8 +198,8 @@ a
 a
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
-    let diff_3 = InputDiff::try_from((
+    )?;
+    let diff_3 = parse_diff_from_string(
         "@@ -1,7 +0,0 @@
 -a
 -a
@@ -210,8 +210,8 @@ a
 -a
 ",
         gitbutler_diff::ChangeType::Deleted,
-    ))?;
-    let diff_4 = InputDiff::try_from((
+    )?;
+    let diff_4 = parse_diff_from_string(
         "@@ -0,0 +1,5 @@
 +c
 +c
@@ -220,7 +220,7 @@ a
 +c
 ",
         gitbutler_diff::ChangeType::Added,
-    ))?;
+    )?;
     let stack_ranges = &mut PathRanges::default();
     let stack_id = StackId::generate();
     let commit_a_id = git2::Oid::from_str("a")?;
@@ -247,7 +247,7 @@ a
 
 #[test]
 fn uncommitted_file_deletion() -> anyhow::Result<()> {
-    let diff_1 = InputDiff::try_from((
+    let diff_1 = parse_diff_from_string(
         "@@ -1,0 +1,7 @@
 +a
 +a
@@ -258,7 +258,7 @@ fn uncommitted_file_deletion() -> anyhow::Result<()> {
 +a
 ",
         gitbutler_diff::ChangeType::Added,
-    ))?;
+    )?;
     let stack_ranges = &mut PathRanges::default();
     let stack_id = StackId::generate();
     let commit_id = git2::Oid::from_str("a")?;
@@ -274,7 +274,7 @@ fn uncommitted_file_deletion() -> anyhow::Result<()> {
 
 #[test]
 fn stack_overwrite_file() -> anyhow::Result<()> {
-    let diff_1 = InputDiff::try_from((
+    let diff_1 = parse_diff_from_string(
         "@@ -0,0 +1,7 @@
 +1
 +2
@@ -285,8 +285,8 @@ fn stack_overwrite_file() -> anyhow::Result<()> {
 +7
 ",
         gitbutler_diff::ChangeType::Added,
-    ))?;
-    let diff_2 = InputDiff::try_from((
+    )?;
+    let diff_2 = parse_diff_from_string(
         "@@ -1,7 +1,7 @@
 -1
 -2
@@ -304,7 +304,7 @@ fn stack_overwrite_file() -> anyhow::Result<()> {
 +g
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     let stack_ranges = &mut PathRanges::default();
     let stack_id = StackId::generate();
     let commit_a_id = git2::Oid::from_str("a")?;
@@ -322,7 +322,7 @@ fn stack_overwrite_file() -> anyhow::Result<()> {
 
 #[test]
 fn stack_overwrite_line() -> anyhow::Result<()> {
-    let diff_1 = InputDiff::try_from((
+    let diff_1 = parse_diff_from_string(
         "@@ -1,6 +1,7 @@
 1
 2
@@ -333,8 +333,8 @@ fn stack_overwrite_line() -> anyhow::Result<()> {
 7
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
-    let diff_2 = InputDiff::try_from((
+    )?;
+    let diff_2 = parse_diff_from_string(
         "@@ -1,7 +1,7 @@
 1
 2
@@ -346,7 +346,7 @@ fn stack_overwrite_line() -> anyhow::Result<()> {
 7
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     let stack_ranges = &mut PathRanges::default();
     let stack_id = StackId::generate();
     let commit_a_id = git2::Oid::from_str("a")?;
@@ -364,7 +364,7 @@ fn stack_overwrite_line() -> anyhow::Result<()> {
 
 #[test]
 fn stack_complex() -> anyhow::Result<()> {
-    let diff_1 = InputDiff::try_from((
+    let diff_1 = parse_diff_from_string(
         "@@ -1,6 +1,7 @@
 1
 2
@@ -375,8 +375,8 @@ fn stack_complex() -> anyhow::Result<()> {
 7
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
-    let diff_2 = InputDiff::try_from((
+    )?;
+    let diff_2 = parse_diff_from_string(
         "@@ -2,6 +2,7 @@
 2
 3
@@ -387,7 +387,7 @@ fn stack_complex() -> anyhow::Result<()> {
 7
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
 
     let stack_ranges = &mut PathRanges::default();
     let stack_id = StackId::generate();
@@ -412,7 +412,7 @@ fn stack_complex() -> anyhow::Result<()> {
 
 #[test]
 fn stack_basic_line_shift() -> anyhow::Result<()> {
-    let diff_1 = InputDiff::try_from((
+    let diff_1 = parse_diff_from_string(
         "@@ -1,4 +1,5 @@
 a
 +b
@@ -421,8 +421,8 @@ a
 a
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
-    let diff_2 = InputDiff::try_from((
+    )?;
+    let diff_2 = parse_diff_from_string(
         "@@ -1,3 +1,4 @@
 +c
 a
@@ -430,7 +430,7 @@ b
 a
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
 
     let stack_ranges = &mut PathRanges::default();
     let stack_id = StackId::generate();
@@ -490,7 +490,7 @@ fn stack_complex_line_shift() -> anyhow::Result<()> {
     let stack_id = StackId::generate();
 
     let commit1_id = git2::Oid::from_str("a")?;
-    let diff1 = InputDiff::try_from((
+    let diff1 = parse_diff_from_string(
         "@@ -1,4 +1,5 @@
 a
 +b
@@ -499,10 +499,10 @@ a
 a
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
 
     let commit2_id = git2::Oid::from_str("b")?;
-    let diff2 = InputDiff::try_from((
+    let diff2 = parse_diff_from_string(
         "@@ -1,3 +1,4 @@
 +c
 a
@@ -510,10 +510,10 @@ b
 a
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
 
     let commit3_id = git2::Oid::from_str("c")?;
-    let diff3 = InputDiff::try_from((
+    let diff3 = parse_diff_from_string(
         "@@ -1,4 +1,3 @@
 -c
 -a
@@ -522,10 +522,10 @@ b
 a
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
 
     let commit4_id = git2::Oid::from_str("d")?;
-    let diff4 = InputDiff::try_from((
+    let diff4 = parse_diff_from_string(
         "@@ -1,3 +1,5 @@
 b
 b
@@ -534,10 +534,10 @@ b
 a
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
 
     let commit5_id = git2::Oid::from_str("e")?;
-    let diff5 = InputDiff::try_from((
+    let diff5 = parse_diff_from_string(
         "@@ -1,5 +1,6 @@
 b
 -b
@@ -549,7 +549,7 @@ added
 a
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
 
     let commit6_id = git2::Oid::from_str("f")?;
     // Delete the first line
@@ -746,7 +746,7 @@ fn stack_multiple_overwrites() -> anyhow::Result<()> {
     let stack_id = StackId::generate();
 
     let commit1_id = git2::Oid::from_str("a")?;
-    let diff_1 = InputDiff::try_from((
+    let diff_1 = parse_diff_from_string(
         "@@ -0,0 +1,7 @@
 +a
 +a
@@ -757,11 +757,11 @@ fn stack_multiple_overwrites() -> anyhow::Result<()> {
 +a
 ",
         gitbutler_diff::ChangeType::Added,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit1_id, vec![diff_1])?;
 
     let commit2_id = git2::Oid::from_str("b")?;
-    let diff2 = InputDiff::try_from((
+    let diff2 = parse_diff_from_string(
         "@@ -1,5 +1,5 @@
 a
 -a
@@ -771,11 +771,11 @@ a
 a
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit2_id, vec![diff2])?;
 
     let commit3_id = git2::Oid::from_str("c")?;
-    let diff3 = InputDiff::try_from((
+    let diff3 = parse_diff_from_string(
         "@@ -1,7 +1,7 @@
 a
 b
@@ -787,11 +787,11 @@ a
 a
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit3_id, vec![diff3])?;
 
     let commit4_id = git2::Oid::from_str("d")?;
-    let diff4 = InputDiff::try_from((
+    let diff4 = parse_diff_from_string(
         "@@ -3,5 +3,5 @@
 a
 b
@@ -801,7 +801,7 @@ a
 a
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit4_id, vec![diff4])?;
 
     let result = stack_ranges.intersection(1, 1);
@@ -829,7 +829,7 @@ fn stack_detect_deletion() -> anyhow::Result<()> {
     let stack_id = StackId::generate();
 
     let commit1_id = git2::Oid::from_str("a")?;
-    let diff_1 = InputDiff::try_from((
+    let diff_1 = parse_diff_from_string(
         "@@ -1,7 +1,6 @@
 a
 a
@@ -840,7 +840,7 @@ a
 a
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit1_id, vec![diff_1])?;
 
     let result = stack_ranges.intersection(3, 2);
@@ -856,7 +856,7 @@ fn stack_offset_and_split() -> anyhow::Result<()> {
     let stack_id = StackId::generate();
 
     let commit1_id = git2::Oid::from_str("a")?;
-    let diff_1 = InputDiff::try_from((
+    let diff_1 = parse_diff_from_string(
         "@@ -10,6 +10,9 @@
 a
 a
@@ -869,11 +869,11 @@ a
 a
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit1_id, vec![diff_1])?;
 
     let commit2_id = git2::Oid::from_str("b")?;
-    let diff_2 = InputDiff::try_from((
+    let diff_2 = parse_diff_from_string(
         "@@ -1,6 +1,9 @@
 a
 a
@@ -886,11 +886,11 @@ a
 a
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit2_id, vec![diff_2])?;
 
     let commit3_id = git2::Oid::from_str("c")?;
-    let diff_3 = InputDiff::try_from((
+    let diff_3 = parse_diff_from_string(
         "@@ -14,7 +14,7 @@
 a
 a
@@ -902,7 +902,7 @@ a
 a
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit3_id, vec![diff_3])?;
 
     assert_eq!(stack_ranges.intersection(4, 3)[0].commit_id, commit2_id);
@@ -921,7 +921,7 @@ fn create_file_update_and_trim() -> anyhow::Result<()> {
     let stack_id = StackId::generate();
 
     let commit1_id = git2::Oid::from_str("a")?;
-    let diff_1 = InputDiff::try_from((
+    let diff_1 = parse_diff_from_string(
         "@@ -0,0 +1,9 @@
 +a
 +b
@@ -933,7 +933,7 @@ fn create_file_update_and_trim() -> anyhow::Result<()> {
 +h
 +i",
         gitbutler_diff::ChangeType::Added,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit1_id, vec![diff_1])?;
     let hunks = &stack_ranges.hunk_ranges;
     assert_eq!(
@@ -949,13 +949,13 @@ fn create_file_update_and_trim() -> anyhow::Result<()> {
     );
 
     let commit2_id = git2::Oid::from_str("b")?;
-    let diff_2 = InputDiff::try_from((
+    let diff_2 = parse_diff_from_string(
         "@@ -7,3 +7,0 @@
 -g
 -h
 -i",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit2_id, vec![diff_2])?;
     let hunks = &stack_ranges.hunk_ranges;
     assert_eq!(
@@ -971,12 +971,12 @@ fn create_file_update_and_trim() -> anyhow::Result<()> {
     );
 
     let commit3_id = git2::Oid::from_str("c")?;
-    let diff_3 = InputDiff::try_from((
+    let diff_3 = parse_diff_from_string(
         "@@ -1,1 +1,1 @@
 -a
 +1",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit3_id, vec![diff_3])?;
     let hunks = &stack_ranges.hunk_ranges;
     assert_eq!(
@@ -1010,7 +1010,7 @@ fn adding_line_splits_range() -> anyhow::Result<()> {
     let stack_id = StackId::generate();
 
     let commit1_id = git2::Oid::from_str("a")?;
-    let diff_1 = InputDiff::try_from((
+    let diff_1 = parse_diff_from_string(
         "@@ -2,2 +2,2 @@
 -1
 -1
@@ -1018,7 +1018,7 @@ fn adding_line_splits_range() -> anyhow::Result<()> {
 +c
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit1_id, vec![diff_1])?;
     let hunks = &stack_ranges.hunk_ranges;
     assert_eq!(
@@ -1034,12 +1034,12 @@ fn adding_line_splits_range() -> anyhow::Result<()> {
     );
 
     let commit2_id = git2::Oid::from_str("b")?;
-    let diff_2 = InputDiff::try_from((
+    let diff_2 = parse_diff_from_string(
         "@@ -2,0 +3,1 @@
 +b
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit2_id, vec![diff_2])?;
     let hunks = &stack_ranges.hunk_ranges;
     assert_eq!(
@@ -1081,7 +1081,7 @@ fn adding_line_before_shifts_range() -> anyhow::Result<()> {
     let stack_id = StackId::generate();
 
     let commit1_id = git2::Oid::from_str("a")?;
-    let diff_1 = InputDiff::try_from((
+    let diff_1 = parse_diff_from_string(
         "@@ -2,2 +2,2 @@
 -1
 -1
@@ -1089,7 +1089,7 @@ fn adding_line_before_shifts_range() -> anyhow::Result<()> {
 +c
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit1_id, vec![diff_1])?;
     let hunks = &stack_ranges.hunk_ranges;
     assert_eq!(
@@ -1105,12 +1105,12 @@ fn adding_line_before_shifts_range() -> anyhow::Result<()> {
     );
 
     let commit2_id = git2::Oid::from_str("b")?;
-    let diff_2 = InputDiff::try_from((
+    let diff_2 = parse_diff_from_string(
         "@@ -1,0 +2,1 @@
 +b
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit2_id, vec![diff_2])?;
     let hunks = &stack_ranges.hunk_ranges;
     assert_eq!(
@@ -1144,7 +1144,7 @@ fn adding_line_after_shifts_range() -> anyhow::Result<()> {
     let stack_id = StackId::generate();
 
     let commit1_id = git2::Oid::from_str("a")?;
-    let diff_1 = InputDiff::try_from((
+    let diff_1 = parse_diff_from_string(
         "@@ -2,2 +2,2 @@
 -1
 -1
@@ -1152,7 +1152,7 @@ fn adding_line_after_shifts_range() -> anyhow::Result<()> {
 +c
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit1_id, vec![diff_1])?;
     let hunks = &stack_ranges.hunk_ranges;
     assert_eq!(
@@ -1168,12 +1168,12 @@ fn adding_line_after_shifts_range() -> anyhow::Result<()> {
     );
 
     let commit2_id = git2::Oid::from_str("b")?;
-    let diff_2 = InputDiff::try_from((
+    let diff_2 = parse_diff_from_string(
         "@@ -3,0 +4,1 @@
 +b
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit2_id, vec![diff_2])?;
     let hunks = &stack_ranges.hunk_ranges;
     assert_eq!(
@@ -1207,7 +1207,7 @@ fn removing_line_updates_range() -> anyhow::Result<()> {
     let stack_id = StackId::generate();
 
     let commit1_id = git2::Oid::from_str("a")?;
-    let diff_1 = InputDiff::try_from((
+    let diff_1 = parse_diff_from_string(
         "@@ -2,2 +2,3 @@
 -1
 -1
@@ -1216,7 +1216,7 @@ fn removing_line_updates_range() -> anyhow::Result<()> {
 +c
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit1_id, vec![diff_1])?;
     let hunks = &stack_ranges.hunk_ranges;
     assert_eq!(
@@ -1232,12 +1232,12 @@ fn removing_line_updates_range() -> anyhow::Result<()> {
     );
 
     let commit2_id = git2::Oid::from_str("b")?;
-    let diff_2 = InputDiff::try_from((
+    let diff_2 = parse_diff_from_string(
         "@@ -3,1 +2,0 @@
 -b
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit2_id, vec![diff_2])?;
     let hunks = &stack_ranges.hunk_ranges;
     assert_eq!(
@@ -1261,7 +1261,7 @@ fn removing_line_before_shifts_range() -> anyhow::Result<()> {
     let stack_id = StackId::generate();
 
     let commit1_id = git2::Oid::from_str("a")?;
-    let diff_1 = InputDiff::try_from((
+    let diff_1 = parse_diff_from_string(
         "@@ -2,2 +2,3 @@
 -1
 -1
@@ -1270,7 +1270,7 @@ fn removing_line_before_shifts_range() -> anyhow::Result<()> {
 +c
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit1_id, vec![diff_1])?;
     let hunks = &stack_ranges.hunk_ranges;
     assert_eq!(
@@ -1286,12 +1286,12 @@ fn removing_line_before_shifts_range() -> anyhow::Result<()> {
     );
 
     let commit2_id = git2::Oid::from_str("b")?;
-    let diff_2 = InputDiff::try_from((
+    let diff_2 = parse_diff_from_string(
         "@@ -1,1 +1,0 @@
 -start
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit2_id, vec![diff_2])?;
     let hunks = &stack_ranges.hunk_ranges;
     assert_eq!(
@@ -1315,7 +1315,7 @@ fn removing_line_after_is_ignored() -> anyhow::Result<()> {
     let stack_id = StackId::generate();
 
     let commit1_id = git2::Oid::from_str("a")?;
-    let diff_1 = InputDiff::try_from((
+    let diff_1 = parse_diff_from_string(
         "@@ -2,2 +2,3 @@
 -1
 -1
@@ -1324,7 +1324,7 @@ fn removing_line_after_is_ignored() -> anyhow::Result<()> {
 +c
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit1_id, vec![diff_1])?;
     let hunks = &stack_ranges.hunk_ranges;
     assert_eq!(
@@ -1340,12 +1340,12 @@ fn removing_line_after_is_ignored() -> anyhow::Result<()> {
     );
 
     let commit2_id = git2::Oid::from_str("b")?;
-    let diff_2 = InputDiff::try_from((
+    let diff_2 = parse_diff_from_string(
         "@@ -5,1 +4,0 @@
 -end
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit2_id, vec![diff_2])?;
     let hunks = &stack_ranges.hunk_ranges;
     assert_eq!(
@@ -1369,7 +1369,7 @@ fn shift_is_correct_after_multiple_changes() -> anyhow::Result<()> {
     let stack_id = StackId::generate();
 
     let commit1_id = git2::Oid::from_str("a")?;
-    let diff_1 = InputDiff::try_from((
+    let diff_1 = parse_diff_from_string(
         "@@ -0,0 +1,10 @@
 +1
 +2
@@ -1383,7 +1383,7 @@ fn shift_is_correct_after_multiple_changes() -> anyhow::Result<()> {
 +10
 ",
         gitbutler_diff::ChangeType::Added,
-    ))?;
+    )?;
     stack_ranges.add(stack_id, commit1_id, vec![diff_1])?;
     let hunks = &stack_ranges.hunk_ranges;
     assert_eq!(
@@ -1399,7 +1399,7 @@ fn shift_is_correct_after_multiple_changes() -> anyhow::Result<()> {
     );
 
     let commit2_id = git2::Oid::from_str("b")?;
-    let diff_2 = InputDiff::try_from((
+    let diff_2 = parse_diff_from_string(
         "@@ -3,1 +3,4 @@
 -3
 + update 3
@@ -1408,32 +1408,32 @@ fn shift_is_correct_after_multiple_changes() -> anyhow::Result<()> {
 + add line 4
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
 
-    let diff_3 = InputDiff::try_from((
+    let diff_3 = parse_diff_from_string(
         "@@ -5,1 +7,0 @@
 -5
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
 
-    let diff_4 = InputDiff::try_from((
+    let diff_4 = parse_diff_from_string(
         "@@ -7,1 +9,2 @@
 -7
 + update 7
 + add line
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
 
-    let diff_5 = InputDiff::try_from((
+    let diff_5 = parse_diff_from_string(
         "@@ -11,0 +14,3 @@
 + added
 + lines
 + at the bottom
 ",
         gitbutler_diff::ChangeType::Modified,
-    ))?;
+    )?;
 
     stack_ranges.add(stack_id, commit2_id, vec![diff_2, diff_3, diff_4, diff_5])?;
     let hunks = &stack_ranges.hunk_ranges;


### PR DESCRIPTION
- Update the comment that explain the ordering the commits need to be in.
- Remove the 'TryFrom' implementation in favor of the string parser function