### PR TITLE
Use user profile image instead of gravatar when available

### DIFF
--- a/apps/desktop/src/lib/commit/CommitCard.svelte
+++ b/apps/desktop/src/lib/commit/CommitCard.svelte
@@ -9,6 +9,7 @@
 	import { DraggableCommit, nonDraggable } from '$lib/dragging/draggables';
 	import BranchFilesList from '$lib/file/BranchFilesList.svelte';
 	import { ModeService } from '$lib/modes/service';
+	import { UserService } from '$lib/stores/user';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { openExternalUrl } from '$lib/utils/url';
 	import { BranchController } from '$lib/vbranches/branchController';
@@ -30,6 +31,9 @@
 	import PopoverActionsItem from '@gitbutler/ui/popoverActions/PopoverActionsItem.svelte';
 	import { getTimeAgo } from '@gitbutler/ui/utils/timeAgo';
 	import { type Snippet } from 'svelte';
+
+	const userService = getContext(UserService);
+	const user = userService.user;
 
 	interface Props {
 		branch?: VirtualBranch | undefined;
@@ -133,6 +137,10 @@
 	}
 
 	const commitShortSha = commit.id.substring(0, 7);
+	const authorImgUrl =
+		commit.author.email?.toLowerCase() === $user?.email?.toLowerCase()
+			? $user?.picture
+			: commit.author.gravatarUrl;
 
 	function handleUncommit(e: MouseEvent) {
 		e.stopPropagation();
@@ -242,7 +250,7 @@
 				label: commit.descriptionTitle,
 				sha: commitShortSha,
 				date: getTimeAgo(commit.createdAt),
-				authorImgUrl: commit.author.gravatarUrl,
+				authorImgUrl: authorImgUrl,
 				commitType: type,
 				data: new DraggableCommit(commit.branchId, commit, isHeadCommit, seriesName),
 				viewportId: 'board-viewport'
@@ -313,7 +321,7 @@
 					{/if}
 
 					<Tooltip text={commit.author.name}>
-						<img class="commit__subtitle-avatar" src={commit.author.gravatarUrl} alt="" />
+						<img class="commit__subtitle-avatar" src={authorImgUrl} alt="" />
 					</Tooltip>
 
 					<span class="commit__subtitle-divider">•</span>

--- a/apps/desktop/src/lib/commit/CommitCard.svelte
+++ b/apps/desktop/src/lib/commit/CommitCard.svelte
@@ -137,10 +137,11 @@
 	}
 
 	const commitShortSha = commit.id.substring(0, 7);
-	const authorImgUrl =
-		commit.author.email?.toLowerCase() === $user?.email?.toLowerCase()
+	const authorImgUrl = $derived.by(() => {
+		return commit.author.email?.toLowerCase() === $user?.email?.toLowerCase()
 			? $user?.picture
 			: commit.author.gravatarUrl;
+	});
 
 	function handleUncommit(e: MouseEvent) {
 		e.stopPropagation();

--- a/apps/desktop/src/lib/components/EditMode.svelte
+++ b/apps/desktop/src/lib/components/EditMode.svelte
@@ -42,7 +42,14 @@
 
 	let initialFiles = $state<[RemoteFile, ConflictEntryPresence | undefined][]>([]);
 	let commit = $state<Commit | undefined>(undefined);
-	let authorImgUrl = $state<string | undefined>(undefined);
+	const authorImgUrl = $derived.by(() => {
+		if (commit) {
+			return commit.author.email?.toLowerCase() === $user?.email?.toLowerCase()
+				? $user?.picture
+				: commit.author.gravatarUrl;
+		}
+		return undefined;
+	});
 
 	let filesList = $state<HTMLDivElement | undefined>(undefined);
 	let contextMenu = $state<ReturnType<typeof FileContextMenu> | undefined>(undefined);
@@ -57,15 +64,6 @@
 		remoteCommitService.find(editModeMetadata.commitOid).then((maybeCommit) => {
 			commit = maybeCommit;
 		});
-	});
-
-	$effect(() => {
-		if (commit) {
-			authorImgUrl =
-				commit.author.email?.toLowerCase() === $user?.email?.toLowerCase()
-					? $user?.picture
-					: commit.author.gravatarUrl;
-		}
 	});
 
 	interface FileEntry {

--- a/apps/desktop/src/lib/components/EditMode.svelte
+++ b/apps/desktop/src/lib/components/EditMode.svelte
@@ -6,6 +6,7 @@
 	import { ModeService, type EditModeMetadata } from '$lib/modes/service';
 	import ScrollableContainer from '$lib/scroll/ScrollableContainer.svelte';
 	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
+	import { UserService } from '$lib/stores/user';
 	import { UncommitedFilesWatcher } from '$lib/uncommitedFiles/watcher';
 	import { getEditorUri, openExternalUrl } from '$lib/utils/url';
 	import { Commit, type RemoteFile } from '$lib/vbranches/types';
@@ -33,11 +34,15 @@
 
 	const uncommitedFiles = uncommitedFileWatcher.uncommitedFiles;
 
+	const userService = getContext(UserService);
+	const user = userService.user;
+
 	let modeServiceAborting = $state<'inert' | 'loading' | 'completed'>('inert');
 	let modeServiceSaving = $state<'inert' | 'loading' | 'completed'>('inert');
 
 	let initialFiles = $state<[RemoteFile, ConflictEntryPresence | undefined][]>([]);
 	let commit = $state<Commit | undefined>(undefined);
+	let authorImgUrl = $state<string | undefined>(undefined);
 
 	let filesList = $state<HTMLDivElement | undefined>(undefined);
 	let contextMenu = $state<ReturnType<typeof FileContextMenu> | undefined>(undefined);
@@ -52,6 +57,15 @@
 		remoteCommitService.find(editModeMetadata.commitOid).then((maybeCommit) => {
 			commit = maybeCommit;
 		});
+	});
+
+	$effect(() => {
+		if (commit) {
+			authorImgUrl =
+				commit.author.email?.toLowerCase() === $user?.email?.toLowerCase()
+					? $user?.picture
+					: commit.author.gravatarUrl;
+		}
 	});
 
 	interface FileEntry {
@@ -191,8 +205,8 @@
 
 			{#if commit}
 				<div class="text-11 commit-card__details">
-					{#if commit.author.gravatarUrl && commit.author.email}
-						<Avatar srcUrl={commit.author.gravatarUrl} tooltip={commit.author.email} />
+					{#if authorImgUrl && commit.author.email}
+						<Avatar srcUrl={authorImgUrl} tooltip={commit.author.email} />
 						<span class="commit-card__divider">•</span>
 					{/if}
 					<span class="">{editModeMetadata.commitOid.slice(0, 7)}</span>

--- a/apps/desktop/src/lib/navigation/BranchListingSidebarEntry.svelte
+++ b/apps/desktop/src/lib/navigation/BranchListingSidebarEntry.svelte
@@ -96,7 +96,10 @@
 		if (ownedByUser) {
 			const name = (await gitConfigService.get('user.name')) || unknownName;
 			const email = (await gitConfigService.get('user.email')) || unknownEmail;
-			const srcUrl = $user?.picture ? $user?.picture : await gravatarUrlFromEmail(email);
+			const srcUrl =
+				email.toLowerCase() === $user?.email?.toLowerCase()
+					? $user?.picture
+					: await gravatarUrlFromEmail(email);
 
 			avatars = [{ name, srcUrl }];
 		} else if (branchListingDetails) {

--- a/apps/desktop/src/lib/navigation/PullRequestSidebarEntry.svelte
+++ b/apps/desktop/src/lib/navigation/PullRequestSidebarEntry.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Project } from '$lib/backend/projects';
+	import { UserService } from '$lib/stores/user';
 	import { getContext } from '@gitbutler/shared/context';
 	import SidebarEntry from '@gitbutler/ui/SidebarEntry.svelte';
 	import AvatarGroup from '@gitbutler/ui/avatar/AvatarGroup.svelte';
@@ -14,6 +15,14 @@
 	const { pullRequest }: Props = $props();
 
 	const project = getContext(Project);
+
+	const userService = getContext(UserService);
+	const user = userService.user;
+
+	const authorImgUrl =
+		pullRequest.author?.email?.toLowerCase() === $user?.email?.toLowerCase()
+			? $user?.picture
+			: pullRequest.author?.gravatarUrl;
 
 	function onMouseDown() {
 		goto(formatPullRequestURL(project, pullRequest.number));
@@ -45,12 +54,12 @@
 	{selected}
 >
 	{#snippet authorAvatars()}
-		{#if pullRequest.author?.gravatarUrl}
+		{#if authorImgUrl}
 			<AvatarGroup
 				avatars={[
 					{
-						srcUrl: pullRequest.author.gravatarUrl,
-						name: pullRequest.author.name || 'unknown'
+						srcUrl: authorImgUrl,
+						name: pullRequest.author?.name || 'unknown'
 					}
 				]}
 			/>

--- a/apps/desktop/src/lib/navigation/PullRequestSidebarEntry.svelte
+++ b/apps/desktop/src/lib/navigation/PullRequestSidebarEntry.svelte
@@ -19,10 +19,11 @@
 	const userService = getContext(UserService);
 	const user = userService.user;
 
-	const authorImgUrl =
-		pullRequest.author?.email?.toLowerCase() === $user?.email?.toLowerCase()
+	const authorImgUrl = $derived.by(() => {
+		return pullRequest.author?.email?.toLowerCase() === $user?.email?.toLowerCase()
 			? $user?.picture
 			: pullRequest.author?.gravatarUrl;
+	});
 
 	function onMouseDown() {
 		goto(formatPullRequestURL(project, pullRequest.number));


### PR DESCRIPTION
## ☕️ Reasoning

Users wanted to see their GitButler profile image instead of the gravatar one when they've suppled one

## 🧢 Changes

Updated locations where gravatarUrl were referenced for various git artifacts to check the users email, and if it's a match, then use the users profile

## 🎫 Affected issues

Fixes: #2589

**NOTE:** I've never worked with this tech stack, but am trying to learn... and really want to contribute to GitButler, so starting small.

If I've completely missed the mark on how to implement this change, please let me know and I'll do some more learning 😅