### PR TITLE
Ability to reset to remote commit

### DIFF
--- a/apps/desktop/src/lib/commit/CommitAction.svelte
+++ b/apps/desktop/src/lib/commit/CommitAction.svelte
@@ -12,7 +12,7 @@
 	const { type, isLast, action }: Props = $props();
 </script>
 
-<div class="action-row" style:--commit-color={getColorFromBranchType(type)}>
+<div class="action-row" class:is-last={isLast} style:--commit-color={getColorFromBranchType(type)}>
 	<div class="commit-line-wrapper">
 		<div class="commit-line" class:dashed={isLast}></div>
 	</div>
@@ -29,10 +29,11 @@
 		background-color: var(--clr-bg-1);
 		border-top: 1px solid var(--clr-border-3);
 		overflow: hidden;
-	}
 
-	.background-color {
-		background-color: var(--clr-bg-2);
+		&.is-last {
+			border-bottom: 1px solid var(--clr-border-3);
+			border-radius: 0 0 var(--radius-m) var(--radius-m);
+		}
 	}
 
 	.action {
@@ -48,23 +49,5 @@
 		position: relative;
 		margin-left: 20px;
 		margin-right: 20px;
-	}
-
-	/* MODIFIERS */
-	.bottom-border {
-		border-bottom: 1px solid var(--clr-border-2);
-	}
-
-	.sticky {
-		position: sticky;
-		bottom: 0;
-	}
-
-	.sticky-z-index {
-		z-index: var(--z-lifted);
-	}
-
-	.not-in-viewport {
-		box-shadow: 0 0 0 1px var(--clr-border-2);
 	}
 </style>

--- a/apps/desktop/src/lib/commit/CommitAction.svelte
+++ b/apps/desktop/src/lib/commit/CommitAction.svelte
@@ -1,43 +1,22 @@
 <script lang="ts">
-	import { intersectionObserver } from '$lib/utils/intersectionObserver';
+	import { getColorFromBranchType } from '@gitbutler/ui/utils/getColorFromBranchType';
 	import { type Snippet } from 'svelte';
+	import type { CellType } from '@gitbutler/ui/commitLines/types';
 
 	interface Props {
-		bottomBorder?: boolean;
-		backgroundColor?: boolean;
-		lines: Snippet;
+		type: CellType;
+		isLast?: boolean;
 		action: Snippet;
 	}
 
-	const { bottomBorder = true, backgroundColor = true, lines, action }: Props = $props();
-
-	let isNotInViewport = $state(false);
+	const { type, isLast, action }: Props = $props();
 </script>
 
-<div
-	class="action-row sticky"
-	class:not-in-viewport={!isNotInViewport}
-	class:sticky-z-index={!isNotInViewport}
-	class:bottom-border={bottomBorder}
-	class:background-color={backgroundColor}
-	use:intersectionObserver={{
-		callback: (entry) => {
-			if (entry?.isIntersecting) {
-				isNotInViewport = false;
-			} else {
-				isNotInViewport = true;
-			}
-		},
-		options: {
-			root: null,
-			rootMargin: `-100% 0px 0px 0px`,
-			threshold: 0
-		}
-	}}
->
-	<div>
-		{@render lines()}
+<div class="action-row" style:--commit-color={getColorFromBranchType(type)}>
+	<div class="commit-line-wrapper">
+		<div class="commit-line" class:dashed={isLast}></div>
 	</div>
+
 	<div class="action">
 		{@render action()}
 	</div>
@@ -47,10 +26,9 @@
 	.action-row {
 		position: relative;
 		display: flex;
-
+		background-color: var(--clr-bg-1);
+		border-top: 1px solid var(--clr-border-3);
 		overflow: hidden;
-
-		transition: border-top var(--transition-fast);
 	}
 
 	.background-color {
@@ -61,9 +39,15 @@
 		display: flex;
 		flex-direction: column;
 		width: 100%;
-		padding-top: 10px;
+		padding-top: 14px;
 		padding-right: 14px;
-		padding-bottom: 10px;
+		padding-bottom: 14px;
+	}
+
+	.commit-line-wrapper {
+		position: relative;
+		margin-left: 20px;
+		margin-right: 20px;
 	}
 
 	/* MODIFIERS */

--- a/apps/desktop/src/lib/commit/CommitCard.svelte
+++ b/apps/desktop/src/lib/commit/CommitCard.svelte
@@ -609,6 +609,7 @@
 		flex-direction: column;
 		gap: 12px;
 		padding-bottom: 12px;
+		padding-right: 14px;
 	}
 
 	.commit__actions {

--- a/apps/desktop/src/lib/commit/CommitCard.svelte
+++ b/apps/desktop/src/lib/commit/CommitCard.svelte
@@ -42,6 +42,7 @@
 		isHeadCommit?: boolean;
 		isUnapplied?: boolean;
 		last?: boolean;
+		noBorder?: boolean;
 		type: CommitStatus;
 		lines?: Snippet | undefined;
 		filesToggleable?: boolean;
@@ -56,6 +57,7 @@
 		isHeadCommit = false,
 		isUnapplied = false,
 		last = false,
+		noBorder = false,
 		type,
 		lines = undefined,
 		filesToggleable = true,
@@ -234,6 +236,7 @@
 	class:not-draggable={!isDraggable}
 	class:commit-card-activated={isOpenedByKebabButton || isOpenByMouse}
 	class:is-last={last}
+	class:no-border={last || noBorder}
 	onclick={(e) => {
 		e.preventDefault();
 		toggleFiles();
@@ -279,7 +282,7 @@
 		</PopoverActionsContainer>
 	{/if}
 
-	<div class="commit-card" class:is-last={last}>
+	<div class="commit-card" class:is-last={last} class:no-border={last || noBorder}>
 		<!-- GENERAL INFO -->
 		<div bind:this={draggableCommitElement} class="commit__header" role="button" tabindex="-1">
 			{#if !disableCommitActions}
@@ -465,7 +468,7 @@
 			}
 		}
 
-		&:not(.is-last) {
+		&:not(.no-border) {
 			border-bottom: 1px solid var(--clr-border-2);
 		}
 

--- a/apps/desktop/src/lib/commit/CommitList.svelte
+++ b/apps/desktop/src/lib/commit/CommitList.svelte
@@ -28,12 +28,18 @@
 			label: 'Integrate upstream',
 			stretegy: undefined,
 			style: 'warning',
+			kind: 'solid',
+			outline: false,
+			icon: undefined,
 			action: integrate
 		},
 		reset: {
 			label: 'Reset to remote…',
 			stretegy: 'hardreset',
 			style: 'error',
+			outline: true,
+			kind: 'soft',
+			icon: 'warning-small',
 			action: confirmReset
 		}
 	} as const;
@@ -81,10 +87,6 @@
 	const hasRemoteCommits = $derived(remoteOnlyPatches.length > 0);
 	let isIntegratingCommits = $state(false);
 
-	// const topPatch = $derived(patches[0]);
-	// const branchType = $derived<CommitStatus>(topPatch?.status ?? 'local');
-	// const isBranchIntegrated = $derived(branchType === 'integrated');
-
 	let confirmResetModal = $state<ReturnType<typeof Modal>>();
 
 	async function integrate(strategy?: SeriesIntegrationStrategy): Promise<void> {
@@ -112,8 +114,17 @@
 {/snippet}
 
 {#snippet integrateUpstreamButton(strategy: IntegrationStrategy)}
-	{@const { label, style, action } = integrationStrategies[strategy]}
-	<Button {style} kind="solid" grow loading={isIntegratingCommits} onclick={action}>
+	{@const { label, icon, style, kind, outline, action } = integrationStrategies[strategy]}
+	<Button
+		{style}
+		{kind}
+		{outline}
+		grow
+		{icon}
+		reversedDirection={icon}
+		loading={isIntegratingCommits}
+		onclick={action}
+	>
 		{label}
 	</Button>
 {/snippet}

--- a/apps/desktop/src/lib/commit/CommitList.svelte
+++ b/apps/desktop/src/lib/commit/CommitList.svelte
@@ -217,7 +217,7 @@
 		}}
 	>
 		{#snippet children()}
-			<p class="text-12 text-body helper-text">
+			<p class="text-13 text-body helper-text">
 				This will reset the branch to the state of the remote branch. All local changes will be
 				overwritten.
 			</p>

--- a/apps/desktop/src/lib/commit/CommitList.svelte
+++ b/apps/desktop/src/lib/commit/CommitList.svelte
@@ -103,14 +103,14 @@
 	<div class="commits">
 		<!-- UPSTREAM ONLY COMMITS -->
 		{#if hasRemoteCommits}
-			<UpstreamCommitsAccordion count={Math.min(remoteOnlyPatches.length, 3)}>
+			<UpstreamCommitsAccordion count={Math.min(remoteOnlyPatches.length, 3)} isLast={!hasCommits}>
 				{#each remoteOnlyPatches as commit, idx (commit.id)}
 					<CommitCard
 						type="remote"
 						branch={$branch}
 						{commit}
 						{isUnapplied}
-						last={idx === remoteOnlyPatches.length - 1}
+						noBorder={idx === remoteOnlyPatches.length - 1}
 						commitUrl={$forge?.commitUrl(commit.id)}
 						isHeadCommit={commit.id === headCommit?.id}
 					>

--- a/apps/desktop/src/lib/commit/CommitList.svelte
+++ b/apps/desktop/src/lib/commit/CommitList.svelte
@@ -26,16 +26,14 @@
 	const integrationStrategies = {
 		default: {
 			label: 'Integrate upstream',
-			stretegy: undefined,
 			style: 'warning',
 			kind: 'solid',
 			outline: false,
 			icon: undefined,
-			action: integrate
+			action: () => integrate()
 		},
 		reset: {
 			label: 'Reset to remote…',
-			stretegy: 'hardreset',
 			style: 'ghost',
 			outline: true,
 			kind: 'soft',

--- a/apps/desktop/src/lib/commit/CommitList.svelte
+++ b/apps/desktop/src/lib/commit/CommitList.svelte
@@ -159,8 +159,8 @@
 
 					<!-- RESET TO REMOTE BUTTON -->
 					{#if lastDivergentCommit?.id === commit.id}
-						<div class="action-row">
-							<div class="action-row__line"></div>
+						<div class="action-row" class:last={idx === patches.length - 1}>
+							<div class="action-row__line" class:last={idx === patches.length - 1}></div>
 							<div class="action-row__button-wrapper">
 								{@render integrateUpstreamButton('Reset to remote')}
 							</div>
@@ -206,6 +206,12 @@
 		justify-content: center;
 		background-color: var(--clr-bg-1);
 		border-bottom: 1px solid var(--clr-border-2);
+
+		&.last {
+			border-bottom: none;
+			border-top: 1px solid var(--clr-border-2);
+			border-radius: 0 0 var(--radius-m) var(--radius-m);
+		}
 	}
 
 	.action-row__button-wrapper {
@@ -222,5 +228,10 @@
 		margin: 0 22px 0 20px;
 		background-color: var(--clr-commit-local);
 		--dots-y-shift: -8px;
+
+		&.last {
+			background: linear-gradient(to bottom, var(--clr-commit-local) 50%, transparent 50%);
+			background-size: 4px 4px;
+		}
 	}
 </style>

--- a/apps/desktop/src/lib/commit/CommitList.svelte
+++ b/apps/desktop/src/lib/commit/CommitList.svelte
@@ -156,6 +156,7 @@
 				{@render stackingReorderDropzone(stackingReorderDropzoneManager.topDropzone(seriesName))}
 
 				{#each patches as commit, idx (commit.id)}
+					{@const isResetAction = lastDivergentCommit?.id === commit.id}
 					<CommitDragItem {commit}>
 						<CommitCard
 							type={commit.status}
@@ -163,7 +164,8 @@
 							{commit}
 							{seriesName}
 							{isUnapplied}
-							last={idx === patches.length - 1}
+							noBorder={idx === patches.length - 1}
+							last={idx === patches.length - 1 && !isResetAction}
 							isHeadCommit={commit.id === headCommit?.id}
 							commitUrl={$forge?.commitUrl(commit.id)}
 						>
@@ -181,33 +183,16 @@
 					)}
 
 					<!-- RESET TO REMOTE BUTTON -->
-					{#if lastDivergentCommit?.id === commit.id}
+					{#if isResetAction}
 						<CommitAction type="local" isLast={idx === patches.length - 1}>
 							{#snippet action()}
 								{@render integrateUpstreamButton('reset')}
 							{/snippet}
 						</CommitAction>
-						<!-- <div class="action-row" class:last={idx === patches.length - 1}>
-							<div class="action-row__line" class:last={idx === patches.length - 1}></div>
-							<div class="action-row__button-wrapper">
-								{@render integrateUpstreamButton('reset')}
-							</div>
-						</div> -->
 					{/if}
 				{/each}
 			</div>
 		{/if}
-
-		<!-- {#if remoteOnlyPatches.length > 0 && patches.length === 0 && !isBranchIntegrated && pushButton}
-			<CommitAction>
-				{#snippet lines()}
-					<Line line={lineManager.get(LineSpacer.LocalAndRemote)} />
-				{/snippet}
-				{#snippet action()}
-					{@render pushButton({ disabled: hasConflicts })}
-				{/snippet}
-			</CommitAction>
-		{/if} -->
 	</div>
 
 	<Modal
@@ -247,57 +232,6 @@
 
 		&:last-child {
 			border-bottom: none;
-		}
-	}
-
-	.accordion-row__actions {
-		display: flex;
-		width: 100%;
-		align-items: stretch;
-		padding-right: 14px;
-		background-color: var(--clr-bg-1);
-	}
-
-	.accordion-row__actions__content {
-		display: flex;
-		flex-direction: column;
-		flex: 1;
-		padding: 14px 0 14px;
-	}
-
-	.action-row {
-		display: flex;
-		width: 100%;
-		min-height: 44px;
-		justify-content: center;
-		background-color: var(--clr-bg-1);
-		border-bottom: 1px solid var(--clr-border-2);
-
-		&.last {
-			border-bottom: none;
-			border-top: 1px solid var(--clr-border-2);
-			border-radius: 0 0 var(--radius-m) var(--radius-m);
-		}
-	}
-
-	.action-row__button-wrapper {
-		width: 100%;
-		display: flex;
-		margin-right: 20px;
-		align-items: center;
-	}
-
-	.action-row__line {
-		flex-shrink: 0;
-		position: relative;
-		width: 2px;
-		margin: 0 22px 0 20px;
-		background-color: var(--clr-commit-local);
-		--dots-y-shift: -8px;
-
-		&.last {
-			background: linear-gradient(to bottom, var(--clr-commit-local) 50%, transparent 50%);
-			background-size: 4px 4px;
 		}
 	}
 </style>

--- a/apps/desktop/src/lib/commit/CommitList.svelte
+++ b/apps/desktop/src/lib/commit/CommitList.svelte
@@ -36,7 +36,7 @@
 		reset: {
 			label: 'Reset to remote…',
 			stretegy: 'hardreset',
-			style: 'error',
+			style: 'ghost',
 			outline: true,
 			kind: 'soft',
 			icon: 'warning-small',

--- a/apps/desktop/src/lib/commit/UpstreamCommitsAccordion.svelte
+++ b/apps/desktop/src/lib/commit/UpstreamCommitsAccordion.svelte
@@ -6,12 +6,12 @@
 		count: number;
 		isLast?: boolean;
 		children: Snippet;
-		action: Snippet;
 	}
 
-	const { count, isLast, children, action }: Props = $props();
+	const { count, isLast, children }: Props = $props();
 
 	let isOpen = $state(count === 1);
+	// let isOpen = true;
 
 	function toggle() {
 		isOpen = !isOpen;
@@ -55,13 +55,6 @@
 		<div class="accordion-children">
 			{@render children()}
 		</div>
-
-		<div class="accordion-row__actions">
-			<div class="accordion-row__line"></div>
-			<div class="accordion-row__actions__content">
-				{@render action()}
-			</div>
-		</div>
 	{/if}
 </div>
 
@@ -89,7 +82,7 @@
 		}
 	}
 
-	.accordion-row__actions {
+	/* .accordion-row__actions {
 		display: flex;
 		width: 100%;
 		align-items: stretch;
@@ -102,7 +95,7 @@
 		flex-direction: column;
 		flex: 1;
 		padding: 14px 0 14px;
-	}
+	} */
 
 	.accordion-row__header {
 		display: flex;
@@ -164,6 +157,6 @@
 		min-height: 44px;
 		align-items: stretch;
 		text-align: left;
-		border-bottom: 1px solid var(--clr-border-3);
+		/* border-bottom: 1px solid var(--clr-border-3); */
 	}
 </style>

--- a/apps/desktop/src/lib/commit/UpstreamCommitsAccordion.svelte
+++ b/apps/desktop/src/lib/commit/UpstreamCommitsAccordion.svelte
@@ -3,12 +3,13 @@
 	import type { Snippet } from 'svelte';
 
 	interface Props {
+		count: number;
+		isLast?: boolean;
 		children: Snippet;
 		action: Snippet;
-		count: number;
 	}
 
-	const { children, action, count }: Props = $props();
+	const { count, isLast, children, action }: Props = $props();
 
 	let isOpen = $state(count === 1);
 
@@ -17,9 +18,9 @@
 	}
 </script>
 
-<div class="accordion">
+<div class="accordion" class:is-last={isLast} class:is-open={isOpen}>
 	{#if count !== 1}
-		<button type="button" class="accordion-row header" onclick={toggle}>
+		<button type="button" class="accordion-row__header" onclick={toggle}>
 			<div class="accordion-row__line">
 				<div class="dots">
 					{#if !isOpen}
@@ -55,9 +56,9 @@
 			{@render children()}
 		</div>
 
-		<div class="accordion-row unthemed">
+		<div class="accordion-row__actions">
 			<div class="accordion-row__line"></div>
-			<div class="accordion-row__actions">
+			<div class="accordion-row__actions__content">
 				{@render action()}
 			</div>
 		</div>
@@ -69,67 +70,50 @@
 		position: relative;
 		display: flex;
 		flex-direction: column;
-		background-color: var(--clr-theme-warn-bg);
+		border-bottom: 1px solid var(--clr-border-2);
 
 		&:focus {
 			outline: none;
 		}
+
+		&.is-last {
+			border-bottom: none;
+			border-radius: 0 0 var(--radius-m) var(--radius-m);
+			overflow: hidden;
+		}
+
+		&.is-open {
+			& .accordion-row__header {
+				border-bottom: 1px solid var(--clr-border-2);
+			}
+		}
 	}
 
-	.accordion-row {
+	.accordion-row__actions {
+		display: flex;
+		width: 100%;
+		align-items: stretch;
+		padding-right: 14px;
+		background-color: var(--clr-bg-1);
+	}
+
+	.accordion-row__actions__content {
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+		padding: 14px 0 14px;
+	}
+
+	.accordion-row__header {
 		display: flex;
 		width: 100%;
 		min-height: 44px;
 		align-items: stretch;
 		text-align: left;
-		border-bottom: 1px solid var(--clr-border-2);
-
-		&.unthemed {
-			background-color: var(--clr-bg-1);
-		}
+		background-color: var(--clr-theme-warn-bg);
 
 		&:not(:last-child) {
 			border-bottom: 1px solid var(--clr-border-2);
-		}
-
-		& .accordion-row__line {
-			position: relative;
-			width: 2px;
-			margin: 0 22px 0 20px;
-			background-color: var(--clr-commit-upstream);
-			--dots-y-shift: -8px;
-
-			& .upstream-dot {
-				width: 14px;
-				height: 14px;
-				fill: var(--clr-commit-upstream);
-				stroke: var(--clr-theme-warn-bg);
-				transform: rotate(45deg);
-				margin-top: var(--dots-y-shift);
-			}
-
-			& .dots {
-				position: absolute;
-
-				top: calc(50% - (var(--dots-y-shift) / 2));
-				left: 50%;
-				transform: translate(-50%, -50%);
-			}
-		}
-
-		& .accordion-row__right {
-			display: flex;
-			flex: 1;
-			padding-right: 14px;
-			align-items: center;
-			color: var(--clr-text-2);
-		}
-
-		& .accordion-row__actions {
-			display: flex;
-			flex-direction: column;
-			flex: 1;
-			padding: 14px 14px 14px 0;
 		}
 
 		& .title {
@@ -140,6 +124,39 @@
 		}
 	}
 
+	.accordion-row__line {
+		position: relative;
+		width: 2px;
+		margin: 0 22px 0 20px;
+		background-color: var(--clr-commit-upstream);
+		--dots-y-shift: -8px;
+
+		& .upstream-dot {
+			width: 14px;
+			height: 14px;
+			fill: var(--clr-commit-upstream);
+			stroke: var(--clr-theme-warn-bg);
+			transform: rotate(45deg);
+			margin-top: var(--dots-y-shift);
+		}
+
+		& .dots {
+			position: absolute;
+
+			top: calc(50% - (var(--dots-y-shift) / 2));
+			left: 50%;
+			transform: translate(-50%, -50%);
+		}
+	}
+
+	.accordion-row__right {
+		display: flex;
+		flex: 1;
+		padding-right: 14px;
+		align-items: center;
+		color: var(--clr-text-2);
+	}
+
 	.accordion-children {
 		display: flex;
 		flex-direction: column;
@@ -147,6 +164,6 @@
 		min-height: 44px;
 		align-items: stretch;
 		text-align: left;
-		border-bottom: 1px solid var(--clr-border-2);
+		border-bottom: 1px solid var(--clr-border-3);
 	}
 </style>

--- a/apps/desktop/src/lib/commits/utils.ts
+++ b/apps/desktop/src/lib/commits/utils.ts
@@ -1,0 +1,14 @@
+import type { DetailedCommit } from '$lib/vbranches/types';
+
+/**
+ * Find the last commit that diverged from the remote branch.
+ */
+export function findLastDivergentCommit(commits: DetailedCommit[]): DetailedCommit | undefined {
+	for (let i = commits.length - 1; i >= 0; i--) {
+		const commit = commits[i];
+		if (commit!.id !== commit!.remoteCommitId) {
+			return commit;
+		}
+	}
+	return undefined;
+}

--- a/apps/desktop/src/lib/components/BaseBranch.svelte
+++ b/apps/desktop/src/lib/components/BaseBranch.svelte
@@ -220,10 +220,7 @@
 		{/each}
 
 		{#if base.diverged}
-			<CommitAction backgroundColor={false}>
-				{#snippet lines()}
-					<Line line={lineManager.get(LineSpacer.Remote)} />
-				{/snippet}
+			<CommitAction type={'remote'}>
 				{#snippet action()}
 					<Button
 						wide
@@ -260,10 +257,7 @@
 			</CommitCard>
 		{/each}
 
-		<CommitAction backgroundColor={false}>
-			{#snippet lines()}
-				<Line line={lineManager.get(LineSpacer.Local)} />
-			{/snippet}
+		<CommitAction type={'local'}>
 			{#snippet action()}
 				<div class="local-actions-wrapper">
 					<Button

--- a/apps/desktop/src/lib/stack/EmptySeries.svelte
+++ b/apps/desktop/src/lib/stack/EmptySeries.svelte
@@ -21,11 +21,10 @@
 		display: flex;
 	}
 	.empty-series__label {
-		/* text-align: center; */
 		color: var(--clr-text-2);
 
 		width: 100%;
-		padding: 20px 28px 28px 46px;
+		padding: 20px 28px 26px 46px;
 		opacity: 0.6;
 	}
 	.commit-line {

--- a/apps/desktop/src/lib/stack/SeriesList.svelte
+++ b/apps/desktop/src/lib/stack/SeriesList.svelte
@@ -24,9 +24,6 @@
 	const { branch, lastPush }: Props = $props();
 
 	const branchController = getContext(BranchController);
-	const hasConflicts = $derived(
-		branch.series.flatMap((s) => s.patches).some((patch) => patch.conflicted)
-	);
 
 	const nonArchivedSeries = $derived(branch.series.filter((s) => !s.archived));
 
@@ -82,7 +79,6 @@
 				isUnapplied={false}
 				isBottom={idx === branch.series.length - 1}
 				{stackingReorderDropzoneManager}
-				{hasConflicts}
 			/>
 		{/if}
 	</CurrentSeries>

--- a/apps/desktop/src/lib/vbranches/branchController.ts
+++ b/apps/desktop/src/lib/vbranches/branchController.ts
@@ -8,6 +8,7 @@ import type { BranchPushResult, Hunk, LocalFile, StackOrder } from './types';
 import type { VirtualBranchService } from './virtualBranch';
 
 export type CommitIdOrChangeId = { CommitId: string } | { ChangeId: string };
+export type SeriesIntegrationStrategy = 'merge' | 'rebase' | 'hardreset';
 
 export class BranchController {
 	constructor(
@@ -77,23 +78,18 @@ export class BranchController {
 		}
 	}
 
-	async mergeUpstream(branch: string) {
-		try {
-			await invoke<void>('integrate_upstream_commits', {
-				projectId: this.projectId,
-				branch
-			});
-		} catch (err) {
-			showError('Failed to merge upstream branch', err);
-		}
-	}
-
-	async mergeUpstreamForSeries(branch: string, seriesName: string) {
+	async integrateUpstreamForSeries(
+		branch: string,
+		seriesName: string,
+		strategy?: SeriesIntegrationStrategy
+	) {
+		const integrationStrategy = strategy ? { type: strategy } : undefined;
 		try {
 			await invoke<void>('integrate_upstream_commits', {
 				projectId: this.projectId,
 				branch,
-				seriesName
+				seriesName,
+				integrationStrategy
 			});
 		} catch (err) {
 			showError('Failed to merge upstream branch', err);

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -1,5 +1,6 @@
 use super::r#virtual as vbranch;
 use crate::branch_upstream_integration;
+use crate::branch_upstream_integration::IntegrationStrategy;
 use crate::move_commits;
 use crate::reorder::{self, StackOrder};
 use crate::upstream_integration::{
@@ -173,7 +174,8 @@ pub fn push_base_branch(project: &Project, with_force: bool) -> Result<()> {
 pub fn integrate_upstream_commits(
     project: &Project,
     stack_id: StackId,
-    series_name: Option<String>,
+    series_name: String,
+    integration_strategy: Option<IntegrationStrategy>,
 ) -> Result<()> {
     let ctx = open_with_verify(project)?;
     assure_open_workspace_mode(&ctx)
@@ -183,20 +185,13 @@ pub fn integrate_upstream_commits(
         SnapshotDetails::new(OperationKind::MergeUpstream),
         guard.write_permission(),
     );
-    if let Some(series_name) = series_name {
-        branch_upstream_integration::integrate_upstream_commits_for_series(
-            &ctx,
-            stack_id,
-            guard.write_permission(),
-            series_name,
-        )
-    } else {
-        branch_upstream_integration::integrate_upstream_commits(
-            &ctx,
-            stack_id,
-            guard.write_permission(),
-        )
-    }
+    branch_upstream_integration::integrate_upstream_commits_for_series(
+        &ctx,
+        stack_id,
+        guard.write_permission(),
+        series_name,
+        integration_strategy,
+    )
     .map_err(Into::into)
 }
 

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -1,6 +1,7 @@
 pub mod commands {
     use anyhow::{anyhow, Context};
     use gitbutler_branch::{BranchCreateRequest, BranchUpdateRequest};
+    use gitbutler_branch_actions::branch_upstream_integration::IntegrationStrategy;
     use gitbutler_branch_actions::internal::PushResult;
     use gitbutler_branch_actions::upstream_integration::{
         BaseBranchResolution, BaseBranchResolutionApproach, BranchStatuses, Resolution,
@@ -119,10 +120,16 @@ pub mod commands {
         projects: State<'_, projects::Controller>,
         project_id: ProjectId,
         branch: StackId,
-        series_name: Option<String>,
+        series_name: String,
+        integration_strategy: Option<IntegrationStrategy>,
     ) -> Result<(), Error> {
         let project = projects.get(project_id)?;
-        gitbutler_branch_actions::integrate_upstream_commits(&project, branch, series_name)?;
+        gitbutler_branch_actions::integrate_upstream_commits(
+            &project,
+            branch,
+            series_name,
+            integration_strategy,
+        )?;
         emit_vbranches(&windows, project_id);
         Ok(())
     }

--- a/packages/ui/src/lib/commitLines/Cell.svelte
+++ b/packages/ui/src/lib/commitLines/Cell.svelte
@@ -6,7 +6,7 @@
 	const { isBottom = false }: Props = $props();
 </script>
 
-<div class="commit-line stacked" class:dashed={isBottom}></div>
+<div class="commit-line" class:dashed={isBottom}></div>
 
 <style lang="postcss">
 	.commit-line {


### PR DESCRIPTION
We were able to hard reset to whatever was on the remote, in the case that e.g. one would amend a commit outside of GB and wanted to pull that in.
This re-adds that.

### Report
This was reported in Discord: https://discord.com/channels/1060193121130000425/1073202153163857920/1306629953848213585

### Changes
Adds a button to reset your local branch to whatever is on remote.
This works in the case in which there are divergent commits with the same change ID.`

### Visuals
<img width="394" alt="Screenshot 2024-11-14 at 17 48 17" src="https://github.com/user-attachments/assets/eead3d08-68e0-4f9d-a141-2ba1694e8779">
