### PR TITLE
Fixes a bug where remote branches may incorrectly show more commits

### DIFF
--- a/crates/gitbutler-branch-actions/src/remote.rs
+++ b/crates/gitbutler-branch-actions/src/remote.rs
@@ -102,15 +102,12 @@ pub fn list_local_branches(ctx: &CommandContext) -> Result<Vec<RemoteBranch>> {
 }
 
 pub(crate) fn get_branch_data(ctx: &CommandContext, refname: &Refname) -> Result<RemoteBranchData> {
-    let default_target = default_target(&ctx.project().gb_dir())?;
-
     let branch = ctx
         .repository()
         .maybe_find_branch_by_refname(refname)?
         .ok_or(anyhow::anyhow!("failed to find branch {}", refname))?;
 
-    branch_to_remote_branch_data(ctx, &branch, default_target.sha)?
-        .context("failed to get branch data")
+    branch_to_remote_branch_data(ctx, &branch)?.context("failed to get branch data")
 }
 
 pub(crate) fn get_commit_data(
@@ -162,8 +159,8 @@ pub(crate) fn branch_to_remote_branch(
 pub(crate) fn branch_to_remote_branch_data(
     ctx: &CommandContext,
     branch: &git2::Branch,
-    base: git2::Oid,
 ) -> Result<Option<RemoteBranchData>> {
+    let base = default_target(&ctx.project().gb_dir())?.remote_head(ctx.repository())?;
     branch
         .get()
         .target()

--- a/crates/gitbutler-stack/src/target.rs
+++ b/crates/gitbutler-stack/src/target.rs
@@ -1,4 +1,6 @@
+use anyhow::{Context, Result};
 use gitbutler_reference::RemoteRefname;
+use gitbutler_repo::RepositoryExt;
 use serde::{ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Debug, PartialEq, Clone)]
@@ -30,6 +32,16 @@ impl Target {
             None => self.branch.remote().to_owned(),
         };
         upstream_remote
+    }
+
+    /// Returns the head sha of the remote branch this target is tracking.
+    pub fn remote_head(&self, repo: &git2::Repository) -> Result<git2::Oid> {
+        let branch = repo.find_branch_by_refname(&self.branch.clone().into())?;
+        let oid = branch
+            .get()
+            .target()
+            .context("failed to get default commit")?;
+        Ok(oid)
     }
 }
 


### PR DESCRIPTION
While `default_target.sha` may be appropriate for computing what is new in workspace branches, this would be wrong for computing of what is remote branches.
To get what is the remote branch it needs to be compared to the head of the target branch.