### PR TITLE
fix: only allow creating dependent series from top series

### DIFF
--- a/apps/desktop/src/lib/branch/SeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/SeriesHeader.svelte
@@ -214,6 +214,7 @@
 	rightClickTrigger={seriesHeaderEl}
 	headName={currentSeries.name}
 	seriesCount={branch.series?.length ?? 0}
+	{isTopSeries}
 	{toggleDescription}
 	description={currentSeries.description ?? ''}
 	onGenerateBranchName={generateBranchName}
@@ -244,7 +245,7 @@
 >
 	<Dropzones type="commit">
 		<PopoverActionsContainer class="branch-actions-menu" stayOpen={contextMenuOpened}>
-			{#if $stackingFeatureMultipleSeries}
+			{#if $stackingFeatureMultipleSeries && isTopSeries}
 				<PopoverActionsItem
 					icon="plus-small"
 					tooltip="Add dependent branch"

--- a/apps/desktop/src/lib/branch/SeriesHeaderContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/SeriesHeaderContextMenu.svelte
@@ -20,6 +20,7 @@
 		rightClickTrigger?: HTMLElement;
 		headName: string;
 		seriesCount: number;
+		isTopSeries: boolean;
 		hasForgeBranch: boolean;
 		prUrl?: string;
 		branchType: CommitStatus;
@@ -36,6 +37,7 @@
 		contextMenuEl = $bindable(),
 		leftClickTrigger,
 		rightClickTrigger,
+		isTopSeries,
 		seriesCount,
 		hasForgeBranch,
 		headName,
@@ -93,7 +95,7 @@
 		onMenuToggle?.(isOpen, isLeftClick);
 	}}
 >
-	{#if isOpenedByMouse}
+	{#if isOpenedByMouse && isTopSeries}
 		<ContextMenuSection>
 			<ContextMenuItem
 				label="Add dependent branch"


### PR DESCRIPTION
## ☕️ Reasoning

- New dependent series always get added to the top of the stack anyway, so only allow creating them from the top series for now in order to not break peoples expectations if they attempt to create them from a non-top series.

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->