### PR TITLE
Persist PR content

### DIFF
--- a/apps/desktop/src/lib/branch/SeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/SeriesHeader.svelte
@@ -359,7 +359,7 @@
 		{:else}
 			<PrDetailsModal
 				bind:this={prDetailsModal}
-				type="preview-series"
+				type="preview"
 				{currentSeries}
 				stackId={branch.id}
 			/>

--- a/apps/desktop/src/lib/config/config.ts
+++ b/apps/desktop/src/lib/config/config.ts
@@ -1,4 +1,4 @@
-import { persisted, type Persisted } from '@gitbutler/shared/persisted';
+import { persisted, type Persisted, persistWithExpiration } from '@gitbutler/shared/persisted';
 
 export function projectHttpsWarningBannerDismissed(projectId: string): Persisted<boolean> {
 	const key = 'projectHttpsWarningBannerDismissed_';
@@ -43,6 +43,14 @@ export function projectLaneCollapsed(projectId: string, laneId: string): Persist
 
 export function persistedCommitMessage(projectId: string, branchId: string): Persisted<string> {
 	return persisted('', 'projectCurrentCommitMessage_' + projectId + '_' + branchId);
+}
+
+export function persistedPRBody(projectId: string, seriesName: string): Persisted<string> {
+	return persistWithExpiration('', 'seriesCurrentPRBody_' + projectId + '_' + seriesName, 5);
+}
+
+export function persistedPRTitle(projectId: string, seriesName: string): Persisted<string> {
+	return persistWithExpiration('', 'seriesCurrentPRTitle_' + projectId + '_' + seriesName, 5);
 }
 
 export const showHistoryView = persisted(false, 'showHistoryView');

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -47,6 +47,7 @@
 		"@sveltejs/vite-plugin-svelte": "catalog:svelte",
 		"@terrazzo/cli": "^0.0.11",
 		"@terrazzo/plugin-css": "^0.0.9",
+		"@types/lscache": "^1.3.4",
 		"@types/postcss-pxtorem": "^6.0.3",
 		"autoprefixer": "^10.4.19",
 		"cpy-cli": "^5.0.0",
@@ -62,5 +63,8 @@
 		"vite": "catalog:",
 		"vitest": "^2.0.5"
 	},
-	"type": "module"
+	"type": "module",
+	"dependencies": {
+		"lscache": "^1.3.2"
+	}
 }

--- a/packages/shared/src/lib/persisted.ts
+++ b/packages/shared/src/lib/persisted.ts
@@ -1,6 +1,7 @@
 /**
  * This is simplified copy of the persisted store in square/svelte-store.
  */
+import lscache from 'lscache';
 import { writable, type Writable } from 'svelte/store';
 export type Persisted<T> = Writable<T>;
 
@@ -25,6 +26,68 @@ export function persisted<T>(initial: T, key: string): Persisted<T> {
 
 	function synchronize(set: (value: T) => void): void {
 		const stored = getStorageItem(key);
+		if (stored !== undefined) {
+			set(stored as T);
+		} else {
+			setAndPersist(initial, set);
+		}
+	}
+
+	function update() {
+		throw 'Not implemented';
+	}
+
+	const thisStore = writable<T>(initial, (set) => {
+		synchronize(set);
+	});
+
+	async function set(value: T) {
+		setAndPersist(value, thisStore.set);
+	}
+
+	const subscribe = thisStore.subscribe;
+
+	return {
+		subscribe,
+		set,
+		update
+	};
+}
+
+function setEphemeralStorageItem(key: string, value: unknown, expirationInMinutes: number): void {
+	lscache.set(key, JSON.stringify(value), expirationInMinutes);
+}
+
+function getEphemeralStorageItem(key: string): unknown {
+	const item = lscache.get(key);
+	try {
+		if (!item) {
+			return undefined;
+		}
+
+		const parsed = JSON.parse(item);
+		return parsed;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Create a persisted store that expires after a certain amount of time (in minutes).
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export function persistWithExpiration<T extends {}>(
+	initial: T,
+	key: string,
+	expirationInMinutes: number
+): Persisted<T> {
+	function setAndPersist(value: T, set: (value: T) => void) {
+		setEphemeralStorageItem(key, value, expirationInMinutes);
+		set(value);
+	}
+
+	function synchronize(set: (value: T) => void): void {
+		const stored = getEphemeralStorageItem(key);
 		if (stored !== undefined) {
 			set(stored as T);
 		} else {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,6 +370,10 @@ importers:
         version: 5.2.13(@types/node@22.3.0)
 
   packages/shared:
+    dependencies:
+      lscache:
+        specifier: ^1.3.2
+        version: 1.3.2
     devDependencies:
       '@csstools/postcss-bundler':
         specifier: ^1.0.15
@@ -395,6 +399,9 @@ importers:
       '@terrazzo/plugin-css':
         specifier: ^0.0.9
         version: 0.0.9(@terrazzo/cli@0.0.11)
+      '@types/lscache':
+        specifier: ^1.3.4
+        version: 1.3.4
       '@types/postcss-pxtorem':
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## ☕️ Reasoning

This pull request introduces a new utility function for temporarily persisting values, as well as the implementation of persisting the PR description and title for 5 minutes.

## 🧢 Changes

- Added a shared utility function for the temporary persistence of values. If retrieved after the given number of seconds, the value will be considered not present.
- Implemented the persistence of the PR description and title for 5 minutes, to mitigate the risk of accidentally closing the PR edit modal and having the work lost.