### PR TITLE
fix: assure we convert worktree data to Git before writing it (#5558)

### DIFF
--- a/crates/gitbutler-repo/src/repository_ext.rs
+++ b/crates/gitbutler-repo/src/repository_ext.rs
@@ -195,7 +195,17 @@ impl RepositoryExt for git2::Repository {
     /// or if the HEAD branch has no commits
     #[instrument(level = tracing::Level::DEBUG, skip(self), err(Debug))]
     fn create_wd_tree(&self) -> Result<Tree> {
-        let gix_repo = gix::open(self.path())?;
+        let gix_repo = gix::open_opts(
+            self.path(),
+            gix::open::Options::default().permissions(gix::open::Permissions {
+                config: gix::open::permissions::Config {
+                    // Whenever we deal with worktree filters, we'd want to have the installation configuration as well.
+                    git_binary: cfg!(windows),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+        )?;
         let (mut pipeline, index) = gix_repo.filter_pipeline(None)?;
         let mut tree_update_builder = git2::build::TreeUpdateBuilder::new();
 


### PR DESCRIPTION
Fixes #5558

### Tasks

* [x] first implementation
* [x] assure that on Windows it will also read the installation-configuration to definitely get all the settings

### Notes for the reviewer

* One could also use `git2::Repository::blob_writer(path)` which automatically applies the 'worktree-to-git' filtering as well. That would lead to simpler code, at least, but will have disadvantages in correctness as it doesn't support external filters, nor will it pick up all the configuration.
* These special open-options would probably have to be used in more places, *or* `gitoxide` makes these the default for good measure - right now it prefers performance as that option involves launching `git` to have it tell us where its installation configuration is located. In future, I can see that shift as more features will only work correctly in with this option enabled.