### PR TITLE
Fix applying pr from fork

### DIFF
--- a/apps/desktop/src/lib/branch/SeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/SeriesHeader.svelte
@@ -82,8 +82,8 @@
 
 	// Pretty cumbersome way of getting the PR number, would be great if we can
 	// make it more concise somehow.
-	const hostedListingServiceStore = getForgeListingService();
-	const prStore = $derived($hostedListingServiceStore?.prs);
+	const forgeListing = getForgeListingService();
+	const prStore = $derived($forgeListing?.prs);
 	const prs = $derived(prStore ? $prStore : undefined);
 
 	const listedPr = $derived(prs?.find((pr) => pr.sourceBranch === upstreamName));
@@ -118,15 +118,11 @@
 	});
 
 	async function handleReloadPR() {
-		await Promise.allSettled([
-			prMonitor?.refresh(),
-			checksMonitor?.update(),
-			$hostedListingServiceStore?.refresh()
-		]);
+		await updateStatusAndChecks();
 	}
 
-	function updateStatusAndChecks() {
-		handleReloadPR();
+	async function updateStatusAndChecks() {
+		await Promise.allSettled([prMonitor?.refresh(), checksMonitor?.update()]);
 	}
 
 	const projectService = getContext(ProjectService);
@@ -176,6 +172,7 @@
 			return;
 		}
 		await $prService?.reopen($pr?.number);
+		await $forgeListing?.refresh();
 		await handleReloadPR();
 	}
 

--- a/apps/desktop/src/lib/forge/github/githubPrMonitor.ts
+++ b/apps/desktop/src/lib/forge/github/githubPrMonitor.ts
@@ -19,7 +19,6 @@ export class GitHubPrMonitor implements ForgePrMonitor {
 	readonly error = writable<any>();
 
 	readonly mergeableState = derived(this.pr, (pr) => pr?.mergeableState);
-	readonly lastFetch = writable<Date | undefined>();
 
 	private intervalId: any;
 
@@ -71,7 +70,6 @@ export class GitHubPrMonitor implements ForgePrMonitor {
 			try {
 				const pr = await request();
 				this.pr.set(pr);
-				this.lastFetch.set(new Date());
 
 				// Stop polling polling if merged or mergeable state known.
 				if (pr.mergeableState !== 'unknown' || pr.merged) {

--- a/apps/desktop/src/lib/forge/github/types.ts
+++ b/apps/desktop/src/lib/forge/github/types.ts
@@ -60,7 +60,7 @@ export function ghResponseToInstance(
 		sha: pr.head?.sha,
 		mergedAt: pr.merged_at ? new Date(pr.merged_at) : undefined,
 		closedAt: pr.closed_at ? new Date(pr.closed_at) : undefined,
-		repoName: pr.head?.repo?.full_name,
+		repoOwner: pr.head?.repo?.owner.login,
 		repositorySshUrl: pr.head?.repo?.ssh_url,
 		repositoryHttpsUrl: pr.head?.repo?.clone_url
 	};

--- a/apps/desktop/src/lib/forge/interface/forgePrMonitor.ts
+++ b/apps/desktop/src/lib/forge/interface/forgePrMonitor.ts
@@ -6,7 +6,6 @@ export interface ForgePrMonitor {
 	pr: Readable<DetailedPullRequest | undefined>;
 	loading?: Readable<boolean>;
 	error: Readable<any>;
-	lastFetch?: Readable<Date | undefined>;
 	refresh(): Promise<void>;
 }
 

--- a/apps/desktop/src/lib/forge/interface/types.ts
+++ b/apps/desktop/src/lib/forge/interface/types.ts
@@ -22,9 +22,9 @@ export interface PullRequest {
 	modifiedAt: Date;
 	mergedAt?: Date;
 	closedAt?: Date;
-	repoName?: string;
 	repositorySshUrl?: string;
 	repositoryHttpsUrl?: string;
+	repoOwner?: string;
 }
 
 export interface DetailedPullRequest {

--- a/apps/desktop/src/routes/[projectId]/pull/[number]/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/pull/[number]/+page.svelte
@@ -23,7 +23,7 @@
 		{#if !pr}
 			<FullviewLoading />
 		{:else if pr}
-			<PullRequestPreview pullrequest={pr} />
+			<PullRequestPreview {pr} />
 		{:else}
 			<p>Branch doesn't seem to exist</p>
 		{/if}


### PR DESCRIPTION
We were suggesting a remote name consisting of `$user/$repo`, but at the same time `RemoteRefname` does not handle names containing `/` well. With a remote name of e.g. `$user/$repo`, we have been creating a branch called `$repo/$branch` since `RemoteRefname` doesn't know at what slash to separate branch name from remote name.

- improved error messages
- use fork owner as remote name since remote refnames containing '/' aren't parsed correcty
- svelte5 upgrade for preview component


https://github.com/user-attachments/assets/ac3597c5-92c1-42b0-9caf-505df7f1af55

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- `2.` #5566 👈 
- `1.` #5567 
<!-- GitButler Footer Boundary Bottom -->

