### PR TITLE
Check for existing fork before adding new one

### DIFF
--- a/apps/desktop/src/lib/components/PullRequestPreview.svelte
+++ b/apps/desktop/src/lib/components/PullRequestPreview.svelte
@@ -56,7 +56,7 @@
 		}
 
 		const remotes = await remotesService.remotes(project.id);
-		if (remotes.includes(remoteName)) {
+		if (remotes.find((r) => r.name === remoteName)) {
 			toasts.error('Remote already exists');
 			return;
 		}

--- a/apps/desktop/src/lib/remotes/service.ts
+++ b/apps/desktop/src/lib/remotes/service.ts
@@ -1,16 +1,30 @@
 import { invoke } from '$lib/backend/ipc';
-import { showError } from '$lib/notifications/toasts';
+
+export interface GitRemote {
+	name?: string;
+	url?: string;
+}
 
 export class RemotesService {
 	async remotes(projectId: string) {
-		return await invoke<string[]>('list_remotes', { projectId });
+		return await invoke<GitRemote[]>('list_remotes', { projectId });
 	}
 
 	async addRemote(projectId: string, name: string, url: string) {
-		try {
-			await invoke('add_remote', { projectId, name, url });
-		} catch (e) {
-			showError('Failed to add remote', e);
+		const remotes = await this.remotes(projectId);
+
+		const sameNameRemote = remotes.find((remote) => remote.name === name);
+		if (sameNameRemote) {
+			throw new Error(`Remote with name ${sameNameRemote.name} already exists.`);
 		}
+
+		const sameUrlRemote = remotes.find((remote) => remote.url === url);
+		if (sameUrlRemote) {
+			// This should not happen, and indicates we are incorrectly showing an "apply from fork"
+			// button in the user interface.
+			throw new Error(`Remote ${sameUrlRemote.name} with url ${sameUrlRemote.url} already exists.`);
+		}
+
+		return await invoke<string>('add_remote', { projectId, name, url });
 	}
 }

--- a/crates/gitbutler-repo/src/lib.rs
+++ b/crates/gitbutler-repo/src/lib.rs
@@ -2,6 +2,7 @@ pub mod rebase;
 
 mod commands;
 pub use commands::{FileInfo, RepoCommands};
+pub use remote::GitRemote;
 
 mod repository_ext;
 pub use repository_ext::{GixRepositoryExt, LogUntil, RepositoryExt};
@@ -9,6 +10,7 @@ pub use repository_ext::{GixRepositoryExt, LogUntil, RepositoryExt};
 pub mod credentials;
 
 mod config;
+mod remote;
 
 pub use config::Config;
 

--- a/crates/gitbutler-repo/src/remote.rs
+++ b/crates/gitbutler-repo/src/remote.rs
@@ -1,0 +1,18 @@
+use serde::Serialize;
+
+/// Struct for exposing remote information to the front end.
+#[derive(Default, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitRemote {
+    pub name: Option<String>,
+    pub url: Option<String>,
+}
+
+impl From<git2::Remote<'_>> for GitRemote {
+    fn from(value: git2::Remote) -> Self {
+        GitRemote {
+            name: value.name().map(|name| name.to_owned()),
+            url: value.url().map(|url| url.to_owned()),
+        }
+    }
+}

--- a/crates/gitbutler-tauri/src/remotes.rs
+++ b/crates/gitbutler-tauri/src/remotes.rs
@@ -1,19 +1,18 @@
+use crate::error::Error;
 use gitbutler_project as projects;
 use gitbutler_project::ProjectId;
-use gitbutler_repo::RepoCommands;
+use gitbutler_repo::{GitRemote, RepoCommands};
 use tauri::State;
 use tracing::instrument;
-
-use crate::error::Error;
 
 #[tauri::command(async)]
 #[instrument(skip(projects), err(Debug))]
 pub fn list_remotes(
     projects: State<'_, projects::Controller>,
     project_id: ProjectId,
-) -> Result<Vec<String>, Error> {
+) -> Result<Vec<GitRemote>, Error> {
     let project = projects.get(project_id)?;
-    project.remotes().map_err(Into::into)
+    Ok(project.remotes()?)
 }
 
 #[tauri::command(async)]
@@ -25,5 +24,5 @@ pub fn add_remote(
     url: &str,
 ) -> Result<(), Error> {
     let project = projects.get(project_id)?;
-    project.add_remote(name, url).map_err(Into::into)
+    Ok(project.add_remote(name, url)?)
 }


### PR DESCRIPTION
Adding these checks because a user reported on Discord that a remote was added twice. The root problem was pr preview being broken, but we should nonetheless prevent and show clear error messages if it happens.

- can prevent a cascading error
- exposes remote urls to front end

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- `2.` #5566 
- `1.` #5567 👈 
<!-- GitButler Footer Boundary Bottom -->

