### PR TITLE
Reduce risk of fetching checks in a loop

### DIFF
--- a/apps/desktop/src/lib/branch/SeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/SeriesHeader.svelte
@@ -31,12 +31,11 @@
 	import PopoverActionsItem from '@gitbutler/ui/popoverActions/PopoverActionsItem.svelte';
 	import { getColorFromBranchType } from '@gitbutler/ui/utils/getColorFromBranchType';
 	import { tick } from 'svelte';
-	import type { Writable } from 'svelte/store';
 
 	interface Props {
 		currentSeries: PatchSeries;
 		isTopSeries: boolean;
-		lastPush: Writable<Date | undefined>;
+		lastPush: Date | undefined;
 	}
 
 	const { currentSeries, isTopSeries, lastPush }: Props = $props();
@@ -98,11 +97,18 @@
 		sourceBranch && shouldCheck ? $forge?.checksMonitor(sourceBranch) : undefined
 	);
 
-	// Trigger refresh of pull request status and checks when branch(es) are pushed.
+	// Extra reference to avoid potential infinite loop.
+	let lastSeenPush: Date | undefined;
+
+	// Without lastSeenPush this code has gone into an infinite loop, where lastPush
+	// seemingly kept updating as a result of calling updateStatusAndChecks.
+	// TODO: Refactor such that we do not need `$effect`.
 	$effect(() => {
-		if ($lastPush) {
+		if (!lastPush) return;
+		if (!lastSeenPush || lastPush > lastSeenPush) {
 			updateStatusAndChecks();
 		}
+		lastSeenPush = lastPush;
 	});
 
 	async function handleReloadPR() {

--- a/apps/desktop/src/lib/forge/github/octokit.ts
+++ b/apps/desktop/src/lib/forge/github/octokit.ts
@@ -1,9 +1,22 @@
+import { rateLimit } from '$lib/utils/ratelimit';
 import { Octokit } from '@octokit/rest';
 
 export function octokitFromAccessToken(accessToken: string) {
 	return new Octokit({
 		auth: accessToken,
 		userAgent: 'GitButler Client',
-		baseUrl: 'https://api.github.com'
+		baseUrl: 'https://api.github.com',
+		request: {
+			// Global rate-limiter to mitigate accidental reactivity bugs that
+			// could trigger runaway requests.
+			fetch: rateLimit({
+				name: 'Octokit',
+				limit: 100,
+				windowMs: 60 * 1000,
+				fn: async (input: RequestInfo | URL, init?: RequestInit) => {
+					return await window.fetch(input, init);
+				}
+			})
+		}
 	});
 }

--- a/apps/desktop/src/lib/stack/SeriesList.svelte
+++ b/apps/desktop/src/lib/stack/SeriesList.svelte
@@ -14,11 +14,10 @@
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { PatchSeries, type VirtualBranch } from '$lib/vbranches/types';
 	import { getContext } from '@gitbutler/shared/context';
-	import type { Writable } from 'svelte/store';
 
 	interface Props {
 		branch: VirtualBranch;
-		lastPush: Writable<Date | undefined>;
+		lastPush: Date | undefined;
 	}
 
 	const { branch, lastPush }: Props = $props();

--- a/apps/desktop/src/lib/stack/Stack.svelte
+++ b/apps/desktop/src/lib/stack/Stack.svelte
@@ -22,7 +22,7 @@
 	import Spacer from '@gitbutler/ui/Spacer.svelte';
 	import lscache from 'lscache';
 	import { onMount } from 'svelte';
-	import { writable, type Writable } from 'svelte/store';
+	import { type Writable } from 'svelte/store';
 
 	const {
 		isLaneCollapsed,
@@ -38,7 +38,7 @@
 	const userSettings = getContextStoreBySymbol<Settings>(SETTINGS);
 	const defaultBranchWidthRem = persisted<number>(24, 'defaulBranchWidth' + project.id);
 	const laneWidthKey = 'laneWidth_';
-	const lastPush = writable<Date | undefined>();
+	let lastPush = $state<Date | undefined>();
 
 	let laneWidth: number | undefined = $state();
 
@@ -94,7 +94,7 @@
 		try {
 			await branchController.pushBranch(branch.id, branch.requiresForce);
 			$listingService?.refresh();
-			lastPush.set(new Date());
+			lastPush = new Date();
 		} finally {
 			isPushingCommits = false;
 		}

--- a/apps/desktop/src/lib/utils/ratelimit.ts
+++ b/apps/desktop/src/lib/utils/ratelimit.ts
@@ -1,0 +1,35 @@
+type RateLimitedFunction<T extends (...args: any[]) => any> = (
+	...args: Parameters<T>
+) => ReturnType<T> | void;
+
+// A rate limiting function that can prevent a function being called more than
+// a certain number of times within the given sliding time window.
+export function rateLimit<T extends (...args: any[]) => any>(params: {
+	// Function to rate-limit.
+	fn: T;
+	// A name surfaced when limit exceeded.
+	name: string;
+	// Number of calls permitted within time window.
+	limit: number;
+	// Window length in milliseconds.
+	windowMs: number;
+}): RateLimitedFunction<T> {
+	const { fn, name, limit, windowMs } = params;
+	const timestamps: number[] = [];
+
+	return (...args: Parameters<T>) => {
+		const now = Date.now();
+
+		// Remove timestamps older than the time window
+		while (timestamps.length > 0 && timestamps[0]! <= now - windowMs) {
+			timestamps.shift();
+		}
+
+		if (timestamps.length < limit) {
+			timestamps.push(now);
+			return fn(...args);
+		} else {
+			throw new Error(`Rate limit for ${name} exceeded, ${limit} / ${windowMs}ms.`);
+		}
+	};
+}


### PR DESCRIPTION
- weird store/state behavior observed in dev that caused loop
- introduced checks reduce risk of runaway requests
- added global rate-limiter for outbound github api requests

<!-- GitButler Footer Boundary Top -->
---
This is **part of a stack** made with GitButler:
- #5568 👈 
- #5561 
<!-- GitButler Footer Boundary Bottom -->

