### PR TITLE
Fix bug in finding upstream commits

### DIFF
--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -222,7 +222,7 @@ impl BranchManager<'_> {
             vb_state.find_by_source_refname_where_not_in_workspace(target)
         {
             branch.upstream_head = upstream_branch.is_some().then_some(head_commit.id());
-            branch.upstream = upstream_branch;
+            branch.upstream = upstream_branch; // Used as remote when listing commits.
             branch.ownership = ownership;
             branch.order = order;
             branch.selected_for_changes = selected_for_changes;

--- a/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
@@ -36,7 +36,7 @@ pub fn integrate_upstream_commits_for_series(
         .iter()
         .find(|branch| branch.name == series_name)
         .ok_or(anyhow!("Series not found"))?;
-    let upstream_reference = subject_branch.remote_reference(remote.as_str())?;
+    let upstream_reference = subject_branch.remote_reference(remote.as_str());
     let remote_head = repo.find_reference(&upstream_reference)?.peel_to_commit()?;
 
     let series_head = subject_branch.head_oid(&ctx.to_stack_context()?, &stack)?;
@@ -59,7 +59,7 @@ pub fn integrate_upstream_commits_for_series(
         branch_tree: stack.tree,
         branch_name: &subject_branch.name,
         remote_head: remote_head.id(),
-        remote_branch_name: &subject_branch.remote_reference(&remote)?,
+        remote_branch_name: &subject_branch.remote_reference(&remote),
         strategy,
     };
 

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -281,7 +281,7 @@ fn stack_branch_to_api_branch(
     // anyhow::bail!("Lets pretend this is a real error");
     let remote = default_target.push_remote_name();
     let upstream_reference = if stack_branch.pushed(remote.as_str(), repository)? {
-        stack_branch.remote_reference(remote.as_str()).ok()
+        Some(stack_branch.remote_reference(remote.as_str()))
     } else {
         None
     };


### PR DESCRIPTION
We should be using branch upstream when available for for listing remote commits.