### PR TITLE
Edit mode: Display changed state and warn about conflicts

### DIFF
--- a/apps/desktop/src/lib/components/EditMode.svelte
+++ b/apps/desktop/src/lib/components/EditMode.svelte
@@ -200,6 +200,8 @@
 			openExternalUrl(path);
 		}
 	}
+
+	let isCommitListScrolled = $state(false);
 </script>
 
 <div class="editmode__container">
@@ -235,11 +237,17 @@
 		</div>
 
 		<div bind:this={filesList} class="card files">
-			<div class="header">
+			<div class="header" class:show-border={isCommitListScrolled}>
 				<h3 class="text-13 text-semibold">Commit files</h3>
 				<Badge label={files.length} />
 			</div>
-			<ScrollableContainer>
+			<ScrollableContainer
+				onscroll={(e) => {
+					if (e.target instanceof HTMLElement) {
+						isCommitListScrolled = e.target.scrollTop > 0;
+					}
+				}}
+			>
 				{#each files as file (file.path)}
 					<div class="file">
 						<FileListItem
@@ -364,6 +372,10 @@
 			padding-left: 16px;
 			padding-top: 16px;
 			padding-bottom: 8px;
+
+			&.show-border {
+				border-bottom: 1px solid var(--clr-border-3);
+			}
 		}
 
 		& .file {

--- a/apps/desktop/src/lib/components/EditMode.svelte
+++ b/apps/desktop/src/lib/components/EditMode.svelte
@@ -215,7 +215,7 @@
 
 	<div class="commit-group">
 		<div class="card commit-card">
-			<h3 class="text-13 text-semibold commit-card__title">
+			<h3 class="text-13 text-semibold text-body commit-card__title">
 				{commit?.descriptionTitle || 'Undefined commit'}
 			</h3>
 

--- a/apps/desktop/src/lib/components/EditMode.svelte
+++ b/apps/desktop/src/lib/components/EditMode.svelte
@@ -255,7 +255,6 @@
 							fileStatus={file.status}
 							conflicted={file.conflicted && file.looksConflicted}
 							conflictHint={file.conflictHint}
-							fileStatusStyle={file.status === 'M' ? 'full' : 'dot'}
 							onclick={(e) => {
 								contextMenu?.open(e, { files: [file] });
 							}}

--- a/apps/desktop/src/lib/conflictEntryPresence.ts
+++ b/apps/desktop/src/lib/conflictEntryPresence.ts
@@ -1,3 +1,5 @@
+import type { RemoteFile, RemoteHunk } from './vbranches/types';
+
 export interface ConflictEntryPresence {
 	ours: boolean;
 	theirs: boolean;
@@ -32,4 +34,23 @@ export function conflictEntryHint(presence: ConflictEntryPresence): string {
 	}
 
 	return `You have ${theirsVerb} this file, They have ${oursVerb} this file.`;
+}
+
+function hunkLooksConflicted(hunk: RemoteHunk): boolean {
+	const lines = hunk.diff.split('\n');
+	for (const line of lines) {
+		if (line.startsWith('+<<<<<<<')) {
+			return true;
+		}
+	}
+	return false;
+}
+
+export function fileLooksConflicted(file: RemoteFile): boolean {
+	for (const hunk of file.hunks) {
+		if (hunkLooksConflicted(hunk)) {
+			return true;
+		}
+	}
+	return false;
 }

--- a/apps/desktop/src/lib/utils/fileStatus.ts
+++ b/apps/desktop/src/lib/utils/fileStatus.ts
@@ -1,19 +1,8 @@
-import { RemoteFile, type AnyFile } from '$lib/vbranches/types';
+import { type AnyFile } from '$lib/vbranches/types';
 
 export type FileStatus = 'A' | 'M' | 'D';
 
 export function computeFileStatus(file: AnyFile): FileStatus {
-	if (file instanceof RemoteFile) {
-		if (file.hunks.length === 1) {
-			const diff = file.hunks[0]?.diff as string;
-			if (/^@@ -1,1 /.test(diff)) return 'A';
-			if (/^@@ -0,0 /.test(diff)) return 'A';
-			if (/^@@ -\d+,\d+ \+0,0/.test(diff)) return 'D';
-			if (/^@@ -\d+,\d+ \+1,1/.test(diff)) return 'D';
-		}
-		return 'M';
-	}
-
 	if (file.hunks.length === 1) {
 		const changeType = file.hunks[0]?.changeType;
 		if (changeType === 'added') {

--- a/apps/desktop/src/lib/vbranches/types.ts
+++ b/apps/desktop/src/lib/vbranches/types.ts
@@ -351,6 +351,7 @@ export class RemoteHunk {
 	hash?: string;
 	new_start!: number;
 	new_lines!: number;
+	changeType!: ChangeType;
 
 	get id(): string {
 		return hashCode(this.diff);

--- a/crates/gitbutler-diff/src/diff.rs
+++ b/crates/gitbutler-diff/src/diff.rs
@@ -50,6 +50,7 @@ pub struct GitHunk {
     #[serde(rename = "diff")]
     pub diff_lines: BStringForFrontend,
     pub binary: bool,
+    #[serde(rename = "changeType")]
     pub change_type: ChangeType,
 }
 

--- a/packages/ui/src/lib/file/FileListItem.svelte
+++ b/packages/ui/src/lib/file/FileListItem.svelte
@@ -205,6 +205,8 @@
 	}
 
 	.path-container {
+		display: flex;
+		justify-content: flex-end;
 		flex-shrink: 0;
 		flex-grow: 1;
 		flex-basis: 0px;
@@ -221,7 +223,7 @@
 		opacity: 0.3;
 		transition: opacity var(--transition-fast);
 		direction: rtl;
-		width: 100%;
+		max-width: 100%;
 		text-align: left;
 	}
 
@@ -229,7 +231,7 @@
 	.details {
 		display: flex;
 		align-items: center;
-		gap: 4px;
+		gap: 6px;
 	}
 
 	.details .locked {

--- a/packages/ui/src/lib/file/FileListItem.svelte
+++ b/packages/ui/src/lib/file/FileListItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import FileStatusBadge from './FileStatusBadge.svelte';
+	import Button from '$lib/Button.svelte';
 	import Checkbox from '$lib/Checkbox.svelte';
 	import Icon from '$lib/Icon.svelte';
 	import Tooltip from '$lib/Tooltip.svelte';
@@ -95,13 +96,13 @@
 			{fileInfo.filename}
 		</span>
 
-		<Tooltip text={filePath} delay={1500}>
-			<div class="path-container">
+		<div class="path-container">
+			<Tooltip text={filePath} delay={1200}>
 				<span class="text-12 path truncate">
 					{fileInfo.path}
 				</span>
-			</div>
-		</Tooltip>
+			</Tooltip>
+		</div>
 	</div>
 
 	<div class="details">

--- a/packages/ui/src/lib/file/FileListItem.svelte
+++ b/packages/ui/src/lib/file/FileListItem.svelte
@@ -217,6 +217,7 @@
 		border: 1px solid var(--clr-border-2);
 		border-radius: var(--radius-m);
 		margin: 0 2px;
+		white-space: nowrap;
 		transition:
 			background-color var(--transition-fast),
 			border-color var(--transition-fast);

--- a/packages/ui/src/lib/file/FileListItem.svelte
+++ b/packages/ui/src/lib/file/FileListItem.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import FileStatusBadge from './FileStatusBadge.svelte';
-	import Button from '$lib/Button.svelte';
+	import Badge from '$lib/Badge.svelte';
 	import Checkbox from '$lib/Checkbox.svelte';
 	import Icon from '$lib/Icon.svelte';
 	import Tooltip from '$lib/Tooltip.svelte';
@@ -30,6 +30,7 @@
 			}
 		) => void;
 		onclick?: (e: MouseEvent) => void;
+		onresolveclick?: (e: MouseEvent) => void;
 		onkeydown?: (e: KeyboardEvent) => void;
 		ondragstart?: (e: DragEvent) => void;
 		oncontextmenu?: (e: MouseEvent) => void;
@@ -53,6 +54,7 @@
 		lockText,
 		oncheck,
 		onclick,
+		onresolveclick,
 		onkeydown,
 		ondragstart,
 		oncontextmenu
@@ -112,6 +114,26 @@
 					<Icon name="locked-small" color="warning" />
 				</div>
 			</Tooltip>
+		{/if}
+
+		{#if onresolveclick}
+			{#if !conflicted}
+				<Tooltip text="Conflict resolved">
+					<Badge style="success" label="Resolved" />
+				</Tooltip>
+			{:else}
+				<button
+					type="button"
+					class="mark-resolved-btn"
+					onclick={(e) => {
+						e.stopPropagation();
+						onresolveclick?.(e);
+					}}
+				>
+					<span class="text-11 text-semibold">Mark as resolved</span>
+					<Icon name="tick-small" opacity={0.5} />
+				</button>
+			{/if}
 		{/if}
 
 		{#if conflicted}
@@ -185,6 +207,23 @@
 		transition:
 			width var(--transition-fast),
 			opacity var(--transition-fast);
+	}
+
+	.mark-resolved-btn {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		padding: 3px 6px 3px 6px;
+		border: 1px solid var(--clr-border-2);
+		border-radius: var(--radius-m);
+		margin: 0 2px;
+		transition:
+			background-color var(--transition-fast),
+			border-color var(--transition-fast);
+
+		&:hover {
+			background-color: var(--clr-bg-1);
+		}
 	}
 
 	/* INFO */

--- a/packages/ui/src/stories/fileListItem/DemoFileListItem.svelte
+++ b/packages/ui/src/stories/fileListItem/DemoFileListItem.svelte
@@ -15,6 +15,7 @@
 		lockText?: string;
 		oncheck?: (e: Event) => void;
 		onclick?: () => void;
+		onresolveclick?: () => void;
 		onkeydown?: () => void;
 		ondragstart?: (e: DragEvent) => void;
 		oncontextmenu?: (e: MouseEvent) => void;
@@ -33,18 +34,13 @@
 		lockText,
 		oncheck,
 		onclick,
+		onresolveclick,
 		onkeydown,
 		ondragstart,
 		oncontextmenu
 	}: Props = $props();
 
 	let ref: HTMLDivElement | undefined = $state();
-
-	$effect(() => {
-		if (ref) {
-			console.log('FileListItem updated', ref);
-		}
-	});
 </script>
 
 <FileListItem
@@ -61,6 +57,7 @@
 	{lockText}
 	{oncheck}
 	{onclick}
+	{onresolveclick}
 	{onkeydown}
 	{ondragstart}
 	{oncontextmenu}

--- a/packages/ui/src/stories/fileListItem/FileListItem.stories.ts
+++ b/packages/ui/src/stories/fileListItem/FileListItem.stories.ts
@@ -10,7 +10,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const FileListItemStory: Story = {
-	name: 'FileListItem',
+	name: 'Default',
 	args: {
 		filePath: '/path/to/file.svelte',
 		fileStatus: 'A',
@@ -27,6 +27,25 @@ export const FileListItemStory: Story = {
 		},
 		oncheck: (e: Event) => {
 			console.log('checked', e);
+		}
+	}
+};
+
+export const OnResolveStory: Story = {
+	name: 'Resolve button',
+	args: {
+		filePath: '/path/to/file.svelte',
+		fileStatus: 'A',
+		fileStatusStyle: 'dot',
+		clickable: false,
+		selected: false,
+		conflicted: true,
+		checked: true,
+		onclick: () => {
+			console.log('clicked');
+		},
+		onresolveclick: () => {
+			console.log('resolve clicked');
 		}
 	}
 };


### PR DESCRIPTION
## ☕️ Reasoning

This pull request aims to improve the edit mode experience by displaying the changed state of files and providing a warning when there are still conflicts that need to be resolved.

## 🧢 Changes

- Check whether initially conflicted files are still conflicted. If not, display them as 'Modified' in the files list.
- Warn users about saving files that still look conflicted, to prevent them from accidentally saving conflicted content.

## Issues
As seen in https://github.com/gitbutlerapp/gitbutler/issues/5531

## Visuals
<img width="422" alt="Screenshot 2024-11-18 at 10 08 05" src="https://github.com/user-attachments/assets/e8f41524-25d5-46cd-9e4f-6b8d0e089e95">
<img width="670" alt="Screenshot 2024-11-19 at 17 23 25" src="https://github.com/user-attachments/assets/abcd344d-c156-46de-8a6d-ac4e1269701d">

