### PR TITLE
fix: truncate long path from front, not back

### DIFF
--- a/packages/ui/src/lib/file/FileListItem.svelte
+++ b/packages/ui/src/lib/file/FileListItem.svelte
@@ -96,9 +96,11 @@
 		</span>
 
 		<Tooltip text={filePath} delay={1500}>
-			<span class="text-12 path truncate">
-				{fileInfo.path}
-			</span>
+			<div class="path-container">
+				<span class="text-12 path truncate">
+					{fileInfo.path}
+				</span>
+			</div>
 		</Tooltip>
 	</div>
 
@@ -202,16 +204,25 @@
 		color: var(--clt-text-1);
 	}
 
-	.path {
+	.path-container {
 		flex-shrink: 0;
 		flex-grow: 1;
 		flex-basis: 0px;
 		min-width: 50px;
+		direction: rtl;
+		text-align: left;
+		overflow: hidden;
+	}
+
+	.path {
+		display: inline-block;
 		color: var(--clt-text-1);
 		line-height: 120%;
-		flex-shrink: 1;
 		opacity: 0.3;
 		transition: opacity var(--transition-fast);
+		direction: rtl;
+		width: 100%;
+		text-align: left;
 	}
 
 	/* DETAILS */


### PR DESCRIPTION
## ☕️ Reasoning

- In the case of long paths, truncate from the beginning and show the end.

## 🧢 Changes

### Before
![image](https://github.com/user-attachments/assets/86d753e0-4050-442f-a8a2-f0f7afaf18e0)


### After

![image](https://github.com/user-attachments/assets/96b924a3-3d2e-4b36-8749-9019b9b0070e)


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->