### PR TITLE
Dependecies: Ignore merge commits

### DIFF
--- a/crates/gitbutler-branch-actions/tests/dependencies.rs
+++ b/crates/gitbutler-branch-actions/tests/dependencies.rs
@@ -650,6 +650,76 @@ fn complex_file_manipulation_multiple_hunks_with_uncommitted_changes() -> Result
     Ok(())
 }
 
+#[test]
+fn dependecies_ignore_merge_commits() -> Result<()> {
+    let ctx = command_ctx_after_updates("merge-commit")?;
+    let test_ctx = test_ctx(&ctx)?;
+    let default_target = test_ctx.virtual_branches.get_default_target()?;
+    let my_stack = &test_ctx.stack;
+
+    let file_path = Path::new("file");
+    let file_hunk_1 = GitHunk {
+        old_start: 5,
+        old_lines: 1,
+        new_start: 5,
+        new_lines: 1,
+        diff_lines: "@@ -5,1 +5,1 @@
+-update line 5
++update line 5 again
+"
+        .into(),
+        binary: false,
+        change_type: ChangeType::Modified,
+    };
+
+    let file_hunk_2 = GitHunk {
+        old_start: 8,
+        old_lines: 1,
+        new_start: 8,
+        new_lines: 1,
+        diff_lines: "@@ -8,1 +8,1 @@
+-update line 8
++update line 8 again
+"
+        .into(),
+        binary: false,
+        change_type: ChangeType::Modified,
+    };
+
+    let base_diffs: HashMap<PathBuf, Vec<GitHunk>> = HashMap::from([(
+        file_path.to_path_buf(),
+        vec![file_hunk_1.clone(), file_hunk_2.clone()],
+    )]);
+
+    let dependencies = compute_workspace_dependencies(
+        &ctx,
+        &default_target.sha,
+        &base_diffs,
+        &test_ctx.all_stacks,
+    )?;
+
+    let commit_dependencies = dependencies.commit_dependencies.get(&my_stack.id).unwrap();
+    assert_eq!(commit_dependencies.len(), 0);
+
+    assert_eq!(dependencies.diffs.len(), 1);
+    let file_hunk_1_hash = Hunk::hash_diff(&file_hunk_1.diff_lines);
+    let file_hunk_2_hash = Hunk::hash_diff(&file_hunk_2.diff_lines);
+
+    let hunk_1_locks = dependencies.diffs.get(&file_hunk_1_hash);
+    assert_eq!(hunk_1_locks, None);
+
+    let hunk_2_locks = dependencies.diffs.get(&file_hunk_2_hash).unwrap();
+    assert_eq!(hunk_2_locks.len(), 1);
+    assert_hunk_lock_matches_by_message(
+        hunk_2_locks[0],
+        "update line 8 and delete the line after 7",
+        &ctx,
+        "hunk 2",
+    );
+
+    Ok(())
+}
+
 // Test utility functions
 // ---
 
@@ -750,6 +820,10 @@ fn extract_commit_messages(
 
 fn command_ctx(name: &str) -> Result<CommandContext> {
     gitbutler_testsupport::read_only::fixture("dependencies.sh", name)
+}
+
+fn command_ctx_after_updates(name: &str) -> Result<CommandContext> {
+    gitbutler_testsupport::read_only::fixture("dependencies-after-updates.sh", name)
 }
 
 fn test_ctx(ctx: &CommandContext) -> Result<TestContext> {

--- a/crates/gitbutler-branch-actions/tests/fixtures/dependencies-after-updates.sh
+++ b/crates/gitbutler-branch-actions/tests/fixtures/dependencies-after-updates.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+CLI=${1:?The first argument is the GitButler CLI}
+
+git init remote
+(cd remote
+  echo "1
+2
+3
+4
+5
+6
+7
+8
+9
+" > file
+  git add . && git commit -m "init"
+)
+
+export GITBUTLER_CLI_DATA_DIR=../user/gitbutler/app-data
+
+# Add the project, make some changes.
+git clone remote merge-commit
+(cd merge-commit
+  git config user.name "Author"
+  git config user.email "author@example.com"
+
+  git branch existing-branch
+  $CLI project add --switch-to-workspace "$(git rev-parse --symbolic-full-name @{u})"
+
+
+  $CLI branch create --set-default my_stack
+  echo "this is a" > a
+  $CLI branch commit my_stack -m "add a"
+)
+
+# Create a new commit on the remote.
+(cd remote
+    echo "1
+2
+3
+4
+update line 5
+6
+7
+add this line
+8
+9
+" > file
+  git add . && git commit -m "update line 5 and add a line after 7"
+)
+
+# Update the project.
+(cd merge-commit
+  git fetch origin
+  $CLI integrate-upstream merge
+
+  echo "1
+2
+3
+4
+update line 5
+6
+7
+update line 8
+9
+" > file
+  $CLI branch commit my_stack -m "update line 8 and delete the line after 7"
+)

--- a/crates/gitbutler-cli/src/args.rs
+++ b/crates/gitbutler-cli/src/args.rs
@@ -34,6 +34,7 @@ pub enum Subcommands {
         to_line: u32,
     },
     /// Update the local workspace against an updated remote or target branch.
+    #[clap(visible_alias = "update")]
     IntegrateUpstream {
         /// Specify how all branches should be merged in.
         #[clap(value_enum)]


### PR DESCRIPTION
## ☕️ Reasoning
Obviously don't ignore **all** merge commits. Only some.

Calculating the dependency graph of all changes in a stack, should ignore merge-commits that bring in changes already integrated in the target branch.

## 🧢 Changes

- Added an alias for the upstream integration command to be used in the integration tests.
- Implemented a change to ignore merge commits when computing the dependency graphs, ensuring that the dependency management process is more accurate and reliable.

## Reported
As seen in this Discord thread: https://discord.com/channels/1060193121130000425/1308034358820733029