### PR TITLE
feat: handle error branches in the frontend

### DIFF
--- a/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
@@ -42,7 +42,7 @@
 		allowRebasing = branch.allowRebasing;
 	});
 
-	const allPrIds = $derived(branch.series.map((series) => series.prNumber).filter(isDefined));
+	const allPrIds = $derived(branch.validSeries.map((series) => series.prNumber).filter(isDefined));
 
 	async function toggleAllowRebasing() {
 		branchController.updateBranchAllowRebasing(branch.id, !allowRebasing);
@@ -128,7 +128,7 @@
 				disabled={allPrIds.length === 0}
 				onclick={() => {
 					if ($prService && branch) {
-						const allPrIds = branch.series.map((series) => series.prNumber).filter(isDefined);
+						const allPrIds = branch.validSeries.map((series) => series.prNumber).filter(isDefined);
 						updatePrDescriptionTables($prService, allPrIds);
 					}
 					contextMenuEl?.close();

--- a/apps/desktop/src/lib/branch/SeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/SeriesHeader.svelte
@@ -229,7 +229,7 @@
 	leftClickTrigger={kebabContextMenuTrigger}
 	rightClickTrigger={seriesHeaderEl}
 	headName={currentSeries.name}
-	seriesCount={branch.series?.length ?? 0}
+	seriesCount={branch.validSeries?.length ?? 0}
 	{isTopSeries}
 	{toggleDescription}
 	description={currentSeries.description ?? ''}

--- a/apps/desktop/src/lib/branch/SeriesHeaderContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/SeriesHeaderContextMenu.svelte
@@ -75,7 +75,7 @@
 	const branch = $derived($branchStore);
 
 	export function showSeriesRenameModal(seriesName: string) {
-		renameSeriesModal.show(branch.series.find((s) => s.name === seriesName));
+		renameSeriesModal.show(branch.validSeries.find((s) => s.name === seriesName));
 	}
 
 	let isOpenedByMouse = $state(false);

--- a/apps/desktop/src/lib/dragging/stackingReorderDropzoneManager.ts
+++ b/apps/desktop/src/lib/dragging/stackingReorderDropzoneManager.ts
@@ -51,7 +51,7 @@ export class StackingReorderDropzoneManager {
 		private branch: VirtualBranch
 	) {
 		const seriesMap = new Map();
-		this.branch.series.forEach((series) => {
+		this.branch.validSeries.forEach((series) => {
 			seriesMap.set(series.name, series);
 		});
 		this.series = seriesMap;
@@ -67,7 +67,7 @@ export class StackingReorderDropzoneManager {
 			this.branch.id,
 			this.branchController,
 			currentSeries,
-			this.branch.series,
+			this.branch.validSeries,
 			'top'
 		);
 	}
@@ -82,7 +82,7 @@ export class StackingReorderDropzoneManager {
 			this.branch.id,
 			this.branchController,
 			currentSeries,
-			this.branch.series,
+			this.branch.validSeries,
 			commitId
 		);
 	}

--- a/apps/desktop/src/lib/pr/PrDetailsModal.svelte
+++ b/apps/desktop/src/lib/pr/PrDetailsModal.svelte
@@ -169,7 +169,7 @@
 		}
 
 		// All ids that existed prior to creating a new one (including archived).
-		const prNumbers = branch.series.map((series) => series.prNumber);
+		const prNumbers = branch.validSeries.map((series) => series.prNumber);
 
 		isLoading = true;
 		try {
@@ -205,7 +205,7 @@
 			}
 
 			// Find the index of the current branch so we know where we want to point the pr.
-			const branches = branch.series;
+			const branches = branch.validSeries;
 			const currentIndex = branches.findIndex((b) => b.name === currentSeries.name);
 			if (currentIndex === -1) {
 				throw new Error('Branch index not found.');

--- a/apps/desktop/src/lib/stack/CollapsedLane.svelte
+++ b/apps/desktop/src/lib/stack/CollapsedLane.svelte
@@ -15,7 +15,7 @@
 
 	const branchStore = getContextStore(VirtualBranch);
 	const branch = $derived($branchStore);
-	const nonArchivedSeries = $derived(branch.series.filter((s) => !s.archived));
+	const nonArchivedSeries = $derived(branch.validSeries.filter((s) => !s.archived));
 
 	function expandLane() {
 		$isLaneCollapsed = false;

--- a/apps/desktop/src/lib/stack/ErrorSeries.svelte
+++ b/apps/desktop/src/lib/stack/ErrorSeries.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
 	import { openExternalUrl } from '$lib/utils/url';
 	import LinkButton from '@gitbutler/ui/LinkButton.svelte';
+
+	interface Props {
+		error: Error;
+	}
+	const { error }: Props = $props();
 </script>
 
 <div class="error-series">
 	<div class="commit-line"></div>
-	<div class="text-13 text-body error-series__label">
+	<div class="text-13 text-body error-series__body">
 		This branch failed to load.
-		<br />
-		<br />
+		<pre class="error-series__message">{error.message}</pre>
 		Please check out our
 		<LinkButton
 			icon="copy-small"
@@ -17,7 +21,12 @@
 			}}
 		>
 			documentation
-		</LinkButton> or reload to try again.
+		</LinkButton> or visit our <LinkButton
+			icon="copy-small"
+			onclick={async () => {
+				openExternalUrl('https://discord.com/invite/MmFkmaJ42D');
+			}}>Discord</LinkButton
+		> for support.
 	</div>
 </div>
 
@@ -35,12 +44,16 @@
 		display: flex;
 		overflow: hidden;
 	}
-	.error-series__label {
+	.error-series__body {
 		color: var(--clr-text-2);
 
 		width: 100%;
 		padding: 20px 28px 26px 46px;
 		opacity: 0.6;
+
+		.error-series__message {
+			margin: 8px 0;
+		}
 	}
 	.commit-line {
 		--commit-color: var(--clr-theme-err-element);

--- a/apps/desktop/src/lib/stack/ErrorSeries.svelte
+++ b/apps/desktop/src/lib/stack/ErrorSeries.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import { openExternalUrl } from '$lib/utils/url';
+	import LinkButton from '@gitbutler/ui/LinkButton.svelte';
+</script>
+
+<div class="error-series">
+	<div class="commit-line"></div>
+	<div class="text-13 text-body error-series__label">
+		This branch failed to load.
+		<br />
+		<br />
+		Please check out our
+		<LinkButton
+			icon="copy-small"
+			onclick={async () => {
+				openExternalUrl('http://docs.gitbutler.com/development/debugging');
+			}}
+		>
+			documentation
+		</LinkButton> or reload to try again.
+	</div>
+</div>
+
+<style>
+	.error-series {
+		position: relative;
+		border: 1px solid var(--clr-border-2);
+		border-radius: var(--radius-m);
+		background: var(--clr-bg-1);
+		scroll-margin-top: 120px;
+
+		&:last-child {
+			margin-bottom: 12px;
+		}
+		display: flex;
+		overflow: hidden;
+	}
+	.error-series__label {
+		color: var(--clr-text-2);
+
+		width: 100%;
+		padding: 20px 28px 26px 46px;
+		opacity: 0.6;
+	}
+	.commit-line {
+		--commit-color: var(--clr-theme-err-element);
+		position: absolute;
+		left: 20px;
+	}
+</style>

--- a/apps/desktop/src/lib/stack/SeriesDividerLine.svelte
+++ b/apps/desktop/src/lib/stack/SeriesDividerLine.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
 	import { getColorFromBranchType } from '@gitbutler/ui/utils/getColorFromBranchType';
-	import type { CommitStatus, PatchSeries } from '$lib/vbranches/types';
+	import type { CommitStatus } from '$lib/vbranches/types';
 
 	interface Props {
-		currentSeries: PatchSeries;
+		topPatchStatus?: CommitStatus;
 	}
 
-	const { currentSeries }: Props = $props();
+	const { topPatchStatus }: Props = $props();
 
-	const topPatch = $derived(currentSeries?.patches[0]);
-	const branchType = $derived<CommitStatus>(topPatch?.status ?? 'local');
+	const branchType = $derived<CommitStatus>(topPatchStatus ?? 'local');
 	const lineColor = $derived(getColorFromBranchType(branchType));
 </script>
 

--- a/apps/desktop/src/lib/stack/SeriesDividerLine.svelte
+++ b/apps/desktop/src/lib/stack/SeriesDividerLine.svelte
@@ -2,13 +2,15 @@
 	import { getColorFromBranchType } from '@gitbutler/ui/utils/getColorFromBranchType';
 	import type { CommitStatus } from '$lib/vbranches/types';
 
+	type SeriesStatus = CommitStatus | 'error';
+
 	interface Props {
-		topPatchStatus?: CommitStatus;
+		topPatchStatus?: SeriesStatus;
 	}
 
 	const { topPatchStatus }: Props = $props();
 
-	const branchType = $derived<CommitStatus>(topPatchStatus ?? 'local');
+	const branchType = $derived<SeriesStatus>(topPatchStatus ?? 'local');
 	const lineColor = $derived(getColorFromBranchType(branchType));
 </script>
 

--- a/apps/desktop/src/lib/stack/Stack.svelte
+++ b/apps/desktop/src/lib/stack/Stack.svelte
@@ -20,6 +20,7 @@
 	import Button from '@gitbutler/ui/Button.svelte';
 	import EmptyStatePlaceholder from '@gitbutler/ui/EmptyStatePlaceholder.svelte';
 	import Spacer from '@gitbutler/ui/Spacer.svelte';
+	import { isError } from '@gitbutler/ui/utils/typeguards';
 	import lscache from 'lscache';
 	import { onMount } from 'svelte';
 	import { type Writable } from 'svelte/store';
@@ -65,6 +66,7 @@
 		const branchPatches: DetailedCommit[] = [];
 
 		branch.series.map((series) => {
+			if (isError(series)) return;
 			upstreamPatches.push(...series.upstreamPatches);
 			branchPatches.push(...series.patches);
 			hasConflicts = branchPatches.some((patch) => patch.conflicted);

--- a/apps/desktop/src/lib/stack/Stack.svelte
+++ b/apps/desktop/src/lib/stack/Stack.svelte
@@ -20,7 +20,6 @@
 	import Button from '@gitbutler/ui/Button.svelte';
 	import EmptyStatePlaceholder from '@gitbutler/ui/EmptyStatePlaceholder.svelte';
 	import Spacer from '@gitbutler/ui/Spacer.svelte';
-	import { isError } from '@gitbutler/ui/utils/typeguards';
 	import lscache from 'lscache';
 	import { onMount } from 'svelte';
 	import { type Writable } from 'svelte/store';
@@ -65,8 +64,7 @@
 		const upstreamPatches: DetailedCommit[] = [];
 		const branchPatches: DetailedCommit[] = [];
 
-		branch.series.map((series) => {
-			if (isError(series)) return;
+		branch.validSeries.map((series) => {
 			upstreamPatches.push(...series.upstreamPatches);
 			branchPatches.push(...series.patches);
 			hasConflicts = branchPatches.some((patch) => patch.conflicted);
@@ -192,7 +190,11 @@
 								: undefined}
 							onclick={push}
 						>
-							{branch.requiresForce ? 'Force push' : branch.series.length > 1 ? 'Push All' : 'Push'}
+							{branch.requiresForce
+								? 'Force push'
+								: branch.validSeries.length > 1
+									? 'Push All'
+									: 'Push'}
 						</Button>
 					</div>
 				{/if}

--- a/apps/desktop/src/lib/stack/header/HeaderMetaSection.svelte
+++ b/apps/desktop/src/lib/stack/header/HeaderMetaSection.svelte
@@ -6,7 +6,7 @@
 	import Button from '@gitbutler/ui/Button.svelte';
 
 	interface Props {
-		series: PatchSeries[];
+		series: (PatchSeries | Error)[];
 		onCollapseButtonClick: () => void;
 	}
 

--- a/apps/desktop/src/lib/stack/header/SeriesLabels.svelte
+++ b/apps/desktop/src/lib/stack/header/SeriesLabels.svelte
@@ -13,7 +13,7 @@
 
 	const shiftedSeries = $derived(series.slice(1));
 	const seriesTypes = $derived(
-		shiftedSeries.map((s) => (s.patches[0] ? s.patches[0].status : 'local'))
+		shiftedSeries.map((s) => (s.patches?.[0] ? s.patches?.[0].status : 'local'))
 	);
 </script>
 

--- a/apps/desktop/src/lib/stack/header/SeriesLabels.svelte
+++ b/apps/desktop/src/lib/stack/header/SeriesLabels.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import Select from '$lib/select/Select.svelte';
-	import { PatchSeries } from '$lib/vbranches/types';
+	import { isPatchSeries, PatchSeries } from '$lib/vbranches/types';
 	import Icon from '@gitbutler/ui/Icon.svelte';
 	import SeriesLabelsRow from '@gitbutler/ui/SeriesLabelsRow.svelte';
 
 	interface Props {
-		series: PatchSeries[];
+		series: (PatchSeries | Error)[];
 		disableSelector?: boolean;
 	}
 
@@ -13,7 +13,12 @@
 
 	const shiftedSeries = $derived(series.slice(1));
 	const seriesTypes = $derived(
-		shiftedSeries.map((s) => (s.patches?.[0] ? s.patches?.[0].status : 'local'))
+		shiftedSeries.map((s) => {
+			if (isPatchSeries(s) && s.patches?.[0]) {
+				return s.patches?.[0].status;
+			}
+			return 'error';
+		})
 	);
 </script>
 
@@ -173,6 +178,10 @@
 
 		&.integrated {
 			background-color: var(--clr-commit-integrated);
+		}
+
+		&.error {
+			background-color: var(--clr-theme-err-element);
 		}
 	}
 

--- a/apps/desktop/src/lib/stack/header/StackHeader.svelte
+++ b/apps/desktop/src/lib/stack/header/StackHeader.svelte
@@ -14,7 +14,7 @@
 
 	const { onCollapseButtonClick, branch }: Props = $props();
 
-	const nonArchivedSeries = $derived(branch.series.filter((s) => !s.archived));
+	const nonArchivedSeries = $derived(branch.validSeries.filter((s) => !s.archived));
 </script>
 
 <div class="stack-header">

--- a/apps/desktop/src/lib/stack/header/StackHeader.svelte
+++ b/apps/desktop/src/lib/stack/header/StackHeader.svelte
@@ -4,6 +4,7 @@
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { VirtualBranch } from '$lib/vbranches/types';
 	import { getContext } from '@gitbutler/shared/context';
+	import { isError } from '@gitbutler/ui/utils/typeguards';
 
 	interface Props {
 		branch: VirtualBranch;
@@ -14,7 +15,12 @@
 
 	const { onCollapseButtonClick, branch }: Props = $props();
 
-	const nonArchivedSeries = $derived(branch.validSeries.filter((s) => !s.archived));
+	const nonArchivedSeries = $derived(
+		branch.series.filter((s) => {
+			if (isError(s)) return s;
+			return !s.archived;
+		})
+	);
 </script>
 
 <div class="stack-header">

--- a/apps/desktop/src/lib/vbranches/types.ts
+++ b/apps/desktop/src/lib/vbranches/types.ts
@@ -113,6 +113,10 @@ export class VirtualBranches {
 	skippedFiles!: SkippedFile[];
 }
 
+export function isPatchSeries(item: PatchSeries | Error): item is PatchSeries {
+	return item instanceof PatchSeries;
+}
+
 export class VirtualBranch {
 	id!: string;
 	name!: string;
@@ -154,6 +158,10 @@ export class VirtualBranch {
 	// Used in the stacking context where VirtualBranch === Stack
 	@Transform(({ value }) => transformResultToType(PatchSeries, value))
 	series!: (PatchSeries | Error)[];
+
+	get validSeries(): PatchSeries[] {
+		return this.series.filter(isPatchSeries);
+	}
 
 	get localCommits() {
 		return this.commits.filter((c) => c.status === 'local');

--- a/apps/desktop/src/lib/vbranches/virtualBranch.ts
+++ b/apps/desktop/src/lib/vbranches/virtualBranch.ts
@@ -53,8 +53,8 @@ export class VirtualBranchService {
 		branches.forEach(async (branch) => {
 			const upstreamName = branch.upstream?.name;
 			if (upstreamName) {
-				const upstreamCommits = branch.series.flatMap((series) => series.upstreamPatches);
-				const commits = branch.series.flatMap((series) => series.patches);
+				const upstreamCommits = branch.validSeries.flatMap((series) => series.upstreamPatches);
+				const commits = branch.validSeries.flatMap((series) => series.patches);
 				commits.forEach((commit) => {
 					const upstreamMatch = upstreamCommits.find(
 						(upstreamCommit) => commit.remoteCommitId === upstreamCommit.id

--- a/packages/ui/src/lib/utils/getColorFromBranchType.ts
+++ b/packages/ui/src/lib/utils/getColorFromBranchType.ts
@@ -5,9 +5,10 @@ const colorMap = {
 	localAndRemote: 'var(--clr-commit-remote)',
 	localAndShadow: 'var(--clr-commit-local)',
 	remote: 'var(--clr-commit-upstream)',
-	integrated: 'var(--clr-commit-integrated)'
+	integrated: 'var(--clr-commit-integrated)',
+	error: 'var(--clr-theme-err-element)'
 };
 
-export function getColorFromBranchType(type: CellType): string {
+export function getColorFromBranchType(type: CellType | 'error'): string {
 	return colorMap[type];
 }

--- a/packages/ui/src/lib/utils/typeguards.ts
+++ b/packages/ui/src/lib/utils/typeguards.ts
@@ -21,3 +21,12 @@ export function isNonEmptyObject(something: unknown): something is UnknownObject
 		(Object.keys(something).length > 0 || Object.getOwnPropertySymbols(something).length > 0)
 	);
 }
+
+/**
+ * Checks if the provided value is an Error.
+ * @param value - The value to be checked.
+ * @returns A boolean indicating whether the value is an Error.
+ */
+export function isError(value: unknown): value is Error {
+	return value instanceof Error;
+}


### PR DESCRIPTION
## ☕️ Reasoning

- Branch in stack before me added support for not blowing up the entire `list_virtual_branches` result if one thing errored. The error boundary is at the series level, so the `series` type turned  into `(PatchSeries | Error)[]` from the point of view of the frontend.

## 🧢 Changes

- Added transformation when parsing `branch.series` from `list_virtual_branches` into `VirtualBranch`
- Added `ErrorSeries` card for when a branch is errored
- Updated `SeriesLabels` in `StackHeader` to show errored series + red color

![image](https://github.com/user-attachments/assets/75c4decb-c6e6-4506-ae28-6bfba88fa5c3)



<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->

<!-- GitButler Footer Boundary Top -->
---
This is **part of a stack** made with GitButler:
- #5589 
- #5591 👈 
<!-- GitButler Footer Boundary Bottom -->

