### PR TITLE
Disable PR button on conflict.

### DIFF
--- a/apps/desktop/src/lib/branch/SeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/SeriesHeader.svelte
@@ -74,6 +74,7 @@
 	const hasNoCommits = $derived(
 		currentSeries.upstreamPatches.length === 0 && currentSeries.patches.length === 0
 	);
+	const conflictedSeries = $derived(currentSeries.conflicted);
 
 	// Pretty cumbersome way of getting the PR number, would be great if we can
 	// make it more concise somehow.
@@ -341,8 +342,14 @@
 								style="ghost"
 								wide
 								outline
-								disabled={currentSeries.patches.length === 0 || !$forge || !$prService}
+								disabled={currentSeries.patches.length === 0 ||
+									!$forge ||
+									!$prService ||
+									conflictedSeries}
 								onclick={() => handleOpenPR(!forgeBranch)}
+								tooltip={conflictedSeries
+									? 'Please resolve the conflicts before creating a PR'
+									: undefined}
 							>
 								Create pull request
 							</Button>

--- a/apps/desktop/src/lib/vbranches/types.ts
+++ b/apps/desktop/src/lib/vbranches/types.ts
@@ -474,6 +474,10 @@ export class PatchSeries {
 	get branchName() {
 		return this.name?.replace('refs/remotes/origin/', '');
 	}
+
+	get conflicted() {
+		return this.patches.some((c) => c.conflicted);
+	}
 }
 
 /**


### PR DESCRIPTION
## ☕️ Reasoning

This pull request disables the PR button when a series contains a conflicted patch. This is to prevent users from creating a pull request when there are conflicts that need to be resolved first.

## 🧢 Changes

The main change in this PR is to disable the PR button if a series contains a conflicted patch. This ensures that users cannot create a pull request until the conflicts have been resolved.