### PR TITLE
More PR monitoring fixes

### DIFF
--- a/apps/desktop/src/lib/forge/github/githubChecksMonitor.test.ts
+++ b/apps/desktop/src/lib/forge/github/githubChecksMonitor.test.ts
@@ -80,15 +80,17 @@ describe('GitHubChecksMonitor', () => {
 				}
 			} as ChecksResponse)
 		);
-		await monitor?.update();
-		expect(mock).toHaveBeenCalledOnce();
+		monitor?.update();
+		expect(mock).toHaveBeenCalledTimes(1);
+		await vi.runOnlyPendingTimersAsync();
+		expect(mock).toHaveBeenCalledTimes(2);
 
 		let status = monitor?.getLastStatus();
 		expect(status?.finished).toBeFalsy();
 
 		// Verify that checks are re-fetchd after some timeout.
 		await vi.runOnlyPendingTimersAsync();
-		expect(mock).toHaveBeenCalledTimes(2);
+		expect(mock).toHaveBeenCalledTimes(3);
 		mock.mockRestore();
 
 		// Change response to something considered completed, and reset time so
@@ -110,6 +112,7 @@ describe('GitHubChecksMonitor', () => {
 				}
 			} as ChecksResponse)
 		);
+
 		await vi.runOnlyPendingTimersAsync();
 		expect(mock2).toHaveBeenCalledOnce();
 		status = monitor?.getLastStatus();
@@ -122,6 +125,6 @@ describe('GitHubChecksMonitor', () => {
 
 		// Verify polling has stopped.
 		await vi.runAllTimersAsync();
-		expect(mock2).toHaveBeenCalledTimes(2);
+		expect(mock2).toHaveBeenCalledTimes(3);
 	});
 });

--- a/apps/desktop/src/lib/forge/github/githubPrService.ts
+++ b/apps/desktop/src/lib/forge/github/githubPrService.ts
@@ -16,11 +16,14 @@ import type { Octokit } from '@octokit/rest';
 
 export class GitHubPrService implements ForgePrService {
 	loading = writable(false);
+	private monitors: Map<number, GitHubPrMonitor>;
 
 	constructor(
 		private octokit: Octokit,
 		private repo: RepoInfo
-	) {}
+	) {
+		this.monitors = new Map();
+	}
 
 	async createPr({
 		title,
@@ -94,7 +97,12 @@ export class GitHubPrService implements ForgePrService {
 	}
 
 	prMonitor(prNumber: number): GitHubPrMonitor {
-		return new GitHubPrMonitor(this, prNumber);
+		if (this.monitors.has(prNumber)) {
+			return this.monitors.get(prNumber)!;
+		}
+		const monitor = new GitHubPrMonitor(this, prNumber);
+		this.monitors.set(prNumber, monitor);
+		return monitor;
 	}
 
 	async update(prNumber: number, details: { description?: string; state?: 'open' | 'closed' }) {


### PR DESCRIPTION
## ☕️ Reasoning

1. The PR service now keeps a map of PR monitors, ensuring that if multiple consumers ask for the same PR's monitor, the same object is returned. This fixes an issue where refreshing the monitor wouldn't propagate the update to every consumer.

2. Some PR checks are only listed asynchronously, so initially it might look like all checks have passed.
 The PR checks are now double-checked, to account for false positives that the GitHub API causes.

## 🧢 Changes

- The PR service now maintains a map of PR monitors to ensure consistent updates across consumers.
- The PR check validation process has been improved to handle asynchronous fetching of the check list, reducing the chances of false positives.