### PR TITLE
fix: File navigation in commits

### DIFF
--- a/apps/desktop/src/lib/utils/selection.ts
+++ b/apps/desktop/src/lib/utils/selection.ts
@@ -94,9 +94,8 @@ export function updateSelection({
 		getFileFunc?: (files: AnyFile[], id: string) => AnyFile | undefined
 	) {
 		const file = getFileFunc?.(files, id) ?? getFile(files, id);
-
 		if (file) {
-			fileIdSelection.clearExcept(file.id, commitId);
+			fileIdSelection.set(file, commitId);
 		}
 	}
 
@@ -108,6 +107,7 @@ export function updateSelection({
 				}
 			}
 			break;
+		case 'k':
 		case KeyName.Up:
 			if (shiftKey && allowMultiple) {
 				// Handle case if only one file is selected
@@ -131,6 +131,7 @@ export function updateSelection({
 			}
 			break;
 
+		case 'j':
 		case KeyName.Down:
 			if (shiftKey && allowMultiple) {
 				// Handle case if only one file is selected

--- a/apps/desktop/src/lib/vbranches/fileIdSelection.ts
+++ b/apps/desktop/src/lib/vbranches/fileIdSelection.ts
@@ -190,12 +190,6 @@ export class FileIdSelection implements Readable<string[]> {
 		this.selectedFile.set(undefined);
 	}
 
-	async clearExcept(fileId: string, commitId?: string) {
-		this.selection = [stringifyKey(fileId, commitId)];
-		await this.reloadFiles();
-		this.emit();
-	}
-
 	only(): FileKey | undefined {
 		if (this.selection.length === 0) return;
 		const fileKey = parseFileKey(this.selection[0]!);


### PR DESCRIPTION
Commit files were not navigatable because the component was using an old implementation of the selection update method.

Also:
- Remove old, now unused file selection update method
- Add support for `j`, `k` navigation