### PR TITLE
Fix commit line colors

### DIFF
--- a/apps/desktop/src/lib/branch/stackingUtils.ts
+++ b/apps/desktop/src/lib/branch/stackingUtils.ts
@@ -3,7 +3,6 @@ import type { CellType } from '@gitbutler/ui/commitLines/types';
 const colorMap = {
 	local: 'var(--clr-commit-local)',
 	localAndRemote: 'var(--clr-commit-remote)',
-	localAndShadow: 'var(--clr-commit-local)',
 	remote: 'var(--clr-commit-remote)',
 	integrated: 'var(--clr-commit-integrated)'
 };

--- a/apps/desktop/src/lib/commit/CommitList.svelte
+++ b/apps/desktop/src/lib/commit/CommitList.svelte
@@ -67,15 +67,20 @@
 
 	const forge = getForge();
 
-	const localAndRemoteCommits = $derived(patches.filter((patch) => patch.remoteCommitId));
+	const localAndRemoteCommits = $derived(
+		patches.filter((patch) => patch.status === 'localAndRemote')
+	);
 	const lastDivergentCommit = $derived(findLastDivergentCommit(localAndRemoteCommits));
 
+	// A local or localAndRemote commit probably shouldn't every be integrated,
+	// but the isIntegrated check is a bit fuzzy, and is certainly the most
+	// important state to convey to the user.
 	const lineManager = $derived(
 		lineManagerFactory.build({
-			remoteCommits: remoteOnlyPatches,
-			localCommits: patches.filter((patch) => !patch.remoteCommitId),
-			localAndRemoteCommits,
-			integratedCommits: patches.filter((patch) => patch.isIntegrated)
+			remoteCommits: remoteOnlyPatches.filter((patch) => patch.status === 'remote'),
+			localCommits: patches.filter((patch) => patch.status === 'local'),
+			localAndRemoteCommits: localAndRemoteCommits,
+			integratedCommits: patches.filter((patch) => patch.status === 'integrated')
 		})
 	);
 

--- a/apps/desktop/src/lib/components/BaseBranch.svelte
+++ b/apps/desktop/src/lib/components/BaseBranch.svelte
@@ -305,7 +305,7 @@
 			disableCommitActions={true}
 		>
 			{#snippet lines()}
-				<Line typeOverride="local" line={lineManager.get(commit.id)} />
+				<Line line={lineManager.get(commit.id)} />
 			{/snippet}
 		</CommitCard>
 	{/each}

--- a/apps/desktop/src/lib/stack/SeriesList.svelte
+++ b/apps/desktop/src/lib/stack/SeriesList.svelte
@@ -89,7 +89,7 @@
 
 			{#if currentSeries.upstreamPatches.length > 0 || currentSeries.patches.length > 0}
 				<CommitList
-					remoteOnlyPatches={currentSeries.upstreamPatches.filter((p) => !p.relatedTo)}
+					remoteOnlyPatches={currentSeries.upstreamPatches}
 					patches={currentSeries.patches}
 					seriesName={currentSeries.name}
 					isUnapplied={false}

--- a/apps/desktop/src/lib/vbranches/types.ts
+++ b/apps/desktop/src/lib/vbranches/types.ts
@@ -204,7 +204,7 @@ export class VirtualBranch {
 
 // Used for dependency injection
 export const BRANCH = Symbol('branch');
-export type CommitStatus = 'local' | 'localAndRemote' | 'localAndShadow' | 'integrated' | 'remote';
+export type CommitStatus = 'local' | 'localAndRemote' | 'integrated' | 'remote';
 
 export class ConflictEntries {
 	public entries: Map<string, ConflictEntryPresence> = new Map();
@@ -234,6 +234,7 @@ export class DetailedCommit {
 	@Transform((obj) => new Date(obj.value))
 	createdAt!: Date;
 	isRemote!: boolean;
+	isLocalAndRemote!: boolean;
 	isIntegrated!: boolean;
 	parentIds!: string[];
 	branchId!: string;
@@ -282,12 +283,8 @@ export class DetailedCommit {
 
 	get status(): CommitStatus {
 		if (this.isIntegrated) return 'integrated';
-		if (this.remoteCommitId) {
-			if (this.remoteCommitId !== this.id) {
-				return 'localAndShadow';
-			}
-			return 'localAndRemote';
-		}
+		if (this.isLocalAndRemote) return 'localAndRemote';
+		if (this.isRemote) return 'remote';
 		return 'local';
 	}
 
@@ -473,10 +470,6 @@ export class PatchSeries {
 
 	get remoteCommits() {
 		return this.patches.filter((c) => c.status === 'localAndRemote');
-	}
-
-	get shadowCommits() {
-		return this.patches.filter((c) => c.status === 'localAndShadow');
 	}
 
 	get integratedCommits() {

--- a/crates/gitbutler-branch-actions/src/commit.rs
+++ b/crates/gitbutler-branch-actions/src/commit.rs
@@ -24,8 +24,12 @@ pub struct VirtualBranchCommit {
     pub description: BStringForFrontend,
     pub created_at: u128,
     pub author: Author,
-    /// Dont use, favor `remote_commit_id` instead
+    /// If the commit is remote AND ONLY REMOTE
     pub is_remote: bool,
+    /// If the commit is both local and remote
+    pub is_local_and_remote: bool,
+    /// If the commit is integrated. A commit may be local_and_remote, local,
+    /// or remote, and be integrated.
     pub is_integrated: bool,
     #[serde(with = "gitbutler_serde::oid_vec")]
     pub parent_ids: Vec<git2::Oid>,
@@ -68,6 +72,7 @@ pub(crate) fn commit_to_vbranch_commit(
     commit: &git2::Commit,
     is_integrated: bool,
     is_remote: bool,
+    is_local_and_remote: bool,
     copied_from_remote_id: Option<git2::Oid>,
     remote_commit_id: Option<git2::Oid>,
     commit_dependencies: CommitDependencies,
@@ -111,6 +116,7 @@ pub(crate) fn commit_to_vbranch_commit(
         description: message.into(),
         is_remote,
         is_integrated,
+        is_local_and_remote,
         parent_ids,
         branch_id: stack.id,
         change_id: commit.change_id(),

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
@@ -81,9 +81,9 @@ fn integration() {
             .find(|branch| branch.id == branch_id)
             .unwrap();
 
-        assert!(branch.commits[0].is_remote);
+        assert!(branch.commits[0].is_local_and_remote);
         assert!(!branch.commits[0].is_integrated);
-        assert!(branch.commits[1].is_remote);
+        assert!(branch.commits[1].is_local_and_remote);
         assert!(!branch.commits[1].is_integrated);
 
         repository.rebase_and_merge(&branch_name);
@@ -105,9 +105,9 @@ fn integration() {
             Some(123)
         );
 
-        assert!(branch.commits[0].is_remote);
+        assert!(branch.commits[0].is_local_and_remote);
         assert!(branch.commits[0].is_integrated);
-        assert!(branch.commits[1].is_remote);
+        assert!(branch.commits[1].is_local_and_remote);
         assert!(branch.commits[1].is_integrated);
     }
 }

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/upstream.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/upstream.rs
@@ -33,7 +33,7 @@ fn detect_upstream_commits() {
     };
 
     // push
-    gitbutler_branch_actions::push_virtual_branch(project, branch1_id, false, None).unwrap();
+    gitbutler_branch_actions::stack::push_stack(project, branch1_id, false).unwrap();
 
     let oid3 = {
         // create third commit
@@ -48,11 +48,11 @@ fn detect_upstream_commits() {
         assert_eq!(branches[0].id, branch1_id);
         assert_eq!(branches[0].commits.len(), 3);
         assert_eq!(branches[0].commits[0].id, oid3);
-        assert!(!branches[0].commits[0].is_remote);
+        assert!(!branches[0].commits[0].is_local_and_remote);
         assert_eq!(branches[0].commits[1].id, oid2);
-        assert!(branches[0].commits[1].is_remote);
+        assert!(branches[0].commits[1].is_local_and_remote);
         assert_eq!(branches[0].commits[2].id, oid1);
-        assert!(branches[0].commits[2].is_remote);
+        assert!(branches[0].commits[2].is_local_and_remote);
     }
 }
 

--- a/packages/ui/src/lib/commitLines/CommitNode.svelte
+++ b/packages/ui/src/lib/commitLines/CommitNode.svelte
@@ -14,20 +14,9 @@
 </script>
 
 <div class="container">
-	{#if commitNode.type === 'local'}
-		<Tooltip text={tooltipText}>
-			<svg
-				class="local-commit-dot"
-				viewBox="0 0 10 10"
-				fill="none"
-				xmlns="http://www.w3.org/2000/svg"
-			>
-				<rect width="10" height="10" rx="5" />
-			</svg>
-		</Tooltip>
-	{:else if commitNode.type === 'localAndShadow'}
+	{#if commitNode.type === 'local' && commitNode.commit?.remoteCommitId}
 		<div class="local-shadow-commit-dot">
-			<Tooltip text={commitNode.commit?.remoteCommitId?.substring(0, 7) ?? 'Diverged'}>
+			<Tooltip text={commitNode.commit?.remoteCommitId.substring(0, 7) ?? 'Diverged'}>
 				<svg class="shadow-dot" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
 					<path
 						d="M0.827119 6.41372C0.0460709 5.63267 0.0460709 4.36634 0.827119 3.58529L3.70602 0.706392C4.48707 -0.0746567 5.7534 -0.0746567 6.53445 0.706392L9.41335 3.58529C10.1944 4.36634 10.1944 5.63267 9.41335 6.41372L6.53445 9.29262C5.7534 10.0737 4.48707 10.0737 3.70602 9.29262L0.827119 6.41372Z"
@@ -44,6 +33,17 @@
 				</svg>
 			</Tooltip>
 		</div>
+	{:else if commitNode.type === 'local'}
+		<Tooltip text={tooltipText}>
+			<svg
+				class="local-commit-dot"
+				viewBox="0 0 10 10"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<rect width="10" height="10" rx="5" />
+			</svg>
+		</Tooltip>
 	{:else}
 		<Tooltip text={tooltipText}>
 			<svg class="generic-commit-dot" viewBox="0 0 11 12" xmlns="http://www.w3.org/2000/svg">

--- a/packages/ui/src/lib/commitLines/Line.svelte
+++ b/packages/ui/src/lib/commitLines/Line.svelte
@@ -7,15 +7,14 @@
 	interface Props {
 		line: CommitNodeData;
 		isBottom?: boolean;
-		typeOverride?: CellType;
 	}
 
-	const { line, typeOverride, isBottom = false }: Props = $props();
+	const { line, isBottom = false }: Props = $props();
 
-	const lineType = $derived<CellType>(line.type ?? line.type ?? 'local');
+	const lineType = $derived<CellType>(line.type ?? 'local');
 </script>
 
-<div class="line" style:--commit-color={getColorFromBranchType(typeOverride ?? lineType)}>
+<div class="line" style:--commit-color={getColorFromBranchType(lineType)}>
 	<div class="line-top">
 		<Cell />
 	</div>
@@ -23,7 +22,7 @@
 		<CommitNode
 			commitNode={{
 				commit: line.commit,
-				type: typeOverride ?? line.type
+				type: line.type
 			}}
 		/>
 	{/if}

--- a/packages/ui/src/lib/commitLines/lineManager.ts
+++ b/packages/ui/src/lib/commitLines/lineManager.ts
@@ -22,14 +22,9 @@ function generateLineData({
 	const commitGroups = [
 		{ commits: remoteCommits, type: 'remote' as CellType },
 		{ commits: localCommits, type: 'local' as CellType },
+		{ commits: localAndRemoteCommits, type: 'localAndRemote' as CellType },
 		{ commits: integratedCommits, type: 'integrated' as CellType }
 	];
-
-	const localAndRemoteGroups = localAndRemoteCommits.map((commit) => {
-		const type: CellType =
-			commit.remoteCommitId === commit.id ? 'localAndRemote' : 'localAndShadow';
-		return { commit, commitNode: { type, commit } };
-	});
 
 	const groupedData = commitGroups.flatMap(({ commits, type }) =>
 		commits.map((commit) => ({
@@ -38,10 +33,8 @@ function generateLineData({
 		}))
 	);
 
-	const allCommitData = [...groupedData, ...localAndRemoteGroups];
-
 	const data = new Map<string, CommitNodeData>(
-		allCommitData.map(({ commit, commitNode }) => [commit.id, commitNode])
+		groupedData.map(({ commit, commitNode }) => [commit.id, commitNode])
 	);
 
 	return { data };

--- a/packages/ui/src/lib/commitLines/types.ts
+++ b/packages/ui/src/lib/commitLines/types.ts
@@ -23,4 +23,4 @@ export interface CommitData {
 	remoteCommitId?: string;
 }
 
-export type CellType = 'local' | 'localAndRemote' | 'integrated' | 'remote' | 'localAndShadow';
+export type CellType = 'local' | 'localAndRemote' | 'integrated' | 'remote';

--- a/packages/ui/src/lib/utils/getColorFromBranchType.ts
+++ b/packages/ui/src/lib/utils/getColorFromBranchType.ts
@@ -3,7 +3,7 @@ import type { CellType } from '$lib/commitLines/types';
 const colorMap = {
 	local: 'var(--clr-commit-local)',
 	localAndRemote: 'var(--clr-commit-remote)',
-	localAndShadow: 'var(--clr-commit-local)',
+	localAndShadow: 'var(--clr-commit-remote)',
 	remote: 'var(--clr-commit-upstream)',
 	integrated: 'var(--clr-commit-integrated)',
 	error: 'var(--clr-theme-err-element)'


### PR DESCRIPTION
One problem was that we were over eager in assigning the remote_commit_id property, and ended up with remote commits getting the remote_commit_id set to themselves.

Another problem is that the commit line logic's integrated commit list was supposed to be mutually exclusive from the other arrays. I've added some extra logic to ensure that is the case

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 4 in a stack** made with GitButler:
- `4` #5608 
- `3` #5607 👈 
- `2` #5602 
- `1` #5601 
<!-- GitButler Footer Boundary Bottom -->

