### PR TITLE
Remove rouge logging statement that got integrated

### DIFF
--- a/apps/desktop/src/lib/vbranches/upstreamIntegrationService.ts
+++ b/apps/desktop/src/lib/vbranches/upstreamIntegrationService.ts
@@ -131,7 +131,6 @@ export class UpstreamIntegrationService {
 			[branchStatuses, this.virtualBranchService.branches],
 			([branchStatuses, branches]): StackStatusesWithBranches | undefined => {
 				if (!branchStatuses || !branches) return;
-				console.log('branchStatuses', branchStatuses);
 				if (branchStatuses.type === 'upToDate') return branchStatuses;
 
 				return {


### PR DESCRIPTION
This seems to have been accidentally merged in with the main changes to upstream_integration.

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 4 in a stack** made with GitButler:
- `4` #5608 👈 
- `3` #5607 
- `2` #5602 
- `1` #5601 
<!-- GitButler Footer Boundary Bottom -->

