### PR TITLE
feat: add flatpak output and GHA build step

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -94,6 +94,7 @@ jobs:
     outputs:
       platform: ${{ matrix.platform }}
       channel: ${{ env.channel }}
+      version: ${{ env.version }}
 
     steps:
       # Because GitHub broke perl installations sometime in 2022 on Windows.
@@ -241,21 +242,33 @@ jobs:
           echo "deb_sha=$DEB_SHA" >> $GITHUB_ENV
       - name: Flatpak update manifest file and SHA
         run: |
+          # Update path to .deb and sha in build manifest
           sed -i "s|path: ../../../target.*|path: ../../../${{ env.deb_path }}|" crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
-          sed -i "s|sha256: 5f3.*|sha256: ${{ env.deb_sha }}|" crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
+          sed -i "s|sha256: 3a9.*|sha256: ${{ env.deb_sha }}|" crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
+          FILE_NAME="$(basename -s ".deb" "${{ env.deb_path }}")"
+          echo "filename=$FILE_NAME" >> $GITHUB_ENV
+          # Update version and date of release in metadata xml
+          sed -i "s|0.13.11|${{ needs.build-tauri.outputs.version }}|" crates/gitbutler-tauri/flatpak/com.gitbutler.app.metainfo.xml
+          sed -i "s|2024-11-05|$(date +%Y-%m-%d)|" crates/gitbutler-tauri/flatpak/com.gitbutler.app.metainfo.xml
       - name: Flatpak build
-        uses: flatpak/flatpak-github-actions/flatpak-builder@master
-        with:
-          bundle: com.gitbutler.app.flatpak
-          manifest-path: crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
-          cache-key: flatpak-builder-${{ github.sha }}
-          arch: ${{ matrix.arch }}
+        run: |
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+          flatpak install --noninteractive flathub org.gnome.Platform//47 org.gnome.Sdk//47
+          flatpak-builder --force-clean --install-deps-from=flathub --repo=repo builddir crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
+          flatpak build-bundle repo "${{ env.filename }}.flatpak" "com.gitbutler.app"
       - name: Flatpak upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: com.gitbutler.app.flatpak
+          name: '${{ env.filename }}.flatpak'
           path: ./*.flatpak
           if-no-files-found: error
+      - run: dnf install -y awscli
+      - name: Upload To S3
+        run: aws s3 cp "${{ env.filename }}.flatpak" "s3://releases.gitbutler.com/releases/${{ needs.build-tauri.outputs.channel }}/${{ needs.build-tauri.outputs.version }}-${{ github.run_number }}/linux/x86_64/${{ env.filename }}.flatpak"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
 
   sign-tauri:
     needs: build-tauri

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -243,10 +243,8 @@ jobs:
         run: |
           sed -i "s|path: ../../../target.*|path: ../../../${{ env.deb_path }}|" crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
           sed -i "s|sha256: 5f3.*|sha256: ${{ env.deb_sha }}|" crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
-      - name: Flatpak install Gnome SDK
-        run: flatpak --system install -y --noninteractive flathub org.gnome.Sdk//47
       - name: Flatpak build
-        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        uses: flatpak/flatpak-github-actions/flatpak-builder@master
         with:
           bundle: com.gitbutler.app.flatpak
           manifest-path: crates/gitbutler-tauri/flatpak/manifest.flatpak.yml

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -207,15 +207,15 @@ jobs:
       - name: Find new deb artifact
         if: runner.os == 'Linux'
         run: |
-          DEB_PATH=$(find target/release -iname "*.deb")
-          DEB_SHA=$(sha256sum $DEB_PATH)
+          DEB_PATH="$(find target/release -iname "*.deb")"
+          DEB_SHA="$(sha256sum "$DEB_PATH")"
           echo "deb_path=$DEB_PATH" >> $GITHUB_ENV
           echo "deb_sha=$DEB_SHA" >> $GITHUB_ENV
       - name: Update Manifest File and SHA
         if: runner.os == 'Linux'
         run: |
-          sed -i "s|url: https://releases.gitbutler.com.*|url: file://${{ env.deb_path }}|" crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
-          sed -i "s|sha256:.*|sha256: ${{ env.deb_sha }}|" crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
+          sed -i "s|path: ../../../target.*|path: ../../../${{ env.deb_path }}|" crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
+          sed -i "s|sha256: 5f3.*|sha256: ${{ env.deb_sha }}|" crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
 
       - name: Build Flatpak
         if: runner.os == 'Linux'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -204,36 +204,6 @@ jobs:
           path: release/
           if-no-files-found: error
 
-      - name: Find new deb artifact
-        if: runner.os == 'Linux'
-        run: |
-          DEB_PATH="$(find target/release -iname "*.deb")"
-          DEB_SHA="$(sha256sum "$DEB_PATH")"
-          echo "deb_path=$DEB_PATH" >> $GITHUB_ENV
-          echo "deb_sha=$DEB_SHA" >> $GITHUB_ENV
-      - name: Update Manifest File and SHA
-        if: runner.os == 'Linux'
-        run: |
-          sed -i "s|path: ../../../target.*|path: ../../../${{ env.deb_path }}|" crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
-          sed -i "s|sha256: 5f3.*|sha256: ${{ env.deb_sha }}|" crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
-
-      - name: Build Flatpak
-        if: runner.os == 'Linux'
-        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
-        with:
-          bundle: com.gitbutler.app.flatpak
-          manifest-path: crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
-          cache-key: flatpak-builder-${{ github.sha }}
-          arch: ${{ matrix.arch }}
-
-      - name: Upload Flatpak
-        if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v4
-        with:
-          name: com.gitbutler.app.flatpak
-          path: ./*.flatpak
-          if-no-files-found: error
-
       - name: Prepare Windows Aux Binary Artifacts
         if: runner.os == 'Windows'
         shell: bash
@@ -248,6 +218,45 @@ jobs:
         with:
           name: '${{ env.channel }}-windows-aux-${{ github.run_number }}'
           path: tauri-aux-artifacts/
+          if-no-files-found: error
+
+  bundle-flatpak:
+    needs: build-tauri
+    runs-on: ubuntu-latest
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:gnome-47
+      options: --privileged
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download deb artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: '${{ needs.build-tauri.outputs.channel }}-ubuntu-24.04-${{ github.run_number }}'
+          path: release
+      - name: Flatpak find .deb path and sha256
+        run: |
+          DEB_PATH="$(find release -iname "*.deb")"
+          DEB_SHA="$(sha256sum "$DEB_PATH" | cut -d " " -f 1 )"
+          echo "deb_path=$DEB_PATH" >> $GITHUB_ENV
+          echo "deb_sha=$DEB_SHA" >> $GITHUB_ENV
+      - name: Flatpak update manifest file and SHA
+        run: |
+          sed -i "s|path: ../../../target.*|path: ../../../${{ env.deb_path }}|" crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
+          sed -i "s|sha256: 5f3.*|sha256: ${{ env.deb_sha }}|" crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
+      - name: Flatpak install Gnome SDK
+        run: flatpak --system install -y --noninteractive flathub org.gnome.Sdk//47
+      - name: Flatpak build
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: com.gitbutler.app.flatpak
+          manifest-path: crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
+          cache-key: flatpak-builder-${{ github.sha }}
+          arch: ${{ matrix.arch }}
+      - name: Flatpak upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: com.gitbutler.app.flatpak
+          path: ./*.flatpak
           if-no-files-found: error
 
   sign-tauri:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -204,6 +204,36 @@ jobs:
           path: release/
           if-no-files-found: error
 
+      - name: Find new deb artifact
+        if: runner.os == 'Linux'
+        run: |
+          DEB_PATH=$(find target/release -iname "*.deb")
+          DEB_SHA=$(sha256sum $DEB_PATH)
+          echo "deb_path=$DEB_PATH" >> $GITHUB_ENV
+          echo "deb_sha=$DEB_SHA" >> $GITHUB_ENV
+      - name: Update Manifest File and SHA
+        if: runner.os == 'Linux'
+        run: |
+          sed -i "s|url: https://releases.gitbutler.com.*|url: file://${{ env.deb_path }}|" crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
+          sed -i "s|sha256:.*|sha256: ${{ env.deb_sha }}|" crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
+
+      - name: Build Flatpak
+        if: runner.os == 'Linux'
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: com.gitbutler.app.flatpak
+          manifest-path: crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
+          cache-key: flatpak-builder-${{ github.sha }}
+          arch: ${{ matrix.arch }}
+
+      - name: Upload Flatpak
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: com.gitbutler.app.flatpak
+          path: ./*.flatpak
+          if-no-files-found: error
+
       - name: Prepare Windows Aux Binary Artifacts
         if: runner.os == 'Windows'
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,8 @@ storybook-static
 
 # Rust analyzer
 .rust-analyzer/
+
+# Flatpak
+.flatpak-builder
+/repo
+/builddir

--- a/crates/gitbutler-git/src/executor/tokio/mod.rs
+++ b/crates/gitbutler-git/src/executor/tokio/mod.rs
@@ -30,7 +30,10 @@ unsafe impl super::GitExecutor for TokioExecutor {
         envs: Option<HashMap<String, String>>,
     ) -> Result<(usize, String, String), Self::Error> {
         let git_exe = gix_path::env::exe_invocation();
-        let mut cmd = Command::new(git_exe);
+        // let mut cmd = Command::new(git_exe);
+        //
+        let mut cmd = Command::new("flatpak-spawn");
+        cmd.args(["--host", "git"]);
 
         // Output the command being executed to stderr, for debugging purposes
         // (only on test configs).
@@ -88,6 +91,7 @@ unsafe impl super::GitExecutor for TokioExecutor {
             }
         }
 
+        println!("Cmd: {:?}", cmd);
         let output = cmd.output().await?;
 
         #[cfg(any(test, debug_assertions))]

--- a/crates/gitbutler-git/src/executor/tokio/mod.rs
+++ b/crates/gitbutler-git/src/executor/tokio/mod.rs
@@ -30,8 +30,7 @@ unsafe impl super::GitExecutor for TokioExecutor {
         envs: Option<HashMap<String, String>>,
     ) -> Result<(usize, String, String), Self::Error> {
         // Check if we're running in a flatpak
-        let flatpak = std::env::var("FLATPAK").unwrap_or_else(|_| String::new());
-        println!("FLATPAK: {}", flatpak);
+        let flatpak = std::env::var("FLATPAK_ID").unwrap_or_else(|_| String::new());
 
         let mut cmd = if !flatpak.is_empty() {
             let mut cmd = Command::new("host-spawn");

--- a/crates/gitbutler-git/src/executor/tokio/mod.rs
+++ b/crates/gitbutler-git/src/executor/tokio/mod.rs
@@ -34,8 +34,8 @@ unsafe impl super::GitExecutor for TokioExecutor {
         println!("FLATPAK: {}", flatpak);
 
         let mut cmd = if !flatpak.is_empty() {
-            let mut cmd = Command::new("flatpak-spawn");
-            cmd.args(["--host", "git"]);
+            let mut cmd = Command::new("host-spawn");
+            cmd.args(["git"]);
             cmd
         } else {
             let git_exe = gix_path::env::exe_invocation();

--- a/crates/gitbutler-git/src/repository.rs
+++ b/crates/gitbutler-git/src/repository.rs
@@ -169,7 +169,7 @@ where
             {
                 #[cfg(unix)]
                 {
-                    format!("{setsid_path} ")
+                    format!("'{setsid_path}' ")
                 }
                 #[cfg(windows)]
                 {

--- a/crates/gitbutler-git/src/repository.rs
+++ b/crates/gitbutler-git/src/repository.rs
@@ -169,7 +169,7 @@ where
             {
                 #[cfg(unix)]
                 {
-                    format!("'{setsid_path}' ")
+                    format!("{setsid_path} ")
                 }
                 #[cfg(windows)]
                 {

--- a/crates/gitbutler-tauri/flatpak/com.gitbutler.app.metainfo.xml
+++ b/crates/gitbutler-tauri/flatpak/com.gitbutler.app.metainfo.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.gitbutler.app</id>
+  <name>GitButler</name>
+
+  <developer id="com.gitbutler">
+    <name>GitButler Team</name>
+  </developer>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LicenseRef-FSL-1.1-MIT=https://github.com/gitbutlerapp/gitbutler/blob/master/LICENSE.md</project_license>
+
+  <url type="homepage">https://gitbutler.com/</url>
+  <url type="bugtracker">https://github.com/gitbutlerapp/gitbutler/issues</url>
+  <url type="help">https://docs.gitbutler.com/</url>
+
+  <summary>Git branch management tool</summary>
+
+  <icon type="stock">com.gitbutler.app</icon>
+  <description>
+    <p>VSCodium combines the simplicity of a code editor with what developers need for the core
+      edit-build-debug cycle.</p>
+  </description>
+  <categories>
+    <category>Development</category>
+  </categories>
+  <branding>
+    <color type="primary" scheme_preference="light">#3cb4ae</color>
+    <color type="primary" scheme_preference="dark">#3cb4ae</color>
+  </branding>
+  <launchable type="desktop-id">com.gitbutler.app.desktop</launchable>
+  <releases>
+    <release version="0.13.11" date="2024-11-05">
+      <description></description>
+    </release>
+  </releases>
+
+  <provides>
+    <binary>git-butler</binary>
+  </provides>
+</component>

--- a/crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
+++ b/crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
@@ -17,6 +17,7 @@ finish-args:
   - --allow=devel
   - --socket=system-bus
   - --socket=session-bus
+  - --env=FLATPAK=1
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
   # Required for interacting with git
   - --socket=ssh-auth
@@ -38,15 +39,14 @@ modules:
       - type: file
         dest-filename: gitbutler.deb
         path: ../../../target/debug/bundle/deb/GitButler Nightly_0.0.0_amd64.deb
-        sha256: a57375afe90004501518f815238b58ef7f0c161ebd552e4259272c1de6719d5a
+        sha256: 5f3a4a7e26c28577eb9ccf2dc08810643a75c2de4bebf340e8f1ce05dce39667
     build-commands:
       - ar -x gitbutler.deb
       - tar -xf data.tar.gz
       - install -Dm755 usr/bin/gitbutler-tauri /app/bin/gitbutler-tauri
       - install -Dm755 usr/bin/gitbutler-git-askpass /app/bin/gitbutler-git-askpass
       - install -Dm755 usr/bin/gitbutler-git-setsid /app/bin/gitbutler-git-setsid
-      # - install -Dm644 usr/share/applications/GitButler.desktop /app/share/applications/com.gitbutler.app.desktop
-      - install -Dm644 usr/share/applications/GitButler\ Nightly.desktop /app/share/applications/com.gitbutler.app.desktop
+      - install -Dm644 usr/share/applications/*.desktop /app/share/applications/com.gitbutler.app.desktop
       - desktop-file-edit --set-icon=com.gitbutler.app /app/share/applications/com.gitbutler.app.desktop
       - |
         for size in 32x32 128x128 256x256@2; do
@@ -54,3 +54,14 @@ modules:
         done
       - install -Dm644 com.gitbutler.app.metainfo.xml /app/share/metainfo/com.gitbutler.app.metainfo.xml
       - rm -r *.deb control.tar.* data.tar.gz debian-binary usr
+
+  - name: host-spawn
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 host-spawn /app/bin/host-spawn
+    sources:
+      - type: file
+        url: https://github.com/1player/host-spawn/releases/download/1.5.0/host-spawn-x86_64
+        sha256: dbf67e7e111c4fe1edb0c642cbb4193064ca5b384aeb1054fc2befba6ed88b83
+        dest-filename: host-spawn
+        only-arches: [x86_64]

--- a/crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
+++ b/crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
@@ -4,7 +4,7 @@ runtime: org.gnome.Platform
 runtime-version: '47'
 sdk: org.gnome.Sdk
 
-command: launch.sh
+command: gitbutler-tauri
 finish-args:
   - --share=ipc
   - --socket=wayland
@@ -12,21 +12,18 @@ finish-args:
   - --device=dri
   - --share=network
   - --filesystem=/tmp
-  - --filesystem=/sys
   - --filesystem=/var
   - --filesystem=host
   - --allow=devel
-  - --socket=ssh-auth
-  - --socket=gpg-agent
   - --socket=system-bus
   - --socket=session-bus
-  - --env=PATH=/app/bin:/usr/bin:/run/host/bin
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
-  - --filesystem=xdg-run/gnupg:ro
+  # Required for interacting with git
+  - --socket=ssh-auth
+  - --socket=gpg-agent
   - --talk-name=org.freedesktop.secrets
-  - --talk-name=org.freedesktop.Flatpak
+  - --talk-name=org.freedesktop.Flatpak # Required for flatpak-spawn
   - --talk-name=org.kde.kwalletd6
-  - --talk-name=org.kde.kwalletd5
   - --talk-name=org.gnome.keyring.SystemPrompter
 
 separate-locales: false
@@ -40,28 +37,11 @@ modules:
         path: com.gitbutler.app.metainfo.xml
       - type: file
         dest-filename: gitbutler.deb
-        url: file:///opt/gitbutler/gitbutler/target/debug/bundle/deb/GitButler Nightly_0.0.0_amd64.deb
-        sha256: 94db605fc2b6358c71cc5b94d169093e87fe57488c7855ff92b43977ca776bb1
-      # - type: file
-      #   dest-filename: gitbutler.deb
-      #   url: https://releases.gitbutler.com/releases/release/0.13.11-1445/linux/x86_64/GitButler_0.13.11_amd64.deb
-      #   sha256: 6495589f30c0b5b7d894e268fae6bd569d4e01cbf33de22df262b07cab0507f3
-      #   only-arches:
-      #     - x86_64
-      #   x-checker-data:
-      #     type: json
-      #     url: https://app.gitbutler.com/releases
-      #     version-query: .version
-      #     timestamp-query: .pub_date
-      #     url-query: .platforms."linux-x86_64".url | sub(".AppImage.tar.gz"; ".deb")
-      - type: script
-        commands:
-          - "/app/bin/gitbutler-tauri"
-        dest-filename: "launch.sh"
+        path: ../../../target/debug/bundle/deb/GitButler Nightly_0.0.0_amd64.deb
+        sha256: a57375afe90004501518f815238b58ef7f0c161ebd552e4259272c1de6719d5a
     build-commands:
-      - ar -x *.deb
+      - ar -x gitbutler.deb
       - tar -xf data.tar.gz
-      - install -Dm755 launch.sh /app/bin/launch.sh
       - install -Dm755 usr/bin/gitbutler-tauri /app/bin/gitbutler-tauri
       - install -Dm755 usr/bin/gitbutler-git-askpass /app/bin/gitbutler-git-askpass
       - install -Dm755 usr/bin/gitbutler-git-setsid /app/bin/gitbutler-git-setsid

--- a/crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
+++ b/crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
@@ -1,9 +1,7 @@
 id: com.gitbutler.app
-
 runtime: org.gnome.Platform
 runtime-version: '47'
 sdk: org.gnome.Sdk
-
 command: gitbutler-tauri
 finish-args:
   - --share=ipc
@@ -12,13 +10,13 @@ finish-args:
   - --device=dri
   - --share=network
   - --filesystem=/tmp
-  - --filesystem=/var
   - --filesystem=host
+  - --filesystem=xdg-run/gvfsd
   - --allow=devel
   - --socket=system-bus
   - --socket=session-bus
-  - --env=FLATPAK=1
-  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
+  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons:~/.icons
+  - --talk-name=org.freedesktop.portal.Fcitx
   # Required for interacting with git
   - --socket=ssh-auth
   - --socket=gpg-agent
@@ -39,7 +37,7 @@ modules:
       - type: file
         dest-filename: gitbutler.deb
         path: ../../../target/debug/bundle/deb/GitButler Nightly_0.0.0_amd64.deb
-        sha256: 5f3a4a7e26c28577eb9ccf2dc08810643a75c2de4bebf340e8f1ce05dce39667
+        sha256: 3a919c3ca743131af3f3faf3a9bfe1f9c08f581ec262f9ca3bd2fe1974cc1ff2
     build-commands:
       - ar -x gitbutler.deb
       - tar -xf data.tar.gz
@@ -57,6 +55,8 @@ modules:
 
   - name: host-spawn
     buildsystem: simple
+    build-options:
+      no-debuginfo: true
     build-commands:
       - install -Dm755 host-spawn /app/bin/host-spawn
     sources:
@@ -65,3 +65,8 @@ modules:
         sha256: dbf67e7e111c4fe1edb0c642cbb4193064ca5b384aeb1054fc2befba6ed88b83
         dest-filename: host-spawn
         only-arches: [x86_64]
+      # - type: file
+      #   url: https://github.com/1player/host-spawn/releases/download/1.5.0/host-spawn-aarch64
+      #   sha256: c42c12be6cdd83e374b847bec836659fb45231215797777c9ee1c9c0ae9e3783
+      #   dest-filename: host-spawn
+      #   only-arches: [aarch64]

--- a/crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
+++ b/crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
@@ -4,54 +4,69 @@ runtime: org.gnome.Platform
 runtime-version: '47'
 sdk: org.gnome.Sdk
 
-command: gitbutler-tauri
+command: launch.sh
 finish-args:
   - --share=ipc
   - --socket=wayland
   - --socket=fallback-x11
   - --device=dri
   - --share=network
+  - --filesystem=/tmp
+  - --filesystem=/sys
+  - --filesystem=/var
   - --filesystem=host
   - --allow=devel
   - --socket=ssh-auth
   - --socket=gpg-agent
+  - --socket=system-bus
+  - --socket=session-bus
+  - --env=PATH=/app/bin:/usr/bin:/run/host/bin
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
   - --filesystem=xdg-run/gnupg:ro
-  - --filesystem=xdg-config/kdeglobals:ro
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.freedesktop.Flatpak
   - --talk-name=org.kde.kwalletd6
   - --talk-name=org.kde.kwalletd5
   - --talk-name=org.gnome.keyring.SystemPrompter
-  - --talk-name=com.canonical.AppMenu.Registrar
-  - --system-talk-name=org.freedesktop.login1
 
 separate-locales: false
 modules:
   - name: binary
     buildsystem: simple
+    build-options:
+      no-debuginfo: true
     sources:
       - type: file
         path: com.gitbutler.app.metainfo.xml
       - type: file
         dest-filename: gitbutler.deb
-        url: https://releases.gitbutler.com/releases/release/0.13.11-1445/linux/x86_64/GitButler_0.13.11_amd64.deb
-        sha256: 6495589f30c0b5b7d894e268fae6bd569d4e01cbf33de22df262b07cab0507f3
-        only-arches:
-          - x86_64
-        x-checker-data:
-          type: json
-          url: https://app.gitbutler.com/releases
-          version-query: .version
-          timestamp-query: .pub_date
-          url-query: .platforms."linux-x86_64".url | sub(".AppImage.tar.gz"; ".deb")
+        url: file:///opt/gitbutler/gitbutler/target/debug/bundle/deb/GitButler Nightly_0.0.0_amd64.deb
+        sha256: 94db605fc2b6358c71cc5b94d169093e87fe57488c7855ff92b43977ca776bb1
+      # - type: file
+      #   dest-filename: gitbutler.deb
+      #   url: https://releases.gitbutler.com/releases/release/0.13.11-1445/linux/x86_64/GitButler_0.13.11_amd64.deb
+      #   sha256: 6495589f30c0b5b7d894e268fae6bd569d4e01cbf33de22df262b07cab0507f3
+      #   only-arches:
+      #     - x86_64
+      #   x-checker-data:
+      #     type: json
+      #     url: https://app.gitbutler.com/releases
+      #     version-query: .version
+      #     timestamp-query: .pub_date
+      #     url-query: .platforms."linux-x86_64".url | sub(".AppImage.tar.gz"; ".deb")
+      - type: script
+        commands:
+          - "/app/bin/gitbutler-tauri"
+        dest-filename: "launch.sh"
     build-commands:
       - ar -x *.deb
       - tar -xf data.tar.gz
+      - install -Dm755 launch.sh /app/bin/launch.sh
       - install -Dm755 usr/bin/gitbutler-tauri /app/bin/gitbutler-tauri
       - install -Dm755 usr/bin/gitbutler-git-askpass /app/bin/gitbutler-git-askpass
       - install -Dm755 usr/bin/gitbutler-git-setsid /app/bin/gitbutler-git-setsid
-      - install -Dm644 usr/share/applications/GitButler.desktop /app/share/applications/com.gitbutler.app.desktop
+      # - install -Dm644 usr/share/applications/GitButler.desktop /app/share/applications/com.gitbutler.app.desktop
+      - install -Dm644 usr/share/applications/GitButler\ Nightly.desktop /app/share/applications/com.gitbutler.app.desktop
       - desktop-file-edit --set-icon=com.gitbutler.app /app/share/applications/com.gitbutler.app.desktop
       - |
         for size in 32x32 128x128 256x256@2; do

--- a/crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
+++ b/crates/gitbutler-tauri/flatpak/manifest.flatpak.yml
@@ -1,0 +1,61 @@
+id: com.gitbutler.app
+
+runtime: org.gnome.Platform
+runtime-version: '47'
+sdk: org.gnome.Sdk
+
+command: gitbutler-tauri
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --share=network
+  - --filesystem=host
+  - --allow=devel
+  - --socket=ssh-auth
+  - --socket=gpg-agent
+  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
+  - --filesystem=xdg-run/gnupg:ro
+  - --filesystem=xdg-config/kdeglobals:ro
+  - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.freedesktop.Flatpak
+  - --talk-name=org.kde.kwalletd6
+  - --talk-name=org.kde.kwalletd5
+  - --talk-name=org.gnome.keyring.SystemPrompter
+  - --talk-name=com.canonical.AppMenu.Registrar
+  - --system-talk-name=org.freedesktop.login1
+
+separate-locales: false
+modules:
+  - name: binary
+    buildsystem: simple
+    sources:
+      - type: file
+        path: com.gitbutler.app.metainfo.xml
+      - type: file
+        dest-filename: gitbutler.deb
+        url: https://releases.gitbutler.com/releases/release/0.13.11-1445/linux/x86_64/GitButler_0.13.11_amd64.deb
+        sha256: 6495589f30c0b5b7d894e268fae6bd569d4e01cbf33de22df262b07cab0507f3
+        only-arches:
+          - x86_64
+        x-checker-data:
+          type: json
+          url: https://app.gitbutler.com/releases
+          version-query: .version
+          timestamp-query: .pub_date
+          url-query: .platforms."linux-x86_64".url | sub(".AppImage.tar.gz"; ".deb")
+    build-commands:
+      - ar -x *.deb
+      - tar -xf data.tar.gz
+      - install -Dm755 usr/bin/gitbutler-tauri /app/bin/gitbutler-tauri
+      - install -Dm755 usr/bin/gitbutler-git-askpass /app/bin/gitbutler-git-askpass
+      - install -Dm755 usr/bin/gitbutler-git-setsid /app/bin/gitbutler-git-setsid
+      - install -Dm644 usr/share/applications/GitButler.desktop /app/share/applications/com.gitbutler.app.desktop
+      - desktop-file-edit --set-icon=com.gitbutler.app /app/share/applications/com.gitbutler.app.desktop
+      - |
+        for size in 32x32 128x128 256x256@2; do
+          install -Dm644 usr/share/icons/hicolor/${size}/apps/gitbutler-tauri.png /app/share/icons/hicolor/${size}/apps/com.gitbutler.app.png
+        done
+      - install -Dm644 com.gitbutler.app.metainfo.xml /app/share/metainfo/com.gitbutler.app.metainfo.xml
+      - rm -r *.deb control.tar.* data.tar.gz debian-binary usr

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,8 @@
             wget
             pkg-config
             rustToolchain
+            flatpak-builder
+            appstream
           ] ++ common;
         in
         {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"build": "turbo run build --no-daemon",
 		"build:desktop": "turbo run --filter @gitbutler/desktop build --no-daemon",
 		"build:test": "pnpm exec tauri build --config crates/gitbutler-tauri/tauri.conf.test.json -- --profile dev",
+		"build:flatpak": "flatpak-builder --force-clean --user --install --install-deps-from=flathub --repo=repo builddir crates/gitbutler-tauri/flatpak/manifest.flatpak.yml",
 		"check": "turbo run check --no-daemon",
 		"tauri": "tauri",
 		"lint": "turbo run //#globallint --no-daemon",

--- a/scripts/build-flatpak.sh
+++ b/scripts/build-flatpak.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+MANIFEST_PATH="crates/gitbutler-tauri/flatpak/manifest.flatpak.yml"
+FLATPAK_ID="com.gitbutler.app"
+
+# Add Flathub Repository
+flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+
+# Install Gnome runtimei dependency
+flatpak install --user flathub org.gnome.Platform//46 org.gnome.Sdk//46
+
+# Build the manifest
+flatpak-builder --force-clean --user --install-deps-from=flathub --repo=repo builddir "$MANIFEST_PATH"
+
+# Export gitbutler-tauri.flatpak
+flatpak build-bundle repo "$FLATPAK_ID.flatpak" "$FLATPAK_ID"
+
+# Notes
+# - https://tauri.app/distribute/flatpak/
+# - https://docs.flatpak.org/en/latest/first-build.html
+# - https://github.com/madeofpendletonwool/PinePods/blob/5377b061357d1ba5e04e607b5f626bf349cf09f8/.github/workflows/build-flatpak.yml#L4
+# - https://github.com/Beanow/hi-flatpak
+# - https://github.com/flathub/com.vscodium.codium-insiders/blob/master/com.vscodium.codium-insiders.yaml

--- a/scripts/build-flatpak.sh
+++ b/scripts/build-flatpak.sh
@@ -6,8 +6,8 @@ FLATPAK_ID="com.gitbutler.app"
 # Add Flathub Repository
 flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 
-# Install Gnome runtimei dependency
-flatpak install --user flathub org.gnome.Platform//46 org.gnome.Sdk//46
+# Install Gnome runtime dependency
+flatpak install --user flathub org.gnome.Platform//47 org.gnome.Sdk//47
 
 # Build the manifest
 flatpak-builder --force-clean --user --install-deps-from=flathub --repo=repo builddir "$MANIFEST_PATH"


### PR DESCRIPTION
## ☕️ Reasoning

- Test Flatpak build

## 🧢 Changes

- Add flatpak manifest
- Add flatpak xml metadata file
- Add `build:flatpak` root package.json script
- Add GHA jobs for buliding and uploading flatpak output
	- Unfortunately this can't be totally parallel, because the flatpak relies on consuming the `.deb` output.
	

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
