### PR TITLE
Improve last divergent commit behaviour

### DIFF
--- a/apps/desktop/src/lib/commit/CommitList.svelte
+++ b/apps/desktop/src/lib/commit/CommitList.svelte
@@ -70,14 +70,16 @@
 	const localAndRemoteCommits = $derived(
 		patches.filter((patch) => patch.status === 'localAndRemote')
 	);
-	const lastDivergentCommit = $derived(findLastDivergentCommit(localAndRemoteCommits));
+	const lastDivergentCommit = $derived(
+		findLastDivergentCommit(remoteOnlyPatches, localAndRemoteCommits)
+	);
 
 	// A local or localAndRemote commit probably shouldn't every be integrated,
 	// but the isIntegrated check is a bit fuzzy, and is certainly the most
 	// important state to convey to the user.
 	const lineManager = $derived(
 		lineManagerFactory.build({
-			remoteCommits: remoteOnlyPatches.filter((patch) => patch.status === 'remote'),
+			remoteCommits: remoteOnlyPatches,
 			localCommits: patches.filter((patch) => patch.status === 'local'),
 			localAndRemoteCommits: localAndRemoteCommits,
 			integratedCommits: patches.filter((patch) => patch.status === 'integrated')
@@ -170,7 +172,10 @@
 				{@render stackingReorderDropzone(stackingReorderDropzoneManager.topDropzone(seriesName))}
 
 				{#each patches as commit, idx (commit.id)}
-					{@const isResetAction = lastDivergentCommit?.id === commit.id}
+					{@const isResetAction =
+						(lastDivergentCommit.type === 'localDiverged' &&
+							lastDivergentCommit.commit.id === commit.id) ||
+						(lastDivergentCommit.type === 'onlyRemoteDiverged' && idx === patches.length - 1)}
 					<CommitDragItem {commit}>
 						<CommitCard
 							type={commit.status}

--- a/apps/desktop/src/lib/commits/utils.ts
+++ b/apps/desktop/src/lib/commits/utils.ts
@@ -1,14 +1,34 @@
 import type { DetailedCommit } from '$lib/vbranches/types';
 
+type DivergenceResult =
+	| { type: 'localDiverged'; commit: DetailedCommit }
+	| { type: 'notDiverged' | 'onlyRemoteDiverged' };
+
 /**
  * Find the last commit that diverged from the remote branch.
  */
-export function findLastDivergentCommit(commits: DetailedCommit[]): DetailedCommit | undefined {
+export function findLastDivergentCommit(
+	remoteCommits: DetailedCommit[],
+	commits: DetailedCommit[]
+): DivergenceResult {
+	const noLocalDiverged = commits.every((commit) => !commit.remoteCommitId);
+
+	// If there are no diverged or remote commits, then there is no last
+	// diverged commit.
+	if (noLocalDiverged && remoteCommits.length === 0) {
+		return { type: 'notDiverged' };
+	}
+
+	if (noLocalDiverged) {
+		return { type: 'onlyRemoteDiverged' };
+	}
+
 	for (let i = commits.length - 1; i >= 0; i--) {
-		const commit = commits[i];
-		if (commit!.id !== commit!.remoteCommitId) {
-			return commit;
+		const commit = commits[i]!;
+		if (commit.id !== commit.remoteCommitId) {
+			return { type: 'localDiverged', commit };
 		}
 	}
-	return undefined;
+
+	return { type: 'notDiverged' };
 }


### PR DESCRIPTION
Previously it didn't consider if there were no diverged commits and or no remote commits. This handles those two cases.