### PR TITLE
PR creation: Correctly set the PR description

### DIFF
--- a/apps/desktop/src/lib/pr/PrDetailsModal.svelte
+++ b/apps/desktop/src/lib/pr/PrDetailsModal.svelte
@@ -432,7 +432,7 @@
 							autofocus
 							padding={{ top: 12, right: 12, bottom: 12, left: 12 }}
 							placeholder="Add description…"
-							onchange={(e: InputEvent) => {
+							oninput={(e: InputEvent) => {
 								const target = e.currentTarget as HTMLTextAreaElement;
 								inputBody?.set(target.value.trim());
 							}}


### PR DESCRIPTION
Prefer using the `input` handler instead of the `change` handler.
The change handler will only update the state variable on blur, while the input handler will do so on key press.