### PR TITLE
ai: Pass the correct file hunks when editing a commit message

### DIFF
--- a/apps/desktop/src/lib/ai/service.test.ts
+++ b/apps/desktop/src/lib/ai/service.test.ts
@@ -6,7 +6,14 @@ import {
 	SHORT_DEFAULT_COMMIT_TEMPLATE,
 	SHORT_DEFAULT_PR_TEMPLATE
 } from '$lib/ai/prompts';
-import { AISecretHandle, AIService, GitAIConfigKey, KeyOption, buildDiff } from '$lib/ai/service';
+import {
+	AISecretHandle,
+	AIService,
+	GitAIConfigKey,
+	KeyOption,
+	buildDiff,
+	type DiffInput
+} from '$lib/ai/service';
 import {
 	AnthropicModelName,
 	ModelKind,
@@ -136,6 +143,10 @@ const hunk2 = plainToInstance(Hunk, {
 });
 
 const exampleHunks = [hunk1, hunk2];
+const exampleDiffs: DiffInput[] = exampleHunks.map((hunk) => ({
+	diff: hunk.diff,
+	filePath: hunk.filePath
+}));
 
 function buildDefaultAIService() {
 	const gitConfig = new DummyGitConfigService(structuredClone(defaultGitConfig));
@@ -229,7 +240,7 @@ describe('AIService', () => {
 				(async () => buildFailureFromAny('Failed to build'))()
 			);
 
-			expect(await aiService.summarizeCommit({ hunks: exampleHunks })).toStrictEqual(
+			expect(await aiService.summarizeCommit({ diffInput: exampleDiffs })).toStrictEqual(
 				buildFailureFromAny('Failed to build')
 			);
 		});
@@ -243,7 +254,7 @@ describe('AIService', () => {
 				(async () => ok<AIClient, Error>(new DummyAIClient(clientResponse)))()
 			);
 
-			expect(await aiService.summarizeCommit({ hunks: exampleHunks })).toStrictEqual(
+			expect(await aiService.summarizeCommit({ diffInput: exampleDiffs })).toStrictEqual(
 				ok('single line commit')
 			);
 		});
@@ -257,7 +268,7 @@ describe('AIService', () => {
 				(async () => ok<AIClient, Error>(new DummyAIClient(clientResponse)))()
 			);
 
-			expect(await aiService.summarizeCommit({ hunks: exampleHunks })).toStrictEqual(
+			expect(await aiService.summarizeCommit({ diffInput: exampleDiffs })).toStrictEqual(
 				ok('one\n\nnew line')
 			);
 		});
@@ -272,7 +283,7 @@ describe('AIService', () => {
 			);
 
 			expect(
-				await aiService.summarizeCommit({ hunks: exampleHunks, useBriefStyle: true })
+				await aiService.summarizeCommit({ diffInput: exampleDiffs, useBriefStyle: true })
 			).toStrictEqual(ok('one'));
 		});
 	});

--- a/apps/desktop/src/lib/ai/service.ts
+++ b/apps/desktop/src/lib/ai/service.ts
@@ -21,7 +21,6 @@ import { get } from 'svelte/store';
 import type { GitConfigService } from '$lib/backend/gitConfigService';
 import type { SecretsService } from '$lib/secrets/secretsService';
 import type { TokenMemoryService } from '$lib/stores/tokenMemoryService';
-import type { Hunk } from '$lib/vbranches/types';
 import type { HttpClient } from '@gitbutler/shared/httpClient';
 
 const maxDiffLengthLimitForAPI = 5000;
@@ -54,7 +53,7 @@ interface BaseAIServiceOpts {
 }
 
 interface SummarizeCommitOpts extends BaseAIServiceOpts {
-	hunks: Hunk[];
+	diffInput: DiffInput[];
 	useEmojiStyle?: boolean;
 	useBriefStyle?: boolean;
 	commitTemplate?: Prompt;
@@ -75,7 +74,7 @@ interface SummarizePROpts extends BaseAIServiceOpts {
 	prBodyTemplate?: string;
 }
 
-interface DiffInput {
+export interface DiffInput {
 	filePath: string;
 	diff: string;
 }
@@ -269,7 +268,7 @@ export class AIService {
 	}
 
 	async summarizeCommit({
-		hunks,
+		diffInput,
 		useEmojiStyle = false,
 		useBriefStyle = false,
 		commitTemplate,
@@ -288,7 +287,10 @@ export class AIService {
 				return promptMessage;
 			}
 
-			let content = promptMessage.content.replaceAll('%{diff}', buildDiff(hunks, diffLengthLimit));
+			let content = promptMessage.content.replaceAll(
+				'%{diff}',
+				buildDiff(diffInput, diffLengthLimit)
+			);
 
 			const briefPart = useBriefStyle
 				? 'The commit message must be only one sentence and as short as possible.'

--- a/apps/desktop/src/lib/commit/CommitCard.svelte
+++ b/apps/desktop/src/lib/commit/CommitCard.svelte
@@ -181,6 +181,7 @@
 		<CommitMessageInput
 			bind:commitMessage={description}
 			bind:valid={commitMessageValid}
+			existingCommit={commit}
 			isExpanded={true}
 			cancel={close}
 			commit={submitCommitMessageModal}


### PR DESCRIPTION
Give the commit message generation method the file changes of the commit that's being edited, instead of the uncommited files