### PR TITLE
fix: Hide the push button if there's nothing to push

### DIFF
--- a/apps/desktop/src/lib/stack/Stack.svelte
+++ b/apps/desktop/src/lib/stack/Stack.svelte
@@ -81,9 +81,6 @@
 		if (upstreamPatches.length > 0) return true;
 		if (branchPatches.some((p) => !['localAndRemote', 'integrated'].includes(p.status)))
 			return true;
-		if (branchPatches.some((p) => p.status !== 'integrated' && p.remoteCommitId !== p.id))
-			return true;
-
 		return false;
 	});
 


### PR DESCRIPTION
We can fully trust the patch status when checking whether a patch already has been integrated or published.