### PR TITLE
Simplify function that returns stack commits

### DIFF
--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -280,7 +280,7 @@ fn stack_branch_to_api_branch(
     let branch_commits = stack_branch.commits(ctx, stack)?;
     // anyhow::bail!("Lets pretend this is a real error");
     let remote = default_target.push_remote_name();
-    let upstream_reference = if stack_branch.pushed(remote.as_str(), repository)? {
+    let upstream_reference = if stack_branch.pushed(remote.as_str(), repository) {
         Some(stack_branch.remote_reference(remote.as_str()))
     } else {
         None


### PR DESCRIPTION
- Result<bool> converted to just bool

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5632 
- <kbd>&nbsp;1&nbsp;</kbd> #5631 👈 
<!-- GitButler Footer Boundary Bottom -->

