### PR TITLE
Fix remote commit listing when bottom commit is amended

### DIFF
--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -280,7 +280,7 @@ fn stack_branch_to_api_branch(
     let branch_commits = stack_branch.commits(ctx, stack)?;
     // anyhow::bail!("Lets pretend this is a real error");
     let remote = default_target.push_remote_name();
-    let upstream_reference = if stack_branch.pushed(remote.as_str(), repository)? {
+    let upstream_reference = if stack_branch.pushed(remote.as_str(), repository) {
         Some(stack_branch.remote_reference(remote.as_str()))
     } else {
         None


### PR DESCRIPTION
- should list what's between current branch remote sha and previous branch remote sha

**Before**

![image](https://github.com/user-attachments/assets/945ffcda-23d7-4f5a-bca1-2b7af0e88eb3)

**After**

![image](https://github.com/user-attachments/assets/25134703-b166-430f-8f05-c501381944dc)


<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5632 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5631 
<!-- GitButler Footer Boundary Bottom -->

