### PR TITLE
fix: series errorCard styling and logging

### DIFF
--- a/apps/desktop/src/lib/stack/ErrorSeries.svelte
+++ b/apps/desktop/src/lib/stack/ErrorSeries.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { openExternalUrl } from '$lib/utils/url';
+	import Icon from '@gitbutler/ui/Icon.svelte';
 	import LinkButton from '@gitbutler/ui/LinkButton.svelte';
 
 	interface Props {
@@ -12,7 +14,17 @@
 	<div class="commit-line"></div>
 	<div class="text-13 text-body error-series__body">
 		This branch failed to load.
-		<pre class="error-series__message">{error.message}</pre>
+		<div class="error-series__message">
+			<span>{error.message}</span>
+			<button
+				type="button"
+				class="error-series__message--copy"
+				onclick={() => copyToClipboard(error.message)}
+			>
+				<Icon name="copy-small" />
+			</button>
+		</div>
+
 		Please check out our
 		<LinkButton
 			icon="copy-small"
@@ -44,6 +56,7 @@
 		display: flex;
 		overflow: hidden;
 	}
+
 	.error-series__body {
 		color: var(--clr-text-2);
 
@@ -51,10 +64,28 @@
 		padding: 20px 28px 26px 46px;
 		opacity: 0.6;
 
+		&:hover .error-series__message--copy {
+			width: 16px;
+			opacity: 1;
+		}
+
 		.error-series__message {
+			font-family: monospace;
+			white-space: pre-wrap;
 			margin: 8px 0;
 		}
+
+		.error-series__message--copy {
+			opacity: 0;
+			height: 16px;
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			vertical-align: sub;
+			transition: opacity 150ms ease-in-out;
+		}
 	}
+
 	.commit-line {
 		--commit-color: var(--clr-theme-err-element);
 		position: absolute;

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -253,7 +253,10 @@ pub(crate) fn stack_series(
             &stack_dependencies,
         )
         .map_or_else(
-            |err| (Err(err), false),
+            |err| {
+                tracing::error!("Series Error: {}", err);
+                (Err(err), false)
+            },
             |(patch_series, force)| (Ok(patch_series), force),
         );
         if force {
@@ -278,7 +281,6 @@ fn stack_branch_to_api_branch(
     let mut requires_force = false;
     let repository = ctx.repository();
     let branch_commits = stack_branch.commits(ctx, stack)?;
-    // anyhow::bail!("Lets pretend this is a real error");
     let remote = default_target.push_remote_name();
     let upstream_reference = if stack_branch.pushed(remote.as_str(), repository) {
         Some(stack_branch.remote_reference(remote.as_str()))


### PR DESCRIPTION
## ☕️ Reasoning

- Fix word wrap and add copy to clipboard btn to branch error card
- Ensure we're logging the error from the rust side

Question: is `tracing::error!(...)` the best way to ensure we log the error with all possible info?

## 🧢 Changes

![image](https://github.com/user-attachments/assets/4a8c800a-a99b-4b42-bfa6-562ac24eae18)

> The copy to clipboard btn at the end of the error msg only appears on hover.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->