### PR TITLE
When applying a branch always rebase if there are no change IDs

### DIFF
--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -336,7 +336,8 @@ impl BranchManager<'_> {
                 let commits_to_rebase =
                     repo.l(stack.head(), LogUntil::Commit(merge_base), false)?;
 
-                let head_oid = cherry_rebase_group(repo, default_target.sha, &commits_to_rebase)?;
+                let head_oid =
+                    cherry_rebase_group(repo, default_target.sha, &commits_to_rebase, true)?;
 
                 repo.find_commit(head_oid)?
             } else {

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -331,7 +331,11 @@ impl BranchManager<'_> {
         }
 
         // Do we need to rebase the branch on top of the default target?
-        if merge_base != default_target.sha {
+
+        let has_change_id = repo.find_commit(stack.head())?.change_id().is_some();
+        // If the branch has no change ID for the head commit, we want to rebase it even if the base is the same
+        // This way stacking functionality which relies on change IDs will work as expected
+        if merge_base != default_target.sha || !has_change_id {
             let new_head = if stack.allow_rebasing {
                 let commits_to_rebase =
                     repo.l(stack.head(), LogUntil::Commit(merge_base), false)?;

--- a/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
@@ -207,7 +207,7 @@ impl IntegrateUpstreamContext<'_, '_> {
                 )?;
                 // First rebase the series with it's remote commits
                 let new_series_head =
-                    cherry_rebase_group(self.repository, merge_base, &ordered_commits)?;
+                    cherry_rebase_group(self.repository, merge_base, &ordered_commits, false)?;
                 // Get the commits that come after the series head, until the stack head
                 let remaining_ids_to_rebase =
                     self.repository
@@ -218,6 +218,7 @@ impl IntegrateUpstreamContext<'_, '_> {
                         self.repository,
                         new_series_head,
                         &remaining_ids_to_rebase,
+                        false,
                     )?,
                     new_series_head,
                 )
@@ -233,6 +234,7 @@ impl IntegrateUpstreamContext<'_, '_> {
                         self.repository,
                         remote_head_commit.id(),
                         &remaining_ids_to_rebase,
+                        false,
                     )?,
                     remote_head_commit.id(),
                 )
@@ -276,7 +278,7 @@ impl IntegrateUpstreamContext<'_, '_> {
                     self.remote_head,
                 )?;
 
-                cherry_rebase_group(self.repository, merge_base, &ordered_commits)?
+                cherry_rebase_group(self.repository, merge_base, &ordered_commits, false)?
             }
             IntegrationStrategy::HardReset => self.remote_head,
         };

--- a/crates/gitbutler-branch-actions/src/move_commits.rs
+++ b/crates/gitbutler-branch-actions/src/move_commits.rs
@@ -131,8 +131,12 @@ fn take_commit_from_source_stack(
     let source_commits_without_subject =
         filter_out_commit(repo, source_stack, source_merge_base_oid, &subject_commit)?;
 
-    let new_source_head =
-        cherry_rebase_group(repo, source_merge_base_oid, &source_commits_without_subject)?;
+    let new_source_head = cherry_rebase_group(
+        repo,
+        source_merge_base_oid,
+        &source_commits_without_subject,
+        false,
+    )?;
 
     let BranchHeadAndTree {
         head: new_head_oid,
@@ -154,7 +158,7 @@ fn move_commit_to_destination_stack(
 ) -> Result<(), anyhow::Error> {
     let destination_head_commit_oid = destination_stack.head();
     let new_destination_head_oid =
-        cherry_rebase_group(repo, destination_head_commit_oid, &[commit_id])?;
+        cherry_rebase_group(repo, destination_head_commit_oid, &[commit_id], false)?;
 
     let BranchHeadAndTree {
         head: new_destination_head_oid,

--- a/crates/gitbutler-branch-actions/src/reorder.rs
+++ b/crates/gitbutler-branch-actions/src/reorder.rs
@@ -54,7 +54,7 @@ pub fn reorder_stack(
         .flat_map(|s| s.commit_ids.iter())
         .cloned()
         .collect_vec();
-    let new_head = cherry_rebase_group(repo, merge_base, &ids_to_rebase)?;
+    let new_head = cherry_rebase_group(repo, merge_base, &ids_to_rebase, false)?;
     // Calculate the new head and tree
     let BranchHeadAndTree {
         head: new_head_oid,

--- a/crates/gitbutler-branch-actions/src/undo_commit.rs
+++ b/crates/gitbutler-branch-actions/src/undo_commit.rs
@@ -109,6 +109,7 @@ fn inner_undo_commit(
         repository,
         commit_to_remove.parent_id(0)?,
         &commits_to_rebase,
+        false,
     )?;
 
     Ok(UndoResult {

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -265,7 +265,7 @@ fn get_stack_status(
 
         let rebase_base = last_head;
 
-        let new_head_oid = cherry_rebase_group(repository, rebase_base, &local_commit_ids)?;
+        let new_head_oid = cherry_rebase_group(repository, rebase_base, &local_commit_ids, false)?;
         let rebased_commits = repository.log(new_head_oid, LogUntil::Commit(rebase_base), false)?;
 
         last_head = new_head_oid;
@@ -514,7 +514,7 @@ pub(crate) fn resolve_upstream_integration(
         }
         BaseBranchResolutionApproach::Rebase => {
             let commits = repo.l(old_target_id, LogUntil::Commit(fork_point), false)?;
-            let new_head = cherry_rebase_group(repo, new_target_id, &commits)?;
+            let new_head = cherry_rebase_group(repo, new_target_id, &commits, false)?;
 
             Ok(new_head)
         }
@@ -626,8 +626,12 @@ fn compute_resolutions(
                         })
                         .collect::<Vec<_>>();
 
-                    let new_head =
-                        cherry_rebase_group(repository, new_target.id(), &virtual_branch_commits)?;
+                    let new_head = cherry_rebase_group(
+                        repository,
+                        new_target.id(),
+                        &virtual_branch_commits,
+                        false,
+                    )?;
 
                     // Get the updated tree oid
                     let BranchHeadAndTree {

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -1599,7 +1599,7 @@ pub(crate) fn squash(ctx: &CommandContext, stack_id: StackId, commit_id: git2::O
     .with_context(|| format!("commit {commit_id} not in the branch"))?;
     let ids_to_rebase = ids_to_rebase.to_vec();
 
-    match cherry_rebase_group(ctx.repository(), new_commit_oid, &ids_to_rebase) {
+    match cherry_rebase_group(ctx.repository(), new_commit_oid, &ids_to_rebase, false) {
         Ok(new_head_id) => {
             // save new branch head
             stack.set_stack_head(ctx, new_head_id, None)?;
@@ -1678,7 +1678,7 @@ pub(crate) fn update_commit_message(
     .with_context(|| format!("commit {commit_id} not in the branch"))?;
     let ids_to_rebase = ids_to_rebase.to_vec();
 
-    let new_head_id = cherry_rebase_group(ctx.repository(), new_commit_oid, &ids_to_rebase)
+    let new_head_id = cherry_rebase_group(ctx.repository(), new_commit_oid, &ids_to_rebase, false)
         .map_err(|err| err.context("rebase error"))?;
     // save new branch head
     stack.set_stack_head(ctx, new_head_id, None)?;

--- a/crates/gitbutler-workspace/src/branch_trees.rs
+++ b/crates/gitbutler-workspace/src/branch_trees.rs
@@ -129,7 +129,7 @@ pub fn compute_updated_branch_head_for_commits(
         Default::default(),
     )?;
 
-    let rebased_tree = cherry_rebase_group(repository, new_head, &[commited_tree])?;
+    let rebased_tree = cherry_rebase_group(repository, new_head, &[commited_tree], false)?;
     let rebased_tree = repository.find_commit(rebased_tree)?;
 
     if rebased_tree.is_conflicted() {


### PR DESCRIPTION
This change makes it so that when a branch is applied, if the head does not have a change ID (i.e. was not created with gitbutler), the commits will be rebased even if the base is the same as the workspace.
This will populate the change ID headers. 

This resolves issues related to stacking which relies on change IDs