### PR TITLE
Weave the remote branch into the local one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2969,6 +2969,7 @@ dependencies = [
  "gitbutler-branch",
  "gitbutler-branch-actions",
  "gitbutler-command-context",
+ "gitbutler-commit",
  "gitbutler-oxidize",
  "gitbutler-project",
  "gitbutler-reference",

--- a/apps/desktop/src/lib/backend/projects.ts
+++ b/apps/desktop/src/lib/backend/projects.ts
@@ -27,6 +27,7 @@ export class Project {
 	omit_certificate_check: boolean | undefined;
 	use_diff_context: boolean | undefined;
 	snapshot_lines_threshold!: number | undefined;
+	use_new_branch_integration_algorithm: boolean | undefined;
 	// Produced just for the frontend to determine if the project is open in any window.
 	is_open!: boolean;
 

--- a/apps/desktop/src/lib/settings/userPreferences/PreferencesForm.svelte
+++ b/apps/desktop/src/lib/settings/userPreferences/PreferencesForm.svelte
@@ -11,8 +11,8 @@
 	const project = getContext(Project);
 
 	let snaphotLinesThreshold = project?.snapshot_lines_threshold || 20; // when undefined, the default is 20
-
 	let omitCertificateCheck = project?.omit_certificate_check;
+	let useNewBranchIntegrationAlgorithm = project?.use_new_branch_integration_algorithm;
 
 	const runCommitHooks = projectRunCommitHooks(project.id);
 
@@ -26,8 +26,17 @@
 		await projectsService.updateProject(project);
 	}
 
+	async function setUseNewBranchIntegrationAlgorithm(value: boolean) {
+		project.use_new_branch_integration_algorithm = value;
+		await projectsService.updateProject(project);
+	}
+
 	async function handleOmitCertificateCheckClick(event: MouseEvent) {
 		await setOmitCertificateCheck((event.target as HTMLInputElement)?.checked);
+	}
+
+	async function handleUseNewBranchIntegrationAlgorithmClick(event: MouseEvent) {
+		await setUseNewBranchIntegrationAlgorithm((event.target as HTMLInputElement)?.checked);
 	}
 </script>
 
@@ -42,6 +51,23 @@
 				id="omitCertificateCheck"
 				checked={omitCertificateCheck}
 				onclick={handleOmitCertificateCheckClick}
+			/>
+		</svelte:fragment>
+	</SectionCard>
+
+	<SectionCard orientation="row" labelFor="newBranchIntegrationAlgorithm">
+		<svelte:fragment slot="title">Use new branch integration algorithm</svelte:fragment>
+		<svelte:fragment slot="caption"
+			>Enable this to start using the improved way of integrating remote changes into the local
+			virtual branches in your workspace.
+			<br />
+			This does not affect how the target branch is integrated.</svelte:fragment
+		>
+		<svelte:fragment slot="actions">
+			<Toggle
+				id="newBranchIntegrationAlgorithm"
+				checked={useNewBranchIntegrationAlgorithm}
+				onclick={handleUseNewBranchIntegrationAlgorithmClick}
 			/>
 		</svelte:fragment>
 	</SectionCard>

--- a/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
@@ -1,5 +1,8 @@
+use std::collections::{HashMap, HashSet};
+
 use anyhow::{anyhow, bail, Result};
 use gitbutler_command_context::CommandContext;
+use gitbutler_commit::commit_ext::CommitExt;
 use gitbutler_project::access::WorktreeWritePermission;
 use gitbutler_repo::{
     rebase::{cherry_rebase_group, gitbutler_merge_commits},
@@ -10,6 +13,7 @@ use gitbutler_stack::StackId;
 use gitbutler_workspace::{
     checkout_branch_trees, compute_updated_branch_head_for_commits, BranchHeadAndTree,
 };
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 use crate::{conflicts, VirtualBranchesExt as _};
@@ -304,6 +308,20 @@ fn order_commits_for_rebasing(
     branch_head: git2::Oid,
     remote_head: git2::Oid,
 ) -> Result<OrderCommitsResult> {
+    let use_zipping = false;
+    if use_zipping {
+        order_commits_for_zipping_rebase(repository, target_branch_head, branch_head, remote_head)
+    } else {
+        order_commits_for_stacked_rebase(repository, target_branch_head, branch_head, remote_head)
+    }
+}
+
+fn order_commits_for_stacked_rebase(
+    repository: &git2::Repository,
+    target_branch_head: git2::Oid,
+    branch_head: git2::Oid,
+    remote_head: git2::Oid,
+) -> Result<OrderCommitsResult> {
     let merge_base =
         repository.merge_base_octopussy(&[target_branch_head, branch_head, remote_head])?;
 
@@ -338,10 +356,231 @@ fn order_commits_for_rebasing(
     })
 }
 
+/// Interweave the local and remote commits in the correct order.
+///
+/// The order is determined in the following way:
+/// 1. Whenever there are discrepancies defer to the remote branch.
+/// 2. Match the commits by their change id.
+/// 3. If a remote commit does not match the any local commits, insert it in the order it came.
+/// 4. Insert the unmatched local commits above its parents.
+fn order_commits_for_zipping_rebase(
+    repository: &git2::Repository,
+    target_branch_head: git2::Oid,
+    local_head: git2::Oid,
+    remote_head: git2::Oid,
+) -> Result<OrderCommitsResult> {
+    let merge_base =
+        repository.merge_base_octopussy(&[target_branch_head, local_head, remote_head])?;
+
+    // 1. Build the change id map for the local branch.
+    let local_branch_commits =
+        repository.l(local_head, LogUntil::Commit(target_branch_head), false)?;
+    let remote_branch_commits = repository.l(remote_head, LogUntil::Commit(merge_base), false)?;
+
+    let change_id_map = build_change_id_map(&local_branch_commits, repository)?;
+
+    let mut ordered_for_zipping: Vec<(Option<String>, git2::Oid)> = vec![];
+    let mut added_local_commits: HashSet<git2::Oid> = HashSet::new();
+
+    // 2. Start populating the ordered list with the remote commits
+    // and their respective local commits (matched by change id).
+    process_remote_commits_for_zipping(
+        repository,
+        &change_id_map,
+        remote_branch_commits,
+        &mut ordered_for_zipping,
+        &mut added_local_commits,
+    )?;
+
+    // 3. Add the remaining local commits.
+    insert_remaining_local_commits(
+        repository,
+        target_branch_head,
+        local_branch_commits,
+        &added_local_commits,
+        &mut ordered_for_zipping,
+    )?;
+
+    let ordered_for_zipping = ordered_for_zipping
+        .iter()
+        .map(|(_, id)| *id)
+        .dedup()
+        .collect();
+
+    Ok(OrderCommitsResult {
+        merge_base,
+        ordered_commits: ordered_for_zipping,
+    })
+}
+
+/// Insert the remaining local commits in the correct order.
+///
+/// All the local commits that were not matched by an incoming change id need to be inserted
+/// at the right position in the ordered list.
+fn insert_remaining_local_commits(
+    repository: &git2::Repository,
+    merge_base: git2::Oid,
+    local_branch_commits: Vec<git2::Oid>,
+    added_local_commits: &HashSet<git2::Oid>,
+    ordered_for_zipping: &mut Vec<(Option<String>, git2::Oid)>,
+) -> Result<(), anyhow::Error> {
+    // We iterate over them in reverse order so we can insert them at the correct position
+    let branch_commits_remaining = local_branch_commits
+        .iter()
+        .filter(|commit_id| !added_local_commits.contains(commit_id))
+        .rev();
+
+    for remaining_commit_id in branch_commits_remaining {
+        let insertion_index = find_insertion_index_for_remaining_commit(
+            repository,
+            remaining_commit_id,
+            merge_base,
+            ordered_for_zipping,
+        )?;
+
+        let remaining_commit = repository.find_commit(*remaining_commit_id)?;
+        ordered_for_zipping.insert(
+            insertion_index,
+            (remaining_commit.change_id(), *remaining_commit_id),
+        );
+    }
+    Ok(())
+}
+
+/// Find the correct insertion index for the remaining commit
+///
+/// We want to insert the remaining commit on top of all of its parents
+/// in order to minimize the possibility of conflicts.
+/// We also want to insert the remaining commit on top of as few incoming remote
+/// commits as possible.
+///
+/// The insertion index is the index of the first parent of the remaining commit.
+fn find_insertion_index_for_remaining_commit(
+    repository: &git2::Repository,
+    remaining_commit_id: &git2::Oid,
+    merge_base: git2::Oid,
+    ordered_for_zipping: &[(Option<String>, git2::Oid)],
+) -> Result<usize, anyhow::Error> {
+    let remaining_commit_id_parent_ids =
+        repository.l(*remaining_commit_id, LogUntil::Commit(merge_base), false)?;
+    let remaining_commit_id_parents = remaining_commit_id_parent_ids
+        .iter()
+        .filter_map(|id| repository.find_commit(*id).ok())
+        .collect_vec();
+
+    let mut insertion_index = None;
+
+    for (index, oredered_element) in ordered_for_zipping.iter().enumerate() {
+        match &oredered_element.0 {
+            Some(ordered_change_id) => {
+                let found_parent = remaining_commit_id_parents.iter().any(|parent| {
+                    if let Some(parent_change_id) = parent.change_id() {
+                        parent_change_id == *ordered_change_id
+                    } else {
+                        parent.id() == oredered_element.1
+                    }
+                });
+
+                if found_parent {
+                    if let Some(actual_insertion_index) = insertion_index {
+                        insertion_index = Some(std::cmp::min(index, actual_insertion_index));
+                    } else {
+                        insertion_index = Some(index);
+                    }
+                }
+            }
+            None => {
+                let found_parent = remaining_commit_id_parents
+                    .iter()
+                    .any(|parent| parent.id() == oredered_element.1);
+
+                if found_parent {
+                    if let Some(actual_insertion_index) = insertion_index {
+                        insertion_index = Some(std::cmp::min(index, actual_insertion_index));
+                    } else {
+                        insertion_index = Some(index);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(insertion_index.unwrap_or_default())
+}
+
+/// Start populating the ordered list with the remote commits and matching local commits.
+///
+/// In the order of the remote commits, we add the remote and then local commits that match the change id.
+/// If a change id is not unique, we add all the local commits that match the change id
+/// and once added, we skip the change id the next time we see it.
+///
+/// That process is not ideal, because we assume that the best position to insert the local commits is
+/// right after the first remote commit that matches the change id.
+/// And we are force to assume that because there is no way to know better, yet.
+fn process_remote_commits_for_zipping<'a>(
+    repository: &'a git2::Repository,
+    change_id_map: &'a HashMap<String, Vec<git2::Oid>>,
+    remote_branch_commits: Vec<git2::Oid>,
+    ordered_for_zipping: &'a mut Vec<(Option<String>, git2::Oid)>,
+    added_local_commits: &'a mut HashSet<git2::Oid>,
+) -> Result<(), anyhow::Error> {
+    let mut visited_change_ids = HashSet::new();
+    for remote_commit_id in remote_branch_commits {
+        let remote_commit = repository.find_commit(remote_commit_id)?;
+
+        let change_id = match remote_commit.change_id() {
+            Some(change_id) => change_id,
+            None => {
+                ordered_for_zipping.push((None, remote_commit_id));
+                continue;
+            }
+        };
+
+        ordered_for_zipping.push((Some(change_id.clone()), remote_commit_id));
+
+        if visited_change_ids.contains(&change_id) {
+            continue;
+        }
+
+        if let Some(local_commit_id) = change_id_map.get(&change_id) {
+            local_commit_id.iter().for_each(|id| {
+                ordered_for_zipping.push((Some(change_id.clone()), *id));
+                added_local_commits.insert(*id);
+            });
+        }
+
+        visited_change_ids.insert(change_id);
+    }
+    Ok(())
+}
+
+/// Build a map of change ids to local commits
+///
+/// Usually, a change id is unique to a commit, but it's not a certainty.
+fn build_change_id_map(
+    local_branch_commits: &[git2::Oid],
+    repository: &git2::Repository,
+) -> Result<HashMap<String, Vec<git2::Oid>>> {
+    let mut change_id_map = HashMap::new();
+    for commit_id in local_branch_commits {
+        let commit = repository.find_commit(*commit_id)?;
+        let change_id = match commit.change_id() {
+            Some(change_id) => change_id,
+            None => continue,
+        };
+        change_id_map
+            .entry(change_id)
+            .or_insert_with(Vec::new)
+            .push(*commit_id);
+    }
+    Ok(change_id_map)
+}
+
 #[cfg(test)]
 mod test {
     use crate::branch_upstream_integration::{
-        order_commits_for_rebasing, IntegrateUpstreamContext,
+        order_commits_for_stacked_rebase, order_commits_for_zipping_rebase,
+        IntegrateUpstreamContext,
     };
     use gitbutler_testsupport::testing_repository::{
         assert_commit_tree_matches, TestingRepository,
@@ -1022,7 +1261,7 @@ mod test {
         }
     }
 
-    mod order_commits_for_rebasing {
+    mod order_commits_for_stacked_rebase {
         use super::*;
 
         /// Local:  Base -> A -> B
@@ -1040,7 +1279,7 @@ mod test {
             let remote_x = test_repository.commit_tree(Some(&local_b), &[]);
             let remote_y = test_repository.commit_tree(Some(&remote_x), &[]);
 
-            let commits = order_commits_for_rebasing(
+            let commits = order_commits_for_stacked_rebase(
                 &test_repository.repository,
                 base_commit.id(),
                 local_b.id(),
@@ -1070,7 +1309,7 @@ mod test {
             let remote_b = test_repository.commit_tree(Some(&local_a), &[]);
             let remote_y = test_repository.commit_tree(Some(&remote_b), &[]);
 
-            let commits = order_commits_for_rebasing(
+            let commits = order_commits_for_stacked_rebase(
                 &test_repository.repository,
                 base_commit.id(),
                 local_b.id(),
@@ -1116,7 +1355,7 @@ mod test {
             let remote_y = test_repository.commit_tree(Some(&remote_x), &[]);
             let remote_z = test_repository.commit_tree(Some(&remote_y), &[]);
 
-            let commits = order_commits_for_rebasing(
+            let commits = order_commits_for_stacked_rebase(
                 &test_repository.repository,
                 trunk_n.id(),
                 local_b.id(),
@@ -1131,6 +1370,123 @@ mod test {
                     remote_y.id(),
                     remote_x.id(),
                     local_b.id(),
+                    local_a.id(),
+                    trunk_n.id(),
+                    trunk_m.id()
+                ],
+            );
+        }
+    }
+
+    mod order_commits_for_zipping_rebase {
+        use super::*;
+
+        /// Local:  Base -> A -> B
+        /// Remote: Base -> A -> B -> X -> Y
+        /// Trunk:  Base
+        /// Result: Base -> A -> B -> X -> Y
+        #[test]
+        fn other_added_remote_changes() {
+            let test_repository = TestingRepository::open();
+
+            let base_commit = test_repository.commit_tree(None, &[]);
+            let local_a = test_repository.commit_tree_with_change_id(Some(&base_commit), "a", &[]);
+            let local_b = test_repository.commit_tree_with_change_id(Some(&local_a), "b", &[]);
+
+            let remote_x = test_repository.commit_tree_with_change_id(Some(&local_b), "x", &[]);
+            let remote_y = test_repository.commit_tree_with_change_id(Some(&remote_x), "y", &[]);
+
+            let commits = order_commits_for_zipping_rebase(
+                &test_repository.repository,
+                base_commit.id(),
+                local_b.id(),
+                remote_y.id(),
+            )
+            .unwrap();
+
+            assert_eq!(
+                commits.ordered_commits,
+                vec![remote_y.id(), remote_x.id(), local_b.id(), local_a.id()],
+            );
+        }
+
+        /// Local:  Base -> A -> B
+        /// Remote: Base -> A -> B' -> Y
+        /// Trunk:  Base
+        /// Result: Base -> A -> B -> B' -> Y
+        #[test]
+        fn modified_local_commit() {
+            let test_repository = TestingRepository::open();
+
+            let base_commit = test_repository.commit_tree(None, &[]);
+            let local_a = test_repository.commit_tree_with_change_id(Some(&base_commit), "a", &[]);
+            let local_b = test_repository.commit_tree_with_change_id(Some(&local_a), "b", &[]);
+
+            // imagine someone on the remote rebased local_b
+            let remote_b = test_repository.commit_tree_with_change_id(Some(&local_a), "b", &[]);
+            let remote_y = test_repository.commit_tree_with_change_id(Some(&remote_b), "y", &[]);
+
+            let commits = order_commits_for_zipping_rebase(
+                &test_repository.repository,
+                base_commit.id(),
+                local_b.id(),
+                remote_y.id(),
+            )
+            .unwrap();
+
+            assert_eq!(
+                commits.ordered_commits,
+                vec![remote_y.id(), remote_b.id(), local_b.id(), local_a.id()],
+            );
+        }
+
+        /// Local:  Base -> A -> B
+        /// Remote: Base -> M -> N -> A' -> B' -> Y
+        /// Trunk:  Base -> M -> N
+        /// Result: Base -> M -> N -> A -> A' -> B -> B' -> Y
+        #[test]
+        fn remote_includes_integrated_commits() {
+            let test_repository = TestingRepository::open();
+
+            // Setup:
+            // (z)
+            //  |
+            //  y
+            //  |
+            //  x
+            //  |
+            // (n) (b)
+            //  |   |
+            //  m   a
+            //  \   /
+            //   base_commit
+            let base_commit = test_repository.commit_tree(None, &[]);
+            let trunk_m = test_repository.commit_tree_with_change_id(Some(&base_commit), "m", &[]);
+            let trunk_n = test_repository.commit_tree_with_change_id(Some(&trunk_m), "n", &[]);
+
+            let local_a = test_repository.commit_tree_with_change_id(Some(&base_commit), "a", &[]);
+            let local_b = test_repository.commit_tree_with_change_id(Some(&local_a), "b", &[]);
+
+            // imagine someone on the remote rebased local_a
+            let remote_x = test_repository.commit_tree_with_change_id(Some(&trunk_n), "a", &[]);
+            let remote_y = test_repository.commit_tree_with_change_id(Some(&remote_x), "b", &[]);
+            let remote_z = test_repository.commit_tree_with_change_id(Some(&remote_y), "y", &[]);
+
+            let commits = order_commits_for_zipping_rebase(
+                &test_repository.repository,
+                trunk_n.id(),
+                local_b.id(),
+                remote_z.id(),
+            )
+            .unwrap();
+
+            assert_eq!(
+                commits.ordered_commits,
+                vec![
+                    remote_z.id(),
+                    remote_y.id(),
+                    local_b.id(),
+                    remote_x.id(),
                     local_a.id(),
                     trunk_n.id(),
                     trunk_m.id()

--- a/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
@@ -65,6 +65,7 @@ pub fn integrate_upstream_commits_for_series(
         remote_head: remote_head.id(),
         remote_branch_name: &subject_branch.remote_reference(&remote),
         strategy,
+        use_new_branch_integration_algorithm: ctx.project().use_new_branch_integration_algorithm,
     };
 
     let (BranchHeadAndTree { head, tree }, new_series_head) =
@@ -129,6 +130,7 @@ pub fn integrate_upstream_commits(
         remote_head: upstream_branch_head,
         remote_branch_name: upstream_branch.name()?.unwrap_or("Unknown"),
         strategy: integration_strategy,
+        use_new_branch_integration_algorithm: project.use_new_branch_integration_algorithm,
     };
 
     let BranchHeadAndTree { head, tree } =
@@ -172,6 +174,8 @@ struct IntegrateUpstreamContext<'a, 'b> {
 
     /// Strategy to use when integrating the upstream commits
     strategy: IntegrationStrategy,
+    /// Whether to use the new branch integration algorithm
+    use_new_branch_integration_algorithm: Option<bool>,
 }
 
 impl IntegrateUpstreamContext<'_, '_> {
@@ -204,6 +208,7 @@ impl IntegrateUpstreamContext<'_, '_> {
                     merge_base,
                     ordered_commits,
                 } = order_commits_for_rebasing(
+                    self.use_new_branch_integration_algorithm,
                     self.repository,
                     self.target_branch_head,
                     series_head,
@@ -276,6 +281,7 @@ impl IntegrateUpstreamContext<'_, '_> {
                     merge_base,
                     ordered_commits,
                 } = order_commits_for_rebasing(
+                    self.use_new_branch_integration_algorithm,
                     self.repository,
                     self.target_branch_head,
                     self.branch_head,
@@ -303,12 +309,13 @@ struct OrderCommitsResult {
 }
 
 fn order_commits_for_rebasing(
+    use_new_branch_integration_algorithm: Option<bool>,
     repository: &git2::Repository,
     target_branch_head: git2::Oid,
     branch_head: git2::Oid,
     remote_head: git2::Oid,
 ) -> Result<OrderCommitsResult> {
-    let use_zipping = false;
+    let use_zipping = use_new_branch_integration_algorithm.unwrap_or(false);
     if use_zipping {
         order_commits_for_zipping_rebase(repository, target_branch_head, branch_head, remote_head)
     } else {
@@ -620,6 +627,7 @@ mod test {
                 remote_head: remote_y.id(),
                 remote_branch_name: "test",
                 strategy: IntegrationStrategy::Rebase,
+                use_new_branch_integration_algorithm: None,
             };
 
             let BranchHeadAndTree { head, tree: _tree } =
@@ -675,6 +683,7 @@ mod test {
                 remote_head: remote_y.id(),
                 remote_branch_name: "test",
                 strategy: IntegrationStrategy::Rebase,
+                use_new_branch_integration_algorithm: None,
             };
 
             let (BranchHeadAndTree { head, tree: _tree }, new_series_head) = ctx
@@ -744,6 +753,7 @@ mod test {
                 remote_head: remote_y.id(),
                 remote_branch_name: "test",
                 strategy: IntegrationStrategy::Rebase,
+                use_new_branch_integration_algorithm: None,
             };
 
             let BranchHeadAndTree { head, tree: _tree } =
@@ -860,6 +870,7 @@ mod test {
                 remote_head: remote_y.id(),
                 remote_branch_name: "test",
                 strategy: IntegrationStrategy::Rebase,
+                use_new_branch_integration_algorithm: None,
             };
 
             let BranchHeadAndTree { head, tree: _tree } =
@@ -1001,6 +1012,7 @@ mod test {
                 remote_head: remote_y.id(),
                 remote_branch_name: "test",
                 strategy: IntegrationStrategy::Rebase,
+                use_new_branch_integration_algorithm: None,
             };
 
             let BranchHeadAndTree { head, tree: _tree } =
@@ -1099,6 +1111,7 @@ mod test {
                 remote_head: remote_b.id(),
                 remote_branch_name: "test",
                 strategy: IntegrationStrategy::HardReset,
+                use_new_branch_integration_algorithm: None,
             };
 
             let BranchHeadAndTree { head, tree: _tree } =
@@ -1165,6 +1178,7 @@ mod test {
                 remote_head: remote_c.id(),
                 remote_branch_name: "test",
                 strategy: IntegrationStrategy::HardReset,
+                use_new_branch_integration_algorithm: None,
             };
 
             let BranchHeadAndTree { head, tree: _tree } =
@@ -1232,6 +1246,7 @@ mod test {
                 remote_head: remote_b.id(),
                 remote_branch_name: "test",
                 strategy: IntegrationStrategy::HardReset,
+                use_new_branch_integration_algorithm: None,
             };
 
             let BranchHeadAndTree { head, tree: _tree } =

--- a/crates/gitbutler-project/src/project.rs
+++ b/crates/gitbutler-project/src/project.rs
@@ -94,6 +94,8 @@ pub struct Project {
     pub omit_certificate_check: Option<bool>,
     // The number of changed lines that will trigger a snapshot
     pub snapshot_lines_threshold: Option<usize>,
+    #[serde(default)]
+    pub use_new_branch_integration_algorithm: Option<bool>,
 }
 
 impl Project {

--- a/crates/gitbutler-project/src/storage.rs
+++ b/crates/gitbutler-project/src/storage.rs
@@ -27,6 +27,7 @@ pub struct UpdateRequest {
     pub omit_certificate_check: Option<bool>,
     pub use_diff_context: Option<bool>,
     pub snapshot_lines_threshold: Option<usize>,
+    pub use_new_branch_integration_algorithm: Option<bool>,
 }
 
 impl Storage {
@@ -121,6 +122,12 @@ impl Storage {
 
         if let Some(snapshot_lines_threshold) = update_request.snapshot_lines_threshold {
             project.snapshot_lines_threshold = Some(snapshot_lines_threshold);
+        }
+
+        if let Some(new_branch_integration_algorithm) =
+            update_request.use_new_branch_integration_algorithm
+        {
+            project.use_new_branch_integration_algorithm = Some(new_branch_integration_algorithm);
         }
 
         self.inner

--- a/crates/gitbutler-testsupport/Cargo.toml
+++ b/crates/gitbutler-testsupport/Cargo.toml
@@ -30,4 +30,5 @@ gitbutler-storage.workspace = true
 gitbutler-url.workspace = true
 gitbutler-stack.workspace = true
 gitbutler-oxidize.workspace = true
+gitbutler-commit.workspace = true
 uuid.workspace = true


### PR DESCRIPTION
Add an experimental feature:

When integrating a remote branch into a local patch series, interlock the incoming commits in order to reduce the probability of conflicts on integrate.
The interlocking order is determined by matching Change IDs.

### Benefits
1. This will usually yield less conflicts
2. This will usually yield less duplicated commits
3. The commits will end-up in roughly the desired order (no need to reorder and squashing)

### Things to look-out for
This algorithm works best if all change IDs are present, and all change IDs are uniquely matched to commits.
If that's not the case, the algorithm will still work, but it will just do some guess-work.

Nothing should break. But if we catch some weird decisions in the ordering of some commits, we should try to improve it.

### Visuals
There seems to be a noticeable improvement in some cases:

Before
<img width="409" alt="before" src="https://github.com/user-attachments/assets/2f3ad3d1-29d6-4e17-9a7b-6238d7cae03d">


Current integration algorithm
<img width="409" alt="current" src="https://github.com/user-attachments/assets/35fc9402-66fe-4462-a97a-0d88a5394f5f">


New algo
<img width="409" alt="zipping" src="https://github.com/user-attachments/assets/4ad62c84-ba74-4e90-ae78-643fca78f860">
