### PR TITLE
fix: textbox autofocus in modals

### DIFF
--- a/packages/ui/src/lib/Textbox.svelte
+++ b/packages/ui/src/lib/Textbox.svelte
@@ -2,7 +2,7 @@
 	import { clickOutside } from '$lib/utils/clickOutside';
 	import Icon from '@gitbutler/ui/Icon.svelte';
 	import { pxToRem } from '@gitbutler/ui/utils/pxToRem';
-	import { onMount } from 'svelte';
+	import { onMount, tick } from 'svelte';
 	import type iconsJson from '@gitbutler/ui/data/icons.json';
 
 	interface Props {
@@ -91,7 +91,11 @@
 
 	onMount(() => {
 		if (selectall) htmlInput.select();
-		else if (autofocus) htmlInput.focus();
+		else if (autofocus) {
+			tick().then(() => {
+				htmlInput.focus();
+			});
+		}
 	});
 </script>
 


### PR DESCRIPTION
## ☕️ Reasoning

- Textbox autofocus in modals was not working for me (i.e. the "Create new dependent branch" modal).
	- Couldn't reproduce on Estebans Mac, so maybe a Linux / AppImage specific issue.

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->