### PR TITLE
Warn the user about not deleting their branches

### DIFF
--- a/apps/desktop/src/lib/config/config.ts
+++ b/apps/desktop/src/lib/config/config.ts
@@ -5,6 +5,13 @@ export function projectHttpsWarningBannerDismissed(projectId: string): Persisted
 	return persisted(false, key + projectId);
 }
 
+export function projectDeleteBranchesOnMergeWarningDismissed(
+	projectId: string
+): Persisted<boolean> {
+	const key = 'projectDeleteBranchesOnMergeWarningDismissed_';
+	return persisted(false, key + projectId);
+}
+
 export function projectCommitGenerationExtraConcise(projectId: string): Persisted<boolean> {
 	const key = 'projectCommitGenerationExtraConcise_';
 	return persisted(false, key + projectId);

--- a/apps/desktop/src/lib/forge/azure/azure.ts
+++ b/apps/desktop/src/lib/forge/azure/azure.ts
@@ -1,6 +1,7 @@
 import { AzureBranch } from './azureBranch';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import type { Forge, ForgeName } from '../interface/forge';
+import type { ForgeRepoService } from '../interface/forgeRepoService';
 import type { ForgeArguments } from '../interface/types';
 
 export const AZURE_DOMAIN = 'dev.azure.com';
@@ -42,6 +43,10 @@ export class AzureDevOps implements Forge {
 	}
 
 	prService() {
+		return undefined;
+	}
+
+	repoService(): ForgeRepoService | undefined {
 		return undefined;
 	}
 

--- a/apps/desktop/src/lib/forge/bitbucket/bitbucket.ts
+++ b/apps/desktop/src/lib/forge/bitbucket/bitbucket.ts
@@ -49,6 +49,10 @@ export class BitBucket implements Forge {
 		return undefined;
 	}
 
+	repoService() {
+		return undefined;
+	}
+
 	checksMonitor(_sourceBranch: string) {
 		return undefined;
 	}

--- a/apps/desktop/src/lib/forge/github/github.ts
+++ b/apps/desktop/src/lib/forge/github/github.ts
@@ -2,6 +2,7 @@ import { GitHubBranch } from './githubBranch';
 import { GitHubChecksMonitor } from './githubChecksMonitor';
 import { GitHubListingService } from './githubListingService';
 import { GitHubPrService } from './githubPrService';
+import { GitHubRepoService } from './githubRepoService';
 import { GitHubIssueService } from '$lib/forge/github/issueService';
 import { Octokit } from '@octokit/rest';
 import type { ProjectMetrics } from '$lib/metrics/projectMetrics';
@@ -50,6 +51,13 @@ export class GitHub implements Forge {
 			return;
 		}
 		return new GitHubPrService(this.octokit, this.repo);
+	}
+
+	repoService() {
+		if (!this.octokit) {
+			return;
+		}
+		return new GitHubRepoService(this.octokit, this.repo);
 	}
 
 	issueService() {

--- a/apps/desktop/src/lib/forge/github/githubRepoService.ts
+++ b/apps/desktop/src/lib/forge/github/githubRepoService.ts
@@ -1,0 +1,30 @@
+import { readable, type Readable } from 'svelte/store';
+import type { RepoInfo } from '$lib/url/gitUrl';
+import type { ForgeRepoService, RepoDetailedInfo } from '../interface/forgeRepoService';
+import type { Octokit } from '@octokit/rest';
+
+export class GitHubRepoService implements ForgeRepoService {
+	info: Readable<RepoDetailedInfo | undefined>;
+
+	constructor(
+		private octokit: Octokit,
+		private repo: RepoInfo
+	) {
+		this.info = readable<RepoDetailedInfo | undefined>(undefined, (set) => {
+			this.getInfo().then((info) => {
+				set(info);
+			});
+		});
+	}
+
+	private async getInfo(): Promise<RepoDetailedInfo> {
+		const response = await this.octokit.rest.repos.get({
+			owner: this.repo.owner,
+			repo: this.repo.name
+		});
+
+		return {
+			deleteBranchAfterMerge: response.data.delete_branch_on_merge
+		};
+	}
+}

--- a/apps/desktop/src/lib/forge/gitlab/gitlab.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlab.ts
@@ -50,6 +50,10 @@ export class GitLab implements Forge {
 		return undefined;
 	}
 
+	repoService() {
+		return undefined;
+	}
+
 	checksMonitor(_sourceBranch: string) {
 		return undefined;
 	}

--- a/apps/desktop/src/lib/forge/interface/forge.ts
+++ b/apps/desktop/src/lib/forge/interface/forge.ts
@@ -4,6 +4,7 @@ import type { ForgeBranch } from './forgeBranch';
 import type { ForgeChecksMonitor } from './forgeChecksMonitor';
 import type { ForgeListingService } from './forgeListingService';
 import type { ForgePrService } from './forgePrService';
+import type { ForgeRepoService } from './forgeRepoService';
 
 export type ForgeName = 'github' | 'gitlab' | 'bitbucket' | 'azure';
 
@@ -16,6 +17,9 @@ export interface Forge {
 
 	// Detailed information about a specific PR.
 	prService(): ForgePrService | undefined;
+
+	// Detailed information about the repo.
+	repoService(): ForgeRepoService | undefined;
 
 	// Results from CI check-runs.
 	checksMonitor(branchName: string): ForgeChecksMonitor | undefined;

--- a/apps/desktop/src/lib/forge/interface/forgeRepoService.ts
+++ b/apps/desktop/src/lib/forge/interface/forgeRepoService.ts
@@ -1,0 +1,19 @@
+import { buildContextStore } from '@gitbutler/shared/context';
+import type { Readable } from 'svelte/store';
+
+export interface RepoDetailedInfo {
+	/**
+	 * Whether the repository will delete the branch after merging the PR.
+	 *
+	 * `undefined` if unknown.
+	 */
+	deleteBranchAfterMerge: boolean | undefined;
+}
+
+export const [getForgeRepoService, createForgeRepoServiceStore] = buildContextStore<
+	ForgeRepoService | undefined
+>('forgeRepoService');
+
+export interface ForgeRepoService {
+	info: Readable<RepoDetailedInfo | undefined>;
+}

--- a/apps/desktop/src/lib/pr/PrDetailsModal.svelte
+++ b/apps/desktop/src/lib/pr/PrDetailsModal.svelte
@@ -8,6 +8,7 @@
 
 <script lang="ts">
 	import PrDetailsModalHeader from './PrDetailsModalHeader.svelte';
+	import PrDetailsModalInfo from './PrDetailsModalInfo.svelte';
 	import PrTemplateSection from './PrTemplateSection.svelte';
 	import { AIService } from '$lib/ai/service';
 	import { Project } from '$lib/backend/projects';
@@ -475,6 +476,9 @@
 				</div>
 			{/if}
 		</div>
+
+		<!-- MODAL INFORMATION CONTAINER -->
+		<PrDetailsModalInfo />
 	</ScrollableContainer>
 
 	<!-- FOOTER -->

--- a/apps/desktop/src/lib/pr/PrDetailsModalInfo.svelte
+++ b/apps/desktop/src/lib/pr/PrDetailsModalInfo.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+	import { Project } from '$lib/backend/projects';
+	import { projectDeleteBranchesOnMergeWarningDismissed } from '$lib/config/config';
+	import { getForgeRepoService } from '$lib/forge/interface/forgeRepoService';
+	import InfoMessage from '$lib/shared/InfoMessage.svelte';
+	import { openExternalUrl } from '$lib/utils/url';
+	import { VirtualBranch } from '$lib/vbranches/types';
+	import { getContext, getContextStore } from '@gitbutler/shared/context';
+	import LinkButton from '@gitbutler/ui/LinkButton.svelte';
+
+	const GITHUB_DELETE_ON_MERGE_DOCS_URL =
+		'https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-the-automatic-deletion-of-branches';
+
+	const branchStore = getContextStore(VirtualBranch);
+	const repoService = getForgeRepoService();
+	const project = getContext(Project);
+
+	const deleteBranchesOnMergeWarningDismissed = projectDeleteBranchesOnMergeWarningDismissed(
+		project.id
+	);
+
+	const repoInfoStore = $derived($repoService?.info);
+	const repoInfo = $derived(repoInfoStore && $repoInfoStore);
+
+	const branch = $derived($branchStore);
+	const unarchivedSeries = $derived(branch.validSeries.filter((s) => !s.archived));
+	const hasMultipleSeries = $derived(unarchivedSeries.length > 1);
+
+	const shouldDisplayDeleteOnMergeWarning = $derived(
+		!$deleteBranchesOnMergeWarningDismissed &&
+			repoInfo?.deleteBranchAfterMerge === false &&
+			hasMultipleSeries
+	);
+
+	function acknowledgeWarning() {
+		$deleteBranchesOnMergeWarningDismissed = true;
+	}
+
+	function clickOnGitHubLink() {
+		openExternalUrl(GITHUB_DELETE_ON_MERGE_DOCS_URL);
+	}
+</script>
+
+{#if shouldDisplayDeleteOnMergeWarning}
+	<div class="container">
+		<InfoMessage
+			style="neutral"
+			filled
+			outlined={false}
+			primary="Configure GitHub"
+			primaryIcon="open-link"
+			on:primary={clickOnGitHubLink}
+			secondary="Ok, don't show this again"
+			on:secondary={acknowledgeWarning}
+		>
+			<svelte:fragment slot="title">Branch deletion after merge</svelte:fragment>
+			<svelte:fragment slot="content">
+				After a stacked PR has been merged, its branch should be deleted in order for the next PR to
+				be updated to point to your target branch.
+				<br />
+				You can <LinkButton onclick={clickOnGitHubLink}>
+					{#snippet children()}
+						configure GitHub
+					{/snippet}
+				</LinkButton> to do this automatically or alternatively delete the branch after merging.
+			</svelte:fragment>
+		</InfoMessage>
+	</div>
+{/if}
+
+<style>
+	.container {
+		padding: 0 16px 16px;
+	}
+</style>

--- a/apps/desktop/src/lib/shared/InfoMessage.svelte
+++ b/apps/desktop/src/lib/shared/InfoMessage.svelte
@@ -10,19 +10,22 @@
 	import type iconsJson from '@gitbutler/ui/data/icons.json';
 
 	type IconColor = ComponentColor | undefined;
+	type Icon = keyof typeof iconsJson;
 
-	export let icon: keyof typeof iconsJson | undefined = undefined;
+	export let icon: Icon | undefined = undefined;
 	export let style: MessageStyle = 'neutral';
 	export let outlined: boolean = true;
 	export let filled: boolean = false;
 	export let primary: string | undefined = undefined;
+	export let primaryIcon: Icon | undefined = undefined;
 	export let secondary: string | undefined = undefined;
+	export let secondaryIcon: Icon | undefined = undefined;
 	export let shadow = false;
 	export let error: string | undefined = undefined;
 
 	const dispatch = createEventDispatcher<{ primary: void; secondary: void }>();
 
-	const iconMap: { [Key in MessageStyle]: keyof typeof iconsJson } = {
+	const iconMap: { [Key in MessageStyle]: Icon } = {
 		neutral: 'info',
 		pop: 'info',
 		warning: 'warning',
@@ -78,12 +81,17 @@
 		{#if primary || secondary}
 			<div class="info-message__actions">
 				{#if secondary}
-					<Button style="ghost" outline onclick={() => dispatch('secondary')}>
+					<Button style="ghost" outline onclick={() => dispatch('secondary')} icon={secondaryIcon}>
 						{secondary}
 					</Button>
 				{/if}
 				{#if primary}
-					<Button style={primaryButtonMap[style]} kind="solid" onclick={() => dispatch('primary')}>
+					<Button
+						style={primaryButtonMap[style]}
+						kind="solid"
+						onclick={() => dispatch('primary')}
+						icon={primaryIcon}
+					>
 						{primary}
 					</Button>
 				{/if}

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -22,6 +22,7 @@
 	import { createForgeStore } from '$lib/forge/interface/forge';
 	import { createForgeListingServiceStore } from '$lib/forge/interface/forgeListingService';
 	import { createForgePrServiceStore } from '$lib/forge/interface/forgePrService';
+	import { createForgeRepoServiceStore } from '$lib/forge/interface/forgeRepoService';
 	import History from '$lib/history/History.svelte';
 	import { HistoryService } from '$lib/history/history';
 	import { SyncedSnapshotService } from '$lib/history/syncedSnapshotService';
@@ -106,6 +107,7 @@
 	const listServiceStore = createForgeListingServiceStore(undefined);
 	const forgeStore = createForgeStore(undefined);
 	const prService = createForgePrServiceStore(undefined);
+	const repoService = createForgeRepoServiceStore(undefined);
 
 	$effect.pre(() => {
 		const combinedBranchListingService = new CombinedBranchListingService(
@@ -146,6 +148,7 @@
 		listServiceStore.set(ghListService);
 		forgeStore.set(forge);
 		prService.set(forge ? forge.prService() : undefined);
+		repoService.set(forge ? forge.repoService() : undefined);
 		setPostHogRepo($repoInfo);
 		return () => {
 			setPostHogRepo(undefined);


### PR DESCRIPTION
## ☕️ Reasoning

This pull request adds a warning to branch-stacking users who are using a forge repository that does not automatically delete branches after merging them.

## 🧢 Changes

- Created a `ForgeRepoService` that retrieves information about a given repository, specifically whether it automatically deletes branches on merge.
- Added a warning modal that is displayed to users if the repository they are using does not automatically delete branches on merge.
- The warning modal is only shown once.

### Visuals 👀
<img width="889" alt="Screenshot 2024-11-22 at 17 05 52" src="https://github.com/user-attachments/assets/dc0dd54b-0191-4427-9941-646701b08f06">

