### PR TITLE
Update `gix` to the latest released version for bugfixes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,9 +122,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -9342,7 +9342,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,12 +161,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -177,9 +177,9 @@ checksum = "74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13"
 
 [[package]]
 name = "arbitrary"
-version = "1.3.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -406,7 +406,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -446,7 +446,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -463,7 +463,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -685,7 +685,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
  "syn_derive",
 ]
 
@@ -762,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.18.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
 
 [[package]]
 name = "byteorder"
@@ -813,7 +813,7 @@ dependencies = [
  "glib",
  "libc",
  "once_cell",
- "thiserror",
+ "thiserror 1.0.66",
 ]
 
 [[package]]
@@ -856,7 +856,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.66",
 ]
 
 [[package]]
@@ -1017,7 +1017,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1368,7 +1368,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1378,7 +1378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1432,7 +1432,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1443,7 +1443,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1489,13 +1489,13 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.3.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1508,7 +1508,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1628,7 +1628,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1660,7 +1660,7 @@ checksum = "f2b99bf03862d7f545ebc28ddd33a665b50865f4dfd84031a393823879bd4c54"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1770,7 +1770,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1973,7 +1973,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -2122,7 +2122,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -2333,7 +2333,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.66",
 ]
 
 [[package]]
@@ -2373,7 +2373,7 @@ dependencies = [
  "git2",
  "log",
  "shellexpand",
- "thiserror",
+ "thiserror 1.0.66",
 ]
 
 [[package]]
@@ -2607,12 +2607,12 @@ version = "0.0.0"
 dependencies = [
  "assert_cmd",
  "futures",
- "gix-path 0.10.11",
+ "gix-path",
  "nix 0.29.0",
  "rand 0.8.5",
  "serde",
  "sysinfo",
- "thiserror",
+ "thiserror 1.0.66",
  "tokio",
  "uuid",
  "windows 0.58.0",
@@ -2748,7 +2748,7 @@ dependencies = [
  "gitbutler-tagged-string",
  "gix",
  "serde",
- "thiserror",
+ "thiserror 1.0.66",
 ]
 
 [[package]]
@@ -2778,7 +2778,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.66",
  "toml 0.8.19",
  "tracing",
  "uuid",
@@ -2851,7 +2851,7 @@ dependencies = [
  "gitbutler-testsupport",
  "gitbutler-time",
  "gix",
- "gix-utils 0.1.12",
+ "gix-utils",
  "itertools 0.13.0",
  "serde",
  "tempfile",
@@ -2951,7 +2951,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.66",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -2997,7 +2997,7 @@ name = "gitbutler-url"
 version = "0.0.0"
 dependencies = [
  "bstr",
- "thiserror",
+ "thiserror 1.0.66",
  "url",
 ]
 
@@ -3034,7 +3034,7 @@ dependencies = [
  "gitbutler-user",
  "gix",
  "notify",
- "thiserror",
+ "thiserror 1.0.66",
  "tokio",
  "tokio-util",
  "tracing",
@@ -3062,56 +3062,57 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.67.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04c66359b5e17f92395abc433861df0edf48f39f3f590818d1d7217327dd6a1"
 dependencies = [
- "gix-actor 0.33.0",
- "gix-attributes 0.23.0",
+ "gix-actor 0.33.1",
+ "gix-attributes 0.23.1",
  "gix-command",
- "gix-commitgraph 0.25.0",
+ "gix-commitgraph 0.25.1",
  "gix-config",
  "gix-credentials",
- "gix-date 0.9.1",
+ "gix-date 0.9.2",
  "gix-diff",
  "gix-dir",
- "gix-discover 0.36.0",
- "gix-features 0.39.0",
+ "gix-discover 0.37.0",
+ "gix-features 0.39.1",
  "gix-filter",
  "gix-fs 0.12.0",
- "gix-glob 0.17.0",
- "gix-hash 0.15.0",
+ "gix-glob 0.17.1",
+ "gix-hash 0.15.1",
  "gix-hashtable 0.6.0",
- "gix-ignore 0.12.0",
- "gix-index 0.36.0",
- "gix-lock 15.0.0",
+ "gix-ignore 0.12.1",
+ "gix-index 0.37.0",
+ "gix-lock 15.0.1",
  "gix-merge",
  "gix-negotiate",
- "gix-object 0.45.0",
+ "gix-object 0.46.0",
  "gix-odb",
  "gix-pack",
- "gix-path 0.10.12",
+ "gix-path",
  "gix-pathspec",
  "gix-prompt",
  "gix-protocol",
- "gix-ref 0.48.0",
+ "gix-ref 0.49.0",
  "gix-refspec",
  "gix-revision",
- "gix-revwalk 0.16.0",
- "gix-sec 0.10.9",
+ "gix-revwalk 0.17.0",
+ "gix-sec",
  "gix-status",
  "gix-submodule",
  "gix-tempfile 15.0.0",
- "gix-trace 0.1.11",
+ "gix-trace",
  "gix-transport",
- "gix-traverse 0.42.0",
+ "gix-traverse 0.43.0",
  "gix-url",
- "gix-utils 0.1.13",
- "gix-validate 0.9.1",
- "gix-worktree 0.37.0",
+ "gix-utils",
+ "gix-validate 0.9.2",
+ "gix-worktree 0.38.0",
  "gix-worktree-state",
  "once_cell",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -3122,22 +3123,23 @@ checksum = "a0e454357e34b833cc3a00b6efbbd3dd4d18b24b9fb0c023876ec2645e8aa3f2"
 dependencies = [
  "bstr",
  "gix-date 0.8.7",
- "gix-utils 0.1.12",
+ "gix-utils",
  "itoa 1.0.11",
- "thiserror",
+ "thiserror 1.0.66",
  "winnow 0.6.20",
 ]
 
 [[package]]
 name = "gix-actor"
-version = "0.33.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b24171f514cef7bb4dfb72a0b06dacf609b33ba8ad2489d4c4559a03b7afb3"
 dependencies = [
  "bstr",
- "gix-date 0.9.1",
- "gix-utils 0.1.13",
+ "gix-date 0.9.2",
+ "gix-utils",
  "itoa 1.0.11",
- "thiserror",
+ "thiserror 2.0.3",
  "winnow 0.6.20",
 ]
 
@@ -3149,73 +3151,59 @@ checksum = "ebccbf25aa4a973dd352564a9000af69edca90623e8a16dad9cbc03713131311"
 dependencies = [
  "bstr",
  "gix-glob 0.16.5",
- "gix-path 0.10.11",
- "gix-quote 0.4.12",
- "gix-trace 0.1.10",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
  "kstring",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.66",
  "unicode-bom",
 ]
 
 [[package]]
 name = "gix-attributes"
-version = "0.23.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf9bf852194c0edfe699a2d36422d2c1f28f73b7c6d446c3f0ccd3ba232cadc"
 dependencies = [
  "bstr",
- "gix-glob 0.17.0",
- "gix-path 0.10.12",
- "gix-quote 0.4.13",
- "gix-trace 0.1.11",
+ "gix-glob 0.17.1",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
  "kstring",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.3",
  "unicode-bom",
 ]
 
 [[package]]
 name = "gix-bitmap"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a371db66cbd4e13f0ed9dc4c0fea712d7276805fccc877f77e96374d317e87ae"
+checksum = "d48b897b4bbc881aea994b4a5bbb340a04979d7be9089791304e04a9fbc66b53"
 dependencies = [
- "thiserror",
-]
-
-[[package]]
-name = "gix-bitmap"
-version = "0.2.12"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
-dependencies = [
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "gix-chunk"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c8751169961ba7640b513c3b24af61aa962c967aaf04116734975cd5af0c52"
+checksum = "c6ffbeb3a5c0b8b84c3fe4133a6f8c82fa962f4caefe8d0762eced025d3eb4f7"
 dependencies = [
- "thiserror",
-]
-
-[[package]]
-name = "gix-chunk"
-version = "0.4.9"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
-dependencies = [
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "gix-command"
-version = "0.3.10"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7d6b8f3a64453fd7e8191eb80b351eb7ac0839b40a1237cd2c137d5079fe53"
 dependencies = [
  "bstr",
- "gix-path 0.10.12",
- "gix-trace 0.1.11",
+ "gix-path",
+ "gix-trace",
  "shell-words",
 ]
 
@@ -3226,72 +3214,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "133b06f67f565836ec0c473e2116a60fb74f80b6435e21d88013ac0e3c60fc78"
 dependencies = [
  "bstr",
- "gix-chunk 0.4.8",
+ "gix-chunk",
  "gix-features 0.38.2",
  "gix-hash 0.14.2",
  "memmap2",
- "thiserror",
+ "thiserror 1.0.66",
 ]
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.25.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8da6591a7868fb2b6dabddea6b09988b0b05e0213f938dbaa11a03dd7a48d85"
 dependencies = [
  "bstr",
- "gix-chunk 0.4.9",
- "gix-features 0.39.0",
- "gix-hash 0.15.0",
+ "gix-chunk",
+ "gix-features 0.39.1",
+ "gix-hash 0.15.1",
  "memmap2",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "gix-config"
-version = "0.41.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6649b406ca1f99cb148959cf00468b231f07950f8ec438cc0903cda563606f19"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features 0.39.0",
- "gix-glob 0.17.0",
- "gix-path 0.10.12",
- "gix-ref 0.48.0",
- "gix-sec 0.10.9",
+ "gix-features 0.39.1",
+ "gix-glob 0.17.1",
+ "gix-path",
+ "gix-ref 0.49.0",
+ "gix-sec",
  "memchr",
  "once_cell",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.3",
  "unicode-bom",
  "winnow 0.6.20",
 ]
 
 [[package]]
 name = "gix-config-value"
-version = "0.14.9"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.14.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aaeef5d98390a3bcf9dbc6440b520b793d1bf3ed99317dc407b02be995b28e"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-path 0.10.12",
+ "gix-path",
  "libc",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "gix-credentials"
-version = "0.25.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2be87bb8685fc7e6e7032ef71c45068ffff609724a0c897b8047fde10db6ae71"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-config-value",
- "gix-path 0.10.12",
+ "gix-path",
  "gix-prompt",
- "gix-sec 0.10.9",
- "gix-trace 0.1.11",
+ "gix-sec",
+ "gix-trace",
  "gix-url",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -3302,58 +3294,61 @@ checksum = "9eed6931f21491ee0aeb922751bd7ec97b4b2fe8fbfedcb678e2a2dce5f3b8c0"
 dependencies = [
  "bstr",
  "itoa 1.0.11",
- "thiserror",
+ "thiserror 1.0.66",
  "time",
 ]
 
 [[package]]
 name = "gix-date"
-version = "0.9.1"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "691142b1a34d18e8ed6e6114bc1a2736516c5ad60ef3aa9bd1b694886e3ca92d"
 dependencies = [
  "bstr",
  "itoa 1.0.11",
  "jiff",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "gix-diff"
-version = "0.47.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a327be31a392144b60ab0b1c863362c32a1c8f7effdfa2141d5d5b6b916ef3bf"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-filter",
  "gix-fs 0.12.0",
- "gix-hash 0.15.0",
- "gix-object 0.45.0",
- "gix-path 0.10.12",
+ "gix-hash 0.15.1",
+ "gix-object 0.46.0",
+ "gix-path",
  "gix-tempfile 15.0.0",
- "gix-trace 0.1.11",
- "gix-traverse 0.42.0",
- "gix-worktree 0.37.0",
+ "gix-trace",
+ "gix-traverse 0.43.0",
+ "gix-worktree 0.38.0",
  "imara-diff",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "gix-dir"
-version = "0.9.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acd6a0618958f9cce78a32724f8e06c4f4a57ca7080f645736d53676dc9b4db9"
 dependencies = [
  "bstr",
- "gix-discover 0.36.0",
+ "gix-discover 0.37.0",
  "gix-fs 0.12.0",
- "gix-ignore 0.12.0",
- "gix-index 0.36.0",
- "gix-object 0.45.0",
- "gix-path 0.10.12",
+ "gix-ignore 0.12.1",
+ "gix-index 0.37.0",
+ "gix-object 0.46.0",
+ "gix-path",
  "gix-pathspec",
- "gix-trace 0.1.11",
- "gix-utils 0.1.13",
- "gix-worktree 0.37.0",
- "thiserror",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree 0.38.0",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -3366,25 +3361,26 @@ dependencies = [
  "dunce",
  "gix-fs 0.11.3",
  "gix-hash 0.14.2",
- "gix-path 0.10.11",
+ "gix-path",
  "gix-ref 0.44.1",
- "gix-sec 0.10.8",
- "thiserror",
+ "gix-sec",
+ "thiserror 1.0.66",
 ]
 
 [[package]]
 name = "gix-discover"
-version = "0.36.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bf6dfa4e266a4a9becb4d18fc801f92c3f7cc6c433dd86fdadbcf315ffb6ef"
 dependencies = [
  "bstr",
  "dunce",
  "gix-fs 0.12.0",
- "gix-hash 0.15.0",
- "gix-path 0.10.12",
- "gix-ref 0.48.0",
- "gix-sec 0.10.9",
- "thiserror",
+ "gix-hash 0.15.1",
+ "gix-path",
+ "gix-ref 0.49.0",
+ "gix-sec",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -3394,8 +3390,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac7045ac9fe5f9c727f38799d002a7ed3583cd777e3322a7c4b43e3cf437dc69"
 dependencies = [
  "gix-hash 0.14.2",
- "gix-trace 0.1.10",
- "gix-utils 0.1.12",
+ "gix-trace",
+ "gix-utils",
  "libc",
  "prodash 28.0.0",
  "sha1_smol",
@@ -3404,44 +3400,46 @@ dependencies = [
 
 [[package]]
 name = "gix-features"
-version = "0.39.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d85d673f2e022a340dba4713bed77ef2cf4cd737d2f3e0f159d45e0935fd81f"
 dependencies = [
  "bytes",
  "crc32fast",
  "crossbeam-channel",
  "flate2",
- "gix-hash 0.15.0",
- "gix-trace 0.1.11",
- "gix-utils 0.1.13",
+ "gix-hash 0.15.1",
+ "gix-trace",
+ "gix-utils",
  "libc",
  "once_cell",
  "parking_lot",
  "prodash 29.0.0",
  "sha1",
  "sha1_smol",
- "thiserror",
+ "thiserror 2.0.3",
  "walkdir",
 ]
 
 [[package]]
 name = "gix-filter"
-version = "0.14.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5108cc58d58b27df10ac4de7f31b2eb96d588a33e5eba23739b865f5d8db7995"
 dependencies = [
  "bstr",
  "encoding_rs",
- "gix-attributes 0.23.0",
+ "gix-attributes 0.23.1",
  "gix-command",
- "gix-hash 0.15.0",
- "gix-object 0.45.0",
+ "gix-hash 0.15.1",
+ "gix-object 0.46.0",
  "gix-packetline-blocking",
- "gix-path 0.10.12",
- "gix-quote 0.4.13",
- "gix-trace 0.1.11",
- "gix-utils 0.1.13",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "gix-utils",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -3452,17 +3450,18 @@ checksum = "f2bfe6249cfea6d0c0e0990d5226a4cb36f030444ba9e35e0639275db8f98575"
 dependencies = [
  "fastrand 2.1.1",
  "gix-features 0.38.2",
- "gix-utils 0.1.12",
+ "gix-utils",
 ]
 
 [[package]]
 name = "gix-fs"
 version = "0.12.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34740384d8d763975858fa2c176b68652a6fcc09f616e24e3ce967b0d370e4d8"
 dependencies = [
  "fastrand 2.1.1",
- "gix-features 0.39.0",
- "gix-utils 0.1.13",
+ "gix-features 0.39.1",
+ "gix-utils",
 ]
 
 [[package]]
@@ -3474,18 +3473,19 @@ dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "gix-features 0.38.2",
- "gix-path 0.10.11",
+ "gix-path",
 ]
 
 [[package]]
 name = "gix-glob"
-version = "0.17.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf69a6bec0a3581567484bf99a4003afcaf6c469fd4214352517ea355cf3435"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-features 0.39.0",
- "gix-path 0.10.12",
+ "gix-features 0.39.1",
+ "gix-path",
 ]
 
 [[package]]
@@ -3495,16 +3495,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93d7df7366121b5018f947a04d37f034717e113dcf9ccd85c34b58e57a74d5e"
 dependencies = [
  "faster-hex",
- "thiserror",
+ "thiserror 1.0.66",
 ]
 
 [[package]]
 name = "gix-hash"
-version = "0.15.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5eccc17194ed0e67d49285e4853307e4147e95407f91c1c3e4a13ba9f4e4ce"
 dependencies = [
  "faster-hex",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -3521,9 +3522,10 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.6.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef65b256631078ef733bc5530c4e6b1c2e7d5c2830b75d4e9034ab3997d18fe"
 dependencies = [
- "gix-hash 0.15.0",
+ "gix-hash 0.15.1",
  "hashbrown 0.14.5",
  "parking_lot",
 ]
@@ -3536,20 +3538,21 @@ checksum = "e447cd96598460f5906a0f6c75e950a39f98c2705fc755ad2f2020c9e937fab7"
 dependencies = [
  "bstr",
  "gix-glob 0.16.5",
- "gix-path 0.10.11",
- "gix-trace 0.1.10",
+ "gix-path",
+ "gix-trace",
  "unicode-bom",
 ]
 
 [[package]]
 name = "gix-ignore"
-version = "0.12.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b1fb24d2a4af0aa7438e2771d60c14a80cf2c9bd55c29cf1712b841f05bb8a"
 dependencies = [
  "bstr",
- "gix-glob 0.17.0",
- "gix-path 0.10.12",
- "gix-trace 0.1.11",
+ "gix-glob 0.17.1",
+ "gix-path",
+ "gix-trace",
  "unicode-bom",
 ]
 
@@ -3563,14 +3566,14 @@ dependencies = [
  "bstr",
  "filetime",
  "fnv",
- "gix-bitmap 0.2.11",
+ "gix-bitmap",
  "gix-features 0.38.2",
  "gix-fs 0.11.3",
  "gix-hash 0.14.2",
  "gix-lock 14.0.0",
  "gix-object 0.42.3",
  "gix-traverse 0.39.2",
- "gix-utils 0.1.12",
+ "gix-utils",
  "gix-validate 0.8.5",
  "hashbrown 0.14.5",
  "itoa 1.0.11",
@@ -3578,34 +3581,35 @@ dependencies = [
  "memmap2",
  "rustix 0.38.37",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.66",
 ]
 
 [[package]]
 name = "gix-index"
-version = "0.36.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "270645fd20556b64c8ffa1540d921b281e6994413a0ca068596f97e9367a257a"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "filetime",
  "fnv",
- "gix-bitmap 0.2.12",
- "gix-features 0.39.0",
+ "gix-bitmap",
+ "gix-features 0.39.1",
  "gix-fs 0.12.0",
- "gix-hash 0.15.0",
- "gix-lock 15.0.0",
- "gix-object 0.45.0",
- "gix-traverse 0.42.0",
- "gix-utils 0.1.13",
- "gix-validate 0.9.1",
+ "gix-hash 0.15.1",
+ "gix-lock 15.0.1",
+ "gix-object 0.46.0",
+ "gix-traverse 0.43.0",
+ "gix-utils",
+ "gix-validate 0.9.2",
  "hashbrown 0.14.5",
  "itoa 1.0.11",
  "libc",
  "memmap2",
  "rustix 0.38.37",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -3615,56 +3619,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bc7fe297f1f4614774989c00ec8b1add59571dc9b024b4c00acb7dedd4e19d"
 dependencies = [
  "gix-tempfile 14.0.2",
- "gix-utils 0.1.12",
- "thiserror",
+ "gix-utils",
+ "thiserror 1.0.66",
 ]
 
 [[package]]
 name = "gix-lock"
-version = "15.0.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "15.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd3ab68a452db63d9f3ebdacb10f30dba1fa0d31ac64f4203d395ed1102d940"
 dependencies = [
  "gix-tempfile 15.0.0",
- "gix-utils 0.1.13",
- "thiserror",
+ "gix-utils",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "gix-merge"
-version = "0.0.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d4d0d11ac3fc1a3082f88b5e4cca706512f6b813154c4541264beed7850e62"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-diff",
  "gix-filter",
  "gix-fs 0.12.0",
- "gix-hash 0.15.0",
- "gix-object 0.45.0",
- "gix-path 0.10.12",
- "gix-quote 0.4.13",
+ "gix-hash 0.15.1",
+ "gix-index 0.37.0",
+ "gix-object 0.46.0",
+ "gix-path",
+ "gix-quote",
  "gix-revision",
- "gix-revwalk 0.16.0",
+ "gix-revwalk 0.17.0",
  "gix-tempfile 15.0.0",
- "gix-trace 0.1.11",
- "gix-worktree 0.37.0",
+ "gix-trace",
+ "gix-worktree 0.38.0",
  "imara-diff",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "gix-negotiate"
-version = "0.16.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27f830a16405386e9c83b9d5be8261fe32bbd6b3caf15bd1b284c6b2b7ef1a8"
 dependencies = [
  "bitflags 2.6.0",
- "gix-commitgraph 0.25.0",
- "gix-date 0.9.1",
- "gix-hash 0.15.0",
- "gix-object 0.45.0",
- "gix-revwalk 0.16.0",
+ "gix-commitgraph 0.25.1",
+ "gix-date 0.9.2",
+ "gix-hash 0.15.1",
+ "gix-object 0.46.0",
+ "gix-revwalk 0.17.0",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -3678,182 +3686,168 @@ dependencies = [
  "gix-date 0.8.7",
  "gix-features 0.38.2",
  "gix-hash 0.14.2",
- "gix-utils 0.1.12",
+ "gix-utils",
  "gix-validate 0.8.5",
  "itoa 1.0.11",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.66",
  "winnow 0.6.20",
 ]
 
 [[package]]
 name = "gix-object"
-version = "0.45.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65d93e2bbfa83a307e47f45e45de7b6c04d7375a8bd5907b215f4bf45237d879"
 dependencies = [
  "bstr",
- "gix-actor 0.33.0",
- "gix-date 0.9.1",
- "gix-features 0.39.0",
- "gix-hash 0.15.0",
+ "gix-actor 0.33.1",
+ "gix-date 0.9.2",
+ "gix-features 0.39.1",
+ "gix-hash 0.15.1",
  "gix-hashtable 0.6.0",
- "gix-utils 0.1.13",
- "gix-validate 0.9.1",
+ "gix-utils",
+ "gix-validate 0.9.2",
  "itoa 1.0.11",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.3",
  "winnow 0.6.20",
 ]
 
 [[package]]
 name = "gix-odb"
-version = "0.64.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.65.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93bed6e1b577c25a6bb8e6ecbf4df525f29a671ddf5f2221821a56a8dbeec4e3"
 dependencies = [
  "arc-swap",
- "gix-date 0.9.1",
- "gix-features 0.39.0",
+ "gix-date 0.9.2",
+ "gix-features 0.39.1",
  "gix-fs 0.12.0",
- "gix-hash 0.15.0",
+ "gix-hash 0.15.1",
  "gix-hashtable 0.6.0",
- "gix-object 0.45.0",
+ "gix-object 0.46.0",
  "gix-pack",
- "gix-path 0.10.12",
- "gix-quote 0.4.13",
+ "gix-path",
+ "gix-quote",
  "parking_lot",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "gix-pack"
-version = "0.54.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b91fec04d359544fecbb8e85117ec746fbaa9046ebafcefb58cb74f20dc76d4"
 dependencies = [
  "clru",
- "gix-chunk 0.4.9",
- "gix-features 0.39.0",
- "gix-hash 0.15.0",
+ "gix-chunk",
+ "gix-features 0.39.1",
+ "gix-hash 0.15.1",
  "gix-hashtable 0.6.0",
- "gix-object 0.45.0",
- "gix-path 0.10.12",
+ "gix-object 0.46.0",
+ "gix-path",
  "gix-tempfile 15.0.0",
  "memmap2",
  "parking_lot",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.3",
  "uluru",
 ]
 
 [[package]]
 name = "gix-packetline"
-version = "0.18.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a720e5bebf494c3ceffa85aa89f57a5859450a0da0a29ebe89171e23543fa78"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.11",
- "thiserror",
+ "gix-trace",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "gix-packetline-blocking"
-version = "0.18.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce9004ce1bc00fd538b11c1ec8141a1558fb3af3d2b7ac1ac5c41881f9e42d2a"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.11",
- "thiserror",
+ "gix-trace",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "gix-path"
-version = "0.10.11"
+version = "0.10.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebfc4febd088abdcbc9f1246896e57e37b7a34f6909840045a1767c6dafac7af"
+checksum = "afc292ef1a51e340aeb0e720800338c805975724c1dfbd243185452efd8645b7"
 dependencies = [
  "bstr",
- "gix-trace 0.1.10",
+ "gix-trace",
  "home",
  "once_cell",
- "thiserror",
-]
-
-[[package]]
-name = "gix-path"
-version = "0.10.12"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
-dependencies = [
- "bstr",
- "gix-trace 0.1.11",
- "home",
- "once_cell",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "gix-pathspec"
-version = "0.8.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c472dfbe4a4e96fcf7efddcd4771c9037bb4fdea2faaabf2f4888210c75b81e"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-attributes 0.23.0",
+ "gix-attributes 0.23.1",
  "gix-config-value",
- "gix-glob 0.17.0",
- "gix-path 0.10.12",
- "thiserror",
+ "gix-glob 0.17.1",
+ "gix-path",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "gix-prompt"
-version = "0.8.8"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a7822afc4bc9c5fbbc6ce80b00f41c129306b7685cac3248dbfa14784960594"
 dependencies = [
  "gix-command",
  "gix-config-value",
  "parking_lot",
  "rustix 0.38.37",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "gix-protocol"
-version = "0.46.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.46.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a7e7e51a0dea531d3448c297e2fa919b2de187111a210c324b7e9f81508b8ca"
 dependencies = [
  "bstr",
  "gix-credentials",
- "gix-date 0.9.1",
- "gix-features 0.39.0",
- "gix-hash 0.15.0",
+ "gix-date 0.9.2",
+ "gix-features 0.39.1",
+ "gix-hash 0.15.1",
  "gix-transport",
- "gix-utils 0.1.13",
+ "gix-utils",
  "maybe-async",
- "thiserror",
+ "thiserror 2.0.3",
  "winnow 0.6.20",
 ]
 
 [[package]]
 name = "gix-quote"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbff4f9b9ea3fa7a25a70ee62f545143abef624ac6aa5884344e70c8b0a1d9ff"
+checksum = "64a1e282216ec2ab2816cd57e6ed88f8009e634aec47562883c05ac8a7009a63"
 dependencies = [
  "bstr",
- "gix-utils 0.1.12",
- "thiserror",
-]
-
-[[package]]
-name = "gix-quote"
-version = "0.4.13"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
-dependencies = [
- "bstr",
- "gix-utils 0.1.13",
- "thiserror",
+ "gix-utils",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -3869,63 +3863,66 @@ dependencies = [
  "gix-hash 0.14.2",
  "gix-lock 14.0.0",
  "gix-object 0.42.3",
- "gix-path 0.10.11",
+ "gix-path",
  "gix-tempfile 14.0.2",
- "gix-utils 0.1.12",
+ "gix-utils",
  "gix-validate 0.8.5",
  "memmap2",
- "thiserror",
+ "thiserror 1.0.66",
  "winnow 0.6.20",
 ]
 
 [[package]]
 name = "gix-ref"
-version = "0.48.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eae462723686272a58f49501015ef7c0d67c3e042c20049d8dd9c7eff92efde"
 dependencies = [
- "gix-actor 0.33.0",
- "gix-features 0.39.0",
+ "gix-actor 0.33.1",
+ "gix-features 0.39.1",
  "gix-fs 0.12.0",
- "gix-hash 0.15.0",
- "gix-lock 15.0.0",
- "gix-object 0.45.0",
- "gix-path 0.10.12",
+ "gix-hash 0.15.1",
+ "gix-lock 15.0.1",
+ "gix-object 0.46.0",
+ "gix-path",
  "gix-tempfile 15.0.0",
- "gix-utils 0.1.13",
- "gix-validate 0.9.1",
+ "gix-utils",
+ "gix-validate 0.9.2",
  "memmap2",
- "thiserror",
+ "thiserror 2.0.3",
  "winnow 0.6.20",
 ]
 
 [[package]]
 name = "gix-refspec"
-version = "0.26.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00c056bb747868c7eb0aeb352c9f9181ab8ca3d0a2550f16470803500c6c413d"
 dependencies = [
  "bstr",
- "gix-hash 0.15.0",
+ "gix-hash 0.15.1",
  "gix-revision",
- "gix-validate 0.9.1",
+ "gix-validate 0.9.2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "gix-revision"
-version = "0.30.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44488e0380847967bc3e3cacd8b22652e02ea1eb58afb60edd91847695cd2d8d"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-commitgraph 0.25.0",
- "gix-date 0.9.1",
- "gix-hash 0.15.0",
+ "gix-commitgraph 0.25.1",
+ "gix-date 0.9.2",
+ "gix-hash 0.15.1",
  "gix-hashtable 0.6.0",
- "gix-object 0.45.0",
- "gix-revwalk 0.16.0",
- "gix-trace 0.1.11",
- "thiserror",
+ "gix-object 0.46.0",
+ "gix-revwalk 0.17.0",
+ "gix-trace",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -3940,80 +3937,72 @@ dependencies = [
  "gix-hashtable 0.5.2",
  "gix-object 0.42.3",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.66",
 ]
 
 [[package]]
 name = "gix-revwalk"
-version = "0.16.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
-dependencies = [
- "gix-commitgraph 0.25.0",
- "gix-date 0.9.1",
- "gix-hash 0.15.0",
- "gix-hashtable 0.6.0",
- "gix-object 0.45.0",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "gix-sec"
-version = "0.10.8"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe4d52f30a737bbece5276fab5d3a8b276dc2650df963e293d0673be34e7a5f"
+checksum = "510026fc32f456f8f067d8f37c34088b97a36b2229d88a6a5023ef179fcb109d"
 dependencies = [
- "bitflags 2.6.0",
- "gix-path 0.10.11",
- "libc",
- "windows-sys 0.52.0",
+ "gix-commitgraph 0.25.1",
+ "gix-date 0.9.2",
+ "gix-hash 0.15.1",
+ "gix-hashtable 0.6.0",
+ "gix-object 0.46.0",
+ "smallvec",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "gix-sec"
-version = "0.10.9"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.10.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8b876ef997a955397809a2ec398d6a45b7a55b4918f2446344330f778d14fd6"
 dependencies = [
  "bitflags 2.6.0",
- "gix-path 0.10.12",
+ "gix-path",
  "libc",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "gix-status"
-version = "0.14.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201396192ee4c4dd9e8a84fed4b0d2b33d639fca815fb99b0f653dfeddf38585"
 dependencies = [
  "bstr",
  "filetime",
  "gix-diff",
  "gix-dir",
- "gix-features 0.39.0",
+ "gix-features 0.39.1",
  "gix-filter",
  "gix-fs 0.12.0",
- "gix-hash 0.15.0",
- "gix-index 0.36.0",
- "gix-object 0.45.0",
- "gix-path 0.10.12",
+ "gix-hash 0.15.1",
+ "gix-index 0.37.0",
+ "gix-object 0.46.0",
+ "gix-path",
  "gix-pathspec",
- "gix-worktree 0.37.0",
+ "gix-worktree 0.38.0",
  "portable-atomic",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "gix-submodule"
-version = "0.15.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2455f8c0fcb6ebe2a6e83c8f522d30615d763eb2ef7a23c7d929f9476e89f5c"
 dependencies = [
  "bstr",
  "gix-config",
- "gix-path 0.10.12",
+ "gix-path",
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -4034,7 +4023,8 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "15.0.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2feb86ef094cc77a4a9a5afbfe5de626897351bbbd0de3cb9314baf3049adb82"
 dependencies = [
  "dashmap",
  "gix-fs 0.12.0",
@@ -4072,34 +4062,30 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cae0e8661c3ff92688ce1c8b8058b3efb312aba9492bbe93661a21705ab431b"
-
-[[package]]
-name = "gix-trace"
 version = "0.1.11"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04bdde120c29f1fc23a24d3e115aeeea3d60d8e65bab92cc5f9d90d9302eb952"
 dependencies = [
  "tracing-core",
 ]
 
 [[package]]
 name = "gix-transport"
-version = "0.43.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a1a41357b7236c03e0c984147f823d87c3e445a8581bac7006df141577200b"
 dependencies = [
  "base64 0.22.1",
  "bstr",
  "curl",
  "gix-command",
  "gix-credentials",
- "gix-features 0.39.0",
+ "gix-features 0.39.1",
  "gix-packetline",
- "gix-quote 0.4.13",
- "gix-sec 0.10.9",
+ "gix-quote",
+ "gix-sec",
  "gix-url",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -4116,51 +4102,44 @@ dependencies = [
  "gix-object 0.42.3",
  "gix-revwalk 0.13.2",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.66",
 ]
 
 [[package]]
 name = "gix-traverse"
-version = "0.42.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff2ec9f779680f795363db1c563168b32b8d6728ec58564c628e85c92d29faf"
 dependencies = [
  "bitflags 2.6.0",
- "gix-commitgraph 0.25.0",
- "gix-date 0.9.1",
- "gix-hash 0.15.0",
+ "gix-commitgraph 0.25.1",
+ "gix-date 0.9.2",
+ "gix-hash 0.15.1",
  "gix-hashtable 0.6.0",
- "gix-object 0.45.0",
- "gix-revwalk 0.16.0",
+ "gix-object 0.46.0",
+ "gix-revwalk 0.17.0",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "gix-url"
-version = "0.28.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e09f97db3618fb8e473d7d97e77296b50aaee0ddcd6a867f07443e3e87391099"
 dependencies = [
  "bstr",
- "gix-features 0.39.0",
- "gix-path 0.10.12",
- "thiserror",
+ "gix-features 0.39.1",
+ "gix-path",
+ "thiserror 2.0.3",
  "url",
 ]
 
 [[package]]
 name = "gix-utils"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35192df7fd0fa112263bad8021e2df7167df4cc2a6e6d15892e1e55621d3d4dc"
-dependencies = [
- "fastrand 2.1.1",
- "unicode-normalization",
-]
-
-[[package]]
-name = "gix-utils"
 version = "0.1.13"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba427e3e9599508ed98a6ddf8ed05493db114564e338e41f6a996d2e4790335f"
 dependencies = [
  "bstr",
  "fastrand 2.1.1",
@@ -4174,16 +4153,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82c27dd34a49b1addf193c92070bcbf3beaf6e10f16a78544de6372e146a0acf"
 dependencies = [
  "bstr",
- "thiserror",
+ "thiserror 1.0.66",
 ]
 
 [[package]]
 name = "gix-validate"
-version = "0.9.1"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd520d09f9f585b34b32aba1d0b36ada89ab7fefb54a8ca3fe37fc482a750937"
 dependencies = [
  "bstr",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -4201,45 +4181,47 @@ dependencies = [
  "gix-ignore 0.11.4",
  "gix-index 0.33.1",
  "gix-object 0.42.3",
- "gix-path 0.10.11",
+ "gix-path",
  "gix-validate 0.8.5",
 ]
 
 [[package]]
 name = "gix-worktree"
-version = "0.37.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756dbbe15188fa22540d5eab941f8f9cf511a5364d5aec34c88083c09f4bea13"
 dependencies = [
  "bstr",
- "gix-attributes 0.23.0",
- "gix-features 0.39.0",
+ "gix-attributes 0.23.1",
+ "gix-features 0.39.1",
  "gix-fs 0.12.0",
- "gix-glob 0.17.0",
- "gix-hash 0.15.0",
- "gix-ignore 0.12.0",
- "gix-index 0.36.0",
- "gix-object 0.45.0",
- "gix-path 0.10.12",
- "gix-validate 0.9.1",
+ "gix-glob 0.17.1",
+ "gix-hash 0.15.1",
+ "gix-ignore 0.12.1",
+ "gix-index 0.37.0",
+ "gix-object 0.46.0",
+ "gix-path",
+ "gix-validate 0.9.2",
 ]
 
 [[package]]
 name = "gix-worktree-state"
-version = "0.14.0"
-source = "git+https://github.com/Byron/gitoxide?rev=cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5#cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebd5eead61d37b334bc31810c9980aa72d659044513cae0e342a88fed2c22ba"
 dependencies = [
  "bstr",
- "gix-features 0.39.0",
+ "gix-features 0.39.1",
  "gix-filter",
  "gix-fs 0.12.0",
- "gix-glob 0.17.0",
- "gix-hash 0.15.0",
- "gix-index 0.36.0",
- "gix-object 0.45.0",
- "gix-path 0.10.12",
- "gix-worktree 0.37.0",
+ "gix-glob 0.17.1",
+ "gix-hash 0.15.1",
+ "gix-index 0.37.0",
+ "gix-object 0.46.0",
+ "gix-path",
+ "gix-worktree 0.38.0",
  "io-close",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -4262,7 +4244,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.66",
 ]
 
 [[package]]
@@ -4276,7 +4258,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -4355,7 +4337,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -4932,7 +4914,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.66",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -4954,9 +4936,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -4970,7 +4952,7 @@ dependencies = [
  "jsonptr 0.4.7",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.66",
 ]
 
 [[package]]
@@ -4982,7 +4964,7 @@ dependencies = [
  "jsonptr 0.6.3",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.66",
 ]
 
 [[package]]
@@ -5289,7 +5271,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -5405,7 +5387,7 @@ dependencies = [
  "once_cell",
  "png",
  "serde",
- "thiserror",
+ "thiserror 1.0.66",
  "windows-sys 0.59.0",
 ]
 
@@ -5438,7 +5420,7 @@ dependencies = [
  "ndk-sys",
  "num_enum",
  "raw-window-handle",
- "thiserror",
+ "thiserror 1.0.66",
 ]
 
 [[package]]
@@ -5647,7 +5629,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -5942,7 +5924,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -6209,7 +6191,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -6256,7 +6238,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -6497,9 +6479,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -6540,7 +6522,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -6619,7 +6601,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.5.7",
- "thiserror",
+ "thiserror 1.0.66",
  "tokio",
  "tracing",
 ]
@@ -6636,7 +6618,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "slab",
- "thiserror",
+ "thiserror 1.0.66",
  "tinyvec",
  "tracing",
 ]
@@ -6793,7 +6775,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror",
+ "thiserror 1.0.66",
 ]
 
 [[package]]
@@ -7009,7 +6991,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.86",
+ "syn 2.0.89",
  "unicode-ident",
 ]
 
@@ -7149,9 +7131,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -7180,7 +7162,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -7315,7 +7297,7 @@ checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -7326,7 +7308,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -7349,7 +7331,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -7400,7 +7382,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -7425,7 +7407,7 @@ checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -7727,7 +7709,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -7760,9 +7742,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.86"
+version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89275301d38033efb81a6e60e3497e734dfcc62571f2854bf4b16690398824c"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7778,7 +7760,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -7900,7 +7882,7 @@ checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -7965,7 +7947,7 @@ dependencies = [
  "tauri-runtime",
  "tauri-runtime-wry",
  "tauri-utils",
- "thiserror",
+ "thiserror 1.0.66",
  "tokio",
  "tray-icon",
  "url",
@@ -8016,9 +7998,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "syn 2.0.86",
+ "syn 2.0.89",
  "tauri-utils",
- "thiserror",
+ "thiserror 1.0.66",
  "time",
  "url",
  "uuid",
@@ -8034,7 +8016,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
  "tauri-codegen",
  "tauri-utils",
 ]
@@ -8070,7 +8052,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-plugin-fs",
- "thiserror",
+ "thiserror 1.0.66",
  "url",
 ]
 
@@ -8090,7 +8072,7 @@ dependencies = [
  "serde_repr",
  "tauri",
  "tauri-plugin",
- "thiserror",
+ "thiserror 1.0.66",
  "url",
  "uuid",
 ]
@@ -8111,7 +8093,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-plugin-fs",
- "thiserror",
+ "thiserror 1.0.66",
  "tokio",
  "url",
  "urlpattern",
@@ -8135,7 +8117,7 @@ dependencies = [
  "swift-rs",
  "tauri",
  "tauri-plugin",
- "thiserror",
+ "thiserror 1.0.66",
  "time",
 ]
 
@@ -8154,7 +8136,7 @@ dependencies = [
  "sys-locale",
  "tauri",
  "tauri-plugin",
- "thiserror",
+ "thiserror 1.0.66",
 ]
 
 [[package]]
@@ -8184,7 +8166,7 @@ dependencies = [
  "shared_child",
  "tauri",
  "tauri-plugin",
- "thiserror",
+ "thiserror 1.0.66",
  "tokio",
 ]
 
@@ -8198,7 +8180,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri",
- "thiserror",
+ "thiserror 1.0.66",
  "windows-sys 0.59.0",
  "zbus 4.4.0",
 ]
@@ -8215,7 +8197,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-plugin",
- "thiserror",
+ "thiserror 1.0.66",
  "tokio",
 ]
 
@@ -8241,7 +8223,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.66",
  "time",
  "tokio",
  "url",
@@ -8261,7 +8243,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-plugin",
- "thiserror",
+ "thiserror 1.0.66",
 ]
 
 [[package]]
@@ -8278,7 +8260,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri-utils",
- "thiserror",
+ "thiserror 1.0.66",
  "url",
  "windows 0.58.0",
 ]
@@ -8337,7 +8319,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "swift-rs",
- "thiserror",
+ "thiserror 1.0.66",
  "toml 0.8.19",
  "url",
  "urlpattern",
@@ -8397,7 +8379,16 @@ version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d171f59dbaa811dbbb1aee1e73db92ec2b122911a48e1390dfe327a821ddede"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.66",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
@@ -8408,7 +8399,18 @@ checksum = "b08be0f17bd307950653ce45db00cd31200d82b624b36e181337d9c7d92765b5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -8506,7 +8508,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -8718,7 +8720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
- "thiserror",
+ "thiserror 1.0.66",
  "time",
  "tracing-subscriber",
 ]
@@ -8731,7 +8733,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -8751,7 +8753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee40835db14ddd1e3ba414292272eddde9dad04d3d4b65509656414d1c42592f"
 dependencies = [
  "smallvec",
- "thiserror",
+ "thiserror 1.0.66",
  "tracing",
  "tracing-subscriber",
 ]
@@ -8802,7 +8804,7 @@ dependencies = [
  "once_cell",
  "png",
  "serde",
- "thiserror",
+ "thiserror 1.0.66",
  "windows-sys 0.59.0",
 ]
 
@@ -9081,9 +9083,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9092,24 +9094,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -9119,9 +9121,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9129,22 +9131,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wasm-streams"
@@ -9221,9 +9223,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9304,7 +9306,7 @@ checksum = "1d228f15bba3b9d56dde8bddbee66fa24545bd17b48d5128ccf4a8742b18e431"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -9313,7 +9315,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3a3e2eeb58f82361c93f9777014668eb3d07e7d174ee4c819575a9208011886"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.66",
  "windows 0.58.0",
  "windows-core 0.58.0",
 ]
@@ -9425,7 +9427,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -9436,7 +9438,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -9447,7 +9449,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -9458,7 +9460,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -9782,7 +9784,7 @@ dependencies = [
  "sha2",
  "soup3",
  "tao-macros",
- "thiserror",
+ "thiserror 1.0.66",
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
@@ -9952,7 +9954,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
  "zvariant_utils 2.1.0",
 ]
 
@@ -9996,7 +9998,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -10037,7 +10039,7 @@ dependencies = [
  "displaydoc",
  "indexmap 2.6.0",
  "memchr",
- "thiserror",
+ "thiserror 1.0.66",
 ]
 
 [[package]]
@@ -10119,7 +10121,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
  "zvariant_utils 2.1.0",
 ]
 
@@ -10142,5 +10144,5 @@ checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.86",
+ "syn 2.0.89",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,7 @@ resolver = "2"
 [workspace.dependencies]
 bstr = "1.10.0"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
-gix = { git = "https://github.com/Byron/gitoxide", rev = "cf0c7ee4b3bbe83a6d894d960412b0274f9dc0e5", default-features = false, features = [
-] }
+gix = { version = "0.68.0", default-features = false, features = [] }
 git2 = { version = "0.19.0", features = [
     "vendored-openssl",
     "vendored-libgit2",

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -291,7 +291,8 @@ fn get_stack_status(
     {
         TreeStatus::Empty
     } else {
-        let (merge_options_fail_fast, conflict_kind) = gix_repository.merge_options_fail_fast()?;
+        let (merge_options_fail_fast, conflict_kind) =
+            gix_repository.merge_options_no_rewrites_fail_fast()?;
 
         let tree_merge_base = gix_repository
             .find_commit(new_target_commit_id)?

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -1026,7 +1026,7 @@ impl IsCommitIntegrated<'_, '_, '_> {
         }
 
         // try to merge our tree into the upstream tree
-        let (merge_options, conflict_kind) = self.gix_repo.merge_options_fail_fast()?;
+        let (merge_options, conflict_kind) = self.gix_repo.merge_options_no_rewrites_fail_fast()?;
         let mut merge_output = self
             .gix_repo
             .merge_trees(
@@ -1078,7 +1078,8 @@ pub fn is_remote_branch_mergeable(
 
     let branch_tree = branch_commit.tree().context("failed to find branch tree")?;
     let gix_repo_in_memory = ctx.gix_repository_for_merging()?.with_object_memory();
-    let (merge_options_fail_fast, conflict_kind) = gix_repo_in_memory.merge_options_fail_fast()?;
+    let (merge_options_fail_fast, conflict_kind) =
+        gix_repo_in_memory.merge_options_no_rewrites_fail_fast()?;
     let mergeable = !gix_repo_in_memory
         .merge_trees(
             git2_to_gix_object_id(base_tree.id()),

--- a/crates/gitbutler-repo/src/repository_ext.rs
+++ b/crates/gitbutler-repo/src/repository_ext.rs
@@ -12,7 +12,7 @@ use gitbutler_oxidize::{
 use gitbutler_reference::{Refname, RemoteRefname};
 use gix::filter::plumbing::pipeline::convert::ToGitOutcome;
 use gix::fs::is_executable;
-use gix::merge::tree::{Options, UnresolvedConflict};
+use gix::merge::tree::{Options, TreatAsUnresolved};
 use gix::objs::WriteTo;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -766,7 +766,7 @@ pub trait GixRepositoryExt: Sized {
         &self,
     ) -> Result<(
         gix::merge::tree::Options,
-        gix::merge::tree::UnresolvedConflict,
+        gix::merge::tree::TreatAsUnresolved,
     )>;
 }
 
@@ -809,8 +809,8 @@ impl GixRepositoryExt for gix::Repository {
         Ok(!merge_outcome.has_unresolved_conflicts(conflict_kind))
     }
 
-    fn merge_options_fail_fast(&self) -> Result<(Options, UnresolvedConflict)> {
-        let conflict_kind = gix::merge::tree::UnresolvedConflict::Renames;
+    fn merge_options_fail_fast(&self) -> Result<(Options, TreatAsUnresolved)> {
+        let conflict_kind = gix::merge::tree::TreatAsUnresolved::Renames;
         let options = self
             .tree_merge_options()?
             .with_fail_on_conflict(Some(conflict_kind));


### PR DESCRIPTION
The fix include:

* ability to find references that are all uppercase.
* `tree_merge_options()` now correctly configure rename tracking.
    - Previously it was deactivated entirely, which would yield worse conflict resolution.

### Tasks

* [x] upgrade to latest release
* [x] basic performance testing
    - previously rename-tracking wasn't enabled by accident, let's assure this is a free as I think it is. However, I disabled it in all places were possible just to be sure.
    - Most time is still spent in `git2` tree-diffing, the next big area of oxidisation.
* [x] fix CI - needs help: [failure due to disk-space exhaustion](https://github.com/gitbutlerapp/gitbutler/actions/runs/11995640471/job/33439145855?pr=5657#step:4:818). Must delete cache named `v0-rust-unix-rust-testing-v2-f3cec62a-230fc39e` and it should go through.

### Notes for the Reviewer

* It would probably be good to make a test-release for Windows to assure that the lates `libz-ng-sys@1.1.20` works. Otherwise it could be downgraded with `cargo update --precise 1.1.16 -p libz-ng-sys@1.1.20`.
* One commit blanket-updates all dependencies with `cargo update` in order to fix a [CI failure on Windows](https://github.com/gitbutlerapp/gitbutler/actions/runs/11995200375/job/33438228595#step:4:82) that happens in seemingly unrelated dependencies. This could probably be solved by updating only the right dependency, but generally a blanket update is *probably* more of a benefit than a disadvantage.

Even on master, when running `branch status` in the CLI on the gitlab repository, it runs into an error condition.

```
     Running `target/release/gitbutler-cli -C /Users/byron/dev-gb/gitlab -d branch status`
INFO     gix::dirwalk [ 333ms | 0.32% / 100.00% ]
DEBUG    ┝━ 🐛 [debug]:  | longest_prefix: None | prefix_dir: "" | patterns: []
INFO     ┕━ walk [ 332ms | 99.68% ] root: "/Users/byron/dev-gb/gitlab" | worktree_root: "/Users/byron/dev-gb/gitlab" | options: Options { precompose_unicode: true, ignore_case: false, recurse_repositories: false, emit_pruned: false, emit_ignored: None, for_deletion: None, classify_untracked_bare_repositories: false, emit_tracked: false, emit_untracked: Matching, emit_empty_directories: false, emit_collapsed: None, symlinks_to_directories_are_ignored_like_directories: false, worktree_relative_worktree_dirs: None }
DEBUG       ┕━ 🐛 [debug]:  | statistics: Outcome { read_dir_calls: 16931, returned_entries: 0, seen_entries: 86219 }
INFO     cli-op [ 139s | 0.05% / 100.00% ]
INFO     ┝━ ThreadSafeRepository::discover() [ 2.88ms | 0.00% / 0.00% ]
INFO     │  ┕━ open_from_paths() [ 2.31ms | 0.00% / 0.00% ]
INFO     │     ┕━ gix_odb::Store::at() [ 338µs | 0.00% ]
DEBUG    ┕━ list_virtual_branches_cached [ 139s | 0.00% / 99.95% ]
DEBUG       ┕━ get_applied_status_cached [ 139s | 95.29% / 99.95% ]
DEBUG          ┝━ get_workspace_head [ 125ms | 0.03% / 0.09% ]
INFO           │  ┝━ ThreadSafeRepository::open() [ 250µs | 0.00% / 0.00% ]
INFO           │  │  ┕━ open_from_paths() [ 198µs | 0.00% / 0.00% ]
INFO           │  │     ┕━ gix_odb::Store::at() [ 52.2µs | 0.00% ]
INFO           │  ┝━ gix_index::File::at() [ 9.83ms | 0.01% ]
INFO           │  ┝━ gix_merge::tree [ 57.5ms | 0.04% ] base_tree: Sha1(6ab5488d84bf3076ca5e2d1771a9ec62ced02652) | our_tree: Sha1(6ab5488d84bf3076ca5e2d1771a9ec62ced02652) | their_tree: Sha1(7430f4864a09cef50dda8d45e1469f31e7aa0bc2) | labels: Labels { ancestor: Some("base"), current: Some("ours"), other: Some("theirs") }
INFO           │  ┕━ gix_merge::tree [ 9.94ms | 0.01% ] base_tree: Sha1(6ab5488d84bf3076ca5e2d1771a9ec62ced02652) | our_tree: Sha1(7430f4864a09cef50dda8d45e1469f31e7aa0bc2) | their_tree: Sha1(6ab5488d84bf3076ca5e2d1771a9ec62ced02652) | labels: Labels { ancestor: Some("base"), current: Some("ours"), other: Some("theirs") }
DEBUG          ┕━ workdir [ 6.36s | 4.32% / 4.57% ] commit_oid: 7a851336365c9d53ac450228b5d3e8f3cb897033
DEBUG             ┕━ ignore_large_files_in_diffs [ 342ms | 0.24% / 0.25% ] limit_in_bytes: 50000000
INFO                 ┝━ ThreadSafeRepository::open() [ 257µs | 0.00% / 0.00% ]
INFO                 │  ┕━ open_from_paths() [ 191µs | 0.00% / 0.00% ]
INFO                 │     ┕━ gix_odb::Store::at() [ 48.1µs | 0.00% ]
INFO                 ┕━ gix_index::File::at() [ 8.12ms | 0.01% ]
Error: File recreation must be an addition
```

The error originates in this repository, and still happens with this PR, which was to be expected.
