### PR TITLE
fix: PR creation order checks only unarchived series

### DIFF
--- a/apps/desktop/src/lib/branch/SeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/SeriesHeader.svelte
@@ -24,6 +24,7 @@
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { listCommitFiles } from '$lib/vbranches/remoteCommits';
 	import { PatchSeries, VirtualBranch, type CommitStatus } from '$lib/vbranches/types';
+	import { allPreviousSeriesHavePrNumber } from '$lib/vbranches/virtualBranch';
 	import { CloudBranchesService } from '@gitbutler/shared/cloud/stacks/service';
 	import { getContext, getContextStore } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
@@ -57,8 +58,8 @@
 	const upstreamName = $derived(currentSeries.upstreamReference ? currentSeries.name : undefined);
 	const forgeBranch = $derived(upstreamName ? $forge?.branch(upstreamName) : undefined);
 	const branch = $derived($branchStore);
-	const allPreviousSeriesHavePrNumber = $derived(
-		branch.allPreviousSeriesHavePrNumber(currentSeries.name)
+	const previousSeriesHavePrNumber = $derived(
+		allPreviousSeriesHavePrNumber(currentSeries.name, branch.validSeries)
 	);
 
 	let stackingAddSeriesModal = $state<ReturnType<typeof AddSeriesModal>>();
@@ -160,7 +161,7 @@
 	}
 
 	function handleOpenPR() {
-		if (!allPreviousSeriesHavePrNumber) {
+		if (!previousSeriesHavePrNumber) {
 			confirmCreatePrModal?.show();
 			return;
 		}

--- a/apps/desktop/src/lib/vbranches/types.ts
+++ b/apps/desktop/src/lib/vbranches/types.ts
@@ -188,18 +188,6 @@ export class VirtualBranch {
 			if (commit?.conflicted) return commit;
 		}
 	}
-
-	allPreviousSeriesHavePrNumber(seriesName: string): boolean {
-		for (let i = this.validSeries.length - 1; i >= 0; i--) {
-			const series = this.validSeries[i]!;
-			if (series.name === seriesName) return true;
-			if (series.prNumber === null) return false;
-		}
-
-		// Will only happen if the series name is invalid
-		// or if the series failed to be fetched.
-		return false;
-	}
 }
 
 // Used for dependency injection

--- a/apps/desktop/src/lib/vbranches/virtualBranch.ts
+++ b/apps/desktop/src/lib/vbranches/virtualBranch.ts
@@ -1,9 +1,25 @@
-import { VirtualBranch, VirtualBranches } from './types';
+import { PatchSeries, VirtualBranch, VirtualBranches } from './types';
 import { invoke, listen } from '$lib/backend/ipc';
 import { plainToInstance } from 'class-transformer';
 import { writable } from 'svelte/store';
 import type { BranchListingService } from '$lib/branches/branchListing';
 import type { ProjectMetrics } from '$lib/metrics/projectMetrics';
+
+export function allPreviousSeriesHavePrNumber(
+	seriesName: string,
+	validSeries: PatchSeries[]
+): boolean {
+	const unarchivedSeries = validSeries.filter((series) => !series.archived);
+	for (let i = unarchivedSeries.length - 1; i >= 0; i--) {
+		const series = unarchivedSeries[i]!;
+		if (series.name === seriesName) return true;
+		if (series.prNumber === null) return false;
+	}
+
+	// Will only happen if the series name is invalid
+	// or if the series failed to be fetched.
+	return false;
+}
 
 export class VirtualBranchService {
 	private loading = writable(false);


### PR DESCRIPTION
Whenever we check if all previous series have a PR associated with them, check only unarchived series.