### PR TITLE
FileWatcher: only ignore files if they aren't tracked.

### DIFF
--- a/crates/gitbutler-watcher/src/file_monitor.rs
+++ b/crates/gitbutler-watcher/src/file_monitor.rs
@@ -150,10 +150,18 @@ pub fn spawn(
                     {
                         if let Ok(repo) = gix::open(&worktree_path) {
                             if let Ok(index) = repo.index_or_empty() {
-                                if let Ok(mut excludes) = repo.excludes(&index, None, gix::worktree::stack::state::ignore::Source::WorktreeThenIdMappingIfNotSkipped) {
+                                if let Ok(mut excludes) = repo.excludes(
+                                    &index,
+                                    None,
+                                    gix::worktree::stack::state::ignore::Source::WorktreeThenIdMappingIfNotSkipped,
+                                ) {
                                     for (file_path, kind) in classified_file_paths.iter_mut() {
                                         if let Ok(relative_path) = file_path.strip_prefix(&worktree_path) {
-                                            if excludes.at_path(relative_path, None).map(|platform| platform.is_excluded()).unwrap_or(false) {
+                                            if excludes
+                                                .at_path(relative_path, None)
+                                                .map(|platform| platform.is_excluded())
+                                                .unwrap_or(false)
+                                            {
                                                 *kind = FileKind::ProjectIgnored
                                             }
                                         }

--- a/crates/gitbutler-watcher/src/file_monitor.rs
+++ b/crates/gitbutler-watcher/src/file_monitor.rs
@@ -157,11 +157,13 @@ pub fn spawn(
                                 ) {
                                     for (file_path, kind) in classified_file_paths.iter_mut() {
                                         if let Ok(relative_path) = file_path.strip_prefix(&worktree_path) {
-                                            if excludes
+                                            let is_excluded = excludes
                                                 .at_path(relative_path, None)
                                                 .map(|platform| platform.is_excluded())
-                                                .unwrap_or(false)
-                                            {
+                                                .unwrap_or(false);
+                                            let is_untracked =
+                                                || index.entry_by_path(&gix::path::to_unix_separators_on_windows(gix::path::into_bstr(relative_path))).is_none();
+                                            if is_excluded && is_untracked() {
                                                 *kind = FileKind::ProjectIgnored
                                             }
                                         }

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -1,6 +1,5 @@
 use std::{path::PathBuf, sync::Arc};
 
-use super::{events, Change};
 use anyhow::{Context, Result};
 use gitbutler_branch_actions::VirtualBranches;
 use gitbutler_command_context::CommandContext;
@@ -13,12 +12,13 @@ use gitbutler_oplog::{
     entry::{OperationKind, SnapshotDetails},
     OplogExt,
 };
-use gitbutler_project::ProjectId;
-use gitbutler_project::{self as projects, Project};
+use gitbutler_project::{self as projects, Project, ProjectId};
 use gitbutler_reference::{LocalRefname, Refname};
 use gitbutler_sync::cloud::{push_oplog, push_repo};
 use gitbutler_user as users;
 use tracing::instrument;
+
+use super::{events, Change};
 
 /// A type that contains enough state to make decisions based on changes in the filesystem, which themselves
 /// may trigger [Changes](Change)


### PR DESCRIPTION
This also means that tracked files should always be checked, ignored or not.

Fixes #5662.

### Tasks

* [x] re-invigorate the formatting (even though it still kind of doesn't work for `file_monitor.rs`
    - This usually happens if the nesting level is so high that `cargo fmt` gives up or has actual errors.
* [x] never ignore tracked files

### Notes for the Reviewer

* The formatting changes are mostly made in an attempt to get the formatting to work again. Thus some lines were shortened to the minimum line width (but might still be too long).
* One commit is just for formatting with nightly, which makes imports more consistent in the crate I touched. It's definitely not needed for the fix but since this crate is very stable, I thought it doesn't hurt.
* I only tested this by hand like so (before the PR)
    - change a tracked file
    - add that file to `.gitignore`
    - notice that it either shows up permanently (even after undoing the change) or never shows up as changed
    - with this PR applied, changed files always show up, ignored or not.
    - alternatively, add a file that isn't tracked to the `.gitignore` file to see it disappear/not appear in the UI