### PR TITLE
feat: use top series name for commit generation AI `branch_name` placeholder

### DIFF
--- a/apps/desktop/src/lib/commit/CommitMessageInput.svelte
+++ b/apps/desktop/src/lib/commit/CommitMessageInput.svelte
@@ -114,7 +114,7 @@
 			useEmojiStyle: $commitGenerationUseEmojis,
 			useBriefStyle: $commitGenerationExtraConcise,
 			commitTemplate: prompt,
-			branchName: $branch.name,
+			branchName: $branch.series[0]?.name,
 			onToken: (t) => {
 				if (firstToken) {
 					commitMessage = '';


### PR DESCRIPTION
## ☕️ Reasoning

- AI commit msg generation wasn't respecting `%{branch_name}` placeholder anymore

## 🧢 Changes

- Use the top branch name (i.e. the branch the commit is about to go into) as `%{branch_name}` in the AI prompt 

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->