### PR TITLE
Provide an action when fetching before push

### DIFF
--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -185,7 +185,10 @@ pub fn push_stack(project: &Project, stack_id: StackId, with_force: bool) -> Res
     };
 
     // First fetch, because we dont want to push integrated series
-    ctx.fetch(&default_target.push_remote_name(), None)?;
+    ctx.fetch(
+        &default_target.push_remote_name(),
+        Some("push_stack".into()),
+    )?;
     let gix_repo = ctx.gix_repository_for_merging_non_persisting()?;
     let cache = gix_repo.commit_graph_if_enabled()?;
     let mut graph = gix_repo.revision_graph(cache.as_ref());


### PR DESCRIPTION
When pushing a stack, we need to fetch before. 
In the case that the user has a passphrase set for their SSH key, this fetch action will require input.
For that to happen, we need to pass an action.

As seen in https://github.com/gitbutlerapp/gitbutler/issues/5681