### PR TITLE
fix: disable analytics in dev

### DIFF
--- a/apps/desktop/src/lib/analytics/analytics.ts
+++ b/apps/desktop/src/lib/analytics/analytics.ts
@@ -4,6 +4,8 @@ import { AppSettings } from '$lib/config/appSettings';
 import posthog from 'posthog-js';
 
 export function initAnalyticsIfEnabled(appSettings: AppSettings) {
+	if (import.meta.env.MODE === 'development') return;
+
 	appSettings.appAnalyticsConfirmed.onDisk().then((confirmed) => {
 		if (confirmed) {
 			appSettings.appErrorReportingEnabled.onDisk().then((enabled) => {


### PR DESCRIPTION
## ☕️ Reasoning

- Skip unnecessary usage of analytics services
- Home DNS blocks sentry/posthog so this fixes me having to manually filter all of the failed connection attempts out of the console 😅

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->