### PR TITLE
fix: allow multiple GitButler windows

### DIFF
--- a/crates/gitbutler-tauri/capabilities/main.json
+++ b/crates/gitbutler-tauri/capabilities/main.json
@@ -2,7 +2,9 @@
 	"$schema": "../gen/schemas/desktop-schema.json",
 	"identifier": "main",
 	"description": "permissions for gitbutler tauri",
-	"windows": ["main"],
+	"windows": [
+		"*"
+	],
 	"local": true,
 	"permissions": [
 		"core:default",
@@ -18,8 +20,15 @@
 		"updater:default",
 		"http:allow-fetch",
 		{
-      "identifier": "http:default",
-      "allow": [{ "url": "http://127.0.0.1:*" }, { "url": "http://localhost:*" }]
-    }
+			"identifier": "http:default",
+			"allow": [
+				{
+					"url": "http://127.0.0.1:*"
+				},
+				{
+					"url": "http://localhost:*"
+				}
+			]
+		}
 	]
 }


### PR DESCRIPTION
## ☕️ Reasoning

- Allow spawning another window, i.e. to open multiple projects via alt + click on another project in the project select dropdown, from main window.

Fixes: #5677

Security implications: this field is designed for scoping permissions for windows that can be less privileged, like dialogs or pop-out video viewers, etc. In our case, if we want to allow a whole second main GitButler window, it would need the same privileges as the main one, so therefore `"*"`.

See: https://v2.tauri.app/reference/config/#capability

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->