### PR TITLE
fix: textarea props extend HTMLTextareaElement

### DIFF
--- a/apps/desktop/src/lib/vbranches/upstreamIntegrationService.ts
+++ b/apps/desktop/src/lib/vbranches/upstreamIntegrationService.ts
@@ -17,7 +17,7 @@ export type NameAndBranchStatus = {
 
 export type BranchStatus =
 	| {
-			type: 'empty' | 'integrated' | 'safelyUpdatable';
+			type: 'empty' | 'integrated' | 'saflyUpdatable';
 	  }
 	| {
 			type: 'conflicted';
@@ -34,7 +34,7 @@ export function stackFullyIntegrated(stackStatus: StackStatus): boolean {
 }
 
 export type TreeStatus = {
-	type: 'empty' | 'conflicted' | 'safelyUpdatable';
+	type: 'empty' | 'conflicted' | 'saflyUpdatable';
 };
 
 export type StackStatusInfo = { stack: VirtualBranch; status: StackStatus };

--- a/packages/ui/src/lib/Textarea.svelte
+++ b/packages/ui/src/lib/Textarea.svelte
@@ -1,18 +1,12 @@
 <script lang="ts" module>
-	export interface Props {
-		id?: string;
+	export interface Props extends HTMLTextareaAttributes {
 		textBoxEl?: HTMLTextAreaElement;
 		label?: string;
 		value?: string;
-		placeholder?: string;
-		disabled?: boolean;
 		fontWeight?: 'regular' | 'bold' | 'semibold';
 		fontSize?: number;
 		minRows?: number;
 		maxRows?: number;
-		autofocus?: boolean;
-		spellcheck?: boolean;
-		autocomplete?: string;
 		class?: string;
 		flex?: string;
 		padding?: {
@@ -27,22 +21,12 @@
 		borderBottom?: boolean;
 		borderLeft?: boolean;
 		unstyled?: boolean;
-		oninput?: (e: Event & { currentTarget: EventTarget & HTMLTextAreaElement }) => void;
-		onchange?: (e: Event & { currentTarget: EventTarget & HTMLTextAreaElement }) => void;
-		onfocus?: (
-			this: void,
-			e: FocusEvent & { currentTarget: EventTarget & HTMLTextAreaElement }
-		) => void;
-		onblur?: (
-			this: void,
-			e: FocusEvent & { currentTarget: EventTarget & HTMLTextAreaElement }
-		) => void;
-		onkeydown?: (e: KeyboardEvent & { currentTarget: EventTarget & HTMLTextAreaElement }) => void;
 	}
 </script>
 
 <script lang="ts">
 	import { pxToRem } from '$lib/utils/pxToRem';
+	import type { HTMLTextareaAttributes } from 'svelte/elements';
 
 	let {
 		id,

--- a/packages/ui/src/stories/textarea/textareaDemo.svelte
+++ b/packages/ui/src/stories/textarea/textareaDemo.svelte
@@ -11,7 +11,7 @@
 		changableValue = `## ☕️ Reasoning ## 🧢 Chang sdf sdf sdfsdf sdfsfsd ## 📌 Todos`;
 	}
 
-	function handleDescriptionKeyDown(e: KeyboardEvent & { currentTarget: HTMLTextAreaElement }) {
+	function handleDescriptionKeyDown(e: KeyboardEvent) {
 		if (e.key === 'Escape') {
 			console.log('keyboard', e.key);
 			e.preventDefault();


### PR DESCRIPTION
## ☕️ Reasoning

- Fix textarea props by extending `HTMLTextarea`
- Revert a typo fix (`saflyUpdatable`) due to its usage on the Rust side with that spelling as well. 

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->