### PR TITLE
Select component: Options should be readonly

### DIFF
--- a/apps/desktop/src/lib/select/Select.svelte
+++ b/apps/desktop/src/lib/select/Select.svelte
@@ -26,7 +26,7 @@
 		loading?: boolean;
 		wide?: boolean;
 		flex?: string;
-		options: SelectItem<T>[];
+		options: readonly SelectItem<T>[];
 		value?: T;
 		placeholder?: string;
 		maxHeight?: number;


### PR DESCRIPTION
This those only two things: 
- Guards agains this component changing the option props (nice to have)
- Allows the component consumers to pass `as const` arrays, that improve the type-ergonomics of defining a fixed list of options (needed in some cases)

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5707 
- <kbd>&nbsp;1&nbsp;</kbd> #5706 👈 
<!-- GitButler Footer Boundary Bottom -->

