### PR TITLE
fix: Don't list all parents when calculating dependencies

### DIFF
--- a/crates/gitbutler-branch-actions/src/dependencies.rs
+++ b/crates/gitbutler-branch-actions/src/dependencies.rs
@@ -76,7 +76,7 @@ fn get_commits_to_process<'a>(
     target_sha: &'a git2::Oid,
 ) -> Result<impl Iterator<Item = git2::Oid> + 'a, anyhow::Error> {
     let commit_ids = repo
-        .l(stack.head(), LogUntil::Commit(*target_sha), true)
+        .l(stack.head(), LogUntil::Commit(*target_sha), false)
         .context("failed to list commits")?
         .into_iter()
         .rev()


### PR DESCRIPTION
The commit interdependecy calculation should not list all parents.
Otherwise, the commits being processed might contain unexpected content that could lead to errors being thrown.

About the tests:
The way to test that this works is to create a stack that contains a merge-commit from itself to itself.
This simulates what it would look like to have parts of the base branch *leak* into the stack by not integration the upstream base.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5725 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5724 
<!-- GitButler Footer Boundary Bottom -->

