### PR TITLE
Save and restore project metrics from local storage

### DIFF
--- a/apps/desktop/src/lib/forge/forgeFactory.test.ts
+++ b/apps/desktop/src/lib/forge/forgeFactory.test.ts
@@ -9,7 +9,7 @@ import { expect, test, describe } from 'vitest';
 describe.concurrent('DefaultforgeFactory', () => {
 	const posthog = new PostHogWrapper();
 	const octokit = new Octokit();
-	const projectMetrics = new ProjectMetrics();
+	const projectMetrics = new ProjectMetrics('test-project');
 	test('Create GitHub service', async () => {
 		const monitorFactory = new DefaultForgeFactory(octokit, posthog, projectMetrics);
 		expect(

--- a/apps/desktop/src/lib/forge/github/githubListingService.test.ts
+++ b/apps/desktop/src/lib/forge/github/githubListingService.test.ts
@@ -31,7 +31,7 @@ describe.concurrent('GitHubListingService', () => {
 
 	beforeEach(() => {
 		octokit = new Octokit();
-		projectMetrics = new ProjectMetrics();
+		projectMetrics = new ProjectMetrics('test-project');
 
 		gh = new GitHub({ repo: repoInfo, baseBranch: 'some-base', octokit, projectMetrics, posthog });
 		service = gh.listService();

--- a/apps/desktop/src/lib/metrics/MetricsReporter.svelte
+++ b/apps/desktop/src/lib/metrics/MetricsReporter.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <script lang="ts">
-	import { ProjectMetrics, type ProjectMetricsReport } from './projectMetrics';
+	import { type ProjectMetrics } from './projectMetrics';
 	import { PostHogWrapper } from '$lib/analytics/posthog';
 	import { getContext } from '@gitbutler/shared/context';
 	import { persisted } from '@gitbutler/shared/persisted';
@@ -14,9 +14,6 @@
 
 	const projectId = projectMetrics.projectId;
 	const posthog = getContext(PostHogWrapper);
-
-	// Storing the last known values so we don't report same metrics twice
-	const lastReport = persisted<ProjectMetricsReport>({}, `projectMetrics-${projectId}`);
 	const lastReportMs = persisted<number | undefined>(undefined, `lastMetricsTs-${projectId}`);
 
 	// Any interval or timeout must be cleared on unmount.
@@ -36,9 +33,10 @@
 				project_id: projectId,
 				...metric
 			});
+			// We don't want to report the same static value over and over
+			// again, so after successfully reporting a metric we reset it.
 			projectMetrics.resetMetric(name);
 		}
-		lastReport.set(projectMetrics.getReport());
 	}
 
 	function startInterval() {

--- a/apps/desktop/src/lib/metrics/projectMetrics.test.ts
+++ b/apps/desktop/src/lib/metrics/projectMetrics.test.ts
@@ -1,55 +1,75 @@
 import { ProjectMetrics } from './projectMetrics';
 import { assert, test, describe } from 'vitest';
 
+const PROJECT_ID = 'test-project';
+const METRIC_NAME = 'test-metric';
+
 describe.concurrent('ProjectMetrics', () => {
 	test('set max and min correctly', async () => {
-		const metrics = new ProjectMetrics('fake-id');
-		const metricLabel = 'test_metric';
+		const metrics = new ProjectMetrics(PROJECT_ID);
 
-		metrics.setMetric(metricLabel, 0);
-		assert.deepEqual(metrics.getReport()[metricLabel], { value: 0, minValue: 0, maxValue: 0 });
+		metrics.setMetric(METRIC_NAME, 0);
+		assert.deepEqual(metrics.getReport()[METRIC_NAME], { value: 0, minValue: 0, maxValue: 0 });
 
-		metrics.setMetric(metricLabel, 1);
-		assert.deepEqual(metrics.getReport()[metricLabel], { value: 1, minValue: 0, maxValue: 1 });
+		metrics.setMetric(METRIC_NAME, 1);
+		assert.deepEqual(metrics.getReport()[METRIC_NAME], { value: 1, minValue: 0, maxValue: 1 });
 
-		metrics.setMetric(metricLabel, -1);
-		assert.deepEqual(metrics.getReport()[metricLabel], { value: -1, minValue: -1, maxValue: 1 });
+		metrics.setMetric(METRIC_NAME, -1);
+		assert.deepEqual(metrics.getReport()[METRIC_NAME], { value: -1, minValue: -1, maxValue: 1 });
 
-		metrics.setMetric(metricLabel, 2);
-		assert.deepEqual(metrics.getReport()[metricLabel], { value: 2, minValue: -1, maxValue: 2 });
+		metrics.setMetric(METRIC_NAME, 2);
+		assert.deepEqual(metrics.getReport()[METRIC_NAME], { value: 2, minValue: -1, maxValue: 2 });
 
-		metrics.setMetric(metricLabel, -2);
-		assert.deepEqual(metrics.getReport()[metricLabel], { value: -2, minValue: -2, maxValue: 2 });
+		metrics.setMetric(METRIC_NAME, -2);
+		assert.deepEqual(metrics.getReport()[METRIC_NAME], { value: -2, minValue: -2, maxValue: 2 });
 	});
 
 	test('handle malformed input', async () => {
-		const metrics = new ProjectMetrics('fake-id');
-		const metricLabel = 'test_metric';
-		metrics.setMetric(metricLabel, 1);
-		metrics.setMetric(metricLabel, 2);
+		const metrics = new ProjectMetrics(PROJECT_ID);
+		metrics.setMetric(METRIC_NAME, 1);
+		metrics.setMetric(METRIC_NAME, 2);
 
 		// Expected initial condition.
-		assert.deepEqual(metrics.getReport()[metricLabel], { value: 2, minValue: 1, maxValue: 2 });
+		assert.deepEqual(metrics.getReport()[METRIC_NAME], { value: 2, minValue: 1, maxValue: 2 });
 
 		// @ts-expect-error since we are intentionally violating the type.
-		metrics.setMetric(metricLabel, null);
-		assert.deepEqual(metrics.getReport()[metricLabel], { value: 2, minValue: 1, maxValue: 2 });
+		metrics.setMetric(METRIC_NAME, null);
+		assert.deepEqual(metrics.getReport()[METRIC_NAME], { value: 2, minValue: 1, maxValue: 2 });
 
+		// Pass invalid arguments and verify the are ignored.
 		// @ts-expect-error since we are intentionally violating the type.
-		metrics.setMetric(metricLabel, undefined);
-		assert.deepEqual(metrics.getReport()[metricLabel], { value: 2, minValue: 1, maxValue: 2 });
+		metrics.setMetric(METRIC_NAME, undefined);
+		assert.deepEqual(metrics.getReport()[METRIC_NAME], { value: 2, minValue: 1, maxValue: 2 });
 
-		metrics.setMetric(metricLabel, Infinity);
-		assert.deepEqual(metrics.getReport()[metricLabel], { value: 2, minValue: 1, maxValue: 2 });
+		metrics.setMetric(METRIC_NAME, Infinity);
+		assert.deepEqual(metrics.getReport()[METRIC_NAME], { value: 2, minValue: 1, maxValue: 2 });
 
-		metrics.setMetric(metricLabel, -Infinity);
-		assert.deepEqual(metrics.getReport()[metricLabel], { value: 2, minValue: 1, maxValue: 2 });
+		metrics.setMetric(METRIC_NAME, -Infinity);
+		assert.deepEqual(metrics.getReport()[METRIC_NAME], { value: 2, minValue: 1, maxValue: 2 });
 
-		metrics.setMetric(metricLabel, NaN);
-		assert.deepEqual(metrics.getReport()[metricLabel], { value: 2, minValue: 1, maxValue: 2 });
+		metrics.setMetric(METRIC_NAME, NaN);
+		assert.deepEqual(metrics.getReport()[METRIC_NAME], { value: 2, minValue: 1, maxValue: 2 });
 
 		// Set a new valid value and observe the change.
-		metrics.setMetric(metricLabel, 3);
-		assert.deepEqual(metrics.getReport()[metricLabel], { value: 3, minValue: 1, maxValue: 3 });
+		metrics.setMetric(METRIC_NAME, 3);
+		assert.deepEqual(metrics.getReport()[METRIC_NAME], { value: 3, minValue: 1, maxValue: 3 });
+	});
+
+	test('load previously stored data', async () => {
+		let metrics = new ProjectMetrics(PROJECT_ID);
+		metrics.setMetric(METRIC_NAME, 1);
+		metrics.setMetric(METRIC_NAME, 3);
+		metrics.setMetric(METRIC_NAME, 2);
+		metrics.saveToLocalStorage();
+
+		metrics = new ProjectMetrics(PROJECT_ID);
+		metrics.loadFromLocalStorage();
+		assert.deepEqual(metrics.getReport()[METRIC_NAME], { value: 2, minValue: 1, maxValue: 3 });
+		metrics.saveToLocalStorage();
+
+		metrics = new ProjectMetrics(PROJECT_ID);
+		metrics.loadFromLocalStorage();
+		metrics.setMetric(METRIC_NAME, 4);
+		assert.deepEqual(metrics.getReport()[METRIC_NAME], { value: 4, minValue: 1, maxValue: 4 });
 	});
 });

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -36,6 +36,7 @@
 	import { FeedService } from '@gitbutler/shared/feeds/service';
 	import { DesktopRoutesService, getRoutesService } from '@gitbutler/shared/sharedRoutes';
 	import { onDestroy, setContext, type Snippet } from 'svelte';
+	import type { ProjectMetrics } from '$lib/metrics/projectMetrics';
 	import type { LayoutData } from './$types';
 	import { goto } from '$app/navigation';
 
@@ -162,6 +163,22 @@
 		} else {
 			goto('/onboarding');
 		}
+	});
+
+	// TODO(mattias): This is an ugly hack, fix it somehow?
+	// I want to flush project metrics to local storage before e.g. switching
+	// to a different project. Since `projectMetrics` is defined in layout.ts
+	// we get no heads up when it is about to change, and reactively updated
+	// in this scope through `LayoutData`. Even at time of unMount in e.g.
+	// metrics reporter it seems as if the projectMetrics variable is already
+	// referencing the new instance.
+	let lastProjectMetrics: ProjectMetrics | undefined;
+	$effect(() => {
+		if (lastProjectMetrics) {
+			lastProjectMetrics.saveToLocalStorage();
+		}
+		lastProjectMetrics = projectMetrics;
+		projectMetrics.loadFromLocalStorage();
 	});
 
 	function setupFetchInterval() {

--- a/packages/shared/src/lib/persisted.ts
+++ b/packages/shared/src/lib/persisted.ts
@@ -54,11 +54,15 @@ export function persisted<T>(initial: T, key: string): Persisted<T> {
 	};
 }
 
-function setEphemeralStorageItem(key: string, value: unknown, expirationInMinutes: number): void {
+export function setEphemeralStorageItem(
+	key: string,
+	value: unknown,
+	expirationInMinutes: number
+): void {
 	lscache.set(key, JSON.stringify(value), expirationInMinutes);
 }
 
-function getEphemeralStorageItem(key: string): unknown {
+export function getEphemeralStorageItem(key: string): unknown {
 	const item = lscache.get(key);
 	try {
 		if (!item) {


### PR DESCRIPTION
- prevents loss of metrics when navigating between projects

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5738 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #5737 
- <kbd>&nbsp;1&nbsp;</kbd> #5736 
<!-- GitButler Footer Boundary Bottom -->

