### PR TITLE
fix: button overflow inside branch scrolling container

### DIFF
--- a/apps/desktop/src/lib/stack/Stack.svelte
+++ b/apps/desktop/src/lib/stack/Stack.svelte
@@ -183,7 +183,7 @@
 										disabled={hasConflicts}
 										tooltip={hasConflicts
 											? 'In order to push, please resolve any conflicted commits.'
-											: undefined}w
+											: undefined}
 										onclick={push}
 									>
 										{branch.requiresForce

--- a/apps/desktop/src/lib/stack/Stack.svelte
+++ b/apps/desktop/src/lib/stack/Stack.svelte
@@ -152,49 +152,51 @@
 							</Dropzones>
 						{/if}
 						<Spacer dotted />
-						<div class="lane-branches">
-							<SeriesList {branch} {lastPush} />
+						<div style:position="relative">
+							<div class="lane-branches">
+								<SeriesList {branch} {lastPush} />
+							</div>
+							{#if canPush}
+								<div
+									class="lane-branches__action"
+									class:scroll-end-visible={scrollEndVisible}
+									use:intersectionObserver={{
+										callback: (entry) => {
+											if (entry?.isIntersecting) {
+												scrollEndVisible = false;
+											} else {
+												scrollEndVisible = true;
+											}
+										},
+										options: {
+											root: null,
+											rootMargin: `-100% 0px 0px 0px`,
+											threshold: 0
+										}
+									}}
+								>
+									<Button
+										style="neutral"
+										kind="solid"
+										wide
+										loading={isPushingCommits}
+										disabled={hasConflicts}
+										tooltip={hasConflicts
+											? 'In order to push, please resolve any conflicted commits.'
+											: undefined}w
+										onclick={push}
+									>
+										{branch.requiresForce
+											? 'Force push'
+											: branch.validSeries.length > 1
+												? 'Push All'
+												: 'Push'}
+									</Button>
+								</div>
+							{/if}
 						</div>
 					</div>
 				</div>
-				{#if canPush}
-					<div
-						class="lane-branches__action"
-						class:scroll-end-visible={scrollEndVisible}
-						use:intersectionObserver={{
-							callback: (entry) => {
-								if (entry?.isIntersecting) {
-									scrollEndVisible = false;
-								} else {
-									scrollEndVisible = true;
-								}
-							},
-							options: {
-								root: null,
-								rootMargin: `-100% 0px 0px 0px`,
-								threshold: 0
-							}
-						}}
-					>
-						<Button
-							style="neutral"
-							kind="solid"
-							wide
-							loading={isPushingCommits}
-							disabled={hasConflicts}
-							tooltip={hasConflicts
-								? 'In order to push, please resolve any conflicted commits.'
-								: undefined}
-							onclick={push}
-						>
-							{branch.requiresForce
-								? 'Force push'
-								: branch.validSeries.length > 1
-									? 'Push All'
-									: 'Push'}
-						</Button>
-					</div>
-				{/if}
 			</ScrollableContainer>
 			<div class="divider-line">
 				{#if rsViewport}
@@ -237,11 +239,10 @@
 	}
 
 	.lane-branches__action {
-		position: relative;
 		z-index: var(--z-lifted);
 		position: sticky;
 		padding: 0 12px 12px;
-		margin-bottom: 1px;
+		margin: 0 -12px 1px -12px;
 		bottom: 0;
 		transition: background-color var(--transition-fast);
 


### PR DESCRIPTION
## ☕️ Reasoning

The issue was resulting in confusing UX. Personally it happened to me 3 times to accidentally push changes instead of commit.

### Before changes
The `Push` button hides `Start commit` button and also hides partially the `UncommitedChanges` component.

Base on the thread I know this UI soon will be completely changed but hope it could be fixed before 😁

https://github.com/user-attachments/assets/4d9318c3-dd79-4e7c-afb4-bf8b90678a84

### After changes
The `Push` button is sticky to the bottom still *but* only for its container 

https://github.com/user-attachments/assets/bd1c483e-6c8e-4538-bb11-de2e4ab78afc


## 🧢 Changes

I've changed a bit a structure of the rendered jsx to make the `Push` button sticky to its container instead of the whole scrolling container

## 🎫 Affected issues

Fixes: [Discord thread link](https://discord.com/channels/1060193121130000425/1073202153163857920/1313571433192099941)

