### PR TITLE
refactor: rename repository to repo

### DIFF
--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -111,7 +111,7 @@ pub fn create_virtual_branch(project: &Project, create: &BranchCreateRequest) ->
 /// If there is no such local reference, this function will return an error.
 pub fn delete_local_branch(project: &Project, refname: &Refname, given_name: String) -> Result<()> {
     let ctx = open_with_verify(project)?;
-    let repo = ctx.repository();
+    let repo = ctx.repo();
     let handle = ctx.project().virtual_branches();
     let stack = handle.list_all_stacks()?.into_iter().find(|stack| {
         stack
@@ -149,7 +149,7 @@ pub fn list_commit_files(
     commit_oid: git2::Oid,
 ) -> Result<Vec<RemoteBranchFile>> {
     let ctx = CommandContext::open(project)?;
-    crate::file::list_commit_files(ctx.repository(), commit_oid).map_err(Into::into)
+    crate::file::list_commit_files(ctx.repo(), commit_oid).map_err(Into::into)
 }
 
 pub fn set_base_branch(project: &Project, target_branch: &RemoteRefname) -> Result<BaseBranch> {
@@ -247,7 +247,7 @@ pub fn unapply_without_saving_virtual_branch(project: &Project, stack_id: StackI
     let mut guard = project.exclusive_worktree_access();
     let state = ctx.project().virtual_branches();
     let default_target = state.get_default_target()?;
-    let target_commit = ctx.repository().find_commit(default_target.sha)?;
+    let target_commit = ctx.repo().find_commit(default_target.sha)?;
     // NB: unapply_without_saving is also called from save_and_unapply
     branch_manager.unapply(stack_id, guard.write_permission(), &target_commit, true)?;
     state.delete_branch_entry(&stack_id)
@@ -469,7 +469,7 @@ pub fn find_commit(project: &Project, commit_oid: git2::Oid) -> Result<Option<Re
 pub fn fetch_from_remotes(project: &Project, askpass: Option<String>) -> Result<FetchResult> {
     let ctx = CommandContext::open(project)?;
 
-    let remotes = ctx.repository().remotes_as_string()?;
+    let remotes = ctx.repo().remotes_as_string()?;
     let fetch_errors: Vec<_> = remotes
         .iter()
         .filter_map(|remote| {
@@ -490,7 +490,7 @@ pub fn fetch_from_remotes(project: &Project, askpass: Option<String>) -> Result<
     };
     let state = ctx.project().virtual_branches();
 
-    state.garbage_collect(ctx.repository())?;
+    state.garbage_collect(ctx.repo())?;
 
     Ok(project_data_last_fetched)
 }

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -50,7 +50,7 @@ pub(crate) fn get_base_branch_data(ctx: &CommandContext) -> Result<BaseBranch> {
 }
 
 fn go_back_to_integration(ctx: &CommandContext, default_target: &Target) -> Result<BaseBranch> {
-    let repo = ctx.repository();
+    let repo = ctx.repo();
     let statuses = repo
         .statuses(Some(
             git2::StatusOptions::new()
@@ -110,7 +110,7 @@ pub(crate) fn set_base_branch(
     ctx: &CommandContext,
     target_branch_ref: &RemoteRefname,
 ) -> Result<BaseBranch> {
-    let repo = ctx.repository();
+    let repo = ctx.repo();
 
     // if target exists, and it is the same as the requested branch, we should go back
     if let Ok(target) = default_target(&ctx.project().gb_dir()) {
@@ -258,7 +258,7 @@ pub(crate) fn set_base_branch(
 
 pub(crate) fn set_target_push_remote(ctx: &CommandContext, push_remote_name: &str) -> Result<()> {
     let remote = ctx
-        .repository()
+        .repo()
         .find_remote(push_remote_name)
         .context(format!("failed to find remote {}", push_remote_name))?;
 
@@ -276,7 +276,7 @@ pub(crate) fn set_target_push_remote(ctx: &CommandContext, push_remote_name: &st
 }
 
 fn set_exclude_decoration(ctx: &CommandContext) -> Result<()> {
-    let repo = ctx.repository();
+    let repo = ctx.repo();
     let mut config = repo.config()?;
     config
         .set_multivar("log.excludeDecoration", "refs/gitbutler", "refs/gitbutler")
@@ -306,7 +306,7 @@ fn _print_tree(repo: &git2::Repository, tree: &git2::Tree) -> Result<()> {
 }
 
 pub(crate) fn target_to_base_branch(ctx: &CommandContext, target: &Target) -> Result<BaseBranch> {
-    let repo = ctx.repository();
+    let repo = ctx.repo();
     let branch = repo
         .maybe_find_branch_by_refname(&target.branch.clone().into())?
         .ok_or(anyhow!("failed to get branch"))?;

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -34,7 +34,7 @@ pub(crate) fn get_uncommited_files_raw(
     ctx: &CommandContext,
     _permission: &WorktreeReadPermission,
 ) -> Result<DiffByPathMap> {
-    gitbutler_diff::workdir(ctx.repository(), ctx.repository().head_commit()?.id())
+    gitbutler_diff::workdir(ctx.repo(), ctx.repo().head_commit()?.id())
         .context("Failed to list uncommited files")
 }
 

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -37,7 +37,7 @@ impl BranchManager<'_> {
 
         let commit = self
             .ctx
-            .repository()
+            .repo()
             .find_commit(default_target.sha)
             .context("failed to find default target commit")?;
 
@@ -161,7 +161,7 @@ impl BranchManager<'_> {
             }
         }
 
-        let repo = self.ctx.repository();
+        let repo = self.ctx.repo();
         let head_reference = repo
             .find_reference(&target.to_string())
             .map_err(|err| match err {
@@ -192,12 +192,8 @@ impl BranchManager<'_> {
         let merge_base_tree = repo.find_commit(merge_base_oid)?.tree()?;
 
         // do a diff between the head of this branch and the target base
-        let diff = gitbutler_diff::trees(
-            self.ctx.repository(),
-            &merge_base_tree,
-            &head_commit_tree,
-            true,
-        )?;
+        let diff =
+            gitbutler_diff::trees(self.ctx.repo(), &merge_base_tree, &head_commit_tree, true)?;
 
         // assign ownership to the branch
         let ownership = diff.iter().fold(
@@ -280,7 +276,7 @@ impl BranchManager<'_> {
     ) -> Result<String> {
         self.ctx.assure_resolved()?;
         self.ctx.assure_unconflicted()?;
-        let repo = self.ctx.repository();
+        let repo = self.ctx.repo();
 
         let vb_state = self.ctx.project().virtual_branches();
         let default_target = vb_state.get_default_target()?;

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
@@ -36,7 +36,7 @@ impl BranchManager<'_> {
         let vb_state = self.ctx.project().virtual_branches();
         let target_commit = self
             .ctx
-            .repository()
+            .repo()
             .find_commit(vb_state.get_default_target()?.sha)?;
 
         let mut target_stack = vb_state.get_stack(stack_id)?;
@@ -80,7 +80,7 @@ impl BranchManager<'_> {
             .project()
             .snapshot_branch_deletion(stack.name.clone(), perm);
 
-        let repo = self.ctx.repository();
+        let repo = self.ctx.repo();
 
         let base_tree_id = target_commit
             .tree()
@@ -163,7 +163,7 @@ impl BranchManager<'_> {
 impl BranchManager<'_> {
     #[instrument(level = tracing::Level::DEBUG, skip(self, stack), err(Debug))]
     fn build_real_branch(&self, stack: &mut Stack) -> Result<git2::Branch<'_>> {
-        let repo = self.ctx.repository();
+        let repo = self.ctx.repo();
         let target_commit = repo.find_commit(stack.head())?;
         let branch_name = normalize_branch_name(&stack.id.to_string())?;
 
@@ -182,7 +182,7 @@ impl BranchManager<'_> {
         stack: &mut Stack,
         branch: &git2::Branch<'_>,
     ) -> Result<Option<git2::Oid>> {
-        let repo = self.ctx.repository();
+        let repo = self.ctx.repo();
 
         // Build wip tree as either any uncommitted changes or an empty tree
         let vbranch_wip_tree = repo.find_tree(stack.tree)?;

--- a/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
@@ -27,7 +27,7 @@ pub fn integrate_upstream_commits_for_series(
 ) -> Result<()> {
     conflicts::is_conflicting(ctx, None)?;
 
-    let repo = ctx.repository();
+    let repo = ctx.repo();
     let vb_state = ctx.project().virtual_branches();
 
     let stack = vb_state.get_stack_in_workspace(stack_id)?;
@@ -92,7 +92,7 @@ pub fn integrate_upstream_commits(
 ) -> Result<()> {
     conflicts::is_conflicting(ctx, None)?;
 
-    let repository = ctx.repository();
+    let repository = ctx.repo();
     let project = ctx.project();
     let vb_state = project.virtual_branches();
 

--- a/crates/gitbutler-branch-actions/src/conflicts.rs
+++ b/crates/gitbutler-branch-actions/src/conflicts.rs
@@ -46,11 +46,11 @@ pub(crate) fn mark<P: AsRef<Path>, A: AsRef<[P]>>(
 }
 
 fn conflicts_path(ctx: &CommandContext) -> PathBuf {
-    ctx.repository().path().join("conflicts")
+    ctx.repo().path().join("conflicts")
 }
 
 fn merge_parent_path(ctx: &CommandContext) -> PathBuf {
-    ctx.repository().path().join("base_merge_parent")
+    ctx.repo().path().join("base_merge_parent")
 }
 
 pub(crate) fn merge_parent(ctx: &CommandContext) -> Result<Option<git2::Oid>> {

--- a/crates/gitbutler-branch-actions/src/dependencies.rs
+++ b/crates/gitbutler-branch-actions/src/dependencies.rs
@@ -22,7 +22,7 @@ pub fn compute_workspace_dependencies(
     base_diffs: &BranchStatus,
     stacks: &Vec<Stack>,
 ) -> Result<HunkDependencyResult> {
-    let repo = ctx.repository();
+    let repo = ctx.repo();
 
     let mut stacks_input: Vec<InputStack> = vec![];
     for stack in stacks {

--- a/crates/gitbutler-branch-actions/src/file.rs
+++ b/crates/gitbutler-branch-actions/src/file.rs
@@ -114,14 +114,14 @@ pub(crate) fn list_virtual_commit_files(
         return Ok(vec![]);
     }
     let parent = commit.parent(0).context("failed to get parent commit")?;
-    let repository = ctx.repository();
+    let repository = ctx.repo();
     let commit_tree = repository
         .find_real_tree(commit, Default::default())
         .context("failed to get commit tree")?;
     let parent_tree = repository
         .find_real_tree(&parent, Default::default())
         .context("failed to get parent tree")?;
-    let diff = gitbutler_diff::trees(ctx.repository(), &parent_tree, &commit_tree, context_lines)?;
+    let diff = gitbutler_diff::trees(ctx.repo(), &parent_tree, &commit_tree, context_lines)?;
     let hunks_by_filepath = virtual_hunks_by_file_diffs(&ctx.project().path, diff);
     Ok(virtual_hunks_into_virtual_files(ctx, hunks_by_filepath))
 }

--- a/crates/gitbutler-branch-actions/src/move_commits.rs
+++ b/crates/gitbutler-branch-actions/src/move_commits.rs
@@ -26,7 +26,7 @@ pub(crate) fn move_commit(
 ) -> Result<()> {
     ctx.assure_resolved()?;
     let vb_state = ctx.project().virtual_branches();
-    let repo = ctx.repository();
+    let repo = ctx.repo();
 
     let applied_stacks = vb_state
         .list_stacks_in_workspace()
@@ -82,7 +82,7 @@ fn get_source_branch_diffs(
     ctx: &CommandContext,
     source_stack: &gitbutler_stack::Stack,
 ) -> Result<BranchStatus> {
-    let repo = ctx.repository();
+    let repo = ctx.repo();
     let source_stack_head = repo.find_commit(source_stack.head())?;
     let source_stack_head_tree = source_stack_head.tree()?;
     let uncommitted_changes_tree = repo.find_tree(source_stack.tree)?;

--- a/crates/gitbutler-branch-actions/src/remote.rs
+++ b/crates/gitbutler-branch-actions/src/remote.rs
@@ -48,7 +48,7 @@ pub struct RemoteCommit {
 /// For legacy purposes, this is still named "remote" branches, but it's actually
 /// a list of all the normal (non-gitbutler) git branches.
 pub fn find_git_branches(ctx: &CommandContext, branch_name: &str) -> Result<Vec<RemoteBranchData>> {
-    let repo = ctx.repository();
+    let repo = ctx.repo();
     let remotes_raw = repo.remotes()?;
     let remotes: Vec<_> = remotes_raw.iter().flatten().collect();
 
@@ -92,7 +92,7 @@ pub(crate) fn get_commit_data(
     ctx: &CommandContext,
     sha: git2::Oid,
 ) -> Result<Option<RemoteCommit>> {
-    let commit = match ctx.repository().find_commit(sha) {
+    let commit = match ctx.repo().find_commit(sha) {
         Ok(commit) => commit,
         Err(error) => {
             if error.code() == git2::ErrorCode::NotFound {
@@ -118,8 +118,8 @@ pub(crate) fn branch_to_remote_branch(
     let sha = commit.id();
     let is_remote = reference.is_remote();
 
-    let base = default_target(&ctx.project().gb_dir())?.remote_head(ctx.repository())?;
-    let ahead = ctx.repository().log(sha, LogUntil::Commit(base), false)?;
+    let base = default_target(&ctx.project().gb_dir())?.remote_head(ctx.repo())?;
+    let ahead = ctx.repo().log(sha, LogUntil::Commit(base), false)?;
     let fork_point = ahead.last().and_then(|c| c.parent(0).ok()).map(|c| c.id());
     let behind = ctx.distance(base, sha)?;
 

--- a/crates/gitbutler-branch-actions/src/reorder.rs
+++ b/crates/gitbutler-branch-actions/src/reorder.rs
@@ -36,7 +36,7 @@ pub fn reorder_stack(
     perm: &mut WorktreeWritePermission,
 ) -> Result<()> {
     let state = ctx.project().virtual_branches();
-    let repo = ctx.repository();
+    let repo = ctx.repo();
     let mut stack = state.get_stack(stack_id)?;
     let current_order = commits_order(&ctx.to_stack_context()?, &stack)?;
     new_order.validate(current_order.clone())?;

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -175,7 +175,7 @@ pub fn push_stack(project: &Project, stack_id: StackId, with_force: bool) -> Res
     let state = ctx.project().virtual_branches();
     let stack = state.get_stack(stack_id)?;
 
-    let repo = ctx.repository();
+    let repo = ctx.repo();
     let default_target = state.get_default_target()?;
     let merge_base = repo.find_commit(repo.merge_base(stack.head(), default_target.sha)?)?;
     let merge_base = if let Some(change_id) = merge_base.change_id() {

--- a/crates/gitbutler-branch-actions/src/status.rs
+++ b/crates/gitbutler-branch-actions/src/status.rs
@@ -56,7 +56,7 @@ pub fn get_applied_status_cached(
         .virtual_branches()
         .list_stacks_in_workspace()?;
     let base_file_diffs = worktree_changes.map(Ok).unwrap_or_else(|| {
-        gitbutler_diff::workdir(ctx.repository(), workspace_head.to_owned())
+        gitbutler_diff::workdir(ctx.repo(), workspace_head.to_owned())
             .context("failed to diff workdir")
     })?;
 

--- a/crates/gitbutler-branch-actions/src/undo_commit.rs
+++ b/crates/gitbutler-branch-actions/src/undo_commit.rs
@@ -32,7 +32,7 @@ pub(crate) fn undo_commit(
     let UndoResult {
         new_head: new_head_commit,
         ownership_update,
-    } = inner_undo_commit(ctx.repository(), stack.head(), commit_oid)?;
+    } = inner_undo_commit(ctx.repo(), stack.head(), commit_oid)?;
 
     for ownership in ownership_update {
         stack.ownership.put(ownership);
@@ -40,7 +40,7 @@ pub(crate) fn undo_commit(
 
     stack.set_stack_head(ctx, new_head_commit, None)?;
 
-    let removed_commit = ctx.repository().find_commit(commit_oid)?;
+    let removed_commit = ctx.repo().find_commit(commit_oid)?;
     stack.replace_head(ctx, &removed_commit, &removed_commit.parent(0)?)?;
 
     crate::integration::update_workspace_commit(&vb_state, ctx)

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -161,7 +161,7 @@ impl<'a> UpstreamIntegrationContext<'a> {
     ) -> Result<Self> {
         let virtual_branches_handle = command_context.project().virtual_branches();
         let target = virtual_branches_handle.get_default_target()?;
-        let repository = command_context.repository();
+        let repository = command_context.repo();
         let target_branch = repository
             .maybe_find_branch_by_refname(&target.branch.clone().into())?
             .ok_or(anyhow!("Branch not found"))?;
@@ -497,7 +497,7 @@ pub(crate) fn resolve_upstream_integration(
     permission: &mut WorktreeWritePermission,
 ) -> Result<git2::Oid> {
     let context = UpstreamIntegrationContext::open(command_context, None, permission)?;
-    let repo = command_context.repository();
+    let repo = command_context.repo();
     let new_target_id = context.new_target.id();
     let old_target_id = context.target.sha;
     let fork_point = repo.merge_base(old_target_id, new_target_id)?;

--- a/crates/gitbutler-branch-actions/tests/dependencies.rs
+++ b/crates/gitbutler-branch-actions/tests/dependencies.rs
@@ -783,7 +783,7 @@ fn assert_hunk_lock_matches_by_message(
 }
 
 fn get_commit_message(ctx: &CommandContext, commit_id: git2::Oid) -> String {
-    let repo = ctx.repository();
+    let repo = ctx.repo();
     let commit = repo.find_commit(commit_id).unwrap();
     let commit_message = commit.message().unwrap();
     commit_message.to_string()
@@ -846,7 +846,7 @@ fn extract_commit_messages(
     let mut actual_messages: HashMap<String, Vec<String>> = HashMap::new();
 
     for (oid_key, oid_values) in actual {
-        let repo = ctx.repository();
+        let repo = ctx.repo();
         let key_commit = repo.find_commit(*oid_key).unwrap();
         let key_message = key_commit.message().unwrap().trim().to_string();
         let actual_values: Vec<String> = oid_values

--- a/crates/gitbutler-branch-actions/tests/extra/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/extra/mod.rs
@@ -99,7 +99,7 @@ fn track_binary_files() -> Result<()> {
     ];
     let mut file = std::fs::File::create(Path::new(&project.path).join("image.bin"))?;
     file.write_all(&image_data)?;
-    commit_all(ctx.repository());
+    commit_all(ctx.repo());
 
     set_test_target(ctx)?;
 
@@ -148,9 +148,9 @@ fn track_binary_files() -> Result<()> {
     // status (no files)
     let (branches, _) = internal::list_virtual_branches(ctx, guard.write_permission()).unwrap();
     let commit_id = &branches[0].series[0].clone()?.patches[0].id;
-    let commit_obj = ctx.repository().find_commit(commit_id.to_owned())?;
+    let commit_obj = ctx.repo().find_commit(commit_id.to_owned())?;
     let tree = commit_obj.tree()?;
-    let files = tree_to_entry_list(ctx.repository(), &tree);
+    let files = tree_to_entry_list(ctx.repo(), &tree);
     assert_eq!(files[0].0, "image.bin");
     assert_eq!(
         files[0].3, img_oid_hex,
@@ -172,9 +172,9 @@ fn track_binary_files() -> Result<()> {
     let (branches, _) = internal::list_virtual_branches(ctx, guard.write_permission()).unwrap();
     let commit_id = &branches[0].series[0].clone()?.patches[0].id;
     // get tree from commit_id
-    let commit_obj = ctx.repository().find_commit(commit_id.to_owned())?;
+    let commit_obj = ctx.repo().find_commit(commit_id.to_owned())?;
     let tree = commit_obj.tree()?;
-    let files = tree_to_entry_list(ctx.repository(), &tree);
+    let files = tree_to_entry_list(ctx.repo(), &tree);
 
     assert_eq!(files[0].0, "image.bin");
     assert_eq!(files[0].3, "ea6901a04d1eed6ebf6822f4360bda9f008fa317");
@@ -697,11 +697,11 @@ fn commit_id_can_be_generated_or_specified() -> Result<()> {
         Path::new(&project.path).join(file_path),
         "line1\nline2\nline3\nline4\n",
     )?;
-    commit_all(ctx.repository());
+    commit_all(ctx.repo());
 
     // lets make sure a change id is generated
-    let target_oid = ctx.repository().head().unwrap().target().unwrap();
-    let target = ctx.repository().find_commit(target_oid).unwrap();
+    let target_oid = ctx.repo().head().unwrap().target().unwrap();
+    let target = ctx.repo().find_commit(target_oid).unwrap();
     let change_id = target.change_id();
 
     // make sure we created a change-id
@@ -714,7 +714,7 @@ fn commit_id_can_be_generated_or_specified() -> Result<()> {
         "line1\nline2\nline3\nline4\nline5\n",
     )?;
 
-    let repository = ctx.repository();
+    let repository = ctx.repo();
     let mut index = repository.index().expect("failed to get index");
     index
         .add_all(["."], git2::IndexAddOption::DEFAULT, None)
@@ -724,7 +724,7 @@ fn commit_id_can_be_generated_or_specified() -> Result<()> {
     let signature = git2::Signature::now("test", "test@email.com").unwrap();
     let head = repository.head().expect("failed to get head");
     let refname: Refname = head.name().unwrap().parse().unwrap();
-    ctx.repository()
+    ctx.repo()
         .commit_with_signature(
             Some(&refname),
             &signature,
@@ -746,8 +746,8 @@ fn commit_id_can_be_generated_or_specified() -> Result<()> {
         )
         .expect("failed to commit");
 
-    let target_oid = ctx.repository().head().unwrap().target().unwrap();
-    let target = ctx.repository().find_commit(target_oid).unwrap();
+    let target_oid = ctx.repo().head().unwrap().target().unwrap();
+    let target = ctx.repo().find_commit(target_oid).unwrap();
     let change_id = target.change_id();
 
     // the change id should be what we specified, rather than randomly generated
@@ -787,16 +787,16 @@ fn merge_vbranch_upstream_clean_rebase() -> Result<()> {
         Path::new(&project.path).join(file_path),
         "line1\nline2\nline3\nline4\n",
     )?;
-    commit_all(ctx.repository());
-    let target_oid = ctx.repository().head().unwrap().target().unwrap();
+    commit_all(ctx.repo());
+    let target_oid = ctx.repo().head().unwrap().target().unwrap();
 
     std::fs::write(
         Path::new(&project.path).join(file_path),
         "line1\nline2\nline3\nline4\nupstream\n",
     )?;
     // add a commit to the target branch it's pointing to so there is something "upstream"
-    commit_all(ctx.repository());
-    let last_push = ctx.repository().head().unwrap().target().unwrap();
+    commit_all(ctx.repo());
+    let last_push = ctx.repo().head().unwrap().target().unwrap();
 
     // coworker adds some work
     std::fs::write(
@@ -804,11 +804,11 @@ fn merge_vbranch_upstream_clean_rebase() -> Result<()> {
         "line1\nline2\nline3\nline4\nupstream\ncoworker work\n",
     )?;
 
-    commit_all(ctx.repository());
-    let coworker_work = ctx.repository().head().unwrap().target().unwrap();
+    commit_all(ctx.repo());
+    let coworker_work = ctx.repo().head().unwrap().target().unwrap();
 
     //update repo ref refs/remotes/origin/master to up_target oid
-    ctx.repository().reference(
+    ctx.repo().reference(
         "refs/remotes/origin/master",
         coworker_work,
         true,
@@ -915,16 +915,16 @@ fn merge_vbranch_upstream_conflict() -> Result<()> {
         Path::new(&project.path).join(file_path),
         "line1\nline2\nline3\nline4\n",
     )?;
-    commit_all(ctx.repository());
-    let target_oid = ctx.repository().head().unwrap().target().unwrap();
+    commit_all(ctx.repo());
+    let target_oid = ctx.repo().head().unwrap().target().unwrap();
 
     std::fs::write(
         Path::new(&project.path).join(file_path),
         "line1\nline2\nline3\nline4\nupstream\n",
     )?;
     // add a commit to the target branch it's pointing to so there is something "upstream"
-    commit_all(ctx.repository());
-    let last_push = ctx.repository().head().unwrap().target().unwrap();
+    commit_all(ctx.repo());
+    let last_push = ctx.repo().head().unwrap().target().unwrap();
 
     // coworker adds some work
     std::fs::write(
@@ -932,11 +932,11 @@ fn merge_vbranch_upstream_conflict() -> Result<()> {
         "line1\nline2\nline3\nline4\nupstream\ncoworker work\n",
     )?;
 
-    commit_all(ctx.repository());
-    let coworker_work = ctx.repository().head().unwrap().target().unwrap();
+    commit_all(ctx.repo());
+    let coworker_work = ctx.repo().head().unwrap().target().unwrap();
 
     //update repo ref refs/remotes/origin/master to up_target oid
-    ctx.repository().reference(
+    ctx.repo().reference(
         "refs/remotes/origin/master",
         coworker_work,
         true,
@@ -1078,7 +1078,7 @@ fn unapply_branch() -> Result<()> {
         Path::new(&project.path).join(file_path),
         "line1\nline2\nline3\nline4\n",
     )?;
-    commit_all(ctx.repository());
+    commit_all(ctx.repo());
 
     set_test_target(ctx)?;
 
@@ -1166,7 +1166,7 @@ fn apply_unapply_added_deleted_files() -> Result<()> {
     std::fs::write(Path::new(&project.path).join(file_path), "file1\n")?;
     let file_path2 = Path::new("test2.txt");
     std::fs::write(Path::new(&project.path).join(file_path2), "file2\n")?;
-    commit_all(ctx.repository());
+    commit_all(ctx.repo());
 
     set_test_target(ctx)?;
 
@@ -1256,7 +1256,7 @@ fn detect_mergeable_branch() -> Result<()> {
         Path::new(&project.path).join(file_path),
         "line1\nline2\nline3\nline4\n",
     )?;
-    commit_all(ctx.repository());
+    commit_all(ctx.repo());
 
     set_test_target(ctx)?;
 
@@ -1293,8 +1293,8 @@ fn detect_mergeable_branch() -> Result<()> {
     branch_manager.save_and_unapply(stack1_id, guard.write_permission())?;
     branch_manager.save_and_unapply(stack2_id, guard.write_permission())?;
 
-    ctx.repository().set_head("refs/heads/master")?;
-    ctx.repository()
+    ctx.repo().set_head("refs/heads/master")?;
+    ctx.repo()
         .checkout_head(Some(&mut git2::build::CheckoutBuilder::default().force()))?;
 
     // create an upstream remote conflicting commit
@@ -1302,9 +1302,9 @@ fn detect_mergeable_branch() -> Result<()> {
         Path::new(&project.path).join(file_path),
         "line1\nline2\nline3\nline4\nupstream\n",
     )?;
-    commit_all(ctx.repository());
-    let up_target = ctx.repository().head().unwrap().target().unwrap();
-    ctx.repository().reference(
+    commit_all(ctx.repo());
+    let up_target = ctx.repo().head().unwrap().target().unwrap();
+    ctx.repo().reference(
         "refs/remotes/origin/remote_branch",
         up_target,
         true,
@@ -1318,9 +1318,9 @@ fn detect_mergeable_branch() -> Result<()> {
     )?;
     let file_path3 = Path::new("test3.txt");
     std::fs::write(Path::new(&project.path).join(file_path3), "file3\n")?;
-    commit_all(ctx.repository());
-    let up_target = ctx.repository().head().unwrap().target().unwrap();
-    ctx.repository().reference(
+    commit_all(ctx.repo());
+    let up_target = ctx.repo().head().unwrap().target().unwrap();
+    ctx.repo().reference(
         "refs/remotes/origin/remote_branch2",
         up_target,
         true,
@@ -1329,9 +1329,8 @@ fn detect_mergeable_branch() -> Result<()> {
     // remove file_path3
     std::fs::remove_file(Path::new(&project.path).join(file_path3))?;
 
-    ctx.repository()
-        .set_head("refs/heads/gitbutler/workspace")?;
-    ctx.repository()
+    ctx.repo().set_head("refs/heads/gitbutler/workspace")?;
+    ctx.repo()
         .checkout_head(Some(&mut git2::build::CheckoutBuilder::default().force()))?;
 
     // create branches that conflict with our earlier branches
@@ -1394,16 +1393,16 @@ fn upstream_integrated_vbranch() -> Result<()> {
 
     let vb_state = VirtualBranchesHandle::new(project.gb_dir());
 
-    let base_commit = ctx.repository().head().unwrap().target().unwrap();
+    let base_commit = ctx.repo().head().unwrap().target().unwrap();
 
     std::fs::write(
         Path::new(&project.path).join("test.txt"),
         "file1\nversion2\n",
     )?;
-    commit_all(ctx.repository());
+    commit_all(ctx.repo());
 
-    let upstream_commit = ctx.repository().head().unwrap().target().unwrap();
-    ctx.repository().reference(
+    let upstream_commit = ctx.repo().head().unwrap().target().unwrap();
+    ctx.repo().reference(
         "refs/remotes/origin/master",
         upstream_commit,
         true,
@@ -1416,8 +1415,7 @@ fn upstream_integrated_vbranch() -> Result<()> {
         sha: base_commit,
         push_remote_name: None,
     })?;
-    ctx.repository()
-        .remote("origin", "http://origin.com/project")?;
+    ctx.repo().remote("origin", "http://origin.com/project")?;
     update_workspace_commit(&vb_state, ctx)?;
 
     // create vbranches, one integrated, one not
@@ -1790,8 +1788,8 @@ fn commit_partial_by_file() -> Result<()> {
         (PathBuf::from("test2.txt"), "file2\n"),
     ]));
 
-    let commit1_oid = ctx.repository().head().unwrap().target().unwrap();
-    let commit1 = ctx.repository().find_commit(commit1_oid).unwrap();
+    let commit1_oid = ctx.repo().head().unwrap().target().unwrap();
+    let commit1 = ctx.repo().find_commit(commit1_oid).unwrap();
 
     set_test_target(ctx)?;
 
@@ -1817,17 +1815,17 @@ fn commit_partial_by_file() -> Result<()> {
     // branch one test.txt has just the 1st and 3rd hunks applied
     let commit2 = &branch1.series[0].clone()?.patches[0].id;
     let commit2 = ctx
-        .repository()
+        .repo()
         .find_commit(commit2.to_owned())
         .expect("failed to get commit object");
 
     let tree = commit1.tree().expect("failed to get tree");
-    let file_list = tree_to_file_list(ctx.repository(), &tree);
+    let file_list = tree_to_file_list(ctx.repo(), &tree);
     assert_eq!(file_list, vec!["test.txt", "test2.txt"]);
 
     // get the tree
     let tree = commit2.tree().expect("failed to get tree");
-    let file_list = tree_to_file_list(ctx.repository(), &tree);
+    let file_list = tree_to_file_list(ctx.repo(), &tree);
     assert_eq!(file_list, vec!["test.txt", "test3.txt"]);
 
     Ok(())
@@ -1841,8 +1839,8 @@ fn commit_add_and_delete_files() -> Result<()> {
         (PathBuf::from("test2.txt"), "file2\n"),
     ]));
 
-    let commit1_oid = ctx.repository().head().unwrap().target().unwrap();
-    let commit1 = ctx.repository().find_commit(commit1_oid).unwrap();
+    let commit1_oid = ctx.repo().head().unwrap().target().unwrap();
+    let commit1 = ctx.repo().find_commit(commit1_oid).unwrap();
 
     set_test_target(ctx)?;
 
@@ -1868,17 +1866,17 @@ fn commit_add_and_delete_files() -> Result<()> {
     // branch one test.txt has just the 1st and 3rd hunks applied
     let commit2 = &branch1.series[0].clone()?.patches[0].id;
     let commit2 = ctx
-        .repository()
+        .repo()
         .find_commit(commit2.to_owned())
         .expect("failed to get commit object");
 
     let tree = commit1.tree().expect("failed to get tree");
-    let file_list = tree_to_file_list(ctx.repository(), &tree);
+    let file_list = tree_to_file_list(ctx.repo(), &tree);
     assert_eq!(file_list, vec!["test.txt", "test2.txt"]);
 
     // get the tree
     let tree = commit2.tree().expect("failed to get tree");
-    let file_list = tree_to_file_list(ctx.repository(), &tree);
+    let file_list = tree_to_file_list(ctx.repo(), &tree);
     assert_eq!(file_list, vec!["test.txt", "test3.txt"]);
 
     Ok(())
@@ -1924,13 +1922,13 @@ fn commit_executable_and_symlinks() -> Result<()> {
 
     let commit = &branch1.series[0].clone()?.patches[0].id;
     let commit = ctx
-        .repository()
+        .repo()
         .find_commit(commit.to_owned())
         .expect("failed to get commit object");
 
     let tree = commit.tree().expect("failed to get tree");
 
-    let list = tree_to_entry_list(ctx.repository(), &tree);
+    let list = tree_to_entry_list(ctx.repo(), &tree);
     assert_eq!(list[0].0, "test.txt");
     assert_eq!(list[0].1, "100644");
     assert_eq!(list[1].0, "test2.txt");
@@ -2007,9 +2005,9 @@ fn verify_branch_commits_to_workspace() -> Result<()> {
     //  write two commits
     let file_path2 = Path::new("test2.txt");
     std::fs::write(Path::new(&project.path).join(file_path2), "file")?;
-    commit_all(ctx.repository());
+    commit_all(ctx.repo());
     std::fs::write(Path::new(&project.path).join(file_path2), "update")?;
-    commit_all(ctx.repository());
+    commit_all(ctx.repo());
 
     // verify puts commits onto the virtual branch
     verify_branch(ctx, guard.write_permission()).unwrap();
@@ -2035,7 +2033,7 @@ fn verify_branch_not_workspace() -> Result<()> {
     let mut guard = project.exclusive_worktree_access();
     verify_branch(ctx, guard.write_permission()).unwrap();
 
-    ctx.repository().set_head("refs/heads/master")?;
+    ctx.repo().set_head("refs/heads/master")?;
 
     let verify_result = verify_branch(ctx, guard.write_permission());
     assert!(verify_result.is_err());
@@ -2074,7 +2072,7 @@ fn pre_commit_hook_rejection() -> Result<()> {
     exit 1
             ";
 
-    git2_hooks::create_hook(ctx.repository(), git2_hooks::HOOK_PRE_COMMIT, hook);
+    git2_hooks::create_hook(ctx.repo(), git2_hooks::HOOK_PRE_COMMIT, hook);
 
     let res = internal::commit(ctx, stack1_id, "test commit", None, true);
 
@@ -2113,9 +2111,9 @@ fn post_commit_hook() -> Result<()> {
     touch hook_ran
             ";
 
-    git2_hooks::create_hook(ctx.repository(), git2_hooks::HOOK_POST_COMMIT, hook);
+    git2_hooks::create_hook(ctx.repo(), git2_hooks::HOOK_POST_COMMIT, hook);
 
-    let hook_ran_proof = ctx.repository().path().parent().unwrap().join("hook_ran");
+    let hook_ran_proof = ctx.repo().path().parent().unwrap().join("hook_ran");
 
     assert!(!hook_ran_proof.exists());
 
@@ -2153,7 +2151,7 @@ fn commit_msg_hook_rejection() -> Result<()> {
     exit 1
             ";
 
-    git2_hooks::create_hook(ctx.repository(), git2_hooks::HOOK_COMMIT_MSG, hook);
+    git2_hooks::create_hook(ctx.repo(), git2_hooks::HOOK_COMMIT_MSG, hook);
 
     let res = internal::commit(ctx, stack1_id, "test commit", None, true);
 

--- a/crates/gitbutler-branch-actions/tests/reorder.rs
+++ b/crates/gitbutler-branch-actions/tests/reorder.rs
@@ -317,7 +317,7 @@ fn conflicting_reorder_stack() -> Result<()> {
     // MB:       a    : MB:        a    :
 
     let (ctx, _temp_dir) = command_ctx("overlapping-commits")?;
-    let repo = ctx.repository();
+    let repo = ctx.repo();
     let test = test_ctx(&ctx)?;
 
     // There is a stack of 2:
@@ -452,7 +452,7 @@ fn vb_commits(ctx: &CommandContext) -> Vec<Vec<(git2::Oid, String, bool, u128)>>
 }
 
 fn file(ctx: &CommandContext, commit_id: git2::Oid) -> String {
-    let repo = ctx.repository();
+    let repo = ctx.repo();
     let commit = repo.find_commit(commit_id).unwrap();
     let tree = commit.tree().unwrap();
     let entry = tree.get_name("file").unwrap();

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/workspace_migration.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/workspace_migration.rs
@@ -15,10 +15,7 @@ fn works_on_integration_branch() -> anyhow::Result<()> {
     )?;
 
     // Check that we are on the old `gitbutler/integration` branch.
-    assert_eq!(
-        ctx.repository().head()?.name(),
-        Some(INTEGRATION_BRANCH_REF)
-    );
+    assert_eq!(ctx.repo().head()?.name(), Some(INTEGRATION_BRANCH_REF));
 
     // Should not throw verification error until migration is complete.
     let result = assure_open_workspace_mode(&ctx);
@@ -26,6 +23,6 @@ fn works_on_integration_branch() -> anyhow::Result<()> {
 
     // Updating workspace commit should put us on the workspace branch.
     update_workspace_commit(&VirtualBranchesHandle::new(ctx.project().gb_dir()), &ctx)?;
-    assert_eq!(ctx.repository().head()?.name(), Some(WORKSPACE_BRANCH_REF));
+    assert_eq!(ctx.repo().head()?.name(), Some(WORKSPACE_BRANCH_REF));
     Ok(())
 }

--- a/crates/gitbutler-command-context/src/lib.rs
+++ b/crates/gitbutler-command-context/src/lib.rs
@@ -60,7 +60,7 @@ impl CommandContext {
     }
 
     /// Return the [`project`](Self::project) repository.
-    pub fn repository(&self) -> &git2::Repository {
+    pub fn repo(&self) -> &git2::Repository {
         &self.git_repository
     }
 
@@ -76,14 +76,14 @@ impl CommandContext {
     /// Also note that there are plenty of other places where repositories are opened ad-hoc, and
     /// there is no need to use this type there at all - opening a repo is very cheap still.
     pub fn gix_repository(&self) -> Result<gix::Repository> {
-        Ok(gix::open(self.repository().path())?)
+        Ok(gix::open(self.repo().path())?)
     }
 
     /// Return a newly opened `gitoxide` repository, with all configuration available
     /// to correctly figure out author and committer names (i.e. with most global configuration loaded),
     /// *and* which will perform diffs quickly thanks to an adequate object cache.
     pub fn gix_repository_for_merging(&self) -> Result<gix::Repository> {
-        gix_repository_for_merging(self.repository().path())
+        gix_repository_for_merging(self.repo().path())
     }
 
     /// Return a newly opened `gitoxide` repository, with all configuration available
@@ -103,7 +103,7 @@ impl CommandContext {
     /// commits, fetch or push.
     pub fn gix_repository_minimal(&self) -> Result<gix::Repository> {
         Ok(gix::open_opts(
-            self.repository().path(),
+            self.repo().path(),
             gix::open::Options::isolated(),
         )?)
     }

--- a/crates/gitbutler-diff/src/write.rs
+++ b/crates/gitbutler-diff/src/write.rs
@@ -34,7 +34,7 @@ where
     T: Into<GitHunk> + Clone,
 {
     // read the base sha into an index
-    let git_repository: &git2::Repository = ctx.repository();
+    let git_repository: &git2::Repository = ctx.repo();
 
     let head_commit = git_repository.find_commit(commit_oid)?;
     let base_tree = git_repository.find_real_tree(&head_commit, Default::default())?;
@@ -51,7 +51,7 @@ pub fn hunks_onto_tree<T>(
 where
     T: Into<GitHunk> + Clone,
 {
-    let git_repository = ctx.repository();
+    let git_repository = ctx.repo();
     let mut builder = git2::build::TreeUpdateBuilder::new();
     // now update the index with content in the working directory for each file
     for (rel_path, hunks) in files {
@@ -223,7 +223,7 @@ where
 
     // now write out the tree
     let tree_oid = builder
-        .create_updated(ctx.repository(), base_tree)
+        .create_updated(ctx.repo(), base_tree)
         .context("failed to write updated tree")?;
 
     Ok(tree_oid)

--- a/crates/gitbutler-edit-mode/src/commands.rs
+++ b/crates/gitbutler-edit-mode/src/commands.rs
@@ -22,12 +22,12 @@ pub fn enter_edit_mode(
         .context("Entering edit mode may only be done when the workspace is open")?;
 
     let commit = ctx
-        .repository()
+        .repo()
         .find_commit(commit_oid)
         .context("Failed to find commit")?;
 
     let branch = ctx
-        .repository()
+        .repo()
         .find_reference(&branch_reference_name)
         .context("Failed to find branch reference")?;
 

--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -69,7 +69,7 @@ fn get_commit_index(repository: &git2::Repository, commit: &git2::Commit) -> Res
 }
 
 fn checkout_edit_branch(ctx: &CommandContext, commit: &git2::Commit) -> Result<()> {
-    let repository = ctx.repository();
+    let repository = ctx.repo();
 
     let author_signature = signature(SignaturePurpose::Author)?;
     let committer_signature = signature(SignaturePurpose::Committer)?;
@@ -161,7 +161,7 @@ pub(crate) fn abort_and_return_to_workspace(
     ctx: &CommandContext,
     perm: &mut WorktreeWritePermission,
 ) -> Result<()> {
-    let repository = ctx.repository();
+    let repository = ctx.repo();
 
     // Checkout gitbutler workspace branch
     repository
@@ -178,7 +178,7 @@ pub(crate) fn save_and_return_to_workspace(
     perm: &mut WorktreeWritePermission,
 ) -> Result<()> {
     let edit_mode_metadata = read_edit_mode_metadata(ctx).context("Failed to read metadata")?;
-    let repository = ctx.repository();
+    let repository = ctx.repo();
     let vb_state = VirtualBranchesHandle::new(ctx.project().gb_dir());
 
     // Get important references
@@ -205,7 +205,7 @@ pub(crate) fn save_and_return_to_workspace(
             ..commit_headers
         });
     let new_commit_oid = ctx
-        .repository()
+        .repo()
         .commit_with_signature(
             None,
             &commit.author(),
@@ -259,7 +259,7 @@ pub(crate) fn starting_index_state(
         bail!("Starting index state can only be fetched while in edit mode")
     };
 
-    let repository = ctx.repository();
+    let repository = ctx.repo();
 
     let commit = repository.find_commit(metadata.commit_oid)?;
     let commit_parent_tree = if commit.is_conflicted() {

--- a/crates/gitbutler-operating-modes/src/lib.rs
+++ b/crates/gitbutler-operating-modes/src/lib.rs
@@ -74,7 +74,7 @@ pub enum OperatingMode {
 }
 
 pub fn operating_mode(ctx: &CommandContext) -> OperatingMode {
-    let Ok(head_ref) = ctx.repository().head() else {
+    let Ok(head_ref) = ctx.repo().head() else {
         return OperatingMode::OutsideWorkspace;
     };
 

--- a/crates/gitbutler-operating-modes/tests/operating_modes.rs
+++ b/crates/gitbutler-operating-modes/tests/operating_modes.rs
@@ -3,7 +3,7 @@ use gitbutler_operating_modes::{write_edit_mode_metadata, EditModeMetadata};
 
 /// Creates a branch from the head commit
 fn create_and_checkout_branch(ctx: &CommandContext, branch_name: &str) {
-    let repository = ctx.repository();
+    let repository = ctx.repo();
     repository
         .branch(
             branch_name,

--- a/crates/gitbutler-repo/src/commands.rs
+++ b/crates/gitbutler-repo/src/commands.rs
@@ -126,19 +126,19 @@ pub trait RepoCommands {
 impl RepoCommands for Project {
     fn get_local_config(&self, key: &str) -> Result<Option<String>> {
         let ctx = CommandContext::open(self)?;
-        let config: Config = ctx.repository().into();
+        let config: Config = ctx.repo().into();
         config.get_local(key)
     }
 
     fn set_local_config(&self, key: &str, value: &str) -> Result<()> {
         let ctx = CommandContext::open(self)?;
-        let config: Config = ctx.repository().into();
+        let config: Config = ctx.repo().into();
         config.set_local(key, value)
     }
 
     fn check_signing_settings(&self) -> Result<bool> {
         let ctx = CommandContext::open(self)?;
-        let signed = ctx.repository().sign_buffer(b"test");
+        let signed = ctx.repo().sign_buffer(b"test");
         match signed {
             Ok(_) => Ok(true),
             Err(e) => Err(e),
@@ -147,7 +147,7 @@ impl RepoCommands for Project {
 
     fn remotes(&self) -> anyhow::Result<Vec<GitRemote>> {
         let ctx = CommandContext::open(self)?;
-        let repo = ctx.repository();
+        let repo = ctx.repo();
         let remotes = repo
             .remotes_as_string()?
             .iter()
@@ -161,7 +161,7 @@ impl RepoCommands for Project {
 
     fn add_remote(&self, name: &str, url: &str) -> Result<()> {
         let ctx = CommandContext::open(self)?;
-        let repo = ctx.repository();
+        let repo = ctx.repo();
 
         // Bail if remote with given name already exists.
         if repo.find_remote(name).is_ok() {
@@ -188,7 +188,7 @@ impl RepoCommands for Project {
         probably_relative_path: &Path,
     ) -> Result<FileInfo> {
         let ctx = CommandContext::open(self)?;
-        let repo = ctx.repository();
+        let repo = ctx.repo();
 
         if let Some(treeish) = treeish {
             if !probably_relative_path.is_relative() {

--- a/crates/gitbutler-repo/src/credentials.rs
+++ b/crates/gitbutler-repo/src/credentials.rs
@@ -79,7 +79,7 @@ pub fn help<'a>(
     ctx: &'a CommandContext,
     remote_name: &str,
 ) -> Result<Vec<(git2::Remote<'a>, Vec<Credential>)>, HelpError> {
-    let remote = ctx.repository().find_remote(remote_name)?;
+    let remote = ctx.repo().find_remote(remote_name)?;
     let remote_url = Url::from_str(remote.url().ok_or(HelpError::NoUrlSet)?)
         .context("failed to parse remote url")?;
 
@@ -94,7 +94,7 @@ pub fn help<'a>(
                 Ok(remote)
             } else {
                 let ssh_url = remote_url.as_ssh()?;
-                ctx.repository().remote_anonymous(&ssh_url.to_string())
+                ctx.repo().remote_anonymous(&ssh_url.to_string())
             }?;
 
             Ok(vec![(
@@ -110,7 +110,7 @@ pub fn help<'a>(
                 Ok(remote)
             } else {
                 let url = remote_url.as_https()?;
-                ctx.repository().remote_anonymous(&url.to_string())
+                ctx.repo().remote_anonymous(&url.to_string())
             }?;
             let flow = https_flow(ctx, &remote_url)?
                 .into_iter()
@@ -131,7 +131,7 @@ fn https_flow(ctx: &CommandContext, remote_url: &Url) -> Result<Vec<HttpsCredent
     let mut flow = vec![];
 
     let mut helper = git2::CredentialHelper::new(&remote_url.to_string());
-    let config = ctx.repository().config()?;
+    let config = ctx.repo().config()?;
     helper.config(&config);
     if let Some((username, password)) = helper.execute() {
         flow.push(HttpsCredential::CredentialHelper { username, password });

--- a/crates/gitbutler-repo/src/rebase.rs
+++ b/crates/gitbutler-repo/src/rebase.rs
@@ -27,16 +27,15 @@ pub fn cherry_rebase(
     from_commit_oid: git2::Oid,
 ) -> Result<Option<git2::Oid>> {
     // get a list of the commits to rebase
-    let ids_to_rebase =
-        ctx.repository()
-            .l(from_commit_oid, LogUntil::Commit(to_commit_oid), false)?;
+    let ids_to_rebase = ctx
+        .repo()
+        .l(from_commit_oid, LogUntil::Commit(to_commit_oid), false)?;
 
     if ids_to_rebase.is_empty() {
         return Ok(None);
     }
 
-    let new_head_id =
-        cherry_rebase_group(ctx.repository(), target_commit_oid, &ids_to_rebase, false)?;
+    let new_head_id = cherry_rebase_group(ctx.repo(), target_commit_oid, &ids_to_rebase, false)?;
 
     Ok(Some(new_head_id))
 }

--- a/crates/gitbutler-stack/src/stack_context.rs
+++ b/crates/gitbutler-stack/src/stack_context.rs
@@ -31,6 +31,6 @@ impl CommandContextExt for CommandContext {
         let virtual_branch_state = VirtualBranchesHandle::new(self.project().gb_dir());
         let default_target = virtual_branch_state.get_default_target()?;
 
-        Ok(StackContext::new(self.repository(), default_target))
+        Ok(StackContext::new(self.repo(), default_target))
     }
 }

--- a/crates/gitbutler-stack/tests/mod.rs
+++ b/crates/gitbutler-stack/tests/mod.rs
@@ -66,8 +66,8 @@ fn add_series_top_of_stack() -> Result<()> {
 fn add_series_top_base() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
-    let merge_base = ctx.repository().find_commit(
-        ctx.repository()
+    let merge_base = ctx.repo().find_commit(
+        ctx.repo()
             .merge_base(test_ctx.stack.head(), test_ctx.default_target.sha)?,
     )?;
     let reference = StackBranch {
@@ -817,8 +817,8 @@ fn replace_head_single_with_merge_base() -> Result<()> {
     };
     test_ctx.stack.add_series(&ctx, from_head, None)?;
     // replace with merge base
-    let merge_base = ctx.repository().find_commit(
-        ctx.repository()
+    let merge_base = ctx.repo().find_commit(
+        ctx.repo()
             .merge_base(test_ctx.stack.head(), test_ctx.default_target.sha)?,
     )?;
     let result = test_ctx
@@ -934,7 +934,7 @@ fn replace_non_member_commit_noop_no_error() -> Result<()> {
 fn replace_top_of_stack_single() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
-    let initial_head = ctx.repository().find_commit(test_ctx.stack.head())?;
+    let initial_head = ctx.repo().find_commit(test_ctx.stack.head())?;
 
     let result = test_ctx
         .stack
@@ -1007,7 +1007,7 @@ fn replace_head_multiple() -> Result<()> {
 fn replace_head_top_of_stack_multiple() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
-    let initial_head = ctx.repository().find_commit(test_ctx.stack.head())?;
+    let initial_head = ctx.repo().find_commit(test_ctx.stack.head())?;
     let extra_head = StackBranch {
         name: "extra_head".into(),
         head: CommitOrChangeId::ChangeId(test_ctx.commits[1].change_id().unwrap()),
@@ -1165,12 +1165,12 @@ fn test_ctx(ctx: &CommandContext) -> Result<TestContext> {
     let stack = stacks.iter().find(|b| b.name == "virtual").unwrap();
     let other_stack = stacks.iter().find(|b| b.name != "virtual").unwrap();
     let target = handle.get_default_target()?;
-    let mut branch_commits =
-        ctx.repository()
-            .log(stack.head(), LogUntil::Commit(target.sha), false)?;
+    let mut branch_commits = ctx
+        .repo()
+        .log(stack.head(), LogUntil::Commit(target.sha), false)?;
     branch_commits.reverse();
     let mut other_commits =
-        ctx.repository()
+        ctx.repo()
             .log(other_stack.head(), LogUntil::Commit(target.sha), false)?;
     other_commits.reverse();
     Ok(TestContext {

--- a/crates/gitbutler-sync/src/cloud.rs
+++ b/crates/gitbutler-sync/src/cloud.rs
@@ -109,7 +109,7 @@ fn push_target(
     batch_size: usize,
 ) -> Result<()> {
     let ids = batch_rev_walk(
-        ctx.repository(),
+        ctx.repo(),
         batch_size,
         default_target.sha,
         gb_code_last_commit,
@@ -182,7 +182,7 @@ fn batch_rev_walk(
 
 fn collect_refs(ctx: &CommandContext) -> anyhow::Result<Vec<Refname>> {
     Ok(ctx
-        .repository()
+        .repo()
         .references_glob("refs/*")?
         .flatten()
         .filter_map(|r| {
@@ -315,7 +315,7 @@ fn remote(ctx: &CommandContext, kind: RemoteKind) -> Result<git2::Remote> {
         }
         RemoteKind::Oplog => api_project.git_url.as_str().parse::<Url>(),
     }?;
-    ctx.repository()
+    ctx.repo()
         .remote_anonymous(&url.to_string())
         .map_err(Into::into)
 }

--- a/crates/gitbutler-tauri/src/app.rs
+++ b/crates/gitbutler-tauri/src/app.rs
@@ -38,7 +38,7 @@ impl App {
     pub fn git_remote_branches(&self, project_id: ProjectId) -> Result<Vec<RemoteRefname>> {
         let project = self.projects().get(project_id)?;
         let ctx = CommandContext::open(&project)?;
-        ctx.repository().remote_branches()
+        ctx.repo().remote_branches()
     }
 
     pub fn git_test_push(
@@ -68,7 +68,7 @@ impl App {
         let project = self.projects().get(project_id)?;
         let ctx = CommandContext::open(&project)?;
         let size = ctx
-            .repository()
+            .repo()
             .index()
             .context("failed to get index size")?
             .len();
@@ -78,10 +78,7 @@ impl App {
     pub fn git_head(&self, project_id: ProjectId) -> Result<String> {
         let project = self.projects().get(project_id)?;
         let ctx = CommandContext::open(&project)?;
-        let head = ctx
-            .repository()
-            .head()
-            .context("failed to get repository head")?;
+        let head = ctx.repo().head().context("failed to get repository head")?;
         Ok(head.name().unwrap().to_string())
     }
 

--- a/crates/gitbutler-testsupport/src/lib.rs
+++ b/crates/gitbutler-testsupport/src/lib.rs
@@ -34,7 +34,7 @@ pub mod virtual_branches {
         let vb_state = VirtualBranchesHandle::new(ctx.project().gb_dir());
         let (remote_repo, _tmp) = empty_bare_repository();
         let mut remote = ctx
-            .repository()
+            .repo()
             .remote("origin", remote_repo.path().to_str().unwrap())
             .expect("failed to add remote");
         remote.push(&["refs/heads/master:refs/heads/master"], None)?;

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -195,14 +195,14 @@ impl Handler {
                     // If the user has left gitbutler/workspace, we want to delete the reference.
                     // TODO: why do we want to do this?
                     if in_outside_workspace_mode(&ctx) {
-                        let mut workspace_reference = ctx.repository().find_reference(
+                        let mut workspace_reference = ctx.repo().find_reference(
                             &Refname::from(LocalRefname::new("gitbutler/workspace", None))
                                 .to_string(),
                         )?;
                         workspace_reference.delete()?;
                     }
 
-                    let head_ref = ctx.repository().head().context("failed to get head")?;
+                    let head_ref = ctx.repo().head().context("failed to get head")?;
                     if let Some(head) = head_ref.name() {
                         self.emit_app_event(Change::GitHead {
                             project_id,

--- a/crates/gitbutler-workspace/src/branch_trees.rs
+++ b/crates/gitbutler-workspace/src/branch_trees.rs
@@ -17,7 +17,7 @@ pub fn checkout_branch_trees<'a>(
     ctx: &'a CommandContext,
     _perm: &mut WorktreeWritePermission,
 ) -> Result<git2::Tree<'a>> {
-    let repository = ctx.repository();
+    let repository = ctx.repo();
     let vb_state = VirtualBranchesHandle::new(ctx.project().gb_dir());
     let stacks = vb_state.list_stacks_in_workspace()?;
 


### PR DESCRIPTION
It is clear what repo is and it is less obnoxious