### PR TITLE
fix: use `bash -c` to get interpretation of tilde and env vars in path

### DIFF
--- a/crates/gitbutler-repo/src/repository_ext.rs
+++ b/crates/gitbutler-repo/src/repository_ext.rs
@@ -436,11 +436,18 @@ impl RepositoryExt for git2::Repository {
                         buffer_file_to_sign_path.to_str().unwrap(),
                     ]);
 
-                    let mut gpg_cmd: std::process::Command =
-                        gix::command::prepare(format!("{:?}", cmd))
-                            .with_shell()
-                            .into();
+                    let cmd_str = cmd
+                        .get_args()
+                        .map(|arg| arg.to_str().unwrap_or(""))
+                        .collect::<Vec<&str>>()
+                        .join(" ");
+                    let full_cmd =
+                        format!("{} {}", cmd.get_program().to_str().unwrap_or(""), cmd_str);
 
+                    let mut gpg_cmd: std::process::Command =
+                        gix::command::prepare(full_cmd).with_shell().into();
+
+                    println!("GPG_CMD: {:?}", gpg_cmd);
                     gpg_cmd.stderr(Stdio::piped());
                     gpg_cmd.stdout(Stdio::piped());
                     gpg_cmd.stdin(Stdio::null());
@@ -450,10 +457,16 @@ impl RepositoryExt for git2::Repository {
                 } else {
                     cmd.args([signing_key, buffer_file_to_sign_path_str]);
 
+                    let cmd_str = cmd
+                        .get_args()
+                        .map(|arg| arg.to_str().unwrap_or(""))
+                        .collect::<Vec<&str>>()
+                        .join(" ");
+                    let full_cmd =
+                        format!("{} {}", cmd.get_program().to_str().unwrap_or(""), cmd_str);
+
                     let mut gpg_cmd: std::process::Command =
-                        gix::command::prepare(format!("{:?}", cmd))
-                            .with_shell()
-                            .into();
+                        gix::command::prepare(full_cmd).with_shell().into();
 
                     gpg_cmd.stderr(Stdio::piped());
                     gpg_cmd.stdout(Stdio::piped());

--- a/crates/gitbutler-repo/src/repository_ext.rs
+++ b/crates/gitbutler-repo/src/repository_ext.rs
@@ -408,9 +408,6 @@ impl RepositoryExt for git2::Repository {
                     .ok_or_else(|| anyhow::anyhow!("Failed to convert path to string"))?
                     .to_string();
 
-                #[cfg(windows)]
-                cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
-
                 let output;
                 // support literal ssh key
                 if let (true, signing_key) = is_literal_ssh_key(&signing_key) {
@@ -439,6 +436,9 @@ impl RepositoryExt for git2::Repository {
                     let mut signing_cmd: std::process::Command =
                         gix::command::prepare(cmd_string).with_shell().into();
 
+                    #[cfg(windows)]
+                    signing_cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+
                     signing_cmd.stderr(Stdio::piped());
                     signing_cmd.stdout(Stdio::piped());
                     signing_cmd.stdin(Stdio::null());
@@ -451,6 +451,9 @@ impl RepositoryExt for git2::Repository {
 
                     let mut signing_cmd: std::process::Command =
                         gix::command::prepare(cmd_string).with_shell().into();
+
+                    #[cfg(windows)]
+                    signing_cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
 
                     signing_cmd.stderr(Stdio::piped());
                     signing_cmd.stdout(Stdio::piped());

--- a/crates/gitbutler-repo/src/repository_ext.rs
+++ b/crates/gitbutler-repo/src/repository_ext.rs
@@ -401,7 +401,8 @@ impl RepositoryExt for git2::Repository {
                     gpg_program = "ssh-keygen".to_string();
                 }
 
-                let mut cmd = std::process::Command::new("bash");
+                let shell = std::env::var("SHELL");
+                let mut cmd = std::process::Command::new(shell.unwrap_or("sh".to_string()));
                 cmd.arg("-c");
                 let gpg_cmd = format!("{} -Y sign -n git -f", gpg_program);
 


### PR DESCRIPTION
## ☕️ Reasoning

- Allow users to pass relative paths in signing key path input

## 🧢 Changes

- Use `bash -c ...` to execute our `&gpg_program` command
- Detects the users system default `$SHELL` first, then falls back to `sh` if it cant be found

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->