### PR TITLE
fix: assure the head of edit mode is never a conflicted tree.

### DIFF
--- a/crates/gitbutler-edit-mode/src/commands.rs
+++ b/crates/gitbutler-edit-mode/src/commands.rs
@@ -36,7 +36,7 @@ pub fn enter_edit_mode(
         .context("Failed to prepare snapshot")?;
 
     let edit_mode_metadata =
-        crate::enter_edit_mode(&ctx, &commit, &branch, guard.write_permission())?;
+        crate::enter_edit_mode(&ctx, commit, &branch, guard.write_permission())?;
 
     let _ = project.commit_snapshot(
         snapshot,


### PR DESCRIPTION
Previously, the parent of a commit was unconditionally chosen if the current commit wasn't conflicted. However, the parent can still be conflicted which means it would need a 'fake' commit as well.

https://github.com/user-attachments/assets/4cf73ba0-43c4-4b9c-870c-86684c4f1ed9

### Tasks

* [ ] implement fix
