### PR TITLE
Fix build config zsh incompatibility

### DIFF
--- a/crates/gitbutler-tauri/tauri.conf.json
+++ b/crates/gitbutler-tauri/tauri.conf.json
@@ -3,7 +3,7 @@
 	"identifier": "com.gitbutler.app.dev",
 	"build": {
 		"beforeDevCommand": "pnpm dev:internal-tauri",
-		"beforeBuildCommand": "[ $CI = true ] || pnpm build:desktop -- --mode development",
+		"beforeBuildCommand": "[ \"$CI\" = \"true\" ] || pnpm build:desktop -- --mode development",
 		"frontendDist": "../../apps/desktop/build",
 		"devUrl": "http://localhost:1420"
 	},

--- a/crates/gitbutler-tauri/tauri.conf.nightly.json
+++ b/crates/gitbutler-tauri/tauri.conf.nightly.json
@@ -2,7 +2,7 @@
 	"productName": "GitButler Nightly",
 	"identifier": "com.gitbutler.app.nightly",
 	"build": {
-		"beforeBuildCommand": "[ $CI = true ] || pnpm build:desktop -- --mode nightly && cargo build --release -p gitbutler-git && bash ./crates/gitbutler-tauri/inject-git-binaries.sh"
+		"beforeBuildCommand": "[ \"$CI\" = \"true\" ] || pnpm build:desktop -- --mode nightly && cargo build --release -p gitbutler-git && bash ./crates/gitbutler-tauri/inject-git-binaries.sh"
 	},
 	"bundle": {
 		"active": true,

--- a/crates/gitbutler-tauri/tauri.conf.release.json
+++ b/crates/gitbutler-tauri/tauri.conf.release.json
@@ -2,7 +2,7 @@
 	"productName": "GitButler",
 	"identifier": "com.gitbutler.app",
 	"build": {
-		"beforeBuildCommand": "[ $CI = true ] || pnpm build:desktop -- --mode production && cargo build --release -p gitbutler-git && bash ./crates/gitbutler-tauri/inject-git-binaries.sh"
+		"beforeBuildCommand": "[ \"$CI\" = \"true\" ] || pnpm build:desktop -- --mode production && cargo build --release -p gitbutler-git && bash ./crates/gitbutler-tauri/inject-git-binaries.sh"
 	},
 	"bundle": {
 		"active": true,

--- a/crates/gitbutler-tauri/tauri.conf.test.json
+++ b/crates/gitbutler-tauri/tauri.conf.test.json
@@ -2,6 +2,6 @@
 	"productName": "GitButler Test",
 	"identifier": "com.gitbutler.app.test",
 	"build": {
-		"beforeBuildCommand": "[ $CI = true ] || pnpm build:desktop -- --mode development && cargo build -p gitbutler-git"
+		"beforeBuildCommand": "[ \"$CI\" = \"true\" ] || pnpm build:desktop -- --mode development && cargo build -p gitbutler-git"
 	}
 }


### PR DESCRIPTION
- zsh considers `[ $CI = true ]` a syntax error if CI unset