### PR TITLE
Force default target directory

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [build]
 rustflags = ["--cfg", "tokio_unstable"]
+target-dir = "target" # Needs to be the default directory as this assumption is used by some of the TypeScript files

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -126,7 +126,7 @@ You'll have to re-run this occasionally when our deps change.
 
 ### Run the app
 
-First, run cargo build such that supplementary bins such as `gitbutler-git-askpass` and `gitbutler-git-setsid` are created:
+First, run cargo build such that supplementary bins such as `gitbutler-git-askpass` and `gitbutler-git-setsid` are created (Note the default folder (`target`) will be used for the build):
 
 ```bash
 $ cargo build


### PR DESCRIPTION
## ☕️ Reasoning

The TypeScript code already assumes that the default target directory is being used and if this is not the case the build fails

## 🧢 Changes

Force the target directory to be the default value and add a note to the instructions.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:
