### PR TITLE
fix: calc relative ms for sidebar categories correctly

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -38,6 +38,7 @@
 		"@lezer/common": "^1.2.1",
 		"@lezer/highlight": "^1.2.0",
 		"@octokit/rest": "^20.1.1",
+		"@reduxjs/toolkit": "catalog:redux",
 		"@replit/codemirror-lang-svelte": "^6.0.0",
 		"@sentry/sveltekit": "^8.9.2",
 		"@sveltejs/adapter-static": "catalog:svelte",
@@ -90,10 +91,10 @@
 		"tinykeys": "^2.1.0",
 		"ts-node": "^10.9.2",
 		"vite": "catalog:",
-		"vitest": "^2.0.5",
-		"@reduxjs/toolkit": "catalog:redux"
+		"vitest": "^2.0.5"
 	},
 	"dependencies": {
+		"dayjs": "^1.11.13",
 		"openai": "^4.47.3"
 	}
 }

--- a/apps/desktop/src/lib/branches/branchListing.ts
+++ b/apps/desktop/src/lib/branches/branchListing.ts
@@ -9,6 +9,7 @@ import {
 	type SidebarEntrySubject
 } from '$lib/navigation/types';
 import { debouncedDerive } from '$lib/utils/debounce';
+import { msSinceDaysAgo } from '$lib/utils/time';
 import { persisted, type Persisted } from '@gitbutler/shared/persisted';
 import { Transform, Type, plainToInstance } from 'class-transformer';
 import Fuse from 'fuse.js';
@@ -121,7 +122,6 @@ export class BranchListingService {
 	}
 }
 
-const oneDay = 1000 * 60 * 60 * 24;
 export type GroupedSidebarEntries = Record<
 	'applied' | 'today' | 'yesterday' | 'lastWeek' | 'older',
 	SidebarEntrySubject[]
@@ -283,11 +283,11 @@ export class CombinedBranchListingService {
 
 			if (getEntryWorkspaceStatus(b)) {
 				grouped.applied.push(b);
-			} else if (msSinceLastCommit < oneDay) {
+			} else if (msSinceLastCommit < msSinceDaysAgo(1)) {
 				grouped.today.push(b);
-			} else if (msSinceLastCommit < 2 * oneDay) {
+			} else if (msSinceLastCommit < msSinceDaysAgo(2)) {
 				grouped.yesterday.push(b);
-			} else if (msSinceLastCommit < 7 * oneDay) {
+			} else if (msSinceLastCommit < msSinceDaysAgo(7)) {
 				grouped.lastWeek.push(b);
 			} else {
 				grouped.older.push(b);

--- a/apps/desktop/src/lib/utils/time.ts
+++ b/apps/desktop/src/lib/utils/time.ts
@@ -1,3 +1,5 @@
+import dayjs from 'dayjs';
+
 export function toHumanReadableTime(d: Date) {
 	return d.toLocaleTimeString('en-US', {
 		hour: 'numeric',
@@ -10,4 +12,8 @@ export function toHumanReadableDate(d: Date) {
 		dateStyle: 'short',
 		hour12: false
 	});
+}
+
+export function msSinceDaysAgo(days: number) {
+	return Math.abs(dayjs().subtract(days, 'day').endOf('day').diff(dayjs(), 'millisecond'));
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
 
   apps/desktop:
     dependencies:
+      dayjs:
+        specifier: ^1.11.13
+        version: 1.11.13
       openai:
         specifier: ^4.47.3
         version: 4.47.3


### PR DESCRIPTION
## ☕️ Reasoning

- We weren't calculating the correct offset in ms until 1 day ago, 2 days ago, 7 days ago

Fixes: #5718

## 🧢 Changes

- Make sure to take into account the # of hours we are into today instead of just subtracting 24hrs in ms 
- Install `dayjs` in desktop app. I'm kinda of surprised it wasn't already in there, we're using it in all other packages in our monorepo


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->