### PR TITLE
fix: swallow update on base branch failed for closed pr error

### DIFF
--- a/apps/desktop/src/lib/branch/SeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/SeriesHeader.svelte
@@ -192,6 +192,9 @@
 					await updateStatusAndChecks();
 				})
 				.catch((err) => {
+					if (err.message.includes('Cannot change the base branch of a closed pull request'))
+						return;
+
 					showError('Failed to update PR target base', err.message ? err.message : err);
 					targetBaseError = err;
 				});


### PR DESCRIPTION
## ☕️ Reasoning

- Purposefully swallow "cannot change the base branch of a closed pull request" errors when attmepting to update base.
- Shouldn't happen anyway since we're checking `$pr.state === 'open'` before attempting this, but looks like it can happen anyway.

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->