### PR TITLE
fix: swallow signing error and dont show duplicate error msg

### DIFF
--- a/apps/desktop/src/lib/vbranches/branchController.ts
+++ b/apps/desktop/src/lib/vbranches/branchController.ts
@@ -73,9 +73,9 @@ export class BranchController {
 				showSignError(err);
 			} else {
 				showError('Failed to commit changes', err);
+				throw err;
 			}
 			this.posthog.capture('Commit Failed', err);
-			throw err;
 		}
 	}
 


### PR DESCRIPTION
## ☕️ Reasoning

- We're already showing a special error msg for commit signing failures, no need to throw and re-show error higher up

## 🧢 Changes

### Before

![image](https://github.com/user-attachments/assets/ea9dfa16-a89d-42a9-b9a6-2425ec010e99)


### After

![image](https://github.com/user-attachments/assets/8a1f7153-50d9-4612-bbc7-cc097c11ceb9)


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
