### PR TITLE
fix: move update pr base branch to end of merge event handler

### DIFF
--- a/apps/desktop/src/lib/branch/SeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/SeriesHeader.svelte
@@ -42,11 +42,10 @@
 	interface Props {
 		branch: PatchSeries;
 		isTopBranch: boolean;
-		isBottomBranch: boolean;
 		lastPush: Date | undefined;
 	}
 
-	const { branch, isTopBranch: isTopSeries, isBottomBranch, lastPush }: Props = $props();
+	const { branch, isTopBranch, lastPush }: Props = $props();
 
 	let descriptionVisible = $state(!!branch.description);
 
@@ -281,7 +280,7 @@
 	rightClickTrigger={seriesHeaderEl}
 	headName={branch.name}
 	seriesCount={stack.validSeries?.length ?? 0}
-	{isTopSeries}
+	{isTopBranch}
 	{toggleDescription}
 	description={branch.description ?? ''}
 	onGenerateBranchName={generateBranchName}
@@ -315,7 +314,7 @@
 >
 	<Dropzones type="commit">
 		<PopoverActionsContainer class="branch-actions-menu" stayOpen={contextMenuOpened}>
-			{#if isTopSeries}
+			{#if isTopBranch}
 				<PopoverActionsItem
 					icon="plus-small"
 					tooltip="Add dependent branch"
@@ -347,7 +346,7 @@
 
 		<div class="branch-info">
 			<SeriesHeaderStatusIcon
-				lineTop={isTopSeries ? false : true}
+				lineTop={isTopBranch ? false : true}
 				icon={branchType === 'integrated' ? 'tick-small' : 'branch-small'}
 				iconColor="var(--clr-core-ntrl-100)"
 				color={lineColor}

--- a/apps/desktop/src/lib/branch/SeriesHeaderContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/SeriesHeaderContextMenu.svelte
@@ -21,7 +21,7 @@
 		rightClickTrigger?: HTMLElement;
 		headName: string;
 		seriesCount: number;
-		isTopSeries: boolean;
+		isTopBranch: boolean;
 		hasForgeBranch: boolean;
 		pr?: DetailedPullRequest;
 		branchType: CommitStatus;
@@ -41,7 +41,7 @@
 		contextMenuEl = $bindable(),
 		leftClickTrigger,
 		rightClickTrigger,
-		isTopSeries,
+		isTopBranch,
 		seriesCount,
 		hasForgeBranch,
 		headName,
@@ -102,7 +102,7 @@
 		onMenuToggle?.(isOpen, isLeftClick);
 	}}
 >
-	{#if isOpenedByMouse && isTopSeries}
+	{#if isOpenedByMouse && isTopBranch}
 		<ContextMenuSection>
 			<ContextMenuItem
 				label="Add dependent branch"

--- a/apps/desktop/src/lib/stack/SeriesList.svelte
+++ b/apps/desktop/src/lib/stack/SeriesList.svelte
@@ -71,7 +71,7 @@
 
 	{#if !isError(currentSeries)}
 		<CurrentSeries {currentSeries}>
-			<SeriesHeader branch={currentSeries} {isTopBranch} {isBottomBranch} {lastPush} />
+			<SeriesHeader branch={currentSeries} {isTopBranch} {lastPush} />
 
 			{#if currentSeries.upstreamPatches.length === 0 && currentSeries.patches.length === 0}
 				<div>

--- a/apps/desktop/src/lib/vbranches/virtualBranch.ts
+++ b/apps/desktop/src/lib/vbranches/virtualBranch.ts
@@ -23,6 +23,15 @@ export function allPreviousSeriesHavePrNumber(
 	return false;
 }
 
+export function childBranch(current: PatchSeries, all: PatchSeries[]): PatchSeries | undefined {
+	const index = all.indexOf(current);
+	if (index === -1 || index === 0) {
+		// Either not found or branch is first.
+		return undefined;
+	}
+	return all[index - 1];
+}
+
 export function parentBranch(current: PatchSeries, all: PatchSeries[]): PatchSeries | undefined {
 	const index = all.indexOf(current);
 	if (index === -1 || index === all.length - 1) {


### PR DESCRIPTION
## ☕️ Reasoning

- Update PR base branch in `merge` event handler, instead of `$effect` in `SeriesHeader.svelte`

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->