### PR TITLE
I've found an error that has a message but isn't an instance of error. In case we get more of these types of error, it makes sense to correctly exract their messages

### DIFF
--- a/apps/desktop/src/hooks.client.ts
+++ b/apps/desktop/src/hooks.client.ts
@@ -24,9 +24,23 @@ window.onunhandledrejection = (e: PromiseRejectionEvent) => {
 	logError(e.reason);
 };
 
+interface Errorlike {
+	message: string;
+}
+
+function isErrorlike(target: unknown): target is Errorlike {
+	return (
+		(typeof target === 'object' &&
+			target &&
+			'message' in target &&
+			typeof target.message === 'string') ||
+		false
+	);
+}
+
 function logError(error: unknown) {
 	try {
-		let message = error instanceof Error ? error.message : String(error);
+		let message = error instanceof Error || isErrorlike(error) ? error.message : String(error);
 		const stack = error instanceof Error ? error.stack : undefined;
 
 		const id = captureException(message, {


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #5803 
- <kbd>&nbsp;3&nbsp;</kbd> #5802 
- <kbd>&nbsp;2&nbsp;</kbd> #5801 
- <kbd>&nbsp;1&nbsp;</kbd> #5798 👈 
<!-- GitButler Footer Boundary Bottom -->

