### PR TITLE
style: add default font family to reset.css

### DIFF
--- a/packages/ui/src/styles/core/reset.css
+++ b/packages/ui/src/styles/core/reset.css
@@ -18,6 +18,16 @@
 		padding: 0;
 		margin: 0;
 		line-height: inherit;
+		font-family:
+			Inter,
+			-apple-system,
+			BlinkMacSystemFont,
+			'Segoe UI',
+			Roboto,
+			'Helvetica Neue',
+			Arial,
+			'Noto Sans',
+			sans-serif;
 
 		/* optimise font rendering */
 		-webkit-font-smoothing: antialiased;


### PR DESCRIPTION
Before:
<img width="309" alt="image" src="https://github.com/user-attachments/assets/c2ad8cac-2fc1-4bac-baea-b898cb373c22">


After:
<img width="288" alt="image" src="https://github.com/user-attachments/assets/5edbdd5b-24a4-4857-b459-3b2a6e5e0ee1">

