### PR TITLE
fix the divider line in the `neutral` style dropdown btn

### DIFF
--- a/packages/ui/src/lib/Button.svelte
+++ b/packages/ui/src/lib/Button.svelte
@@ -451,6 +451,7 @@
 			border-bottom-right-radius: 0;
 			border-right: none;
 
+			&.neutral,
 			&.pop,
 			&.success,
 			&.error,

--- a/packages/ui/src/stories/button/Button.stories.svelte
+++ b/packages/ui/src/stories/button/Button.stories.svelte
@@ -44,7 +44,7 @@
 </script>
 
 <Story
-	name="Single"
+	name="Playground"
 	play={async ({ args, canvasElement }) => {
 		const canvas = within(canvasElement);
 		const submitButton = canvas.getByRole('button');

--- a/packages/ui/src/stories/button/Dropdown.stories.svelte
+++ b/packages/ui/src/stories/button/Dropdown.stories.svelte
@@ -1,0 +1,60 @@
+<script module lang="ts">
+	import Button from '$lib/Button.svelte';
+	import {
+		type Args,
+		defineMeta,
+		setTemplate,
+		type StoryContext
+	} from '@storybook/addon-svelte-csf';
+
+	const { Story } = defineMeta({
+		title: 'Inputs / Button',
+		args: {
+			style: 'neutral',
+			kind: 'solid',
+			outline: false
+		},
+		argTypes: {
+			style: {
+				options: ['neutral', 'ghost', 'pop', 'success', 'error', 'warning', 'purple'],
+				control: {
+					type: 'select'
+				}
+			},
+			kind: {
+				options: ['solid', 'soft'],
+				control: {
+					type: 'select'
+				}
+			}
+		}
+	});
+</script>
+
+<script lang="ts">
+	setTemplate(template);
+</script>
+
+{#snippet template({ ...args }: Args<typeof Story>, _context: StoryContext<typeof Story>)}
+	<div class="drodown-btn">
+		<Button style={args.style} kind={args.kind} outline={args.outline} dropdownChild
+			>Dropdown</Button
+		>
+		<Button
+			style={args.style}
+			kind={args.kind}
+			outline={args.outline}
+			icon="chevron-down-small"
+			dropdownChild
+		/>
+	</div>
+{/snippet}
+
+<Story name="Dropdown" />
+
+<style>
+	.drodown-btn {
+		display: flex;
+		max-width: 200px;
+	}
+</style>


### PR DESCRIPTION
Before:
<img width="234" alt="image" src="https://github.com/user-attachments/assets/e00d3144-1c56-4a23-9aeb-ba2644d00906" />

After:
<img width="230" alt="image" src="https://github.com/user-attachments/assets/f84a2d2c-ed9c-4f91-9bf4-79775e9a25fb" />


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
