### PR TITLE
feat: add non-archived branch getter

### DIFF
--- a/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
@@ -37,13 +37,15 @@
 	let isDeleting = $state(false);
 
 	const branch = $derived($branchStore);
-	const commits = $derived(branch.validSeries.flatMap((s) => s.patches));
+	const commits = $derived(branch.validBranches.flatMap((s) => s.patches));
 
 	$effect(() => {
 		allowRebasing = branch.allowRebasing;
 	});
 
-	const allPrIds = $derived(branch.validSeries.map((series) => series.prNumber).filter(isDefined));
+	const allPrIds = $derived(
+		branch.validBranches.map((series) => series.prNumber).filter(isDefined)
+	);
 
 	async function toggleAllowRebasing() {
 		branchController.updateBranchAllowRebasing(branch.id, !allowRebasing);
@@ -123,13 +125,15 @@
 	</ContextMenuSection>
 	{#if $user && $user.role?.includes('admin')}
 		<!-- TODO: Remove after iterating on the pull request footer. -->
-		<ContextMenuSection title="Admin only">
+		<ContextMenuSection>
 			<ContextMenuItem
 				label="Update PR footers"
 				disabled={allPrIds.length === 0}
 				onclick={() => {
 					if ($prService && branch) {
-						const allPrIds = branch.validSeries.map((series) => series.prNumber).filter(isDefined);
+						const allPrIds = branch.validBranches
+							.map((series) => series.prNumber)
+							.filter(isDefined);
 						updatePrDescriptionTables($prService, allPrIds);
 					}
 					contextMenuEl?.close();

--- a/apps/desktop/src/lib/branch/SeriesHeader.svelte
+++ b/apps/desktop/src/lib/branch/SeriesHeader.svelte
@@ -58,15 +58,10 @@
 	const parent = $derived(
 		parentBranch(
 			branch,
-			stack.validSeries.filter((b) => b.archived)
+			stack.validBranches.filter((b) => b.archived)
 		)
 	);
-	const child = $derived(
-		childBranch(
-			branch,
-			stack.validSeries.filter((b) => !b.archived)
-		)
-	);
+	const child = $derived(childBranch(branch, stack.validNonArchivedBranches));
 
 	const aiGenEnabled = projectAiGenEnabled(project.id);
 	const branchController = getContext(BranchController);
@@ -77,7 +72,7 @@
 	const upstreamName = $derived(branch.upstreamReference ? branch.name : undefined);
 	const forgeBranch = $derived(upstreamName ? $forge?.branch(upstreamName) : undefined);
 	const previousSeriesHavePrNumber = $derived(
-		allPreviousSeriesHavePrNumber(branch.name, stack.validSeries)
+		allPreviousSeriesHavePrNumber(branch.name, stack.validBranches)
 	);
 
 	let stackingAddSeriesModal = $state<ReturnType<typeof AddSeriesModal>>();
@@ -279,7 +274,7 @@
 	leftClickTrigger={kebabContextMenuTrigger}
 	rightClickTrigger={seriesHeaderEl}
 	headName={branch.name}
-	seriesCount={stack.validSeries?.length ?? 0}
+	seriesCount={stack.validBranches?.length ?? 0}
 	{isTopBranch}
 	{toggleDescription}
 	description={branch.description ?? ''}

--- a/apps/desktop/src/lib/branch/SeriesHeaderContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/SeriesHeaderContextMenu.svelte
@@ -82,7 +82,7 @@
 	const branch = $derived($branchStore);
 
 	export function showSeriesRenameModal(seriesName: string) {
-		renameSeriesModal.show(branch.validSeries.find((s) => s.name === seriesName));
+		renameSeriesModal.show(branch.validBranches.find((s) => s.name === seriesName));
 	}
 
 	let isOpenedByMouse = $state(false);

--- a/apps/desktop/src/lib/dragging/stackingReorderDropzoneManager.ts
+++ b/apps/desktop/src/lib/dragging/stackingReorderDropzoneManager.ts
@@ -51,7 +51,7 @@ export class StackingReorderDropzoneManager {
 		private branch: VirtualBranch
 	) {
 		const seriesMap = new Map();
-		this.branch.validSeries.forEach((series) => {
+		this.branch.validBranches.forEach((series) => {
 			seriesMap.set(series.name, series);
 		});
 		this.series = seriesMap;
@@ -67,7 +67,7 @@ export class StackingReorderDropzoneManager {
 			this.branch.id,
 			this.branchController,
 			currentSeries,
-			this.branch.validSeries,
+			this.branch.validBranches,
 			'top'
 		);
 	}
@@ -82,7 +82,7 @@ export class StackingReorderDropzoneManager {
 			this.branch.id,
 			this.branchController,
 			currentSeries,
-			this.branch.validSeries,
+			this.branch.validBranches,
 			commitId
 		);
 	}

--- a/apps/desktop/src/lib/pr/PrDetailsModal.svelte
+++ b/apps/desktop/src/lib/pr/PrDetailsModal.svelte
@@ -145,7 +145,7 @@
 		}
 
 		// All ids that existed prior to creating a new one (including archived).
-		const prNumbers = branch.validSeries.map((series) => series.prNumber);
+		const prNumbers = branch.validBranches.map((series) => series.prNumber);
 
 		isLoading = true;
 		try {
@@ -181,7 +181,7 @@
 			}
 
 			// Find the index of the current branch so we know where we want to point the pr.
-			const branches = branch.validSeries;
+			const branches = branch.validBranches;
 			const currentIndex = branches.findIndex((b) => b.name === currentSeries.name);
 			if (currentIndex === -1) {
 				throw new Error('Branch index not found.');

--- a/apps/desktop/src/lib/stack/CollapsedLane.svelte
+++ b/apps/desktop/src/lib/stack/CollapsedLane.svelte
@@ -15,7 +15,7 @@
 
 	const branchStore = getContextStore(VirtualBranch);
 	const branch = $derived($branchStore);
-	const nonArchivedSeries = $derived(branch.validSeries.filter((s) => !s.archived));
+	const nonArchivedSeries = $derived(branch.validNonArchivedBranches);
 
 	function expandLane() {
 		$isLaneCollapsed = false;

--- a/apps/desktop/src/lib/stack/SeriesList.svelte
+++ b/apps/desktop/src/lib/stack/SeriesList.svelte
@@ -35,7 +35,7 @@
 	);
 
 	// All non-errored non-archived series for consumption elsewhere
-	const nonArchivedValidSeries = $derived(branch.validSeries.filter((s) => !s.archived));
+	const validNonArchivedBranches = $derived(branch.validNonArchivedBranches);
 
 	const stackingReorderDropzoneManagerFactory = getContext(StackingReorderDropzoneManagerFactory);
 	const stackingReorderDropzoneManager = $derived(
@@ -77,7 +77,7 @@
 				<div>
 					<Dropzone
 						{accepts}
-						ondrop={(data) => onDrop(data, nonArchivedValidSeries, currentSeries)}
+						ondrop={(data) => onDrop(data, validNonArchivedBranches, currentSeries)}
 					>
 						{#snippet overlay({ hovered, activated })}
 							<CardOverlay {hovered} {activated} label="Move here" />

--- a/apps/desktop/src/lib/stack/Stack.svelte
+++ b/apps/desktop/src/lib/stack/Stack.svelte
@@ -58,7 +58,7 @@
 	let rsViewport = $state<HTMLElement>();
 
 	const branchHasFiles = $derived(branch.files !== undefined && branch.files.length > 0);
-	const branchHasNoCommits = $derived(branch.validSeries.flatMap((s) => s.patches).length === 0);
+	const branchHasNoCommits = $derived(branch.validBranches.flatMap((s) => s.patches).length === 0);
 
 	$effect(() => {
 		if ($commitBoxOpen && branch.files.length === 0) {
@@ -79,7 +79,7 @@
 		const upstreamPatches: DetailedCommit[] = [];
 		const branchPatches: DetailedCommit[] = [];
 
-		branch.validSeries.map((series) => {
+		branch.validBranches.map((series) => {
 			upstreamPatches.push(...series.upstreamPatches);
 			branchPatches.push(...series.patches);
 			hasConflicts = branchPatches.some((patch) => patch.conflicted);
@@ -111,7 +111,7 @@
 	}
 
 	async function checkMergeable() {
-		const nonArchivedBranches = branch.validSeries.filter((s) => !s.archived);
+		const nonArchivedBranches = branch.validNonArchivedBranches;
 		if (nonArchivedBranches.length <= 1) return false;
 
 		const seriesMergeResponse = await Promise.allSettled(
@@ -136,7 +136,7 @@
 	// started last and therefore complete last.
 	const forge = getForge();
 	const checksMonitor = $derived(
-		$forge?.checksMonitor(branch.validSeries.filter((s) => !s.archived)[0]?.name ?? '')
+		$forge?.checksMonitor(branch.validNonArchivedBranches[0]?.name ?? '')
 	);
 	const checks = $derived(checksMonitor?.status);
 
@@ -149,7 +149,7 @@
 	async function mergeAll(method: MergeMethod) {
 		isMergingSeries = true;
 		try {
-			const topBranch = branch.validSeries[0];
+			const topBranch = branch.validBranches[0];
 
 			if (topBranch?.prNumber && $prService) {
 				const targetBase = $baseBranch.branchName.replace(`${$baseBranch.remoteName}/`, '');
@@ -264,7 +264,7 @@
 									>
 										{branch.requiresForce
 											? 'Force push'
-											: branch.validSeries.length > 1
+											: branch.validBranches.length > 1
 												? 'Push All'
 												: 'Push'}
 									</Button>

--- a/apps/desktop/src/lib/stack/UncommittedChanges.svelte
+++ b/apps/desktop/src/lib/stack/UncommittedChanges.svelte
@@ -27,7 +27,7 @@
 		<BranchFiles
 			isUnapplied={false}
 			files={branch.files}
-			branches={branch.validSeries}
+			branches={branch.validBranches}
 			showCheckboxes={$commitBoxOpen}
 			allowMultiple
 			commitDialogExpanded={commitBoxOpen}
@@ -53,7 +53,7 @@
 		bind:this={commitDialog}
 		projectId={project.id}
 		expanded={commitBoxOpen}
-		hasSectionsAfter={branch.validSeries.flatMap((s) => s.patches).length > 0}
+		hasSectionsAfter={branch.validBranches.flatMap((s) => s.patches).length > 0}
 	/>
 </div>
 

--- a/apps/desktop/src/lib/vbranches/types.ts
+++ b/apps/desktop/src/lib/vbranches/types.ts
@@ -129,6 +129,10 @@ export function isPatchSeries(item: PatchSeries | Error): item is PatchSeries {
 	return item instanceof PatchSeries;
 }
 
+export function isNonArchivedPatchSeries(item: PatchSeries | Error): item is PatchSeries {
+	return item instanceof PatchSeries && !item.archived;
+}
+
 export class VirtualBranch {
 	id!: string;
 	name!: string;
@@ -167,13 +171,17 @@ export class VirtualBranch {
 
 	/**
 	 * @desc Used in the stacking context where VirtualBranch === Stack
-	 * @warning You probably want 'validSeries' instead
+	 * @warning You probably want 'validBranches' instead
 	 */
 	@Transform(({ value }) => transformResultToType(PatchSeries, value))
 	series!: (PatchSeries | Error)[];
 
-	get validSeries(): PatchSeries[] {
+	get validBranches(): PatchSeries[] {
 		return this.series.filter(isPatchSeries);
+	}
+
+	get validNonArchivedBranches(): PatchSeries[] {
+		return this.series.filter(isNonArchivedPatchSeries);
 	}
 
 	get displayName() {

--- a/apps/desktop/src/lib/vbranches/virtualBranch.ts
+++ b/apps/desktop/src/lib/vbranches/virtualBranch.ts
@@ -9,9 +9,9 @@ import type { ModeService } from '$lib/modes/service';
 
 export function allPreviousSeriesHavePrNumber(
 	seriesName: string,
-	validSeries: PatchSeries[]
+	validBranches: PatchSeries[]
 ): boolean {
-	const unarchivedSeries = validSeries.filter((series) => !series.archived);
+	const unarchivedSeries = validBranches.filter((series) => !series.archived);
 	for (let i = unarchivedSeries.length - 1; i >= 0; i--) {
 		const series = unarchivedSeries[i]!;
 		if (series.name === seriesName) return true;
@@ -92,8 +92,8 @@ export class VirtualBranchService {
 		branches.forEach(async (branch) => {
 			const upstreamName = branch.upstream?.name;
 			if (upstreamName) {
-				const upstreamCommits = branch.validSeries.flatMap((series) => series.upstreamPatches);
-				const commits = branch.validSeries.flatMap((series) => series.patches);
+				const upstreamCommits = branch.validBranches.flatMap((series) => series.upstreamPatches);
+				const commits = branch.validBranches.flatMap((series) => series.patches);
 				commits.forEach((commit) => {
 					const upstreamMatch = upstreamCommits.find(
 						(upstreamCommit) => commit.remoteCommitId === upstreamCommit.id


### PR DESCRIPTION
## ☕️ Reasoning

- We were using `validSeries.filter((s) => !s.archived)` all over the place, therefore added `validNonArchivedBranch` getter in its place.

## 🧢 Changes

- Add additoinal getter, next to `validSeries` for `validNonArchivedSeries`
- Renamed `validSeries*` to `validBranches*`

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
