### PR TITLE
chore: test building in ubuntu 22.04 and latest libwebkit2gtk-4.1=2.46.4

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -86,7 +86,7 @@ jobs:
         platform:
           - macos-13 # [macOs, x64]
           - macos-latest # [macOs, ARM64]
-          - ubuntu-24.04 # [linux, x64]
+          - ubuntu-22.04 # [linux, x64]
           - windows-latest # [windows, x64]
 
     runs-on: ${{ matrix.platform }}
@@ -164,15 +164,17 @@ jobs:
             libssl-dev \
             libgtk-3-dev \
             libappindicator3-dev \
+            libwebkit2gtk-4.1-0 \
+            libwebkit2gtk-4.1-dev \
             librsvg2-dev;
 
-          sudo apt install -y \
-            libwebkit2gtk-4.1-0=2.44.0-2 \
-            libwebkit2gtk-4.1-dev=2.44.0-2 \
-            libjavascriptcoregtk-4.1-0=2.44.0-2 \
-            libjavascriptcoregtk-4.1-dev=2.44.0-2 \
-            gir1.2-javascriptcoregtk-4.1=2.44.0-2 \
-            gir1.2-webkit2-4.1=2.44.0-2;
+          # sudo apt install -y \
+          #   libwebkit2gtk-4.1-0=2.44.0-2 \
+          #   libwebkit2gtk-4.1-dev=2.44.0-2 \
+          #   libjavascriptcoregtk-4.1-0=2.44.0-2 \
+          #   libjavascriptcoregtk-4.1-dev=2.44.0-2 \
+          #   gir1.2-javascriptcoregtk-4.1=2.44.0-2 \
+          #   gir1.2-webkit2-4.1=2.44.0-2;
 
       - uses: actions/download-artifact@v4
         with:
@@ -262,7 +264,7 @@ jobs:
         platform:
           - macos-13 # [macOs, x64]
           - macos-latest # [macOs, ARM64]
-          - ubuntu-24.04 # [linux, x64]
+          - ubuntu-22.04 # [linux, x64]
           - windows-latest # [windows, x64]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## ☕️ Reasoning

- Ubuntu put `libwebkit2gtk-4.1@2.46.4` on their repos recently, so we're testing if this can be built using Ubuntu 22.04 again without issue :crossed_fingers: 

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
