### PR TITLE
fix: Dependencies should ignore all line-deletion only hunks

### DIFF
--- a/crates/gitbutler-branch-actions/tests/dependencies.rs
+++ b/crates/gitbutler-branch-actions/tests/dependencies.rs
@@ -625,18 +625,40 @@ fn complex_file_manipulation_multiple_hunks_with_uncommitted_changes() -> Result
     let file_hunk_3_hash = Hunk::hash_diff(&file_hunk_3.diff_lines);
 
     let hunk_1_locks = dependencies.diffs.get(&file_hunk_1_hash).unwrap();
-    assert_eq!(hunk_1_locks.len(), 1);
-    assert_hunk_lock_matches_by_message(hunk_1_locks[0], "create file", &ctx, "hunk 1");
+    assert_eq!(hunk_1_locks.len(), 2);
+    assert_hunk_lock_matches_by_message(
+        hunk_1_locks[0],
+        "create file",
+        &ctx,
+        "Hunk depends on the commit that created the file",
+    );
+    assert_hunk_lock_matches_by_message(
+        hunk_1_locks[1],
+        "insert 1 line at the top and bottom, remove lines 3 and 4 and update line 7",
+        &ctx,
+        "Hunk depends on the commit that deleted lines 3 and 4",
+    );
 
     let hunk_2_locks = dependencies.diffs.get(&file_hunk_2_hash).unwrap();
-    assert_eq!(hunk_2_locks.len(), 2);
+    assert_eq!(hunk_2_locks.len(), 3);
     assert_hunk_lock_matches_by_message(
         hunk_2_locks[0],
         "insert 1 line at the top and bottom, remove lines 3 and 4 and update line 7",
         &ctx,
-        "hunk 2",
+        "Hunk depends on the commit that updated the line 7",
     );
-    assert_hunk_lock_matches_by_message(hunk_2_locks[1], "modify lines 4 and 8", &ctx, "hunk 2");
+    assert_hunk_lock_matches_by_message(
+        hunk_2_locks[1],
+        "create file",
+        &ctx,
+        "Hunk depends on the commit that created the file",
+    );
+    assert_hunk_lock_matches_by_message(
+        hunk_2_locks[2],
+        "modify lines 4 and 8",
+        &ctx,
+        "Hunk depends on the commit updated line 8",
+    );
 
     let hunk_3_locks = dependencies.diffs.get(&file_hunk_3_hash).unwrap();
     assert_eq!(hunk_3_locks.len(), 1);

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/locking.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/locking.rs
@@ -129,9 +129,6 @@ async fn hunk_locking_with_deleted_lines_only() -> anyhow::Result<()> {
     )
     .unwrap();
 
-    // These changes now intersect the changes in the default commit and not with the ones in the
-    // first branch.
-    // They should be assigned to the default branch (second branch).
     lines[1] = "modified line 2".to_string();
     repository.write_file("file.txt", &lines);
 
@@ -140,7 +137,7 @@ async fn hunk_locking_with_deleted_lines_only() -> anyhow::Result<()> {
     assert_eq!(branches.len(), 2);
     let first_branch = branches.iter().find(|b| b.id != second_branch_id).unwrap();
     let second_branch = branches.iter().find(|b| b.id == second_branch_id).unwrap();
-    assert_eq!(first_branch.files.len(), 0);
-    assert_eq!(second_branch.files.len(), 1);
+    assert_eq!(first_branch.files.len(), 1);
+    assert_eq!(second_branch.files.len(), 0);
     Ok(())
 }

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/locking.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/locking.rs
@@ -129,6 +129,9 @@ async fn hunk_locking_with_deleted_lines_only() -> anyhow::Result<()> {
     )
     .unwrap();
 
+    // These changes now intersect the changes in the default commit and not with the ones in the
+    // first branch.
+    // They should be assigned to the default branch (second branch).
     lines[1] = "modified line 2".to_string();
     repository.write_file("file.txt", &lines);
 
@@ -137,7 +140,7 @@ async fn hunk_locking_with_deleted_lines_only() -> anyhow::Result<()> {
     assert_eq!(branches.len(), 2);
     let first_branch = branches.iter().find(|b| b.id != second_branch_id).unwrap();
     let second_branch = branches.iter().find(|b| b.id == second_branch_id).unwrap();
-    assert_eq!(first_branch.files.len(), 1);
-    assert_eq!(second_branch.files.len(), 0);
+    assert_eq!(first_branch.files.len(), 0);
+    assert_eq!(second_branch.files.len(), 1);
     Ok(())
 }

--- a/crates/gitbutler-hunk-dependency/src/hunk.rs
+++ b/crates/gitbutler-hunk-dependency/src/hunk.rs
@@ -22,12 +22,6 @@ impl HunkRange {
             return Ok(true);
         }
 
-        if self.lines == 0 {
-            // Special case when point is inside a range, happens
-            // when a change contains only deletions.
-            return Ok(self.start >= start && self.start < start + lines);
-        }
-
         if start == 0 && lines == 0 {
             // Special case when adding lines at the top of the file.
             return Ok(false);
@@ -49,6 +43,21 @@ impl HunkRange {
             1,
             "While calculating the last line of the incoming hunk",
         )?;
+
+        if self.lines == 0 {
+            // Special case when point is inside a range, happens
+            // when a change contains only deletions.
+            if self.line_shift < 0 {
+                let lines_removed = 0 - self.line_shift;
+                let this_start = i32::try_from(self.start)?;
+                let last_line = (this_start + lines_removed) - 1;
+                let incoming_start = i32::try_from(start)?;
+
+                return Ok(self.start <= incoming_last_line && last_line >= incoming_start);
+            }
+
+            return Ok(self.start >= start && self.start < start + lines);
+        }
 
         Ok(self.start <= incoming_last_line && last_line >= start)
     }
@@ -131,7 +140,7 @@ mod test {
             commit_id: git2::Oid::from_str("a").unwrap(),
             start: 1,
             lines: 10,
-            line_shift: 0,
+            line_shift: 10,
         };
 
         assert!(range.intersects(1, 1).unwrap());

--- a/crates/gitbutler-hunk-dependency/src/lib.rs
+++ b/crates/gitbutler-hunk-dependency/src/lib.rs
@@ -4,6 +4,7 @@ pub mod input;
 pub mod locks;
 pub(crate) mod path;
 pub(crate) mod stack;
+pub mod utils;
 pub(crate) mod workspace;
 
 pub use {

--- a/crates/gitbutler-hunk-dependency/src/path.rs
+++ b/crates/gitbutler-hunk-dependency/src/path.rs
@@ -274,6 +274,10 @@ impl PathRanges {
         incoming_hunks: Vec<InputDiff>,
     ) -> anyhow::Result<()> {
         for hunk in incoming_hunks {
+            if hunk.new_lines == 0 {
+                continue;
+            }
+
             self.hunk_ranges.push(HunkRange {
                 change_type: hunk.change_type,
                 stack_id,

--- a/crates/gitbutler-hunk-dependency/src/utils.rs
+++ b/crates/gitbutler-hunk-dependency/src/utils.rs
@@ -1,0 +1,5 @@
+/// Subtract two unsigned integers and return an error if the result is negative.
+pub fn panicless_subtraction(a: u32, b: u32, context: &str) -> anyhow::Result<u32> {
+    a.checked_sub(b)
+        .ok_or_else(|| anyhow::anyhow!("Subtraction overflow: {} - {}. {}", a, b, context))
+}

--- a/crates/gitbutler-hunk-dependency/src/workspace.rs
+++ b/crates/gitbutler-hunk-dependency/src/workspace.rs
@@ -468,18 +468,13 @@ mod tests {
                     commit_id: commit1_id,
                     files: vec![InputFile {
                         path: path.to_owned(),
-                        diffs: vec![parse_diff_from_string(
-                            "@@ -1,6 +1,7 @@
-1
-2
-3
-+4
-5
-6
-7
-",
-                            gitbutler_diff::ChangeType::Modified,
-                        )?],
+                        diffs: vec![InputDiff {
+                            change_type: gitbutler_diff::ChangeType::Modified,
+                            old_start: 2,
+                            old_lines: 1,
+                            new_start: 2,
+                            new_lines: 1,
+                        }],
                     }],
                 }],
             },
@@ -491,24 +486,28 @@ mod tests {
                         path: path.to_owned(),
                         diffs: vec![
                             parse_diff_from_string(
-                                "@@ -1,5 +1,3 @@
--1
--2
-3
-5
+                                "@@ -6,8 +6,6 @@
+
 6
+7
+8
+-9
+-10
+11
+12
+13
 ",
                                 gitbutler_diff::ChangeType::Modified,
                             )?,
                             parse_diff_from_string(
-                                "@@ -10,6 +8,7 @@
-10
-11
-12
-+13
+                                "@@ -14,6 +12,7 @@
 14
 15
 16
++17
+18
+19
+20
 ",
                                 gitbutler_diff::ChangeType::Modified,
                             )?,
@@ -518,15 +517,20 @@ mod tests {
             },
         ])?;
 
-        let dependencies_1 = workspace_ranges.intersection(&path, 4, 1).unwrap();
+        let dependencies_1 = workspace_ranges.intersection(&path, 2, 1).unwrap();
         assert_eq!(dependencies_1.len(), 1);
         assert_eq!(dependencies_1[0].commit_id, commit1_id);
         assert_eq!(dependencies_1[0].stack_id, stack1_id);
 
-        let dependencies_2 = workspace_ranges.intersection(&path, 12, 1).unwrap();
+        let dependencies_2 = workspace_ranges.intersection(&path, 10, 1).unwrap();
         assert_eq!(dependencies_2.len(), 1);
         assert_eq!(dependencies_2[0].commit_id, commit2_id);
         assert_eq!(dependencies_2[0].stack_id, stack2_id);
+
+        let dependencies_3 = workspace_ranges.intersection(&path, 15, 1).unwrap();
+        assert_eq!(dependencies_3.len(), 1);
+        assert_eq!(dependencies_3[0].commit_id, commit2_id);
+        assert_eq!(dependencies_3[0].stack_id, stack2_id);
 
         Ok(())
     }

--- a/crates/gitbutler-hunk-dependency/src/workspace.rs
+++ b/crates/gitbutler-hunk-dependency/src/workspace.rs
@@ -518,7 +518,7 @@ mod tests {
             },
         ])?;
 
-        let dependencies_1 = workspace_ranges.intersection(&path, 2, 1).unwrap();
+        let dependencies_1 = workspace_ranges.intersection(&path, 4, 1).unwrap();
         assert_eq!(dependencies_1.len(), 1);
         assert_eq!(dependencies_1[0].commit_id, commit1_id);
         assert_eq!(dependencies_1[0].stack_id, stack1_id);

--- a/crates/gitbutler-hunk-dependency/src/workspace.rs
+++ b/crates/gitbutler-hunk-dependency/src/workspace.rs
@@ -92,7 +92,7 @@ impl WorkspaceRanges {
         if let Some(hunk_range) = self.paths.get(path) {
             let intersection = hunk_range
                 .iter()
-                .filter(|hunk| hunk.intersects(start, lines))
+                .filter(|hunk| hunk.intersects(start, lines).unwrap_or(false))
                 .collect_vec();
             if !intersection.is_empty() {
                 return Some(intersection);

--- a/crates/gitbutler-hunk-dependency/tests/path.rs
+++ b/crates/gitbutler-hunk-dependency/tests/path.rs
@@ -29,19 +29,14 @@ fn stack_simple() -> anyhow::Result<()> {
 
 #[test]
 fn stack_simple_update() -> anyhow::Result<()> {
-    let diff = parse_diff_from_string(
-        "@@ -1,6 +1,6 @@
-1
-2
-3
--4
-+a
-5
-6
-7
-",
-        gitbutler_diff::ChangeType::Modified,
-    )?;
+    let diff = InputDiff {
+        old_start: 4,
+        old_lines: 1,
+        new_start: 4,
+        new_lines: 1,
+        change_type: gitbutler_diff::ChangeType::Modified,
+    };
+
     let stack_ranges = &mut PathRanges::default();
     let stack_id = StackId::generate();
     let commit_id = git2::Oid::from_str("a")?;
@@ -841,11 +836,11 @@ a
 ",
         gitbutler_diff::ChangeType::Modified,
     )?;
+
     stack_ranges.add(stack_id, commit1_id, vec![diff_1])?;
 
     let result = stack_ranges.intersection(3, 2);
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].commit_id, commit1_id);
+    assert_eq!(result.len(), 0);
 
     Ok(())
 }

--- a/crates/gitbutler-hunk-dependency/tests/path.rs
+++ b/crates/gitbutler-hunk-dependency/tests/path.rs
@@ -701,6 +701,14 @@ a
             HunkRange {
                 change_type: gitbutler_diff::ChangeType::Modified,
                 stack_id,
+                commit_id: commit6_id,
+                start: 1,
+                lines: 0,
+                line_shift: -1
+            },
+            HunkRange {
+                change_type: gitbutler_diff::ChangeType::Modified,
+                stack_id,
                 commit_id: commit5_id,
                 start: 1,
                 lines: 3,
@@ -718,8 +726,9 @@ a
     );
 
     let result = stack_ranges.intersection(1, 1);
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].commit_id, commit5_id);
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0].commit_id, commit6_id);
+    assert_eq!(result[1].commit_id, commit5_id);
 
     let result = stack_ranges.intersection(2, 1);
     assert_eq!(result.len(), 1);
@@ -840,7 +849,8 @@ a
     stack_ranges.add(stack_id, commit1_id, vec![diff_1])?;
 
     let result = stack_ranges.intersection(3, 2);
-    assert_eq!(result.len(), 0);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].commit_id, commit1_id);
 
     Ok(())
 }
@@ -955,14 +965,32 @@ fn create_file_update_and_trim() -> anyhow::Result<()> {
     let hunks = &stack_ranges.hunk_ranges;
     assert_eq!(
         hunks,
-        &vec![HunkRange {
-            change_type: gitbutler_diff::ChangeType::Added,
-            stack_id,
-            commit_id: commit1_id,
-            start: 1,
-            lines: 6,
-            line_shift: 9
-        }]
+        &vec![
+            HunkRange {
+                change_type: gitbutler_diff::ChangeType::Added,
+                stack_id,
+                commit_id: commit1_id,
+                start: 1,
+                lines: 6,
+                line_shift: 9
+            },
+            HunkRange {
+                change_type: gitbutler_diff::ChangeType::Modified,
+                stack_id,
+                commit_id: commit2_id,
+                start: 7,
+                lines: 0,
+                line_shift: -3
+            },
+            HunkRange {
+                change_type: gitbutler_diff::ChangeType::Added,
+                stack_id,
+                commit_id: commit1_id,
+                start: 7,
+                lines: 0,
+                line_shift: 9
+            }
+        ]
     );
 
     let commit3_id = git2::Oid::from_str("c")?;
@@ -992,6 +1020,22 @@ fn create_file_update_and_trim() -> anyhow::Result<()> {
                 start: 2,
                 lines: 5,
                 line_shift: 0
+            },
+            HunkRange {
+                change_type: gitbutler_diff::ChangeType::Modified,
+                stack_id,
+                commit_id: commit2_id,
+                start: 7,
+                lines: 0,
+                line_shift: -3
+            },
+            HunkRange {
+                change_type: gitbutler_diff::ChangeType::Added,
+                stack_id,
+                commit_id: commit1_id,
+                start: 7,
+                lines: 0,
+                line_shift: 9
             }
         ]
     );
@@ -1237,14 +1281,32 @@ fn removing_line_updates_range() -> anyhow::Result<()> {
     let hunks = &stack_ranges.hunk_ranges;
     assert_eq!(
         hunks,
-        &vec![HunkRange {
-            change_type: gitbutler_diff::ChangeType::Modified,
-            stack_id,
-            commit_id: commit1_id,
-            start: 2,
-            lines: 2,
-            line_shift: 1
-        }]
+        &vec![
+            HunkRange {
+                change_type: gitbutler_diff::ChangeType::Modified,
+                stack_id,
+                commit_id: commit1_id,
+                start: 2,
+                lines: 0,
+                line_shift: 1
+            },
+            HunkRange {
+                change_type: gitbutler_diff::ChangeType::Modified,
+                stack_id,
+                commit_id: commit2_id,
+                start: 2,
+                lines: 0,
+                line_shift: -1
+            },
+            HunkRange {
+                change_type: gitbutler_diff::ChangeType::Modified,
+                stack_id,
+                commit_id: commit1_id,
+                start: 2,
+                lines: 2,
+                line_shift: 1
+            }
+        ]
     );
 
     Ok(())
@@ -1291,14 +1353,24 @@ fn removing_line_before_shifts_range() -> anyhow::Result<()> {
     let hunks = &stack_ranges.hunk_ranges;
     assert_eq!(
         hunks,
-        &vec![HunkRange {
-            change_type: gitbutler_diff::ChangeType::Modified,
-            stack_id,
-            commit_id: commit1_id,
-            start: 1,
-            lines: 3,
-            line_shift: 1
-        }]
+        &vec![
+            HunkRange {
+                change_type: gitbutler_diff::ChangeType::Modified,
+                stack_id,
+                commit_id: commit2_id,
+                start: 1,
+                lines: 0,
+                line_shift: -1
+            },
+            HunkRange {
+                change_type: gitbutler_diff::ChangeType::Modified,
+                stack_id,
+                commit_id: commit1_id,
+                start: 1,
+                lines: 3,
+                line_shift: 1
+            }
+        ]
     );
 
     Ok(())
@@ -1345,14 +1417,24 @@ fn removing_line_after_is_ignored() -> anyhow::Result<()> {
     let hunks = &stack_ranges.hunk_ranges;
     assert_eq!(
         hunks,
-        &vec![HunkRange {
-            change_type: gitbutler_diff::ChangeType::Modified,
-            stack_id,
-            commit_id: commit1_id,
-            start: 2,
-            lines: 3,
-            line_shift: 1
-        }]
+        &vec![
+            HunkRange {
+                change_type: gitbutler_diff::ChangeType::Modified,
+                stack_id,
+                commit_id: commit1_id,
+                start: 2,
+                lines: 3,
+                line_shift: 1
+            },
+            HunkRange {
+                change_type: gitbutler_diff::ChangeType::Modified,
+                stack_id,
+                commit_id: commit2_id,
+                start: 4,
+                lines: 0,
+                line_shift: -1
+            },
+        ]
     );
 
     Ok(())
@@ -1450,6 +1532,22 @@ fn shift_is_correct_after_multiple_changes() -> anyhow::Result<()> {
                 start: 3,
                 lines: 4,
                 line_shift: 3
+            },
+            HunkRange {
+                change_type: gitbutler_diff::ChangeType::Added,
+                stack_id,
+                commit_id: commit1_id,
+                start: 7,
+                lines: 0,
+                line_shift: 10
+            },
+            HunkRange {
+                change_type: gitbutler_diff::ChangeType::Modified,
+                stack_id,
+                commit_id: commit2_id,
+                start: 7,
+                lines: 0,
+                line_shift: -1
             },
             HunkRange {
                 change_type: gitbutler_diff::ChangeType::Added,


### PR DESCRIPTION
## ☕️ Reasoning
Ignore line-deletions only hunks, even if those are added out the start.
Hunk intersection calculation fails gracefully.

## 🧢 Changes
- Updated the logic to ignore hunks with 0 lines added, ensuring that such modifications do not interfere with dependency calculations.
- Improved error handling in hunk operations to prevent crashes due to potential subtraction overflows by returning appropriate result types.
- Modified relevant tests to account for these updates and verify that the changes function correctly.