### PR TITLE
fix: compress signed msi for download by tauri updater

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -242,6 +242,8 @@ jobs:
           find release -name "*.msi" -type f -print0 | xargs -0 -n1 -I{} python3 /sign-with-evcodesignd.py "{}"
         env:
           EVCODESIGND_PSK: ${{ secrets.EVCODESIGND_PSK }}
+      - name: Compress signed msi
+        run: find release -name "*.msi" -type f -print0 | zip "release/$(find release -name "*.msi" -type f -printf '%P\n').zip" -@
       - name: Upload signed artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -220,7 +220,7 @@ jobs:
           path: tauri-aux-artifacts/
           if-no-files-found: error
 
-  sign-tauri:
+  sign-windows:
     needs: build-tauri
     runs-on: [self-hosted, evcodesignd]
     strategy:
@@ -242,12 +242,56 @@ jobs:
           find release -name "*.msi" -type f -print0 | xargs -0 -n1 -I{} python3 /sign-with-evcodesignd.py "{}"
         env:
           EVCODESIGND_PSK: ${{ secrets.EVCODESIGND_PSK }}
-      - name: Compress signed msi
+      - name: Upload signed artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: '${{ needs.build-tauri.outputs.channel }}-${{ matrix.platform }}-${{ github.run_number }}'
+          path: release/
+          if-no-files-found: error
+          overwrite: true
+
+  sign-tauri:
+    needs: [sign-windows, build-tauri]
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        platform:
+          - windows-latest # [windows, x64]
+    steps:
+      - name: Clean artifact directory
+        shell: bash
+        run: rm -rf release
+      - name: Download ev-signed artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: '${{ needs.build-tauri.outputs.channel }}-${{ matrix.platform }}-${{ github.run_number }}'
+          path: release
+      - name: Set file as a variable
+        shell: bash
+        id: set-path
+        run: |
+          msi_file=$(find release -name "*.msi" -type f -printf '%P\n')
+          echo "msi_file=$msi_file" >> $GITHUB_OUTPUT
+      - name: Sign our EV signed file
         shell: bash
         run: |
-          apt update && apt install -y zip
-          find release -name "*.msi" -type f -print0 | zip "release/$(find release -name "*.msi" -type f -printf '%P\n').zip" -@
-      - name: Upload signed artifacts
+          set -x  
+          curl -O https://gitbutler-public.s3.us-east-1.amazonaws.com/_win/minisign.exe
+          chmod +x minisign.exe  # Add this line to make the file executable
+          echo "sign release/${{ steps.set-path.outputs.msi_file }}"
+          timestamp=$(date +%s)
+          TRUSTED_COMMENT="timestamp:$timestamp	file:${{ steps.set-path.outputs.msi_file }}"
+          UNTRUSTED_COMMENT="signature from tauri secret key"
+          echo "${{ secrets.TAURI_PRIVATE_KEY }}" >> ./minisign.key.b64
+          perl -MMIME::Base64 -ne 'print decode_base64($_)' ./minisign.key.b64 > minisign.key
+          echo ${{ secrets.TAURI_KEY_PASSWORD }} | ./minisign.exe -S -s minisign.key -t "$TRUSTED_COMMENT" -c "$UNTRUSTED_COMMENT" -m "release/${{ steps.set-path.outputs.msi_file }}"
+          perl -MMIME::Base64 -0777 -ne 'print encode_base64($_, "")' < "release/${{ steps.set-path.outputs.msi_file }}.minisig" > "release/${{ steps.set-path.outputs.msi_file }}.sig"
+          rm "release/${{ steps.set-path.outputs.msi_file }}.minisig"
+          rm "release/${{ steps.set-path.outputs.msi_file }}.zip"
+      - name: Compress files into a ZIP archive
+        run: |
+          Compress-Archive -Force -Path "release/${{ steps.set-path.outputs.msi_file }}" -DestinationPath "release/${{ steps.set-path.outputs.msi_file }}.zip"
+      - name: Upload re-signed artifacts
         uses: actions/upload-artifact@v4
         with:
           name: '${{ needs.build-tauri.outputs.channel }}-${{ matrix.platform }}-${{ github.run_number }}'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -243,7 +243,10 @@ jobs:
         env:
           EVCODESIGND_PSK: ${{ secrets.EVCODESIGND_PSK }}
       - name: Compress signed msi
-        run: find release -name "*.msi" -type f -print0 | zip "release/$(find release -name "*.msi" -type f -printf '%P\n').zip" -@
+        shell: bash
+        run: |
+          apt update && apt install -y zip
+          find release -name "*.msi" -type f -print0 | zip "release/$(find release -name "*.msi" -type f -printf '%P\n').zip" -@
       - name: Upload signed artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## ☕️ Reasoning

- Compress the MSI after signing and replace the unsigned `*.msi.zip` in the S3 bucket dir for download by the Tauri updater.

## 🧢 Changes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
