### PR TITLE
Disable fetching prs when personal access token is restricted

### DIFF
--- a/apps/desktop/src/hooks.client.ts
+++ b/apps/desktop/src/hooks.client.ts
@@ -1,4 +1,5 @@
 import { showError } from '$lib/notifications/toasts';
+import { isErrorlike } from '@gitbutler/ui/utils/typeguards';
 import { captureException } from '@sentry/sveltekit';
 import { error as logErrorToFile } from '@tauri-apps/plugin-log';
 import type { HandleClientError } from '@sveltejs/kit';
@@ -23,20 +24,6 @@ export function handleError({
 window.onunhandledrejection = (e: PromiseRejectionEvent) => {
 	logError(e.reason);
 };
-
-interface Errorlike {
-	message: string;
-}
-
-function isErrorlike(target: unknown): target is Errorlike {
-	return (
-		(typeof target === 'object' &&
-			target &&
-			'message' in target &&
-			typeof target.message === 'string') ||
-		false
-	);
-}
 
 function logError(error: unknown) {
 	try {

--- a/packages/ui/src/lib/utils/typeguards.ts
+++ b/packages/ui/src/lib/utils/typeguards.ts
@@ -30,3 +30,22 @@ export function isNonEmptyObject(something: unknown): something is UnknownObject
 export function isError(value: unknown): value is Error {
 	return value instanceof Error;
 }
+
+interface Errorlike {
+	message: string;
+}
+
+/**
+ * Checks if the provided value is an error like, i.e. it has a message.
+ * @param value - The value to be checked.
+ * @returns A boolean indicating whether the value is an Error.
+ */
+export function isErrorlike(target: unknown): target is Errorlike {
+	return (
+		(typeof target === 'object' &&
+			target &&
+			'message' in target &&
+			typeof target.message === 'string') ||
+		false
+	);
+}


### PR DESCRIPTION
- will reduce very noisy errors
- needs a follow-up to disable integration completely

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5823 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5822 
<!-- GitButler Footer Boundary Bottom -->

