### PR TITLE
fix: rm superfluous checkMonitors check

### DIFF
--- a/apps/desktop/src/lib/stack/Stack.svelte
+++ b/apps/desktop/src/lib/stack/Stack.svelte
@@ -8,7 +8,6 @@
 	import { BaseBranch } from '$lib/baseBranch/baseBranch';
 	import { BaseBranchService } from '$lib/baseBranch/baseBranchService';
 	import Dropzones from '$lib/branch/Dropzones.svelte';
-	import { getForge } from '$lib/forge/interface/forge';
 	import { getForgeListingService } from '$lib/forge/interface/forgeListingService';
 	import { getForgePrService } from '$lib/forge/interface/forgePrService';
 	import { type MergeMethod } from '$lib/forge/interface/types';
@@ -131,20 +130,7 @@
 		});
 	}
 
-	// Create monitor on top series in order for us to trigger mergeabilitiy test once its
-	// checks have completed. Using the top branch as it's checks are most likely to have been
-	// started last and therefore complete last.
-	const forge = getForge();
-	const checksMonitor = $derived(
-		$forge?.checksMonitor(branch.validSeries.filter((s) => !s.archived)[0]?.name ?? '')
-	);
-	const checks = $derived(checksMonitor?.status);
-
-	let canMergeAll = $derived.by(() => {
-		// Force this to rerun once the checks have completed and we can check mergeability again
-		void $checks;
-		return checkMergeable();
-	});
+	let canMergeAll = $derived(checkMergeable());
 
 	async function mergeAll(method: MergeMethod) {
 		isMergingSeries = true;


### PR DESCRIPTION
## ☕️ Reasoning

- `checkMonitor` was beign initialized on _any_ branch, meaning it was attemptingt o call GitHub and check the check status for any branch whether it had a PR or not.

## 🧢 Changes

- Rm additional `checkMontiro` instantiation. The `canMergeAll()` derived seems to still be updated at the correct points in time, so that the "Merge All" button is visible on a set of branches when all their PR's checks are passing.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
