### PR TITLE
Create metadata before checking out edit mode

### DIFF
--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -183,8 +183,8 @@ pub(crate) fn enter_edit_mode(
         bail!("Can not enter edit mode for a reference which does not have a cooresponding virtual branch")
     }
 
-    checkout_edit_branch(ctx, commit).context("Failed to checkout edit branch")?;
     write_edit_mode_metadata(ctx, &edit_mode_metadata).context("Failed to persist metadata")?;
+    checkout_edit_branch(ctx, commit).context("Failed to checkout edit branch")?;
 
     Ok(edit_mode_metadata)
 }


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5831 
- <kbd>&nbsp;1&nbsp;</kbd> #5830 👈 
<!-- GitButler Footer Boundary Bottom -->

