### PR TITLE
maybe fix 5839

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2962,7 +2962,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.68.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "gix-actor 0.33.1",
  "gix-attributes 0.23.1",
@@ -2988,7 +2988,7 @@ dependencies = [
  "gix-object 0.46.0",
  "gix-odb",
  "gix-pack",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-pathspec",
  "gix-prompt",
  "gix-protocol",
@@ -2996,15 +2996,15 @@ dependencies = [
  "gix-refspec",
  "gix-revision",
  "gix-revwalk 0.17.0",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-status",
  "gix-submodule",
  "gix-tempfile 15.0.0",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-transport",
  "gix-traverse 0.43.0",
  "gix-url",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-validate 0.9.2",
  "gix-worktree 0.38.0",
  "gix-worktree-state",
@@ -3030,11 +3030,11 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.33.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "gix-date 0.9.2",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "itoa 1.0.11",
  "thiserror 2.0.9",
  "winnow 0.6.20",
@@ -3060,13 +3060,13 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.23.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "gix-glob 0.17.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "kstring",
  "smallvec",
  "thiserror 2.0.9",
@@ -3085,7 +3085,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.13"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "thiserror 2.0.9",
 ]
@@ -3102,7 +3102,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.10"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "thiserror 2.0.9",
 ]
@@ -3110,11 +3110,11 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.3.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "shell-words",
 ]
 
@@ -3135,10 +3135,10 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.25.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
- "gix-chunk 0.4.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-chunk 0.4.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-features 0.39.1",
  "gix-hash 0.15.1",
  "memmap2",
@@ -3148,15 +3148,15 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.42.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "gix-config-value",
  "gix-features 0.39.1",
  "gix-glob 0.17.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-ref 0.49.0",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "memchr",
  "once_cell",
  "smallvec",
@@ -3168,11 +3168,11 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.14.10"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "libc",
  "thiserror 2.0.9",
 ]
@@ -3180,15 +3180,15 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.25.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-config-value",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-prompt",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-url",
  "thiserror 2.0.9",
 ]
@@ -3208,7 +3208,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.9.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "itoa 1.0.11",
@@ -3219,7 +3219,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.48.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3227,9 +3227,9 @@ dependencies = [
  "gix-fs 0.12.0",
  "gix-hash 0.15.1",
  "gix-object 0.46.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-tempfile 15.0.0",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-traverse 0.43.0",
  "gix-worktree 0.38.0",
  "imara-diff",
@@ -3239,7 +3239,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "gix-discover 0.37.0",
@@ -3247,10 +3247,10 @@ dependencies = [
  "gix-ignore 0.12.1",
  "gix-index 0.37.0",
  "gix-object 0.46.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-pathspec",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-worktree 0.38.0",
  "thiserror 2.0.9",
 ]
@@ -3274,15 +3274,15 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.37.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "dunce",
  "gix-fs 0.12.0",
  "gix-hash 0.15.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-ref 0.49.0",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "thiserror 2.0.9",
 ]
 
@@ -3304,15 +3304,15 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.39.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bytes",
  "crc32fast",
  "crossbeam-channel",
  "flate2",
  "gix-hash 0.15.1",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "libc",
  "once_cell",
  "parking_lot",
@@ -3326,7 +3326,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -3335,10 +3335,10 @@ dependencies = [
  "gix-hash 0.15.1",
  "gix-object 0.46.0",
  "gix-packetline-blocking",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "smallvec",
  "thiserror 2.0.9",
 ]
@@ -3357,11 +3357,11 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "fastrand",
  "gix-features 0.39.1",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
 ]
 
 [[package]]
@@ -3379,12 +3379,12 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.17.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "gix-features 0.39.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
 ]
 
 [[package]]
@@ -3400,7 +3400,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.15.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "faster-hex",
  "thiserror 2.0.9",
@@ -3420,7 +3420,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "gix-hash 0.15.1",
  "hashbrown 0.14.5",
@@ -3443,12 +3443,12 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.12.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "gix-glob 0.17.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "unicode-bom",
 ]
 
@@ -3483,20 +3483,20 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.37.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "filetime",
  "fnv",
- "gix-bitmap 0.2.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-bitmap 0.2.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-features 0.39.1",
  "gix-fs 0.12.0",
  "gix-hash 0.15.1",
  "gix-lock 15.0.1",
  "gix-object 0.46.0",
  "gix-traverse 0.43.0",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-validate 0.9.2",
  "hashbrown 0.14.5",
  "itoa 1.0.11",
@@ -3521,17 +3521,17 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "15.0.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "gix-tempfile 15.0.0",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-merge"
 version = "0.1.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3541,12 +3541,12 @@ dependencies = [
  "gix-hash 0.15.1",
  "gix-index 0.37.0",
  "gix-object 0.46.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-revision",
  "gix-revwalk 0.17.0",
  "gix-tempfile 15.0.0",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-worktree 0.38.0",
  "imara-diff",
  "thiserror 2.0.9",
@@ -3555,7 +3555,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bitflags 2.6.0",
  "gix-commitgraph 0.25.1",
@@ -3589,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.46.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "gix-actor 0.33.1",
@@ -3597,8 +3597,8 @@ dependencies = [
  "gix-features 0.39.1",
  "gix-hash 0.15.1",
  "gix-hashtable 0.6.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-validate 0.9.2",
  "itoa 1.0.11",
  "smallvec",
@@ -3609,7 +3609,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.65.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "arc-swap",
  "gix-date 0.9.2",
@@ -3619,8 +3619,8 @@ dependencies = [
  "gix-hashtable 0.6.0",
  "gix-object 0.46.0",
  "gix-pack",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "parking_lot",
  "tempfile",
  "thiserror 2.0.9",
@@ -3629,15 +3629,15 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.55.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "clru",
- "gix-chunk 0.4.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-chunk 0.4.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-features 0.39.1",
  "gix-hash 0.15.1",
  "gix-hashtable 0.6.0",
  "gix-object 0.46.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-tempfile 15.0.0",
  "memmap2",
  "parking_lot",
@@ -3649,22 +3649,22 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.18.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.18.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "thiserror 2.0.9",
 ]
 
@@ -3684,10 +3684,10 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.13"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "home",
  "once_cell",
  "thiserror 2.0.9",
@@ -3696,21 +3696,21 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.8.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "gix-attributes 0.23.1",
  "gix-config-value",
  "gix-glob 0.17.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-prompt"
 version = "0.8.9"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -3722,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.46.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -3730,7 +3730,7 @@ dependencies = [
  "gix-features 0.39.1",
  "gix-hash 0.15.1",
  "gix-transport",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "maybe-async",
  "thiserror 2.0.9",
  "winnow 0.6.20",
@@ -3750,10 +3750,10 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.4.14"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "thiserror 2.0.9",
 ]
 
@@ -3782,7 +3782,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.49.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "gix-actor 0.33.1",
  "gix-features 0.39.1",
@@ -3790,9 +3790,9 @@ dependencies = [
  "gix-hash 0.15.1",
  "gix-lock 15.0.1",
  "gix-object 0.46.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-tempfile 15.0.0",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-validate 0.9.2",
  "memmap2",
  "thiserror 2.0.9",
@@ -3802,7 +3802,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.27.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "gix-hash 0.15.1",
@@ -3815,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -3825,7 +3825,7 @@ dependencies = [
  "gix-hashtable 0.6.0",
  "gix-object 0.46.0",
  "gix-revwalk 0.17.0",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "thiserror 2.0.9",
 ]
 
@@ -3847,7 +3847,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "gix-commitgraph 0.25.1",
  "gix-date 0.9.2",
@@ -3873,10 +3873,10 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.10.10"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bitflags 2.6.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "filetime",
@@ -3896,7 +3896,7 @@ dependencies = [
  "gix-hash 0.15.1",
  "gix-index 0.37.0",
  "gix-object 0.46.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-pathspec",
  "gix-worktree 0.38.0",
  "portable-atomic",
@@ -3906,11 +3906,11 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "gix-config",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
@@ -3935,7 +3935,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "15.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "dashmap",
  "gix-fs 0.12.0",
@@ -3980,7 +3980,7 @@ checksum = "04bdde120c29f1fc23a24d3e115aeeea3d60d8e65bab92cc5f9d90d9302eb952"
 [[package]]
 name = "gix-trace"
 version = "0.1.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "tracing-core",
 ]
@@ -3988,7 +3988,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.43.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -3997,8 +3997,8 @@ dependencies = [
  "gix-credentials",
  "gix-features 0.39.1",
  "gix-packetline",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-url",
  "thiserror 2.0.9",
 ]
@@ -4023,7 +4023,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.43.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bitflags 2.6.0",
  "gix-commitgraph 0.25.1",
@@ -4039,11 +4039,11 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.28.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "gix-features 0.39.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "percent-encoding",
  "thiserror 2.0.9",
  "url",
@@ -4062,7 +4062,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.1.13"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4082,7 +4082,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.9.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "thiserror 2.0.9",
@@ -4110,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.38.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "gix-attributes 0.23.1",
@@ -4121,14 +4121,14 @@ dependencies = [
  "gix-ignore 0.12.1",
  "gix-index 0.37.0",
  "gix-object 0.46.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-validate 0.9.2",
 ]
 
 [[package]]
 name = "gix-worktree-state"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd#520c832cfcfb34eb7617be55ebe2719ab35595fd"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
 dependencies = [
  "bstr",
  "gix-features 0.39.1",
@@ -4138,7 +4138,7 @@ dependencies = [
  "gix-hash 0.15.1",
  "gix-index 0.37.0",
  "gix-object 0.46.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=520c832cfcfb34eb7617be55ebe2719ab35595fd)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
  "gix-worktree 0.38.0",
  "io-close",
  "thiserror 2.0.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ resolver = "2"
 [workspace.dependencies]
 bstr = "1.11.1"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
-gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "520c832cfcfb34eb7617be55ebe2719ab35595fd", default-features = false, features = [] }
+gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "faa0cdeb35a8135ff9513a1c9884126f6b080f4a", default-features = false, features = [] }
 git2 = { version = "0.19.0", features = [
     "vendored-openssl",
     "vendored-libgit2",

--- a/crates/gitbutler-repo/src/repository_ext.rs
+++ b/crates/gitbutler-repo/src/repository_ext.rs
@@ -333,8 +333,9 @@ impl RepositoryExt for git2::Repository {
                     let args = format!("{} {}", signing_key, buffer_file_to_sign_path_str);
                     cmd_string += &args;
                 };
-                let mut signing_cmd: std::process::Command =
-                    gix::command::prepare(cmd_string).with_shell().into();
+                let mut signing_cmd: std::process::Command = gix::command::prepare(cmd_string)
+                    .with_shell_disallow_manual_argument_splitting()
+                    .into();
                 let output = signing_cmd
                     .stderr(Stdio::piped())
                     .stdout(Stdio::piped())

--- a/crates/gitbutler-repo/src/repository_ext.rs
+++ b/crates/gitbutler-repo/src/repository_ext.rs
@@ -307,7 +307,6 @@ impl RepositoryExt for git2::Repository {
                     .ok_or_else(|| anyhow::anyhow!("Failed to convert path to string"))?
                     .to_string();
 
-                let output;
                 // support literal ssh key
                 if let (true, signing_key) = is_literal_ssh_key(&signing_key) {
                     // write the key to a temp file
@@ -324,43 +323,23 @@ impl RepositoryExt for git2::Repository {
                     }
 
                     let key_file_path = key_storage.into_temp_path();
-
                     let args = format!(
                         "{} -U {}",
                         key_file_path.to_string_lossy(),
                         buffer_file_to_sign_path.to_string_lossy()
                     );
                     cmd_string += &args;
-
-                    let mut signing_cmd: std::process::Command =
-                        gix::command::prepare(cmd_string).with_shell().into();
-
-                    #[cfg(windows)]
-                    signing_cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
-
-                    signing_cmd.stderr(Stdio::piped());
-                    signing_cmd.stdout(Stdio::piped());
-                    signing_cmd.stdin(Stdio::null());
-
-                    let child = signing_cmd.spawn()?;
-                    output = child.wait_with_output()?;
                 } else {
                     let args = format!("{} {}", signing_key, buffer_file_to_sign_path_str);
                     cmd_string += &args;
-
-                    let mut signing_cmd: std::process::Command =
-                        gix::command::prepare(cmd_string).with_shell().into();
-
-                    #[cfg(windows)]
-                    signing_cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
-
-                    signing_cmd.stderr(Stdio::piped());
-                    signing_cmd.stdout(Stdio::piped());
-                    signing_cmd.stdin(Stdio::null());
-
-                    let child = signing_cmd.spawn()?;
-                    output = child.wait_with_output()?;
-                }
+                };
+                let mut signing_cmd: std::process::Command =
+                    gix::command::prepare(cmd_string).with_shell().into();
+                let output = signing_cmd
+                    .stderr(Stdio::piped())
+                    .stdout(Stdio::piped())
+                    .stdin(Stdio::null())
+                    .output()?;
 
                 if output.status.success() {
                     // read signed_storage path plus .sig


### PR DESCRIPTION
This PR makes a few changes to assure the shell is also used on Windows when invoking `gpg`.

That way, more of the typical environment may be picked up, which hopefully affects #5839 positively.

The strange thing is that there it worked before without a shell as well, and since on Windows it did manual argument splitting, ultimately it would make the same command-call like before, calling a pure `gpg` binary without shell involvement.

So chances are that besides unifying the operation on all platforms by using a shell, it might still not work as expected.

Maybe there are other changes that affect #5839 between v0.14.3 and v0.14.4?
