### PR TITLE
Update PR creation terminology to be consistent

### DIFF
--- a/apps/desktop/src/lib/pr/PrDetailsModal.svelte
+++ b/apps/desktop/src/lib/pr/PrDetailsModal.svelte
@@ -473,7 +473,7 @@
 				onclick={async () => await handleCreatePR(close)}
 			>
 				{pushBeforeCreate ? 'Push & ' : ''}
-				{$createDraft ? 'Create pull request draft' : `Create pull request`}
+				{$createDraft ? 'Create draft pull request' : `Create pull request`}
 
 				{#snippet contextMenuSlot()}
 					<ContextMenuSection>


### PR DESCRIPTION
This small change makes the dual-state button's dropdown options consistent with the button coppy