### PR TITLE
style fix: wrap project name instead of truncate

### DIFF
--- a/apps/desktop/src/lib/navigation/ProjectsPopup.svelte
+++ b/apps/desktop/src/lib/navigation/ProjectsPopup.svelte
@@ -214,7 +214,7 @@
 	/* LIST ITEM */
 	.list-item {
 		display: flex;
-		align-items: center;
+		text-align: left;
 		color: var(--clr-scale-ntrl-10);
 		font-weight: 700;
 		padding: 10px 10px;
@@ -236,12 +236,11 @@
 		}
 		& .icon {
 			display: flex;
+			margin-top: 2px;
 			color: var(--clr-scale-ntrl-50);
 		}
 		& .label {
-			height: 16px;
-			text-overflow: ellipsis;
-			overflow: hidden;
+			line-height: 140%;
 		}
 	}
 


### PR DESCRIPTION
Related issue https://github.com/gitbutlerapp/gitbutler/issues/5850

Before:
<img width="368" alt="image" src="https://github.com/user-attachments/assets/b8dab0bc-c0b9-4f57-903e-2ddfe14e59b2" />

After:
<img width="368" alt="image" src="https://github.com/user-attachments/assets/a268978f-52f1-454b-89bc-2f5143ee6ac0" />
