### PR TITLE
feat: enhance context menu labels for branch lane actions

### DIFF
--- a/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
+++ b/apps/desktop/src/lib/branch/BranchLaneContextMenu.svelte
@@ -52,6 +52,10 @@
 	function saveAndUnapply() {
 		branchController.saveAndUnapply(stack.id);
 	}
+
+	const isVirginLane = $derived(
+		stack.name.toLowerCase().includes('lane') && commits.length === 0 && stack.files?.length === 0
+	);
 </script>
 
 <ContextMenu bind:this={contextMenuEl} leftClickTrigger={trigger} {ontoggle}>
@@ -67,6 +71,7 @@
 	<ContextMenuSection>
 		<ContextMenuItem
 			label="Unapply"
+			disabled={isVirginLane}
 			onclick={async () => {
 				if (commits.length === 0 && stack.files?.length === 0) {
 					await branchController.unapplyWithoutSaving(stack.id);
@@ -78,7 +83,8 @@
 		/>
 
 		<ContextMenuItem
-			label="Unapply and drop changes"
+			label={isVirginLane ? 'Remove lane' : 'Unapply & drop changes'}
+			disabled={stack.files?.length === 0 && commits.length !== 0}
 			onclick={async () => {
 				if (
 					stack.name.toLowerCase().includes('lane') &&


### PR DESCRIPTION
**Reasoning:**  

Make the "Unapply" and "Unapply and drop changes" options clearer in different lane states.  

**Related issues:** [#5683](https://github.com/gitbutlerapp/gitbutler/issues/5683)  

---

_Here is how it looks:_

![image](https://github.com/user-attachments/assets/fae65113-955f-480d-a8a0-37a8ce5bf0c7)

---

Let me know if you have any improvements.
