### PR TITLE
Make committed file id distinct from uncommitted file id

### DIFF
--- a/apps/desktop/src/lib/vbranches/types.ts
+++ b/apps/desktop/src/lib/vbranches/types.ts
@@ -348,7 +348,7 @@ export class RemoteFile {
 	large!: boolean;
 
 	get id(): string {
-		return this.path;
+		return 'remote:' + this.path;
 	}
 
 	get filename(): string {


### PR DESCRIPTION
- It's noteworthy that the id for files is just the filepath
- We could/should consider some hash instead
- fixes "ownership not found" edge case in amending files

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5858 
- <kbd>&nbsp;1&nbsp;</kbd> #5857 👈 
<!-- GitButler Footer Boundary Bottom -->

