### PR TITLE
Rename some draggable things -> droppable things

### DIFF
--- a/apps/desktop/src/lib/branch/BranchDropzone.svelte
+++ b/apps/desktop/src/lib/branch/BranchDropzone.svelte
@@ -5,7 +5,7 @@
 	import middleSheetSvg from '$lib/assets/new-branch/middle-sheet.svg?raw';
 	import topSheetSvg from '$lib/assets/new-branch/top-sheet.svg?raw';
 	// import components
-	import { DraggableFile, DraggableHunk } from '$lib/dragging/draggables';
+	import { DroppableFile, DroppableHunk } from '$lib/dragging/draggables';
 	import Dropzone from '$lib/dropzone/Dropzone.svelte';
 	import { BranchController } from '$lib/vbranches/branchController';
 	import { filesToOwnership } from '$lib/vbranches/ownership';
@@ -15,20 +15,20 @@
 	const branchController = getContext(BranchController);
 
 	function accepts(dropData: unknown) {
-		if (dropData instanceof DraggableFile) {
+		if (dropData instanceof DroppableFile) {
 			return !(dropData.isCommitted || dropData.files.some((f) => f.locked));
 		}
-		if (dropData instanceof DraggableHunk) {
+		if (dropData instanceof DroppableHunk) {
 			return !(dropData.isCommitted || dropData.hunk.locked);
 		}
 		return false;
 	}
 
-	function onDrop(data: DraggableFile | DraggableHunk) {
-		if (data instanceof DraggableHunk) {
+	function onDrop(data: DroppableFile | DroppableHunk) {
+		if (data instanceof DroppableHunk) {
 			const ownership = `${data.hunk.filePath}:${data.hunk.id}`;
 			branchController.createBranch({ ownership });
-		} else if (data instanceof DraggableFile) {
+		} else if (data instanceof DroppableFile) {
 			const ownership = filesToOwnership(data.files);
 			branchController.createBranch({ ownership });
 		}

--- a/apps/desktop/src/lib/branches/dragActions.ts
+++ b/apps/desktop/src/lib/branches/dragActions.ts
@@ -1,4 +1,4 @@
-import { DraggableCommit, DraggableHunk, DraggableFile } from '$lib/dragging/draggables';
+import { DroppableCommit, DroppableHunk, DroppableFile } from '$lib/dragging/draggables';
 import { filesToOwnership } from '$lib/vbranches/ownership';
 import { LocalFile, type VirtualBranch } from '$lib/vbranches/types';
 import type { BranchController } from '$lib/vbranches/branchController';
@@ -11,19 +11,19 @@ class BranchDragActions {
 
 	acceptMoveCommit(data: any) {
 		return (
-			data instanceof DraggableCommit && data.branchId !== this.branch.id && !data.commit.conflicted
+			data instanceof DroppableCommit && data.branchId !== this.branch.id && !data.commit.conflicted
 		);
 	}
 
-	onMoveCommit(data: DraggableCommit) {
+	onMoveCommit(data: DroppableCommit) {
 		this.branchController.moveCommit(this.branch.id, data.commit.id, data.commit.branchId);
 	}
 
 	acceptBranchDrop(data: any) {
-		if (data instanceof DraggableHunk && !data.commitId && data.branchId !== this.branch.id) {
+		if (data instanceof DroppableHunk && !data.commitId && data.branchId !== this.branch.id) {
 			return !data.hunk.locked;
 		} else if (
-			data instanceof DraggableFile &&
+			data instanceof DroppableFile &&
 			data.file instanceof LocalFile &&
 			this.branch.id !== data.branchId
 		) {
@@ -33,14 +33,14 @@ class BranchDragActions {
 		}
 	}
 
-	onBranchDrop(data: DraggableHunk | DraggableFile) {
-		if (data instanceof DraggableHunk) {
+	onBranchDrop(data: DroppableHunk | DroppableFile) {
+		if (data instanceof DroppableHunk) {
 			const newOwnership = `${data.hunk.filePath}:${data.hunk.id}`;
 			this.branchController.updateBranchOwnership(
 				this.branch.id,
 				(newOwnership + '\n' + this.branch.ownership).trim()
 			);
-		} else if (data instanceof DraggableFile) {
+		} else if (data instanceof DroppableFile) {
 			const newOwnership = filesToOwnership(data.files);
 			this.branchController.updateBranchOwnership(
 				this.branch.id,

--- a/apps/desktop/src/lib/commit/CommitCard.svelte
+++ b/apps/desktop/src/lib/commit/CommitCard.svelte
@@ -6,7 +6,7 @@
 	import ContextMenu from '$lib/components/contextmenu/ContextMenu.svelte';
 	import { persistedCommitMessage } from '$lib/config/config';
 	import { draggableCommit } from '$lib/dragging/draggable';
-	import { DraggableCommit, NON_DRAGGABLE } from '$lib/dragging/draggables';
+	import { DroppableCommit, NON_DRAGGABLE } from '$lib/dragging/draggables';
 	import BranchFilesList from '$lib/file/BranchFilesList.svelte';
 	import { ModeService } from '$lib/modes/service';
 	import { UserService } from '$lib/stores/user';
@@ -262,7 +262,7 @@
 				date: getTimeAgo(commit.createdAt),
 				authorImgUrl: authorImgUrl,
 				commitType: type,
-				dropData: new DraggableCommit(commit.branchId, commit, isHeadCommit, currentSeries?.name),
+				dropData: new DroppableCommit(commit.branchId, commit, isHeadCommit, currentSeries?.name),
 				viewportId: 'board-viewport'
 			}
 		: NON_DRAGGABLE}

--- a/apps/desktop/src/lib/commits/dragActions.ts
+++ b/apps/desktop/src/lib/commits/dragActions.ts
@@ -1,4 +1,4 @@
-import { DraggableCommit, DraggableFile, DraggableHunk } from '$lib/dragging/draggables';
+import { DroppableCommit, DroppableFile, DroppableHunk } from '$lib/dragging/draggables';
 import { filesToOwnership, filesToSimpleOwnership } from '$lib/vbranches/ownership';
 import {
 	LocalFile,
@@ -32,14 +32,14 @@ export class CommitDragActions {
 		}
 
 		if (
-			dropData instanceof DraggableHunk &&
+			dropData instanceof DroppableHunk &&
 			dropData.branchId === this.branch.id &&
 			dropData.commitId !== this.commit.id &&
 			!this.commit.conflicted
 		) {
 			return true;
 		} else if (
-			dropData instanceof DraggableFile &&
+			dropData instanceof DroppableFile &&
 			dropData.branchId === this.branch.id &&
 			dropData.commit?.id !== this.commit.id &&
 			!this.commit.conflicted
@@ -51,10 +51,10 @@ export class CommitDragActions {
 	}
 
 	onAmend(dropData: unknown): void {
-		if (dropData instanceof DraggableHunk) {
+		if (dropData instanceof DroppableHunk) {
 			const newOwnership = `${dropData.hunk.filePath}:${dropData.hunk.id}`;
 			this.branchController.amendBranch(this.branch.id, this.commit.id, newOwnership);
-		} else if (dropData instanceof DraggableFile) {
+		} else if (dropData instanceof DroppableFile) {
 			if (dropData.file instanceof LocalFile) {
 				// this is an uncommitted file change being amended to a previous commit
 				const newOwnership = filesToOwnership(dropData.files);
@@ -78,7 +78,7 @@ export class CommitDragActions {
 		if (this.commit instanceof Commit) {
 			return false;
 		}
-		if (!(dropData instanceof DraggableCommit)) return false;
+		if (!(dropData instanceof DroppableCommit)) return false;
 		if (dropData.branchId !== this.branch.id) return false;
 
 		if (this.commit.conflicted || dropData.commit.conflicted) return false;
@@ -100,7 +100,7 @@ export class CommitDragActions {
 		if (this.commit instanceof Commit) {
 			return;
 		}
-		if (dropData instanceof DraggableCommit) {
+		if (dropData instanceof DroppableCommit) {
 			if (dropData.commit.isParentOf(this.commit)) {
 				this.branchController.squashBranchCommit(dropData.branchId, this.commit.id);
 			} else if (this.commit.isParentOf(dropData.commit)) {

--- a/apps/desktop/src/lib/dragging/draggable.ts
+++ b/apps/desktop/src/lib/dragging/draggable.ts
@@ -1,4 +1,4 @@
-import { DraggableFile, type Draggable } from './draggables';
+import { DroppableFile, type Droppable } from './draggables';
 import { dropzoneRegistry } from './dropzone';
 import { type CommitStatus } from '$lib/vbranches/types';
 import { getFileIcon } from '@gitbutler/ui/file/getFileIcon';
@@ -20,7 +20,7 @@ export type DraggableConfig = {
 	readonly date?: string;
 	readonly authorImgUrl?: string;
 	readonly commitType?: CommitStatus;
-	readonly dropData?: Draggable;
+	readonly dropData?: Droppable;
 	readonly viewportId?: string;
 };
 
@@ -72,7 +72,7 @@ function setupDragHandlers(
 			return;
 		}
 
-		if (opts.dropData instanceof DraggableFile) {
+		if (opts.dropData instanceof DroppableFile) {
 			selectedElements = [];
 			for (const file of opts.dropData.files) {
 				const element = parentNode.querySelector(`[data-file-id="${file.id}"]`);

--- a/apps/desktop/src/lib/dragging/draggables.ts
+++ b/apps/desktop/src/lib/dragging/draggables.ts
@@ -1,18 +1,11 @@
 import { get, type Readable } from 'svelte/store';
-import type {
-	AnyCommit,
-	AnyFile,
-	DetailedCommit,
-	Hunk,
-	Commit,
-	HunkLock
-} from '../vbranches/types';
+import type { AnyCommit, AnyFile, DetailedCommit, Hunk, HunkLock } from '../vbranches/types';
 
 export const NON_DRAGGABLE = {
 	disabled: true
 };
 
-export class DraggableHunk {
+export class DroppableHunk {
 	constructor(
 		public readonly branchId: string,
 		public readonly hunk: Hunk,
@@ -25,7 +18,7 @@ export class DraggableHunk {
 	}
 }
 
-export class DraggableFile {
+export class DroppableFile {
 	constructor(
 		readonly branchId: string,
 		readonly file: AnyFile,
@@ -54,7 +47,7 @@ export class DraggableFile {
 	}
 }
 
-export class DraggableCommit {
+export class DroppableCommit {
 	constructor(
 		public readonly branchId: string,
 		public readonly commit: DetailedCommit,
@@ -63,11 +56,4 @@ export class DraggableCommit {
 	) {}
 }
 
-export class DraggableRemoteCommit {
-	constructor(
-		public readonly branchId: string,
-		public readonly remoteCommit: Commit
-	) {}
-}
-
-export type Draggable = DraggableFile | DraggableHunk | DraggableCommit;
+export type Droppable = DroppableFile | DroppableHunk | DroppableCommit;

--- a/apps/desktop/src/lib/dragging/stackingReorderDropzoneManager.ts
+++ b/apps/desktop/src/lib/dragging/stackingReorderDropzoneManager.ts
@@ -1,4 +1,4 @@
-import { DraggableCommit } from '$lib/dragging/draggables';
+import { DroppableCommit } from '$lib/dragging/draggables';
 import type { BranchController } from '$lib/vbranches/branchController';
 import type { VirtualBranch, PatchSeries, StackOrder } from '$lib/vbranches/types';
 
@@ -12,7 +12,7 @@ export class StackingReorderDropzone {
 	) {}
 
 	accepts(data: unknown) {
-		if (!(data instanceof DraggableCommit)) return false;
+		if (!(data instanceof DroppableCommit)) return false;
 		if (data.branchId !== this.branchId) return false;
 
 		// Do not show dropzones directly above or below the commit in question
@@ -27,7 +27,7 @@ export class StackingReorderDropzone {
 	}
 
 	onDrop(data: any) {
-		if (!(data instanceof DraggableCommit)) return;
+		if (!(data instanceof DroppableCommit)) return;
 		if (data.branchId !== this.branchId) return;
 
 		const stackOrder = buildNewStackOrder(

--- a/apps/desktop/src/lib/file/FileListItemWrapper.svelte
+++ b/apps/desktop/src/lib/file/FileListItemWrapper.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import FileContextMenu from './FileContextMenu.svelte';
 	import { draggableChips, type DraggableConfig } from '$lib/dragging/draggable';
-	import { DraggableFile } from '$lib/dragging/draggables';
+	import { DroppableFile } from '$lib/dragging/draggables';
 	import { itemsSatisfy } from '$lib/utils/array';
 	import { computeFileStatus } from '$lib/utils/fileStatus';
 	import { getLocalCommits, getLocalAndRemoteCommits } from '$lib/vbranches/contexts';
@@ -73,11 +73,11 @@
 	// Manage the lifecycle of the draggable chips.
 	$effect(() => {
 		if (draggableEl) {
-			const draggableFile = new DraggableFile(branchId || '', file, $commit, selectedFiles);
+			const droppableFile = new DroppableFile(branchId || '', file, $commit, selectedFiles);
 			const config = {
 				label: `${file.filename}`,
 				filePath: file.path,
-				dropData: draggableFile,
+				dropData: droppableFile,
 				disabled: !draggable,
 				viewportId: 'board-viewport',
 				selector: '.selected-draggable'

--- a/apps/desktop/src/lib/hunk/HunkViewer.svelte
+++ b/apps/desktop/src/lib/hunk/HunkViewer.svelte
@@ -2,7 +2,7 @@
 	import HunkDiff from './HunkDiff.svelte';
 	import { Project } from '$lib/backend/projects';
 	import { draggableElement } from '$lib/dragging/draggable';
-	import { DraggableHunk } from '$lib/dragging/draggables';
+	import { DroppableHunk } from '$lib/dragging/draggables';
 	import HunkContextMenu from '$lib/hunk/HunkContextMenu.svelte';
 	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import LargeDiffMessage from '$lib/shared/LargeDiffMessage.svelte';
@@ -78,7 +78,7 @@
 		class:opacity-60={section.hunk.locked && !isFileLocked}
 		oncontextmenu={(e) => e.preventDefault()}
 		use:draggableElement={{
-			dropData: new DraggableHunk($branch?.id || '', section.hunk, section.hunk.lockedTo, commitId),
+			dropData: new DroppableHunk($branch?.id || '', section.hunk, section.hunk.lockedTo, commitId),
 			disabled: draggingDisabled
 		}}
 	>

--- a/apps/desktop/src/lib/stack/SeriesList.svelte
+++ b/apps/desktop/src/lib/stack/SeriesList.svelte
@@ -5,7 +5,7 @@
 	import SeriesDividerLine from './SeriesDividerLine.svelte';
 	import SeriesHeader from '$lib/branch/SeriesHeader.svelte';
 	import CommitList from '$lib/commit/CommitList.svelte';
-	import { DraggableCommit } from '$lib/dragging/draggables';
+	import { DroppableCommit } from '$lib/dragging/draggables';
 	import {
 		StackingReorderDropzoneManagerFactory,
 		buildNewStackOrder
@@ -43,14 +43,14 @@
 	);
 
 	function accepts(data: unknown) {
-		if (!(data instanceof DraggableCommit)) return false;
+		if (!(data instanceof DroppableCommit)) return false;
 		if (data.branchId !== branch.id) return false;
 
 		return true;
 	}
 
-	function onDrop(data: DraggableCommit, allSeries: PatchSeries[], currentSeries: PatchSeries) {
-		if (!(data instanceof DraggableCommit)) return;
+	function onDrop(data: DroppableCommit, allSeries: PatchSeries[], currentSeries: PatchSeries) {
+		if (!(data instanceof DroppableCommit)) return;
 
 		const stackOrder = buildNewStackOrder(allSeries, currentSeries, data.commit.id, 'top');
 


### PR DESCRIPTION
Instances of classes like DraggableFile are used as drop data, not for setting up or handling the dragging.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5860 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5859 
<!-- GitButler Footer Boundary Bottom -->

