### PR TITLE
fix: correct spelling of "ammended" to "amended" in tooltip

### DIFF
--- a/apps/desktop/src/lib/commit/CommitCard.svelte
+++ b/apps/desktop/src/lib/commit/CommitCard.svelte
@@ -318,7 +318,7 @@
 
 					{#if conflicted}
 						<Tooltip
-							text={"Conflicted commits must be resolved before they can be ammended or squashed.\nPlease resolve conflicts using the 'Resolve conflicts' button"}
+							text={"Conflicted commits must be resolved before they can be amended or squashed.\nPlease resolve conflicts using the 'Resolve conflicts' button"}
 						>
 							<div class="commit__conflicted">
 								<Icon name="warning-small" />


### PR DESCRIPTION
Update the tooltip text in CommitCard.svelte to fix the spelling  error of "ammended" to "amended." This improves the clarity and  professionalism of the user interface by ensuring correct language  usage.

## ☕️ Reasoning
To improve general app cleanliness

## 🧢 Changes
Just one spelling error fix I noticed while using the app


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
