### PR TITLE
Introduce commit subset check (part of stack)

### DIFF
--- a/crates/gitbutler-branch-actions/src/commit_ops.rs
+++ b/crates/gitbutler-branch-actions/src/commit_ops.rs
@@ -1,0 +1,238 @@
+use anyhow::{bail, Result};
+use gitbutler_oxidize::GixRepositoryExt;
+
+/// Finds the first parent of a given commit
+fn get_first_parent(commit: gix::Commit) -> Result<gix::Commit> {
+    let first_parent = commit.parent_ids().take(1).collect::<Vec<_>>();
+    let Some(first_parent) = first_parent.first() else {
+        bail!("Failed to find first parent of {}", commit.id())
+    };
+    let first_parent = first_parent.object()?.into_commit();
+    Ok(first_parent)
+}
+
+/// Gets the changes that one commit introduced compared to the base,
+/// excluding anything between the commit and the base
+fn get_exclusive_tree(
+    repository: &gix::Repository,
+    commit_id: gix::ObjectId,
+    base_id: gix::ObjectId,
+) -> Result<gix::ObjectId> {
+    let commit = repository.find_commit(commit_id)?;
+    let commit_parent = get_first_parent(commit.clone())?;
+    let base = repository.find_commit(base_id)?;
+
+    repository
+        .merge_trees(
+            commit_parent.tree_id()?,
+            commit.tree_id()?,
+            base.tree_id()?,
+            Default::default(),
+            repository.merge_options_force_ours()?,
+        )?
+        .tree
+        .write()
+        .map_err(Into::into)
+        .map(Into::into)
+}
+
+/// Takes two commits and determines if one is a subset of or equal to the other
+#[allow(dead_code)]
+fn is_subset(
+    repository: &gix::Repository,
+    superset_id: gix::ObjectId,
+    subset_id: gix::ObjectId,
+    common_base_id: gix::ObjectId,
+) -> Result<bool> {
+    let exclusive_superset = get_exclusive_tree(repository, superset_id, common_base_id)?;
+    let exclusive_subset = get_exclusive_tree(repository, subset_id, common_base_id)?;
+
+    let common_base = repository.find_commit(common_base_id)?;
+
+    let (options, _) = repository.merge_options_fail_fast()?;
+    let mut merged_exclusives = repository.merge_trees(
+        common_base.tree_id()?,
+        exclusive_superset,
+        exclusive_subset,
+        Default::default(),
+        options,
+    )?;
+
+    if merged_exclusives.conflicts.is_empty() {
+        Ok(exclusive_superset == merged_exclusives.tree.write()?)
+    } else {
+        Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use gitbutler_testsupport::testing_repository::TestingRepository;
+    mod get_exclusive_tree {
+        use gitbutler_oxidize::OidExt;
+
+        use super::super::get_exclusive_tree;
+        use super::*;
+
+        #[test]
+        fn when_already_exclusive_returns_self() {
+            let test_repository = TestingRepository::open();
+            let base_commit: git2::Commit =
+                test_repository.commit_tree(None, &[("foo.txt", "foo"), ("bar.txt", "bar")]);
+            let second_commit: git2::Commit = test_repository.commit_tree(
+                Some(&base_commit),
+                &[("foo.txt", "bar"), ("bar.txt", "baz")],
+            );
+
+            let exclusive_tree = get_exclusive_tree(
+                &test_repository.gix_repository(),
+                second_commit.id().to_gix(),
+                base_commit.id().to_gix(),
+            )
+            .unwrap();
+
+            assert_eq!(
+                second_commit.tree_id().to_gix(),
+                exclusive_tree,
+                "The tree returned should match the second commit"
+            )
+        }
+
+        #[test]
+        fn when_on_top_of_other_commit_its_changes_are_dropped() {
+            let test_repository = TestingRepository::open();
+            let base_commit: git2::Commit =
+                test_repository.commit_tree(None, &[("foo.txt", "foo")]);
+            let second_commit: git2::Commit = test_repository.commit_tree(
+                Some(&base_commit),
+                &[("foo.txt", "bar"), ("bar.txt", "baz")],
+            );
+            let third_commit: git2::Commit = test_repository.commit_tree(
+                Some(&second_commit),
+                &[("foo.txt", "bar"), ("bar.txt", "baz"), ("qux.txt", "bax")],
+            );
+
+            // The second commit changed foo.txt, and added bar.txt. We expect
+            // foo.txt to be reverted back to foo, and bar.txt should be dropped
+            let expected_commit: git2::Commit =
+                test_repository.commit_tree(None, &[("foo.txt", "foo"), ("qux.txt", "bax")]);
+
+            let exclusive_tree = get_exclusive_tree(
+                &test_repository.gix_repository(),
+                third_commit.id().to_gix(),
+                base_commit.id().to_gix(),
+            )
+            .unwrap();
+
+            assert_eq!(expected_commit.tree_id().to_gix(), exclusive_tree,)
+        }
+    }
+
+    mod is_subset {
+        use gitbutler_oxidize::OidExt;
+
+        use super::super::is_subset;
+        use super::*;
+
+        #[test]
+        fn a_commit_is_a_subset_of_itself() {
+            let test_repository = TestingRepository::open();
+            let base_commit: git2::Commit =
+                test_repository.commit_tree(None, &[("foo.txt", "foo")]);
+            let second_commit: git2::Commit = test_repository.commit_tree(
+                Some(&base_commit),
+                &[("foo.txt", "bar"), ("bar.txt", "baz")],
+            );
+
+            assert!(is_subset(
+                &test_repository.gix_repository(),
+                second_commit.id().to_gix(),
+                second_commit.id().to_gix(),
+                base_commit.id().to_gix()
+            )
+            .unwrap())
+        }
+
+        #[test]
+        fn basic_subset() {
+            let test_repository = TestingRepository::open();
+            let base_commit: git2::Commit =
+                test_repository.commit_tree(None, &[("foo.txt", "foo")]);
+            let superset: git2::Commit = test_repository.commit_tree(
+                Some(&base_commit),
+                &[("foo.txt", "bar"), ("bar.txt", "baz"), ("baz.txt", "asdf")],
+            );
+            let subset: git2::Commit = test_repository.commit_tree(
+                Some(&base_commit),
+                &[("foo.txt", "bar"), ("bar.txt", "baz")],
+            );
+
+            assert!(is_subset(
+                &test_repository.gix_repository(),
+                superset.id().to_gix(),
+                subset.id().to_gix(),
+                base_commit.id().to_gix()
+            )
+            .unwrap());
+
+            assert!(!is_subset(
+                &test_repository.gix_repository(),
+                subset.id().to_gix(),
+                superset.id().to_gix(),
+                base_commit.id().to_gix()
+            )
+            .unwrap());
+        }
+
+        #[test]
+        fn complex_subset() {
+            let test_repository = TestingRepository::open();
+            let base_commit: git2::Commit =
+                test_repository.commit_tree(None, &[("foo.txt", "foo")]);
+            let i1: git2::Commit = test_repository.commit_tree(
+                Some(&base_commit),
+                &[("foo.txt", "baz"), ("amp.txt", "asfd")],
+            );
+            let superset: git2::Commit = test_repository.commit_tree(
+                Some(&i1),
+                &[
+                    ("foo.txt", "baz"),
+                    ("amp.txt", "asfd"),
+                    ("bar.txt", "baz"),
+                    ("baz.txt", "asdf"),
+                ],
+            );
+            let i2: git2::Commit = test_repository.commit_tree(
+                Some(&base_commit),
+                &[("foo.txt", "xxx"), ("fuzz.txt", "asdf")],
+            );
+            let subset: git2::Commit = test_repository.commit_tree(
+                Some(&i2),
+                &[("foo.txt", "xxx"), ("fuzz.txt", "asdf"), ("bar.txt", "baz")],
+            );
+
+            // This creates two commits "superset" and "subset" which when
+            // compared directly don't have a superset-subset relationship,
+            // but because we take the changes that the subset/superset commits
+            // exclusivly added compared to a common base, we are able to
+            // identify that the changes each commit introduced are infact
+            // a superset/subset of each other
+
+            assert!(is_subset(
+                &test_repository.gix_repository(),
+                superset.id().to_gix(),
+                subset.id().to_gix(),
+                base_commit.id().to_gix()
+            )
+            .unwrap());
+
+            assert!(!is_subset(
+                &test_repository.gix_repository(),
+                subset.id().to_gix(),
+                superset.id().to_gix(),
+                base_commit.id().to_gix()
+            )
+            .unwrap());
+        }
+    }
+}

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -79,4 +79,5 @@ pub use branch::{
 
 pub use integration::GITBUTLER_WORKSPACE_COMMIT_TITLE;
 
+mod commit_ops;
 pub mod stack;

--- a/crates/gitbutler-testsupport/src/testing_repository.rs
+++ b/crates/gitbutler-testsupport/src/testing_repository.rs
@@ -52,6 +52,10 @@ impl TestingRepository {
         }
     }
 
+    pub fn gix_repository(&self) -> gix::Repository {
+        gix::open(self.repository.path()).unwrap()
+    }
+
     pub fn open_with_initial_commit(files: &[(&str, &str)]) -> Self {
         let tempdir = tempdir().unwrap();
         let repository = git2::Repository::init_opts(tempdir.path(), &init_opts()).unwrap();
@@ -90,6 +94,7 @@ impl TestingRepository {
     ) -> git2::Commit<'a> {
         self.commit_tree_inner(parent, &Uuid::new_v4().to_string(), files, Some(change_id))
     }
+
     pub fn commit_tree<'a>(
         &'a self,
         parent: Option<&git2::Commit<'_>>,


### PR DESCRIPTION
Introduces a function for determining if the changes introduced by a commit, are a subset of the changes introduced by another.

This is helpful for an upcoming PR which should greatly improve our integration check.

---

`get_exclusive_tree` is able to take a stack of commits IE `Base -> A -> B`. And return a tree which only contains the introductions of the `B` commit (when diffed against the Base).

We do this by merging commits `B` and `Base` against the parent of `B`. Any conflicts are resolved in favour of the `B` commit.

`is_subset` makes use of `get_exclusive_tree` to be able to compare the subset and superset candidates without worry about changes that they may have been cherry-picked on top of

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5893 
- <kbd>&nbsp;1&nbsp;</kbd> #5881 👈 
<!-- GitButler Footer Boundary Bottom -->

