### PR TITLE
Actually fix http permission for use with Ollama

### DIFF
--- a/crates/gitbutler-tauri/capabilities/main.json
+++ b/crates/gitbutler-tauri/capabilities/main.json
@@ -21,10 +21,10 @@
 			"identifier": "http:default",
 			"allow": [
 				{
-					"url": "http://127.0.0.1:**"
+					"url": "http://127.0.0.1:*/**"
 				},
 				{
-					"url": "http://localhost:**"
+					"url": "http://localhost:*/**"
 				}
 			]
 		}


### PR DESCRIPTION
In my previous commit I sloppily used the glob pattern in the place of the port, rather than path.

Uses crate `urlpattern`, spec is here: https://urlpattern.spec.whatwg.org/