### PR TITLE
use `gix-status` for `create_wd_tree()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2961,8 +2961,8 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.68.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+version = "0.69.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "gix-actor 0.33.1",
  "gix-attributes 0.23.1",
@@ -2970,13 +2970,13 @@ dependencies = [
  "gix-commitgraph 0.25.1",
  "gix-config",
  "gix-credentials",
- "gix-date 0.9.2",
+ "gix-date 0.9.3",
  "gix-diff",
  "gix-dir",
  "gix-discover 0.37.0",
  "gix-features 0.39.1",
  "gix-filter",
- "gix-fs 0.12.0",
+ "gix-fs 0.12.1",
  "gix-glob 0.17.1",
  "gix-hash 0.15.1",
  "gix-hashtable 0.6.0",
@@ -2985,26 +2985,27 @@ dependencies = [
  "gix-lock 15.0.1",
  "gix-merge",
  "gix-negotiate",
- "gix-object 0.46.0",
+ "gix-object 0.46.1",
  "gix-odb",
  "gix-pack",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-pathspec",
  "gix-prompt",
  "gix-protocol",
- "gix-ref 0.49.0",
+ "gix-ref 0.49.1",
  "gix-refspec",
  "gix-revision",
  "gix-revwalk 0.17.0",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-shallow",
  "gix-status",
  "gix-submodule",
  "gix-tempfile 15.0.0",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-transport",
- "gix-traverse 0.43.0",
+ "gix-traverse 0.43.1",
  "gix-url",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-validate 0.9.2",
  "gix-worktree 0.38.0",
  "gix-worktree-state",
@@ -3030,11 +3031,11 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.33.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
- "gix-date 0.9.2",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-date 0.9.3",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "itoa 1.0.11",
  "thiserror 2.0.9",
  "winnow 0.6.20",
@@ -3060,13 +3061,13 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.23.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
  "gix-glob 0.17.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "kstring",
  "smallvec",
  "thiserror 2.0.9",
@@ -3085,7 +3086,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.13"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "thiserror 2.0.9",
 ]
@@ -3102,19 +3103,19 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.10"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-command"
-version = "0.3.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+version = "0.4.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "shell-words",
 ]
 
@@ -3135,10 +3136,10 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.25.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
- "gix-chunk 0.4.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-chunk 0.4.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-features 0.39.1",
  "gix-hash 0.15.1",
  "memmap2",
@@ -3148,15 +3149,15 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.42.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
  "gix-config-value",
  "gix-features 0.39.1",
  "gix-glob 0.17.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
- "gix-ref 0.49.0",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-ref 0.49.1",
+ "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "memchr",
  "once_cell",
  "smallvec",
@@ -3168,27 +3169,27 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.14.10"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "libc",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-credentials"
-version = "0.25.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+version = "0.26.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-config-value",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-prompt",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-url",
  "thiserror 2.0.9",
 ]
@@ -3207,8 +3208,8 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.9.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+version = "0.9.3"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
  "itoa 1.0.11",
@@ -3218,19 +3219,22 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.48.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+version = "0.49.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
+ "gix-attributes 0.23.1",
  "gix-command",
  "gix-filter",
- "gix-fs 0.12.0",
+ "gix-fs 0.12.1",
  "gix-hash 0.15.1",
- "gix-object 0.46.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-index 0.37.0",
+ "gix-object 0.46.1",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-pathspec",
  "gix-tempfile 15.0.0",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
- "gix-traverse 0.43.0",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-traverse 0.43.1",
  "gix-worktree 0.38.0",
  "imara-diff",
  "thiserror 2.0.9",
@@ -3238,19 +3242,19 @@ dependencies = [
 
 [[package]]
 name = "gix-dir"
-version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+version = "0.11.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
  "gix-discover 0.37.0",
- "gix-fs 0.12.0",
+ "gix-fs 0.12.1",
  "gix-ignore 0.12.1",
  "gix-index 0.37.0",
- "gix-object 0.46.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-object 0.46.1",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-pathspec",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-worktree 0.38.0",
  "thiserror 2.0.9",
 ]
@@ -3274,15 +3278,15 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.37.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
  "dunce",
- "gix-fs 0.12.0",
+ "gix-fs 0.12.1",
  "gix-hash 0.15.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
- "gix-ref 0.49.0",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-ref 0.49.1",
+ "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "thiserror 2.0.9",
 ]
 
@@ -3304,15 +3308,15 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.39.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bytes",
  "crc32fast",
  "crossbeam-channel",
  "flate2",
  "gix-hash 0.15.1",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "libc",
  "once_cell",
  "parking_lot",
@@ -3325,20 +3329,20 @@ dependencies = [
 
 [[package]]
 name = "gix-filter"
-version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+version = "0.16.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
  "encoding_rs",
  "gix-attributes 0.23.1",
  "gix-command",
  "gix-hash 0.15.1",
- "gix-object 0.46.0",
+ "gix-object 0.46.1",
  "gix-packetline-blocking",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "smallvec",
  "thiserror 2.0.9",
 ]
@@ -3356,12 +3360,12 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+version = "0.12.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "fastrand",
  "gix-features 0.39.1",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
 ]
 
 [[package]]
@@ -3379,12 +3383,12 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.17.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "gix-features 0.39.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
 ]
 
 [[package]]
@@ -3400,7 +3404,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.15.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "faster-hex",
  "thiserror 2.0.9",
@@ -3420,7 +3424,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "gix-hash 0.15.1",
  "hashbrown 0.14.5",
@@ -3443,12 +3447,12 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.12.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
  "gix-glob 0.17.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "unicode-bom",
 ]
 
@@ -3483,20 +3487,20 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.37.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "filetime",
  "fnv",
- "gix-bitmap 0.2.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-bitmap 0.2.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-features 0.39.1",
- "gix-fs 0.12.0",
+ "gix-fs 0.12.1",
  "gix-hash 0.15.1",
  "gix-lock 15.0.1",
- "gix-object 0.46.0",
- "gix-traverse 0.43.0",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-object 0.46.1",
+ "gix-traverse 0.43.1",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-validate 0.9.2",
  "hashbrown 0.14.5",
  "itoa 1.0.11",
@@ -3521,32 +3525,32 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "15.0.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "gix-tempfile 15.0.0",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-merge"
-version = "0.1.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+version = "0.2.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-diff",
  "gix-filter",
- "gix-fs 0.12.0",
+ "gix-fs 0.12.1",
  "gix-hash 0.15.1",
  "gix-index 0.37.0",
- "gix-object 0.46.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-object 0.46.1",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-revision",
  "gix-revwalk 0.17.0",
  "gix-tempfile 15.0.0",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-worktree 0.38.0",
  "imara-diff",
  "thiserror 2.0.9",
@@ -3555,13 +3559,13 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bitflags 2.6.0",
  "gix-commitgraph 0.25.1",
- "gix-date 0.9.2",
+ "gix-date 0.9.3",
  "gix-hash 0.15.1",
- "gix-object 0.46.0",
+ "gix-object 0.46.1",
  "gix-revwalk 0.17.0",
  "smallvec",
  "thiserror 2.0.9",
@@ -3588,17 +3592,17 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.46.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+version = "0.46.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
  "gix-actor 0.33.1",
- "gix-date 0.9.2",
+ "gix-date 0.9.3",
  "gix-features 0.39.1",
  "gix-hash 0.15.1",
  "gix-hashtable 0.6.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-validate 0.9.2",
  "itoa 1.0.11",
  "smallvec",
@@ -3608,19 +3612,19 @@ dependencies = [
 
 [[package]]
 name = "gix-odb"
-version = "0.65.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+version = "0.66.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "arc-swap",
- "gix-date 0.9.2",
+ "gix-date 0.9.3",
  "gix-features 0.39.1",
- "gix-fs 0.12.0",
+ "gix-fs 0.12.1",
  "gix-hash 0.15.1",
  "gix-hashtable 0.6.0",
- "gix-object 0.46.0",
+ "gix-object 0.46.1",
  "gix-pack",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "parking_lot",
  "tempfile",
  "thiserror 2.0.9",
@@ -3628,16 +3632,16 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.55.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+version = "0.56.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "clru",
- "gix-chunk 0.4.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-chunk 0.4.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-features 0.39.1",
  "gix-hash 0.15.1",
  "gix-hashtable 0.6.0",
- "gix-object 0.46.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-object 0.46.1",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-tempfile 15.0.0",
  "memmap2",
  "parking_lot",
@@ -3648,23 +3652,23 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline"
-version = "0.18.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+version = "0.18.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.18.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "thiserror 2.0.9",
 ]
 
@@ -3684,10 +3688,10 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.13"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "home",
  "once_cell",
  "thiserror 2.0.9",
@@ -3696,21 +3700,21 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.8.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "gix-attributes 0.23.1",
  "gix-config-value",
  "gix-glob 0.17.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-prompt"
-version = "0.8.9"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+version = "0.9.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -3721,16 +3725,24 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.46.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+version = "0.47.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
  "gix-credentials",
- "gix-date 0.9.2",
+ "gix-date 0.9.3",
  "gix-features 0.39.1",
  "gix-hash 0.15.1",
+ "gix-lock 15.0.1",
+ "gix-negotiate",
+ "gix-object 0.46.1",
+ "gix-ref 0.49.1",
+ "gix-refspec",
+ "gix-revwalk 0.17.0",
+ "gix-shallow",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-transport",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "maybe-async",
  "thiserror 2.0.9",
  "winnow 0.6.20",
@@ -3750,10 +3762,10 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.4.14"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "thiserror 2.0.9",
 ]
 
@@ -3781,18 +3793,18 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.49.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+version = "0.49.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "gix-actor 0.33.1",
  "gix-features 0.39.1",
- "gix-fs 0.12.0",
+ "gix-fs 0.12.1",
  "gix-hash 0.15.1",
  "gix-lock 15.0.1",
- "gix-object 0.46.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-object 0.46.1",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-tempfile 15.0.0",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-validate 0.9.2",
  "memmap2",
  "thiserror 2.0.9",
@@ -3802,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.27.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
  "gix-hash 0.15.1",
@@ -3814,18 +3826,18 @@ dependencies = [
 
 [[package]]
 name = "gix-revision"
-version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+version = "0.31.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "gix-commitgraph 0.25.1",
- "gix-date 0.9.2",
+ "gix-date 0.9.3",
  "gix-hash 0.15.1",
  "gix-hashtable 0.6.0",
- "gix-object 0.46.0",
+ "gix-object 0.46.1",
  "gix-revwalk 0.17.0",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "thiserror 2.0.9",
 ]
 
@@ -3847,13 +3859,13 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "gix-commitgraph 0.25.1",
- "gix-date 0.9.2",
+ "gix-date 0.9.3",
  "gix-hash 0.15.1",
  "gix-hashtable 0.6.0",
- "gix-object 0.46.0",
+ "gix-object 0.46.1",
  "smallvec",
  "thiserror 2.0.9",
 ]
@@ -3873,18 +3885,29 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.10.10"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bitflags 2.6.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "libc",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
+name = "gix-shallow"
+version = "0.1.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+dependencies = [
+ "bstr",
+ "gix-hash 0.15.1",
+ "gix-lock 15.0.1",
+ "thiserror 2.0.9",
+]
+
+[[package]]
 name = "gix-status"
-version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+version = "0.16.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
  "filetime",
@@ -3892,11 +3915,11 @@ dependencies = [
  "gix-dir",
  "gix-features 0.39.1",
  "gix-filter",
- "gix-fs 0.12.0",
+ "gix-fs 0.12.1",
  "gix-hash 0.15.1",
  "gix-index 0.37.0",
- "gix-object 0.46.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-object 0.46.1",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-pathspec",
  "gix-worktree 0.38.0",
  "portable-atomic",
@@ -3906,11 +3929,11 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
  "gix-config",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
@@ -3935,10 +3958,10 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "15.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "dashmap",
- "gix-fs 0.12.0",
+ "gix-fs 0.12.1",
  "libc",
  "once_cell",
  "parking_lot",
@@ -3980,15 +4003,15 @@ checksum = "04bdde120c29f1fc23a24d3e115aeeea3d60d8e65bab92cc5f9d90d9302eb952"
 [[package]]
 name = "gix-trace"
 version = "0.1.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "tracing-core",
 ]
 
 [[package]]
 name = "gix-transport"
-version = "0.43.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+version = "0.44.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -3997,8 +4020,8 @@ dependencies = [
  "gix-credentials",
  "gix-features 0.39.1",
  "gix-packetline",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-url",
  "thiserror 2.0.9",
 ]
@@ -4022,15 +4045,15 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.43.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+version = "0.43.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bitflags 2.6.0",
  "gix-commitgraph 0.25.1",
- "gix-date 0.9.2",
+ "gix-date 0.9.3",
  "gix-hash 0.15.1",
  "gix-hashtable 0.6.0",
- "gix-object 0.46.0",
+ "gix-object 0.46.1",
  "gix-revwalk 0.17.0",
  "smallvec",
  "thiserror 2.0.9",
@@ -4038,12 +4061,12 @@ dependencies = [
 
 [[package]]
 name = "gix-url"
-version = "0.28.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+version = "0.28.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
  "gix-features 0.39.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "percent-encoding",
  "thiserror 2.0.9",
  "url",
@@ -4062,7 +4085,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.1.13"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4082,7 +4105,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.9.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
  "thiserror 2.0.9",
@@ -4110,35 +4133,35 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.38.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
  "gix-attributes 0.23.1",
  "gix-features 0.39.1",
- "gix-fs 0.12.0",
+ "gix-fs 0.12.1",
  "gix-glob 0.17.1",
  "gix-hash 0.15.1",
  "gix-ignore 0.12.1",
  "gix-index 0.37.0",
- "gix-object 0.46.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-object 0.46.1",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-validate 0.9.2",
 ]
 
 [[package]]
 name = "gix-worktree-state"
-version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a#faa0cdeb35a8135ff9513a1c9884126f6b080f4a"
+version = "0.16.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
 dependencies = [
  "bstr",
  "gix-features 0.39.1",
  "gix-filter",
- "gix-fs 0.12.0",
+ "gix-fs 0.12.1",
  "gix-glob 0.17.1",
  "gix-hash 0.15.1",
  "gix-index 0.37.0",
- "gix-object 0.46.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=faa0cdeb35a8135ff9513a1c9884126f6b080f4a)",
+ "gix-object 0.46.1",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
  "gix-worktree 0.38.0",
  "io-close",
  "thiserror 2.0.9",
@@ -5158,7 +5181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -9372,7 +9395,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,6 +1029,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "console-api"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1686,6 +1698,12 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -2662,6 +2680,7 @@ dependencies = [
  "gitbutler-user",
  "gix",
  "infer",
+ "insta",
  "itertools 0.14.0",
  "resolve-path",
  "serde",
@@ -2884,6 +2903,7 @@ dependencies = [
  "parking_lot",
  "serde_json",
  "tempfile",
+ "termtree 0.5.1",
  "uuid",
 ]
 
@@ -4830,6 +4850,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.41.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9ffc4d4892617c50a928c52b2961cb5174b6fc6ebf252b2fac9d21955c48b8"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "similar",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5230,6 +5262,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-keyutils"
@@ -6428,7 +6466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
 dependencies = [
  "predicates-core",
- "termtree",
+ "termtree 0.4.1",
 ]
 
 [[package]]
@@ -7585,6 +7623,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8403,6 +8447,12 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thin-slice"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ resolver = "2"
 [workspace.dependencies]
 bstr = "1.11.1"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
-gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "faa0cdeb35a8135ff9513a1c9884126f6b080f4a", default-features = false, features = [] }
+gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "af704f57bb9480c47cdd393465264d586f1d4562", default-features = false, features = [] }
 git2 = { version = "0.20.0", features = [
     "vendored-openssl",
     "vendored-libgit2",

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -13,6 +13,7 @@ use gitbutler_error::error::Marker;
 use gitbutler_oplog::SnapshotExt;
 use gitbutler_oxidize::GixRepositoryExt;
 use gitbutler_project::access::WorktreeWritePermission;
+use gitbutler_project::AUTO_TRACK_LIMIT_BYTES;
 use gitbutler_reference::{Refname, RemoteRefname};
 use gitbutler_repo::logging::{LogUntil, RepositoryExt as _};
 use gitbutler_repo::{
@@ -305,7 +306,7 @@ impl BranchManager<'_> {
 
         // We don't support having two branches applied that conflict with each other
         {
-            let uncommited_changes_tree_id = repo.create_wd_tree()?.id();
+            let uncommited_changes_tree_id = repo.create_wd_tree(AUTO_TRACK_LIMIT_BYTES)?.id();
             let gix_repo = self.ctx.gix_repository_for_merging_non_persisting()?;
             let merges_cleanly = gix_repo
                 .merges_cleanly_compat(

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -26,6 +26,7 @@ use gitbutler_oxidize::{
     git2_signature_to_gix_signature, git2_to_gix_object_id, gix_to_git2_oid, GixRepositoryExt,
 };
 use gitbutler_project::access::WorktreeWritePermission;
+use gitbutler_project::AUTO_TRACK_LIMIT_BYTES;
 use gitbutler_reference::{normalize_branch_name, Refname, RemoteRefname};
 use gitbutler_repo::{
     logging::{LogUntil, RepositoryExt as _},
@@ -1089,7 +1090,7 @@ pub fn is_remote_branch_mergeable(
 
     let base_tree = find_base_tree(ctx.repo(), &branch_commit, &target_commit)?;
 
-    let wd_tree = ctx.repo().create_wd_tree()?;
+    let wd_tree = ctx.repo().create_wd_tree(AUTO_TRACK_LIMIT_BYTES)?;
 
     let branch_tree = branch_commit.tree().context("failed to find branch tree")?;
     let gix_repo_in_memory = ctx.gix_repository_for_merging()?.with_object_memory();

--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -20,6 +20,7 @@ use gitbutler_operating_modes::{
 };
 use gitbutler_oxidize::{git2_to_gix_object_id, gix_to_git2_index, GixRepositoryExt};
 use gitbutler_project::access::{WorktreeReadPermission, WorktreeWritePermission};
+use gitbutler_project::AUTO_TRACK_LIMIT_BYTES;
 use gitbutler_reference::{ReferenceName, Refname};
 use gitbutler_repo::{rebase::cherry_rebase, RepositoryExt};
 use gitbutler_repo::{signature, SignaturePurpose};
@@ -234,7 +235,7 @@ pub(crate) fn save_and_return_to_workspace(
     let parents = commit.parents().collect::<Vec<_>>();
 
     // Recommit commit
-    let tree = repository.create_wd_tree()?;
+    let tree = repository.create_wd_tree(AUTO_TRACK_LIMIT_BYTES)?;
 
     let (_, committer) = repository.signatures()?;
     let commit_headers = commit

--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -20,7 +20,6 @@ use gitbutler_operating_modes::{
 };
 use gitbutler_oxidize::{git2_to_gix_object_id, gix_to_git2_index, GixRepositoryExt};
 use gitbutler_project::access::{WorktreeReadPermission, WorktreeWritePermission};
-use gitbutler_project::AUTO_TRACK_LIMIT_BYTES;
 use gitbutler_reference::{ReferenceName, Refname};
 use gitbutler_repo::{rebase::cherry_rebase, RepositoryExt};
 use gitbutler_repo::{signature, SignaturePurpose};
@@ -235,7 +234,9 @@ pub(crate) fn save_and_return_to_workspace(
     let parents = commit.parents().collect::<Vec<_>>();
 
     // Recommit commit
-    let tree = repository.create_wd_tree(AUTO_TRACK_LIMIT_BYTES)?;
+    // While we perform hard resets we should pick up everything to avoid loosing worktree state.
+    let pick_up_untracked_files_of_any_size = 0;
+    let tree = repository.create_wd_tree(pick_up_untracked_files_of_any_size)?;
 
     let (_, committer) = repository.signatures()?;
     let commit_headers = commit

--- a/crates/gitbutler-project/src/lib.rs
+++ b/crates/gitbutler-project/src/lib.rs
@@ -18,3 +18,6 @@ pub fn configure_git2() {
     // These settings are only changed from `main` of applications.
     git2::opts::strict_object_creation(false);
 }
+
+/// The maximum size of files to automatically start tracking, i.e. untracked files we pick up for tree-creation.
+pub const AUTO_TRACK_LIMIT_BYTES: u64 = 32 * 1024 * 1024;

--- a/crates/gitbutler-project/src/lib.rs
+++ b/crates/gitbutler-project/src/lib.rs
@@ -20,4 +20,5 @@ pub fn configure_git2() {
 }
 
 /// The maximum size of files to automatically start tracking, i.e. untracked files we pick up for tree-creation.
-pub const AUTO_TRACK_LIMIT_BYTES: u64 = 32 * 1024 * 1024;
+/// **Inactive for now** while it's hard to tell if it's safe *not* to pick up everything.
+pub const AUTO_TRACK_LIMIT_BYTES: u64 = 0;

--- a/crates/gitbutler-repo/Cargo.toml
+++ b/crates/gitbutler-repo/Cargo.toml
@@ -39,3 +39,4 @@ path = "tests/mod.rs"
 gitbutler-testsupport.workspace = true
 gitbutler-user.workspace = true
 serde_json = { version = "1.0", features = ["std", "arbitrary_precision"] }
+insta = "1.41.1"

--- a/crates/gitbutler-repo/src/repository_ext.rs
+++ b/crates/gitbutler-repo/src/repository_ext.rs
@@ -2,7 +2,7 @@ use crate::Config;
 use crate::SignaturePurpose;
 use anyhow::{anyhow, bail, Context, Result};
 use bstr::BString;
-use git2::{StatusOptions, Tree};
+use git2::Tree;
 use gitbutler_commit::commit_headers::CommitHeadersV2;
 use gitbutler_config::git::{GbConfig, GitConfig};
 use gitbutler_error::error::Code;
@@ -11,14 +11,13 @@ use gitbutler_oxidize::{
 };
 use gitbutler_reference::{Refname, RemoteRefname};
 use gix::filter::plumbing::pipeline::convert::ToGitOutcome;
-use gix::fs::is_executable;
 use gix::objs::WriteTo;
-use std::io;
+use std::collections::HashSet;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
-use std::{io::Write, path::Path, process::Stdio, str};
+use std::{io::Write, process::Stdio, str};
 use tracing::instrument;
 
 /// Extension trait for `git2::Repository`.
@@ -106,16 +105,22 @@ impl RepositoryExt for git2::Repository {
         Ok(branch)
     }
 
-    /// Note that this will add all untracked and modified files in the worktree to
+    /// Add all untracked and modified files in the worktree to
     /// the object database, and create a tree from it.
     ///
     /// Note that right now, it doesn't skip big files.
     ///
     /// It should also be noted that this will fail if run on an empty branch
-    /// or if the HEAD branch has no commits
+    /// or if the HEAD branch has no commits.
     #[instrument(level = tracing::Level::DEBUG, skip(self), err(Debug))]
     fn create_wd_tree(&self) -> Result<Tree> {
-        let gix_repo = gix::open_opts(
+        use bstr::ByteSlice;
+        use gix::dir::walk::EmissionMode;
+        use gix::status;
+        use gix::status::plumbing::index_as_worktree::{Change, EntryStatus};
+        use gix::status::tree_index::TrackRenames;
+
+        let repo = gix::open_opts(
             self.path(),
             gix::open::Options::default().permissions(gix::open::Permissions {
                 config: gix::open::permissions::Config {
@@ -126,86 +131,185 @@ impl RepositoryExt for git2::Repository {
                 ..Default::default()
             }),
         )?;
-        let (mut pipeline, index) = gix_repo.filter_pipeline(None)?;
-        let mut tree_update_builder = git2::build::TreeUpdateBuilder::new();
-
-        let worktree_path = self.workdir().context("Could not find worktree path")?;
-
-        let statuses = self.statuses(Some(
-            StatusOptions::new()
-                .renames_from_rewrites(false)
-                .renames_head_to_index(false)
-                .renames_index_to_workdir(false)
-                .include_untracked(true)
-                .recurse_untracked_dirs(true),
-        ))?;
-
-        // Truth table for upsert/remove:
-        // | HEAD Tree -> Index | Index -> Worktree | Action    |
-        // | add                | delete            | no-action |
-        // | modify             | delete            | remove    |
-        // |                    | delete            | remove    |
-        // | delete             |                   | remove    |
-        // | delete             | add               | upsert    |
-        // | add                |                   | upsert    |
-        // |                    | add               | upsert    |
-        // | add                | modify            | upsert    |
-        // | modify             | modify            | upsert    |
-
-        let mut buf = Vec::with_capacity(1024);
-        for status_entry in &statuses {
-            let status = status_entry.status();
-            let path = status_entry.path().context("Failed to get path")?;
-            let path = Path::new(path);
-
-            if status.is_index_new() && status.is_wt_deleted() {
-                // This is a no-op
-            } else if (status.is_index_deleted() && !status.is_wt_new()) || status.is_wt_deleted() {
-                tree_update_builder.remove(path);
-            } else {
-                let file_path = worktree_path.join(path).to_owned();
-
-                if file_path.is_symlink() {
-                    let resolved_path = file_path.read_link()?;
-                    let path_str = resolved_path
-                        .to_str()
-                        .context("Failed to convert path to str")?;
-
-                    let blob = self.blob(path_str.as_bytes())?;
-                    tree_update_builder.upsert(path, blob, git2::FileMode::Link);
-                } else if let io::Result::Ok(file) = std::fs::File::open(&file_path) {
-                    // We might have an entry for a file that does not exist on disk,
-                    // like in the case of a file conflict.
-                    let file_for_git = pipeline.convert_to_git(file, path, &index)?;
-                    let data = match file_for_git {
-                        ToGitOutcome::Unchanged(mut file) => {
-                            buf.clear();
-                            std::io::copy(&mut file, &mut buf)?;
-                            &buf
-                        }
-                        ToGitOutcome::Buffer(buf) => buf,
-                        ToGitOutcome::Process(mut read) => {
-                            buf.clear();
-                            std::io::copy(&mut read, &mut buf)?;
-                            &buf
-                        }
-                    };
-                    let blob_id = self.blob(data)?;
-
-                    let file_type = if is_executable(&file_path.metadata()?) {
-                        git2::FileMode::BlobExecutable
-                    } else {
-                        git2::FileMode::Blob
-                    };
-
-                    tree_update_builder.upsert(path, blob_id, file_type);
+        let (mut pipeline, index) = repo.filter_pipeline(None)?;
+        let workdir = repo.work_dir().context("Need non-bare repository")?;
+        let mut head_tree_editor = repo.edit_tree(repo.head_tree_id()?)?;
+        let status_changes = repo
+            .status(gix::progress::Discard)?
+            .tree_index_track_renames(TrackRenames::Disabled)
+            .index_worktree_rewrites(None)
+            .index_worktree_submodules(gix::status::Submodule::Given {
+                ignore: gix::submodule::config::Ignore::Dirty,
+                check_dirty: true,
+            })
+            .index_worktree_options_mut(|opts| {
+                if let Some(opts) = opts.dirwalk_options.as_mut() {
+                    opts.set_emit_ignored(None)
+                        .set_emit_pruned(false)
+                        .set_emit_tracked(false)
+                        .set_emit_untracked(EmissionMode::Matching)
+                        .set_emit_collapsed(None);
                 }
+            })
+            .into_iter(None)?;
+
+        let mut worktreepaths_changed = HashSet::new();
+        for change in status_changes {
+            let change = change?;
+            match change {
+                status::Item::TreeIndex(gix::diff::index::Change::Deletion {
+                    location, ..
+                }) => {
+                    // These changes play second fiddle - they are overwritten by worktree-changes,
+                    // or we assure we don't overwrite, as we may arrive out of order.
+                    if !worktreepaths_changed.contains(location.as_bstr()) {
+                        head_tree_editor.remove(location.as_ref())?;
+                    }
+                }
+                status::Item::TreeIndex(
+                    gix::diff::index::Change::Addition {
+                        location,
+                        entry_mode,
+                        id,
+                        ..
+                    }
+                    | gix::diff::index::Change::Modification {
+                        location,
+                        entry_mode,
+                        id,
+                        ..
+                    },
+                ) => {
+                    if let Some(entry_mode) = entry_mode
+                        .to_tree_entry_mode()
+                        // These changes play second fiddle - they are overwritten by worktree-changes,
+                        // or we assure we don't overwrite, as we may arrive out of order.
+                        .filter(|_| !worktreepaths_changed.contains(location.as_bstr()))
+                    {
+                        head_tree_editor.upsert(
+                            location.as_ref(),
+                            entry_mode.kind(),
+                            id.as_ref(),
+                        )?;
+                    }
+                }
+                status::Item::IndexWorktree(gix::status::index_worktree::Item::Modification {
+                    rela_path,
+                    status: EntryStatus::Change(Change::Removed),
+                    ..
+                }) => {
+                    head_tree_editor.remove(rela_path.as_bstr())?;
+                    worktreepaths_changed.insert(rela_path);
+                }
+                // modified or untracked files are unconditionally added as blob.
+                // Note that this implementation will re-read the whole blob even on type-change
+                status::Item::IndexWorktree(
+                    gix::status::index_worktree::Item::Modification {
+                        rela_path,
+                        status:
+                            EntryStatus::Change(Change::Type | Change::Modification { .. })
+                            | EntryStatus::IntentToAdd,
+                        ..
+                    }
+                    | gix::status::index_worktree::Item::DirectoryContents {
+                        entry:
+                            gix::dir::Entry {
+                                rela_path,
+                                status: gix::dir::entry::Status::Untracked,
+                                ..
+                            },
+                        ..
+                    },
+                ) => {
+                    let rela_path_as_path = gix::path::from_bstr(&rela_path);
+                    let path = workdir.join(&rela_path_as_path);
+                    let Ok(md) = std::fs::symlink_metadata(&path) else {
+                        continue;
+                    };
+                    let (id, kind) = if md.is_symlink() {
+                        let target = std::fs::read_link(&path).with_context(|| {
+                            format!(
+                                "Failed to read link at '{}' for adding to the object database",
+                                path.display()
+                            )
+                        })?;
+                        let id = repo.write_blob(gix::path::into_bstr(target).as_bytes())?;
+                        (id, gix::object::tree::EntryKind::Link)
+                    } else if md.is_file() {
+                        let file = std::fs::File::open(&path).with_context(|| {
+                            format!(
+                                "Could not open file at '{}' for adding it to the object database",
+                                path.display()
+                            )
+                        })?;
+                        let file_for_git =
+                            pipeline.convert_to_git(file, rela_path_as_path.as_ref(), &index)?;
+                        let id = match file_for_git {
+                            ToGitOutcome::Unchanged(mut file) => {
+                                repo.write_blob_stream(&mut file)?
+                            }
+                            ToGitOutcome::Buffer(buf) => repo.write_blob(buf)?,
+                            ToGitOutcome::Process(mut read) => repo.write_blob_stream(&mut read)?,
+                        };
+
+                        let kind = if gix::fs::is_executable(&md) {
+                            gix::object::tree::EntryKind::BlobExecutable
+                        } else {
+                            gix::object::tree::EntryKind::Blob
+                        };
+                        (id, kind)
+                    } else {
+                        // This is probably a type-change to something we can't track. Instead of keeping
+                        // what's in `HEAD^{tree}` we remove the entry.
+                        head_tree_editor.remove(rela_path.as_bstr())?;
+                        worktreepaths_changed.insert(rela_path);
+                        continue;
+                    };
+
+                    head_tree_editor.upsert(rela_path.as_bstr(), kind, id)?;
+                    worktreepaths_changed.insert(rela_path);
+                }
+                status::Item::IndexWorktree(gix::status::index_worktree::Item::Modification {
+                    rela_path,
+                    status: EntryStatus::Change(Change::SubmoduleModification(change)),
+                    ..
+                }) => {
+                    if let Some(possibly_changed_head_commit) = change.checked_out_head_id {
+                        head_tree_editor.upsert(
+                            rela_path.as_bstr(),
+                            gix::object::tree::EntryKind::Commit,
+                            possibly_changed_head_commit,
+                        )?;
+                        worktreepaths_changed.insert(rela_path);
+                    }
+                }
+                status::Item::IndexWorktree(gix::status::index_worktree::Item::Rewrite {
+                    ..
+                })
+                | status::Item::TreeIndex(gix::diff::index::Change::Rewrite { .. }) => {
+                    unreachable!("disabled")
+                }
+                status::Item::IndexWorktree(
+                    gix::status::index_worktree::Item::Modification {
+                        status: EntryStatus::Conflict(_) | EntryStatus::NeedsUpdate(_),
+                        ..
+                    }
+                    | gix::status::index_worktree::Item::DirectoryContents {
+                        entry:
+                            gix::dir::Entry {
+                                status:
+                                    gix::dir::entry::Status::Tracked
+                                    | gix::dir::entry::Status::Pruned
+                                    | gix::dir::entry::Status::Ignored(_),
+                                ..
+                            },
+                        ..
+                    },
+                ) => {}
             }
         }
 
-        let head_tree = self.head()?.peel_to_tree()?;
-        let tree_oid = tree_update_builder.create_updated(self, &head_tree)?;
-
+        let tree_oid = gix_to_git2_oid(head_tree_editor.write()?);
         Ok(self.find_tree(tree_oid)?)
     }
 

--- a/crates/gitbutler-repo/tests/create_wd_tree.rs
+++ b/crates/gitbutler-repo/tests/create_wd_tree.rs
@@ -8,6 +8,8 @@ use gitbutler_testsupport::gix_testtools::scripted_fixture_read_only;
 use gitbutler_testsupport::testing_repository::TestingRepository;
 use gitbutler_testsupport::visualize_git2_tree;
 
+const MAX_SIZE: u64 = 20;
+
 /// These tests exercise the truth table that we use to update the HEAD
 /// tree to match the worktree.
 ///
@@ -40,7 +42,7 @@ mod head_upsert_truthtable {
 
         std::fs::remove_file(test.tempdir.path().join("file1.txt"))?;
 
-        let tree: git2::Tree = test.repository.create_wd_tree()?;
+        let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
 
         assert_eq!(tree.len(), 0, "Tree should end up empty");
         Ok(())
@@ -59,7 +61,7 @@ mod head_upsert_truthtable {
 
         std::fs::remove_file(test.tempdir.path().join("file1.txt"))?;
 
-        let tree: git2::Tree = test.repository.create_wd_tree()?;
+        let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
 
         assert_eq!(tree.len(), 0, "Tree should end up empty");
         Ok(())
@@ -72,7 +74,7 @@ mod head_upsert_truthtable {
 
         std::fs::remove_file(test.tempdir.path().join("file1.txt"))?;
 
-        let tree: git2::Tree = test.repository.create_wd_tree()?;
+        let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
 
         assert_eq!(tree.len(), 0, "Tree should end up empty");
         Ok(())
@@ -87,7 +89,7 @@ mod head_upsert_truthtable {
         index.remove_all(["*"], None)?;
         index.write()?;
 
-        let tree: git2::Tree = test.repository.create_wd_tree()?;
+        let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
 
         // We should ignore whatever happens to the index - the current worktree state matters.
         insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
@@ -108,7 +110,7 @@ mod head_upsert_truthtable {
 
         std::fs::write(test.tempdir.path().join("file1.txt"), "content2")?;
 
-        let tree: git2::Tree = test.repository.create_wd_tree()?;
+        let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
 
         // Tree should match whatever is written on disk
         insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
@@ -129,7 +131,7 @@ mod head_upsert_truthtable {
         index.add_path(Path::new("file1.txt"))?;
         index.write()?;
 
-        let tree: git2::Tree = test.repository.create_wd_tree()?;
+        let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
 
         insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
         f87e9ef
@@ -145,7 +147,7 @@ mod head_upsert_truthtable {
 
         std::fs::write(test.tempdir.path().join("file1.txt"), "content2")?;
 
-        let tree: git2::Tree = test.repository.create_wd_tree()?;
+        let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
 
         insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
         f87e9ef
@@ -167,7 +169,7 @@ mod head_upsert_truthtable {
 
         std::fs::write(test.tempdir.path().join("file1.txt"), "content2")?;
 
-        let tree: git2::Tree = test.repository.create_wd_tree()?;
+        let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
 
         insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
         f87e9ef
@@ -192,7 +194,7 @@ mod head_upsert_truthtable {
         // this change won't be seen.
         std::fs::write(file_path, "content3")?;
 
-        let tree: git2::Tree = test.repository.create_wd_tree()?;
+        let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
 
         insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
         d377861
@@ -213,7 +215,7 @@ mod head_upsert_truthtable {
         index.add_path(Path::new("file1.txt"))?;
         index.write()?;
 
-        let tree: git2::Tree = test.repository.create_wd_tree()?;
+        let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
 
         insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
         f87e9ef
@@ -230,7 +232,7 @@ fn lists_uncommited_changes() -> anyhow::Result<()> {
     std::fs::write(test.tempdir.path().join("file1.txt"), "content1")?;
     std::fs::write(test.tempdir.path().join("file2.txt"), "content2")?;
 
-    let tree = test.repository.create_wd_tree()?;
+    let tree = test.repository.create_wd_tree(MAX_SIZE)?;
 
     insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
     1ae8c21
@@ -253,7 +255,7 @@ fn does_not_include_staged_but_deleted_files() -> anyhow::Result<()> {
     index.write()?;
     std::fs::remove_file(test.tempdir.path().join("file3.txt"))?;
 
-    let tree: git2::Tree = test.repository.create_wd_tree()?;
+    let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
 
     insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
     1ae8c21
@@ -284,7 +286,7 @@ fn should_be_empty_after_checking_out_empty_tree() -> anyhow::Result<()> {
     assert!(!test.tempdir.path().join("file1.txt").exists());
     assert!(!test.tempdir.path().join("file2.txt").exists());
 
-    let tree: git2::Tree = test.repository.create_wd_tree()?;
+    let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
 
     // `create_wd_tree` uses the head commit as the base, and then performs
     // modifications to the tree to match the working tree.
@@ -309,7 +311,7 @@ fn should_track_deleted_files() -> anyhow::Result<()> {
     assert!(!test.tempdir.path().join("file1.txt").exists());
     assert!(test.tempdir.path().join("file2.txt").exists());
 
-    let tree: git2::Tree = test.repository.create_wd_tree()?;
+    let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
 
     insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
     295a2e4
@@ -330,7 +332,7 @@ fn should_not_change_index() -> anyhow::Result<()> {
     let index_tree = test.repository.find_tree(index_tree)?;
     assert_eq!(index_tree.len(), 0);
 
-    let tree: git2::Tree = test.repository.create_wd_tree()?;
+    let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
 
     let mut index = test.repository.index()?;
     let index_tree = index.write_tree()?;
@@ -358,7 +360,7 @@ fn tree_behavior() -> anyhow::Result<()> {
     std::fs::create_dir(test.tempdir.path().join("dir3"))?;
     std::fs::write(test.tempdir.path().join("dir3/file1.txt"), "new2")?;
 
-    let tree: git2::Tree = test.repository.create_wd_tree()?;
+    let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
 
     insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
     c8aa4f7
@@ -383,7 +385,7 @@ fn executable_blobs() -> anyhow::Result<()> {
     file.set_permissions(Permissions::from_mode(0o755))?;
     file.write_all(b"content1")?;
 
-    let tree: git2::Tree = test.repository.create_wd_tree()?;
+    let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
 
     // The executable bit is also present in the tree.
     insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
@@ -400,7 +402,7 @@ fn links() -> anyhow::Result<()> {
 
     std::os::unix::fs::symlink("target", test.tempdir.path().join("link1.txt"))?;
 
-    let tree: git2::Tree = test.repository.create_wd_tree()?;
+    let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
 
     // Links are also present in the tree.
     insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
@@ -422,7 +424,7 @@ fn tracked_file_becomes_directory_in_worktree() -> anyhow::Result<()> {
     std::fs::create_dir(&worktree_path)?;
     std::fs::write(worktree_path.join("file"), "content in directory")?;
 
-    let tree: git2::Tree = test.repository.create_wd_tree().unwrap();
+    let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
     insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
     8b80519
     └── soon-directory:df6d699 
@@ -441,7 +443,7 @@ fn tracked_directory_becomes_file_in_worktree() -> anyhow::Result<()> {
     std::fs::remove_dir_all(&worktree_path)?;
     std::fs::write(worktree_path, "content")?;
 
-    let tree: git2::Tree = test.repository.create_wd_tree().unwrap();
+    let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
     insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
     637be29
     └── soon-file:100644:6b584e8 "content"
@@ -460,7 +462,7 @@ fn non_files_are_ignored() -> anyhow::Result<()> {
         .status()?
         .success());
 
-    let tree: git2::Tree = test.repository.create_wd_tree().unwrap();
+    let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
     assert_eq!(
         tree.len(),
         0,
@@ -481,7 +483,7 @@ fn tracked_file_swapped_with_non_file() -> anyhow::Result<()> {
         .status()?
         .success());
 
-    let tree: git2::Tree = test.repository.create_wd_tree()?;
+    let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
     assert_eq!(
         tree.len(),
         0,
@@ -500,7 +502,7 @@ fn ignored_files() -> anyhow::Result<()> {
     let ignored_path = test.tempdir.path().join("I-am.ignored");
     std::fs::write(&ignored_path, "")?;
 
-    let tree: git2::Tree = test.repository.create_wd_tree()?;
+    let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
     // ignored files aren't picked up.
     insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
     38b94c0
@@ -511,10 +513,26 @@ fn ignored_files() -> anyhow::Result<()> {
 }
 
 #[test]
+fn can_autotrack_empty_files() -> anyhow::Result<()> {
+    let test = TestingRepository::open_with_initial_commit(&[("soon-empty", "content")]);
+
+    let ignored_path = test.tempdir.path().join("soon-empty");
+    std::fs::write(&ignored_path, "")?;
+
+    let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
+    // ignored files aren't picked up.
+    insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
+    4fe2781
+    └── soon-empty:100644:e69de29 ""
+    "#);
+    Ok(())
+}
+
+#[test]
 fn intent_to_add_is_picked_up_just_like_untracked() -> anyhow::Result<()> {
     let repo = repo("intent-to-add")?;
 
-    let tree: git2::Tree = repo.create_wd_tree()?;
+    let tree: git2::Tree = repo.create_wd_tree(MAX_SIZE)?;
     // We pick up what's in the worktree, independently of the intent-to-add flag.
     insta::assert_snapshot!(visualize_git2_tree(tree.id(), &repo), @r#"
     d6a22f9
@@ -527,7 +545,7 @@ fn intent_to_add_is_picked_up_just_like_untracked() -> anyhow::Result<()> {
 fn submodule_in_index_is_picked_up() -> anyhow::Result<()> {
     let repo = repo("with-submodule-in-index")?;
 
-    let tree: git2::Tree = repo.create_wd_tree()?;
+    let tree: git2::Tree = repo.create_wd_tree(MAX_SIZE)?;
     // Everything that is not contending with the worktree that is already in the index
     // is picked up, even if it involves submodules.
     insta::assert_snapshot!(visualize_git2_tree(tree.id(), &repo), @r#"
@@ -542,7 +560,7 @@ fn submodule_in_index_is_picked_up() -> anyhow::Result<()> {
 fn submodule_change() -> anyhow::Result<()> {
     let repo = repo("with-submodule-new-commit")?;
 
-    let tree: git2::Tree = repo.create_wd_tree()?;
+    let tree: git2::Tree = repo.create_wd_tree(MAX_SIZE)?;
 
     // Changes to submodule heads are also picked up.
     insta::assert_snapshot!(visualize_git2_tree(tree.id(), &repo), @r#"
@@ -553,9 +571,68 @@ fn submodule_change() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[test]
+fn big_files_check_is_disabled_with_zero() -> anyhow::Result<()> {
+    let test = TestingRepository::open_with_initial_commit(&[]);
+
+    std::fs::write(&test.tempdir.path().join("empty"), "")?;
+    std::fs::write(&test.tempdir.path().join("with-content"), "content")?;
+
+    let tree: git2::Tree = test.repository.create_wd_tree(0)?;
+
+    // Everything goes with 0
+    insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
+    f6e159b
+    ├── empty:100644:e69de29 ""
+    └── with-content:100644:6b584e8 "content"
+    "#);
+    Ok(())
+}
+
+#[test]
+fn big_files_are_ignored_based_on_threshold_in_working_tree() -> anyhow::Result<()> {
+    let test =
+        TestingRepository::open_with_initial_commit(&[("soon-too-big", "still small enough")]);
+
+    let big_file_path = test.tempdir.path().join("soon-too-big");
+    std::fs::write(&big_file_path, "a massive file above the threshold")?;
+
+    let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
+
+    // It does not pickup the big worktree change.
+    insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
+    26ea3c5
+    └── soon-too-big:100644:7d72316 "still small enough"
+    "#);
+    Ok(())
+}
+
+#[test]
+fn big_files_are_fine_when_in_the_index() -> anyhow::Result<()> {
+    let test =
+        TestingRepository::open_with_initial_commit(&[("soon-too-big", "still small enough")]);
+
+    std::fs::write(
+        test.tempdir.path().join("soon-too-big"),
+        "a massive file above the threshold",
+    )?;
+    let mut index = test.repository.index()?;
+    index.add_path("soon-too-big".as_ref())?;
+    index.write()?;
+
+    let tree: git2::Tree = test.repository.create_wd_tree(MAX_SIZE)?;
+
+    // It keeps files that were already added.
+    insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
+    bbd82c6
+    └── soon-too-big:100644:1799e5a "a massive file above the threshold"
+    "#);
+    Ok(())
+}
+
 fn repo(name: &str) -> anyhow::Result<git2::Repository> {
     let worktree_dir = scripted_fixture_read_only("make_create_wd_tree_repos.sh")
-        .map_err(|err| anyhow::Error::from_boxed(err))?
+        .map_err(anyhow::Error::from_boxed)?
         .join(name);
     Ok(git2::Repository::open(worktree_dir)?)
 }

--- a/crates/gitbutler-repo/tests/create_wd_tree.rs
+++ b/crates/gitbutler-repo/tests/create_wd_tree.rs
@@ -4,9 +4,8 @@ use std::{
 };
 
 use gitbutler_repo::RepositoryExt as _;
-use gitbutler_testsupport::testing_repository::{
-    assert_tree_matches, assert_tree_matches_with_mode, EntryAttribute, TestingRepository,
-};
+use gitbutler_testsupport::testing_repository::TestingRepository;
+use gitbutler_testsupport::visualize_git2_tree;
 
 /// These tests exercise the truth table that we use to update the HEAD
 /// tree to match the worktree.
@@ -25,384 +24,436 @@ use gitbutler_testsupport::testing_repository::{
 #[cfg(test)]
 mod head_upsert_truthtable {
     use super::*;
+    use gitbutler_testsupport::visualize_git2_tree;
 
     // | add                | delete            | no-action |
     #[test]
-    fn index_new_worktree_delete() {
-        let test_repository = TestingRepository::open_with_initial_commit(&[]);
+    fn index_new_worktree_delete() -> anyhow::Result<()> {
+        let test = TestingRepository::open_with_initial_commit(&[]);
 
-        std::fs::write(test_repository.tempdir.path().join("file1.txt"), "content1").unwrap();
+        std::fs::write(test.tempdir.path().join("file1.txt"), "content1")?;
 
-        let mut index = test_repository.repository.index().unwrap();
-        index.add_path(Path::new("file1.txt")).unwrap();
-        index.write().unwrap();
+        let mut index = test.repository.index()?;
+        index.add_path(Path::new("file1.txt"))?;
+        index.write()?;
 
-        std::fs::remove_file(test_repository.tempdir.path().join("file1.txt")).unwrap();
+        std::fs::remove_file(test.tempdir.path().join("file1.txt"))?;
 
-        let tree: git2::Tree = test_repository.repository.create_wd_tree().unwrap();
+        let tree: git2::Tree = test.repository.create_wd_tree()?;
 
         assert_eq!(tree.len(), 0, "Tree should end up empty");
+        Ok(())
     }
 
     // | modify             | delete            | remove    |
     #[test]
-    fn index_modify_worktree_delete() {
-        let test_repository =
-            TestingRepository::open_with_initial_commit(&[("file1.txt", "content1")]);
+    fn index_modify_worktree_delete() -> anyhow::Result<()> {
+        let test = TestingRepository::open_with_initial_commit(&[("file1.txt", "content1")]);
 
-        std::fs::write(test_repository.tempdir.path().join("file1.txt"), "content2").unwrap();
+        std::fs::write(test.tempdir.path().join("file1.txt"), "content2")?;
 
-        let mut index = test_repository.repository.index().unwrap();
-        index.add_path(Path::new("file1.txt")).unwrap();
-        index.write().unwrap();
+        let mut index = test.repository.index()?;
+        index.add_path(Path::new("file1.txt"))?;
+        index.write()?;
 
-        std::fs::remove_file(test_repository.tempdir.path().join("file1.txt")).unwrap();
+        std::fs::remove_file(test.tempdir.path().join("file1.txt"))?;
 
-        let tree: git2::Tree = test_repository.repository.create_wd_tree().unwrap();
+        let tree: git2::Tree = test.repository.create_wd_tree()?;
 
         assert_eq!(tree.len(), 0, "Tree should end up empty");
+        Ok(())
     }
 
     // |                    | delete            | remove    |
     #[test]
-    fn worktree_delete() {
-        let test_repository =
-            TestingRepository::open_with_initial_commit(&[("file1.txt", "content1")]);
+    fn worktree_delete() -> anyhow::Result<()> {
+        let test = TestingRepository::open_with_initial_commit(&[("file1.txt", "content1")]);
 
-        std::fs::remove_file(test_repository.tempdir.path().join("file1.txt")).unwrap();
+        std::fs::remove_file(test.tempdir.path().join("file1.txt"))?;
 
-        let tree: git2::Tree = test_repository.repository.create_wd_tree().unwrap();
+        let tree: git2::Tree = test.repository.create_wd_tree()?;
 
         assert_eq!(tree.len(), 0, "Tree should end up empty");
+        Ok(())
     }
 
     // | delete             |                   | remove    |
     #[test]
-    fn index_delete() {
-        let test_repository =
-            TestingRepository::open_with_initial_commit(&[("file1.txt", "content1")]);
+    fn index_delete() -> anyhow::Result<()> {
+        let test = TestingRepository::open_with_initial_commit(&[("file1.txt", "content1")]);
 
-        let mut index = test_repository.repository.index().unwrap();
-        index.remove_all(["*"], None).unwrap();
-        index.write().unwrap();
+        let mut index = test.repository.index()?;
+        index.remove_all(["*"], None)?;
+        index.write()?;
 
-        let tree: git2::Tree = test_repository.repository.create_wd_tree().unwrap();
+        let tree: git2::Tree = test.repository.create_wd_tree()?;
 
-        // We should ignore whatever happens to the index
-        assert_tree_matches(
-            &test_repository.repository,
-            &tree,
-            &[("file1.txt", b"content1")],
-        );
+        // We should ignore whatever happens to the index - the current worktree state matters.
+        insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
+        7cd1c45
+        └── file1.txt:100644:dd954e7 "content1"
+        "#);
+        Ok(())
     }
 
     // | delete             | add               | upsert    |
     #[test]
-    fn index_delete_worktree_add() {
-        let test_repository =
-            TestingRepository::open_with_initial_commit(&[("file1.txt", "content1")]);
+    fn index_delete_worktree_add() -> anyhow::Result<()> {
+        let test = TestingRepository::open_with_initial_commit(&[("file1.txt", "content1")]);
 
-        let mut index = test_repository.repository.index().unwrap();
-        index.remove_all(["*"], None).unwrap();
-        index.write().unwrap();
+        let mut index = test.repository.index()?;
+        index.remove_all(["*"], None)?;
+        index.write()?;
 
-        std::fs::write(test_repository.tempdir.path().join("file1.txt"), "content2").unwrap();
+        std::fs::write(test.tempdir.path().join("file1.txt"), "content2")?;
 
-        let tree: git2::Tree = test_repository.repository.create_wd_tree().unwrap();
+        let tree: git2::Tree = test.repository.create_wd_tree()?;
 
         // Tree should match whatever is written on disk
-        assert_tree_matches(
-            &test_repository.repository,
-            &tree,
-            &[("file1.txt", b"content2")],
-        );
+        insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
+        f87e9ef
+        └── file1.txt:100644:db00fd6 "content2"
+        "#);
+        Ok(())
     }
 
     // | add                |                   | upsert    |
     #[test]
-    fn index_add() {
-        let test_repository = TestingRepository::open_with_initial_commit(&[]);
+    fn index_add() -> anyhow::Result<()> {
+        let test = TestingRepository::open_with_initial_commit(&[]);
 
-        std::fs::write(test_repository.tempdir.path().join("file1.txt"), "content2").unwrap();
+        std::fs::write(test.tempdir.path().join("file1.txt"), "content2")?;
 
-        let mut index = test_repository.repository.index().unwrap();
-        index.add_path(Path::new("file1.txt")).unwrap();
-        index.write().unwrap();
+        let mut index = test.repository.index()?;
+        index.add_path(Path::new("file1.txt"))?;
+        index.write()?;
 
-        let tree: git2::Tree = test_repository.repository.create_wd_tree().unwrap();
+        let tree: git2::Tree = test.repository.create_wd_tree()?;
 
-        // Tree should match whatever is written on disk
-        assert_tree_matches(
-            &test_repository.repository,
-            &tree,
-            &[("file1.txt", b"content2")],
-        );
+        insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
+        f87e9ef
+        └── file1.txt:100644:db00fd6 "content2"
+        "#);
+        Ok(())
     }
 
     // |                    | add               | upsert    |
     #[test]
-    fn worktree_add() {
-        let test_repository = TestingRepository::open_with_initial_commit(&[]);
+    fn worktree_add() -> anyhow::Result<()> {
+        let test = TestingRepository::open_with_initial_commit(&[]);
 
-        std::fs::write(test_repository.tempdir.path().join("file1.txt"), "content2").unwrap();
+        std::fs::write(test.tempdir.path().join("file1.txt"), "content2")?;
 
-        let tree: git2::Tree = test_repository.repository.create_wd_tree().unwrap();
+        let tree: git2::Tree = test.repository.create_wd_tree()?;
 
-        // Tree should match whatever is written on disk
-        assert_tree_matches(
-            &test_repository.repository,
-            &tree,
-            &[("file1.txt", b"content2")],
-        );
+        insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
+        f87e9ef
+        └── file1.txt:100644:db00fd6 "content2"
+        "#);
+        Ok(())
     }
 
     // | add                | modify            | upsert    |
     #[test]
-    fn index_add_worktree_modify() {
-        let test_repository = TestingRepository::open_with_initial_commit(&[]);
+    fn index_add_worktree_modify() -> anyhow::Result<()> {
+        let test = TestingRepository::open_with_initial_commit(&[]);
 
-        std::fs::write(test_repository.tempdir.path().join("file1.txt"), "content1").unwrap();
+        std::fs::write(test.tempdir.path().join("file1.txt"), "content1")?;
 
-        let mut index = test_repository.repository.index().unwrap();
-        index.add_path(Path::new("file1.txt")).unwrap();
-        index.write().unwrap();
+        let mut index = test.repository.index()?;
+        index.add_path(Path::new("file1.txt"))?;
+        index.write()?;
 
-        std::fs::write(test_repository.tempdir.path().join("file1.txt"), "content2").unwrap();
+        std::fs::write(test.tempdir.path().join("file1.txt"), "content2")?;
 
-        let tree: git2::Tree = test_repository.repository.create_wd_tree().unwrap();
+        let tree: git2::Tree = test.repository.create_wd_tree()?;
 
-        // Tree should match whatever is written on disk
-        assert_tree_matches(
-            &test_repository.repository,
-            &tree,
-            &[("file1.txt", b"content2")],
-        );
+        insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
+        f87e9ef
+        └── file1.txt:100644:db00fd6 "content2"
+        "#);
+        Ok(())
     }
 
     // | modify             | modify            | upsert    |
     #[test]
-    fn index_modify_worktree_modify() {
-        let test_repository =
-            TestingRepository::open_with_initial_commit(&[("file1.txt", "content1")]);
+    fn index_modify_worktree_modify() -> anyhow::Result<()> {
+        let test = TestingRepository::open_with_initial_commit(&[("file1.txt", "content1")]);
 
-        std::fs::write(test_repository.tempdir.path().join("file1.txt"), "content2").unwrap();
+        std::fs::write(test.tempdir.path().join("file1.txt"), "content2")?;
 
-        let mut index = test_repository.repository.index().unwrap();
-        index.add_path(Path::new("file1.txt")).unwrap();
-        index.write().unwrap();
+        let mut index = test.repository.index()?;
+        index.add_path(Path::new("file1.txt"))?;
+        index.write()?;
 
-        std::fs::write(test_repository.tempdir.path().join("file1.txt"), "content3").unwrap();
+        std::fs::write(test.tempdir.path().join("file1.txt"), "content3")?;
 
-        let tree: git2::Tree = test_repository.repository.create_wd_tree().unwrap();
+        let tree: git2::Tree = test.repository.create_wd_tree()?;
 
-        // Tree should match whatever is written on disk
-        assert_tree_matches(
-            &test_repository.repository,
-            &tree,
-            &[("file1.txt", b"content3")],
-        );
+        insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
+        d377861
+        └── file1.txt:100644:a2b3229 "content3"
+        "#);
+        Ok(())
     }
 }
 
 #[test]
-fn lists_uncommited_changes() {
-    let test_repository = TestingRepository::open_with_initial_commit(&[]);
+fn lists_uncommited_changes() -> anyhow::Result<()> {
+    let test = TestingRepository::open_with_initial_commit(&[]);
 
-    std::fs::write(test_repository.tempdir.path().join("file1.txt"), "content1").unwrap();
-    std::fs::write(test_repository.tempdir.path().join("file2.txt"), "content2").unwrap();
+    std::fs::write(test.tempdir.path().join("file1.txt"), "content1")?;
+    std::fs::write(test.tempdir.path().join("file2.txt"), "content2")?;
 
-    let tree = test_repository.repository.create_wd_tree().unwrap();
+    let tree = test.repository.create_wd_tree()?;
 
-    assert_tree_matches(
-        &test_repository.repository,
-        &tree,
-        &[("file1.txt", b"content1"), ("file2.txt", b"content2")],
-    );
+    insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
+    1ae8c21
+    ├── file1.txt:100644:dd954e7 "content1"
+    └── file2.txt:100644:db00fd6 "content2"
+    "#);
+    Ok(())
 }
 
 #[test]
-fn does_not_include_staged_but_deleted_files() {
-    let test_repository = TestingRepository::open_with_initial_commit(&[]);
+fn does_not_include_staged_but_deleted_files() -> anyhow::Result<()> {
+    let test = TestingRepository::open_with_initial_commit(&[]);
 
-    std::fs::write(test_repository.tempdir.path().join("file1.txt"), "content1").unwrap();
-    std::fs::write(test_repository.tempdir.path().join("file2.txt"), "content2").unwrap();
+    std::fs::write(test.tempdir.path().join("file1.txt"), "content1")?;
+    std::fs::write(test.tempdir.path().join("file2.txt"), "content2")?;
 
-    std::fs::write(test_repository.tempdir.path().join("file3.txt"), "content2").unwrap();
-    let mut index: git2::Index = test_repository.repository.index().unwrap();
-    index.add_path(Path::new("file3.txt")).unwrap();
-    index.write().unwrap();
-    std::fs::remove_file(test_repository.tempdir.path().join("file3.txt")).unwrap();
+    std::fs::write(test.tempdir.path().join("file3.txt"), "content2")?;
+    let mut index: git2::Index = test.repository.index()?;
+    index.add_path(Path::new("file3.txt"))?;
+    index.write()?;
+    std::fs::remove_file(test.tempdir.path().join("file3.txt"))?;
 
-    let tree: git2::Tree = test_repository.repository.create_wd_tree().unwrap();
+    let tree: git2::Tree = test.repository.create_wd_tree()?;
 
-    assert_tree_matches(
-        &test_repository.repository,
-        &tree,
-        &[("file1.txt", b"content1"), ("file2.txt", b"content2")],
-    );
-    assert!(tree.get_name("file3.txt").is_none());
+    insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
+    1ae8c21
+    ├── file1.txt:100644:dd954e7 "content1"
+    └── file2.txt:100644:db00fd6 "content2"
+    "#);
+    Ok(())
 }
 
 #[test]
-fn should_be_empty_after_checking_out_empty_tree() {
-    let test_repository = TestingRepository::open_with_initial_commit(&[
+fn should_be_empty_after_checking_out_empty_tree() -> anyhow::Result<()> {
+    let test = TestingRepository::open_with_initial_commit(&[
         ("file1.txt", "content1"),
         ("file2.txt", "content2"),
     ]);
 
     // Checkout an empty tree
     {
-        let tree_oid = test_repository
-            .repository
-            .treebuilder(None)
-            .unwrap()
-            .write()
-            .unwrap();
-        let tree = test_repository.repository.find_tree(tree_oid).unwrap();
-        test_repository
-            .repository
+        let tree_oid = test.repository.treebuilder(None)?.write()?;
+        let tree = test.repository.find_tree(tree_oid)?;
+        test.repository
             .checkout_tree_builder(&tree)
             .force()
             .remove_untracked()
-            .checkout()
-            .unwrap();
+            .checkout()?;
     }
 
-    assert!(!test_repository.tempdir.path().join("file1.txt").exists());
-    assert!(!test_repository.tempdir.path().join("file2.txt").exists());
+    assert!(!test.tempdir.path().join("file1.txt").exists());
+    assert!(!test.tempdir.path().join("file2.txt").exists());
 
-    let tree: git2::Tree = test_repository.repository.create_wd_tree().unwrap();
+    let tree: git2::Tree = test.repository.create_wd_tree()?;
 
-    // Fails because `create_wd_tree` uses the head commit as the base,
-    // and then performs modifications to the tree
+    // `create_wd_tree` uses the head commit as the base, and then performs
+    // modifications to the tree to match the working tree.
     assert_eq!(tree.len(), 0);
+    Ok(())
 }
 
 #[test]
-fn should_track_deleted_files() {
-    let test_repository = TestingRepository::open_with_initial_commit(&[
+fn should_track_deleted_files() -> anyhow::Result<()> {
+    let test = TestingRepository::open_with_initial_commit(&[
         ("file1.txt", "content1"),
         ("file2.txt", "content2"),
     ]);
 
     // Make sure the index is empty, perhaps the user did this action
-    let mut index: git2::Index = test_repository.repository.index().unwrap();
-    index.remove_all(["*"], None).unwrap();
-    index.write().unwrap();
+    let mut index: git2::Index = test.repository.index()?;
+    index.remove_all(["*"], None)?;
+    index.write()?;
 
-    std::fs::remove_file(test_repository.tempdir.path().join("file1.txt")).unwrap();
+    std::fs::remove_file(test.tempdir.path().join("file1.txt"))?;
 
-    assert!(!test_repository.tempdir.path().join("file1.txt").exists());
-    assert!(test_repository.tempdir.path().join("file2.txt").exists());
+    assert!(!test.tempdir.path().join("file1.txt").exists());
+    assert!(test.tempdir.path().join("file2.txt").exists());
 
-    let tree: git2::Tree = test_repository.repository.create_wd_tree().unwrap();
+    let tree: git2::Tree = test.repository.create_wd_tree()?;
 
-    // Fails because `create_wd_tree` uses the head commit as the base,
-    // and then performs modifications to the tree
-    assert!(tree.get_name("file1.txt").is_none());
-    assert!(tree.get_name("file2.txt").is_some());
+    insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
+    295a2e4
+    └── file2.txt:100644:db00fd6 "content2"
+    "#);
+    Ok(())
 }
 
 #[test]
-fn should_not_change_index() {
-    let test_repository = TestingRepository::open_with_initial_commit(&[("file1.txt", "content1")]);
+fn should_not_change_index() -> anyhow::Result<()> {
+    let test = TestingRepository::open_with_initial_commit(&[("file1.txt", "content1")]);
 
-    let mut index = test_repository.repository.index().unwrap();
-    index.remove_all(["*"], None).unwrap();
-    index.write().unwrap();
+    let mut index = test.repository.index()?;
+    index.remove_all(["*"], None)?;
+    index.write()?;
 
-    let index_tree = index.write_tree().unwrap();
-    let index_tree = test_repository.repository.find_tree(index_tree).unwrap();
+    let index_tree = index.write_tree()?;
+    let index_tree = test.repository.find_tree(index_tree)?;
     assert_eq!(index_tree.len(), 0);
 
-    let tree: git2::Tree = test_repository.repository.create_wd_tree().unwrap();
+    let tree: git2::Tree = test.repository.create_wd_tree()?;
 
-    let mut index = test_repository.repository.index().unwrap();
-    let index_tree = index.write_tree().unwrap();
-    let index_tree = test_repository.repository.find_tree(index_tree).unwrap();
+    let mut index = test.repository.index()?;
+    let index_tree = index.write_tree()?;
+    let index_tree = test.repository.find_tree(index_tree)?;
     assert_eq!(index_tree.len(), 0);
 
     // Tree should match whatever is written on disk
-    assert_tree_matches(
-        &test_repository.repository,
-        &tree,
-        &[("file1.txt", b"content1")],
-    );
+    insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
+    7cd1c45
+    └── file1.txt:100644:dd954e7 "content1"
+    "#);
+    Ok(())
 }
 
 #[test]
-fn tree_behavior() {
-    let test_repository = TestingRepository::open_with_initial_commit(&[
+fn tree_behavior() -> anyhow::Result<()> {
+    let test = TestingRepository::open_with_initial_commit(&[
         ("dir1/file1.txt", "content1"),
         ("dir2/file2.txt", "content2"),
     ]);
 
     // Update a file in a directory
-    std::fs::write(
-        test_repository.tempdir.path().join("dir1/file1.txt"),
-        "new1",
-    )
-    .unwrap();
+    std::fs::write(test.tempdir.path().join("dir1/file1.txt"), "new1")?;
     // Make a new directory and file
-    std::fs::create_dir(test_repository.tempdir.path().join("dir3")).unwrap();
-    std::fs::write(
-        test_repository.tempdir.path().join("dir3/file1.txt"),
-        "new2",
-    )
-    .unwrap();
+    std::fs::create_dir(test.tempdir.path().join("dir3"))?;
+    std::fs::write(test.tempdir.path().join("dir3/file1.txt"), "new2")?;
 
-    let tree: git2::Tree = test_repository.repository.create_wd_tree().unwrap();
+    let tree: git2::Tree = test.repository.create_wd_tree()?;
 
-    assert_tree_matches(
-        &test_repository.repository,
-        &tree,
-        &[
-            ("dir1/file1.txt", b"new1"),
-            ("dir2/file2.txt", b"content2"),
-            ("dir3/file1.txt", b"new2"),
-        ],
-    );
+    insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
+    c8aa4f7
+    ├── dir1:dce0d03 
+    │   └── file1.txt:100644:e4a8953 "new1"
+    ├── dir2:295a2e4 
+    │   └── file2.txt:100644:db00fd6 "content2"
+    └── dir3:92e07f7 
+        └── file1.txt:100644:1fda1b4 "new2"
+    "#);
+    Ok(())
 }
 
-#[cfg(unix)]
 #[test]
-fn executable_blobs() {
+#[cfg(unix)]
+fn executable_blobs() -> anyhow::Result<()> {
     use std::{io::Write, os::unix::fs::PermissionsExt as _};
 
-    let test_repository = TestingRepository::open_with_initial_commit(&[]);
+    let test = TestingRepository::open_with_initial_commit(&[]);
 
-    let mut file = File::create(test_repository.tempdir.path().join("file1.txt")).unwrap();
-    file.set_permissions(Permissions::from_mode(0o755)).unwrap();
-    file.write_all(b"content1").unwrap();
+    let mut file = File::create(test.tempdir.path().join("file1.txt"))?;
+    file.set_permissions(Permissions::from_mode(0o755))?;
+    file.write_all(b"content1")?;
 
-    let tree: git2::Tree = test_repository.repository.create_wd_tree().unwrap();
+    let tree: git2::Tree = test.repository.create_wd_tree()?;
 
-    assert_tree_matches_with_mode(
-        &test_repository.repository,
-        tree.id(),
-        &[(
-            "file1.txt",
-            b"content1",
-            &[EntryAttribute::Blob, EntryAttribute::Executable],
-        )],
-    );
+    // The executable bit is also present in the tree.
+    insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
+    4cb9de9
+    └── file1.txt:100755:dd954e7 "content1"
+    "#);
+    Ok(())
 }
 
-#[cfg(unix)]
 #[test]
-fn links() {
-    let test_repository = TestingRepository::open_with_initial_commit(&[("target", "helloworld")]);
+#[cfg(unix)]
+fn links() -> anyhow::Result<()> {
+    let test = TestingRepository::open_with_initial_commit(&[("target", "helloworld")]);
 
-    std::os::unix::fs::symlink("target", test_repository.tempdir.path().join("link1.txt")).unwrap();
+    std::os::unix::fs::symlink("target", test.tempdir.path().join("link1.txt"))?;
 
-    let tree: git2::Tree = test_repository.repository.create_wd_tree().unwrap();
+    let tree: git2::Tree = test.repository.create_wd_tree()?;
 
-    assert_tree_matches_with_mode(
-        &test_repository.repository,
-        tree.id(),
-        &[
-            ("link1.txt", b"target", &[EntryAttribute::Link]),
-            ("target", b"helloworld", &[EntryAttribute::Blob]),
-        ],
+    // Links are also present in the tree.
+    insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r#"
+    0aefe10
+    ├── link1.txt:120000:1de5659 "target"
+    └── target:100644:620ffd0 "helloworld"
+    "#);
+    Ok(())
+}
+
+#[test]
+fn tracked_file_becomes_directory_in_worktree() -> anyhow::Result<()> {
+    let test = TestingRepository::open_with_initial_commit(&[(
+        "soon-directory",
+        "this tracked file becomes a directory",
+    )]);
+    let worktree_path = test.tempdir.path().join("soon-directory");
+    std::fs::remove_file(&worktree_path)?;
+    std::fs::create_dir(&worktree_path)?;
+    std::fs::write(worktree_path.join("file"), "content in directory")?;
+
+    let tree: git2::Tree = test.repository.create_wd_tree().unwrap();
+    insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r"");
+    Ok(())
+}
+
+#[test]
+fn tracked_directory_becomes_file_in_worktree() -> anyhow::Result<()> {
+    let test = TestingRepository::open_with_initial_commit(&[(
+        "soon-file/content",
+        "this tracked is removed and the parent dir becomes a file",
+    )]);
+    let worktree_path = test.tempdir.path().join("soon-file");
+    std::fs::remove_dir_all(&worktree_path)?;
+    std::fs::write(worktree_path, "content")?;
+
+    let tree: git2::Tree = test.repository.create_wd_tree().unwrap();
+    insta::assert_snapshot!(visualize_git2_tree(tree.id(), &test.repository), @r"");
+    Ok(())
+}
+
+#[test]
+#[cfg(unix)]
+fn non_files_are_ignored() -> anyhow::Result<()> {
+    let test = TestingRepository::open_with_initial_commit(&[]);
+
+    let fifo_path = test.tempdir.path().join("fifo");
+    assert!(std::process::Command::new("mkfifo")
+        .arg(&fifo_path)
+        .status()?
+        .success());
+
+    let tree: git2::Tree = test.repository.create_wd_tree().unwrap();
+    assert_eq!(
+        tree.len(),
+        0,
+        "It completely ignores non-files, it doesn't see them, just like Git"
     );
+    Ok(())
+}
+
+#[test]
+#[cfg(unix)]
+fn tracked_file_swapped_with_non_file() -> anyhow::Result<()> {
+    let test = TestingRepository::open_with_initial_commit(&[("soon-fifo", "actual content")]);
+
+    let fifo_path = test.tempdir.path().join("soon-fifo");
+    std::fs::remove_file(&fifo_path)?;
+    assert!(std::process::Command::new("mkfifo")
+        .arg(&fifo_path)
+        .status()?
+        .success());
+
+    let tree: git2::Tree = test.repository.create_wd_tree().unwrap();
+    assert_eq!(
+        tree.len(),
+        0,
+        "It completely ignores non-files, it doesn't see them, just like Git, even when previously tracked"
+    );
+    Ok(())
 }

--- a/crates/gitbutler-repo/tests/create_wd_tree.rs
+++ b/crates/gitbutler-repo/tests/create_wd_tree.rs
@@ -575,8 +575,8 @@ fn submodule_change() -> anyhow::Result<()> {
 fn big_files_check_is_disabled_with_zero() -> anyhow::Result<()> {
     let test = TestingRepository::open_with_initial_commit(&[]);
 
-    std::fs::write(&test.tempdir.path().join("empty"), "")?;
-    std::fs::write(&test.tempdir.path().join("with-content"), "content")?;
+    std::fs::write(test.tempdir.path().join("empty"), "")?;
+    std::fs::write(test.tempdir.path().join("with-content"), "content")?;
 
     let tree: git2::Tree = test.repository.create_wd_tree(0)?;
 

--- a/crates/gitbutler-repo/tests/fixtures/make_create_wd_tree_repos.sh
+++ b/crates/gitbutler-repo/tests/fixtures/make_create_wd_tree_repos.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+git init intent-to-add
+(cd intent-to-add
+  git commit -m "init" --allow-empty
+  echo -n content >to-be-added
+  git add --intent-to-add to-be-added
+)
+
+git init module;
+(cd module
+  mkdir dir
+  touch a dir/b
+  git add . && git commit -m "init"
+)
+
+git init with-submodule-in-index
+(cd with-submodule-in-index
+  git commit -m "init" --allow-empty
+  git submodule add ../module sm
+)
+
+git init with-submodule-new-commit
+(cd with-submodule-new-commit
+  git commit -m "init" --allow-empty
+  git submodule add ../module sm
+  git commit -m "add submodule"
+  (cd sm
+    echo -n change >>a && git commit -am "change file in submodule"
+  )
+)

--- a/crates/gitbutler-testsupport/Cargo.toml
+++ b/crates/gitbutler-testsupport/Cargo.toml
@@ -31,4 +31,5 @@ gitbutler-url.workspace = true
 gitbutler-stack.workspace = true
 gitbutler-oxidize.workspace = true
 gitbutler-commit.workspace = true
+termtree = "0.5.1"
 uuid.workspace = true

--- a/crates/gitbutler-testsupport/src/testing_repository.rs
+++ b/crates/gitbutler-testsupport/src/testing_repository.rs
@@ -145,6 +145,7 @@ impl TestingRepository {
         index
             .add_all(["*"], git2::IndexAddOption::DEFAULT, None)
             .unwrap();
+        index.write().unwrap();
 
         let signature = git2::Signature::now("Caleb", "caleb@gitbutler.com").unwrap();
         let commit_headers =

--- a/crates/gitbutler-workspace/src/branch_trees.rs
+++ b/crates/gitbutler-workspace/src/branch_trees.rs
@@ -4,6 +4,7 @@ use gitbutler_command_context::CommandContext;
 use gitbutler_commit::commit_ext::CommitExt as _;
 use gitbutler_oxidize::{git2_to_gix_object_id, gix_to_git2_oid, GixRepositoryExt};
 use gitbutler_project::access::WorktreeWritePermission;
+use gitbutler_project::AUTO_TRACK_LIMIT_BYTES;
 use gitbutler_repo::rebase::cherry_rebase_group;
 use gitbutler_repo::RepositoryExt as _;
 use gitbutler_stack::{Stack, VirtualBranchesHandle};
@@ -23,7 +24,7 @@ pub fn checkout_branch_trees<'a>(
 
     if stacks.is_empty() {
         // If there are no applied branches, then return the current uncommtied state
-        return repository.create_wd_tree();
+        return repository.create_wd_tree(AUTO_TRACK_LIMIT_BYTES);
     };
 
     if stacks.len() == 1 {

--- a/crates/gitbutler-workspace/tests/mod.rs
+++ b/crates/gitbutler-workspace/tests/mod.rs
@@ -6,6 +6,7 @@ mod checkout_branch_trees {
     use gitbutler_branch::BranchCreateRequest;
     use gitbutler_branch_actions as branch_actions;
     use gitbutler_command_context::CommandContext;
+    use gitbutler_project::AUTO_TRACK_LIMIT_BYTES;
     use gitbutler_repo::RepositoryExt as _;
     use gitbutler_testsupport::{paths, testing_repository::assert_tree_matches, TestProject};
     use gitbutler_workspace::checkout_branch_trees;
@@ -40,7 +41,10 @@ mod checkout_branch_trees {
 
         branch_actions::create_commit(&project, branch_2, "commit two", None, false).unwrap();
 
-        let tree = test_project.local_repository.create_wd_tree().unwrap();
+        let tree = test_project
+            .local_repository
+            .create_wd_tree(AUTO_TRACK_LIMIT_BYTES)
+            .unwrap();
 
         // Assert original state
         assert_tree_matches(
@@ -70,7 +74,10 @@ mod checkout_branch_trees {
 
         // Assert tree is indeed empty
         {
-            let tree: git2::Tree = test_project.local_repository.create_wd_tree().unwrap();
+            let tree: git2::Tree = test_project
+                .local_repository
+                .create_wd_tree(AUTO_TRACK_LIMIT_BYTES)
+                .unwrap();
 
             // Tree should be empty
             assert_eq!(
@@ -85,7 +92,10 @@ mod checkout_branch_trees {
 
         checkout_branch_trees(&ctx, guard.write_permission()).unwrap();
 
-        let tree = test_project.local_repository.create_wd_tree().unwrap();
+        let tree = test_project
+            .local_repository
+            .create_wd_tree(AUTO_TRACK_LIMIT_BYTES)
+            .unwrap();
 
         // Should be back to original state
         assert_tree_matches(


### PR DESCRIPTION
Follow-up to #4912.

### Tasks

* [x] see if additional tests can or should be added
* [x] use new `gix-status` for `create_wd_tree()`
* [x] intent-to-add test
* [x] ignored files test
* [x] submodule test - maybe we can deal with it a little?
* [x] skip huge files
* [x] figure out occasional test failure - racy git probably, but why
* [x] capture performance numbers - 35% more speed
* [x] use `gix` from `main` once https://github.com/GitoxideLabs/gitoxide/pull/1746 is merged.
* [x] wait for improvements made through https://github.com/starship/starship/pull/6476

### Notes for the Reviewer

* When a type-change is detected, it currently re-reads the entire file nonetheless even though it could re-use what's already in the index. It seems acceptable performance wise and can keep things simpler.
* The `gitoxide` version uses the typesystem to enforce exhaustiveness. This is more verbose, but really helps to cover all the bases.
* The previous implementation will not manage to deal with directories that become files or vice-versa due to the behaviour of the git2 tree editor, so it's probably advisable to prefer using `gix::object::tree::Editor` when making arbitrary edits to trees. This is rare though, so probably there aren't anymore bugs like these.
* I implemented submodule support as there is no reason not to include it.
* Sparse indices/repositories aren't supported and it will fail loudly then. This is fine for now as GB also doesn't support these (nor does Git2). It shouldn't be a big deal to make this possible either, it's no my radar.

https://github.com/user-attachments/assets/bf73befa-0922-4bb9-b5d4-018675bdd371

### Performance

Measured on `gitlab` repository where `gitbutler-cli --trace branch apply -b main` was executed. `create_wd_tree()` is called then. Unfortunately, there is no way to call it individually unless one creates a new subcommand for the CLI. As the performance improvement is visible enough, I didn't spend the time on that.

#### With `git2`

*(Best out of two runs)*

```
DEBUG    ┕━ apply_branch [ 4.72s | 1.28% / 94.49% ] stack_id: 4a71e26e-e9c5-4eb3-a46c-92de03ba79a5
DEBUG       ┝━ create_wd_tree [ 439ms | 8.64% / 8.78% ]
```

#### With `gix`

*(Best out of two runs)*

```
DEBUG    ┕━ apply_branch [ 4.70s | 1.35% / 94.42% ] stack_id: 85aa5a75-133f-4596-9a88-e50dad4a4134
DEBUG       ┝━ create_wd_tree [ 317ms | 6.22% / 6.37% ]
```

**`gix` is ~35% faster.**

<details><summary>Research</summary>

### Ordering Issues

The order of entries isn't defined, which makes it hard to decide what the final state actually is, or at least needs extra logic.

Something that doesn't work in our favor is:

```
---- create_wd_tree::tracked_file_becomes_directory_in_worktree stdout ----
[/Users/byron/dev/github.com/GitoxideLabs/gitoxide/gix/src/status/iter/mod.rs:277:9] &item = IndexWorktree(
    DirectoryContents {
        entry: Entry {
            rela_path: "soon-directory/file",
            status: Untracked,
            property: None,
            disk_kind: Some(
                File,
            ),
            index_kind: None,
            pathspec_match: Some(
                Always,
            ),
        },
        collapsed_directory_status: None,
    },
)
[/Users/byron/dev/github.com/GitoxideLabs/gitoxide/gix/src/status/iter/mod.rs:277:9] &item = IndexWorktree(
    Modification {
        entry: Entry {
            stat: Stat {
                mtime: Time {
                    secs: 1736081071,
                    nsecs: 246777717,
                },
                ctime: Time {
                    secs: 1736081071,
                    nsecs: 246777717,
                },
                dev: 0,
                ino: 29004082,
                uid: 501,
                gid: 20,
                size: 37,
            },
            id: Sha1(5781af89edf37bcada102e86c4aa48e129a4ece4),
            flags: Flags(
                0x0,
            ),
            mode: Mode(
                FILE,
            ),
            path: 0..14,
        },
        entry_index: 0,
        rela_path: "soon-directory",
        status: Change(
            Removed,
        ),
    },
)
```

By default, the order is reversed which works out, but like this the second even will remove the changes of the first.
Solved by applying untracked files last.
</details>