### PR TITLE
Make it easier to pass diffs to list vbranch function

### DIFF
--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -79,7 +79,7 @@ pub fn list_virtual_branches(project: &Project) -> Result<StackListResult> {
 
 pub fn list_virtual_branches_cached(
     project: &Project,
-    worktree_changes: Option<DiffByPathMap>,
+    worktree_changes: DiffByPathMap,
 ) -> Result<StackListResult> {
     let ctx = open_with_verify(project)?;
 
@@ -89,7 +89,7 @@ pub fn list_virtual_branches_cached(
     vbranch::list_virtual_branches_cached(
         &ctx,
         project.exclusive_worktree_access().write_permission(),
-        worktree_changes,
+        &worktree_changes,
     )
     .map_err(Into::into)
 }

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -237,7 +237,7 @@ pub(crate) fn set_base_branch(
                 gitbutler_diff::write::hunks_onto_commit(
                     ctx,
                     current_head_commit.id(),
-                    gitbutler_diff::diff_files_into_hunks(wd_diff),
+                    gitbutler_diff::diff_files_into_hunks(&wd_diff),
                 )?,
                 current_head_commit.id(),
                 0,

--- a/crates/gitbutler-branch-actions/src/move_commits.rs
+++ b/crates/gitbutler-branch-actions/src/move_commits.rs
@@ -93,7 +93,7 @@ fn get_source_branch_diffs(
         &uncommitted_changes_tree,
         true,
     )
-    .map(|diff| gitbutler_diff::diff_files_into_hunks(diff).collect::<HashMap<_, _>>())?;
+    .map(|diff| gitbutler_diff::diff_files_into_hunks(&diff).collect::<HashMap<_, _>>())?;
 
     Ok(uncommitted_changes_diff)
 }

--- a/crates/gitbutler-branch-actions/src/undo_commit.rs
+++ b/crates/gitbutler-branch-actions/src/undo_commit.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use anyhow::{bail, Context as _, Result};
 use gitbutler_command_context::CommandContext;
 use gitbutler_commit::commit_ext::CommitExt as _;
@@ -76,12 +74,12 @@ fn inner_undo_commit(
         .context("failed to get parent tree")?;
 
     let diff = gitbutler_diff::trees(repository, &commit_parent_tree, &commit_tree, true)?;
-    let diff: HashMap<_, _> = gitbutler_diff::diff_files_into_hunks(diff).collect();
     let ownership_update = diff
         .iter()
-        .filter_map(|(file_path, hunks)| {
+        .filter_map(|(file_path, file_diff)| {
             let file_path = file_path.clone();
-            let hunks = hunks
+            let hunks = file_diff
+                .hunks
                 .iter()
                 .map(Into::into)
                 .filter(|hunk: &Hunk| hunk.start != 0 && hunk.end != 0)

--- a/crates/gitbutler-diff/src/diff.rs
+++ b/crates/gitbutler-diff/src/diff.rs
@@ -656,9 +656,11 @@ pub fn reverse_hunk_lines(
 }
 
 pub fn diff_files_into_hunks(
-    files: DiffByPathMap,
-) -> impl Iterator<Item = (PathBuf, Vec<GitHunk>)> {
-    files.into_iter().map(|(path, file)| (path, file.hunks))
+    files: &DiffByPathMap,
+) -> impl Iterator<Item = (PathBuf, Vec<GitHunk>)> + '_ {
+    files
+        .iter()
+        .map(|(path, file)| (path.clone(), file.hunks.clone()))
 }
 
 #[cfg(test)]

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -101,7 +101,12 @@ impl Handler {
             .projects
             .get(project_id)
             .context("failed to get project")?;
-        match gitbutler_branch_actions::list_virtual_branches_cached(&project, worktree_changes) {
+        let virtual_branches = if let Some(changes) = worktree_changes {
+            gitbutler_branch_actions::list_virtual_branches_cached(&project, changes)
+        } else {
+            gitbutler_branch_actions::list_virtual_branches(&project)
+        };
+        match virtual_branches {
             Ok(StackListResult {
                 branches,
                 skipped_files,


### PR DESCRIPTION
- cached function should not accept option
- pass reference to diffs rather than consuming them

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5940 
- <kbd>&nbsp;2&nbsp;</kbd> #5894 
- <kbd>&nbsp;1&nbsp;</kbd> #5890 👈 
<!-- GitButler Footer Boundary Bottom -->

