### PR TITLE
upgrade `git2` to v0.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2251,9 +2251,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
@@ -5129,9 +5129,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.17.0+1.8.1"
+version = "0.18.0+1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+checksum = "e1a117465e7e1597e8febea8bb0c410f1c7fb93b1e1cddf34363f8390367ffec"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ resolver = "2"
 bstr = "1.11.1"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
 gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "faa0cdeb35a8135ff9513a1c9884126f6b080f4a", default-features = false, features = [] }
-git2 = { version = "0.19.0", features = [
+git2 = { version = "0.20.0", features = [
     "vendored-openssl",
     "vendored-libgit2",
 ] }


### PR DESCRIPTION
This should bring support for negative refspecs.

Should fix #4961 .