### PR TITLE
Stop running hooks in commit function

### DIFF
--- a/apps/desktop/src/lib/commit/CommitDialog.svelte
+++ b/apps/desktop/src/lib/commit/CommitDialog.svelte
@@ -2,7 +2,7 @@
 	import CommitMessageInput from './CommitMessageInput.svelte';
 	import ContextMenuItem from '$lib/components/contextmenu/ContextMenuItem.svelte';
 	import ContextMenuSection from '$lib/components/contextmenu/ContextMenuSection.svelte';
-	import { persistedCommitMessage, projectRunCommitHooks } from '$lib/config/config';
+	import { persistedCommitMessage } from '$lib/config/config';
 	import { cloudCommunicationFunctionality } from '$lib/config/uiFeatureFlags';
 	import { SyncedSnapshotService } from '$lib/history/syncedSnapshotService';
 	import DropDownButton from '$lib/shared/DropDownButton.svelte';
@@ -29,8 +29,6 @@
 	const canTakeSnapshot = syncedSnapshotService.canTakeSnapshot;
 	const selectedOwnership = getContextStore(SelectedOwnership);
 	const stack = getContextStore(BranchStack);
-
-	const runCommitHooks = projectRunCommitHooks(projectId);
 	const commitMessage = persistedCommitMessage(projectId, $stack.id);
 
 	let commitMessageInput = $state<CommitMessageInput>();
@@ -42,13 +40,7 @@
 		const message = $commitMessage;
 		isCommitting = true;
 		try {
-			await branchController.commitBranch(
-				$stack.id,
-				$stack.name,
-				message.trim(),
-				$selectedOwnership.toString(),
-				$runCommitHooks
-			);
+			await branchController.commitBranch($stack.id, message.trim(), $selectedOwnership.toString());
 			$commitMessage = '';
 
 			if (commitAndPublish) {

--- a/apps/desktop/src/lib/vbranches/branchController.ts
+++ b/apps/desktop/src/lib/vbranches/branchController.ts
@@ -52,20 +52,21 @@ export class BranchController {
 		}
 	}
 
-	async commitBranch(
-		branchId: string,
-		branchName: string,
-		message: string,
-		ownership: string | undefined = undefined,
-		runHooks = false
-	) {
+	async runHooks(stackId: string, ownership: string) {
+		await invoke<void>('run_hooks', {
+			projectId: this.projectId,
+			stackId,
+			ownership
+		});
+	}
+
+	async commitBranch(branchId: string, message: string, ownership: string | undefined = undefined) {
 		try {
 			await invoke<void>('commit_virtual_branch', {
 				projectId: this.projectId,
 				branch: branchId,
 				message,
-				ownership,
-				runHooks: runHooks
+				ownership
 			});
 			this.posthog.capture('Commit Successful');
 		} catch (err: any) {

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -40,13 +40,13 @@ pub fn create_commit(
     stack_id: StackId,
     message: &str,
     ownership: Option<&BranchOwnershipClaims>,
-    run_hooks: bool,
 ) -> Result<git2::Oid> {
     let ctx = open_with_verify(project)?;
     assure_open_workspace_mode(&ctx).context("Creating a commit requires open workspace mode")?;
     let mut guard = project.exclusive_worktree_access();
     let snapshot_tree = ctx.project().prepare_snapshot(guard.read_permission());
-    let result = vbranch::commit(&ctx, stack_id, message, ownership, run_hooks).map_err(Into::into);
+    let result = vbranch::commit(&ctx, stack_id, message, ownership).map_err(Into::into);
+
     let _ = snapshot_tree.and_then(|snapshot_tree| {
         ctx.project().snapshot_commit_creation(
             snapshot_tree,

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/amend.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/amend.rs
@@ -41,8 +41,7 @@ fn forcepush_allowed() -> anyhow::Result<()> {
     // create commit
     fs::write(repository.path().join("file.txt"), "content").unwrap();
     let commit_id =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None).unwrap();
 
     #[allow(deprecated)]
     gitbutler_branch_actions::push_virtual_branch(project, branch_id, false, None).unwrap();
@@ -101,8 +100,7 @@ fn forcepush_forbidden() {
     // create commit
     fs::write(repository.path().join("file.txt"), "content").unwrap();
     let commit_oid =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None).unwrap();
 
     #[allow(deprecated)]
     gitbutler_branch_actions::push_virtual_branch(project, branch_id, false, None).unwrap();
@@ -140,8 +138,7 @@ fn non_locked_hunk() -> anyhow::Result<()> {
     // create commit
     fs::write(repository.path().join("file.txt"), "content").unwrap();
     let commit_oid =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None).unwrap();
 
     let branch = gitbutler_branch_actions::list_virtual_branches(project)
         .unwrap()
@@ -195,8 +192,7 @@ fn locked_hunk() -> anyhow::Result<()> {
     // create commit
     fs::write(repository.path().join("file.txt"), "content").unwrap();
     let commit_oid =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None).unwrap();
 
     let branch = gitbutler_branch_actions::list_virtual_branches(project)
         .unwrap()
@@ -256,8 +252,7 @@ fn non_existing_ownership() {
     // create commit
     fs::write(repository.path().join("file.txt"), "content").unwrap();
     let commit_oid =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None).unwrap();
 
     let branch = gitbutler_branch_actions::list_virtual_branches(project)
         .unwrap()

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/apply_virtual_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/apply_virtual_branch.rs
@@ -37,7 +37,7 @@ fn rebase_commit() {
         .unwrap();
         fs::write(repository.path().join("another_file.txt"), "virtual").unwrap();
 
-        gitbutler_branch_actions::create_commit(project, branch1_id, "virtual commit", None, false)
+        gitbutler_branch_actions::create_commit(project, branch1_id, "virtual commit", None)
             .unwrap();
 
         let list_result = gitbutler_branch_actions::list_virtual_branches(project).unwrap();

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/create_commit.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/create_commit.rs
@@ -34,7 +34,7 @@ fn should_lock_updated_hunks() {
         assert!(!branch.files[0].hunks[0].locked);
     }
 
-    gitbutler_branch_actions::create_commit(project, branch_id, "test", None, false).unwrap();
+    gitbutler_branch_actions::create_commit(project, branch_id, "test", None).unwrap();
 
     {
         // change in the committed hunks leads to hunk locking
@@ -85,14 +85,8 @@ fn should_reset_into_same_branch() {
     lines[0] = "change 1".to_string();
     repository.write_file("file.txt", &lines);
 
-    gitbutler_branch_actions::create_commit(
-        project,
-        branch_2_id,
-        "commit to branch 2",
-        None,
-        false,
-    )
-    .unwrap();
+    gitbutler_branch_actions::create_commit(project, branch_2_id, "commit to branch 2", None)
+        .unwrap();
 
     let files = get_virtual_branch(project, branch_2_id).files;
     assert_eq!(files.len(), 0);

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
@@ -27,7 +27,7 @@ fn integration() {
         .unwrap();
 
         std::fs::write(repository.path().join("file.txt"), "first\n").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "first", None, false).unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "first", None).unwrap();
         #[allow(deprecated)]
         gitbutler_branch_actions::push_virtual_branch(project, branch_id, false, None).unwrap();
 
@@ -59,7 +59,7 @@ fn integration() {
         // add a commit
         std::fs::write(repository.path().join("file.txt"), "first\nsecond").unwrap();
 
-        gitbutler_branch_actions::create_commit(project, branch_id, "second", None, false).unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "second", None).unwrap();
     }
 
     {
@@ -247,8 +247,7 @@ fn conflicts_with_commited() {
         let branches = list_result.branches;
         assert_eq!(branches.len(), 1);
 
-        gitbutler_branch_actions::create_commit(project, branches[0].id, "hej", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, branches[0].id, "hej", None).unwrap();
     };
 
     // branch should be created unapplied, because of the conflict

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/insert_blank_commit.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/insert_blank_commit.rs
@@ -24,21 +24,18 @@ fn insert_blank_commit_down() -> anyhow::Result<()> {
     // create commit
     fs::write(repository.path().join("file.txt"), "content").unwrap();
     let _commit1_id =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None).unwrap();
 
     // create commit
     fs::write(repository.path().join("file2.txt"), "content2").unwrap();
     fs::write(repository.path().join("file3.txt"), "content3").unwrap();
     let commit2_id =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None).unwrap();
 
     // create commit
     fs::write(repository.path().join("file4.txt"), "content4").unwrap();
     let _commit3_id =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None).unwrap();
 
     gitbutler_branch_actions::insert_blank_commit(project, branch_id, commit2_id, 1).unwrap();
 
@@ -99,21 +96,18 @@ fn insert_blank_commit_up() -> anyhow::Result<()> {
     // create commit
     fs::write(repository.path().join("file.txt"), "content").unwrap();
     let _commit1_id =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None).unwrap();
 
     // create commit
     fs::write(repository.path().join("file2.txt"), "content2").unwrap();
     fs::write(repository.path().join("file3.txt"), "content3").unwrap();
     let commit2_id =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None).unwrap();
 
     // create commit
     fs::write(repository.path().join("file4.txt"), "content4").unwrap();
     let _commit3_id =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None).unwrap();
 
     gitbutler_branch_actions::insert_blank_commit(project, branch_id, commit2_id, -1).unwrap();
 

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/locking.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/locking.rs
@@ -30,7 +30,7 @@ async fn hunk_locking_confused_by_line_number_shift() -> anyhow::Result<()> {
     let list_result = list_virtual_branches(project).unwrap();
     let branches = list_result.branches;
 
-    create_commit(project, branches[0].id, "first commit", None, false)?;
+    create_commit(project, branches[0].id, "first commit", None)?;
 
     let list_result = list_virtual_branches(project).unwrap();
     let branches = list_result.branches;
@@ -57,7 +57,7 @@ async fn hunk_locking_confused_by_line_number_shift() -> anyhow::Result<()> {
     // We're forced to call this before making a second commit.
     let list_result = list_virtual_branches(project).unwrap();
     let branches = list_result.branches;
-    create_commit(project, branches[1].id, "second commit", None, false)?;
+    create_commit(project, branches[1].id, "second commit", None)?;
 
     // At this point we expect no uncommitted files, and one commit per branch.
     let list_result = list_virtual_branches(project).unwrap();
@@ -111,7 +111,7 @@ async fn hunk_locking_with_deleted_lines_only() -> anyhow::Result<()> {
     // We have to do this before creating a commit.
     let list_result = list_virtual_branches(project).unwrap();
     let branches = list_result.branches;
-    create_commit(project, branches[0].id, "first commit", None, false)?;
+    create_commit(project, branches[0].id, "first commit", None)?;
 
     let list_result = list_virtual_branches(project).unwrap();
     let branches = list_result.branches;

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/move_commit_file.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/move_commit_file.rs
@@ -26,16 +26,14 @@ fn move_file_down() -> anyhow::Result<()> {
     // create commit
     fs::write(repository.path().join("file.txt"), "content").unwrap();
     let commit1_id =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None).unwrap();
     let commit1 = repository.find_commit(commit1_id).unwrap();
 
     // create commit
     fs::write(repository.path().join("file2.txt"), "content2").unwrap();
     fs::write(repository.path().join("file3.txt"), "content3").unwrap();
     let commit2_id =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None).unwrap();
     let commit2 = repository.find_commit(commit2_id).unwrap();
 
     // amend another hunk
@@ -98,14 +96,12 @@ fn move_file_up() -> anyhow::Result<()> {
     fs::write(repository.path().join("file.txt"), "content").unwrap();
     fs::write(repository.path().join("file2.txt"), "content2").unwrap();
     let commit1_id =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None).unwrap();
 
     // create commit
     fs::write(repository.path().join("file3.txt"), "content3").unwrap();
     let commit2_id =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None).unwrap();
 
     // amend another hunk
     let to_amend: BranchOwnershipClaims = "file2.txt:1-2".parse().unwrap();
@@ -156,14 +152,14 @@ fn move_file_up_overlapping_hunks() {
 
     // create bottom commit
     fs::write(repository.path().join("file.txt"), "content").unwrap();
-    let _commit1_id = gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)
+    let _commit1_id = gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None)
 
         .unwrap();
 
     // create middle commit one
     fs::write(repository.path().join("file2.txt"), "content2\ncontent2a\n").unwrap();
     fs::write(repository.path().join("file3.txt"), "content3").unwrap();
-    let commit2_id = gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None, false)
+    let commit2_id = gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None)
 
         .unwrap();
 
@@ -174,13 +170,13 @@ fn move_file_up_overlapping_hunks() {
     )
     .unwrap();
     fs::write(repository.path().join("file4.txt"), "content4").unwrap();
-    let commit3_id = gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None, false)
+    let commit3_id = gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None)
 
         .unwrap();
 
     // create top commit
     fs::write(repository.path().join("file5.txt"), "content5").unwrap();
-    let _commit4_id = gitbutler_branch_actions::create_commit(project, branch_id, "commit four", None, false)
+    let _commit4_id = gitbutler_branch_actions::create_commit(project, branch_id, "commit four", None)
 
         .unwrap();
 

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/move_commit_to_vbranch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/move_commit_to_vbranch.rs
@@ -28,8 +28,7 @@ fn no_diffs() {
     let source_branch_id = branches[0].id;
 
     let commit_oid =
-        gitbutler_branch_actions::create_commit(project, source_branch_id, "commit", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, source_branch_id, "commit", None).unwrap();
 
     let target_branch_id =
         gitbutler_branch_actions::create_virtual_branch(project, &BranchCreateRequest::default())
@@ -84,22 +83,19 @@ fn multiple_commits() {
     let source_branch_id = branches[0].id;
 
     // Create a commit on the source branch
-    gitbutler_branch_actions::create_commit(project, source_branch_id, "Add a", None, false)
-        .unwrap();
+    gitbutler_branch_actions::create_commit(project, source_branch_id, "Add a", None).unwrap();
 
     std::fs::write(repository.path().join("b.txt"), "This is b").unwrap();
 
     // Create a second commit on the source branch, to be moved
     let commit_oid =
-        gitbutler_branch_actions::create_commit(project, source_branch_id, "Add b", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, source_branch_id, "Add b", None).unwrap();
 
     std::fs::write(repository.path().join("c.txt"), "This is c").unwrap();
 
     // Create a third commit on the source branch
 
-    gitbutler_branch_actions::create_commit(project, source_branch_id, "Add c", None, false)
-        .unwrap();
+    gitbutler_branch_actions::create_commit(project, source_branch_id, "Add c", None).unwrap();
 
     let target_branch_id = gitbutler_branch_actions::create_virtual_branch(
         project,
@@ -113,8 +109,7 @@ fn multiple_commits() {
     std::fs::write(repository.path().join("d.txt"), "This is d").unwrap();
 
     // Create a commit on the destination branch
-    gitbutler_branch_actions::create_commit(project, target_branch_id, "Add d", None, false)
-        .unwrap();
+    gitbutler_branch_actions::create_commit(project, target_branch_id, "Add d", None).unwrap();
 
     // Move the top commit from the source branch to the destination branch
     gitbutler_branch_actions::move_commit(project, target_branch_id, commit_oid, source_branch_id)
@@ -180,15 +175,13 @@ fn multiple_commits_with_diffs() {
     let source_branch_id = branches[0].id;
 
     // Create a commit on the source branch
-    gitbutler_branch_actions::create_commit(project, source_branch_id, "Add a", None, false)
-        .unwrap();
+    gitbutler_branch_actions::create_commit(project, source_branch_id, "Add a", None).unwrap();
 
     std::fs::write(repository.path().join("b.txt"), "This is b").unwrap();
 
     // Create as second commit on the source branch, to be moved
     let commit_oid =
-        gitbutler_branch_actions::create_commit(project, source_branch_id, "Add b", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, source_branch_id, "Add b", None).unwrap();
 
     // Uncommitted changes on the source branch
     std::fs::write(repository.path().join("c.txt"), "This is c").unwrap();
@@ -216,8 +209,7 @@ fn multiple_commits_with_diffs() {
     std::fs::write(repository.path().join("d.txt"), "This is d").unwrap();
 
     // Create a commit on the destination branch
-    gitbutler_branch_actions::create_commit(project, target_branch_id, "Add d", None, false)
-        .unwrap();
+    gitbutler_branch_actions::create_commit(project, target_branch_id, "Add d", None).unwrap();
 
     // Uncommitted changes on the destination branch
     std::fs::write(repository.path().join("e.txt"), "This is e").unwrap();
@@ -313,8 +305,7 @@ fn diffs_on_source_branch() {
     let source_branch_id = branches[0].id;
 
     let commit_oid =
-        gitbutler_branch_actions::create_commit(project, source_branch_id, "commit", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, source_branch_id, "commit", None).unwrap();
 
     std::fs::write(
         repository.path().join("another file.txt"),
@@ -387,8 +378,7 @@ fn diffs_on_target_branch() {
     let source_branch_id = branches[0].id;
 
     let commit_oid =
-        gitbutler_branch_actions::create_commit(project, source_branch_id, "commit", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, source_branch_id, "commit", None).unwrap();
 
     let target_branch_id = gitbutler_branch_actions::create_virtual_branch(
         project,
@@ -466,8 +456,7 @@ fn diffs_on_both_branches() {
     let source_branch_id = branches[0].id;
 
     let commit_oid =
-        gitbutler_branch_actions::create_commit(project, source_branch_id, "commit", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, source_branch_id, "commit", None).unwrap();
 
     // Uncommitted changes on the source branch
     std::fs::write(
@@ -594,8 +583,7 @@ fn target_commit_locked_to_ancestors() {
 
     let source_branch_id = branches[0].id;
 
-    gitbutler_branch_actions::create_commit(project, source_branch_id, "Add a", None, false)
-        .unwrap();
+    gitbutler_branch_actions::create_commit(project, source_branch_id, "Add a", None).unwrap();
 
     std::fs::write(repository.path().join("a.txt"), "This is a \n\n Updated").unwrap();
     std::fs::write(repository.path().join("b.txt"), "This is b").unwrap();
@@ -605,7 +593,6 @@ fn target_commit_locked_to_ancestors() {
         source_branch_id,
         "Add b and update b",
         None,
-        false,
     )
     .unwrap();
 
@@ -648,8 +635,7 @@ fn target_commit_locked_to_descendants() {
 
     let source_branch_id = branches[0].id;
 
-    gitbutler_branch_actions::create_commit(project, source_branch_id, "Add a", None, false)
-        .unwrap();
+    gitbutler_branch_actions::create_commit(project, source_branch_id, "Add a", None).unwrap();
 
     std::fs::write(repository.path().join("b.txt"), "This is b").unwrap();
 
@@ -658,14 +644,12 @@ fn target_commit_locked_to_descendants() {
         source_branch_id,
         "Add b and update b",
         None,
-        false,
     )
     .unwrap();
 
     std::fs::write(repository.path().join("b.txt"), "This is b and an update").unwrap();
 
-    gitbutler_branch_actions::create_commit(project, source_branch_id, "Update b", None, false)
-        .unwrap();
+    gitbutler_branch_actions::create_commit(project, source_branch_id, "Update b", None).unwrap();
 
     let target_branch_id =
         gitbutler_branch_actions::create_virtual_branch(project, &BranchCreateRequest::default())
@@ -707,8 +691,7 @@ fn locked_hunks_on_source_branch() {
     let source_branch_id = branches[0].id;
 
     let commit_oid =
-        gitbutler_branch_actions::create_commit(project, source_branch_id, "commit", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, source_branch_id, "commit", None).unwrap();
 
     std::fs::write(repository.path().join("file.txt"), "locked content").unwrap();
 
@@ -753,8 +736,7 @@ fn no_commit() {
 
     let source_branch_id = branches[0].id;
 
-    gitbutler_branch_actions::create_commit(project, source_branch_id, "commit", None, false)
-        .unwrap();
+    gitbutler_branch_actions::create_commit(project, source_branch_id, "commit", None).unwrap();
 
     let target_branch_id =
         gitbutler_branch_actions::create_virtual_branch(project, &BranchCreateRequest::default())
@@ -797,8 +779,7 @@ fn no_branch() {
     let source_branch_id = branches[0].id;
 
     let commit_oid =
-        gitbutler_branch_actions::create_commit(project, source_branch_id, "commit", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, source_branch_id, "commit", None).unwrap();
 
     let id = StackId::generate();
     assert_eq!(

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/oplog.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/oplog.rs
@@ -43,7 +43,6 @@ fn workdir_vbranch_restore() -> anyhow::Result<()> {
             branch_id,
             &format!("commit {round}"),
             None,
-            false, /* run hook */
         )?;
         assert_eq!(
             wd_file_count(&worktree_dir)?,
@@ -114,7 +113,7 @@ fn basic_oplog() -> anyhow::Result<()> {
     // create commit
     fs::write(repository.path().join("file.txt"), "content")?;
     let _commit1_id =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)?;
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None)?;
 
     // dont store large files
     let file_path = repository.path().join("large.txt");
@@ -129,7 +128,7 @@ fn basic_oplog() -> anyhow::Result<()> {
     fs::write(repository.path().join("file2.txt"), "content2")?;
     fs::write(repository.path().join("file3.txt"), "content3")?;
     let commit2_id =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None, false)?;
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None)?;
 
     // Create conflict state
     let conflicts_path = repository.path().join(".git").join("conflicts");
@@ -146,7 +145,7 @@ fn basic_oplog() -> anyhow::Result<()> {
 
     fs::write(repository.path().join("file4.txt"), "content4")?;
     let _commit3_id =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None, false)?;
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None)?;
 
     let branch = gitbutler_branch_actions::list_virtual_branches(project)?
         .branches
@@ -281,7 +280,7 @@ fn restores_gitbutler_workspace() -> anyhow::Result<()> {
     // create commit
     fs::write(repository.path().join("file.txt"), "content")?;
     let _commit1_id =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)?;
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None)?;
 
     let repo = git2::Repository::open(&project.path)?;
 
@@ -295,7 +294,7 @@ fn restores_gitbutler_workspace() -> anyhow::Result<()> {
     // create second commit
     fs::write(repository.path().join("file.txt"), "changed content")?;
     let _commit2_id =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None, false)?;
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None)?;
 
     // check the workspace commit changed
     let head = repo.head().expect("never unborn");

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/references.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/references.rs
@@ -236,7 +236,7 @@ mod push_virtual_branch {
 
         fs::write(repository.path().join("file.txt"), "content").unwrap();
 
-        gitbutler_branch_actions::create_commit(project, branch1_id, "test", None, false).unwrap();
+        gitbutler_branch_actions::create_commit(project, branch1_id, "test", None).unwrap();
         #[allow(deprecated)]
         gitbutler_branch_actions::push_virtual_branch(project, branch1_id, false, None).unwrap();
 
@@ -284,8 +284,7 @@ mod push_virtual_branch {
             )
             .unwrap();
             fs::write(repository.path().join("file.txt"), "content").unwrap();
-            gitbutler_branch_actions::create_commit(project, branch1_id, "test", None, false)
-                .unwrap();
+            gitbutler_branch_actions::create_commit(project, branch1_id, "test", None).unwrap();
             #[allow(deprecated)]
             gitbutler_branch_actions::push_virtual_branch(project, branch1_id, false, None)
                 .unwrap();
@@ -314,8 +313,7 @@ mod push_virtual_branch {
             )
             .unwrap();
             fs::write(repository.path().join("file.txt"), "updated content").unwrap();
-            gitbutler_branch_actions::create_commit(project, branch2_id, "test", None, false)
-                .unwrap();
+            gitbutler_branch_actions::create_commit(project, branch2_id, "test", None).unwrap();
             #[allow(deprecated)]
             gitbutler_branch_actions::push_virtual_branch(project, branch2_id, false, None)
                 .unwrap();

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/reset_virtual_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/reset_virtual_branch.rs
@@ -27,8 +27,7 @@ fn to_head() {
 
         // commit changes
         let oid =
-            gitbutler_branch_actions::create_commit(project, branch1_id, "commit", None, false)
-                .unwrap();
+            gitbutler_branch_actions::create_commit(project, branch1_id, "commit", None).unwrap();
 
         let list_result = gitbutler_branch_actions::list_virtual_branches(project).unwrap();
         let branches = list_result.branches;
@@ -86,8 +85,7 @@ fn to_target() {
 
         // commit changes
         let oid =
-            gitbutler_branch_actions::create_commit(project, branch1_id, "commit", None, false)
-                .unwrap();
+            gitbutler_branch_actions::create_commit(project, branch1_id, "commit", None).unwrap();
 
         let list_result = gitbutler_branch_actions::list_virtual_branches(project).unwrap();
         let branches = list_result.branches;
@@ -144,8 +142,7 @@ fn to_commit() {
         fs::write(repository.path().join("file.txt"), "content").unwrap();
 
         let oid =
-            gitbutler_branch_actions::create_commit(project, branch1_id, "commit", None, false)
-                .unwrap();
+            gitbutler_branch_actions::create_commit(project, branch1_id, "commit", None).unwrap();
 
         let list_result = gitbutler_branch_actions::list_virtual_branches(project).unwrap();
         let branches = list_result.branches;
@@ -167,8 +164,7 @@ fn to_commit() {
         fs::write(repository.path().join("file.txt"), "more content").unwrap();
 
         let second_commit_oid =
-            gitbutler_branch_actions::create_commit(project, branch1_id, "commit", None, false)
-                .unwrap();
+            gitbutler_branch_actions::create_commit(project, branch1_id, "commit", None).unwrap();
 
         let list_result = gitbutler_branch_actions::list_virtual_branches(project).unwrap();
         let branches = list_result.branches;
@@ -235,8 +231,7 @@ fn to_non_existing() {
 
         // commit changes
         let oid =
-            gitbutler_branch_actions::create_commit(project, branch1_id, "commit", None, false)
-                .unwrap();
+            gitbutler_branch_actions::create_commit(project, branch1_id, "commit", None).unwrap();
 
         let list_result = gitbutler_branch_actions::list_virtual_branches(project).unwrap();
         let branches = list_result.branches;

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/selected_for_changes.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/selected_for_changes.rs
@@ -365,7 +365,7 @@ fn new_locked_hunk_without_modifying_existing() {
     let branches = list_result.branches;
     assert_eq!(branches[0].files.len(), 1);
 
-    gitbutler_branch_actions::create_commit(project, branches[0].id, "second commit", None, false)
+    gitbutler_branch_actions::create_commit(project, branches[0].id, "second commit", None)
         .expect("failed to create commit");
 
     let list_result = gitbutler_branch_actions::list_virtual_branches(project).unwrap();

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/set_base_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/set_base_branch.rs
@@ -65,7 +65,7 @@ mod go_back_to_workspace {
         .unwrap();
 
         std::fs::write(repository.path().join("another file.txt"), "content").unwrap();
-        gitbutler_branch_actions::create_commit(project, vbranch_id, "one", None, false).unwrap();
+        gitbutler_branch_actions::create_commit(project, vbranch_id, "one", None).unwrap();
 
         let list_result = gitbutler_branch_actions::list_virtual_branches(project).unwrap();
         let branches = list_result.branches;

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/squash.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/squash.rs
@@ -22,26 +22,22 @@ fn head() {
 
     {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file two.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file three.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None).unwrap()
     };
 
     let commit_four_oid = {
         fs::write(repository.path().join("file four.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit four", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit four", None).unwrap()
     };
 
     let commit_four_parent_oid = repository
@@ -99,26 +95,22 @@ fn middle() {
 
     {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None).unwrap()
     };
 
     let commit_two_oid = {
         fs::write(repository.path().join("file two.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file three.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file four.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit four", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit four", None).unwrap()
     };
 
     let commit_two_parent_oid = repository
@@ -185,26 +177,22 @@ fn forcepush_allowed() {
 
     {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None).unwrap()
     };
 
     let commit_two_oid = {
         fs::write(repository.path().join("file two.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file three.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file four.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit four", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit four", None).unwrap()
     };
 
     gitbutler_branch_actions::stack::push_stack(project, branch_id, false).unwrap();
@@ -275,26 +263,22 @@ fn forcepush_forbidden() {
 
     {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None).unwrap()
     };
 
     let commit_two_oid = {
         fs::write(repository.path().join("file two.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file three.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file four.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit four", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit four", None).unwrap()
     };
 
     // TODO: flag the old one as deprecated

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/unapply_ownership.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/unapply_ownership.rs
@@ -28,7 +28,7 @@ fn should_unapply_with_commits() {
         "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n",
     )
     .unwrap();
-    gitbutler_branch_actions::create_commit(project, branch_id, "test", None, false).unwrap();
+    gitbutler_branch_actions::create_commit(project, branch_id, "test", None).unwrap();
 
     // change in the committed hunks leads to hunk locking
     fs::write(

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/unapply_without_saving_virtual_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/unapply_without_saving_virtual_branch.rs
@@ -26,7 +26,6 @@ fn should_unapply_diff() {
         branches.first().unwrap().id,
         "asdf",
         None,
-        false,
     );
     assert!(c.is_ok());
 

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/undo_commit.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/undo_commit.rs
@@ -24,21 +24,18 @@ fn undo_commit_simple() -> anyhow::Result<()> {
     // create commit
     fs::write(repository.path().join("file.txt"), "content").unwrap();
     let _commit1_id =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None).unwrap();
 
     // create commit
     fs::write(repository.path().join("file2.txt"), "content2").unwrap();
     fs::write(repository.path().join("file3.txt"), "content3").unwrap();
     let commit2_id =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None).unwrap();
 
     // create commit
     fs::write(repository.path().join("file4.txt"), "content4").unwrap();
     let _commit3_id =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None).unwrap();
 
     gitbutler_branch_actions::undo_commit(project, branch_id, commit2_id).unwrap();
 
@@ -94,21 +91,18 @@ fn undo_commit_in_non_default_branch() -> anyhow::Result<()> {
     // create commit
     fs::write(repository.path().join("file.txt"), "content").unwrap();
     let _commit1_id =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None).unwrap();
 
     // create commit
     fs::write(repository.path().join("file2.txt"), "content2").unwrap();
     fs::write(repository.path().join("file3.txt"), "content3").unwrap();
     let commit2_id =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None).unwrap();
 
     // create commit
     fs::write(repository.path().join("file4.txt"), "content4").unwrap();
     let _commit3_id =
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None, false)
-            .unwrap();
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None).unwrap();
 
     // create default branch
     // this branch should not be affected by the undo

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/update_commit_message.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/update_commit_message.rs
@@ -23,20 +23,17 @@ fn head() {
 
     {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file two.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None).unwrap()
     };
 
     let commit_three_oid = {
         fs::write(repository.path().join("file three.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None).unwrap()
     };
     let commit_three = repository.find_commit(commit_three_oid).unwrap();
     let before_change_id = &commit_three.change_id();
@@ -97,20 +94,17 @@ fn middle() {
 
     {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None).unwrap()
     };
 
     let commit_two_oid = {
         fs::write(repository.path().join("file two.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file three.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None).unwrap()
     };
 
     gitbutler_branch_actions::update_commit_message(
@@ -170,8 +164,7 @@ fn forcepush_allowed() {
 
     let commit_one_oid = {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None).unwrap()
     };
 
     #[allow(deprecated)]
@@ -233,8 +226,7 @@ fn forcepush_forbidden() {
 
     let commit_one_oid = {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None).unwrap()
     };
 
     #[allow(deprecated)]
@@ -273,20 +265,17 @@ fn root() {
 
     let commit_one_oid = {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file two.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit two", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file three.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit three", None).unwrap()
     };
 
     gitbutler_branch_actions::update_commit_message(
@@ -337,8 +326,7 @@ fn empty() {
 
     let commit_one_oid = {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None, false)
-            .unwrap()
+        gitbutler_branch_actions::create_commit(project, branch_id, "commit one", None).unwrap()
     };
 
     assert_eq!(

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/upstream.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/upstream.rs
@@ -23,13 +23,13 @@ fn detect_upstream_commits() {
     let oid1 = {
         // create first commit
         fs::write(repository.path().join("file.txt"), "content").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch1_id, "commit", None, false).unwrap()
+        gitbutler_branch_actions::create_commit(project, branch1_id, "commit", None).unwrap()
     };
 
     let oid2 = {
         // create second commit
         fs::write(repository.path().join("file.txt"), "content2").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch1_id, "commit", None, false).unwrap()
+        gitbutler_branch_actions::create_commit(project, branch1_id, "commit", None).unwrap()
     };
 
     // push
@@ -38,7 +38,7 @@ fn detect_upstream_commits() {
     let oid3 = {
         // create third commit
         fs::write(repository.path().join("file.txt"), "content3").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch1_id, "commit", None, false).unwrap()
+        gitbutler_branch_actions::create_commit(project, branch1_id, "commit", None).unwrap()
     };
 
     {
@@ -78,13 +78,13 @@ fn detect_integrated_commits() {
     let oid1 = {
         // create first commit
         fs::write(repository.path().join("file.txt"), "content").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch1_id, "commit", None, false).unwrap()
+        gitbutler_branch_actions::create_commit(project, branch1_id, "commit", None).unwrap()
     };
 
     let oid2 = {
         // create second commit
         fs::write(repository.path().join("file.txt"), "content2").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch1_id, "commit", None, false).unwrap()
+        gitbutler_branch_actions::create_commit(project, branch1_id, "commit", None).unwrap()
     };
 
     // push
@@ -108,7 +108,7 @@ fn detect_integrated_commits() {
     let oid3 = {
         // create third commit
         fs::write(repository.path().join("file.txt"), "content3").unwrap();
-        gitbutler_branch_actions::create_commit(project, branch1_id, "commit", None, false).unwrap()
+        gitbutler_branch_actions::create_commit(project, branch1_id, "commit", None).unwrap()
     };
 
     {

--- a/crates/gitbutler-cli/src/command/vbranch.rs
+++ b/crates/gitbutler-cli/src/command/vbranch.rs
@@ -186,13 +186,11 @@ pub fn commit(project: Project, branch_name: String, message: String) -> Result<
         )
     }
 
-    let run_hooks = false;
     debug_print(gitbutler_branch_actions::create_commit(
         &project,
         stack.id,
         &message,
         Some(&target_branch.ownership),
-        run_hooks,
     )?)
 }
 

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -36,16 +36,10 @@ pub mod commands {
         branch: StackId,
         message: &str,
         ownership: Option<BranchOwnershipClaims>,
-        run_hooks: bool,
     ) -> Result<String, Error> {
         let project = projects.get(project_id)?;
-        let oid = gitbutler_branch_actions::create_commit(
-            &project,
-            branch,
-            message,
-            ownership.as_ref(),
-            run_hooks,
-        )?;
+        let oid =
+            gitbutler_branch_actions::create_commit(&project, branch, message, ownership.as_ref())?;
         emit_vbranches(&windows, project_id);
         Ok(oid.to_string())
     }

--- a/crates/gitbutler-workspace/tests/mod.rs
+++ b/crates/gitbutler-workspace/tests/mod.rs
@@ -31,7 +31,7 @@ mod checkout_branch_trees {
 
         fs::write(test_project.path().join("foo.txt"), "content").unwrap();
 
-        branch_actions::create_commit(&project, branch_1, "commit one", None, false).unwrap();
+        branch_actions::create_commit(&project, branch_1, "commit one", None).unwrap();
 
         let branch_2 =
             branch_actions::create_virtual_branch(&project, &BranchCreateRequest::default())
@@ -39,7 +39,7 @@ mod checkout_branch_trees {
 
         fs::write(test_project.path().join("bar.txt"), "content").unwrap();
 
-        branch_actions::create_commit(&project, branch_2, "commit two", None, false).unwrap();
+        branch_actions::create_commit(&project, branch_2, "commit two", None).unwrap();
 
         let tree = test_project
             .local_repository


### PR DESCRIPTION
- will be orchestrated by client instead

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5940 
- <kbd>&nbsp;2&nbsp;</kbd> #5894 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5890 
<!-- GitButler Footer Boundary Bottom -->

