### PR TITLE
`gix` for diff tree hunks

### DIFF
--- a/crates/gitbutler-oxidize/Cargo.toml
+++ b/crates/gitbutler-oxidize/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 
 [dependencies]
 anyhow.workspace = true
-gix.workspace = true
 git2.workspace = true
+gix = { workspace = true, features = ["merge"] }

--- a/crates/gitbutler-repo/src/rebase.rs
+++ b/crates/gitbutler-repo/src/rebase.rs
@@ -14,6 +14,7 @@ use gitbutler_commit::{
 };
 use gitbutler_oxidize::{git2_to_gix_object_id, gix_to_git2_oid, GixRepositoryExt as _};
 use serde::{Deserialize, Serialize};
+use tracing::instrument;
 
 /// cherry-pick based rebase, which handles empty commits
 /// this function takes a commit range and generates a Vector of commit oids
@@ -46,6 +47,7 @@ pub fn cherry_rebase(
 /// rebase empty commits (two commits with identical trees)
 ///
 /// the commit id's to rebase should be ordered such that the child most commit is first
+#[instrument(level = tracing::Level::DEBUG, skip(repository, ids_to_rebase))]
 pub fn cherry_rebase_group(
     repository: &git2::Repository,
     target_commit_oid: git2::Oid,


### PR DESCRIPTION
The is to speed up `apply_branch()` which currently takes about 5m even with an uptodate workspace and a single virtual branch with a single commit and a single file changed inside of that.

Compared to the last time I checked, it seems the tree-diff portion is just 10% of the time, while `BranchOwnershipClaim::put()` takes the rest of it. All of this is part of the `undo_commit()` function which is probably related to the WIP commit being undone.

<img width="816" alt="Screenshot 2025-01-08 at 11 33 55" src="https://github.com/user-attachments/assets/1f952ad5-0d2b-44c9-92f6-3902f7b43c5c" />

### Tasks

* [x] profile to figure out what to focus on
* [x] make the issue reproducible with the CLI
* ~~optimize `undo_commit()`~~ - this portion is going to be gone, entirely

### Additional Issues

* WIP-Commit creation causes the signing machinery to run. This is more likely to fail and isn't necessary.
    - If the commit-creation fails the UI seems to go into a very invalid state.
* Branches with WIP commit seem to easily get 'UUID'-branch names <img width="762" alt="Screenshot 2025-01-08 at 13 01 24" src="https://github.com/user-attachments/assets/9badd506-b789-4384-92d2-f78df576c7e9" />
* *Branch Duplication* - and what also happens is that it somehow considers a lot of changed files/lines

https://github.com/user-attachments/assets/32af1984-aa56-4257-901e-aaac02d88902




### Research


#### Before

In GitLab@82895d0a33f4687886c6d36f7fcb6db1f20b522e, 

```
❯ gitbutler-cli -d branch apply -b c1544bac-7804-482e-b75d-705f53a1a61e
some branches already selected for changes
c1544bac-7804-482e-b75d-705f53a1a61e
INFO     cli-op [ 302s | 0.05% / 100.00% ]
INFO     ┝━ ThreadSafeRepository::discover() [ 828µs | 0.00% / 0.00% ]
INFO     │  ┕━ open_from_paths() [ 629µs | 0.00% / 0.00% ]
INFO     │     ┕━ gix_odb::Store::at() [ 234µs | 0.00% ]
INFO     ┝━ create_snapshot [ 69.7ms | 0.02% / 0.02% ]
INFO     │  ┕━ ThreadSafeRepository::open() [ 190µs | 0.00% / 0.00% ]
INFO     │     ┕━ open_from_paths() [ 160µs | 0.00% / 0.00% ]
INFO     │        ┕━ gix_odb::Store::at() [ 88.5µs | 0.00% ]
DEBUG    ┕━ apply_branch [ 302s | 99.32% / 99.92% ] stack_id: c1544bac-7804-482e-b75d-705f53a1a61e
DEBUG       ┝━ create_wd_tree [ 479ms | 0.16% / 0.16% ]
INFO        │  ┝━ ThreadSafeRepository::open() [ 298µs | 0.00% / 0.00% ]
INFO        │  │  ┕━ open_from_paths() [ 263µs | 0.00% / 0.00% ]
INFO        │  │     ┕━ gix_odb::Store::at() [ 139µs | 0.00% ]
INFO        │  ┕━ gix_index::File::at() [ 6.97ms | 0.00% ]
INFO        ┝━ ThreadSafeRepository::open() [ 246µs | 0.00% / 0.00% ]
INFO        │  ┕━ open_from_paths() [ 208µs | 0.00% / 0.00% ]
INFO        │     ┕━ gix_odb::Store::at() [ 107µs | 0.00% ]
INFO        ┝━ gix_index::File::at() [ 7.33ms | 0.00% ]
INFO        ┝━ gix_merge::tree [ 3.40ms | 0.00% ] base_tree: Sha1(f6d74d3680512d925d0d1a0f1121d2d92d07e8c1) | our_tree: Sha1(f6d74d3680512d925d0d1a0f1121d2d92d07e8c1) | their_tree: Sha1(f6d74d3680512d925d0d1a0f1121d2d92d07e8c1) | labels: Labels { ancestor: None, current: None, other: None }
DEBUG       ┝━ update_workspace_commit [ 401ms | 0.08% / 0.13% ]
DEBUG       │  ┕━ get_workspace_head [ 147ms | 0.04% / 0.05% ]
INFO        │     ┝━ ThreadSafeRepository::open() [ 1.35ms | 0.00% / 0.00% ]
INFO        │     │  ┕━ open_from_paths() [ 1.28ms | 0.00% / 0.00% ]
INFO        │     │     ┕━ gix_odb::Store::at() [ 155µs | 0.00% ]
INFO        │     ┝━ gix_index::File::at() [ 9.09ms | 0.00% ]
INFO        │     ┕━ gix_merge::tree [ 3.45ms | 0.00% ] base_tree: Sha1(f6d74d3680512d925d0d1a0f1121d2d92d07e8c1) | our_tree: Sha1(f6d74d3680512d925d0d1a0f1121d2d92d07e8c1) | their_tree: Sha1(f6d74d3680512d925d0d1a0f1121d2d92d07e8c1) | labels: Labels { ancestor: Some("base"), current: Some("ours"), other: Some("theirs") }
DEBUG       ┝━ checkout_branch_trees [ 550ms | 0.18% ]
DEBUG       ┕━ update_workspace_commit [ 389ms | 0.08% / 0.13% ]
DEBUG          ┕━ get_workspace_head [ 141ms | 0.04% / 0.05% ]
INFO              ┝━ ThreadSafeRepository::open() [ 409µs | 0.00% / 0.00% ]
INFO              │  ┕━ open_from_paths() [ 331µs | 0.00% / 0.00% ]
INFO              │     ┕━ gix_odb::Store::at() [ 172µs | 0.00% ]
INFO              ┝━ gix_index::File::at() [ 6.86ms | 0.00% ]
INFO              ┕━ gix_merge::tree [ 3.41ms | 0.00% ] base_tree: Sha1(f6d74d3680512d925d0d1a0f1121d2d92d07e8c1) | our_tree: Sha1(f6d74d3680512d925d0d1a0f1121d2d92d07e8c1) | their_tree: Sha1(f6d74d3680512d925d0d1a0f1121d2d92d07e8c1) | labels: Labels { ancestor: Some("base"), current: Some("ours"), other: Some("theirs") }
```

##### With added debugging

```
❯ /Users/byron/dev/github.com/gitbutlerapp/gitbutler/target/release/gitbutler-cli -d -C gitlab branch apply -b c1544bac-7804-482e-b75d-705f53a1a61e
some branches already selected for changes
c1544bac-7804-482e-b75d-705f53a1a61e
INFO     cli-op [ 297s | 0.06% / 100.00% ]
INFO     ┝━ ThreadSafeRepository::discover() [ 1.74ms | 0.00% / 0.00% ]
INFO     │  ┕━ open_from_paths() [ 1.32ms | 0.00% / 0.00% ]
INFO     │     ┕━ gix_odb::Store::at() [ 420µs | 0.00% ]
INFO     ┝━ create_snapshot [ 84.3ms | 0.03% / 0.03% ]
INFO     │  ┕━ ThreadSafeRepository::open() [ 244µs | 0.00% / 0.00% ]
INFO     │     ┕━ open_from_paths() [ 213µs | 0.00% / 0.00% ]
INFO     │        ┕━ gix_odb::Store::at() [ 124µs | 0.00% ]
DEBUG    ┕━ apply_branch [ 296s | 0.05% / 99.91% ] stack_id: c1544bac-7804-482e-b75d-705f53a1a61e
DEBUG       ┝━ create_wd_tree [ 842ms | 0.28% / 0.28% ]
INFO        │  ┝━ ThreadSafeRepository::open() [ 297µs | 0.00% / 0.00% ]
INFO        │  │  ┕━ open_from_paths() [ 257µs | 0.00% / 0.00% ]
INFO        │  │     ┕━ gix_odb::Store::at() [ 145µs | 0.00% ]
INFO        │  ┕━ gix_index::File::at() [ 7.54ms | 0.00% ]
INFO        ┝━ ThreadSafeRepository::open() [ 307µs | 0.00% / 0.00% ]
INFO        │  ┕━ open_from_paths() [ 270µs | 0.00% / 0.00% ]
INFO        │     ┕━ gix_odb::Store::at() [ 137µs | 0.00% ]
INFO        ┝━ gix_index::File::at() [ 7.33ms | 0.00% ]
INFO        ┝━ gix_merge::tree [ 3.27ms | 0.00% ] base_tree: Sha1(f6d74d3680512d925d0d1a0f1121d2d92d07e8c1) | our_tree: Sha1(f6d74d3680512d925d0d1a0f1121d2d92d07e8c1) | their_tree: Sha1(f6d74d3680512d925d0d1a0f1121d2d92d07e8c1) | labels: Labels { ancestor: None, current: None, other: None }
DEBUG       ┝━ undo_commit [ 294s | 88.92% / 99.24% ] stack_id: c1544bac-7804-482e-b75d-705f53a1a61e | commit_to_remove: d05652ad7cc1edb932ba8ad4e189b0f9c13f3d62
DEBUG       │  ┝━ rebase_all_but_last [ 30.2s | 10.18% ] branch_head_commit: d05652ad7cc1edb932ba8ad4e189b0f9c13f3d62 | commit_to_remove: d05652ad7cc1edb932ba8ad4e189b0f9c13f3d62
DEBUG       │  ┕━ update_workspace_commit [ 403ms | 0.09% / 0.14% ]
DEBUG       │     ┕━ get_workspace_head [ 148ms | 0.04% / 0.05% ]
INFO        │        ┝━ ThreadSafeRepository::open() [ 1.54ms | 0.00% / 0.00% ]
INFO        │        │  ┕━ open_from_paths() [ 1.47ms | 0.00% / 0.00% ]
INFO        │        │     ┕━ gix_odb::Store::at() [ 206µs | 0.00% ]
INFO        │        ┝━ gix_index::File::at() [ 9.81ms | 0.00% ]
INFO        │        ┕━ gix_merge::tree [ 3.62ms | 0.00% ] base_tree: Sha1(f6d74d3680512d925d0d1a0f1121d2d92d07e8c1) | our_tree: Sha1(f6d74d3680512d925d0d1a0f1121d2d92d07e8c1) | their_tree: Sha1(f6d74d3680512d925d0d1a0f1121d2d92d07e8c1) | labels: Labels { ancestor: Some("base"), current: Some("ours"), other: Some("theirs") }
DEBUG       ┝━ checkout_branch_trees [ 601ms | 0.20% ]
DEBUG       ┕━ update_workspace_commit [ 397ms | 0.08% / 0.13% ]
DEBUG          ┕━ get_workspace_head [ 149ms | 0.05% / 0.05% ]
INFO              ┝━ ThreadSafeRepository::open() [ 432µs | 0.00% / 0.00% ]
INFO              │  ┕━ open_from_paths() [ 332µs | 0.00% / 0.00% ]
INFO              │     ┕━ gix_odb::Store::at() [ 175µs | 0.00% ]
INFO              ┝━ gix_index::File::at() [ 7.26ms | 0.00% ]
INFO              ┕━ gix_merge::tree [ 3.34ms | 0.00% ] base_tree: Sha1(f6d74d3680512d925d0d1a0f1121d2d92d07e8c1) | our_tree: Sha1(f6d74d3680512d925d0d1a0f1121d2d92d07e8c1) | their_tree: Sha1(f6d74d3680512d925d0d1a0f1121d2d92d07e8c1) | labels: Labels { ancestor: Some("base"), current: Some("ours"), other: Some("theirs") }
```

```
[crates/gitbutler-branch-actions/src/undo_commit.rs:40:5] &ownership_update.len() = 76936
[crates/gitbutler-branch-actions/src/undo_commit.rs:40:5] stack.ownership.claims.len() = 7010
```
