### PR TITLE
fix: rendering of paths with underscore in them

### DIFF
--- a/packages/ui/src/lib/file/FileListItem.svelte
+++ b/packages/ui/src/lib/file/FileListItem.svelte
@@ -240,12 +240,11 @@
 
 	.path-container {
 		display: flex;
-		justify-content: flex-end;
+		justify-content: flex-start;
 		flex-shrink: 0;
 		flex-grow: 1;
 		flex-basis: 0px;
 		min-width: 50px;
-		direction: rtl;
 		text-align: left;
 		overflow: hidden;
 	}
@@ -256,7 +255,6 @@
 		line-height: 120%;
 		opacity: 0.3;
 		transition: opacity var(--transition-fast);
-		direction: rtl;
 		max-width: 100%;
 		text-align: left;
 	}


### PR DESCRIPTION
## ☕️ Reasoning

- Rendering of changed files with paths like `experiments/experiments/__pycache__` would result in something like `__experiments/experiments/__pycache`

Fixes: #5853

## 🧢 Changes

![image](https://github.com/user-attachments/assets/9c186442-e3a9-4db1-ac52-46b0eee41ebf)


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
