### PR TITLE
signing with login shell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2982,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.69.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "gix-actor 0.33.1",
  "gix-attributes 0.23.1",
@@ -3008,7 +3008,7 @@ dependencies = [
  "gix-object 0.46.1",
  "gix-odb",
  "gix-pack",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-pathspec",
  "gix-prompt",
  "gix-protocol",
@@ -3016,16 +3016,16 @@ dependencies = [
  "gix-refspec",
  "gix-revision",
  "gix-revwalk 0.17.0",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-shallow",
  "gix-status",
  "gix-submodule",
  "gix-tempfile 15.0.0",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-transport",
  "gix-traverse 0.43.1",
  "gix-url",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-validate 0.9.2",
  "gix-worktree 0.38.0",
  "gix-worktree-state",
@@ -3051,11 +3051,11 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.33.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "gix-date 0.9.3",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "itoa 1.0.11",
  "thiserror 2.0.9",
  "winnow 0.6.20",
@@ -3081,13 +3081,13 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.23.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "gix-glob 0.17.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "kstring",
  "smallvec",
  "thiserror 2.0.9",
@@ -3106,7 +3106,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.13"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "thiserror 2.0.9",
 ]
@@ -3123,7 +3123,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.10"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "thiserror 2.0.9",
 ]
@@ -3131,11 +3131,11 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.4.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "shell-words",
 ]
 
@@ -3156,10 +3156,10 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.25.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
- "gix-chunk 0.4.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-chunk 0.4.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-features 0.39.1",
  "gix-hash 0.15.1",
  "memmap2",
@@ -3169,15 +3169,15 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.42.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "gix-config-value",
  "gix-features 0.39.1",
  "gix-glob 0.17.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-ref 0.49.1",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "memchr",
  "once_cell",
  "smallvec",
@@ -3189,11 +3189,11 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.14.10"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "libc",
  "thiserror 2.0.9",
 ]
@@ -3201,15 +3201,15 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.26.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-config-value",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-prompt",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-url",
  "thiserror 2.0.9",
 ]
@@ -3229,7 +3229,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.9.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "itoa 1.0.11",
@@ -3240,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.49.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "gix-attributes 0.23.1",
@@ -3250,10 +3250,10 @@ dependencies = [
  "gix-hash 0.15.1",
  "gix-index 0.37.0",
  "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-pathspec",
  "gix-tempfile 15.0.0",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-traverse 0.43.1",
  "gix-worktree 0.38.0",
  "imara-diff",
@@ -3263,7 +3263,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "gix-discover 0.37.0",
@@ -3271,10 +3271,10 @@ dependencies = [
  "gix-ignore 0.12.1",
  "gix-index 0.37.0",
  "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-pathspec",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-worktree 0.38.0",
  "thiserror 2.0.9",
 ]
@@ -3298,15 +3298,15 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.37.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "dunce",
  "gix-fs 0.12.1",
  "gix-hash 0.15.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-ref 0.49.1",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "thiserror 2.0.9",
 ]
 
@@ -3328,15 +3328,15 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.39.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bytes",
  "crc32fast",
  "crossbeam-channel",
  "flate2",
  "gix-hash 0.15.1",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "libc",
  "once_cell",
  "parking_lot",
@@ -3350,7 +3350,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -3359,10 +3359,10 @@ dependencies = [
  "gix-hash 0.15.1",
  "gix-object 0.46.1",
  "gix-packetline-blocking",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "smallvec",
  "thiserror 2.0.9",
 ]
@@ -3381,11 +3381,11 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.12.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "fastrand",
  "gix-features 0.39.1",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
 ]
 
 [[package]]
@@ -3403,12 +3403,12 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.17.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "gix-features 0.39.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
 ]
 
 [[package]]
@@ -3424,7 +3424,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.15.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "faster-hex",
  "thiserror 2.0.9",
@@ -3444,7 +3444,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "gix-hash 0.15.1",
  "hashbrown 0.14.5",
@@ -3467,12 +3467,12 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.12.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "gix-glob 0.17.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "unicode-bom",
 ]
 
@@ -3507,20 +3507,20 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.37.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "filetime",
  "fnv",
- "gix-bitmap 0.2.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-bitmap 0.2.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-features 0.39.1",
  "gix-fs 0.12.1",
  "gix-hash 0.15.1",
  "gix-lock 15.0.1",
  "gix-object 0.46.1",
  "gix-traverse 0.43.1",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-validate 0.9.2",
  "hashbrown 0.14.5",
  "itoa 1.0.11",
@@ -3545,17 +3545,17 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "15.0.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "gix-tempfile 15.0.0",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-merge"
 version = "0.2.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3565,12 +3565,12 @@ dependencies = [
  "gix-hash 0.15.1",
  "gix-index 0.37.0",
  "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-revision",
  "gix-revwalk 0.17.0",
  "gix-tempfile 15.0.0",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-worktree 0.38.0",
  "imara-diff",
  "thiserror 2.0.9",
@@ -3579,7 +3579,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bitflags 2.6.0",
  "gix-commitgraph 0.25.1",
@@ -3613,7 +3613,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.46.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "gix-actor 0.33.1",
@@ -3621,8 +3621,8 @@ dependencies = [
  "gix-features 0.39.1",
  "gix-hash 0.15.1",
  "gix-hashtable 0.6.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-validate 0.9.2",
  "itoa 1.0.11",
  "smallvec",
@@ -3633,7 +3633,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.66.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "arc-swap",
  "gix-date 0.9.3",
@@ -3643,8 +3643,8 @@ dependencies = [
  "gix-hashtable 0.6.0",
  "gix-object 0.46.1",
  "gix-pack",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "parking_lot",
  "tempfile",
  "thiserror 2.0.9",
@@ -3653,15 +3653,15 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.56.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "clru",
- "gix-chunk 0.4.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-chunk 0.4.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-features 0.39.1",
  "gix-hash 0.15.1",
  "gix-hashtable 0.6.0",
  "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-tempfile 15.0.0",
  "memmap2",
  "parking_lot",
@@ -3673,22 +3673,22 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.18.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.18.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "thiserror 2.0.9",
 ]
 
@@ -3708,10 +3708,10 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.13"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "home",
  "once_cell",
  "thiserror 2.0.9",
@@ -3720,21 +3720,21 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.8.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "gix-attributes 0.23.1",
  "gix-config-value",
  "gix-glob 0.17.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-prompt"
 version = "0.9.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -3746,7 +3746,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.47.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -3760,9 +3760,9 @@ dependencies = [
  "gix-refspec",
  "gix-revwalk 0.17.0",
  "gix-shallow",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-transport",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "maybe-async",
  "thiserror 2.0.9",
  "winnow 0.6.20",
@@ -3782,10 +3782,10 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.4.14"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "thiserror 2.0.9",
 ]
 
@@ -3814,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.49.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "gix-actor 0.33.1",
  "gix-features 0.39.1",
@@ -3822,9 +3822,9 @@ dependencies = [
  "gix-hash 0.15.1",
  "gix-lock 15.0.1",
  "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-tempfile 15.0.0",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-validate 0.9.2",
  "memmap2",
  "thiserror 2.0.9",
@@ -3834,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.27.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "gix-hash 0.15.1",
@@ -3847,7 +3847,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.31.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -3857,7 +3857,7 @@ dependencies = [
  "gix-hashtable 0.6.0",
  "gix-object 0.46.1",
  "gix-revwalk 0.17.0",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "thiserror 2.0.9",
 ]
 
@@ -3879,7 +3879,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "gix-commitgraph 0.25.1",
  "gix-date 0.9.3",
@@ -3905,10 +3905,10 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.10.10"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bitflags 2.6.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -3916,7 +3916,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.1.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "gix-hash 0.15.1",
@@ -3927,7 +3927,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "filetime",
@@ -3939,7 +3939,7 @@ dependencies = [
  "gix-hash 0.15.1",
  "gix-index 0.37.0",
  "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-pathspec",
  "gix-worktree 0.38.0",
  "portable-atomic",
@@ -3949,11 +3949,11 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "gix-config",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
@@ -3978,7 +3978,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "15.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "dashmap",
  "gix-fs 0.12.1",
@@ -4023,7 +4023,7 @@ checksum = "04bdde120c29f1fc23a24d3e115aeeea3d60d8e65bab92cc5f9d90d9302eb952"
 [[package]]
 name = "gix-trace"
 version = "0.1.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "tracing-core",
 ]
@@ -4031,7 +4031,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.44.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -4040,8 +4040,8 @@ dependencies = [
  "gix-credentials",
  "gix-features 0.39.1",
  "gix-packetline",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-url",
  "thiserror 2.0.9",
 ]
@@ -4066,7 +4066,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.43.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bitflags 2.6.0",
  "gix-commitgraph 0.25.1",
@@ -4082,11 +4082,11 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.28.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "gix-features 0.39.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "percent-encoding",
  "thiserror 2.0.9",
  "url",
@@ -4105,7 +4105,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.1.13"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4125,7 +4125,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.9.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "thiserror 2.0.9",
@@ -4153,7 +4153,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.38.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "gix-attributes 0.23.1",
@@ -4164,14 +4164,14 @@ dependencies = [
  "gix-ignore 0.12.1",
  "gix-index 0.37.0",
  "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-validate 0.9.2",
 ]
 
 [[package]]
 name = "gix-worktree-state"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562#af704f57bb9480c47cdd393465264d586f1d4562"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
 dependencies = [
  "bstr",
  "gix-features 0.39.1",
@@ -4181,7 +4181,7 @@ dependencies = [
  "gix-hash 0.15.1",
  "gix-index 0.37.0",
  "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=af704f57bb9480c47cdd393465264d586f1d4562)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
  "gix-worktree 0.38.0",
  "io-close",
  "thiserror 2.0.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2428,7 +2428,9 @@ dependencies = [
  "anyhow",
  "git2",
  "gitbutler-project",
+ "gix",
  "serde",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ resolver = "2"
 [workspace.dependencies]
 bstr = "1.11.1"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
-gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "af704f57bb9480c47cdd393465264d586f1d4562", default-features = false, features = [] }
+gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "a22f13bec0cdd580ee92390a98d5d522eb29978d", default-features = false, features = [] }
 git2 = { version = "0.20.0", features = [
     "vendored-openssl",
     "vendored-libgit2",

--- a/crates/gitbutler-config/Cargo.toml
+++ b/crates/gitbutler-config/Cargo.toml
@@ -7,6 +7,8 @@ publish = false
 
 [dependencies]
 git2.workspace = true
+gix.workspace = true
 anyhow = "1.0.95"
+tracing.workspace = true
 serde = { workspace = true, features = ["std"]}
 gitbutler-project.workspace = true

--- a/crates/gitbutler-repo/src/repository_ext.rs
+++ b/crates/gitbutler-repo/src/repository_ext.rs
@@ -1,7 +1,7 @@
 use crate::Config;
 use crate::SignaturePurpose;
 use anyhow::{anyhow, bail, Context, Result};
-use bstr::{BStr, BString};
+use bstr::{BStr, BString, ByteSlice};
 use git2::Tree;
 use gitbutler_commit::commit_headers::CommitHeadersV2;
 use gitbutler_config::git::{GbConfig, GitConfig};
@@ -13,11 +13,14 @@ use gitbutler_reference::{Refname, RemoteRefname};
 use gix::filter::plumbing::pipeline::convert::ToGitOutcome;
 use gix::objs::WriteTo;
 use gix::status::index_worktree;
+use std::borrow::Cow;
 use std::collections::HashSet;
+use std::ffi::OsStr;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
+use std::path::Path;
 use std::{io::Write, process::Stdio, str};
 use tracing::instrument;
 
@@ -394,127 +397,131 @@ impl RepositoryExt for git2::Repository {
     fn sign_buffer(&self, buffer: &[u8]) -> Result<BString> {
         // check git config for gpg.signingkey
         // TODO: support gpg.ssh.defaultKeyCommand to get the signing key if this value doesn't exist
-        let signing_key = self.config()?.get_string("user.signingkey");
-        if let Ok(signing_key) = signing_key {
-            let sign_format = self.config()?.get_string("gpg.format");
-            let is_ssh = if let Ok(sign_format) = sign_format {
-                sign_format == "ssh"
+        let repo = gix::open(self.path())?;
+        let config = repo.config_snapshot();
+        let signing_key = config.string("user.signingkey");
+        let Some(signing_key) = signing_key else {
+            bail!("No signing key found");
+        };
+        let signing_key = signing_key.to_str().context("non-utf8 signing key")?;
+        let sign_format = config.string("gpg.format");
+        let is_ssh = if let Some(sign_format) = sign_format {
+            sign_format.as_ref() == "ssh"
+        } else {
+            false
+        };
+
+        if is_ssh {
+            // write commit data to a temp file so we can sign it
+            let mut signature_storage = tempfile::NamedTempFile::new()?;
+            signature_storage.write_all(buffer)?;
+            let buffer_file_to_sign_path = signature_storage.into_temp_path();
+
+            let gpg_program = config.trusted_program("gpg.ssh.program");
+            let mut gpg_program = gpg_program.unwrap_or(Cow::Borrowed(OsStr::new("ssh-keygen")));
+            // if cmd is "", use gpg
+            if gpg_program.is_empty() {
+                gpg_program = Cow::Borrowed(OsStr::new("ssh-keygen"));
+            }
+
+            let mut cmd_string = format!(
+                "{} -Y sign -n git -f ",
+                gix::path::os_str_into_bstr(gpg_program.as_ref())?
+            );
+
+            let buffer_file_to_sign_path_str = buffer_file_to_sign_path
+                .to_str()
+                .ok_or_else(|| anyhow::anyhow!("Failed to convert path to string"))?
+                .to_string();
+
+            // support literal ssh key
+            if let (true, signing_key) = is_literal_ssh_key(signing_key) {
+                // write the key to a temp file
+                let mut key_storage = tempfile::NamedTempFile::new()?;
+                key_storage.write_all(signing_key.as_bytes())?;
+
+                // if on unix
+                #[cfg(unix)]
+                {
+                    // make sure the tempfile permissions are acceptable for a private ssh key
+                    let mut permissions = key_storage.as_file().metadata()?.permissions();
+                    permissions.set_mode(0o600);
+                    key_storage.as_file().set_permissions(permissions)?;
+                }
+
+                let key_file_path = key_storage.into_temp_path();
+                let args = format!(
+                    "{} -U {}",
+                    key_file_path.to_string_lossy(),
+                    buffer_file_to_sign_path.to_string_lossy()
+                );
+                cmd_string += &args;
             } else {
-                false
+                let args = format!("{} {}", signing_key, buffer_file_to_sign_path_str);
+                cmd_string += &args;
             };
+            let mut signing_cmd: std::process::Command = gix::command::prepare(cmd_string)
+                .with_shell_disallow_manual_argument_splitting()
+                .into();
+            let output = signing_cmd
+                .stderr(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stdin(Stdio::null())
+                .output()?;
 
-            if is_ssh {
-                // write commit data to a temp file so we can sign it
-                let mut signature_storage = tempfile::NamedTempFile::new()?;
-                signature_storage.write_all(buffer)?;
-                let buffer_file_to_sign_path = signature_storage.into_temp_path();
-
-                let gpg_program = self.config()?.get_string("gpg.ssh.program");
-                let mut gpg_program = gpg_program.unwrap_or("ssh-keygen".to_string());
-                // if cmd is "", use gpg
-                if gpg_program.is_empty() {
-                    gpg_program = "ssh-keygen".to_string();
-                }
-
-                let mut cmd_string = format!("{} -Y sign -n git -f ", gpg_program);
-
-                let buffer_file_to_sign_path_str = buffer_file_to_sign_path
-                    .to_str()
-                    .ok_or_else(|| anyhow::anyhow!("Failed to convert path to string"))?
-                    .to_string();
-
-                // support literal ssh key
-                if let (true, signing_key) = is_literal_ssh_key(&signing_key) {
-                    // write the key to a temp file
-                    let mut key_storage = tempfile::NamedTempFile::new()?;
-                    key_storage.write_all(signing_key.as_bytes())?;
-
-                    // if on unix
-                    #[cfg(unix)]
-                    {
-                        // make sure the tempfile permissions are acceptable for a private ssh key
-                        let mut permissions = key_storage.as_file().metadata()?.permissions();
-                        permissions.set_mode(0o600);
-                        key_storage.as_file().set_permissions(permissions)?;
-                    }
-
-                    let key_file_path = key_storage.into_temp_path();
-                    let args = format!(
-                        "{} -U {}",
-                        key_file_path.to_string_lossy(),
-                        buffer_file_to_sign_path.to_string_lossy()
-                    );
-                    cmd_string += &args;
-                } else {
-                    let args = format!("{} {}", signing_key, buffer_file_to_sign_path_str);
-                    cmd_string += &args;
-                };
-                let mut signing_cmd: std::process::Command = gix::command::prepare(cmd_string)
-                    .with_shell_disallow_manual_argument_splitting()
-                    .into();
-                let output = signing_cmd
-                    .stderr(Stdio::piped())
-                    .stdout(Stdio::piped())
-                    .stdin(Stdio::null())
-                    .output()?;
-
-                if output.status.success() {
-                    // read signed_storage path plus .sig
-                    let signature_path = buffer_file_to_sign_path.with_extension("sig");
-                    let sig_data = std::fs::read(signature_path)?;
-                    let signature = BString::new(sig_data);
-                    return Ok(signature);
-                } else {
-                    let stderr = BString::new(output.stderr);
-                    let stdout = BString::new(output.stdout);
-                    let std_both = format!("{} {}", stdout, stderr);
-                    bail!("Failed to sign SSH: {}", std_both);
-                }
+            if output.status.success() {
+                // read signed_storage path plus .sig
+                let signature_path = buffer_file_to_sign_path.with_extension("sig");
+                let sig_data = std::fs::read(signature_path)?;
+                let signature = BString::new(sig_data);
+                Ok(signature)
             } else {
-                let gpg_program = self
-                    .config()?
-                    .get_path("gpg.program")
-                    .ok()
-                    .filter(|gpg| !gpg.as_os_str().is_empty())
-                    .unwrap_or_else(|| "gpg".into());
+                let stderr = BString::new(output.stderr);
+                let stdout = BString::new(output.stdout);
+                let std_both = format!("{} {}", stdout, stderr);
+                bail!("Failed to sign SSH: {}", std_both);
+            }
+        } else {
+            let gpg_program = config
+                .trusted_program("gpg.program")
+                .map(|program| Cow::Owned(program.into_owned().into()))
+                .unwrap_or_else(|| Path::new("gpg").into());
 
-                let mut cmd = std::process::Command::new(&gpg_program);
+            let mut cmd = std::process::Command::new(gpg_program.as_ref());
 
-                cmd.args(["--status-fd=2", "-bsau", &signing_key])
-                    .arg("-")
-                    .stdout(Stdio::piped())
-                    .stderr(Stdio::piped())
-                    .stdin(Stdio::piped());
+            cmd.args(["--status-fd=2", "-bsau", signing_key])
+                .arg("-")
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .stdin(Stdio::piped());
 
-                #[cfg(windows)]
-                cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+            #[cfg(windows)]
+            cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
 
-                let mut child = match cmd.spawn() {
-                    Ok(child) => child,
-                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                        bail!("Could not find '{}'. Please make sure it is in your `PATH` or configure the full path using `gpg.program` in the Git configuration", gpg_program.display())
-                    }
-                    Err(err) => {
-                        return Err(err)
-                            .context(format!("Could not execute GPG program using {:?}", cmd))
-                    }
-                };
-                child.stdin.take().expect("configured").write_all(buffer)?;
-
-                let output = child.wait_with_output()?;
-                if output.status.success() {
-                    // read stdout
-                    let signature = BString::new(output.stdout);
-                    return Ok(signature);
-                } else {
-                    let stderr = BString::new(output.stderr);
-                    let stdout = BString::new(output.stdout);
-                    let std_both = format!("{} {}", stdout, stderr);
-                    bail!("Failed to sign GPG: {}", std_both);
+            let mut child = match cmd.spawn() {
+                Ok(child) => child,
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                    bail!("Could not find '{}'. Please make sure it is in your `PATH` or configure the full path using `gpg.program` in the Git configuration", gpg_program.display())
                 }
+                Err(err) => {
+                    return Err(err)
+                        .context(format!("Could not execute GPG program using {:?}", cmd))
+                }
+            };
+            child.stdin.take().expect("configured").write_all(buffer)?;
+
+            let output = child.wait_with_output()?;
+            if output.status.success() {
+                // read stdout
+                let signature = BString::new(output.stdout);
+                Ok(signature)
+            } else {
+                let stderr = BString::new(output.stderr);
+                let stdout = BString::new(output.stdout);
+                let std_both = format!("{} {}", stdout, stderr);
+                bail!("Failed to sign GPG: {}", std_both);
             }
         }
-        Err(anyhow::anyhow!("No signing key found"))
     }
 
     fn remotes_as_string(&self) -> Result<Vec<String>> {


### PR DESCRIPTION
Use a login shell for spawning the programs to sign a buffer.

Related to #5839 and #5022.

### Tasks

* [x] cleanup
* [x] use shell for any invocation
* [x] use login shell
* [x] additional fix: use `gix` for all Git configuration

### Notes for the Reviewer

* I did some testing regarding signing, and the UI picking up signing related configuration, but that probably didn't run all the codepaths that changed.
* Fetching git configuration (one key at a time like the UI does) is now about 25% to 40% slower, at ~120microseconds. Still within the range I think.

### Research

#### Environment variables in a release application

Launching a release application on MacOS (through the finder) yields the following environment variables.


```
  (
        "TMPDIR",
        "/var/folders/x7/jgy95vjs3v3ffszwn0wg0gz80000gn/T/",
    ),
    (
        "__CFBundleIdentifier",
        "com.apple.Terminal",
    ),
    (
        "XPC_FLAGS",
        "0x0",
    ),
    (
        "TERM",
        "xterm-256color",
    ),
    (
        "SSH_AUTH_SOCK",
        "/Users/byron/.gnupg/S.gpg-agent.ssh",
    ),
    (
        "XPC_SERVICE_NAME",
        "0",
    ),
    (
        "TERM_PROGRAM",
        "Apple_Terminal",
    ),
    (
        "TERM_PROGRAM_VERSION",
        "455",
    ),
    (
        "TERM_SESSION_ID",
        "<redacted>",
    ),
    (
        "SHELL",
        "/bin/zsh",
    ),
    (
        "HOME",
        "/Users/byron",
    ),
    (
        "LOGNAME",
        "byron",
    ),
    (
        "USER",
        "byron",
    ),
    (
        "PATH",
        "<redacted, but looks complete>",
    ),
    (
        "SHLVL",
        "1",
    ),
    (
        "PWD",
        "/Users/byron",
    ),
    (
        "OLDPWD",
        "/Users/byron",
    ),
    (
        "ZSH",
        "/Users/byron/.oh-my-zsh",
    ),
    (
        "PAGER",
        "less",
    ),
    (
        "LESS",
        "-R",
    ),
    (
        "LSCOLORS",
        "Gxfxcxdxbxegedabagacad",
    ),
    (
        "LS_COLORS",
        "di=1;36:ln=35:so=32:pi=33:ex=31:bd=34;46:cd=34;43:su=30;41:sg=30;46:tw=30;42:ow=30;43",
    ),
    (
        "HOMEBREW_PREFIX",
        "/opt/homebrew",
    ),
    (
        "HOMEBREW_CELLAR",
        "/opt/homebrew/Cellar",
    ),
    (
        "HOMEBREW_REPOSITORY",
        "/opt/homebrew",
    ),
    (
        "INFOPATH",
        "/opt/homebrew/share/info:/opt/homebrew/share/info:",
    ),
    (
        "GPG_TTY",
        "/dev/ttys005",
    ),
    (
        "EDITOR",
        "hx",
    ),
    (
        "BAT_THEME",
        "TwoDark",
    ),
    (
        "STARSHIP_SHELL",
        "zsh",
    ),
    (
        "STARSHIP_SESSION_KEY",
    ),
    (
        "HOMEBREW_NO_ANALYTICS",
        "1",
    ),
    (
        "LC_CTYPE",
        "UTF-8",
    ),
    (
        "_",
        "/Users/byron/dev/github.com/gitbutlerapp/gitbutler/target/debug/gitbutler-tauri",
    ),
    (
        "__CF_USER_TEXT_ENCODING",
        "0x1F5:0x0:0x0",
    ),
]

```

It looks like `$SHELL` can be used to figure out the login shell at least on MacOS. It's notable how many other additional variables are available, as if it was opened through a login shell already.

It really seems that a lot, but not all, of the login shell environment is picked up. It's unclear why 