### PR TITLE
fix: Only remove the the search param if needed

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -59,8 +59,10 @@
 		if (token) {
 			authService.setToken(token);
 
-			$page.url.searchParams.delete('gb_access_token');
-			goto(`?${$page.url.searchParams.toString()}`);
+			if ($page.url.searchParams.has('gb_access_token')) {
+				$page.url.searchParams.delete('gb_access_token');
+				goto(`?${$page.url.searchParams.toString()}`);
+			}
 		}
 	});
 </script>


### PR DESCRIPTION
The code was in a redirection loop because it was always always attempting to remove the token search param regardless of whether it had it.