### PR TITLE
chore: explicitly mark fields as optional in bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug.yml
@@ -49,7 +49,7 @@ body:
   - type: textarea
     id: repro
     attributes:
-      label: How to reproduce
+      label: How to reproduce (Optional)
       description: How do you trigger this bug? Please walk us through it step by step.
       placeholder: |
         1. ...
@@ -61,7 +61,7 @@ body:
   - type: textarea
     id: expected
     attributes:
-      label: Expected behavior
+      label: Expected behavior (Optional)
       description: Explain what you expected to actually have happened.
       placeholder: |
         1. Setting ... option should not crash the application
@@ -70,7 +70,7 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: Relevant log output
+      label: Relevant log output (Optional)
       description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
       render: shell
     validations:


### PR DESCRIPTION
## 🧢 Changes

- Explicitly mark fields as "(Optional)" in Bug issue template.

## ☕️ Reasoning



<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
