### PR TITLE
feat: add option to delete remote branches after merge

### DIFF
--- a/apps/desktop/src/components/GitForgeForm.svelte
+++ b/apps/desktop/src/components/GitForgeForm.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import { projectDeleteRemoteBranchAfterMerge } from '$lib/config/config';
+	import { Project } from '$lib/project/project';
+	import { ProjectsService } from '$lib/project/projectsService';
+	import { getContext } from '@gitbutler/shared/context';
+	import SectionCard from '@gitbutler/ui/SectionCard.svelte';
+	import Toggle from '@gitbutler/ui/Toggle.svelte';
+
+	const project = getContext(Project);
+	const projectsService = getContext(ProjectsService);
+
+	const allowForcePushing = $derived(project?.ok_with_force_push);
+
+	async function setWithForcePush(value: boolean) {
+		project.ok_with_force_push = value;
+		await projectsService.updateProject(project);
+	}
+
+	async function handleAllowForcePushClick(event: MouseEvent) {
+		await setWithForcePush((event.target as HTMLInputElement)?.checked);
+	}
+
+	const deleteRemoteBranchEnabled = projectDeleteRemoteBranchAfterMerge(project.id);
+</script>
+
+<SectionCard orientation="row" labelFor="allowForcePush">
+	{#snippet title()}
+		Allow force pushing
+	{/snippet}
+	{#snippet caption()}
+		Force pushing allows GitButler to override branches even if they were pushed to remote.
+		GitButler will never force push to the target branch.
+	{/snippet}
+	{#snippet actions()}
+		<Toggle id="allowForcePush" checked={allowForcePushing} onclick={handleAllowForcePushClick} />
+	{/snippet}
+</SectionCard>
+
+<SectionCard orientation="row" labelFor="deleteRemoteBranchAfterMerge">
+	{#snippet title()}
+		Delete Remote Branch After Merge
+	{/snippet}
+	{#snippet caption()}
+		If you do not have "Automatically delete head branches" enabled in your repository, GitButler
+		can automatically delete the remote branch from your remote for you after successfully merging.
+	{/snippet}
+	{#snippet actions()}
+		<Toggle id="deleteRemoteBranchAfterMerge" bind:checked={$deleteRemoteBranchEnabled} />
+	{/snippet}
+</SectionCard>

--- a/apps/desktop/src/components/GitForm.svelte
+++ b/apps/desktop/src/components/GitForm.svelte
@@ -1,28 +1,10 @@
 <script lang="ts">
 	import CommitSigningForm from './CommitSigningForm.svelte';
+	import GitForgeForm from '$components/GitForgeForm.svelte';
 	import KeysForm from '$components/KeysForm.svelte';
 	import Section from '$components/Section.svelte';
 	import { platformName } from '$lib/platform/platform';
-	import { Project } from '$lib/project/project';
-	import { ProjectsService } from '$lib/project/projectsService';
-	import { getContext } from '@gitbutler/shared/context';
-	import SectionCard from '@gitbutler/ui/SectionCard.svelte';
 	import Spacer from '@gitbutler/ui/Spacer.svelte';
-	import Toggle from '@gitbutler/ui/Toggle.svelte';
-
-	const project = getContext(Project);
-	const projectsService = getContext(ProjectsService);
-
-	const allowForcePushing = $derived(project?.ok_with_force_push);
-
-	async function setWithForcePush(value: boolean) {
-		project.ok_with_force_push = value;
-		await projectsService.updateProject(project);
-	}
-
-	async function handleAllowForcePushClick(event: MouseEvent) {
-		await setWithForcePush((event.target as HTMLInputElement)?.checked);
-	}
 </script>
 
 <Section>
@@ -33,16 +15,5 @@
 	{/if}
 
 	<Spacer />
-	<SectionCard orientation="row" labelFor="allowForcePush">
-		{#snippet title()}
-			Allow force pushing
-		{/snippet}
-		{#snippet caption()}
-			Force pushing allows GitButler to override branches even if they were pushed to remote.
-			GitButler will never force push to the target branch.
-		{/snippet}
-		{#snippet actions()}
-			<Toggle id="allowForcePush" checked={allowForcePushing} onclick={handleAllowForcePushClick} />
-		{/snippet}
-	</SectionCard>
+	<GitForgeForm />
 </Section>

--- a/apps/desktop/src/lib/config/config.ts
+++ b/apps/desktop/src/lib/config/config.ts
@@ -5,13 +5,6 @@ export function projectHttpsWarningBannerDismissed(projectId: string): Persisted
 	return persisted(false, key + projectId);
 }
 
-export function projectDeleteBranchesOnMergeWarningDismissed(
-	projectId: string
-): Persisted<boolean> {
-	const key = 'projectDeleteBranchesOnMergeWarningDismissed_';
-	return persisted(false, key + projectId);
-}
-
 export function projectCommitGenerationExtraConcise(projectId: string): Persisted<boolean> {
 	const key = 'projectCommitGenerationExtraConcise_';
 	return persisted(false, key + projectId);
@@ -50,6 +43,11 @@ export function projectLaneCollapsed(projectId: string, laneId: string): Persist
 
 export function persistedCommitMessage(projectId: string, branchId: string): Persisted<string> {
 	return persisted('', 'projectCurrentCommitMessage_' + projectId + '_' + branchId);
+}
+
+export function projectDeleteRemoteBranchAfterMerge(projectId: string): Persisted<boolean> {
+	const key = 'projectDeleteRemoteBranchAfterMerge_';
+	return persisted(false, key + projectId);
 }
 
 export const showHistoryView = persisted(false, 'showHistoryView');

--- a/apps/desktop/src/lib/forge/github/githubBranch.ts
+++ b/apps/desktop/src/lib/forge/github/githubBranch.ts
@@ -8,4 +8,11 @@ export class GitHubBranch implements ForgeBranch {
 		}
 		this.url = `${baseUrl}/compare/${baseBranch}...${name}`;
 	}
+
+	/**
+	 * @desc Delete branch from remote only
+	 */
+	async delete(ref: string) {
+		this.octokit.delete();
+	}
 }

--- a/apps/desktop/src/lib/forge/github/githubPrService.ts
+++ b/apps/desktop/src/lib/forge/github/githubPrService.ts
@@ -1,6 +1,7 @@
 import { GitHubPrMonitor } from './githubPrMonitor';
 import { DEFAULT_HEADERS } from './headers';
 import { ghResponseToInstance, parseGitHubDetailedPullRequest } from './types';
+import { projectDeleteRemoteBranchAfterMerge } from '$lib/config/config';
 import { sleep } from '$lib/utils/sleep';
 import { writable } from 'svelte/store';
 import type { PostHogWrapper } from '$lib/analytics/posthog';
@@ -22,7 +23,9 @@ export class GitHubPrService implements ForgePrService {
 		private repo: RepoInfo,
 		private baseBranch: string,
 		private posthog?: PostHogWrapper
-	) {}
+	) {
+		console.log(projectDeleteRemoteBranchAfterMerge());
+	}
 
 	async createPr({
 		title,
@@ -84,6 +87,10 @@ export class GitHubPrService implements ForgePrService {
 			pull_number: prNumber,
 			merge_method: method
 		});
+
+		if (true) {
+			console.log('SHOULD DELETE BRNACH');
+		}
 	}
 
 	async reopen(prNumber: number) {


### PR DESCRIPTION
## 🧢 Changes

- [x] Add "Git" project settings config option for deleting branches after merge (i.e. if user doesn't have the GitHub repo setting enabled to automatically do this)
- [ ] Delete remote branch after merge (TODO)


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

-->
## 🎫 Affected issues

Fixes: #5887


<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
