### PR TITLE
type: Login is of type string

### DIFF
--- a/apps/web/src/lib/user/userService.ts
+++ b/apps/web/src/lib/user/userService.ts
@@ -4,7 +4,7 @@ import type { HttpClient } from '@gitbutler/shared/network/httpClient';
 
 export interface User {
 	id: string;
-	login: any;
+	login: string | undefined;
 	name: string;
 	email: string;
 	created_at: Date;


### PR DESCRIPTION
The username (`login`) might be unset, so it should be string or undefined.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 8 in a stack** made with GitButler:
- <kbd>&nbsp;8&nbsp;</kbd> #5951 
- <kbd>&nbsp;7&nbsp;</kbd> #5950 
- <kbd>&nbsp;6&nbsp;</kbd> #5949 
- <kbd>&nbsp;5&nbsp;</kbd> #5942 
- <kbd>&nbsp;4&nbsp;</kbd> #5938 
- <kbd>&nbsp;3&nbsp;</kbd> #5937 
- <kbd>&nbsp;2&nbsp;</kbd> #5934 
- <kbd>&nbsp;1&nbsp;</kbd> #5933 👈 
<!-- GitButler Footer Boundary Bottom -->

