### PR TITLE
fix: use dbus secret store method for linux keyring crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ uuid = { version = "1.11.0", features = ["v4", "serde"] }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0.9"
 tokio = { version = "1.42.0", default-features = false }
-keyring = { version = "3.6.1", features = ["apple-native", "windows-native", "linux-native", "crypto-rust"] }
+keyring = { version = "3.6.1", features = ["apple-native", "windows-native", "linux-native-sync-persistent", "crypto-rust"] }
 anyhow = "1.0.95"
 parking_lot = "0.12.3"
 futures = "0.3.31"


### PR DESCRIPTION
## 🧢 Changes

- Use `sync-secret-service` linux keyring feature to use dbus to communicate with linux system secret store and therefore allow access via flatpak, for example.

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
