### PR TITLE
Use a single textbox for commit message

### DIFF
--- a/apps/desktop/src/lib/commit/CommitDialog.svelte
+++ b/apps/desktop/src/lib/commit/CommitDialog.svelte
@@ -103,7 +103,6 @@
 	export async function focus() {
 		$expanded = true;
 		await tick();
-		commitMessageInput?.focus();
 	}
 </script>
 


### PR DESCRIPTION
- allows for `cmd + a` select all
- simpler component
- works better with commit message hook

<img width="539" alt="image" src="https://github.com/user-attachments/assets/89a5b48b-d5b4-4ca7-a946-f7a78213aa1d" />

<img width="543" alt="image" src="https://github.com/user-attachments/assets/7fcc4fa6-31d4-4b34-8f4e-c7ddc2b51e56" />
