### PR TITLE
V3 Uncommitted Files, CLI and Filewatching (part 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,6 +668,7 @@ dependencies = [
  "but-workspace",
  "clap",
  "gitbutler-project",
+ "gix",
  "tracing",
  "tracing-forest",
  "tracing-subscriber",
@@ -680,9 +681,9 @@ dependencies = [
  "anyhow",
  "bstr",
  "gix",
+ "gix-testtools",
+ "insta",
  "serde",
- "toml 0.8.19",
- "walkdir",
 ]
 
 [[package]]
@@ -2865,6 +2866,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "backtrace",
+ "but-core",
  "but-workspace",
  "console-subscriber",
  "dirs 5.0.1",
@@ -2897,6 +2899,7 @@ dependencies = [
  "gitbutler-user",
  "gitbutler-watcher",
  "gix",
+ "insta",
  "itertools 0.14.0",
  "log",
  "once_cell",
@@ -3054,6 +3057,7 @@ dependencies = [
  "gix-ignore 0.12.1",
  "gix-index 0.37.0",
  "gix-lock 15.0.1",
+ "gix-mailmap",
  "gix-merge",
  "gix-negotiate",
  "gix-object 0.46.1",
@@ -3081,6 +3085,7 @@ dependencies = [
  "gix-worktree 0.38.0",
  "gix-worktree-state",
  "once_cell",
+ "serde",
  "smallvec",
  "thiserror 2.0.9",
 ]
@@ -3108,6 +3113,7 @@ dependencies = [
  "gix-date 0.9.3",
  "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "itoa 1.0.11",
+ "serde",
  "thiserror 2.0.9",
  "winnow 0.6.20",
 ]
@@ -3140,6 +3146,7 @@ dependencies = [
  "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "kstring",
+ "serde",
  "smallvec",
  "thiserror 2.0.9",
  "unicode-bom",
@@ -3214,6 +3221,7 @@ dependencies = [
  "gix-features 0.39.1",
  "gix-hash 0.15.1",
  "memmap2",
+ "serde",
  "thiserror 2.0.9",
 ]
 
@@ -3262,6 +3270,7 @@ dependencies = [
  "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-url",
+ "serde",
  "thiserror 2.0.9",
 ]
 
@@ -3285,6 +3294,7 @@ dependencies = [
  "bstr",
  "itoa 1.0.11",
  "jiff",
+ "serde",
  "thiserror 2.0.9",
 ]
 
@@ -3460,6 +3470,7 @@ dependencies = [
  "bstr",
  "gix-features 0.39.1",
  "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "serde",
 ]
 
 [[package]]
@@ -3478,6 +3489,7 @@ version = "0.15.1"
 source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "faster-hex",
+ "serde",
  "thiserror 2.0.9",
 ]
 
@@ -3524,6 +3536,7 @@ dependencies = [
  "gix-glob 0.17.1",
  "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "serde",
  "unicode-bom",
 ]
 
@@ -3578,6 +3591,7 @@ dependencies = [
  "libc",
  "memmap2",
  "rustix",
+ "serde",
  "smallvec",
  "thiserror 2.0.9",
 ]
@@ -3600,6 +3614,18 @@ source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d105021
 dependencies = [
  "gix-tempfile 15.0.0",
  "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "thiserror 2.0.9",
+]
+
+[[package]]
+name = "gix-mailmap"
+version = "0.25.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#af704f57bb9480c47cdd393465264d586f1d4562"
+dependencies = [
+ "bstr",
+ "gix-actor 0.33.1",
+ "gix-date 0.9.3",
+ "serde",
  "thiserror 2.0.9",
 ]
 
@@ -3676,6 +3702,7 @@ dependencies = [
  "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-validate 0.9.2",
  "itoa 1.0.11",
+ "serde",
  "smallvec",
  "thiserror 2.0.9",
  "winnow 0.6.20",
@@ -3697,6 +3724,7 @@ dependencies = [
  "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "parking_lot",
+ "serde",
  "tempfile",
  "thiserror 2.0.9",
 ]
@@ -3716,6 +3744,7 @@ dependencies = [
  "gix-tempfile 15.0.0",
  "memmap2",
  "parking_lot",
+ "serde",
  "smallvec",
  "thiserror 2.0.9",
  "uluru",
@@ -3815,6 +3844,7 @@ dependencies = [
  "gix-transport",
  "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "maybe-async",
+ "serde",
  "thiserror 2.0.9",
  "winnow 0.6.20",
 ]
@@ -3878,6 +3908,7 @@ dependencies = [
  "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-validate 0.9.2",
  "memmap2",
+ "serde",
  "thiserror 2.0.9",
  "winnow 0.6.20",
 ]
@@ -3909,6 +3940,7 @@ dependencies = [
  "gix-object 0.46.1",
  "gix-revwalk 0.17.0",
  "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "serde",
  "thiserror 2.0.9",
 ]
 
@@ -3961,6 +3993,7 @@ dependencies = [
  "bitflags 2.6.0",
  "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "libc",
+ "serde",
  "windows-sys 0.52.0",
 ]
 
@@ -3972,6 +4005,7 @@ dependencies = [
  "bstr",
  "gix-hash 0.15.1",
  "gix-lock 15.0.1",
+ "serde",
  "thiserror 2.0.9",
 ]
 
@@ -4094,6 +4128,7 @@ dependencies = [
  "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-url",
+ "serde",
  "thiserror 2.0.9",
 ]
 
@@ -4139,6 +4174,7 @@ dependencies = [
  "gix-features 0.39.1",
  "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "percent-encoding",
+ "serde",
  "thiserror 2.0.9",
  "url",
 ]
@@ -4217,6 +4253,7 @@ dependencies = [
  "gix-object 0.46.1",
  "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-validate 0.9.2",
+ "serde",
 ]
 
 [[package]]
@@ -5172,6 +5209,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
 dependencies = [
+ "serde",
  "static_assertions",
 ]
 
@@ -7699,6 +7737,9 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3033,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.69.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "gix-actor 0.33.1",
  "gix-attributes 0.23.1",
@@ -3059,7 +3059,7 @@ dependencies = [
  "gix-object 0.46.1",
  "gix-odb",
  "gix-pack",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-pathspec",
  "gix-prompt",
  "gix-protocol",
@@ -3067,16 +3067,16 @@ dependencies = [
  "gix-refspec",
  "gix-revision",
  "gix-revwalk 0.17.0",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-shallow",
  "gix-status",
  "gix-submodule",
  "gix-tempfile 15.0.0",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-transport",
  "gix-traverse 0.43.1",
  "gix-url",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-validate 0.9.2",
  "gix-worktree 0.38.0",
  "gix-worktree-state",
@@ -3102,11 +3102,11 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.33.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "gix-date 0.9.3",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "itoa 1.0.11",
  "thiserror 2.0.9",
  "winnow 0.6.20",
@@ -3132,13 +3132,13 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.23.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "gix-glob 0.17.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "kstring",
  "smallvec",
  "thiserror 2.0.9",
@@ -3157,7 +3157,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.13"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "thiserror 2.0.9",
 ]
@@ -3174,7 +3174,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.10"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "thiserror 2.0.9",
 ]
@@ -3182,11 +3182,11 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.4.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "shell-words",
 ]
 
@@ -3207,10 +3207,10 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.25.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
- "gix-chunk 0.4.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-chunk 0.4.10 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-features 0.39.1",
  "gix-hash 0.15.1",
  "memmap2",
@@ -3220,15 +3220,15 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.42.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "gix-config-value",
  "gix-features 0.39.1",
  "gix-glob 0.17.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-ref 0.49.1",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "memchr",
  "once_cell",
  "smallvec",
@@ -3240,11 +3240,11 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.14.10"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "libc",
  "thiserror 2.0.9",
 ]
@@ -3252,15 +3252,15 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.26.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-config-value",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-prompt",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-url",
  "thiserror 2.0.9",
 ]
@@ -3280,7 +3280,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.9.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "itoa 1.0.11",
@@ -3291,7 +3291,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.49.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "gix-attributes 0.23.1",
@@ -3301,10 +3301,10 @@ dependencies = [
  "gix-hash 0.15.1",
  "gix-index 0.37.0",
  "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-pathspec",
  "gix-tempfile 15.0.0",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-traverse 0.43.1",
  "gix-worktree 0.38.0",
  "imara-diff",
@@ -3314,7 +3314,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "gix-discover 0.37.0",
@@ -3322,10 +3322,10 @@ dependencies = [
  "gix-ignore 0.12.1",
  "gix-index 0.37.0",
  "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-pathspec",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-worktree 0.38.0",
  "thiserror 2.0.9",
 ]
@@ -3349,15 +3349,15 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.37.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "dunce",
  "gix-fs 0.12.1",
  "gix-hash 0.15.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-ref 0.49.1",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "thiserror 2.0.9",
 ]
 
@@ -3379,15 +3379,15 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.39.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bytes",
  "crc32fast",
  "crossbeam-channel",
  "flate2",
  "gix-hash 0.15.1",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "libc",
  "once_cell",
  "parking_lot",
@@ -3401,7 +3401,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -3410,10 +3410,10 @@ dependencies = [
  "gix-hash 0.15.1",
  "gix-object 0.46.1",
  "gix-packetline-blocking",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "smallvec",
  "thiserror 2.0.9",
 ]
@@ -3432,11 +3432,11 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.12.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "fastrand",
  "gix-features 0.39.1",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 ]
 
 [[package]]
@@ -3454,12 +3454,12 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.17.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "gix-features 0.39.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 ]
 
 [[package]]
@@ -3475,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.15.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "faster-hex",
  "thiserror 2.0.9",
@@ -3495,7 +3495,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "gix-hash 0.15.1",
  "hashbrown 0.14.5",
@@ -3518,12 +3518,12 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.12.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "gix-glob 0.17.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "unicode-bom",
 ]
 
@@ -3558,20 +3558,20 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.37.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "filetime",
  "fnv",
- "gix-bitmap 0.2.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-bitmap 0.2.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-features 0.39.1",
  "gix-fs 0.12.1",
  "gix-hash 0.15.1",
  "gix-lock 15.0.1",
  "gix-object 0.46.1",
  "gix-traverse 0.43.1",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-validate 0.9.2",
  "hashbrown 0.14.5",
  "itoa 1.0.11",
@@ -3596,17 +3596,17 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "15.0.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "gix-tempfile 15.0.0",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-merge"
 version = "0.2.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3616,12 +3616,12 @@ dependencies = [
  "gix-hash 0.15.1",
  "gix-index 0.37.0",
  "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-revision",
  "gix-revwalk 0.17.0",
  "gix-tempfile 15.0.0",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-worktree 0.38.0",
  "imara-diff",
  "thiserror 2.0.9",
@@ -3630,7 +3630,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bitflags 2.6.0",
  "gix-commitgraph 0.25.1",
@@ -3664,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.46.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "gix-actor 0.33.1",
@@ -3672,8 +3672,8 @@ dependencies = [
  "gix-features 0.39.1",
  "gix-hash 0.15.1",
  "gix-hashtable 0.6.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-validate 0.9.2",
  "itoa 1.0.11",
  "smallvec",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.66.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "arc-swap",
  "gix-date 0.9.3",
@@ -3694,8 +3694,8 @@ dependencies = [
  "gix-hashtable 0.6.0",
  "gix-object 0.46.1",
  "gix-pack",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "parking_lot",
  "tempfile",
  "thiserror 2.0.9",
@@ -3704,15 +3704,15 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.56.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "clru",
- "gix-chunk 0.4.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-chunk 0.4.10 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-features 0.39.1",
  "gix-hash 0.15.1",
  "gix-hashtable 0.6.0",
  "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-tempfile 15.0.0",
  "memmap2",
  "parking_lot",
@@ -3724,22 +3724,22 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.18.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.18.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "thiserror 2.0.9",
 ]
 
@@ -3759,10 +3759,10 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.13"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "home",
  "once_cell",
  "thiserror 2.0.9",
@@ -3771,21 +3771,21 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.8.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "gix-attributes 0.23.1",
  "gix-config-value",
  "gix-glob 0.17.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-prompt"
 version = "0.9.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.47.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -3811,9 +3811,9 @@ dependencies = [
  "gix-refspec",
  "gix-revwalk 0.17.0",
  "gix-shallow",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-transport",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "maybe-async",
  "thiserror 2.0.9",
  "winnow 0.6.20",
@@ -3833,10 +3833,10 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.4.14"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "thiserror 2.0.9",
 ]
 
@@ -3865,7 +3865,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.49.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "gix-actor 0.33.1",
  "gix-features 0.39.1",
@@ -3873,9 +3873,9 @@ dependencies = [
  "gix-hash 0.15.1",
  "gix-lock 15.0.1",
  "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-tempfile 15.0.0",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-validate 0.9.2",
  "memmap2",
  "thiserror 2.0.9",
@@ -3885,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.27.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "gix-hash 0.15.1",
@@ -3898,7 +3898,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.31.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -3908,7 +3908,7 @@ dependencies = [
  "gix-hashtable 0.6.0",
  "gix-object 0.46.1",
  "gix-revwalk 0.17.0",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "thiserror 2.0.9",
 ]
 
@@ -3930,7 +3930,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "gix-commitgraph 0.25.1",
  "gix-date 0.9.3",
@@ -3956,10 +3956,10 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.10.10"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bitflags 2.6.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -3967,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.1.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "gix-hash 0.15.1",
@@ -3978,7 +3978,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "filetime",
@@ -3990,7 +3990,7 @@ dependencies = [
  "gix-hash 0.15.1",
  "gix-index 0.37.0",
  "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-pathspec",
  "gix-worktree 0.38.0",
  "portable-atomic",
@@ -4000,11 +4000,11 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "gix-config",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
@@ -4029,7 +4029,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "15.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "dashmap",
  "gix-fs 0.12.1",
@@ -4074,7 +4074,7 @@ checksum = "04bdde120c29f1fc23a24d3e115aeeea3d60d8e65bab92cc5f9d90d9302eb952"
 [[package]]
 name = "gix-trace"
 version = "0.1.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "tracing-core",
 ]
@@ -4082,7 +4082,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.44.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -4091,8 +4091,8 @@ dependencies = [
  "gix-credentials",
  "gix-features 0.39.1",
  "gix-packetline",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-url",
  "thiserror 2.0.9",
 ]
@@ -4117,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.43.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bitflags 2.6.0",
  "gix-commitgraph 0.25.1",
@@ -4133,11 +4133,11 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.28.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "gix-features 0.39.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "percent-encoding",
  "thiserror 2.0.9",
  "url",
@@ -4156,7 +4156,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.1.13"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4176,7 +4176,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.9.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "thiserror 2.0.9",
@@ -4204,7 +4204,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.38.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "gix-attributes 0.23.1",
@@ -4215,14 +4215,14 @@ dependencies = [
  "gix-ignore 0.12.1",
  "gix-index 0.37.0",
  "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-validate 0.9.2",
 ]
 
 [[package]]
 name = "gix-worktree-state"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d#a22f13bec0cdd580ee92390a98d5d522eb29978d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
 dependencies = [
  "bstr",
  "gix-features 0.39.1",
@@ -4232,7 +4232,7 @@ dependencies = [
  "gix-hash 0.15.1",
  "gix-index 0.37.0",
  "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?rev=a22f13bec0cdd580ee92390a98d5d522eb29978d)",
+ "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-worktree 0.38.0",
  "io-close",
  "thiserror 2.0.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ bstr = "1.11.1"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
 gix = { git = "https://github.com/GitoxideLabs/gitoxide", branch = "main", default-features = false, features = [
 ] }
+gix-testtools = "0.15.0"
+insta = "1.41.1"
 git2 = { version = "0.20.0", features = [
     "vendored-openssl",
     "vendored-libgit2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.dependencies]
 bstr = "1.11.1"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
-gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "a22f13bec0cdd580ee92390a98d5d522eb29978d", default-features = false, features = [
+gix = { git = "https://github.com/GitoxideLabs/gitoxide", branch = "main", default-features = false, features = [
 ] }
 git2 = { version = "0.20.0", features = [
     "vendored-openssl",

--- a/crates/but-cli/Cargo.toml
+++ b/crates/but-cli/Cargo.toml
@@ -17,6 +17,7 @@ but-core.workspace = true
 but-workspace.workspace = true
 
 clap = { version = "4.5.23", features = ["derive", "env"] }
+gix.workspace = true
 anyhow.workspace = true
 tracing-forest = { version = "0.1.6" }
 tracing-subscriber.workspace = true

--- a/crates/but-cli/src/command/mod.rs
+++ b/crates/but-cli/src/command/mod.rs
@@ -5,16 +5,22 @@ pub fn project_from_path(path: PathBuf) -> anyhow::Result<Project> {
     Project::from_path(&path)
 }
 
+pub fn project_repo(path: PathBuf) -> anyhow::Result<gix::Repository> {
+    let project = project_from_path(path)?;
+    Ok(gix::open(project.worktree_path())?)
+}
+
 fn debug_print(this: impl std::fmt::Debug) -> anyhow::Result<()> {
     println!("{:#?}", this);
     Ok(())
 }
 
 pub mod status {
-    use crate::command::debug_print;
+    use crate::command::{debug_print, project_repo};
+    use std::path::PathBuf;
 
-    pub fn doit() -> anyhow::Result<()> {
-        debug_print("call into but-core")
+    pub fn doit(current_dir: PathBuf) -> anyhow::Result<()> {
+        debug_print(but_core::worktree::changes(&project_repo(current_dir)?)?)
     }
 }
 

--- a/crates/but-cli/src/main.rs
+++ b/crates/but-cli/src/main.rs
@@ -15,7 +15,7 @@ fn main() -> Result<()> {
     let _op_span = tracing::info_span!("cli-op").entered();
 
     match args.cmd {
-        args::Subcommands::Status => command::status::doit(),
+        args::Subcommands::Status => command::status::doit(args.current_dir),
         args::Subcommands::Stacks => command::stacks::list(args.current_dir),
     }
 }

--- a/crates/but-core/Cargo.toml
+++ b/crates/but-core/Cargo.toml
@@ -12,6 +12,8 @@ doctest = false
 serde = { workspace = true, features = ["std"] }
 bstr.workspace = true
 anyhow = "1.0.95"
-gix = { workspace = true, features = ["dirwalk", "credentials", "parallel"] }
-walkdir = "2.5.0"
-toml.workspace = true
+gix = { workspace = true, features = ["dirwalk", "credentials", "parallel", "serde", "status"] }
+
+[dev-dependencies]
+gix-testtools.workspace = true
+insta.workspace = true

--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -5,25 +5,49 @@
 //!
 //! ### House-~~Rules~~ Guidance
 //!
-//! * Try hard to do write all the 'right' tests
+//! * **Try hard to do write all the 'right' tests**
 //!    - Tests should challenge the implementation, try hard to break it.
 //!    - capture *all* business requirements
 //!    - Try to avoid doing read-only filesystem fixtures with `tempdir`, instead use `gitbutler-testtools::readonly`.
-//! * minimal dependencies
-//!    - both for the crate and for parameters of functions as well.
+//! * **minimal dependencies**
+//!    - both for the *crate* and for *parameters* of functions as well.
 //!         - i.e. try to avoid 'God' structures so the function only has access to what it needs to.
-//! * The filesystem is `Sync` but we don't have atomic operations
+//! * **The filesystem is `Sync` but we don't have atomic operations**
 //!    - Let's be very careful about changes to the filesystem, must at least be on the level of Git which means `.lock` files instead of direct writes.
 //!    - If only one part of the application is supposed to change the worktree, let's protect the Application from itself by using `gitbutler::access` just like we do now.
-//! * Make it work, make it work right, and if time and profiler permits, make it work fast.
-//! * All of the above can and should be scrutinized and is there is no hard rules.
+//! * **Implement `Serialize` on utility types to facilitate transfer to the frontend**
+//!     - But don't make bigger types frontend-specific. If that is needed, create a new type in the frontend-crate that uses frontend types.
+//!     - `BString` has a `BStringForFrontend` counterpart.
+//!     - `gix::ObjectId` has a `with = gitbutler_serde::object_id` serialization module.
+//! * **Make it work, make it work right, and if time and profiler permits, make it work fast**.
+//! * **All of the above can and should be scrutinized and is there is no hard rules.**
+//!
+//! ### Terminology
+//!
+//! * **Worktree**
+//!     - A git worktree, i.e. the checkout of a tree that makes the tree accessible on disk.
+//! * **Workspace**
+//!     - A GitButler concept of the combination of one or more branches into one worktree. This allows
+//!       multiple branches to be perceived in one worktree, by merging multiple branches together.
+//!
+
+use bstr::BString;
 
 /// Functions related to a Git worktree, i.e. the files checked out from a repository.
-pub mod worktree {
-    use std::path::Path;
+pub mod worktree;
 
-    /// Return a list of items that live underneath `worktree_root` that changed and thus can become part of a commit.
-    pub fn committable_entries(_worktree_root: &Path) -> anyhow::Result<()> {
-        todo!()
-    }
+/// An entry in the worktree that changed and thus is eligible to being committed.
+///
+/// It either lives (or lived) in the in `.git/index`, or in the `worktree`.
+///
+/// ### Note
+///
+/// For simplicity, copy-tracking is not representable right now, but `copy: bool` could be added
+/// if needed.
+#[derive(Debug, Clone)]
+pub struct WorktreeChange {
+    /// The *relative* path in the worktree where the entry can be found.
+    pub path: BString,
+    /// The specific information about this change.
+    pub status: worktree::Status,
 }

--- a/crates/but-core/src/worktree.rs
+++ b/crates/but-core/src/worktree.rs
@@ -1,0 +1,466 @@
+use crate::WorktreeChange;
+use anyhow::Context;
+use bstr::BString;
+use gix::dir::entry;
+use gix::dir::walk::EmissionMode;
+use gix::object::tree::EntryKind;
+use gix::status;
+use gix::status::index_worktree;
+use gix::status::index_worktree::RewriteSource;
+use gix::status::plumbing::index_as_worktree::{self, EntryStatus};
+use gix::status::tree_index::TrackRenames;
+use serde::Serialize;
+
+/// Identify where a [`WorktreeChange`] is from.
+#[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Serialize)]
+pub enum Origin {
+    /// The change was detected when doing a diff between a tree (`HEAD^{tree}`) and an index (`.git/index`).
+    TreeIndex,
+    /// The change was detected when doing a diff between an index (`.git/index`) and a worktree (working tree, working copy or current checkout).
+    IndexWorktree,
+}
+
+/// Specifically defines a [`WorktreeChange`].
+#[derive(Debug, Clone)]
+pub enum Status {
+    /// The *index entry* is in a conflicting state, which means the *worktree* can be in one of many states,
+    /// but none of which is the one the user might desire as they didn't specify it yet.
+    Conflict(gix::status::plumbing::index_as_worktree::Conflict),
+    /// A file that was never tracked by Git.
+    Untracked {
+        /// The kind of file if it was tracked, with unknown content.
+        state: ChangeState,
+    },
+    /// Something was added or scheduled to be added.
+    Addition {
+        /// Where the addition was registered.
+        ///
+        /// * If [`Origin::IndexWorktree`], then `state` is the current state on disk as it may be added to the index.
+        /// * If [`Origin::TreeIndex`], then `state` is what has been added to the index and what should be in the next commit.
+        origin: Origin,
+        /// The current state of what was added or will be added
+        state: ChangeState,
+    },
+    /// Something was deleted.
+    Deletion {
+        /// Where the deletion was registered.
+        ///
+        /// * If [`Origin::IndexWorktree`], then `previous_state` is what was recorded in the index, and the working tree file was deleted.
+        /// * If [`Origin::TreeIndex`], then `previous_state` is what was recorded in `HEAD^{tree}` and the entry from the index was deleted.
+        origin: Origin,
+        /// The that Git stored before the deletion.
+        previous_state: ChangeState,
+    },
+    /// A tracked entry was modified, which might mean:
+    ///
+    /// * the content change, i.e. a file was changed
+    /// * the type changed, a file is now a symlink or something else
+    /// * the executable bit changed, so a file is now executable, or isn't anymore.
+    ///
+    /// This change may sit in the index if `origin` is [`Origin::TreeIndex`] or in the worktree if `origin` is [`Origin::IndexWorktree`].
+    ///
+    /// Note that a modification may be applied in both `origin`s, along with other possible combinations of *two* status changes to the same path.
+    Modification {
+        /// Where the modification was registered.
+        origin: Origin,
+        /// The that Git stored before the modification.
+        previous_state: ChangeState,
+        /// The current state, i.e. the modification itself.
+        state: ChangeState,
+    },
+    /// An entry was renamed from `previous_path` to its current location.
+    ///
+    /// Note that this may include a content change, as well as a change of the executable bit.
+    Rename {
+        /// Where the modification was registered.
+        origin: Origin,
+        /// The path relative to the repository at which the entry was previously located.
+        previous_path: BString,
+        /// The that Git stored before the modification.
+        previous_state: ChangeState,
+        /// The current state, i.e. the modification itself.
+        state: ChangeState,
+    },
+}
+
+impl Status {
+    /// Return the [origin](Origin) of this instance, or extrapolate it if it's not explicitly set.
+    pub fn origin(&self) -> Origin {
+        match self {
+            Status::Conflict(_) | Status::Untracked { .. } => Origin::IndexWorktree,
+            Status::Addition { origin, .. }
+            | Status::Deletion { origin, .. }
+            | Status::Modification { origin, .. }
+            | Status::Rename { origin, .. } => *origin,
+        }
+    }
+}
+
+/// Something that fully identifies the state of a [`WorktreeChange`].
+#[derive(Debug, Clone, Copy)]
+pub struct ChangeState {
+    /// The content of the committable.
+    ///
+    /// If [`null`](gix::ObjectId::is_null), the current state isn't known which can happen
+    /// if this state is living in the worktree and has never been hashed.
+    pub id: gix::ObjectId,
+    /// The kind of the committable.
+    pub kind: gix::object::tree::EntryKind,
+}
+
+/// Return a list of [`WorktreeChange`] that live in the worktree of `repo` that changed and thus can become part of a commit.
+/// Note that the changes are returned by path, and such that [tree-index](Origin::TreeIndex) changes are happening *after*
+/// [index-worktree](Origin::IndexWorktree) changes.
+///
+/// ### Important: possibly non-unique paths
+///
+/// We return entries of different [kinds](Origin), and a path could be changed in the worktree,
+/// but it could also have been staged with a different change in the index.
+///
+/// The [`Origin`] determines which diff was performed to learn about the [`WorktreeChange`].
+pub fn changes(repo: &gix::Repository) -> anyhow::Result<Vec<WorktreeChange>> {
+    let rewrites = Default::default(); /* standard Git rewrite handling for everything */
+    let status_changes = repo
+        .status(gix::progress::Discard)?
+        .tree_index_track_renames(TrackRenames::Given(rewrites))
+        .index_worktree_rewrites(rewrites)
+        // Learn about submodule changes, but only do the cheap checks, showing only what we could commit.
+        .index_worktree_submodules(gix::status::Submodule::Given {
+            ignore: gix::submodule::config::Ignore::Dirty,
+            check_dirty: true,
+        })
+        .index_worktree_options_mut(|opts| {
+            if let Some(opts) = opts.dirwalk_options.as_mut() {
+                opts.set_emit_ignored(None)
+                    .set_emit_pruned(false)
+                    .set_emit_tracked(false)
+                    // Don't collapse directories of untracked files, we need each match
+                    // (relevant if we had a pathspec), so that we can do rename tracking
+                    // on a per-file basis.
+                    .set_emit_untracked(EmissionMode::Matching)
+                    .set_emit_collapsed(None);
+            }
+        })
+        .into_iter(None)?;
+
+    let mut out = Vec::new();
+    for change in status_changes {
+        let change = change?;
+        let change = match change {
+            status::Item::TreeIndex(gix::diff::index::Change::Deletion {
+                location,
+                id,
+                entry_mode,
+                ..
+            }) => WorktreeChange {
+                status: Status::Deletion {
+                    origin: Origin::TreeIndex,
+                    previous_state: ChangeState {
+                        id: id.into_owned(),
+                        kind: into_tree_entry_kind(entry_mode)?,
+                    },
+                },
+                path: location.into_owned(),
+            },
+            status::Item::TreeIndex(gix::diff::index::Change::Addition {
+                location,
+                entry_mode,
+                id,
+                ..
+            }) => WorktreeChange {
+                path: location.into_owned(),
+                status: Status::Addition {
+                    origin: Origin::TreeIndex,
+                    state: ChangeState {
+                        id: id.into_owned(),
+                        kind: into_tree_entry_kind(entry_mode)?,
+                    },
+                },
+            },
+            status::Item::TreeIndex(gix::diff::index::Change::Modification {
+                location,
+                previous_entry_mode,
+                entry_mode,
+                previous_id,
+                id,
+                ..
+            }) => WorktreeChange {
+                path: location.into_owned(),
+                status: Status::Modification {
+                    origin: Origin::TreeIndex,
+                    previous_state: ChangeState {
+                        id: previous_id.into_owned(),
+                        kind: into_tree_entry_kind(previous_entry_mode)?,
+                    },
+                    state: ChangeState {
+                        id: id.into_owned(),
+                        kind: into_tree_entry_kind(entry_mode)?,
+                    },
+                },
+            },
+            status::Item::IndexWorktree(index_worktree::Item::Modification {
+                rela_path,
+                entry,
+                status: EntryStatus::Change(index_as_worktree::Change::Removed),
+                ..
+            }) => WorktreeChange {
+                path: rela_path,
+                status: Status::Deletion {
+                    origin: Origin::IndexWorktree,
+                    previous_state: ChangeState {
+                        id: entry.id,
+                        kind: into_tree_entry_kind(entry.mode)?,
+                    },
+                },
+            },
+            status::Item::IndexWorktree(index_worktree::Item::Modification {
+                rela_path,
+                entry,
+                status: EntryStatus::Change(index_as_worktree::Change::Type { worktree_mode }),
+                ..
+            }) => WorktreeChange {
+                path: rela_path,
+                status: Status::Modification {
+                    origin: Origin::IndexWorktree,
+                    previous_state: ChangeState {
+                        id: entry.id,
+                        kind: into_tree_entry_kind(entry.mode)?,
+                    },
+                    state: ChangeState {
+                        // actual state unclear, type changed to something potentially unhashable
+                        id: repo.object_hash().null(),
+                        kind: into_tree_entry_kind(worktree_mode)?,
+                    },
+                },
+            },
+            status::Item::IndexWorktree(index_worktree::Item::Modification {
+                rela_path,
+                entry,
+                status:
+                    EntryStatus::Change(index_as_worktree::Change::Modification {
+                        executable_bit_changed,
+                        ..
+                    }),
+                ..
+            }) => {
+                let kind = into_tree_entry_kind(entry.mode)?;
+                WorktreeChange {
+                    path: rela_path,
+                    status: Status::Modification {
+                        origin: Origin::IndexWorktree,
+                        previous_state: ChangeState { id: entry.id, kind },
+                        state: ChangeState {
+                            id: repo.object_hash().null(),
+                            kind: if executable_bit_changed {
+                                if kind == gix::object::tree::EntryKind::BlobExecutable {
+                                    gix::object::tree::EntryKind::Blob
+                                } else {
+                                    gix::object::tree::EntryKind::BlobExecutable
+                                }
+                            } else {
+                                kind
+                            },
+                        },
+                    },
+                }
+            }
+            status::Item::IndexWorktree(index_worktree::Item::Modification {
+                rela_path,
+                entry,
+                status: EntryStatus::IntentToAdd,
+                ..
+            }) => WorktreeChange {
+                path: rela_path,
+                // Because `IntentToAdd` stores an empty blob in the index, it's exactly the same diff-result
+                // as if the whole file was added to the index.
+                status: Status::Addition {
+                    origin: Origin::IndexWorktree,
+                    state: ChangeState {
+                        id: repo.object_hash().null(), /* hash unclear for working tree file */
+                        kind: into_tree_entry_kind(entry.mode)?,
+                    },
+                },
+            },
+            status::Item::IndexWorktree(index_worktree::Item::DirectoryContents {
+                entry:
+                    gix::dir::Entry {
+                        rela_path,
+                        disk_kind,
+                        index_kind,
+                        status: gix::dir::entry::Status::Untracked,
+                        ..
+                    },
+                ..
+            }) => WorktreeChange {
+                path: rela_path,
+                status: Status::Untracked {
+                    state: match disk_kind_to_entry_kind(disk_kind, index_kind)? {
+                        None => continue,
+                        Some(kind) => ChangeState {
+                            id: repo.object_hash().null(),
+                            kind,
+                        },
+                    },
+                },
+            },
+            status::Item::IndexWorktree(index_worktree::Item::Modification {
+                rela_path,
+                entry,
+                status:
+                    EntryStatus::Change(index_as_worktree::Change::SubmoduleModification(change)),
+                ..
+            }) => {
+                let Some(checked_out_head_id) = change.checked_out_head_id else {
+                    continue;
+                };
+                WorktreeChange {
+                    path: rela_path,
+                    status: Status::Modification {
+                        origin: Origin::IndexWorktree,
+                        previous_state: ChangeState {
+                            id: entry.id,
+                            kind: into_tree_entry_kind(entry.mode)?,
+                        },
+                        state: ChangeState {
+                            id: checked_out_head_id,
+                            kind: into_tree_entry_kind(entry.mode)?,
+                        },
+                    },
+                }
+            }
+            status::Item::IndexWorktree(index_worktree::Item::Rewrite {
+                source,
+                dirwalk_entry,
+                dirwalk_entry_id,
+                ..
+            }) => WorktreeChange {
+                path: dirwalk_entry.rela_path,
+                status: Status::Rename {
+                    origin: Origin::IndexWorktree,
+                    previous_path: source.rela_path().into(),
+                    previous_state: match source {
+                        RewriteSource::RewriteFromIndex { source_entry, .. } => ChangeState {
+                            id: source_entry.id,
+                            kind: into_tree_entry_kind(source_entry.mode)?,
+                        },
+                        RewriteSource::CopyFromDirectoryEntry {
+                            source_dirwalk_entry,
+                            source_dirwalk_entry_id,
+                            ..
+                        } => ChangeState {
+                            id: source_dirwalk_entry_id,
+                            kind: match disk_kind_to_entry_kind(
+                                source_dirwalk_entry.disk_kind,
+                                source_dirwalk_entry.index_kind,
+                            )? {
+                                None => continue,
+                                Some(kind) => kind,
+                            },
+                        },
+                    },
+                    state: ChangeState {
+                        id: dirwalk_entry_id,
+                        kind: match disk_kind_to_entry_kind(
+                            dirwalk_entry.disk_kind,
+                            dirwalk_entry.index_kind,
+                        )? {
+                            None => continue,
+                            Some(kind) => kind,
+                        },
+                    },
+                },
+            },
+            status::Item::TreeIndex(gix::diff::index::Change::Rewrite {
+                source_location,
+                location,
+                source_entry_mode,
+                source_id,
+                entry_mode,
+                id,
+                ..
+            }) => WorktreeChange {
+                path: location.into_owned(),
+                status: Status::Rename {
+                    origin: Origin::TreeIndex,
+                    previous_path: source_location.into_owned(),
+                    previous_state: ChangeState {
+                        id: source_id.into_owned(),
+                        kind: into_tree_entry_kind(source_entry_mode)?,
+                    },
+                    state: ChangeState {
+                        id: id.into_owned(),
+                        kind: into_tree_entry_kind(entry_mode)?,
+                    },
+                },
+            },
+            status::Item::IndexWorktree(index_worktree::Item::Modification {
+                rela_path,
+                status: EntryStatus::Conflict(conflict),
+                ..
+            }) => WorktreeChange {
+                path: rela_path,
+                status: Status::Conflict(conflict),
+            },
+
+            status::Item::IndexWorktree(
+                index_worktree::Item::Modification {
+                    status: EntryStatus::NeedsUpdate(_),
+                    ..
+                }
+                | index_worktree::Item::DirectoryContents {
+                    entry:
+                        gix::dir::Entry {
+                            status:
+                                gix::dir::entry::Status::Tracked
+                                | gix::dir::entry::Status::Pruned
+                                | gix::dir::entry::Status::Ignored(_),
+                            ..
+                        },
+                    ..
+                },
+            ) => {
+                unreachable!(
+                    "we never return these as the status iteration is configured accordingly"
+                )
+            }
+        };
+        out.push(change);
+    }
+
+    out.sort_by(|a, b| {
+        a.path
+            .cmp(&b.path)
+            .then(a.status.origin().cmp(&b.status.origin()).reverse())
+    });
+    Ok(out)
+}
+
+fn into_tree_entry_kind(
+    mode: gix::index::entry::Mode,
+) -> anyhow::Result<gix::object::tree::EntryKind> {
+    Ok(mode
+        .to_tree_entry_mode()
+        .with_context(|| format!("Entry contained invalid entry mode: {mode:?}"))?
+        .kind())
+}
+
+/// Most importantly, this function allows to skip over untrackable entries, like named pipes, sockets and character devices, just like Git.
+fn disk_kind_to_entry_kind(
+    disk_kind: Option<gix::dir::entry::Kind>,
+    index_kind: Option<gix::dir::entry::Kind>,
+) -> anyhow::Result<Option<gix::object::tree::EntryKind>> {
+    Ok(Some(
+        match disk_kind
+            .or(index_kind)
+            .context("Didn't have any type information for untracked item")?
+        {
+            entry::Kind::Repository => EntryKind::Commit,
+            entry::Kind::Directory => {
+                unreachable!("BUG: we use 'matching' so there are no directories")
+            }
+            entry::Kind::Untrackable => return Ok(None),
+            entry::Kind::File => EntryKind::Blob,
+            entry::Kind::Symlink => EntryKind::Link,
+        },
+    ))
+}

--- a/crates/but-core/tests/core/main.rs
+++ b/crates/but-core/tests/core/main.rs
@@ -1,2 +1,1 @@
-#[test]
-fn itworks() {}
+mod worktree;

--- a/crates/but-core/tests/core/worktree.rs
+++ b/crates/but-core/tests/core/worktree.rs
@@ -1,0 +1,724 @@
+use anyhow::Result;
+use but_core::worktree::changes;
+
+#[test]
+#[cfg(unix)]
+fn non_files_are_ignored() -> Result<()> {
+    let repo = repo_unix("untracked-fifo")?;
+    let actual = changes(&repo)?;
+    assert_eq!(
+        actual.len(),
+        0,
+        "FIFOs don't even show up and are thus completely ignored"
+    );
+    Ok(())
+}
+
+#[test]
+#[cfg(unix)]
+fn executable_bit_added_in_worktree() -> Result<()> {
+    let repo = repo_unix("add-executable-bit-in-worktree")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "exe",
+            status: Modification {
+                origin: IndexWorktree,
+                previous_state: ChangeState {
+                    id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: BlobExecutable,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+#[cfg(unix)]
+fn executable_bit_removed_in_worktree() -> Result<()> {
+    let repo = repo_unix("remove-executable-bit-in-worktree")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "exe",
+            status: Modification {
+                origin: IndexWorktree,
+                previous_state: ChangeState {
+                    id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
+                    kind: BlobExecutable,
+                },
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Blob,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+#[cfg(unix)]
+fn executable_bit_removed_in_index() -> Result<()> {
+    let repo = repo_unix("remove-executable-bit-in-index")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "exe",
+            status: Modification {
+                origin: TreeIndex,
+                previous_state: ChangeState {
+                    id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
+                    kind: BlobExecutable,
+                },
+                state: ChangeState {
+                    id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
+                    kind: Blob,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+#[cfg(unix)]
+fn executable_bit_added_in_index() -> Result<()> {
+    let repo = repo_unix("add-executable-bit-in-index")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "exe",
+            status: Modification {
+                origin: TreeIndex,
+                previous_state: ChangeState {
+                    id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
+                    kind: BlobExecutable,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn untracked_in_unborn() -> Result<()> {
+    let repo = repo("untracked-unborn")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "untracked",
+            status: Untracked {
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Blob,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn added_in_unborn() -> Result<()> {
+    let repo = repo("added-unborn")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "untracked",
+            status: Addition {
+                origin: TreeIndex,
+                state: ChangeState {
+                    id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
+                    kind: Blob,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn submodule_added_in_unborn() -> Result<()> {
+    let repo = repo("submodule-added-unborn")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: ".gitmodules",
+            status: Addition {
+                origin: TreeIndex,
+                state: ChangeState {
+                    id: Sha1(46f8c8b821d79a888a1ea0b30ec9f5d7e90821b0),
+                    kind: Blob,
+                },
+            },
+        },
+        WorktreeChange {
+            path: "submodule",
+            status: Addition {
+                origin: TreeIndex,
+                state: ChangeState {
+                    id: Sha1(e95516bd2f49a83a6cdb98cfec40b2717fbc2c1b),
+                    kind: Commit,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn submodule_changed_head() -> Result<()> {
+    let repo = repo("submodule-changed-head")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "submodule",
+            status: Modification {
+                origin: IndexWorktree,
+                previous_state: ChangeState {
+                    id: Sha1(e95516bd2f49a83a6cdb98cfec40b2717fbc2c1b),
+                    kind: Commit,
+                },
+                state: ChangeState {
+                    id: Sha1(800a5398d76f28db44bc976b561d8885687fd1b6),
+                    kind: Commit,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn case_folding_worktree_changes() -> Result<()> {
+    let repo = repo("case-folding-worktree-changes")?;
+    if !gix::fs::Capabilities::probe(repo.git_dir()).ignore_case {
+        return Ok(());
+    }
+    let actual = changes(&repo)?;
+    // This gives the strange situation that the file seems to have changed because it compares `FILE`
+    // to `file` that is actually checked out on disk.
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "FILE",
+            status: Modification {
+                origin: IndexWorktree,
+                previous_state: ChangeState {
+                    id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Blob,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn case_folding_worktree_and_index_changes() -> Result<()> {
+    let repo = repo("case-folding-worktree-and-index-changes")?;
+    if !gix::fs::Capabilities::probe(repo.git_dir()).ignore_case {
+        return Ok(());
+    }
+    let actual = changes(&repo)?;
+    // Here we change `FILE` to be empty, and add that change to the index. This shows up as expected.
+    // This also means that now `FILE` is compared against `file` on disk which happens to be empty too,
+    // so no worktree change shows up.
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "FILE",
+            status: Modification {
+                origin: TreeIndex,
+                previous_state: ChangeState {
+                    id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
+                    kind: Blob,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn file_to_dir_in_worktree() -> Result<()> {
+    let repo = repo("file-to-dir-in-worktree")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "file-then-dir",
+            status: Deletion {
+                origin: IndexWorktree,
+                previous_state: ChangeState {
+                    id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
+                    kind: Blob,
+                },
+            },
+        },
+        WorktreeChange {
+            path: "file-then-dir/new-file",
+            status: Untracked {
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Blob,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn file_to_dir_in_index() -> Result<()> {
+    let repo = repo("file-to-dir-in-index")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "file-then-dir",
+            status: Deletion {
+                origin: TreeIndex,
+                previous_state: ChangeState {
+                    id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
+                    kind: Blob,
+                },
+            },
+        },
+        WorktreeChange {
+            path: "file-then-dir/new-file",
+            status: Addition {
+                origin: TreeIndex,
+                state: ChangeState {
+                    id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
+                    kind: Blob,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn dir_to_file_in_worktree() -> Result<()> {
+    let repo = repo("dir-to-file-in-worktree")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "dir-soon-file",
+            status: Untracked {
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Blob,
+                },
+            },
+        },
+        WorktreeChange {
+            path: "dir-soon-file/file",
+            status: Deletion {
+                origin: IndexWorktree,
+                previous_state: ChangeState {
+                    id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
+                    kind: Blob,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn dir_to_file_in_index() -> Result<()> {
+    let repo = repo("dir-to-file-in-index")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "dir-soon-file",
+            status: Addition {
+                origin: TreeIndex,
+                state: ChangeState {
+                    id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
+                    kind: Blob,
+                },
+            },
+        },
+        WorktreeChange {
+            path: "dir-soon-file/file",
+            status: Deletion {
+                origin: TreeIndex,
+                previous_state: ChangeState {
+                    id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
+                    kind: Blob,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+#[cfg(unix)]
+fn file_to_symlink_in_worktree() -> Result<()> {
+    let repo = repo_unix("file-to-symlink-in-worktree")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "file-soon-symlink",
+            status: Modification {
+                origin: IndexWorktree,
+                previous_state: ChangeState {
+                    id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Link,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+#[cfg(unix)]
+fn file_to_symlink_in_index() -> Result<()> {
+    let repo = repo_unix("file-to-symlink-in-index")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "file-soon-symlink",
+            status: Modification {
+                origin: TreeIndex,
+                previous_state: ChangeState {
+                    id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(cfa0a46515b5e7117875427e7bb0480066d2e380),
+                    kind: Link,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+#[cfg(unix)]
+fn symlink_to_file_in_worktree() -> Result<()> {
+    let repo = repo_unix("symlink-to-file-in-worktree")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "symlink-soon-file",
+            status: Modification {
+                origin: IndexWorktree,
+                previous_state: ChangeState {
+                    id: Sha1(1de565933b05f74c75ff9a6520af5f9f8a5a2f1d),
+                    kind: Link,
+                },
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Blob,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+#[cfg(unix)]
+fn symlink_to_file_in_index() -> Result<()> {
+    let repo = repo_unix("symlink-to-file-in-index")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "symlink-soon-file",
+            status: Modification {
+                origin: TreeIndex,
+                previous_state: ChangeState {
+                    id: Sha1(1de565933b05f74c75ff9a6520af5f9f8a5a2f1d),
+                    kind: Link,
+                },
+                state: ChangeState {
+                    id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
+                    kind: Blob,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn added_modified_in_worktree() -> Result<()> {
+    let repo = repo("added-modified-in-worktree")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "added",
+            status: Addition {
+                origin: TreeIndex,
+                state: ChangeState {
+                    id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
+                    kind: Blob,
+                },
+            },
+        },
+        WorktreeChange {
+            path: "intent-to-add",
+            status: Modification {
+                origin: IndexWorktree,
+                previous_state: ChangeState {
+                    id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Blob,
+                },
+            },
+        },
+        WorktreeChange {
+            path: "modified",
+            status: Modification {
+                origin: IndexWorktree,
+                previous_state: ChangeState {
+                    id: Sha1(deba01fc8d98200761c46eb139f11ac244cf6eb5),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Blob,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn modified_in_index() -> Result<()> {
+    let repo = repo("modified-in-index")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "modified",
+            status: Modification {
+                origin: TreeIndex,
+                previous_state: ChangeState {
+                    id: Sha1(deba01fc8d98200761c46eb139f11ac244cf6eb5),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(0835e4f9714005ed591f68d306eea0d6d2ae8fd7),
+                    kind: Blob,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn deleted_in_worktree() -> Result<()> {
+    let repo = repo("deleted-in-worktree")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "deleted",
+            status: Deletion {
+                origin: IndexWorktree,
+                previous_state: ChangeState {
+                    id: Sha1(deba01fc8d98200761c46eb139f11ac244cf6eb5),
+                    kind: Blob,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn deleted_in_index() -> Result<()> {
+    let repo = repo("deleted-in-index")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "deleted",
+            status: Deletion {
+                origin: TreeIndex,
+                previous_state: ChangeState {
+                    id: Sha1(deba01fc8d98200761c46eb139f11ac244cf6eb5),
+                    kind: Blob,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn renamed_in_index() -> Result<()> {
+    let repo = repo("renamed-in-index")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "new-name",
+            status: Rename {
+                origin: TreeIndex,
+                previous_path: "to-be-renamed",
+                previous_state: ChangeState {
+                    id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
+                    kind: Blob,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn renamed_in_worktree() -> Result<()> {
+    let repo = repo("renamed-in-worktree")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "new-name",
+            status: Rename {
+                origin: IndexWorktree,
+                previous_path: "to-be-renamed",
+                previous_state: ChangeState {
+                    id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
+                    kind: Blob,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn modified_in_index_and_workingtree() -> Result<()> {
+    let repo = repo("modified-in-index-and-worktree")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "dual-modified",
+            status: Modification {
+                origin: IndexWorktree,
+                previous_state: ChangeState {
+                    id: Sha1(8ea0713f9d637081cc0098035465c365c0c32949),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Blob,
+                },
+            },
+        },
+        WorktreeChange {
+            path: "dual-modified",
+            status: Modification {
+                origin: TreeIndex,
+                previous_state: ChangeState {
+                    id: Sha1(e79c5e8f964493290a409888d5413a737e8e5dd5),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(8ea0713f9d637081cc0098035465c365c0c32949),
+                    kind: Blob,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+fn repo(fixture_name: &str) -> anyhow::Result<gix::Repository> {
+    let root = gix_testtools::scripted_fixture_read_only("worktree-changes.sh")
+        .map_err(anyhow::Error::from_boxed)?;
+    let worktree_root = root.join(fixture_name);
+    Ok(gix::open(worktree_root)?)
+}
+
+fn repo_unix(fixture_name: &str) -> anyhow::Result<gix::Repository> {
+    let root = gix_testtools::scripted_fixture_read_only("worktree-changes-unix.sh")
+        .map_err(anyhow::Error::from_boxed)?;
+    let worktree_root = root.join(fixture_name);
+    Ok(gix::open(worktree_root)?)
+}

--- a/crates/but-core/tests/fixtures/worktree-changes-unix.sh
+++ b/crates/but-core/tests/fixtures/worktree-changes-unix.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+git init untracked-fifo
+(cd untracked-fifo
+  git commit -m "empty" --allow-empty
+  mkfifo named-pipe
+)
+
+git init add-executable-bit-in-worktree
+(cd add-executable-bit-in-worktree
+  touch exe && git add exe
+  git commit -m "init"
+  chmod +x exe
+)
+
+git init remove-executable-bit-in-worktree
+(cd remove-executable-bit-in-worktree
+  touch exe && chmod +x exe && git add exe
+  git commit -m "init"
+  chmod -x exe
+)
+
+git init add-executable-bit-in-index
+(cd add-executable-bit-in-index
+  touch exe && git add exe
+  git commit -m "init"
+  chmod +x exe && git add exe
+)
+
+git init remove-executable-bit-in-index
+(cd remove-executable-bit-in-index
+  touch exe && chmod +x exe && git add exe
+  git commit -m "init"
+  chmod -x exe && git add exe
+)
+
+git init symlink-to-file-in-worktree
+(cd symlink-to-file-in-worktree
+  touch target && ln -s target symlink-soon-file
+  git add . && git commit -m "init"
+  rm symlink-soon-file && echo content >symlink-soon-file
+)
+
+cp -Rv symlink-to-file-in-worktree symlink-to-file-in-index
+(cd symlink-to-file-in-index
+  git add .
+)
+
+git init file-to-symlink-in-worktree
+(cd file-to-symlink-in-worktree
+  echo content >file-soon-symlink
+  git add . && git commit -m "init"
+  rm file-soon-symlink && ln -s does-not-exist file-soon-symlink
+)
+
+cp -Rv file-to-symlink-in-worktree file-to-symlink-in-index
+(cd file-to-symlink-in-index
+  git add .
+)

--- a/crates/but-core/tests/fixtures/worktree-changes.sh
+++ b/crates/but-core/tests/fixtures/worktree-changes.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+git init untracked-unborn
+(cd untracked-unborn
+  touch untracked
+)
+
+git init added-unborn
+(cd added-unborn
+  touch untracked && git add untracked
+)
+
+git init added-modified-in-worktree
+(cd added-modified-in-worktree
+  touch modified intent-to-add
+  echo something >modified
+  git add . && git commit -m "init"
+  echo change >modified
+
+  touch added intent-to-add
+  echo content >intent-to-add
+  git add added
+  git add --intent-to-add intent-to-add
+)
+
+git init modified-in-index
+(cd modified-in-index
+  touch modified
+  echo something >modified
+  git add . && git commit -m "init"
+  echo change >modified && git add modified
+)
+
+git init file-to-dir-in-worktree
+(cd file-to-dir-in-worktree
+  touch file-then-dir && git add file-then-dir && git commit -m "init"
+  rm file-then-dir && mkdir file-then-dir && echo content >file-then-dir/new-file
+)
+
+cp -Rv file-to-dir-in-worktree file-to-dir-in-index
+(cd file-to-dir-in-index
+  git add .
+)
+
+git init dir-to-file-in-worktree
+(cd dir-to-file-in-worktree
+  mkdir dir-soon-file && touch dir-soon-file/file
+  git add dir-soon-file && git commit -m "init"
+  rm -Rf dir-soon-file
+  echo content >dir-soon-file
+)
+
+cp -Rv dir-to-file-in-worktree dir-to-file-in-index
+(cd dir-to-file-in-index
+  git add .
+)
+
+git init deleted-in-worktree
+(cd deleted-in-worktree
+  touch deleted
+  echo something >deleted
+  git add . && git commit -m "init"
+  rm deleted
+)
+
+git init deleted-in-index
+(cd deleted-in-index
+  touch deleted
+  echo something >deleted
+  git add . && git commit -m "init"
+  git rm deleted
+)
+
+git init renamed-in-index
+(cd renamed-in-index
+  echo content >to-be-renamed
+  git add . && git commit -m "init"
+  git mv to-be-renamed new-name
+)
+
+git init renamed-in-worktree
+(cd renamed-in-worktree
+  echo content >to-be-renamed
+  git add . && git commit -m "init"
+  mv to-be-renamed new-name
+)
+
+git init modified-in-index-and-worktree
+(cd modified-in-index-and-worktree
+  echo initial >dual-modified
+  git add . && git commit -m "init"
+  echo change >>dual-modified && git add dual-modified
+  echo second-change >>dual-modified
+)
+
+git init submodule-added-unborn
+(cd submodule-added-unborn
+  git submodule add ../modified-in-index submodule
+)
+
+git init submodule-changed-head
+(cd submodule-changed-head
+  git submodule add ../modified-in-index submodule
+  git commit -m "init"
+  (cd submodule
+    echo change >>modified && git commit -am "change in submodule to adjust its HEAD ref"
+  )
+)
+
+git init case-folding-worktree-changes
+(cd case-folding-worktree-changes
+  git config core.ignorecase false
+  empty_oid=$(git hash-object -w --stdin </dev/null)
+  other_oid=$(echo content | git hash-object -w --stdin)
+  git update-index --index-info <<EOF
+100644 $empty_oid	file
+100644 $other_oid	FILE
+EOF
+  git commit -m "init with two files that fold into one on case-insensitive filesystems"
+  git checkout -f HEAD
+)
+
+cp -Rv case-folding-worktree-changes case-folding-worktree-and-index-changes
+(cd case-folding-worktree-and-index-changes
+  empty_oid=$(git hash-object -w --stdin </dev/null)
+  git update-index --index-info <<EOF
+100644 $empty_oid	FILE
+EOF
+)

--- a/crates/gitbutler-oplog/src/reflog.rs
+++ b/crates/gitbutler-oplog/src/reflog.rs
@@ -50,8 +50,10 @@ impl ReflogCommits {
 /// Then in the reflog entry logs/refs/heads/gitbutler/target we pretend that the ref originally pointed to the
 /// oplog head commit like so:
 ///
+/// ```text
 /// 0000000000000000000000000000000000000000 <target branch head>
 /// <target branch head>                     <oplog head>
+/// ```
 ///
 /// The reflog entry is continuously updated to refer to the current target and oplog head commits.
 pub fn set_reference_to_oplog(worktree_dir: &Path, reflog_commits: ReflogCommits) -> Result<()> {

--- a/crates/gitbutler-repo/Cargo.toml
+++ b/crates/gitbutler-repo/Cargo.toml
@@ -42,4 +42,4 @@ path = "tests/mod.rs"
 gitbutler-testsupport.workspace = true
 gitbutler-user.workspace = true
 serde_json = { version = "1.0", features = ["std", "arbitrary_precision"] }
-insta = "1.41.1"
+insta.workspace = true

--- a/crates/gitbutler-repo/src/repository_ext.rs
+++ b/crates/gitbutler-repo/src/repository_ext.rs
@@ -263,7 +263,7 @@ impl RepositoryExt for git2::Repository {
                 status::Item::IndexWorktree(index_worktree::Item::Modification {
                     rela_path,
                     status:
-                        EntryStatus::Change(Change::Type | Change::Modification { .. })
+                        EntryStatus::Change(Change::Type { .. } | Change::Modification { .. })
                         | EntryStatus::IntentToAdd,
                     ..
                 }) => {
@@ -582,7 +582,8 @@ impl RepositoryExt for git2::Repository {
 pub fn command_with_login_shell(shell_cmd: impl Into<OsString>) -> std::process::Command {
     gix::command::prepare(shell_cmd)
         .with_shell_disallow_manual_argument_splitting()
-        .with_shell_program(gix::path::env::login_shell().unwrap_or("bash".as_ref()))
+        // On Windows, this yields the Git-bundled `sh.exe`, on Linux it uses `/bin/sh`.
+        .with_shell_program(gix::path::env::shell())
         .into()
 }
 

--- a/crates/gitbutler-serde/src/lib.rs
+++ b/crates/gitbutler-serde/src/lib.rs
@@ -69,6 +69,29 @@ pub mod object_id_opt {
     }
 }
 
+/// use like `#[serde(with = "gitbutler_serde::object_id")]` to serialize [`gix::ObjectId`].
+pub mod object_id {
+    use serde::{Deserialize, Deserializer, Serialize};
+    use std::str::FromStr;
+
+    /// serialize an object ID as hex-string.
+    pub fn serialize<S>(v: &gix::ObjectId, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        v.to_string().serialize(s)
+    }
+
+    /// deserialize an object ID from hex-string.
+    pub fn deserialize<'de, D>(d: D) -> Result<gix::ObjectId, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let hex = String::deserialize(d)?;
+        gix::ObjectId::from_str(hex.as_ref()).map_err(serde::de::Error::custom)
+    }
+}
+
 pub mod oid_vec {
     use serde::{Deserialize, Deserializer, Serialize};
 

--- a/crates/gitbutler-stack/src/stack.rs
+++ b/crates/gitbutler-stack/src/stack.rs
@@ -39,7 +39,7 @@ pub type StackId = Id<Stack>;
 pub struct Stack {
     pub id: StackId,
     /// A user-specified name with no restrictions.
-    /// It will be normalized except to be a valid [ref-name](Branch::refname()) if named `refs/gitbutler/<normalize(name)>`.
+    /// It will be normalized except to be a valid ref-name if named `refs/gitbutler/<normalize(name)>`.
     pub name: String,
     pub notes: String,
     /// If set, this means this virtual branch was originally created from `Some(branch)`.

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -21,6 +21,7 @@ tauri-build = { version = "2.0.3", features = [] }
 pretty_assertions = "1.4"
 tempfile = "3.14"
 gitbutler-testsupport.workspace = true
+insta.workspace = true
 
 [dependencies]
 anyhow = "1.0.95"
@@ -85,6 +86,7 @@ gitbutler-forge.workspace = true
 gitbutler-settings.workspace = true
 gitbutler-serde.workspace = true
 but-workspace.workspace = true
+but-core.workspace = true
 open = "5"
 url = "2.5.4"
 itertools = "0.14"

--- a/crates/gitbutler-tauri/src/lib.rs
+++ b/crates/gitbutler-tauri/src/lib.rs
@@ -42,3 +42,4 @@ pub mod stack;
 pub mod zip;
 
 pub mod workspace;
+pub mod worktree;

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -15,7 +15,8 @@ use gitbutler_settings::AppSettingsWithDiskSync;
 use gitbutler_tauri::settings::SettingsStore;
 use gitbutler_tauri::{
     askpass, commands, config, forge, github, logs, menu, modes, open, projects, remotes, repo,
-    secret, settings, stack, undo, users, virtual_branches, workspace, zip, App, WindowState,
+    secret, settings, stack, undo, users, virtual_branches, workspace, worktree, zip, App,
+    WindowState,
 };
 use tauri::Emitter;
 use tauri::{generate_context, Manager};
@@ -247,6 +248,7 @@ fn main() {
                     settings::update_onboarding_complete,
                     settings::update_telemetry,
                     workspace::stacks,
+                    worktree::changes
                 ])
                 .menu(menu::build)
                 .on_window_event(|window, event| match event {

--- a/crates/gitbutler-tauri/src/worktree/mod.rs
+++ b/crates/gitbutler-tauri/src/worktree/mod.rs
@@ -1,0 +1,229 @@
+use crate::error::Error;
+use gitbutler_project::ProjectId;
+use gitbutler_serde::BStringForFrontend;
+use gix::bstr::BString;
+use serde::Serialize;
+use std::path::PathBuf;
+use tracing::instrument;
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct ChangeState {
+    #[serde(with = "gitbutler_serde::object_id")]
+    id: gix::ObjectId,
+    kind: gix::object::tree::EntryKind,
+}
+
+impl From<but_core::worktree::ChangeState> for ChangeState {
+    fn from(but_core::worktree::ChangeState { id, kind }: but_core::worktree::ChangeState) -> Self {
+        ChangeState { id, kind }
+    }
+}
+
+/// Computed using the file kinds/modes of two [`ChangeState`] instances to represent
+/// the *dominant* change to display. Note that it can stack with a content change,
+/// but *should not only in case of a `TypeChange*`*.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum Flags {
+    ExecutableBitAdded,
+    ExecutableBitRemoved,
+    TypeChangeFileToLink,
+    TypeChangeLinkToFile,
+    TypeChange,
+}
+
+impl Flags {
+    fn calculate(
+        old: &but_core::worktree::ChangeState,
+        new: &but_core::worktree::ChangeState,
+    ) -> Option<Self> {
+        Self::calculate_inner(old.kind, new.kind)
+    }
+
+    fn calculate_inner(
+        old: gix::object::tree::EntryKind,
+        new: gix::object::tree::EntryKind,
+    ) -> Option<Self> {
+        use gix::object::tree::EntryKind as E;
+        Some(match (old, new) {
+            (E::Blob, E::BlobExecutable) => Flags::ExecutableBitAdded,
+            (E::BlobExecutable, E::Blob) => Flags::ExecutableBitRemoved,
+            (E::Blob | E::BlobExecutable, E::Link) => Flags::TypeChangeFileToLink,
+            (E::Link, E::Blob | E::BlobExecutable) => Flags::TypeChangeLinkToFile,
+            (a, b) if a != b => Flags::TypeChange,
+            _ => return None,
+        })
+    }
+}
+
+/// For docs, see [`but_core::worktree::Status`].
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", content = "subject")]
+pub enum Status {
+    Addition {
+        state: ChangeState,
+        #[serde(rename = "isUntracked")]
+        is_untracked: bool,
+    },
+    Deletion {
+        #[serde(rename = "previousState")]
+        previous_state: ChangeState,
+    },
+    Modification {
+        #[serde(rename = "previousState")]
+        previous_state: ChangeState,
+        state: ChangeState,
+        flags: Option<Flags>,
+    },
+    Rename {
+        #[serde(rename = "previousPath")]
+        previous_path: BString,
+        #[serde(rename = "previousState")]
+        previous_state: ChangeState,
+        state: ChangeState,
+        flags: Option<Flags>,
+    },
+}
+
+impl From<but_core::worktree::Status> for Status {
+    fn from(value: but_core::worktree::Status) -> Self {
+        use but_core::worktree::Status as E;
+        match value {
+            E::Conflict(_) => unreachable!("BUG: must have been extracted beforehand"),
+            E::Untracked { state } => Status::Addition {
+                state: state.into(),
+                is_untracked: true,
+            },
+            E::Addition { origin: _, state } => Status::Addition {
+                state: state.into(),
+                is_untracked: false,
+            },
+            E::Deletion {
+                origin: _,
+                previous_state,
+            } => Status::Deletion {
+                previous_state: previous_state.into(),
+            },
+            E::Modification {
+                origin: _,
+                previous_state,
+                state,
+            } => Status::Modification {
+                flags: Flags::calculate(&previous_state, &state),
+                previous_state: previous_state.into(),
+                state: state.into(),
+            },
+            E::Rename {
+                origin: _,
+                previous_path,
+                previous_state,
+                state,
+            } => Status::Rename {
+                flags: Flags::calculate(&previous_state, &state),
+                previous_path,
+                previous_state: previous_state.into(),
+                state: state.into(),
+            },
+        }
+    }
+}
+
+/// For documentation, see [`but_core::WorktreeChange`].
+#[derive(Debug, Clone, Serialize)]
+pub struct WorktreeChange {
+    path: BStringForFrontend,
+    status: Status,
+}
+
+impl From<but_core::WorktreeChange> for WorktreeChange {
+    fn from(but_core::WorktreeChange { path, status }: but_core::WorktreeChange) -> Self {
+        WorktreeChange {
+            path: path.into(),
+            status: status.into(),
+        }
+    }
+}
+
+/// The status we can't handle.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", content = "subject")]
+pub enum IgnoredChangeStatus {
+    /// A conflicting entry in the index. The worktree state of the entry is unclear.
+    Conflict,
+    /// A change in the `.git/index` that was overruled by a change to the same path in the *worktree*.
+    TreeIndex,
+}
+
+/// A way to indicate that a path in the index isn't suitable for committing and needs to be dealt with.
+#[derive(Debug, Clone, Serialize)]
+pub struct IgnoredChange {
+    /// The worktree-relative path to the change.
+    path: BStringForFrontend,
+    status: IgnoredChangeStatus,
+}
+
+/// Keeps simplified [`WorktreeChanges`] along with changes that were applied to the index that we chose to ignore.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorktreeChanges {
+    /// Changes that could be committed.
+    pub changes: Vec<WorktreeChange>,
+    /// Changes that were in the index that we can't handle. The user can see them and interact with them to clear them out before a commit can be made.
+    pub ignored_changes: Vec<IgnoredChange>,
+}
+
+/// This UI-version of [`but_core::worktree::changes()`] simplifies the `git status` information for display in
+/// the user interface as it is right now. From here, it's always possible to add more information as the need arises.
+///
+/// ### Notable Transformations
+/// * There is no notion of an index (`.git/index`) - all changes seem to have happened in the worktree.
+/// * Modifications that were made to the index will be ignored *only if* there is a worktree modification to the same file.
+/// * conflicts are ignored
+///
+/// All ignored status changes are also provided so they can be displayed separately.
+#[tauri::command(async)]
+#[instrument(skip(projects), err(Debug))]
+pub fn changes(
+    projects: tauri::State<'_, gitbutler_project::Controller>,
+    project_id: ProjectId,
+) -> anyhow::Result<WorktreeChanges, Error> {
+    let project = projects.get(project_id)?;
+    Ok(changes_in_worktree(project.path)?)
+}
+
+fn changes_in_worktree(worktree_dir: PathBuf) -> anyhow::Result<WorktreeChanges> {
+    let repo = gix::open(worktree_dir).map_err(anyhow::Error::new)?;
+    let detailed_changes = but_core::worktree::changes(&repo)?;
+
+    let (mut changes, mut ignored_changes) = (Vec::new(), Vec::new());
+    let mut last_path = None;
+    for change in detailed_changes {
+        if last_path.as_ref() == Some(&change.path) {
+            assert_eq!(
+                change.status.origin(),
+                but_core::worktree::Origin::TreeIndex,
+                "worktree-changes should happen before tree-index changes, sorting is guaranteed by the API"
+            );
+            ignored_changes.push(IgnoredChange {
+                path: change.path.into(),
+                status: IgnoredChangeStatus::TreeIndex,
+            });
+            continue;
+        }
+        if matches!(change.status, but_core::worktree::Status::Conflict(_)) {
+            ignored_changes.push(IgnoredChange {
+                path: change.path.into(),
+                status: IgnoredChangeStatus::Conflict,
+            });
+            continue;
+        }
+        last_path = Some(change.path.clone());
+        changes.push(change.into());
+    }
+    Ok(WorktreeChanges {
+        changes,
+        ignored_changes,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/gitbutler-tauri/src/worktree/tests.rs
+++ b/crates/gitbutler-tauri/src/worktree/tests.rs
@@ -1,0 +1,257 @@
+use super::*;
+
+mod flags {
+    use crate::worktree::Flags;
+    use gix::objs::tree::EntryKind;
+
+    #[test]
+    fn calculate() {
+        for ((old, new), expected) in [
+            ((EntryKind::Blob, EntryKind::Blob), None),
+            (
+                (EntryKind::Blob, EntryKind::BlobExecutable),
+                Some(Flags::ExecutableBitAdded),
+            ),
+            (
+                (EntryKind::BlobExecutable, EntryKind::Blob),
+                Some(Flags::ExecutableBitRemoved),
+            ),
+            (
+                (EntryKind::BlobExecutable, EntryKind::Link),
+                Some(Flags::TypeChangeFileToLink),
+            ),
+            (
+                (EntryKind::Blob, EntryKind::Link),
+                Some(Flags::TypeChangeFileToLink),
+            ),
+            (
+                (EntryKind::Link, EntryKind::BlobExecutable),
+                Some(Flags::TypeChangeLinkToFile),
+            ),
+            (
+                (EntryKind::Link, EntryKind::Blob),
+                Some(Flags::TypeChangeLinkToFile),
+            ),
+            (
+                (EntryKind::Commit, EntryKind::Blob),
+                Some(Flags::TypeChange),
+            ),
+            (
+                (EntryKind::Blob, EntryKind::Commit),
+                Some(Flags::TypeChange),
+            ),
+        ] {
+            assert_eq!(Flags::calculate_inner(old, new), expected);
+        }
+    }
+}
+
+#[test]
+fn worktree_change_json_sample() {
+    let actual = serde_json::to_string_pretty(&WorktreeChange {
+        path: BString::from("some/file").into(),
+        status: Status::Modification {
+            flags: Some(Flags::ExecutableBitAdded),
+            previous_state: ChangeState {
+                id: gix::hash::Kind::Sha1.null(),
+                kind: gix::object::tree::EntryKind::Blob,
+            },
+            state: ChangeState {
+                id: gix::hash::Kind::Sha1.null(),
+                kind: gix::object::tree::EntryKind::Blob,
+            },
+        },
+    })
+    .unwrap();
+    insta::assert_snapshot!(actual, @r#"
+    {
+      "path": "some/file",
+      "status": {
+        "type": "Modification",
+        "subject": {
+          "previousState": {
+            "id": "0000000000000000000000000000000000000000",
+            "kind": "Blob"
+          },
+          "state": {
+            "id": "0000000000000000000000000000000000000000",
+            "kind": "Blob"
+          },
+          "flags": "ExecutableBitAdded"
+        }
+      }
+    }
+    "#);
+}
+
+#[test]
+fn worktree_changes_example() -> anyhow::Result<()> {
+    let root = gitbutler_testsupport::gix_testtools::scripted_fixture_read_only("status_repo.sh")
+        .map_err(anyhow::Error::from_boxed)?;
+    let actual = serde_json::to_string_pretty(&changes_in_worktree(root)?)?;
+    insta::assert_snapshot!(actual, @r#"
+    {
+      "changes": [
+        {
+          "path": "added-to-index",
+          "status": {
+            "type": "Addition",
+            "subject": {
+              "state": {
+                "id": "d95f3ad14dee633a758d2e331151e950dd13e4ed",
+                "kind": "Blob"
+              },
+              "isUntracked": false
+            }
+          }
+        },
+        {
+          "path": "executable-bit-added",
+          "status": {
+            "type": "Modification",
+            "subject": {
+              "previousState": {
+                "id": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                "kind": "Blob"
+              },
+              "state": {
+                "id": "0000000000000000000000000000000000000000",
+                "kind": "BlobExecutable"
+              },
+              "flags": "ExecutableBitAdded"
+            }
+          }
+        },
+        {
+          "path": "file-to-link",
+          "status": {
+            "type": "Modification",
+            "subject": {
+              "previousState": {
+                "id": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                "kind": "Blob"
+              },
+              "state": {
+                "id": "0000000000000000000000000000000000000000",
+                "kind": "Link"
+              },
+              "flags": "TypeChangeFileToLink"
+            }
+          }
+        },
+        {
+          "path": "intent-to-add",
+          "status": {
+            "type": "Addition",
+            "subject": {
+              "state": {
+                "id": "0000000000000000000000000000000000000000",
+                "kind": "Blob"
+              },
+              "isUntracked": false
+            }
+          }
+        },
+        {
+          "path": "modified-in-index",
+          "status": {
+            "type": "Modification",
+            "subject": {
+              "previousState": {
+                "id": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                "kind": "Blob"
+              },
+              "state": {
+                "id": "9ab7cfa60ddcda5e498ef1b5330cc0ba762ebd72",
+                "kind": "Blob"
+              },
+              "flags": null
+            }
+          }
+        },
+        {
+          "path": "modified-in-worktree",
+          "status": {
+            "type": "Modification",
+            "subject": {
+              "previousState": {
+                "id": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                "kind": "Blob"
+              },
+              "state": {
+                "id": "0000000000000000000000000000000000000000",
+                "kind": "Blob"
+              },
+              "flags": null
+            }
+          }
+        },
+        {
+          "path": "removed-in-index",
+          "status": {
+            "type": "Deletion",
+            "subject": {
+              "previousState": {
+                "id": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                "kind": "Blob"
+              }
+            }
+          }
+        },
+        {
+          "path": "removed-in-index-changed-in-worktree",
+          "status": {
+            "type": "Addition",
+            "subject": {
+              "state": {
+                "id": "0000000000000000000000000000000000000000",
+                "kind": "Blob"
+              },
+              "isUntracked": true
+            }
+          }
+        },
+        {
+          "path": "removed-in-worktree",
+          "status": {
+            "type": "Deletion",
+            "subject": {
+              "previousState": {
+                "id": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                "kind": "Blob"
+              }
+            }
+          }
+        },
+        {
+          "path": "untracked",
+          "status": {
+            "type": "Addition",
+            "subject": {
+              "state": {
+                "id": "0000000000000000000000000000000000000000",
+                "kind": "Blob"
+              },
+              "isUntracked": true
+            }
+          }
+        }
+      ],
+      "ignoredChanges": [
+        {
+          "path": "conflicting",
+          "status": {
+            "type": "Conflict"
+          }
+        },
+        {
+          "path": "removed-in-index-changed-in-worktree",
+          "status": {
+            "type": "TreeIndex"
+          }
+        }
+      ]
+    }
+    "#);
+    Ok(())
+}

--- a/crates/gitbutler-tauri/tests/fixtures/status_repo.sh
+++ b/crates/gitbutler-tauri/tests/fixtures/status_repo.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+git init
+
+touch removed-in-worktree \
+      removed-in-index \
+      modified-in-worktree \
+      modified-in-index \
+      removed-in-index-changed-in-worktree \
+      executable-bit-added \
+      file-to-link \
+      untracked
+
+echo "content not to add to the index" >intent-to-add
+
+git add . :!untracked :!intent-to-add
+git add --intent-to-add intent-to-add
+git commit -m "init"
+
+rm removed-in-worktree
+git rm removed-in-index
+
+echo change-in-worktree >>modified-in-worktree
+echo change-in-index >>modified-in-index
+git add modified-in-index
+
+git rm --cached removed-in-index-changed-in-worktree
+echo worktree-change >>removed-in-index-changed-in-worktree
+
+chmod +x executable-bit-added
+
+echo content >added-to-index && git add added-to-index
+
+rm file-to-link && ln -s link-target file-to-link
+
+empty=$(git hash-object -w --stdin </dev/null)
+a=$(echo "a" | git hash-object -w --stdin)
+b=$(echo "b" | git hash-object -w --stdin)
+git update-index --index-info <<EOF
+100644 $empty 1	conflicting
+100644 $a 2	conflicting
+100644 $b 3	conflicting
+EOF
+

--- a/crates/gitbutler-workspace/src/branch_trees.rs
+++ b/crates/gitbutler-workspace/src/branch_trees.rs
@@ -104,9 +104,9 @@ pub fn compute_updated_branch_head(
 /// Given a new head for a branch, this comptues how the tree should be
 /// rebased on top of the new head. If the rebased tree is conflicted, then
 /// the function will return a new head commit which is the conflicted
-/// tree commit, and the the tree oid will be the auto-resolved tree.
+/// tree commit, and the tree oid will be the auto-resolved tree.
 ///
-/// If you have access to a [`Branch`] object, it's probably preferable to
+/// If you have access to a [`Stack`] object, it's probably preferable to
 /// use [`compute_updated_branch_head`] instead to prevent programmer error.
 ///
 /// This does not mutate the branch, or update the virtual_branches.toml.


### PR DESCRIPTION
This PR introduces a new crate for the code that will drive the V3 of the UI design, with the goal of sketching out the API that shows how to deal with **uncommited files**.

This sketch should also include an idea how to listen to changes to the filesystem to produce events that help maintain the current state.

Follow-up of #5912 .

### Tasks

* [x] initial state of uncommitted files
* [x] a new CLI to show uncommitted files
* [x] tests
     - [x] case-insensitive FS test
     - [x] also: see what happens if there are case-collisions (two files fold into one name on a case-insensitive fs)
* [x] **IMPORTANT**: use `gix` from `main` before merging
    - [x] executable bit + modified == modified? Doesn't matter, just be sure UI can easily show it.
    - [x] untracked must be obvious
    - ~~blend `gix::*::Change::Type` into `Change::Modification` maybe~~
        - Actually this helps the code, even though on the consumer side it's a little awkward to use
    - [x] sort changes in tests
    - [x] One set of information per path, worktree takes precedence and and overrides the index
        - ignore the index, but not untracked
    - [x] no IntentToAdd for Frontend
    - [x] Flag with TypeChange or `+x` or `-x`

### Notes for the reviewer

* I left the code in `but-core` besides `gix` there are no dependencies needed to handle the `but_core::WorktreeChanges`.
* Definitely needs `.git/index` tracking - if it changes while a commit is made, we have to reconcile (or at least assure nothing can go wrong)

### For later

* provide patch for a change
* locking information
