### PR TITLE
chore: disable in-app updater for Flatpak build

### DIFF
--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -5,6 +5,7 @@ import { check } from '@tauri-apps/plugin-updater';
 export class Tauri {
 	invoke = invokeIpc;
 	listen = listenIpc;
-	checkUpdate = check;
+	// Disable in-app updater for Flatpak builds
+	checkUpdate = process.env.FLATPAK_ID ? () => null : check;
 	currentVersion = getVersion;
 }


### PR DESCRIPTION
## 🧢 Changes

- There are patches in the `ndom91/gitbutler-flathub` flatpak build repository which disables the tauri updater for Flatpak builds because they install (and update) via the flathub store. Trying to see if I can avoid using a patch and just build this conditional righ tinto the codebase

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
