### PR TITLE
Ability to refetch the chat channel

### DIFF
--- a/packages/shared/src/lib/chat/chatChannelsService.ts
+++ b/packages/shared/src/lib/chat/chatChannelsService.ts
@@ -52,6 +52,10 @@ export class ChatChannelsService {
 			.createInterest();
 	}
 
+	async refetchChatChannel(projectId: string, changeId?: string): Promise<void> {
+		await this.chatMessagesInterests.invalidate({ projectId, changeId });
+	}
+
 	async sendChatMessage(params: SendChatMessageParams): Promise<void> {
 		try {
 			await this.httpClient.post(`chat_messages/${params.projectId}/branch/${params.branchId}`, {


### PR DESCRIPTION
- **Interest Store**: Modified the refetch mechanism to be awaitable, allowing for better handling of asynchronous operations.
- **Imperative Upsert**: Updated the functionality to allow the upsert function to be called imperatively and awaited, ensuring that data is refreshed correctly when required.
- **Chat Channel Functionality**: Added a dedicated method for refetching a chat channel which enhances the ability to keep channel data up to date without requiring manual intervention.