### PR TITLE
fix: button styles

### DIFF
--- a/apps/desktop/src/components/CommitDialog.svelte
+++ b/apps/desktop/src/components/CommitDialog.svelte
@@ -137,7 +137,7 @@
 	<div class="actions" class:commit-box__actions-expanded={$expanded}>
 		{#if $expanded && !isCommitting}
 			<div class="cancel-btn-wrapper" transition:slideFade={{ duration: 200, axis: 'x' }}>
-				<Button style="neutral" id="commit-to-branch" onclick={close}>Cancel</Button>
+				<Button style="neutral" kind="outline" id="commit-to-branch" onclick={close}>Cancel</Button>
 			</div>
 		{/if}
 		{#if $expanded && canShowCommitAndPublish}

--- a/apps/desktop/src/components/DropDownButton.svelte
+++ b/apps/desktop/src/components/DropDownButton.svelte
@@ -25,7 +25,7 @@
 	const {
 		icon,
 		style = 'neutral',
-		kind = 'outline',
+		kind = 'solid',
 		disabled = false,
 		loading = false,
 		wide = false,


### PR DESCRIPTION
Some button styles were mixed up because of the latest button component updates.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5966 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5965 
<!-- GitButler Footer Boundary Bottom -->

