### PR TITLE
Use branch UUIDs as the primary key

### DIFF
--- a/apps/desktop/src/lib/redux/store.svelte.ts
+++ b/apps/desktop/src/lib/redux/store.svelte.ts
@@ -1,4 +1,5 @@
 import { branchesReducer } from '@gitbutler/shared/branches/branchesSlice';
+import { latestBranchLookupsReducer } from '@gitbutler/shared/branches/latestBranchLookupSlice';
 import { patchSectionsReducer } from '@gitbutler/shared/branches/patchSectionsSlice';
 import { patchesReducer } from '@gitbutler/shared/branches/patchesSlice';
 import { chatChannelsReducer } from '@gitbutler/shared/chat/chatChannelsSlice';
@@ -65,6 +66,7 @@ export class DesktopState extends AppState implements AppDesktopOnlyState {
 			patchSections: patchSectionsReducer,
 			chatChannels: chatChannelsReducer,
 			repositoryIdLookups: repositoryIdLookupsReducer,
+			latestBranchLookups: latestBranchLookupsReducer,
 			desktopOnly: desktopOnly.reducer
 		}
 	});

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -41,6 +41,7 @@
 	import * as events from '$lib/utils/events';
 	import { unsubscribe } from '$lib/utils/unsubscribe';
 	import { BranchService as CloudBranchService } from '@gitbutler/shared/branches/branchService';
+	import { LatestBranchLookupService } from '@gitbutler/shared/branches/latestBranchLookupService';
 	import { PatchService as CloudPatchService } from '@gitbutler/shared/branches/patchService';
 	import { FeedService } from '@gitbutler/shared/feeds/service';
 	import { HttpClient } from '@gitbutler/shared/network/httpClient';
@@ -78,6 +79,7 @@
 	const cloudBranchService = new CloudBranchService(data.cloud, appState.appDispatch);
 	const cloudPatchService = new CloudPatchService(data.cloud, appState.appDispatch);
 	const repositoryIdLookupService = new RepositoryIdLookupService(data.cloud, appState.appDispatch);
+	const latestBranchLookupService = new LatestBranchLookupService(data.cloud, appState.appDispatch);
 
 	setContext(AppState, appState);
 	setContext(AppDispatch, appState.appDispatch);
@@ -90,6 +92,7 @@
 	setContext(CloudBranchService, cloudBranchService);
 	setContext(CloudPatchService, cloudPatchService);
 	setContext(RepositoryIdLookupService, repositoryIdLookupService);
+	setContext(LatestBranchLookupService, latestBranchLookupService);
 	setContext(HooksService, data.hooksService);
 	setContext(SettingsService, data.settingsService);
 

--- a/apps/web/src/lib/components/branches/BranchIndexCard.svelte
+++ b/apps/web/src/lib/components/branches/BranchIndexCard.svelte
@@ -19,18 +19,18 @@
 
 	type Props = {
 		repositoryId: string;
-		branchId: string;
+		uuid: string;
 		linkParams: ProjectParameters;
 		roundedTop: boolean;
 		roundedBottom: boolean;
 	};
 
-	const { branchId, repositoryId, linkParams, roundedTop, roundedBottom }: Props = $props();
+	const { uuid, repositoryId, linkParams, roundedTop, roundedBottom }: Props = $props();
 
 	const appState = getContext(AppState);
 	const branchService = getContext(BranchService);
 
-	const branch = $derived(getBranchReview(appState, branchService, repositoryId, branchId));
+	const branch = $derived(getBranchReview(appState, branchService, repositoryId, uuid));
 
 	const contributors = $derived(
 		isFound(branch.current) ? getContributorsWithAvatars(branch.current.value) : Promise.resolve([])
@@ -55,7 +55,7 @@
 			<td><div>{branch.stackOrder}</div></td>
 			<td>
 				<div>
-					<a href={projectReviewBranchPath({ ...linkParams, branchId })}>
+					<a href={projectReviewBranchPath({ ...linkParams, branchId: branch.branchId })}>
 						{branch.title}
 					</a>
 				</div>

--- a/apps/web/src/lib/components/changes/ChangeIndexCard.svelte
+++ b/apps/web/src/lib/components/changes/ChangeIndexCard.svelte
@@ -39,13 +39,13 @@
 
 {#snippet status(status: 'approved' | 'changes-requested' | 'unreviewed' | 'in-discussion')}
 	{#if status === 'approved'}
-		<Badge>Approved</Badge>
+		<Badge style="success">Approved</Badge>
 	{:else if status === 'changes-requested'}
-		<Badge>Changes Requested</Badge>
+		<Badge style="error">Changes Requested</Badge>
 	{:else if status === 'unreviewed'}
-		<Badge>Unreviewed</Badge>
+		<Badge style="neuteral" kind="soft">Unreviewed</Badge>
 	{:else if status === 'in-discussion'}
-		<Badge>In Discussion</Badge>
+		<Badge style="warning" kind="soft">In Discussion</Badge>
 	{/if}
 {/snippet}
 

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
 	import Navigation from '$lib/components/Navigation.svelte';
 	import { UserService } from '$lib/user/userService';
 	import { BranchService } from '@gitbutler/shared/branches/branchService';
+	import { LatestBranchLookupService } from '@gitbutler/shared/branches/latestBranchLookupService';
 	import { PatchService } from '@gitbutler/shared/branches/patchService';
 	import { ChatChannelsService } from '@gitbutler/shared/chat/chatChannelsService';
 	import { FeedService } from '@gitbutler/shared/feeds/service';
@@ -57,6 +58,8 @@
 	setContext(ChatChannelsService, chatChannelService);
 	const repositoryIdLookupService = new RepositoryIdLookupService(httpClient, appState.appDispatch);
 	setContext(RepositoryIdLookupService, repositoryIdLookupService);
+	const latestBranchLookupService = new LatestBranchLookupService(httpClient, appState.appDispatch);
+	setContext(LatestBranchLookupService, latestBranchLookupService);
 
 	$effect(() => {
 		const token = get(authService.token) || $page.url.searchParams.get('gb_access_token');

--- a/apps/web/src/routes/[ownerSlug]/[projectSlug]/reviews/+page.svelte
+++ b/apps/web/src/routes/[ownerSlug]/[projectSlug]/reviews/+page.svelte
@@ -56,7 +56,7 @@
 						<BranchIndexCard
 							{repositoryId}
 							linkParams={data}
-							branchId={branch.branchId}
+							uuid={branch.uuid}
 							roundedTop={j === 0 && i !== 0}
 							roundedBottom={j === branches.length - 1}
 						/>

--- a/apps/web/src/routes/[ownerSlug]/[projectSlug]/reviews/[branchId]/+page.svelte
+++ b/apps/web/src/routes/[ownerSlug]/[projectSlug]/reviews/[branchId]/+page.svelte
@@ -7,9 +7,11 @@
 		getBranchReview,
 		getContributorsWithAvatars
 	} from '@gitbutler/shared/branches/branchesPreview.svelte';
+	import { lookupLatestBranchUuid } from '@gitbutler/shared/branches/latestBranchLookup.svelte';
+	import { LatestBranchLookupService } from '@gitbutler/shared/branches/latestBranchLookupService';
 	import { getContext } from '@gitbutler/shared/context';
 	import Loading from '@gitbutler/shared/network/Loading.svelte';
-	import { isFound, and } from '@gitbutler/shared/network/loadable';
+	import { isFound, and, dig, compose } from '@gitbutler/shared/network/loadable';
 	import { lookupProject } from '@gitbutler/shared/organizations/repositoryIdLookupPreview.svelte';
 	import { RepositoryIdLookupService } from '@gitbutler/shared/organizations/repositoryIdLookupService';
 	import { AppState } from '@gitbutler/shared/redux/store.svelte';
@@ -31,16 +33,29 @@
 	let { data }: Props = $props();
 
 	const repositoryIdLookupService = getContext(RepositoryIdLookupService);
+	const latestBranchLookupService = getContext(LatestBranchLookupService);
 	const branchService = getContext(BranchService);
 	const appState = getContext(AppState);
 
 	const repositoryId = $derived(
 		lookupProject(appState, repositoryIdLookupService, data.ownerSlug, data.projectSlug)
 	);
+
+	const branchUuid = $derived(
+		dig(repositoryId.current, (repositoryId) => {
+			return lookupLatestBranchUuid(
+				appState,
+				latestBranchLookupService,
+				repositoryId,
+				data.branchId
+			);
+		})
+	);
+
 	const branch = $derived(
-		isFound(repositoryId.current)
-			? getBranchReview(appState, branchService, repositoryId.current.value, data.branchId)
-			: undefined
+		dig(compose(repositoryId.current, branchUuid?.current), ([repositoryId, branchUuid]) => {
+			return getBranchReview(appState, branchService, repositoryId, branchUuid);
+		})
 	);
 
 	const contributors = $derived(
@@ -64,7 +79,7 @@
 
 <h2>Review page: {data.ownerSlug}/{data.projectSlug} {data.branchId}</h2>
 
-<Loading loadable={and(repositoryId.current, branch?.current)}>
+<Loading loadable={and(repositoryId.current, and(branchUuid?.current, branch?.current))}>
 	{#snippet children(branch)}
 		<div class="layout">
 			<div class="information">

--- a/packages/shared/src/lib/branches/branchesPreview.svelte.ts
+++ b/packages/shared/src/lib/branches/branchesPreview.svelte.ts
@@ -21,7 +21,11 @@ export function getBranchReviewsForRepository(
 		const groupedBranches = new Map<string, Branch[]>();
 
 		branchesSelectors.selectAll(appState.branches).forEach((loadableBranch) => {
-			if (!isFound(loadableBranch) || loadableBranch.value.repositoryId !== repositoryId) {
+			if (
+				!isFound(loadableBranch) ||
+				loadableBranch.value.repositoryId !== repositoryId ||
+				loadableBranch.value.status === BranchStatus.Previous
+			) {
 				return;
 			}
 			const branch = loadableBranch.value;
@@ -48,13 +52,13 @@ export function getBranchReview(
 	appState: AppBranchesState,
 	branchService: BranchService,
 	repositoryId: string,
-	branchId: string,
+	uuid: string,
 	inView?: InView
 ): Reactive<LoadableBranch | undefined> {
-	const branchReviewInterest = branchService.getBranchInterest(repositoryId, branchId);
+	const branchReviewInterest = branchService.getBranchInterest(repositoryId, uuid);
 	registerInterest(branchReviewInterest, inView);
 
-	const branchReview = $derived(branchesSelectors.selectById(appState.branches, branchId));
+	const branchReview = $derived(branchesSelectors.selectById(appState.branches, uuid));
 
 	return {
 		get current() {

--- a/packages/shared/src/lib/branches/latestBranchLookup.svelte.ts
+++ b/packages/shared/src/lib/branches/latestBranchLookup.svelte.ts
@@ -1,0 +1,25 @@
+import { LatestBranchLookupService } from '$lib/branches/latestBranchLookupService';
+import { latestBranchLookupsSelectors } from '$lib/branches/latestBranchLookupSlice';
+import { registerInterest, type InView } from '$lib/interest/registerInterestFunction.svelte';
+import type { LoadableBranchUuid } from '$lib/branches/types';
+import type { AppLatestBranchLookupsState } from '$lib/redux/store.svelte';
+import type { Reactive } from '$lib/storeUtils';
+
+export function lookupLatestBranchUuid(
+	appState: AppLatestBranchLookupsState,
+	latestBranchLookupService: LatestBranchLookupService,
+	repositoryId: string,
+	branchId: string,
+	inView?: InView
+): Reactive<LoadableBranchUuid | undefined> {
+	registerInterest(latestBranchLookupService.getBranchUuidInterest(repositoryId, branchId), inView);
+	const branchUuid = $derived(
+		latestBranchLookupsSelectors.selectById(appState.latestBranchLookups, branchId)
+	);
+
+	return {
+		get current() {
+			return branchUuid;
+		}
+	};
+}

--- a/packages/shared/src/lib/branches/latestBranchLookupService.ts
+++ b/packages/shared/src/lib/branches/latestBranchLookupService.ts
@@ -1,0 +1,40 @@
+import { addBranchUuid, upsertBranchUuid } from '$lib/branches/latestBranchLookupSlice';
+import { InterestStore, type Interest } from '$lib/interest/interestStore';
+import { errorToLoadable } from '$lib/network/loadable';
+import { POLLING_REGULAR } from '$lib/polling';
+import type { ApiBranch } from '$lib/branches/types';
+import type { HttpClient } from '$lib/network/httpClient';
+import type { AppDispatch } from '$lib/redux/store.svelte';
+
+export class LatestBranchLookupService {
+	private readonly branchLookupInterests = new InterestStore<{ branchId: string }>(POLLING_REGULAR);
+
+	constructor(
+		private readonly httpClient: HttpClient,
+		private readonly appDispatch: AppDispatch
+	) {}
+
+	getBranchUuidInterest(repositoryId: string, branchId: string): Interest {
+		return this.branchLookupInterests
+			.findOrCreateSubscribable({ branchId }, async () => {
+				this.appDispatch.dispatch(addBranchUuid({ status: 'loading', id: branchId }));
+
+				try {
+					const branch = await this.httpClient.get<ApiBranch>(
+						`patch_stack/${repositoryId}/${branchId}`
+					);
+
+					this.appDispatch.dispatch(
+						upsertBranchUuid({
+							status: 'found',
+							id: branchId,
+							value: branch.uuid
+						})
+					);
+				} catch (error: unknown) {
+					this.appDispatch.dispatch(upsertBranchUuid(errorToLoadable(error, branchId)));
+				}
+			})
+			.createInterest();
+	}
+}

--- a/packages/shared/src/lib/branches/latestBranchLookupSlice.ts
+++ b/packages/shared/src/lib/branches/latestBranchLookupSlice.ts
@@ -1,0 +1,35 @@
+import { loadableUpsert, loadableUpsertMany } from '$lib/network/loadable';
+import { createEntityAdapter, createSlice } from '@reduxjs/toolkit';
+import type { LoadableBranchUuid } from '$lib/branches/types';
+
+const latestBranchLookupsAdapter = createEntityAdapter<
+	LoadableBranchUuid,
+	LoadableBranchUuid['id']
+>({
+	selectId: (project: LoadableBranchUuid) => project.id
+});
+
+const latestBranchLookupsSlice = createSlice({
+	name: 'repositoryIds',
+	initialState: latestBranchLookupsAdapter.getInitialState(),
+	reducers: {
+		addBranchUuid: latestBranchLookupsAdapter.addOne,
+		addBranchUuids: latestBranchLookupsAdapter.addMany,
+		removeBranchUuid: latestBranchLookupsAdapter.removeOne,
+		removeBranchUuids: latestBranchLookupsAdapter.removeMany,
+		upsertBranchUuid: loadableUpsert(latestBranchLookupsAdapter),
+		upsertBranchUuids: loadableUpsertMany(latestBranchLookupsAdapter)
+	}
+});
+
+export const latestBranchLookupsReducer = latestBranchLookupsSlice.reducer;
+
+export const latestBranchLookupsSelectors = latestBranchLookupsAdapter.getSelectors();
+export const {
+	addBranchUuid,
+	addBranchUuids,
+	removeBranchUuid,
+	removeBranchUuids,
+	upsertBranchUuid,
+	upsertBranchUuids
+} = latestBranchLookupsSlice.actions;

--- a/packages/shared/src/lib/branches/types.ts
+++ b/packages/shared/src/lib/branches/types.ts
@@ -247,7 +247,8 @@ export enum BranchStatus {
 	Inactive = 'inactive',
 	Closed = 'closed',
 	Loading = 'loading',
-	All = 'all'
+	All = 'all',
+	Previous = 'previous'
 }
 
 export type ApiBranch = {
@@ -286,7 +287,7 @@ export type Branch = {
 	stackOrder: number;
 };
 
-export type LoadableBranch = LoadableData<Branch, Branch['branchId']>;
+export type LoadableBranch = LoadableData<Branch, Branch['uuid']>;
 
 export function apiToBranch(api: ApiBranch): Branch {
 	return {
@@ -308,3 +309,5 @@ export function apiToBranch(api: ApiBranch): Branch {
 		stackOrder: api.branch_stack_order || 1
 	};
 }
+
+export type LoadableBranchUuid = LoadableData<string, string>;

--- a/packages/shared/src/lib/network/loadable.ts
+++ b/packages/shared/src/lib/network/loadable.ts
@@ -69,9 +69,11 @@ export function loadableUpsertMany<T, Id extends EntityId>(
 				merged = payload.value;
 			} else {
 				merged = { ...entity.value };
+				console.log({ ...entity.value });
+				console.log({ ...payload.value });
 
 				for (const [key, value] of Object.entries(payload.value as object)) {
-					if (value !== undefined || value !== null) {
+					if (value !== undefined && value !== null) {
 						// @ts-expect-error This is fine
 						merged[key] = value;
 					}

--- a/packages/shared/src/lib/redux/store.svelte.ts
+++ b/packages/shared/src/lib/redux/store.svelte.ts
@@ -1,4 +1,5 @@
 import { branchesReducer } from '$lib/branches/branchesSlice';
+import { latestBranchLookupsReducer } from '$lib/branches/latestBranchLookupSlice';
 import { patchSectionsReducer } from '$lib/branches/patchSectionsSlice';
 import { patchesReducer } from '$lib/branches/patchesSlice';
 import { chatChannelsReducer } from '$lib/chat/chatChannelsSlice';
@@ -59,6 +60,10 @@ export interface AppRepositoryIdLookupsState {
 	readonly repositoryIdLookups: ReturnType<typeof repositoryIdLookupsReducer>;
 }
 
+export interface AppLatestBranchLookupsState {
+	readonly latestBranchLookups: ReturnType<typeof latestBranchLookupsReducer>;
+}
+
 export class AppDispatch {
 	constructor(readonly dispatch: typeof AppState.prototype._store.dispatch) {}
 }
@@ -75,7 +80,8 @@ export class AppState
 		AppBranchesState,
 		AppPatchSectionsState,
 		AppChatChannelsState,
-		AppRepositoryIdLookupsState
+		AppRepositoryIdLookupsState,
+		AppLatestBranchLookupsState
 {
 	/**
 	 * The base store.
@@ -95,7 +101,8 @@ export class AppState
 			branches: branchesReducer,
 			patchSections: patchSectionsReducer,
 			chatChannels: chatChannelsReducer,
-			repositoryIdLookups: repositoryIdLookupsReducer
+			repositoryIdLookups: repositoryIdLookupsReducer,
+			latestBranchLookups: latestBranchLookupsReducer
 		}
 	});
 
@@ -145,6 +152,10 @@ export class AppState
 		[this.selectSelf],
 		(rootState) => rootState.repositoryIdLookups
 	);
+	private readonly selectLatestBranchLookups = createSelector(
+		[this.selectSelf],
+		(rootState) => rootState.latestBranchLookups
+	);
 
 	readonly example = $derived(this.selectExample(this.rootState));
 	readonly posts = $derived(this.selectPosts(this.rootState));
@@ -157,6 +168,7 @@ export class AppState
 	readonly patchSections = $derived(this.selectPatchSections(this.rootState));
 	readonly chatChannels = $derived(this.selectChatChannels(this.rootState));
 	readonly repositoryIdLookups = $derived(this.selectRepositoryIdLookups(this.rootState));
+	readonly latestBranchLookups = $derived(this.selectLatestBranchLookups(this.rootState));
 
 	constructor() {
 		$effect(() => {


### PR DESCRIPTION
Branch UUIDs are the correct primary key for branches.

There are multiple records for each BranchId that represent versions through time. This PR keeps the routing to use the BranchId and adds a lookup to find the latest version of the branch

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5983 
- <kbd>&nbsp;2&nbsp;</kbd> #5979 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5978 
<!-- GitButler Footer Boundary Bottom -->

