### PR TITLE
v3 stack branches endpoint WIP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,6 +667,7 @@ dependencies = [
  "but-core",
  "but-workspace",
  "clap",
+ "gitbutler-command-context",
  "gitbutler-project",
  "gix",
  "tracing",
@@ -692,8 +693,14 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bstr",
+ "git2",
+ "gitbutler-command-context",
+ "gitbutler-commit",
  "gitbutler-id",
+ "gitbutler-oxidize",
+ "gitbutler-repo",
  "gitbutler-stack",
+ "gix",
  "itertools 0.14.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,6 +702,7 @@ dependencies = [
  "gitbutler-stack",
  "gix",
  "itertools 0.14.0",
+ "serde",
 ]
 
 [[package]]

--- a/crates/but-cli/Cargo.toml
+++ b/crates/but-cli/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 doctest = false
 
 [dependencies]
+gitbutler-command-context.workspace = true
 gitbutler-project.workspace = true
 but-core.workspace = true
 but-workspace.workspace = true

--- a/crates/but-cli/src/args.rs
+++ b/crates/but-cli/src/args.rs
@@ -24,6 +24,9 @@ pub enum Subcommands {
     },
     /// Returns the list of stacks that are currently part of the GitButler workspace.
     Stacks,
+    StackBranches {
+        id: String,
+    },
 }
 
 #[cfg(test)]

--- a/crates/but-cli/src/command/mod.rs
+++ b/crates/but-cli/src/command/mod.rs
@@ -42,10 +42,19 @@ pub mod status {
 pub mod stacks {
     use std::path::PathBuf;
 
+    use but_workspace::stack_branches;
+    use gitbutler_command_context::CommandContext;
+
     use crate::command::{debug_print, project_from_path};
 
     pub fn list(current_dir: PathBuf) -> anyhow::Result<()> {
         let project = project_from_path(current_dir)?;
         debug_print(but_workspace::stacks(&project.gb_dir()))
+    }
+
+    pub fn branches(id: String, current_dir: PathBuf) -> anyhow::Result<()> {
+        let project = project_from_path(current_dir)?;
+        let ctx = CommandContext::open(&project)?;
+        debug_print(stack_branches(id, &ctx))
     }
 }

--- a/crates/but-cli/src/main.rs
+++ b/crates/but-cli/src/main.rs
@@ -19,6 +19,7 @@ fn main() -> Result<()> {
             command::status::doit(args.current_dir, unified_diff)
         }
         args::Subcommands::Stacks => command::stacks::list(args.current_dir),
+        args::Subcommands::StackBranches { id } => command::stacks::branches(id, args.current_dir),
     }
 }
 

--- a/crates/but-workspace/Cargo.toml
+++ b/crates/but-workspace/Cargo.toml
@@ -11,6 +11,13 @@ doctest = false
 [dependencies]
 anyhow.workspace = true
 bstr.workspace = true
+git2.workspace = true
 gitbutler-id.workspace = true
+gix = { workspace = true, features = ["dirwalk", "credentials", "parallel", "serde", "status"] }
 gitbutler-stack.workspace = true
+gitbutler-command-context.workspace = true
+gitbutler-oxidize.workspace = true
+gitbutler-commit.workspace = true
+gitbutler-repo.workspace = true
+serde = { workspace = true, features = ["std"] }
 itertools = "0.14"

--- a/crates/but-workspace/src/integrated.rs
+++ b/crates/but-workspace/src/integrated.rs
@@ -1,0 +1,130 @@
+//! ### Detecting if a commit is integrated
+//!
+//! This code is a fork of the [`gitbutler_branch_actions::virtual::IsCommitIntegrated`] in crate gitbutler-branch-actions
+//! This code is a fork of the [`gitbutler_branch_actions::r#virtual::list_virtual_branches`] in crate gitbutler-branch-actions
+
+use anyhow::anyhow;
+use anyhow::{Context, Result};
+use gitbutler_command_context::CommandContext;
+use gitbutler_commit::commit_ext::CommitExt;
+use gitbutler_oxidize::{git2_to_gix_object_id, gix_to_git2_oid, GixRepositoryExt};
+use gitbutler_repo::{
+    logging::{LogUntil, RepositoryExt},
+    RepositoryExt as _,
+};
+use gitbutler_stack::Target;
+use itertools::Itertools;
+
+pub(crate) struct IsCommitIntegrated<'repo, 'cache, 'graph> {
+    gix_repo: &'repo gix::Repository,
+    graph: &'graph mut MergeBaseCommitGraph<'repo, 'cache>,
+    target_commit_id: gix::ObjectId,
+    upstream_tree_id: gix::ObjectId,
+    upstream_commits: Vec<git2::Oid>,
+    upstream_change_ids: Vec<String>,
+}
+
+impl<'repo, 'cache, 'graph> IsCommitIntegrated<'repo, 'cache, 'graph> {
+    pub(crate) fn new(
+        ctx: &'repo CommandContext,
+        target: &Target,
+        gix_repo: &'repo gix::Repository,
+        graph: &'graph mut MergeBaseCommitGraph<'repo, 'cache>,
+    ) -> anyhow::Result<Self> {
+        let remote_branch = ctx
+            .repo()
+            .maybe_find_branch_by_refname(&target.branch.clone().into())?
+            .ok_or(anyhow!("failed to get branch"))?;
+        let remote_head = remote_branch.get().peel_to_commit()?;
+        let upstream_tree_id = ctx.repo().find_commit(remote_head.id())?.tree_id();
+
+        let upstream_commits =
+            ctx.repo()
+                .log(remote_head.id(), LogUntil::Commit(target.sha), true)?;
+        let upstream_change_ids = upstream_commits
+            .iter()
+            .filter_map(|commit| commit.change_id())
+            .sorted()
+            .collect();
+        let upstream_commits = upstream_commits
+            .iter()
+            .map(|commit| commit.id())
+            .sorted()
+            .collect();
+        Ok(Self {
+            gix_repo,
+            graph,
+            target_commit_id: git2_to_gix_object_id(target.sha),
+            upstream_tree_id: git2_to_gix_object_id(upstream_tree_id),
+            upstream_commits,
+            upstream_change_ids,
+        })
+    }
+    pub(crate) fn is_integrated(&mut self, commit: &git2::Commit<'_>) -> Result<bool> {
+        if self.target_commit_id == git2_to_gix_object_id(commit.id()) {
+            // could not be integrated if heads are the same.
+            return Ok(false);
+        }
+
+        if self.upstream_commits.is_empty() {
+            // could not be integrated - there is nothing new upstream.
+            return Ok(false);
+        }
+
+        if let Some(change_id) = commit.change_id() {
+            if self.upstream_change_ids.binary_search(&change_id).is_ok() {
+                return Ok(true);
+            }
+        }
+
+        if self.upstream_commits.binary_search(&commit.id()).is_ok() {
+            return Ok(true);
+        }
+
+        let merge_base_id = self.gix_repo.merge_base_with_graph(
+            self.target_commit_id,
+            git2_to_gix_object_id(commit.id()),
+            self.graph,
+        )?;
+        if gix_to_git2_oid(merge_base_id).eq(&commit.id()) {
+            // if merge branch is the same as branch head and there are upstream commits
+            // then it's integrated
+            return Ok(true);
+        }
+
+        let merge_base_tree_id = self.gix_repo.find_commit(merge_base_id)?.tree_id()?;
+        if merge_base_tree_id == self.upstream_tree_id {
+            // if merge base is the same as upstream tree, then it's integrated
+            return Ok(true);
+        }
+
+        // try to merge our tree into the upstream tree
+        let (merge_options, conflict_kind) = self.gix_repo.merge_options_no_rewrites_fail_fast()?;
+        let mut merge_output = self
+            .gix_repo
+            .merge_trees(
+                merge_base_tree_id,
+                git2_to_gix_object_id(commit.tree_id()),
+                self.upstream_tree_id,
+                Default::default(),
+                merge_options,
+            )
+            .context("failed to merge trees")?;
+
+        if merge_output.has_unresolved_conflicts(conflict_kind) {
+            return Ok(false);
+        }
+
+        let merge_tree_id = merge_output.tree.write()?.detach();
+
+        // if the merge_tree is the same as the new_target_tree and there are no files (uncommitted changes)
+        // then the vbranch is fully merged
+        Ok(merge_tree_id == self.upstream_tree_id)
+    }
+}
+
+type MergeBaseCommitGraph<'repo, 'cache> = gix::revwalk::Graph<
+    'repo,
+    'cache,
+    gix::revision::plumbing::graph::Commit<gix::revision::plumbing::merge_base::Flags>,
+>;

--- a/crates/but-workspace/src/integrated.rs
+++ b/crates/but-workspace/src/integrated.rs
@@ -1,7 +1,6 @@
 //! ### Detecting if a commit is integrated
 //!
-//! This code is a fork of the [`gitbutler_branch_actions::virtual::IsCommitIntegrated`] in crate gitbutler-branch-actions
-//! This code is a fork of the [`gitbutler_branch_actions::r#virtual::list_virtual_branches`] in crate gitbutler-branch-actions
+//! This code is a fork of the [`gitbutler_branch_actions::virtual::IsCommitIntegrated`]
 
 use anyhow::anyhow;
 use anyhow::{Context, Result};

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -8,13 +8,29 @@
 //!       multiple branches to be perceived in one worktree, by merging multiple branches together.
 //!     - Currently, there is only one workspace per repository, but this is something we intend to change
 //!       in the future to facilitate new use cases.
+//!
+//! * **Stack**
+//!   - GitButler implements the concept of a branch stack. This is essentially a collection of "heads"
+//!     (pseudo branches) that contain each other.
+//!   - Always contains at least one branch.
+//!   - High level documentation here: https://docs.gitbutler.com/features/stacked-branches
+//!
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use bstr::BString;
+use gitbutler_command_context::CommandContext;
+use gitbutler_commit::commit_ext::CommitExt;
 use gitbutler_id::id::Id;
-use gitbutler_stack::VirtualBranchesHandle;
+use gitbutler_oxidize::OidExt;
+use gitbutler_stack::stack_context::CommandContextExt;
+use gitbutler_stack::{stack_context::StackContext, Stack, Target, VirtualBranchesHandle};
+use gix::ObjectId;
+use integrated::IsCommitIntegrated;
 use itertools::Itertools;
 use std::path::Path;
+use std::str::FromStr;
+
+mod integrated;
 
 /// Represents a lightweight version of a [`gitbutler_stack::Stack`] for listing.
 #[derive(Debug, Clone)]
@@ -43,6 +59,197 @@ pub fn stacks(gb_dir: &Path) -> Result<Vec<StackEntry>> {
             branch_names: stack.heads().into_iter().map(Into::into).collect(),
         })
         .collect())
+}
+
+/// Represents the state a commit could be in.
+#[derive(Debug, Clone)]
+pub enum CommitState {
+    /// The commit is only local
+    LocalOnly,
+    /// The commit is also present at the remote tracking branch.
+    /// This is the commit state if:
+    ///  - The commit has been pushed to the remote
+    ///  - The commit has been copied from a remote commit (when applying a remote branch)
+    ///
+    /// This variant carries the remote commit id.
+    /// The `remote_commit_id` may be the same as the `id` or it may be different if the local commit has been rebased or updated in another way.
+    LocalAndRemote(gix::ObjectId),
+    /// The commit is considered integrated.
+    /// This should happen when this commit or the contents of this commit is already part of the base.
+    Integrated,
+}
+
+/// Commit that is a part of a [`StackBranch`] and, as such, containing state derived in relation to the specific branch.
+#[derive(Debug, Clone)]
+pub struct Commit {
+    /// The OID of the commit.
+    pub id: gix::ObjectId,
+    /// The message of the commit.
+    pub message: BString,
+    /// Whether the commit is in a conflicted state.
+    /// Conflicted state of a commit is a GitButler concept.
+    /// GitButler will perform rebasing/reordering etc without interruptions and flag commits as conflicted if needed.
+    /// Conflicts are resolved via the Edit Mode mechanism.
+    pub has_conflicts: bool,
+    /// Represents wether the the commit is considered integrated, local only,
+    /// or local and remote with respect to the branch it belongs to.
+    /// Note that remote only commits in the context of a branch are expressed with the [`UpstreamCommit`] struct instead of this.
+    pub state: CommitState,
+}
+
+/// Commit that is only at the remote.
+/// Unlike the `Commit` struct, there is no knowledge of GitButler concepts like conflicted state etc.
+#[derive(Debug, Clone)]
+pub struct UpstreamCommit {
+    /// The OID of the commit.
+    pub id: gix::ObjectId,
+    /// The message of the commit.
+    pub message: BString,
+}
+
+impl Commit {
+    fn matches(&self, id: ObjectId) -> bool {
+        self.id == id
+            || match self.state {
+                CommitState::LocalAndRemote(remote_commit_id) => remote_commit_id == id,
+                _ => false,
+            }
+    }
+}
+
+/// Replesents a branch in a [`gitbutler_stack::Stack`]. It contains commits derived from the local pseudo branch and it's respective remote
+#[derive(Debug, Clone)]
+pub struct Branch {
+    /// The name of the branch.
+    pub name: BString,
+    /// Upstream reference, e.g. `refs/remotes/origin/base-branch-improvements`
+    pub remote_tracking_branch: Option<BString>,
+    /// List of commits beloning to this branch. Ordered from newest to oldest.
+    /// Created from the local pseudo branch (head currently stored in the TOML file)
+    /// This includes the commits from the tip of the stack to the merge base with the trunk / target branch (not including the merge base).
+    pub commits: Vec<Commit>,
+    /// List of commits that exist **only** on the upstream branch. Ordered from newest to oldest.
+    /// Created from the tip of the local tracking branch eg. refs/remotes/origin/my-branch -> refs/heads/my-branch
+    /// This does **not** include the commits that are in the commits list (local)
+    pub upstream_commits: Vec<UpstreamCommit>,
+    /// Description of the branch.
+    /// Can include arbitrary utf8 data, eg. markdown etc.
+    pub description: Option<String>,
+    /// The pull(merge) request associated with the branch, or None if no such entity has not been created.
+    pub pr_number: Option<usize>,
+    /// A unique identifier for the GitButler review associated with the branch, if any.
+    pub review_id: Option<String>,
+    /// Archived represents the state when series/branch has been integrated and is below the merge base of the branch.
+    /// This would occur when the branch has been merged at the remote and the workspace has been updated with that change.
+    pub archived: bool,
+}
+
+/// Provides the relevant details of a particular [`gitbutler_stack::Stack`]
+/// The entries are ordered from newest to oldest.
+pub fn stack_branches(stack_id: String, ctx: &CommandContext) -> Result<Vec<Branch>> {
+    let state = state_handle(&ctx.project().gb_dir());
+    let default_target = state
+        .get_default_target()
+        .context("failed to get default target")?;
+    let stack_ctx = &ctx.to_stack_context()?;
+
+    let repo = ctx.gix_repository()?;
+    let cache = repo.commit_graph_if_enabled()?;
+    let mut graph = repo.revision_graph(cache.as_ref());
+    let mut check_commit = IsCommitIntegrated::new(ctx, &default_target, &repo, &mut graph)?;
+
+    let mut stack_branches = vec![];
+    let stack = state.get_stack(Id::from_str(&stack_id)?)?;
+    for internal in stack.branches() {
+        let result = convert(
+            stack_ctx,
+            internal,
+            &stack,
+            &default_target,
+            &mut check_commit,
+            stack_branches.clone(),
+        )?;
+        stack_branches.push(result);
+    }
+    stack_branches.reverse();
+    Ok(stack_branches)
+}
+
+fn convert(
+    ctx: &StackContext<'_>,
+    stack_branch: gitbutler_stack::StackBranch,
+    stack: &Stack,
+    default_target: &Target,
+    check_commit: &mut IsCommitIntegrated<'_, '_, '_>,
+    parent_series: Vec<Branch>,
+) -> Result<Branch> {
+    let branch_commits = stack_branch.commits(ctx, stack)?;
+    let remote = default_target.push_remote_name();
+    let mut patches: Vec<Commit> = vec![];
+    let mut is_integrated = false;
+
+    // Reverse first instead of later, so that we catch the first integrated commit
+    for commit in branch_commits.clone().local_commits.iter().rev() {
+        if !is_integrated {
+            is_integrated = check_commit.is_integrated(commit)?;
+        }
+        let api_commit = Commit {
+            id: commit.id().to_gix(),
+            message: commit.message_bstr().into(),
+            has_conflicts: commit.is_conflicted(),
+            state: CommitState::LocalOnly, // TODO: implement this
+        };
+        patches.push(api_commit);
+    }
+    // There should be no duplicates, but dedup just in case
+    patches.dedup_by(|a, b| a.id == b.id);
+
+    let mut upstream_patches = vec![];
+    for commit in branch_commits.remote_commits.iter().rev() {
+        if patches.iter().any(|p| p.matches(commit.id().to_gix())) {
+            // Skip if we already have this commit in the list
+            continue;
+        }
+
+        if parent_series.iter().any(|series| {
+            if series.archived {
+                return false;
+            };
+
+            series
+                .commits
+                .iter()
+                .any(|p| p.matches(commit.id().to_gix()))
+        }) {
+            // Skip if we already have this commit in the list
+            continue;
+        }
+
+        let upstream_commit = UpstreamCommit {
+            id: commit.id().to_gix(),
+            message: commit.message_bstr().into(),
+        };
+        upstream_patches.push(upstream_commit);
+    }
+    upstream_patches.reverse();
+    // There should be no duplicates, but dedup just in case
+    upstream_patches.dedup_by(|a, b| a.id == b.id);
+
+    let upstream_reference = ctx
+        .repository()
+        .find_reference(&stack_branch.remote_reference(remote.as_str()))
+        .ok()
+        .map(|_| stack_branch.remote_reference(remote.as_str()));
+    Ok(Branch {
+        name: stack_branch.name.into(),
+        remote_tracking_branch: upstream_reference.map(Into::into),
+        commits: patches,
+        upstream_commits: upstream_patches,
+        description: stack_branch.description.map(Into::into),
+        pr_number: stack_branch.pr_number,
+        review_id: stack_branch.review_id,
+        archived: stack_branch.archived,
+    })
 }
 
 fn state_handle(gb_state_path: &Path) -> VirtualBranchesHandle {

--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -1,4 +1,5 @@
 use crate::error::Error;
+use gitbutler_command_context::CommandContext;
 use gitbutler_id::id::Id;
 use gitbutler_project as projects;
 use gitbutler_project::ProjectId;
@@ -17,6 +18,18 @@ pub fn stacks(
     let project = projects.get(project_id)?;
     let stacks = but_workspace::stacks(&project.gb_dir())?;
     Ok(stacks.into_iter().map(Into::into).collect())
+}
+
+#[tauri::command(async)]
+#[instrument(skip(projects), err(Debug))]
+pub fn stack_branches(
+    projects: State<'_, projects::Controller>,
+    project_id: ProjectId,
+    stack_id: String,
+) -> anyhow::Result<Vec<but_workspace::Branch>, Error> {
+    let project = projects.get(project_id)?;
+    let ctx = CommandContext::open(&project)?;
+    but_workspace::stack_branches(stack_id, &ctx).map_err(Into::into)
 }
 
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
This is a port of "list_virtual_branches" but operating on a single stack at a time and without dependency to the `gitbutler-branch-actions` code.

The key constraint here is to keep this compatible with the stacks implementation. 

Tasks:
- [x] Port over the implementation
- [x] CLI integration
- [x] Tauri API
- [ ] Tests