### PR TITLE
fix: disable in-app updater for flatpak

### DIFF
--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -5,6 +5,6 @@ import { check } from '@tauri-apps/plugin-updater';
 export class Tauri {
 	invoke = invokeIpc;
 	listen = listenIpc;
-	checkUpdate = check;
+	checkUpdate = import.meta.env.VITE_FLATPAK_ID ? () => null : check;
 	currentVersion = getVersion;
 }


### PR DESCRIPTION
- Check `VITE_FLATPAK_ID` env var for implementing Tauri updater `check` fn