### PR TITLE
Get-Patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2426,6 +2426,7 @@ dependencies = [
  "gitbutler-command-context",
  "gitbutler-diff",
  "gitbutler-oplog",
+ "gitbutler-oxidize",
  "gitbutler-project",
  "gitbutler-reference",
  "gitbutler-stack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,7 +2560,7 @@ version = "0.0.0"
 dependencies = [
  "assert_cmd",
  "futures",
- "gix-path 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-path 0.10.13",
  "nix",
  "rand 0.8.5",
  "serde",
@@ -2814,7 +2814,7 @@ dependencies = [
  "gitbutler-testsupport",
  "gitbutler-time",
  "gix",
- "gix-utils 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-utils 0.1.13",
  "itertools 0.14.0",
  "serde",
  "tempfile",
@@ -3037,54 +3037,54 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.69.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.70.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
- "gix-actor 0.33.1",
- "gix-attributes 0.23.1",
+ "gix-actor 0.33.2",
+ "gix-attributes 0.24.0",
  "gix-command",
- "gix-commitgraph 0.25.1",
+ "gix-commitgraph 0.26.0",
  "gix-config",
  "gix-credentials",
  "gix-date 0.9.3",
  "gix-diff",
  "gix-dir",
- "gix-discover 0.37.0",
- "gix-features 0.39.1",
+ "gix-discover 0.38.0",
+ "gix-features 0.40.0",
  "gix-filter",
- "gix-fs 0.12.1",
- "gix-glob 0.17.1",
- "gix-hash 0.15.1",
- "gix-hashtable 0.6.0",
- "gix-ignore 0.12.1",
- "gix-index 0.37.0",
- "gix-lock 15.0.1",
+ "gix-fs 0.13.0",
+ "gix-glob 0.18.0",
+ "gix-hash 0.16.0",
+ "gix-hashtable 0.7.0",
+ "gix-ignore 0.13.0",
+ "gix-index 0.38.0",
+ "gix-lock 16.0.0",
  "gix-mailmap",
  "gix-merge",
  "gix-negotiate",
- "gix-object 0.46.1",
+ "gix-object 0.47.0",
  "gix-odb",
  "gix-pack",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-path 0.10.14",
  "gix-pathspec",
  "gix-prompt",
  "gix-protocol",
- "gix-ref 0.49.1",
+ "gix-ref 0.50.0",
  "gix-refspec",
  "gix-revision",
- "gix-revwalk 0.17.0",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-revwalk 0.18.0",
+ "gix-sec 0.10.11",
  "gix-shallow",
  "gix-status",
  "gix-submodule",
- "gix-tempfile 15.0.0",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-tempfile 16.0.0",
+ "gix-trace 0.1.12",
  "gix-transport",
- "gix-traverse 0.43.1",
+ "gix-traverse 0.44.0",
  "gix-url",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-validate 0.9.2",
- "gix-worktree 0.38.0",
+ "gix-utils 0.1.14",
+ "gix-validate 0.9.3",
+ "gix-worktree 0.39.0",
  "gix-worktree-state",
  "once_cell",
  "serde",
@@ -3100,7 +3100,7 @@ checksum = "a0e454357e34b833cc3a00b6efbbd3dd4d18b24b9fb0c023876ec2645e8aa3f2"
 dependencies = [
  "bstr",
  "gix-date 0.8.7",
- "gix-utils 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-utils 0.1.13",
  "itoa 1.0.11",
  "thiserror 1.0.69",
  "winnow 0.6.20",
@@ -3108,12 +3108,12 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.33.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.33.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
  "gix-date 0.9.3",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-utils 0.1.14",
  "itoa 1.0.11",
  "serde",
  "thiserror 2.0.9",
@@ -3128,9 +3128,9 @@ checksum = "ebccbf25aa4a973dd352564a9000af69edca90623e8a16dad9cbc03713131311"
 dependencies = [
  "bstr",
  "gix-glob 0.16.5",
- "gix-path 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-quote 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-trace 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-path 0.10.13",
+ "gix-quote 0.4.14",
+ "gix-trace 0.1.11",
  "kstring",
  "smallvec",
  "thiserror 1.0.69",
@@ -3139,14 +3139,14 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.23.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.24.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
- "gix-glob 0.17.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-glob 0.18.0",
+ "gix-path 0.10.14",
+ "gix-quote 0.4.15",
+ "gix-trace 0.1.12",
  "kstring",
  "serde",
  "smallvec",
@@ -3165,8 +3165,8 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.2.13"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.2.14"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "thiserror 2.0.9",
 ]
@@ -3182,20 +3182,20 @@ dependencies = [
 
 [[package]]
 name = "gix-chunk"
-version = "0.4.10"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.4.11"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-command"
-version = "0.4.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.4.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-path 0.10.14",
+ "gix-trace 0.1.12",
  "shell-words",
 ]
 
@@ -3206,7 +3206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "133b06f67f565836ec0c473e2116a60fb74f80b6435e21d88013ac0e3c60fc78"
 dependencies = [
  "bstr",
- "gix-chunk 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-chunk 0.4.10",
  "gix-features 0.38.2",
  "gix-hash 0.14.2",
  "memmap2",
@@ -3215,13 +3215,13 @@ dependencies = [
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.25.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.26.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
- "gix-chunk 0.4.10 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-features 0.39.1",
- "gix-hash 0.15.1",
+ "gix-chunk 0.4.11",
+ "gix-features 0.40.0",
+ "gix-hash 0.16.0",
  "memmap2",
  "serde",
  "thiserror 2.0.9",
@@ -3229,16 +3229,16 @@ dependencies = [
 
 [[package]]
 name = "gix-config"
-version = "0.42.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.43.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features 0.39.1",
- "gix-glob 0.17.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-ref 0.49.1",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-features 0.40.0",
+ "gix-glob 0.18.0",
+ "gix-path 0.10.14",
+ "gix-ref 0.50.0",
+ "gix-sec 0.10.11",
  "memchr",
  "once_cell",
  "smallvec",
@@ -3249,28 +3249,28 @@ dependencies = [
 
 [[package]]
 name = "gix-config-value"
-version = "0.14.10"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.14.11"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-path 0.10.14",
  "libc",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-credentials"
-version = "0.26.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.27.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-config-value",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-path 0.10.14",
  "gix-prompt",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-sec 0.10.11",
+ "gix-trace 0.1.12",
  "gix-url",
  "serde",
  "thiserror 2.0.9",
@@ -3291,7 +3291,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.9.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
  "itoa 1.0.11",
@@ -3302,43 +3302,43 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.49.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.50.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
- "gix-attributes 0.23.1",
+ "gix-attributes 0.24.0",
  "gix-command",
  "gix-filter",
- "gix-fs 0.12.1",
- "gix-hash 0.15.1",
- "gix-index 0.37.0",
- "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-fs 0.13.0",
+ "gix-hash 0.16.0",
+ "gix-index 0.38.0",
+ "gix-object 0.47.0",
+ "gix-path 0.10.14",
  "gix-pathspec",
- "gix-tempfile 15.0.0",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-traverse 0.43.1",
- "gix-worktree 0.38.0",
+ "gix-tempfile 16.0.0",
+ "gix-trace 0.1.12",
+ "gix-traverse 0.44.0",
+ "gix-worktree 0.39.0",
  "imara-diff",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-dir"
-version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.12.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
- "gix-discover 0.37.0",
- "gix-fs 0.12.1",
- "gix-ignore 0.12.1",
- "gix-index 0.37.0",
- "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-discover 0.38.0",
+ "gix-fs 0.13.0",
+ "gix-ignore 0.13.0",
+ "gix-index 0.38.0",
+ "gix-object 0.47.0",
+ "gix-path 0.10.14",
  "gix-pathspec",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-worktree 0.38.0",
+ "gix-trace 0.1.12",
+ "gix-utils 0.1.14",
+ "gix-worktree 0.39.0",
  "thiserror 2.0.9",
 ]
 
@@ -3352,24 +3352,24 @@ dependencies = [
  "dunce",
  "gix-fs 0.11.3",
  "gix-hash 0.14.2",
- "gix-path 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-path 0.10.13",
  "gix-ref 0.44.1",
- "gix-sec 0.10.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-sec 0.10.10",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "gix-discover"
-version = "0.37.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.38.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
  "dunce",
- "gix-fs 0.12.1",
- "gix-hash 0.15.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-ref 0.49.1",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-fs 0.13.0",
+ "gix-hash 0.16.0",
+ "gix-path 0.10.14",
+ "gix-ref 0.50.0",
+ "gix-sec 0.10.11",
  "thiserror 2.0.9",
 ]
 
@@ -3380,8 +3380,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac7045ac9fe5f9c727f38799d002a7ed3583cd777e3322a7c4b43e3cf437dc69"
 dependencies = [
  "gix-hash 0.14.2",
- "gix-trace 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-utils 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-trace 0.1.11",
+ "gix-utils 0.1.13",
  "libc",
  "prodash 28.0.0",
  "sha1_smol",
@@ -3390,16 +3390,16 @@ dependencies = [
 
 [[package]]
 name = "gix-features"
-version = "0.39.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.40.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bytes",
  "crc32fast",
  "crossbeam-channel",
  "flate2",
- "gix-hash 0.15.1",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-hash 0.16.0",
+ "gix-trace 0.1.12",
+ "gix-utils 0.1.14",
  "libc",
  "once_cell",
  "parking_lot",
@@ -3412,20 +3412,20 @@ dependencies = [
 
 [[package]]
 name = "gix-filter"
-version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.17.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
  "encoding_rs",
- "gix-attributes 0.23.1",
+ "gix-attributes 0.24.0",
  "gix-command",
- "gix-hash 0.15.1",
- "gix-object 0.46.1",
+ "gix-hash 0.16.0",
+ "gix-object 0.47.0",
  "gix-packetline-blocking",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-path 0.10.14",
+ "gix-quote 0.4.15",
+ "gix-trace 0.1.12",
+ "gix-utils 0.1.14",
  "smallvec",
  "thiserror 2.0.9",
 ]
@@ -3438,17 +3438,17 @@ checksum = "f2bfe6249cfea6d0c0e0990d5226a4cb36f030444ba9e35e0639275db8f98575"
 dependencies = [
  "fastrand",
  "gix-features 0.38.2",
- "gix-utils 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-utils 0.1.13",
 ]
 
 [[package]]
 name = "gix-fs"
-version = "0.12.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.13.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "fastrand",
- "gix-features 0.39.1",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-features 0.40.0",
+ "gix-utils 0.1.14",
 ]
 
 [[package]]
@@ -3460,18 +3460,18 @@ dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "gix-features 0.38.2",
- "gix-path 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-path 0.10.13",
 ]
 
 [[package]]
 name = "gix-glob"
-version = "0.17.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.18.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-features 0.39.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-features 0.40.0",
+ "gix-path 0.10.14",
  "serde",
 ]
 
@@ -3487,8 +3487,8 @@ dependencies = [
 
 [[package]]
 name = "gix-hash"
-version = "0.15.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.16.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "faster-hex",
  "serde",
@@ -3508,10 +3508,10 @@ dependencies = [
 
 [[package]]
 name = "gix-hashtable"
-version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.7.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
- "gix-hash 0.15.1",
+ "gix-hash 0.16.0",
  "hashbrown 0.14.5",
  "parking_lot",
 ]
@@ -3524,20 +3524,20 @@ checksum = "e447cd96598460f5906a0f6c75e950a39f98c2705fc755ad2f2020c9e937fab7"
 dependencies = [
  "bstr",
  "gix-glob 0.16.5",
- "gix-path 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-trace 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-path 0.10.13",
+ "gix-trace 0.1.11",
  "unicode-bom",
 ]
 
 [[package]]
 name = "gix-ignore"
-version = "0.12.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.13.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
- "gix-glob 0.17.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-glob 0.18.0",
+ "gix-path 0.10.14",
+ "gix-trace 0.1.12",
  "serde",
  "unicode-bom",
 ]
@@ -3552,14 +3552,14 @@ dependencies = [
  "bstr",
  "filetime",
  "fnv",
- "gix-bitmap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-bitmap 0.2.13",
  "gix-features 0.38.2",
  "gix-fs 0.11.3",
  "gix-hash 0.14.2",
  "gix-lock 14.0.0",
  "gix-object 0.42.3",
  "gix-traverse 0.39.2",
- "gix-utils 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-utils 0.1.13",
  "gix-validate 0.8.5",
  "hashbrown 0.14.5",
  "itoa 1.0.11",
@@ -3572,22 +3572,22 @@ dependencies = [
 
 [[package]]
 name = "gix-index"
-version = "0.37.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.38.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
  "filetime",
  "fnv",
- "gix-bitmap 0.2.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-features 0.39.1",
- "gix-fs 0.12.1",
- "gix-hash 0.15.1",
- "gix-lock 15.0.1",
- "gix-object 0.46.1",
- "gix-traverse 0.43.1",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-validate 0.9.2",
+ "gix-bitmap 0.2.14",
+ "gix-features 0.40.0",
+ "gix-fs 0.13.0",
+ "gix-hash 0.16.0",
+ "gix-lock 16.0.0",
+ "gix-object 0.47.0",
+ "gix-traverse 0.44.0",
+ "gix-utils 0.1.14",
+ "gix-validate 0.9.3",
  "hashbrown 0.14.5",
  "itoa 1.0.11",
  "libc",
@@ -3605,27 +3605,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bc7fe297f1f4614774989c00ec8b1add59571dc9b024b4c00acb7dedd4e19d"
 dependencies = [
  "gix-tempfile 14.0.2",
- "gix-utils 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-utils 0.1.13",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "gix-lock"
-version = "15.0.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "16.0.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
- "gix-tempfile 15.0.0",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-tempfile 16.0.0",
+ "gix-utils 0.1.14",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-mailmap"
-version = "0.25.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#af704f57bb9480c47cdd393465264d586f1d4562"
+version = "0.25.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
- "gix-actor 0.33.1",
+ "gix-actor 0.33.2",
  "gix-date 0.9.3",
  "serde",
  "thiserror 2.0.9",
@@ -3633,39 +3633,39 @@ dependencies = [
 
 [[package]]
 name = "gix-merge"
-version = "0.2.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.3.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-diff",
  "gix-filter",
- "gix-fs 0.12.1",
- "gix-hash 0.15.1",
- "gix-index 0.37.0",
- "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-fs 0.13.0",
+ "gix-hash 0.16.0",
+ "gix-index 0.38.0",
+ "gix-object 0.47.0",
+ "gix-path 0.10.14",
+ "gix-quote 0.4.15",
  "gix-revision",
- "gix-revwalk 0.17.0",
- "gix-tempfile 15.0.0",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-worktree 0.38.0",
+ "gix-revwalk 0.18.0",
+ "gix-tempfile 16.0.0",
+ "gix-trace 0.1.12",
+ "gix-worktree 0.39.0",
  "imara-diff",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-negotiate"
-version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.18.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bitflags 2.6.0",
- "gix-commitgraph 0.25.1",
+ "gix-commitgraph 0.26.0",
  "gix-date 0.9.3",
- "gix-hash 0.15.1",
- "gix-object 0.46.1",
- "gix-revwalk 0.17.0",
+ "gix-hash 0.16.0",
+ "gix-object 0.47.0",
+ "gix-revwalk 0.18.0",
  "smallvec",
  "thiserror 2.0.9",
 ]
@@ -3681,7 +3681,7 @@ dependencies = [
  "gix-date 0.8.7",
  "gix-features 0.38.2",
  "gix-hash 0.14.2",
- "gix-utils 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-utils 0.1.13",
  "gix-validate 0.8.5",
  "itoa 1.0.11",
  "smallvec",
@@ -3691,18 +3691,18 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.46.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.47.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
- "gix-actor 0.33.1",
+ "gix-actor 0.33.2",
  "gix-date 0.9.3",
- "gix-features 0.39.1",
- "gix-hash 0.15.1",
- "gix-hashtable 0.6.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-validate 0.9.2",
+ "gix-features 0.40.0",
+ "gix-hash 0.16.0",
+ "gix-hashtable 0.7.0",
+ "gix-path 0.10.14",
+ "gix-utils 0.1.14",
+ "gix-validate 0.9.3",
  "itoa 1.0.11",
  "serde",
  "smallvec",
@@ -3712,19 +3712,19 @@ dependencies = [
 
 [[package]]
 name = "gix-odb"
-version = "0.66.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.67.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "arc-swap",
  "gix-date 0.9.3",
- "gix-features 0.39.1",
- "gix-fs 0.12.1",
- "gix-hash 0.15.1",
- "gix-hashtable 0.6.0",
- "gix-object 0.46.1",
+ "gix-features 0.40.0",
+ "gix-fs 0.13.0",
+ "gix-hash 0.16.0",
+ "gix-hashtable 0.7.0",
+ "gix-object 0.47.0",
  "gix-pack",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-path 0.10.14",
+ "gix-quote 0.4.15",
  "parking_lot",
  "serde",
  "tempfile",
@@ -3733,17 +3733,17 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.56.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.57.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "clru",
- "gix-chunk 0.4.10 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-features 0.39.1",
- "gix-hash 0.15.1",
- "gix-hashtable 0.6.0",
- "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-tempfile 15.0.0",
+ "gix-chunk 0.4.11",
+ "gix-features 0.40.0",
+ "gix-hash 0.16.0",
+ "gix-hashtable 0.7.0",
+ "gix-object 0.47.0",
+ "gix-path 0.10.14",
+ "gix-tempfile 16.0.0",
  "memmap2",
  "parking_lot",
  "serde",
@@ -3754,23 +3754,23 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline"
-version = "0.18.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.18.3"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-trace 0.1.12",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-packetline-blocking"
-version = "0.18.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.18.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-trace 0.1.12",
  "thiserror 2.0.9",
 ]
 
@@ -3781,7 +3781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afc292ef1a51e340aeb0e720800338c805975724c1dfbd243185452efd8645b7"
 dependencies = [
  "bstr",
- "gix-trace 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-trace 0.1.11",
  "home",
  "once_cell",
  "thiserror 2.0.9",
@@ -3789,11 +3789,11 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.10.13"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.10.14"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-trace 0.1.12",
  "home",
  "once_cell",
  "thiserror 2.0.9",
@@ -3801,22 +3801,22 @@ dependencies = [
 
 [[package]]
 name = "gix-pathspec"
-version = "0.8.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.9.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-attributes 0.23.1",
+ "gix-attributes 0.24.0",
  "gix-config-value",
- "gix-glob 0.17.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-glob 0.18.0",
+ "gix-path 0.10.14",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-prompt"
-version = "0.9.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.9.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -3827,24 +3827,24 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.47.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.48.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
  "gix-credentials",
  "gix-date 0.9.3",
- "gix-features 0.39.1",
- "gix-hash 0.15.1",
- "gix-lock 15.0.1",
+ "gix-features 0.40.0",
+ "gix-hash 0.16.0",
+ "gix-lock 16.0.0",
  "gix-negotiate",
- "gix-object 0.46.1",
- "gix-ref 0.49.1",
+ "gix-object 0.47.0",
+ "gix-ref 0.50.0",
  "gix-refspec",
- "gix-revwalk 0.17.0",
+ "gix-revwalk 0.18.0",
  "gix-shallow",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-trace 0.1.12",
  "gix-transport",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-utils 0.1.14",
  "maybe-async",
  "serde",
  "thiserror 2.0.9",
@@ -3858,17 +3858,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64a1e282216ec2ab2816cd57e6ed88f8009e634aec47562883c05ac8a7009a63"
 dependencies = [
  "bstr",
- "gix-utils 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-utils 0.1.13",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-quote"
-version = "0.4.14"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.4.15"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-utils 0.1.14",
  "thiserror 2.0.9",
 ]
 
@@ -3885,9 +3885,9 @@ dependencies = [
  "gix-hash 0.14.2",
  "gix-lock 14.0.0",
  "gix-object 0.42.3",
- "gix-path 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-path 0.10.13",
  "gix-tempfile 14.0.2",
- "gix-utils 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-utils 0.1.13",
  "gix-validate 0.8.5",
  "memmap2",
  "thiserror 1.0.69",
@@ -3896,19 +3896,19 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.49.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.50.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
- "gix-actor 0.33.1",
- "gix-features 0.39.1",
- "gix-fs 0.12.1",
- "gix-hash 0.15.1",
- "gix-lock 15.0.1",
- "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-tempfile 15.0.0",
- "gix-utils 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-validate 0.9.2",
+ "gix-actor 0.33.2",
+ "gix-features 0.40.0",
+ "gix-fs 0.13.0",
+ "gix-hash 0.16.0",
+ "gix-lock 16.0.0",
+ "gix-object 0.47.0",
+ "gix-path 0.10.14",
+ "gix-tempfile 16.0.0",
+ "gix-utils 0.1.14",
+ "gix-validate 0.9.3",
  "memmap2",
  "serde",
  "thiserror 2.0.9",
@@ -3917,31 +3917,31 @@ dependencies = [
 
 [[package]]
 name = "gix-refspec"
-version = "0.27.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.28.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
- "gix-hash 0.15.1",
+ "gix-hash 0.16.0",
  "gix-revision",
- "gix-validate 0.9.2",
+ "gix-validate 0.9.3",
  "smallvec",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-revision"
-version = "0.31.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.32.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-commitgraph 0.25.1",
+ "gix-commitgraph 0.26.0",
  "gix-date 0.9.3",
- "gix-hash 0.15.1",
- "gix-hashtable 0.6.0",
- "gix-object 0.46.1",
- "gix-revwalk 0.17.0",
- "gix-trace 0.1.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-hash 0.16.0",
+ "gix-hashtable 0.7.0",
+ "gix-object 0.47.0",
+ "gix-revwalk 0.18.0",
+ "gix-trace 0.1.12",
  "serde",
  "thiserror 2.0.9",
 ]
@@ -3963,14 +3963,14 @@ dependencies = [
 
 [[package]]
 name = "gix-revwalk"
-version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.18.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
- "gix-commitgraph 0.25.1",
+ "gix-commitgraph 0.26.0",
  "gix-date 0.9.3",
- "gix-hash 0.15.1",
- "gix-hashtable 0.6.0",
- "gix-object 0.46.1",
+ "gix-hash 0.16.0",
+ "gix-hashtable 0.7.0",
+ "gix-object 0.47.0",
  "smallvec",
  "thiserror 2.0.9",
 ]
@@ -3982,18 +3982,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8b876ef997a955397809a2ec398d6a45b7a55b4918f2446344330f778d14fd6"
 dependencies = [
  "bitflags 2.6.0",
- "gix-path 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-path 0.10.13",
  "libc",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "gix-sec"
-version = "0.10.10"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.10.11"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bitflags 2.6.0",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-path 0.10.14",
  "libc",
  "serde",
  "windows-sys 0.52.0",
@@ -4001,46 +4001,46 @@ dependencies = [
 
 [[package]]
 name = "gix-shallow"
-version = "0.1.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.2.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
- "gix-hash 0.15.1",
- "gix-lock 15.0.1",
+ "gix-hash 0.16.0",
+ "gix-lock 16.0.0",
  "serde",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-status"
-version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.17.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
  "filetime",
  "gix-diff",
  "gix-dir",
- "gix-features 0.39.1",
+ "gix-features 0.40.0",
  "gix-filter",
- "gix-fs 0.12.1",
- "gix-hash 0.15.1",
- "gix-index 0.37.0",
- "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-fs 0.13.0",
+ "gix-hash 0.16.0",
+ "gix-index 0.38.0",
+ "gix-object 0.47.0",
+ "gix-path 0.10.14",
  "gix-pathspec",
- "gix-worktree 0.38.0",
+ "gix-worktree 0.39.0",
  "portable-atomic",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-submodule"
-version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.17.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
  "gix-config",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-path 0.10.14",
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
@@ -4064,11 +4064,11 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "15.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "16.0.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "dashmap",
- "gix-fs 0.12.1",
+ "gix-fs 0.13.0",
  "libc",
  "once_cell",
  "parking_lot",
@@ -4109,26 +4109,26 @@ checksum = "04bdde120c29f1fc23a24d3e115aeeea3d60d8e65bab92cc5f9d90d9302eb952"
 
 [[package]]
 name = "gix-trace"
-version = "0.1.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.1.12"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "tracing-core",
 ]
 
 [[package]]
 name = "gix-transport"
-version = "0.44.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.45.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "base64 0.22.1",
  "bstr",
  "curl",
  "gix-command",
  "gix-credentials",
- "gix-features 0.39.1",
+ "gix-features 0.40.0",
  "gix-packetline",
- "gix-quote 0.4.14 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-sec 0.10.10 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-quote 0.4.15",
+ "gix-sec 0.10.11",
  "gix-url",
  "serde",
  "thiserror 2.0.9",
@@ -4153,28 +4153,28 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.43.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.44.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bitflags 2.6.0",
- "gix-commitgraph 0.25.1",
+ "gix-commitgraph 0.26.0",
  "gix-date 0.9.3",
- "gix-hash 0.15.1",
- "gix-hashtable 0.6.0",
- "gix-object 0.46.1",
- "gix-revwalk 0.17.0",
+ "gix-hash 0.16.0",
+ "gix-hashtable 0.7.0",
+ "gix-object 0.47.0",
+ "gix-revwalk 0.18.0",
  "smallvec",
  "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "gix-url"
-version = "0.28.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.29.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
- "gix-features 0.39.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+ "gix-features 0.40.0",
+ "gix-path 0.10.14",
  "percent-encoding",
  "serde",
  "thiserror 2.0.9",
@@ -4193,8 +4193,8 @@ dependencies = [
 
 [[package]]
 name = "gix-utils"
-version = "0.1.13"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.1.14"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4213,8 +4213,8 @@ dependencies = [
 
 [[package]]
 name = "gix-validate"
-version = "0.9.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.9.3"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
  "thiserror 2.0.9",
@@ -4235,44 +4235,44 @@ dependencies = [
  "gix-ignore 0.11.4",
  "gix-index 0.33.1",
  "gix-object 0.42.3",
- "gix-path 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-path 0.10.13",
  "gix-validate 0.8.5",
 ]
 
 [[package]]
 name = "gix-worktree"
-version = "0.38.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.39.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
- "gix-attributes 0.23.1",
- "gix-features 0.39.1",
- "gix-fs 0.12.1",
- "gix-glob 0.17.1",
- "gix-hash 0.15.1",
- "gix-ignore 0.12.1",
- "gix-index 0.37.0",
- "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-validate 0.9.2",
+ "gix-attributes 0.24.0",
+ "gix-features 0.40.0",
+ "gix-fs 0.13.0",
+ "gix-glob 0.18.0",
+ "gix-hash 0.16.0",
+ "gix-ignore 0.13.0",
+ "gix-index 0.38.0",
+ "gix-object 0.47.0",
+ "gix-path 0.10.14",
+ "gix-validate 0.9.3",
  "serde",
 ]
 
 [[package]]
 name = "gix-worktree-state"
-version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#c2d1a5d1050212ffae8072314f90613c10200b31"
+version = "0.17.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
 dependencies = [
  "bstr",
- "gix-features 0.39.1",
+ "gix-features 0.40.0",
  "gix-filter",
- "gix-fs 0.12.1",
- "gix-glob 0.17.1",
- "gix-hash 0.15.1",
- "gix-index 0.37.0",
- "gix-object 0.46.1",
- "gix-path 0.10.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
- "gix-worktree 0.38.0",
+ "gix-fs 0.13.0",
+ "gix-glob 0.18.0",
+ "gix-hash 0.16.0",
+ "gix-index 0.38.0",
+ "gix-object 0.47.0",
+ "gix-path 0.10.14",
+ "gix-worktree 0.39.0",
  "io-close",
  "thiserror 2.0.9",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.dependencies]
 bstr = "1.11.1"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
-gix = { git = "https://github.com/GitoxideLabs/gitoxide", branch = "main", default-features = false, features = [
+gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755", default-features = false, features = [
 ] }
 gix-testtools = "0.15.0"
 insta = "1.41.1"

--- a/crates/but-cli/src/args.rs
+++ b/crates/but-cli/src/args.rs
@@ -17,7 +17,11 @@ pub struct Args {
 #[derive(Debug, clap::Subcommand)]
 pub enum Subcommands {
     /// Update the local workspace against an updated remote or target branch.
-    Status,
+    Status {
+        /// Also compute unified diffs for each tree-change.
+        #[clap(long, short = 'd')]
+        unified_diff: bool,
+    },
     /// Returns the list of stacks that are currently part of the GitButler workspace.
     Stacks,
 }

--- a/crates/but-cli/src/command/mod.rs
+++ b/crates/but-cli/src/command/mod.rs
@@ -19,8 +19,23 @@ pub mod status {
     use crate::command::{debug_print, project_repo};
     use std::path::PathBuf;
 
-    pub fn doit(current_dir: PathBuf) -> anyhow::Result<()> {
-        debug_print(but_core::worktree::changes(&project_repo(current_dir)?)?)
+    pub fn doit(current_dir: PathBuf, unified_diff: bool) -> anyhow::Result<()> {
+        let repo = project_repo(current_dir)?;
+        let changes = but_core::worktree::changes(&repo)?;
+        if unified_diff {
+            debug_print(
+                changes
+                    .into_iter()
+                    .map(|tree_change| {
+                        tree_change
+                            .unified_diff(&repo, 3)
+                            .map(|diff| (tree_change, diff))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?,
+            )
+        } else {
+            debug_print(changes)
+        }
     }
 }
 

--- a/crates/but-cli/src/main.rs
+++ b/crates/but-cli/src/main.rs
@@ -15,7 +15,9 @@ fn main() -> Result<()> {
     let _op_span = tracing::info_span!("cli-op").entered();
 
     match args.cmd {
-        args::Subcommands::Status => command::status::doit(args.current_dir),
+        args::Subcommands::Status { unified_diff } => {
+            command::status::doit(args.current_dir, unified_diff)
+        }
         args::Subcommands::Stacks => command::stacks::list(args.current_dir),
     }
 }

--- a/crates/but-core/Cargo.toml
+++ b/crates/but-core/Cargo.toml
@@ -16,4 +16,5 @@ gix = { workspace = true, features = ["dirwalk", "credentials", "parallel", "ser
 
 [dev-dependencies]
 gix-testtools.workspace = true
+gix = { workspace = true, features = ["revision"] }
 insta.workspace = true

--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -36,6 +36,34 @@ use bstr::BString;
 /// Functions related to a Git worktree, i.e. the files checked out from a repository.
 pub mod worktree;
 
+///
+pub mod unified_diff;
+
+/// A patch in unified diff format to show how a resource changed or now looks like (in case it was newly added),
+/// or how it previously looked like in case of a deletion.
+pub enum UnifiedDiff {
+    /// The resource was a binary and couldn't be diffed.
+    Binary,
+    /// The file was too large and couldn't be diffed.
+    TooLarge {
+        /// The size of the file on disk that made it too large.
+        size_in_bytes: u64,
+    },
+    /// A patch that if applied to the previous state of the resource would yield the current state.
+    Patch {
+        /// All non-overlapping hunks, including their context lines.
+        hunks: Vec<unified_diff::DiffHunk>,
+    },
+}
+
+/// The patch that turns the previous version of a resource into the current one.
+pub struct BlobDiff {
+    /// The worktree-relative path at which the diffed blob lives, in the working tree and/or in the repository.
+    pub path: BString,
+    /// All patches along with their context lines, or `None` if the patch could not be created as the content
+    pub hunks: Option<Vec<()>>,
+}
+
 /// An entry in the worktree that changed and thus is eligible to being committed.
 ///
 /// It either lives (or lived) in the in `.git/index`, or in the `worktree`.

--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -36,11 +36,12 @@ use bstr::BString;
 /// Functions related to a Git worktree, i.e. the files checked out from a repository.
 pub mod worktree;
 
-///
+/// utility types
 pub mod unified_diff;
 
 /// A patch in unified diff format to show how a resource changed or now looks like (in case it was newly added),
 /// or how it previously looked like in case of a deletion.
+#[derive(Debug, Clone)]
 pub enum UnifiedDiff {
     /// The resource was a binary and couldn't be diffed.
     Binary,

--- a/crates/but-core/src/unified_diff.rs
+++ b/crates/but-core/src/unified_diff.rs
@@ -1,5 +1,8 @@
-use super::UnifiedDiff;
-use bstr::BString;
+use super::{worktree, UnifiedDiff};
+use bstr::{BStr, BString, ByteSlice};
+use gix::diff::blob::platform::prepare_diff::Operation;
+use gix::diff::blob::unified_diff::ContextSize;
+use gix::diff::blob::ResourceKind;
 
 /// A hunk as used in a [UnifiedDiff].
 #[derive(Debug, Clone)]
@@ -30,202 +33,142 @@ pub struct DiffHunk {
 
 impl UnifiedDiff {
     /// Given a worktree-relative `path` to a resource already tracked in Git, or one that is currently untracked,
-    /// create a patch in unified diff format that turns `previous_state` into `current_state_or_null` with the given
+    /// create a patch in unified diff format that turns `previous_state` into `current_state`, with the given
     /// amount of `context_lines`.
-    /// `current_state_or_null` is either the hash of the state we know the resource currently has, or is a null-hash
-    /// if the current state lives in the filesystem of the current worktree.
-    /// If it is `None`, then there is no current state, and as long as a previous state is given, this will produce a
-    /// unified diff for a deletion.
+    /// If `previous_path` is not `None`, this indicates a rename happened, and would require both states to be given.
+    /// If `None`, both resources are assumed to live in (or have lived in) `path`.
+    /// Note that the path is relevant for reading `.gitattributes`, typically related to worktree or diff filters.
+    ///
+    /// `current_state` is either the state we know the resource currently has, or is `None`, if there is no current state.
     /// `previous_state`, if `None`, indicates the file is new so there is nothing to compare to.
-    /// Otherwise, it's the hash of the previously known state. It is never the null-hash.
+    /// Otherwise, it's the state of the resource as previously known.
     pub fn compute(
         repo: &gix::Repository,
-        path: BString,
-        current_state_or_null: impl Into<Option<gix::ObjectId>>,
-        previous_state: impl Into<Option<gix::ObjectId>>,
-        context_lines: usize,
+        path: &BStr,
+        previous_path: Option<&BStr>,
+        current_state: impl Into<Option<worktree::State>>,
+        previous_state: impl Into<Option<worktree::State>>,
+        context_lines: u32,
     ) -> anyhow::Result<Self> {
-        todo!()
-    }
-}
+        let current_state = current_state.into();
+        let previous_state = previous_state.into();
+        let mut cache = repo.diff_resource_cache(
+            gix::diff::blob::pipeline::Mode::ToGitUnlessBinaryToTextIsPresent,
+            gix::diff::blob::pipeline::WorktreeRoots {
+                old_root: None,
+                new_root: current_state
+                    .filter(|state| state.id.is_null())
+                    .and_then(|_| repo.work_dir().map(ToOwned::to_owned)),
+            },
+        )?;
 
-mod sink {
-    /// Defines the size of the context printed before and after each change.
-    ///
-    /// Similar to the -U option in git diff or gnu-diff. If the context overlaps
-    /// with previous or next change, the context gets reduced accordingly.
-    #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Ord, PartialOrd)]
-    pub struct ContextSize {
-        /// Defines the size of the context printed before and after each change.
-        symmetrical: u32,
-    }
+        cache.set_resource(
+            current_state.map_or(repo.object_hash().null(), |state| state.id),
+            current_state.map_or_else(
+                || {
+                    previous_state
+                        .expect("BUG: at least one non-none state")
+                        .kind
+                },
+                |state| state.kind,
+            ),
+            path.as_bstr(),
+            ResourceKind::NewOrDestination,
+            repo,
+        )?;
+        cache.set_resource(
+            previous_state.map_or(repo.object_hash().null(), |state| state.id),
+            previous_state.map_or_else(
+                || {
+                    current_state
+                        .expect("BUG: at least one non-none state")
+                        .kind
+                },
+                |state| state.kind,
+            ),
+            previous_path.unwrap_or(path.as_bstr()),
+            ResourceKind::OldOrSource,
+            repo,
+        )?;
 
-    impl Default for ContextSize {
-        fn default() -> Self {
-            ContextSize::symmetrical(3)
-        }
-    }
+        let prep = cache.prepare_diff()?;
+        Ok(match prep.operation {
+            Operation::InternalDiff { algorithm } => {
+                #[derive(Default)]
+                struct ProduceDiffHunk {
+                    hunks: Vec<DiffHunk>,
+                }
+                impl gix::diff::blob::unified_diff::ConsumeHunk for ProduceDiffHunk {
+                    type Out = Vec<DiffHunk>;
 
-    /// Instantiation
-    impl ContextSize {
-        /// Create a symmetrical context with `n` lines before and after a changed hunk.
-        pub fn symmetrical(n: u32) -> Self {
-            ContextSize { symmetrical: n }
-        }
-    }
+                    fn consume_hunk(
+                        &mut self,
+                        before_hunk_start: u32,
+                        before_hunk_len: u32,
+                        after_hunk_start: u32,
+                        after_hunk_len: u32,
+                        header: &str,
+                        hunk: &[u8],
+                    ) -> std::io::Result<()> {
+                        self.hunks.push(DiffHunk {
+                            old_start: before_hunk_start,
+                            old_lines: before_hunk_len,
+                            new_start: after_hunk_start,
+                            new_lines: after_hunk_len,
+                            diff: {
+                                let mut buf = Vec::with_capacity(header.len() + hunk.len());
+                                buf.extend_from_slice(header.as_bytes());
+                                buf.extend_from_slice(hunk);
+                                buf.into()
+                            },
+                        });
+                        Ok(())
+                    }
 
-    pub(super) mod _impl {
-        use gix::diff::blob::{intern, Sink};
-        use std::fmt::{Display, Write};
-        use std::hash::Hash;
-        use std::ops::Range;
-
-        use super::ContextSize;
-        use intern::{InternedInput, Interner, Token};
-
-        /// A [`Sink`] that creates a textual diff
-        /// in the format typically output by git or gnu-diff if the `-u` option is used
-        pub struct UnifiedDiffBuilder<'a, W, T>
-        where
-            W: Write,
-            T: Hash + Eq + Display,
-        {
-            before: &'a [Token],
-            after: &'a [Token],
-            interner: &'a Interner<T>,
-
-            pos: u32,
-            before_hunk_start: u32,
-            after_hunk_start: u32,
-            before_hunk_len: u32,
-            after_hunk_len: u32,
-            /// Symmetrical context before and after the changed hunk.
-            ctx_size: u32,
-
-            buffer: String,
-            dst: W,
-        }
-
-        impl<'a, T> UnifiedDiffBuilder<'a, String, T>
-        where
-            T: Hash + Eq + Display,
-        {
-            /// Create a new `UnifiedDiffBuilder` for the given `input`,
-            /// displaying `context_size` lines of context around each change,
-            /// that will return a [`String`].
-            pub fn new(input: &'a InternedInput<T>, context_size: ContextSize) -> Self {
-                Self {
-                    before_hunk_start: 0,
-                    after_hunk_start: 0,
-                    before_hunk_len: 0,
-                    after_hunk_len: 0,
-                    buffer: String::with_capacity(8),
-                    dst: String::new(),
-                    interner: &input.interner,
-                    before: &input.before,
-                    after: &input.after,
-                    pos: 0,
-                    ctx_size: context_size.symmetrical,
+                    fn finish(self) -> Self::Out {
+                        self.hunks
+                    }
+                }
+                let input = prep.interned_input();
+                UnifiedDiff::Patch {
+                    hunks: gix::diff::blob::diff(
+                        algorithm,
+                        &input,
+                        gix::diff::blob::UnifiedDiff::new(
+                            &input,
+                            ProduceDiffHunk::default(),
+                            "\n",
+                            ContextSize::symmetrical(context_lines),
+                        ),
+                    )?,
                 }
             }
-        }
-
-        impl<'a, W, T> UnifiedDiffBuilder<'a, W, T>
-        where
-            W: Write,
-            T: Hash + Eq + Display,
-        {
-            /// Create a new `UnifiedDiffBuilder` for the given `input`,
-            /// displaying `context_size` lines of context around each change,
-            /// that will writes it output to the provided implementation of [`Write`].
-            pub fn with_writer(
-                input: &'a InternedInput<T>,
-                writer: W,
-                context_size: Option<u32>,
-            ) -> Self {
-                Self {
-                    before_hunk_start: 0,
-                    after_hunk_start: 0,
-                    before_hunk_len: 0,
-                    after_hunk_len: 0,
-                    buffer: String::with_capacity(8),
-                    dst: writer,
-                    interner: &input.interner,
-                    before: &input.before,
-                    after: &input.after,
-                    pos: 0,
-                    ctx_size: context_size.unwrap_or(3),
+            Operation::ExternalCommand { .. } => {
+                unreachable!("BUG: `gix` disables this, as it knows we always need to be able to run our own diff machinery")
+            }
+            Operation::SourceOrDestinationIsBinary => {
+                use gix::diff::blob::platform::resource::Data;
+                fn size_for_data(data: Data<'_>) -> Option<u64> {
+                    match data {
+                        Data::Missing | Data::Buffer(_) => None,
+                        Data::Binary { size } => Some(size),
+                    }
+                }
+                let (old, new) = cache
+                    .resources()
+                    .expect("prepare would have failed if a resource is missing");
+                let size = size_for_data(old.data)
+                    .or(size_for_data(new.data))
+                    .expect("BUG: one of the resources must have been binary/too big");
+                let big_file_size = repo.big_file_threshold()?;
+                if size > big_file_size {
+                    UnifiedDiff::TooLarge {
+                        size_in_bytes: size,
+                    }
+                } else {
+                    UnifiedDiff::Binary
                 }
             }
-
-            fn print_tokens(&mut self, tokens: &[Token], prefix: char) {
-                for &token in tokens {
-                    writeln!(&mut self.buffer, "{prefix}{}", self.interner[token]).unwrap();
-                }
-            }
-
-            fn flush(&mut self) {
-                if self.before_hunk_len == 0 && self.after_hunk_len == 0 {
-                    return;
-                }
-
-                let end = (self.pos + self.ctx_size).min(self.before.len() as u32);
-                self.update_pos(end, end);
-
-                writeln!(
-                    &mut self.dst,
-                    "@@ -{},{} +{},{} @@",
-                    self.before_hunk_start + 1,
-                    self.before_hunk_len,
-                    self.after_hunk_start + 1,
-                    self.after_hunk_len,
-                )
-                .unwrap();
-                write!(&mut self.dst, "{}", &self.buffer).unwrap();
-                self.buffer.clear();
-                self.before_hunk_len = 0;
-                self.after_hunk_len = 0
-            }
-
-            fn update_pos(&mut self, print_to: u32, move_to: u32) {
-                self.print_tokens(&self.before[self.pos as usize..print_to as usize], ' ');
-                let len = print_to - self.pos;
-                self.pos = move_to;
-                self.before_hunk_len += len;
-                self.after_hunk_len += len;
-            }
-        }
-
-        impl<W, T> Sink for UnifiedDiffBuilder<'_, W, T>
-        where
-            W: Write,
-            T: Hash + Eq + Display,
-        {
-            type Out = W;
-
-            fn process_change(&mut self, before: Range<u32>, after: Range<u32>) {
-                if ((self.pos == 0) && (before.start - self.pos > self.ctx_size))
-                    || (before.start - self.pos > 2 * self.ctx_size)
-                {
-                    self.flush();
-                    self.pos = before.start - self.ctx_size;
-                    self.before_hunk_start = self.pos;
-                    self.after_hunk_start = after.start - self.ctx_size;
-                }
-                self.update_pos(before.start, before.end);
-                self.before_hunk_len += before.end - before.start;
-                self.after_hunk_len += after.end - after.start;
-                self.print_tokens(
-                    &self.before[before.start as usize..before.end as usize],
-                    '-',
-                );
-                self.print_tokens(&self.after[after.start as usize..after.end as usize], '+');
-            }
-
-            fn finish(mut self) -> Self::Out {
-                self.flush();
-                self.dst
-            }
-        }
+        })
     }
 }

--- a/crates/but-core/src/unified_diff.rs
+++ b/crates/but-core/src/unified_diff.rs
@@ -46,8 +46,8 @@ impl UnifiedDiff {
         repo: &gix::Repository,
         path: &BStr,
         previous_path: Option<&BStr>,
-        current_state: impl Into<Option<worktree::State>>,
-        previous_state: impl Into<Option<worktree::State>>,
+        current_state: impl Into<Option<worktree::ChangeState>>,
+        previous_state: impl Into<Option<worktree::ChangeState>>,
         context_lines: u32,
     ) -> anyhow::Result<Self> {
         let current_state = current_state.into();

--- a/crates/but-core/src/unified_diff.rs
+++ b/crates/but-core/src/unified_diff.rs
@@ -48,3 +48,184 @@ impl UnifiedDiff {
         todo!()
     }
 }
+
+mod sink {
+    /// Defines the size of the context printed before and after each change.
+    ///
+    /// Similar to the -U option in git diff or gnu-diff. If the context overlaps
+    /// with previous or next change, the context gets reduced accordingly.
+    #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Ord, PartialOrd)]
+    pub struct ContextSize {
+        /// Defines the size of the context printed before and after each change.
+        symmetrical: u32,
+    }
+
+    impl Default for ContextSize {
+        fn default() -> Self {
+            ContextSize::symmetrical(3)
+        }
+    }
+
+    /// Instantiation
+    impl ContextSize {
+        /// Create a symmetrical context with `n` lines before and after a changed hunk.
+        pub fn symmetrical(n: u32) -> Self {
+            ContextSize { symmetrical: n }
+        }
+    }
+
+    pub(super) mod _impl {
+        use gix::diff::blob::{intern, Sink};
+        use std::fmt::{Display, Write};
+        use std::hash::Hash;
+        use std::ops::Range;
+
+        use super::ContextSize;
+        use intern::{InternedInput, Interner, Token};
+
+        /// A [`Sink`] that creates a textual diff
+        /// in the format typically output by git or gnu-diff if the `-u` option is used
+        pub struct UnifiedDiffBuilder<'a, W, T>
+        where
+            W: Write,
+            T: Hash + Eq + Display,
+        {
+            before: &'a [Token],
+            after: &'a [Token],
+            interner: &'a Interner<T>,
+
+            pos: u32,
+            before_hunk_start: u32,
+            after_hunk_start: u32,
+            before_hunk_len: u32,
+            after_hunk_len: u32,
+            /// Symmetrical context before and after the changed hunk.
+            ctx_size: u32,
+
+            buffer: String,
+            dst: W,
+        }
+
+        impl<'a, T> UnifiedDiffBuilder<'a, String, T>
+        where
+            T: Hash + Eq + Display,
+        {
+            /// Create a new `UnifiedDiffBuilder` for the given `input`,
+            /// displaying `context_size` lines of context around each change,
+            /// that will return a [`String`].
+            pub fn new(input: &'a InternedInput<T>, context_size: ContextSize) -> Self {
+                Self {
+                    before_hunk_start: 0,
+                    after_hunk_start: 0,
+                    before_hunk_len: 0,
+                    after_hunk_len: 0,
+                    buffer: String::with_capacity(8),
+                    dst: String::new(),
+                    interner: &input.interner,
+                    before: &input.before,
+                    after: &input.after,
+                    pos: 0,
+                    ctx_size: context_size.symmetrical,
+                }
+            }
+        }
+
+        impl<'a, W, T> UnifiedDiffBuilder<'a, W, T>
+        where
+            W: Write,
+            T: Hash + Eq + Display,
+        {
+            /// Create a new `UnifiedDiffBuilder` for the given `input`,
+            /// displaying `context_size` lines of context around each change,
+            /// that will writes it output to the provided implementation of [`Write`].
+            pub fn with_writer(
+                input: &'a InternedInput<T>,
+                writer: W,
+                context_size: Option<u32>,
+            ) -> Self {
+                Self {
+                    before_hunk_start: 0,
+                    after_hunk_start: 0,
+                    before_hunk_len: 0,
+                    after_hunk_len: 0,
+                    buffer: String::with_capacity(8),
+                    dst: writer,
+                    interner: &input.interner,
+                    before: &input.before,
+                    after: &input.after,
+                    pos: 0,
+                    ctx_size: context_size.unwrap_or(3),
+                }
+            }
+
+            fn print_tokens(&mut self, tokens: &[Token], prefix: char) {
+                for &token in tokens {
+                    writeln!(&mut self.buffer, "{prefix}{}", self.interner[token]).unwrap();
+                }
+            }
+
+            fn flush(&mut self) {
+                if self.before_hunk_len == 0 && self.after_hunk_len == 0 {
+                    return;
+                }
+
+                let end = (self.pos + self.ctx_size).min(self.before.len() as u32);
+                self.update_pos(end, end);
+
+                writeln!(
+                    &mut self.dst,
+                    "@@ -{},{} +{},{} @@",
+                    self.before_hunk_start + 1,
+                    self.before_hunk_len,
+                    self.after_hunk_start + 1,
+                    self.after_hunk_len,
+                )
+                .unwrap();
+                write!(&mut self.dst, "{}", &self.buffer).unwrap();
+                self.buffer.clear();
+                self.before_hunk_len = 0;
+                self.after_hunk_len = 0
+            }
+
+            fn update_pos(&mut self, print_to: u32, move_to: u32) {
+                self.print_tokens(&self.before[self.pos as usize..print_to as usize], ' ');
+                let len = print_to - self.pos;
+                self.pos = move_to;
+                self.before_hunk_len += len;
+                self.after_hunk_len += len;
+            }
+        }
+
+        impl<W, T> Sink for UnifiedDiffBuilder<'_, W, T>
+        where
+            W: Write,
+            T: Hash + Eq + Display,
+        {
+            type Out = W;
+
+            fn process_change(&mut self, before: Range<u32>, after: Range<u32>) {
+                if ((self.pos == 0) && (before.start - self.pos > self.ctx_size))
+                    || (before.start - self.pos > 2 * self.ctx_size)
+                {
+                    self.flush();
+                    self.pos = before.start - self.ctx_size;
+                    self.before_hunk_start = self.pos;
+                    self.after_hunk_start = after.start - self.ctx_size;
+                }
+                self.update_pos(before.start, before.end);
+                self.before_hunk_len += before.end - before.start;
+                self.after_hunk_len += after.end - after.start;
+                self.print_tokens(
+                    &self.before[before.start as usize..before.end as usize],
+                    '-',
+                );
+                self.print_tokens(&self.after[after.start as usize..after.end as usize], '+');
+            }
+
+            fn finish(mut self) -> Self::Out {
+                self.flush();
+                self.dst
+            }
+        }
+    }
+}

--- a/crates/but-core/src/unified_diff.rs
+++ b/crates/but-core/src/unified_diff.rs
@@ -1,0 +1,50 @@
+use super::UnifiedDiff;
+use bstr::BString;
+
+/// A hunk as used in a [UnifiedDiff].
+#[derive(Debug, Clone)]
+pub struct DiffHunk {
+    /// The 1-based line number at which the previous version of the file started.
+    pub old_start: u32,
+    /// The non-zero amount of lines included in the previous version of the file.
+    pub old_lines: u32,
+    /// The 1-based line number at which the new version of the file started.
+    pub new_start: u32,
+    /// The non-zero amount of lines included in the new version of the file.
+    pub new_lines: u32,
+    /// A unified-diff formatted patch like:
+    ///
+    /// ```diff
+    /// @@ -1,6 +1,8 @@
+    /// This is the first line of the original text.
+    /// -Line to be removed.
+    /// +Line that has been replaced.
+    ///  This is another line in the file.
+    /// +This is a new line added at the end.
+    /// ```
+    ///
+    /// The line separator is the one used in the original file and may be `LF` or `CRLF`.
+    /// Note that the file-portion of the header isn't used here.
+    pub diff: BString,
+}
+
+impl UnifiedDiff {
+    /// Given a worktree-relative `path` to a resource already tracked in Git, or one that is currently untracked,
+    /// create a patch in unified diff format that turns `previous_state` into `current_state_or_null` with the given
+    /// amount of `context_lines`.
+    /// `current_state_or_null` is either the hash of the state we know the resource currently has, or is a null-hash
+    /// if the current state lives in the filesystem of the current worktree.
+    /// If it is `None`, then there is no current state, and as long as a previous state is given, this will produce a
+    /// unified diff for a deletion.
+    /// `previous_state`, if `None`, indicates the file is new so there is nothing to compare to.
+    /// Otherwise, it's the hash of the previously known state. It is never the null-hash.
+    pub fn compute(
+        repo: &gix::Repository,
+        path: BString,
+        current_state_or_null: impl Into<Option<gix::ObjectId>>,
+        previous_state: impl Into<Option<gix::ObjectId>>,
+        context_lines: usize,
+    ) -> anyhow::Result<Self> {
+        todo!()
+    }
+}

--- a/crates/but-core/src/worktree.rs
+++ b/crates/but-core/src/worktree.rs
@@ -29,7 +29,7 @@ pub enum Status {
     /// A file that was never tracked by Git.
     Untracked {
         /// The kind of file if it was tracked, with unknown content.
-        state: ChangeState,
+        state: State,
     },
     /// Something was added or scheduled to be added.
     Addition {
@@ -39,7 +39,7 @@ pub enum Status {
         /// * If [`Origin::TreeIndex`], then `state` is what has been added to the index and what should be in the next commit.
         origin: Origin,
         /// The current state of what was added or will be added
-        state: ChangeState,
+        state: State,
     },
     /// Something was deleted.
     Deletion {
@@ -49,7 +49,7 @@ pub enum Status {
         /// * If [`Origin::TreeIndex`], then `previous_state` is what was recorded in `HEAD^{tree}` and the entry from the index was deleted.
         origin: Origin,
         /// The that Git stored before the deletion.
-        previous_state: ChangeState,
+        previous_state: State,
     },
     /// A tracked entry was modified, which might mean:
     ///
@@ -64,9 +64,9 @@ pub enum Status {
         /// Where the modification was registered.
         origin: Origin,
         /// The that Git stored before the modification.
-        previous_state: ChangeState,
+        previous_state: State,
         /// The current state, i.e. the modification itself.
-        state: ChangeState,
+        state: State,
     },
     /// An entry was renamed from `previous_path` to its current location.
     ///
@@ -77,9 +77,9 @@ pub enum Status {
         /// The path relative to the repository at which the entry was previously located.
         previous_path: BString,
         /// The that Git stored before the modification.
-        previous_state: ChangeState,
+        previous_state: State,
         /// The current state, i.e. the modification itself.
-        state: ChangeState,
+        state: State,
     },
 }
 
@@ -98,14 +98,14 @@ impl Status {
 
 /// Something that fully identifies the state of a [`TreeChange`].
 #[derive(Debug, Clone, Copy)]
-pub struct ChangeState {
+pub struct State {
     /// The content of the committable.
     ///
     /// If [`null`](gix::ObjectId::is_null), the current state isn't known which can happen
     /// if this state is living in the worktree and has never been hashed.
     pub id: gix::ObjectId,
     /// The kind of the committable.
-    pub kind: gix::object::tree::EntryKind,
+    pub kind: EntryKind,
 }
 
 /// Return a list of [`TreeChange`] that live in the worktree of `repo` that changed and thus can become part of a commit.
@@ -155,7 +155,7 @@ pub fn changes(repo: &gix::Repository) -> anyhow::Result<Vec<TreeChange>> {
             }) => TreeChange {
                 status: Status::Deletion {
                     origin: Origin::TreeIndex,
-                    previous_state: ChangeState {
+                    previous_state: State {
                         id: id.into_owned(),
                         kind: into_tree_entry_kind(entry_mode)?,
                     },
@@ -171,7 +171,7 @@ pub fn changes(repo: &gix::Repository) -> anyhow::Result<Vec<TreeChange>> {
                 path: location.into_owned(),
                 status: Status::Addition {
                     origin: Origin::TreeIndex,
-                    state: ChangeState {
+                    state: State {
                         id: id.into_owned(),
                         kind: into_tree_entry_kind(entry_mode)?,
                     },
@@ -188,11 +188,11 @@ pub fn changes(repo: &gix::Repository) -> anyhow::Result<Vec<TreeChange>> {
                 path: location.into_owned(),
                 status: Status::Modification {
                     origin: Origin::TreeIndex,
-                    previous_state: ChangeState {
+                    previous_state: State {
                         id: previous_id.into_owned(),
                         kind: into_tree_entry_kind(previous_entry_mode)?,
                     },
-                    state: ChangeState {
+                    state: State {
                         id: id.into_owned(),
                         kind: into_tree_entry_kind(entry_mode)?,
                     },
@@ -207,7 +207,7 @@ pub fn changes(repo: &gix::Repository) -> anyhow::Result<Vec<TreeChange>> {
                 path: rela_path,
                 status: Status::Deletion {
                     origin: Origin::IndexWorktree,
-                    previous_state: ChangeState {
+                    previous_state: State {
                         id: entry.id,
                         kind: into_tree_entry_kind(entry.mode)?,
                     },
@@ -222,11 +222,11 @@ pub fn changes(repo: &gix::Repository) -> anyhow::Result<Vec<TreeChange>> {
                 path: rela_path,
                 status: Status::Modification {
                     origin: Origin::IndexWorktree,
-                    previous_state: ChangeState {
+                    previous_state: State {
                         id: entry.id,
                         kind: into_tree_entry_kind(entry.mode)?,
                     },
-                    state: ChangeState {
+                    state: State {
                         // actual state unclear, type changed to something potentially unhashable
                         id: repo.object_hash().null(),
                         kind: into_tree_entry_kind(worktree_mode)?,
@@ -248,14 +248,14 @@ pub fn changes(repo: &gix::Repository) -> anyhow::Result<Vec<TreeChange>> {
                     path: rela_path,
                     status: Status::Modification {
                         origin: Origin::IndexWorktree,
-                        previous_state: ChangeState { id: entry.id, kind },
-                        state: ChangeState {
+                        previous_state: State { id: entry.id, kind },
+                        state: State {
                             id: repo.object_hash().null(),
                             kind: if executable_bit_changed {
-                                if kind == gix::object::tree::EntryKind::BlobExecutable {
-                                    gix::object::tree::EntryKind::Blob
+                                if kind == EntryKind::BlobExecutable {
+                                    EntryKind::Blob
                                 } else {
-                                    gix::object::tree::EntryKind::BlobExecutable
+                                    EntryKind::BlobExecutable
                                 }
                             } else {
                                 kind
@@ -275,7 +275,7 @@ pub fn changes(repo: &gix::Repository) -> anyhow::Result<Vec<TreeChange>> {
                 // as if the whole file was added to the index.
                 status: Status::Addition {
                     origin: Origin::IndexWorktree,
-                    state: ChangeState {
+                    state: State {
                         id: repo.object_hash().null(), /* hash unclear for working tree file */
                         kind: into_tree_entry_kind(entry.mode)?,
                     },
@@ -296,7 +296,7 @@ pub fn changes(repo: &gix::Repository) -> anyhow::Result<Vec<TreeChange>> {
                 status: Status::Untracked {
                     state: match disk_kind_to_entry_kind(disk_kind, index_kind)? {
                         None => continue,
-                        Some(kind) => ChangeState {
+                        Some(kind) => State {
                             id: repo.object_hash().null(),
                             kind,
                         },
@@ -317,11 +317,11 @@ pub fn changes(repo: &gix::Repository) -> anyhow::Result<Vec<TreeChange>> {
                     path: rela_path,
                     status: Status::Modification {
                         origin: Origin::IndexWorktree,
-                        previous_state: ChangeState {
+                        previous_state: State {
                             id: entry.id,
                             kind: into_tree_entry_kind(entry.mode)?,
                         },
-                        state: ChangeState {
+                        state: State {
                             id: checked_out_head_id,
                             kind: into_tree_entry_kind(entry.mode)?,
                         },
@@ -339,7 +339,7 @@ pub fn changes(repo: &gix::Repository) -> anyhow::Result<Vec<TreeChange>> {
                     origin: Origin::IndexWorktree,
                     previous_path: source.rela_path().into(),
                     previous_state: match source {
-                        RewriteSource::RewriteFromIndex { source_entry, .. } => ChangeState {
+                        RewriteSource::RewriteFromIndex { source_entry, .. } => State {
                             id: source_entry.id,
                             kind: into_tree_entry_kind(source_entry.mode)?,
                         },
@@ -347,7 +347,7 @@ pub fn changes(repo: &gix::Repository) -> anyhow::Result<Vec<TreeChange>> {
                             source_dirwalk_entry,
                             source_dirwalk_entry_id,
                             ..
-                        } => ChangeState {
+                        } => State {
                             id: source_dirwalk_entry_id,
                             kind: match disk_kind_to_entry_kind(
                                 source_dirwalk_entry.disk_kind,
@@ -358,7 +358,7 @@ pub fn changes(repo: &gix::Repository) -> anyhow::Result<Vec<TreeChange>> {
                             },
                         },
                     },
-                    state: ChangeState {
+                    state: State {
                         id: dirwalk_entry_id,
                         kind: match disk_kind_to_entry_kind(
                             dirwalk_entry.disk_kind,
@@ -383,11 +383,11 @@ pub fn changes(repo: &gix::Repository) -> anyhow::Result<Vec<TreeChange>> {
                 status: Status::Rename {
                     origin: Origin::TreeIndex,
                     previous_path: source_location.into_owned(),
-                    previous_state: ChangeState {
+                    previous_state: State {
                         id: source_id.into_owned(),
                         kind: into_tree_entry_kind(source_entry_mode)?,
                     },
-                    state: ChangeState {
+                    state: State {
                         id: id.into_owned(),
                         kind: into_tree_entry_kind(entry_mode)?,
                     },
@@ -435,9 +435,7 @@ pub fn changes(repo: &gix::Repository) -> anyhow::Result<Vec<TreeChange>> {
     Ok(out)
 }
 
-fn into_tree_entry_kind(
-    mode: gix::index::entry::Mode,
-) -> anyhow::Result<gix::object::tree::EntryKind> {
+fn into_tree_entry_kind(mode: gix::index::entry::Mode) -> anyhow::Result<EntryKind> {
     Ok(mode
         .to_tree_entry_mode()
         .with_context(|| format!("Entry contained invalid entry mode: {mode:?}"))?
@@ -448,7 +446,7 @@ fn into_tree_entry_kind(
 fn disk_kind_to_entry_kind(
     disk_kind: Option<gix::dir::entry::Kind>,
     index_kind: Option<gix::dir::entry::Kind>,
-) -> anyhow::Result<Option<gix::object::tree::EntryKind>> {
+) -> anyhow::Result<Option<EntryKind>> {
     Ok(Some(
         match disk_kind
             .or(index_kind)

--- a/crates/but-core/tests/core/main.rs
+++ b/crates/but-core/tests/core/main.rs
@@ -1,1 +1,2 @@
+mod unified_diff;
 mod worktree;

--- a/crates/but-core/tests/core/unified_diff.rs
+++ b/crates/but-core/tests/core/unified_diff.rs
@@ -8,7 +8,7 @@ fn file_added_in_worktree() -> anyhow::Result<()> {
         &repo,
         "modified".into(),
         None,
-        worktree::State {
+        worktree::ChangeState {
             id: repo.object_hash().null(),
             kind: EntryKind::Blob,
         },
@@ -37,7 +37,7 @@ fn binary_text_in_unborn() -> anyhow::Result<()> {
         &repo,
         "file.binary".into(),
         None,
-        worktree::State {
+        worktree::ChangeState {
             id: repo.object_hash().null(),
             kind: EntryKind::Blob,
         },
@@ -67,11 +67,11 @@ fn binary_text_renamed_unborn() -> anyhow::Result<()> {
         &repo,
         "after-rename.binary".into(),
         Some("before-rename.binary".into()),
-        worktree::State {
+        worktree::ChangeState {
             id: repo.object_hash().null(),
             kind: EntryKind::Blob,
         },
-        worktree::State {
+        worktree::ChangeState {
             id: repo.rev_parse_single(":before-rename.binary")?.into(),
             kind: EntryKind::Blob,
         },
@@ -96,7 +96,7 @@ fn binary_text_renamed_unborn() -> anyhow::Result<()> {
 fn file_deleted_in_worktree() -> anyhow::Result<()> {
     let repo = crate::worktree::repo("added-modified-in-worktree")?;
     // Pretending there is no current version does the trick.
-    let previous_state = worktree::State {
+    let previous_state = worktree::ChangeState {
         id: repo.rev_parse_single("@:modified")?.into(),
         kind: EntryKind::Blob,
     };
@@ -133,7 +133,7 @@ fn big_file_20_in_worktree() -> anyhow::Result<()> {
         &repo,
         "big".into(),
         None,
-        worktree::State {
+        worktree::ChangeState {
             id: repo.object_hash().null(),
             kind: EntryKind::Blob,
         },
@@ -161,7 +161,7 @@ fn binary_file_in_worktree() -> anyhow::Result<()> {
         &repo,
         "with-null-bytes".into(),
         None,
-        worktree::State {
+        worktree::ChangeState {
             id: repo.object_hash().null(),
             kind: EntryKind::Blob,
         },
@@ -187,11 +187,11 @@ fn symlink_modified_in_worktree() -> anyhow::Result<()> {
         &repo,
         "symlink".into(),
         None,
-        worktree::State {
+        worktree::ChangeState {
             id: repo.object_hash().null(),
             kind: EntryKind::Link,
         },
-        worktree::State {
+        worktree::ChangeState {
             id: repo.rev_parse_single("@:symlink")?.into(),
             kind: EntryKind::Link,
         },

--- a/crates/but-core/tests/core/unified_diff.rs
+++ b/crates/but-core/tests/core/unified_diff.rs
@@ -1,29 +1,220 @@
-use but_core::worktree::changes;
-use but_core::UnifiedDiff;
+use but_core::{unified_diff, worktree, UnifiedDiff};
+use gix::object::tree::EntryKind;
 
 #[test]
-fn untracked_in_unborn() -> anyhow::Result<()> {
-    let repo = crate::worktree::repo("untracked-unborn")?;
-    UnifiedDiff::compute(
+fn file_added_in_worktree() -> anyhow::Result<()> {
+    let repo = crate::worktree::repo("added-modified-in-worktree")?;
+    let actual = extract_patch(UnifiedDiff::compute(
         &repo,
-        "untracked".into(),
-        repo.object_hash().null(),
+        "modified".into(),
+        None,
+        worktree::State {
+            id: repo.object_hash().null(),
+            kind: EntryKind::Blob,
+        },
         None,
         3,
-    )?;
-    let actual = changes(&repo)?;
+    )?);
+
     insta::assert_debug_snapshot!(actual, @r#"
     [
-        WorktreeChange {
-            path: "untracked",
-            status: Untracked {
-                state: ChangeState {
-                    id: Sha1(0000000000000000000000000000000000000000),
-                    kind: Blob,
-                },
-            },
+        DiffHunk {
+            old_start: 1,
+            old_lines: 0,
+            new_start: 1,
+            new_lines: 1,
+            diff: "@@ -1,0 +1,1 @@\n+change\n\n",
         },
     ]
     "#);
     Ok(())
+}
+
+#[test]
+fn binary_text_in_unborn() -> anyhow::Result<()> {
+    let repo = crate::worktree::repo("diff-binary-to-text-unborn")?;
+    let actual = extract_patch(UnifiedDiff::compute(
+        &repo,
+        "file.binary".into(),
+        None,
+        worktree::State {
+            id: repo.object_hash().null(),
+            kind: EntryKind::Blob,
+        },
+        None,
+        3,
+    )?);
+
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        DiffHunk {
+            old_start: 1,
+            old_lines: 0,
+            new_start: 1,
+            new_lines: 1,
+            diff: "@@ -1,0 +1,1 @@\n+hi\n\n",
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn binary_text_renamed_unborn() -> anyhow::Result<()> {
+    let repo = crate::worktree::repo("diff-binary-to-text-renamed-in-worktree")?;
+    // In case of renames, it uses the name of the previous file for attribute lookups.
+    let actual = extract_patch(UnifiedDiff::compute(
+        &repo,
+        "after-rename.binary".into(),
+        Some("before-rename.binary".into()),
+        worktree::State {
+            id: repo.object_hash().null(),
+            kind: EntryKind::Blob,
+        },
+        worktree::State {
+            id: repo.rev_parse_single(":before-rename.binary")?.into(),
+            kind: EntryKind::Blob,
+        },
+        3,
+    )?);
+
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        DiffHunk {
+            old_start: 1,
+            old_lines: 1,
+            new_start: 1,
+            new_lines: 1,
+            diff: "@@ -1,1 +1,1 @@\n-hi\n\n+ho\n\n",
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn file_deleted_in_worktree() -> anyhow::Result<()> {
+    let repo = crate::worktree::repo("added-modified-in-worktree")?;
+    // Pretending there is no current version does the trick.
+    let previous_state = worktree::State {
+        id: repo.rev_parse_single("@:modified")?.into(),
+        kind: EntryKind::Blob,
+    };
+    let no_current_state = None;
+    let actual = extract_patch(UnifiedDiff::compute(
+        &repo,
+        "modified".into(),
+        None,
+        no_current_state,
+        previous_state,
+        3,
+    )?);
+
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        DiffHunk {
+            old_start: 1,
+            old_lines: 1,
+            new_start: 1,
+            new_lines: 0,
+            diff: "@@ -1,1 +1,0 @@\n-something\n\n",
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn big_file_20_in_worktree() -> anyhow::Result<()> {
+    let mut repo = crate::worktree::repo("big-file-20-unborn")?;
+    repo.config_snapshot_mut()
+        .set_value(&gix::config::tree::Core::BIG_FILE_THRESHOLD, "20")?;
+    let actual = UnifiedDiff::compute(
+        &repo,
+        "big".into(),
+        None,
+        worktree::State {
+            id: repo.object_hash().null(),
+            kind: EntryKind::Blob,
+        },
+        None,
+        3,
+    )?;
+    match actual {
+        UnifiedDiff::Binary | UnifiedDiff::Patch { .. } => {
+            unreachable!("Should be considered too large")
+        }
+        UnifiedDiff::TooLarge { size_in_bytes } => {
+            assert_eq!(
+                size_in_bytes, 21,
+                "at this size, it's one too large for the big-file limit"
+            )
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn binary_file_in_worktree() -> anyhow::Result<()> {
+    let repo = crate::worktree::repo("binary-file-unborn")?;
+    let actual = UnifiedDiff::compute(
+        &repo,
+        "with-null-bytes".into(),
+        None,
+        worktree::State {
+            id: repo.object_hash().null(),
+            kind: EntryKind::Blob,
+        },
+        None,
+        3,
+    )?;
+    match actual {
+        UnifiedDiff::TooLarge { .. } | UnifiedDiff::Patch { .. } => {
+            unreachable!("Should be considered binary, but was {actual:?}");
+        }
+        UnifiedDiff::Binary => {
+            // There is no more information here, binary files aren't diffed.
+        }
+    }
+    Ok(())
+}
+
+#[test]
+#[cfg(unix)]
+fn symlink_modified_in_worktree() -> anyhow::Result<()> {
+    let repo = crate::worktree::repo_unix("symlink-change-in-worktree")?;
+    let actual = extract_patch(UnifiedDiff::compute(
+        &repo,
+        "symlink".into(),
+        None,
+        worktree::State {
+            id: repo.object_hash().null(),
+            kind: EntryKind::Link,
+        },
+        worktree::State {
+            id: repo.rev_parse_single("@:symlink")?.into(),
+            kind: EntryKind::Link,
+        },
+        3,
+    )?);
+
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        DiffHunk {
+            old_start: 1,
+            old_lines: 1,
+            new_start: 1,
+            new_lines: 1,
+            diff: "@@ -1,1 +1,1 @@\n-target-to-be-changed\n+changed-target\n",
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+fn extract_patch(diff: UnifiedDiff) -> Vec<unified_diff::DiffHunk> {
+    match diff {
+        UnifiedDiff::Binary | UnifiedDiff::TooLarge { .. } => unreachable!("should have patches"),
+        UnifiedDiff::Patch { hunks } => hunks,
+    }
 }

--- a/crates/but-core/tests/core/unified_diff.rs
+++ b/crates/but-core/tests/core/unified_diff.rs
@@ -1,0 +1,29 @@
+use but_core::worktree::changes;
+use but_core::UnifiedDiff;
+
+#[test]
+fn untracked_in_unborn() -> anyhow::Result<()> {
+    let repo = crate::worktree::repo("untracked-unborn")?;
+    UnifiedDiff::compute(
+        &repo,
+        "untracked".into(),
+        repo.object_hash().null(),
+        None,
+        3,
+    )?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        WorktreeChange {
+            path: "untracked",
+            status: Untracked {
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Blob,
+                },
+            },
+        },
+    ]
+    "#);
+    Ok(())
+}

--- a/crates/but-core/tests/core/worktree.rs
+++ b/crates/but-core/tests/core/worktree.rs
@@ -26,11 +26,11 @@ fn executable_bit_added_in_worktree() -> Result<()> {
             path: "exe",
             status: Modification {
                 origin: IndexWorktree,
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: Blob,
                 },
-                state: State {
+                state: ChangeState {
                     id: Sha1(0000000000000000000000000000000000000000),
                     kind: BlobExecutable,
                 },
@@ -59,11 +59,11 @@ fn executable_bit_removed_in_worktree() -> Result<()> {
             path: "exe",
             status: Modification {
                 origin: IndexWorktree,
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: BlobExecutable,
                 },
-                state: State {
+                state: ChangeState {
                     id: Sha1(0000000000000000000000000000000000000000),
                     kind: Blob,
                 },
@@ -92,11 +92,11 @@ fn executable_bit_removed_in_index() -> Result<()> {
             path: "exe",
             status: Modification {
                 origin: TreeIndex,
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: BlobExecutable,
                 },
-                state: State {
+                state: ChangeState {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: Blob,
                 },
@@ -125,11 +125,11 @@ fn executable_bit_added_in_index() -> Result<()> {
             path: "exe",
             status: Modification {
                 origin: TreeIndex,
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: Blob,
                 },
-                state: State {
+                state: ChangeState {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: BlobExecutable,
                 },
@@ -156,7 +156,7 @@ fn untracked_in_unborn() -> Result<()> {
         TreeChange {
             path: "untracked",
             status: Untracked {
-                state: State {
+                state: ChangeState {
                     id: Sha1(0000000000000000000000000000000000000000),
                     kind: Blob,
                 },
@@ -184,7 +184,7 @@ fn added_in_unborn() -> Result<()> {
             path: "untracked",
             status: Addition {
                 origin: TreeIndex,
-                state: State {
+                state: ChangeState {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: Blob,
                 },
@@ -212,7 +212,7 @@ fn submodule_added_in_unborn() -> Result<()> {
             path: ".gitmodules",
             status: Addition {
                 origin: TreeIndex,
-                state: State {
+                state: ChangeState {
                     id: Sha1(46f8c8b821d79a888a1ea0b30ec9f5d7e90821b0),
                     kind: Blob,
                 },
@@ -222,7 +222,7 @@ fn submodule_added_in_unborn() -> Result<()> {
             path: "submodule",
             status: Addition {
                 origin: TreeIndex,
-                state: State {
+                state: ChangeState {
                     id: Sha1(e95516bd2f49a83a6cdb98cfec40b2717fbc2c1b),
                     kind: Commit,
                 },
@@ -247,11 +247,11 @@ fn submodule_changed_head() -> Result<()> {
             path: "submodule",
             status: Modification {
                 origin: IndexWorktree,
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(e95516bd2f49a83a6cdb98cfec40b2717fbc2c1b),
                     kind: Commit,
                 },
-                state: State {
+                state: ChangeState {
                     id: Sha1(800a5398d76f28db44bc976b561d8885687fd1b6),
                     kind: Commit,
                 },
@@ -281,11 +281,11 @@ fn case_folding_worktree_changes() -> Result<()> {
             path: "FILE",
             status: Modification {
                 origin: IndexWorktree,
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
                     kind: Blob,
                 },
-                state: State {
+                state: ChangeState {
                     id: Sha1(0000000000000000000000000000000000000000),
                     kind: Blob,
                 },
@@ -327,11 +327,11 @@ fn case_folding_worktree_and_index_changes() -> Result<()> {
             path: "FILE",
             status: Modification {
                 origin: TreeIndex,
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
                     kind: Blob,
                 },
-                state: State {
+                state: ChangeState {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: Blob,
                 },
@@ -367,7 +367,7 @@ fn file_to_dir_in_worktree() -> Result<()> {
             path: "file-then-dir",
             status: Deletion {
                 origin: IndexWorktree,
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: Blob,
                 },
@@ -376,7 +376,7 @@ fn file_to_dir_in_worktree() -> Result<()> {
         TreeChange {
             path: "file-then-dir/new-file",
             status: Untracked {
-                state: State {
+                state: ChangeState {
                     id: Sha1(0000000000000000000000000000000000000000),
                     kind: Blob,
                 },
@@ -415,7 +415,7 @@ fn file_to_dir_in_index() -> Result<()> {
             path: "file-then-dir",
             status: Deletion {
                 origin: TreeIndex,
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: Blob,
                 },
@@ -425,7 +425,7 @@ fn file_to_dir_in_index() -> Result<()> {
             path: "file-then-dir/new-file",
             status: Addition {
                 origin: TreeIndex,
-                state: State {
+                state: ChangeState {
                     id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
                     kind: Blob,
                 },
@@ -463,7 +463,7 @@ fn dir_to_file_in_worktree() -> Result<()> {
         TreeChange {
             path: "dir-soon-file",
             status: Untracked {
-                state: State {
+                state: ChangeState {
                     id: Sha1(0000000000000000000000000000000000000000),
                     kind: Blob,
                 },
@@ -473,7 +473,7 @@ fn dir_to_file_in_worktree() -> Result<()> {
             path: "dir-soon-file/file",
             status: Deletion {
                 origin: IndexWorktree,
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: Blob,
                 },
@@ -512,7 +512,7 @@ fn dir_to_file_in_index() -> Result<()> {
             path: "dir-soon-file",
             status: Addition {
                 origin: TreeIndex,
-                state: State {
+                state: ChangeState {
                     id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
                     kind: Blob,
                 },
@@ -522,7 +522,7 @@ fn dir_to_file_in_index() -> Result<()> {
             path: "dir-soon-file/file",
             status: Deletion {
                 origin: TreeIndex,
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: Blob,
                 },
@@ -562,11 +562,11 @@ fn file_to_symlink_in_worktree() -> Result<()> {
             path: "file-soon-symlink",
             status: Modification {
                 origin: IndexWorktree,
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
                     kind: Blob,
                 },
-                state: State {
+                state: ChangeState {
                     id: Sha1(0000000000000000000000000000000000000000),
                     kind: Link,
                 },
@@ -625,11 +625,11 @@ fn file_to_symlink_in_index() -> Result<()> {
             path: "file-soon-symlink",
             status: Modification {
                 origin: TreeIndex,
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
                     kind: Blob,
                 },
-                state: State {
+                state: ChangeState {
                     id: Sha1(cfa0a46515b5e7117875427e7bb0480066d2e380),
                     kind: Link,
                 },
@@ -666,11 +666,11 @@ fn symlink_to_file_in_worktree() -> Result<()> {
             path: "symlink-soon-file",
             status: Modification {
                 origin: IndexWorktree,
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(1de565933b05f74c75ff9a6520af5f9f8a5a2f1d),
                     kind: Link,
                 },
-                state: State {
+                state: ChangeState {
                     id: Sha1(0000000000000000000000000000000000000000),
                     kind: Blob,
                 },
@@ -707,11 +707,11 @@ fn symlink_to_file_in_index() -> Result<()> {
             path: "symlink-soon-file",
             status: Modification {
                 origin: TreeIndex,
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(1de565933b05f74c75ff9a6520af5f9f8a5a2f1d),
                     kind: Link,
                 },
-                state: State {
+                state: ChangeState {
                     id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
                     kind: Blob,
                 },
@@ -747,7 +747,7 @@ fn added_modified_in_worktree() -> Result<()> {
             path: "added",
             status: Addition {
                 origin: TreeIndex,
-                state: State {
+                state: ChangeState {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: Blob,
                 },
@@ -757,11 +757,11 @@ fn added_modified_in_worktree() -> Result<()> {
             path: "intent-to-add",
             status: Modification {
                 origin: IndexWorktree,
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: Blob,
                 },
-                state: State {
+                state: ChangeState {
                     id: Sha1(0000000000000000000000000000000000000000),
                     kind: Blob,
                 },
@@ -771,11 +771,11 @@ fn added_modified_in_worktree() -> Result<()> {
             path: "modified",
             status: Modification {
                 origin: IndexWorktree,
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(deba01fc8d98200761c46eb139f11ac244cf6eb5),
                     kind: Blob,
                 },
-                state: State {
+                state: ChangeState {
                     id: Sha1(0000000000000000000000000000000000000000),
                     kind: Blob,
                 },
@@ -825,11 +825,11 @@ fn modified_in_index() -> Result<()> {
             path: "modified",
             status: Modification {
                 origin: TreeIndex,
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(deba01fc8d98200761c46eb139f11ac244cf6eb5),
                     kind: Blob,
                 },
-                state: State {
+                state: ChangeState {
                     id: Sha1(0835e4f9714005ed591f68d306eea0d6d2ae8fd7),
                     kind: Blob,
                 },
@@ -865,7 +865,7 @@ fn deleted_in_worktree() -> Result<()> {
             path: "deleted",
             status: Deletion {
                 origin: IndexWorktree,
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(deba01fc8d98200761c46eb139f11ac244cf6eb5),
                     kind: Blob,
                 },
@@ -901,7 +901,7 @@ fn deleted_in_index() -> Result<()> {
             path: "deleted",
             status: Deletion {
                 origin: TreeIndex,
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(deba01fc8d98200761c46eb139f11ac244cf6eb5),
                     kind: Blob,
                 },
@@ -938,11 +938,11 @@ fn renamed_in_index() -> Result<()> {
             status: Rename {
                 origin: TreeIndex,
                 previous_path: "to-be-renamed",
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
                     kind: Blob,
                 },
-                state: State {
+                state: ChangeState {
                     id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
                     kind: Blob,
                 },
@@ -971,11 +971,11 @@ fn renamed_in_worktree() -> Result<()> {
             status: Rename {
                 origin: IndexWorktree,
                 previous_path: "to-be-renamed",
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
                     kind: Blob,
                 },
-                state: State {
+                state: ChangeState {
                     id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
                     kind: Blob,
                 },
@@ -1003,11 +1003,11 @@ fn modified_in_index_and_workingtree() -> Result<()> {
             path: "dual-modified",
             status: Modification {
                 origin: IndexWorktree,
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(8ea0713f9d637081cc0098035465c365c0c32949),
                     kind: Blob,
                 },
-                state: State {
+                state: ChangeState {
                     id: Sha1(0000000000000000000000000000000000000000),
                     kind: Blob,
                 },
@@ -1017,11 +1017,11 @@ fn modified_in_index_and_workingtree() -> Result<()> {
             path: "dual-modified",
             status: Modification {
                 origin: TreeIndex,
-                previous_state: State {
+                previous_state: ChangeState {
                     id: Sha1(e79c5e8f964493290a409888d5413a737e8e5dd5),
                     kind: Blob,
                 },
-                state: State {
+                state: ChangeState {
                     id: Sha1(8ea0713f9d637081cc0098035465c365c0c32949),
                     kind: Blob,
                 },

--- a/crates/but-core/tests/core/worktree.rs
+++ b/crates/but-core/tests/core/worktree.rs
@@ -425,6 +425,23 @@ fn file_to_symlink_in_worktree() -> Result<()> {
 }
 
 #[test]
+fn conflict() -> Result<()> {
+    let repo = repo("conflicting")?;
+    let actual = changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    [
+        TreeChange {
+            path: "conflicting",
+            status: Conflict(
+                BothModified,
+            ),
+        },
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
 #[cfg(unix)]
 fn file_to_symlink_in_index() -> Result<()> {
     let repo = repo_unix("file-to-symlink-in-index")?;

--- a/crates/but-core/tests/core/worktree.rs
+++ b/crates/but-core/tests/core/worktree.rs
@@ -726,7 +726,7 @@ fn modified_in_index_and_workingtree() -> Result<()> {
     Ok(())
 }
 
-fn repo(fixture_name: &str) -> anyhow::Result<gix::Repository> {
+pub fn repo(fixture_name: &str) -> anyhow::Result<gix::Repository> {
     let root = gix_testtools::scripted_fixture_read_only("worktree-changes.sh")
         .map_err(anyhow::Error::from_boxed)?;
     let worktree_root = root.join(fixture_name);

--- a/crates/but-core/tests/core/worktree.rs
+++ b/crates/but-core/tests/core/worktree.rs
@@ -25,11 +25,11 @@ fn executable_bit_added_in_worktree() -> Result<()> {
             path: "exe",
             status: Modification {
                 origin: IndexWorktree,
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: Blob,
                 },
-                state: ChangeState {
+                state: State {
                     id: Sha1(0000000000000000000000000000000000000000),
                     kind: BlobExecutable,
                 },
@@ -51,11 +51,11 @@ fn executable_bit_removed_in_worktree() -> Result<()> {
             path: "exe",
             status: Modification {
                 origin: IndexWorktree,
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: BlobExecutable,
                 },
-                state: ChangeState {
+                state: State {
                     id: Sha1(0000000000000000000000000000000000000000),
                     kind: Blob,
                 },
@@ -77,11 +77,11 @@ fn executable_bit_removed_in_index() -> Result<()> {
             path: "exe",
             status: Modification {
                 origin: TreeIndex,
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: BlobExecutable,
                 },
-                state: ChangeState {
+                state: State {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: Blob,
                 },
@@ -103,11 +103,11 @@ fn executable_bit_added_in_index() -> Result<()> {
             path: "exe",
             status: Modification {
                 origin: TreeIndex,
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: Blob,
                 },
-                state: ChangeState {
+                state: State {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: BlobExecutable,
                 },
@@ -127,7 +127,7 @@ fn untracked_in_unborn() -> Result<()> {
         TreeChange {
             path: "untracked",
             status: Untracked {
-                state: ChangeState {
+                state: State {
                     id: Sha1(0000000000000000000000000000000000000000),
                     kind: Blob,
                 },
@@ -148,7 +148,7 @@ fn added_in_unborn() -> Result<()> {
             path: "untracked",
             status: Addition {
                 origin: TreeIndex,
-                state: ChangeState {
+                state: State {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: Blob,
                 },
@@ -169,7 +169,7 @@ fn submodule_added_in_unborn() -> Result<()> {
             path: ".gitmodules",
             status: Addition {
                 origin: TreeIndex,
-                state: ChangeState {
+                state: State {
                     id: Sha1(46f8c8b821d79a888a1ea0b30ec9f5d7e90821b0),
                     kind: Blob,
                 },
@@ -179,7 +179,7 @@ fn submodule_added_in_unborn() -> Result<()> {
             path: "submodule",
             status: Addition {
                 origin: TreeIndex,
-                state: ChangeState {
+                state: State {
                     id: Sha1(e95516bd2f49a83a6cdb98cfec40b2717fbc2c1b),
                     kind: Commit,
                 },
@@ -200,11 +200,11 @@ fn submodule_changed_head() -> Result<()> {
             path: "submodule",
             status: Modification {
                 origin: IndexWorktree,
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(e95516bd2f49a83a6cdb98cfec40b2717fbc2c1b),
                     kind: Commit,
                 },
-                state: ChangeState {
+                state: State {
                     id: Sha1(800a5398d76f28db44bc976b561d8885687fd1b6),
                     kind: Commit,
                 },
@@ -230,11 +230,11 @@ fn case_folding_worktree_changes() -> Result<()> {
             path: "FILE",
             status: Modification {
                 origin: IndexWorktree,
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
                     kind: Blob,
                 },
-                state: ChangeState {
+                state: State {
                     id: Sha1(0000000000000000000000000000000000000000),
                     kind: Blob,
                 },
@@ -261,11 +261,11 @@ fn case_folding_worktree_and_index_changes() -> Result<()> {
             path: "FILE",
             status: Modification {
                 origin: TreeIndex,
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
                     kind: Blob,
                 },
-                state: ChangeState {
+                state: State {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: Blob,
                 },
@@ -286,7 +286,7 @@ fn file_to_dir_in_worktree() -> Result<()> {
             path: "file-then-dir",
             status: Deletion {
                 origin: IndexWorktree,
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: Blob,
                 },
@@ -295,7 +295,7 @@ fn file_to_dir_in_worktree() -> Result<()> {
         TreeChange {
             path: "file-then-dir/new-file",
             status: Untracked {
-                state: ChangeState {
+                state: State {
                     id: Sha1(0000000000000000000000000000000000000000),
                     kind: Blob,
                 },
@@ -316,7 +316,7 @@ fn file_to_dir_in_index() -> Result<()> {
             path: "file-then-dir",
             status: Deletion {
                 origin: TreeIndex,
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: Blob,
                 },
@@ -326,7 +326,7 @@ fn file_to_dir_in_index() -> Result<()> {
             path: "file-then-dir/new-file",
             status: Addition {
                 origin: TreeIndex,
-                state: ChangeState {
+                state: State {
                     id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
                     kind: Blob,
                 },
@@ -346,7 +346,7 @@ fn dir_to_file_in_worktree() -> Result<()> {
         TreeChange {
             path: "dir-soon-file",
             status: Untracked {
-                state: ChangeState {
+                state: State {
                     id: Sha1(0000000000000000000000000000000000000000),
                     kind: Blob,
                 },
@@ -356,7 +356,7 @@ fn dir_to_file_in_worktree() -> Result<()> {
             path: "dir-soon-file/file",
             status: Deletion {
                 origin: IndexWorktree,
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: Blob,
                 },
@@ -377,7 +377,7 @@ fn dir_to_file_in_index() -> Result<()> {
             path: "dir-soon-file",
             status: Addition {
                 origin: TreeIndex,
-                state: ChangeState {
+                state: State {
                     id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
                     kind: Blob,
                 },
@@ -387,7 +387,7 @@ fn dir_to_file_in_index() -> Result<()> {
             path: "dir-soon-file/file",
             status: Deletion {
                 origin: TreeIndex,
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: Blob,
                 },
@@ -409,11 +409,11 @@ fn file_to_symlink_in_worktree() -> Result<()> {
             path: "file-soon-symlink",
             status: Modification {
                 origin: IndexWorktree,
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
                     kind: Blob,
                 },
-                state: ChangeState {
+                state: State {
                     id: Sha1(0000000000000000000000000000000000000000),
                     kind: Link,
                 },
@@ -452,11 +452,11 @@ fn file_to_symlink_in_index() -> Result<()> {
             path: "file-soon-symlink",
             status: Modification {
                 origin: TreeIndex,
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
                     kind: Blob,
                 },
-                state: ChangeState {
+                state: State {
                     id: Sha1(cfa0a46515b5e7117875427e7bb0480066d2e380),
                     kind: Link,
                 },
@@ -478,11 +478,11 @@ fn symlink_to_file_in_worktree() -> Result<()> {
             path: "symlink-soon-file",
             status: Modification {
                 origin: IndexWorktree,
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(1de565933b05f74c75ff9a6520af5f9f8a5a2f1d),
                     kind: Link,
                 },
-                state: ChangeState {
+                state: State {
                     id: Sha1(0000000000000000000000000000000000000000),
                     kind: Blob,
                 },
@@ -504,11 +504,11 @@ fn symlink_to_file_in_index() -> Result<()> {
             path: "symlink-soon-file",
             status: Modification {
                 origin: TreeIndex,
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(1de565933b05f74c75ff9a6520af5f9f8a5a2f1d),
                     kind: Link,
                 },
-                state: ChangeState {
+                state: State {
                     id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
                     kind: Blob,
                 },
@@ -529,7 +529,7 @@ fn added_modified_in_worktree() -> Result<()> {
             path: "added",
             status: Addition {
                 origin: TreeIndex,
-                state: ChangeState {
+                state: State {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: Blob,
                 },
@@ -539,11 +539,11 @@ fn added_modified_in_worktree() -> Result<()> {
             path: "intent-to-add",
             status: Modification {
                 origin: IndexWorktree,
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
                     kind: Blob,
                 },
-                state: ChangeState {
+                state: State {
                     id: Sha1(0000000000000000000000000000000000000000),
                     kind: Blob,
                 },
@@ -553,11 +553,11 @@ fn added_modified_in_worktree() -> Result<()> {
             path: "modified",
             status: Modification {
                 origin: IndexWorktree,
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(deba01fc8d98200761c46eb139f11ac244cf6eb5),
                     kind: Blob,
                 },
-                state: ChangeState {
+                state: State {
                     id: Sha1(0000000000000000000000000000000000000000),
                     kind: Blob,
                 },
@@ -578,11 +578,11 @@ fn modified_in_index() -> Result<()> {
             path: "modified",
             status: Modification {
                 origin: TreeIndex,
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(deba01fc8d98200761c46eb139f11ac244cf6eb5),
                     kind: Blob,
                 },
-                state: ChangeState {
+                state: State {
                     id: Sha1(0835e4f9714005ed591f68d306eea0d6d2ae8fd7),
                     kind: Blob,
                 },
@@ -603,7 +603,7 @@ fn deleted_in_worktree() -> Result<()> {
             path: "deleted",
             status: Deletion {
                 origin: IndexWorktree,
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(deba01fc8d98200761c46eb139f11ac244cf6eb5),
                     kind: Blob,
                 },
@@ -624,7 +624,7 @@ fn deleted_in_index() -> Result<()> {
             path: "deleted",
             status: Deletion {
                 origin: TreeIndex,
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(deba01fc8d98200761c46eb139f11ac244cf6eb5),
                     kind: Blob,
                 },
@@ -646,11 +646,11 @@ fn renamed_in_index() -> Result<()> {
             status: Rename {
                 origin: TreeIndex,
                 previous_path: "to-be-renamed",
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
                     kind: Blob,
                 },
-                state: ChangeState {
+                state: State {
                     id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
                     kind: Blob,
                 },
@@ -672,11 +672,11 @@ fn renamed_in_worktree() -> Result<()> {
             status: Rename {
                 origin: IndexWorktree,
                 previous_path: "to-be-renamed",
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
                     kind: Blob,
                 },
-                state: ChangeState {
+                state: State {
                     id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
                     kind: Blob,
                 },
@@ -697,11 +697,11 @@ fn modified_in_index_and_workingtree() -> Result<()> {
             path: "dual-modified",
             status: Modification {
                 origin: IndexWorktree,
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(8ea0713f9d637081cc0098035465c365c0c32949),
                     kind: Blob,
                 },
-                state: ChangeState {
+                state: State {
                     id: Sha1(0000000000000000000000000000000000000000),
                     kind: Blob,
                 },
@@ -711,11 +711,11 @@ fn modified_in_index_and_workingtree() -> Result<()> {
             path: "dual-modified",
             status: Modification {
                 origin: TreeIndex,
-                previous_state: ChangeState {
+                previous_state: State {
                     id: Sha1(e79c5e8f964493290a409888d5413a737e8e5dd5),
                     kind: Blob,
                 },
-                state: ChangeState {
+                state: State {
                     id: Sha1(8ea0713f9d637081cc0098035465c365c0c32949),
                     kind: Blob,
                 },
@@ -733,7 +733,7 @@ pub fn repo(fixture_name: &str) -> anyhow::Result<gix::Repository> {
     Ok(gix::open(worktree_root)?)
 }
 
-fn repo_unix(fixture_name: &str) -> anyhow::Result<gix::Repository> {
+pub fn repo_unix(fixture_name: &str) -> anyhow::Result<gix::Repository> {
     let root = gix_testtools::scripted_fixture_read_only("worktree-changes-unix.sh")
         .map_err(anyhow::Error::from_boxed)?;
     let worktree_root = root.join(fixture_name);

--- a/crates/but-core/tests/fixtures/worktree-changes-unix.sh
+++ b/crates/but-core/tests/fixtures/worktree-changes-unix.sh
@@ -59,3 +59,10 @@ cp -Rv file-to-symlink-in-worktree file-to-symlink-in-index
 (cd file-to-symlink-in-index
   git add .
 )
+
+git init symlink-change-in-worktree
+(cd symlink-change-in-worktree
+  ln -s target-to-be-changed symlink
+  git add . && git commit -m "init"
+  rm symlink && ln -s changed-target symlink
+)

--- a/crates/but-core/tests/fixtures/worktree-changes.sh
+++ b/crates/but-core/tests/fixtures/worktree-changes.sh
@@ -143,3 +143,40 @@ git init conflicting
 100644 $b 3	conflicting
 EOF
 )
+
+git init big-file-20-unborn
+(cd big-file-20-unborn
+  seq 10 >big
+)
+
+git init binary-file-unborn
+(cd binary-file-unborn
+  printf '\0hi\0' >with-null-bytes
+)
+
+git init diff-binary-to-text-unborn
+(cd diff-binary-to-text-unborn
+  printf '\0hi\0' >file.binary
+  echo "*.binary diff=say-hi" >.gitattributes
+
+cat <<EOF >>.git/config
+[diff "say-hi"]
+	textconv = "shift; echo hi"
+EOF
+)
+
+git init diff-binary-to-text-renamed-in-worktree
+(cd diff-binary-to-text-renamed-in-worktree
+  printf '\0hi\0' >before-rename.binary
+  echo "before-rename.binary diff=say-hi" >.gitattributes
+  echo "after-rename.binary diff=say-ho" >>.gitattributes
+  git add .
+  mv before-rename.binary after-rename.binary
+
+cat <<EOF >>.git/config
+[diff "say-hi"]
+	textconv = "shift; echo hi"
+[diff "say-ho"]
+	textconv = "shift; echo ho"
+EOF
+)

--- a/crates/but-core/tests/fixtures/worktree-changes.sh
+++ b/crates/but-core/tests/fixtures/worktree-changes.sh
@@ -129,3 +129,17 @@ cp -Rv case-folding-worktree-changes case-folding-worktree-and-index-changes
 100644 $empty_oid	FILE
 EOF
 )
+
+git init conflicting
+(cd conflicting
+  touch unrelated && git add . && git commit -m "init"
+
+  empty=$(git hash-object -w --stdin </dev/null)
+  a=$(echo "a" | git hash-object -w --stdin)
+  b=$(echo "b" | git hash-object -w --stdin)
+  git update-index --index-info <<EOF
+100644 $empty 1	conflicting
+100644 $a 2	conflicting
+100644 $b 3	conflicting
+EOF
+)

--- a/crates/gitbutler-cli/Cargo.toml
+++ b/crates/gitbutler-cli/Cargo.toml
@@ -19,6 +19,7 @@ gitbutler-command-context.workspace = true
 gitbutler-branch.workspace = true
 gitbutler-diff.workspace = true
 gitbutler-stack.workspace = true
+gitbutler-oxidize.workspace = true
 gix = { workspace = true, features = ["max-performance", "tracing"] }
 dirs-next = "2.0.0"
 clap = { version = "4.5.23", features = ["derive", "env"] }

--- a/crates/gitbutler-cli/src/args.rs
+++ b/crates/gitbutler-cli/src/args.rs
@@ -71,6 +71,11 @@ pub mod vbranch {
             /// The name of the remote branch to integrate with, like `origin/main`.
             short_tracking_branch_name: String,
         },
+        /// List all changes of a commit, along with their patches.
+        ListCommitFiles {
+            /// The hex-id of the commit to produce information for.
+            commit_id: String,
+        },
         /// Make the named branch the default so all worktree or index changes are associated with it automatically.
         SetDefault {
             /// The name of the new default virtual branch.

--- a/crates/gitbutler-cli/src/command/vbranch.rs
+++ b/crates/gitbutler-cli/src/command/vbranch.rs
@@ -2,11 +2,20 @@ use anyhow::{bail, Context, Result};
 use gitbutler_branch::{BranchCreateRequest, BranchIdentity, BranchUpdateRequest};
 use gitbutler_branch_actions::{get_branch_listing_details, list_branches, BranchManagerExt};
 use gitbutler_command_context::CommandContext;
+use gitbutler_oxidize::ObjectIdExt;
 use gitbutler_project::Project;
 use gitbutler_reference::{LocalRefname, Refname};
 use gitbutler_stack::{Stack, VirtualBranchesHandle};
 
 use crate::command::debug_print;
+
+pub fn list_commit_files(project: Project, commit_id_hex: String) -> Result<()> {
+    let commit_id = gix::ObjectId::from_hex(commit_id_hex.as_bytes())?;
+    debug_print(gitbutler_branch_actions::list_commit_files(
+        &project,
+        commit_id.to_git2(),
+    )?)
+}
 
 pub fn set_base(project: Project, short_tracking_branch_name: String) -> Result<()> {
     let branch_name = format!("refs/remotes/{}", short_tracking_branch_name)

--- a/crates/gitbutler-cli/src/main.rs
+++ b/crates/gitbutler-cli/src/main.rs
@@ -32,6 +32,9 @@ fn main() -> Result<()> {
         args::Subcommands::Branch(vbranch::Platform { cmd }) => {
             let project = command::prepare::project_from_path(args.current_dir)?;
             match cmd {
+                Some(vbranch::SubCommands::ListCommitFiles { commit_id }) => {
+                    command::vbranch::list_commit_files(project, commit_id)
+                }
                 Some(vbranch::SubCommands::SetBase {
                     short_tracking_branch_name,
                 }) => command::vbranch::set_base(project, short_tracking_branch_name),

--- a/crates/gitbutler-serde/src/bstring.rs
+++ b/crates/gitbutler-serde/src/bstring.rs
@@ -1,5 +1,5 @@
 use bstr::{BStr, BString, ByteSlice};
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::ops::{Deref, DerefMut};
 
 /// A form of `BString` for use in structures that are going to be serialized for the frontend as string.
@@ -18,6 +18,15 @@ impl Serialize for BStringForFrontend {
         S: Serializer,
     {
         self.0.to_str_lossy().serialize(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for BStringForFrontend {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        String::deserialize(deserializer).map(Into::into)
     }
 }
 

--- a/crates/gitbutler-tauri/src/diff.rs
+++ b/crates/gitbutler-tauri/src/diff.rs
@@ -5,9 +5,10 @@ use gitbutler_serde::BStringForFrontend;
 use serde::Serialize;
 use tracing::instrument;
 
+/// The array of unified diffs matches `changes`, so that `result[n] = unified_diff_of(changes[n])`.
 #[tauri::command(async)]
 #[instrument(skip(projects, changes), err(Debug))]
-pub fn unified_diffs(
+pub fn tree_change_diffs(
     projects: tauri::State<'_, gitbutler_project::Controller>,
     project_id: ProjectId,
     changes: Vec<TreeChange>,

--- a/crates/gitbutler-tauri/src/diff.rs
+++ b/crates/gitbutler-tauri/src/diff.rs
@@ -1,0 +1,81 @@
+use crate::error::Error;
+use crate::worktree::TreeChange;
+use gitbutler_project::ProjectId;
+use gitbutler_serde::BStringForFrontend;
+use serde::Serialize;
+use tracing::instrument;
+
+#[tauri::command(async)]
+#[instrument(skip(projects, changes), err(Debug))]
+pub fn unified_diffs(
+    projects: tauri::State<'_, gitbutler_project::Controller>,
+    project_id: ProjectId,
+    changes: Vec<TreeChange>,
+) -> anyhow::Result<Vec<UnifiedDiff>, Error> {
+    let project = projects.get(project_id)?;
+    let repo = gix::open(project.path).map_err(anyhow::Error::from)?;
+
+    Ok(changes
+        .into_iter()
+        .map(|tree_change| tree_change.unified_diff(&repo))
+        .collect::<Result<Vec<_>, _>>()?)
+}
+
+/// A frontend version of [`but_core::unified_diff::DiffHunk`].
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiffHunk {
+    pub old_start: u32,
+    pub old_lines: u32,
+    pub new_start: u32,
+    pub new_lines: u32,
+    pub diff: BStringForFrontend,
+}
+
+impl From<but_core::unified_diff::DiffHunk> for DiffHunk {
+    fn from(
+        but_core::unified_diff::DiffHunk {
+            old_start,
+            old_lines,
+            new_start,
+            new_lines,
+            diff,
+        }: but_core::unified_diff::DiffHunk,
+    ) -> Self {
+        DiffHunk {
+            old_start,
+            old_lines,
+            new_start,
+            new_lines,
+            diff: diff.into(),
+        }
+    }
+}
+
+/// The frontend version of [`but_core::UnifiedDiff`].
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", content = "subject", rename_all = "camelCase")]
+pub enum UnifiedDiff {
+    Binary,
+    TooLarge {
+        #[serde(rename = "sizeInBytes")]
+        size_in_bytes: u64,
+    },
+    Patch {
+        hunks: Vec<DiffHunk>,
+    },
+}
+
+impl From<but_core::UnifiedDiff> for UnifiedDiff {
+    fn from(value: but_core::UnifiedDiff) -> Self {
+        match value {
+            but_core::UnifiedDiff::Binary => UnifiedDiff::Binary,
+            but_core::UnifiedDiff::TooLarge { size_in_bytes } => {
+                UnifiedDiff::TooLarge { size_in_bytes }
+            }
+            but_core::UnifiedDiff::Patch { hunks } => UnifiedDiff::Patch {
+                hunks: hunks.into_iter().map(Into::into).collect(),
+            },
+        }
+    }
+}

--- a/crates/gitbutler-tauri/src/lib.rs
+++ b/crates/gitbutler-tauri/src/lib.rs
@@ -41,5 +41,6 @@ pub mod settings;
 pub mod stack;
 pub mod zip;
 
+pub mod diff;
 pub mod workspace;
 pub mod worktree;

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -14,8 +14,8 @@
 use gitbutler_settings::AppSettingsWithDiskSync;
 use gitbutler_tauri::settings::SettingsStore;
 use gitbutler_tauri::{
-    askpass, commands, config, forge, github, logs, menu, modes, open, projects, remotes, repo,
-    secret, settings, stack, undo, users, virtual_branches, workspace, worktree, zip, App,
+    askpass, commands, config, diff, forge, github, logs, menu, modes, open, projects, remotes,
+    repo, secret, settings, stack, undo, users, virtual_branches, workspace, worktree, zip, App,
     WindowState,
 };
 use tauri::Emitter;
@@ -248,7 +248,8 @@ fn main() {
                     settings::update_onboarding_complete,
                     settings::update_telemetry,
                     workspace::stacks,
-                    worktree::worktree_changes
+                    worktree::worktree_changes,
+                    diff::unified_diffs
                 ])
                 .menu(menu::build)
                 .on_window_event(|window, event| match event {

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -249,7 +249,7 @@ fn main() {
                     settings::update_telemetry,
                     workspace::stacks,
                     worktree::worktree_changes,
-                    diff::unified_diffs
+                    diff::tree_change_diffs
                 ])
                 .menu(menu::build)
                 .on_window_event(|window, event| match event {

--- a/crates/gitbutler-tauri/src/worktree/mod.rs
+++ b/crates/gitbutler-tauri/src/worktree/mod.rs
@@ -1,11 +1,11 @@
 use crate::error::Error;
 use gitbutler_project::ProjectId;
 use gitbutler_serde::BStringForFrontend;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use tracing::instrument;
 
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct ChangeState {
     #[serde(with = "gitbutler_serde::object_id")]
     id: gix::ObjectId,
@@ -18,10 +18,19 @@ impl From<but_core::worktree::State> for ChangeState {
     }
 }
 
+impl From<ChangeState> for but_core::worktree::State {
+    fn from(value: ChangeState) -> Self {
+        but_core::worktree::State {
+            id: value.id,
+            kind: value.kind,
+        }
+    }
+}
+
 /// Computed using the file kinds/modes of two [`ChangeState`] instances to represent
 /// the *dominant* change to display. Note that it can stack with a content change,
 /// but *should not only in case of a `TypeChange*`*.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Flags {
     ExecutableBitAdded,
     ExecutableBitRemoved,
@@ -52,7 +61,7 @@ impl Flags {
 }
 
 /// For docs, see [`but_core::worktree::Status`].
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", content = "subject")]
 pub enum Status {
     Addition {
@@ -124,7 +133,7 @@ impl From<but_core::worktree::Status> for Status {
 }
 
 /// For documentation, see [`but_core::Change`].
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TreeChange {
     path: BStringForFrontend,
     status: Status,
@@ -136,6 +145,63 @@ impl From<but_core::TreeChange> for TreeChange {
             path: path.into(),
             status: status.into(),
         }
+    }
+}
+
+impl TreeChange {
+    /// Obtain a unified diff by comparing the previous and current state of this change,
+    /// using `repo` to retrieve objects or for obtaining a working tree to read files from disk.
+    pub fn unified_diff(&self, repo: &gix::Repository) -> anyhow::Result<crate::diff::UnifiedDiff> {
+        use gix::bstr::ByteSlice;
+        let context_lines = 3;
+        let diff = match &self.status {
+            Status::Addition {
+                state,
+                is_untracked: _,
+            } => but_core::UnifiedDiff::compute(
+                repo,
+                self.path.as_bstr(),
+                None,
+                Some((*state).into()),
+                None,
+                context_lines,
+            ),
+            Status::Deletion { previous_state } => but_core::UnifiedDiff::compute(
+                repo,
+                self.path.as_bstr(),
+                None,
+                None,
+                Some((*previous_state).into()),
+                context_lines,
+            ),
+            Status::Modification {
+                state,
+                previous_state,
+                flags: _,
+            } => but_core::UnifiedDiff::compute(
+                repo,
+                self.path.as_bstr(),
+                None,
+                Some((*state).into()),
+                Some((*previous_state).into()),
+                context_lines,
+            ),
+            Status::Rename {
+                previous_path,
+                previous_state,
+                state,
+                flags: _,
+            } => but_core::UnifiedDiff::compute(
+                repo,
+                self.path.as_bstr(),
+                Some(previous_path.as_bstr()),
+                Some((*state).into()),
+                Some((*previous_state).into()),
+                context_lines,
+            ),
+        }?
+        .into();
+        Ok(diff)
     }
 }
 

--- a/crates/gitbutler-tauri/src/worktree/mod.rs
+++ b/crates/gitbutler-tauri/src/worktree/mod.rs
@@ -12,8 +12,8 @@ pub struct ChangeState {
     kind: gix::object::tree::EntryKind,
 }
 
-impl From<but_core::worktree::ChangeState> for ChangeState {
-    fn from(but_core::worktree::ChangeState { id, kind }: but_core::worktree::ChangeState) -> Self {
+impl From<but_core::worktree::State> for ChangeState {
+    fn from(but_core::worktree::State { id, kind }: but_core::worktree::State) -> Self {
         ChangeState { id, kind }
     }
 }
@@ -31,10 +31,7 @@ pub enum Flags {
 }
 
 impl Flags {
-    fn calculate(
-        old: &but_core::worktree::ChangeState,
-        new: &but_core::worktree::ChangeState,
-    ) -> Option<Self> {
+    fn calculate(old: &but_core::worktree::State, new: &but_core::worktree::State) -> Option<Self> {
         Self::calculate_inner(old.kind, new.kind)
     }
 

--- a/crates/gitbutler-tauri/src/worktree/tests.rs
+++ b/crates/gitbutler-tauri/src/worktree/tests.rs
@@ -251,3 +251,129 @@ fn worktree_changes_example() -> anyhow::Result<()> {
     "#);
     Ok(())
 }
+
+#[test]
+fn worktree_changes_unified_diffs_json_example() -> anyhow::Result<()> {
+    let root = gitbutler_testsupport::gix_testtools::scripted_fixture_read_only("status_repo.sh")
+        .map_err(anyhow::Error::from_boxed)?;
+    let repo = gix::open(&root)?;
+    let diffs: Vec<crate::diff::UnifiedDiff> = changes_in_worktree(root)?
+        .changes
+        .iter()
+        .map(|tree_change| tree_change.unified_diff(&repo))
+        .collect::<Result<_, _>>()?;
+    let actual = serde_json::to_string_pretty(&diffs)?;
+    insta::assert_snapshot!(actual, @r#"
+    [
+      {
+        "type": "patch",
+        "subject": {
+          "hunks": [
+            {
+              "oldStart": 1,
+              "oldLines": 0,
+              "newStart": 1,
+              "newLines": 1,
+              "diff": "@@ -1,0 +1,1 @@\n+content\n\n"
+            }
+          ]
+        }
+      },
+      {
+        "type": "patch",
+        "subject": {
+          "hunks": []
+        }
+      },
+      {
+        "type": "patch",
+        "subject": {
+          "hunks": [
+            {
+              "oldStart": 1,
+              "oldLines": 0,
+              "newStart": 1,
+              "newLines": 1,
+              "diff": "@@ -1,0 +1,1 @@\n+link-target\n"
+            }
+          ]
+        }
+      },
+      {
+        "type": "patch",
+        "subject": {
+          "hunks": [
+            {
+              "oldStart": 1,
+              "oldLines": 0,
+              "newStart": 1,
+              "newLines": 1,
+              "diff": "@@ -1,0 +1,1 @@\n+content not to add to the index\n\n"
+            }
+          ]
+        }
+      },
+      {
+        "type": "patch",
+        "subject": {
+          "hunks": [
+            {
+              "oldStart": 1,
+              "oldLines": 0,
+              "newStart": 1,
+              "newLines": 1,
+              "diff": "@@ -1,0 +1,1 @@\n+change-in-index\n\n"
+            }
+          ]
+        }
+      },
+      {
+        "type": "patch",
+        "subject": {
+          "hunks": [
+            {
+              "oldStart": 1,
+              "oldLines": 0,
+              "newStart": 1,
+              "newLines": 1,
+              "diff": "@@ -1,0 +1,1 @@\n+change-in-worktree\n\n"
+            }
+          ]
+        }
+      },
+      {
+        "type": "patch",
+        "subject": {
+          "hunks": []
+        }
+      },
+      {
+        "type": "patch",
+        "subject": {
+          "hunks": [
+            {
+              "oldStart": 1,
+              "oldLines": 0,
+              "newStart": 1,
+              "newLines": 1,
+              "diff": "@@ -1,0 +1,1 @@\n+worktree-change\n\n"
+            }
+          ]
+        }
+      },
+      {
+        "type": "patch",
+        "subject": {
+          "hunks": []
+        }
+      },
+      {
+        "type": "patch",
+        "subject": {
+          "hunks": []
+        }
+      }
+    ]
+    "#);
+    Ok(())
+}


### PR DESCRIPTION
Add a tauri-callable function to produce a patch from information that was returned by `but_core::workspace::changes()`.

Follow-up of #5945.

### Tasks

* [x] find the right abstractions - what's native diff output, what's processed for frontend
* [x] `but_core::workspace::unified_diff()
    - [x] test patch creation with overlapping context
    - [x] test symlink diffing
    - [x] deleted files must be convenient
    - [x] test rename
    - [x] diff with diff filtering
    - [x] big file
    - [x] binary file
* [x] tauri bindings
* [x] `but status` with `--patch` 
* [x] Don't forget: update `gitoxide` to use latest from `main`