### PR TITLE
Only create project if required

### DIFF
--- a/apps/desktop/src/components/BranchListingSidebarEntry.svelte
+++ b/apps/desktop/src/components/BranchListingSidebarEntry.svelte
@@ -100,11 +100,11 @@
 			const name = (await gitConfigService.get('user.name')) || unknownName;
 			const email = (await gitConfigService.get('user.email')) || unknownEmail;
 			const srcUrl =
-				email.toLowerCase() === $user?.email?.toLowerCase()
+				email.toLowerCase() === $user?.email?.toLowerCase() && $user?.picture
 					? $user?.picture
 					: await gravatarUrlFromEmail(email);
 
-			avatars = [{ name, srcUrl }];
+			avatars = [{ name, srcUrl: srcUrl }];
 		} else if (branchListingDetails) {
 			avatars = await Promise.all(
 				branchListingDetails.authors.map(async (author) => {

--- a/apps/desktop/src/lib/user/user.ts
+++ b/apps/desktop/src/lib/user/user.ts
@@ -4,7 +4,7 @@ export class User {
 	given_name: string | undefined;
 	family_name: string | undefined;
 	email!: string | undefined;
-	picture!: string;
+	picture?: string;
 	locale!: string | undefined;
 	created_at!: string;
 	updated_at!: string;

--- a/apps/desktop/src/lib/user/userService.ts
+++ b/apps/desktop/src/lib/user/userService.ts
@@ -7,9 +7,10 @@ import { sleep } from '$lib/utils/sleep';
 import { openExternalUrl } from '$lib/utils/url';
 import { type HttpClient } from '@gitbutler/shared/network/httpClient';
 import { plainToInstance } from 'class-transformer';
-import { derived, writable } from 'svelte/store';
+import { derived, writable, type Readable } from 'svelte/store';
 import type { PostHogWrapper } from '$lib/analytics/posthog';
 import type { TokenMemoryService } from '$lib/stores/tokenMemoryService';
+import type { ApiUser } from '@gitbutler/shared/users/types';
 
 export type LoginToken = {
 	token: string;
@@ -23,6 +24,16 @@ export class UserService {
 	readonly user = writable<User | undefined>(undefined, () => {
 		this.refresh();
 	});
+	readonly userLogin = derived<Readable<User | undefined>, string | undefined>(
+		this.user,
+		(user, set) => {
+			if (user) {
+				this.getUser().then((user) => set(user.login));
+			} else {
+				set(undefined);
+			}
+		}
+	);
 	readonly error = writable();
 
 	async refresh() {
@@ -130,7 +141,7 @@ export class UserService {
 		return await this.httpClient.get(`login/user/${token}.json`);
 	}
 
-	async getUser(): Promise<User> {
+	async getUser(): Promise<ApiUser> {
 		return await this.httpClient.get('user.json');
 	}
 

--- a/apps/desktop/src/routes/settings/profile/+page.svelte
+++ b/apps/desktop/src/routes/settings/profile/+page.svelte
@@ -12,6 +12,7 @@
 	import SectionCard from '@gitbutler/ui/SectionCard.svelte';
 	import Spacer from '@gitbutler/ui/Spacer.svelte';
 	import Textbox from '@gitbutler/ui/Textbox.svelte';
+	import type { User } from '$lib/user/user';
 	import { goto } from '$app/navigation';
 
 	const userService = getContext(UserService);
@@ -33,9 +34,22 @@
 		if ($user && !loaded) {
 			loaded = true;
 			userService.getUser().then((cloudUser) => {
-				cloudUser.github_access_token = $user?.github_access_token; // prevent overwriting with null
-				userPicture = cloudUser.picture;
-				userService.setUser(cloudUser);
+				const userData: User = {
+					...cloudUser,
+					name: cloudUser.name || 'unkown',
+					given_name: cloudUser.given_name || 'unkown',
+					family_name: cloudUser.family_name || 'unkown',
+					email: cloudUser.email || 'unkown@example.com',
+					picture: cloudUser.picture || '#',
+					locale: cloudUser.locale || 'en',
+					access_token: cloudUser.access_token || 'impossible-situation',
+					role: cloudUser.role || 'user',
+					supporter: cloudUser.supporter || false,
+					github_access_token: $user?.github_access_token,
+					github_username: $user?.github_username
+				};
+				userPicture = userData.picture;
+				userService.setUser(userData);
 			});
 			newName = $user?.name || '';
 		}

--- a/packages/shared/src/lib/users/types.ts
+++ b/packages/shared/src/lib/users/types.ts
@@ -6,6 +6,15 @@ export type ApiUser = {
 	name?: string;
 	email?: string;
 	avatar_url?: string;
+	given_name?: string;
+	family_name?: string;
+	picture?: string;
+	locale?: string;
+	access_token?: string;
+	updated_at: string;
+	created_at: string;
+	supporter?: boolean;
+	role?: string;
 };
 
 export type User = {


### PR DESCRIPTION
If there is an existing project matching both the user login and project title, then use that instead.

For some unfathomable reason, we don't store the user login after they login, so for now I'm just deriving it from the user.

## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
