### PR TITLE
Pushing stack does not require sync enabled

### DIFF
--- a/apps/desktop/src/lib/history/stackPublishingService.ts
+++ b/apps/desktop/src/lib/history/stackPublishingService.ts
@@ -25,7 +25,7 @@ export class StackPublishingService {
 		});
 
 		this.canPublish = derived(this.#joinedUserAndProject, ({ user, project }) => {
-			return this.canTakeSnapshotGivenUserAndProject(user, project);
+			return this.canPublishStack(user, project);
 		});
 	}
 
@@ -34,7 +34,7 @@ export class StackPublishingService {
 		const { user, project } = get(this.#joinedUserAndProject);
 
 		// Project and user are now defined
-		if (!this.canTakeSnapshotGivenUserAndProject(user, project)) {
+		if (!this.canPublishStack(user, project)) {
 			throw new Error('Cannot publish branch');
 		}
 
@@ -45,7 +45,7 @@ export class StackPublishingService {
 		});
 	}
 
-	private canTakeSnapshotGivenUserAndProject(user: User | undefined, project: Project | undefined) {
-		return user !== undefined && !!project?.api?.sync;
+	private canPublishStack(user: User | undefined, project: Project | undefined) {
+		return user !== undefined && !!project?.api;
 	}
 }


### PR DESCRIPTION


Requiring sync to be enabled was an old gitbutler requirement when we were using the snapshot method for uploading branches

## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
