### PR TITLE
Add types for consuming worktree changes on the frontend

### DIFF
--- a/apps/desktop/src/lib/worktree/worktree.ts
+++ b/apps/desktop/src/lib/worktree/worktree.ts
@@ -58,6 +58,6 @@ export class IgnoredChange {
 /** The status we can't handle.*/
 export type IgnoredChangeStatus =
 	/** A conflicting entry in the index. The worktree state of the entry is unclear.*/
-	| { type: 'Conflict' }
+	| 'Conflict'
 	/** A change in the `.git/index` that was overruled by a change to the same path in the *worktree*.*/
-	| { type: 'TreeIndex' };
+	| 'TreeIndex';

--- a/apps/desktop/src/lib/worktree/worktree.ts
+++ b/apps/desktop/src/lib/worktree/worktree.ts
@@ -1,0 +1,63 @@
+import { invoke } from '$lib/backend/ipc';
+
+/** Gets the current status of the worktree */
+export async function worktree_changes(projectId: string): Promise<WorktreeChanges> {
+	return await invoke<WorktreeChanges>('changes', { projectId });
+}
+
+/** Contains the changes that are in the worktree */
+export class WorktreeChanges {
+	/** Changes that could be committed. */
+	changes!: [WorktreeChange];
+	/**
+	Changes that were in the index that we can't handle.
+	The user can see them and interact with them to clear them out before a commit can be made.
+	*/
+	ignoredChanges!: [IgnoredChange];
+}
+
+/**
+An entry in the worktree that changed and thus is eligible to being committed.
+It either lives (or lived) in the in `.git/index`, or in the `worktree`.
+*/
+export class WorktreeChange {
+	/** The *relative* path in the worktree where the entry can be found.*/
+	path!: string;
+	/** The specific information about this change.*/
+	status!: Status;
+}
+
+export type Flags =
+	| 'ExecutableBitAdded'
+	| 'ExecutableBitRemoved'
+	| 'TypeChangeFileToLink'
+	| 'TypeChangeLinkToFile'
+	| 'TypeChange';
+
+export type Status =
+	/** Something was added or scheduled to be added.*/
+	| { type: 'Addition'; subject: { isUntracked: boolean } }
+	/** Something was deleted.*/
+	| { type: 'Deletion' }
+	/** A tracked entry was modified, i.e. content change, type change (eg. it is now a symlink), executable bit change.*/
+	| { type: 'Modification'; subject: { flags: Flags | undefined } }
+	/**
+	An entry was renamed from `previous_path` to its current location.
+	Note that this may include a content change, as well as a change of the executable bit.
+	*/
+	| { type: 'Rename'; subject: { previousPath: string; flags: Flags | undefined } };
+
+/** A way to indicate that a path in the index isn't suitable for committing and needs to be dealt with.*/
+export class IgnoredChange {
+	/** The worktree-relative path to the change.*/
+	path!: string;
+	/** The reason for the change being ignored.*/
+	status!: IgnoredChangeStatus;
+}
+
+/** The status we can't handle.*/
+export type IgnoredChangeStatus =
+	/** A conflicting entry in the index. The worktree state of the entry is unclear.*/
+	| { type: 'Conflict' }
+	/** A change in the `.git/index` that was overruled by a change to the same path in the *worktree*.*/
+	| { type: 'TreeIndex' };

--- a/apps/desktop/src/lib/worktree/worktree.ts
+++ b/apps/desktop/src/lib/worktree/worktree.ts
@@ -40,12 +40,12 @@ export type Status =
 	/** Something was deleted.*/
 	| { type: 'Deletion' }
 	/** A tracked entry was modified, i.e. content change, type change (eg. it is now a symlink), executable bit change.*/
-	| { type: 'Modification'; subject: { flags: Flags | undefined } }
+	| { type: 'Modification'; subject: { flags: Flags | null } }
 	/**
 	An entry was renamed from `previous_path` to its current location.
 	Note that this may include a content change, as well as a change of the executable bit.
 	*/
-	| { type: 'Rename'; subject: { previousPath: string; flags: Flags | undefined } };
+	| { type: 'Rename'; subject: { previousPath: string; flags: Flags | null } };
 
 /** A way to indicate that a path in the index isn't suitable for committing and needs to be dealt with.*/
 export class IgnoredChange {

--- a/crates/gitbutler-tauri/src/worktree/mod.rs
+++ b/crates/gitbutler-tauri/src/worktree/mod.rs
@@ -1,7 +1,6 @@
 use crate::error::Error;
 use gitbutler_project::ProjectId;
 use gitbutler_serde::BStringForFrontend;
-use gix::bstr::BString;
 use serde::Serialize;
 use std::path::PathBuf;
 use tracing::instrument;
@@ -76,7 +75,7 @@ pub enum Status {
     },
     Rename {
         #[serde(rename = "previousPath")]
-        previous_path: BString,
+        previous_path: BStringForFrontend,
         #[serde(rename = "previousState")]
         previous_state: ChangeState,
         state: ChangeState,
@@ -119,7 +118,7 @@ impl From<but_core::worktree::Status> for Status {
                 state,
             } => Status::Rename {
                 flags: Flags::calculate(&previous_state, &state),
-                previous_path,
+                previous_path: previous_path.into(),
                 previous_state: previous_state.into(),
                 state: state.into(),
             },

--- a/crates/gitbutler-tauri/src/worktree/mod.rs
+++ b/crates/gitbutler-tauri/src/worktree/mod.rs
@@ -144,7 +144,6 @@ impl From<but_core::WorktreeChange> for WorktreeChange {
 
 /// The status we can't handle.
 #[derive(Debug, Clone, Serialize)]
-#[serde(tag = "type", content = "subject")]
 pub enum IgnoredChangeStatus {
     /// A conflicting entry in the index. The worktree state of the entry is unclear.
     Conflict,

--- a/crates/gitbutler-tauri/src/worktree/tests.rs
+++ b/crates/gitbutler-tauri/src/worktree/tests.rs
@@ -49,7 +49,7 @@ mod flags {
 #[test]
 fn worktree_change_json_sample() {
     let actual = serde_json::to_string_pretty(&WorktreeChange {
-        path: BString::from("some/file").into(),
+        path: "some/file".into(),
         status: Status::Modification {
             flags: Some(Flags::ExecutableBitAdded),
             previous_state: ChangeState {

--- a/crates/gitbutler-tauri/src/worktree/tests.rs
+++ b/crates/gitbutler-tauri/src/worktree/tests.rs
@@ -240,15 +240,11 @@ fn worktree_changes_example() -> anyhow::Result<()> {
       "ignoredChanges": [
         {
           "path": "conflicting",
-          "status": {
-            "type": "Conflict"
-          }
+          "status": "Conflict"
         },
         {
           "path": "removed-in-index-changed-in-worktree",
-          "status": {
-            "type": "TreeIndex"
-          }
+          "status": "TreeIndex"
         }
       ]
     }


### PR DESCRIPTION
This code is currently inert, but will provide type hints whenever interactions with the new "status" API are being implemented.

@Byron I skipped adding hits for `ChangeState` (the state and previous_state). I am not sure if the UI needs this information for anything. Let me know if I am missing something. Also had to make the previous_path utf8 for the frontend
