### PR TITLE
fix: chrome review improvements

### DIFF
--- a/apps/desktop/src/components/Chrome.svelte
+++ b/apps/desktop/src/components/Chrome.svelte
@@ -22,21 +22,21 @@
 		flex-grow: 1;
 		flex-direction: column;
 		max-height: 100vh;
+	}
 
-		.wrapper {
-			display: flex;
-			flex-grow: 1;
-			height: 100%;
-			overflow-y: scroll;
+	.wrapper {
+		display: flex;
+		flex-grow: 1;
+		height: 100%;
+		overflow-y: scroll;
+	}
 
-			.content {
-				display: flex;
-				flex-grow: 1;
-				padding: 16px 0 0 16px;
-				align-items: self-start;
-				user-select: none;
-				background-color: var(--clr-bg-2);
-			}
-		}
+	.content {
+		display: flex;
+		flex-grow: 1;
+		padding: 16px 0 0 16px;
+		align-items: self-start;
+		user-select: none;
+		background-color: var(--clr-bg-2);
 	}
 </style>

--- a/apps/desktop/src/components/Chrome.svelte
+++ b/apps/desktop/src/components/Chrome.svelte
@@ -3,13 +3,13 @@
 	import Sidebar from '$components/ChromeSidebar.svelte';
 	import type { Snippet } from 'svelte';
 
-	const { children, projectId }: { children: Snippet; projectId: string } = $props();
+	const { children }: { children: Snippet } = $props();
 </script>
 
 <div class="chrome">
 	<Header />
 	<div class="wrapper">
-		<Sidebar {projectId} />
+		<Sidebar />
 		<div class="content">
 			{@render children()}
 		</div>

--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -4,14 +4,13 @@
 	import { Project } from '$lib/project/project';
 	import { getContext } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
-	import { env } from '$env/dynamic/public';
 
 	const project = getContext(Project);
 </script>
 
 <nav>
 	<div class="left">
-		{#if platformName === 'macos' || env.PUBLIC_TESTING}
+		{#if platformName === 'macos'}
 			<div class="traffic-lights-placeholder" data-tauri-drag-region></div>
 		{/if}
 		<SyncButton size="button" />

--- a/apps/desktop/src/components/ChromeSidebar.svelte
+++ b/apps/desktop/src/components/ChromeSidebar.svelte
@@ -1,26 +1,20 @@
 <script lang="ts">
+	import { DesktopRoutesService } from '$lib/routes/routes.svelte';
 	import { User } from '$lib/user/user';
 	import { getContextStore } from '@gitbutler/shared/context';
+	import { getContext } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import Icon from '@gitbutler/ui/Icon.svelte';
 	import { goto } from '$app/navigation';
 
-	interface Props {
-		projectId: string;
-	}
-
-	const { projectId }: Props = $props();
-
-	function navigateInProject(target: string) {
-		goto(`/${projectId}/${target}`);
-	}
+	const routes = getContext(DesktopRoutesService);
 
 	const user = getContextStore(User);
 </script>
 
 <nav class="wrapper">
 	<div class="top">
-		<Button kind="outline" onclick={() => navigateInProject('workspace')} width={34} height={34}>
+		<Button kind="outline" onclick={() => goto(routes.workspacePath)} width={34} height={34}>
 			<svg viewBox="0 0 16 13" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<g opacity="0.7">
 					<path
@@ -34,7 +28,7 @@
 				</g>
 			</svg>
 		</Button>
-		<Button kind="outline" onclick={() => navigateInProject('branches')} width={34} height={34}>
+		<Button kind="outline" onclick={() => goto(routes.branchesPath)} width={34} height={34}>
 			<svg viewBox="0 0 16 14" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<g opacity="0.7">
 					<path d="M5 3L11 3" stroke-width="1.5" />
@@ -48,7 +42,7 @@
 				</g>
 			</svg>
 		</Button>
-		<Button kind="outline" onclick={() => navigateInProject('target')} width={34} height={34}>
+		<Button kind="outline" onclick={() => goto(routes.targetPath)} width={34} height={34}>
 			<svg viewBox="0 0 18 16" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<g opacity="0.7">
 					<path
@@ -61,7 +55,7 @@
 				</g>
 			</svg>
 		</Button>
-		<Button kind="outline" onclick={() => navigateInProject('history')} width={34} height={34}>
+		<Button kind="outline" onclick={() => goto(routes.historyPath)} width={34} height={34}>
 			<svg viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<g opacity="0.7">
 					<path d="M8 5V10H13" stroke-width="1.5" />
@@ -74,7 +68,7 @@
 		<Button
 			icon="settings"
 			kind="outline"
-			onclick={() => navigateInProject('settings')}
+			onclick={() => goto(routes.settingsPath)}
 			width={34}
 			height={34}
 		/>

--- a/apps/desktop/src/components/ChromeSidebar.svelte
+++ b/apps/desktop/src/components/ChromeSidebar.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { Project } from '$lib/project/project';
 	import { DesktopRoutesService } from '$lib/routes/routes.svelte';
 	import { User } from '$lib/user/user';
 	import { getContextStore } from '@gitbutler/shared/context';
@@ -8,13 +9,18 @@
 	import { goto } from '$app/navigation';
 
 	const routes = getContext(DesktopRoutesService);
-
+	const project = getContext(Project);
 	const user = getContextStore(User);
 </script>
 
 <nav class="wrapper">
 	<div class="top">
-		<Button kind="outline" onclick={() => goto(routes.workspacePath)} width={34} height={34}>
+		<Button
+			kind="outline"
+			onclick={() => goto(routes.workspacePath(project.id))}
+			width={34}
+			height={34}
+		>
 			<svg viewBox="0 0 16 13" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<g opacity="0.7">
 					<path
@@ -28,7 +34,12 @@
 				</g>
 			</svg>
 		</Button>
-		<Button kind="outline" onclick={() => goto(routes.branchesPath)} width={34} height={34}>
+		<Button
+			kind="outline"
+			onclick={() => goto(routes.branchesPath(project.id))}
+			width={34}
+			height={34}
+		>
 			<svg viewBox="0 0 16 14" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<g opacity="0.7">
 					<path d="M5 3L11 3" stroke-width="1.5" />
@@ -42,7 +53,12 @@
 				</g>
 			</svg>
 		</Button>
-		<Button kind="outline" onclick={() => goto(routes.targetPath)} width={34} height={34}>
+		<Button
+			kind="outline"
+			onclick={() => goto(routes.targetPath(project.id))}
+			width={34}
+			height={34}
+		>
 			<svg viewBox="0 0 18 16" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<g opacity="0.7">
 					<path
@@ -55,7 +71,12 @@
 				</g>
 			</svg>
 		</Button>
-		<Button kind="outline" onclick={() => goto(routes.historyPath)} width={34} height={34}>
+		<Button
+			kind="outline"
+			onclick={() => goto(routes.historyPath(project.id))}
+			width={34}
+			height={34}
+		>
 			<svg viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<g opacity="0.7">
 					<path d="M8 5V10H13" stroke-width="1.5" />
@@ -68,7 +89,7 @@
 		<Button
 			icon="settings"
 			kind="outline"
-			onclick={() => goto(routes.settingsPath)}
+			onclick={() => goto(routes.settingsPath(project.id))}
 			width={34}
 			height={34}
 		/>

--- a/apps/desktop/src/lib/routes/routes.svelte.ts
+++ b/apps/desktop/src/lib/routes/routes.svelte.ts
@@ -1,0 +1,22 @@
+export class DesktopRoutesService {
+	constructor(private readonly projectId: string) {}
+
+	get projectPath() {
+		return `/${this.projectId}`;
+	}
+	get settingsPath() {
+		return `/${this.projectId}/settings`;
+	}
+	get workspacePath() {
+		return `/${this.projectId}/workspace`;
+	}
+	get branchesPath() {
+		return `/${this.projectId}/branches`;
+	}
+	get targetPath() {
+		return `/${this.projectId}/target`;
+	}
+	get historyPath() {
+		return `/${this.projectId}/history`;
+	}
+}

--- a/apps/desktop/src/lib/routes/routes.svelte.ts
+++ b/apps/desktop/src/lib/routes/routes.svelte.ts
@@ -1,22 +1,22 @@
 export class DesktopRoutesService {
-	constructor(private readonly projectId: string) {}
+	constructor() {}
 
-	get projectPath() {
-		return `/${this.projectId}`;
+	projectPath(projectId: string) {
+		return `/${projectId}`;
 	}
-	get settingsPath() {
-		return `/${this.projectId}/settings`;
+	settingsPath(projectId: string) {
+		return `/${projectId}/settings`;
 	}
-	get workspacePath() {
-		return `/${this.projectId}/workspace`;
+	workspacePath(projectId: string) {
+		return `/${projectId}/workspace`;
 	}
-	get branchesPath() {
-		return `/${this.projectId}/branches`;
+	branchesPath(projectId: string) {
+		return `/${projectId}/branches`;
 	}
-	get targetPath() {
-		return `/${this.projectId}/target`;
+	targetPath(projectId: string) {
+		return `/${projectId}/target`;
 	}
-	get historyPath() {
-		return `/${this.projectId}/history`;
+	historyPath(projectId: string) {
+		return `/${projectId}/history`;
 	}
 }

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -36,6 +36,7 @@
 	import { PromptService } from '$lib/prompt/promptService';
 	import { DesktopDispatch, DesktopState } from '$lib/redux/store.svelte';
 	import { RemotesService } from '$lib/remotes/remotesService';
+	import { DesktopRoutesService } from '$lib/routes/routes.svelte';
 	import { setSecretsService } from '$lib/secrets/secretsService';
 	import { SETTINGS, loadUserSettings } from '$lib/settings/userSettings';
 	import { UpdaterService } from '$lib/updater/updater';
@@ -81,6 +82,7 @@
 	const repositoryIdLookupService = new RepositoryIdLookupService(data.cloud, appState.appDispatch);
 	const latestBranchLookupService = new LatestBranchLookupService(data.cloud, appState.appDispatch);
 	const webRoutesService = new WebRoutesService(env.PUBLIC_CLOUD_BASE_URL);
+	const desktopRouteService = new DesktopRoutesService();
 
 	setContext(AppState, appState);
 	setContext(AppDispatch, appState.appDispatch);
@@ -95,6 +97,7 @@
 	setContext(RepositoryIdLookupService, repositoryIdLookupService);
 	setContext(LatestBranchLookupService, latestBranchLookupService);
 	setContext(WebRoutesService, webRoutesService);
+	setContext(DesktopRoutesService, desktopRouteService);
 	setContext(HooksService, data.hooksService);
 	setContext(SettingsService, data.settingsService);
 	setContext(FileService, data.fileService);

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -35,6 +35,7 @@
 	import { Project } from '$lib/project/project';
 	import { projectCloudSync } from '$lib/project/projectCloudSync.svelte';
 	import { ProjectService } from '$lib/project/projectService';
+	import { DesktopRoutesService } from '$lib/routes/routes.svelte';
 	import { UpstreamIntegrationService } from '$lib/upstream/upstreamIntegrationService';
 	import { debounce } from '$lib/utils/debounce';
 	import { getContext } from '@gitbutler/shared/context';
@@ -93,6 +94,7 @@
 		// Cloud related services
 		setContext(SyncedSnapshotService, data.syncedSnapshotService);
 		setContext(StackPublishingService, data.stackPublishingService);
+		setContext(DesktopRoutesService, new DesktopRoutesService(projectId));
 	});
 
 	let intervalId: any;
@@ -231,7 +233,7 @@
 		{#if $mode?.type === 'OpenWorkspace' || $mode?.type === 'Edit'}
 			<div class="view-wrap" role="group" ondragover={(e) => e.preventDefault()}>
 				{#if $v3}
-					<Chrome {projectId}>
+					<Chrome>
 						{@render children()}
 					</Chrome>
 				{:else}

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -236,10 +236,10 @@
 					</Chrome>
 				{:else}
 					<Navigation />
-					{#if $showHistoryView}
-						<History onHide={() => ($showHistoryView = false)} />
-					{/if}
 					{@render children()}
+				{/if}
+				{#if $showHistoryView}
+					<History onHide={() => ($showHistoryView = false)} />
 				{/if}
 			</div>
 		{:else if $mode?.type === 'OutsideWorkspace'}

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -35,7 +35,6 @@
 	import { Project } from '$lib/project/project';
 	import { projectCloudSync } from '$lib/project/projectCloudSync.svelte';
 	import { ProjectService } from '$lib/project/projectService';
-	import { DesktopRoutesService } from '$lib/routes/routes.svelte';
 	import { UpstreamIntegrationService } from '$lib/upstream/upstreamIntegrationService';
 	import { debounce } from '$lib/utils/debounce';
 	import { getContext } from '@gitbutler/shared/context';
@@ -94,7 +93,6 @@
 		// Cloud related services
 		setContext(SyncedSnapshotService, data.syncedSnapshotService);
 		setContext(StackPublishingService, data.stackPublishingService);
-		setContext(DesktopRoutesService, new DesktopRoutesService(projectId));
 	});
 
 	let intervalId: any;

--- a/packages/ui/src/lib/Button.svelte
+++ b/packages/ui/src/lib/Button.svelte
@@ -12,7 +12,7 @@
 		shrinkable?: boolean;
 		reversedDirection?: boolean;
 		height?: number | string | undefined;
-		width?: number | undefined;
+		width?: number | string | undefined;
 		maxWidth?: number | undefined;
 		size?: 'tag' | 'button' | 'cta';
 		wide?: boolean;
@@ -109,7 +109,11 @@
 				? pxToRem(height)
 				: height
 			: undefined}
-		style:width={width !== undefined ? pxToRem(width) : undefined}
+		style:width={width !== undefined
+			? typeof width === 'number'
+				? pxToRem(width)
+				: width
+			: undefined}
 		style:max-width={maxWidth !== undefined ? pxToRem(maxWidth) : undefined}
 		disabled={disabled || loading}
 		onclick={handleAction}


### PR DESCRIPTION
## 🧢 Changes

- Pulled `History.svelte` out of the `!$v3` logic branch so that we can use it during v3 development for now. Seems to work in initial testing (<kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>H</kbd> only for some reason)
- Remove nested CSS in `Chrome.svelte`
- Remove unused `env.PUBLIC_TESTING`
- Allow strings for `width` in `Button.svelte` props as well, i.e. for `"auto"`, `"100%"`, etc.
  - Used in our use-case for the "vertical" user-profile switcher button in the Chrome Sidebar bottom left
- Created `routes.svelte.ts` for new desktop routes with getters for all important routes

Follow-up to #6011

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
