### PR TITLE
feat: allow passing custom classes to `Button` component

### DIFF
--- a/packages/ui/src/lib/Button.svelte
+++ b/packages/ui/src/lib/Button.svelte
@@ -23,6 +23,7 @@
 		style?: ComponentColorType;
 		kind?: ComponentKindType;
 		solidBackground?: boolean;
+		class?: string;
 		// Additional elements
 		icon?: keyof typeof iconsJson | undefined;
 		tooltip?: string;
@@ -69,6 +70,7 @@
 		style = 'neutral',
 		kind = 'solid',
 		solidBackground = false,
+		class: className = '',
 		testId,
 		icon,
 		tooltip,
@@ -94,15 +96,21 @@
 <Tooltip text={tooltip} align={tooltipAlign} position={tooltipPosition}>
 	<button
 		bind:this={el}
-		class="btn focus-state {style} {kind} {size}-size"
-		class:solidBackground
-		class:reversed-direction={reversedDirection}
-		class:shrinkable
-		class:wide
-		class:grow
-		class:is-dropdown={dropdownChild}
-		class:fixed-width={!children && !wide}
-		class:activated
+		class={[
+			'btn focus-state',
+			style,
+			kind,
+			size && `${size}-size`,
+			activated,
+			grow,
+			wide,
+			shrinkable,
+			solidBackground,
+			reversedDirection && 'reversed-direction',
+			dropdownChild && 'is-dropdown',
+			!children && !wide && 'fixed-width',
+			className
+		]}
 		style:align-self={align}
 		style:height={height !== undefined
 			? typeof height === 'number'


### PR DESCRIPTION
## 🧢 Changes

- Allow passing custom classes to our `Button.svelte` component via the `class` prop
- Uses new `class` array syntax (https://svelte.dev/docs/svelte/class#Attributes-Objects-and-arrays)

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
