### PR TITLE
feat: chrome interaction and styling 2

### DIFF
--- a/apps/desktop/src/components/Chrome.svelte
+++ b/apps/desktop/src/components/Chrome.svelte
@@ -22,6 +22,7 @@
 		flex-grow: 1;
 		flex-direction: column;
 		max-height: 100vh;
+		background-color: var(--clr-bg-2);
 	}
 
 	.wrapper {
@@ -37,6 +38,5 @@
 		padding: 16px 0 0 16px;
 		align-items: self-start;
 		user-select: none;
-		background-color: var(--clr-bg-2);
 	}
 </style>

--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -36,7 +36,10 @@
 		{#if platformName === 'macos'}
 			<div class="traffic-lights-placeholder" data-tauri-drag-region></div>
 		{/if}
-		<SyncButton size="button" />
+		<div class="left-buttons">
+			<SyncButton size="button" />
+			<Button style="pop">3 upstream commits</Button>
+		</div>
 	</div>
 	<div class="center">
 		<Select
@@ -108,6 +111,16 @@
 		display: flex;
 		justify-content: space-between;
 		margin: 16px 16px 0 16px;
+	}
+
+	.left {
+		display: flex;
+		gap: 16px;
+	}
+
+	.left-buttons {
+		display: flex;
+		gap: 8px;
 	}
 
 	.selector-series-select {

--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -55,7 +55,7 @@
 		>
 			{#snippet customSelectButton()}
 				<div class="selector-series-select">
-					<span class="text-13 text-bold">{project.title}</span>
+					<span class="text-13 text-bold">{project?.title}</span>
 					<div class="selector-series-select__icon"><Icon name="select-chevron" /></div>
 				</div>
 			{/snippet}

--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -1,11 +1,34 @@
 <script lang="ts">
+	import OptionsGroup from '$components/OptionsGroup.svelte';
+	import Select from '$components/Select.svelte';
+	import SelectItem from '$components/SelectItem.svelte';
 	import SyncButton from '$components/SyncButton.svelte';
 	import { platformName } from '$lib/platform/platform';
 	import { Project } from '$lib/project/project';
-	import { getContext } from '@gitbutler/shared/context';
+	import { ProjectsService } from '$lib/project/projectsService';
+	import { DesktopRoutesService } from '$lib/routes/routes.svelte';
+	import { getContext, maybeGetContext } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
+	import Icon from '@gitbutler/ui/Icon.svelte';
+	import { goto } from '$app/navigation';
 
-	const project = getContext(Project);
+	const routes = getContext(DesktopRoutesService);
+	const projectsService = getContext(ProjectsService);
+	const project = maybeGetContext(Project);
+
+	const projects = $derived(projectsService.projects);
+
+	const mappedProjects = $derived(
+		$projects?.map((project) => ({
+			value: project.id,
+			label: project.title
+		})) || []
+	);
+
+	let selectedProjectId: string | undefined = $state(project ? project.id : undefined);
+
+	let newProjectLoading = $state(false);
+	let cloneProjectLoading = $state(false);
 </script>
 
 <nav>
@@ -16,7 +39,64 @@
 		<SyncButton size="button" />
 	</div>
 	<div class="center">
-		{project.title}
+		<Select
+			wide
+			searchable
+			value={selectedProjectId}
+			options={mappedProjects}
+			loading={newProjectLoading || cloneProjectLoading}
+			disabled={newProjectLoading || cloneProjectLoading}
+			onselect={(value: string) => {
+				selectedProjectId = value;
+				goto(routes.changeProjectPath(selectedProjectId));
+			}}
+			popupAlign="center"
+			customWidth={300}
+		>
+			{#snippet customSelectButton()}
+				<div class="selector-series-select">
+					<span class="text-13 text-bold">{project.title}</span>
+					<div class="selector-series-select__icon"><Icon name="select-chevron" /></div>
+				</div>
+			{/snippet}
+
+			{#snippet itemSnippet({ item, highlighted })}
+				<SelectItem selected={item.value === selectedProjectId} {highlighted}>
+					{item.label}
+				</SelectItem>
+			{/snippet}
+
+			<OptionsGroup>
+				<SelectItem
+					icon="plus"
+					loading={newProjectLoading}
+					onClick={async () => {
+						newProjectLoading = true;
+						try {
+							await projectsService.addProject();
+						} finally {
+							newProjectLoading = false;
+						}
+					}}
+				>
+					Add local repository
+				</SelectItem>
+				<SelectItem
+					icon="clone"
+					loading={cloneProjectLoading}
+					onClick={async () => {
+						cloneProjectLoading = true;
+						try {
+							goto('/onboarding/clone');
+						} finally {
+							cloneProjectLoading = false;
+						}
+					}}
+				>
+					Clone repository
+				</SelectItem>
+			</OptionsGroup>
+		</Select>
 	</div>
 	<div class="right">
 		<Button kind="ghost" icon="bell" />
@@ -28,5 +108,20 @@
 		display: flex;
 		justify-content: space-between;
 		margin: 16px 16px 0 16px;
+	}
+
+	.selector-series-select {
+		display: flex;
+		align-items: center;
+		gap: 2px;
+		padding: 2px 4px 2px 6px;
+		margin-left: -2px;
+		color: var(--clr-text-1);
+		text-wrap: nowrap;
+	}
+
+	.selector-series-select__icon {
+		display: flex;
+		color: var(--clr-text-2);
 	}
 </style>

--- a/apps/desktop/src/components/ChromeSidebar.svelte
+++ b/apps/desktop/src/components/ChromeSidebar.svelte
@@ -174,7 +174,7 @@
 				kind="outline"
 				onclick={() => goto(routes.settingsPath(project.id))}
 				width={34}
-				class="btn-square"
+				class={['btn-square', routes.isSettingsPath && 'btn-active']}
 			/>
 		</div>
 		<Button
@@ -202,35 +202,37 @@
 			</div>
 		</Button>
 
-		<Button
-			icon="keyboard"
-			kind="ghost"
-			style="neutral"
-			tooltip="Keyboard Shortcuts"
-			tooltipPosition="top"
-			tooltipAlign="start"
-			width={34}
-			class="fill-text-2"
-		/>
-		<Button
-			icon="mail"
-			kind="ghost"
-			tooltip="Share feedback"
-			tooltipPosition="top"
-			tooltipAlign="start"
-			width={34}
-			class="fill-text-2"
-			onclick={() => {
-				shareIssueModal?.show();
-			}}
-		/>
+		<div>
+			<Button
+				icon="keyboard"
+				kind="ghost"
+				style="neutral"
+				tooltip="Keyboard Shortcuts"
+				tooltipPosition="top"
+				tooltipAlign="start"
+				width={34}
+				class="fill-text-2"
+			/>
+			<Button
+				icon="mail"
+				kind="ghost"
+				tooltip="Share feedback"
+				tooltipPosition="top"
+				tooltipAlign="start"
+				width={34}
+				class="fill-text-2"
+				onclick={() => {
+					shareIssueModal?.show();
+				}}
+			/>
+		</div>
 	</div>
 </nav>
 
 <ContextMenu
 	bind:this={contextMenuEl}
 	leftClickTrigger={contextTriggerButton}
-	verticalAlign="bottom"
+	verticalAlign="top"
 	horizontalAlign="left"
 >
 	<ContextMenuSection>
@@ -288,7 +290,12 @@
 	.bottom {
 		display: flex;
 		flex-direction: column;
+	}
+	.top {
 		gap: 4px;
+	}
+	.bottom {
+		gap: 8px;
 	}
 
 	.user-button {
@@ -297,6 +304,15 @@
 		justify-content: center;
 		align-items: center;
 		width: 34px;
+		padding: 4px;
+		gap: 4px;
+	}
+	.user-button img {
+		border-radius: var(--radius-m);
+	}
+
+	.profile-picture {
+		border-radius: var(--radius-m);
 	}
 
 	.active-page-indicator {
@@ -352,15 +368,19 @@
 
 	:global(.btn-height-auto) {
 		height: auto !important;
+		border-radius: var(--radius-ml) !important;
 		opacity: 0.7;
+		padding: 0 !important;
 	}
 
 	:global(.btn-square) {
 		aspect-ratio: 1 / 1;
 		height: unset !important;
 		opacity: 0.7;
+		border-radius: var(--radius-ml) !important;
 	}
 	:global(.btn-square.btn-active) {
 		opacity: 1 !important;
+		background-color: var(--clr-scale-ntrl-100);
 	}
 </style>

--- a/apps/desktop/src/components/ChromeSidebar.svelte
+++ b/apps/desktop/src/components/ChromeSidebar.svelte
@@ -307,8 +307,13 @@
 		padding: 4px;
 		gap: 4px;
 	}
+
 	.user-button img {
 		border-radius: var(--radius-m);
+	}
+
+	:global(.user-button svg) {
+		opacity: 0.7;
 	}
 
 	.profile-picture {
@@ -369,7 +374,6 @@
 	:global(.btn-height-auto) {
 		height: auto !important;
 		border-radius: var(--radius-ml) !important;
-		opacity: 0.7;
 		padding: 0 !important;
 	}
 

--- a/apps/desktop/src/components/ChromeSidebar.svelte
+++ b/apps/desktop/src/components/ChromeSidebar.svelte
@@ -6,6 +6,7 @@
 	import { getContext } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import Icon from '@gitbutler/ui/Icon.svelte';
+	import { slide } from 'svelte/transition';
 	import { goto } from '$app/navigation';
 
 	const routes = getContext(DesktopRoutesService);
@@ -13,16 +14,24 @@
 	const user = getContextStore(User);
 </script>
 
-<nav class="wrapper">
+<nav class="sidebar">
 	<div class="top">
-		<Button
-			kind="outline"
-			onclick={() => goto(routes.workspacePath(project.id))}
-			width={34}
-			class="btn-square"
-		>
-			<svg viewBox="0 0 16 13" fill="none" xmlns="http://www.w3.org/2000/svg">
-				<g opacity="0.7">
+		<div class="">
+			{#if routes.isWorkspacePath}
+				<div class="active-page-indicator" in:slide={{ axis: 'x', duration: 150 }}></div>
+			{/if}
+			<Button
+				kind="outline"
+				onclick={() => goto(routes.workspacePath(project.id))}
+				width={34}
+				class="btn-square"
+			>
+				<svg
+					viewBox="0 0 16 13"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+					class={[routes.isWorkspacePath && 'stroke-orange']}
+				>
 					<path
 						d="M2 12L3.5 7.5M14 12L12.5 7.5M12.5 7.5L11 3H5L3.5 7.5M12.5 7.5H3.5"
 						stroke-width="1.5"
@@ -31,59 +40,121 @@
 						d="M1.24142 3H14.7586C14.8477 3 14.8923 2.89229 14.8293 2.82929L13.0293 1.02929C13.0105 1.01054 12.9851 1 12.9586 1H3.04142C3.0149 1 2.98946 1.01054 2.97071 1.02929L1.17071 2.82929C1.10771 2.89229 1.15233 3 1.24142 3Z"
 						stroke-width="1.5"
 					/>
-				</g>
-			</svg>
-		</Button>
-		<Button
-			kind="outline"
-			onclick={() => goto(routes.branchesPath(project.id))}
-			width={34}
-			class="btn-square"
-		>
-			<svg viewBox="0 0 16 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-				<g opacity="0.7">
+				</svg>
+			</Button>
+		</div>
+		<div class="">
+			{#if routes.isBranchesPath}
+				<div class="active-page-indicator" in:slide={{ axis: 'x', duration: 150 }}></div>
+			{/if}
+			<Button
+				kind="outline"
+				onclick={() => goto(routes.branchesPath(project.id))}
+				width={34}
+				class="btn-square"
+			>
+				<svg
+					viewBox="0 0 16 14"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+					class={[routes.isBranchesPath && 'stroke-purple']}
+				>
 					<path d="M5 3L11 3" stroke-width="1.5" />
 					<path
 						d="M3 5L3 7.17157C3 7.70201 3.21071 8.21071 3.58579 8.58579L5.41421 10.4142C5.78929 10.7893 6.29799 11 6.82843 11L11.5 11"
 						stroke-width="1.5"
 					/>
-					<rect x="15" y="1" width="4" height="4" transform="rotate(90 15 1)" stroke-width="1.5" />
-					<rect x="15" y="9" width="4" height="4" transform="rotate(90 15 9)" stroke-width="1.5" />
-					<rect x="5" y="1" width="4" height="4" transform="rotate(90 5 1)" stroke-width="1.5" />
-				</g>
-			</svg>
-		</Button>
-		<Button
-			kind="outline"
-			onclick={() => goto(routes.targetPath(project.id))}
-			width={34}
-			class="btn-square"
-		>
-			<svg viewBox="0 0 18 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-				<g opacity="0.7">
+					<rect
+						x="15"
+						y="1"
+						width="4"
+						height="4"
+						transform="rotate(90 15 1)"
+						stroke-width="1.5"
+						class={[routes.isBranchesPath && 'fill-purple']}
+					/>
+					<rect
+						x="15"
+						y="9"
+						width="4"
+						height="4"
+						transform="rotate(90 15 9)"
+						stroke-width="1.5"
+						class={[routes.isBranchesPath && 'fill-purple']}
+					/>
+					<rect
+						x="5"
+						y="1"
+						width="4"
+						height="4"
+						transform="rotate(90 5 1)"
+						stroke-width="1.5"
+						class={[routes.isBranchesPath && 'fill-purple']}
+					/>
+				</svg>
+			</Button>
+		</div>
+		<div class="">
+			{#if routes.isTargetPath}
+				<div class="active-page-indicator" in:slide={{ axis: 'x', duration: 150 }}></div>
+			{/if}
+			<Button
+				kind="outline"
+				onclick={() => goto(routes.targetPath(project.id))}
+				width={34}
+				class="btn-square"
+			>
+				<svg
+					viewBox="0 0 18 16"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+					class={[routes.isTargetPath && 'fill-orange stroke-orange']}
+				>
 					<path
 						d="M10.6906 1C12.1197 1 13.4402 1.7624 14.1547 3L15.8453 5.9282C16.5598 7.16581 16.5598 8.6906 15.8453 9.9282L14.1547 12.8564C13.4402 14.094 12.1197 14.8564 10.6906 14.8564H7.3094C5.88034 14.8564 4.55983 14.094 3.8453 12.8564L2.1547 9.9282C1.44017 8.6906 1.44017 7.16581 2.1547 5.9282L3.8453 3C4.55983 1.7624 5.88034 1 7.3094 1H10.6906Z"
 						stroke-width="1.5"
+						class={[routes.isTargetPath && 'stroke-orange']}
 					/>
-					<path d="M9 14.5V10.5M9 5V1" stroke-width="1.5" />
-					<path d="M2.25 7.75L6.25 7.75M11.75 7.75L15.75 7.75" stroke-width="1.5" />
-					<circle cx="9" cy="8" r="1" fill="#272321" />
-				</g>
-			</svg>
-		</Button>
-		<Button
-			kind="outline"
-			onclick={() => goto(routes.historyPath(project.id))}
-			width={34}
-			class="btn-square"
-		>
-			<svg viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-				<g opacity="0.7">
-					<path d="M8 5V10H13" stroke-width="1.5" />
-					<rect x="1" y="1" width="16" height="16" rx="6" stroke-width="1.5" />
-				</g>
-			</svg>
-		</Button>
+					<path
+						d="M9 14.5V10.5M9 5V1"
+						stroke-width="1.5"
+						class={[routes.isTargetPath && 'stroke-white']}
+					/>
+					<path
+						d="M2.25 7.75L6.25 7.75M11.75 7.75L15.75 7.75"
+						stroke-width="1.5"
+						class={[routes.isTargetPath && 'stroke-white']}
+					/>
+					<circle cx="9" cy="8" r="1" class={[routes.isTargetPath && 'stroke-white']} />
+				</svg>
+			</Button>
+		</div>
+		<div class="">
+			{#if routes.isHistoryPath}
+				<div class="active-page-indicator" in:slide={{ axis: 'x', duration: 150 }}></div>
+			{/if}
+			<Button
+				kind="outline"
+				onclick={() => goto(routes.historyPath(project.id))}
+				width={34}
+				class="btn-square"
+			>
+				<svg
+					viewBox="0 0 18 18"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+					stroke-width="1.5"
+					style="padding: 1px;"
+				>
+					<rect width="18" height="18" rx="6" class={[routes.isHistoryPath && 'fill-yellow']} />
+					<path
+						d="M8 3V10H13"
+						stroke-width="1.5"
+						class={[routes.isHistoryPath && 'stroke-black']}
+					/>
+				</svg>
+			</Button>
+		</div>
 	</div>
 	<div class="bottom">
 		<Button
@@ -131,7 +202,7 @@
 </nav>
 
 <style>
-	.wrapper {
+	.sidebar {
 		display: flex;
 		flex-direction: column;
 		align-items: flex-start;
@@ -156,10 +227,50 @@
 		width: 34px;
 	}
 
+	.active-page-indicator {
+		content: '';
+		position: absolute;
+		left: 0;
+		width: 12px;
+		height: 18px;
+		border-radius: var(--radius-m);
+		background-color: var(--clr-theme-pop-element);
+		transform: translateX(-50%) translateY(50%);
+	}
+
 	svg {
 		width: 16px;
 		height: 16px;
 		stroke: var(--clr-btn-ntrl-outline-text);
+	}
+
+	.stroke-white {
+		stroke: #fff;
+	}
+
+	.fill-orange {
+		fill: #ff9774;
+	}
+
+	.stroke-orange {
+		stroke: #ff9774;
+	}
+
+	.fill-purple {
+		fill: #a486c8;
+	}
+
+	.stroke-purple {
+		stroke: #a486c8;
+	}
+
+	.fill-yellow {
+		fill: #fbdb79;
+		stroke: #fbdb79;
+	}
+
+	.stroke-black {
+		stroke: #000 !important;
 	}
 
 	:global(.btn-height-auto) {

--- a/apps/desktop/src/components/ChromeSidebar.svelte
+++ b/apps/desktop/src/components/ChromeSidebar.svelte
@@ -221,7 +221,7 @@
 			width={34}
 			class="fill-text-2"
 			onclick={() => {
-				shareIssueModal.show();
+				shareIssueModal?.show();
 			}}
 		/>
 	</div>

--- a/apps/desktop/src/components/ChromeSidebar.svelte
+++ b/apps/desktop/src/components/ChromeSidebar.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
+	import ShareIssueModal from '$components/ShareIssueModal.svelte';
 	import { Project } from '$lib/project/project';
 	import { DesktopRoutesService } from '$lib/routes/routes.svelte';
 	import { User } from '$lib/user/user';
 	import { getContextStore } from '@gitbutler/shared/context';
 	import { getContext } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
+	import ContextMenu from '@gitbutler/ui/ContextMenu.svelte';
+	import ContextMenuItem from '@gitbutler/ui/ContextMenuItem.svelte';
+	import ContextMenuSection from '@gitbutler/ui/ContextMenuSection.svelte';
 	import Icon from '@gitbutler/ui/Icon.svelte';
 	import { slide } from 'svelte/transition';
 	import { goto } from '$app/navigation';
@@ -12,6 +16,10 @@
 	const routes = getContext(DesktopRoutesService);
 	const project = getContext(Project);
 	const user = getContextStore(User);
+
+	let contextTriggerButton = $state<HTMLDivElement>();
+	let contextMenuEl = $state<ContextMenu>();
+	let shareIssueModal = $state<ShareIssueModal>();
 </script>
 
 <nav class="sidebar">
@@ -24,7 +32,7 @@
 				kind="outline"
 				onclick={() => goto(routes.workspacePath(project.id))}
 				width={34}
-				class="btn-square"
+				class={['btn-square', routes.isWorkspacePath && 'btn-active']}
 			>
 				<svg
 					viewBox="0 0 16 13"
@@ -51,7 +59,7 @@
 				kind="outline"
 				onclick={() => goto(routes.branchesPath(project.id))}
 				width={34}
-				class="btn-square"
+				class={['btn-square', routes.isBranchesPath && 'btn-active']}
 			>
 				<svg
 					viewBox="0 0 16 14"
@@ -102,7 +110,7 @@
 				kind="outline"
 				onclick={() => goto(routes.targetPath(project.id))}
 				width={34}
-				class="btn-square"
+				class={['btn-square', routes.isTargetPath && 'btn-active']}
 			>
 				<svg
 					viewBox="0 0 18 16"
@@ -137,7 +145,7 @@
 				kind="outline"
 				onclick={() => goto(routes.historyPath(project.id))}
 				width={34}
-				class="btn-square"
+				class={['btn-square', routes.isHistoryPath && 'btn-active']}
 			>
 				<svg
 					viewBox="0 0 18 18"
@@ -156,15 +164,27 @@
 			</Button>
 		</div>
 	</div>
-	<div class="bottom">
+	<div class="bottom" bind:this={contextTriggerButton}>
+		<div class="">
+			{#if routes.isSettingsPath}
+				<div class="active-page-indicator" in:slide={{ axis: 'x', duration: 150 }}></div>
+			{/if}
+			<Button
+				icon="settings"
+				kind="outline"
+				onclick={() => goto(routes.settingsPath(project.id))}
+				width={34}
+				class="btn-square"
+			/>
+		</div>
 		<Button
-			icon="settings"
 			kind="outline"
-			onclick={() => goto(routes.settingsPath(project.id))}
 			width={34}
-			class="btn-square"
-		/>
-		<Button kind="outline" width={34} class="btn-height-auto">
+			class="btn-height-auto"
+			onclick={() => {
+				contextMenuEl?.toggle();
+			}}
+		>
 			<div class="user-button">
 				{#if $user?.picture}
 					<img
@@ -181,6 +201,7 @@
 				<Icon name="select-chevron" />
 			</div>
 		</Button>
+
 		<Button
 			icon="keyboard"
 			kind="ghost"
@@ -189,6 +210,7 @@
 			tooltipPosition="top"
 			tooltipAlign="start"
 			width={34}
+			class="fill-text-2"
 		/>
 		<Button
 			icon="mail"
@@ -197,9 +219,59 @@
 			tooltipPosition="top"
 			tooltipAlign="start"
 			width={34}
+			class="fill-text-2"
+			onclick={() => {
+				shareIssueModal.show();
+			}}
 		/>
 	</div>
 </nav>
+
+<ContextMenu
+	bind:this={contextMenuEl}
+	leftClickTrigger={contextTriggerButton}
+	verticalAlign="bottom"
+	horizontalAlign="left"
+>
+	<ContextMenuSection>
+		<ContextMenuItem
+			label="Preferences"
+			onclick={() => {
+				contextMenuEl?.close();
+			}}
+		/>
+	</ContextMenuSection>
+	<ContextMenuSection title="Theme (⌘K)">
+		<ContextMenuItem
+			label="Dark"
+			onclick={async () => {
+				contextMenuEl?.close();
+			}}
+		/>
+		<ContextMenuItem
+			label="Light"
+			onclick={async () => {
+				contextMenuEl?.close();
+			}}
+		/>
+		<ContextMenuItem
+			label="System"
+			onclick={async () => {
+				contextMenuEl?.close();
+			}}
+		/>
+	</ContextMenuSection>
+	<ContextMenuSection>
+		<ContextMenuItem
+			label="Logout"
+			onclick={async () => {
+				contextMenuEl?.close();
+			}}
+		/>
+	</ContextMenuSection>
+</ContextMenu>
+
+<ShareIssueModal bind:this={shareIssueModal} />
 
 <style>
 	.sidebar {
@@ -273,12 +345,22 @@
 		stroke: #000 !important;
 	}
 
+	:global(.fill-text-2) {
+		fill: var(--clr-text-2) !important;
+		opacity: 0.5;
+	}
+
 	:global(.btn-height-auto) {
 		height: auto !important;
+		opacity: 0.7;
 	}
 
 	:global(.btn-square) {
 		aspect-ratio: 1 / 1;
 		height: unset !important;
+		opacity: 0.7;
+	}
+	:global(.btn-square.btn-active) {
+		opacity: 1 !important;
 	}
 </style>

--- a/apps/desktop/src/components/ChromeSidebar.svelte
+++ b/apps/desktop/src/components/ChromeSidebar.svelte
@@ -19,7 +19,7 @@
 			kind="outline"
 			onclick={() => goto(routes.workspacePath(project.id))}
 			width={34}
-			height={34}
+			class="btn-square"
 		>
 			<svg viewBox="0 0 16 13" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<g opacity="0.7">
@@ -38,7 +38,7 @@
 			kind="outline"
 			onclick={() => goto(routes.branchesPath(project.id))}
 			width={34}
-			height={34}
+			class="btn-square"
 		>
 			<svg viewBox="0 0 16 14" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<g opacity="0.7">
@@ -57,7 +57,7 @@
 			kind="outline"
 			onclick={() => goto(routes.targetPath(project.id))}
 			width={34}
-			height={34}
+			class="btn-square"
 		>
 			<svg viewBox="0 0 18 16" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<g opacity="0.7">
@@ -75,7 +75,7 @@
 			kind="outline"
 			onclick={() => goto(routes.historyPath(project.id))}
 			width={34}
-			height={34}
+			class="btn-square"
 		>
 			<svg viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<g opacity="0.7">
@@ -91,9 +91,9 @@
 			kind="outline"
 			onclick={() => goto(routes.settingsPath(project.id))}
 			width={34}
-			height={34}
+			class="btn-square"
 		/>
-		<Button kind="outline" width={34} height="100%">
+		<Button kind="outline" width={34} class="btn-height-auto">
 			<div class="user-button">
 				{#if $user?.picture}
 					<img
@@ -160,5 +160,14 @@
 		width: 16px;
 		height: 16px;
 		stroke: var(--clr-btn-ntrl-outline-text);
+	}
+
+	:global(.btn-height-auto) {
+		height: auto !important;
+	}
+
+	:global(.btn-square) {
+		aspect-ratio: 1 / 1;
+		height: unset !important;
 	}
 </style>

--- a/apps/desktop/src/components/SyncButton.svelte
+++ b/apps/desktop/src/components/SyncButton.svelte
@@ -47,7 +47,7 @@
 	{#if loading}
 		<div class="sync-btn__busy-label">busy…</div>
 	{:else if $baseBranch?.lastFetched}
-		<TimeAgo date={$baseBranch?.lastFetched} />
+		<TimeAgo date={$baseBranch?.lastFetched} addSuffix={true} />
 	{/if}
 </Button>
 

--- a/apps/desktop/src/lib/routes/routes.svelte.ts
+++ b/apps/desktop/src/lib/routes/routes.svelte.ts
@@ -1,22 +1,42 @@
+import { page } from '$app/state';
+
+function isUrl<T>(id: string): T | undefined {
+	if (page.route.id === id) {
+		return page.params as T;
+	}
+}
 export class DesktopRoutesService {
 	constructor() {}
 
 	projectPath(projectId: string) {
 		return `/${projectId}`;
 	}
+	isProjectPath = $derived(isUrl<{ projectId: string }>('/[projectId]'));
+
 	settingsPath(projectId: string) {
 		return `/${projectId}/settings`;
 	}
+	isSettingsPath = $derived(isUrl<{ projectId: string }>('/[projectId]/settings'));
+
 	workspacePath(projectId: string) {
 		return `/${projectId}/workspace`;
 	}
+	isWorkspacePath = $derived(
+		isUrl<{ projectId: string; branchId?: string }>('/[projectId]/workspace/[[branchId]]')
+	);
+
 	branchesPath(projectId: string) {
 		return `/${projectId}/branches`;
 	}
+	isBranchesPath = $derived(isUrl<{ projectId: string }>('/[projectId]/branches'));
+
 	targetPath(projectId: string) {
 		return `/${projectId}/target`;
 	}
+	isTargetPath = $derived(isUrl<{ projectId: string }>('/[projectId]/target'));
+
 	historyPath(projectId: string) {
 		return `/${projectId}/history`;
 	}
+	isHistoryPath = $derived(isUrl<{ projectId: string }>('/[projectId]/history'));
 }

--- a/apps/desktop/src/lib/routes/routes.svelte.ts
+++ b/apps/desktop/src/lib/routes/routes.svelte.ts
@@ -39,4 +39,12 @@ export class DesktopRoutesService {
 		return `/${projectId}/history`;
 	}
 	isHistoryPath = $derived(isUrl<{ projectId: string }>('/[projectId]/history'));
+
+	changeProjectPath(targetProjectId: string) {
+		if (!page.route.id) {
+			return '/';
+		}
+		const targetRestPath = page.route.id?.replace('/[projectId]/', '');
+		return `/${targetProjectId}/${targetRestPath}`;
+	}
 }

--- a/apps/desktop/src/routes/[projectId]/workspace/[[branchId]]/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/workspace/[[branchId]]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { SettingsService } from '$lib/config/appSettingsV2';
 	import { getContext } from '@gitbutler/shared/context';
+	import Button from '@gitbutler/ui/Button.svelte';
 	import type { LayoutData } from '../../$types';
 	import { goto } from '$app/navigation';
 
@@ -17,4 +18,115 @@
 	});
 </script>
 
-<div>Workspace Page</div>
+<section>
+	<div class="sidebar">
+		<div class="sidebar-header">
+			<div class="text-14 text-semibold">Uncommitted changes</div>
+			<Button kind="ghost" icon="sidebar-unfold" />
+		</div>
+
+		<div class="sidebar-body">
+			<svg
+				width="120"
+				height="100"
+				viewBox="0 0 120 100"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<g clip-path="url(#clip0_3811_12702)">
+					<path
+						opacity="0.25"
+						d="M34.9721 79.0019L80.0676 76.1588C86.5068 75.7528 89.7264 75.5498 92.0114 73.9701C93.3532 73.0424 94.4477 71.8007 95.1994 70.353C96.4797 67.8876 96.2767 64.668 95.8707 58.2289L94.2907 33.1676C93.8847 26.7285 93.6817 23.5089 92.102 21.2238C91.1743 19.882 89.9325 18.7876 88.4849 18.0358C86.0195 16.7556 82.7999 16.9586 76.3608 17.3645L49.3649 19.0665C47.8159 19.1642 47.0415 19.213 46.3575 19.3534C42.9543 20.0517 40.1574 22.4662 38.9699 25.7311C38.7312 26.3872 38.5699 27.1463 38.2472 28.6644L35.5957 41.1388C35.1265 43.3462 34.892 44.4498 34.4482 45.4324C33.7959 46.8766 32.8098 48.1451 31.571 49.1333C30.7282 49.8057 29.7025 50.3121 27.6511 51.3248C24.9728 52.6471 23.6336 53.3082 22.6206 54.212C21.0266 55.6341 19.9298 57.5292 19.491 59.6198C19.2121 60.9484 19.3048 62.4177 19.4901 65.3563C19.7592 69.6252 19.8938 71.7597 20.6434 73.4219C21.8252 76.0423 24.0775 78.0274 26.8255 78.8707C28.5687 79.4056 30.7032 79.2711 34.9721 79.0019Z"
+						fill="#D4D0CE"
+					/>
+					<path
+						d="M50.3304 47.3764L61.1532 55.4794C62.7942 56.708 65.0983 56.4972 66.4891 54.9913L82.9404 37.1779"
+						stroke="#CDC9C6"
+						stroke-width="2"
+					/>
+					<path
+						opacity="0.21"
+						d="M36.1051 91.1107L47.659 78.2018L66.8838 76.9898L82.7672 88.1687L36.1051 91.1107Z"
+						fill="#867E79"
+					/>
+					<path
+						opacity="0.3"
+						d="M1.9933 22.2747L6.56951 18.386C9.20709 16.1447 10.6359 12.7926 10.4264 9.33772L10.0437 3.02781L14.0383 7.92725C16.2255 10.6099 19.5478 12.1066 23.0062 11.9674L29.0067 11.7258L24.4304 15.6145C21.7929 17.8558 20.364 21.2078 20.5736 24.6628L20.9563 30.9727L16.9617 26.0732C14.7745 23.3906 11.4522 21.8939 7.99373 22.0331L1.9933 22.2747Z"
+						fill="#3CB4AE"
+					/>
+					<path
+						opacity="0.3"
+						d="M114.049 76.3141L119.746 88.5636L108.951 96.6858L103.254 84.4363L114.049 76.3141Z"
+						fill="#3CB4AE"
+					/>
+				</g>
+				<defs>
+					<clipPath id="clip0_3811_12702">
+						<rect width="120" height="100" fill="white" />
+					</clipPath>
+				</defs>
+			</svg>
+			<div class="text-12 text-body helper-text">
+				<div>You're all caught up!</div>
+				<div>No files need committing</div>
+			</div>
+		</div>
+	</div>
+	<div class="content">Tab Area</div>
+</section>
+
+<style>
+	section {
+		display: flex;
+		flex: 1;
+		align-items: stretch;
+		padding-bottom: 16px;
+		padding-right: 16px;
+		height: 100%;
+		gap: 14px;
+	}
+
+	.sidebar {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: flex-start;
+		width: 290px;
+		background-color: var(--clr-bg-1);
+		border-radius: var(--radius-ml);
+		padding: 8px;
+	}
+
+	.sidebar-header {
+		width: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+
+	.sidebar-body {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.content {
+		flex: 1;
+		padding: 8px;
+		border-radius: var(--radius-ml);
+
+		background-color: #f3f3f2;
+		opacity: 0.4;
+		background-image: radial-gradient(#867e79 0.35000000000000003px, #f3f3f2 0.35000000000000003px);
+		background-size: 7px 7px;
+	}
+
+	.helper-text {
+		text-align: center;
+		color: var(--clr-text-2);
+		opacity: 0.6;
+		margin-top: 10px;
+	}
+</style>

--- a/apps/desktop/src/routes/[projectId]/workspace/[[branchId]]/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/workspace/[[branchId]]/+page.svelte
@@ -12,7 +12,7 @@
 
 	// Redirect to board if we have switched away from V3 feature.
 	$effect(() => {
-		if (!$settingsStore?.featureFlags.v3) {
+		if ($settingsStore && !$settingsStore.featureFlags.v3) {
 			goto(`/${data.projectId}/board`);
 		}
 	});
@@ -94,7 +94,7 @@
 		width: 290px;
 		background-color: var(--clr-bg-1);
 		border-radius: var(--radius-ml);
-		padding: 8px;
+		border: 1px solid var(--clr-border-2);
 	}
 
 	.sidebar-header {
@@ -102,6 +102,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
+		padding: 10px 8px 10px 14px;
 	}
 
 	.sidebar-body {
@@ -115,6 +116,7 @@
 	.content {
 		flex: 1;
 		padding: 8px;
+		border: 1px solid var(--clr-border-2);
 		border-radius: var(--radius-ml);
 
 		background-color: #f3f3f2;

--- a/packages/ui/src/lib/Button.svelte
+++ b/packages/ui/src/lib/Button.svelte
@@ -11,7 +11,6 @@
 		// Layout props
 		shrinkable?: boolean;
 		reversedDirection?: boolean;
-		height?: number | string | undefined;
 		width?: number | string | undefined;
 		maxWidth?: number | undefined;
 		size?: 'tag' | 'button' | 'cta';
@@ -23,7 +22,7 @@
 		style?: ComponentColorType;
 		kind?: ComponentKindType;
 		solidBackground?: boolean;
-		class?: string;
+		class?: string | (string | undefined)[] | Record<string, string>;
 		// Additional elements
 		icon?: keyof typeof iconsJson | undefined;
 		tooltip?: string;
@@ -59,7 +58,6 @@
 		type = 'button',
 		shrinkable = false,
 		reversedDirection = false,
-		height,
 		width,
 		maxWidth,
 		size = 'button',
@@ -112,11 +110,6 @@
 			className
 		]}
 		style:align-self={align}
-		style:height={height !== undefined
-			? typeof height === 'number'
-				? pxToRem(height)
-				: height
-			: undefined}
 		style:width={width !== undefined
 			? typeof width === 'number'
 				? pxToRem(width)


### PR DESCRIPTION
## 🧢 Changes

- Further Chrome styling  implementation based off of [this Figma](https://www.figma.com/design/ShIiR6hI5dzH7sT5L03Jg1/App-Design-3.0)
- Add 'Workspace' page placeholder items

### Todos in follow-up PR(s):

- [ ] Notification btn (top-right) needs the panel written and API wired up ([Ticket](https://linear.app/gitbutler/issue/GB-923/notification-panel))
- [ ] Keyboard shortcut btn (bottom left) needs the modal it will open written ([Ticket](https://linear.app/gitbutler/issue/GB-925/keyboard-shortcut-panel))
- [ ] "3 upstream commits" needs wired up to an API ([Ticket](https://linear.app/gitbutler/issue/GB-927/chrome-new-base-commits-notification-btn))
- [ ] Profile pic context menu needs alignment when open to the right fixed ([Ticket](https://linear.app/gitbutler/issue/GB-926/profile-pic-context-menu))
	- [ ] Context menu items need wired up

Preview:

![image](https://github.com/user-attachments/assets/00d896de-8362-4945-9ab7-21d80deb51c8)


## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
