### PR TITLE
v3 subscription API for worktree changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2995,6 +2995,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "backoff",
+ "but-core",
  "gitbutler-branch-actions",
  "gitbutler-command-context",
  "gitbutler-diff",

--- a/apps/desktop/src/lib/worktree/worktree.ts
+++ b/apps/desktop/src/lib/worktree/worktree.ts
@@ -1,8 +1,18 @@
-import { invoke } from '$lib/backend/ipc';
+import { listen, invoke } from '$lib/backend/ipc';
 
 /** Gets the current status of the worktree */
 export async function worktree_changes(projectId: string): Promise<WorktreeChanges> {
 	return await invoke<WorktreeChanges>('worktree_changes', { projectId });
+}
+
+/** Subscibes for worktree_changes updates */
+export function subscribe<WorktreeChanges>(
+	projectId: string,
+	callback: (changes: WorktreeChanges) => void
+) {
+	return listen<WorktreeChanges>(`project://${projectId}/worktree_changes`, (event) =>
+		callback(event.payload)
+	);
 }
 
 /** Contains the changes that are in the worktree */

--- a/crates/gitbutler-tauri/src/window.rs
+++ b/crates/gitbutler-tauri/src/window.rs
@@ -54,8 +54,16 @@ pub(crate) mod state {
                         project_id,
                     },
                     Change::UncommitedFiles { project_id, files } => ChangeForFrontend {
-                        name: format!("project://{}/uncommited-files", project_id),
+                        name: format!("project://{}/uncommited-files", project_id), // This appears to be something related to "EditMode"
                         payload: serde_json::json!(files),
+                        project_id,
+                    },
+                    Change::WorktreeChanges {
+                        project_id,
+                        changes,
+                    } => ChangeForFrontend {
+                        name: format!("project://{}/worktree_changes", project_id),
+                        payload: serde_json::json!(crate::worktree::to_worktree_changes(changes)),
                         project_id,
                     },
                 }

--- a/crates/gitbutler-tauri/src/worktree/mod.rs
+++ b/crates/gitbutler-tauri/src/worktree/mod.rs
@@ -191,7 +191,10 @@ pub fn worktree_changes(
 fn changes_in_worktree(worktree_dir: PathBuf) -> anyhow::Result<WorktreeChanges> {
     let repo = gix::open(worktree_dir).map_err(anyhow::Error::new)?;
     let detailed_changes = but_core::worktree::changes(&repo)?;
+    Ok(to_worktree_changes(detailed_changes))
+}
 
+pub(crate) fn to_worktree_changes(detailed_changes: Vec<but_core::TreeChange>) -> WorktreeChanges {
     let (mut changes, mut ignored_changes) = (Vec::new(), Vec::new());
     let mut last_path = None;
     for change in detailed_changes {
@@ -217,10 +220,10 @@ fn changes_in_worktree(worktree_dir: PathBuf) -> anyhow::Result<WorktreeChanges>
         last_path = Some(change.path.clone());
         changes.push(change.into());
     }
-    Ok(WorktreeChanges {
+    WorktreeChanges {
         changes,
         ignored_changes,
-    })
+    }
 }
 
 #[cfg(test)]

--- a/crates/gitbutler-watcher/Cargo.toml
+++ b/crates/gitbutler-watcher/Cargo.toml
@@ -25,6 +25,7 @@ gitbutler-user.workspace = true
 gitbutler-reference.workspace = true
 gitbutler-error.workspace = true
 gitbutler-operating-modes.workspace = true
+but-core.workspace = true
 
 backoff = "0.4.0"
 notify = { version = "6.0.1" }

--- a/crates/gitbutler-watcher/src/events.rs
+++ b/crates/gitbutler-watcher/src/events.rs
@@ -1,5 +1,6 @@
 use std::{fmt::Display, path::PathBuf};
 
+use but_core::TreeChange;
 use gitbutler_branch_actions::{RemoteBranchFile, VirtualBranches};
 use gitbutler_operating_modes::OperatingMode;
 use gitbutler_project::ProjectId;
@@ -104,5 +105,9 @@ pub enum Change {
     UncommitedFiles {
         project_id: ProjectId,
         files: Vec<RemoteBranchFile>,
+    },
+    WorktreeChanges {
+        project_id: ProjectId,
+        changes: Vec<TreeChange>,
     },
 }

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -55,7 +55,7 @@ impl Handler {
     pub(super) fn handle(&self, event: events::InternalEvent) -> Result<()> {
         match event {
             events::InternalEvent::ProjectFilesChange(project_id, paths) => {
-                self.recalculate_everything(paths, project_id)
+                self.project_files_change(paths, project_id)
             }
 
             events::InternalEvent::GitFilesChange(project_id, paths) => self
@@ -132,7 +132,7 @@ impl Handler {
     }
 
     #[instrument(skip(self, paths, project_id), fields(paths = paths.len()))]
-    fn recalculate_everything(&self, paths: Vec<PathBuf>, project_id: ProjectId) -> Result<()> {
+    fn project_files_change(&self, paths: Vec<PathBuf>, project_id: ProjectId) -> Result<()> {
         let ctx = self.open_command_context(project_id)?;
 
         let worktree_changes = self.emit_uncommited_files(ctx.project()).ok();


### PR DESCRIPTION
This hooks into the existing filesystem watching and whenever project files or the index change, the worktree changes are computed and a frontend event is emitted.