### PR TITLE
feat: allow center aligning select dropdown options below select element

### DIFF
--- a/apps/desktop/src/components/Select.svelte
+++ b/apps/desktop/src/components/Select.svelte
@@ -33,7 +33,7 @@
 		maxHeight?: number;
 		searchable?: boolean;
 		customWidth?: number;
-		popupAlign?: 'left' | 'right';
+		popupAlign?: 'left' | 'right' | 'center';
 		customSelectButton?: Snippet;
 		itemSnippet: Snippet<[{ item: SelectItem<T>; highlighted: boolean; idx: number }]>;
 		children?: Snippet;
@@ -219,7 +219,9 @@
 					: undefined}
 				style:right={inputBoundingRect?.right && popupAlign === 'right'
 					? `${window.innerWidth - inputBoundingRect.right}px`
-					: undefined}
+					: inputBoundingRect && popupAlign === 'center'
+						? `${window.innerWidth - inputBoundingRect.right - inputBoundingRect.width / 2}px`
+						: undefined}
 				style:max-height={maxHeightState && `${maxHeightState}px`}
 			>
 				<ScrollableContainer initiallyVisible>

--- a/apps/desktop/src/components/SelectItem.svelte
+++ b/apps/desktop/src/components/SelectItem.svelte
@@ -59,6 +59,7 @@
 		justify-content: space-between;
 		border-radius: var(--radius-m);
 		width: 100%;
+		gap: 16px;
 		white-space: nowrap;
 		&:not(.selected):hover:enabled,
 		&:not(.selected):focus:enabled {


### PR DESCRIPTION
## 🧢 Changes

- Allow `'center'` aligning the `Select` component Options pop-up under the select element.
- Add a minimum gap of `0.5rem` between `SelectItem` label and Icon

![image](https://github.com/user-attachments/assets/7597b938-3978-45e2-970c-02c5680ab1a0)


## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6030 
- <kbd>&nbsp;1&nbsp;</kbd> #6027 👈 
<!-- GitButler Footer Boundary Bottom -->

