### PR TITLE
fix: `Select.svelte` options group pop-up centering implementation

### DIFF
--- a/apps/desktop/src/components/Select.svelte
+++ b/apps/desktop/src/components/Select.svelte
@@ -64,6 +64,7 @@
 	}: SelectProps = $props();
 
 	let selectWrapperEl: HTMLElement;
+	let optionsGroupEl = $state<HTMLElement>();
 
 	let highlightedIndex: number | undefined = $state(undefined);
 	let searchValue = $state('');
@@ -73,6 +74,7 @@
 	let maxHeightState = $state(maxHeight);
 	let listOpen = $state(false);
 	let inputBoundingRect = $state<DOMRect>();
+	let optionsGroupBoundingRect = $state<DOMRect>();
 
 	const maxBottomPadding = 20;
 
@@ -100,6 +102,9 @@
 	function getInputBoundingRect() {
 		if (selectWrapperEl) {
 			inputBoundingRect = selectWrapperEl.getBoundingClientRect();
+		}
+		if (optionsGroupEl) {
+			optionsGroupBoundingRect = optionsGroupEl.getBoundingClientRect();
 		}
 	}
 
@@ -209,23 +214,24 @@
 		>
 			<div
 				class="options card"
-				style:width={customWidth ? 'fit-content' : `${inputBoundingRect?.width}px`}
+				bind:this={optionsGroupEl}
+				style:width={customWidth ? '100%' : `${inputBoundingRect?.width}px`}
 				style:max-width={customWidth && pxToRem(customWidth)}
 				style:top={inputBoundingRect?.top
 					? `${inputBoundingRect.top + inputBoundingRect.height}px`
 					: undefined}
 				style:left={inputBoundingRect?.left && popupAlign === 'left'
 					? `${inputBoundingRect.left}px`
-					: undefined}
+					: optionsGroupBoundingRect && inputBoundingRect && popupAlign === 'center'
+						? `${window.innerWidth / 2 - (optionsGroupBoundingRect.width - inputBoundingRect.width / 2) / 2}px`
+						: undefined}
 				style:right={inputBoundingRect?.right && popupAlign === 'right'
 					? `${window.innerWidth - inputBoundingRect.right}px`
-					: inputBoundingRect && popupAlign === 'center'
-						? `${window.innerWidth - inputBoundingRect.right - inputBoundingRect.width / 2}px`
-						: undefined}
+					: undefined}
 				style:max-height={maxHeightState && `${maxHeightState}px`}
 			>
 				<ScrollableContainer initiallyVisible>
-					{#if searchable && options.length > 5}
+					{#if searchable && options.length >= 3}
 						<SearchItem bind:searchValue />
 					{/if}
 					<OptionsGroup>
@@ -285,6 +291,7 @@
 		box-shadow: var(--fx-shadow-s);
 		overflow: hidden;
 		transform-origin: top;
+		width: 100%;
 
 		animation: fadeIn 0.16s ease-out forwards;
 	}


### PR DESCRIPTION
## 🧢 Changes

- Fix implementation of `Select.svelte` Options group centering implementation to use the width of the options group correctly when calculating offset

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6030 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #6027 
<!-- GitButler Footer Boundary Bottom -->

