### PR TITLE
fix: don't hide app updater pop-up entirely in flatpak package

### DIFF
--- a/apps/desktop/src/components/AppUpdater.svelte
+++ b/apps/desktop/src/components/AppUpdater.svelte
@@ -4,6 +4,7 @@
 	import { getContext } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import { fade } from 'svelte/transition';
+	import { env } from '$env/dynamic/public';
 
 	const updaterService = getContext(UpdaterService);
 	const update = updaterService.update;
@@ -20,6 +21,8 @@
 	function handleDismiss() {
 		updaterService.dismiss();
 	}
+
+	const inFlatpak = $derived(!!env.PUBLIC_FLATPAK_ID);
 </script>
 
 {#if version || status === 'Up-to-date'}
@@ -130,45 +133,47 @@
 					Release notes
 				</Button>
 			{/if}
-			<div class="status-section">
-				{#if status !== 'Error' && status !== 'Up-to-date'}
-					<div class="sliding-gradient"></div>
-				{/if}
-				<div class="cta-btn" transition:fade={{ duration: 100 }}>
-					{#if !status}
-						<Button
-							wide
-							style="pop"
-							testId="download-update"
-							onmousedown={async () => {
-								await updaterService.downloadAndInstall();
-							}}
-						>
-							Update to {version}
-						</Button>
-					{:else if status === 'Up-to-date'}
-						<Button
-							wide
-							style="pop"
-							testId="got-it"
-							onmousedown={async () => {
-								updaterService.dismiss();
-							}}
-						>
-							Got it!
-						</Button>
-					{:else if status === 'Done'}
-						<Button
-							style="pop"
-							wide
-							testId="restart-app"
-							onclick={async () => await updaterService.relaunchApp()}
-						>
-							Restart
-						</Button>
+			{#if !inFlatpak}
+				<div class="status-section">
+					{#if status !== 'Error' && status !== 'Up-to-date'}
+						<div class="sliding-gradient"></div>
 					{/if}
+					<div class="cta-btn" transition:fade={{ duration: 100 }}>
+						{#if !status}
+							<Button
+								wide
+								style="pop"
+								testId="download-update"
+								onmousedown={async () => {
+									await updaterService.downloadAndInstall();
+								}}
+							>
+								Update to {version}
+							</Button>
+						{:else if status === 'Up-to-date'}
+							<Button
+								wide
+								style="pop"
+								testId="got-it"
+								onmousedown={async () => {
+									updaterService.dismiss();
+								}}
+							>
+								Got it!
+							</Button>
+						{:else if status === 'Done'}
+							<Button
+								style="pop"
+								wide
+								testId="restart-app"
+								onclick={async () => await updaterService.relaunchApp()}
+							>
+								Restart
+							</Button>
+						{/if}
+					</div>
 				</div>
-			</div>
+			{/if}
 		</div>
 	</div>
 {/if}

--- a/apps/desktop/src/components/AppUpdater.test.ts
+++ b/apps/desktop/src/components/AppUpdater.test.ts
@@ -18,6 +18,13 @@ describe('AppUpdater', () => {
 		updater = new UpdaterService(tauri, posthog);
 		context = new Map([[UpdaterService, updater]]);
 		vi.spyOn(tauri, 'listen').mockReturnValue(async () => {});
+		vi.mock('$env/dynamic/public', () => {
+			return {
+				env: {
+					PUBLIC_FLATPAK_ID: undefined
+				}
+			};
+		});
 	});
 
 	afterEach(() => {

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -5,6 +5,6 @@ import { check } from '@tauri-apps/plugin-updater';
 export class Tauri {
 	invoke = invokeIpc;
 	listen = listenIpc;
-	checkUpdate = import.meta.env.VITE_FLATPAK_ID ? () => null : check;
+	checkUpdate = check;
 	currentVersion = getVersion;
 }


### PR DESCRIPTION
## 🧢 Changes

- After talking with Kiril, we decided that in the flatpak we should still show the update notification, even if flatpak users cant use our in-app updater. This way they're at least more quickly aware of new releases and are less likely to be stuck on an old release.
- Note to self: update `VITE_FLATPAK_ID` env var in flatpak build script to `PUBLIC_FLATPAK_ID`

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
