### PR TITLE
refactor: simplify tree_change_diffs to handle a single change

### DIFF
--- a/apps/desktop/src/lib/worktree/worktree.ts
+++ b/apps/desktop/src/lib/worktree/worktree.ts
@@ -19,8 +19,8 @@ export function subscribe<WorktreeChanges>(
  * Gets the unified diff for a given TreeChange.
  * This probably does not belong in a package called "worktree" since this also operates on commit-to-commit changes and not only worktree changes
  */
-export async function treeChangeDiffs(projectId: string, changes: TreeChange[]) {
-	return await invoke<UnifiedDiff[]>('tree_change_diffs', { projectId, changes });
+export async function treeChangeDiffs(projectId: string, change: TreeChange) {
+	return await invoke<UnifiedDiff>('tree_change_diffs', { projectId, change });
 }
 
 /**

--- a/crates/gitbutler-tauri/src/diff.rs
+++ b/crates/gitbutler-tauri/src/diff.rs
@@ -7,19 +7,15 @@ use tracing::instrument;
 
 /// The array of unified diffs matches `changes`, so that `result[n] = unified_diff_of(changes[n])`.
 #[tauri::command(async)]
-#[instrument(skip(projects, changes), err(Debug))]
+#[instrument(skip(projects, change), err(Debug))]
 pub fn tree_change_diffs(
     projects: tauri::State<'_, gitbutler_project::Controller>,
     project_id: ProjectId,
-    changes: Vec<TreeChange>,
-) -> anyhow::Result<Vec<UnifiedDiff>, Error> {
+    change: TreeChange,
+) -> anyhow::Result<UnifiedDiff, Error> {
     let project = projects.get(project_id)?;
     let repo = gix::open(project.path).map_err(anyhow::Error::from)?;
-
-    Ok(changes
-        .into_iter()
-        .map(|tree_change| tree_change.unified_diff(&repo))
-        .collect::<Result<Vec<_>, _>>()?)
+    change.unified_diff(&repo).map_err(Into::into)
 }
 
 /// A frontend version of [`but_core::unified_diff::DiffHunk`].


### PR DESCRIPTION
There is no material cost to making many requests and enforcing that we do the fetching one at a time will allow for better error handling and in general having the UI be more lazy in loading data