### PR TITLE
follow-up to #6028

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3057,7 +3057,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.70.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "gix-actor 0.33.2",
  "gix-attributes 0.24.0",
@@ -3128,7 +3128,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.33.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "gix-date 0.9.3",
@@ -3159,7 +3159,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.24.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "gix-glob 0.18.0",
@@ -3185,7 +3185,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.14"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "thiserror 2.0.9",
 ]
@@ -3202,7 +3202,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "thiserror 2.0.9",
 ]
@@ -3210,7 +3210,7 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.4.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "gix-path 0.10.14",
@@ -3235,7 +3235,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.26.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "gix-chunk 0.4.11",
@@ -3249,7 +3249,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.43.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -3269,7 +3269,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.14.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -3281,7 +3281,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.27.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3310,7 +3310,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.9.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "itoa 1.0.11",
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.50.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "gix-attributes 0.24.0",
@@ -3345,7 +3345,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "gix-discover 0.38.0",
@@ -3380,7 +3380,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.38.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "dunce",
@@ -3410,7 +3410,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.40.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -3432,7 +3432,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -3463,7 +3463,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "fastrand",
  "gix-features 0.40.0",
@@ -3485,7 +3485,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.18.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -3507,7 +3507,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "faster-hex",
  "serde",
@@ -3528,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.7.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "gix-hash 0.16.0",
  "hashbrown 0.14.5",
@@ -3551,7 +3551,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "gix-glob 0.18.0",
@@ -3592,7 +3592,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.38.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -3631,7 +3631,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "16.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "gix-tempfile 16.0.0",
  "gix-utils 0.1.14",
@@ -3641,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.25.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "gix-actor 0.33.2",
@@ -3653,7 +3653,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.3.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3677,7 +3677,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.18.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bitflags 2.6.0",
  "gix-commitgraph 0.26.0",
@@ -3711,7 +3711,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.47.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "gix-actor 0.33.2",
@@ -3732,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.67.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "arc-swap",
  "gix-date 0.9.3",
@@ -3753,7 +3753,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.57.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "clru",
  "gix-chunk 0.4.11",
@@ -3774,7 +3774,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.18.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -3785,7 +3785,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.18.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -3809,7 +3809,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.14"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "gix-trace 0.1.12",
@@ -3821,7 +3821,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.9.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -3835,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.9.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -3847,7 +3847,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.48.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.4.15"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "gix-utils 0.1.14",
@@ -3916,7 +3916,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.50.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "gix-actor 0.33.2",
  "gix-features 0.40.0",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "gix-hash 0.16.0",
@@ -3950,7 +3950,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -3983,7 +3983,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.18.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "gix-commitgraph 0.26.0",
  "gix-date 0.9.3",
@@ -4009,7 +4009,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.10.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bitflags 2.6.0",
  "gix-path 0.10.14",
@@ -4021,7 +4021,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.2.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "gix-hash 0.16.0",
@@ -4033,7 +4033,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "filetime",
@@ -4055,7 +4055,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "gix-config",
@@ -4084,7 +4084,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "16.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "dashmap",
  "gix-fs 0.13.0",
@@ -4129,7 +4129,7 @@ checksum = "04bdde120c29f1fc23a24d3e115aeeea3d60d8e65bab92cc5f9d90d9302eb952"
 [[package]]
 name = "gix-trace"
 version = "0.1.12"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "tracing-core",
 ]
@@ -4137,7 +4137,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.45.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -4173,7 +4173,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.44.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bitflags 2.6.0",
  "gix-commitgraph 0.26.0",
@@ -4189,7 +4189,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "gix-features 0.40.0",
@@ -4213,7 +4213,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.1.14"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.9.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "thiserror 2.0.9",
@@ -4261,7 +4261,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.39.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "gix-attributes 0.24.0",
@@ -4280,7 +4280,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755#1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=cc7b614e541aa4a485f470f36516589619e2de5e#cc7b614e541aa4a485f470f36516589619e2de5e"
 dependencies = [
  "bstr",
  "gix-features 0.40.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.dependencies]
 bstr = "1.11.1"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
-gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "1a69c4080bc38ef9151bc8ebfb9d5f87f19b5755", default-features = false, features = [
+gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "cc7b614e541aa4a485f470f36516589619e2de5e", default-features = false, features = [
 ] }
 gix-testtools = "0.15.0"
 insta = "1.41.1"


### PR DESCRIPTION
This should work more reliably and will prevent this 'string-command' style from growing in this codebase.

### Tasks

* [x] update `gitoxide` to the latest version on `main`