### PR TITLE
fix: chrome header project Select.svelte alignment

### DIFF
--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -43,7 +43,6 @@
 	</div>
 	<div class="center">
 		<Select
-			wide
 			searchable
 			value={selectedProjectId}
 			options={mappedProjects}
@@ -121,6 +120,14 @@
 	.left-buttons {
 		display: flex;
 		gap: 8px;
+	}
+
+	.center {
+		position: absolute;
+		left: 0;
+		width: 100%;
+		display: flex;
+		justify-content: center;
 	}
 
 	.selector-series-select {

--- a/apps/desktop/src/components/Select.svelte
+++ b/apps/desktop/src/components/Select.svelte
@@ -223,7 +223,7 @@
 				style:left={inputBoundingRect?.left && popupAlign === 'left'
 					? `${inputBoundingRect.left}px`
 					: optionsGroupBoundingRect && inputBoundingRect && popupAlign === 'center'
-						? `${window.innerWidth / 2 - (optionsGroupBoundingRect.width - inputBoundingRect.width / 2) / 2}px`
+						? `${window.innerWidth / 2 - optionsGroupBoundingRect.width / 2}px`
 						: undefined}
 				style:right={inputBoundingRect?.right && popupAlign === 'right'
 					? `${window.innerWidth - inputBoundingRect.right}px`


### PR DESCRIPTION
## 🧢 Changes

- Align project name / select trigger btn globally center in header
- Tweak select dropdown `'center'` alignment calculation

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
