### PR TITLE
create_virtual_branch now returns StackEntry instead of just ID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2364,6 +2364,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bstr",
+ "but-workspace",
  "criterion",
  "diffy",
  "git2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,6 +700,7 @@ dependencies = [
  "gitbutler-id",
  "gitbutler-oxidize",
  "gitbutler-repo",
+ "gitbutler-serde",
  "gitbutler-stack",
  "gix",
  "itertools 0.14.0",

--- a/crates/but-workspace/Cargo.toml
+++ b/crates/but-workspace/Cargo.toml
@@ -13,11 +13,18 @@ anyhow.workspace = true
 bstr.workspace = true
 git2.workspace = true
 gitbutler-id.workspace = true
-gix = { workspace = true, features = ["dirwalk", "credentials", "parallel", "serde", "status"] }
+gix = { workspace = true, features = [
+    "dirwalk",
+    "credentials",
+    "parallel",
+    "serde",
+    "status",
+] }
 gitbutler-stack.workspace = true
 gitbutler-command-context.workspace = true
 gitbutler-oxidize.workspace = true
 gitbutler-commit.workspace = true
 gitbutler-repo.workspace = true
 serde = { workspace = true, features = ["std"] }
+gitbutler-serde.workspace = true
 itertools = "0.14"

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -26,19 +26,22 @@ use gitbutler_stack::stack_context::CommandContextExt;
 use gitbutler_stack::{stack_context::StackContext, Stack, Target, VirtualBranchesHandle};
 use integrated::IsCommitIntegrated;
 use itertools::Itertools;
+use serde::Serialize;
 use std::path::Path;
 use std::str::FromStr;
 
 mod integrated;
 
 /// Represents a lightweight version of a [`gitbutler_stack::Stack`] for listing.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct StackEntry {
     /// The ID of the stack.
     pub id: Id<gitbutler_stack::Stack>,
     /// The list of the branch names that are part of the stack.
     /// The list is never empty.
     /// The first entry in the list is always the most recent branch on top the stack.
+    #[serde(with = "gitbutler_serde::bstring_vec_lossy")]
     pub branch_names: Vec<BString>,
 }
 

--- a/crates/gitbutler-branch-actions/Cargo.toml
+++ b/crates/gitbutler-branch-actions/Cargo.toml
@@ -32,6 +32,7 @@ gitbutler-oxidize.workspace = true
 gitbutler-stack.workspace = true
 gitbutler-hunk-dependency.workspace = true
 gitbutler-workspace.workspace = true
+but-workspace.workspace = true
 serde = { workspace = true, features = ["std"] }
 serde-error = "0.1.3"
 bstr.workspace = true

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/apply_virtual_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/apply_virtual_branch.rs
@@ -23,30 +23,31 @@ fn rebase_commit() {
     gitbutler_branch_actions::set_base_branch(ctx, &"refs/remotes/origin/master".parse().unwrap())
         .unwrap();
 
-    let mut branch1_id = {
+    let mut stack_1_id = {
         // create a branch with some commited work
-        let branch1_id =
+        let stack_entry_1 =
             gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
                 .unwrap();
         fs::write(repository.path().join("another_file.txt"), "virtual").unwrap();
 
-        gitbutler_branch_actions::create_commit(ctx, branch1_id, "virtual commit", None).unwrap();
+        gitbutler_branch_actions::create_commit(ctx, stack_entry_1.id, "virtual commit", None)
+            .unwrap();
 
         let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
         let branches = list_result.branches;
         assert_eq!(branches.len(), 1);
-        assert_eq!(branches[0].id, branch1_id);
+        assert_eq!(branches[0].id, stack_entry_1.id);
         assert!(branches[0].active);
         assert_eq!(branches[0].files.len(), 0);
         assert_eq!(branches[0].series[0].clone().unwrap().patches.len(), 1);
 
-        branch1_id
+        stack_entry_1.id
     };
 
     let unapplied_branch = {
         // unapply first vbranch
         let unapplied_branch =
-            gitbutler_branch_actions::save_and_unapply_virutal_branch(ctx, branch1_id).unwrap();
+            gitbutler_branch_actions::save_and_unapply_virutal_branch(ctx, stack_1_id).unwrap();
 
         assert_eq!(
             fs::read_to_string(repository.path().join("another_file.txt")).unwrap(),
@@ -85,7 +86,7 @@ fn rebase_commit() {
 
     {
         // apply first vbranch again
-        branch1_id = gitbutler_branch_actions::create_virtual_branch_from_branch(
+        stack_1_id = gitbutler_branch_actions::create_virtual_branch_from_branch(
             ctx,
             &unapplied_branch,
             None,
@@ -97,7 +98,7 @@ fn rebase_commit() {
         let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
         let branches = list_result.branches;
         assert_eq!(branches.len(), 1);
-        assert_eq!(branches[0].id, branch1_id);
+        assert_eq!(branches[0].id, stack_1_id);
         assert_eq!(branches[0].files.len(), 0);
         assert_eq!(branches[0].series[0].clone().unwrap().patches.len(), 1);
         assert!(branches[0].active);
@@ -133,9 +134,9 @@ fn rebase_work() {
     gitbutler_branch_actions::set_base_branch(ctx, &"refs/remotes/origin/master".parse().unwrap())
         .unwrap();
 
-    let mut branch1_id = {
+    let mut stack_1_id = {
         // make a branch with some work
-        let branch1_id =
+        let stack_entry_1 =
             gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
                 .unwrap();
         fs::write(repository.path().join("another_file.txt"), "").unwrap();
@@ -143,18 +144,18 @@ fn rebase_work() {
         let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
         let branches = list_result.branches;
         assert_eq!(branches.len(), 1);
-        assert_eq!(branches[0].id, branch1_id);
+        assert_eq!(branches[0].id, stack_entry_1.id);
         assert!(branches[0].active);
         assert_eq!(branches[0].files.len(), 1);
         assert_eq!(branches[0].series[0].clone().unwrap().patches.len(), 0);
 
-        branch1_id
+        stack_entry_1.id
     };
 
     let unapplied_branch = {
         // unapply first vbranch
         let unapplied_branch =
-            gitbutler_branch_actions::save_and_unapply_virutal_branch(ctx, branch1_id).unwrap();
+            gitbutler_branch_actions::save_and_unapply_virutal_branch(ctx, stack_1_id).unwrap();
 
         let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
         let branches = list_result.branches;
@@ -181,7 +182,7 @@ fn rebase_work() {
 
     {
         // apply first vbranch again
-        branch1_id = gitbutler_branch_actions::create_virtual_branch_from_branch(
+        stack_1_id = gitbutler_branch_actions::create_virtual_branch_from_branch(
             ctx,
             &unapplied_branch,
             None,
@@ -193,7 +194,7 @@ fn rebase_work() {
         let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
         let branches = list_result.branches;
         assert_eq!(branches.len(), 1);
-        assert_eq!(branches[0].id, branch1_id);
+        assert_eq!(branches[0].id, stack_1_id);
         assert_eq!(branches[0].files.len(), 1);
         assert_eq!(branches[0].series[0].clone().unwrap().patches.len(), 0);
         assert!(branches[0].active);

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
@@ -15,25 +15,26 @@ fn integration() {
     let branch_name = {
         // make a remote branch
 
-        let branch_id =
+        let stack_entry =
             gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
                 .unwrap();
 
         std::fs::write(repository.path().join("file.txt"), "first\n").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "first", None).unwrap();
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "first", None).unwrap();
         #[allow(deprecated)]
-        gitbutler_branch_actions::push_virtual_branch(ctx, branch_id, false, None).unwrap();
+        gitbutler_branch_actions::push_virtual_branch(ctx, stack_entry.id, false, None).unwrap();
 
         let branch = gitbutler_branch_actions::list_virtual_branches(ctx)
             .unwrap()
             .branches
             .into_iter()
-            .find(|branch| branch.id == branch_id)
+            .find(|branch| branch.id == stack_entry.id)
             .unwrap();
 
         let name = branch.upstream.unwrap().name;
 
-        gitbutler_branch_actions::unapply_without_saving_virtual_branch(ctx, branch_id).unwrap();
+        gitbutler_branch_actions::unapply_without_saving_virtual_branch(ctx, stack_entry.id)
+            .unwrap();
 
         name
     };

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/insert_blank_commit.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/insert_blank_commit.rs
@@ -12,33 +12,33 @@ fn insert_blank_commit_down() -> anyhow::Result<()> {
     gitbutler_branch_actions::set_base_branch(ctx, &"refs/remotes/origin/master".parse().unwrap())
         .unwrap();
 
-    let branch_id =
+    let stack_entry =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
 
     // create commit
     fs::write(repository.path().join("file.txt"), "content").unwrap();
     let _commit1_id =
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit one", None).unwrap();
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit one", None).unwrap();
 
     // create commit
     fs::write(repository.path().join("file2.txt"), "content2").unwrap();
     fs::write(repository.path().join("file3.txt"), "content3").unwrap();
     let commit2_id =
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit two", None).unwrap();
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit two", None).unwrap();
 
     // create commit
     fs::write(repository.path().join("file4.txt"), "content4").unwrap();
     let _commit3_id =
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit three", None).unwrap();
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit three", None).unwrap();
 
-    gitbutler_branch_actions::insert_blank_commit(ctx, branch_id, commit2_id, 1).unwrap();
+    gitbutler_branch_actions::insert_blank_commit(ctx, stack_entry.id, commit2_id, 1).unwrap();
 
     let branch = gitbutler_branch_actions::list_virtual_branches(ctx)
         .unwrap()
         .branches
         .into_iter()
-        .find(|b| b.id == branch_id)
+        .find(|b| b.id == stack_entry.id)
         .unwrap();
 
     assert_eq!(branch.series[0].clone()?.patches.len(), 4);
@@ -79,33 +79,33 @@ fn insert_blank_commit_up() -> anyhow::Result<()> {
     gitbutler_branch_actions::set_base_branch(ctx, &"refs/remotes/origin/master".parse().unwrap())
         .unwrap();
 
-    let branch_id =
+    let stack_entry =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
 
     // create commit
     fs::write(repository.path().join("file.txt"), "content").unwrap();
     let _commit1_id =
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit one", None).unwrap();
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit one", None).unwrap();
 
     // create commit
     fs::write(repository.path().join("file2.txt"), "content2").unwrap();
     fs::write(repository.path().join("file3.txt"), "content3").unwrap();
     let commit2_id =
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit two", None).unwrap();
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit two", None).unwrap();
 
     // create commit
     fs::write(repository.path().join("file4.txt"), "content4").unwrap();
     let _commit3_id =
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit three", None).unwrap();
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit three", None).unwrap();
 
-    gitbutler_branch_actions::insert_blank_commit(ctx, branch_id, commit2_id, -1).unwrap();
+    gitbutler_branch_actions::insert_blank_commit(ctx, stack_entry.id, commit2_id, -1).unwrap();
 
     let branch = gitbutler_branch_actions::list_virtual_branches(ctx)
         .unwrap()
         .branches
         .into_iter()
-        .find(|b| b.id == branch_id)
+        .find(|b| b.id == stack_entry.id)
         .unwrap();
 
     assert_eq!(branch.series[0].clone()?.patches.len(), 4);

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/locking.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/locking.rs
@@ -116,7 +116,7 @@ async fn hunk_locking_with_deleted_lines_only() -> anyhow::Result<()> {
 
     // Commit some changes to the second branch that will push the first changes
     // down when diffing workspace head against the default target.
-    let second_branch_id = create_virtual_branch(
+    let second_stack_entry = create_virtual_branch(
         ctx,
         &BranchCreateRequest {
             selected_for_changes: Some(true),
@@ -131,8 +131,14 @@ async fn hunk_locking_with_deleted_lines_only() -> anyhow::Result<()> {
     let list_result = list_virtual_branches(ctx)?;
     let branches = list_result.branches;
     assert_eq!(branches.len(), 2);
-    let first_branch = branches.iter().find(|b| b.id != second_branch_id).unwrap();
-    let second_branch = branches.iter().find(|b| b.id == second_branch_id).unwrap();
+    let first_branch = branches
+        .iter()
+        .find(|b| b.id != second_stack_entry.id)
+        .unwrap();
+    let second_branch = branches
+        .iter()
+        .find(|b| b.id == second_stack_entry.id)
+        .unwrap();
     assert_eq!(first_branch.files.len(), 1);
     assert_eq!(second_branch.files.len(), 0);
     Ok(())

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/references.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/references.rs
@@ -17,14 +17,14 @@ mod create_virtual_branch {
         )
         .unwrap();
 
-        let branch_id =
+        let stack_entry =
             gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
                 .unwrap();
 
         let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
         let branches = list_result.branches;
         assert_eq!(branches.len(), 1);
-        assert_eq!(branches[0].id, branch_id);
+        assert_eq!(branches[0].id, stack_entry.id);
         assert_eq!(branches[0].name, "Lane");
 
         let refnames = repository
@@ -47,7 +47,7 @@ mod create_virtual_branch {
         )
         .unwrap();
 
-        let branch1_id = gitbutler_branch_actions::create_virtual_branch(
+        let stack_entry_1 = gitbutler_branch_actions::create_virtual_branch(
             ctx,
             &BranchCreateRequest {
                 name: Some("name".to_string()),
@@ -56,7 +56,7 @@ mod create_virtual_branch {
         )
         .unwrap();
 
-        let branch2_id = gitbutler_branch_actions::create_virtual_branch(
+        let stack_entry_2 = gitbutler_branch_actions::create_virtual_branch(
             ctx,
             &BranchCreateRequest {
                 name: Some("name".to_string()),
@@ -68,9 +68,9 @@ mod create_virtual_branch {
         let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
         let branches = list_result.branches;
         assert_eq!(branches.len(), 2);
-        assert_eq!(branches[0].id, branch1_id);
+        assert_eq!(branches[0].id, stack_entry_1.id);
         assert_eq!(branches[0].name, "name");
-        assert_eq!(branches[1].id, branch2_id);
+        assert_eq!(branches[1].id, stack_entry_2.id);
         assert_eq!(branches[1].name, "name 1");
 
         let refnames = repository
@@ -100,7 +100,7 @@ mod update_virtual_branch {
         )
         .unwrap();
 
-        let branch_id = gitbutler_branch_actions::create_virtual_branch(
+        let stack_entry = gitbutler_branch_actions::create_virtual_branch(
             ctx,
             &BranchCreateRequest {
                 name: Some("name".to_string()),
@@ -112,7 +112,7 @@ mod update_virtual_branch {
         gitbutler_branch_actions::update_virtual_branch(
             ctx,
             BranchUpdateRequest {
-                id: branch_id,
+                id: stack_entry.id,
                 name: Some("new name".to_string()),
                 ..Default::default()
             },
@@ -122,7 +122,7 @@ mod update_virtual_branch {
         let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
         let branches = list_result.branches;
         assert_eq!(branches.len(), 1);
-        assert_eq!(branches[0].id, branch_id);
+        assert_eq!(branches[0].id, stack_entry.id);
         assert_eq!(branches[0].name, "new name");
 
         let refnames = repository
@@ -146,7 +146,7 @@ mod update_virtual_branch {
         )
         .unwrap();
 
-        let branch1_id = gitbutler_branch_actions::create_virtual_branch(
+        let stack_entry_1 = gitbutler_branch_actions::create_virtual_branch(
             ctx,
             &BranchCreateRequest {
                 name: Some("name".to_string()),
@@ -155,7 +155,7 @@ mod update_virtual_branch {
         )
         .unwrap();
 
-        let branch2_id = gitbutler_branch_actions::create_virtual_branch(
+        let stack_entry_2 = gitbutler_branch_actions::create_virtual_branch(
             ctx,
             &BranchCreateRequest {
                 ..Default::default()
@@ -166,7 +166,7 @@ mod update_virtual_branch {
         gitbutler_branch_actions::update_virtual_branch(
             ctx,
             BranchUpdateRequest {
-                id: branch2_id,
+                id: stack_entry_2.id,
                 name: Some("name".to_string()),
                 ..Default::default()
             },
@@ -176,9 +176,9 @@ mod update_virtual_branch {
         let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
         let branches = list_result.branches;
         assert_eq!(branches.len(), 2);
-        assert_eq!(branches[0].id, branch1_id);
+        assert_eq!(branches[0].id, stack_entry_1.id);
         assert_eq!(branches[0].name, "name");
-        assert_eq!(branches[1].id, branch2_id);
+        assert_eq!(branches[1].id, stack_entry_2.id);
         assert_eq!(branches[1].name, "name 1");
 
         let refnames = repository
@@ -208,7 +208,7 @@ mod push_virtual_branch {
         )
         .unwrap();
 
-        let branch1_id = gitbutler_branch_actions::create_virtual_branch(
+        let stack_entry_1 = gitbutler_branch_actions::create_virtual_branch(
             ctx,
             &BranchCreateRequest {
                 name: Some("name".to_string()),
@@ -219,14 +219,14 @@ mod push_virtual_branch {
 
         fs::write(repository.path().join("file.txt"), "content").unwrap();
 
-        gitbutler_branch_actions::create_commit(ctx, branch1_id, "test", None).unwrap();
+        gitbutler_branch_actions::create_commit(ctx, stack_entry_1.id, "test", None).unwrap();
         #[allow(deprecated)]
-        gitbutler_branch_actions::push_virtual_branch(ctx, branch1_id, false, None).unwrap();
+        gitbutler_branch_actions::push_virtual_branch(ctx, stack_entry_1.id, false, None).unwrap();
 
         let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
         let branches = list_result.branches;
         assert_eq!(branches.len(), 1);
-        assert_eq!(branches[0].id, branch1_id);
+        assert_eq!(branches[0].id, stack_entry_1.id);
         assert_eq!(branches[0].name, "name");
         assert_eq!(
             branches[0].upstream.as_ref().unwrap().name.to_string(),
@@ -253,9 +253,9 @@ mod push_virtual_branch {
         )
         .unwrap();
 
-        let branch1_id = {
+        let stack_entry = {
             // create and push branch with some work
-            let branch1_id = gitbutler_branch_actions::create_virtual_branch(
+            let stack_entry_1 = gitbutler_branch_actions::create_virtual_branch(
                 ctx,
                 &BranchCreateRequest {
                     name: Some("name".to_string()),
@@ -264,26 +264,27 @@ mod push_virtual_branch {
             )
             .unwrap();
             fs::write(repository.path().join("file.txt"), "content").unwrap();
-            gitbutler_branch_actions::create_commit(ctx, branch1_id, "test", None).unwrap();
+            gitbutler_branch_actions::create_commit(ctx, stack_entry_1.id, "test", None).unwrap();
             #[allow(deprecated)]
-            gitbutler_branch_actions::push_virtual_branch(ctx, branch1_id, false, None).unwrap();
-            branch1_id
+            gitbutler_branch_actions::push_virtual_branch(ctx, stack_entry_1.id, false, None)
+                .unwrap();
+            stack_entry_1
         };
 
         // rename first branch
         gitbutler_branch_actions::update_virtual_branch(
             ctx,
             BranchUpdateRequest {
-                id: branch1_id,
+                id: stack_entry.id,
                 name: Some("updated name".to_string()),
                 ..Default::default()
             },
         )
         .unwrap();
 
-        let branch2_id = {
+        let stack_entry_2 = {
             // create another branch with first branch's old name and push it
-            let branch2_id = gitbutler_branch_actions::create_virtual_branch(
+            let stack_entry_2 = gitbutler_branch_actions::create_virtual_branch(
                 ctx,
                 &BranchCreateRequest {
                     name: Some("name".to_string()),
@@ -292,24 +293,25 @@ mod push_virtual_branch {
             )
             .unwrap();
             fs::write(repository.path().join("file.txt"), "updated content").unwrap();
-            gitbutler_branch_actions::create_commit(ctx, branch2_id, "test", None).unwrap();
+            gitbutler_branch_actions::create_commit(ctx, stack_entry_2.id, "test", None).unwrap();
             #[allow(deprecated)]
-            gitbutler_branch_actions::push_virtual_branch(ctx, branch2_id, false, None).unwrap();
-            branch2_id
+            gitbutler_branch_actions::push_virtual_branch(ctx, stack_entry_2.id, false, None)
+                .unwrap();
+            stack_entry_2
         };
 
         let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
         let branches = list_result.branches;
         assert_eq!(branches.len(), 2);
         // first branch is pushing to old ref remotely
-        assert_eq!(branches[0].id, branch1_id);
+        assert_eq!(branches[0].id, stack_entry.id);
         assert_eq!(branches[0].name, "updated name");
         assert_eq!(
             branches[0].upstream.as_ref().unwrap().name,
             "refs/remotes/origin/name".parse().unwrap()
         );
         // new branch is pushing to new ref remotely
-        assert_eq!(branches[1].id, branch2_id);
+        assert_eq!(branches[1].id, stack_entry_2.id);
         assert_eq!(branches[1].name, "name");
         assert_eq!(
             branches[1].upstream.as_ref().unwrap().name,

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/reset_virtual_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/reset_virtual_branch.rs
@@ -13,7 +13,7 @@ fn to_head() {
     gitbutler_branch_actions::set_base_branch(ctx, &"refs/remotes/origin/master".parse().unwrap())
         .unwrap();
 
-    let branch1_id =
+    let stack_entry =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
 
@@ -21,12 +21,13 @@ fn to_head() {
         fs::write(repository.path().join("file.txt"), "content").unwrap();
 
         // commit changes
-        let oid = gitbutler_branch_actions::create_commit(ctx, branch1_id, "commit", None).unwrap();
+        let oid =
+            gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit", None).unwrap();
 
         let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
         let branches = list_result.branches;
         assert_eq!(branches.len(), 1);
-        assert_eq!(branches[0].id, branch1_id);
+        assert_eq!(branches[0].id, stack_entry.id);
         assert_eq!(branches[0].series[0].clone().unwrap().patches.len(), 1);
         assert_eq!(branches[0].series[0].clone().unwrap().patches[0].id, oid);
         assert_eq!(branches[0].files.len(), 0);
@@ -40,12 +41,12 @@ fn to_head() {
 
     {
         // reset changes to head
-        gitbutler_branch_actions::reset_virtual_branch(ctx, branch1_id, oid).unwrap();
+        gitbutler_branch_actions::reset_virtual_branch(ctx, stack_entry.id, oid).unwrap();
 
         let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
         let branches = list_result.branches;
         assert_eq!(branches.len(), 1);
-        assert_eq!(branches[0].id, branch1_id);
+        assert_eq!(branches[0].id, stack_entry.id);
         assert_eq!(branches[0].series[0].clone().unwrap().patches.len(), 1);
         assert_eq!(branches[0].series[0].clone().unwrap().patches[0].id, oid);
         assert_eq!(branches[0].files.len(), 0);
@@ -68,7 +69,7 @@ fn to_target() {
     )
     .unwrap();
 
-    let branch1_id =
+    let stack_entry_1 =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
 
@@ -76,12 +77,13 @@ fn to_target() {
         fs::write(repository.path().join("file.txt"), "content").unwrap();
 
         // commit changes
-        let oid = gitbutler_branch_actions::create_commit(ctx, branch1_id, "commit", None).unwrap();
+        let oid =
+            gitbutler_branch_actions::create_commit(ctx, stack_entry_1.id, "commit", None).unwrap();
 
         let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
         let branches = list_result.branches;
         assert_eq!(branches.len(), 1);
-        assert_eq!(branches[0].id, branch1_id);
+        assert_eq!(branches[0].id, stack_entry_1.id);
         assert_eq!(branches[0].series[0].clone().unwrap().patches.len(), 1);
         assert_eq!(branches[0].series[0].clone().unwrap().patches[0].id, oid);
         assert_eq!(branches[0].files.len(), 0);
@@ -93,13 +95,13 @@ fn to_target() {
 
     {
         // reset changes to head
-        gitbutler_branch_actions::reset_virtual_branch(ctx, branch1_id, base_branch.base_sha)
+        gitbutler_branch_actions::reset_virtual_branch(ctx, stack_entry_1.id, base_branch.base_sha)
             .unwrap();
 
         let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
         let branches = list_result.branches;
         assert_eq!(branches.len(), 1);
-        assert_eq!(branches[0].id, branch1_id);
+        assert_eq!(branches[0].id, stack_entry_1.id);
         assert_eq!(branches[0].series[0].clone().unwrap().patches.len(), 0);
         assert_eq!(branches[0].files.len(), 1);
         assert_eq!(
@@ -118,7 +120,7 @@ fn to_commit() {
     gitbutler_branch_actions::set_base_branch(ctx, &"refs/remotes/origin/master".parse().unwrap())
         .unwrap();
 
-    let branch1_id =
+    let stack_entry_1 =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
 
@@ -127,12 +129,13 @@ fn to_commit() {
 
         fs::write(repository.path().join("file.txt"), "content").unwrap();
 
-        let oid = gitbutler_branch_actions::create_commit(ctx, branch1_id, "commit", None).unwrap();
+        let oid =
+            gitbutler_branch_actions::create_commit(ctx, stack_entry_1.id, "commit", None).unwrap();
 
         let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
         let branches = list_result.branches;
         assert_eq!(branches.len(), 1);
-        assert_eq!(branches[0].id, branch1_id);
+        assert_eq!(branches[0].id, stack_entry_1.id);
         assert_eq!(branches[0].series[0].clone().unwrap().patches.len(), 1);
         assert_eq!(branches[0].series[0].clone().unwrap().patches[0].id, oid);
         assert_eq!(branches[0].files.len(), 0);
@@ -149,12 +152,12 @@ fn to_commit() {
         fs::write(repository.path().join("file.txt"), "more content").unwrap();
 
         let second_commit_oid =
-            gitbutler_branch_actions::create_commit(ctx, branch1_id, "commit", None).unwrap();
+            gitbutler_branch_actions::create_commit(ctx, stack_entry_1.id, "commit", None).unwrap();
 
         let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
         let branches = list_result.branches;
         assert_eq!(branches.len(), 1);
-        assert_eq!(branches[0].id, branch1_id);
+        assert_eq!(branches[0].id, stack_entry_1.id);
         assert_eq!(branches[0].series[0].clone().unwrap().patches.len(), 2);
         assert_eq!(
             branches[0].series[0].clone().unwrap().patches[0].id,
@@ -173,12 +176,13 @@ fn to_commit() {
 
     {
         // reset changes to the first commit
-        gitbutler_branch_actions::reset_virtual_branch(ctx, branch1_id, first_commit_oid).unwrap();
+        gitbutler_branch_actions::reset_virtual_branch(ctx, stack_entry_1.id, first_commit_oid)
+            .unwrap();
 
         let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
         let branches = list_result.branches;
         assert_eq!(branches.len(), 1);
-        assert_eq!(branches[0].id, branch1_id);
+        assert_eq!(branches[0].id, stack_entry_1.id);
         assert_eq!(branches[0].series[0].clone().unwrap().patches.len(), 1);
         assert_eq!(
             branches[0].series[0].clone().unwrap().patches[0].id,
@@ -201,7 +205,7 @@ fn to_non_existing() {
     gitbutler_branch_actions::set_base_branch(ctx, &"refs/remotes/origin/master".parse().unwrap())
         .unwrap();
 
-    let branch1_id =
+    let stack_entry_1 =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
 
@@ -209,12 +213,13 @@ fn to_non_existing() {
         fs::write(repository.path().join("file.txt"), "content").unwrap();
 
         // commit changes
-        let oid = gitbutler_branch_actions::create_commit(ctx, branch1_id, "commit", None).unwrap();
+        let oid =
+            gitbutler_branch_actions::create_commit(ctx, stack_entry_1.id, "commit", None).unwrap();
 
         let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
         let branches = list_result.branches;
         assert_eq!(branches.len(), 1);
-        assert_eq!(branches[0].id, branch1_id);
+        assert_eq!(branches[0].id, stack_entry_1.id);
         assert_eq!(branches[0].series[0].clone().unwrap().patches.len(), 1);
         assert_eq!(branches[0].series[0].clone().unwrap().patches[0].id, oid);
         assert_eq!(branches[0].files.len(), 0);
@@ -229,7 +234,7 @@ fn to_non_existing() {
     assert_eq!(
         gitbutler_branch_actions::reset_virtual_branch(
             ctx,
-            branch1_id,
+            stack_entry_1.id,
             "fe14df8c66b73c6276f7bb26102ad91da680afcb".parse().unwrap()
         )
         .unwrap_err()

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/selected_for_changes.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/selected_for_changes.rs
@@ -14,26 +14,26 @@ fn unapplying_selected_branch_selects_anther() {
     std::fs::write(repository.path().join("file one.txt"), "").unwrap();
 
     // first branch should be created as default
-    let b_id =
+    let stack_entry_1 =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
 
     // if default branch exists, new branch should not be created as default
-    let b2_id =
+    let stack_entry_2 =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
 
     let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
     let branches = list_result.branches;
 
-    let b = branches.iter().find(|b| b.id == b_id).unwrap();
+    let b = branches.iter().find(|b| b.id == stack_entry_1.id).unwrap();
 
-    let b2 = branches.iter().find(|b| b.id == b2_id).unwrap();
+    let b2 = branches.iter().find(|b| b.id == stack_entry_2.id).unwrap();
 
     assert!(b.selected_for_changes);
     assert!(!b2.selected_for_changes);
 
-    gitbutler_branch_actions::save_and_unapply_virutal_branch(ctx, b_id).unwrap();
+    gitbutler_branch_actions::save_and_unapply_virutal_branch(ctx, stack_entry_1.id).unwrap();
 
     let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
     let branches = list_result.branches;
@@ -52,26 +52,26 @@ fn deleting_selected_branch_selects_anther() {
         .unwrap();
 
     // first branch should be created as default
-    let b_id =
+    let stack_entry =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
 
     // if default branch exists, new branch should not be created as default
-    let b2_id =
+    let stack_entry_2 =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
 
     let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
     let branches = list_result.branches;
 
-    let b = branches.iter().find(|b| b.id == b_id).unwrap();
+    let b = branches.iter().find(|b| b.id == stack_entry.id).unwrap();
 
-    let b2 = branches.iter().find(|b| b.id == b2_id).unwrap();
+    let b2 = branches.iter().find(|b| b.id == stack_entry_2.id).unwrap();
 
     assert!(b.selected_for_changes);
     assert!(!b2.selected_for_changes);
 
-    gitbutler_branch_actions::unapply_without_saving_virtual_branch(ctx, b_id).unwrap();
+    gitbutler_branch_actions::unapply_without_saving_virtual_branch(ctx, stack_entry.id).unwrap();
 
     let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
     let branches = list_result.branches;
@@ -89,31 +89,31 @@ fn create_virtual_branch_should_set_selected_for_changes() {
         .unwrap();
 
     // first branch should be created as default
-    let b_id =
+    let stack_entry =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
     let branch = gitbutler_branch_actions::list_virtual_branches(ctx)
         .unwrap()
         .branches
         .into_iter()
-        .find(|b| b.id == b_id)
+        .find(|b| b.id == stack_entry.id)
         .unwrap();
     assert!(branch.selected_for_changes);
 
     // if default branch exists, new branch should not be created as default
-    let b_id =
+    let stack_entry =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
     let branch = gitbutler_branch_actions::list_virtual_branches(ctx)
         .unwrap()
         .branches
         .into_iter()
-        .find(|b| b.id == b_id)
+        .find(|b| b.id == stack_entry.id)
         .unwrap();
     assert!(!branch.selected_for_changes);
 
     // explicitly don't make this one default
-    let b_id = gitbutler_branch_actions::create_virtual_branch(
+    let stack_entry = gitbutler_branch_actions::create_virtual_branch(
         ctx,
         &BranchCreateRequest {
             selected_for_changes: Some(false),
@@ -125,12 +125,12 @@ fn create_virtual_branch_should_set_selected_for_changes() {
         .unwrap()
         .branches
         .into_iter()
-        .find(|b| b.id == b_id)
+        .find(|b| b.id == stack_entry.id)
         .unwrap();
     assert!(!branch.selected_for_changes);
 
     // explicitly make this one default
-    let b_id = gitbutler_branch_actions::create_virtual_branch(
+    let stack_entry = gitbutler_branch_actions::create_virtual_branch(
         ctx,
         &BranchCreateRequest {
             selected_for_changes: Some(true),
@@ -142,7 +142,7 @@ fn create_virtual_branch_should_set_selected_for_changes() {
         .unwrap()
         .branches
         .into_iter()
-        .find(|b| b.id == b_id)
+        .find(|b| b.id == stack_entry.id)
         .unwrap();
     assert!(branch.selected_for_changes);
 }
@@ -154,32 +154,32 @@ fn update_virtual_branch_should_reset_selected_for_changes() {
     gitbutler_branch_actions::set_base_branch(ctx, &"refs/remotes/origin/master".parse().unwrap())
         .unwrap();
 
-    let b1_id =
+    let stack_entry_1 =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
     let b1 = gitbutler_branch_actions::list_virtual_branches(ctx)
         .unwrap()
         .branches
         .into_iter()
-        .find(|b| b.id == b1_id)
+        .find(|b| b.id == stack_entry_1.id)
         .unwrap();
     assert!(b1.selected_for_changes);
 
-    let b2_id =
+    let stack_entry_2 =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
     let b2 = gitbutler_branch_actions::list_virtual_branches(ctx)
         .unwrap()
         .branches
         .into_iter()
-        .find(|b| b.id == b2_id)
+        .find(|b| b.id == stack_entry_2.id)
         .unwrap();
     assert!(!b2.selected_for_changes);
 
     gitbutler_branch_actions::update_virtual_branch(
         ctx,
         BranchUpdateRequest {
-            id: b2_id,
+            id: stack_entry_2.id,
             selected_for_changes: Some(true),
             ..Default::default()
         },
@@ -190,7 +190,7 @@ fn update_virtual_branch_should_reset_selected_for_changes() {
         .unwrap()
         .branches
         .into_iter()
-        .find(|b| b.id == b1_id)
+        .find(|b| b.id == stack_entry_1.id)
         .unwrap();
     assert!(!b1.selected_for_changes);
 
@@ -198,7 +198,7 @@ fn update_virtual_branch_should_reset_selected_for_changes() {
         .unwrap()
         .branches
         .into_iter()
-        .find(|b| b.id == b2_id)
+        .find(|b| b.id == stack_entry_2.id)
         .unwrap();
     assert!(b2.selected_for_changes);
 }
@@ -212,7 +212,7 @@ fn unapply_virtual_branch_should_reset_selected_for_changes() {
     gitbutler_branch_actions::set_base_branch(ctx, &"refs/remotes/origin/master".parse().unwrap())
         .unwrap();
 
-    let b1_id =
+    let stack_entry_1 =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
     std::fs::write(repository.path().join("file.txt"), "content").unwrap();
@@ -221,11 +221,11 @@ fn unapply_virtual_branch_should_reset_selected_for_changes() {
         .unwrap()
         .branches
         .into_iter()
-        .find(|b| b.id == b1_id)
+        .find(|b| b.id == stack_entry_1.id)
         .unwrap();
     assert!(b1.selected_for_changes);
 
-    let b2_id =
+    let stack_entry_2 =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
 
@@ -233,17 +233,17 @@ fn unapply_virtual_branch_should_reset_selected_for_changes() {
         .unwrap()
         .branches
         .into_iter()
-        .find(|b| b.id == b2_id)
+        .find(|b| b.id == stack_entry_2.id)
         .unwrap();
     assert!(!b2.selected_for_changes);
 
-    gitbutler_branch_actions::save_and_unapply_virutal_branch(ctx, b1_id).unwrap();
+    gitbutler_branch_actions::save_and_unapply_virutal_branch(ctx, stack_entry_1.id).unwrap();
 
     assert!(gitbutler_branch_actions::list_virtual_branches(ctx)
         .unwrap()
         .branches
         .into_iter()
-        .any(|b| b.selected_for_changes && b.id != b1_id))
+        .any(|b| b.selected_for_changes && b.id != stack_entry_1.id))
 }
 
 #[test]

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/set_base_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/set_base_branch.rs
@@ -53,12 +53,12 @@ mod go_back_to_workspace {
         )
         .unwrap();
 
-        let vbranch_id =
+        let stack_entry =
             gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
                 .unwrap();
 
         std::fs::write(repository.path().join("another file.txt"), "content").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, vbranch_id, "one", None).unwrap();
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "one", None).unwrap();
 
         let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
         let branches = list_result.branches;
@@ -76,7 +76,7 @@ mod go_back_to_workspace {
         let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
         let branches = list_result.branches;
         assert_eq!(branches.len(), 1);
-        assert_eq!(branches[0].id, vbranch_id);
+        assert_eq!(branches[0].id, stack_entry.id);
         assert!(branches[0].active);
     }
 

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/squash.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/squash.rs
@@ -11,28 +11,28 @@ fn head() {
     gitbutler_branch_actions::set_base_branch(ctx, &"refs/remotes/origin/master".parse().unwrap())
         .unwrap();
 
-    let branch_id =
+    let stack_entry =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
 
     {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit one", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit one", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file two.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit two", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit two", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file three.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit three", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit three", None).unwrap()
     };
 
     let commit_four_oid = {
         fs::write(repository.path().join("file four.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit four", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit four", None).unwrap()
     };
 
     let commit_four_parent_oid = repository
@@ -44,7 +44,7 @@ fn head() {
 
     gitbutler_branch_actions::squash_commits(
         ctx,
-        branch_id,
+        stack_entry.id,
         vec![commit_four_oid],
         commit_four_parent_oid,
     )
@@ -54,7 +54,7 @@ fn head() {
         .unwrap()
         .branches
         .into_iter()
-        .find(|b| b.id == branch_id)
+        .find(|b| b.id == stack_entry.id)
         .unwrap();
 
     let descriptions = branch.series[0]
@@ -79,28 +79,28 @@ fn middle() {
     gitbutler_branch_actions::set_base_branch(ctx, &"refs/remotes/origin/master".parse().unwrap())
         .unwrap();
 
-    let branch_id =
+    let stack_entry =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
 
     {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit one", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit one", None).unwrap()
     };
 
     let commit_two_oid = {
         fs::write(repository.path().join("file two.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit two", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit two", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file three.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit three", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit three", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file four.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit four", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit four", None).unwrap()
     };
 
     let commit_two_parent_oid = repository
@@ -112,7 +112,7 @@ fn middle() {
 
     gitbutler_branch_actions::squash_commits(
         ctx,
-        branch_id,
+        stack_entry.id,
         vec![commit_two_oid],
         commit_two_parent_oid,
     )
@@ -122,7 +122,7 @@ fn middle() {
         .unwrap()
         .branches
         .into_iter()
-        .find(|b| b.id == branch_id)
+        .find(|b| b.id == stack_entry.id)
         .unwrap();
 
     let descriptions = branch.series[0]
@@ -159,31 +159,31 @@ fn forcepush_allowed() {
     gitbutler_branch_actions::set_base_branch(ctx, &"refs/remotes/origin/master".parse().unwrap())
         .unwrap();
 
-    let branch_id =
+    let stack_entry =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
 
     {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit one", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit one", None).unwrap()
     };
 
     let commit_two_oid = {
         fs::write(repository.path().join("file two.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit two", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit two", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file three.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit three", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit three", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file four.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit four", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit four", None).unwrap()
     };
 
-    gitbutler_branch_actions::stack::push_stack(ctx, branch_id, false).unwrap();
+    gitbutler_branch_actions::stack::push_stack(ctx, stack_entry.id, false).unwrap();
 
     let commit_two_parent_oid = repository
         .find_commit(commit_two_oid)
@@ -194,7 +194,7 @@ fn forcepush_allowed() {
 
     gitbutler_branch_actions::squash_commits(
         ctx,
-        branch_id,
+        stack_entry.id,
         vec![commit_two_oid],
         commit_two_parent_oid,
     )
@@ -204,7 +204,7 @@ fn forcepush_allowed() {
         .unwrap()
         .branches
         .into_iter()
-        .find(|b| b.id == branch_id)
+        .find(|b| b.id == stack_entry.id)
         .unwrap();
 
     let descriptions = branch.series[0]
@@ -230,14 +230,14 @@ fn forcepush_forbidden() {
     gitbutler_branch_actions::set_base_branch(ctx, &"refs/remotes/origin/master".parse().unwrap())
         .unwrap();
 
-    let branch_id =
+    let stack_entry =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
 
     gitbutler_branch_actions::update_virtual_branch(
         ctx,
         BranchUpdateRequest {
-            id: branch_id,
+            id: stack_entry.id,
             allow_rebasing: Some(false),
             ..Default::default()
         },
@@ -246,26 +246,26 @@ fn forcepush_forbidden() {
 
     {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit one", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit one", None).unwrap()
     };
 
     let commit_two_oid = {
         fs::write(repository.path().join("file two.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit two", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit two", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file three.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit three", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit three", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file four.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit four", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit four", None).unwrap()
     };
 
     // TODO: flag the old one as deprecated
-    gitbutler_branch_actions::stack::push_stack(ctx, branch_id, false).unwrap();
+    gitbutler_branch_actions::stack::push_stack(ctx, stack_entry.id, false).unwrap();
 
     let commit_two_parent_oid = repository
         .find_commit(commit_two_oid)
@@ -277,7 +277,7 @@ fn forcepush_forbidden() {
     assert_eq!(
         gitbutler_branch_actions::squash_commits(
             ctx,
-            branch_id,
+            stack_entry.id,
             vec![commit_two_oid],
             commit_two_parent_oid,
         )

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/unapply_ownership.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/unapply_ownership.rs
@@ -14,7 +14,7 @@ fn should_unapply_with_commits() {
     gitbutler_branch_actions::set_base_branch(ctx, &"refs/remotes/origin/master".parse().unwrap())
         .unwrap();
 
-    let branch_id =
+    let stack_entry =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
 
@@ -23,7 +23,7 @@ fn should_unapply_with_commits() {
         "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n",
     )
     .unwrap();
-    gitbutler_branch_actions::create_commit(ctx, branch_id, "test", None).unwrap();
+    gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "test", None).unwrap();
 
     // change in the committed hunks leads to hunk locking
     fs::write(
@@ -44,7 +44,7 @@ fn should_unapply_with_commits() {
         .unwrap()
         .branches
         .into_iter()
-        .find(|b| b.id == branch_id)
+        .find(|b| b.id == stack_entry.id)
         .unwrap();
     assert!(branch.files.is_empty());
 }

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/unapply_without_saving_virtual_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/unapply_without_saving_virtual_branch.rs
@@ -52,7 +52,7 @@ fn should_remove_reference() {
     gitbutler_branch_actions::set_base_branch(ctx, &"refs/remotes/origin/master".parse().unwrap())
         .unwrap();
 
-    let id = gitbutler_branch_actions::create_virtual_branch(
+    let stack_entry = gitbutler_branch_actions::create_virtual_branch(
         ctx,
         &BranchCreateRequest {
             name: Some("name".to_string()),
@@ -61,7 +61,7 @@ fn should_remove_reference() {
     )
     .unwrap();
 
-    gitbutler_branch_actions::unapply_without_saving_virtual_branch(ctx, id).unwrap();
+    gitbutler_branch_actions::unapply_without_saving_virtual_branch(ctx, stack_entry.id).unwrap();
 
     let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
     let branches = list_result.branches;

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/update_commit_message.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/update_commit_message.rs
@@ -12,30 +12,30 @@ fn head() {
     gitbutler_branch_actions::set_base_branch(ctx, &"refs/remotes/origin/master".parse().unwrap())
         .unwrap();
 
-    let branch_id =
+    let stack_entry =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
 
     {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit one", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit one", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file two.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit two", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit two", None).unwrap()
     };
 
     let commit_three_oid = {
         fs::write(repository.path().join("file three.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit three", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit three", None).unwrap()
     };
     let commit_three = repository.find_commit(commit_three_oid).unwrap();
     let before_change_id = &commit_three.change_id();
 
     gitbutler_branch_actions::update_commit_message(
         ctx,
-        branch_id,
+        stack_entry.id,
         commit_three_oid,
         "commit three updated",
     )
@@ -45,7 +45,7 @@ fn head() {
         .unwrap()
         .branches
         .into_iter()
-        .find(|b| b.id == branch_id)
+        .find(|b| b.id == stack_entry.id)
         .unwrap();
 
     let descriptions = branch.series[0]
@@ -78,28 +78,28 @@ fn middle() {
     gitbutler_branch_actions::set_base_branch(ctx, &"refs/remotes/origin/master".parse().unwrap())
         .unwrap();
 
-    let branch_id =
+    let stack_entry =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
 
     {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit one", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit one", None).unwrap()
     };
 
     let commit_two_oid = {
         fs::write(repository.path().join("file two.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit two", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit two", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file three.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit three", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit three", None).unwrap()
     };
 
     gitbutler_branch_actions::update_commit_message(
         ctx,
-        branch_id,
+        stack_entry.id,
         commit_two_oid,
         "commit two updated",
     )
@@ -109,7 +109,7 @@ fn middle() {
         .unwrap()
         .branches
         .into_iter()
-        .find(|b| b.id == branch_id)
+        .find(|b| b.id == stack_entry.id)
         .unwrap();
 
     let descriptions = branch.series[0]
@@ -146,21 +146,21 @@ fn forcepush_allowed() {
         })
         .unwrap();
 
-    let branch_id =
+    let stack_entry =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
 
     let commit_one_oid = {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit one", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit one", None).unwrap()
     };
 
     #[allow(deprecated)]
-    gitbutler_branch_actions::push_virtual_branch(ctx, branch_id, false, None).unwrap();
+    gitbutler_branch_actions::push_virtual_branch(ctx, stack_entry.id, false, None).unwrap();
 
     gitbutler_branch_actions::update_commit_message(
         ctx,
-        branch_id,
+        stack_entry.id,
         commit_one_oid,
         "commit one updated",
     )
@@ -170,7 +170,7 @@ fn forcepush_allowed() {
         .unwrap()
         .branches
         .into_iter()
-        .find(|b| b.id == branch_id)
+        .find(|b| b.id == stack_entry.id)
         .unwrap();
 
     let descriptions = branch.series[0]
@@ -193,14 +193,14 @@ fn forcepush_forbidden() {
     gitbutler_branch_actions::set_base_branch(ctx, &"refs/remotes/origin/master".parse().unwrap())
         .unwrap();
 
-    let branch_id =
+    let stack_entry =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
 
     gitbutler_branch_actions::update_virtual_branch(
         ctx,
         BranchUpdateRequest {
-            id: branch_id,
+            id: stack_entry.id,
             allow_rebasing: Some(false),
             ..Default::default()
         },
@@ -209,16 +209,16 @@ fn forcepush_forbidden() {
 
     let commit_one_oid = {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit one", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit one", None).unwrap()
     };
 
     #[allow(deprecated)]
-    gitbutler_branch_actions::push_virtual_branch(ctx, branch_id, false, None).unwrap();
+    gitbutler_branch_actions::push_virtual_branch(ctx, stack_entry.id, false, None).unwrap();
 
     assert_eq!(
         gitbutler_branch_actions::update_commit_message(
             ctx,
-            branch_id,
+            stack_entry.id,
             commit_one_oid,
             "commit one updated",
         )
@@ -243,22 +243,22 @@ fn root() {
 
     let commit_one_oid = {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit one", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, branch_id.id, "commit one", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file two.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit two", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, branch_id.id, "commit two", None).unwrap()
     };
 
     {
         fs::write(repository.path().join("file three.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit three", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, branch_id.id, "commit three", None).unwrap()
     };
 
     gitbutler_branch_actions::update_commit_message(
         ctx,
-        branch_id,
+        branch_id.id,
         commit_one_oid,
         "commit one updated",
     )
@@ -268,7 +268,7 @@ fn root() {
         .unwrap()
         .branches
         .into_iter()
-        .find(|b| b.id == branch_id)
+        .find(|b| b.id == branch_id.id)
         .unwrap();
 
     let descriptions = branch.series[0]
@@ -299,11 +299,11 @@ fn empty() {
 
     let commit_one_oid = {
         fs::write(repository.path().join("file one.txt"), "").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch_id, "commit one", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, branch_id.id, "commit one", None).unwrap()
     };
 
     assert_eq!(
-        gitbutler_branch_actions::update_commit_message(ctx, branch_id, commit_one_oid, "",)
+        gitbutler_branch_actions::update_commit_message(ctx, branch_id.id, commit_one_oid, "",)
             .unwrap_err()
             .to_string(),
         "commit message can not be empty"

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/upstream.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/upstream.rs
@@ -11,29 +11,29 @@ fn detect_upstream_commits() {
     gitbutler_branch_actions::set_base_branch(ctx, &"refs/remotes/origin/master".parse().unwrap())
         .unwrap();
 
-    let branch1_id =
+    let stack_entry_1 =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
 
     let oid1 = {
         // create first commit
         fs::write(repository.path().join("file.txt"), "content").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch1_id, "commit", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry_1.id, "commit", None).unwrap()
     };
 
     let oid2 = {
         // create second commit
         fs::write(repository.path().join("file.txt"), "content2").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch1_id, "commit", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry_1.id, "commit", None).unwrap()
     };
 
     // push
-    gitbutler_branch_actions::stack::push_stack(ctx, branch1_id, false).unwrap();
+    gitbutler_branch_actions::stack::push_stack(ctx, stack_entry_1.id, false).unwrap();
 
     let oid3 = {
         // create third commit
         fs::write(repository.path().join("file.txt"), "content3").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch1_id, "commit", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry_1.id, "commit", None).unwrap()
     };
 
     {
@@ -41,7 +41,7 @@ fn detect_upstream_commits() {
         let list_result = gitbutler_branch_actions::list_virtual_branches(ctx).unwrap();
         let branches = list_result.branches;
         assert_eq!(branches.len(), 1);
-        assert_eq!(branches[0].id, branch1_id);
+        assert_eq!(branches[0].id, stack_entry_1.id);
         assert_eq!(branches[0].series[0].clone().unwrap().patches.len(), 3);
         assert_eq!(branches[0].series[0].clone().unwrap().patches[0].id, oid3);
         assert!(!branches[0].series[0].clone().unwrap().patches[0].is_local_and_remote);
@@ -61,25 +61,25 @@ fn detect_integrated_commits() {
     gitbutler_branch_actions::set_base_branch(ctx, &"refs/remotes/origin/master".parse().unwrap())
         .unwrap();
 
-    let branch1_id =
+    let stack_entry_1 =
         gitbutler_branch_actions::create_virtual_branch(ctx, &BranchCreateRequest::default())
             .unwrap();
 
     let oid1 = {
         // create first commit
         fs::write(repository.path().join("file.txt"), "content").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch1_id, "commit", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry_1.id, "commit", None).unwrap()
     };
 
     let oid2 = {
         // create second commit
         fs::write(repository.path().join("file.txt"), "content2").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch1_id, "commit", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry_1.id, "commit", None).unwrap()
     };
 
     // push
     #[allow(deprecated)]
-    gitbutler_branch_actions::push_virtual_branch(ctx, branch1_id, false, None).unwrap();
+    gitbutler_branch_actions::push_virtual_branch(ctx, stack_entry_1.id, false, None).unwrap();
 
     {
         // merge branch upstream
@@ -87,7 +87,7 @@ fn detect_integrated_commits() {
             .unwrap()
             .branches
             .into_iter()
-            .find(|b| b.id == branch1_id)
+            .find(|b| b.id == stack_entry_1.id)
             .unwrap();
         repository
             .merge(&branch.upstream.as_ref().unwrap().name)
@@ -98,7 +98,7 @@ fn detect_integrated_commits() {
     let oid3 = {
         // create third commit
         fs::write(repository.path().join("file.txt"), "content3").unwrap();
-        gitbutler_branch_actions::create_commit(ctx, branch1_id, "commit", None).unwrap()
+        gitbutler_branch_actions::create_commit(ctx, stack_entry_1.id, "commit", None).unwrap()
     };
 
     {
@@ -107,7 +107,7 @@ fn detect_integrated_commits() {
         let branches = list_result.branches;
 
         assert_eq!(branches.len(), 1);
-        assert_eq!(branches[0].id, branch1_id);
+        assert_eq!(branches[0].id, stack_entry_1.id);
         assert_eq!(branches[0].series[0].clone().unwrap().patches.len(), 3);
         assert_eq!(branches[0].series[0].clone().unwrap().patches[0].id, oid3);
         assert!(!branches[0].series[0].clone().unwrap().patches[0].is_integrated);

--- a/crates/gitbutler-cli/src/command/vbranch.rs
+++ b/crates/gitbutler-cli/src/command/vbranch.rs
@@ -118,7 +118,7 @@ fn apply_from_branch(project: Project, branch_name: String) -> Result<()> {
 
 pub fn create(project: Project, branch_name: String, set_default: bool) -> Result<()> {
     let ctx = CommandContext::open(&project, AppSettings::default())?;
-    let new = gitbutler_branch_actions::create_virtual_branch(
+    let new_stack_entry = gitbutler_branch_actions::create_virtual_branch(
         &ctx,
         &BranchCreateRequest {
             name: Some(branch_name),
@@ -126,10 +126,10 @@ pub fn create(project: Project, branch_name: String, set_default: bool) -> Resul
         },
     )?;
     if set_default {
-        let new = VirtualBranchesHandle::new(project.gb_dir()).get_stack(new)?;
+        let new = VirtualBranchesHandle::new(project.gb_dir()).get_stack(new_stack_entry.id)?;
         set_default_branch(&project, &new)?;
     }
-    debug_print(new)
+    debug_print(new_stack_entry)
 }
 
 pub fn set_default(project: Project, branch_name: String) -> Result<()> {

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -1,5 +1,6 @@
 pub mod commands {
     use anyhow::{anyhow, Context};
+    use but_workspace::StackEntry;
     use gitbutler_branch::{BranchCreateRequest, BranchUpdateRequest};
     use gitbutler_branch_actions::branch_upstream_integration::IntegrationStrategy;
     use gitbutler_branch_actions::internal::StackListResult;
@@ -79,12 +80,12 @@ pub mod commands {
         settings: State<'_, AppSettingsWithDiskSync>,
         project_id: ProjectId,
         branch: BranchCreateRequest,
-    ) -> Result<StackId, Error> {
+    ) -> Result<StackEntry, Error> {
         let project = projects.get(project_id)?;
         let ctx = CommandContext::open(&project, settings.get()?.clone())?;
-        let branch_id = gitbutler_branch_actions::create_virtual_branch(&ctx, &branch)?;
+        let stack_entry = gitbutler_branch_actions::create_virtual_branch(&ctx, &branch)?;
         emit_vbranches(&windows, project_id);
-        Ok(branch_id)
+        Ok(stack_entry)
     }
 
     #[tauri::command(async)]

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -1,6 +1,5 @@
 pub mod commands {
     use anyhow::{anyhow, Context};
-    use but_workspace::StackEntry;
     use gitbutler_branch::{BranchCreateRequest, BranchUpdateRequest};
     use gitbutler_branch_actions::branch_upstream_integration::IntegrationStrategy;
     use gitbutler_branch_actions::internal::StackListResult;
@@ -80,12 +79,12 @@ pub mod commands {
         settings: State<'_, AppSettingsWithDiskSync>,
         project_id: ProjectId,
         branch: BranchCreateRequest,
-    ) -> Result<StackEntry, Error> {
+    ) -> Result<StackId, Error> {
         let project = projects.get(project_id)?;
         let ctx = CommandContext::open(&project, settings.get()?.clone())?;
         let stack_entry = gitbutler_branch_actions::create_virtual_branch(&ctx, &branch)?;
         emit_vbranches(&windows, project_id);
-        Ok(stack_entry)
+        Ok(stack_entry.id)
     }
 
     #[tauri::command(async)]

--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -1,12 +1,9 @@
 use crate::error::Error;
+use but_workspace::StackEntry;
 use gitbutler_command_context::CommandContext;
-use gitbutler_id::id::Id;
 use gitbutler_project as projects;
 use gitbutler_project::ProjectId;
-use gitbutler_serde::BStringForFrontend;
 use gitbutler_settings::AppSettingsWithDiskSync;
-use gitbutler_stack::Stack;
-use serde::Serialize;
 use tauri::State;
 use tracing::instrument;
 
@@ -17,8 +14,7 @@ pub fn stacks(
     project_id: ProjectId,
 ) -> anyhow::Result<Vec<StackEntry>, Error> {
     let project = projects.get(project_id)?;
-    let stacks = but_workspace::stacks(&project.gb_dir())?;
-    Ok(stacks.into_iter().map(Into::into).collect())
+    but_workspace::stacks(&project.gb_dir()).map_err(Into::into)
 }
 
 #[tauri::command(async)]
@@ -32,20 +28,4 @@ pub fn stack_branches(
     let project = projects.get(project_id)?;
     let ctx = CommandContext::open(&project, settings.get()?.clone())?;
     but_workspace::stack_branches(stack_id, &ctx).map_err(Into::into)
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StackEntry {
-    id: Id<Stack>,
-    branch_names: Vec<BStringForFrontend>,
-}
-
-impl From<but_workspace::StackEntry> for StackEntry {
-    fn from(but_workspace::StackEntry { id, branch_names }: but_workspace::StackEntry) -> Self {
-        StackEntry {
-            id,
-            branch_names: branch_names.into_iter().map(Into::into).collect(),
-        }
-    }
 }

--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -12,7 +12,7 @@ use tracing::instrument;
 pub fn stacks(
     projects: State<'_, projects::Controller>,
     project_id: ProjectId,
-) -> anyhow::Result<Vec<StackEntry>, Error> {
+) -> Result<Vec<StackEntry>, Error> {
     let project = projects.get(project_id)?;
     but_workspace::stacks(&project.gb_dir()).map_err(Into::into)
 }
@@ -24,7 +24,7 @@ pub fn stack_branches(
     settings: State<'_, AppSettingsWithDiskSync>,
     project_id: ProjectId,
     stack_id: String,
-) -> anyhow::Result<Vec<but_workspace::Branch>, Error> {
+) -> Result<Vec<but_workspace::Branch>, Error> {
     let project = projects.get(project_id)?;
     let ctx = CommandContext::open(&project, settings.get()?.clone())?;
     but_workspace::stack_branches(stack_id, &ctx).map_err(Into::into)

--- a/crates/gitbutler-workspace/tests/mod.rs
+++ b/crates/gitbutler-workspace/tests/mod.rs
@@ -28,19 +28,19 @@ mod checkout_branch_trees {
         branch_actions::set_base_branch(&ctx, &"refs/remotes/origin/master".parse().unwrap())
             .unwrap();
 
-        let branch_1 =
+        let stach_entry_1 =
             branch_actions::create_virtual_branch(&ctx, &BranchCreateRequest::default()).unwrap();
 
         fs::write(test_project.path().join("foo.txt"), "content").unwrap();
 
-        branch_actions::create_commit(&ctx, branch_1, "commit one", None).unwrap();
+        branch_actions::create_commit(&ctx, stach_entry_1.id, "commit one", None).unwrap();
 
-        let branch_2 =
+        let stack_entry_2 =
             branch_actions::create_virtual_branch(&ctx, &BranchCreateRequest::default()).unwrap();
 
         fs::write(test_project.path().join("bar.txt"), "content").unwrap();
 
-        branch_actions::create_commit(&ctx, branch_2, "commit two", None).unwrap();
+        branch_actions::create_commit(&ctx, stack_entry_2.id, "commit two", None).unwrap();
 
         let tree = test_project
             .local_repository


### PR DESCRIPTION
Also, make the but-workspace StackEntry serializable instead of doing that with a gitbutler-tauri struct.

Since this PR does not change the frontend, the tauri command still returns only the ID