### PR TITLE
Empty commits should have (need) change IDs

### DIFF
--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -1469,7 +1469,7 @@ pub(crate) fn insert_blank_commit(
     let commit_tree = repository
         .find_real_tree(&commit, Default::default())
         .unwrap();
-    let blank_commit_oid = ctx.commit("", &commit_tree, &[&commit], None)?;
+    let blank_commit_oid = ctx.commit("", &commit_tree, &[&commit], Some(Default::default()))?;
 
     if commit.id() == stack.head() && offset < 0 {
         // inserting before the first commit


### PR DESCRIPTION
Passing the Defalt::default() as the headers option creates a new change id

BR: https://cloud.gitbutler.com/caleb-owens/gitbutler-client/reviews/05424011-caf4-452c-87bb-94cbbb37cf80