### PR TITLE
Use goto over setting location

### DIFF
--- a/apps/web/src/routes/[ownerSlug]/[projectSlug]/reviews/[branchId]/commit/[changeId]/+page.svelte
+++ b/apps/web/src/routes/[ownerSlug]/[projectSlug]/reviews/[branchId]/commit/[changeId]/+page.svelte
@@ -20,6 +20,7 @@
 		WebRoutesService,
 		type ProjectReviewCommitParameters
 	} from '@gitbutler/shared/routing/webRoutes.svelte';
+	import { goto } from '$app/navigation';
 
 	const BRANCH_TITLE_PLACE_HOLDER = 'No branch title provided';
 	const DESCRIPTION_PLACE_HOLDER = 'No description provided';
@@ -80,7 +81,7 @@
 			changeId
 		});
 
-		window.location.href = url;
+		goto(url);
 	}
 </script>
 


### PR DESCRIPTION
Setting the location doesn't give svelte a chance to intercept the navigation and due to this, the whole page gets reloaded.

BR: https://cloud.gitbutler.com/caleb-owens/gitbutler-client/reviews/77d3836d-db85-4ef0-aa55-67a859e4cb4b

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #6075 
- <kbd>&nbsp;2&nbsp;</kbd> #6074 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #6068 
<!-- GitButler Footer Boundary Bottom -->

