### PR TITLE
fix: made keyboard shortcut list non-mac os friendly

### DIFF
--- a/apps/desktop/src/components/KeyboardShortcutsModal.svelte
+++ b/apps/desktop/src/components/KeyboardShortcutsModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { platformName } from '$lib/platform/platform';
 	import { ShortcutService } from '$lib/shortcuts/shortcutService.svelte';
 	import { shortcuts } from '$lib/utils/hotkeys';
 	import { getContext } from '@gitbutler/shared/context';
@@ -18,7 +19,13 @@
 	function keysStringToArr(keys: string): string[] {
 		return keys.split('+').map((key) => {
 			if (key === 'Shift') return '⇧';
-			if (key === '$mod') return '⌘';
+			if (key === '$mod') {
+				if (platformName === 'macos') {
+					return '⌘';
+				} else {
+					return 'Ctrl';
+				}
+			}
 			return key;
 		});
 	}
@@ -108,6 +115,7 @@
 		font-size: 12px;
 		min-width: 18px;
 		height: 18px;
+		padding: 0 4px;
 		background-color: var(--clr-bg-2);
 		border-radius: var(--radius-m);
 		display: flex;


### PR DESCRIPTION
## 🧢 Changes

- Make keyboard shortcut modal listings more non-Mac OS friendly

![image](https://github.com/user-attachments/assets/d12ec5a6-003e-489e-972f-22e518481416)

View of the `cmd` button icon with this additional `4px` of padding:

![image](https://github.com/user-attachments/assets/abdd0ec8-1c7c-4e37-89bd-83ca3d720a5f)


## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
