### PR TITLE
feat: reposition darwin traffic-lights in title bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2969,6 +2969,7 @@ dependencies = [
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "tauri-plugin-store",
+ "tauri-plugin-traffic-lights",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tokio",
@@ -8423,6 +8424,16 @@ dependencies = [
  "thiserror 2.0.9",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "tauri-plugin-traffic-lights"
+version = "1.0.0"
+dependencies = [
+ "cocoa",
+ "objc",
+ "rand 0.8.5",
+ "tauri",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/gitbutler-*", "crates/but-*"]
+members = ["crates/gitbutler-*", "crates/but-*", "crates/tauri-plugin-*"]
 resolver = "2"
 
 [workspace.dependencies]
@@ -71,6 +71,9 @@ but-debugging = { path = "crates/but-debugging" }
 but-core = { path = "crates/but-core" }
 but-workspace = { path = "crates/but-workspace" }
 but-hunk-dependency = { path = "crates/but-hunk-dependency" }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+tauri-plugin-traffic-lights = { path = "crates/tauri-plugin-traffic-lights" }
 
 [profile.release]
 codegen-units = 1 # Compile crates one after another so the compiler can optimize better

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,9 +72,6 @@ but-core = { path = "crates/but-core" }
 but-workspace = { path = "crates/but-workspace" }
 but-hunk-dependency = { path = "crates/but-hunk-dependency" }
 
-[target.'cfg(target_os = "macos")'.dependencies]
-tauri-plugin-traffic-lights = { path = "crates/tauri-plugin-traffic-lights" }
-
 [profile.release]
 codegen-units = 1 # Compile crates one after another so the compiler can optimize better
 lto = true        # Enables link to optimizations

--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -119,6 +119,10 @@
 		padding: 14px 14px 14px 84px;
 	}
 
+	.traffic-lights-placeholder {
+		width: 58px;
+	}
+
 	.left {
 		display: flex;
 		gap: 14px;

--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -119,10 +119,6 @@
 		padding: 14px 14px 14px 84px;
 	}
 
-	.traffic-lights-placeholder {
-		width: 58px;
-	}
-
 	.left {
 		display: flex;
 		gap: 14px;

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -43,9 +43,6 @@ tauri-plugin-store = "2.2.0"
 tauri-plugin-updater = "2.3.0"
 tauri-plugin-window-state = "2.2.0"
 
-[target.'cfg(target_os = "macos")'.dependencies]
-tauri-plugin-traffic-lights = { path = "../tauri-plugin-traffic-lights" }
-
 parking_lot.workspace = true
 log = "^0.4"
 # The features here optimize for performance.
@@ -81,6 +78,9 @@ but-core.workspace = true
 but-hunk-dependency.workspace = true
 open = "5"
 url = "2.5.4"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+tauri-plugin-traffic-lights = { path = "../tauri-plugin-traffic-lights" }
 
 [lints.clippy]
 all = "deny"

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -42,6 +42,10 @@ tauri-plugin-single-instance = "2.2.0"
 tauri-plugin-store = "2.2.0"
 tauri-plugin-updater = "2.3.0"
 tauri-plugin-window-state = "2.2.0"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+tauri-plugin-traffic-lights = { path = "../tauri-plugin-traffic-lights" }
+
 parking_lot.workspace = true
 log = "^0.4"
 # The features here optimize for performance.

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -51,6 +51,20 @@ fn main() {
                     )
                     .expect("Failed to create window");
 
+                    #[cfg(target_os = "macos")]
+                    use tauri::LogicalPosition;
+                    #[cfg(target_os = "macos")]
+                    use tauri_plugin_traffic_lights::WindowExt;
+                    #[cfg(target_os = "macos")]
+                    // NOTE: Make sure you only call this ONCE per window.
+                    {
+                        if let Some(window) = tauri_app.get_window("main") {
+                            #[cfg(target_os = "macos")]
+                            // NOTE: Make sure you only call this ONCE per window.
+                            window.setup_traffic_lights_inset(LogicalPosition::new(18.0, 22.0))?;
+                        };
+                    }
+
                     // TODO(mtsgrd): Is there a better way to disable devtools in E2E tests?
                     #[cfg(debug_assertions)]
                     if tauri_app.config().product_name != Some("GitButler Test".to_string()) {
@@ -106,7 +120,7 @@ fn main() {
 
                     app_handle.manage(WindowState::new(app_handle.clone()));
 
-                    let mut app_settings = AppSettingsWithDiskSync::new(config_dir)?;
+                    let mut app_settings = AppSettingsWithDiskSync::new(config_dir.clone())?;
                     app_settings.watch_in_background({
                         let app_handle = app_handle.clone();
                         move |app_settings| {
@@ -133,7 +147,15 @@ fn main() {
                         menu::handle_event(&window.clone(), &event)
                     });
 
-                    if app_settings.feature_flags.v3 {
+                    let mut app_settings = AppSettingsWithDiskSync::new(config_dir)?;
+                    app_settings.watch_in_background({
+                        let app_handle = app_handle.clone();
+                        move |app_settings| {
+                            gitbutler_tauri::ChangeForFrontend::from(app_settings).send(&app_handle)
+                        }
+                    })?;
+
+                    if app_settings.get()?.clone().feature_flags.v3 {
                         #[cfg(target_os = "macos")]
                         use tauri::LogicalPosition;
                         #[cfg(target_os = "macos")]

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -51,6 +51,10 @@ fn main() {
                     )
                     .expect("Failed to create window");
 
+                    #[cfg(target_os = "macos")]
+                    // NOTE: Make sure you only call this ONCE per window.
+                    let _ = window.setup_traffic_lights_inset(LogicalPosition::new(20.0, 24.0));
+
                     // TODO(mtsgrd): Is there a better way to disable devtools in E2E tests?
                     #[cfg(debug_assertions)]
                     if tauri_app.config().product_name != Some("GitButler Test".to_string()) {

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -52,8 +52,18 @@ fn main() {
                     .expect("Failed to create window");
 
                     #[cfg(target_os = "macos")]
+                    use tauri::LogicalPosition;
+                    #[cfg(target_os = "macos")]
+                    use tauri_plugin_traffic_lights::WindowExt;
+                    #[cfg(target_os = "macos")]
                     // NOTE: Make sure you only call this ONCE per window.
-                    let _ = window.setup_traffic_lights_inset(LogicalPosition::new(20.0, 24.0));
+                    {
+                        if let Some(window) = tauri_app.get_window("main") {
+                            #[cfg(target_os = "macos")]
+                            // NOTE: Make sure you only call this ONCE per window.
+                            window.setup_traffic_lights_inset(LogicalPosition::new(20.0, 24.0))?;
+                        };
+                    }
 
                     // TODO(mtsgrd): Is there a better way to disable devtools in E2E tests?
                     #[cfg(debug_assertions)]

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -51,20 +51,6 @@ fn main() {
                     )
                     .expect("Failed to create window");
 
-                    #[cfg(target_os = "macos")]
-                    use tauri::LogicalPosition;
-                    #[cfg(target_os = "macos")]
-                    use tauri_plugin_traffic_lights::WindowExt;
-                    #[cfg(target_os = "macos")]
-                    // NOTE: Make sure you only call this ONCE per window.
-                    {
-                        if let Some(window) = tauri_app.get_window("main") {
-                            #[cfg(target_os = "macos")]
-                            // NOTE: Make sure you only call this ONCE per window.
-                            window.setup_traffic_lights_inset(LogicalPosition::new(16.0, 25.0))?;
-                        };
-                    }
-
                     // TODO(mtsgrd): Is there a better way to disable devtools in E2E tests?
                     #[cfg(debug_assertions)]
                     if tauri_app.config().product_name != Some("GitButler Test".to_string()) {
@@ -127,7 +113,6 @@ fn main() {
                             gitbutler_tauri::ChangeForFrontend::from(app_settings).send(&app_handle)
                         }
                     })?;
-                    app_handle.manage(app_settings);
                     let app = App {
                         app_data_dir: app_data_dir.clone(),
                     };
@@ -147,14 +132,6 @@ fn main() {
                         menu::handle_event(&window.clone(), &event)
                     });
 
-                    let mut app_settings = AppSettingsWithDiskSync::new(config_dir)?;
-                    app_settings.watch_in_background({
-                        let app_handle = app_handle.clone();
-                        move |app_settings| {
-                            gitbutler_tauri::ChangeForFrontend::from(app_settings).send(&app_handle)
-                        }
-                    })?;
-
                     if app_settings.get()?.clone().feature_flags.v3 {
                         #[cfg(target_os = "macos")]
                         use tauri::LogicalPosition;
@@ -171,6 +148,7 @@ fn main() {
                             };
                         }
                     }
+                    app_handle.manage(app_settings);
 
                     Ok(())
                 })

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -61,7 +61,7 @@ fn main() {
                         if let Some(window) = tauri_app.get_window("main") {
                             #[cfg(target_os = "macos")]
                             // NOTE: Make sure you only call this ONCE per window.
-                            window.setup_traffic_lights_inset(LogicalPosition::new(18.0, 22.0))?;
+                            window.setup_traffic_lights_inset(LogicalPosition::new(16.0, 25.0))?;
                         };
                     }
 
@@ -167,7 +167,7 @@ fn main() {
                                 #[cfg(target_os = "macos")]
                                 // NOTE: Make sure you only call this ONCE per window.
                                 window
-                                    .setup_traffic_lights_inset(LogicalPosition::new(20.0, 24.0))?;
+                                    .setup_traffic_lights_inset(LogicalPosition::new(16.0, 25.0))?;
                             };
                         }
                     }

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -51,20 +51,6 @@ fn main() {
                     )
                     .expect("Failed to create window");
 
-                    #[cfg(target_os = "macos")]
-                    use tauri::LogicalPosition;
-                    #[cfg(target_os = "macos")]
-                    use tauri_plugin_traffic_lights::WindowExt;
-                    #[cfg(target_os = "macos")]
-                    // NOTE: Make sure you only call this ONCE per window.
-                    {
-                        if let Some(window) = tauri_app.get_window("main") {
-                            #[cfg(target_os = "macos")]
-                            // NOTE: Make sure you only call this ONCE per window.
-                            window.setup_traffic_lights_inset(LogicalPosition::new(20.0, 24.0))?;
-                        };
-                    }
-
                     // TODO(mtsgrd): Is there a better way to disable devtools in E2E tests?
                     #[cfg(debug_assertions)]
                     if tauri_app.config().product_name != Some("GitButler Test".to_string()) {
@@ -146,6 +132,24 @@ fn main() {
                     tauri_app.on_menu_event(move |_handle, event| {
                         menu::handle_event(&window.clone(), &event)
                     });
+
+                    if app_settings.feature_flags.v3 {
+                        #[cfg(target_os = "macos")]
+                        use tauri::LogicalPosition;
+                        #[cfg(target_os = "macos")]
+                        use tauri_plugin_traffic_lights::WindowExt;
+                        #[cfg(target_os = "macos")]
+                        // NOTE: Make sure you only call this ONCE per window.
+                        {
+                            if let Some(window) = tauri_app.get_window("main") {
+                                #[cfg(target_os = "macos")]
+                                // NOTE: Make sure you only call this ONCE per window.
+                                window
+                                    .setup_traffic_lights_inset(LogicalPosition::new(20.0, 24.0))?;
+                            };
+                        }
+                    }
+
                     Ok(())
                 })
                 .plugin(tauri_plugin_http::init())

--- a/crates/gitbutler-tauri/tauri.conf.json
+++ b/crates/gitbutler-tauri/tauri.conf.json
@@ -12,7 +12,14 @@
 		"category": "DeveloperTool",
 		"copyright": "Copyright © 2023-2024 GitButler. All rights reserved.",
 		"createUpdaterArtifacts": "v1Compatible",
-		"targets": ["app", "dmg", "appimage", "deb", "rpm", "msi"],
+		"targets": [
+			"app",
+			"dmg",
+			"appimage",
+			"deb",
+			"rpm",
+			"msi"
+		],
 		"icon": [
 			"icons/dev/32x32.png",
 			"icons/dev/128x128.png",
@@ -25,10 +32,15 @@
 		},
 		"linux": {
 			"rpm": {
-				"depends": ["webkit2gtk4.1"]
+				"depends": [
+					"webkit2gtk4.1"
+				]
 			},
 			"deb": {
-				"depends": ["libwebkit2gtk-4.1-0", "libgtk-3-0"]
+				"depends": [
+					"libwebkit2gtk-4.1-0",
+					"libgtk-3-0"
+				]
 			}
 		}
 	},

--- a/crates/tauri-plugin-traffic-lights/Cargo.toml
+++ b/crates/tauri-plugin-traffic-lights/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "tauri-plugin-traffic-lights"
+version = "1.0.0"
+authors = ["ItsEeleeya"]
+description = "A Tauri v2 plugin to help setting the position of the window traffic lights on macOS."
+edition = "2021"
+rust-version = "1.60"
+license = "MIT"
+repository = "https://github.com/itseeleeya/tauri-plugin-trafficlights-positioner/"
+keywords = ["tauri", "tauri-plugin", "tauri-plugin-macos"]
+publish = false
+
+[lib]
+doctest = false
+path = "src/lib.rs"
+
+[dependencies]
+tauri = { version = "^2.1.1", features = ["unstable"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+cocoa = "0.26.0"
+objc = "0.2.7"
+rand = "0.8.5"

--- a/crates/tauri-plugin-traffic-lights/src/lib.rs
+++ b/crates/tauri-plugin-traffic-lights/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "macos")]
 use tauri::{LogicalPosition, Runtime, Window};
 
 #[cfg(target_os = "macos")]

--- a/crates/tauri-plugin-traffic-lights/src/lib.rs
+++ b/crates/tauri-plugin-traffic-lights/src/lib.rs
@@ -1,0 +1,34 @@
+use tauri::{LogicalPosition, Runtime, Window};
+
+#[cfg(target_os = "macos")]
+mod positioner;
+
+#[cfg(target_os = "macos")]
+#[macro_use]
+extern crate cocoa;
+
+#[cfg(target_os = "macos")]
+pub trait WindowExt {
+    fn setup_traffic_lights_inset(&self, offset: LogicalPosition<f64>) -> tauri::Result<()>;
+}
+
+#[cfg(target_os = "macos")]
+impl<R: Runtime> WindowExt for Window<R> {
+    fn setup_traffic_lights_inset(&self, inset: LogicalPosition<f64>) -> tauri::Result<()> {
+        let win = self.clone();
+        self.on_window_event(move |event| {
+            if let tauri::WindowEvent::ThemeChanged(_) = event {
+                let win_clone = win.clone();
+
+                let _ = win.clone().run_on_main_thread(move || {
+                    positioner::update(&win_clone, &inset);
+                });
+            }
+        });
+
+        let win = self.clone();
+        self.run_on_main_thread(move || {
+            positioner::setup_nswindow_delegates(win, inset);
+        })
+    }
+}

--- a/crates/tauri-plugin-traffic-lights/src/positioner.rs
+++ b/crates/tauri-plugin-traffic-lights/src/positioner.rs
@@ -1,0 +1,349 @@
+/**
+ * Almost all credits for this code goes to @haasal, @charrondev and Hoppscotch
+ * This is also similar to how it is implemented in Zed.dev editor
+ *
+ * https://github.com/haasal
+ * https://gist.github.com/charrondev
+ * https://github.com/hoppscotch/hoppscotch
+ * https://github.com/clearlysid/tauri-plugin-decorum/
+ *
+ * (Issue) https://github.com/tauri-apps/tauri/issues/4789
+ * (Gist) https://gist.github.com/charrondev/43150e940bd2771b1ea88256d491c7a9
+ * (Hoppscotch) https://github.com/hoppscotch/hoppscotch/blob/286fcd2bb08a84f027b10308d1e18da368f95ebf/packages/hoppscotch-selfhost-desktop/src-tauri/src/mac/window.rs
+ */
+use objc::{msg_send, sel, sel_impl};
+use rand::{distributions::Alphanumeric, Rng};
+use tauri::{Emitter, LogicalPosition, Runtime, Window};
+
+struct UnsafeWindowHandle(*mut std::ffi::c_void);
+unsafe impl Send for UnsafeWindowHandle {}
+unsafe impl Sync for UnsafeWindowHandle {}
+
+pub(crate) fn update<R: Runtime>(window: &Window<R>, inset: &LogicalPosition<f64>) {
+    position_traffic_lights(
+        UnsafeWindowHandle(window.ns_window().expect("Failed to create window handle")),
+        inset,
+    );
+}
+
+fn position_traffic_lights(ns_window_handle: UnsafeWindowHandle, inset: &LogicalPosition<f64>) {
+    use cocoa::appkit::{NSView, NSWindow, NSWindowButton};
+    use cocoa::foundation::NSRect;
+    let ns_window = ns_window_handle.0 as cocoa::base::id;
+    unsafe {
+        let close = ns_window.standardWindowButton_(NSWindowButton::NSWindowCloseButton);
+        let minimize = ns_window.standardWindowButton_(NSWindowButton::NSWindowMiniaturizeButton);
+        let zoom = ns_window.standardWindowButton_(NSWindowButton::NSWindowZoomButton);
+
+        let title_bar_container_view = close.superview().superview();
+
+        let close_rect: NSRect = msg_send![close, frame];
+        let button_height = close_rect.size.height;
+
+        let title_bar_frame_height = button_height + inset.y;
+        let mut title_bar_rect = NSView::frame(title_bar_container_view);
+        title_bar_rect.size.height = title_bar_frame_height;
+        title_bar_rect.origin.y = NSView::frame(ns_window).size.height - title_bar_frame_height;
+        let _: () = msg_send![title_bar_container_view, setFrame: title_bar_rect];
+
+        let window_buttons = vec![close, minimize, zoom];
+        let space_between = NSView::frame(minimize).origin.x - NSView::frame(close).origin.x;
+
+        for (i, button) in window_buttons.into_iter().enumerate() {
+            let mut rect: NSRect = NSView::frame(button);
+            rect.origin.x = inset.x + (i as f64 * space_between);
+            button.setFrameOrigin(rect.origin);
+        }
+    }
+}
+
+#[derive(Debug)]
+struct WindowState<R: Runtime> {
+    window: Window<R>,
+    traffic_lights_inset: LogicalPosition<f64>,
+}
+
+pub(crate) fn setup_nswindow_delegates<R: Runtime>(
+    window: Window<R>,
+    traffic_lights_inset: LogicalPosition<f64>,
+) {
+    use cocoa::appkit::NSWindow;
+    use cocoa::base::{id, BOOL};
+    use cocoa::foundation::NSUInteger;
+    use objc::runtime::{Object, Sel};
+    use std::ffi::c_void;
+
+    // Initial update.
+    update(&window, &traffic_lights_inset);
+
+    // Ensure they stay in place while resizing the window.
+    fn with_window_state<R: Runtime, F: FnOnce(&mut WindowState<R>) -> T, T>(
+        this: &Object,
+        func: F,
+    ) {
+        let ptr = unsafe {
+            let x: *mut c_void = *this.get_ivar("app_box");
+            &mut *(x as *mut WindowState<R>)
+        };
+        func(ptr);
+    }
+
+    unsafe {
+        let ns_win = window
+            .ns_window()
+            .expect("NS Window should exist to mount traffic light delegate.")
+            as id;
+
+        let current_delegate: id = ns_win.delegate();
+
+        extern "C" fn on_window_should_close(this: &Object, _cmd: Sel, sender: id) -> BOOL {
+            unsafe {
+                let super_del: id = *this.get_ivar("super_delegate");
+                msg_send![super_del, windowShouldClose: sender]
+            }
+        }
+        extern "C" fn on_window_will_close(this: &Object, _cmd: Sel, notification: id) {
+            unsafe {
+                let super_del: id = *this.get_ivar("super_delegate");
+                let _: () = msg_send![super_del, windowWillClose: notification];
+            }
+        }
+
+        extern "C" fn on_window_did_resize<R: Runtime>(this: &Object, _cmd: Sel, notification: id) {
+            unsafe {
+                with_window_state(this, |state: &mut WindowState<R>| {
+                    let _id = state
+                        .window
+                        .ns_window()
+                        .expect("NS window should exist on state to handle resize")
+                        as id;
+
+                    update(&state.window, &state.traffic_lights_inset);
+                });
+
+                let super_del: id = *this.get_ivar("super_delegate");
+                let _: () = msg_send![super_del, windowDidResize: notification];
+            }
+        }
+        extern "C" fn on_window_did_move(this: &Object, _cmd: Sel, notification: id) {
+            unsafe {
+                let super_del: id = *this.get_ivar("super_delegate");
+                let _: () = msg_send![super_del, windowDidMove: notification];
+            }
+        }
+        extern "C" fn on_window_did_change_backing_properties(
+            this: &Object,
+            _cmd: Sel,
+            notification: id,
+        ) {
+            unsafe {
+                let super_del: id = *this.get_ivar("super_delegate");
+                let _: () = msg_send![super_del, windowDidChangeBackingProperties: notification];
+            }
+        }
+        extern "C" fn on_window_did_become_key(this: &Object, _cmd: Sel, notification: id) {
+            unsafe {
+                let super_del: id = *this.get_ivar("super_delegate");
+                let _: () = msg_send![super_del, windowDidBecomeKey: notification];
+            }
+        }
+        extern "C" fn on_window_did_resign_key(this: &Object, _cmd: Sel, notification: id) {
+            unsafe {
+                let super_del: id = *this.get_ivar("super_delegate");
+                let _: () = msg_send![super_del, windowDidResignKey: notification];
+            }
+        }
+        extern "C" fn on_dragging_entered(this: &Object, _cmd: Sel, notification: id) -> BOOL {
+            unsafe {
+                let super_del: id = *this.get_ivar("super_delegate");
+                msg_send![super_del, draggingEntered: notification]
+            }
+        }
+        extern "C" fn on_prepare_for_drag_operation(
+            this: &Object,
+            _cmd: Sel,
+            notification: id,
+        ) -> BOOL {
+            unsafe {
+                let super_del: id = *this.get_ivar("super_delegate");
+                msg_send![super_del, prepareForDragOperation: notification]
+            }
+        }
+        extern "C" fn on_perform_drag_operation(this: &Object, _cmd: Sel, sender: id) -> BOOL {
+            unsafe {
+                let super_del: id = *this.get_ivar("super_delegate");
+                msg_send![super_del, performDragOperation: sender]
+            }
+        }
+        extern "C" fn on_conclude_drag_operation(this: &Object, _cmd: Sel, notification: id) {
+            unsafe {
+                let super_del: id = *this.get_ivar("super_delegate");
+                let _: () = msg_send![super_del, concludeDragOperation: notification];
+            }
+        }
+        extern "C" fn on_dragging_exited(this: &Object, _cmd: Sel, notification: id) {
+            unsafe {
+                let super_del: id = *this.get_ivar("super_delegate");
+                let _: () = msg_send![super_del, draggingExited: notification];
+            }
+        }
+        extern "C" fn on_window_will_use_full_screen_presentation_options(
+            this: &Object,
+            _cmd: Sel,
+            window: id,
+            proposed_options: NSUInteger,
+        ) -> NSUInteger {
+            unsafe {
+                let super_del: id = *this.get_ivar("super_delegate");
+                msg_send![super_del, window: window willUseFullScreenPresentationOptions: proposed_options]
+            }
+        }
+        extern "C" fn on_window_did_enter_full_screen<R: Runtime>(
+            this: &Object,
+            _cmd: Sel,
+            notification: id,
+        ) {
+            unsafe {
+                with_window_state(this, |state: &mut WindowState<R>| {
+                    state
+                        .window
+                        .emit("did-enter-fullscreen", ())
+                        .expect("Failed to emit event");
+                });
+
+                let super_del: id = *this.get_ivar("super_delegate");
+                let _: () = msg_send![super_del, windowDidEnterFullScreen: notification];
+            }
+        }
+        extern "C" fn on_window_will_enter_full_screen<R: Runtime>(
+            this: &Object,
+            _cmd: Sel,
+            notification: id,
+        ) {
+            unsafe {
+                with_window_state(this, |state: &mut WindowState<R>| {
+                    state
+                        .window
+                        .emit("will-enter-fullscreen", ())
+                        .expect("Failed to emit event");
+                });
+
+                let super_del: id = *this.get_ivar("super_delegate");
+                let _: () = msg_send![super_del, windowWillEnterFullScreen: notification];
+            }
+        }
+        extern "C" fn on_window_did_exit_full_screen<R: Runtime>(
+            this: &Object,
+            _cmd: Sel,
+            notification: id,
+        ) {
+            unsafe {
+                with_window_state(this, |state: &mut WindowState<R>| {
+                    state
+                        .window
+                        .emit("did-exit-fullscreen", ())
+                        .expect("Failed to emit event");
+
+                    update(&state.window, &state.traffic_lights_inset);
+                });
+
+                let super_del: id = *this.get_ivar("super_delegate");
+                let _: () = msg_send![super_del, windowDidExitFullScreen: notification];
+            }
+        }
+        extern "C" fn on_window_will_exit_full_screen<R: Runtime>(
+            this: &Object,
+            _cmd: Sel,
+            notification: id,
+        ) {
+            unsafe {
+                with_window_state(this, |state: &mut WindowState<R>| {
+                    state
+                        .window
+                        .emit("will-exit-fullscreen", ())
+                        .expect("Failed to emit event");
+                });
+
+                let super_del: id = *this.get_ivar("super_delegate");
+                let _: () = msg_send![super_del, windowWillExitFullScreen: notification];
+            }
+        }
+        extern "C" fn on_window_did_fail_to_enter_full_screen(
+            this: &Object,
+            _cmd: Sel,
+            window: id,
+        ) {
+            unsafe {
+                let super_del: id = *this.get_ivar("super_delegate");
+                let _: () = msg_send![super_del, windowDidFailToEnterFullScreen: window];
+            }
+        }
+        extern "C" fn on_effective_appearance_did_change(
+            this: &Object,
+            _cmd: Sel,
+            notification: id,
+        ) {
+            unsafe {
+                let super_del: id = *this.get_ivar("super_delegate");
+                let _: () = msg_send![super_del, effectiveAppearanceDidChange: notification];
+            }
+        }
+        extern "C" fn on_effective_appearance_did_changed_on_main_thread(
+            this: &Object,
+            _cmd: Sel,
+            notification: id,
+        ) {
+            unsafe {
+                let super_del: id = *this.get_ivar("super_delegate");
+                let _: () = msg_send![
+                    super_del,
+                    effectiveAppearanceDidChangedOnMainThread: notification
+                ];
+            }
+        }
+
+        let window_label = window.label().to_string();
+
+        let app_state = WindowState {
+            window,
+            traffic_lights_inset,
+        };
+        let app_box = Box::into_raw(Box::new(app_state)) as *mut c_void;
+        let random_str: String = rand::thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(20)
+            .map(char::from)
+            .collect();
+
+        // We need to ensure we have a unique delegate name, otherwise we will panic while trying to create a duplicate
+        // delegate with the same name.
+        let delegate_name = format!("windowDelegate_tfp_{}_{}", window_label, random_str);
+
+        ns_win.setDelegate_(delegate!(&delegate_name, {
+            window: id = ns_win,
+            app_box: *mut c_void = app_box,
+            toolbar: id = cocoa::base::nil,
+            super_delegate: id = current_delegate,
+            (windowShouldClose:) => on_window_should_close as extern fn(&Object, Sel, id) -> BOOL,
+            (windowWillClose:) => on_window_will_close as extern fn(&Object, Sel, id),
+            (windowDidResize:) => on_window_did_resize::<R> as extern fn(&Object, Sel, id),
+            (windowDidMove:) => on_window_did_move as extern fn(&Object, Sel, id),
+            (windowDidChangeBackingProperties:) => on_window_did_change_backing_properties as extern fn(&Object, Sel, id),
+            (windowDidBecomeKey:) => on_window_did_become_key as extern fn(&Object, Sel, id),
+            (windowDidResignKey:) => on_window_did_resign_key as extern fn(&Object, Sel, id),
+            (draggingEntered:) => on_dragging_entered as extern fn(&Object, Sel, id) -> BOOL,
+            (prepareForDragOperation:) => on_prepare_for_drag_operation as extern fn(&Object, Sel, id) -> BOOL,
+            (performDragOperation:) => on_perform_drag_operation as extern fn(&Object, Sel, id) -> BOOL,
+            (concludeDragOperation:) => on_conclude_drag_operation as extern fn(&Object, Sel, id),
+            (draggingExited:) => on_dragging_exited as extern fn(&Object, Sel, id),
+            (window:willUseFullScreenPresentationOptions:) => on_window_will_use_full_screen_presentation_options as extern fn(&Object, Sel, id, NSUInteger) -> NSUInteger,
+            (windowDidEnterFullScreen:) => on_window_did_enter_full_screen::<R> as extern fn(&Object, Sel, id),
+            (windowWillEnterFullScreen:) => on_window_will_enter_full_screen::<R> as extern fn(&Object, Sel, id),
+            (windowDidExitFullScreen:) => on_window_did_exit_full_screen::<R> as extern fn(&Object, Sel, id),
+            (windowWillExitFullScreen:) => on_window_will_exit_full_screen::<R> as extern fn(&Object, Sel, id),
+            (windowDidFailToEnterFullScreen:) => on_window_did_fail_to_enter_full_screen as extern fn(&Object, Sel, id),
+            (effectiveAppearanceDidChange:) => on_effective_appearance_did_change as extern fn(&Object, Sel, id),
+            (effectiveAppearanceDidChangedOnMainThread:) => on_effective_appearance_did_changed_on_main_thread as extern fn(&Object, Sel, id)
+        }))
+    }
+}


### PR DESCRIPTION
## 🧢 Changes

- Test Mac OS title bar traffic lights repositioning
- Based off of this plugin + PR for Tauri v2 (https://github.com/ItsEeleeya/tauri-plugin-trafficlights-positioner/pull/4/files)

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
