### PR TITLE
Svelte config: Fix the css compiler options

### DIFF
--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -9,7 +9,11 @@ const config = {
 		alias: {
 			$home: 'src/routes/home'
 		}
-	}
+	},
+	compilerOptions: {
+		css: 'injected',
+		enableSourcemap: true
+	},
 };
 
 export default config;


### PR DESCRIPTION
Use the correct configuration for the css compiler