### PR TITLE
Chat: Reverse messages

### DIFF
--- a/apps/web/src/lib/components/ChatComponent.svelte
+++ b/apps/web/src/lib/components/ChatComponent.svelte
@@ -118,6 +118,8 @@
 	}
 
 	.chat-messages {
+		display: flex;
+		flex-direction: column-reverse;
 		flex-grow: 1;
 		overflow-y: scroll;
 		scrollbar-width: none;

--- a/packages/shared/src/lib/chat/chatChannelsService.ts
+++ b/packages/shared/src/lib/chat/chatChannelsService.ts
@@ -33,6 +33,10 @@ export class ChatChannelsService {
 						`chat_messages/${projectId}/chats/${changeId ?? ''}`
 					);
 
+					// Return the messages in reverse order so that
+					// the newest messages are at the bottom
+					apiChatMessages.reverse();
+
 					const chatChannel: LoadableChatChannel = {
 						status: 'found',
 						id: chatChannelKey,


### PR DESCRIPTION
Reverse the chat messages order, so that we can easlily display the latest messages at the bottom using a reverse-column flex box