### PR TITLE
feat: add support for keyboardShortcut prop in ContextMenuItem

### DIFF
--- a/apps/desktop/src/components/KeyboardShortcutsModal.svelte
+++ b/apps/desktop/src/components/KeyboardShortcutsModal.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import { platformName } from '$lib/platform/platform';
 	import { ShortcutService } from '$lib/shortcuts/shortcutService.svelte';
 	import { shortcuts } from '$lib/utils/hotkeys';
 	import { getContext } from '@gitbutler/shared/context';
 	import Modal from '@gitbutler/ui/Modal.svelte';
+	import { keysStringToArr } from '@gitbutler/ui/utils/hotkeys';
 
 	let modal: ReturnType<typeof Modal> | undefined = $state();
 
@@ -14,20 +14,6 @@
 
 	export function show() {
 		modal?.show();
-	}
-
-	function keysStringToArr(keys: string): string[] {
-		return keys.split('+').map((key) => {
-			if (key === 'Shift') return '⇧';
-			if (key === '$mod') {
-				if (platformName === 'macos') {
-					return '⌘';
-				} else {
-					return 'Ctrl';
-				}
-			}
-			return key;
-		});
 	}
 </script>
 

--- a/packages/ui/src/lib/ContextMenuItem.svelte
+++ b/packages/ui/src/lib/ContextMenuItem.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Icon from '@gitbutler/ui/Icon.svelte';
-	import { keysStringToArr } from '@gitbutler/ui/utils/hotkeys';
+	import { keysStringToArr } from '$lib/utils/hotkeys';
 	import type iconsJson from '@gitbutler/ui/data/icons.json';
 	import type { Snippet } from 'svelte';
 

--- a/packages/ui/src/lib/ContextMenuItem.svelte
+++ b/packages/ui/src/lib/ContextMenuItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Icon from '@gitbutler/ui/Icon.svelte';
+	import { keysStringToArr } from '@gitbutler/ui/utils/hotkeys';
 	import type iconsJson from '@gitbutler/ui/data/icons.json';
 	import type { Snippet } from 'svelte';
 
@@ -8,10 +9,11 @@
 		label: string;
 		disabled?: boolean;
 		control?: Snippet;
+		keyboardShortcut?: string;
 		onclick: (e: MouseEvent) => void;
 	}
 
-	const { onclick, icon, label, disabled, control }: Props = $props();
+	const { onclick, icon, label, disabled, control, keyboardShortcut }: Props = $props();
 </script>
 
 <button type="button" class="menu-item no-select" class:disabled {disabled} {onclick}>
@@ -22,6 +24,13 @@
 	<span class="menu-item__label text-12">
 		{label}
 	</span>
+	{#if keyboardShortcut}
+		<span class="menu-item__shortcut text-12">
+			{#each keysStringToArr(keyboardShortcut) as key}
+				<span>{key}</span>
+			{/each}
+		</span>
+	{/if}
 	{#if control}
 		{@render control()}
 	{/if}
@@ -58,5 +67,11 @@
 	.menu-item__label {
 		flex-grow: 1;
 		white-space: nowrap;
+	}
+
+	.menu-item__shortcut {
+		display: flex;
+		gap: 4px;
+		color: var(--clr-text-3);
 	}
 </style>

--- a/packages/ui/src/lib/utils/hotkeys.ts
+++ b/packages/ui/src/lib/utils/hotkeys.ts
@@ -1,0 +1,17 @@
+import { platform } from '@tauri-apps/plugin-os';
+
+export const platformName = platform();
+
+export function keysStringToArr(keys: string): string[] {
+	return keys.split('+').map((key) => {
+		if (key === 'Shift') return '⇧';
+		if (key === '$mod') {
+			if (platformName === 'macos') {
+				return '⌘';
+			} else {
+				return 'Ctrl';
+			}
+		}
+		return key;
+	});
+}

--- a/packages/ui/src/lib/utils/hotkeys.ts
+++ b/packages/ui/src/lib/utils/hotkeys.ts
@@ -1,12 +1,12 @@
-import { platform } from '@tauri-apps/plugin-os';
-
-export const platformName = platform();
+import { determinePlatform } from '$lib/utils/url';
 
 export function keysStringToArr(keys: string): string[] {
+	const platform = determinePlatform(navigator.userAgent);
+
 	return keys.split('+').map((key) => {
 		if (key === 'Shift') return '⇧';
 		if (key === '$mod') {
-			if (platformName === 'macos') {
+			if (platform === 'macos') {
 				return '⌘';
 			} else {
 				return 'Ctrl';

--- a/packages/ui/src/lib/utils/url.ts
+++ b/packages/ui/src/lib/utils/url.ts
@@ -1,0 +1,13 @@
+export function determinePlatform(userAgent: string) {
+	const ua = userAgent.toLowerCase();
+
+	if (ua.includes('mac os')) {
+		return 'macos';
+	} else if (ua.includes('windows')) {
+		return 'windows';
+	} else if (ua.includes('linux')) {
+		return 'linux';
+	}
+
+	return 'unknown';
+}


### PR DESCRIPTION
## 🧢 Changes

- Add a `keyboardShortcut` prop to `ContextMenuItem.svelte` in order to render things like this:

![image](https://github.com/user-attachments/assets/18bb9978-842d-4df1-8604-86b8272519b6)

- Resulting `ContextMenuItem.svelte`:

![image](https://github.com/user-attachments/assets/9f3d9b3e-5042-4cc5-b054-ccb0fa20ad88)


## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
