### PR TITLE
feat: add button for overflow menu in stack tab

### DIFF
--- a/apps/desktop/src/components/StackTab.svelte
+++ b/apps/desktop/src/components/StackTab.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
 	import { stackPath } from '$lib/routes/routes.svelte';
+	import Button from '@gitbutler/ui/Button.svelte';
+	import ContextMenuSection from '@gitbutler/ui/ContextMenuSection.svelte';
 	import Icon from '@gitbutler/ui/Icon.svelte';
 	import type { Tab } from '$lib/tabs/tab';
 	import { goto } from '$app/navigation';
+	import ContextMenu from '@gitbutler/ui/ContextMenu.svelte';
+	import ContextMenuItem from '@gitbutler/ui/ContextMenuItem.svelte';
 
 	type Props = {
 		projectId: string;
@@ -11,6 +15,10 @@
 		last: boolean;
 		selected: boolean;
 	};
+
+	let kebabMenuTrigger = $state<HTMLElement>();
+	let contextMenuEl = $state<ContextMenu>();
+	let isContextMenuOpen = $state(false);
 
 	const { projectId, tab, first, last, selected }: Props = $props();
 </script>
@@ -36,6 +44,42 @@
 	<div class="name">
 		{tab.name}
 	</div>
+	<div class="tab__overflow-menu">
+		<Button
+			kind="ghost"
+			icon="kebab"
+			bind:el={kebabMenuTrigger}
+			onclick={() => {
+				contextMenuEl?.toggle();
+			}}
+			activated={isContextMenuOpen}
+		></Button>
+	</div>
+
+	<ContextMenu
+		bind:this={contextMenuEl}
+		leftClickTrigger={kebabMenuTrigger}
+		ontoggle={(isOpen) => (isContextMenuOpen = isOpen)}
+		side="bottom"
+		horizontalAlign="left"
+	>
+		<ContextMenuSection>
+			<ContextMenuItem
+				label="Unapply Stack"
+				keyboardShortcut="$mod+X"
+				onclick={() => {
+					contextMenuEl?.close();
+				}}
+			/>
+			<ContextMenuItem
+				label="Rename"
+				keyboardShortcut="$mod+R"
+				onclick={() => {
+					contextMenuEl?.close();
+				}}
+			/>
+		</ContextMenuSection>
+	</ContextMenu>
 </button>
 
 <style lang="postcss">
@@ -53,6 +97,23 @@
 
 		&.first {
 			border-radius: var(--radius-ml) 0 0 0;
+		}
+
+		.tab__overflow-menu {
+			opacity: 0;
+			width: 0px;
+			transition:
+				opacity 100ms ease-in,
+				width 100ms ease-in-out;
+		}
+
+		&:active .tab__overflow-menu,
+		&:hover .tab__overflow-menu,
+		&:focus .tab__overflow-menu {
+			margin-right: 8px;
+			display: flex;
+			opacity: 1;
+			width: 16px;
 		}
 	}
 

--- a/apps/desktop/src/components/StackTab.svelte
+++ b/apps/desktop/src/components/StackTab.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import { stackPath } from '$lib/routes/routes.svelte';
 	import Button from '@gitbutler/ui/Button.svelte';
+	import ContextMenu from '@gitbutler/ui/ContextMenu.svelte';
+	import ContextMenuItem from '@gitbutler/ui/ContextMenuItem.svelte';
 	import ContextMenuSection from '@gitbutler/ui/ContextMenuSection.svelte';
 	import Icon from '@gitbutler/ui/Icon.svelte';
 	import type { Tab } from '$lib/tabs/tab';
 	import { goto } from '$app/navigation';
-	import ContextMenu from '@gitbutler/ui/ContextMenu.svelte';
-	import ContextMenuItem from '@gitbutler/ui/ContextMenuItem.svelte';
 
 	type Props = {
 		projectId: string;
@@ -19,6 +19,7 @@
 	let kebabMenuTrigger = $state<HTMLElement>();
 	let contextMenuEl = $state<ContextMenu>();
 	let isContextMenuOpen = $state(false);
+	let isHovered = $state(false);
 
 	const { projectId, tab, first, last, selected }: Props = $props();
 </script>
@@ -44,7 +45,12 @@
 	<div class="name">
 		{tab.name}
 	</div>
-	<div class="tab__overflow-menu">
+	<div
+		class={['tab__overflow-menu', isContextMenuOpen || isHovered ? 'active' : '']}
+		role="region"
+		onmouseenter={() => (isHovered = true)}
+		onmouseleave={() => (isHovered = false)}
+	>
 		<Button
 			kind="ghost"
 			icon="kebab"
@@ -102,14 +108,18 @@
 		.tab__overflow-menu {
 			opacity: 0;
 			width: 0px;
+			pointer-events: none;
 			transition:
 				opacity 100ms ease-in,
 				width 100ms ease-in-out;
 		}
 
+		.tab__overflow-menu.active,
 		&:active .tab__overflow-menu,
 		&:hover .tab__overflow-menu,
+		&:focus-within .tab__overflow-menu,
 		&:focus .tab__overflow-menu {
+			pointer-events: auto;
 			margin-right: 8px;
 			display: flex;
 			opacity: 1;


### PR DESCRIPTION
## 🧢 Changes

- Create stackTab overflow ContextMenu only visible on hover/focus of tab
- Todo in follow-up PR(s):
	- Figure out which actions we want in the stack tab overflow menu
	- Decide on shortcuts / implement the handlers for them


![image](https://github.com/user-attachments/assets/306a4245-0a9a-4bf0-8172-0131334fcc18)


## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
