### PR TITLE
fix: ChromeHeader absolute positioned element bug

### DIFF
--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -124,10 +124,15 @@
 
 	.center {
 		position: absolute;
-		left: 0;
 		width: 100%;
+		left: 0;
 		display: flex;
 		justify-content: center;
+		pointer-events: none;
+
+		& * {
+			pointer-events: auto;
+		}
 	}
 
 	.selector-series-select {


### PR DESCRIPTION
## 🧢 Changes

- Globally centered project title element was blocking mouse interaction on other btns in chrome header

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
