### PR TITLE
Chat: Display patch events

### DIFF
--- a/apps/web/src/lib/chat/subscribe.ts
+++ b/apps/web/src/lib/chat/subscribe.ts
@@ -1,11 +1,12 @@
-import { type SubscriptionEvent, getActionCableEndpoint, isSubscriptionEvent } from './utils';
+import { getActionCableEndpoint } from './utils';
+import { isApiPatchEvent, type ApiPatchEvent } from '@gitbutler/shared/branches/types';
 import { createConsumer } from '@rails/actioncable';
 
 export interface ChatChannelSubscriptionParams {
 	token: string;
 	changeId: string;
 	projectId: string;
-	onEvent: (data: SubscriptionEvent) => void;
+	onEvent: (data: ApiPatchEvent) => void;
 }
 
 export function subscribeToChatChannel({
@@ -20,7 +21,7 @@ export function subscribeToChatChannel({
 		{ channel: 'ChatChannel', change_id: changeId, project_id: projectId },
 		{
 			received(data: unknown) {
-				if (!isSubscriptionEvent(data)) return;
+				if (!isApiPatchEvent(data)) return;
 				onData(data);
 			}
 		}

--- a/apps/web/src/lib/chat/utils.ts
+++ b/apps/web/src/lib/chat/utils.ts
@@ -2,26 +2,6 @@ import { getTimeAgo } from '@gitbutler/ui/utils/timeAgo';
 import type { ChatMessage } from '@gitbutler/shared/chat/types';
 import { env } from '$env/dynamic/public';
 
-export type SubscriptionEvent = {
-	uuid: string;
-	event_type: string;
-	data: unknown;
-	object: unknown;
-	created_at: string;
-	updated_at: string;
-};
-
-export function isSubscriptionEvent(data: unknown): data is SubscriptionEvent {
-	return (
-		typeof data === 'object' &&
-		data !== null &&
-		typeof (data as any).uuid === 'string' &&
-		typeof (data as any).event_type === 'string' &&
-		typeof (data as any).created_at === 'string' &&
-		typeof (data as any).updated_at === 'string'
-	);
-}
-
 export function getActionCableEndpoint(token: string): string {
 	const domain = env.PUBLIC_APP_HOST.replace('http', 'ws');
 	const url = new URL('cable', domain);

--- a/apps/web/src/lib/chat/utils.ts
+++ b/apps/web/src/lib/chat/utils.ts
@@ -1,5 +1,4 @@
 import { getTimeAgo } from '@gitbutler/ui/utils/timeAgo';
-import type { ChatMessage } from '@gitbutler/shared/chat/types';
 import { env } from '$env/dynamic/public';
 
 export function getActionCableEndpoint(token: string): string {
@@ -13,8 +12,13 @@ export function getActionCableEndpoint(token: string): string {
 	return url.toString();
 }
 
-export function messageTimeStamp(message: ChatMessage): string {
-	const creationDate = new Date(message.createdAt);
+export type TimestampedEvent = {
+	createdAt: string;
+	updatedAt: string;
+};
+
+export function eventTimeStamp(event: TimestampedEvent): string {
+	const creationDate = new Date(event.createdAt);
 	const hoursAgo = Math.round((Date.now() - creationDate.getTime()) / 1000 / 60 / 60);
 
 	if (hoursAgo < 24) {

--- a/apps/web/src/lib/components/ChatComponent.svelte
+++ b/apps/web/src/lib/components/ChatComponent.svelte
@@ -2,7 +2,7 @@
 	import { AuthService } from '$lib/auth/authService';
 	import { subscribeToChatChannel } from '$lib/chat/subscribe';
 	import ChatInput from '$lib/components/chat/ChatInput.svelte';
-	import Message from '$lib/components/chat/Message.svelte';
+	import Event from '$lib/components/chat/Event.svelte';
 	import blankChat from '$lib/images/blank-chat.svg?raw';
 	import { PatchEventsService } from '@gitbutler/shared/branches/patchEventsService';
 	import { getPatchEvents } from '@gitbutler/shared/branches/patchesPreview.svelte';
@@ -64,9 +64,7 @@
 			{#snippet children(patchEvents)}
 				{#if patchEvents.events.length > 0}
 					{#each patchEvents.events as event}
-						{#if event.eventType === 'chat' && event.object}
-							<Message {projectId} {changeId} message={event.object} />
-						{/if}
+						<Event {projectId} {changeId} {event} />
 					{/each}
 				{:else}
 					<div class="blank-state">

--- a/apps/web/src/lib/components/ChatComponent.svelte
+++ b/apps/web/src/lib/components/ChatComponent.svelte
@@ -4,12 +4,12 @@
 	import ChatInput from '$lib/components/chat/ChatInput.svelte';
 	import Message from '$lib/components/chat/Message.svelte';
 	import blankChat from '$lib/images/blank-chat.svg?raw';
-	import { getChatChannel } from '@gitbutler/shared/chat/chatChannelsPreview.svelte';
-	import { ChatChannelsService } from '@gitbutler/shared/chat/chatChannelsService';
+	import { PatchEventsService } from '@gitbutler/shared/branches/patchEventsService';
+	import { getPatchEvents } from '@gitbutler/shared/branches/patchesPreview.svelte';
 	import { getContext } from '@gitbutler/shared/context';
 	import Loading from '@gitbutler/shared/network/Loading.svelte';
 	import { AppState } from '@gitbutler/shared/redux/store.svelte';
-	import type { SubscriptionEvent } from '$lib/chat/utils';
+	import type { ApiPatchEvent } from '@gitbutler/shared/branches/types';
 
 	interface Props {
 		branchUuid: string;
@@ -23,9 +23,9 @@
 	const authService = getContext(AuthService);
 	const token = $derived(authService.token);
 	const appState = getContext(AppState);
-	const chatChannelService = getContext(ChatChannelsService);
-	const chatChannel = $derived(getChatChannel(appState, chatChannelService, projectId, changeId));
+	const patchEventsService = getContext(PatchEventsService);
 
+	const patchEvents = $derived(getPatchEvents(appState, patchEventsService, projectId, changeId));
 	let chatMessagesContainer = $state<HTMLDivElement>();
 
 	const seenEventIds = new Set<string>();
@@ -36,13 +36,11 @@
 		}
 	}
 
-	async function onEvent(event: SubscriptionEvent) {
+	async function onEvent(event: ApiPatchEvent) {
 		if (seenEventIds.has(event.uuid)) return;
 		seenEventIds.add(event.uuid);
-		if (event.event_type === 'chat') {
-			await chatChannelService.refetchChatChannel(projectId, changeId);
-			scrollToBottom();
-		}
+		await patchEventsService.refreshPatchEvents(projectId, changeId);
+		scrollToBottom();
 	}
 
 	$effect(() => {
@@ -62,31 +60,31 @@
 
 <div class="chat-card">
 	<div class="chat-messages" bind:this={chatMessagesContainer}>
-		{#if chatChannel}
-			<Loading loadable={chatChannel.current}>
-				{#snippet children(channel)}
-					{#if channel.messages.length > 0}
-						{#each channel.messages as message}
-							<Message {projectId} {changeId} {message} />
-						{/each}
-					{:else}
-						<div class="blank-state">
-							<div class="blank-state-content">
-								{@html blankChat}
-								<div class="blank-message">
-									<div class="blank-message-title">Give some feedback!</div>
-									<p class="blank-message-text">
-										If you're here, you must be important. This patch can use your help. Leave a
-										comment or ask a question. Does this look right to you? How can it be improved?
-										Is it perfect? Just let us know!
-									</p>
-								</div>
+		<Loading loadable={patchEvents.current}>
+			{#snippet children(patchEvents)}
+				{#if patchEvents.events.length > 0}
+					{#each patchEvents.events as event}
+						{#if event.eventType === 'chat' && event.object}
+							<Message {projectId} {changeId} message={event.object} />
+						{/if}
+					{/each}
+				{:else}
+					<div class="blank-state">
+						<div class="blank-state-content">
+							{@html blankChat}
+							<div class="blank-message">
+								<div class="blank-message-title">Give some feedback!</div>
+								<p class="blank-message-text">
+									If you're here, you must be important. This patch can use your help. Leave a
+									comment or ask a question. Does this look right to you? How can it be improved? Is
+									it perfect? Just let us know!
+								</p>
 							</div>
 						</div>
-					{/if}
-				{/snippet}
-			</Loading>
-		{/if}
+					</div>
+				{/if}
+			{/snippet}
+		</Loading>
 	</div>
 	<ChatInput {branchUuid} {projectId} {branchId} {changeId} />
 </div>

--- a/apps/web/src/lib/components/chat/Event.svelte
+++ b/apps/web/src/lib/components/chat/Event.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import IssueUpdate from './IssueUpdate.svelte';
+	import Message from './Message.svelte';
+	import type { PatchEvent } from '@gitbutler/shared/branches/types';
+
+	interface Props {
+		projectId: string;
+		changeId: string;
+		event: PatchEvent;
+	}
+
+	const { event, projectId, changeId }: Props = $props();
+</script>
+
+{#if event.eventType === 'chat' && event.object}
+	<Message {projectId} {changeId} message={event.object} />
+{:else if event.eventType === 'issue_status'}
+	<IssueUpdate issueUpdate={event.object} />
+{/if}

--- a/apps/web/src/lib/components/chat/IssueUpdate.svelte
+++ b/apps/web/src/lib/components/chat/IssueUpdate.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+	import { eventTimeStamp } from '$lib/chat/utils';
+	import Icon from '@gitbutler/ui/Icon.svelte';
+	import type { IssueUpdate } from '@gitbutler/shared/branches/types';
+
+	const UNKNOWN_AUTHOR = 'Unknown author';
+
+	interface Props {
+		issueUpdate: IssueUpdate;
+	}
+
+	const { issueUpdate }: Props = $props();
+
+	const authorName = $derived(
+		issueUpdate.user?.login ?? issueUpdate.user?.name ?? issueUpdate.user?.email ?? UNKNOWN_AUTHOR
+	);
+
+	const timestamp = $derived(eventTimeStamp(issueUpdate));
+</script>
+
+<div class="issue-update">
+	<div class="issue-update__header">
+		{#if issueUpdate.user}
+			<img class="issue-update__avatar" src={issueUpdate.user.avatarUrl} alt={authorName} />
+		{/if}
+
+		<div class="issue-update__author-name">{authorName}</div>
+
+		{#if issueUpdate.resolved}
+			<div class="issue-update__status-icon">
+				<Icon name="tick-extrasmall" />
+			</div>
+
+			<p class="issue-update__status">resolved</p>
+		{/if}
+
+		<div class="issue-update__timestamp">{timestamp}</div>
+	</div>
+</div>
+
+<style lang="postcss">
+	.issue-update {
+		display: flex;
+		flex-direction: column;
+		padding: 14px 16px;
+		gap: 12px;
+
+		border-left: 4px solid var(--theme-succ-element, #4ab582);
+	}
+
+	.issue-update__header {
+		display: flex;
+		gap: 8px;
+	}
+
+	.issue-update__avatar {
+		width: 16px;
+		height: 16px;
+		border-radius: 20px;
+	}
+
+	.issue-update__author-name {
+		overflow: hidden;
+		color: var(--clr-text-1, #1a1614);
+		text-overflow: ellipsis;
+
+		/* base/13-bold */
+		font-family: var(--text-fontfamily-default, Inter);
+		font-size: 13px;
+		font-style: normal;
+		font-weight: 600;
+		line-height: 120%; /* 15.6px */
+	}
+
+	.issue-update__status-icon {
+		display: flex;
+		width: 16px;
+		align-items: center;
+
+		border-radius: var(--radius-m, 6px);
+		background: var(--clr-theme-succ-element, #4ab582);
+		color: var(--clr-core-ntrl-100);
+	}
+
+	.issue-update__status {
+		overflow: hidden;
+		color: var(--clr-text-1, #1a1614);
+		text-overflow: ellipsis;
+
+		/* base/12 */
+		font-family: var(--text-fontfamily-default, Inter);
+		font-size: 12px;
+		font-style: normal;
+		font-weight: var(--text-weight-regular, 400);
+		line-height: 120%; /* 14.4px */
+	}
+
+	.issue-update__timestamp {
+		overflow: hidden;
+		color: var(--clr-text-1, #1a1614);
+		text-overflow: ellipsis;
+
+		/* base/12 */
+		font-family: var(--text-fontfamily-default, Inter);
+		font-size: 12px;
+		font-style: normal;
+		font-weight: var(--text-weight-regular, 400);
+		line-height: 120%; /* 14.4px */
+
+		opacity: 0.4;
+	}
+</style>

--- a/apps/web/src/lib/components/chat/Message.svelte
+++ b/apps/web/src/lib/components/chat/Message.svelte
@@ -1,6 +1,4 @@
 <script lang="ts" module>
-	import { messageTimeStamp } from '$lib/chat/utils';
-	import Icon from '@gitbutler/ui/Icon.svelte';
 	import type { ChatMessage } from '@gitbutler/shared/chat/types';
 
 	export interface MessageProps {
@@ -12,7 +10,9 @@
 
 <script lang="ts">
 	import MessageActions from './MessageActions.svelte';
+	import { eventTimeStamp } from '$lib/chat/utils';
 	import Badge from '@gitbutler/ui/Badge.svelte';
+	import Icon from '@gitbutler/ui/Icon.svelte';
 	import Markdown from '@gitbutler/ui/markdown/Markdown.svelte';
 
 	const UNKNOWN_AUTHOR = 'Unknown author';
@@ -23,7 +23,7 @@
 		message.user.login ?? message.user.name ?? message.user.email ?? UNKNOWN_AUTHOR
 	);
 
-	const timestamp = $derived(messageTimeStamp(message));
+	const timestamp = $derived(eventTimeStamp(message));
 </script>
 
 <div

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -5,6 +5,7 @@
 	import { UserService } from '$lib/user/userService';
 	import { BranchService } from '@gitbutler/shared/branches/branchService';
 	import { LatestBranchLookupService } from '@gitbutler/shared/branches/latestBranchLookupService';
+	import { PatchEventsService } from '@gitbutler/shared/branches/patchEventsService';
 	import { PatchService } from '@gitbutler/shared/branches/patchService';
 	import { ChatChannelsService } from '@gitbutler/shared/chat/chatChannelsService';
 	import { FeedService } from '@gitbutler/shared/feeds/service';
@@ -53,6 +54,8 @@
 	setContext(BranchService, branchService);
 	const patchSerice = new PatchService(httpClient, appState.appDispatch);
 	setContext(PatchService, patchSerice);
+	const patchEventsService = new PatchEventsService(httpClient, appState.appDispatch);
+	setContext(PatchEventsService, patchEventsService);
 	const chatChannelService = new ChatChannelsService(httpClient, appState.appDispatch);
 	setContext(ChatChannelsService, chatChannelService);
 	const repositoryIdLookupService = new RepositoryIdLookupService(httpClient, appState.appDispatch);

--- a/packages/shared/src/lib/branches/patchEventsService.ts
+++ b/packages/shared/src/lib/branches/patchEventsService.ts
@@ -1,0 +1,65 @@
+import { upsertPatchEvent } from '$lib/branches/patchEventsSlice';
+import {
+	type ApiPatchEvent,
+	apiToPatchEvent,
+	createPatchEventChannelKey,
+	type LoadablePatchEventChannel
+} from '$lib/branches/types';
+import { InterestStore, type Interest } from '$lib/interest/interestStore';
+import { errorToLoadable } from '$lib/network/loadable';
+import { POLLING_GLACIALLY } from '$lib/polling';
+import type { HttpClient } from '$lib/network/httpClient';
+import type { AppDispatch } from '$lib/redux/store.svelte';
+
+export class PatchEventsService {
+	private readonly patchEventsInterests = new InterestStore<{
+		projectId: string;
+		changeId: string;
+	}>(POLLING_GLACIALLY);
+
+	constructor(
+		private readonly httpClient: HttpClient,
+		private readonly appDispatch: AppDispatch
+	) {}
+
+	getPatchEventsInterest(projectId: string, changeId: string): Interest {
+		return this.patchEventsInterests
+			.findOrCreateSubscribable({ projectId, changeId }, async () => {
+				const patchEventChannelKey = createPatchEventChannelKey(projectId, changeId);
+				try {
+					const apiPatchEvents = await this.httpClient.get<ApiPatchEvent[]>(
+						`patch_events/${projectId}/patch/${changeId}`
+					);
+
+					// Return the events in reverse order so that
+					// the newest events are at the bottom
+					apiPatchEvents.reverse();
+
+					const events = apiPatchEvents.map(apiToPatchEvent);
+					const patchEventChannel: LoadablePatchEventChannel = {
+						status: 'found',
+						id: patchEventChannelKey,
+						value: {
+							id: patchEventChannelKey,
+							projectId,
+							changeId,
+							events
+						}
+					};
+
+					this.appDispatch.dispatch(upsertPatchEvent(patchEventChannel));
+				} catch (error: unknown) {
+					this.appDispatch.dispatch(
+						upsertPatchEvent(
+							errorToLoadable(error, createPatchEventChannelKey(projectId, changeId))
+						)
+					);
+				}
+			})
+			.createInterest();
+	}
+
+	async refreshPatchEvents(projectId: string, changeId: string): Promise<void> {
+		await this.patchEventsInterests.invalidate({ projectId, changeId });
+	}
+}

--- a/packages/shared/src/lib/branches/patchEventsSlice.ts
+++ b/packages/shared/src/lib/branches/patchEventsSlice.ts
@@ -1,0 +1,35 @@
+import { type LoadablePatchEventChannel } from './types';
+import { loadableUpsert, loadableUpsertMany } from '$lib/network/loadable';
+import { createEntityAdapter, createSlice } from '@reduxjs/toolkit';
+
+const patchEventsAdapter = createEntityAdapter<
+	LoadablePatchEventChannel,
+	LoadablePatchEventChannel['id']
+>({
+	selectId: (patchEvent) => patchEvent.id
+});
+
+const patchEventsSlice = createSlice({
+	name: 'patchEvents',
+	initialState: patchEventsAdapter.getInitialState(),
+	reducers: {
+		addPatchEvent: patchEventsAdapter.addOne,
+		addPatchEvents: patchEventsAdapter.addMany,
+		removePatchEvent: patchEventsAdapter.removeOne,
+		removePatchEvents: patchEventsAdapter.removeMany,
+		upsertPatchEvent: loadableUpsert(patchEventsAdapter),
+		upsertPatchEvents: loadableUpsertMany(patchEventsAdapter)
+	}
+});
+
+export const patchEventsReducer = patchEventsSlice.reducer;
+
+export const patchEventsSelectors = patchEventsAdapter.getSelectors();
+export const {
+	addPatchEvent,
+	addPatchEvents,
+	removePatchEvent,
+	removePatchEvents,
+	upsertPatchEvent,
+	upsertPatchEvents
+} = patchEventsSlice.actions;

--- a/packages/shared/src/lib/branches/patchesPreview.svelte.ts
+++ b/packages/shared/src/lib/branches/patchesPreview.svelte.ts
@@ -1,10 +1,21 @@
+import { patchEventsSelectors } from './patchEventsSlice';
 import { patchSectionsSelectors } from '$lib/branches/patchSectionsSlice';
 import { patchesSelectors } from '$lib/branches/patchesSlice';
+import {
+	createPatchEventChannelKey,
+	type LoadablePatch,
+	type LoadablePatchEventChannel,
+	type Section
+} from '$lib/branches/types';
 import { registerInterest, type InView } from '$lib/interest/registerInterestFunction.svelte';
 import type { PatchService } from '$lib/branches/patchService';
-import type { LoadablePatch, Section } from '$lib/branches/types';
-import type { AppPatchesState, AppPatchSectionsState } from '$lib/redux/store.svelte';
+import type {
+	AppPatchesState,
+	AppPatchEventsState,
+	AppPatchSectionsState
+} from '$lib/redux/store.svelte';
 import type { Reactive } from '$lib/storeUtils';
+import type { PatchEventsService } from './patchEventsService';
 
 export function getPatch(
 	appState: AppPatchesState,
@@ -47,6 +58,28 @@ export function getPatchSections(
 	return {
 		get current() {
 			return sections;
+		}
+	};
+}
+
+export function getPatchEvents(
+	appState: AppPatchEventsState,
+	patchEventsService: PatchEventsService,
+	projectId: string,
+	changeId: string,
+	inView?: InView
+): Reactive<LoadablePatchEventChannel | undefined> {
+	const patchEventsInterest = patchEventsService.getPatchEventsInterest(projectId, changeId);
+	registerInterest(patchEventsInterest, inView);
+
+	const patchEventChannelKey = createPatchEventChannelKey(projectId, changeId);
+	const patchEvents = $derived(
+		patchEventsSelectors.selectById(appState.patchEvents, patchEventChannelKey)
+	);
+
+	return {
+		get current() {
+			return patchEvents;
 		}
 	};
 }

--- a/packages/shared/src/lib/chat/chatChannelsService.ts
+++ b/packages/shared/src/lib/chat/chatChannelsService.ts
@@ -11,7 +11,7 @@ import {
 } from '$lib/chat/types';
 import { InterestStore, type Interest } from '$lib/interest/interestStore';
 import { errorToLoadable } from '$lib/network/loadable';
-import { POLLING_REGULAR } from '$lib/polling';
+import { POLLING_GLACIALLY } from '$lib/polling';
 import type { HttpClient } from '$lib/network/httpClient';
 import type { AppDispatch } from '$lib/redux/store.svelte';
 
@@ -19,7 +19,7 @@ export class ChatChannelsService {
 	private readonly chatMessagesInterests = new InterestStore<{
 		projectId: string;
 		changeId?: string;
-	}>(POLLING_REGULAR);
+	}>(POLLING_GLACIALLY);
 
 	constructor(
 		private readonly httpClient: HttpClient,

--- a/packages/shared/src/lib/redux/store.svelte.ts
+++ b/packages/shared/src/lib/redux/store.svelte.ts
@@ -1,6 +1,7 @@
 import { branchReviewListingsReducer } from '$lib/branches/branchReviewListingsSlice';
 import { branchesReducer } from '$lib/branches/branchesSlice';
 import { latestBranchLookupsReducer } from '$lib/branches/latestBranchLookupSlice';
+import { patchEventsReducer } from '$lib/branches/patchEventsSlice';
 import { patchSectionsReducer } from '$lib/branches/patchSectionsSlice';
 import { patchesReducer } from '$lib/branches/patchesSlice';
 import { chatChannelsReducer } from '$lib/chat/chatChannelsSlice';
@@ -45,6 +46,10 @@ export interface AppPatchesState {
 	readonly patches: ReturnType<typeof patchesReducer>;
 }
 
+export interface AppPatchEventsState {
+	readonly patchEvents: ReturnType<typeof patchEventsReducer>;
+}
+
 export interface AppBranchesState {
 	readonly branches: ReturnType<typeof branchesReducer>;
 }
@@ -82,6 +87,7 @@ export class AppState
 		AppUsersState,
 		AppProjectsState,
 		AppPatchesState,
+		AppPatchEventsState,
 		AppBranchesState,
 		AppPatchSectionsState,
 		AppChatChannelsState,
@@ -104,6 +110,7 @@ export class AppState
 			users: usersReducer,
 			projects: projectsReducer,
 			patches: patchesReducer,
+			patchEvents: patchEventsReducer,
 			branches: branchesReducer,
 			patchSections: patchSectionsReducer,
 			chatChannels: chatChannelsReducer,
@@ -143,6 +150,10 @@ export class AppState
 		[this.selectSelf],
 		(rootState) => rootState.patches
 	);
+	private readonly selectPatchEvents = createSelector(
+		[this.selectSelf],
+		(rootState) => rootState.patchEvents
+	);
 	private readonly selectBranches = createSelector(
 		[this.selectSelf],
 		(rootState) => rootState.branches
@@ -175,6 +186,7 @@ export class AppState
 	readonly users = $derived(this.selectUsers(this.rootState));
 	readonly projects = $derived(this.selectProjects(this.rootState));
 	readonly patches = $derived(this.selectPatches(this.rootState));
+	readonly patchEvents = $derived(this.selectPatchEvents(this.rootState));
 	readonly branches = $derived(this.selectBranches(this.rootState));
 	readonly patchSections = $derived(this.selectPatchSections(this.rootState));
 	readonly chatChannels = $derived(this.selectChatChannels(this.rootState));

--- a/packages/shared/src/lib/users/types.ts
+++ b/packages/shared/src/lib/users/types.ts
@@ -8,6 +8,18 @@ export type ApiUserSimple = {
 	name: string | null;
 };
 
+export function isApiUserSimple(data: unknown): data is ApiUserSimple {
+	return (
+		typeof data === 'object' &&
+		data !== null &&
+		typeof (data as any).id === 'number' &&
+		(typeof (data as any).avatar_url === 'string' || (data as any).avatar_url === null) &&
+		(typeof (data as any).email === 'string' || (data as any).email === null) &&
+		(typeof (data as any).login === 'string' || (data as any).login === null) &&
+		(typeof (data as any).name === 'string' || (data as any).name === null)
+	);
+}
+
 export type UserSimple = {
 	id: number;
 	avatarUrl: string | undefined;


### PR DESCRIPTION
Use the patch events API to populate the chat content, in order to be able to display other updates there.

- Display issue status updates