### PR TITLE
Events: Display the patch status updates in the chat

### DIFF
--- a/apps/web/src/lib/chat/utils.ts
+++ b/apps/web/src/lib/chat/utils.ts
@@ -1,5 +1,8 @@
 import { getTimeAgo } from '@gitbutler/ui/utils/timeAgo';
+import type { UserMaybe } from '@gitbutler/shared/users/types';
 import { env } from '$env/dynamic/public';
+
+const UNKNOWN_AUTHOR = 'Unknown author';
 
 export function getActionCableEndpoint(token: string): string {
 	const domain = env.PUBLIC_APP_HOST.replace('http', 'ws');
@@ -41,4 +44,21 @@ export function eventTimeStamp(event: TimestampedEvent): string {
 	}
 
 	return getTimeAgo(creationDate);
+}
+
+export function getMultipleContributorNames(contributors: UserMaybe[]): string {
+	if (contributors.length === 0) {
+		return UNKNOWN_AUTHOR;
+	}
+
+	return contributors
+		.map((contributor) => {
+			if (contributor.user) {
+				const user = contributor.user;
+				return user.login ?? user.name ?? user.email ?? UNKNOWN_AUTHOR;
+			} else {
+				return contributor.email;
+			}
+		})
+		.join(', ');
 }

--- a/apps/web/src/lib/components/chat/Event.svelte
+++ b/apps/web/src/lib/components/chat/Event.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import IssueUpdate from './IssueUpdate.svelte';
 	import Message from './Message.svelte';
+	import PatchStatus from './PatchStatus.svelte';
 	import PatchVersion from './PatchVersion.svelte';
 	import type { PatchEvent } from '@gitbutler/shared/branches/types';
 
@@ -19,4 +20,6 @@
 	<IssueUpdate {event} />
 {:else if event.eventType === 'patch_version'}
 	<PatchVersion {event} />
+{:else if event.eventType === 'patch_status'}
+	<PatchStatus {event} />
 {/if}

--- a/apps/web/src/lib/components/chat/PatchStatus.svelte
+++ b/apps/web/src/lib/components/chat/PatchStatus.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+	import { eventTimeStamp } from '$lib/chat/utils';
+	import Icon from '@gitbutler/ui/Icon.svelte';
+	import type { PatchStatusEvent } from '@gitbutler/shared/branches/types';
+
+	const UNKNOWN_USER = 'Unknown User';
+
+	interface Props {
+		event: PatchStatusEvent;
+	}
+
+	const { event }: Props = $props();
+
+	const userName = $derived(
+		event.user?.login ?? event.user?.name ?? event.user?.email ?? UNKNOWN_USER
+	);
+	const statusAction = $derived(event.data.status ? 'approved' : 'rejected');
+	const timestamp = $derived(eventTimeStamp(event));
+</script>
+
+<div class="patch-status">
+	{#if event.data.status}
+		<div class="patch-status__icon">
+			<Icon name="confeti" />
+		</div>
+	{/if}
+
+	<div class="patch-status__header">
+		<p class="patch-status__name">{userName}</p>
+		<p class="patch-status__message">{statusAction} this commit</p>
+		<div class="patch-status__timestamp">{timestamp}</div>
+	</div>
+</div>
+
+<style lang="postcss">
+	.patch-status {
+		display: flex;
+		padding: 14px 16px;
+		padding-left: 10px;
+		gap: 12px;
+
+		border-left: 4px solid var(--clr-theme-succ-element, #4ab582);
+		border-bottom: 1px solid var(--clr-border-3, #eae9e8);
+		background: var(--clr-theme-succ-bg, #f6fcfb);
+	}
+
+	.patch-status__icon {
+		display: flex;
+		width: 24px;
+		height: 24px;
+		padding: 4px;
+		justify-content: center;
+		align-items: center;
+
+		border-radius: 8px;
+		background: var(--clr-theme-succ-element, #4ab582);
+		color: var(--clr-core-ntrl-100);
+	}
+
+	.patch-status__header {
+		display: flex;
+		align-items: center;
+		padding-top: 4px;
+		gap: 8px;
+	}
+
+	.patch-status__name {
+		overflow: hidden;
+		color: var(--clr-text-1, #1a1614);
+		text-overflow: ellipsis;
+
+		/* base/13-bold */
+		font-family: var(--text-fontfamily-default, Inter);
+		font-size: 13px;
+		font-style: normal;
+		font-weight: 600;
+		line-height: 120%; /* 15.6px */
+	}
+
+	.patch-status__message {
+		overflow: hidden;
+		color: var(--clr-text-1, #1a1614);
+		text-overflow: ellipsis;
+
+		/* base/12 */
+		font-family: var(--text-fontfamily-default, Inter);
+		font-size: 12px;
+		font-style: normal;
+		font-weight: var(--text-weight-regular, 400);
+		line-height: 120%; /* 14.4px */
+	}
+
+	.patch-status__timestamp {
+		overflow: hidden;
+		color: var(--clr-text-1, #1a1614);
+		text-overflow: ellipsis;
+
+		/* base/12 */
+		font-family: var(--text-fontfamily-default, Inter);
+		font-size: 12px;
+		font-style: normal;
+		font-weight: var(--text-weight-regular, 400);
+		line-height: 120%; /* 14.4px */
+
+		opacity: 0.4;
+	}
+</style>

--- a/apps/web/src/lib/components/chat/PatchVersion.svelte
+++ b/apps/web/src/lib/components/chat/PatchVersion.svelte
@@ -1,13 +1,11 @@
 <script lang="ts">
-	import { eventTimeStamp } from '$lib/chat/utils';
+	import { eventTimeStamp, getMultipleContributorNames } from '$lib/chat/utils';
 	import {
 		getPatchContributorsWithAvatars,
 		type PatchVersionEvent
 	} from '@gitbutler/shared/branches/types';
 	import Icon from '@gitbutler/ui/Icon.svelte';
 	import AvatarGroup from '@gitbutler/ui/avatar/AvatarGroup.svelte';
-
-	const UNKNOWN_AUTHOR = 'Unknown author';
 
 	interface Props {
 		event: PatchVersionEvent;
@@ -17,20 +15,7 @@
 
 	const patch = $derived(event.object);
 
-	const authorNames = $derived.by(() => {
-		return patch.contributors.length > 0
-			? patch.contributors
-					.map((contributor) => {
-						if (contributor.user) {
-							const user = contributor.user;
-							return user.login ?? user.name ?? user.email ?? UNKNOWN_AUTHOR;
-						} else {
-							return contributor.email;
-						}
-					})
-					.join(', ')
-			: UNKNOWN_AUTHOR;
-	});
+	const authorNames = $derived(getMultipleContributorNames(patch.contributors));
 	const authorAvatars = $derived(getPatchContributorsWithAvatars(patch));
 
 	const timestamp = $derived(eventTimeStamp(event));

--- a/packages/shared/src/lib/branches/types.ts
+++ b/packages/shared/src/lib/branches/types.ts
@@ -413,6 +413,7 @@ export type ApiPatchVersionEvent = ApiPatchEventBase & {
 };
 
 export type ApiPatchStatusEvent = ApiPatchEventBase & {
+	data: { status: boolean };
 	event_type: 'patch_status';
 	object: ApiPatch;
 };
@@ -481,6 +482,7 @@ export type PatchVersionEvent = PatchEventBase & {
 };
 
 export type PatchStatusEvent = PatchEventBase & {
+	data: { status: boolean };
 	eventType: 'patch_status';
 	object: Patch;
 };
@@ -540,8 +542,20 @@ export function apiToPatchEvent(api: ApiPatchEvent): PatchEvent | undefined {
 				updatedAt: api.updated_at
 			};
 		case 'patch_version':
+			// Ignore version 1 patches
+			if (api.object.version === 1) return undefined;
+			return {
+				eventType: api.event_type,
+				uuid: api.uuid,
+				user: api.user ? apiToUserSimple(api.user) : undefined,
+				data: api.data,
+				object: apiToPatch(api.object),
+				createdAt: api.created_at,
+				updatedAt: api.updated_at
+			};
 		case 'patch_status':
-			if (api.event_type === 'patch_version' && api.object.version === 1) return undefined;
+			// Ignore status updates that are not approved
+			if (!api.data.status) return undefined;
 			return {
 				eventType: api.event_type,
 				uuid: api.uuid,


### PR DESCRIPTION
1. **Patch status: Ignore rejection events** - This commit modifies the event handling to ignore rejection events, as they are now managed through issue messages instead of the chat feed.

2. **Patch version: Factor out the author names calculation** - This commit refactors the code to extract the calculation of author names into a separate function, improving code organization and readability.

3. **Patch status: Display the status updates** - This commit enhances the chat feed by enabling it to display patch status updates, providing users with timely information about their patches.
