### PR TITLE
Patch status: Sign off message

### DIFF
--- a/apps/web/src/lib/components/chat/ChatInput.svelte
+++ b/apps/web/src/lib/components/chat/ChatInput.svelte
@@ -76,7 +76,7 @@
 	let dropDownButton = $state<ReturnType<typeof DropDownButton>>();
 
 	async function approve() {
-		await patchService.updatePatch(branchUuid, changeId, { signOff: true });
+		await patchService.updatePatch(branchUuid, changeId, { signOff: true, message });
 	}
 
 	async function requestChanges() {
@@ -90,7 +90,6 @@
 			switch (action) {
 				case 'approve':
 					await approve();
-					await handleSendMessage();
 					break;
 				case 'requestChanges':
 					await requestChanges();

--- a/apps/web/src/lib/components/chat/PatchStatus.svelte
+++ b/apps/web/src/lib/components/chat/PatchStatus.svelte
@@ -25,10 +25,16 @@
 		</div>
 	{/if}
 
-	<div class="patch-status__header">
-		<p class="patch-status__name">{userName}</p>
-		<p class="patch-status__message">{statusAction} this commit</p>
-		<div class="patch-status__timestamp">{timestamp}</div>
+	<div class="patch-status-content">
+		<div class="patch-status__header">
+			<p class="patch-status__name">{userName}</p>
+			<p class="patch-status__message">{statusAction} this commit</p>
+			<div class="patch-status__timestamp">{timestamp}</div>
+		</div>
+
+		{#if event.data.message}
+			<p class="patch-status__text-content">{event.data.message}</p>
+		{/if}
 	</div>
 </div>
 
@@ -55,6 +61,13 @@
 		border-radius: 8px;
 		background: var(--clr-theme-succ-element, #4ab582);
 		color: var(--clr-core-ntrl-100);
+	}
+
+	.patch-status-content {
+		display: flex;
+		flex-direction: column;
+
+		gap: 12px;
 	}
 
 	.patch-status__header {
@@ -103,5 +116,16 @@
 		line-height: 120%; /* 14.4px */
 
 		opacity: 0.4;
+	}
+
+	.patch-status__text-content {
+		color: var(--clr-text-1, #1a1614);
+
+		/* base-body/13 */
+		font-family: var(--text-fontfamily-default, Inter);
+		font-size: 13px;
+		font-style: normal;
+		font-weight: var(--text-weight-regular, 400);
+		line-height: 160%; /* 20.8px */
 	}
 </style>

--- a/packages/shared/src/lib/branches/patchService.ts
+++ b/packages/shared/src/lib/branches/patchService.ts
@@ -10,6 +10,7 @@ import type { AppDispatch } from '$lib/redux/store.svelte';
 type PatchUpdateParams = {
 	signOff?: boolean;
 	sectionOrder?: string[];
+	message?: string;
 };
 
 export class PatchService {
@@ -56,7 +57,8 @@ export class PatchService {
 			{
 				body: {
 					sign_off: params.signOff,
-					section_order: params.sectionOrder
+					section_order: params.sectionOrder,
+					message: params.message
 				}
 			}
 		);

--- a/packages/shared/src/lib/branches/types.ts
+++ b/packages/shared/src/lib/branches/types.ts
@@ -413,7 +413,7 @@ export type ApiPatchVersionEvent = ApiPatchEventBase & {
 };
 
 export type ApiPatchStatusEvent = ApiPatchEventBase & {
-	data: { status: boolean };
+	data: { status: boolean; message: string | null };
 	event_type: 'patch_status';
 	object: ApiPatch;
 };
@@ -482,10 +482,17 @@ export type PatchVersionEvent = PatchEventBase & {
 };
 
 export type PatchStatusEvent = PatchEventBase & {
-	data: { status: boolean };
+	data: { status: boolean; message: string | undefined };
 	eventType: 'patch_status';
 	object: Patch;
 };
+
+export function apiToPatchStatusData(api: ApiPatchStatusEvent['data']): PatchStatusEvent['data'] {
+	return {
+		status: api.status,
+		message: api.message ?? undefined
+	};
+}
 
 export type IssueUpdate = {
 	uuid: string;
@@ -560,7 +567,7 @@ export function apiToPatchEvent(api: ApiPatchEvent): PatchEvent | undefined {
 				eventType: api.event_type,
 				uuid: api.uuid,
 				user: api.user ? apiToUserSimple(api.user) : undefined,
-				data: api.data,
+				data: apiToPatchStatusData(api.data),
 				object: apiToPatch(api.object),
 				createdAt: api.created_at,
 				updatedAt: api.updated_at


### PR DESCRIPTION
Use the new sign off params, in order to correctly update the sign off status of a patch with a message.

Display the optional message in the patch status component