### PR TITLE
Change default context menu positioning

### DIFF
--- a/packages/ui/src/lib/ContextMenu.svelte
+++ b/packages/ui/src/lib/ContextMenu.svelte
@@ -30,7 +30,7 @@
 	let {
 		leftClickTrigger,
 		rightClickTrigger,
-		side = 'right',
+		side = 'bottom',
 		verticalAlign = 'bottom',
 		horizontalAlign = 'right',
 		children,


### PR DESCRIPTION
All context menus had wrong positioning.

before:

<img width="325" alt="image" src="https://github.com/user-attachments/assets/37bde75d-53e4-4720-8850-c2d1e339fc71" />

after:

<img width="228" alt="image" src="https://github.com/user-attachments/assets/4ea20ed1-d592-4223-ae05-f511b0dd11ab" />
