### PR TITLE
fix: move "publish branch" buthub btn to series header with padding

### DIFF
--- a/apps/desktop/src/components/HeaderMetaSection.svelte
+++ b/apps/desktop/src/components/HeaderMetaSection.svelte
@@ -2,50 +2,87 @@
 	import SeriesRowLabels from './SeriesLabels.svelte';
 	import BranchLaneContextMenu from '$components/BranchLaneContextMenu.svelte';
 	import { PatchSeries } from '$lib/branches/branch';
+	import { cloudReviewFunctionality } from '$lib/config/uiFeatureFlags';
+	import { StackPublishingService } from '$lib/history/stackPublishingService';
+	import { getContext } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import ContextMenu from '@gitbutler/ui/ContextMenu.svelte';
 
 	interface Props {
 		series: (PatchSeries | Error)[];
 		onCollapseButtonClick: () => void;
+		stackId?: string;
 	}
 
-	const { series, onCollapseButtonClick }: Props = $props();
+	const { series, onCollapseButtonClick, stackId }: Props = $props();
 
 	let contextMenu = $state<ReturnType<typeof ContextMenu>>();
 	let kebabButtonEl: HTMLButtonElement | undefined = $state();
 	let isContextMenuOpen = $state(false);
+
+	const stackPublishingService = getContext(StackPublishingService);
+	const canPublish = stackPublishingService.canPublish;
+	let publishing = $state<'inert' | 'loading' | 'complete'>('inert');
+
+	async function publishStack() {
+		publishing = 'loading';
+		await stackPublishingService.upsertStack(stackId);
+		publishing = 'complete';
+	}
 </script>
 
 <div class="stack-meta">
-	<SeriesRowLabels {series} />
+	<div class="stack-meta-top">
+		<SeriesRowLabels {series} />
 
-	<Button
-		bind:el={kebabButtonEl}
-		activated={isContextMenuOpen}
-		kind="ghost"
-		icon="kebab"
-		size="tag"
-		onclick={() => {
-			contextMenu?.toggle();
-		}}
-	/>
-	<BranchLaneContextMenu
-		bind:contextMenuEl={contextMenu}
-		trigger={kebabButtonEl}
-		onCollapse={onCollapseButtonClick}
-		ontoggle={(isOpen) => (isContextMenuOpen = isOpen)}
-	/>
+		<Button
+			bind:el={kebabButtonEl}
+			activated={isContextMenuOpen}
+			kind="ghost"
+			icon="kebab"
+			size="tag"
+			onclick={() => {
+				contextMenu?.toggle();
+			}}
+		/>
+		<BranchLaneContextMenu
+			bind:contextMenuEl={contextMenu}
+			trigger={kebabButtonEl}
+			onCollapse={onCollapseButtonClick}
+			ontoggle={(isOpen) => (isContextMenuOpen = isOpen)}
+		/>
+	</div>
+	{#if $cloudReviewFunctionality && $canPublish}
+		<div class="stack-meta-bottom">
+			<Button wide onclick={publishStack} loading={publishing === 'loading'}>Publish stack</Button>
+		</div>
+	{/if}
 </div>
 
 <style lang="postcss">
 	.stack-meta {
+		width: 100%;
+		align-items: start;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 4px;
+		background-color: var(--clr-bg-1);
+		border: 1px solid var(--clr-border-2);
+		border-top: none;
+	}
+
+	.stack-meta-top {
+		width: 100%;
 		display: flex;
 		align-items: center;
 		gap: 8px;
 		padding: 12px;
-		background-color: var(--clr-bg-1);
-		border: 1px solid var(--clr-border-2);
-		border-top: none;
+	}
+
+	.stack-meta-bottom {
+		width: 100%;
+		display: flex;
+		padding: 0 12px 12px 12px;
 	}
 </style>

--- a/apps/desktop/src/components/StackHeader.svelte
+++ b/apps/desktop/src/components/StackHeader.svelte
@@ -3,10 +3,7 @@
 	import HeaderMetaSection from './HeaderMetaSection.svelte';
 	import { BranchStack } from '$lib/branches/branch';
 	import { BranchController } from '$lib/branches/branchController';
-	import { cloudReviewFunctionality } from '$lib/config/uiFeatureFlags';
-	import { StackPublishingService } from '$lib/history/stackPublishingService';
 	import { getContext } from '@gitbutler/shared/context';
-	import Button from '@gitbutler/ui/Button.svelte';
 	import { isError } from '@gitbutler/ui/utils/typeguards';
 
 	interface Props {
@@ -24,16 +21,6 @@
 			return !s.archived;
 		})
 	);
-
-	const stackPublishingService = getContext(StackPublishingService);
-	const canPublish = stackPublishingService.canPublish;
-	let publishing = $state<'inert' | 'loading' | 'complete'>('inert');
-
-	async function publishStack() {
-		publishing = 'loading';
-		await stackPublishingService.upsertStack(stack.id);
-		publishing = 'complete';
-	}
 </script>
 
 <div class="stack-header">
@@ -44,10 +31,7 @@
 			await branchController.setSelectedForChanges(stack.id);
 		}}
 	/>
-	<HeaderMetaSection series={nonArchivedSeries} {onCollapseButtonClick} />
-	{#if $cloudReviewFunctionality && $canPublish}
-		<Button onclick={publishStack} loading={publishing === 'loading'}>Publish stack</Button>
-	{/if}
+	<HeaderMetaSection series={nonArchivedSeries} {onCollapseButtonClick} stackId={stack.id} />
 </div>
 
 <style lang="postcss">


### PR DESCRIPTION
## 🧢 Changes

- Move "Publish Branch" buthub button to the SeriesHeader
- Add appropriate padding around the button
- I know this probably isn't the final design, but its much better than the placeholder we currently have for the positionining / design of this button :sweat_smile: 


### Before

![image](https://github.com/user-attachments/assets/33a09693-1f33-44ef-8dab-fafd5fdb8bd6)


### After

![image](https://github.com/user-attachments/assets/ae9a42d1-84af-47d6-81bd-56e5cd043f0e)


## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
