### PR TITLE
Added two feature flags to guide users away from incomplete features

### DIFF
--- a/apps/web/src/lib/components/Navigation.svelte
+++ b/apps/web/src/lib/components/Navigation.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { AuthService } from '$lib/auth/authService.svelte';
 	import Breadcrumbs from '$lib/components/breadcrumbs/Breadcrumbs.svelte';
+	import { featureShowOrganizations } from '$lib/featureFlags';
 	import { UserService } from '$lib/user/userService';
 	import { getContext } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
@@ -105,10 +106,10 @@
 		<ContextMenuItem
 			label="Preferences"
 			onclick={() => {
-				goto('/settings/profile');
+				goto('/profile');
 			}}
 		/>
-		{#if $token}
+		{#if $token && $featureShowOrganizations}
 			<ContextMenuItem label="Organizations" onclick={() => goto('/organizations')} />
 		{/if}
 	</ContextMenuSection>

--- a/apps/web/src/lib/components/projects/ProjectIndexCard.svelte
+++ b/apps/web/src/lib/components/projects/ProjectIndexCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { featureShowProjectPage } from '$lib/featureFlags';
 	import { getContext } from '@gitbutler/shared/context';
 	import Loading from '@gitbutler/shared/network/Loading.svelte';
 	import { ProjectService } from '@gitbutler/shared/organizations/projectService';
@@ -17,6 +18,7 @@
 	const routes = getContext(WebRoutesService);
 
 	const project = getProjectByRepositoryId(appState, projectService, projectId);
+	const projectRoute = $featureShowProjectPage ? routes.projectPath : routes.projectReviewPath;
 </script>
 
 <Loading loadable={project.current}>
@@ -27,7 +29,7 @@
 			</td>
 			<td>
 				<div>
-					<a href={routes.projectPath({ ownerSlug: project.owner, projectSlug: project.slug })}>
+					<a href={projectRoute({ ownerSlug: project.owner, projectSlug: project.slug })}>
 						<p>{project.slug}</p>
 					</a>
 				</div>

--- a/apps/web/src/lib/featureFlags.ts
+++ b/apps/web/src/lib/featureFlags.ts
@@ -1,0 +1,4 @@
+import { persisted } from '@gitbutler/shared/persisted';
+
+export const featureShowOrganizations = persisted(false, 'feature-showOrganizations');
+export const featureShowProjectPage = persisted(false, 'feature-skipProjectPage');

--- a/apps/web/src/routes/profile/+page.svelte
+++ b/apps/web/src/routes/profile/+page.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 	import { AuthService } from '$lib/auth/authService.svelte';
+	import { featureShowOrganizations, featureShowProjectPage } from '$lib/featureFlags';
 	import { UserService } from '$lib/user/userService';
 	import { getContext } from '@gitbutler/shared/context';
+	import SectionCard from '@gitbutler/ui/SectionCard.svelte';
+	import Toggle from '@gitbutler/ui/Toggle.svelte';
 
 	const authService = getContext(AuthService);
 	const userService = getContext(UserService);
@@ -28,12 +31,43 @@
 	</div>
 {/if}
 
+<div class="experimental-settings">
+	<h1>Experimental settings</h1>
+	<SectionCard labelFor="showOrganizations" orientation="row">
+		{#snippet title()}Organizations{/snippet}
+		{#snippet caption()}
+			Organizations are a way of linking together projects.
+		{/snippet}
+		{#snippet actions()}
+			<Toggle
+				id="showOrganizations"
+				checked={$featureShowOrganizations}
+				onclick={() => ($featureShowOrganizations = !$featureShowOrganizations)}
+			/>
+		{/snippet}
+	</SectionCard>
+	<SectionCard labelFor="showProjectPage" orientation="row">
+		{#snippet title()}Project Page{/snippet}
+		{#snippet caption()}
+			The project page provides an overview of the project.
+		{/snippet}
+		{#snippet actions()}
+			<Toggle
+				id="showProjectPage"
+				checked={$featureShowProjectPage}
+				onclick={() => ($featureShowProjectPage = !$featureShowProjectPage)}
+			/>
+		{/snippet}
+	</SectionCard>
+</div>
+
 <style>
 	h1 {
 		font-size: 1.5rem;
 		margin-bottom: 10px;
 	}
-	.profile {
+	.profile,
+	.experimental-settings {
 		display: flex;
 		flex-direction: column;
 		gap: 0.5rem;


### PR DESCRIPTION
In an effort to smooth out the initial user experience, I've hidden some pages that the user would otherwise have to page through in order to make use of the currently implemented features.

Namly, this hides the organizations page (which is currently hard to understand & mostly unused) as well as the project page. In the future the project page will be similar to the GH repo page.

This commit also corrects the link to the `/profile` page. Previously it was linking to the nonexistant `/settings/profile` page, which due to it's unforutnate bout of nonexistance was getting interpreted as a project instead.

The experimental settings are toggle-able on the now accessable `/profile` page