### PR TITLE
feat:  upload pnpm store as GHA artifact

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -68,6 +68,12 @@ jobs:
         env:
           SENTRY_RELEASE: ${{ env.version }}
       - uses: actions/upload-artifact@v4
+        name: Upload pnpm-store contents
+        with:
+          name: pnpm-store
+          path: /home/runner/setup-pnpm/node_modules/.bin/store/v3
+          retention-days: 7
+      - uses: actions/upload-artifact@v4
         name: Upload SvelteKit build output
         with:
           name: sveltekit-build
@@ -275,7 +281,7 @@ jobs:
       - name: Sign our EV signed file
         shell: bash
         run: |
-          set -x  
+          set -x
           curl -O https://gitbutler-public.s3.us-east-1.amazonaws.com/_win/minisign.exe
           chmod +x minisign.exe  # Add this line to make the file executable
           echo "sign release/${{ steps.set-path.outputs.msi_file }}"


### PR DESCRIPTION
## 🧢 Changes

- Upload `pnpm-store` artifact from our `Sveltekit Build` step. 
- This pnpm store artifact can then be consumed in our flatpak build to complete the offline compile of GitButler for the flathub store.

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
