### PR TITLE
fix: header padding for platforms other than Mac OS

### DIFF
--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -34,7 +34,7 @@
 	let isNotificationsUnread = $state(false);
 </script>
 
-<div class="header">
+<div class="header" class:isMac={platformName === 'macos'}>
 	<div class="left">
 		<div class="left-buttons" class:macos={platformName === 'macos'}>
 			<SyncButton size="button" />
@@ -116,7 +116,11 @@
 	.header {
 		display: flex;
 		justify-content: space-between;
-		padding: 14px 14px 14px 84px;
+		padding: 14px;
+
+		&.isMac {
+			padding: 14px 14px 14px 84px;
+		}
 	}
 
 	.left {


### PR DESCRIPTION
## 🧢 Changes

- Additional padding was added globally, however, this is only required when running on Mac OS and we place the traffic-lights in that corner

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
