### PR TITLE
fix: bump node and corepack in nix setup

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
           };
           pkgs = import nixpkgs {
             system = system;
-            overlays = [ nix-playwright-browsers.overlays.${system}.default];
+            overlays = [ nix-playwright-browsers.overlays.${system}.default ];
           };
 
           rustToolchain = unstable.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
@@ -39,8 +39,8 @@
             libsoup_3
             webkitgtk
             webkitgtk_4_1
-            nodejs_20
-            corepack_20
+            nodejs_22
+            corepack_22
             pkgs.playwright-browsers_v1_47_0
           ];
 


### PR DESCRIPTION
## 🧢 Changes

- Bump `nodejs` and `corepack` packages in `flake.nix`

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
