### PR TITLE
fix: StackedTabs overflow shadow alignment

### DIFF
--- a/apps/desktop/src/components/StackTabs.svelte
+++ b/apps/desktop/src/components/StackTabs.svelte
@@ -106,7 +106,7 @@
 	.shadow-left {
 		pointer-events: none;
 		opacity: 0;
-		left: 0;
+		left: -18px;
 		background: linear-gradient(to right, var(--clr-bg-1) 0%, transparent 100%);
 		transition: opacity var(--transition-fast);
 
@@ -118,7 +118,7 @@
 	.shadow-right {
 		pointer-events: none;
 		opacity: 0;
-		right: 0;
+		right: -18px;
 		background: linear-gradient(to left, var(--clr-bg-1) 0%, transparent 100%);
 		transition: opacity var(--transition-fast);
 


### PR DESCRIPTION
## 🧢 Changes

- Fix alignment of shadows in the StackTabs when they're overflowed
- Somehow the positioning got thrown off in some PR lately

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
