### PR TITLE
feat: css gap utils

### DIFF
--- a/apps/desktop/src/components/StackContentPlaceholder.svelte
+++ b/apps/desktop/src/components/StackContentPlaceholder.svelte
@@ -112,7 +112,7 @@
 				target="_blank"
 				underline={false}
 				externalIcon={false}
-				class="text-13 text-semibold text-clr2"><Icon name="discord" /> Join Community</Link
+				class="text-13 text-semibold text-clr2 gap-4"><Icon name="discord" /> Join Community</Link
 			>
 		</div>
 	</div>

--- a/apps/desktop/src/components/StackContentPlaceholder.svelte
+++ b/apps/desktop/src/components/StackContentPlaceholder.svelte
@@ -98,21 +98,21 @@
 				target="_blank"
 				underline={false}
 				externalIcon={false}
-				class="text-13 text-semibold text-clr2"><Icon name="doc" /> GitButler Docs</Link
+				class="text-13 text-semibold text-clr2 gap-2"><Icon name="doc" /> GitButler Docs</Link
 			>
 			<Link
 				href="https://github.com/gitbutlerapp/gitbutler"
 				target="_blank"
 				underline={false}
 				externalIcon={false}
-				class="text-13 text-semibold text-clr2"><Icon name="github" /> Source Code</Link
+				class="text-13 text-semibold text-clr2 gap-2"><Icon name="github" /> Source Code</Link
 			>
 			<Link
 				href="https://discord.com/invite/MmFkmaJ42D"
 				target="_blank"
 				underline={false}
 				externalIcon={false}
-				class="text-13 text-semibold text-clr2 gap-4"><Icon name="discord" /> Join Community</Link
+				class="text-13 text-semibold text-clr2 gap-2"><Icon name="discord" /> Join Community</Link
 			>
 		</div>
 	</div>

--- a/packages/ui/src/lib/link/Link.svelte
+++ b/packages/ui/src/lib/link/Link.svelte
@@ -44,8 +44,8 @@
 	{href}
 	{target}
 	{rel}
-	class="link {role} {classes}"
 	bind:this={element}
+	class={['link', role, classes]}
 	class:disabled
 	class:underline
 	onclick={(e) => {

--- a/packages/ui/src/styles/utility/helpers.css
+++ b/packages/ui/src/styles/utility/helpers.css
@@ -87,25 +87,25 @@ pre {
 }
 
 .gap-1 {
-	gap: 4px;
+	gap: 4px !important;
 }
 
 .gap-2 {
-	gap: 8px;
+	gap: 8px !important;
 }
 
 .gap-3 {
-	gap: 12px;
+	gap: 12px !important;
 }
 
 .gap-4 {
-	gap: 16px;
+	gap: 16px !important;
 }
 
 .gap-5 {
-	gap: 20px;
+	gap: 20px !important;
 }
 
 .gap-6 {
-	gap: 24px;
+	gap: 24px !important;
 }

--- a/packages/ui/src/styles/utility/helpers.css
+++ b/packages/ui/src/styles/utility/helpers.css
@@ -68,16 +68,44 @@ pre {
 	0% {
 		transform: translateX(-3px);
 	}
+
 	25% {
 		transform: translateX(3px);
 	}
+
 	50% {
 		transform: translateX(-2px);
 	}
+
 	75% {
 		transform: translateX(2px);
 	}
+
 	100% {
 		transform: translateX(0);
 	}
+}
+
+.gap-1 {
+	gap: 4px;
+}
+
+.gap-2 {
+	gap: 8px;
+}
+
+.gap-3 {
+	gap: 12px;
+}
+
+.gap-4 {
+	gap: 16px;
+}
+
+.gap-5 {
+	gap: 20px;
+}
+
+.gap-6 {
+	gap: 24px;
 }


### PR DESCRIPTION
## 🧢 Changes

- Add `gap` utility classes
- @PavelLaptev do you know a better way to do this? To avoid using `!important` on these util classes?
	- The svelte component `Link` has a predefined `gap: 2px` in it's scoped styles for the class `link`. Which oddly also comes _before_ our prop  class,  so you'd think our prop classes would override it (i.e. something like `class="link ${classes}"`), but I guess it wins on specificity due to the additional svelte scoping auto-generated class name :shrug: 

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
