### PR TITLE
fix: if we render without a selected stack, and there are some available, goto the first one

### DIFF
--- a/apps/desktop/src/components/StackTabs.svelte
+++ b/apps/desktop/src/components/StackTabs.svelte
@@ -11,9 +11,8 @@
 		projectId: string;
 		selectedId: string | undefined;
 		previewing: boolean;
-		width: number | undefined;
 	};
-	let { projectId, selectedId, width = $bindable() }: Props = $props();
+	let { projectId, selectedId }: Props = $props();
 
 	const stackService = getContext(StackService);
 	const result = $derived(stackService.getStacks(projectId));
@@ -35,7 +34,6 @@
 	onMount(() => {
 		const observer = new ResizeObserver(() => {
 			scrollable = scroller ? scroller.scrollWidth > scroller.offsetWidth : false;
-			width = inner?.offsetWidth;
 		});
 		observer.observe(inner!);
 		return () => {

--- a/apps/desktop/src/routes/[projectId]/workspace/[[stackId]]/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/workspace/[[stackId]]/+page.svelte
@@ -7,6 +7,7 @@
 	import { SettingsService } from '$lib/config/appSettingsV2';
 	import { IdSelection } from '$lib/selection/idSelection.svelte';
 	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
+	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { createKeybind } from '$lib/utils/hotkeys';
 	import { WorktreeService } from '$lib/worktree/worktreeService.svelte';
 	import { getContext, getContextStoreBySymbol } from '@gitbutler/shared/context';
@@ -24,11 +25,20 @@
 
 	const projectId = $derived(data.projectId);
 	const stackId = $derived(page.params.stackId);
+	const stackService = getContext(StackService);
+	const result = $derived(stackService.getStacks(projectId));
 
 	// Redirect to board if we have switched away from V3 feature.
 	$effect(() => {
 		if ($settingsStore && !$settingsStore.featureFlags.v3) {
 			goto(`/${data.projectId}/board`);
+		}
+	});
+
+	$effect(() => {
+		if (!stackId && result.current.data?.[0]) {
+			const firstStackId = result.current.data?.[0]?.id;
+			goto(`/${data.projectId}/workspace/${firstStackId}`);
 		}
 	});
 
@@ -91,7 +101,7 @@
 		<WorktreeChanges {projectId} />
 	</div>
 	<div class="right" bind:this={rightEl}>
-		<StackTabs {projectId} selectedId={stackId} previewing={$previewing} bind:width />
+		<StackTabs {projectId} selectedId={stackId} previewing={$previewing} />
 		<div class="contents" class:rounded>
 			{#if stackId}
 				<StackDetails {projectId} {stackId} />


### PR DESCRIPTION
## 🧢 Changes

- Goto first avialable stack instead of rendering empty workspace page area

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
