### PR TITLE
style the commit description more normally

### DIFF
--- a/apps/web/src/routes/[ownerSlug]/[projectSlug]/reviews/[branchId]/commit/[changeId]/+page.svelte
+++ b/apps/web/src/routes/[ownerSlug]/[projectSlug]/reviews/[branchId]/commit/[changeId]/+page.svelte
@@ -127,7 +127,11 @@
 				</div>
 
 				<p class="review-main-content-description">
-					<Markdown content={patch.description?.trim() || DESCRIPTION_PLACE_HOLDER} />
+					{#if patch.description?.trim() === ''}
+						<span class="none">{DESCRIPTION_PLACE_HOLDER}</span>
+					{:else}
+						<Markdown content={patch.description?.trim()} />
+					{/if}
 				</p>
 
 				<ReviewInfo projectId={repositoryId} {patch} />
@@ -194,11 +198,15 @@
 
 	.review-main-content-description {
 		color: var(--text-1, #1a1614);
-		font-family: var(--fontfamily-mono, 'Geist Mono');
-		font-size: 12px;
+		font-size: 14px;
 		font-style: normal;
 		font-weight: var(--weight-regular, 400);
 		line-height: 160%; /* 19.2px */
+	}
+
+	.review-main-content-description .none {
+		color: var(--text-2, #6e6e6e);
+		font-style: italic;
 	}
 
 	.review-chat {


### PR DESCRIPTION
if there is no commit description, make it lighter and italics

Old style:

![CleanShot 2025-02-07 at 13 52 03@2x](https://github.com/user-attachments/assets/e2c0a2a8-0ac6-49a8-a781-9939a86f5aef)

New style:

![CleanShot 2025-02-07 at 13 51 43@2x](https://github.com/user-attachments/assets/6396479e-b92b-4581-9598-07ca0cc71af1)


No description:

![CleanShot 2025-02-07 at 13 53 46@2x](https://github.com/user-attachments/assets/ecbc538e-b927-4e62-95fa-af2a00262a05)

