### PR TITLE
Display the 'request changes' events

### DIFF
--- a/apps/web/src/lib/components/chat/Message.svelte
+++ b/apps/web/src/lib/components/chat/Message.svelte
@@ -56,7 +56,7 @@
 				{#if message.resolved}
 					<Badge style="success">Issue resolved</Badge>
 				{:else}
-					<Badge style="error">Issue</Badge>
+					<Badge style="warning">Issue</Badge>
 				{/if}
 			{/if}
 
@@ -101,7 +101,7 @@
 
 		&.open-issue {
 			padding-left: 12px;
-			border-left: 4px solid var(--clr-scale-err-50);
+			border-left: 4px solid var(--clr-br-commit-changes-requested-bg);
 		}
 
 		&.resolved {
@@ -124,8 +124,8 @@
 		flex-shrink: 0;
 
 		border-radius: 8px;
-		background: var(--clr-scale-err-50, #dc606b);
-		color: var(--clr-theme-err-soft);
+		background: var(--clr-br-commit-changes-requested-bg);
+		color: var(--clr-br-commit-changes-requested-text);
 
 		&.resolved {
 			background: var(--clr-core-ntrl-60, #b4afac);

--- a/apps/web/src/lib/components/chat/PatchStatus.svelte
+++ b/apps/web/src/lib/components/chat/PatchStatus.svelte
@@ -14,16 +14,14 @@
 	const userName = $derived(
 		event.user?.login ?? event.user?.name ?? event.user?.email ?? UNKNOWN_USER
 	);
-	const statusAction = $derived(event.data.status ? 'approved' : 'rejected');
+	const statusAction = $derived(event.data.status ? 'approved' : 'requested changes on');
 	const timestamp = $derived(eventTimeStamp(event));
 </script>
 
-<div class="patch-status">
-	{#if event.data.status}
-		<div class="patch-status__icon">
-			<Icon name="confeti" />
-		</div>
-	{/if}
+<div class="patch-status" class:request-changes={!event.data.status}>
+	<div class="patch-status__icon" class:request-changes={!event.data.status}>
+		<Icon name={event.data.status ? 'confeti' : 'refresh-in-circle'} />
+	</div>
 
 	<div class="patch-status-content">
 		<div class="patch-status__header">
@@ -51,6 +49,11 @@
 		border-left: 4px solid var(--clr-theme-succ-element, #4ab582);
 		border-bottom: 1px solid var(--clr-border-3, #eae9e8);
 		background: var(--clr-theme-succ-bg, #f6fcfb);
+
+		&.request-changes {
+			border-left-color: var(--clr-br-commit-changes-requested-bg);
+			background: var(--clr-bg-1);
+		}
 	}
 
 	.patch-status__icon {
@@ -62,8 +65,12 @@
 		align-items: center;
 
 		border-radius: 8px;
-		background: var(--clr-theme-succ-element, #4ab582);
+		background: var(--clr-theme-succ-element);
 		color: var(--clr-core-ntrl-100);
+
+		&.request-changes {
+			background: var(--clr-br-commit-changes-requested-bg);
+		}
 	}
 
 	.patch-status-content {

--- a/packages/shared/src/lib/branches/types.ts
+++ b/packages/shared/src/lib/branches/types.ts
@@ -582,8 +582,6 @@ export function apiToPatchEvent(api: ApiPatchEvent): PatchEvent | undefined {
 				updatedAt: api.updated_at
 			};
 		case 'patch_status':
-			// Ignore status updates that are not approved
-			if (!api.data.status) return undefined;
 			return {
 				eventType: api.event_type,
 				uuid: api.uuid,


### PR DESCRIPTION
Requesting changes will display a chat event component

## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
