### PR TITLE
fix: absolutely center project select without need for pointer-events overrides

### DIFF
--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -34,7 +34,7 @@
 	let isNotificationsUnread = $state(false);
 </script>
 
-<div class="header" class:isMac={platformName === 'macos'}>
+<div class="header" class:mac={platformName === 'macos'}>
 	<div class="left">
 		<div class="left-buttons" class:macos={platformName === 'macos'}>
 			<SyncButton size="button" />
@@ -115,12 +115,10 @@
 <style>
 	.header {
 		display: flex;
-		justify-content: space-between;
 		padding: 14px;
-
-		&.isMac {
-			padding: 14px 14px 14px 84px;
-		}
+		align-items: center;
+		justify-content: space-between;
+		overflow: hidden;
 	}
 
 	.left {
@@ -128,17 +126,30 @@
 		gap: 14px;
 	}
 
+	.center {
+		flex-shrink: 1;
+	}
+
+	.right {
+		display: flex;
+		justify-content: right;
+	}
+
+	/** Flex basis 0 means they grow by the same amount. */
+	.right,
+	.left {
+		flex-basis: 0;
+		flex-grow: 1;
+	}
+
 	.left-buttons {
 		display: flex;
 		gap: 8px;
 	}
 
-	.center {
-		position: absolute;
-		left: 0;
-		right: 0;
-		margin-inline: auto;
-		width: fit-content;
+	/** Mac padding added here to not affect header flex-box sizing. */
+	.mac .left-buttons {
+		padding-left: 70px;
 	}
 
 	.selector-series-select {

--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -135,15 +135,10 @@
 
 	.center {
 		position: absolute;
-		width: 100%;
 		left: 0;
-		display: flex;
-		justify-content: center;
-		pointer-events: none;
-
-		& * {
-			pointer-events: auto;
-		}
+		right: 0;
+		margin-inline: auto;
+		width: fit-content;
 	}
 
 	.selector-series-select {


### PR DESCRIPTION
## 🧢 Changes

- Absolutely center the project selector in the chrome header in such a way that the element is only as large as its content and leverages auto margins for centering. 
	- This avoids the element being the full width of the viewport and therefore needing to hackaround it covering other buttons with `pointer-events` 

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
