### PR TITLE
Fix issue with committing new empty file

### DIFF
--- a/crates/gitbutler-diff/src/diff.rs
+++ b/crates/gitbutler-diff/src/diff.rs
@@ -83,7 +83,7 @@ impl GitHunk {
             new_lines: 0,
             diff_lines: Default::default(),
             binary: false,
-            change_type: ChangeType::Added,
+            change_type: ChangeType::Untracked,
         }
     }
 }


### PR DESCRIPTION
If you try to commit a new file we get no hunk data from git2, so we create a `GitHunk` object manually. This wasn't accounted for when refactoring the git hooks integration, where a separation between `Added` and `Untracked` was introduced.

https://github.com/gitbutlerapp/gitbutler/blob/00c0c9ab5a1ea92224d663fa4c48045beae504d3/crates/gitbutler-diff/src/diff.rs#L336-L338