### PR TITLE
Change "Open in VS Code" to "Open in Editor" in drop-down menu

### DIFF
--- a/crates/gitbutler-tauri/src/menu.rs
+++ b/crates/gitbutler-tauri/src/menu.rs
@@ -171,7 +171,7 @@ pub fn build<R: Runtime>(handle: &AppHandle<R>) -> tauri::Result<tauri::menu::Me
                 .accelerator("CmdOrCtrl+Shift+H")
                 .build(handle)?,
         )
-        .text("project/open-in-vscode", "Open in editor")
+        .text("project/open-in-vscode", "Open in Editor")
         .separator()
         .text("project/settings", "Project Settings")
         .build()?;

--- a/crates/gitbutler-tauri/src/menu.rs
+++ b/crates/gitbutler-tauri/src/menu.rs
@@ -171,7 +171,7 @@ pub fn build<R: Runtime>(handle: &AppHandle<R>) -> tauri::Result<tauri::menu::Me
                 .accelerator("CmdOrCtrl+Shift+H")
                 .build(handle)?,
         )
-        .text("project/open-in-vscode", "Open in VS Code")
+        .text("project/open-in-vscode", "Open in editor")
         .separator()
         .text("project/settings", "Project Settings")
         .build()?;


### PR DESCRIPTION
## 🧢 Changes
Change "Open in VS Code" to "Open in Editor" in drop-down menu

## ☕️ Reasoning
VS Code isn't the only editor GitButler can work with

## 🎫 Affected issues

Fixes: #7318
