### PR TITLE
V3 update file list item

### DIFF
--- a/apps/desktop/src/components/v3/FileContextMenu.svelte
+++ b/apps/desktop/src/components/v3/FileContextMenu.svelte
@@ -12,7 +12,7 @@
 	import ContextMenuItem from '@gitbutler/ui/ContextMenuItem.svelte';
 	import ContextMenuSection from '@gitbutler/ui/ContextMenuSection.svelte';
 	import Modal from '@gitbutler/ui/Modal.svelte';
-	import FileListItem from '@gitbutler/ui/file/FileListItem.svelte';
+	import FileListItem from '@gitbutler/ui/file/FileListItemV3.svelte';
 	import * as toasts from '@gitbutler/ui/toasts';
 	import { join } from '@tauri-apps/api/path';
 	import type { Writable } from 'svelte/store';

--- a/apps/desktop/src/components/v3/FileListItemWrapper.svelte
+++ b/apps/desktop/src/components/v3/FileListItemWrapper.svelte
@@ -10,7 +10,7 @@
 	import { key } from '$lib/selection/key';
 	import { computeChangeStatus } from '$lib/utils/fileStatus';
 	import { getContext, maybeGetContextStore } from '@gitbutler/shared/context';
-	import FileListItem from '@gitbutler/ui/file/FileListItem.svelte';
+	import FileListItem from '@gitbutler/ui/file/FileListItemV3.svelte';
 	import type { TreeChange } from '$lib/hunks/change';
 	import type { Snippet } from 'svelte';
 
@@ -94,7 +94,12 @@
 		{onkeydown}
 		locked={false}
 		conflicted={false}
-		{onclick}
+		onclick={(e) => {
+			onclick(e);
+		}}
+		ondblclick={() => {
+			open = !open;
+		}}
 		oncheck={onCheck}
 		oncontextmenu={(e) => {
 			const changes = idSelection.treeChanges(projectId);
@@ -107,12 +112,13 @@
 	/>
 </div>
 {#if open}
-	<div class="diff">
+	<div class:diff-selected={selected}>
 		{@render children()}
 	</div>
 {/if}
 
 <style lang="postcss">
-	.diff {
+	.diff-selected {
+		background-color: var(--clr-theme-pop-bg-muted);
 	}
 </style>

--- a/packages/ui/src/lib/file/FileListItem.svelte
+++ b/packages/ui/src/lib/file/FileListItem.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import FileStatusBadge from './FileStatusBadge.svelte';
 	import Badge from '$lib/Badge.svelte';
-	import Button from '$lib/Button.svelte';
 	import Checkbox from '$lib/Checkbox.svelte';
 	import Icon from '$lib/Icon.svelte';
 	import Tooltip from '$lib/Tooltip.svelte';
@@ -25,7 +24,6 @@
 		conflictHint?: string;
 		locked?: boolean;
 		lockText?: string;
-		open?: boolean;
 		oncheck?: (
 			e: Event & {
 				currentTarget: EventTarget & HTMLInputElement;
@@ -39,7 +37,6 @@
 
 	let {
 		ref = $bindable(),
-		open = $bindable(),
 		id,
 		filePath,
 		fileStatus,
@@ -139,22 +136,6 @@
 					<Icon name="warning-small" color="error" />
 				</div>
 			</Tooltip>
-		{/if}
-
-		{#if open !== undefined}
-			<div class="chevron">
-				<Button
-					style=""
-					kind="ghost"
-					size="icon"
-					icon={open ? 'chevron-up-small' : 'chevron-down-small'}
-					onclick={(e) => {
-						open = !open;
-						e.stopPropagation();
-						e.preventDefault();
-					}}
-				/>
-			</div>
 		{/if}
 
 		{#if fileStatus}
@@ -294,23 +275,5 @@
 
 	.selected-draggable {
 		background-color: var(--clr-theme-pop-bg-muted) !important;
-	}
-
-	.file-list-item:hover .chevron {
-		display: inline-block;
-		opacity: 0.5;
-		transition-delay: 300ms;
-	}
-
-	.chevron {
-		display: none;
-		opacity: 0;
-		transition: opacity var(--transition-fast);
-		line-height: 10px;
-	}
-
-	.file-list-item.open .chevron {
-		display: inline-block;
-		opacity: 0.5;
 	}
 </style>

--- a/packages/ui/src/lib/file/FileListItemV3.svelte
+++ b/packages/ui/src/lib/file/FileListItemV3.svelte
@@ -154,19 +154,17 @@
 	</div>
 
 	{#if open !== undefined}
-		<Tooltip text={open ? 'Collapse' : 'Expand'} delay={1200}>
-			<button
-				class="chevron"
-				type="button"
-				onclick={(e) => {
-					open = !open;
-					e.stopPropagation();
-					e.preventDefault();
-				}}
-			>
-				<Icon name={open ? 'chevron-up-small' : 'chevron-down-small'} />
-			</button>
-		</Tooltip>
+		<button
+			class="chevron"
+			type="button"
+			onclick={(e) => {
+				open = !open;
+				e.stopPropagation();
+				e.preventDefault();
+			}}
+		>
+			<Icon name={open ? 'chevron-up-small' : 'chevron-down-small'} />
+		</button>
 	{/if}
 </div>
 
@@ -315,7 +313,7 @@
 		transition: opacity var(--transition-fast);
 
 		&:hover {
-			opacity: 0.9;
+			opacity: 0.8;
 		}
 	}
 

--- a/packages/ui/src/lib/file/FileListItemV3.svelte
+++ b/packages/ui/src/lib/file/FileListItemV3.svelte
@@ -1,0 +1,329 @@
+<script lang="ts">
+	import FileStatusBadge from './FileStatusBadge.svelte';
+	import Badge from '$lib/Badge.svelte';
+	import Checkbox from '$lib/Checkbox.svelte';
+	import Icon from '$lib/Icon.svelte';
+	import Tooltip from '$lib/Tooltip.svelte';
+	import FileIcon from '$lib/file/FileIcon.svelte';
+	import { splitFilePath } from '$lib/utils/filePath';
+	import type { FileStatus } from './types';
+
+	interface Props {
+		ref?: HTMLDivElement;
+		id?: string;
+		filePath: string;
+		fileStatus?: FileStatus;
+		fileStatusStyle?: 'dot' | 'full';
+		draggable?: boolean;
+		selected?: boolean;
+		clickable?: boolean;
+		showCheckbox?: boolean;
+		checked?: boolean;
+		indeterminate?: boolean;
+		conflicted?: boolean;
+		conflictHint?: string;
+		locked?: boolean;
+		lockText?: string;
+		open?: boolean;
+		oncheck?: (
+			e: Event & {
+				currentTarget: EventTarget & HTMLInputElement;
+			}
+		) => void;
+		onclick?: (e: MouseEvent) => void;
+		ondblclick?: (e: MouseEvent) => void;
+		onresolveclick?: (e: MouseEvent) => void;
+		onkeydown?: (e: KeyboardEvent) => void;
+		oncontextmenu?: (e: MouseEvent) => void;
+	}
+
+	let {
+		ref = $bindable(),
+		open = $bindable(),
+		id,
+		filePath,
+		fileStatus,
+		fileStatusStyle = 'dot',
+		draggable = false,
+		selected = false,
+		clickable = true,
+		showCheckbox = false,
+		checked = $bindable(),
+		indeterminate,
+		conflicted,
+		conflictHint,
+		locked,
+		lockText,
+		oncheck,
+		onclick,
+		ondblclick,
+		onresolveclick,
+		onkeydown,
+		oncontextmenu
+	}: Props = $props();
+
+	const fileInfo = $derived(splitFilePath(filePath));
+</script>
+
+<div
+	bind:this={ref}
+	data-locked={locked}
+	data-file-id={id}
+	class="file-list-item"
+	class:selected-draggable={selected}
+	class:clickable
+	class:draggable
+	class:open
+	aria-selected={selected}
+	role="option"
+	tabindex="-1"
+	{onclick}
+	{ondblclick}
+	{onkeydown}
+	oncontextmenu={(e) => {
+		if (oncontextmenu) {
+			e.preventDefault();
+			e.stopPropagation();
+			oncontextmenu(e);
+		}
+	}}
+>
+	{#if draggable && !showCheckbox}
+		<div class="draggable-handle">
+			<Icon name="draggable-narrow" />
+		</div>
+	{/if}
+	{#if showCheckbox}
+		<Checkbox small {checked} {indeterminate} onchange={oncheck} />
+	{/if}
+	<div class="info">
+		<FileIcon fileName={fileInfo.filename} />
+		<span class="text-12 text-semibold name truncate">
+			{fileInfo.filename}
+		</span>
+
+		<div class="path-container">
+			<Tooltip text={filePath} delay={1200}>
+				<span class="text-12 path truncate">
+					{fileInfo.path}
+				</span>
+			</Tooltip>
+		</div>
+	</div>
+
+	<div class="details">
+		{#if locked}
+			<Tooltip text={lockText}>
+				<div class="locked">
+					<Icon name="locked-small" color="warning" />
+				</div>
+			</Tooltip>
+		{/if}
+
+		{#if onresolveclick}
+			{#if !conflicted}
+				<Tooltip text="Conflict resolved">
+					<Badge style="success">Resolved</Badge>
+				</Tooltip>
+			{:else}
+				<button
+					type="button"
+					class="mark-resolved-btn"
+					onclick={(e) => {
+						e.stopPropagation();
+						onresolveclick?.(e);
+					}}
+				>
+					<span class="text-11 text-semibold">Mark as resolved</span>
+					<Icon name="tick-small" opacity={0.5} />
+				</button>
+			{/if}
+		{/if}
+
+		{#if conflicted}
+			<Tooltip text={conflictHint}>
+				<div class="conflicted">
+					<Icon name="warning-small" color="error" />
+				</div>
+			</Tooltip>
+		{/if}
+
+		{#if fileStatus}
+			<FileStatusBadge status={fileStatus} style={fileStatusStyle} />
+		{/if}
+	</div>
+
+	{#if open !== undefined}
+		<Tooltip text={open ? 'Collapse' : 'Expand'} delay={1200}>
+			<button
+				class="chevron"
+				type="button"
+				onclick={(e) => {
+					open = !open;
+					e.stopPropagation();
+					e.preventDefault();
+				}}
+			>
+				<Icon name={open ? 'chevron-up-small' : 'chevron-down-small'} />
+			</button>
+		</Tooltip>
+	{/if}
+</div>
+
+<style lang="postcss">
+	.file-list-item {
+		display: flex;
+		align-items: center;
+		padding: 6px 12px 6px 14px;
+		gap: 10px;
+		height: 32px;
+		overflow: hidden;
+		text-align: left;
+		user-select: none;
+		outline: none;
+		background: transparent;
+		border-bottom: 1px solid var(--clr-border-3);
+		/* background-color: var(--clr-bg-2); */
+
+		/* &:last-child {
+			border-bottom: none;
+		} */
+
+		/* &:not(:last-child) {
+			border-bottom: 1px solid var(--clr-border-3);
+		} */
+	}
+
+	.file-list-item.clickable {
+		cursor: pointer;
+
+		&:not(.selected-draggable):hover {
+			background-color: var(--clr-bg-1-muted);
+		}
+	}
+
+	.draggable {
+		&:hover {
+			& .draggable-handle {
+				opacity: 1;
+			}
+		}
+	}
+
+	.draggable-handle {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--clr-text-3);
+		opacity: 0;
+		height: 24px;
+		margin-left: -14px;
+		margin-right: -12px;
+		transition: opacity var(--transition-fast);
+	}
+
+	.mark-resolved-btn {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		padding: 3px 6px 3px 6px;
+		border: 1px solid var(--clr-border-2);
+		border-radius: var(--radius-m);
+		margin: 0 2px;
+		white-space: nowrap;
+		transition:
+			background-color var(--transition-fast),
+			border-color var(--transition-fast);
+
+		&:hover {
+			background-color: var(--clr-bg-1);
+		}
+	}
+
+	.info {
+		display: flex;
+		align-items: center;
+		flex-shrink: 1;
+		min-width: 32px;
+		gap: 6px;
+		overflow: hidden;
+	}
+
+	.name {
+		flex-shrink: 1;
+		flex-grow: 0;
+		min-width: 40px;
+		pointer-events: none;
+		color: var(--clt-text-1);
+	}
+
+	.path-container {
+		display: flex;
+		justify-content: flex-start;
+		flex-shrink: 0;
+		flex-grow: 1;
+		flex-basis: 0px;
+		min-width: 50px;
+		text-align: left;
+		overflow: hidden;
+	}
+
+	.path {
+		display: inline-block;
+		color: var(--clt-text-1);
+		line-height: 120%;
+		opacity: 0.3;
+		transition: opacity var(--transition-fast);
+		max-width: 100%;
+		text-align: left;
+	}
+
+	.details {
+		flex-grow: 1;
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.details .locked {
+		display: flex;
+	}
+
+	.details .conflicted {
+		display: flex;
+	}
+
+	.selected-draggable {
+		background-color: var(--clr-theme-pop-bg-muted);
+	}
+
+	.file-list-item:hover .chevron {
+		display: inline-block;
+		display: flex;
+	}
+
+	.chevron {
+		display: none;
+		align-items: center;
+		justify-content: center;
+		color: var(--clr-text-1);
+		opacity: 0.4;
+		padding-left: 10px;
+		padding-right: 10px;
+		height: 28px;
+		margin-right: -12px;
+		transition: opacity var(--transition-fast);
+
+		&:hover {
+			opacity: 0.9;
+		}
+	}
+
+	.file-list-item.open {
+		border-bottom: 1px solid transparent;
+
+		& .chevron {
+			display: flex;
+		}
+	}
+</style>

--- a/packages/ui/src/lib/file/FileListItemV3.svelte
+++ b/packages/ui/src/lib/file/FileListItemV3.svelte
@@ -102,13 +102,15 @@
 			{fileInfo.filename}
 		</span>
 
-		<div class="path-container">
-			<Tooltip text={filePath} delay={1200}>
-				<span class="text-12 path truncate">
-					{fileInfo.path}
-				</span>
-			</Tooltip>
-		</div>
+		{#if fileInfo.path}
+			<div class="path-container">
+				<Tooltip text={filePath} delay={1200}>
+					<span class="text-12 path truncate">
+						{fileInfo.path}
+					</span>
+				</Tooltip>
+			</div>
+		{/if}
 	</div>
 
 	<div class="details">
@@ -181,15 +183,6 @@
 		outline: none;
 		background: transparent;
 		border-bottom: 1px solid var(--clr-border-3);
-		/* background-color: var(--clr-bg-2); */
-
-		/* &:last-child {
-			border-bottom: none;
-		} */
-
-		/* &:not(:last-child) {
-			border-bottom: 1px solid var(--clr-border-3);
-		} */
 	}
 
 	.file-list-item.clickable {
@@ -261,8 +254,8 @@
 		flex-shrink: 0;
 		flex-grow: 1;
 		flex-basis: 0px;
-		min-width: 50px;
 		text-align: left;
+		min-width: 16px;
 		overflow: hidden;
 	}
 
@@ -271,7 +264,6 @@
 		color: var(--clt-text-1);
 		line-height: 120%;
 		opacity: 0.3;
-		transition: opacity var(--transition-fast);
 		max-width: 100%;
 		text-align: left;
 	}

--- a/packages/ui/src/lib/file/FileStatusBadge.svelte
+++ b/packages/ui/src/lib/file/FileStatusBadge.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Badge from '$lib/Badge.svelte';
+	import Tooltip from '$lib/Tooltip.svelte';
 	import type { ComponentColorType } from '$lib/utils/colorTypes';
 	import type { FileStatus } from './types';
 
@@ -38,14 +39,40 @@
 </script>
 
 {#if style === 'dot'}
-	<div class="status-dot-wrap">
-		<div
-			class="status-dot"
-			class:added={status === 'A'}
-			class:modified={status === 'M'}
-			class:deleted={status === 'D'}
-		></div>
-	</div>
+	<Tooltip text={getFullStatusText(status)}>
+		<div class="status-dot-wrap">
+			<div
+				class="status-dot"
+				class:added={status === 'A'}
+				class:modified={status === 'M'}
+				class:deleted={status === 'D'}
+			></div>
+
+			<svg
+				width="10"
+				height="10"
+				viewBox="0 0 10 10"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+				class="status-dot"
+				class:added={status === 'A'}
+				class:modified={status === 'M'}
+				class:deleted={status === 'D'}
+			>
+				<path
+					d="M3 0.75H7C8.24264 0.75 9.25 1.75736 9.25 3V7C9.25 8.24264 8.24264 9.25 7 9.25H3C1.75736 9.25 0.75 8.24264 0.75 7V3C0.75 1.75736 1.75736 0.75 3 0.75Z"
+					stroke-width="1.5"
+				/>
+				{#if status === 'A'}
+					<path d="M7.75 5H2.25M5 2.25V7.75" stroke-width="1.5" />
+				{:else if status === 'M'}
+					<path d="M6 4L4 6" stroke-width="2" />
+				{:else if status === 'D'}
+					<path d="M7.5 5H2.5" stroke-width="2" />
+				{/if}
+			</svg>
+		</div>
+	</Tooltip>
 {:else if style === 'full'}
 	<Badge style={getStatusColor(status)}>{getFullStatusText(status)}</Badge>
 {/if}
@@ -59,21 +86,15 @@
 	}
 
 	.status-dot {
-		border-radius: 100%;
-		width: 8px;
-		height: 8px;
-		border-radius: 100%;
 		flex-shrink: 0;
 	}
-	.status-dot.added {
-		background: var(--clr-scale-succ-60);
+	.status-dot.added path {
+		stroke: var(--clr-scale-succ-60);
 	}
-	.status-dot.modified {
-		background: var(--clr-scale-warn-60);
-		opacity: 0.6;
+	.status-dot.modified path {
+		stroke: var(--clr-scale-warn-60);
 	}
-	.status-dot.deleted {
-		background: var(--clr-scale-err-50);
-		opacity: 0.8;
+	.status-dot.deleted path {
+		stroke: var(--clr-scale-err-60);
 	}
 </style>

--- a/packages/ui/src/stories/fileListItem/FileListItemV3.stories.svelte
+++ b/packages/ui/src/stories/fileListItem/FileListItemV3.stories.svelte
@@ -1,0 +1,50 @@
+<script module lang="ts">
+	import FileListItem from '$lib/file/FileListItemV3.svelte';
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+
+	const { Story } = defineMeta({
+		title: 'List items / FileListItemV3',
+		component: FileListItem
+	});
+</script>
+
+<Story
+	name="Playground"
+	args={{
+		filePath: '/path/to/file.svelte',
+		fileStatus: 'A',
+		fileStatusStyle: 'dot',
+		clickable: true,
+		selected: false,
+		conflicted: true,
+		draggable: true,
+		showCheckbox: true,
+		checked: true,
+		lockText: 'Locked by someone',
+		onclick: () => {
+			console.log('clicked');
+		},
+		oncheck: (e: Event) => {
+			console.log('checked', e);
+		}
+	}}
+/>
+
+<Story
+	name="Resolve conflict"
+	args={{
+		filePath: '/path/to/file.svelte',
+		fileStatus: 'A',
+		fileStatusStyle: 'dot',
+		clickable: false,
+		selected: false,
+		conflicted: true,
+		checked: true,
+		onclick: () => {
+			console.log('clicked');
+		},
+		onresolveclick: () => {
+			console.log('resolve clicked');
+		}
+	}}
+/>


### PR DESCRIPTION
## 🧢 Changes

- Created new v3 `FileListItem`. v3 and v2 differ not only in some props but also in the layout.
- Cleaned up the v2 `FileListItem` by removing v3 props.
- Added double-click functionality to unfold the file preview.
- Enlarged the clickable area of the `FileListItem` "unfold" button.
- New accessible `FileStatusBadge` design (see Discord thread [here](https://discord.com/channels/1060193121130000425/1340993556088619050)).

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
