### PR TITLE
feat: add scroll-snap and svelte-keepfocus to StackTabs

### DIFF
--- a/apps/desktop/src/components/v3/StackTab.svelte
+++ b/apps/desktop/src/components/v3/StackTab.svelte
@@ -14,14 +14,15 @@
 		selected: boolean;
 	};
 
-	let kebabMenuTrigger = $state<HTMLElement>();
-	let contextMenuEl = $state<ContextMenu>();
-	let isContextMenuOpen = $state(false);
-
 	const { projectId, tab, first, last, selected }: Props = $props();
+
+	let kebabMenuTrigger = $state<HTMLElement>();
+	let contextMenu = $state<ContextMenu>();
+	let isContextMenuOpen = $state(false);
 </script>
 
 <a
+	data-sveltekit-keepfocus
 	href={stackPath(projectId, tab.id)}
 	class="tab"
 	class:first
@@ -30,11 +31,7 @@
 	class:menu-open={isContextMenuOpen}
 >
 	<div class="icon">
-		{#if tab.anchors.length > 0}
-			<Icon name="chain-link" verticalAlign="top" />
-		{:else}
-			<Icon name="branch-small" verticalAlign="top" />
-		{/if}
+		<Icon name={tab.anchors.length > 0 ? 'chain-link' : 'branch-small'} verticalAlign="top" />
 	</div>
 	<div class="content">
 		<div class="text-12 text-semibold name">
@@ -47,7 +44,7 @@
 				onclick={(e) => {
 					e.preventDefault();
 					e.stopPropagation();
-					contextMenuEl?.toggle();
+					contextMenu?.toggle();
 				}}
 				bind:this={kebabMenuTrigger}
 				type="button"
@@ -59,7 +56,7 @@
 </a>
 
 <ContextMenu
-	bind:this={contextMenuEl}
+	bind:this={contextMenu}
 	leftClickTrigger={kebabMenuTrigger}
 	ontoggle={(isOpen) => (isContextMenuOpen = isOpen)}
 	side="bottom"
@@ -69,14 +66,14 @@
 			label="Unapply Stack"
 			keyboardShortcut="$mod+X"
 			onclick={() => {
-				contextMenuEl?.close();
+				contextMenu?.close();
 			}}
 		/>
 		<ContextMenuItem
 			label="Rename"
 			keyboardShortcut="$mod+R"
 			onclick={() => {
-				contextMenuEl?.close();
+				contextMenu?.close();
 			}}
 		/>
 	</ContextMenuSection>
@@ -93,6 +90,8 @@
 		border-right: 1px solid var(--clr-border-2);
 		overflow: hidden;
 		min-width: 100px;
+		flex: 0 0 auto;
+		scroll-snap-align: start;
 
 		&::after {
 			content: '';
@@ -115,6 +114,7 @@
 
 	.content {
 		display: flex;
+		flex-grow: 1;
 		align-items: center;
 		overflow: hidden;
 		position: relative;
@@ -186,6 +186,7 @@
 	}
 
 	.name {
+		width: 100%;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		overflow: hidden;

--- a/apps/desktop/src/components/v3/StackTabs.svelte
+++ b/apps/desktop/src/components/v3/StackTabs.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import StackTabNew from './StackTabNew.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
 	import StackTab from '$components/v3/StackTab.svelte';
+	import StackTabNew from '$components/v3/StackTabNew.svelte';
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { stacksToTabs } from '$lib/tabs/mapping';
 	import { getContext } from '@gitbutler/shared/context';
@@ -44,52 +44,48 @@
 	});
 </script>
 
-<menu class="tabs">
+<div class="tabs">
 	<div class="inner" bind:this={inner}>
-		<div class="shadows">
-			<div class="scroller" bind:this={scroller} class:scrolled {onscroll}>
-				<ReduxResult result={result.current}>
-					{#snippet children(result)}
-						{@const tabs = stacksToTabs(result)}
-						{#each tabs as tab, i (tab.name)}
-							{@const first = i === 0}
-							{@const last = i === tabs.length - 1}
-							{@const selected = tab.id === selectedId}
-							<StackTab {projectId} {tab} {first} {last} {selected} />
-						{/each}
-					{/snippet}
-					{#snippet empty()}
-						no stacks
-					{/snippet}
-				</ReduxResult>
-			</div>
-			<div class="shadow shadow-left" class:scrolled></div>
-			<div class="shadow shadow-right" class:scrollable class:scrolled-end={scrolledEnd}></div>
+		<div class="scroller" bind:this={scroller} class:scrolled {onscroll}>
+			<ReduxResult result={result.current}>
+				{#snippet children(result)}
+					{@const tabs = stacksToTabs(result)}
+					{#each tabs as tab, i (tab.name)}
+						{@const first = i === 0}
+						{@const last = i === tabs.length - 1}
+						{@const selected = tab.id === selectedId}
+						<StackTab {projectId} {tab} {first} {last} {selected} />
+					{/each}
+				{/snippet}
+				{#snippet empty()}
+					no stacks
+				{/snippet}
+			</ReduxResult>
 		</div>
-		<StackTabNew {projectId} />
+		<div class="shadow shadow-left" class:scrolled></div>
+		<div class="shadow shadow-right" class:scrollable class:scrolled-end={scrolledEnd}></div>
 	</div>
-</menu>
+	<StackTabNew {projectId} />
+</div>
 
 <style lang="postcss">
 	.tabs {
-		display: flex;
-	}
-	.inner {
 		display: flex;
 		max-width: 100%;
 	}
 
 	.scroller {
 		display: flex;
-		position: relative;
 		overflow-x: scroll;
+		scroll-snap-type: x proximity;
+		scroll-behavior: smooth;
 	}
 
 	.scroller::-webkit-scrollbar {
 		display: none;
 	}
 
-	.shadows {
+	.inner {
 		position: relative;
 		overflow-x: hidden;
 		border-radius: 10px 0 0 0;


### PR DESCRIPTION
## 🧢 Changes

- Added scroll-snap to tabs
- Added `data-svelte-keepfocus` attribute to tab 
  - If folks are navigating via keyboard and press "Enter" on a tab, to navigate to that route, normally it would put focus back tot he top of the dom tree, but this keeps it on the selected tab, figured this is closer to user expectations and would be helpful later on with our focus/select management.
- Cleanup some of the existing code

![image](https://github.com/user-attachments/assets/5a1e8d71-7287-4132-a901-a478fc9bc84c)

![image](https://github.com/user-attachments/assets/a8db33f0-35f3-4aa5-8337-e183de572cae)


## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
