### PR TITLE
fix: gradient in stackTab shadow

### DIFF
--- a/apps/desktop/src/components/v3/StackTabs.svelte
+++ b/apps/desktop/src/components/v3/StackTabs.svelte
@@ -104,7 +104,11 @@
 		pointer-events: none;
 		opacity: 0;
 		left: 0;
-		background: linear-gradient(to right, var(--clr-bg-2) 0%, transparent 100%);
+		background: linear-gradient(
+			to right,
+			var(--clr-bg-3) 0%,
+			oklch(from var(--clr-bg-3) l c h / 0) 100%
+		);
 		transition: opacity var(--transition-fast);
 
 		&.scrolled {
@@ -116,7 +120,11 @@
 		pointer-events: none;
 		opacity: 0;
 		right: 0;
-		background: linear-gradient(to left, var(--clr-bg-2) 0%, transparent 100%);
+		background: linear-gradient(
+			to left,
+			var(--clr-bg-3) 0%,
+			oklch(from var(--clr-bg-3) l c h / 0) 100%
+		);
 		transition: opacity var(--transition-fast);
 
 		&.scrollable {


### PR DESCRIPTION
## 🧢 Changes

- StackTabs scroller shadows gradients on left/right were broken on webkit linux

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
