### PR TITLE
fix: move `createCommit` (v3) method to `StackService`

### DIFF
--- a/apps/desktop/src/components/EditMode.svelte
+++ b/apps/desktop/src/components/EditMode.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import ReduxResult from './ReduxResult.svelte';
 	import FileContextMenu from '$components/FileContextMenu.svelte';
 	import ScrollableContainer from '$components/ScrollableContainer.svelte';
+	import { Commit } from '$lib/commits/commit';
 	import { CommitService } from '$lib/commits/commitService.svelte';
 	import {
 		conflictEntryHint,
@@ -51,13 +51,21 @@
 	let modeServiceSaving = $state<'inert' | 'loading' | 'completed'>('inert');
 
 	let initialFiles = $state<[RemoteFile, ConflictEntryPresence | undefined][]>([]);
-	const commit = $derived(remoteCommitService.find(project.id, editModeMetadata.commitOid));
+	let commit = $state<Commit>();
+
+	async function getCommitData() {
+		commit = await remoteCommitService.find(project.id, editModeMetadata.commitOid);
+	}
+
+	$effect(() => {
+		getCommitData();
+	});
+
 	const authorImgUrl = $derived.by(() => {
-		const commitData = commit.current.data;
-		if (commitData) {
-			return commitData.author.email?.toLowerCase() === $user?.email?.toLowerCase()
+		if (commit) {
+			return commit.author.email?.toLowerCase() === $user?.email?.toLowerCase()
 				? $user?.picture
-				: commitData.author.gravatarUrl;
+				: commit.author.gravatarUrl;
 		}
 		return undefined;
 	});
@@ -227,109 +235,105 @@
 	const loading = $derived(modeServiceSaving === 'loading' || modeServiceAborting === 'loading');
 </script>
 
-<ReduxResult result={commit.current}>
-	{#snippet children(commit)}
-		<div class="editmode__container">
-			<h2 class="editmode__title text-18 text-body text-bold">
-				You are editing commit <span class="code-string">
-					{editModeMetadata.commitOid.slice(0, 7)}
-				</span>
-				<InfoButton title="Edit Mode">
-					Edit Mode lets you modify an existing commit in isolation or resolve conflicts. Any
-					changes made, including new files, will be added to the selected commit.
-				</InfoButton>
-			</h2>
+<div class="editmode__container">
+	<h2 class="editmode__title text-18 text-body text-bold">
+		You are editing commit <span class="code-string">
+			{editModeMetadata.commitOid.slice(0, 7)}
+		</span>
+		<InfoButton title="Edit Mode">
+			Edit Mode lets you modify an existing commit in isolation or resolve conflicts. Any changes
+			made, including new files, will be added to the selected commit.
+		</InfoButton>
+	</h2>
 
-			<div class="commit-group">
-				<div class="card commit-card">
-					<h3 class="text-13 text-semibold text-body commit-card__title">
-						{commit?.descriptionTitle || 'Undefined commit'}
-					</h3>
+	<div class="commit-group">
+		<div class="card commit-card">
+			<h3 class="text-13 text-semibold text-body commit-card__title">
+				{commit?.descriptionTitle || 'Undefined commit'}
+			</h3>
 
-					{#if commit}
-						<div class="text-11 commit-card__details">
-							{#if authorImgUrl && commit.author.email}
-								<Avatar srcUrl={authorImgUrl} tooltip={commit.author.email} />
-								<span class="commit-card__divider">•</span>
-							{/if}
-							<span class="">{editModeMetadata.commitOid.slice(0, 7)}</span>
-							<span class="commit-card__divider">•</span>
-							<span class="">{commit.author.name}</span>
-						</div>
+			{#if commit}
+				<div class="text-11 commit-card__details">
+					{#if authorImgUrl && commit.author.email}
+						<Avatar srcUrl={authorImgUrl} tooltip={commit.author.email} />
+						<span class="commit-card__divider">•</span>
 					{/if}
-
-					<div class="commit-card__type-indicator"></div>
+					<span class="">{editModeMetadata.commitOid.slice(0, 7)}</span>
+					<span class="commit-card__divider">•</span>
+					<span class="">{commit.author.name}</span>
 				</div>
+			{/if}
 
-				<div bind:this={filesList} class="card files">
-					<div class="header" class:show-border={isCommitListScrolled}>
-						<h3 class="text-13 text-semibold">Commit files</h3>
-						<Badge>{files.length}</Badge>
-					</div>
-					<ScrollableContainer
-						onscroll={(e) => {
-							if (e.target instanceof HTMLElement) {
-								isCommitListScrolled = e.target.scrollTop > 0;
-							}
-						}}
-					>
-						{#each files as file (file.path)}
-							<div class="file">
-								<FileListItem
-									filePath={file.path}
-									fileStatus={file.status}
-									conflicted={isConflicted(file)}
-									onresolveclick={file.conflicted
-										? () => manuallyResolvedFiles.add(file.path)
-										: undefined}
-									conflictHint={file.conflictHint}
-									onclick={(e) => {
-										contextMenu?.open(e, { files: [file] });
-									}}
-									oncontextmenu={(e) => {
-										contextMenu?.open(e, { files: [file] });
-									}}
-								/>
-							</div>
-						{/each}
-					</ScrollableContainer>
-				</div>
-			</div>
-
-			<FileContextMenu
-				bind:this={contextMenu}
-				trigger={filesList}
-				isUnapplied={false}
-				branchId={undefined}
-			/>
-
-			<p class="text-12 text-body editmode__helptext">
-				Please don't make any commits while in edit mode.
-				<br />
-				To exit edit mode, use the provided actions.
-			</p>
-
-			<div class="editmode__actions">
-				<Button kind="outline" onclick={abort} disabled={loading} {loading}>Cancel</Button>
-				{#if conflictedFiles.length > 0}
-					<Button
-						style="neutral"
-						onclick={openAllConflictedFiles}
-						icon="open-link"
-						tooltip={conflictedFiles.length === 1
-							? 'Open the conflicted file in your editor'
-							: 'Open all files with conflicts in your editor'}
-					>
-						Open conflicted files
-					</Button>
-				{/if}
-				<Button style="pop" icon="tick-small" onclick={handleSave} disabled={loading} {loading}>
-					Save and exit
-				</Button>
-			</div>
+			<div class="commit-card__type-indicator"></div>
 		</div>
-	{/snippet}
-</ReduxResult>
+
+		<div bind:this={filesList} class="card files">
+			<div class="header" class:show-border={isCommitListScrolled}>
+				<h3 class="text-13 text-semibold">Commit files</h3>
+				<Badge>{files.length}</Badge>
+			</div>
+			<ScrollableContainer
+				onscroll={(e) => {
+					if (e.target instanceof HTMLElement) {
+						isCommitListScrolled = e.target.scrollTop > 0;
+					}
+				}}
+			>
+				{#each files as file (file.path)}
+					<div class="file">
+						<FileListItem
+							filePath={file.path}
+							fileStatus={file.status}
+							conflicted={isConflicted(file)}
+							onresolveclick={file.conflicted
+								? () => manuallyResolvedFiles.add(file.path)
+								: undefined}
+							conflictHint={file.conflictHint}
+							onclick={(e) => {
+								contextMenu?.open(e, { files: [file] });
+							}}
+							oncontextmenu={(e) => {
+								contextMenu?.open(e, { files: [file] });
+							}}
+						/>
+					</div>
+				{/each}
+			</ScrollableContainer>
+		</div>
+	</div>
+
+	<FileContextMenu
+		bind:this={contextMenu}
+		trigger={filesList}
+		isUnapplied={false}
+		branchId={undefined}
+	/>
+
+	<p class="text-12 text-body editmode__helptext">
+		Please don't make any commits while in edit mode.
+		<br />
+		To exit edit mode, use the provided actions.
+	</p>
+
+	<div class="editmode__actions">
+		<Button kind="outline" onclick={abort} disabled={loading} {loading}>Cancel</Button>
+		{#if conflictedFiles.length > 0}
+			<Button
+				style="neutral"
+				onclick={openAllConflictedFiles}
+				icon="open-link"
+				tooltip={conflictedFiles.length === 1
+					? 'Open the conflicted file in your editor'
+					: 'Open all files with conflicts in your editor'}
+			>
+				Open conflicted files
+			</Button>
+		{/if}
+		<Button style="pop" icon="tick-small" onclick={handleSave} disabled={loading} {loading}>
+			Save and exit
+		</Button>
+	</div>
+</div>
 
 <Modal
 	bind:this={confirmSaveModal}

--- a/apps/desktop/src/components/v3/NewCommit.svelte
+++ b/apps/desktop/src/components/v3/NewCommit.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { BaseBranchService } from '$lib/baseBranch/baseBranchService';
-	import { CommitService } from '$lib/commits/commitService.svelte';
 	import { showError } from '$lib/notifications/toasts';
 	import { stackPath } from '$lib/routes/routes.svelte';
 	import { ChangeSelectionService } from '$lib/selection/changeSelection.svelte';
@@ -17,7 +16,6 @@
 	const { projectId, stackId }: { projectId: string; stackId: string } = $props();
 
 	const stackService = getContext(StackService);
-	const commitService = getContext(CommitService);
 
 	const baseBranchService = getContext(BaseBranchService);
 	const base = $derived(baseBranchService.base);
@@ -59,7 +57,7 @@
 
 	function createCommit() {
 		try {
-			commitService.createCommit(projectId, {
+			stackService.createCommit(projectId, {
 				message: commitMessage,
 				parentId: commitParent!,
 				stackId,

--- a/apps/desktop/src/lib/commits/commitService.svelte.ts
+++ b/apps/desktop/src/lib/commits/commitService.svelte.ts
@@ -1,19 +1,7 @@
 import { Commit } from './commit';
 import { ReduxTag } from '$lib/state/tags';
 import { plainToInstance } from 'class-transformer';
-import type { HunkHeader } from '$lib/hunks/hunk';
 import type { ClientState } from '$lib/state/clientState.svelte';
-
-type CreateCommitRequest = {
-	stackId: string;
-	message: string;
-	parentId: string;
-	worktreeChanges: {
-		previousPathBytes?: number[];
-		pathBytes: number[];
-		hunkHeaders: HunkHeader[];
-	}[];
-};
 
 export class CommitService {
 	private api: ReturnType<typeof injectEndpoints>;
@@ -24,12 +12,6 @@ export class CommitService {
 
 	find(projectId: string, commitOid: string) {
 		const result = $derived(this.api.endpoints.find.useQuery({ projectId, commitOid }));
-		return result;
-	}
-
-	// eslint-disable-next-line @typescript-eslint/promise-function-async
-	createCommit(projectId: string, request: CreateCommitRequest) {
-		const result = $derived(this.api.endpoints.createCommit.useMutation({ projectId, ...request }));
 		return result;
 	}
 }
@@ -44,13 +26,6 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				}),
 				transformResponse: (response: unknown) => plainToInstance(Commit, response),
 				providesTags: [ReduxTag.Commit]
-			}),
-			createCommit: build.mutation<Commit, { projectId: string } & CreateCommitRequest>({
-				query: ({ projectId, ...commitData }) => ({
-					command: 'create_commit_from_worktree_changes',
-					params: { projectId, ...commitData }
-				}),
-				invalidatesTags: [ReduxTag.StackBranches, ReduxTag.Commit]
 			})
 		})
 	});

--- a/apps/desktop/src/lib/commits/commitService.svelte.ts
+++ b/apps/desktop/src/lib/commits/commitService.svelte.ts
@@ -1,32 +1,9 @@
 import { Commit } from './commit';
-import { ReduxTag } from '$lib/state/tags';
+import { invoke } from '$lib/backend/ipc';
 import { plainToInstance } from 'class-transformer';
-import type { ClientState } from '$lib/state/clientState.svelte';
 
 export class CommitService {
-	private api: ReturnType<typeof injectEndpoints>;
-
-	constructor(state: ClientState) {
-		this.api = injectEndpoints(state.backendApi);
+	async find(projectId: string, commitOid: string) {
+		return plainToInstance(Commit, await invoke<Commit>('find_commit', { projectId, commitOid }));
 	}
-
-	find(projectId: string, commitOid: string) {
-		const result = $derived(this.api.endpoints.find.useQuery({ projectId, commitOid }));
-		return result;
-	}
-}
-
-function injectEndpoints(api: ClientState['backendApi']) {
-	return api.injectEndpoints({
-		endpoints: (build) => ({
-			find: build.query<Commit, { projectId: string; commitOid: string }>({
-				query: ({ projectId, commitOid }) => ({
-					command: 'find_commit',
-					params: { projectId, commitOid }
-				}),
-				transformResponse: (response: unknown) => plainToInstance(Commit, response),
-				providesTags: [ReduxTag.Commit]
-			})
-		})
-	});
 }

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -101,7 +101,7 @@
 	const desktopRouteService = new DesktopRoutesService();
 	const diffService = new DiffService(clientState);
 	const shortcutService = new ShortcutService(data.tauri);
-	const commitService = new CommitService(clientState);
+	const commitService = new CommitService();
 
 	shortcutService.listen();
 


### PR DESCRIPTION
## 🧢 Changes

- Move the v3 `createCommit` method to the (v3-only) `StackService`
	- The `commitService`, where it lived previously, was also dealing with v2-typed `Commit`s
- Revert `commitService.find` method to call `invoke` directly (no Redux), beacuse the `plainToInstance`-ed `Commit` cannot be put into Redux store due to non-serializable `Date` fields
    - Required updating its usage in 1 place (`EditMode.svelte`) as well

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
