### PR TITLE
Refactor StackBranch

### DIFF
--- a/crates/but-workspace/src/commit_engine/refs.rs
+++ b/crates/but-workspace/src/commit_engine/refs.rs
@@ -56,7 +56,7 @@ pub fn rewrite(
                             updated_refs.push(UpdatedReference {
                                 old_commit_id: old,
                                 new_commit_id: new,
-                                reference: but_core::Reference::Virtual(branch.name.clone()),
+                                reference: but_core::Reference::Virtual(branch.name()),
                             });
                         }
                     }
@@ -70,7 +70,7 @@ pub fn rewrite(
                             updated_refs.push(UpdatedReference {
                                 old_commit_id: old,
                                 new_commit_id: new,
-                                reference: but_core::Reference::Virtual(branch.name.clone()),
+                                reference: but_core::Reference::Virtual(branch.name()),
                             });
                         }
                     }

--- a/crates/but-workspace/src/commit_engine/refs.rs
+++ b/crates/but-workspace/src/commit_engine/refs.rs
@@ -56,7 +56,7 @@ pub fn rewrite(
                             updated_refs.push(UpdatedReference {
                                 old_commit_id: old,
                                 new_commit_id: new,
-                                reference: but_core::Reference::Virtual(branch.name()),
+                                reference: but_core::Reference::Virtual(branch.name().clone()),
                             });
                         }
                     }
@@ -70,7 +70,7 @@ pub fn rewrite(
                             updated_refs.push(UpdatedReference {
                                 old_commit_id: old,
                                 new_commit_id: new,
-                                reference: but_core::Reference::Virtual(branch.name()),
+                                reference: but_core::Reference::Virtual(branch.name().clone()),
                             });
                         }
                     }

--- a/crates/but-workspace/src/commit_engine/refs.rs
+++ b/crates/but-workspace/src/commit_engine/refs.rs
@@ -42,9 +42,9 @@ pub fn rewrite(
                 });
             }
             for branch in stack.heads.iter_mut() {
-                match &mut branch.head {
+                match &mut branch.head() {
                     CommitOrChangeId::CommitId(id_hex) => {
-                        let Some((id, branch_target_id_hex)) =
+                        let Some((id, _branch_target_id_hex)) =
                             gix::ObjectId::from_hex(id_hex.as_bytes())
                                 .ok()
                                 .map(|id| (id, id_hex))
@@ -52,7 +52,7 @@ pub fn rewrite(
                             continue;
                         };
                         if id == old {
-                            *branch_target_id_hex = new.to_string();
+                            branch.set_head(CommitOrChangeId::CommitId(new.to_string()));
                             updated_refs.push(UpdatedReference {
                                 old_commit_id: old,
                                 new_commit_id: new,
@@ -66,7 +66,7 @@ pub fn rewrite(
                             continue;
                         };
                         if *commit_id == old {
-                            branch.head = CommitOrChangeId::CommitId(new.to_string());
+                            branch.set_head(CommitOrChangeId::CommitId(new.to_string()));
                             updated_refs.push(UpdatedReference {
                                 old_commit_id: old,
                                 new_commit_id: new,

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -339,7 +339,7 @@ fn convert(
         .ok()
         .map(|_| stack_branch.remote_reference(remote.as_str()));
     Ok(Branch {
-        name: stack_branch.name.into(),
+        name: stack_branch.name().into(),
         remote_tracking_branch: upstream_reference.map(Into::into),
         description: stack_branch.description,
         pr_number: stack_branch.pr_number,

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -339,7 +339,7 @@ fn convert(
         .ok()
         .map(|_| stack_branch.remote_reference(remote.as_str()));
     Ok(Branch {
-        name: stack_branch.name().into(),
+        name: stack_branch.name().to_owned().into(),
         remote_tracking_branch: upstream_reference.map(Into::into),
         description: stack_branch.description,
         pr_number: stack_branch.pr_number,

--- a/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
@@ -931,14 +931,11 @@ mod utils {
     }
 
     fn new_stack_branch(name: &str, head: gix::ObjectId) -> gitbutler_stack::StackBranch {
-        gitbutler_stack::StackBranch {
-            head: CommitOrChangeId::CommitId(head.to_string()),
-            name: name.into(),
-            description: None,
-            pr_number: None,
-            archived: false,
-            review_id: None,
-        }
+        gitbutler_stack::StackBranch::new(
+            CommitOrChangeId::CommitId(head.to_string()),
+            name.into(),
+            None,
+        )
     }
 
     /// Turn all heads from `vbranches` into an aptly named standard reference.
@@ -959,7 +956,7 @@ mod utils {
                 };
                 let commit_id = gix::ObjectId::from_hex(commit_id.as_bytes())?;
                 repo.reference(
-                    format!("refs/heads/{}", branch.name),
+                    format!("refs/heads/{}", branch.name()),
                     commit_id,
                     PreviousValue::Any,
                     "create branch head for visualization",

--- a/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
@@ -951,7 +951,7 @@ mod utils {
                 "create stack head for visualization",
             )?;
             for branch in &stack.heads {
-                let CommitOrChangeId::CommitId(commit_id) = &branch.head else {
+                let CommitOrChangeId::CommitId(commit_id) = branch.head() else {
                     continue;
                 };
                 let commit_id = gix::ObjectId::from_hex(commit_id.as_bytes())?;

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -137,14 +137,14 @@ pub fn list_branches(
             let head_matches_stack_name = stack
                 .branches()
                 .iter()
-                .any(|branch| branch.name == normalized_name);
+                .any(|branch| branch.name() == normalized_name);
 
             !head_matches_stack_name
         })
         .flat_map(|s| {
             s.branches()
                 .into_iter()
-                .map(|b| BString::from(b.name))
+                .map(|b| BString::from(b.name()))
                 .collect_vec()
         })
         .collect_vec();
@@ -271,12 +271,12 @@ fn branch_group_to_branch(
             .branches()
             .iter()
             .rev()
-            .map(|b| b.name.clone())
+            .map(|b| b.name())
             .collect_vec(),
         pull_requests: stack
             .branches()
             .iter()
-            .filter_map(|b| b.pr_number.map(|pr| (b.name.clone(), pr)))
+            .filter_map(|b| b.pr_number.map(|pr| (b.name(), pr)))
             .collect(),
     });
 

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -137,14 +137,14 @@ pub fn list_branches(
             let head_matches_stack_name = stack
                 .branches()
                 .iter()
-                .any(|branch| branch.name() == normalized_name);
+                .any(|branch| branch.name() == &normalized_name);
 
             !head_matches_stack_name
         })
         .flat_map(|s| {
             s.branches()
                 .into_iter()
-                .map(|b| BString::from(b.name()))
+                .map(|b| BString::from(b.name().to_owned()))
                 .collect_vec()
         })
         .collect_vec();
@@ -272,11 +272,12 @@ fn branch_group_to_branch(
             .iter()
             .rev()
             .map(|b| b.name())
+            .cloned()
             .collect_vec(),
         pull_requests: stack
             .branches()
             .iter()
-            .filter_map(|b| b.pr_number.map(|pr| (b.name(), pr)))
+            .filter_map(|b| b.pr_number.map(|pr| (b.name().to_owned(), pr)))
             .collect(),
     });
 

--- a/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
@@ -39,7 +39,7 @@ pub fn integrate_upstream_commits_for_series(
 
     let subject_branch = branches
         .iter()
-        .find(|branch| branch.name() == series_name)
+        .find(|branch| branch.name() == &series_name)
         .ok_or(anyhow!("Series not found"))?;
     let upstream_reference = subject_branch.remote_reference(remote.as_str());
     let remote_head = repo.find_reference(&upstream_reference)?.peel_to_commit()?;
@@ -62,7 +62,7 @@ pub fn integrate_upstream_commits_for_series(
         target_branch_head: default_target.sha,
         branch_head: stack.head(),
         branch_tree: stack.tree,
-        branch_name: &subject_branch.name(),
+        branch_name: subject_branch.name(),
         remote_head: remote_head.id(),
         remote_branch_name: &subject_branch.remote_reference(&remote),
         strategy,

--- a/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
@@ -39,7 +39,7 @@ pub fn integrate_upstream_commits_for_series(
 
     let subject_branch = branches
         .iter()
-        .find(|branch| branch.name == series_name)
+        .find(|branch| branch.name() == series_name)
         .ok_or(anyhow!("Series not found"))?;
     let upstream_reference = subject_branch.remote_reference(remote.as_str());
     let remote_head = repo.find_reference(&upstream_reference)?.peel_to_commit()?;
@@ -49,7 +49,7 @@ pub fn integrate_upstream_commits_for_series(
 
     let strategy = integration_strategy.unwrap_or_else(|| {
         let do_rebease = stack.allow_rebasing
-            || Some(subject_branch.name.clone()) != branches.first().map(|b| b.name.clone());
+            || Some(subject_branch.name()) != branches.first().map(|b| b.name());
         if do_rebease {
             IntegrationStrategy::Rebase
         } else {
@@ -62,7 +62,7 @@ pub fn integrate_upstream_commits_for_series(
         target_branch_head: default_target.sha,
         branch_head: stack.head(),
         branch_tree: stack.tree,
-        branch_name: &subject_branch.name,
+        branch_name: &subject_branch.name(),
         remote_head: remote_head.id(),
         remote_branch_name: &subject_branch.remote_reference(&remote),
         strategy,

--- a/crates/gitbutler-branch-actions/src/reorder.rs
+++ b/crates/gitbutler-branch-actions/src/reorder.rs
@@ -202,7 +202,7 @@ pub fn commits_order(stack_context: &StackContext, stack: &Stack) -> Result<Stac
         .rev()
         .map(|b| {
             Ok(SeriesOrder {
-                name: b.name.clone(),
+                name: b.name(),
                 commit_ids: b
                     .commits(stack_context, stack)?
                     .local_commits

--- a/crates/gitbutler-branch-actions/src/reorder.rs
+++ b/crates/gitbutler-branch-actions/src/reorder.rs
@@ -202,7 +202,7 @@ pub fn commits_order(stack_context: &StackContext, stack: &Stack) -> Result<Stac
         .rev()
         .map(|b| {
             Ok(SeriesOrder {
-                name: b.name(),
+                name: b.name().to_owned(),
                 commit_ids: b
                     .commits(stack_context, stack)?
                     .local_commits

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -49,14 +49,7 @@ pub fn create_series(
     if let Some(target_patch) = req.target_patch {
         stack.add_series(
             ctx,
-            StackBranch {
-                head: target_patch,
-                name: normalized_head_name,
-                description: req.description,
-                pr_number: Default::default(),
-                archived: Default::default(),
-                review_id: None,
-            },
+            StackBranch::new(target_patch, normalized_head_name, req.description),
             req.preceding_head,
         )
     } else {
@@ -208,7 +201,7 @@ pub fn push_stack(ctx: &CommandContext, stack_id: StackId, with_force: bool) -> 
             // Already integrated, nothing to push
             continue;
         }
-        let push_details = stack.push_details(ctx, branch.name)?;
+        let push_details = stack.push_details(ctx, branch.name())?;
         ctx.push(
             push_details.head,
             &push_details.remote_refname,
@@ -424,7 +417,7 @@ fn stack_branch_to_api_branch(
     }
     Ok((
         PatchSeries {
-            name: stack_branch.name,
+            name: stack_branch.name(),
             description: stack_branch.description,
             upstream_reference,
             patches,

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -201,7 +201,7 @@ pub fn push_stack(ctx: &CommandContext, stack_id: StackId, with_force: bool) -> 
             // Already integrated, nothing to push
             continue;
         }
-        let push_details = stack.push_details(ctx, branch.name())?;
+        let push_details = stack.push_details(ctx, branch.name().to_owned())?;
         ctx.push(
             push_details.head,
             &push_details.remote_refname,
@@ -417,7 +417,7 @@ fn stack_branch_to_api_branch(
     }
     Ok((
         PatchSeries {
-            name: stack_branch.name(),
+            name: stack_branch.name().to_owned(),
             description: stack_branch.description,
             upstream_reference,
             patches,

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -193,7 +193,7 @@ pub fn push_stack(ctx: &CommandContext, stack_id: StackId, with_force: bool) -> 
             // Nothing to push for this one
             continue;
         }
-        if branch.head == merge_base {
+        if *branch.head() == merge_base {
             // Nothing to push for this one
             continue;
         }

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -232,7 +232,7 @@ fn get_stack_status(
             && branch_integrated(&mut check_commit, branch, &stack_context, stack)?
         {
             branch_statuses.push(NameAndStatus {
-                name: branch.name.clone(),
+                name: branch.name(),
                 status: BranchStatus::Integrated,
             });
 
@@ -250,7 +250,7 @@ fn get_stack_status(
 
         if commits.local_commits.is_empty() {
             branch_statuses.push(NameAndStatus {
-                name: branch.name.clone(),
+                name: branch.name(),
                 status: BranchStatus::Empty,
             });
 
@@ -275,7 +275,7 @@ fn get_stack_status(
         let any_conflicted = rebased_commits.iter().any(|commit| commit.is_conflicted());
 
         branch_statuses.push(NameAndStatus {
-            name: branch.name.clone(),
+            name: branch.name(),
             status: if any_conflicted {
                 BranchStatus::Conflicted { rebasable: false }
             } else {
@@ -567,7 +567,7 @@ fn compute_resolutions(
 
                     // These two go into the merge commit message.
                     let incoming_branch_name = target.branch.fullname();
-                    let target_branch_name = &top_branch.name;
+                    let target_branch_name = &top_branch.name();
 
                     let new_head = gitbutler_merge_commits(
                         repository,

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -232,7 +232,7 @@ fn get_stack_status(
             && branch_integrated(&mut check_commit, branch, &stack_context, stack)?
         {
             branch_statuses.push(NameAndStatus {
-                name: branch.name(),
+                name: branch.name().to_owned(),
                 status: BranchStatus::Integrated,
             });
 
@@ -250,7 +250,7 @@ fn get_stack_status(
 
         if commits.local_commits.is_empty() {
             branch_statuses.push(NameAndStatus {
-                name: branch.name(),
+                name: branch.name().to_owned(),
                 status: BranchStatus::Empty,
             });
 
@@ -275,7 +275,7 @@ fn get_stack_status(
         let any_conflicted = rebased_commits.iter().any(|commit| commit.is_conflicted());
 
         branch_statuses.push(NameAndStatus {
-            name: branch.name(),
+            name: branch.name().to_owned(),
             status: if any_conflicted {
                 BranchStatus::Conflicted { rebasable: false }
             } else {

--- a/crates/gitbutler-branch-actions/tests/squash.rs
+++ b/crates/gitbutler-branch-actions/tests/squash.rs
@@ -469,13 +469,13 @@ fn test_ctx<'a>(ctx: &'a CommandContext, stack_ctx: &'a StackContext) -> Result<
     let stacks = handle.list_all_stacks()?;
     let stack = stacks.iter().find(|b| b.name == "my_stack").unwrap();
     let branches = stack.branches();
-    let branch_1 = branches.iter().find(|b| b.name == "a-branch-1").unwrap();
+    let branch_1 = branches.iter().find(|b| b.name() == "a-branch-1").unwrap();
     let commit_1 = branch_1.commits(stack_ctx, stack)?.local_commits[0].clone();
-    let branch_2 = branches.iter().find(|b| b.name == "a-branch-2").unwrap();
+    let branch_2 = branches.iter().find(|b| b.name() == "a-branch-2").unwrap();
     let commit_2 = branch_2.commits(stack_ctx, stack)?.local_commits[0].clone();
     let commit_3 = branch_2.commits(stack_ctx, stack)?.local_commits[1].clone();
     let commit_4 = branch_2.commits(stack_ctx, stack)?.local_commits[2].clone();
-    let branch_3 = branches.iter().find(|b| b.name == "a-branch-3").unwrap();
+    let branch_3 = branches.iter().find(|b| b.name() == "a-branch-3").unwrap();
     let commit_5 = branch_3.commits(stack_ctx, stack)?.local_commits[0].clone();
     Ok(TestContext {
         stack: stack.clone(),

--- a/crates/gitbutler-stack/src/heads.rs
+++ b/crates/gitbutler-stack/src/heads.rs
@@ -10,7 +10,7 @@ pub(crate) fn get_head(heads: &[StackBranch], name: &str) -> Result<(usize, Stac
     let (idx, head) = heads
         .iter()
         .enumerate()
-        .find(|(_, h)| h.name == name)
+        .find(|(_, h)| h.name() == name)
         .ok_or_else(|| anyhow!("Series with name {} not found", name))?;
     Ok((idx, head.clone()))
 }
@@ -123,7 +123,7 @@ pub(crate) fn add_head(
             if last_head.head != last_patch.clone() {
                 // error - invalid state - this would result in orphaned patches
                 bail!(
-                    "The newest head must point to the newest patch in the stack. The newest patch is {}, while the newest head with name {} points patch {}", last_patch, last_head.name, last_head.head
+                    "The newest head must point to the newest patch in the stack. The newest patch is {}, while the newest head with name {} points patch {}", last_patch, last_head.name(), last_head.head
                 );
             }
         } else {
@@ -144,31 +144,23 @@ mod test {
     use super::*;
     #[test]
     fn add_head_with_archived_bottom_head() -> Result<()> {
-        let head_1_archived = StackBranch {
-            head: CommitOrChangeId::CommitId("328447a2-08aa-4c4d-a1bc-08d5cd82bcd4".to_string()),
-            name: "kv-branch-3".to_string(),
-            description: None,
-            pr_number: None,
-            archived: true,
-            review_id: None,
-        };
-        let head_2 = StackBranch {
-            head: CommitOrChangeId::CommitId("11609175-039d-44ee-9d4a-6baa9ad2a750".to_string()),
-            name: "more-on-top".to_string(),
-            description: None,
-            pr_number: None,
-            archived: false,
-            review_id: None,
-        };
+        let mut head_1_archived = StackBranch::new(
+            CommitOrChangeId::CommitId("328447a2-08aa-4c4d-a1bc-08d5cd82bcd4".to_string()),
+            "kv-branch-3".to_string(),
+            None,
+        );
+        head_1_archived.archived = true;
+        let head_2 = StackBranch::new(
+            CommitOrChangeId::CommitId("11609175-039d-44ee-9d4a-6baa9ad2a750".to_string()),
+            "more-on-top".to_string(),
+            None,
+        );
         let existing_heads = vec![head_1_archived.clone(), head_2.clone()];
-        let new_head = StackBranch {
-            head: CommitOrChangeId::CommitId("11609175-039d-44ee-9d4a-6baa9ad2a750".to_string()),
-            name: "abcd".to_string(),
-            description: None,
-            pr_number: None,
-            archived: false,
-            review_id: None,
-        };
+        let new_head = StackBranch::new(
+            CommitOrChangeId::CommitId("11609175-039d-44ee-9d4a-6baa9ad2a750".to_string()),
+            "abcd".to_string(),
+            None,
+        );
         let patches = vec![
             CommitOrChangeId::CommitId("92a89ae608d77ff75c1ce52ea9dccc0bccd577e9".to_string()),
             CommitOrChangeId::CommitId("11609175-039d-44ee-9d4a-6baa9ad2a750".to_string()),

--- a/crates/gitbutler-stack/src/heads.rs
+++ b/crates/gitbutler-stack/src/heads.rs
@@ -34,7 +34,7 @@ pub(crate) fn remove_head(
         let prior_head = heads
             .get_mut(idx - 1)
             .ok_or_else(|| anyhow!("Cannot get the head before the head being removed"))?;
-        prior_head.head = head.head.clone();
+        prior_head.set_head(head.head().to_owned());
         moved_another_reference = true;
     }
     heads.remove(idx);
@@ -56,7 +56,7 @@ pub(crate) fn add_head(
     // If there are multiple heads that point to the same patch, the order is disambiguated by specifying the `preceding_head`
     // If `preceding_head` is specified, it must be in the list of existing heads, and it must be a head for the same patch as the `new_head`
     if let Some(preceding_head) = &preceding_head {
-        if preceding_head.head != new_head.head {
+        if preceding_head.head() != new_head.head() {
             return Err(anyhow!(
                 "Preceding head needs to be one that point to the same patch as new_head"
             ));
@@ -69,12 +69,12 @@ pub(crate) fn add_head(
     }
     let archived_heads = existing_heads
         .iter()
-        .filter(|h| !patches.contains(&h.head))
+        .filter(|h| !patches.contains(h.head()))
         .cloned()
         .collect_vec();
     let mut existing_heads = existing_heads
         .iter()
-        .filter(|h| patches.contains(&h.head))
+        .filter(|h| patches.contains(h.head()))
         .cloned()
         .collect_vec();
     let mut updated_heads: Vec<StackBranch> = vec![];
@@ -86,8 +86,7 @@ pub(crate) fn add_head(
             match (existing_head, &new_head) {
                 // Both the new head and the next existing head reference the patch as a target
                 (Some(existing_head), Some(new_head_ref))
-                    if existing_head.head == patch.clone()
-                        && new_head_ref.head == patch.clone() =>
+                    if existing_head.head() == patch && new_head_ref.head() == patch =>
                 {
                     if preceding_head.is_none() {
                         updated_heads.push(new_head_ref.clone()); // no preceding head specified, so add the new head first
@@ -101,12 +100,12 @@ pub(crate) fn add_head(
                     }
                 }
                 // Only the next existing head matches the patch as a target
-                (Some(existing_head), _) if existing_head.head == patch.clone() => {
+                (Some(existing_head), _) if existing_head.head() == patch => {
                     updated_heads.push(existing_head.clone()); // add the nex existing head as the next entry
                     existing_heads.remove(0); // consume the next in line from the existing heads
                 }
                 // Only the new head matches the patch as a target
-                (_, Some(new_head_ref)) if new_head_ref.head == patch.clone() => {
+                (_, Some(new_head_ref)) if new_head_ref.head() == patch => {
                     updated_heads.push(new_head_ref.clone()); // add the new head as the next entry
                     new_head = None; // the `new_head` is now consumed
                 }
@@ -120,10 +119,10 @@ pub(crate) fn add_head(
     // the last head must point to the last commit in the stack of patches
     if let Some(last_head) = updated_heads.last() {
         if let Some(last_patch) = patches.last() {
-            if last_head.head != last_patch.clone() {
+            if last_head.head() != last_patch {
                 // error - invalid state - this would result in orphaned patches
                 bail!(
-                    "The newest head must point to the newest patch in the stack. The newest patch is {}, while the newest head with name {} points patch {}", last_patch, last_head.name(), last_head.head
+                    "The newest head must point to the newest patch in the stack. The newest patch is {}, while the newest head with name {} points patch {}", last_patch, last_head.name(), last_head.head()
                 );
             }
         } else {

--- a/crates/gitbutler-stack/src/stack_branch.rs
+++ b/crates/gitbutler-stack/src/stack_branch.rs
@@ -16,7 +16,7 @@ use crate::{commit_by_oid_or_change_id, stack_context::StackContext, Stack};
 pub struct StackBranch {
     /// The target of the reference - this can be a commit or a change that points to a commit.
     #[serde(alias = "target")]
-    pub head: CommitOrChangeId,
+    head: CommitOrChangeId,
     /// The name of the reference e.g. `master` or `feature/branch`. This should **NOT** include the `refs/heads/` prefix.
     /// The name must be unique within the repository.
     name: String,
@@ -85,8 +85,8 @@ impl StackBranch {
         }
     }
 
-    pub fn head(&self) -> CommitOrChangeId {
-        self.head.clone()
+    pub fn head(&self) -> &CommitOrChangeId {
+        &self.head
     }
 
     pub fn set_head(&mut self, head: CommitOrChangeId) {

--- a/crates/gitbutler-stack/src/stack_branch.rs
+++ b/crates/gitbutler-stack/src/stack_branch.rs
@@ -93,8 +93,8 @@ impl StackBranch {
         self.head = head;
     }
 
-    pub fn name(&self) -> String {
-        self.name.clone()
+    pub fn name(&self) -> &String {
+        &self.name
     }
 
     pub fn set_name(&mut self, name: String) {

--- a/crates/gitbutler-stack/src/stack_branch.rs
+++ b/crates/gitbutler-stack/src/stack_branch.rs
@@ -19,7 +19,7 @@ pub struct StackBranch {
     pub head: CommitOrChangeId,
     /// The name of the reference e.g. `master` or `feature/branch`. This should **NOT** include the `refs/heads/` prefix.
     /// The name must be unique within the repository.
-    pub name: String,
+    name: String,
     /// Optional description of the series. This could be markdown or anything our hearts desire.
     pub description: Option<String>,
     /// The pull request associated with the branch, or None if a pull request has not been created.
@@ -74,6 +74,33 @@ impl RepositoryExt for git2::Repository {
 }
 
 impl StackBranch {
+    pub fn new(head: CommitOrChangeId, name: String, description: Option<String>) -> Self {
+        StackBranch {
+            head,
+            name,
+            description,
+            pr_number: None,
+            archived: false,
+            review_id: None,
+        }
+    }
+
+    pub fn head(&self) -> CommitOrChangeId {
+        self.head.clone()
+    }
+
+    pub fn set_head(&mut self, head: CommitOrChangeId) {
+        self.head = head;
+    }
+
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    pub fn set_name(&mut self, name: String) {
+        self.name = name;
+    }
+
     pub fn head_oid(&self, stack_context: &StackContext, stack: &Stack) -> Result<Oid> {
         match self.head.clone() {
             CommitOrChangeId::CommitId(id) => id.parse().map_err(Into::into),

--- a/crates/gitbutler-stack/tests/mod.rs
+++ b/crates/gitbutler-stack/tests/mod.rs
@@ -306,7 +306,7 @@ fn remove_series_with_multiple_last_heads() -> Result<()> {
     assert!(result.is_ok());
     assert_eq!(head_names(&test_ctx), vec!["to_stay"]);
     assert_eq!(
-        test_ctx.stack.heads[0].head,
+        *test_ctx.stack.heads[0].head(),
         CommitOrChangeId::CommitId(test_ctx.commits.last().unwrap().id().to_string())
     ); // it references the newest commit
     Ok(())
@@ -336,7 +336,7 @@ fn remove_series_no_orphan_commits() -> Result<()> {
     assert!(result.is_ok());
     assert_eq!(head_names(&test_ctx), vec!["to_stay"]);
     assert_eq!(
-        test_ctx.stack.heads[0].head,
+        *test_ctx.stack.heads[0].head(),
         CommitOrChangeId::CommitId(test_ctx.commits.last().unwrap().id().to_string())
     ); // it was updated to reference the newest commit
     Ok(())
@@ -504,7 +504,7 @@ fn update_series_target_success() -> Result<()> {
     let series_1 = StackBranch::new(commit_0_change_id.clone(), "series_1".into(), None);
     let result = test_ctx.stack.add_series(&ctx, series_1, None);
     assert!(result.is_ok());
-    assert_eq!(test_ctx.stack.heads[0].head, commit_0_change_id);
+    assert_eq!(*test_ctx.stack.heads[0].head(), commit_0_change_id);
     let commit_1_change_id = CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string());
     let update = PatchReferenceUpdate {
         name: None,
@@ -518,7 +518,7 @@ fn update_series_target_success() -> Result<()> {
         .stack
         .update_series(&ctx, "series_1".into(), &update);
     assert!(result.is_ok());
-    assert_eq!(test_ctx.stack.heads[0].head, commit_1_change_id);
+    assert_eq!(*test_ctx.stack.heads[0].head(), commit_1_change_id);
     // Assert persisted
     assert_eq!(
         test_ctx.stack,
@@ -698,7 +698,7 @@ fn set_stack_head() -> Result<()> {
     assert!(result.is_ok());
     let branches = test_ctx.stack.branches();
     assert_eq!(
-        branches.first().unwrap().head,
+        *branches.first().unwrap().head(),
         CommitOrChangeId::CommitId(commit.id().to_string())
     );
     assert_eq!(
@@ -712,7 +712,7 @@ fn set_stack_head() -> Result<()> {
 fn replace_head_single() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
-    let top_of_stack = test_ctx.stack.heads.last().unwrap().head.clone();
+    let top_of_stack = test_ctx.stack.heads.last().unwrap().head().clone();
     let from_head = StackBranch::new(
         CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string()),
         "from_head".into(),
@@ -726,11 +726,11 @@ fn replace_head_single() -> Result<()> {
     assert!(result.is_ok());
     // the head is updated to point to the new commit
     assert_eq!(
-        test_ctx.stack.heads[0].head,
+        *test_ctx.stack.heads[0].head(),
         CommitOrChangeId::CommitId(test_ctx.commits[0].id().to_string())
     );
     // the top of the stack is not changed
-    assert_eq!(test_ctx.stack.heads.last().unwrap().head, top_of_stack);
+    assert_eq!(*test_ctx.stack.heads.last().unwrap().head(), top_of_stack);
     // the state was persisted
     assert_eq!(
         test_ctx.stack,
@@ -743,7 +743,7 @@ fn replace_head_single() -> Result<()> {
 fn replace_head_single_with_merge_base() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
-    let top_of_stack = test_ctx.stack.heads.last().unwrap().head.clone();
+    let top_of_stack = test_ctx.stack.heads.last().unwrap().head().clone();
     let from_head = StackBranch::new(
         CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string()),
         "from_head".into(),
@@ -762,11 +762,11 @@ fn replace_head_single_with_merge_base() -> Result<()> {
     // the head is updated to point to the new commit
     // this time it's a commit id
     assert_eq!(
-        test_ctx.stack.heads[0].head,
+        *test_ctx.stack.heads[0].head(),
         CommitOrChangeId::CommitId(merge_base.id().to_string())
     );
     // the top of the stack is not changed
-    assert_eq!(test_ctx.stack.heads.last().unwrap().head, top_of_stack);
+    assert_eq!(*test_ctx.stack.heads.last().unwrap().head(), top_of_stack);
     // the state was persisted
     assert_eq!(
         test_ctx.stack,
@@ -872,7 +872,7 @@ fn replace_top_of_stack_single() -> Result<()> {
     assert!(result.is_ok());
     // the head is updated to point to the new commit
     assert_eq!(
-        test_ctx.stack.heads[0].head,
+        *test_ctx.stack.heads[0].head(),
         CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string())
     );
     assert_eq!(test_ctx.stack.head(), test_ctx.commits[1].id());
@@ -889,7 +889,7 @@ fn replace_top_of_stack_single() -> Result<()> {
 fn replace_head_multiple() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
-    let top_of_stack = test_ctx.stack.heads.last().unwrap().head.clone();
+    let top_of_stack = test_ctx.stack.heads.last().unwrap().head().clone();
     let from_head_1 = StackBranch::new(
         CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string()),
         "from_head_1".into(),
@@ -912,15 +912,18 @@ fn replace_head_multiple() -> Result<()> {
     assert!(result.is_ok());
     // both heads are  updated to point to the new commit
     assert_eq!(
-        test_ctx.stack.heads[0].head,
+        test_ctx.stack.heads[0].head().clone(),
         CommitOrChangeId::CommitId(test_ctx.commits[0].id().to_string())
     );
     assert_eq!(
-        test_ctx.stack.heads[1].head,
+        test_ctx.stack.heads[1].head().clone(),
         CommitOrChangeId::CommitId(test_ctx.commits[0].id().to_string())
     );
     // the top of the stack is not changed
-    assert_eq!(test_ctx.stack.heads.last().unwrap().head, top_of_stack);
+    assert_eq!(
+        test_ctx.stack.heads.last().unwrap().head().clone(),
+        top_of_stack
+    );
     // the state was persisted
     assert_eq!(
         test_ctx.stack,
@@ -948,11 +951,11 @@ fn replace_head_top_of_stack_multiple() -> Result<()> {
     assert!(result.is_ok());
     // both heads are  updated to point to the new commit
     assert_eq!(
-        test_ctx.stack.heads[0].head,
+        test_ctx.stack.heads[0].head().clone(),
         CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string())
     );
     assert_eq!(
-        test_ctx.stack.heads[1].head,
+        test_ctx.stack.heads[1].head().clone(),
         CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string())
     );
     assert_eq!(test_ctx.stack.head(), test_ctx.commits[1].id());

--- a/crates/gitbutler-stack/tests/mod.rs
+++ b/crates/gitbutler-stack/tests/mod.rs
@@ -15,18 +15,15 @@ use tempfile::TempDir;
 fn add_series_success() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
-    let reference = StackBranch {
-        name: "asdf".into(),
-        head: CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string()),
-        description: Some("my description".into()),
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
+    let reference = StackBranch::new(
+        CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string()),
+        "asdf".into(),
+        Some("my description".into()),
+    );
     let result = test_ctx.stack.add_series(&ctx, reference, None);
     assert!(result.is_ok());
     assert_eq!(test_ctx.stack.heads.len(), 2);
-    assert_eq!(test_ctx.stack.heads[0].name, "asdf");
+    assert_eq!(test_ctx.stack.heads[0].name(), "asdf");
     assert_eq!(
         test_ctx.stack.heads[0].description,
         Some("my description".into())
@@ -49,7 +46,7 @@ fn add_series_top_of_stack() -> Result<()> {
             .add_series_top_of_stack(&ctx, "asdf".into(), Some("my description".into()));
     assert!(result.is_ok());
     assert_eq!(test_ctx.stack.heads.len(), 2);
-    assert_eq!(test_ctx.stack.heads[1].name, "asdf");
+    assert_eq!(test_ctx.stack.heads[1].name(), "asdf");
     assert_eq!(
         test_ctx.stack.heads[1].description,
         Some("my description".into())
@@ -70,14 +67,11 @@ fn add_series_top_base() -> Result<()> {
         ctx.repo()
             .merge_base(test_ctx.stack.head(), test_ctx.default_target.sha)?,
     )?;
-    let reference = StackBranch {
-        name: "asdf".into(),
-        head: CommitOrChangeId::CommitId(merge_base.id().to_string()),
-        description: Some("my description".into()),
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
+    let reference = StackBranch::new(
+        CommitOrChangeId::CommitId(merge_base.id().to_string()),
+        "asdf".into(),
+        Some("my description".into()),
+    );
     let result = test_ctx.stack.add_series(&ctx, reference, None);
     println!("{:?}", result);
     // Assert persisted
@@ -97,28 +91,22 @@ fn add_multiple_series() -> Result<()> {
     assert_eq!(head_names(&test_ctx), vec!["a-branch-2"]); // defaults to stack name
     let default_head = test_ctx.stack.heads[0].clone();
 
-    let head_4 = StackBranch {
-        name: "head_4".into(),
-        head: CommitOrChangeId::CommitId(test_ctx.commits.last().unwrap().id().to_string()),
-        description: None,
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
+    let head_4 = StackBranch::new(
+        CommitOrChangeId::CommitId(test_ctx.commits.last().unwrap().id().to_string()),
+        "head_4".into(),
+        None,
+    );
     let result = test_ctx
         .stack
-        .add_series(&ctx, head_4, Some(default_head.name.clone()));
+        .add_series(&ctx, head_4, Some(default_head.name().clone()));
     assert!(result.is_ok());
     assert_eq!(head_names(&test_ctx), vec!["a-branch-2", "head_4"]);
 
-    let head_2 = StackBranch {
-        name: "head_2".into(),
-        head: CommitOrChangeId::CommitId(test_ctx.commits.last().unwrap().id().to_string()),
-        description: None,
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
+    let head_2 = StackBranch::new(
+        CommitOrChangeId::CommitId(test_ctx.commits.last().unwrap().id().to_string()),
+        "head_2".into(),
+        None,
+    );
     let result = test_ctx.stack.add_series(&ctx, head_2, None);
     assert!(result.is_ok());
     assert_eq!(
@@ -126,14 +114,11 @@ fn add_multiple_series() -> Result<()> {
         vec!["head_2", "a-branch-2", "head_4"]
     );
 
-    let head_1 = StackBranch {
-        name: "head_1".into(),
-        head: CommitOrChangeId::CommitId(test_ctx.commits.first().unwrap().id().to_string()),
-        description: None,
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
+    let head_1 = StackBranch::new(
+        CommitOrChangeId::CommitId(test_ctx.commits.first().unwrap().id().to_string()),
+        "head_1".into(),
+        None,
+    );
 
     let result = test_ctx.stack.add_series(&ctx, head_1, None);
     assert!(result.is_ok());
@@ -153,14 +138,11 @@ fn add_multiple_series() -> Result<()> {
 fn add_series_invalid_name_fails() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
-    let reference = StackBranch {
-        name: "name with spaces".into(),
-        head: CommitOrChangeId::CommitId(test_ctx.commits[0].id().to_string()),
-        description: None,
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
+    let reference = StackBranch::new(
+        CommitOrChangeId::CommitId(test_ctx.commits[0].id().to_string()),
+        "name with spaces".into(),
+        None,
+    );
     let result = test_ctx.stack.add_series(&ctx, reference, None);
     assert_eq!(result.err().unwrap().to_string(), "Invalid branch name");
     Ok(())
@@ -170,14 +152,11 @@ fn add_series_invalid_name_fails() -> Result<()> {
 fn add_series_duplicate_name_fails() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
-    let reference = StackBranch {
-        name: "asdf".into(),
-        head: CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string()),
-        description: None,
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
+    let reference = StackBranch::new(
+        CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string()),
+        "asdf".into(),
+        None,
+    );
     let result = test_ctx.stack.add_series(&ctx, reference.clone(), None);
     assert!(result.is_ok());
     let result = test_ctx.stack.add_series(&ctx, reference, None);
@@ -192,14 +171,11 @@ fn add_series_duplicate_name_fails() -> Result<()> {
 fn add_series_matching_git_ref_is_ok() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
-    let reference = StackBranch {
-        name: "existing-branch".into(),
-        head: test_ctx.commits[0].clone().into(),
-        description: None,
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
+    let reference = StackBranch::new(
+        test_ctx.commits[0].clone().into(),
+        "existing-branch".into(),
+        None,
+    );
     let result = test_ctx.stack.add_series(&ctx, reference.clone(), None);
     assert!(result.is_ok()); // allow this
     Ok(())
@@ -209,14 +185,11 @@ fn add_series_matching_git_ref_is_ok() -> Result<()> {
 fn add_series_including_refs_head_fails() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
-    let reference = StackBranch {
-        name: "refs/heads/my-branch".into(),
-        head: CommitOrChangeId::CommitId(test_ctx.commits[0].id().to_string()),
-        description: None,
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
+    let reference = StackBranch::new(
+        CommitOrChangeId::CommitId(test_ctx.commits[0].id().to_string()),
+        "refs/heads/my-branch".into(),
+        None,
+    );
     let result = test_ctx.stack.add_series(&ctx, reference.clone(), None);
     assert_eq!(
         result.err().unwrap().to_string(),
@@ -229,14 +202,11 @@ fn add_series_including_refs_head_fails() -> Result<()> {
 fn add_series_target_commit_doesnt_exist() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
-    let reference = StackBranch {
-        name: "my-branch".into(),
-        head: CommitOrChangeId::CommitId("30696678319e0fa3a20e54f22d47fc8cf1ceaade".into()), // does not exist
-        description: None,
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
+    let reference = StackBranch::new(
+        CommitOrChangeId::CommitId("30696678319e0fa3a20e54f22d47fc8cf1ceaade".into()), // does not exist
+        "my-branch".into(),
+        None,
+    );
     let result = test_ctx.stack.add_series(&ctx, reference.clone(), None);
     assert!(result
         .err()
@@ -250,14 +220,11 @@ fn add_series_target_commit_doesnt_exist() -> Result<()> {
 fn add_series_target_change_id_doesnt_exist() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
-    let reference = StackBranch {
-        name: "my-branch".into(),
-        head: CommitOrChangeId::CommitId("10696678319e0fa3a20e54f22d47fc8cf1ceaade".into()), // does not exist
-        description: None,
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
+    let reference = StackBranch::new(
+        CommitOrChangeId::CommitId("10696678319e0fa3a20e54f22d47fc8cf1ceaade".into()), // does not exist
+        "my-branch".into(),
+        None,
+    );
     let result = test_ctx.stack.add_series(&ctx, reference.clone(), None);
     assert_eq!(
         result.err().unwrap().to_string(),
@@ -271,14 +238,11 @@ fn add_series_target_commit_not_in_stack() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
     let other_commit_id = test_ctx.other_commits.last().unwrap().id().to_string();
-    let reference = StackBranch {
-        name: "my-branch".into(),
-        head: CommitOrChangeId::CommitId(other_commit_id.clone()), // does not exist
-        description: None,
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
+    let reference = StackBranch::new(
+        CommitOrChangeId::CommitId(other_commit_id.clone()), // does not exist
+        "my-branch".into(),
+        None,
+    );
     let result = test_ctx.stack.add_series(&ctx, reference.clone(), None);
     assert_eq!(
         result.err().unwrap().to_string(),
@@ -296,7 +260,7 @@ fn remove_series_last_fails() -> Result<()> {
     let mut test_ctx = test_ctx(&ctx)?;
     let result = test_ctx
         .stack
-        .remove_series(&ctx, test_ctx.stack.heads[0].name.clone());
+        .remove_series(&ctx, test_ctx.stack.heads[0].name().clone());
     assert_eq!(
         result.err().unwrap().to_string(),
         "Cannot remove the last branch from the stack"
@@ -327,21 +291,18 @@ fn remove_series_with_multiple_last_heads() -> Result<()> {
     assert_eq!(head_names(&test_ctx), vec!["a-branch-2"]); // defaults to stack name
     let default_head = test_ctx.stack.heads[0].clone();
 
-    let to_stay = StackBranch {
-        name: "to_stay".into(),
-        head: CommitOrChangeId::CommitId(test_ctx.commits.last().unwrap().id().to_string()),
-        description: None,
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
+    let to_stay = StackBranch::new(
+        CommitOrChangeId::CommitId(test_ctx.commits.last().unwrap().id().to_string()),
+        "to_stay".into(),
+        None,
+    );
     let result = test_ctx.stack.add_series(&ctx, to_stay.clone(), None);
     assert!(result.is_ok());
     assert_eq!(head_names(&test_ctx), vec!["to_stay", "a-branch-2"]);
 
     let result = test_ctx
         .stack
-        .remove_series(&ctx, default_head.name.clone());
+        .remove_series(&ctx, default_head.name().clone());
     assert!(result.is_ok());
     assert_eq!(head_names(&test_ctx), vec!["to_stay"]);
     assert_eq!(
@@ -360,21 +321,18 @@ fn remove_series_no_orphan_commits() -> Result<()> {
     assert_eq!(head_names(&test_ctx), vec!["a-branch-2"]); // defaults to stack name
     let default_head = test_ctx.stack.heads[0].clone(); // references the newest commit
 
-    let to_stay = StackBranch {
-        name: "to_stay".into(),
-        head: CommitOrChangeId::CommitId(test_ctx.commits.first().unwrap().id().to_string()),
-        description: None,
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    }; // references the oldest commit
+    let to_stay = StackBranch::new(
+        CommitOrChangeId::CommitId(test_ctx.commits.first().unwrap().id().to_string()),
+        "to_stay".into(),
+        None,
+    ); // references the oldest commit
     let result = test_ctx.stack.add_series(&ctx, to_stay.clone(), None);
     assert!(result.is_ok());
     assert_eq!(head_names(&test_ctx), vec!["to_stay", "a-branch-2"]);
 
     let result = test_ctx
         .stack
-        .remove_series(&ctx, default_head.name.clone());
+        .remove_series(&ctx, default_head.name().clone());
     assert!(result.is_ok());
     assert_eq!(head_names(&test_ctx), vec!["to_stay"]);
     assert_eq!(
@@ -427,7 +385,7 @@ fn update_series_name_success() -> Result<()> {
         .stack
         .update_series(&ctx, "a-branch-2".into(), &update);
     assert!(result.is_ok());
-    assert_eq!(test_ctx.stack.heads[0].name, "new-name");
+    assert_eq!(test_ctx.stack.heads[0].name(), "new-name");
     // Assert persisted
     assert_eq!(
         test_ctx.stack,
@@ -543,14 +501,7 @@ fn update_series_target_success() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
     let commit_0_change_id = CommitOrChangeId::CommitId(test_ctx.commits[0].id().to_string());
-    let series_1 = StackBranch {
-        name: "series_1".into(),
-        head: commit_0_change_id.clone(),
-        description: None,
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
+    let series_1 = StackBranch::new(commit_0_change_id.clone(), "series_1".into(), None);
     let result = test_ctx.stack.add_series(&ctx, series_1, None);
     assert!(result.is_ok());
     assert_eq!(test_ctx.stack.heads[0].head, commit_0_change_id);
@@ -629,7 +580,7 @@ fn list_series_default_head() -> Result<()> {
     let branches = test_ctx.stack.branches();
     // the number of series matches the number of heads
     assert_eq!(branches.len(), test_ctx.stack.heads.len());
-    assert_eq!(branches[0].name, "a-branch-2");
+    assert_eq!(branches[0].name(), "a-branch-2");
     assert_eq!(
         branches[0]
             .commits(&ctx.to_stack_context()?, &test_ctx.stack)?
@@ -646,14 +597,11 @@ fn list_series_default_head() -> Result<()> {
 fn list_series_two_heads_same_commit() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
-    let head_before = StackBranch {
-        name: "head_before".into(),
-        head: CommitOrChangeId::CommitId(test_ctx.commits.last().unwrap().id().to_string()),
-        description: None,
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
+    let head_before = StackBranch::new(
+        CommitOrChangeId::CommitId(test_ctx.commits.last().unwrap().id().to_string()),
+        "head_before".into(),
+        None,
+    );
     // add `head_before` before the initial head
     let result = test_ctx.stack.add_series(&ctx, head_before, None);
     assert!(result.is_ok());
@@ -674,7 +622,7 @@ fn list_series_two_heads_same_commit() -> Result<()> {
             .collect_vec(),
         test_ctx.commits.iter().map(|c| c.id()).collect_vec()
     );
-    assert_eq!(branches[0].name, "head_before");
+    assert_eq!(branches[0].name(), "head_before");
     assert_eq!(
         branches[1]
             .commits(&stack_context, &test_ctx.stack)?
@@ -684,7 +632,7 @@ fn list_series_two_heads_same_commit() -> Result<()> {
             .collect_vec(),
         vec![]
     );
-    assert_eq!(branches[1].name, "a-branch-2");
+    assert_eq!(branches[1].name(), "a-branch-2");
     Ok(())
 }
 
@@ -692,15 +640,11 @@ fn list_series_two_heads_same_commit() -> Result<()> {
 fn list_series_two_heads_different_commit() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
-    let head_before = StackBranch {
-        name: "head_before".into(),
-        // point to the first commit
-        head: CommitOrChangeId::CommitId(test_ctx.commits.first().unwrap().id().to_string()),
-        description: None,
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
+    let head_before = StackBranch::new(
+        CommitOrChangeId::CommitId(test_ctx.commits.first().unwrap().id().to_string()),
+        "head_before".into(),
+        None,
+    );
 
     let stack_context = ctx.to_stack_context()?;
 
@@ -720,7 +664,7 @@ fn list_series_two_heads_different_commit() -> Result<()> {
             .collect_vec(),
         vec![expected_patches.remove(0)]
     );
-    assert_eq!(branches[0].name, "head_before");
+    assert_eq!(branches[0].name(), "head_before");
     assert_eq!(expected_patches.len(), 2);
     assert_eq!(
         branches[1]
@@ -731,7 +675,7 @@ fn list_series_two_heads_different_commit() -> Result<()> {
             .collect_vec(),
         expected_patches
     ); // the other two patches are in the second series
-    assert_eq!(branches[1].name, "a-branch-2");
+    assert_eq!(branches[1].name(), "a-branch-2");
 
     Ok(())
 }
@@ -769,14 +713,11 @@ fn replace_head_single() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
     let top_of_stack = test_ctx.stack.heads.last().unwrap().head.clone();
-    let from_head = StackBranch {
-        name: "from_head".into(),
-        head: CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string()),
-        description: None,
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
+    let from_head = StackBranch::new(
+        CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string()),
+        "from_head".into(),
+        None,
+    );
     test_ctx.stack.add_series(&ctx, from_head, None)?;
     // replace with previous head
     let result = test_ctx
@@ -803,14 +744,11 @@ fn replace_head_single_with_merge_base() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
     let top_of_stack = test_ctx.stack.heads.last().unwrap().head.clone();
-    let from_head = StackBranch {
-        name: "from_head".into(),
-        head: CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string()),
-        description: None,
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
+    let from_head = StackBranch::new(
+        CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string()),
+        "from_head".into(),
+        None,
+    );
     test_ctx.stack.add_series(&ctx, from_head, None)?;
     // replace with merge base
     let merge_base = ctx.repo().find_commit(
@@ -841,14 +779,11 @@ fn replace_head_single_with_merge_base() -> Result<()> {
 fn replace_head_with_invalid_commit_error() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
-    let from_head = StackBranch {
-        name: "from_head".into(),
-        head: CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string()),
-        description: None,
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
+    let from_head = StackBranch::new(
+        CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string()),
+        "from_head".into(),
+        None,
+    );
     test_ctx.stack.add_series(&ctx, from_head, None)?;
     let stack = test_ctx.stack.clone();
     let result =
@@ -870,14 +805,11 @@ fn replace_head_with_invalid_commit_error() -> Result<()> {
 fn replace_head_with_same_noop() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
-    let from_head = StackBranch {
-        name: "from_head".into(),
-        head: CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string()),
-        description: None,
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
+    let from_head = StackBranch::new(
+        CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string()),
+        "from_head".into(),
+        None,
+    );
     test_ctx.stack.add_series(&ctx, from_head, None)?;
     let stack = test_ctx.stack.clone();
     let result = test_ctx
@@ -958,22 +890,16 @@ fn replace_head_multiple() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
     let top_of_stack = test_ctx.stack.heads.last().unwrap().head.clone();
-    let from_head_1 = StackBranch {
-        name: "from_head_1".into(),
-        head: CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string()),
-        description: None,
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
-    let from_head_2 = StackBranch {
-        name: "from_head_2".into(),
-        head: CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string()),
-        description: None,
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
+    let from_head_1 = StackBranch::new(
+        CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string()),
+        "from_head_1".into(),
+        None,
+    );
+    let from_head_2 = StackBranch::new(
+        CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string()),
+        "from_head_2".into(),
+        None,
+    );
     // both references point to the same commit
     test_ctx.stack.add_series(&ctx, from_head_1, None)?;
     test_ctx
@@ -1008,14 +934,11 @@ fn replace_head_top_of_stack_multiple() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
     let initial_head = ctx.repo().find_commit(test_ctx.stack.head())?;
-    let extra_head = StackBranch {
-        name: "extra_head".into(),
-        head: CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string()),
-        description: None,
-        pr_number: Default::default(),
-        archived: Default::default(),
-        review_id: None,
-    };
+    let extra_head = StackBranch::new(
+        CommitOrChangeId::CommitId(test_ctx.commits[1].id().to_string()),
+        "extra_head".into(),
+        None,
+    );
     // an extra head just beneath the top of the stack
     test_ctx.stack.add_series(&ctx, extra_head, None)?;
     // replace top of stack the commit
@@ -1034,7 +957,7 @@ fn replace_head_top_of_stack_multiple() -> Result<()> {
     );
     assert_eq!(test_ctx.stack.head(), test_ctx.commits[1].id());
     // order is the same
-    assert_eq!(test_ctx.stack.heads[0].name, "extra_head");
+    assert_eq!(test_ctx.stack.heads[0].name(), "extra_head");
     // the state was persisted
     assert_eq!(
         test_ctx.stack,
@@ -1065,14 +988,11 @@ fn archive_heads_success() -> Result<()> {
     // adding a commit that is not in the stack
     test_ctx.stack.heads.insert(
         0,
-        StackBranch {
-            head: test_ctx.other_commits.first().cloned().unwrap().into(),
-            name: "foo".to_string(),
-            description: None,
-            pr_number: Default::default(),
-            archived: Default::default(),
-            review_id: None,
-        },
+        StackBranch::new(
+            test_ctx.other_commits.first().cloned().unwrap().into(),
+            "foo".to_string(),
+            None,
+        ),
     );
     assert_eq!(test_ctx.stack.heads.len(), 2);
     test_ctx.stack.archive_integrated_heads(&ctx)?;
@@ -1157,7 +1077,7 @@ fn head_names(test_ctx: &TestContext) -> Vec<String> {
         .stack
         .heads
         .iter()
-        .map(|h| h.name.clone())
+        .map(|h| h.name().clone())
         .collect_vec()
 }
 

--- a/crates/gitbutler-sync/src/stack_upload.rs
+++ b/crates/gitbutler-sync/src/stack_upload.rs
@@ -90,7 +90,7 @@ fn branch_heads(
     // found branch, so we iterate in reverse.
     for head in stack.heads.iter_mut().rev() {
         if !top_head_found {
-            if head.name == top_branch {
+            if head.name() == top_branch {
                 top_head_found = true;
             } else {
                 continue;
@@ -107,7 +107,7 @@ fn branch_heads(
         heads.push(BranchHead {
             id: head_oid,
             review_id: review_id.clone(),
-            name: head.name.to_owned(),
+            name: head.name(),
         })
     }
 

--- a/crates/gitbutler-sync/src/stack_upload.rs
+++ b/crates/gitbutler-sync/src/stack_upload.rs
@@ -90,7 +90,7 @@ fn branch_heads(
     // found branch, so we iterate in reverse.
     for head in stack.heads.iter_mut().rev() {
         if !top_head_found {
-            if head.name() == top_branch {
+            if head.name() == &top_branch {
                 top_head_found = true;
             } else {
                 continue;
@@ -107,7 +107,7 @@ fn branch_heads(
         heads.push(BranchHead {
             id: head_oid,
             review_id: review_id.clone(),
-            name: head.name(),
+            name: head.name().to_owned(),
         })
     }
 


### PR DESCRIPTION
Make StackBranch setting of head and name go through a method - this will allow us to set/update real references in a controlled way.