### PR TITLE
research apply-branch and implement head-info, stack-listing and stack-details

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,6 +779,7 @@ dependencies = [
  "git2",
  "gitbutler-command-context",
  "gitbutler-commit",
+ "gitbutler-fs",
  "gitbutler-id",
  "gitbutler-oxidize",
  "gitbutler-project",
@@ -789,7 +790,10 @@ dependencies = [
  "insta",
  "itertools 0.14.0",
  "md5",
+ "regex",
  "serde",
+ "toml 0.8.19",
+ "tracing",
  "url",
 ]
 

--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -43,6 +43,7 @@
 
 use bstr::{BStr, BString};
 use gix::object::tree::EntryKind;
+use gix::refs::FullNameRef;
 use serde::Serialize;
 use std::any::Any;
 use std::ops::{Deref, DerefMut};
@@ -77,7 +78,7 @@ pub mod ref_metadata;
 pub trait RefMetadata {
     /// An implementation-defined wrapper for all data to keep additional information that it might need
     /// to more easily store the data.
-    type Handle<T>: Deref<Target = T> + DerefMut + ref_metadata::ValueInfo;
+    type Handle<T>: Deref<Target = T> + DerefMut + ref_metadata::ValueInfo + AsRef<FullNameRef>;
 
     /// Traverse all available metadata entries and see if their names still exist in the Git ref database.
     ///
@@ -99,23 +100,14 @@ pub trait RefMetadata {
         ref_name: &gix::refs::FullNameRef,
     ) -> anyhow::Result<Self::Handle<ref_metadata::Branch>>;
 
-    /// Set workspace metadata for `ref_name` to `Some(_)` or create it.
-    ///
-    /// It's not an error if the `ref_name` has no data in case `value` is `None`.
+    /// Set workspace metadata to match `value`.
     fn set_workspace(
         &mut self,
-        ref_name: &gix::refs::FullNameRef,
         value: &Self::Handle<ref_metadata::Workspace>,
     ) -> anyhow::Result<()>;
 
-    /// Set branch metadata for `ref_name` to `Some(_)` or create it.
-    ///
-    /// It's not an error if the `ref_name` has no data in case `value` is `None`.
-    fn set_branch(
-        &mut self,
-        ref_name: &gix::refs::FullNameRef,
-        value: &Self::Handle<ref_metadata::Branch>,
-    ) -> anyhow::Result<()>;
+    /// Set branch metadata to match `value`.
+    fn set_branch(&mut self, value: &Self::Handle<ref_metadata::Branch>) -> anyhow::Result<()>;
 
     /// Delete the metadata associated with the given `ref_name` and return `true` if it existed, or `false` otherwise.
     ///

--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -83,13 +83,9 @@ pub trait RefMetadata {
     ///
     /// If not, they are dangling, and can then be downcast to their actual type to deal with them in some way,
     /// either by [removing](Self::remove) them, or by re-associating them with an existing reference.
-    fn iter(&self) -> impl Iterator<Item = (gix::refs::FullName, Box<dyn Any>)> + '_;
-
-    /// Retrieve metadata for the branch to integrate with.
-    ///
-    /// Just for compatibility, as we should store the global value in `GITBUTLER_TARGET` or
-    /// per-workspace values in the workspace configuration of a workspace ref.
-    fn target(&self) -> anyhow::Result<Self::Handle<ref_metadata::Target>>;
+    fn iter(
+        &self,
+    ) -> impl Iterator<Item = anyhow::Result<(gix::refs::FullName, Box<dyn Any>)>> + '_;
 
     /// Retrieve workspace metadata for `ref_name` or create it if it wasn't present yet.
     fn workspace(
@@ -121,10 +117,10 @@ pub trait RefMetadata {
         value: &Self::Handle<ref_metadata::Branch>,
     ) -> anyhow::Result<()>;
 
-    /// Delete the metadata associated with the given `ref_name` and return it.
+    /// Delete the metadata associated with the given `ref_name` and return `true` if it existed, or `false` otherwise.
     ///
-    /// It is OK to delete something that doesn't exist
-    fn remove(&mut self, ref_name: &gix::refs::FullNameRef) -> anyhow::Result<Box<dyn Any>>;
+    /// It is OK to delete something that doesn't exist.
+    fn remove(&mut self, ref_name: &gix::refs::FullNameRef) -> anyhow::Result<bool>;
 }
 
 /// A decoded commit object with easy access to additional GitButler information.

--- a/crates/but-core/src/ref_metadata.rs
+++ b/crates/but-core/src/ref_metadata.rs
@@ -1,0 +1,177 @@
+/// Metadata about workspaces, associated with references that are designated to a workspace,
+/// i.e. `refs/heads/gitbutler/workspaces/<name>`.
+/// Such a ref either points to a *Workspace Commit* which we rewrite at will, or a commit
+/// owned by the user.
+///
+/// Note that associating data with the workspace, particularly with its parents, is very safe
+/// as the commit is under our control and merges aren't usually changed. However, users could
+/// point it to another commit merely by `git checkout` which means our stored data is completely
+/// out of sync.
+///
+/// We would have to detect this case by validating parents, and the refs pointing to it, before
+/// using the metadata, or at least have a way to communicate possible states when trying to use
+/// this information.
+#[derive(Debug, Clone)]
+pub struct Workspace {
+    /// Standard data we want to know about any ref.
+    pub ref_info: RefInfo,
+
+    /// An array entry for each parent of the *workspace commit* the last time we saw it.
+    /// The first parent, and always the first parent, could have a tip that is named `Self::target_ref`,
+    /// and if so it's not meant to be visible when asking for stacks.
+    pub stacks: Vec<WorkspaceStack>,
+
+    /// The name of the reference to integrate with, if present.
+    ///
+    /// If there is no target name, this is a local workspace.
+    pub target_ref: Option<gix::refs::FullName>,
+}
+
+/// Metadata about branches, associated with any Git branch.
+#[derive(Debug, Clone)]
+pub struct Branch {
+    /// Standard data we want to know about any ref.
+    pub ref_info: RefInfo,
+    /// More details about the branch.
+    pub description: Option<String>,
+    /// Information about possibly ongoing reviews in various forges.
+    pub review: Review,
+    /// If `true`, this means we created the branch as part of creating a new stack.
+    /// This means we may also remove it and its remote tracking branch if it's removed
+    /// from the stack *and* integrated.
+    pub is_managed: bool,
+}
+
+/// Metadata about the repository Target.
+///
+/// This is only needed while we have to be compatible with the TOML file,
+/// and otherwise is associated with `GITBUTLER_TARGET`.
+#[derive(Debug, Clone)]
+pub struct Target {
+    /// The configured target, as read from the TOML file.
+    pub ref_name: Option<gix::refs::FullName>,
+}
+
+/// Basic information to know about an reference we store with the metadata system.
+// TODO: is this really needed?
+#[derive(Debug, Clone)]
+pub struct RefInfo {
+    /// The time of creation, if we created the reference.
+    pub create_at: Option<gix::date::Time>,
+    /// The time at which the reference was last modified, if we modified it.
+    pub updated_at: Option<gix::date::Time>,
+}
+
+/// A stack that was applied to the workspace, i.e. a parent of the *workspace commit*.
+#[derive(Debug, Clone)]
+pub struct WorkspaceStack {
+    /// All refs that were reachable from the tip of the stack that at the time it was merged into
+    /// the *workspace commit*.
+    /// `[0]` is the first reachable ref-name, usually the tip of the stack, and `[N]` is the last
+    /// reachable branch before reaching the merge-base among all stacks or the `target_ref`.
+    ///
+    /// Thus, reference names are stored in traversal order, from the tip towards the base.
+    pub ref_names: Vec<gix::refs::FullName>,
+}
+
+impl WorkspaceStack {
+    /// The name of the stack itself, if it exists.
+    pub fn ref_name(&self) -> Option<&gix::refs::FullName> {
+        self.ref_names.first()
+    }
+}
+
+/// Metadata about branches, associated with any Git branch.
+#[derive(Debug, Clone)]
+pub struct Review {
+    /// The number for the PR that was associated with this branch.
+    pub pull_request: Option<usize>,
+    /// A handle to the review created with the GitButler review system.
+    pub review_id: Option<String>,
+}
+
+/// Additional information about the RefMetadata value itself.
+pub trait ValueInfo {
+    /// Return `true` if the value didn't exist for a given `ref_name` and thus was defaulted.
+    fn is_default(&self) -> bool;
+}
+
+mod virtual_branches_toml {
+    use crate::ref_metadata::{Branch, Target, ValueInfo, Workspace};
+    use crate::RefMetadata;
+    use gix::refs::{FullName, FullNameRef};
+    use std::any::Any;
+    use std::ops::{Deref, DerefMut};
+    use std::path::PathBuf;
+
+    /// An implementation to read and write metadata from the `virtual_branches.toml` file.
+    pub struct VirtualBranchesTomlMetadata {
+        _path: PathBuf,
+    }
+
+    impl RefMetadata for VirtualBranchesTomlMetadata {
+        type Handle<T> = VBTomlMetadataHandle<T>;
+
+        fn iter(&self) -> impl Iterator<Item = (FullName, Box<dyn Any>)> + '_ {
+            vec![].into_iter()
+        }
+
+        fn target(&self) -> anyhow::Result<Self::Handle<Target>> {
+            todo!()
+        }
+
+        fn workspace(&self, _ref_name: &FullNameRef) -> anyhow::Result<Self::Handle<Workspace>> {
+            todo!()
+        }
+
+        fn branch(&self, _ref_name: &FullNameRef) -> anyhow::Result<Self::Handle<Branch>> {
+            todo!()
+        }
+
+        fn set_workspace(
+            &mut self,
+            _ref_name: &FullNameRef,
+            _value: &Self::Handle<Workspace>,
+        ) -> anyhow::Result<()> {
+            todo!()
+        }
+
+        fn set_branch(
+            &mut self,
+            _ref_name: &FullNameRef,
+            _value: &Self::Handle<Branch>,
+        ) -> anyhow::Result<()> {
+            todo!()
+        }
+
+        fn remove(&mut self, _ref_name: &FullNameRef) -> anyhow::Result<Box<dyn Any>> {
+            todo!()
+        }
+    }
+
+    pub struct VBTomlMetadataHandle<T> {
+        is_default: bool,
+        value: T,
+    }
+
+    impl<T> Deref for VBTomlMetadataHandle<T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            &self.value
+        }
+    }
+
+    impl<T> DerefMut for VBTomlMetadataHandle<T> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.value
+        }
+    }
+
+    impl<T> ValueInfo for VBTomlMetadataHandle<T> {
+        fn is_default(&self) -> bool {
+            self.is_default
+        }
+    }
+}
+pub use virtual_branches_toml::VirtualBranchesTomlMetadata;

--- a/crates/but-core/src/ref_metadata.rs
+++ b/crates/but-core/src/ref_metadata.rs
@@ -11,7 +11,7 @@
 /// We would have to detect this case by validating parents, and the refs pointing to it, before
 /// using the metadata, or at least have a way to communicate possible states when trying to use
 /// this information.
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Workspace {
     /// Standard data we want to know about any ref.
     pub ref_info: RefInfo,
@@ -22,13 +22,44 @@ pub struct Workspace {
     pub stacks: Vec<WorkspaceStack>,
 
     /// The name of the reference to integrate with, if present.
+    /// Fetch its metadata for more inforamtion.
     ///
-    /// If there is no target name, this is a local workspace.
+    /// If there is no target name, this is a local workspace (and if no global target is set).
+    /// Note that even though this is per workspace, the implementation can fill in global information at will.
     pub target_ref: Option<gix::refs::FullName>,
 }
 
+impl Workspace {
+    /// Return `true` if `name` is a reference mentioned in our [stacks](Workspace::stacks).
+    pub fn contains_ref(&self, name: &gix::refs::FullNameRef) -> bool {
+        self.stacks
+            .iter()
+            .any(|stack| stack.branches.iter().any(|b| b.ref_name.as_ref() == name))
+    }
+
+    /// Find a given `name` within our stack branches and return it for modification.
+    pub fn find_branch_mut(
+        &mut self,
+        name: &gix::refs::FullNameRef,
+    ) -> Option<&mut WorkspaceStackBranch> {
+        self.stacks.iter_mut().find_map(|stack| {
+            stack
+                .branches
+                .iter_mut()
+                .find(|b| b.ref_name.as_ref() == name)
+        })
+    }
+
+    /// Find a given `name` within our stack branches and return it.
+    pub fn find_branch(&self, name: &gix::refs::FullNameRef) -> Option<&WorkspaceStackBranch> {
+        self.stacks
+            .iter()
+            .find_map(|stack| stack.branches.iter().find(|b| b.ref_name.as_ref() == name))
+    }
+}
+
 /// Metadata about branches, associated with any Git branch.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct Branch {
     /// Standard data we want to know about any ref.
     pub ref_info: RefInfo,
@@ -36,53 +67,66 @@ pub struct Branch {
     pub description: Option<String>,
     /// Information about possibly ongoing reviews in various forges.
     pub review: Review,
-    /// If `true`, this means we created the branch as part of creating a new stack.
-    /// This means we may also remove it and its remote tracking branch if it's removed
-    /// from the stack *and* integrated.
-    pub is_managed: bool,
 }
 
-/// Metadata about the repository Target.
+/// Basic information to know about a reference we store with the metadata system.
 ///
-/// This is only needed while we have to be compatible with the TOML file,
-/// and otherwise is associated with `GITBUTLER_TARGET`.
-#[derive(Debug, Clone)]
-pub struct Target {
-    /// The configured target, as read from the TOML file.
-    pub ref_name: Option<gix::refs::FullName>,
-}
-
-/// Basic information to know about an reference we store with the metadata system.
-// TODO: is this really needed?
-#[derive(Debug, Clone)]
+/// It allows to keep track of when it changed, but also if we created it initially, a useful
+/// bit of information.
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RefInfo {
-    /// The time of creation, if we created the reference.
-    pub create_at: Option<gix::date::Time>,
+    /// The time of creation, *if we created the reference*.
+    pub created_at: Option<gix::date::Time>,
     /// The time at which the reference was last modified, if we modified it.
     pub updated_at: Option<gix::date::Time>,
 }
 
+/// Access
+impl RefInfo {
+    /// If `true`, this means we created the branch as part of creating a new stack.
+    /// This means we may also remove it and its remote tracking branch if it's removed
+    /// from the stack *and* integrated.
+    pub fn is_managed(&self) -> bool {
+        self.created_at.is_some()
+    }
+}
+
 /// A stack that was applied to the workspace, i.e. a parent of the *workspace commit*.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WorkspaceStack {
-    /// All refs that were reachable from the tip of the stack that at the time it was merged into
+    /// All branches that were reachable from the tip of the stack that at the time it was merged into
     /// the *workspace commit*.
-    /// `[0]` is the first reachable ref-name, usually the tip of the stack, and `[N]` is the last
+    /// `[0]` is the first reachable branch, usually the tip of the stack, and `[N]` is the last
     /// reachable branch before reaching the merge-base among all stacks or the `target_ref`.
     ///
-    /// Thus, reference names are stored in traversal order, from the tip towards the base.
-    pub ref_names: Vec<gix::refs::FullName>,
+    /// Thus, branches are stored in traversal order, from the tip towards the base.
+    pub branches: Vec<WorkspaceStackBranch>,
+}
+
+/// A branch within a [`WorkspaceStack`], holding per-branch metadata that is
+/// stored alongside a stack that is available in a workspace.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WorkspaceStackBranch {
+    /// The name of the branch.
+    pub ref_name: gix::refs::FullName,
+    /// Archived represents the state when series/branch has been integrated and is below the merge base with the current target branch.
+    /// This would occur when the branch has been merged at the remote and the workspace has been updated with that change.
+    ///
+    /// Note that this is a cache to help speed up certain operations.
+    // TODO: given that most operations require a graph walk, will this really be necessary if a graph cache is used consistently?
+    //       Staleness can be a problem if targets can be changed after the fact. At least we'd need to recompute it.
+    pub archived: bool,
 }
 
 impl WorkspaceStack {
     /// The name of the stack itself, if it exists.
     pub fn ref_name(&self) -> Option<&gix::refs::FullName> {
-        self.ref_names.first()
+        self.branches.first().map(|b| &b.ref_name)
     }
 }
 
 /// Metadata about branches, associated with any Git branch.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct Review {
     /// The number for the PR that was associated with this branch.
     pub pull_request: Option<usize>,
@@ -95,83 +139,3 @@ pub trait ValueInfo {
     /// Return `true` if the value didn't exist for a given `ref_name` and thus was defaulted.
     fn is_default(&self) -> bool;
 }
-
-mod virtual_branches_toml {
-    use crate::ref_metadata::{Branch, Target, ValueInfo, Workspace};
-    use crate::RefMetadata;
-    use gix::refs::{FullName, FullNameRef};
-    use std::any::Any;
-    use std::ops::{Deref, DerefMut};
-    use std::path::PathBuf;
-
-    /// An implementation to read and write metadata from the `virtual_branches.toml` file.
-    pub struct VirtualBranchesTomlMetadata {
-        _path: PathBuf,
-    }
-
-    impl RefMetadata for VirtualBranchesTomlMetadata {
-        type Handle<T> = VBTomlMetadataHandle<T>;
-
-        fn iter(&self) -> impl Iterator<Item = (FullName, Box<dyn Any>)> + '_ {
-            vec![].into_iter()
-        }
-
-        fn target(&self) -> anyhow::Result<Self::Handle<Target>> {
-            todo!()
-        }
-
-        fn workspace(&self, _ref_name: &FullNameRef) -> anyhow::Result<Self::Handle<Workspace>> {
-            todo!()
-        }
-
-        fn branch(&self, _ref_name: &FullNameRef) -> anyhow::Result<Self::Handle<Branch>> {
-            todo!()
-        }
-
-        fn set_workspace(
-            &mut self,
-            _ref_name: &FullNameRef,
-            _value: &Self::Handle<Workspace>,
-        ) -> anyhow::Result<()> {
-            todo!()
-        }
-
-        fn set_branch(
-            &mut self,
-            _ref_name: &FullNameRef,
-            _value: &Self::Handle<Branch>,
-        ) -> anyhow::Result<()> {
-            todo!()
-        }
-
-        fn remove(&mut self, _ref_name: &FullNameRef) -> anyhow::Result<Box<dyn Any>> {
-            todo!()
-        }
-    }
-
-    pub struct VBTomlMetadataHandle<T> {
-        is_default: bool,
-        value: T,
-    }
-
-    impl<T> Deref for VBTomlMetadataHandle<T> {
-        type Target = T;
-
-        fn deref(&self) -> &Self::Target {
-            &self.value
-        }
-    }
-
-    impl<T> DerefMut for VBTomlMetadataHandle<T> {
-        fn deref_mut(&mut self) -> &mut Self::Target {
-            &mut self.value
-        }
-    }
-
-    impl<T> ValueInfo for VBTomlMetadataHandle<T> {
-        fn is_default(&self) -> bool {
-            self.is_default
-        }
-    }
-}
-pub use virtual_branches_toml::VirtualBranchesTomlMetadata;

--- a/crates/but-workspace/Cargo.toml
+++ b/crates/but-workspace/Cargo.toml
@@ -28,6 +28,11 @@ itertools = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 md5 = "0.7.0"
 
+# For virtual branches metadata
+gitbutler-fs.workspace = true
+toml.workspace = true
+tracing.workspace = true
+
 [dev-dependencies]
 but-testsupport.workspace = true
 insta = "1.42.1"
@@ -35,3 +40,4 @@ but-core = { workspace = true, features = ["testing"] }
 # for stable hashes in `gitbuter-` crates while we use them.
 # TODO: remove once `gitbutler-repo` isn't needed anymore.
 gitbutler-commit = { workspace = true, features = ["testing"] }
+regex = "1.11.1"

--- a/crates/but-workspace/src/branch.rs
+++ b/crates/but-workspace/src/branch.rs
@@ -43,6 +43,14 @@
 //!     - Are listed in such a way that they don't repeat across multiple stacks, i.e. only commits that aren't in
 //!      any of the other stacks or in the target branch (if present).
 //!
+//! TODO:
+//!  - sketch for detached HEAD, unapply last branch. Then applying another branch checks that out.
+//!  - unapplying everything with target should go to the tip of target
+//!  - how about a workspace that has a shared commit so assignment isn't clear
+//!  - About reference points for rev-walks (WMB, TMB, auto-target when branch has PR with target to merge into)
+//!    Without reference points, walks will be indefinite.
+//!  - What happens if the user points to a merge commit? Can they use GitButler to more easily see what's going on?
+//!
 //! ## Operations
 //!
 //! * **add branch from workspace**
@@ -318,7 +326,7 @@
 //!  │   │                                         Now there are new changes, WTC2       switches back
 //!  └───┘
 //! ```
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use bstr::BString;
 use but_core::RefMetadata;
 use gix::prelude::ObjectIdExt;

--- a/crates/but-workspace/src/branch.rs
+++ b/crates/but-workspace/src/branch.rs
@@ -1,0 +1,512 @@
+#![allow(unused_variables)]
+//! What follows is a description of all entities we need to implement Workspaces,
+//! a set of *two or more* branches that are merged together.
+//!
+//! ## tl/dr
+//!
+//! - `Switch` is a way to checkout any branch
+//!
+//! ## Rules
+//!
+//! The following rules and values govern how certain operations work. Ideally, everything that is written here can be
+//! reproduced by extrapolating them.
+//!
+//! * `HEAD` always points to a workspace.
+//!     - **Implicit Workspace**
+//!          - a commit (zero, one or more parents) created by the user, possibly pointed to by a branch.
+//!     - **Implicit Workspace with Metadata**
+//!          - like above, but has a `gitbutler/workspace/name` ref pointing to it which typically carries *ref-metadata*
+//!     - **Workspace with Metadata**
+//!          - a *workspace commit* with `gitbutler/workspace/name` reference pointing to it.
+//!          - always has two or more parents, otherwise it has no reason to exist.
+//! * _Optional_ *Target branches* are implied, globally explicit or don't exist at all
+//!     - If they exist, allow computing the highest/most-recent *target merge-base* that *stacks* in the
+//!       *workspace* are forked-off from.
+//!     - The *target merge-base* informs about how many commits we are behind *or* ahead.
+//!     - The whole workspace can be made to include more recent (or older) versions of the *target branch*
+//!     - A *target branch* is typically initialized from the remote tracking branch of the current branch at `HEAD`.
+//!     - Alternatively it's configured for the whole project.
+//!  * *Target merge bases* _should_ not change implicitly
+//!     - This merge-base is the 'view of the world' for the user as it's the *most recent merge-base with the target branch available in the worktree*.
+//!       Hence, it should remain stable.
+//!     - Adding branches to the workspace with *their* *target merge base* in our *past* is OK.
+//!     - Adding branches to the workspace with *their* *target merge base* in our *future* is not OK
+//!       unless the user allows it, or…
+//!        - We may try to *rebase* branches from the future onto our *target merge base*
+//!          if they have no remote tracking branch.
+//!  * *Workspace Merge Base*
+//!     - Is automatically the *Target Merge Base* if there is just a single branch.
+//!     - Is the octopus merge-base between all stacks in a workspace, i.e. a commit reachable from the tips of all stacks.
+//!  * *Remote Tracking Branches* are considered to integrate stacks with
+//!     - The *Target branch* can be the remote tracking branch of a local tracking branch that is part of the workspace.
+//!  * *Stacks* and their commits
+//!     - Are listed in such a way that they don't repeat across multiple stacks, i.e. only commits that aren't in
+//!      any of the other stacks or in the target branch (if present).
+//!
+//! ## Operations
+//!
+//! * **add branch from workspace**
+//!    - Add a branch to a *workspace commit* so it also includes the tip of the branch.
+//! * **remove branch from workspace**
+//!    - Remove a branch from a *workspace commit*
+//!    - Alternatively, checkout the *target branch*
+//! * **switch**
+//!    - Switch between branches of any kind, similar to `git switch`, but with automatic worktree stashing.
+//! * **stash changes**
+//!    - Implicit, causes worktree changes to be raised into their own tree and commit on top of `HEAD`.
+//! * **apply stashed changes**
+//!    - Lower previously stashed changes by re-applying them to a possibly changed tree, and checking them
+//!      out to the working tree.
+//!
+//! ## Metadata
+//!
+//! Metadata is all data that doesn't refer to Git objects (i.e. anything with a SHA1), and can be associated with
+//! a full reference name.
+//!
+//! ## Target Branch
+//!
+//! The branch that every branch in a workspace wants to get integrated with,
+//! either by merging or by being rebased onto it.
+//!
+//! The target branch is always a *remote tracking branch*, and as such it's not expected to be checked out
+//! nor would it be committed into directly.
+//!
+//! ## Rebase Considerations
+//!
+//! We avoid rebasing when adding something to the workspace,
+//! either because the added stack as a remote tracking branch, or because its merge-base with the target branch
+//! is in the past.
+//!
+//! If we were to *rebase* as part of a workspace update or adding to the stack, we would have to try to assure that the user isn't
+//! *accidentally pushing auto-resolved conflicting commits* that this might generate.
+//!
+//! This could be achieved by temporarily removing branch remote configuration (literally), so it can
+//! be put back once it's safe to push. Alternatively, and additionally, the ref could just be put back to
+//! its previous location.
+//!
+//! Alternatively, auto-resolves could be deactivated if we are in Git mode, and instead they are applied
+//! to the worktree directly, and we wait (with sequencer support) until the conflict has been resolved.
+//!
+//! ## Workspace Tip
+//!
+//! This is the elaborate name of the commit that currently represents what's visible in the working tree,
+//! i.e. the commit that `HEAD` points to.
+//!
+//! `HEAD` can point to Git commits, and to *Workspace Commits*, and the user switches `HEAD` locations
+//! at will with any tool of choice.
+//!
+//! ## Workspace Commits
+//!
+//! Whenever there are more than one branch to show, a *workspace commit* is created to keep track of the branches
+//! that are contained in it, making it *always a merge commit*.
+//!
+//! ### Workspace References
+//!
+//! Whenever a workspace is officially created by means of a *workspace commit*, a `refs/heads/gitbutler/workspace/<name>`
+//! is also created to point to it.
+//! These are removed once the corresponding *workspace commit* is going out of scope and if they don't contain any
+//! ref-metadata worth holding on to.
+//!
+//! *This also makes workspaces enumerable*.
+//!
+//! ## Worktree Stashes via Stash Commits
+//!
+//! Whenever there are worktree changes present before switching `HEAD` to another location,
+//! we will leave them if they don't interfere with the new `HEAD^{tree}` that we are about switch to, as a `safe` checkout
+//! is assumed.
+//! Those that *do interfere* we pick up and place as special *stash commit* on top of the commit
+//! that can accommodate them and let a *stash reference* point to it.
+//!
+//! ### Stash References
+//!
+//! The *stash reference* is created in the *gitbutler-stashes* [Git namespace](gix::refs::file::Store::namespace) to
+//! fully isolate them from the original reference name. This also means that we should disallow renaming branches with
+//! an associated *stash reference* and make it possible to list orphaned stashes as well, along with recovery options.
+//!
+//! For instance, if a references is `refs/heads/gitbutler/workspace/one`, then the stash reference is in
+//! `<namespace: gitbutler-stashes>/refs/heads/gitbutler/workspace/one`. The reason for this is that they will not
+//! be garbage-collected that way.
+//! Note that any ref, like `refs/heads/feature` can carry a stash, so *workspace references* aren't special.
+//!
+//! *This also makes stashes enumerable*. It's notable that it's entirely possible for stashes to become *orphaned*,
+//! i.e. their workspace commit (that the stash commit sits on top of) doesn't have a reference *with the same name*
+//! pointing to it anymore. What's great is that these can easily be recovered, along with the stash
+//! as it's trivial to find the *workspace commit* as only parent of the *stash commit*.
+//!
+//! They can also be *desynced*, meaning that the parent reference doesn't point to the parent of the *stash commit* anymore.
+//!
+//! ### Raising a Stash
+//!
+//! This is the process of knowing what to put in a stash in the first place before changing the worktree.
+//! The idea is to *minimize* the stash and leave everything that isn't going to be touched by the final checkout in place.
+//! That way what's in the stash is only the files that need to be merged back, minimizing the chance for conflicts.
+//!
+//! ### Apply Stashed Changes/Lowering a Stash
+//!
+//! Stashed changes are cherry-picked onto the target tree, but *merge conflicts* have to be kept and checked out
+//! to manifest them, similar to what happens when a Git stash is popped.
+//!
+//! If the destination of an unapply operation already has a stash, both source and destination stash will be merged
+//! with merge-conflicts manifesting in the tree.
+//!
+//! ### Shortcomings
+//!
+//! * **changed indices prevent stash creation**
+//!     - If changes in the .git/index would be ignored, data stored only there would be lost.
+//!     - conflicts would be lost, and should probably prevent the stash in any case.
+//! * **complexities with multiple worktree stashes**
+//!     - The user can leave a stash in each worktree that they switch away from.
+//!     - When switching back to a commit with stash we now have to deal with two stashes, the one that was already
+//!       there and the one we newly created before switching. Depending on the operation we may have to merge both
+//!       stashes, which can conflict.
+//!
+//! ## Sketches
+//!
+//! ```text
+//!  ┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+//!  │  H: Head | S: Stack | T: Target | GT: Global Target | RTB: Remote Tracking Branch | TMB: Target Merge Base | WTC: Worktree Changes   │
+//!  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+//!  │                                                      WMB: Workspace Merge Base                                                       │
+//!  └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+//!
+//!           ████████████████████ Apply feat ██████████████████████████████████████  Unapply main ████████████████████████████
+//! ┌───┐
+//! │   │
+//! │   │                                                                                                       - WARN: TMB changed
+//! │   │                                                                                                       - keep T info in ws/1
+//! │ C │                                                     ┌──┐
+//! │ a │                                                     │WS│◀── ws/1
+//! │ u │    T:RTB/main                 T:RTB/main ──┐        └──┘                               T:RTB/main
+//! │ g │         │                                  │          ▲                                     │
+//! │ h │         │                                  │   ┌──────┴─────┐                               │            ┌────H:ws/1
+//! │ t │         ▼  H:S:main                        │   │            │                               ▼            ▼
+//! │   │        ┌─┐     │    ┌─┐                    │  ┌─┐          ┌─┐                             ┌─┐          ┌─┐
+//! │ U │        TMB◀────┘    └─┘◀── feat            └─▶TMB◀─S:foo   └─┘◀┬─S:feat                    └─┘◀─ foo    └─┘◀─S:feat⇕⇡1⇣1
+//! │ p │         │            │                         │            │  │                            │            │
+//! │   │         │            │                         │            │  │                            │            │
+//! │   │         │            │                         │           RTB/feat                         │            │
+//! │   │        ┌─┐           │                        ┌─┐           │                              ┌─┐           │
+//! │   │        WMB───────────┘                        WMB───────────┘                              WMB───────────┘
+//! └───┘                                                                                            TMB
+//!
+//!
+//!           ████████████████████ Apply feat ██████████████████████████████████████  Unapply main ████████████████████████████
+//! ┌───┐
+//! │   │
+//! │   │
+//! │ N │      WMB missing                                    ┌──┐                             MB missing
+//! │ o │      - show all reachable commits                   │WS│◀── ws/1                     - show all reachable commits
+//! │   │                                                     └──┘
+//! │ T │                                                       ▲
+//! │ a │                                                ┌──────┴─────┐
+//! │ r │            H:S:main                            │            │
+//! │ g │        ┌─┐     │    ┌─┐                       ┌─┐          ┌─┐                             ┌─┐          ┌─┐
+//! │ e │        └─┘◀────┘    └─┘◀── feat               └─┘◀─S:main  └─┘◀──S:feat                    └─┘◀─ main   └─┘◀─H:S:feat
+//! │ t │         │            │                         │            │                               │            │
+//! │   │         │            │                         │            │                               │            │
+//! │   │         │            │                         │            │                               │            │
+//! │   │        ┌─┐           │                        ┌─┐           │                              ┌─┐           │
+//! └───┘        └─┘───────────┘                        WMB───────────┘                              └─┘───────────┘
+//!
+//!
+//!
+//!           ████████████████████ Apply feat ██████████████████████████████████████████████ FF main in Git ██████████████████████ Unapply feat ████████
+//! ┌───┐
+//! │   │    GT:RTB/main
+//! │ T │         │                                           ┌──┐                S:main ─┐       ┌──┐                  H:S:main─┐        - It goes back to the ref
+//! │ a │         ▼                                     ┌─┐   │WS│◀──H:ws/1               │ ┌─┐   │WS│◀──H:ws/1                  │ ┌─┐    - TMB moved
+//! │ r │        ┌─┐                       GT:RTB/main─▶└─┘   └──┘            GT:RTB/main─┴▶└─┘   └──┘               GT:RTB/main─┴▶TMB
+//! │ g │        └─┘                                     │      ▲                            │      ▲                               │           ┌─┐
+//! │ e │         │                                      ├──────┴─────┐                      ├──────┴─────┐                         │           └─┘◀── feat
+//! │ t │         │  H:S:main⇕⇣1             S:main⇕⇣1   │            │                      │            │                         │            │
+//! │   │        ┌─┐      │   ┌─┐                │      ┌─┐          ┌─┐                    ┌─┐          ┌─┐                       ┌─┐           │
+//! │ A │        TMB◀─────┘   └─┘◀── feat        └─────▶TMB          └─┘◀──S:feat           TMB          └─┘◀──S:feat              └─┘           │
+//! │ h │         │            │                         │            │                      │            │                         │            │
+//! │ e │         │            │                         │            │                      │            │                         │            │
+//! │ a │         │            │                         │            │                      │            │                         │            │
+//! │ d │        ┌─┐           │                        ┌─┐           │                     ┌─┐           │                        ┌─┐           │
+//! │   │        └─┘───────────┘                        WMB───────────┘                     WMB───────────┘                        └─┘───────────┘
+//! └───┘
+//!
+//! ┌───┐
+//! │ W │     ███████████ Create Commit ██████████████ Push to remote ██████████ Create commit ████████████ Push to remote ████████████
+//! │ o │
+//! │ r │
+//! │ k │
+//! │   │
+//! │ o │                                                                                   ┌─┐        T:RTB/main ──┐  ┌─┐
+//! │ n │                                                                  H:S:main⇕⇡1 ────▶└─┘          H:S:main ──┴─▶└─┘
+//! │   │                                                                                    │                         WMB
+//! │ T │                                                                                    │                         TMB
+//! │ a │                                               T:RTB/main─┐                         │                          │
+//! │ r │                                        ┌─┐               │  ┌─┐                   ┌─┐                        ┌─┐
+//! │ g │          H:S:main         H:S:main────▶└─┘      H:S:main─┴─▶└─┘ T:RTB/main⇕⇣1 ───▶└─┘                        └─┘
+//! │ e │                                                                                   WMB
+//! │ t │                                                                                   TMB
+//! │   │
+//! └───┘                                                                  Target branch is behind
+//!
+//!
+//!
+//! ┌───┐     ███████████ Create Commit ██████████████Create Stack █████████████Create Branch █████████████████████ Commit feat/1 ████████████████████ Insert Commit to feat ██████████████████████ Commit main ████████████████████████████████ Push main █████████████████████████████████ Push S:feat/1 and B:feat ████████████████ Merge feat/1 PR and fetch ████████████████████████████ Update Workspace █████████████████████████████ Prune Integrated ██████████████████████████
+//! │   │
+//! │ F │                                                                                                                    ┌──┐                                ┌──┐                                    ┌──┐                                      ┌──┐                                         ┌──┐                                             H:ws/1
+//! │ r │                                                                                                          H:ws/1 ──▶│WS│────┐                 H:ws/1 ──▶│WS│───┐   ┌─┐                H:ws/1 ──▶│WS│───┐   ┌─┐                  H:ws/1 ──▶│WS│───┐   ┌─┐                     H:ws/1 ──▶│WS│───┐   ┌─┐ ┌── RTB/feat/1                 ┌─┐   │                                                ┌──┐
+//! │ e │                                                                                                                    └──┘    │                           └──┘   └───└─┘◀─── S:feat/1             └──┘   └───└─┘◀─── S:feat/1               └──┘   └───└─┘◀─── S:feat/1                  └──┘   └───└─┘◀┴── S:feat/1    T:RTB/main ───▶└─┘◀──┼─────────┐                                 ┌────│WS│──────┐
+//! │ s │                                                            ┌──┐                       ┌──┐              WS aids      │    ┌─┐                            │         │                             │         │                               │         │                                  │         │                                  │    ▼         │                                 │    └──┘      │
+//! │ h │                                                 H:ws/1 ───▶│WS│            H:ws/1 ───▶│WS│              traversal by │    └─┘◀─── S:feat/1               │        ┌┴┐                       ┌────┘        ┌┴┐                         ┌────┘        ┌┴┐                            ┌────┘        ┌┴┐ ┌──  RTB/feat                   │  ┌──┐        │                 T:RTB/main ─┐  ┌─┐     ▲       │                T:RTB/main ─┐  ┌─┐
+//! │   │                                                            └──┘                       └──┘              parent       │     │                             ├────────┴─┘◀─── B:feat            │             └┬┘◀─── B:feat              │             └┬┘◀─── B:feat                 │             └┬┘◀┴── B:feat                      │  │WS│───┐   ┌─┐ ┌── RTB/feat/1     S:main ─┴─▶TMB─────┼───────┤                   H:S:main─┴─▶└─┘─────────────┐
+//! │ I │                                                              │                          │                            ├─────┘                             │                                 ┌─┐             │                         ┌─┐             │                            ┌─┐             │                                  │  └──┘   └───└─┘◀┴── S:feat/1                   │      │       │                               WMB             │
+//! │ n │                                                              │                          │                            │                                   │                       S:main ──▶└─┘──┐          │              S:main ─┬─▶└─┘──┐          │                 S:main ─┬─▶└─┘──┐          │                                  │    │         │                                 │   H:ws/1    ┌─┐ ┌── RTB/feat/1               TMB            ┌─┐
+//! │ i │                                        ┌─┐                  ┌─┐                        ┌─┐ ┌─ S:feat/1              ┌─┐                                 ┌─┐                                     └─┬─┬──────┘          T:RTB/main ─┘       └─┬─┬──────┘             T:RTB/main ─┘       └─┬─┬──────┘                                  ├────┘        ┌┴┐ ┌──  RTB/feat                  │             └─┘◀┴── S:feat/1                  │             └─┘
+//! │ t │          H:S:main         H:S:main────▶└─┘      S:main ────▶└─┘◀── S:feat    S:main ──▶└─┘◀┴─ B:feat      S:main ──▶WMB◀───── B:feat          S:main ──▶WMB                                       WMB                                       └─┘                                          └─┘                                         │             └┬┘◀┴── B:feat                     │              │                                │              │
+//! │   │                                                                                                                                                                                                                                             WMB                                          WMB                                        ┌─┐             │                                 │             ┌┴┐ ┌──  RTB/feat                 │             ┌┴┐
+//! │   │                                                                                                                                                                                                                                             TMB                                          TMB                            S:main⇕⇣───▶└─┘──┐          │                                 │             └┬┘◀┴── B:feat                    │             └┬┘
+//! └───┘                                                 Need ws/1 for metadata:      - Need ws/1 for metadata:                                                                                                                                                                                                                                   └─┬─┬──────┘                                ┌─┐             │                               ┌─┐             │
+//!                                                       stack order                    stack + branch order                                                                                                                                                                                                                                        └─┘                                       └─┘──┐          │                               └─┘──┐          │
+//!                                                                                    - Stack name changed to                                                                                                                                                                                                                                       WMB                                            └─┬─┬──────┘                                    └─┬─┬──────┘
+//!                                                                                      feat/1                                                                                                                                                                                                                                                      TMB                                              WMB                                             └─┘
+//!
+//!
+//!
+//!  ┌───┐     ████████████████████ switch to feat and change WT ██████████████████ switch to main █████████████████████████████                                                                                                                                                                                                                                                   - FF S:main                                     - delete all of S:feat/1 as we created it as well.
+//!  │   │                                                       ┌─┐                                                   ┌─┐                                                                                                                                                                                                                                                         - Detect S:feat/1 and B:feat are merged and     - delete ws/1 as its metadata can be inferred
+//!  │ A │                                            WTC/main ─▶└─┘                                        WTC/feat ─▶└─┘                                                                                                                                                                                                                                                           do nothing.
+//!  │ u │                                                        │                                                     │                                                                                                                                                                                                                                                          - remerge WS as S:main tip changed
+//!  │ t │                                                        │                                                     │
+//!  │ o │                ┌─┐      ┌─┐                           ┌─┐      ┌─┐                                 ┌─┐      ┌─┐
+//!  │ S │ H:S:WTC:main ─▶└─┘      └─┘◀── feat            main ─▶└─┘      └─┘◀── H:S:WTC:feat              ┌─▶└─┘      └─┘◀── feat
+//!  │ t │                 │        │                             │        │                               │   │        │
+//!  │ a │                 │        │                             │        │                 H:S:WTC:main ─┘   │        │
+//!  │ s │                 │        │                             │        │                                   │        │
+//!  │ h │                ┌─┐       │                            ┌─┐       │                                  ┌─┐       │
+//!  │   │                └─┘───────┘                            └─┘───────┘                                  └─┘───────┘
+//!  │ o │
+//!  │ n │
+//!  │   │
+//!  │ s │      main has WTC before the switch         stash was raised and tracked                  - stash was raised and tracked
+//!  │ w │                                             with WTC ref for main                           with WTC ref for feat
+//!  │ i │                                                                                           - apply stash on main
+//!  │ t │
+//!  │ c │
+//!  │ h │
+//!  │   │
+//!  └───┘
+//!
+//!
+//!            ██████████████████ Apply feat and change WT ███████████████████████████ Unapply feat but WTC2 needs it █████████████████ switch to feat ██████████████████████████████████████
+//!  ┌───┐
+//!  │   │                                                    ┌──┐
+//!  │   │                                                    │WS│◀─── H:WTC2:ws/1
+//!  │ E │                                                    └──┘                                     ┌─┐                          ┌─┐
+//!  │ p │   H:S:WTC:main                                       │                       H:S:WTC:main   └─┘◀──WTC/feat   WTC/main ──▶└─┘
+//!  │ h │         │                                      ┌─────┴────┐                        │         │                            │
+//!  │ e │         ▼                                      │          │                        ▼         │                            │
+//!  │ m │        ┌─┐       ┌─┐                          ┌─┐        ┌─┐                      ┌─┐       ┌─┐                          ┌─┐       ┌─┐
+//!  │ e │        └─┘       └─┘◀── feat         S:main ─▶└─┘        └─┘◀── S:feat            └─┘       └─┘◀── feat         main ───▶└─┘       └─┘◀──H:S:WTC
+//!  │ r │         │         │                            │          │                        │         │                            │         │
+//!  │ a │         │         │                            │          │                        │         │                            │         │
+//!  │ l │         │         │                            │          │                        │         │                            │         │
+//!  │   │        ┌─┐        │                           ┌─┐         │                       ┌─┐        │                           ┌─┐        │
+//!  │ S │        └─┘────────┘                           └─┘─────────┘                       └─┘────────┘                           └─┘────────┘
+//!  │ t │
+//!  │ a │                                                                               Some worktree changes only fit       stashed WTC were auto-applied
+//!  │ s │                                         stash was raised from main,           onto feat, so they have been         upon switch.
+//!  │ h │                                         then dropped again after              stashed onto it.
+//!  │   │                                         switching to WS commit.
+//!  │   │                                                                               It will be applied once the user
+//!  │   │                                         Now there are new changes, WTC2       switches back
+//!  └───┘
+//! ```
+use anyhow::{bail, Context};
+use bstr::BString;
+use but_core::RefMetadata;
+use gix::prelude::ObjectIdExt;
+
+/// The result of [`add_branch_to_workspace`].
+#[derive(Debug, Clone)]
+pub struct ApplyOutcome {
+    /// The new location of the workspace tip if the existing one was moved, or if a new one was created.
+    /// This is equivalent to where `HEAD` should be.
+    pub workspace_tip: gix::ObjectId,
+    /// If we rebased something, this is the result of that operation.
+    /// If `None`, this means `branch_id` was checked out.
+    pub rebase_output: Option<but_rebase::RebaseOutput>,
+}
+
+/// Apply the given `branch_tip` so that it is part of the given `workspace_tip`,
+/// which may also be initialized with `HEAD` and for all intends and purposes is equivalent to what `HEAD` points to.
+/// After the operation, `branch_tip` should be part of the returned `workspace_tip`
+/// If not available, a new tip will be provided which may be the commit the `branch` is currently pointing to,
+/// indicating the workspace tip is now just the tip of an ordinary branch.
+/// `target_tip`, if present, is the tip of the branch to integrate all workspace branches with ultimatley.
+///
+/// Note that at this point, the worktree will not have been touched, nor will references have been updated.
+/// However, the `vb` will be updated where appropriate to match new ref positions in case the `branch` had to be
+/// rebased.
+pub fn add_branch_to_workspace(
+    repo: &gix::Repository,
+    branch_tip: gix::ObjectId,
+    workspace_tip: gix::ObjectId,
+    target_tip: Option<gix::ObjectId>,
+    metadata: &mut impl RefMetadata,
+) -> anyhow::Result<ApplyOutcome> {
+    if crate::WorkspaceCommit::from_id(branch_tip.attach(repo))?.is_managed() {
+        bail!("Cannot bring a workspace into another one")
+    }
+
+    let cache = repo.commit_graph_if_enabled()?;
+    let mut graph = repo.revision_graph(cache.as_ref());
+    let merge_base = repo
+        .merge_base_with_graph(workspace_tip, branch_tip, &mut graph)
+        .context("Branch and workspace must have a merge-base")?;
+    if merge_base == branch_tip || merge_base == workspace_tip {
+        bail!("Cannot add branch that is already integrated")
+    }
+    todo!()
+}
+
+/// Like [`add_branch_to_workspace`], but will also update the involved references, and change `HEAD` to point to possibly newly
+/// created `workspace_tip`.
+/// `workspace_tip` can also be a detached `HEAD`, that's valid.
+// TODO: maybe rather work with refs and add dry-run?
+pub fn add_branch_to_workspace_and_update_refs(
+    repo: &gix::Repository,
+    branch_tip: gix::refs::PartialName,
+    workspace_tip: gix::refs::FullName,
+    target_tip: Option<gix::refs::PartialName>,
+    metadata: &mut impl RefMetadata,
+) -> anyhow::Result<ApplyOutcome> {
+    todo!()
+}
+
+/// The inverse of [`add_branch_to_workspace`] where `workspace_tip` is the current `HEAD` and `branch_tip` is the tip to *not* include in the
+/// `workspace_tip` anymore.
+pub fn remove_branch_from_workspace(
+    repo: &gix::Repository,
+    branch_tip: gix::ObjectId,
+    workspace_tip: gix::ObjectId,
+    target_tip: Option<gix::ObjectId>,
+    metadata: &mut impl RefMetadata,
+) -> anyhow::Result<ApplyOutcome> {
+    todo!()
+}
+
+/// An even more minimal version of the [`StackEntry](crate::StackEntry) with enough information to query
+/// more information about a Stack.
+///
+/// Mote that a stack is also used to represent detached heads, which is far-fetched but necessary
+#[derive(Debug, Clone)]
+pub struct Stack {
+    /// The index into the parents-array of its [`WorkspaceCommit`](crate::WorkspaceCommit), but for our
+    /// purposes just a way to refer to the stack.
+    ///
+    /// The actual index is dependent on the order in which they are merged into the workspace commit,
+    /// if the stack is merged at all.
+    pub index: usize,
+    /// The commit that the tip of the stack is pointing to.
+    pub tip: gix::ObjectId,
+    /// The reference name that points to the tip of the stack, i.e. the top-most known commit.
+    /// It is `None` if the `HEAD` is detached.
+    pub ref_name: Option<gix::refs::FullName>,
+    /// Additional information about possibly still available stashes, sitting on top of this stack.
+    ///
+    /// This means the stash is still there to be applied, something that can happen if the user switches branches
+    /// using Git commands.
+    ///
+    /// The backend auto-applies floating stashes, but if that didn't happen, the frontend may guide the user.
+    pub stash_status: Option<StashStatus>,
+}
+
+/// A list of all commits
+#[derive(Debug, Clone)]
+pub struct BranchCommit {
+    /// The hash of the commit.
+    pub id: gix::ObjectId,
+    /// The first line of the commit message.
+    pub title: BString,
+    /// The timestamp at which the commit was created.
+    pub committed_date: gix::date::Time,
+}
+
+/// A more detailed specification of a reference associated with a workspace.
+#[derive(Debug, Clone)]
+pub enum BranchRefLocation {
+    /// The workspace commit can reach the given reference using a graph-walk.
+    ///
+    /// This is the common case.
+    ReachableFromWorkspaceCommit(gix::refs::FullName),
+    /// The given reference can reach into this workspace segment, but isn't inside of it.
+    ///
+    /// This happens if someone checked out the reference directly and commited into it.
+    OutsideOfWorkspace(gix::refs::FullName),
+}
+
+/// A list of all commits in a branch segment of a [`Stack`].
+#[derive(Debug, Clone)]
+pub struct BranchSegment {
+    /// The name of the branch at the tip of it, and the starting point of the walk.
+    ///
+    /// It is `None` if this branch is the top-most branch segment and the `ref_name` wasn't pointing to
+    /// a commit anymore that was reached by our rev-walk.
+    /// This can happen if the ref is deleted, or if it was advanced by other means.
+    pub ref_name: Option<BranchRefLocation>,
+    /// The portion of commits that can be reached from the tip of the *branch* downwards, so that they are unique
+    /// for that branch segment and not included in any other stack or the *target branch*.
+    ///
+    /// The list could be empty.
+    pub commits_unique_from_tip: Vec<BranchCommit>,
+    /// The comits that are reachable from this branch, but not from the tip of the *Stack*.
+    /// This happens if the branch is advanced/moved by other means.
+    pub commits_unintegratd_local: Vec<BranchCommit>,
+    /// Commits that are reachable from the remote-tracking branch associated with this branch,
+    /// but are not reachable from this branch.
+    pub commits_unintegrated_upstream: Vec<BranchCommit>,
+    /// The name of the remote tracking branch of this segment, if present, i.e. `refs/remotes/origin/main`.
+    /// Its presence means that a remote is configured and that the stack content
+    pub remote_tracking_ref_name: Option<gix::refs::FullName>,
+    /// Metadata with additional information.
+    pub metadata: but_core::ref_metadata::Branch,
+}
+
+/// Information about a stash which is associated with the tip of a stack.
+#[derive(Debug, Copy, Clone)]
+pub enum StashStatus {
+    /// The parent reference is still present, but it doesn't point to the first parent of the *stash commit* anymore.
+    Desynced,
+    /// The parent reference could not be found. Maybe it was removed, maybe it was renamed.
+    Orphaned,
+}
+
+/// Further clarify where a workspace reference was located.
+#[derive(Debug, Clone)]
+pub enum WorkspaceRefLocation {
+    /// The given workspace can reach `HEAD^{commit}` through its worktree commits.
+    Reachable(gix::refs::FullName),
+    /// `HEAD` is pointing to the given workspace ref directly.
+    Head(gix::refs::FullName),
+}
+
+/// Information about where the user is currently looking at.
+#[derive(Debug, Clone)]
+pub struct HeadInfo {
+    /// Set if `HEAD` points to a GitButler reference, `refs/heads/gitbutler/workspace/<name>`.
+    pub workspace_ref: Option<WorkspaceRefLocation>,
+    /// The stacks visible in the current workspace.
+    pub stacks: Vec<Stack>,
+    /// The full name to the target reference that we should integrate with, if present.
+    pub target_ref: Option<gix::refs::FullName>,
+}
+
+/// Gather information about the current `HEAD` and the workspace that might be associated with it.
+pub fn head_info(
+    repo: &gix::Repository,
+    metadata: &mut impl but_core::RefMetadata,
+) -> anyhow::Result<HeadInfo> {
+    todo!()
+}
+
+/// Return all branch segments within the given `stack`.
+pub fn stack_branch_segments(stack: Stack) -> anyhow::Result<Vec<BranchSegment>> {
+    todo!()
+}

--- a/crates/but-workspace/src/commit.rs
+++ b/crates/but-workspace/src/commit.rs
@@ -1,0 +1,104 @@
+use crate::{StackEntry, WorkspaceCommit};
+use bstr::ByteSlice;
+
+/// Construction
+impl<'repo> WorkspaceCommit<'repo> {
+    const GITBUTLER_INTEGRATION_COMMIT_TITLE: &'static str = "GitButler Integration Commit";
+    const GITBUTLER_WORKSPACE_COMMIT_TITLE: &'static str = "GitButler Workspace Commit";
+
+    /// Decode the object at `commit_id` and keep its data for later query.
+    pub fn from_id(commit_id: gix::Id<'repo>) -> anyhow::Result<Self> {
+        let commit = commit_id.object()?.try_into_commit()?.decode()?.into();
+        Ok(WorkspaceCommit {
+            id: commit_id,
+            inner: commit,
+        })
+    }
+
+    /// Create a new commit which presents itself as the merge of all the given `stacks`.
+    ///
+    /// Note that the returned commit lives entirely in memory and would still have to be written to disk.
+    /// It still needs its tree set to something non-empty.
+    ///
+    /// `object_hash` is needed to create an empty tree hash.
+    pub fn create_commit_from_vb_state(
+        stacks: &[StackEntry],
+        object_hash: gix::hash::Kind,
+    ) -> gix::objs::Commit {
+        // message that says how to get back to where they were
+        let mut message = Self::GITBUTLER_WORKSPACE_COMMIT_TITLE.to_string();
+        message.push_str("\n\n");
+        if !stacks.is_empty() {
+            message.push_str("This is a merge commit the virtual branches in your workspace.\n\n");
+        } else {
+            message.push_str("This is placeholder commit and will be replaced by a merge of your virtual branches.\n\n");
+        }
+        message.push_str(
+            "Due to GitButler managing multiple virtual branches, you cannot switch back and\n",
+        );
+        message.push_str("forth between git branches and virtual branches easily. \n\n");
+
+        message.push_str(
+            "If you switch to another branch, GitButler will need to be reinitialized.\n",
+        );
+        message.push_str("If you commit on this branch, GitButler will throw it away.\n\n");
+        if !stacks.is_empty() {
+            message.push_str("Here are the branches that are currently applied:\n");
+            for branch in stacks {
+                if let Some(name) = branch.name() {
+                    message.push_str(" - ");
+                    message.push_str(name.to_str_lossy().as_ref());
+                    message.push('\n');
+                }
+
+                message.push_str("   branch head: ");
+                message.push_str(&branch.tip.to_string());
+                message.push('\n');
+            }
+        }
+        message.push_str("For more information about what we're doing here, check out our docs:\n");
+        message
+            .push_str("https://docs.gitbutler.com/features/virtual-branches/integration-branch\n");
+
+        let author = gix::actor::Signature {
+            name: "GitButler".into(),
+            email: "gitbutler@gitbutler.com".into(),
+            time: gix::date::Time::now_local_or_utc(),
+        };
+        gix::objs::Commit {
+            tree: gix::ObjectId::empty_tree(object_hash),
+            parents: stacks.iter().map(|s| s.tip).collect(),
+            committer: author.clone(),
+            author,
+            encoding: Some("UTF-8".into()),
+            message: message.into(),
+            extra_headers: vec![],
+        }
+    }
+}
+
+/// Query
+impl WorkspaceCommit<'_> {
+    /// Return `true` if this commit is managed by GitButler.
+    /// If `false`, this is the tip of the stack itself which will be put underneath a *managed* workspace commit
+    /// once another branch is added to the workspace.
+    pub fn is_managed(&self) -> bool {
+        let message = gix::objs::commit::MessageRef::from_bytes(&self.message);
+        message.title == Self::GITBUTLER_INTEGRATION_COMMIT_TITLE
+            || message.title == Self::GITBUTLER_WORKSPACE_COMMIT_TITLE
+    }
+}
+
+impl std::ops::Deref for WorkspaceCommit<'_> {
+    type Target = gix::objs::Commit;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl std::ops::DerefMut for WorkspaceCommit<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -49,6 +49,9 @@ pub mod branch;
 
 mod commit;
 
+mod virtual_branches_metadata;
+pub use virtual_branches_metadata::VirtualBranchesTomlMetadata;
+
 /// A representation of the commit that is the tip of the workspace, i.e. usually what `HEAD` points to,
 /// possibly in its managed form in which it merges two or more stacks together and we can rewrite it at will.
 pub struct WorkspaceCommit<'repo> {

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -44,6 +44,20 @@ mod integrated;
 
 pub mod commit_engine;
 
+/// utilities for applying and unapplying branches.
+pub mod branch;
+
+mod commit;
+
+/// A representation of the commit that is the tip of the workspace, i.e. usually what `HEAD` points to,
+/// possibly in its managed form in which it merges two or more stacks together and we can rewrite it at will.
+pub struct WorkspaceCommit<'repo> {
+    /// The id of the commit itself.
+    pub id: gix::Id<'repo>,
+    /// The decoded commit for direct access.
+    pub inner: gix::objs::Commit,
+}
+
 /// An ID uniquely identifying stacks.
 pub use gitbutler_stack::StackId;
 

--- a/crates/but-workspace/src/virtual_branches_metadata.rs
+++ b/crates/but-workspace/src/virtual_branches_metadata.rs
@@ -1,0 +1,499 @@
+use anyhow::{Context, bail};
+use but_core::RefMetadata;
+use but_core::ref_metadata::{
+    Branch, RefInfo, ValueInfo, Workspace, WorkspaceStack, WorkspaceStackBranch,
+};
+use gitbutler_stack::{StackId, VirtualBranchesState};
+use gix::date::SecondsSinceUnixEpoch;
+use gix::refs::{FullName, FullNameRef};
+use std::any::Any;
+use std::cell::RefCell;
+use std::ops::{Deref, DerefMut};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+struct Snapshot {
+    /// The time at which the `content` was changed, before it was written to disk.
+    changed_at: Option<Instant>,
+    content: VirtualBranchesState,
+    path: PathBuf,
+}
+
+impl Snapshot {
+    fn from_path(path: PathBuf) -> anyhow::Result<Self> {
+        let content = gitbutler_fs::read_toml_file_or_default(&path)?;
+        Ok(Self {
+            path,
+            changed_at: None,
+            content,
+        })
+    }
+
+    fn write_if_changed(&mut self) -> anyhow::Result<()> {
+        if self.changed_at.is_some() {
+            if self.content == Default::default() {
+                std::fs::remove_file(&self.path)?;
+            } else {
+                gitbutler_fs::write(&self.path, toml::to_string(&self.content)?)?;
+            }
+            self.changed_at.take();
+        }
+        Ok(())
+    }
+
+    fn try_write_if_changed(&mut self) {
+        let res = self.write_if_changed();
+        if let Err(err) = res {
+            tracing::error!(
+                "Could not write back changes to virtual branches toml file to '{}': {err}",
+                self.path.display()
+            );
+        }
+    }
+
+    /// Assure we don't think the content changed, so writing it if changed will do nothing.
+    fn claim_unchanged(&mut self) {
+        self.changed_at.take();
+    }
+}
+
+/// An implementation to read and write metadata from the `virtual_branches.toml` file, meant to be a short-lived item
+/// that is possibly written multiple times. It will write itself on drop only, and log write failures.
+///
+/// The idea is that it's forgiving and easy to use, while helping to eventually migrate to a database.
+pub struct VirtualBranchesTomlMetadata {
+    // What is currently in memory for query or edits.
+    snapshot: Snapshot,
+}
+
+impl VirtualBranchesTomlMetadata {
+    /// Initialize a store backed by a file on disk.
+    ///
+    /// Also, set-up a thread for debounced writing.
+    pub fn from_path(path: impl Into<PathBuf>) -> anyhow::Result<Self> {
+        let path = path.into();
+        Ok(Self {
+            snapshot: Snapshot::from_path(path)?,
+        })
+    }
+
+    /// Return the path at which the toml file is located.
+    ///
+    /// We will write changes to it on drop.
+    pub fn path(&self) -> &Path {
+        &self.snapshot.path
+    }
+}
+
+// Emergency-behaviour in case the application winds down, we don't want data-loss (at least a chance).
+impl Drop for VirtualBranchesTomlMetadata {
+    fn drop(&mut self) {
+        self.snapshot.try_write_if_changed();
+    }
+}
+
+const INTEGRATION_BRANCH_LEGACY: &str = "refs/heads/gitbutler/integration";
+const INTEGRATION_BRANCH: &str = "refs/heads/gitbutler/workspace";
+
+impl RefMetadata for VirtualBranchesTomlMetadata {
+    type Handle<T> = VBTomlMetadataHandle<T>;
+
+    fn iter(&self) -> impl Iterator<Item = anyhow::Result<(FullName, Box<dyn Any>)>> + '_ {
+        let data = &self.snapshot.content;
+        // Keep it simple - dump everything into a Vec, pre-allocated.
+        let mut out = Vec::new();
+        if data.branches.is_empty() {
+            return out.into_iter();
+        }
+
+        // Brute force, but simple.
+        for stack in data.branches.values() {
+            for branch_ref_name in stack
+                .heads
+                .iter()
+                .filter_map(|branch| full_branch_name(branch.name()))
+            {
+                out.push(self.branch(branch_ref_name.as_ref()).map(|branch| {
+                    (
+                        branch_ref_name.clone(),
+                        Box::new((*branch).clone()) as Box<dyn Any>,
+                    )
+                }));
+            }
+        }
+
+        // Workspace last, also so that journey test has a harder time as it can delete the branches one by one.
+        out.push(Ok((
+            gix::refs::FullName::try_from(INTEGRATION_BRANCH).expect("known to be valid"),
+            Box::new(Self::workspace_from_data(data)),
+        )));
+        out.into_iter()
+    }
+
+    fn workspace(&self, ref_name: &FullNameRef) -> anyhow::Result<Self::Handle<Workspace>> {
+        if is_workspace_ref(ref_name) {
+            let value = Self::workspace_from_data(&self.snapshot.content);
+            Ok(VBTomlMetadataHandle {
+                is_default: value == default_workspace(),
+                stack_id: None.into(),
+                value,
+            })
+        } else {
+            bail!("This backend doesn't support arbitrary workspaces");
+        }
+    }
+
+    fn branch(&self, ref_name: &FullNameRef) -> anyhow::Result<Self::Handle<Branch>> {
+        let Some((stack, branch)) = self.snapshot.content.branches.values().find_map(|stack| {
+            stack.heads.iter().find_map(|branch| {
+                full_branch_name(branch.name().as_str()).and_then(|full_name| {
+                    (full_name.as_ref() == ref_name).then_some((stack, branch))
+                })
+            })
+        }) else {
+            return Ok(VBTomlMetadataHandle {
+                is_default: true,
+                stack_id: None.into(),
+                value: Branch::default(),
+            });
+        };
+
+        let ref_info = RefInfo {
+            // keep None, as otherwise it means we created it, which allows us to delete the ref.
+            // However, for it's too early for that logic.
+            created_at: None,
+            updated_at: Some(gix::date::Time {
+                seconds: (stack.updated_timestamp_ms / 1000) as SecondsSinceUnixEpoch,
+                ..gix::date::Time::now_local_or_utc()
+            }),
+        };
+        Ok(VBTomlMetadataHandle {
+            is_default: false,
+            stack_id: Some(stack.id).into(),
+            value: Branch {
+                ref_info,
+                description: branch.description.clone(),
+                review: but_core::ref_metadata::Review {
+                    pull_request: branch.pr_number,
+                    review_id: branch.review_id.clone(),
+                },
+            },
+        })
+    }
+
+    fn set_workspace(
+        &mut self,
+        ref_name: &FullNameRef,
+        value: &Self::Handle<Workspace>,
+    ) -> anyhow::Result<()> {
+        if !is_workspace_ref(ref_name) {
+            bail!("This backend doesn't support arbitrary workspaces");
+        }
+
+        // Find exactly one stack-id per branch name, and assign all branches to it.
+        // `stacks` is the target state, and we have to make an actual stack look like it.
+        for stack in &value.stacks {
+            let stack_branches = &stack.branches;
+            let mut branches_without_data = Vec::new();
+            let mut stack_id = None::<StackId>;
+            for stack_branch in stack_branches {
+                let branch = self.branch(stack_branch.ref_name.as_ref())?;
+                if branch.is_default() {
+                    branches_without_data.push(stack_branch);
+                    continue;
+                }
+                if stack_id.is_none() {
+                    stack_id = *branch.stack_id.borrow();
+                } else if stack_id != *branch.stack_id.borrow() {
+                    *branch.stack_id.borrow_mut() = stack_id;
+                    self.set_branch(stack_branch.ref_name.as_ref(), &branch)?;
+                }
+            }
+
+            let stack = match stack_id {
+                None => {
+                    todo!("create a new stack with all ref-names")
+                }
+                Some(stack_id) => {
+                    let stack = self
+                        .snapshot
+                        .content
+                        .branches
+                        .get_mut(&stack_id)
+                        .expect("we just looked it up");
+
+                    for branch in branches_without_data {
+                        stack.heads.push(branch_to_stack_branch(
+                            branch.ref_name.as_ref(),
+                            &Branch::default(),
+                            branch.archived,
+                        ))
+                    }
+                    stack.in_workspace = !stack.heads.is_empty();
+                    stack
+                }
+            };
+            stack.heads.sort_by_key(|head| {
+                stack_branches.iter().enumerate().find_map(|(idx, branch)| {
+                    (branch.ref_name.shorten() == head.name().as_str()).then_some(idx)
+                })
+            });
+            stack.heads.reverse()
+        }
+        Ok(())
+    }
+
+    fn set_branch(
+        &mut self,
+        ref_name: &FullNameRef,
+        value: &Self::Handle<Branch>,
+    ) -> anyhow::Result<()> {
+        let stack_id = *value.stack_id.borrow();
+        let ws = self.workspace(INTEGRATION_BRANCH.try_into().unwrap())?;
+        match stack_id {
+            Some(stack_id) => {
+                let stack = self
+                    .snapshot
+                    .content
+                    .branches
+                    .get_mut(&stack_id)
+                    .with_context(|| format!("Couldn't find stack with id {stack_id}"))?;
+
+                let short_name = ref_name.shorten();
+                match stack
+                    .heads
+                    .iter_mut()
+                    .find(|b| short_name == b.name().as_str())
+                {
+                    None => {
+                        todo!("insert into existing stack")
+                    }
+                    Some(gitbutler_stack::StackBranch {
+                        description,
+                        pr_number,
+                        archived,
+                        review_id,
+                        ..
+                    }) => {
+                        let stack_branch = ws.find_branch(ref_name);
+                        self.snapshot.changed_at = Some(Instant::now());
+                        *description = value.description.clone();
+                        *pr_number = value.review.pull_request;
+                        *review_id = value.review.review_id.clone();
+                        stack.in_workspace = stack_branch.is_some();
+                        if let Some(stack_branch) = stack_branch {
+                            *archived = stack_branch.archived;
+                        }
+                        Ok(())
+                    }
+                }
+            }
+            None => {
+                let now_ms = (gix::date::Time::now_local_or_utc().seconds * 1000) as u128;
+                let stack = gitbutler_stack::Stack {
+                    id: StackId::default(),
+                    created_timestamp_ms: now_ms,
+                    updated_timestamp_ms: now_ms,
+                    order: self.snapshot.content.branches.len(),
+                    allow_rebasing: true, //  default in V2
+                    in_workspace: ws.contains_ref(ref_name),
+                    heads: vec![branch_to_stack_branch(ref_name, value, false)],
+
+                    // Don't keep redundant information
+                    tree: git2::Oid::zero(),
+                    head: git2::Oid::zero(),
+                    source_refname: None,
+                    upstream: None,
+                    upstream_head: None,
+
+                    // Unused - everything is defined by the top-most branch name.
+                    name: "".to_string(),
+                    notes: "".to_string(),
+
+                    // Related to ownership, obsolete.
+                    selected_for_changes: None,
+                    // unclear, obsolete
+                    not_in_workspace_wip_change_id: None,
+                    // unclear
+                    post_commits: false,
+                    ownership: Default::default(),
+                };
+                *value.stack_id.borrow_mut() = Some(stack.id);
+                self.snapshot.content.branches.insert(stack.id, stack);
+                self.snapshot.changed_at = Some(Instant::now());
+                Ok(())
+            }
+        }
+    }
+
+    fn remove(&mut self, ref_name: &FullNameRef) -> anyhow::Result<bool> {
+        if is_workspace_ref(ref_name) {
+            // There is only one workspace, and it's the same as deleting everything.
+            // The real implementation of this would just delete data associated with a ref, no special case needed there.
+            if let Err(err) = std::fs::remove_file(&self.snapshot.path) {
+                if err.kind() != std::io::ErrorKind::NotFound {
+                    Err(err.into())
+                } else {
+                    Ok(false)
+                }
+            } else {
+                let existed_as_non_default =
+                    Self::workspace_from_data(&self.snapshot.content) != default_workspace();
+                self.snapshot.content = Default::default();
+                // Make sure it's not going to be written in its default state.
+                self.snapshot.claim_unchanged();
+                Ok(existed_as_non_default)
+            }
+        } else {
+            let branch = self.branch(ref_name)?;
+            if branch.is_default() {
+                return Ok(false);
+            }
+
+            let Some((stack_id, branch_idx)) =
+                self.snapshot.content.branches.values().find_map(|stack| {
+                    stack
+                        .heads
+                        .iter()
+                        .enumerate()
+                        .find_map(|(branch_idx, branch)| {
+                            full_branch_name(branch.name().as_str()).and_then(|full_name| {
+                                (full_name.as_ref() == ref_name).then_some((stack.id, branch_idx))
+                            })
+                        })
+                })
+            else {
+                return Ok(false);
+            };
+
+            let stack = self
+                .snapshot
+                .content
+                .branches
+                .get_mut(&stack_id)
+                .expect("still there");
+            stack.heads.remove(branch_idx);
+            if stack.heads.is_empty() {
+                self.snapshot.content.branches.remove(&stack_id);
+            }
+            self.snapshot.changed_at = Some(Instant::now());
+            Ok(true)
+        }
+    }
+}
+
+impl VirtualBranchesTomlMetadata {
+    fn workspace_from_data(data: &VirtualBranchesState) -> Workspace {
+        let target_branch = data
+            .default_target
+            .as_ref()
+            .and_then(|target| gix::refs::FullName::try_from(target.branch.to_string()).ok());
+
+        let mut stacks: Vec<_> = data.branches.values().cloned().collect();
+        stacks.sort_by_key(|s| s.order);
+
+        let workspace = but_core::ref_metadata::Workspace {
+            ref_info: managed_ref_info(),
+            stacks: stacks
+                .iter()
+                .filter(|s| s.in_workspace)
+                .map(|s| WorkspaceStack {
+                    branches: s
+                        .heads
+                        .iter()
+                        .rev()
+                        .filter_map(|sb| {
+                            full_branch_name(sb.name()).map(|ref_name| WorkspaceStackBranch {
+                                ref_name,
+                                archived: sb.archived,
+                            })
+                        })
+                        .collect(),
+                })
+                .collect(),
+            target_ref: target_branch,
+        };
+        workspace
+    }
+}
+
+pub struct VBTomlMetadataHandle<T> {
+    is_default: bool,
+    // Allow faster lookup next time. This is more like a PoC,
+    // other storage backends like database may have similar handles to avoid searches by name.
+    stack_id: RefCell<Option<StackId>>,
+    value: T,
+}
+
+impl<T> Deref for VBTomlMetadataHandle<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<T> DerefMut for VBTomlMetadataHandle<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
+    }
+}
+
+impl<T> ValueInfo for VBTomlMetadataHandle<T> {
+    fn is_default(&self) -> bool {
+        self.is_default
+    }
+}
+
+/// We can't store time, so put a placeholder that helps to mimic proper behaviour.
+fn standard_time() -> gix::date::Time {
+    gix::date::Time::new(1675176957, 0)
+}
+
+fn is_workspace_ref(ref_name: &FullNameRef) -> bool {
+    ref_name.as_bstr() == INTEGRATION_BRANCH || ref_name.as_bstr() == INTEGRATION_BRANCH_LEGACY
+}
+
+fn default_workspace() -> Workspace {
+    Workspace {
+        ref_info: RefInfo {
+            created_at: Some(standard_time()),
+            updated_at: None,
+        },
+        ..Default::default()
+    }
+}
+
+fn full_branch_name(name: &str) -> Option<gix::refs::FullName> {
+    gix::refs::FullName::try_from(format!("refs/heads/{name}")).ok()
+}
+
+/// Make it appear managed, which it is as we created it. Can only make the date up though,
+/// which shouldn't matter yet. Let's hope we never use the time while this store is in play.
+fn managed_ref_info() -> RefInfo {
+    RefInfo {
+        created_at: Some(standard_time()),
+        updated_at: None,
+    }
+}
+
+fn branch_to_stack_branch(
+    ref_name: &gix::refs::FullNameRef,
+    Branch {
+        ref_info: _, // TODO: should change parent stack if it's the top.
+        description,
+        review,
+    }: &Branch,
+    archived: bool,
+) -> gitbutler_stack::StackBranch {
+    gitbutler_stack::StackBranch {
+        name: ref_name.shorten().to_string(),
+        description: description.clone(),
+        pr_number: review.pull_request,
+        archived,
+        review_id: review.review_id.clone(),
+
+        // Redundant, unused.
+        head: gitbutler_stack::CommitOrChangeId::CommitId(git2::Oid::zero().to_string()),
+    }
+}

--- a/crates/but-workspace/tests/fixtures/virtual-branches-01.toml
+++ b/crates/but-workspace/tests/fixtures/virtual-branches-01.toml
@@ -1,0 +1,178 @@
+[default_target]
+branchName = "master"
+remoteName = "origin"
+remoteUrl = "https://github.com/Byron/small"
+sha = "267d3974c43329e98d67818c15316b92cea4ef81"
+pushRemoteName = "origin"
+
+[branch_targets]
+
+[branches.702ffd01-134b-46a1-9230-56d01c210ad0]
+id = "702ffd01-134b-46a1-9230-56d01c210ad0"
+name = "Lane 5"
+notes = ""
+created_timestamp_ms = "1740394788617"
+updated_timestamp_ms = "1740394788617"
+tree = "7fa7a9f8d8c85292908e170458241700839a995a"
+head = "267d3974c43329e98d67818c15316b92cea4ef81"
+ownership = ""
+order = 3
+allow_rebasing = true
+in_workspace = true
+post_commits = false
+
+[[branches.702ffd01-134b-46a1-9230-56d01c210ad0.heads]]
+name = "D"
+archived = false
+
+[branches.702ffd01-134b-46a1-9230-56d01c210ad0.heads.head]
+CommitId = "267d3974c43329e98d67818c15316b92cea4ef81"
+
+[[branches.702ffd01-134b-46a1-9230-56d01c210ad0.heads]]
+name = "D-top"
+archived = false
+
+[branches.702ffd01-134b-46a1-9230-56d01c210ad0.heads.head]
+CommitId = "267d3974c43329e98d67818c15316b92cea4ef81"
+
+[branches.ed8161c6-0559-4265-9fb5-baa0267b7654]
+id = "ed8161c6-0559-4265-9fb5-baa0267b7654"
+name = "Lane 6"
+notes = ""
+created_timestamp_ms = "1740394801307"
+updated_timestamp_ms = "1740394801307"
+tree = "7fa7a9f8d8c85292908e170458241700839a995a"
+head = "267d3974c43329e98d67818c15316b92cea4ef81"
+ownership = ""
+order = 4
+allow_rebasing = true
+in_workspace = true
+post_commits = false
+
+[[branches.ed8161c6-0559-4265-9fb5-baa0267b7654.heads]]
+name = "E"
+archived = false
+
+[branches.ed8161c6-0559-4265-9fb5-baa0267b7654.heads.head]
+CommitId = "267d3974c43329e98d67818c15316b92cea4ef81"
+
+[branches.c9ec92d4-caa9-457c-bfd8-2f60a6f57fd1]
+id = "c9ec92d4-caa9-457c-bfd8-2f60a6f57fd1"
+name = "Lane 4"
+notes = ""
+created_timestamp_ms = "1740394683828"
+updated_timestamp_ms = "1740394757463"
+tree = "bc096ab1005a594d4c66dcf3d08355e1f35f9971"
+head = "e7fce5d8c8004dbe584ae752e41b2532c1733873"
+ownership = ""
+order = 0
+selected_for_changes = 1740394683827
+allow_rebasing = true
+in_workspace = true
+post_commits = false
+
+[[branches.c9ec92d4-caa9-457c-bfd8-2f60a6f57fd1.heads]]
+name = "A"
+pr_number = 12
+archived = false
+
+[branches.c9ec92d4-caa9-457c-bfd8-2f60a6f57fd1.heads.head]
+CommitId = "e7fce5d8c8004dbe584ae752e41b2532c1733873"
+
+[branches.837d404d-c9c8-4bc6-8978-498e88004b52]
+id = "837d404d-c9c8-4bc6-8978-498e88004b52"
+name = "Lane 3"
+notes = ""
+created_timestamp_ms = "1740326704077"
+updated_timestamp_ms = "1740394670855"
+tree = "7fa7a9f8d8c85292908e170458241700839a995a"
+head = "267d3974c43329e98d67818c15316b92cea4ef81"
+ownership = ""
+order = 2
+allow_rebasing = true
+in_workspace = true
+post_commits = false
+
+[[branches.837d404d-c9c8-4bc6-8978-498e88004b52.heads]]
+name = "D-empty"
+archived = true
+
+[branches.837d404d-c9c8-4bc6-8978-498e88004b52.heads.head]
+CommitId = "25b76a17cda5140e885302923f63409ef48453e0"
+
+[[branches.837d404d-c9c8-4bc6-8978-498e88004b52.heads]]
+name = "D-middle-empty"
+archived = true
+
+[branches.837d404d-c9c8-4bc6-8978-498e88004b52.heads.head]
+CommitId = "25b76a17cda5140e885302923f63409ef48453e0"
+
+[[branches.837d404d-c9c8-4bc6-8978-498e88004b52.heads]]
+name = "D-top-empty"
+archived = true
+
+[branches.837d404d-c9c8-4bc6-8978-498e88004b52.heads.head]
+CommitId = "267d3974c43329e98d67818c15316b92cea4ef81"
+
+[[branches.837d404d-c9c8-4bc6-8978-498e88004b52.heads]]
+name = "C"
+archived = false
+
+[branches.837d404d-c9c8-4bc6-8978-498e88004b52.heads.head]
+CommitId = "267d3974c43329e98d67818c15316b92cea4ef81"
+
+[[branches.837d404d-c9c8-4bc6-8978-498e88004b52.heads]]
+name = "C-middle"
+archived = false
+
+[branches.837d404d-c9c8-4bc6-8978-498e88004b52.heads.head]
+CommitId = "267d3974c43329e98d67818c15316b92cea4ef81"
+
+[[branches.837d404d-c9c8-4bc6-8978-498e88004b52.heads]]
+name = "C-top"
+archived = false
+
+[branches.837d404d-c9c8-4bc6-8978-498e88004b52.heads.head]
+CommitId = "267d3974c43329e98d67818c15316b92cea4ef81"
+
+[branches.f6291523-56b1-45fc-85ac-8782b2f13227]
+id = "f6291523-56b1-45fc-85ac-8782b2f13227"
+name = "Lane 2"
+notes = ""
+created_timestamp_ms = "1740326670101"
+updated_timestamp_ms = "1740394727921"
+tree = "305791a43f9acd5362f6eede4ee0f0185032213e"
+head = "703e506fa1c22d8cac601d33de90e7a5df7fdd05"
+ownership = ""
+order = 1
+allow_rebasing = true
+in_workspace = true
+post_commits = false
+
+[[branches.f6291523-56b1-45fc-85ac-8782b2f13227.heads]]
+name = "C-empty"
+archived = true
+
+[branches.f6291523-56b1-45fc-85ac-8782b2f13227.heads.head]
+CommitId = "25b76a17cda5140e885302923f63409ef48453e0"
+
+[[branches.f6291523-56b1-45fc-85ac-8782b2f13227.heads]]
+name = "C-top-empty"
+archived = true
+
+[branches.f6291523-56b1-45fc-85ac-8782b2f13227.heads.head]
+CommitId = "267d3974c43329e98d67818c15316b92cea4ef81"
+
+[[branches.f6291523-56b1-45fc-85ac-8782b2f13227.heads]]
+name = "B"
+archived = false
+
+[branches.f6291523-56b1-45fc-85ac-8782b2f13227.heads.head]
+CommitId = "703e506fa1c22d8cac601d33de90e7a5df7fdd05"
+
+[[branches.f6291523-56b1-45fc-85ac-8782b2f13227.heads]]
+name = "B-top"
+archived = false
+
+[branches.f6291523-56b1-45fc-85ac-8782b2f13227.heads.head]
+CommitId = "703e506fa1c22d8cac601d33de90e7a5df7fdd05"

--- a/crates/but-workspace/tests/workspace/main.rs
+++ b/crates/but-workspace/tests/workspace/main.rs
@@ -1,1 +1,2 @@
 mod commit_engine;
+mod ref_metadata;

--- a/crates/but-workspace/tests/workspace/ref_metadata.rs
+++ b/crates/but-workspace/tests/workspace/ref_metadata.rs
@@ -45,130 +45,113 @@ mod virtual_branches_toml {
         let (mut store, _tmp) = vb_store_rw("virtual-branches-01")?;
         let ws = store.workspace("refs/heads/gitbutler/workspace".try_into()?)?;
         assert!(!ws.is_default(), "value read from file");
-        insta::assert_debug_snapshot!(ws.deref(), @r#"
-        Workspace {
-            ref_info: RefInfo {
-                created_at: Some(
-                    Time {
-                        seconds: 1675176957,
-                        offset: 0,
-                        sign: Plus,
+        insta::assert_debug_snapshot!(ws.stacks, @r#"
+        [
+            WorkspaceStack {
+                branches: [
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/A",
+                        ),
+                        archived: false,
                     },
-                ),
-                updated_at: None,
+                ],
             },
-            stacks: [
-                WorkspaceStack {
-                    branches: [
-                        WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/A",
-                            ),
-                            archived: false,
-                        },
-                    ],
-                },
-                WorkspaceStack {
-                    branches: [
-                        WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/B-top",
-                            ),
-                            archived: false,
-                        },
-                        WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/B",
-                            ),
-                            archived: false,
-                        },
-                        WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/C-top-empty",
-                            ),
-                            archived: true,
-                        },
-                        WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/C-empty",
-                            ),
-                            archived: true,
-                        },
-                    ],
-                },
-                WorkspaceStack {
-                    branches: [
-                        WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/C-top",
-                            ),
-                            archived: false,
-                        },
-                        WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/C-middle",
-                            ),
-                            archived: false,
-                        },
-                        WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/C",
-                            ),
-                            archived: false,
-                        },
-                        WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/D-top-empty",
-                            ),
-                            archived: true,
-                        },
-                        WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/D-middle-empty",
-                            ),
-                            archived: true,
-                        },
-                        WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/D-empty",
-                            ),
-                            archived: true,
-                        },
-                    ],
-                },
-                WorkspaceStack {
-                    branches: [
-                        WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/D-top",
-                            ),
-                            archived: false,
-                        },
-                        WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/D",
-                            ),
-                            archived: false,
-                        },
-                    ],
-                },
-                WorkspaceStack {
-                    branches: [
-                        WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/E",
-                            ),
-                            archived: false,
-                        },
-                    ],
-                },
-            ],
-            target_ref: Some(
-                FullName(
-                    "refs/remotes/origin/master",
-                ),
-            ),
-        }
+            WorkspaceStack {
+                branches: [
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/B-top",
+                        ),
+                        archived: false,
+                    },
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/B",
+                        ),
+                        archived: false,
+                    },
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/C-top-empty",
+                        ),
+                        archived: true,
+                    },
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/C-empty",
+                        ),
+                        archived: true,
+                    },
+                ],
+            },
+            WorkspaceStack {
+                branches: [
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/C-top",
+                        ),
+                        archived: false,
+                    },
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/C-middle",
+                        ),
+                        archived: false,
+                    },
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/C",
+                        ),
+                        archived: false,
+                    },
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/D-top-empty",
+                        ),
+                        archived: true,
+                    },
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/D-middle-empty",
+                        ),
+                        archived: true,
+                    },
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/D-empty",
+                        ),
+                        archived: true,
+                    },
+                ],
+            },
+            WorkspaceStack {
+                branches: [
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/D-top",
+                        ),
+                        archived: false,
+                    },
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/D",
+                        ),
+                        archived: false,
+                    },
+                ],
+            },
+            WorkspaceStack {
+                branches: [
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/E",
+                        ),
+                        archived: false,
+                    },
+                ],
+            },
+        ]
         "#);
 
         let branches = ws
@@ -190,7 +173,7 @@ mod virtual_branches_toml {
                     updated_at: Some(
                         Time {
                             seconds: 1740394757,
-                            offset: 3600,
+                            offset: 0,
                             sign: Plus,
                         },
                     ),
@@ -209,7 +192,7 @@ mod virtual_branches_toml {
                     updated_at: Some(
                         Time {
                             seconds: 1740394727,
-                            offset: 3600,
+                            offset: 0,
                             sign: Plus,
                         },
                     ),
@@ -226,7 +209,7 @@ mod virtual_branches_toml {
                     updated_at: Some(
                         Time {
                             seconds: 1740394727,
-                            offset: 3600,
+                            offset: 0,
                             sign: Plus,
                         },
                     ),
@@ -243,7 +226,7 @@ mod virtual_branches_toml {
                     updated_at: Some(
                         Time {
                             seconds: 1740394727,
-                            offset: 3600,
+                            offset: 0,
                             sign: Plus,
                         },
                     ),
@@ -260,7 +243,7 @@ mod virtual_branches_toml {
                     updated_at: Some(
                         Time {
                             seconds: 1740394727,
-                            offset: 3600,
+                            offset: 0,
                             sign: Plus,
                         },
                     ),
@@ -277,7 +260,7 @@ mod virtual_branches_toml {
                     updated_at: Some(
                         Time {
                             seconds: 1740394670,
-                            offset: 3600,
+                            offset: 0,
                             sign: Plus,
                         },
                     ),
@@ -294,7 +277,7 @@ mod virtual_branches_toml {
                     updated_at: Some(
                         Time {
                             seconds: 1740394670,
-                            offset: 3600,
+                            offset: 0,
                             sign: Plus,
                         },
                     ),
@@ -311,7 +294,7 @@ mod virtual_branches_toml {
                     updated_at: Some(
                         Time {
                             seconds: 1740394670,
-                            offset: 3600,
+                            offset: 0,
                             sign: Plus,
                         },
                     ),
@@ -328,7 +311,7 @@ mod virtual_branches_toml {
                     updated_at: Some(
                         Time {
                             seconds: 1740394670,
-                            offset: 3600,
+                            offset: 0,
                             sign: Plus,
                         },
                     ),
@@ -345,7 +328,7 @@ mod virtual_branches_toml {
                     updated_at: Some(
                         Time {
                             seconds: 1740394670,
-                            offset: 3600,
+                            offset: 0,
                             sign: Plus,
                         },
                     ),
@@ -362,7 +345,7 @@ mod virtual_branches_toml {
                     updated_at: Some(
                         Time {
                             seconds: 1740394670,
-                            offset: 3600,
+                            offset: 0,
                             sign: Plus,
                         },
                     ),
@@ -379,7 +362,7 @@ mod virtual_branches_toml {
                     updated_at: Some(
                         Time {
                             seconds: 1740394788,
-                            offset: 3600,
+                            offset: 0,
                             sign: Plus,
                         },
                     ),
@@ -396,7 +379,7 @@ mod virtual_branches_toml {
                     updated_at: Some(
                         Time {
                             seconds: 1740394788,
-                            offset: 3600,
+                            offset: 0,
                             sign: Plus,
                         },
                     ),
@@ -413,7 +396,7 @@ mod virtual_branches_toml {
                     updated_at: Some(
                         Time {
                             seconds: 1740394801,
-                            offset: 3600,
+                            offset: 0,
                             sign: Plus,
                         },
                     ),
@@ -474,7 +457,7 @@ mod virtual_branches_toml {
             pull_request: Some(42),
             review_id: Some("review-id".into()),
         };
-        store.set_branch(branch_name.as_ref(), &branch)?;
+        store.set_branch(&branch)?;
 
         let workspace_name: gix::refs::FullName = "refs/heads/gitbutler/workspace".try_into()?;
         let mut ws = store.workspace(workspace_name.as_ref())?;
@@ -495,37 +478,24 @@ mod virtual_branches_toml {
             }],
         });
         store
-            .set_workspace(workspace_name.as_ref(), &ws)
+            .set_workspace(&ws)
             .expect("This is the way to add branches");
 
         // Assure `ws` is what we think it should be - a single stack with one branch.
         let mut ws = store.workspace(workspace_name.as_ref())?;
-        insta::assert_debug_snapshot!(ws.deref(), @r#"
-        Workspace {
-            ref_info: RefInfo {
-                created_at: Some(
-                    Time {
-                        seconds: 1675176957,
-                        offset: 0,
-                        sign: Plus,
+        insta::assert_debug_snapshot!(ws.stacks, @r#"
+        [
+            WorkspaceStack {
+                branches: [
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/feat",
+                        ),
+                        archived: false,
                     },
-                ),
-                updated_at: None,
+                ],
             },
-            stacks: [
-                WorkspaceStack {
-                    branches: [
-                        WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/feat",
-                            ),
-                            archived: false,
-                        },
-                    ],
-                },
-            ],
-            target_ref: None,
-        }
+        ]
         "#);
 
         // Put a new branch on top, changing the stack name
@@ -539,42 +509,29 @@ mod virtual_branches_toml {
         );
         assert_eq!(ws.stacks[0].ref_name(), Some(&stacked_branch_name));
         store
-            .set_workspace(workspace_name.as_ref(), &ws)
+            .set_workspace(&ws)
             .expect("This is the way to add branches");
 
         let mut ws = store.workspace(workspace_name.as_ref())?;
-        insta::assert_debug_snapshot!(ws.deref(), @r#"
-        Workspace {
-            ref_info: RefInfo {
-                created_at: Some(
-                    Time {
-                        seconds: 1675176957,
-                        offset: 0,
-                        sign: Plus,
+        insta::assert_debug_snapshot!(ws.stacks, @r#"
+        [
+            WorkspaceStack {
+                branches: [
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/feat-on-top",
+                        ),
+                        archived: false,
                     },
-                ),
-                updated_at: None,
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/feat",
+                        ),
+                        archived: false,
+                    },
+                ],
             },
-            stacks: [
-                WorkspaceStack {
-                    branches: [
-                        WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/feat-on-top",
-                            ),
-                            archived: false,
-                        },
-                        WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/feat",
-                            ),
-                            archived: false,
-                        },
-                    ],
-                },
-            ],
-            target_ref: None,
-        }
+        ]
         "#);
 
         drop(store);
@@ -622,38 +579,25 @@ mod virtual_branches_toml {
             ws.deref(),
             "It's still what it was before - it was persisted"
         );
-        insta::assert_debug_snapshot!(ws.deref(), @r#"
-        Workspace {
-            ref_info: RefInfo {
-                created_at: Some(
-                    Time {
-                        seconds: 1675176957,
-                        offset: 0,
-                        sign: Plus,
+        insta::assert_debug_snapshot!(ws.stacks, @r#"
+        [
+            WorkspaceStack {
+                branches: [
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/feat-on-top",
+                        ),
+                        archived: false,
                     },
-                ),
-                updated_at: None,
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/feat",
+                        ),
+                        archived: false,
+                    },
+                ],
             },
-            stacks: [
-                WorkspaceStack {
-                    branches: [
-                        WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/feat-on-top",
-                            ),
-                            archived: false,
-                        },
-                        WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/feat",
-                            ),
-                            archived: false,
-                        },
-                    ],
-                },
-            ],
-            target_ref: None,
-        }
+        ]
         "#);
 
         // Archived middle branch
@@ -665,47 +609,132 @@ mod virtual_branches_toml {
                 archived: true,
             },
         );
-        store.set_workspace(workspace_name.as_ref(), &ws)?;
-        let ws = store.workspace(workspace_name.as_ref())?;
-        insta::assert_debug_snapshot!(ws.deref(), @r#"
-        Workspace {
-            ref_info: RefInfo {
-                created_at: Some(
-                    Time {
-                        seconds: 1675176957,
-                        offset: 0,
-                        sign: Plus,
+        store.set_workspace(&ws)?;
+        let mut ws = store.workspace(workspace_name.as_ref())?;
+        insta::assert_debug_snapshot!(ws.stacks, @r#"
+        [
+            WorkspaceStack {
+                branches: [
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/feat-on-top",
+                        ),
+                        archived: false,
                     },
-                ),
-                updated_at: None,
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/feat-in-middle",
+                        ),
+                        archived: true,
+                    },
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/feat",
+                        ),
+                        archived: false,
+                    },
+                ],
             },
-            stacks: [
-                WorkspaceStack {
-                    branches: [
-                        WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/feat-on-top",
-                            ),
-                            archived: false,
-                        },
-                        WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/feat-in-middle",
-                            ),
-                            archived: true,
-                        },
-                        WorkspaceStackBranch {
-                            ref_name: FullName(
-                                "refs/heads/feat",
-                            ),
-                            archived: false,
-                        },
-                    ],
-                },
-            ],
-            target_ref: None,
-        }
+        ]
         "#);
+
+        ws.stacks[0].branches[1].archived = false;
+        store.set_workspace(&ws)?;
+        let ws = store.workspace(ws.as_ref())?;
+        assert!(
+            !ws.stacks[0].branches[1].archived,
+            "it's possible to turn the archived flag off on existing branches"
+        );
+
+        let second_stack: gix::refs::FullName = "refs/heads/second-stack".try_into()?;
+        let mut branch = store.branch(second_stack.as_ref())?;
+        branch.review.pull_request = Some(23);
+        store.set_branch(&branch)?;
+
+        let mut ws = store.workspace(ws.as_ref())?;
+        assert_eq!(
+            ws.stacks.len(),
+            1,
+            "The workspace wasn't automatically updated"
+        );
+        // insert it as archived just because.
+        ws.stacks.push(WorkspaceStack {
+            branches: vec![WorkspaceStackBranch {
+                ref_name: second_stack.clone(),
+                archived: true,
+            }],
+        });
+        store.set_workspace(&ws)?;
+        let mut ws = store.workspace(ws.as_ref())?;
+        // Two snapshots are present now.
+        insta::assert_debug_snapshot!(ws.stacks, @r#"
+        [
+            WorkspaceStack {
+                branches: [
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/feat-on-top",
+                        ),
+                        archived: false,
+                    },
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/feat-in-middle",
+                        ),
+                        archived: false,
+                    },
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/feat",
+                        ),
+                        archived: false,
+                    },
+                ],
+            },
+            WorkspaceStack {
+                branches: [
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/second-stack",
+                        ),
+                        archived: true,
+                    },
+                ],
+            },
+        ]
+        "#);
+
+        ws.stacks.pop();
+        store.set_workspace(&ws)?;
+        let mut ws = store.workspace(ws.as_ref())?;
+        assert_eq!(
+            ws.stacks.len(),
+            1,
+            "The stack is still gone because we just removed it"
+        );
+
+        // Add it again, then remove it by removing the branch.
+        ws.stacks.push(WorkspaceStack {
+            branches: vec![WorkspaceStackBranch {
+                ref_name: second_stack.clone(),
+                archived: true,
+            }],
+        });
+        store.set_workspace(&ws)?;
+        let ws = store.workspace(ws.as_ref())?;
+        assert_eq!(
+            ws.stacks.len(),
+            2,
+            "re-added second stack to be able to remove it again"
+        );
+
+        assert!(store.remove(second_stack.as_ref())?);
+        let ws = store.workspace(ws.as_ref())?;
+        assert_eq!(
+            ws.stacks.len(),
+            1,
+            "second stack must have been removed -  a specialty of stacks implicitly defining the workspace."
+        );
 
         // Remove everything
         assert!(
@@ -758,7 +787,127 @@ mod virtual_branches_toml {
 
     #[test]
     fn create_workspace_from_scratch_workspace_first() -> anyhow::Result<()> {
-        let (store, tmp) = empty_vb_store_rw()?;
+        let (mut store, _tmp) = empty_vb_store_rw()?;
+        let workspace_name = "refs/heads/gitbutler/integration".try_into()?;
+        let mut ws = store.workspace(workspace_name)?;
+        ws.stacks.push(WorkspaceStack {
+            branches: vec![
+                WorkspaceStackBranch {
+                    ref_name: "refs/heads/top".try_into()?,
+                    archived: false,
+                },
+                WorkspaceStackBranch {
+                    ref_name: "refs/heads/one-below-top".try_into()?,
+                    archived: true,
+                },
+                WorkspaceStackBranch {
+                    ref_name: "refs/heads/base".try_into()?,
+                    archived: true,
+                },
+            ],
+        });
+        ws.stacks.push(WorkspaceStack {
+            branches: vec![WorkspaceStackBranch {
+                ref_name: "refs/heads/second-branch".try_into()?,
+                archived: false,
+            }],
+        });
+
+        insta::assert_debug_snapshot!(ws.stacks, @r#"
+        [
+            WorkspaceStack {
+                branches: [
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/top",
+                        ),
+                        archived: false,
+                    },
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/one-below-top",
+                        ),
+                        archived: true,
+                    },
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/base",
+                        ),
+                        archived: true,
+                    },
+                ],
+            },
+            WorkspaceStack {
+                branches: [
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/second-branch",
+                        ),
+                        archived: false,
+                    },
+                ],
+            },
+        ]
+        "#);
+        store.set_workspace(&ws)?;
+        let stored_ws = store.workspace(workspace_name)?;
+        assert_eq!(stored_ws.deref(), ws.deref());
+
+        // Pop archived branch.
+        ws.stacks[0].branches.pop();
+        store.set_workspace(&ws)?;
+        let mut ws = store.workspace(workspace_name)?;
+        insta::assert_debug_snapshot!(ws.stacks, @r#"
+        [
+            WorkspaceStack {
+                branches: [
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/top",
+                        ),
+                        archived: false,
+                    },
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/one-below-top",
+                        ),
+                        archived: true,
+                    },
+                ],
+            },
+            WorkspaceStack {
+                branches: [
+                    WorkspaceStackBranch {
+                        ref_name: FullName(
+                            "refs/heads/second-branch",
+                        ),
+                        archived: false,
+                    },
+                ],
+            },
+        ]
+        "#);
+
+        // Remove the last branch, but leave the stack.
+        ws.stacks[1].branches.pop();
+
+        let err = store.set_workspace(&ws).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "BUG: do not pop off the last branch, remove the whole stack"
+        );
+        ws.stacks.pop();
+        store.set_workspace(&ws)?;
+
+        let stored_ws = store.workspace(workspace_name)?;
+        assert_eq!(stored_ws.deref(), ws.deref());
+
+        let below_top: &gix::refs::FullNameRef = "refs/heads/one-below-top".try_into()?;
+        let branch = store.branch(below_top)?;
+        assert!(
+            !branch.is_default(),
+            "Workspace branches are implicitly created, this isn't the case in a normal backend implementation"
+        );
         Ok(())
     }
 
@@ -786,7 +935,7 @@ mod virtual_branches_toml {
 
     fn empty_vb_store_rw() -> anyhow::Result<(VirtualBranchesTomlMetadata, TempDir)> {
         let tmp = tempdir()?;
-        let store = VirtualBranchesTomlMetadata::from_path(&tmp.path().join("vb.toml"))?;
+        let store = VirtualBranchesTomlMetadata::from_path(tmp.path().join("vb.toml"))?;
         Ok((store, tmp))
     }
 }
@@ -800,7 +949,7 @@ fn roundtrip_journey(metadata: &mut impl RefMetadata) -> anyhow::Result<()> {
         if let Some(ws_from_iter) = md.downcast_ref::<but_core::ref_metadata::Workspace>() {
             let ws = metadata.workspace(ref_name.as_ref())?;
             assert!(!ws.is_default(), "default data won't be iterated");
-            if let Err(err) = metadata.set_workspace(ref_name.as_ref(), &ws) {
+            if let Err(err) = metadata.set_workspace(&ws) {
                 if err.to_string().contains("unsupported") {
                     continue;
                 }
@@ -814,7 +963,7 @@ fn roundtrip_journey(metadata: &mut impl RefMetadata) -> anyhow::Result<()> {
             let br = metadata.branch(ref_name.as_ref())?;
             assert!(!br.is_default(), "default data won't be iterated");
             metadata
-                .set_branch(ref_name.as_ref(), &br)
+                .set_branch(&br)
                 .expect("updates have no reason to fail, even if no-op");
             assert_eq!(
                 &*metadata.branch(ref_name.as_ref())?,

--- a/crates/but-workspace/tests/workspace/ref_metadata.rs
+++ b/crates/but-workspace/tests/workspace/ref_metadata.rs
@@ -1,0 +1,867 @@
+use but_core::RefMetadata;
+use but_core::ref_metadata::ValueInfo;
+use std::collections::HashMap;
+
+mod virtual_branches_toml {
+    use crate::ref_metadata::{roundtrip_journey, sanitize_uuids_and_timestamps};
+    use but_core::RefMetadata;
+    use but_core::ref_metadata::{ValueInfo, WorkspaceStack, WorkspaceStackBranch};
+    use but_testsupport::gix_testtools::tempfile::{TempDir, tempdir};
+    use but_workspace::VirtualBranchesTomlMetadata;
+    use std::mem::ManuallyDrop;
+    use std::ops::Deref;
+    use std::path::PathBuf;
+
+    #[test]
+    fn journey() -> anyhow::Result<()> {
+        let (mut store, _tmp) = vb_store_rw("virtual-branches-01")?;
+
+        assert_eq!(store.iter().count(), 15, "There are items to test on");
+        roundtrip_journey(&mut store)?;
+        let writable_toml_path = store.path().to_owned();
+        drop(store);
+
+        assert!(
+            !writable_toml_path.exists(),
+            "The file is deleted when the workspace is removed"
+        );
+        let store = VirtualBranchesTomlMetadata::from_path(&writable_toml_path)?;
+        assert_eq!(
+            store.iter().count(),
+            0,
+            "on drop we write the file immediately"
+        );
+        drop(store);
+        assert!(
+            !writable_toml_path.exists(),
+            "default content isn't written back either"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn read_only() -> anyhow::Result<()> {
+        let (mut store, _tmp) = vb_store_rw("virtual-branches-01")?;
+        let ws = store.workspace("refs/heads/gitbutler/workspace".try_into()?)?;
+        assert!(!ws.is_default(), "value read from file");
+        insta::assert_debug_snapshot!(ws.deref(), @r#"
+        Workspace {
+            ref_info: RefInfo {
+                created_at: Some(
+                    Time {
+                        seconds: 1675176957,
+                        offset: 0,
+                        sign: Plus,
+                    },
+                ),
+                updated_at: None,
+            },
+            stacks: [
+                WorkspaceStack {
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/A",
+                            ),
+                            archived: false,
+                        },
+                    ],
+                },
+                WorkspaceStack {
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/B-top",
+                            ),
+                            archived: false,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/B",
+                            ),
+                            archived: false,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/C-top-empty",
+                            ),
+                            archived: true,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/C-empty",
+                            ),
+                            archived: true,
+                        },
+                    ],
+                },
+                WorkspaceStack {
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/C-top",
+                            ),
+                            archived: false,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/C-middle",
+                            ),
+                            archived: false,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/C",
+                            ),
+                            archived: false,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/D-top-empty",
+                            ),
+                            archived: true,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/D-middle-empty",
+                            ),
+                            archived: true,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/D-empty",
+                            ),
+                            archived: true,
+                        },
+                    ],
+                },
+                WorkspaceStack {
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/D-top",
+                            ),
+                            archived: false,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/D",
+                            ),
+                            archived: false,
+                        },
+                    ],
+                },
+                WorkspaceStack {
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/E",
+                            ),
+                            archived: false,
+                        },
+                    ],
+                },
+            ],
+            target_ref: Some(
+                FullName(
+                    "refs/remotes/origin/master",
+                ),
+            ),
+        }
+        "#);
+
+        let branches = ws
+            .stacks
+            .iter()
+            .flat_map(|stack| &stack.branches)
+            .map(|branch| {
+                store
+                    .branch(branch.ref_name.as_ref())
+                    .expect("branch is present for each refs mentioned in workspace")
+                    .clone()
+            })
+            .collect::<Vec<_>>();
+        insta::assert_debug_snapshot!(branches, @r"
+        [
+            Branch {
+                ref_info: RefInfo {
+                    created_at: None,
+                    updated_at: Some(
+                        Time {
+                            seconds: 1740394757,
+                            offset: 3600,
+                            sign: Plus,
+                        },
+                    ),
+                },
+                description: None,
+                review: Review {
+                    pull_request: Some(
+                        12,
+                    ),
+                    review_id: None,
+                },
+            },
+            Branch {
+                ref_info: RefInfo {
+                    created_at: None,
+                    updated_at: Some(
+                        Time {
+                            seconds: 1740394727,
+                            offset: 3600,
+                            sign: Plus,
+                        },
+                    ),
+                },
+                description: None,
+                review: Review {
+                    pull_request: None,
+                    review_id: None,
+                },
+            },
+            Branch {
+                ref_info: RefInfo {
+                    created_at: None,
+                    updated_at: Some(
+                        Time {
+                            seconds: 1740394727,
+                            offset: 3600,
+                            sign: Plus,
+                        },
+                    ),
+                },
+                description: None,
+                review: Review {
+                    pull_request: None,
+                    review_id: None,
+                },
+            },
+            Branch {
+                ref_info: RefInfo {
+                    created_at: None,
+                    updated_at: Some(
+                        Time {
+                            seconds: 1740394727,
+                            offset: 3600,
+                            sign: Plus,
+                        },
+                    ),
+                },
+                description: None,
+                review: Review {
+                    pull_request: None,
+                    review_id: None,
+                },
+            },
+            Branch {
+                ref_info: RefInfo {
+                    created_at: None,
+                    updated_at: Some(
+                        Time {
+                            seconds: 1740394727,
+                            offset: 3600,
+                            sign: Plus,
+                        },
+                    ),
+                },
+                description: None,
+                review: Review {
+                    pull_request: None,
+                    review_id: None,
+                },
+            },
+            Branch {
+                ref_info: RefInfo {
+                    created_at: None,
+                    updated_at: Some(
+                        Time {
+                            seconds: 1740394670,
+                            offset: 3600,
+                            sign: Plus,
+                        },
+                    ),
+                },
+                description: None,
+                review: Review {
+                    pull_request: None,
+                    review_id: None,
+                },
+            },
+            Branch {
+                ref_info: RefInfo {
+                    created_at: None,
+                    updated_at: Some(
+                        Time {
+                            seconds: 1740394670,
+                            offset: 3600,
+                            sign: Plus,
+                        },
+                    ),
+                },
+                description: None,
+                review: Review {
+                    pull_request: None,
+                    review_id: None,
+                },
+            },
+            Branch {
+                ref_info: RefInfo {
+                    created_at: None,
+                    updated_at: Some(
+                        Time {
+                            seconds: 1740394670,
+                            offset: 3600,
+                            sign: Plus,
+                        },
+                    ),
+                },
+                description: None,
+                review: Review {
+                    pull_request: None,
+                    review_id: None,
+                },
+            },
+            Branch {
+                ref_info: RefInfo {
+                    created_at: None,
+                    updated_at: Some(
+                        Time {
+                            seconds: 1740394670,
+                            offset: 3600,
+                            sign: Plus,
+                        },
+                    ),
+                },
+                description: None,
+                review: Review {
+                    pull_request: None,
+                    review_id: None,
+                },
+            },
+            Branch {
+                ref_info: RefInfo {
+                    created_at: None,
+                    updated_at: Some(
+                        Time {
+                            seconds: 1740394670,
+                            offset: 3600,
+                            sign: Plus,
+                        },
+                    ),
+                },
+                description: None,
+                review: Review {
+                    pull_request: None,
+                    review_id: None,
+                },
+            },
+            Branch {
+                ref_info: RefInfo {
+                    created_at: None,
+                    updated_at: Some(
+                        Time {
+                            seconds: 1740394670,
+                            offset: 3600,
+                            sign: Plus,
+                        },
+                    ),
+                },
+                description: None,
+                review: Review {
+                    pull_request: None,
+                    review_id: None,
+                },
+            },
+            Branch {
+                ref_info: RefInfo {
+                    created_at: None,
+                    updated_at: Some(
+                        Time {
+                            seconds: 1740394788,
+                            offset: 3600,
+                            sign: Plus,
+                        },
+                    ),
+                },
+                description: None,
+                review: Review {
+                    pull_request: None,
+                    review_id: None,
+                },
+            },
+            Branch {
+                ref_info: RefInfo {
+                    created_at: None,
+                    updated_at: Some(
+                        Time {
+                            seconds: 1740394788,
+                            offset: 3600,
+                            sign: Plus,
+                        },
+                    ),
+                },
+                description: None,
+                review: Review {
+                    pull_request: None,
+                    review_id: None,
+                },
+            },
+            Branch {
+                ref_info: RefInfo {
+                    created_at: None,
+                    updated_at: Some(
+                        Time {
+                            seconds: 1740394801,
+                            offset: 3600,
+                            sign: Plus,
+                        },
+                    ),
+                },
+                description: None,
+                review: Review {
+                    pull_request: None,
+                    review_id: None,
+                },
+            },
+        ]
+        ");
+
+        let toml_path = store.path().to_owned();
+        assert!(toml_path.exists(), "the file is still present");
+        let was_deleted = store.remove("refs/heads/gitbutler/workspace".try_into()?)?;
+        assert!(was_deleted, "This basically clears out everything");
+        assert!(!toml_path.exists(), "implemented brutally by file deletion");
+
+        // Asking for the workspace
+        let workspace = store.workspace("refs/heads/gitbutler/integration".try_into()?)?;
+        assert!(
+            workspace.is_default(),
+            "The workspace was deleted so it doesn't exist anymore"
+        );
+
+        let was_deleted = store.remove("refs/heads/gitbutler/workspace".try_into()?)?;
+        assert!(
+            !was_deleted,
+            "and clearing out everything can only happen once"
+        );
+        assert_eq!(
+            store.iter().count(),
+            0,
+            "deleting the workspace deletes all stacks, at least in this backend"
+        );
+
+        drop(store);
+
+        assert!(
+            !toml_path.exists(),
+            "It won't recreate a previously deleted file"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn create_workspace_and_stacks_with_branches_from_scratch() -> anyhow::Result<()> {
+        let (mut store, _tmp) = empty_vb_store_rw()?;
+        let toml_path = store.path().to_owned();
+        let branch_name: gix::refs::FullName = "refs/heads/feat".try_into()?;
+        let mut branch = store.branch(branch_name.as_ref())?;
+        assert!(branch.is_default(), "nothing was there yet");
+        assert!(!toml_path.exists(), "file wasn't written yet");
+
+        branch.description = Some("mine".into());
+        branch.review = but_core::ref_metadata::Review {
+            pull_request: Some(42),
+            review_id: Some("review-id".into()),
+        };
+        store.set_branch(branch_name.as_ref(), &branch)?;
+
+        let workspace_name: gix::refs::FullName = "refs/heads/gitbutler/workspace".try_into()?;
+        let mut ws = store.workspace(workspace_name.as_ref())?;
+        assert!(
+            ws.is_default(),
+            "the branch isn't auto-added to the workspace - this needs us to modify the workspace itself"
+        );
+        assert_eq!(
+            ws.stacks.len(),
+            0,
+            "stacks aren't visible unless a branch is explicitly added to the workspace"
+        );
+        // add the first branch to the workspace.
+        ws.stacks.push(WorkspaceStack {
+            branches: vec![WorkspaceStackBranch {
+                ref_name: branch_name.clone(),
+                archived: false,
+            }],
+        });
+        store
+            .set_workspace(workspace_name.as_ref(), &ws)
+            .expect("This is the way to add branches");
+
+        // Assure `ws` is what we think it should be - a single stack with one branch.
+        let mut ws = store.workspace(workspace_name.as_ref())?;
+        insta::assert_debug_snapshot!(ws.deref(), @r#"
+        Workspace {
+            ref_info: RefInfo {
+                created_at: Some(
+                    Time {
+                        seconds: 1675176957,
+                        offset: 0,
+                        sign: Plus,
+                    },
+                ),
+                updated_at: None,
+            },
+            stacks: [
+                WorkspaceStack {
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/feat",
+                            ),
+                            archived: false,
+                        },
+                    ],
+                },
+            ],
+            target_ref: None,
+        }
+        "#);
+
+        // Put a new branch on top, changing the stack name
+        let stacked_branch_name: gix::refs::FullName = "refs/heads/feat-on-top".try_into()?;
+        ws.stacks[0].branches.insert(
+            0,
+            WorkspaceStackBranch {
+                ref_name: stacked_branch_name.clone(),
+                archived: false,
+            },
+        );
+        assert_eq!(ws.stacks[0].ref_name(), Some(&stacked_branch_name));
+        store
+            .set_workspace(workspace_name.as_ref(), &ws)
+            .expect("This is the way to add branches");
+
+        let mut ws = store.workspace(workspace_name.as_ref())?;
+        insta::assert_debug_snapshot!(ws.deref(), @r#"
+        Workspace {
+            ref_info: RefInfo {
+                created_at: Some(
+                    Time {
+                        seconds: 1675176957,
+                        offset: 0,
+                        sign: Plus,
+                    },
+                ),
+                updated_at: None,
+            },
+            stacks: [
+                WorkspaceStack {
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/feat-on-top",
+                            ),
+                            archived: false,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/feat",
+                            ),
+                            archived: false,
+                        },
+                    ],
+                },
+            ],
+            target_ref: None,
+        }
+        "#);
+
+        drop(store);
+
+        assert!(toml_path.exists(), "file was written due to change");
+        insta::assert_snapshot!(sanitize_uuids_and_timestamps(std::fs::read_to_string(&toml_path)?), @r#"
+        [branch_targets]
+
+        [branches.1]
+        id = "1"
+        name = ""
+        notes = ""
+        created_timestamp_ms = 12345
+        updated_timestamp_ms = 12345
+        tree = "0000000000000000000000000000000000000000"
+        head = "0000000000000000000000000000000000000000"
+        ownership = ""
+        order = 0
+        allow_rebasing = true
+        in_workspace = true
+        post_commits = false
+
+        [[branches.1.heads]]
+        name = "feat"
+        description = "mine"
+        pr_number = 42
+        archived = false
+        review_id = "review-id"
+
+        [branches.1.heads.head]
+        CommitId = "0000000000000000000000000000000000000000"
+
+        [[branches.1.heads]]
+        name = "feat-on-top"
+        archived = false
+
+        [branches.1.heads.head]
+        CommitId = "0000000000000000000000000000000000000000"
+        "#);
+
+        let mut store = VirtualBranchesTomlMetadata::from_path(&toml_path)?;
+        let new_ws = store.workspace(workspace_name.as_ref())?;
+        assert_eq!(
+            new_ws.deref(),
+            ws.deref(),
+            "It's still what it was before - it was persisted"
+        );
+        insta::assert_debug_snapshot!(ws.deref(), @r#"
+        Workspace {
+            ref_info: RefInfo {
+                created_at: Some(
+                    Time {
+                        seconds: 1675176957,
+                        offset: 0,
+                        sign: Plus,
+                    },
+                ),
+                updated_at: None,
+            },
+            stacks: [
+                WorkspaceStack {
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/feat-on-top",
+                            ),
+                            archived: false,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/feat",
+                            ),
+                            archived: false,
+                        },
+                    ],
+                },
+            ],
+            target_ref: None,
+        }
+        "#);
+
+        // Archived middle branch
+        let archived_branch: gix::refs::FullName = "refs/heads/feat-in-middle".try_into()?;
+        ws.stacks[0].branches.insert(
+            1,
+            WorkspaceStackBranch {
+                ref_name: archived_branch.clone(),
+                archived: true,
+            },
+        );
+        store.set_workspace(workspace_name.as_ref(), &ws)?;
+        let ws = store.workspace(workspace_name.as_ref())?;
+        insta::assert_debug_snapshot!(ws.deref(), @r#"
+        Workspace {
+            ref_info: RefInfo {
+                created_at: Some(
+                    Time {
+                        seconds: 1675176957,
+                        offset: 0,
+                        sign: Plus,
+                    },
+                ),
+                updated_at: None,
+            },
+            stacks: [
+                WorkspaceStack {
+                    branches: [
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/feat-on-top",
+                            ),
+                            archived: false,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/feat-in-middle",
+                            ),
+                            archived: true,
+                        },
+                        WorkspaceStackBranch {
+                            ref_name: FullName(
+                                "refs/heads/feat",
+                            ),
+                            archived: false,
+                        },
+                    ],
+                },
+            ],
+            target_ref: None,
+        }
+        "#);
+
+        // Remove everything
+        assert!(
+            store.remove(stacked_branch_name.as_ref())?,
+            "there was something to remove"
+        );
+        assert!(
+            !store.remove(stacked_branch_name.as_ref())?,
+            "nothing left to remove"
+        );
+        assert!(
+            store.remove(branch_name.as_ref())?,
+            "there was something to remove, still"
+        );
+        assert!(
+            !store.remove(branch_name.as_ref())?,
+            "nothing left to remove"
+        );
+        assert!(store.remove(archived_branch.as_ref())?);
+
+        let ws = store.workspace(workspace_name.as_ref())?;
+        assert!(
+            ws.is_default(),
+            "it's empty, so no difference to a default one"
+        );
+        insta::assert_debug_snapshot!(ws.deref(), @r"
+        Workspace {
+            ref_info: RefInfo {
+                created_at: Some(
+                    Time {
+                        seconds: 1675176957,
+                        offset: 0,
+                        sign: Plus,
+                    },
+                ),
+                updated_at: None,
+            },
+            stacks: [],
+            target_ref: None,
+        }
+        ");
+
+        drop(store);
+        assert!(
+            !toml_path.exists(),
+            "if everything is just the default, the file is deleted on write"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn create_workspace_from_scratch_workspace_first() -> anyhow::Result<()> {
+        let (store, tmp) = empty_vb_store_rw()?;
+        Ok(())
+    }
+
+    fn vb_fixture(name: &str) -> PathBuf {
+        format!("tests/fixtures/{name}.toml").into()
+    }
+
+    /// A store that won't write itself back.
+    // TODO: use it or remove it.
+    #[allow(dead_code)]
+    fn vb_store_ro(name: &str) -> anyhow::Result<ManuallyDrop<VirtualBranchesTomlMetadata>> {
+        Ok(ManuallyDrop::new(VirtualBranchesTomlMetadata::from_path(
+            vb_fixture(name),
+        )?))
+    }
+
+    fn vb_store_rw(name: &str) -> anyhow::Result<(VirtualBranchesTomlMetadata, TempDir)> {
+        let tmp = TempDir::new()?;
+        let writable_toml_path = tmp.path().join("vb.toml");
+        std::fs::copy(vb_fixture(name), &writable_toml_path)?;
+
+        let store = VirtualBranchesTomlMetadata::from_path(&writable_toml_path)?;
+        Ok((store, tmp))
+    }
+
+    fn empty_vb_store_rw() -> anyhow::Result<(VirtualBranchesTomlMetadata, TempDir)> {
+        let tmp = tempdir()?;
+        let store = VirtualBranchesTomlMetadata::from_path(&tmp.path().join("vb.toml"))?;
+        Ok((store, tmp))
+    }
+}
+
+/// Assure everything can round-trip and the data looks consistent, independently of the actual data,
+/// from a store that already contains data.
+fn roundtrip_journey(metadata: &mut impl RefMetadata) -> anyhow::Result<()> {
+    // TODO: retrieve and set tests for all items, round-tripping
+    let all_items = metadata.iter().map(Result::unwrap).collect::<Vec<_>>();
+    for (ref_name, md) in &all_items {
+        if let Some(ws_from_iter) = md.downcast_ref::<but_core::ref_metadata::Workspace>() {
+            let ws = metadata.workspace(ref_name.as_ref())?;
+            assert!(!ws.is_default(), "default data won't be iterated");
+            if let Err(err) = metadata.set_workspace(ref_name.as_ref(), &ws) {
+                if err.to_string().contains("unsupported") {
+                    continue;
+                }
+            }
+            assert_eq!(
+                &*metadata.workspace(ref_name.as_ref())?,
+                ws_from_iter,
+                "nothing should change, it's a no-op"
+            );
+        } else if let Some(br_from_iter) = md.downcast_ref::<but_core::ref_metadata::Branch>() {
+            let br = metadata.branch(ref_name.as_ref())?;
+            assert!(!br.is_default(), "default data won't be iterated");
+            metadata
+                .set_branch(ref_name.as_ref(), &br)
+                .expect("updates have no reason to fail, even if no-op");
+            assert_eq!(
+                &*metadata.branch(ref_name.as_ref())?,
+                br_from_iter,
+                "nothing should change, it's a no-op"
+            );
+        }
+    }
+
+    for (ref_name, _md) in all_items {
+        metadata.remove(ref_name.as_ref())?;
+    }
+    assert_eq!(metadata.iter().count(), 0, "Nothing is left after deletion");
+    Ok(())
+}
+
+fn sanitize_uuids_and_timestamps(input: String) -> String {
+    let uuid_regex = regex::Regex::new(
+        r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+    )
+    .unwrap();
+    let timestamp_regex = regex::Regex::new(r#""\d{13}""#).unwrap();
+
+    let mut uuid_map: HashMap<String, usize> = HashMap::new();
+    let mut uuid_counter = 1;
+
+    let mut timestamp_map: HashMap<String, usize> = HashMap::new();
+    let mut timestamp_counter = 12_345;
+
+    let result = uuid_regex.replace_all(&input, |caps: &regex::Captures| {
+        let uuid = caps.get(0).unwrap().as_str().to_string();
+        let entry = uuid_map.entry(uuid).or_insert_with(|| {
+            let num = uuid_counter;
+            uuid_counter += 1;
+            num
+        });
+        entry.to_string()
+    });
+    let result = timestamp_regex.replace_all(&result, |caps: &regex::Captures| {
+        let timestamp = caps.get(0).unwrap().as_str().to_string();
+        let entry = timestamp_map.entry(timestamp).or_insert_with(|| {
+            let num = timestamp_counter;
+            timestamp_counter += 1;
+            num
+        });
+        entry.to_string()
+    });
+
+    result.to_string()
+}

--- a/crates/gitbutler-stack/src/stack_branch.rs
+++ b/crates/gitbutler-stack/src/stack_branch.rs
@@ -21,10 +21,10 @@ use crate::{commit_by_oid_or_change_id, stack_context::StackContext, Stack};
 pub struct StackBranch {
     /// The target of the reference - this can be a commit or a change that points to a commit.
     #[serde(alias = "target")]
-    head: CommitOrChangeId,
+    pub head: CommitOrChangeId,
     /// The name of the reference e.g. `master` or `feature/branch`. This should **NOT** include the `refs/heads/` prefix.
     /// The name must be unique within the repository.
-    name: String,
+    pub name: String,
     /// Optional description of the series. This could be markdown or anything our hearts desire.
     pub description: Option<String>,
     /// The pull request associated with the branch, or None if a pull request has not been created.

--- a/crates/gitbutler-stack/src/state.rs
+++ b/crates/gitbutler-stack/src/state.rs
@@ -383,3 +383,6 @@ fn alter_parentage(
     ));
     Ok(repository.write_object(to_rewrite)?.into())
 }
+
+/// Additional functionality for the [`VirtualBranches`] structure.
+mod state_extensions {}


### PR DESCRIPTION
Make workspace updates possible, i.e. rebasing multiple branches in a workspace onto a new base.

Follow-up on #7315.
Sibling of #7330

### Tasks

* [x] research
* [x] metadata API sketch
* [x] finish tent-pole ASCII drawings
* [x] strategy for buckets sitting on top of each other
* [x] virtual branches toml adapter for new branch-ref trait
    - [x] retrieve workspace
    - [x] delete workspace
    - [x] update workspace
    - [x] retrieve branch
    - [x] delete branch
    - [x] update branch
    - [x] Make handle carry the ref-name as well (or else it can be surprising)

### Next PRs

* sketch for archived stacks
* head-info, stacks and details API with key scenarios
* graph-based integration checks with target and remote
* integration checking with target
* integration checking with remote tracking branch

### Known Shortcomings (for now)

* ⚠️ rebase engine needs a way to know which parent to rewrite if there are two parents pointing to the same commit in a starting configuration with two stacks at the same commit. Alternatively, `create_commit` would have to create a workspace commit, which seems worse than adding a WS commit in the moment there are two stacks.
* ⚠️ **merge conflicts** are created from either cherry-picks or normal merges (legacy?), but cherry-pick would need to know that to either choose the auto-resolution. That's OK as long as the 'old' merge-commit isn't run as it would create a semantically different tree-setup in the conflicted commit.
* ⚠️ **commit listing** are ambiguous
    - Certain less common but possible branch configuration make ambiguous to assign commits to one branch or another. It won't be super trivial to make this work right.
* ⚠️Even though Git does not list *namespaced references*, `tig` will happily list everything. `set reference-format = hide:other` fixes this though
* empty commits aren't specifically highlighted when rebasing, or handled or prevented. The UI could detect that and show them.
* Moving hunks or files will need multi-branch rebases with merge-commit handling. This can be added to the rebase engine as we know it today. This will also enable worktree-updates.
* reordering in such a way that only heads a moved and nothing else happens (in terms of commit rewrites) probably wouldn't work yet in `but-rebase`.
* Index adjustments (tree to disk index) lack a lot of tests, particularly those for automatic conflict removal.
* if changes are added to the wrong spot, then they may apply cleanly *and* yield different results after merging, so the worktree differs from what's in Git. This is where hunk-dependencies/auto-hunk-splitting comes into play.
* Right now sub-hunks can't be selected as they won't match when it tries to find exact matches. However, that check could be changed to a 'contains' or 'is-included' to allow sub-hunks. Maybe this doesn't naturally work though or do the right thing.
* Workspace commits with a single branch will get signed if they were signed before. This shouldn't be a real problem, and ideally it will go away soon enough.


### For follow-up PRs

In any order (probably)

* Rebase-engine with insert empty commit (below and above, insert as first parent support)
* What happens in Git if one rebases non-linear branches? Can it retain the structure?
    - Rebase engine probably has to learn to re-schedule picks (and remember the base, a feature useful for multi-stacks as well, which then wouldn't need a special case anymore)
* move file out of commit into worktree (uncommit something)
* per-hunk exclusion if hunk didn't match (right now it rejects the whole file)
* run hooks on an index created from the tree that would be committed.
* move hunks from one commit into another


### Out of scope

* **hunk-dependencies**
    - These should be added once the commit-engine is feature-complete, the idea is that the UI can function well enough without them as a baseline.
* **atomic object writes**
    - In theory, new objects should only be written to disk if they actually end up in a tree. For instance, if a change is rejected, the object associated with it shouldn't be in the object database.
    - However, even though implementing this with the in-memory object feature is very possible, it feels like an optimization for another day. In general, I really think only objects that end up in a tree should actually be written, so that the implementation doesn't have to rely on `git gc` to cleanup.






