### PR TITLE
Limit reference updates if new commits are created to the top-most ref.

### DIFF
--- a/crates/but-workspace/src/commit_engine/mod.rs
+++ b/crates/but-workspace/src/commit_engine/mod.rs
@@ -368,7 +368,6 @@ pub fn create_commit_and_update_refs(
                 }
                 builder.rebase()?
             };
-
             refs::rewrite(
                 repo,
                 vb,

--- a/crates/but-workspace/tests/workspace/commit_engine/new_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/new_commit.rs
@@ -6,7 +6,7 @@ use crate::commit_engine::utils::{
 };
 use but_testsupport::assure_stable_env;
 use but_workspace::commit_engine;
-use but_workspace::commit_engine::{Destination, DiffSpec};
+use commit_engine::{Destination, DiffSpec};
 use gix::prelude::ObjectIdExt;
 
 mod with_refs_update {}
@@ -154,7 +154,7 @@ fn unborn_with_added_submodules() -> anyhow::Result<()> {
 
     let (repo, _tmp) = writable_scenario("unborn-with-submodules");
     let worktree_changes = but_core::diff::worktree_changes(&repo)?;
-    let outcome = but_workspace::commit_engine::create_commit(
+    let outcome = commit_engine::create_commit(
         &repo,
         Destination::NewCommit {
             parent_commit_id: None,
@@ -303,7 +303,7 @@ fn submodule_typechanges() -> anyhow::Result<()> {
         },
     ]
     "#);
-    let outcome = but_workspace::commit_engine::create_commit(
+    let outcome = commit_engine::create_commit(
         &repo,
         Destination::NewCommit {
             parent_commit_id: Some(repo.rev_parse_single("HEAD")?.into()),
@@ -366,7 +366,7 @@ fn commit_to_one_below_tip_with_three_context_lines() -> anyhow::Result<()> {
                 .into(),
         };
 
-        let outcome = but_workspace::commit_engine::create_commit(
+        let outcome = commit_engine::create_commit(
             &repo,
             first_commit,
             None,

--- a/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
@@ -739,7 +739,13 @@ fn commit_on_top_of_branch_in_workspace() -> anyhow::Result<()> {
 
     let branch_a = repo.rev_parse_single("A")?.detach();
     let mut vb = VirtualBranchesState::default();
-    let stack = stack_with_branches("s1", branch_a, [("s1-b/top", branch_a)]);
+    let stack = stack_with_branches(
+        "s1",
+        branch_a,
+        // The order indicates which one actually is on top, even though they both point to the
+        // same commit.
+        [("s1-b/below-top", branch_a), ("s1-b/top", branch_a)],
+    );
     vb.branches.insert(stack.id, stack);
 
     // initial is 1-30, make a change that transfers correctly to A where it is 5-20.
@@ -769,7 +775,7 @@ fn commit_on_top_of_branch_in_workspace() -> anyhow::Result<()> {
     *   5c49248 (HEAD -> merge) Merge branch 'A' into merge
     |\  
     | * 10bb1a3 (s1-b/top, s1, A) remove 5 lines from beginning
-    | * 7f389ed add 10 to the beginning
+    | * 7f389ed (s1-b/below-top) add 10 to the beginning
     * | 91ef6f6 (B) add 10 to the end
     |/  
     * ff045ef (main) init


### PR DESCRIPTION
This is how the application acts currently, and previously we'd update too many branches.
