### PR TITLE
feat: add parentIds to Commit type and serialization logic

### DIFF
--- a/apps/desktop/src/lib/branches/v3.ts
+++ b/apps/desktop/src/lib/branches/v3.ts
@@ -63,6 +63,8 @@ export type Commits = {
 export type Commit = {
 	/** The OID of the commit.*/
 	readonly id: string;
+	/** The parent OIDs of the commit. */
+	readonly parentIds: string[];
 	/** The message of the commit.*/
 	readonly message: string;
 	/**

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -124,6 +124,9 @@ pub struct Commit {
     /// The OID of the commit.
     #[serde(with = "gitbutler_serde::object_id")]
     pub id: gix::ObjectId,
+    /// The parent OIDs of the commit.
+    #[serde(with = "gitbutler_serde::object_id_vec")]
+    pub parent_ids: Vec<gix::ObjectId>,
     /// The message of the commit.
     #[serde(with = "gitbutler_serde::bstring_lossy")]
     pub message: BString,
@@ -300,6 +303,7 @@ fn convert(
 
         let api_commit = Commit {
             id: commit.id().to_gix(),
+            parent_ids: commit.parents().map(|p| p.id().to_gix()).collect(),
             message: commit.message_bstr().into(),
             has_conflicts: commit.is_conflicted(),
             state,

--- a/crates/gitbutler-serde/src/lib.rs
+++ b/crates/gitbutler-serde/src/lib.rs
@@ -129,6 +129,36 @@ pub mod object_id {
     }
 }
 
+pub mod object_id_vec {
+    use serde::{Deserialize, Deserializer, Serialize};
+    use std::str::FromStr;
+
+    /// serialize an object ID as hex-string.
+    pub fn serialize<S>(v: &[gix::ObjectId], s: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let vec: Vec<String> = v.iter().map(|v| v.to_string()).collect();
+        vec.serialize(s)
+    }
+
+    /// deserialize an object ID from hex-string.
+    pub fn deserialize<'de, D>(d: D) -> Result<Vec<gix::ObjectId>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let hex = <Vec<String> as Deserialize>::deserialize(d)?;
+        let hex: Result<Vec<gix::ObjectId>, D::Error> = hex
+            .into_iter()
+            .map(|v| {
+                gix::ObjectId::from_str(v.as_ref())
+                    .map_err(|err| serde::de::Error::custom(err.to_string()))
+            })
+            .collect();
+        hex
+    }
+}
+
 pub mod oid_vec {
     use serde::{Deserialize, Deserializer, Serialize};
 


### PR DESCRIPTION
This pull request introduces a new feature that enhances the `Commit` type by adding a `parentIds` field. This addition allows for better tracking of commit relationships in the version control system. 

Key changes include:
- Updated the `Commit` type to include the `parentIds` property.
- Implemented serialization logic to ensure that the `parentIds` are correctly handled during data processing.

These changes aim to improve the functionality and usability of the commit data structure, facilitating more complex commit histories and better integration with other components of the system. 