### PR TITLE
Use one commit only for obtaining changes for Commit

### DIFF
--- a/apps/desktop/src/lib/worktree/worktreeService.svelte.ts
+++ b/apps/desktop/src/lib/worktree/worktreeService.svelte.ts
@@ -44,7 +44,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 			 * entity entity adapter to create the necessary selectors.
 			 */
 			getChanges: build.query<EntityState<TreeChange, string>, { projectId: string }>({
-				query: ({ projectId }) => ({ command: 'worktree_changes', params: { projectId } }),
+				query: ({ projectId }) => ({ command: 'changes_in_worktree', params: { projectId } }),
 				/** Invalidating tags causes data to be refreshed. */
 				providesTags: [ReduxTag.WorktreeChanges],
 				/**

--- a/crates/but-core/src/diff/ui.rs
+++ b/crates/but-core/src/diff/ui.rs
@@ -1,4 +1,5 @@
 use crate::ui::{TreeChange, WorktreeChanges};
+use gix::prelude::ObjectIdExt;
 use std::path::PathBuf;
 
 /// See [`super::worktree_changes()`].
@@ -10,10 +11,16 @@ pub fn worktree_changes_by_worktree_dir(worktree_dir: PathBuf) -> anyhow::Result
 /// See [`super::commit_changes()`].
 pub fn commit_changes_by_worktree_dir(
     worktree_dir: PathBuf,
-    old_commit_id: Option<gix::ObjectId>,
-    new_commit_id: gix::ObjectId,
+    commit_id: gix::ObjectId,
 ) -> anyhow::Result<Vec<TreeChange>> {
     let repo = gix::open(worktree_dir)?;
-    super::commit_changes(&repo, old_commit_id, new_commit_id)
+    let parent_id = commit_id
+        .attach(&repo)
+        .object()?
+        .into_commit()
+        .parent_ids()
+        .map(|id| id.detach())
+        .next();
+    super::commit_changes(&repo, parent_id, commit_id)
         .map(|c| c.into_iter().map(Into::into).collect())
 }

--- a/crates/but-core/tests/core/diff/ui.rs
+++ b/crates/but-core/tests/core/diff/ui.rs
@@ -376,7 +376,6 @@ fn commit_to_commit() -> anyhow::Result<()> {
     let actual =
         serde_json::to_string_pretty(&but_core::diff::ui::commit_changes_by_worktree_dir(
             worktree_dir,
-            Some(repo.rev_parse_single("@~1")?.into()),
             repo.rev_parse_single("@")?.into(),
         )?)?;
     insta::assert_snapshot!(actual, @r#"

--- a/crates/gitbutler-tauri/src/diff.rs
+++ b/crates/gitbutler-tauri/src/diff.rs
@@ -24,19 +24,14 @@ pub fn tree_change_diffs(
 
 #[tauri::command(async)]
 #[instrument(skip(projects), err(Debug))]
-pub fn commit_changes(
+pub fn changes_in_commit(
     projects: tauri::State<'_, gitbutler_project::Controller>,
     project_id: ProjectId,
-    old_commit_id: Option<HexHash>,
-    new_commit_id: HexHash,
+    commit_id: HexHash,
 ) -> anyhow::Result<Vec<TreeChange>, Error> {
     let project = projects.get(project_id)?;
-    but_core::diff::ui::commit_changes_by_worktree_dir(
-        project.path,
-        old_commit_id.map(Into::into),
-        new_commit_id.into(),
-    )
-    .map_err(Into::into)
+    but_core::diff::ui::commit_changes_by_worktree_dir(project.path, commit_id.into())
+        .map_err(Into::into)
 }
 
 /// This UI-version of [`but_core::diff::worktree_changes()`] simplifies the `git status` information for display in
@@ -50,7 +45,7 @@ pub fn commit_changes(
 /// All ignored status changes are also provided so they can be displayed separately.
 #[tauri::command(async)]
 #[instrument(skip(projects), err(Debug))]
-pub fn worktree_changes(
+pub fn changes_in_worktree(
     projects: tauri::State<'_, gitbutler_project::Controller>,
     project_id: ProjectId,
 ) -> anyhow::Result<WorktreeChanges, Error> {

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -271,8 +271,8 @@ fn main() {
                     workspace::hunk_dependencies_for_workspace_changes,
                     workspace::create_commit_from_worktree_changes,
                     workspace::amend_commit_from_worktree_changes,
-                    diff::worktree_changes,
-                    diff::commit_changes,
+                    diff::changes_in_worktree,
+                    diff::changes_in_commit,
                     diff::tree_change_diffs,
                     // `env_vars` is only supposed to be avaialble in debug mode, not in production.
                     #[cfg(debug_assertions)]


### PR DESCRIPTION
## 🧢 Changes

## ☕️ Reasoning

That way it's easier to use from the frontend.
It's notable that this cements that we traverse the first parent only
when listing stack commits, which is now something we assume.
Should be alright though.

