### PR TITLE
Remove cruft from tsconfig.json

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -31,8 +31,6 @@
 		"src/**/*.svelte",
 		"tests/**/*.js",
 		"tests/**/*.ts",
-		"tests/**/*.svelte",
-		"../../packages/shared/src/lib/actionCable/utils.ts",
-		"../../packages/shared/src/lib/actionCable/utils.ts"
+		"tests/**/*.svelte"
 	]
 }


### PR DESCRIPTION
When files are dragged from one TS package to another, vscode/LSP updates the tsconfig.json to try and include the file via some absurd relative import.

The presense of these extra lines is not problematic, it is just simply unhygenic and we should just try to avoid commiting them in the future (FWIW, I know I'm guilty of committing these erronius lines in the past)

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #7355 
- <kbd>&nbsp;2&nbsp;</kbd> #7354 
- <kbd>&nbsp;1&nbsp;</kbd> #7353 👈 
<!-- GitButler Footer Boundary Bottom -->

