### PR TITLE
fix: v3 cleanup after engineering meeting

### DIFF
--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -6,14 +6,13 @@
 	import { platformName } from '$lib/platform/platform';
 	import { Project } from '$lib/project/project';
 	import { ProjectsService } from '$lib/project/projectsService';
-	import { DesktopRoutesService } from '$lib/routes/routes.svelte';
+	import { projectPath } from '$lib/routes/routes.svelte';
 	import { getContext, maybeGetContext } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import Icon from '@gitbutler/ui/Icon.svelte';
 	import NotificationButton from '@gitbutler/ui/NotificationButton.svelte';
 	import { goto } from '$app/navigation';
 
-	const routes = getContext(DesktopRoutesService);
 	const projectsService = getContext(ProjectsService);
 	const project = maybeGetContext(Project);
 
@@ -50,7 +49,7 @@
 			disabled={newProjectLoading || cloneProjectLoading}
 			onselect={(value: string) => {
 				selectedProjectId = value;
-				goto(routes.projectPath(selectedProjectId));
+				goto(projectPath(selectedProjectId));
 			}}
 			popupAlign="center"
 			customWidth={300}

--- a/apps/desktop/src/components/ChromeSidebar.svelte
+++ b/apps/desktop/src/components/ChromeSidebar.svelte
@@ -2,7 +2,18 @@
 	import KeyboardShortcutsModal from '$components/KeyboardShortcutsModal.svelte';
 	import ShareIssueModal from '$components/ShareIssueModal.svelte';
 	import { Project } from '$lib/project/project';
-	import { DesktopRoutesService } from '$lib/routes/routes.svelte';
+	import {
+		branchesPath,
+		historyPath,
+		isBranchesPath,
+		isHistoryPath,
+		isProjectSettingsPath,
+		isTargetPath,
+		isWorkspacePath,
+		projectSettingsPath,
+		targetPath,
+		workspacePath
+	} from '$lib/routes/routes.svelte';
 	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import { User } from '$lib/user/user';
 	import { UserService } from '$lib/user/userService';
@@ -18,7 +29,6 @@
 	import type { Writable } from 'svelte/store';
 	import { goto } from '$app/navigation';
 
-	const routes = getContext(DesktopRoutesService);
 	const project = getContext(Project);
 	const user = getContextStore(User);
 
@@ -34,14 +44,14 @@
 <div class="sidebar">
 	<div class="top">
 		<div>
-			{#if routes.isWorkspacePath}
+			{#if isWorkspacePath()}
 				<div class="active-page-indicator" in:slide={{ axis: 'x', duration: 150 }}></div>
 			{/if}
 			<Button
 				kind="outline"
-				onclick={() => goto(routes.workspacePath(project.id))}
+				onclick={() => goto(workspacePath(project.id))}
 				width={34}
-				class={['btn-square', routes.isWorkspacePath && 'btn-active']}
+				class={['btn-square', isWorkspacePath() && 'btn-active']}
 				tooltip="Workspace"
 			>
 				<svg viewBox="0 0 16 13" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -60,14 +70,14 @@
 			</Button>
 		</div>
 		<div>
-			{#if routes.isBranchesPath}
+			{#if isBranchesPath()}
 				<div class="active-page-indicator" in:slide={{ axis: 'x', duration: 150 }}></div>
 			{/if}
 			<Button
 				kind="outline"
-				onclick={() => goto(routes.branchesPath(project.id))}
+				onclick={() => goto(branchesPath(project.id))}
 				width={34}
-				class={['btn-square', routes.isBranchesPath && 'btn-active']}
+				class={['btn-square', isBranchesPath() && 'btn-active']}
 				tooltip="Branches"
 			>
 				<svg viewBox="0 0 16 14" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -111,14 +121,14 @@
 			</Button>
 		</div>
 		<div>
-			{#if routes.isTargetPath}
+			{#if isTargetPath()}
 				<div class="active-page-indicator" in:slide={{ axis: 'x', duration: 150 }}></div>
 			{/if}
 			<Button
 				kind="outline"
-				onclick={() => goto(routes.targetPath(project.id))}
+				onclick={() => goto(targetPath(project.id))}
 				width={34}
-				class={['btn-square', routes.isTargetPath && 'btn-active']}
+				class={['btn-square', isTargetPath() && 'btn-active']}
 				tooltip="Target"
 			>
 				<svg viewBox="0 0 18 16" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -139,14 +149,14 @@
 			</Button>
 		</div>
 		<div>
-			{#if routes.isHistoryPath}
+			{#if isHistoryPath()}
 				<div class="active-page-indicator" in:slide={{ axis: 'x', duration: 150 }}></div>
 			{/if}
 			<Button
 				kind="outline"
-				onclick={() => goto(routes.historyPath(project.id))}
+				onclick={() => goto(historyPath(project.id))}
 				width={34}
-				class={['btn-square', routes.isHistoryPath && 'btn-active']}
+				class={['btn-square', isHistoryPath() && 'btn-active']}
 				tooltip="History"
 			>
 				<svg
@@ -171,15 +181,15 @@
 	<div class="bottom">
 		<div class="bottom__primary-actions">
 			<div>
-				{#if routes.isProjectSettingsPath}
+				{#if isProjectSettingsPath()}
 					<div class="active-page-indicator" in:slide={{ axis: 'x', duration: 150 }}></div>
 				{/if}
 				<Button
 					icon="settings"
 					kind="outline"
-					onclick={() => goto(routes.projectSettingsPath(project.id))}
+					onclick={() => goto(projectSettingsPath(project.id))}
 					width={34}
-					class={['btn-square', routes.isProjectSettingsPath && 'btn-active']}
+					class={['btn-square', isProjectSettingsPath() && 'btn-active']}
 					tooltipPosition="top"
 					tooltipAlign="start"
 					tooltip="Project settings"

--- a/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
+++ b/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { showHistoryView } from '$lib/config/config';
 	import { Project } from '$lib/project/project';
-	import { DesktopRoutesService } from '$lib/routes/routes.svelte';
+	import { projectSettingsPath } from '$lib/routes/routes.svelte';
 	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import { ShortcutService } from '$lib/shortcuts/shortcutService.svelte';
 	import * as events from '$lib/utils/events';
@@ -16,10 +16,9 @@
 	const project = getContext(Project);
 	const userSettings = getContextStoreBySymbol<Settings, Writable<Settings>>(SETTINGS);
 	const shortcutService = getContext(ShortcutService);
-	const routes = getContext(DesktopRoutesService);
 
 	shortcutService.on('project-settings', () => {
-		goto(routes.projectSettingsPath(project.id));
+		goto(projectSettingsPath(project.id));
 	});
 
 	shortcutService.on('open-in-vscode', () => {

--- a/apps/desktop/src/components/v3/Branch.svelte
+++ b/apps/desktop/src/components/v3/Branch.svelte
@@ -29,13 +29,13 @@
 
 	const [stackService] = inject(StackService);
 	const branchResult = $derived(stackService.branchByName(projectId, stackId, branchName).current);
-	const commitsResult = $derived(stackService.commitAt(projectId, stackId, branchName, 0).current);
+	const commitResult = $derived(stackService.commitAt(projectId, stackId, branchName, 0).current);
 </script>
 
-<ReduxResult result={combineResults(branchResult, commitsResult)}>
-	{#snippet children([branch, commits])}
+<ReduxResult result={combineResults(branchResult, commitResult)}>
+	{#snippet children([branch, commit])}
 		{#if !first}
-			<BranchDividerLine topPatchStatus={commits?.state.type ?? 'Error'} />
+			<BranchDividerLine topPatchStatus={commit?.state.type ?? 'Error'} />
 		{/if}
 		<div class="branch" class:selected data-series-name={branchName}>
 			<BranchHeader {projectId} {stackId} {branch} isTopBranch={first} />

--- a/apps/desktop/src/components/v3/Branch.svelte
+++ b/apps/desktop/src/components/v3/Branch.svelte
@@ -29,13 +29,13 @@
 
 	const [stackService] = inject(StackService);
 	const branchResult = $derived(stackService.branchByName(projectId, stackId, branchName).current);
-	const commitsResult = $derived(stackService.commits(projectId, stackId, branchName).current);
+	const commitsResult = $derived(stackService.commitAt(projectId, stackId, branchName, 0).current);
 </script>
 
 <ReduxResult result={combineResults(branchResult, commitsResult)}>
 	{#snippet children([branch, commits])}
 		{#if !first}
-			<BranchDividerLine topPatchStatus={commits.at(0)?.state.type ?? 'Error'} />
+			<BranchDividerLine topPatchStatus={commits?.state.type ?? 'Error'} />
 		{/if}
 		<div class="branch" class:selected data-series-name={branchName}>
 			<BranchHeader {projectId} {stackId} {branch} isTopBranch={first} />

--- a/apps/desktop/src/components/v3/BranchView.svelte
+++ b/apps/desktop/src/components/v3/BranchView.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+	import ReduxResult from '$components/ReduxResult.svelte';
+	import Resizer from '$components/Resizer.svelte';
+	import Branch from '$components/v3/Branch.svelte';
+	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
+	import { StackService } from '$lib/stacks/stackService.svelte';
+	import { getContextStoreBySymbol, inject } from '@gitbutler/shared/context';
+	import { persisted } from '@gitbutler/shared/persisted';
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		stackId: string;
+		projectId: string;
+		selectedBranchName: string;
+		selectedCommitId?: string;
+		children: Snippet;
+	}
+
+	const { stackId, projectId, selectedBranchName, selectedCommitId, children }: Props = $props();
+
+	const [stackService] = inject(StackService);
+	const userSettings = getContextStoreBySymbol<Settings>(SETTINGS);
+
+	const stackBranchWidthKey = $derived('defaultStackBranchWidth_ ' + projectId);
+	const result = $derived(stackService.branches(projectId, stackId).current);
+
+	let resizeStackBranches = $state<HTMLElement>();
+	let stackBranchWidth = $derived(persisted<number>(22.5, stackBranchWidthKey));
+</script>
+
+<div class="stack-view">
+	<ReduxResult {result}>
+		{#snippet children(branches)}
+			<div class="branches" bind:this={resizeStackBranches} style:width={$stackBranchWidth + 'rem'}>
+				<Resizer
+					viewport={resizeStackBranches}
+					direction="right"
+					minWidth={22.5}
+					onWidth={(value) => {
+						$stackBranchWidth = value / (16 * $userSettings.zoom);
+					}}
+				/>
+				{#if stackId && branches.length >= 0}
+					{#each branches as branch, i (branch.name)}
+						{@const first = i === 0}
+						{@const last = i === branches.length - 1}
+						<Branch
+							{projectId}
+							{stackId}
+							branchName={branch.name}
+							selected={selectedBranchName === branch.name}
+							{selectedCommitId}
+							{first}
+							{last}
+						/>
+					{/each}
+				{/if}
+			</div>
+		{/snippet}
+	</ReduxResult>
+	{@render children()}
+</div>
+
+<style>
+	.stack-view {
+		position: relative;
+		height: 100%;
+		flex-grow: 1;
+		display: flex;
+		border-radius: 0 var(--radius-ml) var(--radius-ml);
+	}
+
+	.branches {
+		position: relative;
+		display: flex;
+		width: 22.5rem;
+		flex-direction: column;
+		padding: 16px;
+		overflow: hidden;
+
+		background-color: transparent;
+		opacity: 1;
+		background-image: radial-gradient(
+			oklch(from var(--clr-scale-ntrl-50) l c h / 0.5) 0.6px,
+			#ffffff00 0.6px
+		);
+		background-size: 6px 6px;
+		border-right: 1px solid var(--clr-border-2);
+	}
+</style>

--- a/apps/desktop/src/components/v3/BranchView.svelte
+++ b/apps/desktop/src/components/v3/BranchView.svelte
@@ -28,7 +28,7 @@
 	let stackBranchWidth = $derived(persisted<number>(22.5, stackBranchWidthKey));
 </script>
 
-<div class="stack-view">
+<div class="branch-view">
 	<ReduxResult {result}>
 		{#snippet children(branches)}
 			<div class="branches" bind:this={resizeStackBranches} style:width={$stackBranchWidth + 'rem'}>
@@ -62,7 +62,7 @@
 </div>
 
 <style>
-	.stack-view {
+	.branch-view {
 		position: relative;
 		height: 100%;
 		flex-grow: 1;

--- a/apps/desktop/src/components/v3/StackTabPreview.svelte
+++ b/apps/desktop/src/components/v3/StackTabPreview.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	import { DesktopRoutesService } from '$lib/routes/routes.svelte';
-	import { getContext } from '@gitbutler/shared/context';
+	import { workspacePath } from '$lib/routes/routes.svelte';
 	import { goto } from '$app/navigation';
 
 	type Props = {
@@ -9,10 +8,9 @@
 		selected: boolean;
 	};
 	const { projectId, count, selected }: Props = $props();
-	const routes = getContext(DesktopRoutesService);
 
 	async function addNew() {
-		goto(routes.workspacePath(projectId));
+		goto(workspacePath(projectId));
 	}
 </script>
 

--- a/apps/desktop/src/components/v3/StackTabs.svelte
+++ b/apps/desktop/src/components/v3/StackTabs.svelte
@@ -18,7 +18,7 @@
 	const stackService = getContext(StackService);
 	const result = $derived(stackService.stacks(projectId));
 
-	let inner = $state<HTMLDivElement>();
+	let tabs = $state<HTMLDivElement>();
 	let scroller = $state<HTMLDivElement>();
 
 	let scrollable = $state(false);
@@ -35,17 +35,17 @@
 	onMount(() => {
 		const observer = new ResizeObserver(() => {
 			scrollable = scroller ? scroller.scrollWidth > scroller.offsetWidth : false;
-			width = inner?.offsetWidth;
+			width = tabs?.offsetWidth;
 		});
-		observer.observe(inner!);
+		observer.observe(tabs!);
 		return () => {
 			observer.disconnect();
 		};
 	});
 </script>
 
-<div class="tabs">
-	<div class="inner" bind:this={inner}>
+<div class="tabs" bind:this={tabs}>
+	<div class="inner">
 		<div class="scroller" bind:this={scroller} class:scrolled {onscroll}>
 			<ReduxResult result={result.current}>
 				{#snippet children(result)}
@@ -73,6 +73,7 @@
 	.tabs {
 		display: flex;
 		max-width: 100%;
+		width: fit-content;
 	}
 
 	.scroller {

--- a/apps/desktop/src/components/v3/StackView.svelte
+++ b/apps/desktop/src/components/v3/StackView.svelte
@@ -50,7 +50,7 @@
 	});
 </script>
 
-<div class="workspace">
+<div class="stack-view">
 	<div class="left">
 		<div class="resizable-area" bind:this={resizeViewport} style:width={$trayWidth + 'rem'}>
 			<WorktreeChanges {projectId} {stackId} {branchName} />
@@ -73,7 +73,7 @@
 </div>
 
 <style>
-	.workspace {
+	.stack-view {
 		display: flex;
 		flex: 1;
 		align-items: stretch;

--- a/apps/desktop/src/components/v3/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/v3/WorktreeChanges.svelte
@@ -3,7 +3,7 @@
 	import FileList from '$components/v3/FileList.svelte';
 	import noChanges from '$lib/assets/illustrations/no-changes.svg?raw';
 	import { createCommitStore } from '$lib/commits/contexts';
-	import { createCommitPath, DesktopRoutesService } from '$lib/routes/routes.svelte';
+	import { createCommitPath, isCommitPath } from '$lib/routes/routes.svelte';
 	import { ChangeSelectionService } from '$lib/selection/changeSelection.svelte';
 	import { WorktreeService } from '$lib/worktree/worktreeService.svelte';
 	import { getContext } from '@gitbutler/shared/context';
@@ -20,11 +20,10 @@
 
 	const changeSelection = getContext(ChangeSelectionService);
 	const worktreeService = getContext(WorktreeService);
-	const desktopRouteService = getContext(DesktopRoutesService);
 	createCommitStore(undefined);
 
 	const result = $derived(worktreeService.getChanges(projectId).current);
-	const disabled = $derived(!!desktopRouteService.isCommitPath);
+	const disabled = $derived(!!isCommitPath);
 
 	/** Clear any selected changes that no longer exist. */
 	$effect(() => {

--- a/apps/desktop/src/lib/routes/routes.svelte.ts
+++ b/apps/desktop/src/lib/routes/routes.svelte.ts
@@ -5,44 +5,57 @@ function isUrl<T>(id: string): T | undefined {
 		return page.params as T;
 	}
 }
-export class DesktopRoutesService {
-	constructor() {}
 
-	projectPath(projectId: string) {
-		return `/${projectId}`;
-	}
-	isProjectPath = $derived(isUrl<{ projectId: string }>('/[projectId]'));
+export function projectPath(projectId: string) {
+	return `/${projectId}`;
+}
 
-	projectSettingsPath(projectId: string) {
-		return `/${projectId}/settings`;
-	}
-	isProjectSettingsPath = $derived(isUrl<{ projectId: string }>('/[projectId]/settings'));
+export function isProjectPath() {
+	return isUrl<{ projectId: string }>('/[projectId]');
+}
 
-	workspacePath(projectId: string) {
-		return `/${projectId}/workspace`;
-	}
-	isWorkspacePath = $derived(
-		isUrl<{ projectId: string; branchId?: string }>('/[projectId]/workspace/[[stackId]]')
-	);
+export function projectSettingsPath(projectId: string) {
+	return `/${projectId}/settings`;
+}
 
-	branchesPath(projectId: string) {
-		return `/${projectId}/branches`;
-	}
-	isBranchesPath = $derived(isUrl<{ projectId: string }>('/[projectId]/branches'));
+export function isProjectSettingsPath() {
+	return isUrl<{ projectId: string }>('/[projectId]/settings');
+}
 
-	targetPath(projectId: string) {
-		return `/${projectId}/target`;
-	}
-	isTargetPath = $derived(isUrl<{ projectId: string }>('/[projectId]/target'));
+export function workspacePath(projectId: string) {
+	return `/${projectId}/workspace`;
+}
 
-	historyPath(projectId: string) {
-		return `/${projectId}/history`;
-	}
-	isHistoryPath = $derived(isUrl<{ projectId: string }>('/[projectId]/history'));
+export function isWorkspacePath() {
+	return isUrl<{ projectId: string; branchId?: string }>('/[projectId]/workspace/[[stackId]]');
+}
 
-	isCommitPath = $derived(
-		isUrl<{ projectId: string; stackId: string }>('/[projectId]/workspace/[[stackId]]/commit')
-	);
+export function branchesPath(projectId: string) {
+	return `/${projectId}/branches`;
+}
+
+export function isBranchesPath() {
+	return isUrl<{ projectId: string }>('/[projectId]/branches');
+}
+
+export function targetPath(projectId: string) {
+	return `/${projectId}/target`;
+}
+
+export function isTargetPath() {
+	return isUrl<{ projectId: string }>('/[projectId]/target');
+}
+
+export function historyPath(projectId: string) {
+	return `/${projectId}/history`;
+}
+
+export function isHistoryPath() {
+	return isUrl<{ projectId: string }>('/[projectId]/history');
+}
+
+export function isCommitPath() {
+	return isUrl<{ projectId: string; stackId: string }>('/[projectId]/workspace/[[stackId]]/commit');
 }
 
 export function settingsPath() {

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -36,7 +36,6 @@
 	import { ProjectsService } from '$lib/project/projectsService';
 	import { PromptService } from '$lib/prompt/promptService';
 	import { RemotesService } from '$lib/remotes/remotesService';
-	import { DesktopRoutesService } from '$lib/routes/routes.svelte';
 	import { setSecretsService } from '$lib/secrets/secretsService';
 	import { ChangeSelectionService } from '$lib/selection/changeSelection.svelte';
 	import { SETTINGS, loadUserSettings } from '$lib/settings/userSettings';
@@ -98,7 +97,6 @@
 	const repositoryIdLookupService = new RepositoryIdLookupService(data.cloud, appState.appDispatch);
 	const latestBranchLookupService = new LatestBranchLookupService(data.cloud, appState.appDispatch);
 	const webRoutesService = new WebRoutesService(env.PUBLIC_CLOUD_BASE_URL);
-	const desktopRouteService = new DesktopRoutesService();
 	const diffService = new DiffService(clientState);
 	const shortcutService = new ShortcutService(data.tauri);
 	const commitService = new CommitService();
@@ -120,7 +118,6 @@
 	setContext(RepositoryIdLookupService, repositoryIdLookupService);
 	setContext(LatestBranchLookupService, latestBranchLookupService);
 	setContext(WebRoutesService, webRoutesService);
-	setContext(DesktopRoutesService, desktopRouteService);
 	setContext(HooksService, data.hooksService);
 	setContext(SettingsService, data.settingsService);
 	setContext(FileService, data.fileService);

--- a/apps/desktop/src/routes/[projectId]/workspace/[stackId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/workspace/[stackId]/+layout.svelte
@@ -43,17 +43,13 @@
 	let resizeViewport = $state<HTMLElement>();
 
 	/** Offset width for tabs component. */
-	let width: number | undefined = $state();
+	let width = $state<number>();
 	/** Content area on the right for stack details. */
 	let rightEl = $state<HTMLDivElement>();
 	/** Width of content area on the right. */
-	let rightWidth: number | undefined = $state();
+	let rightWidth = $state<number>();
 	/** True if content area should be rounded. */
-	let rounded = $state(false);
-
-	$effect(() => {
-		rounded = rightWidth !== width;
-	});
+	const rounded = $derived(rightWidth !== width);
 
 	onMount(() => {
 		const observer = new ResizeObserver(() => (rightWidth = rightEl?.offsetWidth));

--- a/apps/desktop/src/routes/[projectId]/workspace/[stackId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/workspace/[stackId]/+layout.svelte
@@ -1,20 +1,13 @@
 <script lang="ts">
-	import Resizer from '$components/Resizer.svelte';
-	import StackTabs from '$components/v3/StackTabs.svelte';
-	import WorktreeChanges from '$components/v3/WorktreeChanges.svelte';
+	import StackView from '$components/v3/StackView.svelte';
 	import { SettingsService } from '$lib/config/appSettingsV2';
-	import { IdSelection } from '$lib/selection/idSelection.svelte';
-	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
-	import { WorktreeService } from '$lib/worktree/worktreeService.svelte';
-	import { getContext, getContextStoreBySymbol } from '@gitbutler/shared/context';
-	import { persisted } from '@gitbutler/shared/persisted';
-	import { onMount, setContext, type Snippet } from 'svelte';
+	import { getContext } from '@gitbutler/shared/context';
 	import type { PageData } from '../$types';
+	import type { Snippet } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 
 	const settingsService = getContext(SettingsService);
-	const worktreeService = getContext(WorktreeService);
 	const settingsStore = settingsService.appSettings;
 
 	const { data, children }: { data: PageData; children: Snippet } = $props();
@@ -29,104 +22,6 @@
 			goto(`/${data.projectId}/board`);
 		}
 	});
-
-	const userSettings = getContextStoreBySymbol<Settings>(SETTINGS);
-	const idSelection = new IdSelection(worktreeService);
-	setContext(IdSelection, idSelection);
-
-	const trayWidthKey = $derived('defaulTrayWidth_ ' + projectId);
-	const trayWidth = $derived(persisted<number>(240, trayWidthKey));
-
-	const previewingKey = $derived('previewing_' + projectId);
-	const previewing = $derived(persisted<boolean>(false, previewingKey));
-
-	let resizeViewport = $state<HTMLElement>();
-
-	/** Offset width for tabs component. */
-	let width = $state<number>();
-	/** Content area on the right for stack details. */
-	let rightEl = $state<HTMLDivElement>();
-	/** Width of content area on the right. */
-	let rightWidth = $state<number>();
-	/** True if content area should be rounded. */
-	const rounded = $derived(rightWidth !== width);
-
-	onMount(() => {
-		const observer = new ResizeObserver(() => (rightWidth = rightEl?.offsetWidth));
-		observer.observe(rightEl!);
-		return () => {
-			observer.disconnect();
-		};
-	});
 </script>
 
-<div class="workspace">
-	<div class="left">
-		<div class="resizable-area" bind:this={resizeViewport} style:width={$trayWidth + 'rem'}>
-			<WorktreeChanges {projectId} {stackId} {branchName} />
-		</div>
-		<Resizer
-			viewport={resizeViewport}
-			direction="right"
-			minWidth={36}
-			onWidth={(value) => {
-				$trayWidth = value / (16 * $userSettings.zoom);
-			}}
-		/>
-	</div>
-	<div class="right" bind:this={rightEl}>
-		<StackTabs {projectId} selectedId={stackId} previewing={$previewing} bind:width />
-		<div class="contents" class:rounded>
-			{@render children()}
-		</div>
-	</div>
-</div>
-
-<style>
-	.workspace {
-		display: flex;
-		flex: 1;
-		align-items: stretch;
-		height: 100%;
-		width: 100%;
-		position: relative;
-	}
-
-	.left {
-		display: flex;
-		flex-direction: column;
-		justify-content: flex-start;
-		overflow: hidden;
-		position: relative;
-		padding-right: 8px;
-	}
-
-	.resizable-area {
-		display: flex;
-		flex-direction: column;
-		background-color: var(--clr-bg-1);
-		border-radius: var(--radius-ml);
-		border: 1px solid var(--clr-border-2);
-		height: 100%;
-	}
-
-	.right {
-		display: flex;
-		flex: 1;
-		margin-left: 6px;
-		flex-direction: column;
-		overflow: hidden;
-	}
-
-	.right .contents {
-		display: flex;
-		border: 1px solid var(--clr-border-2);
-		flex: 1;
-		border-radius: 0 0 var(--radius-ml) var(--radius-ml);
-		overflow: hidden;
-
-		&.rounded {
-			border-radius: 0 var(--radius-ml) var(--radius-ml) var(--radius-ml);
-		}
-	}
-</style>
+<StackView {children} {projectId} {stackId} {branchName} />

--- a/apps/desktop/src/routes/[projectId]/workspace/[stackId]/[branchName]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/workspace/[stackId]/[branchName]/+layout.svelte
@@ -19,6 +19,3 @@
 	selectedCommitId={commitId}
 	{children}
 />
-
-<style>
-</style>

--- a/apps/desktop/src/routes/[projectId]/workspace/[stackId]/[branchName]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/workspace/[stackId]/[branchName]/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import StackView from '$components/v3/StackView.svelte';
+	import BranchView from '$components/v3/BranchView.svelte';
 	import { type Snippet } from 'svelte';
 	import type { PageData } from '../$types';
 	import { page } from '$app/state';
@@ -12,7 +12,7 @@
 	const commitId = $derived(page.url.searchParams.get('commitId') || undefined);
 </script>
 
-<StackView
+<BranchView
 	{projectId}
 	{stackId}
 	selectedBranchName={branchName}


### PR DESCRIPTION
## 🧢 Changes

v3 Workspace Page Cleanups:

- [x] `[X]Query` should be `[X]Result`
- [x] StackTabs `bind:inner`
- [x] Rm `DesktopRouteService` class
    - [x] Just expose static functions
- [x] `commits.at()` has a new API `CommitsNth()`
- [x] `stackService.svelte.ts` `getCommitChnages` needs renamed to new API name
- [x] `[stackId]/+layout.svelte` shold have some of its body extracted to component
  to only be minimal routing-related stuff in layout


## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
