### PR TITLE
Fix: when updating references it's okay if an existing reference doesnt match the existing value

### DIFF
--- a/crates/gitbutler-stack/src/stack_branch.rs
+++ b/crates/gitbutler-stack/src/stack_branch.rs
@@ -201,14 +201,10 @@ impl StackBranch {
             CommitOrChangeId::CommitId(id) => gix::ObjectId::from_str(id)?,
             CommitOrChangeId::ChangeId(_) => return Ok(None), // noop
         };
-        let old_oid: gix::ObjectId = match self.head.clone() {
-            CommitOrChangeId::CommitId(id) => gix::ObjectId::from_str(&id)?,
-            CommitOrChangeId::ChangeId(_) => return Ok(None), // noop
-        };
         let reference = repo.reference(
             qualified_reference_name(self.name()),
             new_oid,
-            PreviousValue::ExistingMustMatch(old_oid.into()),
+            PreviousValue::Any,
             "GitButler reference",
         )?;
         Ok(Some(reference.name().as_bstr().to_owned()))


### PR DESCRIPTION
This is allowed because previously we had code which would create a git reference when a stack is unapplied but then never update what it points to. A reference that is out of date in this case would prevent operations