### PR TITLE
assure there are no trees in commit-changes

### DIFF
--- a/crates/but-core/src/diff/commit.rs
+++ b/crates/but-core/src/diff/commit.rs
@@ -29,7 +29,11 @@ pub fn commit_changes(
         .map(|obj| obj.into_tree())?;
 
     let changes = repo.diff_tree_to_tree(lhs_tree.as_ref(), &rhs_tree, None)?;
-    let mut out: Vec<TreeChange> = changes.into_iter().map(Into::into).collect();
+    let mut out: Vec<TreeChange> = changes
+        .into_iter()
+        .filter(|c| !c.entry_mode().is_tree())
+        .map(Into::into)
+        .collect();
     out.sort_by(|a, b| a.path.cmp(&b.path));
     Ok(out)
 }

--- a/crates/but-core/tests/core/diff/commit_changes.rs
+++ b/crates/but-core/tests/core/diff/commit_changes.rs
@@ -106,6 +106,16 @@ fn without_previous_tree() -> anyhow::Result<()> {
             },
         },
         TreeChange {
+            path: "dir/nested",
+            status: Addition {
+                state: ChangeState {
+                    id: Sha1(e69de29bb2d1d6434b8b29ae775ad8c2e48c5391),
+                    kind: Blob,
+                },
+                is_untracked: false,
+            },
+        },
+        TreeChange {
             path: "executable-bit-added",
             status: Addition {
                 state: ChangeState {
@@ -178,8 +188,8 @@ fn changes_between_conflicted_and_normal_commit() -> anyhow::Result<()> {
         "#);
     Ok(())
 }
-#[test]
 
+#[test]
 fn changes_between_conflicted_and_conflicted_commit() -> anyhow::Result<()> {
     let repo = conflict_repo("normal-and-artificial")?;
     let changes = but_core::diff::commit_changes(

--- a/crates/but-core/tests/fixtures/status-repo.sh
+++ b/crates/but-core/tests/fixtures/status-repo.sh
@@ -48,7 +48,9 @@ EOF
 
 git init many-in-tree
 (cd many-in-tree
+  mkdir dir
   touch removed \
+        dir/nested \
         modified \
         executable-bit-added \
         file-to-link


### PR DESCRIPTION
The reason for this shortcoming was quite literally that no test ever created a change in a directory.
This was done now to assure it won't regress.
