### PR TITLE
fix: use `LocalOnly` as fallback color for `BranchDividerLine`

### DIFF
--- a/apps/desktop/src/components/v3/Branch.svelte
+++ b/apps/desktop/src/components/v3/Branch.svelte
@@ -35,7 +35,7 @@
 <ReduxResult result={combineResults(branchResult, commitResult)}>
 	{#snippet children([branch, commit])}
 		{#if !first}
-			<BranchDividerLine topPatchStatus={commit?.state.type ?? 'Error'} />
+			<BranchDividerLine topPatchStatus={commit?.state.type ?? 'LocalOnly'} />
 		{/if}
 		<div class="branch" class:selected data-series-name={branchName}>
 			<BranchHeader {projectId} {stackId} {branch} isTopBranch={first} />


### PR DESCRIPTION
## 🧢 Changes

- Update fallback color for divider line between branches from `Error` (red) to `LocalOnly` (gray)

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
