### PR TITLE
Make amending new files possible in the commit-engine

### DIFF
--- a/crates/but-workspace/src/commit_engine/mod.rs
+++ b/crates/but-workspace/src/commit_engine/mod.rs
@@ -64,7 +64,8 @@ pub struct DiffSpec {
     pub path: BString,
     /// If one or more hunks are specified, match them with actual changes currently in the worktree.
     /// Failure to match them will lead to the change being dropped.
-    /// If empty, the whole file is taken as is.
+    /// If empty, the whole file is taken as is if this seems to be an addition.
+    /// Otherwise, the whole file is being deleted.
     pub hunk_headers: Vec<HunkHeader>,
 }
 


### PR DESCRIPTION
### Tasks

* [x] amend a new file
* [x] amend a deletion
* [x] Figure out what's going on - it seems to work fine, what's different? It's this: https://github.com/gitbutlerapp/gitbutler/blob/3b3939f02be50b4900605ae1ad7895c9bd969181/crates/but-workspace/tests/workspace/commit_engine/utils.rs#L106-L110
* [x] make untracked file addable as hunks

### Next PR

* [ ] make rejections easier to understand (and thus debug)