### PR TITLE
fix: load webapp css after marketing css file

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -13,8 +13,8 @@
 	import { get } from 'svelte/store';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
-	import '$lib/styles/global.css';
 	import '$home/styles/styles.css';
+	import '$lib/styles/global.css';
 
 	interface Props {
 		children: Snippet;


### PR DESCRIPTION
## 🧢 Changes

- Swap the order that marketing / webapp global css files are loaded
- Longer term we want to rm the `../home/styles/styles.css`. Talked to Pavel already

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
