### PR TITLE
fix: avoid 1px tr height hack

### DIFF
--- a/apps/web/src/lib/components/branches/BranchIndexCard.svelte
+++ b/apps/web/src/lib/components/branches/BranchIndexCard.svelte
@@ -75,20 +75,16 @@
 		font-size: 0.8em;
 		color: var(--clr-text-2);
 	}
+
 	.row {
-		/*
-			This is a magical incantation that lets the divs take up the full
-			height of the cell. Nobody knows why this makes any difference
-			because it's completly ingnored, but it does!
-		*/
-		height: 1px;
+		min-height: 50px;
 
 		> td {
 			padding: 0;
-			/* This is also part of the magical spell. */
-			height: 1px;
+			height: 100%;
 
 			> div {
+				min-height: 50px;
 				height: 100%;
 
 				background-color: var(--clr-bg-1);

--- a/apps/web/src/lib/components/changes/ChangeIndexCard.svelte
+++ b/apps/web/src/lib/components/changes/ChangeIndexCard.svelte
@@ -89,19 +89,14 @@
 
 <style lang="postcss">
 	.row {
-		/*
-			This is a magical incantation that lets the divs take up the full
-			height of the cell. Nobody knows why this makes any difference
-			because it's completly ingnored, but it does!
-		*/
-		height: 1px;
+		min-height: 50px;
 
 		> td {
 			padding: 0;
-			/* This is also part of the magical spell. */
-			height: 1px;
+			height: 100%;
 
 			> div {
+				min-height: 50px;
 				height: 100%;
 
 				background-color: var(--clr-bg-1);

--- a/apps/web/src/lib/components/projects/ProjectIndexCard.svelte
+++ b/apps/web/src/lib/components/projects/ProjectIndexCard.svelte
@@ -51,19 +51,14 @@
 
 <style lang="postcss">
 	.row {
-		/*
-			This is a magical incantation that lets the divs take up the full
-			height of the cell. Nobody knows why this makes any difference
-			because it's completly ingnored, but it does!
-		*/
-		height: 1px;
+		min-height: 50px;
 
 		> td {
 			padding: 0;
-			/* This is also part of the magical spell. */
-			height: 1px;
+			height: 100%;
 
 			> div {
+				min-height: 50px;
 				height: 100%;
 
 				background-color: var(--clr-bg-1);


### PR DESCRIPTION
## 🧢 Changes

- Rm `height: 1px` hack on `tr`'s in Project, Branch, and Change -Index table rows.

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
