### PR TITLE
Code quoting: handle it being all touchy and mobile

### DIFF
--- a/apps/web/src/lib/chat/minimize.svelte.ts
+++ b/apps/web/src/lib/chat/minimize.svelte.ts
@@ -11,6 +11,10 @@ export class ChatMinimize {
 		return event.key === SHORTCUT_KEY && (event.ctrlKey || event.metaKey);
 	}
 
+	expand() {
+		this._minimize = false;
+	}
+
 	get value() {
 		return this._minimize;
 	}

--- a/apps/web/src/lib/diff/lineSelection.svelte.ts
+++ b/apps/web/src/lib/diff/lineSelection.svelte.ts
@@ -9,6 +9,7 @@ import {
 	encodeDiffFileLine
 } from '@gitbutler/ui/utils/diffParsing';
 import { SvelteSet } from 'svelte/reactivity';
+import type { ChatMinimize } from '$lib/chat/minimize.svelte';
 import type { DiffPatch } from '@gitbutler/shared/chat/types';
 import type { LineClickParams } from '@gitbutler/ui/HunkDiff.svelte';
 import type { ContentSection, DiffFileLineId, LineSelector } from '@gitbutler/ui/utils/diffParsing';
@@ -82,6 +83,8 @@ export default class DiffLineSelection {
 		calculateSelectedLines(this._selectedDiffLines)
 	);
 	private _selectedDiffFile = $state<DiffFileKey>();
+
+	constructor(private readonly chatMinimizer: ChatMinimize) {}
 
 	clear(fileName?: string) {
 		if (fileName && this._selectedDiffFile) {
@@ -159,6 +162,7 @@ export default class DiffLineSelection {
 	}
 
 	quote() {
+		this.chatMinimizer.expand();
 		this._quote = true;
 	}
 

--- a/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/reviews/[branchId]/commit/[changeId]/+page.svelte
+++ b/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/reviews/[branchId]/commit/[changeId]/+page.svelte
@@ -44,7 +44,7 @@
 	const userService = getContext(UserService);
 	const user = $derived(userService.user);
 	const chatMinimizer = new ChatMinimize();
-	const diffLineSelection = new DiffLineSelection();
+	const diffLineSelection = new DiffLineSelection(chatMinimizer);
 
 	const repositoryId = $derived(
 		lookupProject(appState, repositoryIdLookupService, data.ownerSlug, data.projectSlug)

--- a/packages/ui/src/lib/hunkDiff/HunkDiffBody.svelte
+++ b/packages/ui/src/lib/hunkDiff/HunkDiffBody.svelte
@@ -57,6 +57,9 @@
 <tbody
 	onmouseenter={() => (hoveringOverTable = true)}
 	onmouseleave={() => (hoveringOverTable = false)}
+	ontouchstart={(ev) => lineSelection.onTouchStart(ev)}
+	ontouchmove={(ev) => lineSelection.onTouchMove(ev)}
+	ontouchend={() => lineSelection.onEnd()}
 	use:clickOutside={{
 		handler: () => {
 			if (hasSelectedLines) clearLineSelection?.();

--- a/packages/ui/src/lib/hunkDiff/HunkDiffRow.svelte
+++ b/packages/ui/src/lib/hunkDiff/HunkDiffRow.svelte
@@ -1,4 +1,6 @@
 <script lang="ts" module>
+	import { isTouchDevice } from '$lib/utils/browserAgent';
+
 	export function getHunkLineId(rowEncodedId: DiffFileLineId): string {
 		return `hunk-line-${rowEncodedId}`;
 	}
@@ -45,11 +47,45 @@
 		hoveringOverTable
 	}: Props = $props();
 
+	const touchDevice = isTouchDevice();
+
 	let rowElement = $state<HTMLTableRowElement>();
 	let overflowMenuHeight = $state<number>(0);
 
+	const rowTop = $derived(rowElement?.getBoundingClientRect().top);
+	const rowLeft = $derived(rowElement?.getBoundingClientRect().left);
 	const rowWidth = $derived(rowElement?.getBoundingClientRect().width);
 	const rowHeight = $derived(rowElement?.getBoundingClientRect().height);
+
+	$effect(() => {
+		if (
+			lineSelection.touchStart !== undefined &&
+			rowTop !== undefined &&
+			rowLeft !== undefined &&
+			numberHeaderWidth !== undefined &&
+			rowHeight !== undefined
+		) {
+			const rowTouchStartY =
+				lineSelection.touchStart.y > rowTop && lineSelection.touchStart.y < rowTop + rowHeight;
+			const rowTouchStartX =
+				lineSelection.touchStart.x > rowLeft &&
+				lineSelection.touchStart.x < rowLeft + numberHeaderWidth;
+			if (rowTouchStartY && rowTouchStartX) {
+				lineSelection.touchSelectionStart(row, idx);
+			}
+
+			if (lineSelection.touchMove !== undefined) {
+				const rowTouchEndsY =
+					lineSelection.touchMove.y > rowTop && lineSelection.touchMove.y < rowTop + rowHeight;
+				const rowTouchEndsX =
+					lineSelection.touchMove.x > rowLeft &&
+					lineSelection.touchMove.x < rowLeft + numberHeaderWidth;
+				if (rowTouchEndsY && rowTouchEndsX) {
+					lineSelection.touchSelectionEnd(row, idx);
+				}
+			}
+		}
+	});
 </script>
 
 {#snippet countColumn(row: Row, side: CountColumnSide, idx: number)}
@@ -106,7 +142,7 @@
 				<div
 					bind:clientHeight={overflowMenuHeight}
 					class="table__selected-row-overflow-menu"
-					class:hovered={hoveringOverTable}
+					class:visible={hoveringOverTable || touchDevice}
 					style="--number-col-width: {numberHeaderWidth}px; --height: {rowHeight}px; --overflow-menu-height: {overflowMenuHeight}px;"
 				>
 					{#if onQuoteSelection}
@@ -211,7 +247,7 @@
 			border-right: 1px solid var(--clr-border-2);
 		}
 
-		&.hovered {
+		&.visible {
 			opacity: 1;
 			pointer-events: all;
 		}
@@ -227,6 +263,7 @@
 		text-align: right;
 		vertical-align: top;
 		user-select: none;
+		touch-action: none;
 
 		position: sticky;
 		left: calc(var(--number-col-width));

--- a/packages/ui/src/lib/utils/browserAgent.ts
+++ b/packages/ui/src/lib/utils/browserAgent.ts
@@ -1,0 +1,7 @@
+export function isTouchDevice() {
+	return (
+		'ontouchstart' in window ||
+		navigator.maxTouchPoints > 0 ||
+		(navigator as any).msMaxTouchPoints > 0
+	);
+}


### PR DESCRIPTION
Enable multi-line code quoting on mobile.

Disclaimer: This was only tested in the Chrome emulator, so needs to be tested after deploying it.
