### PR TITLE
patch page: header is stuck is less jumpy

### DIFF
--- a/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/reviews/[branchId]/commit/[changeId]/+page.svelte
+++ b/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/reviews/[branchId]/commit/[changeId]/+page.svelte
@@ -90,15 +90,16 @@
 
 	let header = $state<HTMLDivElement>();
 	let headerIsStuck = $state(false);
+	const HEADER_STUCK_THRESHOLD = 4;
 
 	window.onscroll = () => {
 		if (header) {
 			const top = header.getBoundingClientRect().top;
-			if (!headerIsStuck && top <= 0) {
+			if (!headerIsStuck && top <= HEADER_STUCK_THRESHOLD) {
 				headerIsStuck = true;
 			}
 
-			if (headerIsStuck && top > 0) {
+			if (headerIsStuck && top > HEADER_STUCK_THRESHOLD) {
 				headerIsStuck = false;
 			}
 		}


### PR DESCRIPTION
In mobile safari, the header was a bit jumpy, in order to avoid that, increase the threshold to 4px