### PR TITLE
style fix: Let the pointer events through when the chat is in tablet mode

### DIFF
--- a/apps/web/src/lib/components/ChatComponent.svelte
+++ b/apps/web/src/lib/components/ChatComponent.svelte
@@ -128,6 +128,7 @@
 
 <style lang="postcss">
 	.chat-wrapper {
+		pointer-events: all;
 		width: 100%;
 		display: flex;
 		flex-direction: column;

--- a/apps/web/src/lib/components/ShowChatButton.svelte
+++ b/apps/web/src/lib/components/ShowChatButton.svelte
@@ -61,6 +61,7 @@
 
 <style lang="postcss">
 	.show-chat {
+		pointer-events: all;
 		position: fixed;
 		bottom: 20px;
 		right: 20px;

--- a/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/reviews/[branchId]/commit/[changeId]/+page.svelte
+++ b/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/reviews/[branchId]/commit/[changeId]/+page.svelte
@@ -240,10 +240,7 @@
 						branchId={data.branchId}
 						changeId={data.changeId}
 						minimized={chatMinimizer.value}
-						onMinimizeToggle={() => {
-							chatMinimizer.toggle();
-							console.log('chat minimized', chatMinimizer.value);
-						}}
+						onMinimizeToggle={() => chatMinimizer.toggle()}
 						diffSelection={diffLineSelection.diffSelection}
 						clearDiffSelection={() => diffLineSelection.clear()}
 					/>
@@ -393,7 +390,7 @@
 			top: unset;
 			left: 0;
 			bottom: 0;
-			box-shadow: var(--fx-shadow-s);
+			pointer-events: none;
 		}
 	}
 </style>


### PR DESCRIPTION
When the view port matches the tablet width, it covers the whole screen.
This stops all pointer events, so we need to explicitly let them through