### PR TITLE
follow-up style fix for the code blocks

### DIFF
--- a/apps/web/src/lib/components/chat/Message.svelte
+++ b/apps/web/src/lib/components/chat/Message.svelte
@@ -136,8 +136,6 @@
 		&.highlight {
 			animation: temporary-highlight 2s ease-out;
 		}
-
-		overflow: hidden;
 	}
 
 	.chat-message__issue-icon {
@@ -178,6 +176,7 @@
 		width: 100%;
 		gap: 12px;
 		flex-grow: 0;
+		min-width: 0;
 	}
 
 	.chat-message__header {

--- a/apps/web/src/lib/components/chat/MessageCode.svelte
+++ b/apps/web/src/lib/components/chat/MessageCode.svelte
@@ -24,18 +24,21 @@
 
 <style>
 	.code-wrapper {
-		width: 100%;
 		display: flex;
+		min-width: 0;
+		overflow-x: scroll;
+		border-radius: var(--radius-s);
+
+		border: 1px solid var(--clr-border-2);
+		padding: 4px 8px;
 	}
 	.code {
 		width: 100%;
-		border-radius: var(--radius-s);
-		background-color: var(--clr-diff-line-bg);
-		border: 1px solid var(--clr-border-2);
-		overflow-x: scroll;
-		padding: 4px 8px;
+		max-width: 100%;
 		font-family: var(--fontfamily-mono);
 		box-sizing: border-box;
+		background-color: var(--clr-diff-line-bg);
+		border: none;
 	}
 
 	.line {


### PR DESCRIPTION
Code blocks now fully shrink to the size of their parents, avoiding overflow by being correctly scrolable