### PR TITLE
Fix an issue where rebasing the workspace 'flattens' stacks

### DIFF
--- a/crates/but-cli/src/command/mod.rs
+++ b/crates/but-cli/src/command/mod.rs
@@ -123,11 +123,12 @@ pub mod stacks {
     pub fn branch_commits(id: &str, name: &str, current_dir: &Path) -> anyhow::Result<()> {
         let project = project_from_path(current_dir)?;
         let ctx = CommandContext::open(&project, AppSettings::default())?;
+        let repo = ctx.gix_repository()?;
         let local_and_remote =
-            stack_branch_local_and_remote_commits(id.to_string(), name.to_string(), &ctx);
+            stack_branch_local_and_remote_commits(id.to_string(), name.to_string(), &ctx, &repo);
         debug_print(local_and_remote)?;
         let upstream_only =
-            stack_branch_upstream_only_commits(id.to_string(), name.to_string(), &ctx);
+            stack_branch_upstream_only_commits(id.to_string(), name.to_string(), &ctx, &repo);
         debug_print(upstream_only)
     }
 }

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -604,8 +604,13 @@ pub fn upstream_integration_statuses(
 ) -> Result<StackStatuses> {
     let mut guard = ctx.project().exclusive_worktree_access();
 
-    let context =
-        UpstreamIntegrationContext::open(ctx, target_commit_oid, guard.write_permission())?;
+    let gix_repo = ctx.gix_repository()?;
+    let context = UpstreamIntegrationContext::open(
+        ctx,
+        target_commit_oid,
+        guard.write_permission(),
+        &gix_repo,
+    )?;
 
     upstream_integration::upstream_integration_statuses(&context)
 }

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use anyhow::{Context, Result};
+use but_rebase::RebaseStep;
 use gitbutler_command_context::CommandContext;
 use gitbutler_commit::commit_ext::CommitExt;
 use gitbutler_oplog::entry::{OperationKind, SnapshotDetails};
@@ -429,4 +430,37 @@ fn stack_branch_to_api_branch(
         },
         requires_force,
     ))
+}
+
+pub(crate) fn stack_as_rebase_steps(
+    ctx: &CommandContext,
+    stack_id: StackId,
+) -> Result<Vec<RebaseStep>> {
+    let mut steps: Vec<RebaseStep> = Vec::new();
+    let repo = ctx.gix_repository()?;
+    for branch in but_workspace::stack_branches(stack_id.to_string(), ctx)? {
+        if branch.archived {
+            continue;
+        }
+        let reference_step = if let Some(reference) = repo.try_find_reference(&branch.name)? {
+            RebaseStep::Reference(but_core::Reference::Git(reference.name().to_owned()))
+        } else {
+            RebaseStep::Reference(but_core::Reference::Virtual(branch.name.to_string()))
+        };
+        steps.push(reference_step);
+        let commits = but_workspace::stack_branch_local_and_remote_commits(
+            stack_id.to_string(),
+            branch.name.to_string(),
+            ctx,
+        )?;
+        for commit in commits {
+            let pick_step = RebaseStep::Pick {
+                commit_id: commit.id,
+                new_message: None,
+            };
+            steps.push(pick_step);
+        }
+    }
+    steps.reverse();
+    Ok(steps)
 }

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -434,10 +434,10 @@ fn stack_branch_to_api_branch(
 
 pub(crate) fn stack_as_rebase_steps(
     ctx: &CommandContext,
+    repo: &gix::Repository,
     stack_id: StackId,
 ) -> Result<Vec<RebaseStep>> {
     let mut steps: Vec<RebaseStep> = Vec::new();
-    let repo = ctx.gix_repository()?;
     for branch in but_workspace::stack_branches(stack_id.to_string(), ctx)? {
         if branch.archived {
             continue;
@@ -452,6 +452,7 @@ pub(crate) fn stack_as_rebase_steps(
             stack_id.to_string(),
             branch.name.to_string(),
             ctx,
+            repo,
         )?;
         for commit in commits {
             let pick_step = RebaseStep::Pick {

--- a/crates/gitbutler-branch-actions/src/undo_commit.rs
+++ b/crates/gitbutler-branch-actions/src/undo_commit.rs
@@ -37,7 +37,8 @@ pub(crate) fn undo_commit(
 
     let stack_ctx = ctx.to_stack_context()?;
     let merge_base = stack.merge_base(&stack_ctx)?;
-    let steps = stack_as_rebase_steps(ctx, stack.id)?
+    let repo = ctx.gix_repository()?;
+    let steps = stack_as_rebase_steps(ctx, &repo, stack.id)?
         .into_iter()
         .filter(|s| match s {
             RebaseStep::Pick {
@@ -48,7 +49,6 @@ pub(crate) fn undo_commit(
         })
         .collect::<Vec<_>>();
 
-    let repo = ctx.gix_repository()?;
     let mut rebase = but_rebase::Rebase::new(&repo, Some(merge_base.to_gix()), None)?;
     rebase.rebase_noops(false);
     rebase.steps(steps)?;

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -1,10 +1,13 @@
-use crate::stack::branch_integrated;
+use crate::stack::{branch_integrated, stack_as_rebase_steps};
 use crate::{r#virtual::IsCommitIntegrated, BranchManagerExt, VirtualBranchesExt as _};
 use anyhow::{anyhow, bail, Context, Result};
+use but_rebase::RebaseStep;
 use gitbutler_cherry_pick::RepositoryExt;
 use gitbutler_command_context::CommandContext;
 use gitbutler_commit::commit_ext::CommitExt as _;
-use gitbutler_oxidize::{git2_to_gix_object_id, gix_to_git2_oid, GixRepositoryExt};
+use gitbutler_oxidize::{
+    git2_to_gix_object_id, gix_to_git2_oid, GixRepositoryExt, ObjectIdExt, OidExt,
+};
 use gitbutler_project::access::WorktreeWritePermission;
 use gitbutler_repo::logging::RepositoryExt as _;
 use gitbutler_repo::RepositoryExt as _;
@@ -159,6 +162,8 @@ pub struct UpstreamIntegrationContext<'a> {
     stacks_in_workspace: Vec<Stack>,
     new_target: git2::Commit<'a>,
     target: Target,
+    ctx: &'a CommandContext,
+    gix_repo: &'a gix::Repository,
 }
 
 impl<'a> UpstreamIntegrationContext<'a> {
@@ -166,6 +171,7 @@ impl<'a> UpstreamIntegrationContext<'a> {
         command_context: &'a CommandContext,
         target_commit_oid: Option<git2::Oid>,
         permission: &'a mut WorktreeWritePermission,
+        gix_repo: &'a gix::Repository,
     ) -> Result<Self> {
         let virtual_branches_handle = command_context.project().virtual_branches();
         let target = virtual_branches_handle.get_default_target()?;
@@ -187,6 +193,8 @@ impl<'a> UpstreamIntegrationContext<'a> {
             new_target,
             target: target.clone(),
             stacks_in_workspace,
+            ctx: command_context,
+            gix_repo,
         })
     }
 }
@@ -376,7 +384,13 @@ pub(crate) fn integrate_upstream(
         .map(|r| (Some(r.target_commit_oid), Some(r.approach)))
         .unwrap_or((None, None));
 
-    let context = UpstreamIntegrationContext::open(command_context, target_commit_oid, permission)?;
+    let gix_repo = command_context.gix_repository()?;
+    let context = UpstreamIntegrationContext::open(
+        command_context,
+        target_commit_oid,
+        permission,
+        &gix_repo,
+    )?;
     let virtual_branches_state = VirtualBranchesHandle::new(command_context.project().gb_dir());
     let default_target = virtual_branches_state.get_default_target()?;
 
@@ -510,7 +524,8 @@ pub(crate) fn resolve_upstream_integration(
     resolution_approach: BaseBranchResolutionApproach,
     permission: &mut WorktreeWritePermission,
 ) -> Result<git2::Oid> {
-    let context = UpstreamIntegrationContext::open(command_context, None, permission)?;
+    let gix_repo = command_context.gix_repository()?;
+    let context = UpstreamIntegrationContext::open(command_context, None, permission, &gix_repo)?;
     let repo = command_context.repo();
     let new_target_id = context.new_target.id();
     let old_target_id = context.target.sha;
@@ -630,33 +645,37 @@ fn compute_resolutions(
                         new_target.id()
                     };
 
-                    // Rebase virtual branches' commits
-                    let virtual_branch_commits = repository.log(
-                        branch_stack.head(),
-                        LogUntil::Commit(lower_bound),
-                        false,
-                    )?;
-
+                    let steps =
+                        stack_as_rebase_steps(context.ctx, context.gix_repo, branch_stack.id)?;
                     // Filter out any integrated commits
-                    let virtual_branch_commits = virtual_branch_commits
+                    let steps = steps
                         .into_iter()
-                        .filter_map(|commit| {
-                            let is_integrated = check_commit.is_integrated(&commit).ok()?;
-                            if is_integrated {
-                                None
-                            } else {
-                                Some(commit.id())
+                        .filter_map(|s| match s {
+                            RebaseStep::Pick {
+                                commit_id,
+                                new_message: _,
+                            } => {
+                                let commit = repository.find_commit(commit_id.to_git2()).ok()?;
+                                let is_integrated = check_commit.is_integrated(&commit).ok()?;
+                                if is_integrated {
+                                    None
+                                } else {
+                                    Some(s)
+                                }
                             }
+                            _ => Some(s),
                         })
                         .collect::<Vec<_>>();
 
-                    let new_head = cherry_rebase_group(
-                        repository,
-                        new_target.id(),
-                        &virtual_branch_commits,
-                        false,
-                        false,
+                    let mut rebase = but_rebase::Rebase::new(
+                        context.gix_repo,
+                        Some(lower_bound.to_gix()),
+                        None,
                     )?;
+                    rebase.rebase_noops(false);
+                    rebase.steps(steps)?;
+                    let output = rebase.rebase()?;
+                    let new_head = output.top_commit.to_git2();
 
                     // Get the updated tree oid
                     let BranchHeadAndTree {

--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -46,7 +46,8 @@ pub fn stack_branch_local_and_remote_commits(
 ) -> Result<Vec<but_workspace::Commit>, Error> {
     let project = projects.get(project_id)?;
     let ctx = CommandContext::open(&project, settings.get()?.clone())?;
-    but_workspace::stack_branch_local_and_remote_commits(stack_id, branch_name, &ctx)
+    let repo = ctx.gix_repository()?;
+    but_workspace::stack_branch_local_and_remote_commits(stack_id, branch_name, &ctx, &repo)
         .map_err(Into::into)
 }
 
@@ -61,7 +62,8 @@ pub fn stack_branch_upstream_only_commits(
 ) -> Result<Vec<but_workspace::UpstreamCommit>, Error> {
     let project = projects.get(project_id)?;
     let ctx = CommandContext::open(&project, settings.get()?.clone())?;
-    but_workspace::stack_branch_upstream_only_commits(stack_id, branch_name, &ctx)
+    let repo = ctx.gix_repository()?;
+    but_workspace::stack_branch_upstream_only_commits(stack_id, branch_name, &ctx, &repo)
         .map_err(Into::into)
 }
 


### PR DESCRIPTION
The integrate upstream never had specific handling for stacks - previously it just worked because the heads were referred to via the change id.

This changeset updates the relevant code to use the new rebase engine, which also provides us with a references mapping.

Fixes [#7398](https://github.com/gitbutlerapp/gitbutler/issues/7398)