### PR TITLE
Fix reactivity in v3

### DIFF
--- a/apps/desktop/src/components/ReduxResult.svelte
+++ b/apps/desktop/src/components/ReduxResult.svelte
@@ -1,5 +1,6 @@
 <script lang="ts" generics="A">
 	import Icon from '@gitbutler/ui/Icon.svelte';
+	import { isErrorlike } from '@gitbutler/ui/utils/typeguards';
 	import { QueryStatus } from '@reduxjs/toolkit/query';
 	import type { Snippet } from 'svelte';
 
@@ -30,7 +31,11 @@
 		<Icon name="spinner" />
 	</div>
 {:else if status === 'rejected'}
-	{String(error)}
+	{#if isErrorlike(error)}
+		{error.message}
+	{:else}
+		{String(error)}
+	{/if}
 {:else if status === 'uninitialized'}
 	Uninitialized...
 {/if}

--- a/apps/desktop/src/components/v3/Branch.svelte
+++ b/apps/desktop/src/components/v3/Branch.svelte
@@ -41,9 +41,9 @@
 
 	const [stackService] = inject(StackService);
 
-	const branchResult = $derived(stackService.branchByName(projectId, stackId, branchName).current);
-	const branchesResult = $derived(stackService.branches(projectId, stackId).current);
-	const commitResult = $derived(stackService.commitAt(projectId, stackId, branchName, 0).current);
+	const branchResult = $derived(stackService.branchByName(projectId, stackId, branchName));
+	const branchesResult = $derived(stackService.branches(projectId, stackId));
+	const commitResult = $derived(stackService.commitAt(projectId, stackId, branchName, 0));
 
 	const forge = getForge();
 	const forgeBranch = $derived($forge?.branch(branchName));
@@ -68,7 +68,9 @@
 	}
 </script>
 
-<ReduxResult result={combineResults(branchResult, branchesResult, commitResult)}>
+<ReduxResult
+	result={combineResults(branchResult.current, branchesResult.current, commitResult.current)}
+>
 	{#snippet children([branch, branches, commit])}
 		{@const parentIsPushed = !!parent}
 		{@const hasParent = !!parent}

--- a/apps/desktop/src/components/v3/BranchList.svelte
+++ b/apps/desktop/src/components/v3/BranchList.svelte
@@ -14,10 +14,10 @@
 	const { projectId, stackId, selectedBranchName, selectedCommitId }: Props = $props();
 	const [stackService] = inject(StackService);
 
-	const result = $derived(stackService.branches(projectId, stackId).current);
+	const result = $derived(stackService.branches(projectId, stackId));
 </script>
 
-<ReduxResult {result}>
+<ReduxResult result={result.current}>
 	{#snippet children(branches)}
 		{#each branches as branch, i (branch.name)}
 			{@const first = i === 0}

--- a/apps/desktop/src/components/v3/BranchView.svelte
+++ b/apps/desktop/src/components/v3/BranchView.svelte
@@ -23,14 +23,14 @@
 	const userSettings = getContextStoreBySymbol<Settings>(SETTINGS);
 
 	const stackBranchWidthKey = $derived('defaultStackBranchWidth_ ' + projectId);
-	const result = $derived(stackService.branches(projectId, stackId).current);
+	const branchesResult = $derived(stackService.branches(projectId, stackId));
 
 	let resizeStackBranches = $state<HTMLElement>();
 	let stackBranchWidth = $derived(persisted<number>(22.5, stackBranchWidthKey));
 </script>
 
 <div class="branch-view">
-	<ReduxResult {result}>
+	<ReduxResult result={branchesResult.current}>
 		{#snippet children(branches)}
 			<div class="branches" bind:this={resizeStackBranches} style:width={$stackBranchWidth + 'rem'}>
 				<Resizer

--- a/apps/desktop/src/components/v3/CommitView.svelte
+++ b/apps/desktop/src/components/v3/CommitView.svelte
@@ -16,10 +16,10 @@
 	const { projectId, commitKey, onClose }: Props = $props();
 
 	const [stackService] = inject(StackService);
-	const commit = $derived(stackService.commitById(projectId, commitKey).current);
+	const commitResult = $derived(stackService.commitById(projectId, commitKey));
 </script>
 
-<ReduxResult result={commit}>
+<ReduxResult result={commitResult.current}>
 	{#snippet children(commit)}
 		<div class="commit-view">
 			<div>

--- a/apps/desktop/src/components/v3/NewCommit.svelte
+++ b/apps/desktop/src/components/v3/NewCommit.svelte
@@ -28,15 +28,15 @@
 	const base = $derived(baseBranchService.base);
 
 	const changeSelection = getContext(ChangeSelectionService);
-	const selection = $derived(changeSelection.list().current);
+	const selection = $derived(changeSelection.list());
 
 	/**
 	 * Toggles use of markdown on/off in the message editor.
 	 */
 	let markdown = persisted(true, 'useMarkdown__' + projectId);
 
-	const commitResult = $derived(stackService.commitAt(projectId, stackId, branchName, 0).current);
-	const commit = $derived(commitResult.data);
+	const commitResult = $derived(stackService.commitAt(projectId, stackId, branchName, 0));
+	const commit = $derived(commitResult.current.data);
 
 	const baseSha = $derived($base?.baseSha);
 	const defaultParentId = $derived(commit ? commit.id : baseSha);
@@ -63,7 +63,7 @@
 			parentId,
 			message: message,
 			stackBranchName: branchName,
-			worktreeChanges: selection.map((item) =>
+			worktreeChanges: selection.current.map((item) =>
 				item.type === 'full'
 					? {
 							pathBytes: item.pathBytes,

--- a/apps/desktop/src/components/v3/StackDetailsFileList.svelte
+++ b/apps/desktop/src/components/v3/StackDetailsFileList.svelte
@@ -12,25 +12,23 @@
 
 	const { projectId, commit }: Props = $props();
 	const [stackService] = inject(StackService);
-	const result = $derived(stackService.commitChanges(projectId, commit.id).current);
+	const changesResult = $derived(stackService.commitChanges(projectId, commit.id));
 </script>
 
 <div class="wrapper">
 	<div class="header text-13 text-bold">Changed files</div>
-	{#if result}
-		<ReduxResult {result}>
-			{#snippet children(changes)}
-				{#if changes.length > 0}
-					<FileList {projectId} {changes} />
-				{:else}
-					<div class="text-12 text-body helper-text">
-						<div>You're all caught up!</div>
-						<div>No files need committing</div>
-					</div>
-				{/if}
-			{/snippet}
-		</ReduxResult>
-	{/if}
+	<ReduxResult result={changesResult.current}>
+		{#snippet children(changes)}
+			{#if changes.length > 0}
+				<FileList {projectId} {changes} />
+			{:else}
+				<div class="text-12 text-body helper-text">
+					<div>You're all caught up!</div>
+					<div>No files need committing</div>
+				</div>
+			{/if}
+		{/snippet}
+	</ReduxResult>
 </div>
 
 <style>

--- a/apps/desktop/src/components/v3/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/v3/UnifiedDiffView.svelte
@@ -15,7 +15,7 @@
 
 	const { projectId, selectable = false, change }: Props = $props();
 	const [diffService, changeSelection] = inject(DiffService, ChangeSelectionService);
-	const result = $derived(diffService.getDiff(projectId, change).current);
+	const diffResult = $derived(diffService.getDiff(projectId, change));
 
 	const selection = $derived(changeSelection.getById(change.path).current);
 	const pathData = $derived({
@@ -86,7 +86,7 @@
 </script>
 
 <div class="diff-section">
-	<ReduxResult {result}>
+	<ReduxResult result={diffResult.current}>
 		{#snippet children(diff)}
 			{#if diff.type === 'Patch'}
 				{#each diff.subject.hunks as hunk}

--- a/apps/desktop/src/components/v3/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/v3/WorktreeChanges.svelte
@@ -22,12 +22,12 @@
 	const worktreeService = getContext(WorktreeService);
 	createCommitStore(undefined);
 
-	const result = $derived(worktreeService.getChanges(projectId).current);
+	const changesResult = $derived(worktreeService.getChanges(projectId));
 	const disabled = $derived(!!isCommitPath());
 
 	/** Clear any selected changes that no longer exist. */
 	$effect(() => {
-		const affectedPaths = result.data?.map((c) => c.path);
+		const affectedPaths = changesResult.current.data?.map((c) => c.path);
 		changeSelection.retain(affectedPaths);
 	});
 </script>
@@ -37,7 +37,7 @@
 	<Button kind="ghost" icon="sidebar-unfold" />
 </div>
 
-<ReduxResult {result}>
+<ReduxResult result={changesResult.current}>
 	{#snippet children(changes)}
 		{#if changes.length > 0}
 			<div class="uncommitted-changes">

--- a/apps/desktop/src/lib/state/backendQuery.ts
+++ b/apps/desktop/src/lib/state/backendQuery.ts
@@ -13,7 +13,7 @@ export async function tauriBaseQuery(
 		return { data: await api.extra.tauri.invoke(args.command, args.params) };
 	} catch (error: unknown) {
 		if (isBackendError(error)) {
-			return { error: { message: error.message, code: error.code } };
+			return { error };
 		}
 		return { error: { message: String(error) } };
 	}

--- a/apps/desktop/src/routes/[projectId]/workspace/[stackId]/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/workspace/[stackId]/+page.svelte
@@ -11,11 +11,11 @@
 	const stackId = $derived(page.params.stackId);
 
 	const stackService = getContext(StackService);
+	const branchResult = $derived(stackService.branchAt(projectId!, stackId!, 0));
 </script>
 
 {#if projectId && stackId}
-	{@const result = stackService.branchAt(projectId, stackId, 0).current}
-	<ReduxResult {result}>
+	<ReduxResult result={branchResult.current}>
 		{#snippet children(branch)}
 			{#if branch}
 				{goto(branchPath(projectId, stackId, branch.name))}

--- a/apps/desktop/src/routes/[projectId]/workspace/[stackId]/[branchName]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/workspace/[stackId]/[branchName]/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import StackView from '$components/v3/StackView.svelte';
 	import { type Snippet } from 'svelte';
-	import type { PageData } from '../$types';
+	import type { PageData } from './$types';
 	import { page } from '$app/state';
 
 	const { data, children }: { data: PageData; children: Snippet } = $props();


### PR DESCRIPTION
Accessing `.current` from a `Reactive` type inside a $derived statement leads to the function being called again
 anytime the value inside the reactive changes.