### PR TITLE
Exclude `lexical` from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-major']
+      - dependency-name: '*lexical*'
+        # Lexical must match svelte-lexical, updating manually.
+        update-types: ['version-update:semver-minor']
     groups:
       npm-updates:
         update-types: [minor, patch]


### PR DESCRIPTION
- needs to be in sync with `svelte-lexical`