### PR TITLE
Use dropdown for visibility

### DIFF
--- a/apps/desktop/src/components/CloudProjectSettings.svelte
+++ b/apps/desktop/src/components/CloudProjectSettings.svelte
@@ -8,6 +8,7 @@
 	import { getContext, getContextStore } from '@gitbutler/shared/context';
 	import Loading from '@gitbutler/shared/network/Loading.svelte';
 	import { isFound, map } from '@gitbutler/shared/network/loadable';
+	import PermissionsSelector from '@gitbutler/shared/organizations/PermissionsSelector.svelte';
 	import { OrganizationService } from '@gitbutler/shared/organizations/organizationService';
 	import { getOrganizations } from '@gitbutler/shared/organizations/organizationsPreview.svelte';
 	import { ProjectService as CloudProjectService } from '@gitbutler/shared/organizations/projectService';
@@ -21,6 +22,7 @@
 	import Link from '@gitbutler/ui/link/Link.svelte';
 	import type { Project as BackendProject } from '$lib/project/project';
 	import type { Project } from '@gitbutler/shared/organizations/types';
+
 	const appState = getContext(AppState);
 	const projectsService = getContext(ProjectsService);
 	const projectService = getContext(ProjectService);
@@ -227,19 +229,6 @@
 							{/snippet}
 						</SectionCard>
 					{/if}
-
-					<br />
-
-					<div class="api-link text-12">
-						<Link
-							target="_blank"
-							rel="noreferrer"
-							href={webRoutes.projectUrl({
-								ownerSlug: cloudProject.owner,
-								projectSlug: cloudProject.slug
-							})}>Go to GitButler Server Project</Link
-						>
-					</div>
 				{/snippet}
 			</Section>
 
@@ -279,6 +268,35 @@
 					</Section>
 				{/if}
 			{/if}
+
+			<br />
+
+			<SectionCard orientation="row" centerAlign>
+				{#snippet title()}
+					Project visibility
+				{/snippet}
+				{#snippet caption()}
+					Choose your project's visiblility. Public projects will get indexed, unlisted projects can
+					only be found by direct link, and private projects can only be seen by organization
+					members.
+				{/snippet}
+				{#snippet actions()}
+					<PermissionsSelector repositoryId={cloudProject.repositoryId} />
+				{/snippet}
+			</SectionCard>
+
+			<br />
+
+			<div class="api-link text-12">
+				<Link
+					target="_blank"
+					rel="noreferrer"
+					href={webRoutes.projectUrl({
+						ownerSlug: cloudProject.owner,
+						projectSlug: cloudProject.slug
+					})}>Go to GitButler Server Project</Link
+				>
+			</div>
 		{/snippet}
 	</Loading>
 {/if}

--- a/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/+page.svelte
+++ b/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/+page.svelte
@@ -2,11 +2,11 @@
 	import { getContext } from '@gitbutler/shared/context';
 	import Loading from '@gitbutler/shared/network/Loading.svelte';
 	import { combine, map } from '@gitbutler/shared/network/loadable';
+	import PermissionsSelector from '@gitbutler/shared/organizations/PermissionsSelector.svelte';
 	import { ProjectService } from '@gitbutler/shared/organizations/projectService';
 	import { getProjectByRepositoryId } from '@gitbutler/shared/organizations/projectsPreview.svelte';
 	import { lookupProject } from '@gitbutler/shared/organizations/repositoryIdLookupPreview.svelte';
 	import { RepositoryIdLookupService } from '@gitbutler/shared/organizations/repositoryIdLookupService';
-	import { ShareLevel } from '@gitbutler/shared/permissions';
 	import { AppState } from '@gitbutler/shared/redux/store.svelte';
 	import {
 		WebRoutesService,
@@ -45,13 +45,6 @@
 		await projectService.deleteProject(repositoryId);
 		goto(routes.projectsPath());
 	}
-
-	async function updatePermission(
-		repositoryId: string,
-		shareLevel: ShareLevel.Public | ShareLevel.Private
-	) {
-		await projectService.updateProject(repositoryId, { shareLevel });
-	}
 </script>
 
 <h2>Project page: {data.ownerSlug}/{data.projectSlug}</h2>
@@ -67,17 +60,7 @@
 				<div>
 					<p>This project is <b>{project.permissions.shareLevel}</b></p>
 
-					{#if project.permissions.shareLevel === 'public'}
-						<AsyncButton
-							action={async () => await updatePermission(repositoryId, ShareLevel.Private)}
-							>Make private</AsyncButton
-						>
-					{:else}
-						<AsyncButton
-							action={async () => await updatePermission(repositoryId, ShareLevel.Public)}
-							>Make public</AsyncButton
-						>
-					{/if}
+					<PermissionsSelector repositoryId={project.repositoryId} />
 				</div>
 
 				<AsyncButton style="error" action={async () => await deleteProject(repositoryId)}

--- a/packages/shared/src/lib/organizations/PermissionsSelector.svelte
+++ b/packages/shared/src/lib/organizations/PermissionsSelector.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	import { getContext } from '$lib/context';
+	import Loading from '$lib/network/Loading.svelte';
+	import { ProjectService } from '$lib/organizations/projectService';
+	import { getProjectByRepositoryId } from '$lib/organizations/projectsPreview.svelte';
+	import { ShareLevel } from '$lib/permissions';
+	import { AppState } from '$lib/redux/store.svelte';
+	import ContextMenuItem from '@gitbutler/ui/ContextMenuItem.svelte';
+	import ContextMenuSection from '@gitbutler/ui/ContextMenuSection.svelte';
+	import DropDownButton from '@gitbutler/ui/DropDownButton.svelte';
+
+	type Props = {
+		repositoryId: string;
+	};
+
+	const { repositoryId }: Props = $props();
+
+	const appState = getContext(AppState);
+	const projectService = getContext(ProjectService);
+
+	const project = $derived(getProjectByRepositoryId(appState, projectService, repositoryId));
+
+	const options = [
+		{
+			label: 'Private',
+			key: ShareLevel.Private
+		},
+		{
+			label: 'Unlisted',
+			key: ShareLevel.Unlisted
+		},
+		{
+			label: 'Public',
+			key: ShareLevel.Public
+		}
+	];
+
+	async function updatePermission(shareLevel: ShareLevel) {
+		dropDownEnabled = false;
+		try {
+			await projectService.updateProject(repositoryId, { shareLevel });
+		} finally {
+			dropDownEnabled = true;
+			dropDownButton?.close();
+		}
+	}
+
+	let dropDownButton = $state<DropDownButton>();
+	let dropDownEnabled = $state(true);
+</script>
+
+<Loading loadable={project.current}>
+	{#snippet children(project)}
+		<DropDownButton bind:this={dropDownButton} loading={!dropDownEnabled} kind="outline">
+			{options.find((option) => option.key === project.permissions.shareLevel)?.label}
+
+			{#snippet contextMenuSlot()}
+				<ContextMenuSection>
+					{#each options as option}
+						<ContextMenuItem
+							label={option.label}
+							disabled={option.key === project.permissions.shareLevel}
+							onclick={() => updatePermission(option.key)}
+						/>
+					{/each}
+				</ContextMenuSection>
+			{/snippet}
+		</DropDownButton>
+	{/snippet}
+</Loading>

--- a/packages/shared/src/lib/organizations/projectService.ts
+++ b/packages/shared/src/lib/organizations/projectService.ts
@@ -21,14 +21,14 @@ type UpdateParams = {
 	slug?: string;
 	name?: string;
 	description?: string;
-	shareLevel?: ShareLevel.Public | ShareLevel.Private;
+	shareLevel?: ShareLevel;
 };
 
 type ApiUpdateParams = {
 	slug?: string;
 	name?: string;
 	description?: string;
-	share_level?: ShareLevel.Public | ShareLevel.Private;
+	share_level?: ShareLevel;
 };
 
 function toApiUpdateParams(real: UpdateParams): ApiUpdateParams {


### PR DESCRIPTION
This PR uses a dropdown to enable users to select their permissions. It also introduces this option into the desktop client to make new project setup easier

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #7520 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #7519 
<!-- GitButler Footer Boundary Bottom -->

