### PR TITLE
Make error serializable

### DIFF
--- a/packages/shared/src/lib/network/Loading.svelte
+++ b/packages/shared/src/lib/network/Loading.svelte
@@ -21,6 +21,7 @@
 {:else if loadable.status === 'not-found'}
 	<span>Not found</span>
 {:else if loadable.status === 'error'}
+	<span>{loadable.error.name}</span>
 	<span>{loadable.error.message}</span>
 {:else}
 	<span>Unknown state</span>

--- a/packages/shared/src/lib/network/loadable.ts
+++ b/packages/shared/src/lib/network/loadable.ts
@@ -1,4 +1,4 @@
-import { ApiError, type Loadable, type LoadableData } from '$lib/network/types';
+import { ApiError, toSerializable, type Loadable, type LoadableData } from '$lib/network/types';
 import type { EntityId, EntityAdapter, EntityState } from '@reduxjs/toolkit';
 
 export function isFound<T>(loadable?: Loadable<T>): loadable is {
@@ -22,10 +22,10 @@ export function errorToLoadable<T, Id>(error: unknown, id: Id): LoadableData<T, 
 			return { status: 'not-found', id };
 		}
 
-		return { status: 'error', id, error };
+		return { status: 'error', id, error: toSerializable(error) };
 	}
 
-	return { status: 'error', id, error: new Error(String(error)) };
+	return { status: 'error', id, error: toSerializable(error) };
 }
 
 export function loadableUpsert<T, Id extends EntityId>(

--- a/packages/shared/src/lib/network/types.ts
+++ b/packages/shared/src/lib/network/types.ts
@@ -7,9 +7,30 @@ export class ApiError extends Error {
 	}
 }
 
+export type SerializableError = {
+	name: string;
+	message: string;
+	stack?: string;
+};
+
+export function toSerializable(error: unknown): SerializableError {
+	if (error instanceof Error) {
+		return {
+			name: error.name,
+			message: error.message,
+			stack: error.stack
+		};
+	}
+
+	return {
+		name: 'Unknown error',
+		message: String(error)
+	};
+}
+
 export type Loadable<T> =
 	| { status: 'loading' | 'not-found' }
 	| { status: 'found'; value: T }
-	| { status: 'error'; error: Error };
+	| { status: 'error'; error: SerializableError };
 
 export type LoadableData<T, Id> = Loadable<T> & { id: Id };


### PR DESCRIPTION
This change means that we could persist these errors with redux-persist, gives us the ability to shallow compare errors, and makes redux happy