### PR TITLE
Fix commit engine committing with multiple empty stacks

### DIFF
--- a/crates/but-cli/src/command/commit.rs
+++ b/crates/but-cli/src/command/commit.rs
@@ -1,9 +1,11 @@
 use crate::command::debug_print;
 use anyhow::bail;
 use but_core::TreeChange;
-use but_workspace::commit_engine::{DiffSpec, ReferenceFrame, create_commit_and_update_refs};
+use but_workspace::commit_engine::{
+    DiffSpec, ReferenceFrame, StackSegmentId, create_commit_and_update_refs,
+};
 use gitbutler_project::Project;
-use gitbutler_stack::VirtualBranchesState;
+use gitbutler_stack::{VirtualBranchesHandle, VirtualBranchesState};
 
 pub fn commit(
     repo: gix::Repository,
@@ -21,20 +23,34 @@ pub fn commit(
         .unwrap_or_else(|| Ok(repo.head_id()?))?
         .detach();
 
-    let destination = if amend {
-        if message.is_some() {
-            bail!("Messages aren't used when amending");
-        }
-        but_workspace::commit_engine::Destination::AmendCommit(parent_id)
-    } else {
-        but_workspace::commit_engine::Destination::NewCommit {
-            parent_commit_id: Some(parent_id),
-            message: message.unwrap_or_default().to_owned(),
-            stack_segment_ref: stack_segment_ref.map(|rn| rn.try_into()).transpose()?,
-        }
-    };
     let changes = to_whole_file_diffspec(but_core::diff::worktree_changes(&repo)?.changes);
     if let Some(project) = project.as_ref() {
+        let destination = if amend {
+            if message.is_some() {
+                bail!("Messages aren't used when amending");
+            }
+            but_workspace::commit_engine::Destination::AmendCommit(parent_id)
+        } else {
+            let stack_segment = if let Some(stack_segment_ref) = stack_segment_ref {
+                let full_name = gix::refs::FullName::try_from(stack_segment_ref)?;
+                VirtualBranchesHandle::new(project.gb_dir())
+                    .list_stacks_in_workspace()?
+                    .iter()
+                    .find(|s| s.heads().contains(&stack_segment_ref.to_string()))
+                    .map(|s| s.id)
+                    .map(|id| StackSegmentId {
+                        segment_ref: full_name,
+                        stack_id: id,
+                    })
+            } else {
+                None
+            };
+            but_workspace::commit_engine::Destination::NewCommit {
+                parent_commit_id: Some(parent_id),
+                message: message.unwrap_or_default().to_owned(),
+                stack_segment,
+            }
+        };
         let mut guard = project.exclusive_worktree_access();
         debug_print(
             but_workspace::commit_engine::create_commit_and_update_refs_with_project(
@@ -49,6 +65,18 @@ pub fn commit(
             )?,
         )?;
     } else {
+        let destination = if amend {
+            if message.is_some() {
+                bail!("Messages aren't used when amending");
+            }
+            but_workspace::commit_engine::Destination::AmendCommit(parent_id)
+        } else {
+            but_workspace::commit_engine::Destination::NewCommit {
+                parent_commit_id: Some(parent_id),
+                message: message.unwrap_or_default().to_owned(),
+                stack_segment: None,
+            }
+        };
         debug_print(create_commit_and_update_refs(
             &repo,
             ReferenceFrame {

--- a/crates/but-workspace/src/commit_engine/mod.rs
+++ b/crates/but-workspace/src/commit_engine/mod.rs
@@ -56,11 +56,9 @@ pub struct StackSegmentId {
 }
 
 impl Destination {
-    pub(self) fn stack_segment(&self) -> Option<&gix::refs::FullName> {
+    pub(self) fn stack_segment(&self) -> Option<&StackSegmentId> {
         match self {
-            Destination::NewCommit { stack_segment, .. } => {
-                stack_segment.as_ref().map(|s| &s.segment_ref)
-            }
+            Destination::NewCommit { stack_segment, .. } => stack_segment.as_ref(),
             Destination::AmendCommit(..) => None,
         }
     }

--- a/crates/but-workspace/src/commit_engine/mod.rs
+++ b/crates/but-workspace/src/commit_engine/mod.rs
@@ -37,8 +37,8 @@ pub enum Destination {
         ///
         /// To create a commit at the position of the first commit of a branch, the parent has to be the merge-base with the *target branch*.
         parent_commit_id: Option<gix::ObjectId>,
-        /// The name of the ref pointing to the tip of the stack segment the commit is supposed to go into. It is necessary to disambiguate the reference update.
-        stack_segment_ref: Option<gix::refs::FullName>,
+        /// The stack and reference the commit is supposed to go into. It is necessary to disambiguate the reference update.
+        stack_segment: Option<StackSegmentId>,
         /// Use `message` as commit message for the new commit.
         message: String,
     },
@@ -46,12 +46,21 @@ pub enum Destination {
     AmendCommit(gix::ObjectId),
 }
 
+/// The stack and the branch the commit is supposed to go into.
+#[derive(Debug, Clone)]
+pub struct StackSegmentId {
+    /// Identifies the stack the commit is destined to (without it, ambiguity is still possible, e.g. when all stacks have no commits)
+    pub stack_id: StackId,
+    /// The name of the ref pointing to the tip of the stack segment the commit is supposed to go into. It is necessary to disambiguate the reference update.
+    pub segment_ref: gix::refs::FullName,
+}
+
 impl Destination {
     pub(self) fn stack_segment(&self) -> Option<&gix::refs::FullName> {
         match self {
-            Destination::NewCommit {
-                stack_segment_ref, ..
-            } => stack_segment_ref.as_ref(),
+            Destination::NewCommit { stack_segment, .. } => {
+                stack_segment.as_ref().map(|s| &s.segment_ref)
+            }
             Destination::AmendCommit(..) => None,
         }
     }
@@ -240,7 +249,7 @@ pub fn create_commit(
             Destination::NewCommit {
                 message,
                 parent_commit_id: _,
-                stack_segment_ref: _,
+                stack_segment: _,
             } => {
                 let (author, committer) = repo.commit_signatures()?;
                 let new_commit = create_possibly_signed_commit(

--- a/crates/but-workspace/src/commit_engine/refs.rs
+++ b/crates/but-workspace/src/commit_engine/refs.rs
@@ -7,6 +7,8 @@ use gix::refs::transaction::PreviousValue;
 use gix::revision::walk::Sorting;
 use std::collections::BTreeMap;
 
+use super::StackSegmentId;
+
 /// Rewrite all references as mapped by their target in `refs_by_commit_id` so that those
 /// pointing to `old` in `changed_commits` will then point to `new`.
 /// Do the same for the virtual refs in `state` place information about all performed updates
@@ -20,7 +22,7 @@ pub fn rewrite(
     mut refs_by_commit_id: gix::hashtable::HashMap<gix::ObjectId, Vec<gix::refs::FullName>>,
     changed_commits: impl IntoIterator<Item = (gix::ObjectId, gix::ObjectId)>,
     updated_refs: &mut Vec<UpdatedReference>,
-    stack_segment_ref: Option<&gix::refs::FullName>,
+    stack_segment: Option<&StackSegmentId>,
 ) -> anyhow::Result<()> {
     let mut ref_edits = Vec::new();
     let changed_commits: Vec<_> = changed_commits.into_iter().collect();
@@ -31,6 +33,11 @@ pub fn rewrite(
         let old_git2 = old.to_git2();
         let mut already_updated_refs = Vec::<BString>::new();
         for stack in &mut stacks_ordered {
+            if let Some(stack_segment) = stack_segment {
+                if stack_segment.stack_id != stack.id {
+                    continue; // Dont rewrite refs for other stacks
+                }
+            }
             if stack.head == old_git2 {
                 stack.head = new.to_git2();
                 stack.tree = new
@@ -45,15 +52,18 @@ pub fn rewrite(
                     reference: but_core::Reference::Virtual(stack.name.clone()),
                 });
             }
-            let update_up_to_idx = stack_segment_ref.and_then(|up_to_ref| {
-                let short_name = up_to_ref.shorten();
-                stack
-                    .heads
-                    .iter()
-                    .rev()
-                    .enumerate()
-                    .find_map(|(idx, h)| (h.name == short_name).then_some(idx))
-            });
+            let update_up_to_idx =
+                stack_segment
+                    .map(|s| s.segment_ref.as_ref())
+                    .and_then(|up_to_ref| {
+                        let short_name = up_to_ref.shorten();
+                        stack
+                            .heads
+                            .iter()
+                            .rev()
+                            .enumerate()
+                            .find_map(|(idx, h)| (h.name == short_name).then_some(idx))
+                    });
             for (idx, branch) in stack.heads.iter_mut().rev().enumerate() {
                 let id = match &mut branch.head() {
                     CommitOrChangeId::CommitId(id_hex) => {

--- a/crates/but-workspace/tests/workspace/commit_engine/new_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/new_commit.rs
@@ -21,7 +21,7 @@ fn from_unborn_head() -> anyhow::Result<()> {
         Destination::NewCommit {
             parent_commit_id: None,
             message: "the commit message".into(),
-            stack_segment_ref: None,
+            stack_segment: None,
         },
     )?;
     insta::assert_debug_snapshot!(&outcome, @r"
@@ -64,7 +64,7 @@ fn from_unborn_head() -> anyhow::Result<()> {
         Destination::NewCommit {
             parent_commit_id: Some(new_commit_id),
             message: "the second commit".into(),
-            stack_segment_ref: None,
+            stack_segment: None,
         },
     )?;
 
@@ -102,7 +102,7 @@ fn from_unborn_head_all_file_types() -> anyhow::Result<()> {
         Destination::NewCommit {
             parent_commit_id: None,
             message: "the commit message".into(),
-            stack_segment_ref: None,
+            stack_segment: None,
         },
     )?;
 
@@ -138,7 +138,7 @@ fn from_first_commit_all_file_types_changed() -> anyhow::Result<()> {
         Destination::NewCommit {
             parent_commit_id: Some(repo.rev_parse_single("HEAD")?.into()),
             message: "the commit message".into(),
-            stack_segment_ref: None,
+            stack_segment: None,
         },
     )?;
 
@@ -166,7 +166,7 @@ fn unborn_with_added_submodules() -> anyhow::Result<()> {
                 "submodules have to be given as whole files but can then be handled correctly \
             (but without Git's special handling)"
                     .into(),
-            stack_segment_ref: None,
+            stack_segment: None,
         },
         None,
         to_change_specs_whole_file(worktree_changes),
@@ -208,7 +208,7 @@ fn deletions() -> anyhow::Result<()> {
         Destination::NewCommit {
             parent_commit_id: Some(head_commit.into()),
             message: "deletions maybe a bit special".into(),
-            stack_segment_ref: None,
+            stack_segment: None,
         },
     )?;
 
@@ -241,7 +241,7 @@ fn renames() -> anyhow::Result<()> {
         Destination::NewCommit {
             parent_commit_id: Some(head_commit.into()),
             message: "renames need special care to delete the source".into(),
-            stack_segment_ref: None,
+            stack_segment: None,
         },
     )?;
 
@@ -318,7 +318,7 @@ fn submodule_typechanges() -> anyhow::Result<()> {
                 "submodules have to be given as whole files but can then be handled correctly \
             (but without Git's special handling)"
                     .into(),
-            stack_segment_ref: None,
+            stack_segment: None,
         },
         None,
         to_change_specs_whole_file(worktree_changes),
@@ -350,7 +350,7 @@ fn commit_to_one_below_tip() -> anyhow::Result<()> {
     let first_commit = Destination::NewCommit {
         parent_commit_id: Some(repo.rev_parse_single("first-commit")?.into()),
         message: "we apply a change with line offsets on top of the first commit, so the patch wouldn't apply cleanly.".into(),
-        stack_segment_ref: None,
+        stack_segment: None,
     };
 
     let outcome = commit_whole_files_and_all_hunks_from_workspace(&repo, first_commit)?;
@@ -373,7 +373,7 @@ fn commit_to_one_below_tip_with_three_context_lines() -> anyhow::Result<()> {
             parent_commit_id: Some(repo.rev_parse_single("first-commit")?.into()),
             message: "When using context lines, we'd still think this works just like before"
                 .into(),
-            stack_segment_ref: None,
+            stack_segment: None,
         };
 
         let outcome = commit_engine::create_commit(
@@ -428,7 +428,7 @@ fn commit_to_branches_below_merge_commit() -> anyhow::Result<()> {
         Destination::NewCommit {
             parent_commit_id: Some(repo.rev_parse_single("B")?.into()),
             message: "a new commit onto B, changing only the lines that it wrote".into(),
-            stack_segment_ref: None,
+            stack_segment: None,
         },
     )?;
 
@@ -444,7 +444,7 @@ fn commit_to_branches_below_merge_commit() -> anyhow::Result<()> {
         Destination::NewCommit {
             parent_commit_id: Some(repo.rev_parse_single("A")?.into()),
             message: "a new commit onto A, changing only the lines that it wrote".into(),
-            stack_segment_ref: None,
+            stack_segment: None,
         },
     )?;
 
@@ -478,7 +478,7 @@ fn commit_whole_file_to_conflicting_position() -> anyhow::Result<()> {
                 message: "this commit can't be done as it covers multiple commits, \
             which will conflict on cherry-picking"
                     .into(),
-                stack_segment_ref: None,
+                stack_segment: None,
             },
         )?;
         assert_eq!(
@@ -497,7 +497,7 @@ fn commit_whole_file_to_conflicting_position() -> anyhow::Result<()> {
         Destination::NewCommit {
             parent_commit_id: Some(repo.head_id()?.into()),
             message: "but it can be applied directly to the tip, the merge commit itself, it always works".into(),
-            stack_segment_ref: None,
+            stack_segment: None,
         },
     )?;
     let tree = visualize_tree(&repo, &outcome)?;
@@ -528,7 +528,7 @@ fn commit_whole_file_to_conflicting_position_one_unconflicting_file_remains() ->
                 message: "this commit can't be done as it covers multiple commits, \
             which will conflict on cherry-picking"
                     .into(),
-                stack_segment_ref: None,
+                stack_segment: None,
             },
         )?;
         assert_eq!(
@@ -573,7 +573,7 @@ fn commit_whole_file_to_conflicting_position_one_unconflicting_file_remains() ->
             message: "but it can be applied directly to the tip, \
             the merge commit itself, it always works"
                 .into(),
-            stack_segment_ref: None,
+            stack_segment: None,
         },
     )?;
     let tree = visualize_tree(&repo, &outcome)?;
@@ -595,7 +595,7 @@ fn unborn_untracked_worktree_filters_are_applied_to_whole_files() -> anyhow::Res
         Destination::NewCommit {
             parent_commit_id: None,
             message: "the commit message".into(),
-            stack_segment_ref: None,
+            stack_segment: None,
         },
     )?;
     insta::assert_debug_snapshot!(&outcome, @r"
@@ -633,7 +633,7 @@ fn unborn_untracked_worktree_filters_are_applied_to_whole_files() -> anyhow::Res
         Destination::NewCommit {
             parent_commit_id: Some(new_commit_id),
             message: "the second commit".into(),
-            stack_segment_ref: None,
+            stack_segment: None,
         },
     )?;
 
@@ -683,7 +683,7 @@ fn signatures_are_redone() -> anyhow::Result<()> {
         Destination::NewCommit {
             parent_commit_id: Some(head_id),
             message: "a commit with signature".into(),
-            stack_segment_ref: None,
+            stack_segment: None,
         },
     )?;
 
@@ -729,7 +729,7 @@ fn validate_no_change_on_noop() -> anyhow::Result<()> {
             message: "the file has no worktree changes even though we claim it - \
         so it's rejected and no new commit is created"
                 .into(),
-            stack_segment_ref: None,
+            stack_segment: None,
         },
         None,
         specs.clone(),

--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -4,6 +4,7 @@ use but_hunk_dependency::ui::{
     hunk_dependencies_for_workspace_changes_by_worktree_dir, HunkDependencies,
 };
 use but_settings::AppSettingsWithDiskSync;
+use but_workspace::commit_engine::StackSegmentId;
 use but_workspace::{commit_engine, StackEntry};
 use gitbutler_command_context::CommandContext;
 use gitbutler_oplog::{OplogExt, SnapshotExt};
@@ -130,11 +131,12 @@ pub fn create_commit_from_worktree_changes(
         commit_engine::Destination::NewCommit {
             parent_commit_id,
             message: message.clone(),
-            stack_segment_ref: Some(
-                format!("refs/heads/{stack_branch_name}")
+            stack_segment: Some(StackSegmentId {
+                stack_id,
+                segment_ref: format!("refs/heads/{stack_branch_name}")
                     .try_into()
                     .map_err(anyhow::Error::from)?,
-            ),
+            }),
         },
         None,
         worktree_changes.into_iter().map(Into::into).collect(),


### PR DESCRIPTION
Because of incorrect reference updates, it appeared as if the commit was added to all of the empty stacks. This adds a check an additional check preventing that