### PR TITLE
feat(clipboard): move the toast-handling into writeClipboard function

### DIFF
--- a/apps/desktop/src/components/FileContextMenu.svelte
+++ b/apps/desktop/src/components/FileContextMenu.svelte
@@ -78,29 +78,18 @@
 					<ContextMenuItem
 						label="Copy Path"
 						onclick={async () => {
-							try {
-								if (!project) return;
-								const absPath = await join(project.path, item.files[0].path);
-								writeClipboard(absPath);
-								contextMenu.close();
-								// dismiss();
-							} catch (err) {
-								console.error('Failed to copy path', err);
-								toasts.error('Failed to copy path');
-							}
+							if (!project) return;
+							const absPath = await join(project.path, item.files[0].path);
+							await writeClipboard(absPath, 'Failed to copy path');
+							contextMenu.close();
 						}}
 					/>
 					<ContextMenuItem
 						label="Copy Relative Path"
-						onclick={() => {
-							try {
-								if (!project) return;
-								writeClipboard(item.files[0].path);
-								contextMenu.close();
-							} catch (err) {
-								console.error('Failed to copy relative path', err);
-								toasts.error('Failed to copy relative path');
-							}
+						onclick={async () => {
+							if (!project) return;
+							await writeClipboard(item.files[0].path, 'Failed to copy relative path');
+							contextMenu.close();
 						}}
 					/>
 				{/if}

--- a/apps/desktop/src/components/v3/FileContextMenu.svelte
+++ b/apps/desktop/src/components/v3/FileContextMenu.svelte
@@ -88,29 +88,19 @@
 						<ContextMenuItem
 							label="Copy Path"
 							onclick={async () => {
-								try {
-									if (!project) return;
-									const absPath = await join(project.path, changes[0]!.path);
-									writeClipboard(absPath);
-									contextMenu.close();
-									// dismiss();
-								} catch (err) {
-									console.error('Failed to copy path', err);
-									toasts.error('Failed to copy path');
-								}
+								if (!project) return;
+								const absPath = await join(project.path, changes[0]!.path);
+								await writeClipboard(absPath, 'Failed to copy path');
+								contextMenu.close();
+								// dismiss();
 							}}
 						/>
 						<ContextMenuItem
 							label="Copy Relative Path"
-							onclick={() => {
-								try {
-									if (!project) return;
-									writeClipboard(changes[0]!.path);
-									contextMenu.close();
-								} catch (err) {
-									console.error('Failed to copy relative path', err);
-									toasts.error('Failed to copy relative path');
-								}
+							onclick={async () => {
+								if (!project) return;
+								await writeClipboard(changes[0]!.path, 'Failed to copy relative path');
+								contextMenu.close();
 							}}
 						/>
 					{/if}

--- a/apps/desktop/src/lib/backend/clipboard.ts
+++ b/apps/desktop/src/lib/backend/clipboard.ts
@@ -1,7 +1,23 @@
+import * as toasts from '@gitbutler/ui/toasts';
 import { writeText, readText } from '@tauri-apps/plugin-clipboard-manager';
 
-export async function writeClipboard(text: string) {
-	await writeText(text);
+/**
+ * Copy the provided text into the the system clipboard. Upon completion, a toast will be displayed which contains
+ * information about the success of this operation.
+ *
+ * @param text text to be copied into the system clipboard.
+ * @param errorMessage optional custom error message which will be displayed if the operation failes. If this is
+ *                     not provided, a default generic message will be used.
+ */
+export async function writeClipboard(text: string, errorMessage = 'Failed to copy') {
+	await writeText(text)
+		.then(() => {
+			toasts.success('Copied to clipboard');
+		})
+		.catch((err) => {
+			toasts.error(errorMessage);
+			console.error(errorMessage, err);
+		});
 }
 
 export async function readClipboard() {


### PR DESCRIPTION
## 🧢 Changes

Move the toast handling (and, therefore, the error handling as well) of copying text to the clipboard into the `writeClipboard` function. 

## ☕️ Reasoning

Previously, we managed the error handling (i.e., the display of a toast) individually for each call to `writeClipboard`. To unify this, the handling is moved into the function. 

## 🎫 Affected issues

Fixes: #7490 