### PR TITLE
Fix the project popup

### DIFF
--- a/apps/desktop/src/components/ProjectsPopup.svelte
+++ b/apps/desktop/src/components/ProjectsPopup.svelte
@@ -7,7 +7,6 @@
 	import { resizeObserver } from '@gitbutler/ui/utils/resizeObserver';
 	import type iconsJson from '@gitbutler/ui/data/icons.json';
 	import { goto } from '$app/navigation';
-	import { page } from '$app/stores';
 
 	interface ItemSnippetProps {
 		label: string;
@@ -109,13 +108,10 @@
 				<ScrollableContainer maxHeight="20rem">
 					<div class="popup__projects">
 						{#each $projects as project}
-							{@const selected =
-								project.id === $page.params.projectId ||
-								$projects.some((p) => p.is_open && p.id === project.id)}
 							{@render itemSnippet({
 								label: project.title,
-								selected,
-								icon: selected ? 'tick' : undefined,
+								selected: project.is_open,
+								icon: project.is_open ? 'tick' : undefined,
 								onclick: async (event: any) => {
 									if (event.altKey) {
 										await projectsService.openProjectInNewWindow(project.id);

--- a/apps/desktop/src/routes/[projectId]/+layout.ts
+++ b/apps/desktop/src/routes/[projectId]/+layout.ts
@@ -38,6 +38,7 @@ export const load: LayoutLoad = async ({ params, parent }) => {
 	try {
 		project = await projectsService.getProject(projectId);
 		await invoke('set_project_active', { id: projectId });
+		await projectsService.reload();
 	} catch (err: any) {
 		const errorCode = getUserErrorCode(err);
 		throw error(400, {


### PR DESCRIPTION
When we call setActiveProject, it causes the project.is_open boolean to update on the rust side. We however don't have anything to refresh the copy of the state after we call setActiveProject on the backend.