### PR TITLE
Fix startup loop

### DIFF
--- a/apps/desktop/src/lib/project/projectsService.ts
+++ b/apps/desktop/src/lib/project/projectsService.ts
@@ -40,6 +40,11 @@ export class ProjectsService {
 		this.projects.set(await this.loadAll());
 	}
 
+	async setActiveProject(projectId: string): Promise<void> {
+		await invoke('set_project_active', { id: projectId });
+		await this.reload();
+	}
+
 	async getProject(projectId: string, noValidation?: boolean) {
 		return plainToInstance(Project, await invoke('get_project', { id: projectId, noValidation }));
 	}

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -228,6 +228,10 @@
 	onDestroy(() => {
 		clearFetchInterval();
 	});
+
+	$effect(() => {
+		projectsService.setActiveProject(projectId);
+	});
 </script>
 
 <!-- forces components to be recreated when projectId changes -->

--- a/apps/desktop/src/routes/[projectId]/+layout.ts
+++ b/apps/desktop/src/routes/[projectId]/+layout.ts
@@ -1,4 +1,4 @@
-import { getUserErrorCode, invoke } from '$lib/backend/ipc';
+import { getUserErrorCode } from '$lib/backend/ipc';
 import { BaseBranchService } from '$lib/baseBranch/baseBranchService';
 import { BranchController } from '$lib/branches/branchController';
 import { BranchListingService } from '$lib/branches/branchListing';
@@ -37,8 +37,6 @@ export const load: LayoutLoad = async ({ params, parent }) => {
 	let project: Project | undefined = undefined;
 	try {
 		project = await projectsService.getProject(projectId);
-		await invoke('set_project_active', { id: projectId });
-		await projectsService.reload();
 	} catch (err: any) {
 		const errorCode = getUserErrorCode(err);
 		throw error(400, {


### PR DESCRIPTION
In the base page, we have something that reacts to changes in the list of all projects, and tries to redirect to one of those projects.

Unfortunately, if we update hte list of all projects inside of the load function, the base page gets ahead of us, and actually triggers a second navigation call, which in turn updates the list of projects, ad infinitum. 

We _do_ want to react to the list of projects in the base page, so we should instead consider not updating the list inside of the load function (and in generally, having the load function cause side effects is not a nice thing).

---

 I've firstly made `setActiveProject` a method on the `ProjectsService` and tied the reload to it, so that is all encapsulated in one call.

To actually fix the issue, I've moved the call to `setActiveProject` outside of the load function, and put it in an `afterNavigate` call, which has a little extra logic, to make sure it's only run whenever the projectId in the path changes.