### PR TITLE
Run GPG in shell on Unix as well (#7467)

### DIFF
--- a/crates/but-core/src/cmd.rs
+++ b/crates/but-core/src/cmd.rs
@@ -8,7 +8,9 @@ pub fn prepare_with_shell(program: impl Into<OsString>) -> gix::command::Prepare
         // On Windows, this means a shell will always be used.
         .command_may_be_shell_script_disallow_manual_argument_splitting()
         // On Windows, this yields the Git-bundled `sh.exe`, which is what we want.
-        .with_shell_program(gix::path::env::shell())
+        .with_shell_program(
+            std::env::var_os("SHELL").unwrap_or_else(|| gix::path::env::shell().into()),
+        )
         // force using a shell, we want access to additional programs here
         .with_shell()
         // We know `program` is a path, so quote it.

--- a/crates/but-core/src/cmd.rs
+++ b/crates/but-core/src/cmd.rs
@@ -1,17 +1,16 @@
 use std::ffi::OsString;
 
-/// Prepare `program` for invocation with a shell on Windows, and directly everywhere else.
-pub fn prepare_with_shell_on_windows(program: impl Into<OsString>) -> gix::command::Prepare {
-    let prepare = gix::command::prepare(program);
-    if cfg!(windows) {
-        prepare
-            .command_may_be_shell_script_disallow_manual_argument_splitting()
-            // On Windows, this yields the Git-bundled `sh.exe`, which is what we want.
-            .with_shell_program(gix::path::env::shell())
-            // force using a shell, we want access to additional programs here
-            .with_shell()
-            .with_quoted_command()
-    } else {
-        prepare
-    }
+/// Prepare `program` for invocation with a Git-compatible shell to help it pick up more of the usual environment.
+///
+/// On Windows, this specifically uses the Git-bundled shell, further increasing compatibility.
+pub fn prepare_with_shell(program: impl Into<OsString>) -> gix::command::Prepare {
+    gix::command::prepare(program)
+        // On Windows, this means a shell will always be used.
+        .command_may_be_shell_script_disallow_manual_argument_splitting()
+        // On Windows, this yields the Git-bundled `sh.exe`, which is what we want.
+        .with_shell_program(gix::path::env::shell())
+        // force using a shell, we want access to additional programs here
+        .with_shell()
+        // We know `program` is a path, so quote it.
+        .with_quoted_command()
 }


### PR DESCRIPTION
This way there are higher chances of picking up the required PATH configuration, making
signing operations more likely to work.

Fixes #7467 .

### Tasks

* [x] implementation
* [x] see if this improves anything on MacOS (where signing doesn't work for me either without running from a terminal)
    - It doesn't just magically work for me which is expected as `sh` isn't `zsh`, which would be more likely to work
* [x] try with `SHELL`.
     - It still doesn't work for me, despite `zsh`, but that's merely a problem of my setup which requires a login shell. <img width="618" alt="Screenshot 2025-03-11 at 12 16 31" src="https://github.com/user-attachments/assets/6e481de5-f670-4455-b102-977b57a8e529" />
     - However, I think doing this will greatly improve the chances that signing works out of the box.
* [x] ❌ validate on windows (not easy, forgot there is a special incantation for ARM VMs), but nonetheless it doesn't startup, giving a null-pointer exception somewhere in tauri each time.
