### PR TITLE
Allow smaller than 25 rem sized branches

### DIFF
--- a/apps/desktop/src/components/BranchLane.svelte
+++ b/apps/desktop/src/components/BranchLane.svelte
@@ -79,7 +79,7 @@
 			<Resizer
 				viewport={rsViewport}
 				direction="right"
-				minWidth={25}
+				minWidth={20}
 				defaultLineColor="var(--clr-border-2)"
 				onWidth={(value) => ($width = value)}
 			/>


### PR DESCRIPTION
This seems like there was an accidental regression here. I typicaly have my branches sized around 21 rem, as I use gitbutler on my laptop monitor whilst zoomed one level.

This restores the resize range back to around where it was before