### PR TITLE
Changes in branch API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3067,6 +3067,7 @@ dependencies = [
  "gitbutler-id",
  "gitbutler-operating-modes",
  "gitbutler-oplog",
+ "gitbutler-oxidize",
  "gitbutler-project",
  "gitbutler-reference",
  "gitbutler-repo",

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -330,6 +330,19 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					return changesAdapter.addMany(changesAdapter.getInitialState(), changes);
 				}
 			}),
+			branchChanges: build.query<
+				EntityState<TreeChange, string>,
+				{ projectId: string; stackId: string; branchName: string }
+			>({
+				query: ({ projectId, stackId, branchName }) => ({
+					command: 'changes_in_branch',
+					params: { projectId, stackId, branchName }
+				}),
+				providesTags: [ReduxTag.BranchChanges],
+				transformResponse(changes: TreeChange[]) {
+					return changesAdapter.addMany(changesAdapter.getInitialState(), changes);
+				}
+			}),
 			updateCommitMessage: build.mutation<
 				void,
 				{ projectId: string; branchId: string; commitOid: string; message: string }

--- a/apps/desktop/src/lib/state/tags.ts
+++ b/apps/desktop/src/lib/state/tags.ts
@@ -5,5 +5,6 @@ export enum ReduxTag {
 	Stacks = 'Stacks',
 	WorktreeChanges = 'WorktreeChanges',
 	StackBranches = 'StackBranches',
-	CommitChanges = 'CommitChanges'
+	CommitChanges = 'CommitChanges',
+	BranchChanges = 'BranchChanges'
 }

--- a/crates/but-core/src/diff/ui.rs
+++ b/crates/but-core/src/diff/ui.rs
@@ -24,3 +24,14 @@ pub fn commit_changes_by_worktree_dir(
     super::commit_changes(&repo, parent_id, commit_id)
         .map(|c| c.into_iter().map(Into::into).collect())
 }
+
+/// See [`super::commit_changes()`].
+pub fn changes_in_commit_range(
+    worktree_dir: PathBuf,
+    commit_id: gix::ObjectId,
+    base: gix::ObjectId,
+) -> anyhow::Result<Vec<TreeChange>> {
+    let repo = gix::open(worktree_dir)?;
+    super::commit_changes(&repo, Some(base), commit_id)
+        .map(|c| c.into_iter().map(Into::into).collect())
+}

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -66,6 +66,7 @@ gitbutler-reference.workspace = true
 gitbutler-error.workspace = true
 gitbutler-secret.workspace = true
 gitbutler-id.workspace = true
+gitbutler-oxidize.workspace = true
 gitbutler-stack.workspace = true
 gitbutler-diff.workspace = true
 gitbutler-operating-modes.workspace = true

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -276,6 +276,7 @@ fn main() {
                     workspace::amend_commit_from_worktree_changes,
                     diff::changes_in_worktree,
                     diff::changes_in_commit,
+                    diff::changes_in_branch,
                     diff::tree_change_diffs,
                     // `env_vars` is only supposed to be avaialble in debug mode, not in production.
                     #[cfg(debug_assertions)]


### PR DESCRIPTION
Adds a new endpoint `changes_in_branch` which gives the tree changes for the entire branch (up to it's base).
The base of the branch is either the head of the branch it is stacked on top of or the merge base of the stack (when it is the bottom one)
<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#5ufpxPWxl`](https://gitbutler.com/krlvi/gitbutler/reviews/5ufpxPWxl)

**branch-changes-in-branch**


1 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Changes in branch API](https://gitbutler.com/krlvi/gitbutler/reviews/5ufpxPWxl/commit/d951eae5-cd3f-4fbf-b40a-5160e9db022f) | 💬 | <img width="20" height="20" src="https://app.gitbutler.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6NDE5NSwicHVyIjoiYmxvYl9pZCJ9fQ==--147ecfceb24a90d5c6f5a3c7be7da9c044672825/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJqcGciLCJyZXNpemVfdG9fbGltaXQiOlsyNTAsMjUwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--b925482a8ef8d05fa0ec590081629c1490ae5e79/profile.jpg">, <img width="20" height="20" src="https://app.gitbutler.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6Mzc2NSwicHVyIjoiYmxvYl9pZCJ9fQ==--dc26d51c5e164a387a94bae0306f29454c88e8f1/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJqcGciLCJyZXNpemVfdG9fbGltaXQiOlsyNTAsMjUwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--b925482a8ef8d05fa0ec590081629c1490ae5e79/Kiril_Videlov_2024_bw_square.jpg"> |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/krlvi/gitbutler/reviews/5ufpxPWxl)_
<!-- GitButler Review Footer Boundary Bottom -->
