### PR TITLE
use max_completion_tokens instead of max_tokens for OpenAI

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -77,6 +77,6 @@
 	"dependencies": {
 		"@tauri-apps/plugin-clipboard-manager": "^2.2.1",
 		"dayjs": "^1.11.13",
-		"openai": "^4.47.3"
+		"openai": "^4.87.3"
 	}
 }

--- a/apps/desktop/src/lib/ai/openAIClient.ts
+++ b/apps/desktop/src/lib/ai/openAIClient.ts
@@ -25,7 +25,7 @@ export class OpenAIClient implements AIClient {
 
 	async evaluate(prompt: Prompt, options?: AIEvalOptions): Promise<string> {
 		const response = await this.client.chat.completions.create({
-			max_tokens: options?.maxTokens ?? DEFAULT_MAX_TOKENS,
+			max_completion_tokens: options?.maxTokens ?? DEFAULT_MAX_TOKENS,
 			messages: prompt,
 			model: this.modelName,
 			stream: true

--- a/apps/desktop/src/lib/ai/openAIClient.ts
+++ b/apps/desktop/src/lib/ai/openAIClient.ts
@@ -24,6 +24,10 @@ export class OpenAIClient implements AIClient {
 	}
 
 	async evaluate(prompt: Prompt, options?: AIEvalOptions): Promise<string> {
+		// The 'max_tokens' parameter has been renamed to 'max_completion_tokens' in the OpenAI API.
+		// This change aligns with the updated API specification where 'max_completion_tokens'
+		// specifically controls the maximum number of tokens for the completion portion of the response.
+		// https://platform.openai.com/docs/api-reference/completions/create
 		const response = await this.client.chat.completions.create({
 			max_completion_tokens: options?.maxTokens ?? DEFAULT_MAX_TOKENS,
 			messages: prompt,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,8 +113,8 @@ importers:
         specifier: ^1.11.13
         version: 1.11.13
       openai:
-        specifier: ^4.47.3
-        version: 4.47.3
+        specifier: ^4.87.3
+        version: 4.87.3(ws@8.18.0)
     devDependencies:
       '@anthropic-ai/sdk':
         specifier: ^0.27.3
@@ -5525,9 +5525,17 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
-  openai@4.47.3:
-    resolution: {integrity: sha512-470d4ibH5kizXflCzgur22GpM4nOjrg7WQ9jTOa3dNKEn248oBy4+pjOyfcFR4V4YUn/YlDNjp6h83PbviCCKQ==}
+  openai@4.87.3:
+    resolution: {integrity: sha512-d2D54fzMuBYTxMW8wcNmhT1rYKcTfMJ8t+4KjH2KtvYenygITiGBgHoIrzHwnDQWW+C5oCA+ikIR2jgPCFqcKQ==}
     hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
@@ -7201,8 +7209,8 @@ packages:
     resolution: {integrity: sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==}
     engines: {node: '>= 0.4'}
 
-  which-typed-array@1.1.18:
-    resolution: {integrity: sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==}
+  which-typed-array@1.1.19:
+    resolution: {integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==}
     engines: {node: '>= 0.4'}
 
   which@2.0.2:
@@ -10035,7 +10043,7 @@ snapshots:
       sirv: 3.0.0
       tinyglobby: 0.2.10
       tinyrainbow: 2.0.0
-      vitest: 3.0.5(@types/debug@4.1.12)(@types/node@22.3.0)(@vitest/ui@3.0.5)(happy-dom@14.12.3)(jsdom@24.1.1)(msw@2.7.0(@types/node@22.3.0)(typescript@5.7.3))(sass-embedded@1.82.0)(yaml@2.7.0)
+      vitest: 3.0.5(@types/debug@4.1.12)(@types/node@22.3.0)(@vitest/browser@3.0.3)(@vitest/ui@3.0.5)(happy-dom@14.12.3)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.3.0)(typescript@5.4.5))(sass-embedded@1.82.0)(yaml@2.7.0)
 
   '@vitest/utils@2.0.5':
     dependencies:
@@ -11195,7 +11203,7 @@ snapshots:
       typed-array-byte-offset: 1.0.4
       typed-array-length: 1.0.7
       unbox-primitive: 1.1.0
-      which-typed-array: 1.1.18
+      which-typed-array: 1.1.19
     optional: true
 
   es-define-property@1.0.0:
@@ -12414,7 +12422,7 @@ snapshots:
 
   is-typed-array@1.1.15:
     dependencies:
-      which-typed-array: 1.1.18
+      which-typed-array: 1.1.19
     optional: true
 
   is-unicode-supported@0.1.0: {}
@@ -13111,7 +13119,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@4.47.3:
+  openai@4.87.3(ws@8.18.0):
     dependencies:
       '@types/node': 18.19.22
       '@types/node-fetch': 2.6.11
@@ -13120,7 +13128,8 @@ snapshots:
       form-data-encoder: 1.7.2
       formdata-node: 4.4.1
       node-fetch: 2.7.0
-      web-streams-polyfill: 3.3.3
+    optionalDependencies:
+      ws: 8.18.0
     transitivePeerDependencies:
       - encoding
 
@@ -15085,7 +15094,7 @@ snapshots:
       isarray: 2.0.5
       which-boxed-primitive: 1.1.1
       which-collection: 1.0.2
-      which-typed-array: 1.1.18
+      which-typed-array: 1.1.19
     optional: true
 
   which-collection@1.0.2:
@@ -15104,12 +15113,13 @@ snapshots:
       gopd: 1.0.1
       has-tostringtag: 1.0.2
 
-  which-typed-array@1.1.18:
+  which-typed-array@1.1.19:
     dependencies:
       available-typed-arrays: 1.0.7
       call-bind: 1.0.8
       call-bound: 1.0.4
       for-each: 0.3.5
+      get-proto: 1.0.1
       gopd: 1.2.0
       has-tostringtag: 1.0.2
     optional: true


### PR DESCRIPTION
## 🧢 Changes

max_tokens has been deprecated in favor of max_completion_tokens as described here: https://platform.openai.com/docs/api-reference/completions/create