### PR TITLE
Don't word diff long lines

### DIFF
--- a/apps/desktop/src/components/HunkDiff.svelte
+++ b/apps/desktop/src/components/HunkDiff.svelte
@@ -257,6 +257,15 @@
 				return acc;
 			}
 
+			// Don't do word diff on super long lines
+			if (
+				prevSection.lines.some((line) => line.content.length > 300) ||
+				nextSection.lines.some((line) => line.content.length > 300)
+			) {
+				acc.push(...createRowData(nextSection));
+				return acc;
+			}
+
 			if (inlineUnifiedDiffs) {
 				const rows = computeInlineWordDiff(prevSection, nextSection);
 

--- a/packages/ui/src/lib/utils/diffParsing.ts
+++ b/packages/ui/src/lib/utils/diffParsing.ts
@@ -704,6 +704,15 @@ export function generateRows(
 			return acc;
 		}
 
+		// Don't do word diff on super long lines
+		if (
+			prevSection.lines.some((line) => line.content.length > 300) ||
+			nextSection.lines.some((line) => line.content.length > 300)
+		) {
+			acc.push(...createRowData(filePath, nextSection, parser, selectedLines));
+			return acc;
+		}
+
 		if (inlineUnifiedDiffs) {
 			const rows = computeInlineWordDiff(filePath, prevSection, nextSection, parser, selectedLines);
 


### PR DESCRIPTION
Doing so causes big performance issues
<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#5L4ktrGJQ`](https://gitbutler.com/caleb-owens/gitbutler-client-d443/reviews/5L4ktrGJQ)

**don't-word-diff-long-lines**


1 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Don't word diff long lines](https://gitbutler.com/caleb-owens/gitbutler-client-d443/reviews/5L4ktrGJQ/commit/8f14ed87-d5f2-4949-bc1f-d9bba340c3b5) | ⚠️ | <img width="20" height="20" src="https://gitbutler-public.s3.us-east-1.amazonaws.com/images/gb-logo.png">, <img width="20" height="20" src="https://app.gitbutler.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MTc5OSwicHVyIjoiYmxvYl9pZCJ9fQ==--687bcccbc32853fc081271e42902a4f2fe2d0554/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJwbmciLCJyZXNpemVfdG9fbGltaXQiOlsyNTAsMjUwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--7ee67cd2edc36c03e1be048e50e661945f3999b0/96BE8547-FD64-407D-9769-7AB30DB85615.png">, <img width="20" height="20" src="https://app.gitbutler.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6Mzc2NSwicHVyIjoiYmxvYl9pZCJ9fQ==--dc26d51c5e164a387a94bae0306f29454c88e8f1/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJqcGciLCJyZXNpemVfdG9fbGltaXQiOlsyNTAsMjUwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--b925482a8ef8d05fa0ec590081629c1490ae5e79/Kiril_Videlov_2024_bw_square.jpg"> |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/caleb-owens/gitbutler-client-d443/reviews/5L4ktrGJQ)_
<!-- GitButler Review Footer Boundary Bottom -->
