### PR TITLE
allows a username other than git when using an ssh key

### DIFF
--- a/crates/gitbutler-repo/src/credentials.rs
+++ b/crates/gitbutler-repo/src/credentials.rs
@@ -35,7 +35,7 @@ impl From<Credential> for git2::RemoteCallbacks<'_> {
                 key_path,
                 passphrase,
             }) => {
-                remote_callbacks.credentials(move |url, _username_from_url, _allowed_types| {
+                remote_callbacks.credentials(move |url, username_from_url, _allowed_types| {
                     use resolve_path::PathResolveExt;
                     let key_path = key_path.resolve();
                     tracing::info!(
@@ -43,7 +43,7 @@ impl From<Credential> for git2::RemoteCallbacks<'_> {
                         url,
                         key_path.display()
                     );
-                    git2::Cred::ssh_key("git", None, &key_path, passphrase.as_deref())
+                    git2::Cred::ssh_key(username_from_url.unwrap_or("git"), None, &key_path, passphrase.as_deref())
                 });
             }
             Credential::Https(HttpsCredential::CredentialHelper { username, password }) => {

--- a/crates/gitbutler-repo/src/credentials.rs
+++ b/crates/gitbutler-repo/src/credentials.rs
@@ -43,7 +43,12 @@ impl From<Credential> for git2::RemoteCallbacks<'_> {
                         url,
                         key_path.display()
                     );
-                    git2::Cred::ssh_key(username_from_url.unwrap_or("git"), None, &key_path, passphrase.as_deref())
+                    git2::Cred::ssh_key(
+                        username_from_url.unwrap_or("git"),
+                        None,
+                        &key_path,
+                        passphrase.as_deref(),
+                    )
                 });
             }
             Credential::Https(HttpsCredential::CredentialHelper { username, password }) => {


### PR DESCRIPTION
## 🧢 Changes

Get username from ssh git URI and use it in the libgit2 API.

## ☕️ Reasoning

I have a use case where the ssh git URI use `gitea` as username and i need to use an ssh key.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
