### PR TITLE
Reduce BRtoPR gh API load

### DIFF
--- a/apps/desktop/src/lib/forge/brToPrSync.svelte.ts
+++ b/apps/desktop/src/lib/forge/brToPrSync.svelte.ts
@@ -79,5 +79,5 @@ function untrackedUpdate(pr: DetailedPullRequest, project: CloudProject, branch:
 		ownerSlug: project.owner
 	});
 
-	updateButRequestPrDescription(prService, pr.number, butlerRequestUrl, branch);
+	updateButRequestPrDescription(prService, pr.body || '\n', pr.number, butlerRequestUrl, branch);
 }

--- a/apps/desktop/src/lib/forge/shared/prFooter.ts
+++ b/apps/desktop/src/lib/forge/shared/prFooter.ts
@@ -15,10 +15,20 @@ export function unixifyNewlines(target: string): string {
 
 export async function updateButRequestPrDescription(
 	prService: ForgePrService,
+	cachedBody: string,
 	prNumber: number,
 	butRequestUrl: string,
 	butReview: Branch
 ) {
+	// First check to see if cached value differs
+	const cachedUnixedBody = unixifyNewlines(cachedBody || '\n');
+	const newCachedBody = unixifyNewlines(
+		formatButRequestDescription(cachedBody, butRequestUrl, butReview)
+	);
+
+	if (cachedUnixedBody === newCachedBody) return;
+
+	// Then we can do a more accurate comparison of the latest body
 	const pr = await prService.get(prNumber);
 	const prBody = unixifyNewlines(pr.body || '\n');
 


### PR DESCRIPTION
By checking the cached value first, we get a reasonable idea as to whether there are changes we need to update. If they meet the first check we can then make a second fetch to get the latest content
<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#9H5jBBRX7`](https://gitbutler.com/caleb-owens/gitbutler-client-d443/reviews/9H5jBBRX7)

**reduce-github-API-load**


1 commit series (version 2)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Reduce BRtoPR gh API load](https://gitbutler.com/caleb-owens/gitbutler-client-d443/reviews/9H5jBBRX7/commit/30a51cf4-5ab4-421b-8296-92fe7f81ea26) | ⚠️ | <img width="20" height="20" src="https://gitbutler-public.s3.us-east-1.amazonaws.com/images/gb-logo.png">, <img width="20" height="20" src="https://app.gitbutler.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MTc5OSwicHVyIjoiYmxvYl9pZCJ9fQ==--687bcccbc32853fc081271e42902a4f2fe2d0554/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJwbmciLCJyZXNpemVfdG9fbGltaXQiOlsyNTAsMjUwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--7ee67cd2edc36c03e1be048e50e661945f3999b0/96BE8547-FD64-407D-9769-7AB30DB85615.png">, <img width="20" height="20" src="https://app.gitbutler.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6NDE5NSwicHVyIjoiYmxvYl9pZCJ9fQ==--147ecfceb24a90d5c6f5a3c7be7da9c044672825/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJqcGciLCJyZXNpemVfdG9fbGltaXQiOlsyNTAsMjUwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--b925482a8ef8d05fa0ec590081629c1490ae5e79/profile.jpg">, <img width="20" height="20" src="https://app.gitbutler.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6Mzc2NSwicHVyIjoiYmxvYl9pZCJ9fQ==--dc26d51c5e164a387a94bae0306f29454c88e8f1/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJqcGciLCJyZXNpemVfdG9fbGltaXQiOlsyNTAsMjUwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--b925482a8ef8d05fa0ec590081629c1490ae5e79/Kiril_Videlov_2024_bw_square.jpg"> |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/caleb-owens/gitbutler-client-d443/reviews/9H5jBBRX7)_
<!-- GitButler Review Footer Boundary Bottom -->
