### PR TITLE
Do not, ever, use login shells. (#7575)

### DIFF
--- a/crates/but-core/src/cmd.rs
+++ b/crates/but-core/src/cmd.rs
@@ -8,9 +8,8 @@ pub fn prepare_with_shell(program: impl Into<OsString>) -> gix::command::Prepare
         // On Windows, this means a shell will always be used.
         .command_may_be_shell_script_disallow_manual_argument_splitting()
         // On Windows, this yields the Git-bundled `sh.exe`, which is what we want.
-        .with_shell_program(
-            std::env::var_os("SHELL").unwrap_or_else(|| gix::path::env::shell().into()),
-        )
+        // Do NOT attempt to use a login shell here, we don't know its syntax.
+        .with_shell_program(gix::path::env::shell())
         // force using a shell, we want access to additional programs here
         .with_shell()
         // We know `program` is a path, so quote it.


### PR DESCRIPTION
These could be anything, and don't have to be compatible to a posix shell at all or in the slightest.

There simply is no other way but to get the login environment from somewhere else if more terminal-like behaviour is desired.
