### PR TITLE
review-details-modal-updates

### DIFF
--- a/apps/desktop/src/components/ReviewDetailsModal.svelte
+++ b/apps/desktop/src/components/ReviewDetailsModal.svelte
@@ -49,6 +49,7 @@
 	import Textbox from '@gitbutler/ui/Textbox.svelte';
 	import Toggle from '@gitbutler/ui/Toggle.svelte';
 	import ToggleButton from '@gitbutler/ui/ToggleButton.svelte';
+	import Link from '@gitbutler/ui/link/Link.svelte';
 	import Markdown from '@gitbutler/ui/markdown/Markdown.svelte';
 	import Select from '@gitbutler/ui/select/Select.svelte';
 	import SelectItem from '@gitbutler/ui/select/SelectItem.svelte';
@@ -537,9 +538,14 @@
 				{#if canPublishBR && canPublishPR}
 					<div class="options">
 						{#if canPublishBR}
-							<div class="option">
-								<p class="text-13">Create Butler Review</p>
-								<Toggle bind:checked={$createButlerRequest} />
+							<div class="stacked-options">
+								<div class="option">
+									<p class="text-13">Create Butler Review</p>
+									<Toggle bind:checked={$createButlerRequest} />
+								</div>
+								<div class="option text-13">
+									<Link href="https://docs.gitbutler.com/review/overview">Learn more</Link>
+								</div>
 							</div>
 						{/if}
 						{#if canPublishPR}

--- a/apps/desktop/src/components/ReviewDetailsModal.svelte
+++ b/apps/desktop/src/components/ReviewDetailsModal.svelte
@@ -584,6 +584,17 @@
 						{/if}
 					</div>
 					<Spacer dotted margin={0} />
+				{:else if canPublishBR}
+					<div class="options">
+						<div class="option text-13">
+							Creates a Butler Review for this branch.
+							<Link href="https://docs.gitbutler.com/review/overview">Learn more</Link>
+						</div>
+					</div>
+				{:else if canPublishPR}
+					<div class="options">
+						<div class="option text-13">Creates a Pull Request for this branch.</div>
+					</div>
 				{/if}
 				<div class="actions">
 					<Button kind="outline" onclick={close}>Cancel</Button>


### PR DESCRIPTION
There was ambiguity and lack of clarity of what is being created. This PR adds:
1. link to docs for the butler review
3. if there is only PR configured it spells out that a PR is being created
4. if there is only a BR configured it spells out that a BR is being created

<img width="594" alt="Screenshot 2025-03-14 at 07 23 52" src="https://github.com/user-attachments/assets/5e7610a5-bab6-44fc-96fe-66c866c4ffec" />

<img width="601" alt="Screenshot 2025-03-14 at 07 24 58" src="https://github.com/user-attachments/assets/471615ae-9335-4fba-b8b8-0d07fa5be998" />

<img width="608" alt="Screenshot 2025-03-14 at 07 24 09" src="https://github.com/user-attachments/assets/0a396b5f-eb7c-4dc8-9a2e-50a36f21851c" />

It still looks like shit, styles to be updated in a separate pull request





<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#9BGe6Jtnb`](https://gitbutler.com/krlvi/gitbutler/reviews/9BGe6Jtnb)

**review-details-modal-updates**


2 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 2/2 | [Add clarification in the "Submit for review" modal](https://gitbutler.com/krlvi/gitbutler/reviews/9BGe6Jtnb/commit/68e9065c-b41a-4050-b2b2-2f90097a1cc1) | ⏳ |  |
| 1/2 | [Add link to docs of But Requests in the creation modal](https://gitbutler.com/krlvi/gitbutler/reviews/9BGe6Jtnb/commit/113d4f78-1922-4fd0-a84e-9757b70727f0) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/krlvi/gitbutler/reviews/9BGe6Jtnb)_
<!-- GitButler Review Footer Boundary Bottom -->
