### PR TITLE
chat: Fix disappearing emojis

### DIFF
--- a/packages/ui/src/lib/richText/plugins/EmojiSuggestions.svelte
+++ b/packages/ui/src/lib/richText/plugins/EmojiSuggestions.svelte
@@ -90,9 +90,17 @@
 		return true;
 	}
 
+	let windowScrollY = $state(window.scrollY);
+	const selectionPosition = $derived(getSelectionPosition(windowScrollY));
+
 	$effect(() => {
 		if (suggestedEmojis !== undefined && suggestedEmojis.length > 0) {
-			position = getSelectionPosition();
+			position = selectionPosition;
+		}
+	});
+
+	$effect(() => {
+		if (suggestedEmojis !== undefined && suggestedEmojis.length > 0) {
 			selectedSuggestionIndex = 0;
 
 			const unregisterArrowUp = editor.registerCommand(
@@ -130,6 +138,8 @@
 		position = undefined;
 	});
 </script>
+
+<svelte:window bind:scrollY={windowScrollY} />
 
 {#if position && suggestedEmojis !== undefined}
 	<div

--- a/packages/ui/src/lib/richText/selection.ts
+++ b/packages/ui/src/lib/richText/selection.ts
@@ -10,12 +10,14 @@ export function getCursorPosition() {
 	}
 }
 
-export function getSelectionPosition() {
+export function getSelectionPosition(windowScrollY?: number) {
 	const nativeSelection = window.getSelection();
 	const domRect = nativeSelection?.getRangeAt(0).getBoundingClientRect();
 
 	if (domRect) {
-		return { left: domRect.left - 10, top: domRect.top };
+		const top = domRect.top + (windowScrollY ?? 0);
+		const left = domRect.left - 10;
+		return { left, top };
 	}
 }
 


### PR DESCRIPTION
The floating emoji selection component sometimes would fly away free, because it wouldn't take into account the window scroll