### PR TITLE
Refactor commit_by_oid_or_change_id

### DIFF
--- a/crates/gitbutler-stack/src/lib.rs
+++ b/crates/gitbutler-stack/src/lib.rs
@@ -14,7 +14,7 @@ pub use target::Target;
 
 mod heads;
 pub use heads::add_head;
-pub use stack::{commit_by_oid_or_change_id, CommitsForId, PatchReferenceUpdate, TargetUpdate};
+pub use stack::{commit_by_oid_or_change_id, PatchReferenceUpdate, TargetUpdate};
 
 // This is here because CommitOrChangeId::ChangeId is deprecated, for some reason allow cant be done on the CommitOrChangeId struct
 #[allow(deprecated)]

--- a/crates/gitbutler-stack/src/stack_branch.rs
+++ b/crates/gitbutler-stack/src/stack_branch.rs
@@ -225,7 +225,6 @@ impl StackBranch {
                 let merge_base = stack.merge_base(stack_context)?;
                 let head_commit =
                     commit_by_oid_or_change_id(&self.head, repository, stack.head(), merge_base)?
-                        .head
                         .id();
                 Ok(head_commit)
             }
@@ -262,7 +261,7 @@ impl StackBranch {
                 upstream_only: vec![],
             });
         }
-        let head_commit = head_commit?.head.id();
+        let head_commit = head_commit?.id();
 
         // Find the previous head in the stack - if it is not archived, use it as base
         // Otherwise use the merge base
@@ -271,7 +270,7 @@ impl StackBranch {
             .filter(|predacessor| !predacessor.archived)
             .map_or(merge_base, |predacessor| {
                 commit_by_oid_or_change_id(&predacessor.head, repository, stack.head(), merge_base)
-                    .map(|commit| commit.head.id())
+                    .map(|commit| commit.id())
                     .unwrap_or(merge_base)
             });
 


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#4lLYuqXVk`](https://gitbutler.com/krlvi/gitbutler/reviews/4lLYuqXVk)

**Refactor commit_by_oid_or_change_id**


Change ids are on their way out with regards to stacking

1 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Refactor commit_by_oid_or_change_id](https://gitbutler.com/krlvi/gitbutler/reviews/4lLYuqXVk/commit/42b37d31-41d1-4cce-82cf-f067238fe817) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/krlvi/gitbutler/reviews/4lLYuqXVk)_
<!-- GitButler Review Footer Boundary Bottom -->
