### PR TITLE
Proactively migrate change IDs to commit ids in the stack heads

### DIFF
--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -249,7 +249,7 @@ pub fn stack_branches(stack_id: String, ctx: &CommandContext) -> Result<Vec<Bran
         .push_remote_name();
 
     let mut stack_branches = vec![];
-    let stack = state.get_stack(Id::from_str(&stack_id)?)?;
+    let mut stack = state.get_stack(Id::from_str(&stack_id)?)?;
     let stack_ctx = ctx.to_stack_context()?;
     let mut current_base = stack.merge_base(&stack_ctx)?.to_gix();
     for internal in stack.branches() {
@@ -270,6 +270,7 @@ pub fn stack_branches(stack_id: String, ctx: &CommandContext) -> Result<Vec<Bran
         current_base = internal.head_oid(&stack_ctx, &stack)?.to_gix();
         stack_branches.push(result);
     }
+    _ = stack.migrate_change_ids(ctx); // If it fails thats ok - best effort migration
     stack_branches.reverse();
     Ok(stack_branches)
 }

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -423,6 +423,7 @@ pub fn list_virtual_branches_cached(
         }
 
         let head = branch.head();
+        let _ = branch.migrate_change_ids(ctx); // If it fails thats ok - best effort migration
         let branch = VirtualBranch {
             id: branch.id,
             name: branch.name,


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#3F7ckaMOe`](https://gitbutler.com/krlvi/gitbutler/reviews/3F7ckaMOe)

**Proactively migrate change IDs to commit ids in the stack heads**


While not failing on error

1 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Proactively migrate change IDs to commit ids in the stack heads](https://gitbutler.com/krlvi/gitbutler/reviews/3F7ckaMOe/commit/9357b71c-a4ea-4b62-b231-3952f5324c5d) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/krlvi/gitbutler/reviews/3F7ckaMOe)_
<!-- GitButler Review Footer Boundary Bottom -->
