### PR TITLE
push stack

### DIFF
--- a/apps/desktop/src/components/v3/BranchList.svelte
+++ b/apps/desktop/src/components/v3/BranchList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Branch from './Branch.svelte';
+	import PushButton from './PushButton.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { inject } from '@gitbutler/shared/context';
@@ -11,21 +12,18 @@
 
 	const { projectId, stackId }: Props = $props();
 	const [stackService] = inject(StackService);
-
-	const result = $derived(stackService.branches(projectId, stackId));
+	const branchesResult = $derived(stackService.branches(projectId, stackId));
 </script>
 
-{#if stackId && result}
-	<ReduxResult result={result.current}>
+{#if stackId && branchesResult}
+	<ReduxResult result={branchesResult.current}>
 		{#snippet children(branches)}
 			{#each branches as branch, i (branch.name)}
 				{@const first = i === 0}
 				{@const last = i === branches.length - 1}
 				<Branch {projectId} {stackId} branchName={branch.name} {first} {last} />
 			{/each}
+			<PushButton {projectId} {stackId} multipleBranches={branches.length > 0} />
 		{/snippet}
 	</ReduxResult>
 {/if}
-
-<style lang="postcss">
-</style>

--- a/apps/desktop/src/components/v3/PushButton.svelte
+++ b/apps/desktop/src/components/v3/PushButton.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+	import { StackService } from '$lib/stacks/stackService.svelte';
+	import { intersectionObserver } from '$lib/utils/intersectionObserver';
+	import { inject } from '@gitbutler/shared/context';
+	import Button from '@gitbutler/ui/Button.svelte';
+
+	type Props = {
+		projectId: string;
+		stackId: string;
+		multipleBranches: boolean;
+	};
+
+	const { projectId, stackId, multipleBranches }: Props = $props();
+
+	const [stackService] = inject(StackService);
+	const stackInfoResult = $derived(stackService.stackInfo(projectId, stackId));
+	const stackInfo = $derived(stackInfoResult.current.data);
+	const { result: pushResult, triggerMutation } = stackService.pushStack();
+	let scrollEndVisible = $state(true);
+
+	function push() {
+		if (!stackInfo) return;
+		triggerMutation({ projectId, stackId, withForce: stackInfo.requiresForce });
+	}
+
+	const loading = $derived(pushResult.current.isLoading || stackInfoResult.current.isLoading);
+</script>
+
+<div
+	class="push-button"
+	class:scroll-end-visible={scrollEndVisible}
+	use:intersectionObserver={{
+		callback: (entry) => {
+			if (entry?.isIntersecting) {
+				scrollEndVisible = false;
+			} else {
+				scrollEndVisible = true;
+			}
+		},
+		options: {
+			root: null,
+			rootMargin: `-100% 0px 0px 0px`,
+			threshold: 0
+		}
+	}}
+>
+	<div class="push-button__inner">
+		<Button
+			style="neutral"
+			wide
+			{loading}
+			disabled={stackInfo?.isConflicted || !stackInfo?.isDirty}
+			tooltip={stackInfo?.isConflicted
+				? 'In order to push, please resolve any conflicted commits.'
+				: undefined}
+			onclick={push}
+		>
+			{stackInfo?.requiresForce ? 'Force push' : multipleBranches ? 'Push All' : 'Push'}
+		</Button>
+	</div>
+</div>
+
+<style lang="postcss">
+	.push-button {
+		z-index: var(--z-lifted);
+		position: sticky;
+		padding: 20px 12px 12px;
+		bottom: 0;
+
+		transition: background-color var(--transition-fast);
+
+		&:global(.merge-all > button:not(:last-child)) {
+			margin-bottom: 8px;
+		}
+
+		&:after {
+			content: '';
+			display: block;
+			position: absolute;
+			bottom: 0;
+			left: 0;
+			height: calc(100% + 12px);
+			width: 100%;
+			z-index: -1;
+			background-color: var(--clr-bg-1);
+			border-top: 1px solid var(--clr-border-2);
+
+			transform: translateY(0);
+			opacity: 0;
+			transition: opacity var(--transition-fast);
+		}
+
+		&:not(.scroll-end-visible):after {
+			opacity: 1;
+		}
+	}
+
+	.push-button__inner {
+		/* This is just here so that the disabled button is still opaque */
+		border-radius: var(--radius-m);
+		background-color: var(--clr-bg-1);
+	}
+</style>

--- a/apps/desktop/src/lib/stacks/stack.ts
+++ b/apps/desktop/src/lib/stacks/stack.ts
@@ -10,3 +10,20 @@ export function getStackName(stack: Stack): string | undefined {
 	const lastBranch = stack.branchNames[stack.branchNames.length - 1];
 	return lastBranch;
 }
+
+export type StackInfo = {
+	id: string;
+	name: string;
+	/**
+	 * Whether the stack contains any conflicted changes.
+	 */
+	isConflicted: boolean;
+	/**
+	 * Whether there are local changes that can be pushed to the remote.
+	 */
+	isDirty: boolean;
+	/**
+	 * Whether the stack requires a force push to the remote.
+	 */
+	requiresForce: boolean;
+};

--- a/apps/desktop/src/lib/state/backendQuery.ts
+++ b/apps/desktop/src/lib/state/backendQuery.ts
@@ -29,7 +29,7 @@ type ApiArgs = {
 	params: Record<string, unknown>;
 };
 
-type TauriCommandError = { message: string; code?: string };
+export type TauriCommandError = { message: string; code?: string };
 
 /**
  * Typeguard for accessing injected Tauri dependency safely.

--- a/apps/desktop/src/lib/state/tags.ts
+++ b/apps/desktop/src/lib/state/tags.ts
@@ -3,6 +3,7 @@ export enum ReduxTag {
 	Commits = 'Commits',
 	Commit = 'Commit',
 	Stacks = 'Stacks',
+	StackInfo = 'StackInfo',
 	WorktreeChanges = 'WorktreeChanges',
 	StackBranches = 'StackBranches',
 	CommitChanges = 'CommitChanges',

--- a/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
+++ b/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
@@ -137,7 +137,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: `integrate_upstream`,
 					params: { projectId, resolutions, baseBranchResolution }
 				}),
-				invalidatesTags: [ReduxTag.Stacks, ReduxTag.StackBranches]
+				invalidatesTags: [ReduxTag.Stacks, ReduxTag.StackBranches, ReduxTag.StackInfo]
 			}),
 			resolveUpstreamIntegration: build.mutation<
 				string,

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -89,7 +89,7 @@
 		reactive(() => changeSelection),
 		clientState.dispatch
 	);
-	const stackService = new StackService(clientState);
+	const stackService = new StackService(clientState, data.posthog);
 	const worktreeService = new WorktreeService(clientState);
 	const feedService = new FeedService(data.cloud, appState.appDispatch);
 	const organizationService = new OrganizationService(data.cloud, appState.appDispatch);

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -136,6 +136,86 @@ pub fn stacks(gb_dir: &Path) -> Result<Vec<StackEntry>> {
         .collect())
 }
 
+/// Information about the current state of a stack
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StackInfo {
+    /// The ID of the stack.
+    pub id: StackId,
+    /// Stack name.
+    pub name: BString,
+    /// Whether the stack contains any conflicted changes.
+    pub is_conflicted: bool,
+    /// Whether there are local changes that can be pushed to the remote.
+    pub is_dirty: bool,
+    /// Whether the stack requires a force push to the remote.
+    pub requires_force: bool,
+}
+
+fn is_requires_force(ctx: &CommandContext, stack: &Stack) -> Result<bool> {
+    let upstream = if let Some(upstream) = &stack.upstream {
+        upstream
+    } else {
+        return Ok(false);
+    };
+
+    let reference = match ctx.repo().refname_to_id(&upstream.to_string()) {
+        Ok(reference) => reference,
+        Err(err) if err.code() == git2::ErrorCode::NotFound => return Ok(false),
+        Err(other) => return Err(other).context("failed to find upstream reference"),
+    };
+
+    let upstream_commit = ctx
+        .repo()
+        .find_commit(reference)
+        .context("failed to find upstream commit")?;
+
+    let merge_base = ctx.repo().merge_base(upstream_commit.id(), stack.head())?;
+
+    Ok(merge_base != upstream_commit.id())
+}
+
+/// Returns information about the current state of a stack.
+/// If the stack is not found, an error is returned.
+///
+/// - `gb_dir`: The path to the GitButler state for the project. Normally this is `.git/gitbutler` in the project's repository.
+/// - `stack_id`: The ID of the stack to get information about.
+/// - `ctx`: The command context for the project.
+pub fn get_stack_info(gb_dir: &Path, stack_id: StackId, ctx: &CommandContext) -> Result<StackInfo> {
+    let state = state_handle(gb_dir);
+    let stack = state.get_stack(stack_id)?;
+    let branches = stack.branches();
+    let repo = ctx.gix_repository()?;
+
+    let mut is_conflicted = false;
+    let mut is_dirty = false;
+
+    for branch in branches {
+        if is_conflicted && is_dirty {
+            break;
+        }
+        let commits = local_and_remote_commits(ctx, &repo, branch, &stack)?;
+        for commit in commits {
+            if !is_conflicted && commit.has_conflicts {
+                is_conflicted = true;
+            }
+            if !is_dirty && matches!(commit.state, CommitState::LocalOnly) {
+                is_dirty = true;
+            }
+        }
+    }
+
+    let requires_force = is_requires_force(ctx, &stack)?;
+
+    Ok(StackInfo {
+        id: stack.id,
+        name: stack.name.to_owned().into(),
+        is_conflicted,
+        is_dirty,
+        requires_force,
+    })
+}
+
 /// Returns the last-seen fork-point that the workspace has with the target branch with which it wants to integrate.
 // TODO: at some point this should be optional, integration branch doesn't have to be defined.
 pub fn common_merge_base_with_target_branch(gb_dir: &Path) -> Result<gix::ObjectId> {

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -268,6 +268,7 @@ fn main() {
                     settings::update_telemetry,
                     settings::update_feature_flags,
                     workspace::stacks,
+                    workspace::stack_info,
                     workspace::stack_branches,
                     workspace::stack_branch_local_and_remote_commits,
                     workspace::stack_branch_upstream_only_commits,

--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -26,6 +26,19 @@ pub fn stacks(
 
 #[tauri::command(async)]
 #[instrument(skip(projects, settings), err(Debug))]
+pub fn stack_info(
+    projects: State<'_, projects::Controller>,
+    settings: State<'_, AppSettingsWithDiskSync>,
+    project_id: ProjectId,
+    stack_id: StackId,
+) -> Result<but_workspace::StackInfo, Error> {
+    let project = projects.get(project_id)?;
+    let ctx = CommandContext::open(&project, settings.get()?.clone())?;
+    but_workspace::get_stack_info(&project.gb_dir(), stack_id, &ctx).map_err(Into::into)
+}
+
+#[tauri::command(async)]
+#[instrument(skip(projects, settings), err(Debug))]
 pub fn stack_branches(
     projects: State<'_, projects::Controller>,
     settings: State<'_, AppSettingsWithDiskSync>,


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#7g519aIr1`](https://gitbutler.com/estib/gitbutler/reviews/7g519aIr1)

**push stack**


- Added a mutation for pushing the stack.
- Integrated PostHog analytics to track push events.
- Implemented toast error notifications for push errors.
- Created a backend endpoint to return current stack information.
- Developed a query to fetch details for a specified stack, invalidated by mutations.
- Built a component for the push button functionality for the stack.

4 commit series (version 2)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 4/4 | [v3 Push button](https://gitbutler.com/estib/gitbutler/reviews/7g519aIr1/commit/67a9b796-a8b4-4496-b9f8-3b94ae3d20f4) | ⏳ |  |
| 3/4 | [stack service: Add Stack info query](https://gitbutler.com/estib/gitbutler/reviews/7g519aIr1/commit/23e318a0-0450-4fbc-b82e-de27ffd5d6a5) | 💬 |  |
| 2/4 | [Workspace API: Stack info](https://gitbutler.com/estib/gitbutler/reviews/7g519aIr1/commit/ae68c466-9f46-4f86-8d51-8564175c28bd) | 💬 |  |
| 1/4 | [stack service: push stack](https://gitbutler.com/estib/gitbutler/reviews/7g519aIr1/commit/0045042d-c208-42bb-b5f3-78592b9449ee) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/estib/gitbutler/reviews/7g519aIr1)_
<!-- GitButler Review Footer Boundary Bottom -->
