### PR TITLE
Fixes a bug where amending multiple files into a commit amends only one

### DIFF
--- a/apps/desktop/src/lib/commits/dragActions.ts
+++ b/apps/desktop/src/lib/commits/dragActions.ts
@@ -66,14 +66,14 @@ export class CommitDragActions {
 			]);
 		} else if (dropData instanceof FileDropData) {
 			if (dropData.file instanceof LocalFile) {
-				// this is an uncommitted file change being amended to a previous commit
-				this.branchController.amendBranch(this.stack.id, this.commit.id, [
-					{
+				const worktreeChanges = dropData.files.map((file) => {
+					return {
 						previousPathBytes: null,
-						pathBytes: dropData.file.path, // Can we get the path in bytes here?
+						pathBytes: file.path, // Can we get the path in bytes here?
 						hunkHeaders: [] // An empty list of hunk headers means use everything for the file
-					}
-				]);
+					};
+				});
+				this.branchController.amendBranch(this.stack.id, this.commit.id, worktreeChanges);
 			} else if (dropData.file instanceof RemoteFile) {
 				// this is a file from a commit, rather than an uncommitted file
 				const newOwnership = filesToSimpleOwnership(dropData.files);


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#6rlKwfuuF`](https://gitbutler.com/krlvi/gitbutler/reviews/6rlKwfuuF)

**Fixes a bug where amending multiple files into a commit amends only one**


1 commit series (version 2)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Fixes a bug where amending multiple files into a commit amends only one](https://gitbutler.com/krlvi/gitbutler/reviews/6rlKwfuuF/commit/d38873e2-0741-40cb-bd7d-ed1f07fe2bca) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/krlvi/gitbutler/reviews/6rlKwfuuF)_
<!-- GitButler Review Footer Boundary Bottom -->
