### PR TITLE
discard changes: hunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,9 +1984,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.34"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
  "libz-ng-sys",
@@ -3128,7 +3128,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.70.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "gix-actor 0.33.2",
  "gix-attributes 0.24.0",
@@ -3199,7 +3199,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.33.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "gix-date 0.9.3",
@@ -3230,7 +3230,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.24.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "gix-glob 0.18.0",
@@ -3256,7 +3256,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.14"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "thiserror 2.0.9",
 ]
@@ -3273,7 +3273,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "thiserror 2.0.9",
 ]
@@ -3281,7 +3281,7 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.4.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "gix-path 0.10.14",
@@ -3307,7 +3307,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.26.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "gix-chunk 0.4.11",
@@ -3321,7 +3321,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.43.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -3341,7 +3341,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.14.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -3353,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.27.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3382,7 +3382,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.9.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "itoa 1.0.11",
@@ -3394,7 +3394,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.50.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "gix-attributes 0.24.0",
@@ -3417,7 +3417,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "gix-discover 0.38.0",
@@ -3452,7 +3452,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.38.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "dunce",
@@ -3482,7 +3482,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.40.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -3504,7 +3504,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -3535,7 +3535,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "fastrand",
  "gix-features 0.40.0",
@@ -3557,7 +3557,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.18.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -3579,7 +3579,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "faster-hex",
  "serde",
@@ -3600,7 +3600,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.7.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "gix-hash 0.16.0",
  "hashbrown 0.14.5",
@@ -3623,7 +3623,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "gix-glob 0.18.0",
@@ -3664,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.38.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -3703,7 +3703,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "16.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "gix-tempfile 16.0.0",
  "gix-utils 0.1.14",
@@ -3713,7 +3713,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.25.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "gix-actor 0.33.2",
@@ -3725,7 +3725,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.3.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3749,7 +3749,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.18.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bitflags 2.6.0",
  "gix-commitgraph 0.26.0",
@@ -3783,7 +3783,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.47.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "gix-actor 0.33.2",
@@ -3804,7 +3804,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.67.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "arc-swap",
  "gix-date 0.9.3",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.57.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "clru",
  "gix-chunk 0.4.11",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.18.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -3857,7 +3857,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.18.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -3881,7 +3881,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.14"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "gix-trace 0.1.12",
@@ -3893,7 +3893,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.9.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -3907,7 +3907,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.9.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -3919,7 +3919,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.48.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -3956,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.4.15"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "gix-utils 0.1.14",
@@ -3988,7 +3988,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.50.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "gix-actor 0.33.2",
  "gix-features 0.40.0",
@@ -4009,7 +4009,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "gix-hash 0.16.0",
@@ -4022,7 +4022,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -4055,7 +4055,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.18.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "gix-commitgraph 0.26.0",
  "gix-date 0.9.3",
@@ -4081,7 +4081,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.10.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bitflags 2.6.0",
  "gix-path 0.10.14",
@@ -4093,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.2.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "gix-hash 0.16.0",
@@ -4105,7 +4105,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "filetime",
@@ -4127,7 +4127,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "gix-config",
@@ -4156,7 +4156,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "16.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "dashmap",
  "gix-fs 0.13.0",
@@ -4201,7 +4201,7 @@ checksum = "04bdde120c29f1fc23a24d3e115aeeea3d60d8e65bab92cc5f9d90d9302eb952"
 [[package]]
 name = "gix-trace"
 version = "0.1.12"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "tracing-core",
 ]
@@ -4209,7 +4209,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.45.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -4245,7 +4245,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.44.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bitflags 2.6.0",
  "gix-commitgraph 0.26.0",
@@ -4261,7 +4261,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "gix-features 0.40.0",
@@ -4285,7 +4285,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.1.14"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4305,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.9.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "thiserror 2.0.9",
@@ -4333,7 +4333,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.39.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "gix-attributes 0.24.0",
@@ -4352,7 +4352,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e#0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=7255a5fc0aa790b54e3176e8ecf066457acd9eef#7255a5fc0aa790b54e3176e8ecf066457acd9eef"
 dependencies = [
  "bstr",
  "gix-features 0.40.0",
@@ -5398,7 +5398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5612,9 +5612,9 @@ checksum = "a05b5d0594e0cb1ad8cee3373018d2b84e25905dc75b2468114cc9a8e86cfc20"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
  "simd-adler32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.dependencies]
 bstr = "1.11.1"
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
-gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "0bf1d5b9f0b0971b9f25a8e44b7818e37c78d68e", default-features = false, features = [
+gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "7255a5fc0aa790b54e3176e8ecf066457acd9eef", default-features = false, features = [
 ] }
 gix-testtools = "0.15.0"
 insta = "1.41.1"

--- a/crates/but-cli/src/args.rs
+++ b/crates/but-cli/src/args.rs
@@ -46,6 +46,9 @@ pub enum Subcommands {
     /// List all uncommitted working tree changes.
     Status {
         /// Also compute unified diffs for each tree-change.
+        #[clap(long, short = 'c', default_value_t = 3)]
+        context_lines: u32,
+        /// Also compute unified diffs for each tree-change.
         #[clap(long, short = 'd')]
         unified_diff: bool,
     },

--- a/crates/but-cli/src/command/mod.rs
+++ b/crates/but-cli/src/command/mod.rs
@@ -3,6 +3,8 @@ use gitbutler_project::Project;
 use gix::bstr::BString;
 use std::path::Path;
 
+const UI_CONTEXT_LINES: u32 = 3;
+
 pub fn project_from_path(path: &Path) -> anyhow::Result<Project> {
     Project::from_path(path)
 }

--- a/crates/but-cli/src/main.rs
+++ b/crates/but-cli/src/main.rs
@@ -37,9 +37,10 @@ fn main() -> Result<()> {
             )
         }
         args::Subcommands::HunkDependency => command::diff::locks(&args.current_dir),
-        args::Subcommands::Status { unified_diff } => {
-            command::diff::status(&args.current_dir, *unified_diff)
-        }
+        args::Subcommands::Status {
+            unified_diff,
+            context_lines,
+        } => command::diff::status(&args.current_dir, *unified_diff, *context_lines),
         args::Subcommands::CommitChanges {
             unified_diff,
             current_commit,

--- a/crates/but-core/src/diff/mod.rs
+++ b/crates/but-core/src/diff/mod.rs
@@ -1,8 +1,130 @@
 pub(crate) mod commit;
+
+use bstr::{BStr, ByteSlice};
 pub use commit::commit_changes;
 
 mod worktree;
+use crate::{ChangeState, ModeFlags, TreeChange, TreeStatus, TreeStatusKind};
 pub use worktree::worktree_changes;
 
 /// conversion functions for use in the UI
 pub mod ui;
+
+impl TreeStatus {
+    /// Learn what kind of status this is, useful if only this information is needed.
+    pub fn kind(&self) -> TreeStatusKind {
+        match self {
+            TreeStatus::Addition { .. } => TreeStatusKind::Addition,
+            TreeStatus::Deletion { .. } => TreeStatusKind::Deletion,
+            TreeStatus::Modification { .. } => TreeStatusKind::Modification,
+            TreeStatus::Rename { .. } => TreeStatusKind::Rename,
+        }
+    }
+
+    /// Return the state in which the change is currently. May be `None` if there is no current state after a deletion.
+    pub fn state(&self) -> Option<ChangeState> {
+        match self {
+            TreeStatus::Addition { state, .. }
+            | TreeStatus::Rename { state, .. }
+            | TreeStatus::Modification { state, .. } => Some(*state),
+            TreeStatus::Deletion { .. } => None,
+        }
+    }
+
+    /// Return the previous state that the change originated from. May be `None` if there is no previous state, for instance after an addition.
+    /// Also provide the path from which the state was possibly obtained.
+    pub fn previous_state_and_path(&self) -> Option<(ChangeState, Option<&BStr>)> {
+        match self {
+            TreeStatus::Addition { .. } => None,
+            TreeStatus::Rename {
+                previous_state,
+                previous_path,
+                ..
+            } => Some((*previous_state, Some(previous_path.as_bstr()))),
+            TreeStatus::Modification { previous_state, .. }
+            | TreeStatus::Deletion { previous_state, .. } => Some((*previous_state, None)),
+        }
+    }
+}
+
+impl TreeChange {
+    /// Return the path at which this directory entry was previously located, if it was renamed.
+    pub fn previous_path(&self) -> Option<&BStr> {
+        match &self.status {
+            TreeStatus::Addition { .. }
+            | TreeStatus::Deletion { .. }
+            | TreeStatus::Modification { .. } => None,
+            TreeStatus::Rename { previous_path, .. } => Some(previous_path.as_ref()),
+        }
+    }
+}
+
+impl ModeFlags {
+    fn calculate(old: &ChangeState, new: &ChangeState) -> Option<Self> {
+        Self::calculate_inner(old.kind, new.kind)
+    }
+
+    fn calculate_inner(
+        old: gix::object::tree::EntryKind,
+        new: gix::object::tree::EntryKind,
+    ) -> Option<Self> {
+        use gix::object::tree::EntryKind as E;
+        Some(match (old, new) {
+            (E::Blob, E::BlobExecutable) => ModeFlags::ExecutableBitAdded,
+            (E::BlobExecutable, E::Blob) => ModeFlags::ExecutableBitRemoved,
+            (E::Blob | E::BlobExecutable, E::Link) => ModeFlags::TypeChangeFileToLink,
+            (E::Link, E::Blob | E::BlobExecutable) => ModeFlags::TypeChangeLinkToFile,
+            (a, b) if a != b => ModeFlags::TypeChange,
+            _ => return None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod flags {
+        use crate::ModeFlags;
+        use gix::objs::tree::EntryKind;
+
+        #[test]
+        fn calculate() {
+            for ((old, new), expected) in [
+                ((EntryKind::Blob, EntryKind::Blob), None),
+                (
+                    (EntryKind::Blob, EntryKind::BlobExecutable),
+                    Some(ModeFlags::ExecutableBitAdded),
+                ),
+                (
+                    (EntryKind::BlobExecutable, EntryKind::Blob),
+                    Some(ModeFlags::ExecutableBitRemoved),
+                ),
+                (
+                    (EntryKind::BlobExecutable, EntryKind::Link),
+                    Some(ModeFlags::TypeChangeFileToLink),
+                ),
+                (
+                    (EntryKind::Blob, EntryKind::Link),
+                    Some(ModeFlags::TypeChangeFileToLink),
+                ),
+                (
+                    (EntryKind::Link, EntryKind::BlobExecutable),
+                    Some(ModeFlags::TypeChangeLinkToFile),
+                ),
+                (
+                    (EntryKind::Link, EntryKind::Blob),
+                    Some(ModeFlags::TypeChangeLinkToFile),
+                ),
+                (
+                    (EntryKind::Commit, EntryKind::Blob),
+                    Some(ModeFlags::TypeChange),
+                ),
+                (
+                    (EntryKind::Blob, EntryKind::Commit),
+                    Some(ModeFlags::TypeChange),
+                ),
+            ] {
+                assert_eq!(ModeFlags::calculate_inner(old, new), expected);
+            }
+        }
+    }
+}

--- a/crates/but-core/src/diff/worktree.rs
+++ b/crates/but-core/src/diff/worktree.rs
@@ -1,17 +1,20 @@
 use crate::{
     ChangeState, IgnoredWorktreeChange, IgnoredWorktreeTreeChangeStatus, ModeFlags, TreeChange,
-    TreeStatus, TreeStatusKind, UnifiedDiff, WorktreeChanges,
+    TreeStatus, UnifiedDiff, WorktreeChanges,
 };
-use anyhow::Context;
-use bstr::{BString, ByteSlice};
+use anyhow::{Context, bail};
+use bstr::{BStr, BString, ByteSlice};
 use gix::dir::entry;
 use gix::dir::walk::EmissionMode;
+use gix::filter::plumbing::pipeline::convert::ToGitOutcome;
 use gix::object::tree::EntryKind;
 use gix::status;
 use gix::status::index_worktree;
 use gix::status::index_worktree::RewriteSource;
 use gix::status::plumbing::index_as_worktree::{self, EntryStatus};
 use gix::status::tree_index::TrackRenames;
+use std::cmp::Ordering;
+use std::io::Read;
 use std::path::PathBuf;
 
 /// Identify where a [`TreeChange`] is from.
@@ -411,52 +414,263 @@ pub fn worktree_changes(repo: &gix::Repository) -> anyhow::Result<WorktreeChange
     }
 
     tmp.sort_by(|(a_origin, a), (b_origin, b)| {
-        a.path.cmp(&b.path).then(a_origin.cmp(b_origin).reverse())
+        cmp_prefer_overlapping(a, b).then(a_origin.cmp(b_origin).reverse())
     });
 
-    let mut last_path = None;
+    let mut last_change = None::<&TreeChange>;
     let mut changes = Vec::<TreeChange>::with_capacity(tmp.len());
-    for (_origin, mut change) in tmp {
-        if last_path.as_ref() == Some(&change.path) {
+    let (mut filter, index) = repo.filter_pipeline(None)?;
+    let mut path_check = gix::status::plumbing::SymlinkCheck::new(
+        repo.workdir().map(ToOwned::to_owned).context("non-bare")?,
+    );
+    for (_origin, change) in tmp {
+        // At this point we know that the current `change` is the tree/index variant
+        // of a prior change between index/worktree.
+        if last_change
+            .as_ref()
+            .is_some_and(|last_change| cmp_prefer_overlapping(last_change, &change).is_eq())
+        {
+            last_change = None;
             // This is usually two modifications, but it's also possible that
             // This one is a rename. In that case, we want the rename, combined
-            // with the current state pointing to the worktree.
-            if change.status.kind() == TreeStatusKind::Rename {
-                if let TreeChange {
-                    status: TreeStatus::Modification { state, .. },
-                    path: _,
-                } = changes
-                    .last()
-                    .expect("last_path is present, so must be its item")
-                {
-                    if let TreeStatus::Rename {
-                        state: must_be_worktree_change,
-                        ..
-                    } = &mut change.status
-                    {
-                        let state = *state;
-                        changes.pop();
-                        *must_be_worktree_change = state;
-                        changes.push(change);
-                        continue;
-                    }
-                    unreachable!("BUG: we know it's a rename");
+            // with the current state pointing to the worktree,
+            // which we expect to be a modification
+            let index_wt_change = changes
+                .pop()
+                .expect("the reason we are here is the previous change");
+            let change_path = change.path.clone();
+            let tree_index_change = change;
+            let status = match merge_changes(
+                tree_index_change,
+                index_wt_change,
+                &mut filter,
+                &index,
+                &mut path_check,
+            )? {
+                None => IgnoredWorktreeTreeChangeStatus::TreeIndexWorktreeChangeIneffective,
+                Some(merged) => {
+                    changes.push(merged);
+                    IgnoredWorktreeTreeChangeStatus::TreeIndex
                 }
-            }
+            };
             ignored_changes.push(IgnoredWorktreeChange {
-                path: change.path,
-                status: IgnoredWorktreeTreeChangeStatus::TreeIndex,
+                path: change_path,
+                status,
             });
             continue;
         }
-        last_path = Some(change.path.clone());
         changes.push(change);
+        last_change = changes.last();
     }
 
     Ok(WorktreeChanges {
         changes,
         ignored_changes,
     })
+}
+
+fn cmp_prefer_overlapping(a: &TreeChange, b: &TreeChange) -> Ordering {
+    if a.path == b.path
+        || a.previous_path() == Some(b.path.as_bstr())
+        || Some(a.path.as_bstr()) == b.previous_path()
+    {
+        Ordering::Equal
+    } else {
+        a.path.cmp(&b.path)
+    }
+}
+
+/// Merge changes from tree/index into changes of `index_wt` and assure the merged result isn't a no-op,
+/// which is when `None` is returned.
+/// Note that this case is more expensive as we have to hash the worktree version to check for a no-op.
+/// `diff_filter` is used to obtain hashes of worktree content.
+fn merge_changes(
+    mut tree_index: TreeChange,
+    mut index_wt: TreeChange,
+    filter: &mut gix::filter::Pipeline<'_>,
+    index: &gix::index::State,
+    path_check: &mut gix::status::plumbing::SymlinkCheck,
+) -> anyhow::Result<Option<TreeChange>> {
+    let merged = match (&mut tree_index.status, &mut index_wt.status) {
+        (TreeStatus::Modification { .. }, TreeStatus::Addition { .. })
+        | (TreeStatus::Deletion { .. }, TreeStatus::Deletion { .. })
+        | (TreeStatus::Deletion { .. }, TreeStatus::Rename { .. })
+        | (TreeStatus::Deletion { .. }, TreeStatus::Modification { .. })
+        | (
+            TreeStatus::Deletion { .. },
+            TreeStatus::Addition {
+                is_untracked: false,
+                ..
+            },
+        )
+        | (TreeStatus::Addition { .. }, TreeStatus::Addition { .. }) => {
+            bail!(
+                "BUG: entered unreachable code with tree_index_change = {:?} and index_wt_change = {:?}",
+                tree_index.status.kind(),
+                index_wt.status.kind()
+            );
+        }
+        (
+            TreeStatus::Addition {
+                is_untracked,
+                state,
+            },
+            TreeStatus::Modification {
+                state: state_wt, ..
+            },
+        ) => {
+            *is_untracked = true;
+            *state = *state_wt;
+            return Ok(Some(tree_index));
+        }
+        (TreeStatus::Addition { .. }, TreeStatus::Deletion { .. }) => {
+            // keep the most recent known state, which is from the index.
+            return Ok(Some(index_wt));
+        }
+        (
+            TreeStatus::Addition { state, .. },
+            TreeStatus::Rename {
+                previous_state: ps_wt,
+                ..
+            },
+        ) => {
+            // This is conflicting actually, and a little bit unclear what commiting this will do.
+            // Pretend the added file (in index) is the one that was deleted, hence the rename.
+            *ps_wt = *state;
+            // Can't be no-op as this is a rename
+            return Ok(Some(index_wt));
+        }
+        (
+            TreeStatus::Deletion { previous_state, .. },
+            TreeStatus::Addition {
+                is_untracked: true,
+                state,
+            },
+        ) => {
+            index_wt.status = TreeStatus::Modification {
+                previous_state: *previous_state,
+                state: *state,
+                flags: None,
+            };
+            index_wt
+        }
+        (
+            TreeStatus::Modification { previous_state, .. },
+            TreeStatus::Modification {
+                previous_state: ps_wt,
+                ..
+            },
+        ) => {
+            *ps_wt = *previous_state;
+            index_wt
+        }
+        (TreeStatus::Modification { .. }, TreeStatus::Deletion { .. }) => {
+            return Ok(Some(index_wt));
+        }
+        (
+            TreeStatus::Modification { previous_state, .. },
+            TreeStatus::Rename {
+                previous_state: ps_wt,
+                ..
+            },
+        ) => {
+            *ps_wt = *previous_state;
+            index_wt
+        }
+        (TreeStatus::Rename { .. }, TreeStatus::Modification { .. }) => {
+            todo!("rename - mod")
+        }
+        (TreeStatus::Rename { .. }, TreeStatus::Rename { .. }) => {
+            todo!("rename - rename")
+        }
+        (TreeStatus::Rename { .. }, TreeStatus::Deletion { .. }) => {
+            todo!("rename - del")
+        }
+        (TreeStatus::Rename { .. }, TreeStatus::Addition { .. }) => {
+            todo!("rename-add")
+        }
+    };
+
+    let current = id_or_hash_from_worktree(
+        merged.status.state(),
+        merged.path.as_bstr(),
+        filter,
+        index,
+        path_check,
+    )?;
+    let (prev_state, prev_path) = merged
+        .status
+        .previous_state_and_path()
+        .map(|(a, b)| (Some(a), b))
+        .unwrap_or((None, None));
+    let previous = id_or_hash_from_worktree(
+        prev_state,
+        prev_path.unwrap_or(merged.path.as_bstr()),
+        filter,
+        index,
+        path_check,
+    )?;
+    Ok(if current == previous {
+        None
+    } else {
+        Some(merged)
+    })
+}
+
+// TODO(gix): worktree-status already can do hashing and to-git conversions while dealing with links, but it's not exposed.
+//            Make this easier in Gix.
+/// Produces hashes for comparing states, or produce a hash from what's on disk if no hash is available.
+/// Note that null-hash will be returned if no directory entry is available.
+fn id_or_hash_from_worktree(
+    change: Option<ChangeState>,
+    rela_path: &BStr,
+    filter: &mut gix::filter::Pipeline<'_>,
+    index: &gix::index::State,
+    path_check: &mut gix::status::plumbing::SymlinkCheck,
+) -> anyhow::Result<gix::ObjectId> {
+    let Some(change) = change else {
+        return Ok(index.object_hash().null());
+    };
+    if !change.id.is_null() {
+        return Ok(change.id);
+    }
+
+    let path = path_check.verified_path_allow_nonexisting(rela_path)?;
+    let md = path.symlink_metadata()?;
+    let repo = filter.repo;
+    let id = if md.is_file() {
+        let to_git = filter.convert_to_git(
+            std::fs::File::open(path)?,
+            // TODO(gix): definitely use `ToCompoents` here to avoid these conversions.
+            //            Whatever you do, it's never right, so must be abstract.
+            &gix::path::try_from_bstr(rela_path)?,
+            index,
+        )?;
+        match to_git {
+            ToGitOutcome::Unchanged(mut stream) => gix::objs::compute_stream_hash(
+                repo.object_hash(),
+                gix::object::Kind::Blob,
+                &mut stream,
+                md.len(),
+                &mut gix::progress::Discard,
+                &gix::interrupt::IS_INTERRUPTED,
+            )?,
+            ToGitOutcome::Process(mut stream) => {
+                let mut buf = repo.empty_reusable_buffer();
+                stream.read_to_end(&mut buf)?;
+                gix::objs::compute_hash(repo.object_hash(), gix::object::Kind::Blob, &buf)
+            }
+            ToGitOutcome::Buffer(buf) => {
+                gix::objs::compute_hash(repo.object_hash(), gix::object::Kind::Blob, buf)
+            }
+        }
+    } else if md.is_symlink() {
+        let bytes = gix::path::os_string_into_bstring(std::fs::read_link(path)?.into())?;
+        gix::objs::compute_hash(repo.object_hash(), gix::object::Kind::Blob, &bytes)
+    } else {
+        bail!("Cannot hash directory entries that aren't files or symlinks");
+    };
+    Ok(id)
 }
 
 fn into_tree_entry_kind(mode: gix::index::entry::Mode) -> anyhow::Result<EntryKind> {

--- a/crates/but-core/src/diff/worktree.rs
+++ b/crates/but-core/src/diff/worktree.rs
@@ -291,7 +291,9 @@ pub fn worktree_changes(repo: &gix::Repository) -> anyhow::Result<WorktreeChange
             status::Item::IndexWorktree(index_worktree::Item::Rewrite {
                 source,
                 dirwalk_entry,
-                dirwalk_entry_id,
+                // This ID is usually null, but might be set if used for comparisons.
+                // However, this wouldn't mean the object exists.
+                dirwalk_entry_id: _,
                 ..
             }) => {
                 let previous_path: BString = source.rela_path().into();
@@ -317,7 +319,8 @@ pub fn worktree_changes(repo: &gix::Repository) -> anyhow::Result<WorktreeChange
                     },
                 };
                 let state = ChangeState {
-                    id: dirwalk_entry_id,
+                    // Use the worktree version
+                    id: repo.object_hash().null(),
                     kind: match disk_kind_to_entry_kind(
                         dirwalk_entry.disk_kind,
                         dirwalk_entry.index_kind,

--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -41,7 +41,7 @@
 //!     - A list of patches in unified diff format, with easily accessible line number information. It isn't baked into the patch string itself.
 //!
 
-use bstr::{BStr, BString};
+use bstr::BString;
 use gix::object::tree::EntryKind;
 use gix::refs::FullNameRef;
 use serde::Serialize;
@@ -200,18 +200,6 @@ pub struct TreeChange {
     pub status: TreeStatus,
 }
 
-impl TreeChange {
-    /// Return the path at which this directory entry was previously located, if it was renamed.
-    pub fn previous_path(&self) -> Option<&BStr> {
-        match &self.status {
-            TreeStatus::Addition { .. }
-            | TreeStatus::Deletion { .. }
-            | TreeStatus::Modification { .. } => None,
-            TreeStatus::Rename { previous_path, .. } => Some(previous_path.as_ref()),
-        }
-    }
-}
-
 /// Specifically defines a [`TreeChange`].
 #[derive(Debug, Clone)]
 pub enum TreeStatus {
@@ -293,6 +281,9 @@ pub enum IgnoredWorktreeTreeChangeStatus {
     Conflict,
     /// A change in the `.git/index` that was overruled by a change to the same path in the *worktree*.
     TreeIndex,
+    /// A tree-index change was effectively undone by an index-worktree change. Thus, the version in the worktree
+    /// is the same as what Git is currently tracking.
+    TreeIndexWorktreeChangeIneffective,
 }
 
 /// A way to indicate that a path in the index isn't suitable for committing and needs to be dealt with.
@@ -325,96 +316,4 @@ pub enum ModeFlags {
     TypeChangeFileToLink,
     TypeChangeLinkToFile,
     TypeChange,
-}
-
-impl ModeFlags {
-    fn calculate(old: &ChangeState, new: &ChangeState) -> Option<Self> {
-        Self::calculate_inner(old.kind, new.kind)
-    }
-
-    fn calculate_inner(
-        old: gix::object::tree::EntryKind,
-        new: gix::object::tree::EntryKind,
-    ) -> Option<Self> {
-        use gix::object::tree::EntryKind as E;
-        Some(match (old, new) {
-            (E::Blob, E::BlobExecutable) => ModeFlags::ExecutableBitAdded,
-            (E::BlobExecutable, E::Blob) => ModeFlags::ExecutableBitRemoved,
-            (E::Blob | E::BlobExecutable, E::Link) => ModeFlags::TypeChangeFileToLink,
-            (E::Link, E::Blob | E::BlobExecutable) => ModeFlags::TypeChangeLinkToFile,
-            (a, b) if a != b => ModeFlags::TypeChange,
-            _ => return None,
-        })
-    }
-}
-
-impl TreeStatus {
-    /// Learn what kind of status this is, useful if only this information is needed.
-    pub fn kind(&self) -> TreeStatusKind {
-        match self {
-            TreeStatus::Addition { .. } => TreeStatusKind::Addition,
-            TreeStatus::Deletion { .. } => TreeStatusKind::Deletion,
-            TreeStatus::Modification { .. } => TreeStatusKind::Modification,
-            TreeStatus::Rename { .. } => TreeStatusKind::Rename,
-        }
-    }
-
-    /// Return the state in which the change is currently. May be `None` if there is no current state after a deletion.
-    pub fn state(&self) -> Option<ChangeState> {
-        match self {
-            TreeStatus::Addition { state, .. }
-            | TreeStatus::Rename { state, .. }
-            | TreeStatus::Modification { state, .. } => Some(*state),
-            TreeStatus::Deletion { .. } => None,
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    mod flags {
-        use crate::ModeFlags;
-        use gix::objs::tree::EntryKind;
-
-        #[test]
-        fn calculate() {
-            for ((old, new), expected) in [
-                ((EntryKind::Blob, EntryKind::Blob), None),
-                (
-                    (EntryKind::Blob, EntryKind::BlobExecutable),
-                    Some(ModeFlags::ExecutableBitAdded),
-                ),
-                (
-                    (EntryKind::BlobExecutable, EntryKind::Blob),
-                    Some(ModeFlags::ExecutableBitRemoved),
-                ),
-                (
-                    (EntryKind::BlobExecutable, EntryKind::Link),
-                    Some(ModeFlags::TypeChangeFileToLink),
-                ),
-                (
-                    (EntryKind::Blob, EntryKind::Link),
-                    Some(ModeFlags::TypeChangeFileToLink),
-                ),
-                (
-                    (EntryKind::Link, EntryKind::BlobExecutable),
-                    Some(ModeFlags::TypeChangeLinkToFile),
-                ),
-                (
-                    (EntryKind::Link, EntryKind::Blob),
-                    Some(ModeFlags::TypeChangeLinkToFile),
-                ),
-                (
-                    (EntryKind::Commit, EntryKind::Blob),
-                    Some(ModeFlags::TypeChange),
-                ),
-                (
-                    (EntryKind::Blob, EntryKind::Commit),
-                    Some(ModeFlags::TypeChange),
-                ),
-            ] {
-                assert_eq!(ModeFlags::calculate_inner(old, new), expected);
-            }
-        }
-    }
 }

--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -358,6 +358,16 @@ impl TreeStatus {
             TreeStatus::Rename { .. } => TreeStatusKind::Rename,
         }
     }
+
+    /// Return the state in which the change is currently. May be `None` if there is no current state after a deletion.
+    pub fn state(&self) -> Option<ChangeState> {
+        match self {
+            TreeStatus::Addition { state, .. }
+            | TreeStatus::Rename { state, .. }
+            | TreeStatus::Modification { state, .. } => Some(*state),
+            TreeStatus::Deletion { .. } => None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/but-core/tests/core/diff/ui.rs
+++ b/crates/but-core/tests/core/diff/ui.rs
@@ -284,13 +284,17 @@ fn worktree_changes() -> anyhow::Result<()> {
             101
           ],
           "status": {
-            "type": "Addition",
+            "type": "Modification",
             "subject": {
+              "previousState": {
+                "id": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                "kind": "Blob"
+              },
               "state": {
                 "id": "0000000000000000000000000000000000000000",
                 "kind": "Blob"
               },
-              "isUntracked": true
+              "flags": null
             }
           }
         },

--- a/crates/but-core/tests/core/diff/worktree_changes.rs
+++ b/crates/but-core/tests/core/diff/worktree_changes.rs
@@ -1164,8 +1164,290 @@ fn renamed_in_worktree_with_executable_bit() -> Result<()> {
 }
 
 #[test]
-fn modified_in_index_and_workingtree() -> Result<()> {
-    let repo = repo("modified-in-index-and-worktree")?;
+fn modified_in_index_and_worktree_mod_mod() -> Result<()> {
+    let repo = repo("modified-in-index-and-worktree-mod-mod")?;
+    let actual = diff::worktree_changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    WorktreeChanges {
+        changes: [
+            TreeChange {
+                path: "dual-modified",
+                status: Modification {
+                    previous_state: ChangeState {
+                        id: Sha1(e79c5e8f964493290a409888d5413a737e8e5dd5),
+                        kind: Blob,
+                    },
+                    state: ChangeState {
+                        id: Sha1(0000000000000000000000000000000000000000),
+                        kind: Blob,
+                    },
+                    flags: None,
+                },
+            },
+        ],
+        ignored_changes: [
+            IgnoredWorktreeChange {
+                path: "dual-modified",
+                status: TreeIndex,
+            },
+        ],
+    }
+    "#);
+
+    let [UnifiedDiff::Patch { ref hunks }] = unified_diffs(actual, &repo)?[..] else {
+        unreachable!("need hunks")
+    };
+    insta::assert_snapshot!(hunks[0].diff, @r"
+    @@ -1,1 +1,3 @@
+     initial
+    +change
+    +second-change
+    ");
+
+    let repo = crate::diff::worktree_changes::repo("modified-in-index-and-worktree-mod-mod-noop")?;
+    insta::assert_debug_snapshot!(diff::worktree_changes(&repo)?, @r#"
+    WorktreeChanges {
+        changes: [],
+        ignored_changes: [
+            IgnoredWorktreeChange {
+                path: "dual-modified",
+                status: TreeIndexWorktreeChangeIneffective,
+            },
+        ],
+    }
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn modified_in_index_and_worktree_mod_mod_symlink() -> Result<()> {
+    let repo = repo("modified-in-index-and-worktree-mod-mod-symlink")?;
+    let actual = diff::worktree_changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    WorktreeChanges {
+        changes: [
+            TreeChange {
+                path: "link",
+                status: Modification {
+                    previous_state: ChangeState {
+                        id: Sha1(db2424764122191b9f3bc032bbf4b09e1b31d301),
+                        kind: Link,
+                    },
+                    state: ChangeState {
+                        id: Sha1(0000000000000000000000000000000000000000),
+                        kind: Link,
+                    },
+                    flags: None,
+                },
+            },
+        ],
+        ignored_changes: [
+            IgnoredWorktreeChange {
+                path: "link",
+                status: TreeIndex,
+            },
+        ],
+    }
+    "#);
+
+    let [UnifiedDiff::Patch { ref hunks }] = unified_diffs(actual, &repo)?[..] else {
+        unreachable!("need hunks")
+    };
+    insta::assert_snapshot!(hunks[0].diff, @r"
+    @@ -1,1 +1,1 @@
+    -nonexisting-initial
+    +nonexisting-wt-change
+    ");
+
+    let repo =
+        crate::diff::worktree_changes::repo("modified-in-index-and-worktree-mod-mod-symlink-noop")?;
+    insta::assert_debug_snapshot!(diff::worktree_changes(&repo)?, @r#"
+    WorktreeChanges {
+        changes: [],
+        ignored_changes: [
+            IgnoredWorktreeChange {
+                path: "link",
+                status: TreeIndexWorktreeChangeIneffective,
+            },
+        ],
+    }
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn modified_in_index_and_worktree_add_mod() -> Result<()> {
+    let repo = repo("modified-in-index-and-worktree-add-mod")?;
+    let actual = diff::worktree_changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    WorktreeChanges {
+        changes: [
+            TreeChange {
+                path: "file",
+                status: Addition {
+                    state: ChangeState {
+                        id: Sha1(0000000000000000000000000000000000000000),
+                        kind: Blob,
+                    },
+                    is_untracked: true,
+                },
+            },
+        ],
+        ignored_changes: [
+            IgnoredWorktreeChange {
+                path: "file",
+                status: TreeIndex,
+            },
+        ],
+    }
+    "#);
+
+    let [UnifiedDiff::Patch { ref hunks }] = unified_diffs(actual, &repo)?[..] else {
+        unreachable!("need hunks")
+    };
+    insta::assert_snapshot!(hunks[0].diff, @r"
+    @@ -1,0 +1,2 @@
+    +initial
+    +wt-change
+    ");
+    Ok(())
+}
+
+#[test]
+fn modified_in_index_and_worktree_add_del() -> Result<()> {
+    let repo = repo("modified-in-index-and-worktree-add-del")?;
+    let actual = diff::worktree_changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    WorktreeChanges {
+        changes: [
+            TreeChange {
+                path: "file",
+                status: Deletion {
+                    previous_state: ChangeState {
+                        id: Sha1(e79c5e8f964493290a409888d5413a737e8e5dd5),
+                        kind: Blob,
+                    },
+                },
+            },
+        ],
+        ignored_changes: [
+            IgnoredWorktreeChange {
+                path: "file",
+                status: TreeIndex,
+            },
+        ],
+    }
+    "#);
+
+    let [UnifiedDiff::Patch { ref hunks }] = unified_diffs(actual, &repo)?[..] else {
+        unreachable!("need hunks")
+    };
+    insta::assert_snapshot!(hunks[0].diff, @r"
+    @@ -1,1 +1,0 @@
+    -initial
+    ");
+    Ok(())
+}
+
+#[test]
+fn modified_in_index_and_worktree_del_add() -> Result<()> {
+    let repo = repo("modified-in-index-and-worktree-del-add")?;
+    let actual = diff::worktree_changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    WorktreeChanges {
+        changes: [
+            TreeChange {
+                path: "file",
+                status: Modification {
+                    previous_state: ChangeState {
+                        id: Sha1(e79c5e8f964493290a409888d5413a737e8e5dd5),
+                        kind: Blob,
+                    },
+                    state: ChangeState {
+                        id: Sha1(0000000000000000000000000000000000000000),
+                        kind: Blob,
+                    },
+                    flags: None,
+                },
+            },
+        ],
+        ignored_changes: [
+            IgnoredWorktreeChange {
+                path: "file",
+                status: TreeIndex,
+            },
+        ],
+    }
+    "#);
+
+    let [UnifiedDiff::Patch { ref hunks }] = unified_diffs(actual, &repo)?[..] else {
+        unreachable!("need hunks")
+    };
+    insta::assert_snapshot!(hunks[0].diff, @r"
+    @@ -1,1 +1,2 @@
+     initial
+    +wt-changed
+    ");
+
+    let repo = crate::diff::worktree_changes::repo("modified-in-index-and-worktree-del-add-noop")?;
+    insta::assert_debug_snapshot!(diff::worktree_changes(&repo)?, @r#"
+    WorktreeChanges {
+        changes: [],
+        ignored_changes: [
+            IgnoredWorktreeChange {
+                path: "file",
+                status: TreeIndexWorktreeChangeIneffective,
+            },
+        ],
+    }
+    "#);
+    Ok(())
+}
+
+#[test]
+fn modified_in_index_and_worktree_mod_del() -> Result<()> {
+    let repo = repo("modified-in-index-and-worktree-mod-del")?;
+    let actual = diff::worktree_changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    WorktreeChanges {
+        changes: [
+            TreeChange {
+                path: "file",
+                status: Deletion {
+                    previous_state: ChangeState {
+                        id: Sha1(983aca27780b0a4bcb122a7d603aad940e694d3d),
+                        kind: Blob,
+                    },
+                },
+            },
+        ],
+        ignored_changes: [
+            IgnoredWorktreeChange {
+                path: "file",
+                status: TreeIndex,
+            },
+        ],
+    }
+    "#);
+
+    let [UnifiedDiff::Patch { ref hunks }] = unified_diffs(actual, &repo)?[..] else {
+        unreachable!("need hunks")
+    };
+    // newlines at the end should work.
+    insta::assert_snapshot!(hunks[0].diff, @r"
+    @@ -1,2 +1,0 @@
+    -initial
+    -index
+    ");
+    Ok(())
+}
+
+#[test]
+#[ignore = "TBD later"]
+fn modified_in_index_and_worktree_rename_mod() -> Result<()> {
+    let repo = repo("modified-in-index-and-worktree-rename-mod")?;
     let actual = diff::worktree_changes(&repo)?;
     insta::assert_debug_snapshot!(actual, @r#"
     WorktreeChanges {
@@ -1194,32 +1476,233 @@ fn modified_in_index_and_workingtree() -> Result<()> {
     }
     "#);
 
-    let actual = unified_diffs(actual, &repo)?;
-    insta::assert_debug_snapshot!(actual, @r#"
-    [
-        Patch {
-            hunks: [
-                DiffHunk {
-                    old_start: 1,
-                    old_lines: 2,
-                    new_start: 1,
-                    new_lines: 3,
-                    diff: "@@ -1,2 +1,3 @@\n initial\n change\n+second-change\n",
-                },
-            ],
-        },
-    ]
-    "#);
-    let [UnifiedDiff::Patch { hunks }] = &actual[..] else {
+    let [UnifiedDiff::Patch { ref hunks }] = unified_diffs(actual, &repo)?[..] else {
         unreachable!("need hunks")
     };
-    // newlines at the end should work.
     insta::assert_snapshot!(hunks[0].diff, @r"
     @@ -1,2 +1,3 @@
      initial
      change
     +second-change
     ");
+    Ok(())
+}
+
+#[test]
+#[ignore = "TBD later"]
+fn modified_in_index_and_worktree_rename_rename() -> Result<()> {
+    let repo = repo("modified-in-index-and-worktree-rename-rename")?;
+    let actual = diff::worktree_changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    WorktreeChanges {
+        changes: [
+            TreeChange {
+                path: "dual-modified",
+                status: Modification {
+                    previous_state: ChangeState {
+                        id: Sha1(8ea0713f9d637081cc0098035465c365c0c32949),
+                        kind: Blob,
+                    },
+                    state: ChangeState {
+                        id: Sha1(0000000000000000000000000000000000000000),
+                        kind: Blob,
+                    },
+                    flags: None,
+                },
+            },
+        ],
+        ignored_changes: [
+            IgnoredWorktreeChange {
+                path: "dual-modified",
+                status: TreeIndex,
+            },
+        ],
+    }
+    "#);
+
+    let [UnifiedDiff::Patch { ref hunks }] = unified_diffs(actual, &repo)?[..] else {
+        unreachable!("need hunks")
+    };
+    insta::assert_snapshot!(hunks[0].diff, @r"
+    @@ -1,2 +1,3 @@
+     initial
+     change
+    +second-change
+    ");
+    Ok(())
+}
+
+#[test]
+#[ignore = "TBD later"]
+fn modified_in_index_and_worktree_rename_del() -> Result<()> {
+    let repo = repo("modified-in-index-and-worktree-rename-del")?;
+    let actual = diff::worktree_changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    WorktreeChanges {
+        changes: [
+            TreeChange {
+                path: "dual-modified",
+                status: Modification {
+                    previous_state: ChangeState {
+                        id: Sha1(8ea0713f9d637081cc0098035465c365c0c32949),
+                        kind: Blob,
+                    },
+                    state: ChangeState {
+                        id: Sha1(0000000000000000000000000000000000000000),
+                        kind: Blob,
+                    },
+                    flags: None,
+                },
+            },
+        ],
+        ignored_changes: [
+            IgnoredWorktreeChange {
+                path: "dual-modified",
+                status: TreeIndex,
+            },
+        ],
+    }
+    "#);
+
+    let [UnifiedDiff::Patch { ref hunks }] = unified_diffs(actual, &repo)?[..] else {
+        unreachable!("need hunks")
+    };
+    insta::assert_snapshot!(hunks[0].diff, @r"
+    @@ -1,2 +1,3 @@
+     initial
+     change
+    +second-change
+    ");
+    Ok(())
+}
+
+#[test]
+fn modified_in_index_and_worktree_mod_rename() -> Result<()> {
+    let repo = repo("modified-in-index-and-worktree-mod-rename")?;
+    let actual = diff::worktree_changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    WorktreeChanges {
+        changes: [
+            TreeChange {
+                path: "file-renamed-in-wt",
+                status: Rename {
+                    previous_path: "file",
+                    previous_state: ChangeState {
+                        id: Sha1(e79c5e8f964493290a409888d5413a737e8e5dd5),
+                        kind: Blob,
+                    },
+                    state: ChangeState {
+                        id: Sha1(0000000000000000000000000000000000000000),
+                        kind: Blob,
+                    },
+                    flags: None,
+                },
+            },
+        ],
+        ignored_changes: [
+            IgnoredWorktreeChange {
+                path: "file",
+                status: TreeIndex,
+            },
+        ],
+    }
+    "#);
+
+    let [UnifiedDiff::Patch { ref hunks }] = unified_diffs(actual, &repo)?[..] else {
+        unreachable!("need hunks")
+    };
+    insta::assert_snapshot!(hunks[0].diff, @r"
+    @@ -1,1 +1,3 @@
+     initial
+    +index
+    +wt-change
+    ");
+    Ok(())
+}
+
+#[test]
+#[ignore = "TBD later"]
+fn modified_in_index_and_worktree_rename_add() -> Result<()> {
+    let repo = repo("modified-in-index-and-worktree-rename-add")?;
+    let actual = diff::worktree_changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    WorktreeChanges {
+        changes: [
+            TreeChange {
+                path: "file-renamed-in-index",
+                status: Rename {
+                    previous_path: "file",
+                    previous_state: ChangeState {
+                        id: Sha1(0000000000000000000000000000000000000000),
+                        kind: Blob,
+                    },
+                    state: ChangeState {
+                        id: Sha1(e79c5e8f964493290a409888d5413a737e8e5dd5),
+                        kind: Blob,
+                    },
+                    flags: None,
+                },
+            },
+        ],
+        ignored_changes: [
+            IgnoredWorktreeChange {
+                path: "file-renamed-in-index",
+                status: TreeIndex,
+            },
+        ],
+    }
+    "#);
+
+    let [UnifiedDiff::Patch { ref hunks }] = unified_diffs(actual, &repo)?[..] else {
+        unreachable!("need hunks")
+    };
+    insta::assert_snapshot!(hunks[0].diff, @r"
+    @@ -1,0 +1,1 @@
+    +initial
+    ");
+    Ok(())
+}
+
+#[test]
+fn modified_in_index_and_worktree_add_rename() -> Result<()> {
+    let repo = repo("modified-in-index-and-worktree-add-rename")?;
+    let actual = diff::worktree_changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    WorktreeChanges {
+        changes: [
+            TreeChange {
+                path: "file-renamed-in-wt",
+                status: Rename {
+                    previous_path: "file",
+                    previous_state: ChangeState {
+                        id: Sha1(e79c5e8f964493290a409888d5413a737e8e5dd5),
+                        kind: Blob,
+                    },
+                    state: ChangeState {
+                        id: Sha1(0000000000000000000000000000000000000000),
+                        kind: Blob,
+                    },
+                    flags: None,
+                },
+            },
+        ],
+        ignored_changes: [
+            IgnoredWorktreeChange {
+                path: "file",
+                status: TreeIndex,
+            },
+        ],
+    }
+    "#);
+
+    let [UnifiedDiff::Patch { ref hunks }] = unified_diffs(actual, &repo)?[..] else {
+        unreachable!("need hunks")
+    };
+    assert_eq!(
+        hunks.len(),
+        0,
+        "the file didn't actually change, it's just renamed"
+    );
     Ok(())
 }
 

--- a/crates/but-core/tests/core/diff/worktree_changes.rs
+++ b/crates/but-core/tests/core/diff/worktree_changes.rs
@@ -1107,7 +1107,7 @@ fn renamed_in_worktree() -> Result<()> {
                         kind: Blob,
                     },
                     state: ChangeState {
-                        id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
+                        id: Sha1(0000000000000000000000000000000000000000),
                         kind: Blob,
                     },
                     flags: None,
@@ -1143,7 +1143,7 @@ fn renamed_in_worktree_with_executable_bit() -> Result<()> {
                         kind: BlobExecutable,
                     },
                     state: ChangeState {
-                        id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
+                        id: Sha1(0000000000000000000000000000000000000000),
                         kind: BlobExecutable,
                     },
                     flags: None,

--- a/crates/but-core/tests/fixtures/worktree-changes.sh
+++ b/crates/but-core/tests/fixtures/worktree-changes.sh
@@ -101,12 +101,113 @@ git init renamed-in-worktree-with-executable-bit
   mv to-be-renamed new-name
 )
 
-git init modified-in-index-and-worktree
-(cd modified-in-index-and-worktree
+git init modified-in-index-and-worktree-mod-mod
+(cd modified-in-index-and-worktree-mod-mod
   echo initial >dual-modified
   git add . && git commit -m "init"
   echo change >>dual-modified && git add dual-modified
   echo second-change >>dual-modified
+)
+
+git init modified-in-index-and-worktree-mod-mod-noop
+(cd modified-in-index-and-worktree-mod-mod-noop
+  echo initial >dual-modified
+  git add . && git commit -m "init"
+  echo change >>dual-modified && git add dual-modified
+  echo initial >dual-modified
+)
+
+git init modified-in-index-and-worktree-mod-mod-symlink
+(cd modified-in-index-and-worktree-mod-mod-symlink
+  ln -s nonexisting-initial link
+  git add . && git commit -m "init"
+  rm link && ln -s nonexisting-index link && git add .
+  rm link && ln -s nonexisting-wt-change link
+)
+
+git init modified-in-index-and-worktree-mod-mod-symlink-noop
+(cd modified-in-index-and-worktree-mod-mod-symlink-noop
+  ln -s nonexisting-initial link
+  git add . && git commit -m "init"
+  rm link && ln -s nonexisting-index link && git add .
+  rm link && ln -s nonexisting-initial link
+)
+
+git init modified-in-index-and-worktree-add-mod
+(cd modified-in-index-and-worktree-add-mod
+  echo initial >file
+  git add .
+  echo wt-change >>file
+)
+
+git init modified-in-index-and-worktree-add-del
+(cd modified-in-index-and-worktree-add-del
+  echo initial >file
+  git add .
+  rm file
+)
+
+git init modified-in-index-and-worktree-del-add
+(cd modified-in-index-and-worktree-del-add
+  echo initial >file && git add . && git commit -m "init"
+  git rm file
+  echo $'initial\nwt-changed' >file
+)
+
+git init modified-in-index-and-worktree-del-add-noop
+(cd modified-in-index-and-worktree-del-add-noop
+  echo initial >file && git add . && git commit -m "init"
+  git rm file
+  echo initial >file
+)
+
+git init modified-in-index-and-worktree-mod-del
+(cd modified-in-index-and-worktree-mod-del
+  echo initial >file && git add . && git commit -m "init"
+  echo index >>file && git add .
+  rm file
+)
+
+git init modified-in-index-and-worktree-rename-mod
+(cd modified-in-index-and-worktree-rename-mod
+  echo initial >file && git add . && git commit -m "init"
+  git mv file file-renamed
+  echo wt-change >>file-renamed
+)
+
+git init modified-in-index-and-worktree-rename-rename
+(cd modified-in-index-and-worktree-rename-rename
+  echo initial >file && git add . && git commit -m "init"
+  git mv file file-renamed-in-index
+  mv file-renamed-in-index file-renamed-in-wt
+)
+
+git init modified-in-index-and-worktree-rename-del
+(cd modified-in-index-and-worktree-rename-del
+  echo initial >file && git add . && git commit -m "init"
+  git mv file file-renamed-in-index
+  rm file-renamed-in-index
+)
+
+git init modified-in-index-and-worktree-mod-rename
+(cd modified-in-index-and-worktree-mod-rename
+  echo initial >file && git add . && git commit -m "init"
+  echo index >>file && git add .
+  echo wt-change >>file
+  mv file file-renamed-in-wt
+)
+
+git init modified-in-index-and-worktree-rename-add
+(cd modified-in-index-and-worktree-rename-add
+  echo initial >file && git add . && git commit -m "init"
+  git mv file file-renamed-in-index
+  echo $'initial\nwt-change' >file
+)
+
+git init modified-in-index-and-worktree-add-rename
+(cd modified-in-index-and-worktree-add-rename
+  echo initial >file && git add .
+  mv file file-renamed-in-wt
 )
 
 git init submodule-added-unborn

--- a/crates/but-workspace/src/discard/file.rs
+++ b/crates/but-workspace/src/discard/file.rs
@@ -1,0 +1,344 @@
+use crate::discard::file::index::mark_entry_for_deletion;
+use crate::discard::locked_resource_at;
+use anyhow::{Context, bail};
+use bstr::{BStr, BString, ByteSlice, ByteVec};
+use but_core::ChangeState;
+use gix::filter::plumbing::driver::apply::Delay;
+use gix::object::tree::EntryKind;
+use gix::prelude::ObjectIdExt;
+use std::borrow::Cow;
+use std::path::Path;
+
+pub enum RestoreMode {
+    /// Assume the resource to be restored doesn't exist as it was deleted.
+    Deleted,
+    /// A similar resource is in its place that needs to be updated.
+    Update,
+}
+
+/// Restore `state` by writing it into the worktree of `repo`, possibly re-adding or updating the
+/// `index` with it so that it matches the worktree.
+pub fn restore_state_to_worktree(
+    pipeline: &mut gix::filter::Pipeline<'_>,
+    index: &mut gix::index::State,
+    rela_path: &BStr,
+    state: ChangeState,
+    mode: RestoreMode,
+    path_check: &mut gix::status::plumbing::SymlinkCheck,
+    num_sorted_entries: &mut usize,
+) -> anyhow::Result<()> {
+    if state.id.is_null() {
+        bail!(
+            "Change to discard at '{rela_path}' didn't have a last-known tracked state - this is a bug"
+        );
+    }
+
+    let mut update_index = |md| -> anyhow::Result<()> {
+        crate::commit_engine::index::upsert_index_entry(
+            index,
+            rela_path,
+            &md,
+            state.id,
+            state.kind.into(),
+            gix::index::entry::Flags::UPDATE,
+            num_sorted_entries,
+        )?;
+        Ok(())
+    };
+
+    let repo = pipeline.repo;
+    let wt_root = path_check.inner.root().to_owned();
+    let file_path = path_check
+        .verified_path(&gix::path::from_bstr(rela_path))
+        .map(Cow::Borrowed)
+        .or_else(|err| {
+            if err.kind() == std::io::ErrorKind::NotFound {
+                Ok(Cow::Owned(wt_root.join(gix::path::from_bstr(rela_path))))
+            } else {
+                Err(err)
+            }
+        })?;
+    match state.kind {
+        EntryKind::Blob | EntryKind::BlobExecutable => {
+            let mut dest_lock_file = locked_resource_at(wt_root, &file_path, state.kind)?;
+            let obj_in_git = state.id.attach(repo).object()?;
+            let mut stream =
+                pipeline.convert_to_worktree(&obj_in_git.data, rela_path, Delay::Forbid)?;
+            std::io::copy(&mut stream, &mut dest_lock_file)?;
+
+            let (file_path, maybe_file) = match dest_lock_file.commit() {
+                Ok(res) => res,
+                Err(err) => {
+                    if err.error.kind() == std::io::ErrorKind::IsADirectory {
+                        // It's OK to remove everything that's in the way.
+                        // Alternatives to this is to let it be handled by the stack.
+                        std::fs::remove_dir_all(err.instance.resource_path())?;
+                        err.instance.commit()?
+                    } else {
+                        return Err(err.into());
+                    }
+                }
+            };
+            update_index(match maybe_file {
+                None => gix::index::fs::Metadata::from_path_no_follow(&file_path)?,
+                Some(file) => gix::index::fs::Metadata::from_file(&file)?,
+            })?;
+        }
+        EntryKind::Link => {
+            let link_path = file_path;
+            if let RestoreMode::Update = mode {
+                std::fs::remove_file(&link_path)?;
+            }
+            let link_target = state.id.attach(repo).object()?;
+            let link_target = gix::path::from_bstr(link_target.data.as_bstr());
+            if let Err(err) = gix::fs::symlink::create(&link_target, &link_path) {
+                // When directories are replaced, the user could undo everything. Then
+                // it's a matter of order if *we* have already created the directory content.
+                if err.kind() != std::io::ErrorKind::AlreadyExists
+                    || !link_path.symlink_metadata()?.is_symlink()
+                {
+                    return Err(err.into());
+                }
+            }
+            update_index(gix::index::fs::Metadata::from_path_no_follow(&link_path)?)?;
+        }
+        EntryKind::Commit => {
+            if let RestoreMode::Update = mode {
+                // TODO(gix): actual checkout/reset functionality - it will be fine to support that fully.
+                // Since `git2` doesn't support filters, it will save us some trouble to just use Git for that.
+                let submodule_repo_dir = &file_path;
+                let out = std::process::Command::from(
+                    gix::command::prepare(format!(
+                        "git reset --hard {id} && git clean -fxd",
+                        id = state.id
+                    ))
+                    .with_shell(),
+                )
+                .current_dir(submodule_repo_dir)
+                .output()?;
+                if !out.status.success() {
+                    bail!(
+                        "Could not reset submodule at '{sm_dir}' to commit {id}: {err}",
+                        sm_dir = submodule_repo_dir.display(),
+                        id = state.id,
+                        err = out.stderr.as_bstr()
+                    );
+                }
+            } else {
+                let sm_repo = repo
+                    .submodules()?
+                    .into_iter()
+                    .flatten()
+                    .find_map(|sm| {
+                        let is_active = sm.is_active().ok()?;
+                        is_active.then(|| -> anyhow::Result<_> {
+                            Ok(
+                                if sm.path().ok().is_some_and(|sm_path| sm_path == rela_path) {
+                                    sm.open()?
+                                } else {
+                                    None
+                                },
+                            )
+                        })
+                    })
+                    .transpose()?
+                    .flatten();
+                match sm_repo {
+                    None => {
+                        // A directory is what git creates with `git restore` even if the thing to restore is a submodule.
+                        // We are trying to be better than that if we find a submodule, hoping that this is what users expect.
+                        // We do that as baseline as there is no need to fail here.
+                    }
+                    Some(repo) => {
+                        // We will only restore the submodule if there is a local clone already available, to avoid any network
+                        // activity that would likely happen during an actual clone.
+                        // Thus, all we have to do is to check out the submodule.
+                        // TODO(gix): find a way to deal with nested submodules - they should also be checked out which
+                        //            isn't done by `gitoxide`, but probably should be an option there.
+                        checkout_repo_worktree(&wt_root, repo)?;
+                    }
+                }
+                std::fs::create_dir(&file_path).or_else(|err| {
+                    if err.kind() == std::io::ErrorKind::AlreadyExists {
+                        Ok(())
+                    } else {
+                        Err(err)
+                    }
+                })?;
+            }
+            update_index(gix::index::fs::Metadata::from_path_no_follow(&file_path)?)?;
+        }
+        EntryKind::Tree => {
+            mark_entry_for_deletion(index, rela_path, *num_sorted_entries);
+            let checkout_destination = file_path;
+            let mut sub_index = repo.index_from_tree(&state.id)?;
+            let mut opts =
+                repo.checkout_options(gix::worktree::stack::state::attributes::Source::IdMapping)?;
+            // there may be situations where files already exist in that spot, likely because we put them
+            // there earlier as part of a sweeping 'discard'. Still, try not to mess with the user.
+            opts.overwrite_existing = false;
+            if !checkout_destination.exists() {
+                std::fs::create_dir(&checkout_destination)?;
+                opts.destination_is_initially_empty = true;
+            }
+            // TODO(gix): make it possible to have this checkout submodules as well.
+            let out = gix::worktree::state::checkout(
+                &mut sub_index,
+                checkout_destination.as_ref(),
+                repo.clone().objects.into_arc()?,
+                &gix::progress::Discard,
+                &gix::progress::Discard,
+                &gix::interrupt::IS_INTERRUPTED,
+                opts,
+            )?;
+            tracing::debug!(directory = ?checkout_destination, outcome = ?out, "directory checkout result");
+
+            let (entries, path_storage) = sub_index.into_parts().0.into_entries();
+            let mut rela_path = with_trailing_slash(rela_path);
+            let prefix_len = rela_path.len();
+            for entry in entries {
+                let partial_rela_path = entry.path_in(&path_storage);
+                rela_path.extend_from_slice(partial_rela_path);
+
+                if index.entry_by_path(rela_path.as_bstr()).is_none() {
+                    index.dangerously_push_entry(
+                        entry.stat,
+                        entry.id,
+                        entry.flags | gix::index::entry::Flags::UPDATE,
+                        entry.mode,
+                        rela_path.as_bstr(),
+                    );
+                }
+                rela_path.truncate(prefix_len);
+            }
+            // These might be re-visited later if the user was able to add individual deletions in a directory.
+            // Sort to make index-lookups work.
+            index.sort_entries();
+            *num_sorted_entries = index.entries().len();
+        }
+    };
+    Ok(())
+}
+
+fn with_trailing_slash(rela_path: &BStr) -> BString {
+    if rela_path.ends_with_str(b"/") {
+        return rela_path.to_owned();
+    }
+    let mut buf = rela_path.to_owned();
+    buf.push(b'/');
+    buf
+}
+
+fn checkout_repo_worktree(
+    parent_worktree_dir: &Path,
+    mut repo: gix::Repository,
+) -> anyhow::Result<()> {
+    // No need to cache anything, it's just single-use for the most part.
+    repo.object_cache_size(0);
+    let mut index = repo.index_from_tree(&repo.head_tree_id_or_empty()?)?;
+    if index.entries().is_empty() {
+        // The worktree directory is created later, so we don't have to deal with it here.
+        return Ok(());
+    }
+    for entry in index.entries_mut().iter_mut().filter(|e| {
+        e.mode
+            .contains(gix::index::entry::Mode::DIR | gix::index::entry::Mode::COMMIT)
+    }) {
+        entry.flags.insert(gix::index::entry::Flags::SKIP_WORKTREE);
+    }
+
+    let mut opts =
+        repo.checkout_options(gix::worktree::stack::state::attributes::Source::IdMapping)?;
+    opts.destination_is_initially_empty = true;
+    opts.keep_going = true;
+
+    let checkout_destination = repo.workdir().context("non-bare repository")?.to_owned();
+    if !checkout_destination.exists() {
+        std::fs::create_dir(&checkout_destination)?;
+    }
+    let sm_repo_dir = gix::path::relativize_with_prefix(
+        repo.path().strip_prefix(parent_worktree_dir)?,
+        checkout_destination.strip_prefix(parent_worktree_dir)?,
+    )
+    .into_owned();
+    let out = gix::worktree::state::checkout(
+        &mut index,
+        checkout_destination.clone(),
+        repo,
+        &gix::progress::Discard,
+        &gix::progress::Discard,
+        &gix::interrupt::IS_INTERRUPTED,
+        opts,
+    )?;
+
+    let mut buf = BString::from("gitdir: ");
+    buf.extend_from_slice(&gix::path::os_string_into_bstring(sm_repo_dir.into())?);
+    buf.push_byte(b'\n');
+    std::fs::write(checkout_destination.join(".git"), &buf)?;
+
+    tracing::debug!(directory = ?checkout_destination, outcome = ?out, "submodule checkout result");
+    Ok(())
+}
+
+/// Remove files present at `rela_path`, restore the index at that place, if possible,
+/// and if necessary, checkout everything that this revealed.
+/// This is required when handling renames.
+pub fn purge_and_restore_from_head_tree(
+    index: &mut gix::index::State,
+    rela_path: &BStr,
+    path_check: &mut gix::status::plumbing::SymlinkCheck,
+    num_sorted_entries: usize,
+) -> anyhow::Result<()> {
+    if let Some(range) = index.entry_range(with_trailing_slash(rela_path).as_bstr()) {
+        #[allow(clippy::indexing_slicing)]
+        for entry in &mut index.entries_mut()[range] {
+            entry.flags.insert(gix::index::entry::Flags::REMOVE);
+        }
+    } else {
+        mark_entry_for_deletion(index, rela_path, num_sorted_entries);
+    }
+
+    // TODO(motivational test): restore what was there in the the index, and then on disk by checkout.
+    let path = path_check.verified_path(&gix::path::from_bstr(rela_path))?;
+    if !path.is_dir() {
+        // Should always exist, this is why it's a rename in the first place.
+        std::fs::remove_file(path).or_else(|err| {
+            if matches!(
+                err.kind(),
+                std::io::ErrorKind::NotADirectory | std::io::ErrorKind::NotFound
+            ) {
+                Ok(())
+            } else {
+                Err(err)
+            }
+        })?;
+    } else {
+        bail!("BUG: it's unclear how this case would occur, get a test for it")
+    }
+    Ok(())
+}
+
+pub(super) mod index {
+    use bstr::BStr;
+    use gix::index::entry::Stage;
+
+    pub fn mark_entry_for_deletion(
+        state: &mut gix::index::State,
+        rela_path: &BStr,
+        num_sorted_entries: usize,
+    ) {
+        for stage in [Stage::Unconflicted, Stage::Base, Stage::Ours, Stage::Theirs] {
+            // TODO(perf): `gix` should offer a way to get the *first* index by path so the
+            //             binary search doesn't have to be repeated.
+            let Some(entry_idx) =
+                state.entry_index_by_path_and_stage_bounded(rela_path, stage, num_sorted_entries)
+            else {
+                continue;
+            };
+            #[allow(clippy::indexing_slicing)]
+            state.entries_mut()[entry_idx]
+                .flags
+                .insert(gix::index::entry::Flags::REMOVE);
+        }
+    }
+}

--- a/crates/but-workspace/src/discard/function.rs
+++ b/crates/but-workspace/src/discard/function.rs
@@ -1,13 +1,7 @@
-use crate::discard::DiscardSpec;
-use crate::discard::function::index::mark_entry_for_deletion;
-use anyhow::{Context, bail};
-use bstr::{BStr, BString, ByteSlice, ByteVec};
+use crate::discard::{DiscardSpec, file};
+use anyhow::Context;
+use bstr::ByteSlice;
 use but_core::{ChangeState, TreeStatus};
-use gix::filter::plumbing::driver::apply::Delay;
-use gix::object::tree::EntryKind;
-use gix::prelude::ObjectIdExt;
-use std::borrow::Cow;
-use std::path::{Path, PathBuf};
 
 /// Discard the given `changes` in the worktree of `repo`. If a change could not be matched with an actual worktree change, for
 /// instance due to a race, that's not an error, instead it will be returned in the result Vec.
@@ -53,7 +47,7 @@ pub fn discard_workspace_changes(
                             .verified_path(&gix::path::from_bstr(wt_change.path.as_bstr()))?,
                     )?;
                     if !is_untracked {
-                        index::mark_entry_for_deletion(
+                        file::index::mark_entry_for_deletion(
                             &mut index,
                             wt_change.path.as_bstr(),
                             initial_entries_len,
@@ -62,7 +56,7 @@ pub fn discard_workspace_changes(
                     if let Some(entry) =
                         head_tree.lookup_entry(wt_change.path.split(|b| *b == b'/'))?
                     {
-                        restore_state_to_worktree(
+                        file::restore_state_to_worktree(
                             &mut pipeline,
                             &mut index,
                             wt_change.path.as_bstr(),
@@ -70,30 +64,30 @@ pub fn discard_workspace_changes(
                                 id: entry.object_id(),
                                 kind: entry.mode().into(),
                             },
-                            RestoreMode::Deleted,
+                            file::RestoreMode::Deleted,
                             &mut path_check,
                             &mut initial_entries_len,
                         )?
                     }
                 }
                 TreeStatus::Deletion { previous_state } => {
-                    restore_state_to_worktree(
+                    file::restore_state_to_worktree(
                         &mut pipeline,
                         &mut index,
                         wt_change.path.as_bstr(),
                         previous_state,
-                        RestoreMode::Deleted,
+                        file::RestoreMode::Deleted,
                         &mut path_check,
                         &mut initial_entries_len,
                     )?;
                 }
                 TreeStatus::Modification { previous_state, .. } => {
-                    restore_state_to_worktree(
+                    file::restore_state_to_worktree(
                         &mut pipeline,
                         &mut index,
                         wt_change.path.as_bstr(),
                         previous_state,
-                        RestoreMode::Update,
+                        file::RestoreMode::Update,
                         &mut path_check,
                         &mut initial_entries_len,
                     )?;
@@ -103,18 +97,16 @@ pub fn discard_workspace_changes(
                     previous_state,
                     ..
                 } => {
-                    restore_state_to_worktree(
+                    file::restore_state_to_worktree(
                         &mut pipeline,
                         &mut index,
                         previous_path.as_bstr(),
                         previous_state,
-                        RestoreMode::Deleted,
+                        file::RestoreMode::Deleted,
                         &mut path_check,
                         &mut initial_entries_len,
                     )?;
-                    purge_and_restore_from_head_tree(
-                        &head_tree,
-                        &mut pipeline,
+                    file::purge_and_restore_from_head_tree(
                         &mut index,
                         wt_change.path.as_bstr(),
                         &mut path_check,
@@ -140,370 +132,4 @@ pub fn discard_workspace_changes(
         index.write(Default::default())?;
     }
     Ok(dropped)
-}
-
-enum RestoreMode {
-    /// Assume the resource to be restored doesn't exist as it was deleted.
-    Deleted,
-    /// A similar resource is in its place that needs to be updated.
-    Update,
-}
-
-/// Restore `state` by writing it into the worktree of `repo`, possibly re-adding or updating the
-/// `index` with it so that it matches the worktree.
-fn restore_state_to_worktree(
-    pipeline: &mut gix::filter::Pipeline<'_>,
-    index: &mut gix::index::State,
-    rela_path: &BStr,
-    state: ChangeState,
-    mode: RestoreMode,
-    path_check: &mut gix::status::plumbing::SymlinkCheck,
-    num_sorted_entries: &mut usize,
-) -> anyhow::Result<()> {
-    if state.id.is_null() {
-        bail!(
-            "Change to discard at '{rela_path}' didn't have a last-known tracked state - this is a bug"
-        );
-    }
-
-    let mut update_index = |md| -> anyhow::Result<()> {
-        crate::commit_engine::index::upsert_index_entry(
-            index,
-            rela_path,
-            &md,
-            state.id,
-            state.kind.into(),
-            gix::index::entry::Flags::UPDATE,
-            num_sorted_entries,
-        )?;
-        Ok(())
-    };
-
-    let repo = pipeline.repo;
-    let wt_root = path_check.inner.root().to_owned();
-    let file_path = path_check
-        .verified_path(&gix::path::from_bstr(rela_path))
-        .map(Cow::Borrowed)
-        .or_else(|err| {
-            if err.kind() == std::io::ErrorKind::NotFound {
-                Ok(Cow::Owned(wt_root.join(gix::path::from_bstr(rela_path))))
-            } else {
-                Err(err)
-            }
-        })?;
-    match state.kind {
-        EntryKind::Blob | EntryKind::BlobExecutable => {
-            let mut dest_lock_file = locked_resource_at(wt_root, &file_path, state.kind)?;
-            let obj_in_git = state.id.attach(repo).object()?;
-            let mut stream =
-                pipeline.convert_to_worktree(&obj_in_git.data, rela_path, Delay::Forbid)?;
-            std::io::copy(&mut stream, &mut dest_lock_file)?;
-
-            let (file_path, maybe_file) = match dest_lock_file.commit() {
-                Ok(res) => res,
-                Err(err) => {
-                    if err.error.kind() == std::io::ErrorKind::IsADirectory {
-                        // It's OK to remove everything that's in the way.
-                        // Alternatives to this is to let it be handled by the stack.
-                        std::fs::remove_dir_all(err.instance.resource_path())?;
-                        err.instance.commit()?
-                    } else {
-                        return Err(err.into());
-                    }
-                }
-            };
-            update_index(match maybe_file {
-                None => gix::index::fs::Metadata::from_path_no_follow(&file_path)?,
-                Some(file) => gix::index::fs::Metadata::from_file(&file)?,
-            })?;
-        }
-        EntryKind::Link => {
-            let link_path = file_path;
-            if let RestoreMode::Update = mode {
-                std::fs::remove_file(&link_path)?;
-            }
-            let link_target = state.id.attach(repo).object()?;
-            let link_target = gix::path::from_bstr(link_target.data.as_bstr());
-            if let Err(err) = gix::fs::symlink::create(&link_target, &link_path) {
-                // When directories are replaced, the user could undo everything. Then
-                // it's a matter of order if *we* have already created the directory content.
-                if err.kind() != std::io::ErrorKind::AlreadyExists
-                    || !link_path.symlink_metadata()?.is_symlink()
-                {
-                    return Err(err.into());
-                }
-            }
-            update_index(gix::index::fs::Metadata::from_path_no_follow(&link_path)?)?;
-        }
-        EntryKind::Commit => {
-            if let RestoreMode::Update = mode {
-                // TODO(gix): actual checkout/reset functionality - it will be fine to support that fully.
-                // Since `git2` doesn't support filters, it will save us some trouble to just use Git for that.
-                let submodule_repo_dir = &file_path;
-                let out = std::process::Command::from(
-                    gix::command::prepare(format!(
-                        "git reset --hard {id} && git clean -fxd",
-                        id = state.id
-                    ))
-                    .with_shell(),
-                )
-                .current_dir(submodule_repo_dir)
-                .output()?;
-                if !out.status.success() {
-                    bail!(
-                        "Could not reset submodule at '{sm_dir}' to commit {id}: {err}",
-                        sm_dir = submodule_repo_dir.display(),
-                        id = state.id,
-                        err = out.stderr.as_bstr()
-                    );
-                }
-            } else {
-                let sm_repo = repo
-                    .submodules()?
-                    .into_iter()
-                    .flatten()
-                    .find_map(|sm| {
-                        let is_active = sm.is_active().ok()?;
-                        is_active.then(|| -> anyhow::Result<_> {
-                            Ok(
-                                if sm.path().ok().is_some_and(|sm_path| sm_path == rela_path) {
-                                    sm.open()?
-                                } else {
-                                    None
-                                },
-                            )
-                        })
-                    })
-                    .transpose()?
-                    .flatten();
-                match sm_repo {
-                    None => {
-                        // A directory is what git creates with `git restore` even if the thing to restore is a submodule.
-                        // We are trying to be better than that if we find a submodule, hoping that this is what users expect.
-                        // We do that as baseline as there is no need to fail here.
-                    }
-                    Some(repo) => {
-                        // We will only restore the submodule if there is a local clone already available, to avoid any network
-                        // activity that would likely happen during an actual clone.
-                        // Thus, all we have to do is to check out the submodule.
-                        // TODO(gix): find a way to deal with nested submodules - they should also be checked out which
-                        //            isn't done by `gitoxide`, but probably should be an option there.
-                        checkout_repo_worktree(&wt_root, repo)?;
-                    }
-                }
-                std::fs::create_dir(&file_path).or_else(|err| {
-                    if err.kind() == std::io::ErrorKind::AlreadyExists {
-                        Ok(())
-                    } else {
-                        Err(err)
-                    }
-                })?;
-            }
-            update_index(gix::index::fs::Metadata::from_path_no_follow(&file_path)?)?;
-        }
-        EntryKind::Tree => {
-            mark_entry_for_deletion(index, rela_path, *num_sorted_entries);
-            let checkout_destination = file_path;
-            let mut sub_index = repo.index_from_tree(&state.id)?;
-            let mut opts =
-                repo.checkout_options(gix::worktree::stack::state::attributes::Source::IdMapping)?;
-            // there may be situations where files already exist in that spot, likely because we put them
-            // there earlier as part of a sweeping 'discard'. Still, try not to mess with the user.
-            opts.overwrite_existing = false;
-            if !checkout_destination.exists() {
-                std::fs::create_dir(&checkout_destination)?;
-                opts.destination_is_initially_empty = true;
-            }
-            // TODO(gix): make it possible to have this checkout submodules as well.
-            let out = gix::worktree::state::checkout(
-                &mut sub_index,
-                checkout_destination.as_ref(),
-                repo.clone().objects.into_arc()?,
-                &gix::progress::Discard,
-                &gix::progress::Discard,
-                &gix::interrupt::IS_INTERRUPTED,
-                opts,
-            )?;
-            tracing::debug!(directory = ?checkout_destination, outcome = ?out, "directory checkout result");
-
-            let (entries, path_storage) = sub_index.into_parts().0.into_entries();
-            let mut rela_path = with_trailing_slash(rela_path);
-            let prefix_len = rela_path.len();
-            for entry in entries {
-                let partial_rela_path = entry.path_in(&path_storage);
-                rela_path.extend_from_slice(partial_rela_path);
-
-                if index.entry_by_path(rela_path.as_bstr()).is_none() {
-                    index.dangerously_push_entry(
-                        entry.stat,
-                        entry.id,
-                        entry.flags | gix::index::entry::Flags::UPDATE,
-                        entry.mode,
-                        rela_path.as_bstr(),
-                    );
-                }
-                rela_path.truncate(prefix_len);
-            }
-            // These might be re-visited later if the user was able to add individual deletions in a directory.
-            // Sort to make index-lookups work.
-            index.sort_entries();
-            *num_sorted_entries = index.entries().len();
-        }
-    };
-    Ok(())
-}
-
-fn with_trailing_slash(rela_path: &BStr) -> BString {
-    if rela_path.ends_with_str(b"/") {
-        return rela_path.to_owned();
-    }
-    let mut buf = rela_path.to_owned();
-    buf.push(b'/');
-    buf
-}
-
-fn checkout_repo_worktree(
-    parent_worktree_dir: &Path,
-    mut repo: gix::Repository,
-) -> anyhow::Result<()> {
-    // No need to cache anything, it's just single-use for the most part.
-    repo.object_cache_size(0);
-    let mut index = repo.index_from_tree(&repo.head_tree_id_or_empty()?)?;
-    if index.entries().is_empty() {
-        // The worktree directory is created later, so we don't have to deal with it here.
-        return Ok(());
-    }
-    for entry in index.entries_mut().iter_mut().filter(|e| {
-        e.mode
-            .contains(gix::index::entry::Mode::DIR | gix::index::entry::Mode::COMMIT)
-    }) {
-        entry.flags.insert(gix::index::entry::Flags::SKIP_WORKTREE);
-    }
-
-    let mut opts =
-        repo.checkout_options(gix::worktree::stack::state::attributes::Source::IdMapping)?;
-    opts.destination_is_initially_empty = true;
-    opts.keep_going = true;
-
-    let checkout_destination = repo.workdir().context("non-bare repository")?.to_owned();
-    if !checkout_destination.exists() {
-        std::fs::create_dir(&checkout_destination)?;
-    }
-    let sm_repo_dir = gix::path::relativize_with_prefix(
-        repo.path().strip_prefix(parent_worktree_dir)?,
-        checkout_destination.strip_prefix(parent_worktree_dir)?,
-    )
-    .into_owned();
-    let out = gix::worktree::state::checkout(
-        &mut index,
-        checkout_destination.clone(),
-        repo,
-        &gix::progress::Discard,
-        &gix::progress::Discard,
-        &gix::interrupt::IS_INTERRUPTED,
-        opts,
-    )?;
-
-    let mut buf = BString::from("gitdir: ");
-    buf.extend_from_slice(&gix::path::os_string_into_bstring(sm_repo_dir.into())?);
-    buf.push_byte(b'\n');
-    std::fs::write(checkout_destination.join(".git"), &buf)?;
-
-    tracing::debug!(directory = ?checkout_destination, outcome = ?out, "submodule checkout result");
-    Ok(())
-}
-
-/// Remove files present at `rela_path`, restore the index at that place, if possible,
-/// and if necessary, checkout everything that this revealed.
-/// This is required when handling renames.
-fn purge_and_restore_from_head_tree<'repo>(
-    _head_tree: &gix::Tree<'repo>,
-    _pipeline: &mut gix::filter::Pipeline<'repo>,
-    index: &mut gix::index::State,
-    rela_path: &BStr,
-    path_check: &mut gix::status::plumbing::SymlinkCheck,
-    num_sorted_entries: usize,
-) -> anyhow::Result<()> {
-    if let Some(range) = index.entry_range(with_trailing_slash(rela_path).as_bstr()) {
-        #[allow(clippy::indexing_slicing)]
-        for entry in &mut index.entries_mut()[range] {
-            entry.flags.insert(gix::index::entry::Flags::REMOVE);
-        }
-    } else {
-        mark_entry_for_deletion(index, rela_path, num_sorted_entries);
-    }
-
-    // TODO(motivational test): restore what was there in the the index, and then on disk by checkout.
-    let path = path_check.verified_path(&gix::path::from_bstr(rela_path))?;
-    if !path.is_dir() {
-        // Should always exist, this is why it's a rename in the first place.
-        std::fs::remove_file(path).or_else(|err| {
-            if matches!(
-                err.kind(),
-                std::io::ErrorKind::NotADirectory | std::io::ErrorKind::NotFound
-            ) {
-                Ok(())
-            } else {
-                Err(err)
-            }
-        })?;
-    } else {
-        bail!("BUG: it's unclear how this case would occur, get a test for it")
-    }
-    Ok(())
-}
-
-mod index {
-    use bstr::BStr;
-    use gix::index::entry::Stage;
-
-    pub fn mark_entry_for_deletion(
-        state: &mut gix::index::State,
-        rela_path: &BStr,
-        num_sorted_entries: usize,
-    ) {
-        for stage in [Stage::Unconflicted, Stage::Base, Stage::Ours, Stage::Theirs] {
-            // TODO(perf): `gix` should offer a way to get the *first* index by path so the
-            //             binary search doesn't have to be repeated.
-            let Some(entry_idx) =
-                state.entry_index_by_path_and_stage_bounded(rela_path, stage, num_sorted_entries)
-            else {
-                continue;
-            };
-            #[allow(clippy::indexing_slicing)]
-            state.entries_mut()[entry_idx]
-                .flags
-                .insert(gix::index::entry::Flags::REMOVE);
-        }
-    }
-}
-
-#[cfg(unix)]
-fn locked_resource_at(
-    root: PathBuf,
-    path: &Path,
-    kind: EntryKind,
-) -> anyhow::Result<gix::lock::File> {
-    use std::os::unix::fs::PermissionsExt;
-    Ok(
-        gix::lock::File::acquire_to_update_resource_with_permissions(
-            path,
-            gix::lock::acquire::Fail::Immediately,
-            Some(root),
-            || std::fs::Permissions::from_mode(kind as u32),
-        )?,
-    )
-}
-
-#[cfg(windows)]
-fn locked_resource_at(
-    root: PathBuf,
-    path: &Path,
-    _kind: EntryKind,
-) -> anyhow::Result<gix::lock::File> {
-    Ok(gix::lock::File::acquire_to_update_resource(
-        path,
-        gix::lock::acquire::Fail::Immediately,
-        Some(root),
-    )?)
 }

--- a/crates/but-workspace/tests/workspace/discard/hunk.rs
+++ b/crates/but-workspace/tests/workspace/discard/hunk.rs
@@ -1,0 +1,17 @@
+#[test]
+#[ignore = "TBD"]
+fn non_modifications_trigger_error() -> anyhow::Result<()> {
+    Ok(())
+}
+
+#[test]
+#[ignore = "TBD"]
+fn deletion_modification_addition_mixed_in_worktree() -> anyhow::Result<()> {
+    Ok(())
+}
+
+#[test]
+#[ignore = "TBD"]
+fn deletion_modification_addition_mixed_in_index() -> anyhow::Result<()> {
+    Ok(())
+}

--- a/crates/but-workspace/tests/workspace/discard/mod.rs
+++ b/crates/but-workspace/tests/workspace/discard/mod.rs
@@ -1,0 +1,2 @@
+mod file;
+mod hunk;


### PR DESCRIPTION
Add V3 facilities for discarding changes in the worktree or index, this time it's about hunks specifically.

Follow-up of #7597.

### Tasks

* [x] figure out what's going on with the test and 'object not found' (and fix it)
* [x] fix content-conversions and hunk-references into said content for commit-engine 
* [x] fix tree/index/worktree bug
     - [x] assure tests for no-ops
     - [x] check with symlinks at least once
     - [x] ~~deduplicate match~~ - no need, will just be harder to read then

### For next PR

* [ ] reset changed hunks in a file
* [ ] merge https://github.com/GitoxideLabs/gitoxide/pull/1898 and refer to it from `main`.


### Notes for the reviewer

* I find it difficult to imagine how meaningful discarding parts of hunks in whole-file deletions and additions can be so I chose to disallow it. The UI can still offer discarding the single whole hunk that a deletion or addition of a file would come with, but internally it, as always, would discard the file instead. Discarding of lines or selections would have to be disallowed on the UI level though, as this is currently only available for modified (or renamed + modified) files.

### For the next PR

* **See what happens if one tries to commit these special cases** (i.e. the 'pretend there is  no index' changes)
    - implement remaining ignored cases
* **gitoxide informs about diff-filter changes** and this information is passed to the frontend
    - differentiate binary-to-text , otherwise it applies worktree conversions (which is fine). We ignore external diff programs anyway.
* **reset individual lines** (but as free selections of sub-hunks)


### Shortcomings

* Index-handling is low-level and I think there needs to be something like a tree-editor, but for indices. Maybe it's a mix of using the pretty-neat tree-editor, and a way to transfer index information from one index to another, similar to 'apply', to avoid loosing information.

### Out of Scope

* snapshot integration - should be left to @krlvi to warm up with the new code.

### Research

* **V2 implementation**
    - spread across `unapply_lines`, `unapply_ownership` and `reset_files`

