### PR TITLE
The "stack staus" API used before updating workspace now returns the worktree conflict state

### DIFF
--- a/apps/desktop/src/lib/upstream/types.ts
+++ b/apps/desktop/src/lib/upstream/types.ts
@@ -152,5 +152,5 @@ export type BranchStatusesResponse =
 	  }
 	| {
 			type: 'updatesRequired';
-			subject: [string, StackStatus][];
+			subject: { worktreeConflicted: boolean; statuses: [string, StackStatus][] };
 	  };

--- a/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
+++ b/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
@@ -50,7 +50,7 @@ export class UpstreamIntegrationService {
 
 			const stackStatusesWithBranches: StackStatusesWithBranchesV3 = {
 				type: 'updatesRequired',
-				subject: branchStatusesData.subject
+				subject: branchStatusesData.subject.statuses
 					.map((status) => {
 						const stack = stackData.find((appliedBranch) => appliedBranch.id === status[0]);
 

--- a/apps/desktop/src/lib/upstream/upstreamIntegrationService.ts
+++ b/apps/desktop/src/lib/upstream/upstreamIntegrationService.ts
@@ -39,7 +39,7 @@ export class UpstreamIntegrationService {
 
 		const stackStatusesWithBranches: StackStatusesWithBranches = {
 			type: 'updatesRequired',
-			subject: branchStatuses.subject
+			subject: branchStatuses.subject.statuses
 				.map((status) => {
 					const stack = branches.find((appliedBranch) => appliedBranch.id === status[0]);
 


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#5DJ7qlKN5`](https://gitbutler.com/krlvi/gitbutler/reviews/5DJ7qlKN5)

**The "stack staus" API used before updating workspace now returns the worktree conflict state**


This allows us to dispaly if an update to the workspace will result in a conflict with the worktree

1 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [The "stack staus" API used before updating workspace now returns the worktree conflict state](https://gitbutler.com/krlvi/gitbutler/reviews/5DJ7qlKN5/commit/6f903382-1149-4999-946d-1928b87e9df7) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/krlvi/gitbutler/reviews/5DJ7qlKN5)_
<!-- GitButler Review Footer Boundary Bottom -->
