### PR TITLE
fix: ensure template toggle overrides blank content (#7556) only when…

### DIFF
--- a/apps/desktop/src/components/PrTemplateSection.svelte
+++ b/apps/desktop/src/components/PrTemplateSection.svelte
@@ -38,17 +38,15 @@
 	}
 
 	$effect(() => {
-		if (templates) {
-			if ($lastTemplate && templates.includes($lastTemplate)) {
-				loadAndEmit($lastTemplate);
-			} else if (templates.length === 1) {
+		(() => {
+			if (!templates) return;
+			if ($lastTemplate && templates.includes($lastTemplate)) return loadAndEmit($lastTemplate);
+			if (templates.length === 1) {
 				const path = templates.at(0);
-				if (path) {
-					loadAndEmit(path);
-					lastTemplate.set(path);
-				}
+				if (!path) return;
+				return loadAndEmit(path), lastTemplate.set(path);
 			}
-		}
+		})();
 	});
 </script>
 

--- a/apps/desktop/src/components/PrTemplateSection.svelte
+++ b/apps/desktop/src/components/PrTemplateSection.svelte
@@ -38,15 +38,17 @@
 	}
 
 	$effect(() => {
-		(() => {
-			if (!templates) return;
-			if ($lastTemplate && templates.includes($lastTemplate)) return loadAndEmit($lastTemplate);
-			if (templates.length === 1) {
+		if (templates) {
+			if ($lastTemplate && templates.includes($lastTemplate)) {
+				loadAndEmit($lastTemplate);
+			} else if (templates.length === 1) {
 				const path = templates.at(0);
-				if (!path) return;
-				return loadAndEmit(path), lastTemplate.set(path);
+				if (path) {
+					loadAndEmit(path);
+					lastTemplate.set(path);
+				}
 			}
-		})();
+		}
 	});
 </script>
 

--- a/apps/desktop/src/components/ReviewDetailsModal.svelte
+++ b/apps/desktop/src/components/ReviewDetailsModal.svelte
@@ -374,6 +374,27 @@
 		}, 2000);
 	}
 
+	function handlePRDescriptionFieldInput(
+		e: Event & { currentTarget: EventTarget & HTMLTextAreaElement }
+	) {
+		const target = e.currentTarget;
+		const isEmpty = !target.value;
+
+		if (isEmpty && $useTemplate && templateBody) {
+			// Force a reset to ensure an update even when the new value equals the current template
+			prBody.reset();
+			prBody.set(templateBody);
+			return;
+		}
+
+		if (isEmpty) {
+			prBody.reset();
+			return;
+		}
+
+		prBody.set(target.value);
+	}
+
 	export function show() {
 		modal?.show();
 	}
@@ -456,14 +477,7 @@
 							autofocus
 							padding={{ top: 12, right: 12, bottom: 12, left: 12 }}
 							placeholder="Add description…"
-							oninput={(e: Event & { currentTarget: EventTarget & HTMLTextAreaElement }) => {
-								const target = e.currentTarget as HTMLTextAreaElement;
-								if (!target.value) {
-									prBody.reset();
-									return;
-								}
-								prBody.set(target.value);
-							}}
+							oninput={handlePRDescriptionFieldInput}
 						/>
 
 						<!-- AI GENRATION -->

--- a/apps/desktop/src/components/ReviewDetailsModal.svelte
+++ b/apps/desktop/src/components/ReviewDetailsModal.svelte
@@ -458,6 +458,10 @@
 							placeholder="Add description…"
 							oninput={(e: Event & { currentTarget: EventTarget & HTMLTextAreaElement }) => {
 								const target = e.currentTarget as HTMLTextAreaElement;
+								if (!target.value) {
+									prBody.reset();
+									return;
+								}
 								prBody.set(target.value);
 							}}
 						/>

--- a/apps/desktop/src/lib/forge/prContents.svelte.ts
+++ b/apps/desktop/src/lib/forge/prContents.svelte.ts
@@ -1,4 +1,8 @@
-import { getEphemeralStorageItem, setEphemeralStorageItem } from '@gitbutler/shared/persisted';
+import {
+	getEphemeralStorageItem,
+	setEphemeralStorageItem,
+	clearEphemeralStorageItem
+} from '@gitbutler/shared/persisted';
 import type { DetailedCommit } from '$lib/commits/commit';
 
 const PERSITANCE_TIME_MIN = 5;
@@ -13,6 +17,7 @@ function getPersistedTitleKey(projectId: string, branchName: string) {
 
 export function setPersistedPRBody(projectId: string, branchName: string, body: string): void {
 	const key = getPersistedBodyKey(projectId, branchName);
+	if (!body) return clearEphemeralStorageItem(key);
 	setEphemeralStorageItem(key, body, PERSITANCE_TIME_MIN);
 }
 

--- a/apps/desktop/src/lib/forge/prContents.svelte.ts
+++ b/apps/desktop/src/lib/forge/prContents.svelte.ts
@@ -15,9 +15,13 @@ function getPersistedTitleKey(projectId: string, branchName: string) {
 	return 'seriesCurrentPRTitle_' + projectId + '_' + branchName;
 }
 
+export function clearPersistedPRBody(projectId: string, branchName: string): void {
+	const key = getPersistedBodyKey(projectId, branchName);
+	return clearEphemeralStorageItem(key);
+}
+
 export function setPersistedPRBody(projectId: string, branchName: string, body: string): void {
 	const key = getPersistedBodyKey(projectId, branchName);
-	if (!body) return clearEphemeralStorageItem(key);
 	setEphemeralStorageItem(key, body, PERSITANCE_TIME_MIN);
 }
 
@@ -124,6 +128,7 @@ export class ReactivePRBody {
 	}
 
 	reset() {
-		this.set('');
+		this._value = '';
+		clearPersistedPRBody(this.projectId, this.branchName);
 	}
 }

--- a/packages/shared/src/lib/persisted.ts
+++ b/packages/shared/src/lib/persisted.ts
@@ -54,6 +54,10 @@ export function persisted<T>(initial: T, key: string): Persisted<T> {
 	};
 }
 
+export function clearEphemeralStorageItem(key: string): void {
+	lscache.remove(key);
+}
+
 export function setEphemeralStorageItem(
 	key: string,
 	value: unknown,


### PR DESCRIPTION
Hello GitButler team! 👋
I'm Tomás, a software engineer who recently applied for the `Senior TypeScript Developer` position in Berlin. While familiarizing myself with your product, I noticed this issue (#7556 ) and wanted to contribute a small improvement. I'm genuinely excited about GitButler's mission and would love to join and contribute more in the future. 🚀

## 🧢 Changes
* Ensured that enabling the template toggle overrides blank content as expected.
* Adjusted logic to check if content is empty before applying the template.
* While investigating this, I realized that the Rust helper only checks .github/ for templates, even though GitHub supports templates in the root directory as well—this may be worth addressing separately.

## ☕️ Reasoning
The main fix ensures that when the template toggle is turned on, it properly overrides blank content as expected.

While working on this, I refactored the method for selecting a template for clarity while investigating why the templates I had in my root directory were not being read. I ensured the logic remains unchanged but easier to follow.

Additionally, I realized that the Rust helper only checks inside the directory specified for the current forge (in my case, .github) for templates, whereas GitHub itself recognizes template files located in the repository root as well. This might not be directly related to the issue at hand but could be worth investigating separately.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues
Fixes: #7556 
-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
