### PR TITLE
discard changes: hunks

### DIFF
--- a/crates/but-cli/src/command/mod.rs
+++ b/crates/but-cli/src/command/mod.rs
@@ -151,6 +151,7 @@ pub(crate) fn discard_change(
     debug_print(but_workspace::discard_workspace_changes(
         &repo,
         Some(spec.into()),
+        UI_CONTEXT_LINES,
     )?)
 }
 

--- a/crates/but-core/src/diff/mod.rs
+++ b/crates/but-core/src/diff/mod.rs
@@ -80,6 +80,19 @@ impl ModeFlags {
     }
 }
 
+impl ModeFlags {
+    /// Returns `true` if this instance indicates a type-change.
+    /// The only reason this isn't the case is if the executable bit changed.
+    pub fn is_typechange(&self) -> bool {
+        match self {
+            ModeFlags::ExecutableBitAdded | ModeFlags::ExecutableBitRemoved => false,
+            ModeFlags::TypeChangeFileToLink
+            | ModeFlags::TypeChangeLinkToFile
+            | ModeFlags::TypeChange => true,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     mod flags {

--- a/crates/but-core/src/diff/worktree.rs
+++ b/crates/but-core/src/diff/worktree.rs
@@ -805,7 +805,7 @@ impl TreeChange {
         let mut diff_filter = crate::unified_diff::filter_from_state(
             repo,
             self.status.state(),
-            gix::diff::blob::pipeline::Mode::ToGitUnlessBinaryToTextIsPresent,
+            UnifiedDiff::CONVERSION_MODE,
         )?;
         self.unified_diff_with_filter(repo, context_lines, &mut diff_filter)
     }

--- a/crates/but-workspace/src/commit_engine/hunks.rs
+++ b/crates/but-workspace/src/commit_engine/hunks.rs
@@ -1,0 +1,62 @@
+use crate::commit_engine::HunkHeader;
+use anyhow::Context;
+use bstr::{BStr, BString, ByteSlice};
+
+/// Given an `old_image` and a `new_image`, along with `hunks` that represent selections in `new_image`, apply these
+/// hunks to `old_image` and return the newly constructed image.
+/// This works like an overlay where selections from `new_image` are inserted into `new_image` with `hunks` as Windows.
+///
+/// Note that we assume that both images are human-readable because we assume lines to be present,
+/// either with Windows or Unix newlines, and we assume that the hunks match up with these lines.
+/// This constraint means that the tokens used for diffing are the same lines.
+pub fn apply_hunks(
+    old_image: &BStr,
+    new_image: &BStr,
+    hunks: &[HunkHeader],
+) -> anyhow::Result<BString> {
+    let mut worktree_base_cursor = 1; /* 1-based counting */
+    let mut old_iter = old_image.lines_with_terminator();
+    let mut worktree_actual_cursor = 1; /* 1-based counting */
+    let mut new_iter = new_image.lines_with_terminator();
+    let mut result_image: BString = Vec::with_capacity(old_image.len().max(new_image.len())).into();
+
+    // To each selected hunk, put the old-lines into a buffer.
+    // Skip over the old hunk in old hunk in old lines.
+    // Skip all new lines till the beginning of the new hunk.
+    // Write the new hunk.
+    // Repeat for each hunk, and write all remaining old lines.
+    for selected_hunk in hunks {
+        let catchup_base_lines = old_iter.by_ref().take(
+            (selected_hunk.old_start as usize)
+                .checked_sub(worktree_base_cursor)
+                .context("hunks must be in order from top to bottom of the file")?,
+        );
+        for line in catchup_base_lines {
+            result_image.extend_from_slice(line);
+        }
+        let _consume_old_hunk_to_replace_with_new = old_iter
+            .by_ref()
+            .take(selected_hunk.old_lines as usize)
+            .count();
+        worktree_base_cursor += selected_hunk.old_lines as usize;
+
+        let new_hunk_lines = new_iter
+            .by_ref()
+            .skip(
+                (selected_hunk.new_start as usize)
+                    .checked_sub(worktree_actual_cursor)
+                    .context("hunks for new lines must be in order")?,
+            )
+            .take(selected_hunk.new_lines as usize);
+
+        for line in new_hunk_lines {
+            result_image.extend_from_slice(line);
+        }
+        worktree_actual_cursor += selected_hunk.new_lines as usize;
+    }
+
+    for line in old_iter {
+        result_image.extend_from_slice(line);
+    }
+    Ok(result_image)
+}

--- a/crates/but-workspace/src/commit_engine/mod.rs
+++ b/crates/but-workspace/src/commit_engine/mod.rs
@@ -1,5 +1,6 @@
 //! The machinery used to alter and mutate commits in various ways whilst adjusting descendant commits within a [reference frame](ReferenceFrame).
 
+use crate::commit_engine::reference_frame::InferenceMode;
 use anyhow::{Context, bail};
 use bstr::BString;
 use but_core::RepositoryExt;
@@ -13,13 +14,15 @@ use gix::refs::transaction::PreviousValue;
 use serde::{Deserialize, Serialize};
 
 mod tree;
-use crate::commit_engine::reference_frame::InferenceMode;
 use tree::{CreateTreeOutcome, create_tree};
 
 pub(crate) mod index;
 /// Utility types
 pub mod reference_frame;
 mod refs;
+
+mod hunks;
+pub use hunks::apply_hunks;
 
 /// Types for use in the frontend with serialization support.
 pub mod ui;

--- a/crates/but-workspace/src/commit_engine/mod.rs
+++ b/crates/but-workspace/src/commit_engine/mod.rs
@@ -13,7 +13,7 @@ use gix::prelude::ObjectIdExt as _;
 use gix::refs::transaction::PreviousValue;
 use serde::{Deserialize, Serialize};
 
-mod tree;
+pub(crate) mod tree;
 use tree::{CreateTreeOutcome, create_tree};
 
 pub(crate) mod index;
@@ -94,7 +94,7 @@ pub struct DiffSpec {
 }
 
 /// The header of a hunk that represents a change to a file.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HunkHeader {
     /// The 1-based line number at which the previous version of the file started.

--- a/crates/but-workspace/src/discard/hunk.rs
+++ b/crates/but-workspace/src/discard/hunk.rs
@@ -1,0 +1,93 @@
+use crate::commit_engine::tree::worktree_file_to_git_in_buf;
+use crate::commit_engine::{HunkHeader, apply_hunks};
+use anyhow::bail;
+use bstr::ByteSlice;
+use but_core::{ChangeState, TreeChange, UnifiedDiff};
+use gix::filter::plumbing::driver::apply::{Delay, MaybeDelayed};
+use gix::filter::plumbing::pipeline::convert::ToWorktreeOutcome;
+use gix::prelude::ObjectIdExt;
+
+/// Discard `hunks_to_discard` in the resource at `wt_change`, whose previous version is `previous_state` and is expected to
+/// be tracked and readable from the object database. We will always read what's currently on disk as the current version
+/// and overwrite it.
+///
+/// The general idea is to rebuild the file, but without the `hunks_to_discard`, write it into the worktree replacing
+/// the previous file. `hunks_to_discard` are hunks based on a diff of what's in Git.
+///
+/// Note that an index update isn't necessary, as for the purpose of the application it might as well not exist due to the
+/// way our worktree-changes function ignores the index entirely.
+///
+/// Note that `hunks_to_discard` that weren't present in the actual set of worktree changes will remain, so when everything
+/// worked `hunks_to_discard` will be empty.
+pub fn restore_state_to_worktree(
+    wt_change: &TreeChange,
+    previous_state: ChangeState,
+    hunks_to_discard: &mut Vec<HunkHeader>,
+    path_check: &mut gix::status::plumbing::SymlinkCheck,
+    pipeline: &mut gix::filter::Pipeline<'_>,
+    index: &gix::index::State,
+    context_lines: u32,
+) -> anyhow::Result<()> {
+    let repo = pipeline.repo;
+    let state_in_worktree = ChangeState {
+        id: repo.object_hash().null(),
+        kind: previous_state.kind,
+    };
+    let mut diff_filter = but_core::unified_diff::filter_from_state(
+        repo,
+        Some(state_in_worktree),
+        UnifiedDiff::CONVERSION_MODE,
+    )?;
+    let UnifiedDiff::Patch { hunks } =
+        wt_change.unified_diff_with_filter(repo, context_lines, &mut diff_filter)?
+    else {
+        bail!("Couldn't obtain diff for worktree changes.")
+    };
+
+    let prev_len = hunks_to_discard.len();
+    let hunks_to_keep: Vec<HunkHeader> = hunks
+        .into_iter()
+        .map(Into::into)
+        .filter(|hunk| {
+            match hunks_to_discard
+                .iter()
+                .enumerate()
+                .find_map(|(idx, hunk_to_discard)| (hunk_to_discard == hunk).then_some(idx))
+            {
+                None => true,
+                Some(idx_to_remove) => {
+                    hunks_to_discard.remove(idx_to_remove);
+                    false
+                }
+            }
+        })
+        .collect();
+    if prev_len == hunks_to_discard.len() {
+        // We want to keep everything, so nothing has to be done.
+        return Ok(());
+    }
+
+    let old = previous_state.id.attach(repo).object()?.detach().data;
+    let mut new = repo.empty_reusable_buffer();
+    let rela_path = wt_change.path.as_bstr();
+    let worktree_path = path_check.verified_path_allow_nonexisting(rela_path)?;
+    worktree_file_to_git_in_buf(&mut new, rela_path, &worktree_path, pipeline, index)?;
+
+    let base_with_patches = apply_hunks(old.as_bstr(), new.as_bstr(), &hunks_to_keep)?;
+
+    let to_worktree = pipeline.convert_to_worktree(&base_with_patches, rela_path, Delay::Forbid)?;
+    match to_worktree {
+        ToWorktreeOutcome::Unchanged(buf) => {
+            std::fs::write(&worktree_path, buf)?;
+        }
+        ToWorktreeOutcome::Buffer(buf) => {
+            std::fs::write(&worktree_path, buf)?;
+        }
+        ToWorktreeOutcome::Process(MaybeDelayed::Immediate(mut stream)) => {
+            let mut file = std::fs::File::create(&worktree_path)?;
+            std::io::copy(&mut stream, &mut file)?;
+        }
+        ToWorktreeOutcome::Process(MaybeDelayed::Delayed(_)) => unreachable!("disabled"),
+    }
+    Ok(())
+}

--- a/crates/but-workspace/src/discard/mod.rs
+++ b/crates/but-workspace/src/discard/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::commit_engine::DiffSpec;
 use gix::object::tree::EntryKind;
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 
 /// A specification of what should be discarded, either changes to the whole file, or a portion of it.
@@ -24,6 +24,12 @@ impl Deref for DiscardSpec {
     }
 }
 
+impl DerefMut for DiscardSpec {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 impl From<DiscardSpec> for DiffSpec {
     fn from(value: DiscardSpec) -> Self {
         value.0
@@ -38,6 +44,7 @@ pub mod ui {
 }
 
 mod file;
+mod hunk;
 
 #[cfg(unix)]
 fn locked_resource_at(

--- a/crates/but-workspace/tests/fixtures/generated-archives/.gitignore
+++ b/crates/but-workspace/tests/fixtures/generated-archives/.gitignore
@@ -21,3 +21,5 @@
 /all-file-types-renamed-and-overwriting-existing.tar
 /move-directory-into-sibling-file.tar
 /merge-with-two-branches-conflict.tar
+/deletion-addition-untracked.tar
+/mixed-hunk-modifications.tar

--- a/crates/but-workspace/tests/fixtures/scenario/deletion-addition-untracked.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/deletion-addition-untracked.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+### Description
+# Provide a deleted file, an added one, and an untracked one.
+set -eu -o pipefail
+
+git init
+echo content >to-be-deleted
+echo content2 >to-be-deleted-in-index
+git add . && git commit -m "init"
+
+echo new >added-to-index && git add added-to-index
+echo untracked >untracked
+rm to-be-deleted
+git rm to-be-deleted-in-index
+

--- a/crates/but-workspace/tests/fixtures/scenario/mixed-hunk-modifications.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/mixed-hunk-modifications.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+### Description
+# A single tracked file, modified in the workspace to have:
+# - added lines at the beginning
+# - deleted lines at the end
+# - modified lines, added lines, and deleted lines directly after one another in the middle.
+set -eu -o pipefail
+
+git init
+seq 5 18 >file
+seq 5 18 >file-in-index
+seq 5 18 >file-to-be-renamed
+seq 5 18 >file-to-be-renamed-in-index
+git add . && git commit -m "init"
+
+cat <<EOF >file
+1
+2
+3
+4
+5
+6-7
+8
+9
+ten
+eleven
+12
+20
+21
+22
+15
+16
+EOF
+
+cp file file-in-index && git add file-in-index
+
+
+seq 2 18 >file-to-be-renamed && mv file-to-be-renamed file-renamed
+cp file file-to-be-renamed-in-index && git mv file-to-be-renamed-in-index file-renamed-in-index
+
+

--- a/crates/but-workspace/tests/workspace/commit_engine/new_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/new_commit.rs
@@ -141,6 +141,7 @@ fn from_first_commit_all_file_types_changed() -> anyhow::Result<()> {
             stack_segment: None,
         },
     )?;
+    assert_eq!(outcome.rejected_specs, []);
 
     let tree = visualize_tree(&repo, &outcome)?;
     insta::assert_snapshot!(tree, @r#"

--- a/crates/but-workspace/tests/workspace/discard/file.rs
+++ b/crates/but-workspace/tests/workspace/discard/file.rs
@@ -1,4 +1,4 @@
-use crate::utils::{visualize_index, writable_scenario, writable_scenario_slow};
+use crate::utils::{CONTEXT_LINES, visualize_index, writable_scenario, writable_scenario_slow};
 use but_testsupport::{CommandExt, git, git_status, visualize_disk_tree_skip_dot_git};
 use but_workspace::discard_workspace_changes;
 use util::{file_to_spec, renamed_file_to_spec, worktree_changes_to_discard_specs};
@@ -12,7 +12,11 @@ fn all_file_types_from_unborn() -> anyhow::Result<()> {
 ?? untracked-exe
 ");
 
-    let dropped = discard_workspace_changes(&repo, worktree_changes_to_discard_specs(&repo))?;
+    let dropped = discard_workspace_changes(
+        &repo,
+        worktree_changes_to_discard_specs(&repo),
+        CONTEXT_LINES,
+    )?;
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
@@ -29,7 +33,11 @@ A  untracked
 A  untracked-exe
 ");
 
-    let dropped = discard_workspace_changes(&repo, worktree_changes_to_discard_specs(&repo))?;
+    let dropped = discard_workspace_changes(
+        &repo,
+        worktree_changes_to_discard_specs(&repo),
+        CONTEXT_LINES,
+    )?;
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
@@ -48,7 +56,11 @@ D link
 D submodule
 ");
 
-    let dropped = discard_workspace_changes(&repo, worktree_changes_to_discard_specs(&repo))?;
+    let dropped = discard_workspace_changes(
+        &repo,
+        worktree_changes_to_discard_specs(&repo),
+        CONTEXT_LINES,
+    )?;
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
@@ -90,7 +102,11 @@ fn replace_dir_with_file_discard_all_in_order_in_worktree() -> anyhow::Result<()
 ?? dir
 ");
 
-    let dropped = discard_workspace_changes(&repo, worktree_changes_to_discard_specs(&repo))?;
+    let dropped = discard_workspace_changes(
+        &repo,
+        worktree_changes_to_discard_specs(&repo),
+        CONTEXT_LINES,
+    )?;
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
@@ -137,7 +153,11 @@ D  dir/link
 D  dir/submodule
 ");
 
-    let dropped = discard_workspace_changes(&repo, worktree_changes_to_discard_specs(&repo))?;
+    let dropped = discard_workspace_changes(
+        &repo,
+        worktree_changes_to_discard_specs(&repo),
+        CONTEXT_LINES,
+    )?;
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
@@ -183,7 +203,7 @@ fn replace_dir_with_file_discard_just_the_file_in_worktree() -> anyhow::Result<(
 ?? dir
 ");
 
-    let dropped = discard_workspace_changes(&repo, Some(file_to_spec("dir")))?;
+    let dropped = discard_workspace_changes(&repo, Some(file_to_spec("dir")), CONTEXT_LINES)?;
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
@@ -224,7 +244,7 @@ fn conflicts_are_invisible() -> anyhow::Result<()> {
 100644:e33f5e9 file
 ");
 
-    let dropped = discard_workspace_changes(&repo, Some(file_to_spec("file")))?;
+    let dropped = discard_workspace_changes(&repo, Some(file_to_spec("file")), CONTEXT_LINES)?;
     assert_eq!(
         dropped,
         vec![file_to_spec("file")],
@@ -259,7 +279,7 @@ D  dir/link
 D  dir/submodule
 ");
 
-    let dropped = discard_workspace_changes(&repo, Some(file_to_spec("dir")))?;
+    let dropped = discard_workspace_changes(&repo, Some(file_to_spec("dir")), CONTEXT_LINES)?;
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
@@ -307,7 +327,11 @@ M soon-not-executable
 └── soon-not-executable:100644
 ");
 
-    let dropped = discard_workspace_changes(&repo, worktree_changes_to_discard_specs(&repo))?;
+    let dropped = discard_workspace_changes(
+        &repo,
+        worktree_changes_to_discard_specs(&repo),
+        CONTEXT_LINES,
+    )?;
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
@@ -347,7 +371,11 @@ M  soon-not-executable
 └── soon-not-executable:100644
 ");
 
-    let dropped = discard_workspace_changes(&repo, worktree_changes_to_discard_specs(&repo))?;
+    let dropped = discard_workspace_changes(
+        &repo,
+        worktree_changes_to_discard_specs(&repo),
+        CONTEXT_LINES,
+    )?;
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
@@ -395,7 +423,11 @@ M submodule
 160000:a047f81 submodule
 ");
 
-    let dropped = discard_workspace_changes(&repo, worktree_changes_to_discard_specs(&repo))?;
+    let dropped = discard_workspace_changes(
+        &repo,
+        worktree_changes_to_discard_specs(&repo),
+        CONTEXT_LINES,
+    )?;
     assert!(dropped.is_empty());
 
     // The embedded repository we don't currently see due to a `gix` shortcoming - it ignores embedded repos
@@ -438,7 +470,11 @@ MM submodule
 160000:6d5e0a5 submodule
 ");
 
-    let dropped = discard_workspace_changes(&repo, worktree_changes_to_discard_specs(&repo))?;
+    let dropped = discard_workspace_changes(
+        &repo,
+        worktree_changes_to_discard_specs(&repo),
+        CONTEXT_LINES,
+    )?;
     assert!(dropped.is_empty());
 
     // `gix status` is able to see the 'embedded-repository' if it's in the index, and we can reset it as well.
@@ -474,7 +510,11 @@ fn all_file_types_renamed_and_modified_in_worktree() -> anyhow::Result<()> {
 └── link-renamed:120755
 ");
 
-    let dropped = discard_workspace_changes(&repo, worktree_changes_to_discard_specs(&repo))?;
+    let dropped = discard_workspace_changes(
+        &repo,
+        worktree_changes_to_discard_specs(&repo),
+        CONTEXT_LINES,
+    )?;
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
@@ -520,7 +560,11 @@ A  link-renamed
 └── link-renamed:120755
 ");
 
-    let dropped = discard_workspace_changes(&repo, worktree_changes_to_discard_specs(&repo))?;
+    let dropped = discard_workspace_changes(
+        &repo,
+        worktree_changes_to_discard_specs(&repo),
+        CONTEXT_LINES,
+    )?;
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
@@ -579,7 +623,11 @@ fn all_file_types_renamed_overwriting_existing_and_modified_in_worktree() -> any
 └── to-be-overwritten:100644
 ");
 
-    let dropped = discard_workspace_changes(&repo, worktree_changes_to_discard_specs(&repo))?;
+    let dropped = discard_workspace_changes(
+        &repo,
+        worktree_changes_to_discard_specs(&repo),
+        CONTEXT_LINES,
+    )?;
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
@@ -645,7 +693,11 @@ M  to-be-overwritten
 └── to-be-overwritten:100644
 ");
 
-    let dropped = discard_workspace_changes(&repo, worktree_changes_to_discard_specs(&repo))?;
+    let dropped = discard_workspace_changes(
+        &repo,
+        worktree_changes_to_discard_specs(&repo),
+        CONTEXT_LINES,
+    )?;
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
@@ -714,6 +766,7 @@ fn all_file_types_renamed_overwriting_existing_and_modified_in_worktree_discard_
             renamed_file_to_spec("executable", "dir-to-be-file"),
             renamed_file_to_spec("file", "file-to-be-dir/file"),
         ],
+        CONTEXT_LINES,
     )?;
     assert_eq!(dropped, []);
 
@@ -741,7 +794,11 @@ D file-to-be-dir
 
     // Try again with what remains, something that the user will likely do as well, not really knowing
     // why that is.
-    let dropped = discard_workspace_changes(&repo, worktree_changes_to_discard_specs(&repo))?;
+    let dropped = discard_workspace_changes(
+        &repo,
+        worktree_changes_to_discard_specs(&repo),
+        CONTEXT_LINES,
+    )?;
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @r"");
@@ -797,7 +854,11 @@ D a/sibling
 ");
 
     // This naturally starts with `a/sibling`
-    let dropped = discard_workspace_changes(&repo, worktree_changes_to_discard_specs(&repo))?;
+    let dropped = discard_workspace_changes(
+        &repo,
+        worktree_changes_to_discard_specs(&repo),
+        CONTEXT_LINES,
+    )?;
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
@@ -845,6 +906,7 @@ D a/sibling
             renamed_file_to_spec("a/b/link", "a/sibling/link"),
             file_to_spec("a/sibling"),
         ],
+        CONTEXT_LINES,
     )?;
     assert!(dropped.is_empty());
 
@@ -880,7 +942,11 @@ R  a/b/file -> a/sibling/file
 R  a/b/link -> a/sibling/link
 ");
 
-    let dropped = discard_workspace_changes(&repo, worktree_changes_to_discard_specs(&repo))?;
+    let dropped = discard_workspace_changes(
+        &repo,
+        worktree_changes_to_discard_specs(&repo),
+        CONTEXT_LINES,
+    )?;
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");
@@ -916,7 +982,11 @@ D submodule
 ");
     git(&repo).args(["add", "."]).run();
 
-    let dropped = discard_workspace_changes(&repo, worktree_changes_to_discard_specs(&repo))?;
+    let dropped = discard_workspace_changes(
+        &repo,
+        worktree_changes_to_discard_specs(&repo),
+        CONTEXT_LINES,
+    )?;
     assert!(dropped.is_empty());
 
     insta::assert_snapshot!(git_status(&repo)?, @"");

--- a/crates/but-workspace/tests/workspace/discard/hunk.rs
+++ b/crates/but-workspace/tests/workspace/discard/hunk.rs
@@ -1,17 +1,179 @@
+use crate::discard::hunk::util::hunk_header;
+use crate::utils::{
+    CONTEXT_LINES, read_only_in_memory_scenario, to_change_specs_all_hunks, visualize_index,
+    writable_scenario,
+};
+use but_testsupport::git_status;
+use but_workspace::commit_engine::DiffSpec;
+use but_workspace::discard_workspace_changes;
+
 #[test]
-#[ignore = "TBD"]
 fn non_modifications_trigger_error() -> anyhow::Result<()> {
+    let repo = read_only_in_memory_scenario("deletion-addition-untracked")?;
+    insta::assert_snapshot!(git_status(&repo)?, @r"
+    A  added-to-index
+     D to-be-deleted
+    D  to-be-deleted-in-index
+    ?? untracked
+    ");
+
+    let add_single_line = hunk_header("-1,0", "+1,1");
+    let remove_single_line = hunk_header("-1,1", "+1,0");
+    for (file_name, hunk) in [
+        ("untracked", add_single_line),
+        ("added-to-index", add_single_line),
+        ("to-be-deleted", remove_single_line),
+        ("to-be-deleted-in-index", remove_single_line),
+    ] {
+        let err = discard_workspace_changes(
+            &repo,
+            Some(
+                DiffSpec {
+                    previous_path: None,
+                    path: file_name.into(),
+                    hunk_headers: vec![hunk],
+                }
+                .into(),
+            ),
+            CONTEXT_LINES,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().starts_with(
+                "Deletions or additions aren't well-defined for hunk-based operations - use the whole-file mode instead"
+            ),
+        );
+    }
     Ok(())
 }
 
 #[test]
-#[ignore = "TBD"]
-fn deletion_modification_addition_mixed_in_worktree() -> anyhow::Result<()> {
+fn deletion_modification_addition_of_hunks_mixed_discard_all_in_workspace() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario("mixed-hunk-modifications");
+    // Note that one of these renames can't be detected by Git but is visible to us.
+    insta::assert_snapshot!(git_status(&repo)?, @r"
+     M file
+    M  file-in-index
+    RM file-to-be-renamed-in-index -> file-renamed-in-index
+     D file-to-be-renamed
+    ?? file-renamed
+    ");
+
+    // Show that we detect renames correctly, despite the rename + modification.
+    let wt_changes = but_core::diff::worktree_changes(&repo)?;
+    insta::assert_debug_snapshot!(wt_changes.changes, @r#"
+    [
+        TreeChange {
+            path: "file",
+            status: Modification {
+                previous_state: ChangeState {
+                    id: Sha1(3d3b36f021391fa57312d7dfd1ad8cf5a13dca6d),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Blob,
+                },
+                flags: None,
+            },
+        },
+        TreeChange {
+            path: "file-in-index",
+            status: Modification {
+                previous_state: ChangeState {
+                    id: Sha1(3d3b36f021391fa57312d7dfd1ad8cf5a13dca6d),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(cb89473a55c3443b5567e990e2a0293895c91a4a),
+                    kind: Blob,
+                },
+                flags: None,
+            },
+        },
+        TreeChange {
+            path: "file-renamed",
+            status: Rename {
+                previous_path: "file-to-be-renamed",
+                previous_state: ChangeState {
+                    id: Sha1(3d3b36f021391fa57312d7dfd1ad8cf5a13dca6d),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Blob,
+                },
+                flags: None,
+            },
+        },
+        TreeChange {
+            path: "file-renamed-in-index",
+            status: Rename {
+                previous_path: "file-to-be-renamed-in-index",
+                previous_state: ChangeState {
+                    id: Sha1(3d3b36f021391fa57312d7dfd1ad8cf5a13dca6d),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Blob,
+                },
+                flags: None,
+            },
+        },
+    ]
+    "#);
+
+    let specs = to_change_specs_all_hunks(&repo, wt_changes)?;
+    let dropped =
+        discard_workspace_changes(&repo, specs.into_iter().map(Into::into), CONTEXT_LINES)?;
+    assert!(dropped.is_empty());
+
+    // TODO: this most definitely isn't correct, figure out what's going on.
+    // Notably, discarding all hunks leaves the renamed file in place, but without modifications.
+    insta::assert_snapshot!(git_status(&repo)?, @r"
+    MM file-in-index
+    R  file-to-be-renamed-in-index -> file-renamed-in-index
+     D file-to-be-renamed
+    ?? file-renamed
+    ");
+    // The index still only holds what was in the index before, but is representing the changed worktree.
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    100644:3d3b36f file
+    100644:cb89473 file-in-index
+    100644:3d3b36f file-renamed-in-index
+    100644:3d3b36f file-to-be-renamed
+    ");
+
+    // TODO: content checks.
+
     Ok(())
 }
 
-#[test]
-#[ignore = "TBD"]
-fn deletion_modification_addition_mixed_in_index() -> anyhow::Result<()> {
-    Ok(())
+mod util {
+    use but_workspace::commit_engine::HunkHeader;
+
+    /// Choose a slightly more obvious, yet easy to type syntax than a function with 4 parameters.
+    pub fn hunk_header(old: &str, new: &str) -> HunkHeader {
+        fn parse_header(hunk_info: &str) -> (u32, u32) {
+            let hunk_info = hunk_info.trim_start_matches(['-', '+'].as_slice());
+            let parts: Vec<_> = hunk_info.split(',').collect();
+            let start = parts[0].parse().unwrap();
+            let lines = if parts.len() > 1 {
+                parts[1].parse().unwrap()
+            } else {
+                1
+            };
+            (start, lines)
+        }
+
+        let (old_start, old_lines) = parse_header(old);
+        let (new_start, new_lines) = parse_header(new);
+        HunkHeader {
+            old_start,
+            old_lines,
+            new_start,
+            new_lines,
+        }
+    }
 }

--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -206,9 +206,10 @@ pub fn amend_commit_from_worktree_changes(
 ///
 /// Returns the `worktree_changes` that couldn't be applied,
 #[tauri::command(async)]
-#[instrument(skip(projects), err(Debug))]
+#[instrument(skip(projects, settings), err(Debug))]
 pub fn discard_worktree_changes(
     projects: State<'_, projects::Controller>,
+    settings: State<'_, AppSettingsWithDiskSync>,
     project_id: ProjectId,
     worktree_changes: Vec<but_workspace::discard::ui::DiscardSpec>,
 ) -> Result<Vec<but_workspace::discard::ui::DiscardSpec>, Error> {
@@ -223,6 +224,7 @@ pub fn discard_worktree_changes(
                 change,
             ))
         }),
+        settings.get()?.context_lines,
     )?;
     Ok(refused
         .into_iter()


### PR DESCRIPTION
Add V3 facilities for discarding changes in the worktree or index, this time it's about hunks specifically.

Follow-up of #7677.

### Tasks

* [x] finish remaining cases for tree-index-wt merge
* [x] see if existing implementation in commit-engine can be used for that (and refactor to make it usable)
* [ ] reset changed hunks in a file
    - [ ] assure test for executable bits
    - [ ] test for a dropped hunk
* [ ] use latest version of `gix`


### Notes for the reviewer

* I find it difficult to imagine how meaningful discarding parts of hunks in whole-file deletions and additions can be so I chose to disallow it. The UI can still offer discarding the single whole hunk that a deletion or addition of a file would come with, but internally it, as always, would discard the file instead. Discarding of lines or selections would have to be disallowed on the UI level though, as this is currently only available for modified (or renamed + modified) files.

### For the next PRs

* **reset individual lines** (but as free selections of sub-hunks)
    - How does this work with context lines? In theory, they will mess everything up so it's probably something to avoid. After all, they will combine multiple hunks into one and the UI really would have to provide hunks without them.
* **See what happens if one tries to commit these special cases** (i.e. the 'pretend there is  no index' changes)
    - implement remaining ignored cases
* **gitoxide informs about diff-filter changes** and this information is passed to the frontend
    - differentiate binary-to-text , otherwise it applies worktree conversions (which is fine). We ignore external diff programs anyway.



### Shortcomings

* Index-handling is low-level and I think there needs to be something like a tree-editor, but for indices. Maybe it's a mix of using the pretty-neat tree-editor, and a way to transfer index information from one index to another, similar to 'apply', to avoid loosing information.

### Out of Scope

* snapshot integration - should be left to @krlvi to warm up with the new code.

### Research

* **V2 implementation**
    - spread across `unapply_lines`, `unapply_ownership` and `reset_files`


