### PR TITLE
Keep the commit selection even after editing a commit

### DIFF
--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -450,7 +450,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				}
 			}),
 			updateCommitMessage: build.mutation<
-				void,
+				string,
 				{ projectId: string; stackId: string; commitId: string; message: string }
 			>({
 				query: ({ projectId, stackId, commitId, message }) => ({

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -503,7 +503,7 @@ pub fn update_commit_message(
     stack_id: StackId,
     commit_oid: git2::Oid,
     message: &str,
-) -> Result<()> {
+) -> Result<git2::Oid> {
     ctx.verify()?;
     assure_open_workspace_mode(ctx)
         .context("Updating a commit message requires open workspace mode")?;

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -1375,7 +1375,7 @@ pub(crate) fn update_commit_message(
     stack_id: StackId,
     commit_id: git2::Oid,
     message: &str,
-) -> Result<()> {
+) -> Result<git2::Oid> {
     if message.is_empty() {
         bail!("commit message can not be empty");
     }
@@ -1442,7 +1442,7 @@ pub(crate) fn update_commit_message(
 
     crate::integration::update_workspace_commit(&vb_state, ctx)
         .context("failed to update gitbutler workspace")?;
-    Ok(())
+    Ok(new_commit_oid)
 }
 
 // Goes through a set of changes and checks if conflicts are present. If no conflicts

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -618,13 +618,14 @@ pub mod commands {
         branch_id: StackId,
         commit_oid: String,
         message: &str,
-    ) -> Result<(), Error> {
+    ) -> Result<String, Error> {
         let project = projects.get(project_id)?;
         let ctx = CommandContext::open(&project, settings.get()?.clone())?;
         let commit_oid = git2::Oid::from_str(&commit_oid).map_err(|e| anyhow!(e))?;
-        gitbutler_branch_actions::update_commit_message(&ctx, branch_id, commit_oid, message)?;
+        let new_commit_oid =
+            gitbutler_branch_actions::update_commit_message(&ctx, branch_id, commit_oid, message)?;
         emit_vbranches(&windows, project_id, ctx.app_settings());
-        Ok(())
+        Ok(new_commit_oid.to_string())
     }
 
     #[tauri::command(async)]


### PR DESCRIPTION
**Changes Made:**
- Modified the API to ensure that when a commit message is edited, it returns a new commit ID. This change is crucial for the frontend to accurately keep track of the selected commit.
- Updated the logic to refresh the selection based on the new commit ID returned after the edit operation.