### PR TITLE
PR templates: Accept docs and root templates

### DIFF
--- a/crates/gitbutler-tauri/src/forge.rs
+++ b/crates/gitbutler-tauri/src/forge.rs
@@ -41,7 +41,7 @@ pub mod commands {
             ..
         } = get_review_template_functions(&forge);
 
-        if !is_valid_review_template_path(relative_path, &project.path) {
+        if !is_valid_review_template_path(relative_path) {
             return Err(anyhow::format_err!(
                 "Invalid review template path: {:?}",
                 Path::join(&project.path, relative_path)


### PR DESCRIPTION
Match the valid pr template paths from https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository#adding-a-pull-request-template