### PR TITLE
discard changes: hunks part 2

### DIFF
--- a/crates/but-cli/src/args.rs
+++ b/crates/but-cli/src/args.rs
@@ -46,14 +46,18 @@ pub enum Subcommands {
     /// List all uncommitted working tree changes.
     Status {
         /// Also compute unified diffs for each tree-change.
-        #[clap(long, short = 'c', default_value_t = 3)]
+        #[clap(long, short = 'c', default_value_t = crate::command::UI_CONTEXT_LINES)]
         context_lines: u32,
         /// Also compute unified diffs for each tree-change.
         #[clap(long, short = 'd')]
         unified_diff: bool,
     },
     /// Discard the specified worktree change.
+    #[clap(disable_help_flag(true))]
     DiscardChange {
+        /// The zero-based indices of all hunks to discard.
+        #[clap(long, short = 'h')]
+        hunk_indices: Vec<usize>,
         /// The repo-relative path to the changed file to discard.
         current_path: PathBuf,
         /// If the change is a rename, identify the repo-relative path of the source.

--- a/crates/but-cli/src/main.rs
+++ b/crates/but-cli/src/main.rs
@@ -17,9 +17,15 @@ fn main() -> Result<()> {
 
     match &args.cmd {
         args::Subcommands::DiscardChange {
+            hunk_indices,
             current_path,
             previous_path,
-        } => command::discard_change(&args.current_dir, current_path, previous_path.as_deref()),
+        } => command::discard_change(
+            &args.current_dir,
+            current_path,
+            previous_path.as_deref(),
+            hunk_indices,
+        ),
         args::Subcommands::Commit {
             message,
             amend,

--- a/crates/but-workspace/tests/fixtures/scenario/mixed-hunk-modifications.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/mixed-hunk-modifications.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 
 ### Description
-# A single tracked file, modified in the workspace to have:
-# - added lines at the beginning
-# - deleted lines at the end
-# - modified lines, added lines, and deleted lines directly after one another in the middle.
+# Various files, of which two are in the worktree (with changes) and in the index (with changes).
+# Another pair of files was deleted, both in the worktree and in the index.
+# Lastly, each of these have specific worktree modifications in multiple hunks, and a plain file was made
+# executable in the index, and another rename destination was made executable, too.
+# Lastly, a simple file was executable, which isn't executable anymore.
 set -eu -o pipefail
 
 git init
-seq 5 18 >file
+seq 5 18 >file && chmod +x file
 seq 5 18 >file-in-index
 seq 5 18 >file-to-be-renamed
 seq 5 18 >file-to-be-renamed-in-index
@@ -33,10 +34,17 @@ eleven
 16
 EOF
 
-cp file file-in-index && git add file-in-index
+chmod -x file
+
+cp file file-in-index && \
+  chmod +x file-in-index && \
+  git add file-in-index
 
 
-seq 2 18 >file-to-be-renamed && mv file-to-be-renamed file-renamed
-cp file file-to-be-renamed-in-index && git mv file-to-be-renamed-in-index file-renamed-in-index
+seq 2 18 >file-to-be-renamed && \
+  mv file-to-be-renamed file-renamed && \
+  chmod +x file-renamed
+cp file file-to-be-renamed-in-index && \
+  git mv file-to-be-renamed-in-index file-renamed-in-index
 
 

--- a/crates/but-workspace/tests/workspace/discard/file.rs
+++ b/crates/but-workspace/tests/workspace/discard/file.rs
@@ -969,7 +969,7 @@ R  a/b/link -> a/sibling/link
     Ok(())
 }
 
-// Copy of `all_file_types_deleted_in_worktree`, but can't be loop due to `insta`.
+// Copy of `all_file_types_deleted_in_worktree`, could also be a loop but insta::allow_duplicates!() isn't pretty.
 #[test]
 #[cfg(unix)]
 fn all_file_types_deleted_in_index() -> anyhow::Result<()> {

--- a/crates/but-workspace/tests/workspace/discard/hunk.rs
+++ b/crates/but-workspace/tests/workspace/discard/hunk.rs
@@ -1,10 +1,12 @@
-use crate::discard::hunk::util::hunk_header;
+use crate::discard::hunk::util::{hunk_header, previous_change_text};
 use crate::utils::{
     CONTEXT_LINES, read_only_in_memory_scenario, to_change_specs_all_hunks, visualize_index,
     writable_scenario,
 };
-use but_testsupport::git_status;
-use but_workspace::commit_engine::DiffSpec;
+use bstr::{BString, ByteSlice};
+use but_core::UnifiedDiff;
+use but_testsupport::{git_status, visualize_disk_tree_skip_dot_git};
+use but_workspace::commit_engine::{DiffSpec, HunkHeader};
 use but_workspace::discard_workspace_changes;
 
 #[test]
@@ -48,6 +50,235 @@ fn non_modifications_trigger_error() -> anyhow::Result<()> {
 }
 
 #[test]
+fn hunk_removal_from_end() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario("mixed-hunk-modifications");
+    let mut hunk_info = Vec::new();
+    let filename = "file-in-index";
+    let file_content = || std::fs::read(repo.workdir().unwrap().join(filename)).map(BString::from);
+    insta::assert_snapshot!(file_content()?, @r"
+    1
+    2
+    3
+    4
+    5
+    6-7
+    8
+    9
+    ten
+    eleven
+    12
+    20
+    21
+    22
+    15
+    16
+    ");
+    while let Some(change) = but_core::diff::worktree_changes(&repo)?
+        .changes
+        .into_iter()
+        .find(|change| change.path == "file-in-index")
+    {
+        let previous_text = previous_change_text(&repo, &change)?;
+        insta::allow_duplicates!(insta::assert_snapshot!(previous_text, @r"
+        5
+        6
+        7
+        8
+        9
+        10
+        11
+        12
+        13
+        14
+        15
+        16
+        17
+        18
+        "));
+        let UnifiedDiff::Patch { mut hunks } = change.unified_diff(&repo, CONTEXT_LINES)? else {
+            unreachable!("We know there are hunks")
+        };
+        assert_ne!(
+            hunks.len(),
+            0,
+            "the reason we see it is file modifications: {change:#?}"
+        );
+
+        let before = file_content()?;
+        let mut last_hunk = hunks
+            .pop()
+            .expect("there is always one change if the file is only modified");
+        let discarded_patch = std::mem::take(&mut last_hunk.diff);
+        let discard_spec = DiffSpec {
+            previous_path: None,
+            path: change.path.clone(),
+            hunk_headers: vec![last_hunk.into()],
+        };
+        let dropped = discard_workspace_changes(&repo, Some(discard_spec.into()), CONTEXT_LINES)?;
+        assert_eq!(
+            dropped.len(),
+            0,
+            "the hunk could be found and was discarded"
+        );
+        let after = file_content()?;
+        hunk_info.push((before, discarded_patch, after));
+    }
+
+    insta::assert_debug_snapshot!(hunk_info, @r#"
+    [
+        (
+            "1\n2\n3\n4\n5\n6-7\n8\n9\nten\neleven\n12\n20\n21\n22\n15\n16\n",
+            "@@ -13,2 +17,0 @@\n-17\n-18\n",
+            "1\n2\n3\n4\n5\n6-7\n8\n9\nten\neleven\n12\n20\n21\n22\n15\n16\n17\n18\n",
+        ),
+        (
+            "1\n2\n3\n4\n5\n6-7\n8\n9\nten\neleven\n12\n20\n21\n22\n15\n16\n17\n18\n",
+            "@@ -9,2 +12,3 @@\n-13\n-14\n+20\n+21\n+22\n",
+            "1\n2\n3\n4\n5\n6-7\n8\n9\nten\neleven\n12\n13\n14\n15\n16\n17\n18\n",
+        ),
+        (
+            "1\n2\n3\n4\n5\n6-7\n8\n9\nten\neleven\n12\n13\n14\n15\n16\n17\n18\n",
+            "@@ -6,2 +9,2 @@\n-10\n-11\n+ten\n+eleven\n",
+            "1\n2\n3\n4\n5\n6-7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n",
+        ),
+        (
+            "1\n2\n3\n4\n5\n6-7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n",
+            "@@ -2,2 +6,1 @@\n-6\n-7\n+6-7\n",
+            "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n",
+        ),
+        (
+            "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n",
+            "@@ -1,0 +1,4 @@\n+1\n+2\n+3\n+4\n",
+            "5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n",
+        ),
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn dropped_hunks() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario("mixed-hunk-modifications");
+    let change = but_core::diff::worktree_changes(&repo)?
+        .changes
+        .into_iter()
+        .find(|change| change.path == "file")
+        .expect("known to have modifications");
+
+    let UnifiedDiff::Patch { hunks } = change.unified_diff(&repo, CONTEXT_LINES)? else {
+        unreachable!("We know there are hunks")
+    };
+
+    let mut hunks_to_discard: Vec<HunkHeader> = hunks.into_iter().map(Into::into).collect();
+    hunks_to_discard.push(hunk_header("-10,1", "+13,3"));
+    hunks_to_discard.insert(0, hunk_header("-1,1", "+1,0"));
+
+    let discard_spec = DiffSpec {
+        previous_path: None,
+        path: change.path,
+        hunk_headers: hunks_to_discard,
+    };
+    let dropped = discard_workspace_changes(&repo, Some(discard_spec.into()), CONTEXT_LINES)?;
+    // It drops just the two missing ones hunks
+    insta::assert_debug_snapshot!(dropped, @r#"
+    [
+        DiscardSpec(
+            DiffSpec {
+                previous_path: None,
+                path: "file",
+                hunk_headers: [
+                    HunkHeader {
+                        old_start: 1,
+                        old_lines: 1,
+                        new_start: 1,
+                        new_lines: 0,
+                    },
+                    HunkHeader {
+                        old_start: 10,
+                        old_lines: 1,
+                        new_start: 13,
+                        new_lines: 3,
+                    },
+                ],
+            },
+        ),
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn hunk_removal_from_beginning() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario("mixed-hunk-modifications");
+    let mut hunk_info = Vec::new();
+    let filename = "file-in-index";
+    let file_content = || std::fs::read(repo.workdir().unwrap().join(filename)).map(BString::from);
+    while let Some(change) = but_core::diff::worktree_changes(&repo)?
+        .changes
+        .into_iter()
+        .find(|change| change.path == "file-in-index")
+    {
+        let UnifiedDiff::Patch { mut hunks } = change.unified_diff(&repo, CONTEXT_LINES)? else {
+            unreachable!("We know there are hunks")
+        };
+        assert_ne!(
+            hunks.len(),
+            0,
+            "the reason we see it is file modifications: {change:#?}"
+        );
+
+        let before = file_content()?;
+        let mut first_hun_hunk = hunks.remove(0);
+        let discarded_patch = std::mem::take(&mut first_hun_hunk.diff);
+        let discard_spec = DiffSpec {
+            previous_path: None,
+            path: change.path.clone(),
+            hunk_headers: vec![first_hun_hunk.into()],
+        };
+        let dropped = discard_workspace_changes(&repo, Some(discard_spec.into()), CONTEXT_LINES)?;
+        assert_eq!(
+            dropped.len(),
+            0,
+            "the hunk could be found and was discarded"
+        );
+        let after = file_content()?;
+        hunk_info.push((before, discarded_patch, after));
+    }
+
+    insta::assert_debug_snapshot!(hunk_info, @r#"
+    [
+        (
+            "1\n2\n3\n4\n5\n6-7\n8\n9\nten\neleven\n12\n20\n21\n22\n15\n16\n",
+            "@@ -1,0 +1,4 @@\n+1\n+2\n+3\n+4\n",
+            "5\n6-7\n8\n9\nten\neleven\n12\n20\n21\n22\n15\n16\n",
+        ),
+        (
+            "5\n6-7\n8\n9\nten\neleven\n12\n20\n21\n22\n15\n16\n",
+            "@@ -2,2 +2,1 @@\n-6\n-7\n+6-7\n",
+            "5\n6\n7\n8\n9\nten\neleven\n12\n20\n21\n22\n15\n16\n",
+        ),
+        (
+            "5\n6\n7\n8\n9\nten\neleven\n12\n20\n21\n22\n15\n16\n",
+            "@@ -6,2 +6,2 @@\n-10\n-11\n+ten\n+eleven\n",
+            "5\n6\n7\n8\n9\n10\n11\n12\n20\n21\n22\n15\n16\n",
+        ),
+        (
+            "5\n6\n7\n8\n9\n10\n11\n12\n20\n21\n22\n15\n16\n",
+            "@@ -9,2 +9,3 @@\n-13\n-14\n+20\n+21\n+22\n",
+            "5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n",
+        ),
+        (
+            "5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n",
+            "@@ -13,2 +13,0 @@\n-17\n-18\n",
+            "5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n",
+        ),
+    ]
+    "#);
+    Ok(())
+}
+
+#[test]
+#[cfg(unix)]
 fn deletion_modification_addition_of_hunks_mixed_discard_all_in_workspace() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario("mixed-hunk-modifications");
     // Note that one of these renames can't be detected by Git but is visible to us.
@@ -59,69 +290,100 @@ fn deletion_modification_addition_of_hunks_mixed_discard_all_in_workspace() -> a
     ?? file-renamed
     ");
 
+    insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
+    100755:3d3b36f file
+    100755:cb89473 file-in-index
+    100644:3d3b36f file-renamed-in-index
+    100644:3d3b36f file-to-be-renamed
+    ");
+
+    let workdir = repo.workdir().unwrap();
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(workdir)?, @r"
+    .
+    ├── .git:40755
+    ├── file:100644
+    ├── file-in-index:100755
+    ├── file-renamed:100755
+    └── file-renamed-in-index:100644
+    ");
+
     // Show that we detect renames correctly, despite the rename + modification.
     let wt_changes = but_core::diff::worktree_changes(&repo)?;
-    insta::assert_debug_snapshot!(wt_changes.changes, @r#"
-    [
-        TreeChange {
-            path: "file",
-            status: Modification {
-                previous_state: ChangeState {
-                    id: Sha1(3d3b36f021391fa57312d7dfd1ad8cf5a13dca6d),
-                    kind: Blob,
+    insta::assert_debug_snapshot!(wt_changes, @r#"
+    WorktreeChanges {
+        changes: [
+            TreeChange {
+                path: "file",
+                status: Modification {
+                    previous_state: ChangeState {
+                        id: Sha1(3d3b36f021391fa57312d7dfd1ad8cf5a13dca6d),
+                        kind: BlobExecutable,
+                    },
+                    state: ChangeState {
+                        id: Sha1(0000000000000000000000000000000000000000),
+                        kind: Blob,
+                    },
+                    flags: Some(
+                        ExecutableBitRemoved,
+                    ),
                 },
-                state: ChangeState {
-                    id: Sha1(0000000000000000000000000000000000000000),
-                    kind: Blob,
-                },
-                flags: None,
             },
-        },
-        TreeChange {
-            path: "file-in-index",
-            status: Modification {
-                previous_state: ChangeState {
-                    id: Sha1(3d3b36f021391fa57312d7dfd1ad8cf5a13dca6d),
-                    kind: Blob,
+            TreeChange {
+                path: "file-in-index",
+                status: Modification {
+                    previous_state: ChangeState {
+                        id: Sha1(3d3b36f021391fa57312d7dfd1ad8cf5a13dca6d),
+                        kind: Blob,
+                    },
+                    state: ChangeState {
+                        id: Sha1(cb89473a55c3443b5567e990e2a0293895c91a4a),
+                        kind: BlobExecutable,
+                    },
+                    flags: Some(
+                        ExecutableBitAdded,
+                    ),
                 },
-                state: ChangeState {
-                    id: Sha1(cb89473a55c3443b5567e990e2a0293895c91a4a),
-                    kind: Blob,
-                },
-                flags: None,
             },
-        },
-        TreeChange {
-            path: "file-renamed",
-            status: Rename {
-                previous_path: "file-to-be-renamed",
-                previous_state: ChangeState {
-                    id: Sha1(3d3b36f021391fa57312d7dfd1ad8cf5a13dca6d),
-                    kind: Blob,
+            TreeChange {
+                path: "file-renamed",
+                status: Rename {
+                    previous_path: "file-to-be-renamed",
+                    previous_state: ChangeState {
+                        id: Sha1(3d3b36f021391fa57312d7dfd1ad8cf5a13dca6d),
+                        kind: Blob,
+                    },
+                    state: ChangeState {
+                        id: Sha1(0000000000000000000000000000000000000000),
+                        kind: BlobExecutable,
+                    },
+                    flags: Some(
+                        ExecutableBitAdded,
+                    ),
                 },
-                state: ChangeState {
-                    id: Sha1(0000000000000000000000000000000000000000),
-                    kind: Blob,
-                },
-                flags: None,
             },
-        },
-        TreeChange {
-            path: "file-renamed-in-index",
-            status: Rename {
-                previous_path: "file-to-be-renamed-in-index",
-                previous_state: ChangeState {
-                    id: Sha1(3d3b36f021391fa57312d7dfd1ad8cf5a13dca6d),
-                    kind: Blob,
+            TreeChange {
+                path: "file-renamed-in-index",
+                status: Rename {
+                    previous_path: "file-to-be-renamed-in-index",
+                    previous_state: ChangeState {
+                        id: Sha1(3d3b36f021391fa57312d7dfd1ad8cf5a13dca6d),
+                        kind: Blob,
+                    },
+                    state: ChangeState {
+                        id: Sha1(0000000000000000000000000000000000000000),
+                        kind: Blob,
+                    },
+                    flags: None,
                 },
-                state: ChangeState {
-                    id: Sha1(0000000000000000000000000000000000000000),
-                    kind: Blob,
-                },
-                flags: None,
             },
-        },
-    ]
+        ],
+        ignored_changes: [
+            IgnoredWorktreeChange {
+                path: "file-renamed-in-index",
+                status: TreeIndex,
+            },
+        ],
+    }
     "#);
 
     let specs = to_change_specs_all_hunks(&repo, wt_changes)?;
@@ -129,9 +391,32 @@ fn deletion_modification_addition_of_hunks_mixed_discard_all_in_workspace() -> a
         discard_workspace_changes(&repo, specs.into_iter().map(Into::into), CONTEXT_LINES)?;
     assert!(dropped.is_empty());
 
-    // TODO: this most definitely isn't correct, figure out what's going on.
+    insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
+    .
+    ├── .git:40755
+    ├── file:100644
+    ├── file-in-index:100755
+    ├── file-renamed:100755
+    └── file-renamed-in-index:100644
+    ");
+
+    for filename in [
+        "file",
+        "file-in-index",
+        "file-renamed",
+        "file-renamed-in-index",
+    ] {
+        let content = std::fs::read(workdir.join(filename))?;
+        assert_eq!(
+            content.as_bstr(),
+            "5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n",
+            "{filename}: All files have the same content after worktree-discards"
+        );
+    }
+
     // Notably, discarding all hunks leaves the renamed file in place, but without modifications.
     insta::assert_snapshot!(git_status(&repo)?, @r"
+     M file
     MM file-in-index
     R  file-to-be-renamed-in-index -> file-renamed-in-index
      D file-to-be-renamed
@@ -139,19 +424,100 @@ fn deletion_modification_addition_of_hunks_mixed_discard_all_in_workspace() -> a
     ");
     // The index still only holds what was in the index before, but is representing the changed worktree.
     insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
-    100644:3d3b36f file
-    100644:cb89473 file-in-index
+    100755:3d3b36f file
+    100755:cb89473 file-in-index
     100644:3d3b36f file-renamed-in-index
     100644:3d3b36f file-to-be-renamed
     ");
 
-    // TODO: content checks.
+    // The index is transparent, so `file-in-index` was reverted to the version in the `HEAD^{tree}`
+    let wt_changes = but_core::diff::worktree_changes(&repo)?;
+    insta::assert_debug_snapshot!(wt_changes, @r#"
+    WorktreeChanges {
+        changes: [
+            TreeChange {
+                path: "file",
+                status: Modification {
+                    previous_state: ChangeState {
+                        id: Sha1(3d3b36f021391fa57312d7dfd1ad8cf5a13dca6d),
+                        kind: BlobExecutable,
+                    },
+                    state: ChangeState {
+                        id: Sha1(0000000000000000000000000000000000000000),
+                        kind: Blob,
+                    },
+                    flags: Some(
+                        ExecutableBitRemoved,
+                    ),
+                },
+            },
+            TreeChange {
+                path: "file-renamed",
+                status: Rename {
+                    previous_path: "file-to-be-renamed",
+                    previous_state: ChangeState {
+                        id: Sha1(3d3b36f021391fa57312d7dfd1ad8cf5a13dca6d),
+                        kind: Blob,
+                    },
+                    state: ChangeState {
+                        id: Sha1(0000000000000000000000000000000000000000),
+                        kind: BlobExecutable,
+                    },
+                    flags: Some(
+                        ExecutableBitAdded,
+                    ),
+                },
+            },
+            TreeChange {
+                path: "file-renamed-in-index",
+                status: Rename {
+                    previous_path: "file-to-be-renamed-in-index",
+                    previous_state: ChangeState {
+                        id: Sha1(3d3b36f021391fa57312d7dfd1ad8cf5a13dca6d),
+                        kind: Blob,
+                    },
+                    state: ChangeState {
+                        id: Sha1(3d3b36f021391fa57312d7dfd1ad8cf5a13dca6d),
+                        kind: Blob,
+                    },
+                    flags: None,
+                },
+            },
+        ],
+        ignored_changes: [
+            IgnoredWorktreeChange {
+                path: "file-in-index",
+                status: TreeIndexWorktreeChangeIneffective,
+            },
+        ],
+    }
+    "#);
 
     Ok(())
 }
 
 mod util {
+    use bstr::BString;
+    use but_core::TreeChange;
     use but_workspace::commit_engine::HunkHeader;
+    use gix::prelude::ObjectIdExt;
+
+    pub fn previous_change_text(
+        repo: &gix::Repository,
+        change: &TreeChange,
+    ) -> anyhow::Result<BString> {
+        Ok(change
+            .status
+            .previous_state_and_path()
+            .expect("modification")
+            .0
+            .id
+            .attach(repo)
+            .object()?
+            .detach()
+            .data
+            .into())
+    }
 
     /// Choose a slightly more obvious, yet easy to type syntax than a function with 4 parameters.
     pub fn hunk_header(old: &str, new: &str) -> HunkHeader {


### PR DESCRIPTION
Add V3 facilities for discarding changes in the worktree or index, this time it's about hunks specifically.

Follow-up of #7752.

### Tasks

* [x] reset changed hunks in a file
    - [x] assure test for executable bits
    - [x] test for a dropped hunk
    - [x] should the index be updated after all? - No
    - [x] figure out what's wrong with the hunk application - it already does the wrong thing 'in the middle', maybe it never worked 100% correctly, or maybe there are assumptions an additive approach?
* [x] ~~use latest version of `gix`~~ - nothing essential


### Notes for the reviewer

* I find it difficult to imagine how meaningful discarding parts of hunks in whole-file deletions and additions can be so I chose to disallow it. The UI can still offer discarding the single whole hunk that a deletion or addition of a file would come with, but internally it, as always, would discard the file instead. Discarding of lines or selections would have to be disallowed on the UI level though, as this is currently only available for modified (or renamed + modified) files.

### For the next PRs

* **reset individual lines** (but as free selections of sub-hunks)
    - How does this work with context lines? In theory, they will mess everything up so it's probably something to avoid. After all, they will combine multiple hunks into one and the UI really would have to provide hunks without them.
* **See what happens if one tries to commit these special cases** (i.e. the 'pretend there is  no index' changes)
    - implement remaining ignored cases
* **gitoxide informs about diff-filter changes** and this information is passed to the frontend
    - differentiate binary-to-text , otherwise it applies worktree conversions (which is fine). We ignore external diff programs anyway.



### Shortcomings

* Index-handling is low-level and I think there needs to be something like a tree-editor, but for indices. Maybe it's a mix of using the pretty-neat tree-editor, and a way to transfer index information from one index to another, similar to 'apply', to avoid loosing information.

### Out of Scope

* snapshot integration - should be left to @krlvi to warm up with the new code.

### Research

* **V2 implementation**
    - spread across `unapply_lines`, `unapply_ownership` and `reset_files`


