### PR TITLE
fix: update copyright year in tauri configuration

### DIFF
--- a/crates/gitbutler-tauri/tauri.conf.json
+++ b/crates/gitbutler-tauri/tauri.conf.json
@@ -10,7 +10,7 @@
 	"bundle": {
 		"active": false,
 		"category": "DeveloperTool",
-		"copyright": "Copyright © 2023-2024 GitButler. All rights reserved.",
+		"copyright": "Copyright © 2023-2025 GitButler. All rights reserved.",
 		"createUpdaterArtifacts": "v1Compatible",
 		"targets": [
 			"app",


### PR DESCRIPTION
Updates the copyright year in the tauri configuration file  to reflect the current year, ensuring compliance with  intellectual property standards.

## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
