### PR TITLE
fix: auto detect system os to download correct target

### DIFF
--- a/apps/web/src/app.d.ts
+++ b/apps/web/src/app.d.ts
@@ -9,6 +9,21 @@ declare global {
 		// interface PageState {}
 		// interface Platform {}
 	}
+
+	declare interface Navigator {
+		userAgentData?: {
+			getHighEntropyValues(hints: string[]): Promise<{
+				readonly brands?: { readonly brand: string; readonly version: string }[];
+				readonly mobile?: boolean;
+				readonly platform?: string;
+				readonly architecture?: string;
+				readonly bitness?: string;
+				readonly formFactor?: string[];
+				readonly model?: string;
+				readonly platformVersion?: string;
+			}>;
+		};
+	}
 }
 
 export {};

--- a/apps/web/src/routes/(home)/components/CtaBlock.svelte
+++ b/apps/web/src/routes/(home)/components/CtaBlock.svelte
@@ -5,6 +5,7 @@
 	import { latestClientVersion } from '$lib/store';
 	import { quadIn } from 'svelte/easing';
 	import { fly } from 'svelte/transition';
+	import { onMount } from 'svelte';
 
 	let videoElement = $state<HTMLVideoElement>();
 	interface Props {
@@ -45,6 +46,34 @@
 	function handleClickOutside() {
 		showSelect = false;
 	}
+
+	async function detectDefaultDownload() {
+		const platform = navigator.userAgent.toLowerCase();
+
+		if (platform.includes('mac')) {
+			const userAgentData = await navigator.userAgentData?.getHighEntropyValues(['architecture']);
+			if (userAgentData?.architecture === 'arm' || userAgentData === undefined) {
+				return jsonLinks.downloads.appleSilicon;
+			} else {
+				return jsonLinks.downloads.intelMac;
+			}
+			return;
+		}
+
+		if (platform.includes('win')) {
+			return jsonLinks.downloads.windowsMsi;
+		}
+
+		if (platform.includes('linux')) {
+			return jsonLinks.downloads.linuxAppimage;
+		}
+	}
+
+	onMount(() => {
+		detectDefaultDownload().then(
+			(platformDownload) => platformDownload && targetDownload.set(platformDownload)
+		);
+	});
 </script>
 
 <section class="wrapper">

--- a/apps/web/src/routes/(home)/components/CtaBlock.svelte
+++ b/apps/web/src/routes/(home)/components/CtaBlock.svelte
@@ -3,9 +3,9 @@
 	import { clickOutside } from '$lib/hooks/clickOutside';
 	import { targetDownload } from '$lib/store';
 	import { latestClientVersion } from '$lib/store';
+	import { onMount } from 'svelte';
 	import { quadIn } from 'svelte/easing';
 	import { fly } from 'svelte/transition';
-	import { onMount } from 'svelte';
 
 	let videoElement = $state<HTMLVideoElement>();
 	interface Props {
@@ -57,7 +57,6 @@
 			} else {
 				return jsonLinks.downloads.intelMac;
 			}
-			return;
 		}
 
 		if (platform.includes('win')) {


### PR DESCRIPTION
## 🧢 Changes
- add function that triggers on CtaBlock component mount, that detects default download target for OS of the user
- extend necessary global interface according to this: https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData - this allows to differentiate between Apple Silicon and Apple Intel 

## ☕️ Reasoning

- For Apple if available look for architecture: if something other than arm - change the target to Intel, if arm or architecture not available, stay with Apple Silicon
- For linux, I've set it to AppImage by default
- For windows it's set to windows - (BUT - I haven't had a chance to test it on windows, so it would appreciated)

If you don't want to use experimental browser features - I change it to: for all MacOS devices, default to Apple Silicon - we won't need to extend Navigator interface and it would simplify the logi


If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: #7772 



<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
