### PR TITLE
help with #7821

### DIFF
--- a/crates/but-cli/src/args.rs
+++ b/crates/but-cli/src/args.rs
@@ -39,6 +39,10 @@ pub enum Subcommands {
         /// Amend to the current or given commit.
         #[clap(long)]
         amend: bool,
+        /// The rev-spec of the tip of the workspace.
+        // TODO: this should be replaced with head-info discovery once available.
+        #[clap(long)]
+        workspace_tip: Option<String>,
         /// The revspec to create the commit on top of, or the commit to amend to.
         #[clap(long)]
         parent: Option<String>,

--- a/crates/but-cli/src/main.rs
+++ b/crates/but-cli/src/main.rs
@@ -30,6 +30,7 @@ fn main() -> Result<()> {
             message,
             amend,
             parent,
+            workspace_tip,
             stack_segment_ref,
         } => {
             let (repo, project) = repo_and_maybe_project(&args, RepositoryOpenMode::Merge)?;
@@ -40,6 +41,7 @@ fn main() -> Result<()> {
                 *amend,
                 parent.as_deref(),
                 stack_segment_ref.as_deref(),
+                workspace_tip.as_deref(),
             )
         }
         args::Subcommands::HunkDependency => command::diff::locks(&args.current_dir),

--- a/crates/but-workspace/src/commit_engine/mod.rs
+++ b/crates/but-workspace/src/commit_engine/mod.rs
@@ -403,7 +403,7 @@ pub fn create_commit_and_update_refs(
                 .collect();
             if !found_marker {
                 bail!(
-                    "Branch tip at {branch_tip} didn't contain the affected commit - cannot rebase"
+                    "Branch tip at {branch_tip} didn't contain the affected commit {commit_in_graph} - cannot rebase"
                 );
             }
 


### PR DESCRIPTION
This PR makes #7821 reproducible on the command-line, while also providing a remedy to futures issues of this kind.

The problem is that the real world and the world in virtual-branches.toml aren't in sync, so the parent-commit for the new commit is indeed not contained in the workspace tip as we know it.

Related to #7821.
