### PR TITLE
Remove usage of checkout branch trees in v3

### DIFF
--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -20,6 +20,7 @@ use gitbutler_repo::{
 use gitbutler_serde::BStringForFrontend;
 use gitbutler_stack::stack_context::StackContext;
 use gitbutler_stack::{Stack, StackId, Target, VirtualBranchesHandle};
+use gitbutler_workspace::branch_trees::{update_uncommited_changes, WorkspaceState};
 #[allow(deprecated)]
 use gitbutler_workspace::{checkout_branch_trees, compute_updated_branch_head};
 use gix::merge::tree::TreatAsUnresolved;
@@ -454,6 +455,8 @@ pub(crate) fn integrate_upstream(
     base_branch_resolution: Option<BaseBranchResolution>,
     permission: &mut WorktreeWritePermission,
 ) -> Result<IntegrationOutcome> {
+    let old_workspace = WorkspaceState::create(command_context, permission.read_permission())?;
+
     let (target_commit_oid, base_branch_resolution_approach) = base_branch_resolution
         .map(|r| (Some(r.target_commit_oid), Some(r.approach)))
         .unwrap_or((None, None));
@@ -600,9 +603,22 @@ pub(crate) fn integrate_upstream(
                 .remove_untracked()
                 .checkout()?;
         } else {
-            // Now that we've potentially updated the branch trees, lets checkout
-            // the result of merging them all together.
-            checkout_branch_trees(command_context, permission)?;
+            let new_workspace =
+                WorkspaceState::create(command_context, permission.read_permission())?;
+
+            if command_context.app_settings().feature_flags.v3 {
+                update_uncommited_changes(
+                    command_context,
+                    old_workspace,
+                    new_workspace,
+                    permission,
+                )?;
+            } else {
+                // Now that we've potentially updated the branch trees, lets checkout
+                // the result of merging them all together.
+                #[allow(deprecated)]
+                checkout_branch_trees(command_context, permission)?;
+            }
         }
 
         crate::integration::update_workspace_commit(&virtual_branches_state, command_context)?;

--- a/crates/gitbutler-workspace/src/branch_trees.rs
+++ b/crates/gitbutler-workspace/src/branch_trees.rs
@@ -1,19 +1,24 @@
-use anyhow::{bail, Result};
-use gitbutler_cherry_pick::RepositoryExt;
+use anyhow::{bail, Context, Result};
+use gitbutler_cherry_pick::{ConflictedTreeKey, GixRepositoryExt as _, RepositoryExt};
 use gitbutler_command_context::CommandContext;
 use gitbutler_commit::commit_ext::CommitExt as _;
-use gitbutler_oxidize::{git2_to_gix_object_id, gix_to_git2_oid, GixRepositoryExt};
-use gitbutler_project::access::WorktreeWritePermission;
+use gitbutler_oxidize::{
+    git2_to_gix_object_id, gix_to_git2_oid, GixRepositoryExt, ObjectIdExt, OidExt,
+};
+use gitbutler_project::access::{WorktreeReadPermission, WorktreeWritePermission};
 use gitbutler_project::AUTO_TRACK_LIMIT_BYTES;
 use gitbutler_repo::rebase::cherry_rebase_group;
 use gitbutler_repo::RepositoryExt as _;
 use gitbutler_stack::{Stack, VirtualBranchesHandle};
 use tracing::instrument;
 
+use crate::workspace_base;
+
 /// Checks out the combined trees of all branches in the workspace.
 ///
 /// This function will fail if the applied branches conflict with each other.
 #[instrument(level = tracing::Level::DEBUG, skip(ctx, _perm), err(Debug))]
+#[deprecated]
 pub fn checkout_branch_trees<'a>(
     ctx: &'a CommandContext,
     _perm: &mut WorktreeWritePermission,
@@ -72,6 +77,136 @@ pub fn checkout_branch_trees<'a>(
 
         Ok(final_tree)
     }
+}
+
+pub struct WorkspaceState {
+    heads: Vec<gix::ObjectId>,
+    base: gix::ObjectId,
+}
+
+impl WorkspaceState {
+    pub fn create(ctx: &CommandContext, perm: &WorktreeReadPermission) -> Result<Self> {
+        let repository = ctx.gix_repository()?;
+        let vb_state = VirtualBranchesHandle::new(ctx.project().gb_dir());
+
+        let heads = vb_state
+            .list_stacks_in_workspace()?
+            .iter()
+            .map(|stack| -> Result<gix::ObjectId> {
+                let tree_id = repository
+                    .find_real_tree(&stack.head().to_gix(), ConflictedTreeKey::AutoResolution)?;
+                Ok(tree_id.detach())
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let base = workspace_base(ctx, perm)?;
+
+        Ok(WorkspaceState { heads, base })
+    }
+}
+
+/// Take the
+pub fn update_uncommited_changes(
+    ctx: &CommandContext,
+    old: WorkspaceState,
+    new: WorkspaceState,
+    perm: &mut WorktreeWritePermission,
+) -> Result<()> {
+    let git2_repository = ctx.repo();
+    let uncommited_changes = git2_repository.create_wd_tree(0)?.id().to_gix();
+
+    update_uncommited_changes_with_tree(ctx, old, new, uncommited_changes, perm)
+}
+
+pub fn update_uncommited_changes_with_tree(
+    ctx: &CommandContext,
+    old: WorkspaceState,
+    new: WorkspaceState,
+    tree: gix::ObjectId,
+    _perm: &mut WorktreeWritePermission,
+) -> Result<()> {
+    let repository = ctx.gix_repository()?;
+    let git2_repository = ctx.repo();
+
+    let new_uncommited_changes = move_tree_between_workspaces(&repository, tree, old, new)?;
+    let new_uncommited_changes = git2_repository.find_tree(new_uncommited_changes.to_git2())?;
+
+    git2_repository
+        .checkout_tree_builder(&new_uncommited_changes)
+        .force()
+        .checkout()
+        .context("failed to checkout tree")?;
+
+    Ok(())
+}
+
+/// Take the changes on top of one workspace and return what they would look
+/// like if they were on top of the new workspace.
+fn move_tree_between_workspaces(
+    repository: &gix::Repository,
+    tree: gix::ObjectId,
+    old: WorkspaceState,
+    new: WorkspaceState,
+) -> Result<gix::ObjectId> {
+    let old_workspace = merge_workspace(repository, old)?;
+    let new_workspace = merge_workspace(repository, new)?;
+    move_tree(repository, tree, old_workspace, new_workspace)
+}
+
+/// Cherry pick a tree from one base tree on to another, favoring the contents of the tree when conflicts occur
+fn move_tree(
+    repository: &gix::Repository,
+    tree: gix::ObjectId,
+    old_workspace: gix::ObjectId,
+    new_workspace: gix::ObjectId,
+) -> Result<gix::ObjectId> {
+    let merge_options = repository
+        .tree_merge_options()?
+        .with_file_favor(Some(gix::merge::tree::FileFavor::Ours))
+        .with_tree_favor(Some(gix::merge::tree::TreeFavor::Ours));
+
+    // Read: Take the diff between old_workspace and tree, and apply it on top
+    //   of new_workspace
+    let mut merge = repository.merge_trees(
+        old_workspace,
+        tree,
+        new_workspace,
+        repository.default_merge_labels(),
+        merge_options,
+    )?;
+
+    Ok(merge.tree.write()?.detach())
+}
+
+/// Octopus merge
+/// What: Takes N trees and a base tree and all the heads together with respect
+/// to the given base.
+///
+/// If there are no heads provided, the base will be returned.
+fn merge_workspace(
+    repository: &gix::Repository,
+    workspace: WorkspaceState,
+) -> Result<gix::ObjectId> {
+    let mut output = workspace.base;
+
+    for head in workspace.heads {
+        let (merge_options_fail_fast, conflict_kind) = repository.merge_options_fail_fast()?;
+        let mut merge = repository.merge_trees(
+            workspace.base,
+            output,
+            head,
+            repository.default_merge_labels(),
+            merge_options_fail_fast.clone(),
+        )?;
+
+        if merge.has_unresolved_conflicts(conflict_kind) {
+            bail!("There appears to be conflicts between the virtual branches");
+        };
+
+        output = merge.tree.write()?.detach();
+    }
+
+    Ok(output)
 }
 
 pub struct BranchHeadAndTree {

--- a/crates/gitbutler-workspace/src/lib.rs
+++ b/crates/gitbutler-workspace/src/lib.rs
@@ -1,4 +1,4 @@
-mod branch_trees;
+pub mod branch_trees;
 
 #[allow(deprecated)]
 pub use branch_trees::{

--- a/crates/gitbutler-workspace/tests/mod.rs
+++ b/crates/gitbutler-workspace/tests/mod.rs
@@ -11,6 +11,7 @@ mod checkout_branch_trees {
     use gitbutler_project::AUTO_TRACK_LIMIT_BYTES;
     use gitbutler_repo::RepositoryExt as _;
     use gitbutler_testsupport::{paths, testing_repository::assert_tree_matches, TestProject};
+    #[allow(deprecated)]
     use gitbutler_workspace::checkout_branch_trees;
 
     #[test]
@@ -91,6 +92,7 @@ mod checkout_branch_trees {
 
         let mut guard = project.exclusive_worktree_access();
 
+        #[allow(deprecated)]
         checkout_branch_trees(&ctx, guard.write_permission()).unwrap();
 
         let tree = test_project


### PR DESCRIPTION
This PR introduces a new function `update_uncommited_changes` which performs the v3 equivalent to checkout_branch_trees.

The logic behind this can be thought of as a fancy git reset, or git cherry-pick, or both simultaneously!

This operates on the following entities:
- The uncommitted changes (UC)
- The result of merging all the old stackheads (OW)
- The result of merging all the new stack heads (NW)

The operation is to do a three way merge where OW is the base, UC is the "ours" side, and "NW" is the "theirs" side. If there are conflicts we take the "ours" side.

This is effectively like taking the diff between OW and UC, and then applying it on top of NW