### PR TITLE
fix: rename newBranchName to newName

### DIFF
--- a/apps/desktop/src/lib/branches/branchController.ts
+++ b/apps/desktop/src/lib/branches/branchController.ts
@@ -128,13 +128,13 @@ export class BranchController {
 	 * Updates the name of the series and resets the forge id to undefined.
 	 * @note - Ported to redux
 	 */
-	async updateBranchName(stackId: string, branchName: string, newBranchName: string) {
+	async updateBranchName(stackId: string, branchName: string, newName: string) {
 		try {
 			await invoke<void>('update_branch_name', {
 				projectId: this.projectId,
 				stackId,
 				branchName,
-				newBranchName
+				newName
 			});
 		} catch (err) {
 			showError('Failed to update remote name', err);


### PR DESCRIPTION
## 🧢 Changes

Change the name of the argument passed to `update_branch_name` in `branchController.ts` to `newName` to reflect the naming on the Rust/Tauri side. 

## ☕️ Reasoning

Tauri uses named arguments for Tauri commands. Thus, you need to name each property in the passed object like the "counter part" on the rust side. 