### PR TITLE
Move focus manager event listening to last in line

### DIFF
--- a/packages/ui/src/lib/utils/mergeUnlisten.ts
+++ b/packages/ui/src/lib/utils/mergeUnlisten.ts
@@ -1,0 +1,21 @@
+type UnlistenFunc = () => void;
+
+/**
+ * Helper function to merge multiple unlisten callbacks.
+ *
+ * @example
+ * $effect(()=> {
+ *   return mergeUnlisten(
+ *     on(document, 'mousedown', onMouseDown),
+ *     on(document, 'mouseup', onMouseUp)
+ *   );
+ * })
+ */
+export function mergeUnlisten(...callbacks: Array<UnlistenFunc>): () => void {
+	return () => {
+		for (let i = callbacks.length - 1; i >= 0; i--) {
+			callbacks[i]();
+		}
+		callbacks.length = 0;
+	};
+}


### PR DESCRIPTION
Before this change the focus manager listened to the document in the capture phase, meaning it fired before anything else. This, however, prevents us from stopping propagation e.g. when resizing the commit drawer.

After this change it listens to the document still, but in the bubble phase, giving all other events a possibility to cancel the change in focus.