### PR TITLE
more fixes: slice the remote response & conditionally get the base branch

### DIFF
--- a/apps/desktop/src/components/KeysForm.svelte
+++ b/apps/desktop/src/components/KeysForm.svelte
@@ -7,7 +7,7 @@
 	import { showError } from '$lib/notifications/toasts';
 	import { type Key, type KeyType, Project } from '$lib/project/project';
 	import { ProjectsService } from '$lib/project/projectsService';
-	import { getContext } from '@gitbutler/shared/context';
+	import { getContext, maybeGetContext } from '@gitbutler/shared/context';
 	import SectionCard from '@gitbutler/ui/SectionCard.svelte';
 	import Textbox from '@gitbutler/ui/Textbox.svelte';
 	import Link from '@gitbutler/ui/link/Link.svelte';
@@ -15,7 +15,7 @@
 
 	const project = $state(getContext(Project));
 
-	const baseBranch = getContext(BaseBranch);
+	const baseBranch = maybeGetContext(BaseBranch);
 	const projectsService = getContext(ProjectsService);
 
 	interface Props {

--- a/apps/desktop/src/components/ProjectSetupTarget.svelte
+++ b/apps/desktop/src/components/ProjectSetupTarget.svelte
@@ -44,7 +44,7 @@
 	);
 
 	let selectedBranch = $state<RemoteBranchInfo | undefined>(undefined);
-	const defaultBranch = $derived(getBestBranch(remoteBranches));
+	const defaultBranch = $derived(getBestBranch(remoteBranches.slice()));
 	const branch = $derived(selectedBranch ?? defaultBranch);
 
 	let selectedRemote = $state<string | undefined>(undefined);


### PR DESCRIPTION
The base branch might not be in the context, so be careful

Also, the list of remotes come from redux now, so it needs to be sliced before being sorted