### PR TITLE
invalidate the upstream integration on fetch

### DIFF
--- a/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
+++ b/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
@@ -141,7 +141,12 @@ function injectEndpoints(api: BackendApi) {
 					command: 'fetch_from_remotes',
 					params: { projectId, action: action ?? 'auto' }
 				}),
-				invalidatesTags: [ReduxTag.BaseBranchData, ReduxTag.Stacks, ReduxTag.Commits],
+				invalidatesTags: [
+					ReduxTag.BaseBranchData,
+					ReduxTag.Stacks,
+					ReduxTag.Commits,
+					ReduxTag.UpstreamIntegrationStatus
+				],
 				transformErrorResponse: (error) => {
 					// This is good enough while we check the best way to handle this
 					return error.toString();

--- a/apps/desktop/src/lib/state/tags.ts
+++ b/apps/desktop/src/lib/state/tags.ts
@@ -12,5 +12,6 @@ export enum ReduxTag {
 	GitLabPullRequests = 'GitLabPullRequests',
 	Checks = 'Checks',
 	RepoInfo = 'RepoInfo',
-	BaseBranchData = 'BaseBranchData'
+	BaseBranchData = 'BaseBranchData',
+	UpstreamIntegrationStatus = 'UpstreamIntegrationStatus'
 }

--- a/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
+++ b/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
@@ -111,7 +111,8 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				query: ({ projectId, targetCommitOid }) => ({
 					command: `upstream_integration_statuses`,
 					params: { projectId, targetCommitOid }
-				})
+				}),
+				providesTags: [ReduxTag.UpstreamIntegrationStatus]
 			}),
 			integrateUpstream: build.mutation<
 				IntegrationOutcome,
@@ -125,7 +126,12 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: `integrate_upstream`,
 					params: { projectId, resolutions, baseBranchResolution }
 				}),
-				invalidatesTags: [ReduxTag.Stacks, ReduxTag.StackBranches, ReduxTag.StackInfo]
+				invalidatesTags: [
+					ReduxTag.UpstreamIntegrationStatus,
+					ReduxTag.Stacks,
+					ReduxTag.StackBranches,
+					ReduxTag.StackInfo
+				]
 			}),
 			resolveUpstreamIntegration: build.mutation<
 				string,
@@ -134,7 +140,8 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				query: ({ projectId, resolutionApproach }) => ({
 					command: `resolve_upstream_integration`,
 					params: { projectId, resolutionApproach }
-				})
+				}),
+				invalidatesTags: [ReduxTag.UpstreamIntegrationStatus]
 			})
 		})
 	});


### PR DESCRIPTION
Fetching the remotes invalidates the upstream integration status, ensuring that any changes made to the upstream integration are reflected in the application state.