### PR TITLE
feat: add "Open in Finder" menu option

### DIFF
--- a/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
+++ b/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
@@ -31,7 +31,7 @@
 	});
 
 	shortcutService.on('open-in-finder', () => {
-        const path = `file://${project.path}`;
+		const path = `file://${project.path}`;
 		openExternalUrl(path);
 	});
 

--- a/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
+++ b/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
@@ -30,6 +30,11 @@
 		openExternalUrl(path);
 	});
 
+	shortcutService.on('open-in-finder', () => {
+        const path = `file://${project.path}`;
+		openExternalUrl(path);
+	});
+
 	shortcutService.on('history', () => {
 		$showHistoryView = !$showHistoryView;
 	});

--- a/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
+++ b/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
@@ -6,7 +6,7 @@
 	import { ShortcutService } from '$lib/shortcuts/shortcutService.svelte';
 	import * as events from '$lib/utils/events';
 	import { unsubscribe } from '$lib/utils/unsubscribe';
-	import { getEditorUri, openExternalUrl } from '$lib/utils/url';
+	import { getEditorUri, openExternalFile, openExternalUrl } from '$lib/utils/url';
 	import { getContextStoreBySymbol } from '@gitbutler/shared/context';
 	import { getContext } from '@gitbutler/shared/context';
 	import { onMount } from 'svelte';
@@ -31,8 +31,7 @@
 	});
 
 	shortcutService.on('open-in-finder', () => {
-		const path = `file://${project.path}`;
-		openExternalUrl(path);
+		openExternalFile(project.path);
 	});
 
 	shortcutService.on('history', () => {

--- a/apps/desktop/src/lib/utils/url.ts
+++ b/apps/desktop/src/lib/utils/url.ts
@@ -22,6 +22,25 @@ export async function openExternalUrl(href: string) {
 	}
 }
 
+export async function openExternalFile(path: string) {
+	try {
+		// Use the Opener plugin to reveal the folder in the native file explorer
+		await invoke('plugin:opener|reveal_item_in_dir', { path: path });
+	} catch (e) {
+		if (typeof e === 'string' || e instanceof String) {
+			const message = `
+                Failed to reveal directory in file explorer:
+
+                ${path}
+            `;
+			showToast({ title: 'Explorer error', message, style: 'error' });
+		}
+
+		// Rethrowing for sentry and posthog
+		throw e;
+	}
+}
+
 // turn a git remote url into a web url (github, gitlab, bitbucket, etc)
 export function convertRemoteToWebUrl(url: string): string {
 	const gitRemote = GitUrlParse(url);

--- a/crates/gitbutler-tauri/src/menu.rs
+++ b/crates/gitbutler-tauri/src/menu.rs
@@ -172,6 +172,7 @@ pub fn build<R: Runtime>(handle: &AppHandle<R>) -> tauri::Result<tauri::menu::Me
                 .build(handle)?,
         )
         .text("project/open-in-vscode", "Open in Editor")
+        .text("project/open-in-finder", "Open in Finder")
         .separator()
         .text("project/settings", "Project Settings")
         .build()?;
@@ -296,6 +297,11 @@ pub fn handle_event(webview: &WebviewWindow, event: &MenuEvent) {
 
     if event.id() == "project/open-in-vscode" {
         emit(webview, SHORTCUT_EVENT, "open-in-vscode");
+        return;
+    }
+
+    if event.id() == "project/open-in-finder" {
+        emit(webview, SHORTCUT_EVENT, "open-in-finder");
         return;
     }
 

--- a/crates/gitbutler-tauri/src/open.rs
+++ b/crates/gitbutler-tauri/src/open.rs
@@ -16,6 +16,7 @@ pub(crate) fn open_that(path: &str) -> anyhow::Result<()> {
         "zed",
         "windsurf",
         "cursor",
+        "file",
     ]
     .contains(&target_url.scheme())
     {


### PR DESCRIPTION
## 🧢 Changes

Added an `Open in Finder` menu option.

## ☕️ Reasoning

Uses `file://` and the `project.path` (opening in Windows uses `\\` so I didn't use `project.vscodePath`).

I originally was going to add a function similar to `getEditorUri`, but that seemed like too much of a project change for too little code and for a first contribution. Might be best to create a `getFinderUri` and write os-specific implementations if it is necessary.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

-->
## 🎫 Affected issues

Fixes: #7853
<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->