### PR TITLE
feat(UnifiedDiffView): add user settings to v3 UnifiedDiffView

### DIFF
--- a/apps/desktop/src/components/v3/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/v3/UnifiedDiffView.svelte
@@ -8,8 +8,9 @@
 		ChangeSelectionService,
 		type PartiallySelectedFile
 	} from '$lib/selection/changeSelection.svelte';
+	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import { UiState } from '$lib/state/uiState.svelte';
-	import { inject } from '@gitbutler/shared/context';
+	import { getContextStoreBySymbol, inject } from '@gitbutler/shared/context';
 	import HunkDiff from '@gitbutler/ui/HunkDiff.svelte';
 	import type { TreeChange } from '$lib/hunks/change';
 	import type { DiffHunk } from '$lib/hunks/hunk';
@@ -40,6 +41,8 @@
 	});
 
 	const lineSelection = new LineSelection(changeSelection);
+
+	const userSettings = getContextStoreBySymbol<Settings>(SETTINGS);
 
 	$effect(() => {
 		lineSelection.setChange(change);
@@ -164,6 +167,12 @@
 						hunkStr={hunk.diff}
 						{staged}
 						{stagedLines}
+						diffLigatures={$userSettings.diffLigatures}
+						tabSize={$userSettings.tabSize}
+						wrapText={$userSettings.wrapText}
+						diffFont={$userSettings.diffFont}
+						diffContrast={$userSettings.diffContrast}
+						inlineUnifiedDiffs={$userSettings.inlineUnifiedDiffs}
 						onLineClick={(p) =>
 							lineSelection.toggleStageLines(selection, hunk, p, diff.subject.hunks)}
 						onChangeStage={(selected) => {


### PR DESCRIPTION
## 🧢 Changes

This PR adds user settings to the `UnifiedDiffView` component for v3. Users can now customize the appearance and behavior of the diff view to their preferences.

## ☕️ Reasoning

The v3 Unified Diff View was not passing the user settings from preferences to the component.

![Screenshot 2025-03-28 at 3 42 24 PM](https://github.com/user-attachments/assets/d395ca28-59ac-4e74-8779-1764d18b3dc9)
![Screenshot 2025-03-28 at 3 42 33 PM](https://github.com/user-attachments/assets/5cfcfefb-7b7e-4de1-8038-8dc548b3df3c)