### PR TITLE
commit hunk selections

### DIFF
--- a/crates/but-cli/src/args.rs
+++ b/crates/but-cli/src/args.rs
@@ -28,6 +28,19 @@ pub struct Args {
 pub enum Subcommands {
     /// Commit or amend all worktree changes to a new commit.
     Commit {
+        /// The repo-relative path to the changed file to commit.
+        #[clap(requires_if(clap::builder::ArgPredicate::IsPresent, "hunk_headers"))]
+        current_path: Option<PathBuf>,
+        /// If the change is a rename, identify the repo-relative path of the source.
+        previous_path: Option<PathBuf>,
+        /// The 1-based pairs of 4 numbers equivalent to '(old_start,old_lines,new_start,new_lines)'
+        #[clap(
+            long,
+            requires_if(clap::builder::ArgPredicate::IsPresent, "current_path"),
+            num_args = 4,
+            value_names = ["old-start", "old-lines", "new-start", "new-lines"])
+        ]
+        hunk_headers: Vec<u32>,
         /// The message of the new commit.
         #[clap(long, short = 'm')]
         message: Option<String>,

--- a/crates/but-cli/src/main.rs
+++ b/crates/but-cli/src/main.rs
@@ -1,4 +1,5 @@
 //! A debug-CLI for making `but`-crates functionality available in real-world repositories.
+#![deny(rust_2018_idioms)]
 use anyhow::Result;
 
 mod args;
@@ -38,6 +39,9 @@ fn main() -> Result<()> {
             },
         ),
         args::Subcommands::Commit {
+            current_path,
+            previous_path,
+            hunk_headers,
             message,
             amend,
             parent,
@@ -53,6 +57,13 @@ fn main() -> Result<()> {
                 parent.as_deref(),
                 stack_segment_ref.as_deref(),
                 workspace_tip.as_deref(),
+                current_path.as_deref(),
+                previous_path.as_deref(),
+                if !hunk_headers.is_empty() {
+                    Some(hunk_headers)
+                } else {
+                    None
+                },
             )
         }
         args::Subcommands::HunkDependency => command::diff::locks(&args.current_dir),

--- a/crates/but-core/src/unified_diff.rs
+++ b/crates/but-core/src/unified_diff.rs
@@ -6,7 +6,7 @@ use gix::diff::blob::unified_diff::ContextSize;
 use serde::Serialize;
 
 /// A hunk as used in a [UnifiedDiff], which also contains all added and removed lines.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DiffHunk {
     /// The 1-based line number at which the previous version of the file started.
@@ -32,6 +32,12 @@ pub struct DiffHunk {
     /// Note that the file-portion of the header isn't used here.
     #[serde(serialize_with = "gitbutler_serde::bstring_lossy::serialize")]
     pub diff: BString,
+}
+
+impl std::fmt::Debug for DiffHunk {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, r#"DiffHunk("{}")"#, self.diff)
+    }
 }
 
 impl UnifiedDiff {

--- a/crates/but-core/tests/core/diff/worktree_changes.rs
+++ b/crates/but-core/tests/core/diff/worktree_changes.rs
@@ -356,13 +356,9 @@ fn case_folding_worktree_changes() -> Result<()> {
     [
         Patch {
             hunks: [
-                DiffHunk {
-                    old_start: 1,
-                    old_lines: 1,
-                    new_start: 1,
-                    new_lines: 0,
-                    diff: "@@ -1,1 +1,0 @@\n-content\n",
-                },
+                DiffHunk("@@ -1,1 +1,0 @@
+                -content
+                "),
             ],
             is_result_of_binary_to_text_conversion: false,
         },
@@ -406,13 +402,9 @@ fn case_folding_worktree_and_index_changes() -> Result<()> {
     [
         Patch {
             hunks: [
-                DiffHunk {
-                    old_start: 1,
-                    old_lines: 1,
-                    new_start: 1,
-                    new_lines: 0,
-                    diff: "@@ -1,1 +1,0 @@\n-content\n",
-                },
+                DiffHunk("@@ -1,1 +1,0 @@
+                -content
+                "),
             ],
             is_result_of_binary_to_text_conversion: false,
         },
@@ -459,13 +451,9 @@ fn file_to_dir_in_worktree() -> Result<()> {
         },
         Patch {
             hunks: [
-                DiffHunk {
-                    old_start: 1,
-                    old_lines: 0,
-                    new_start: 1,
-                    new_lines: 1,
-                    diff: "@@ -1,0 +1,1 @@\n+content\n",
-                },
+                DiffHunk("@@ -1,0 +1,1 @@
+                +content
+                "),
             ],
             is_result_of_binary_to_text_conversion: false,
         },
@@ -512,13 +500,9 @@ fn file_to_dir_in_index() -> Result<()> {
         },
         Patch {
             hunks: [
-                DiffHunk {
-                    old_start: 1,
-                    old_lines: 0,
-                    new_start: 1,
-                    new_lines: 1,
-                    diff: "@@ -1,0 +1,1 @@\n+content\n",
-                },
+                DiffHunk("@@ -1,0 +1,1 @@
+                +content
+                "),
             ],
             is_result_of_binary_to_text_conversion: false,
         },
@@ -561,13 +545,9 @@ fn dir_to_file_in_worktree() -> Result<()> {
     [
         Patch {
             hunks: [
-                DiffHunk {
-                    old_start: 1,
-                    old_lines: 0,
-                    new_start: 1,
-                    new_lines: 1,
-                    diff: "@@ -1,0 +1,1 @@\n+content\n",
-                },
+                DiffHunk("@@ -1,0 +1,1 @@
+                +content
+                "),
             ],
             is_result_of_binary_to_text_conversion: false,
         },
@@ -614,13 +594,9 @@ fn dir_to_file_in_index() -> Result<()> {
     [
         Patch {
             hunks: [
-                DiffHunk {
-                    old_start: 1,
-                    old_lines: 0,
-                    new_start: 1,
-                    new_lines: 1,
-                    diff: "@@ -1,0 +1,1 @@\n+content\n",
-                },
+                DiffHunk("@@ -1,0 +1,1 @@
+                +content
+                "),
             ],
             is_result_of_binary_to_text_conversion: false,
         },
@@ -665,13 +641,10 @@ fn file_to_symlink_in_worktree() -> Result<()> {
     [
         Patch {
             hunks: [
-                DiffHunk {
-                    old_start: 1,
-                    old_lines: 1,
-                    new_start: 1,
-                    new_lines: 1,
-                    diff: "@@ -1,1 +1,1 @@\n-content\n+does-not-exist\n",
-                },
+                DiffHunk("@@ -1,1 +1,1 @@
+                -content
+                +does-not-exist
+                "),
             ],
             is_result_of_binary_to_text_conversion: false,
         },
@@ -730,13 +703,10 @@ fn file_to_symlink_in_index() -> Result<()> {
     [
         Patch {
             hunks: [
-                DiffHunk {
-                    old_start: 1,
-                    old_lines: 1,
-                    new_start: 1,
-                    new_lines: 1,
-                    diff: "@@ -1,1 +1,1 @@\n-content\n+does-not-exist\n",
-                },
+                DiffHunk("@@ -1,1 +1,1 @@
+                -content
+                +does-not-exist
+                "),
             ],
             is_result_of_binary_to_text_conversion: false,
         },
@@ -777,13 +747,10 @@ fn symlink_to_file_in_worktree() -> Result<()> {
     [
         Patch {
             hunks: [
-                DiffHunk {
-                    old_start: 1,
-                    old_lines: 1,
-                    new_start: 1,
-                    new_lines: 1,
-                    diff: "@@ -1,1 +1,1 @@\n-target\n+content\n",
-                },
+                DiffHunk("@@ -1,1 +1,1 @@
+                -target
+                +content
+                "),
             ],
             is_result_of_binary_to_text_conversion: false,
         },
@@ -824,13 +791,10 @@ fn symlink_to_file_in_index() -> Result<()> {
     [
         Patch {
             hunks: [
-                DiffHunk {
-                    old_start: 1,
-                    old_lines: 1,
-                    new_start: 1,
-                    new_lines: 1,
-                    diff: "@@ -1,1 +1,1 @@\n-target\n+content\n",
-                },
+                DiffHunk("@@ -1,1 +1,1 @@
+                -target
+                +content
+                "),
             ],
             is_result_of_binary_to_text_conversion: false,
         },
@@ -896,25 +860,18 @@ fn added_modified_in_worktree() -> Result<()> {
         },
         Patch {
             hunks: [
-                DiffHunk {
-                    old_start: 1,
-                    old_lines: 0,
-                    new_start: 1,
-                    new_lines: 1,
-                    diff: "@@ -1,0 +1,1 @@\n+content\n",
-                },
+                DiffHunk("@@ -1,0 +1,1 @@
+                +content
+                "),
             ],
             is_result_of_binary_to_text_conversion: false,
         },
         Patch {
             hunks: [
-                DiffHunk {
-                    old_start: 1,
-                    old_lines: 1,
-                    new_start: 1,
-                    new_lines: 1,
-                    diff: "@@ -1,1 +1,1 @@\n-something\n+change\n",
-                },
+                DiffHunk("@@ -1,1 +1,1 @@
+                -something
+                +change
+                "),
             ],
             is_result_of_binary_to_text_conversion: false,
         },
@@ -952,13 +909,10 @@ fn modified_in_index() -> Result<()> {
     [
         Patch {
             hunks: [
-                DiffHunk {
-                    old_start: 1,
-                    old_lines: 1,
-                    new_start: 1,
-                    new_lines: 1,
-                    diff: "@@ -1,1 +1,1 @@\n-something\n+change\n",
-                },
+                DiffHunk("@@ -1,1 +1,1 @@
+                -something
+                +change
+                "),
             ],
             is_result_of_binary_to_text_conversion: false,
         },
@@ -991,13 +945,9 @@ fn deleted_in_worktree() -> Result<()> {
     [
         Patch {
             hunks: [
-                DiffHunk {
-                    old_start: 1,
-                    old_lines: 1,
-                    new_start: 1,
-                    new_lines: 0,
-                    diff: "@@ -1,1 +1,0 @@\n-something\n",
-                },
+                DiffHunk("@@ -1,1 +1,0 @@
+                -something
+                "),
             ],
             is_result_of_binary_to_text_conversion: false,
         },
@@ -1030,13 +980,9 @@ fn deleted_in_index() -> Result<()> {
     [
         Patch {
             hunks: [
-                DiffHunk {
-                    old_start: 1,
-                    old_lines: 1,
-                    new_start: 1,
-                    new_lines: 0,
-                    diff: "@@ -1,1 +1,0 @@\n-something\n",
-                },
+                DiffHunk("@@ -1,1 +1,0 @@
+                -something
+                "),
             ],
             is_result_of_binary_to_text_conversion: false,
         },

--- a/crates/but-core/tests/core/unified_diff.rs
+++ b/crates/but-core/tests/core/unified_diff.rs
@@ -18,13 +18,9 @@ fn file_added_in_worktree() -> anyhow::Result<()> {
 
     insta::assert_debug_snapshot!(actual, @r#"
     [
-        DiffHunk {
-            old_start: 1,
-            old_lines: 0,
-            new_start: 1,
-            new_lines: 1,
-            diff: "@@ -1,0 +1,1 @@\n+change\n",
-        },
+        DiffHunk("@@ -1,0 +1,1 @@
+        +change
+        "),
     ]
     "#);
     Ok(())
@@ -47,13 +43,9 @@ fn binary_text_in_unborn() -> anyhow::Result<()> {
 
     insta::assert_debug_snapshot!(actual, @r#"
     [
-        DiffHunk {
-            old_start: 1,
-            old_lines: 0,
-            new_start: 1,
-            new_lines: 1,
-            diff: "@@ -1,0 +1,1 @@\n+hi\n",
-        },
+        DiffHunk("@@ -1,0 +1,1 @@
+        +hi
+        "),
     ]
     "#);
     Ok(())
@@ -80,13 +72,10 @@ fn binary_text_renamed_unborn() -> anyhow::Result<()> {
 
     insta::assert_debug_snapshot!(actual, @r#"
     [
-        DiffHunk {
-            old_start: 1,
-            old_lines: 1,
-            new_start: 1,
-            new_lines: 1,
-            diff: "@@ -1,1 +1,1 @@\n-hi\n+ho\n",
-        },
+        DiffHunk("@@ -1,1 +1,1 @@
+        -hi
+        +ho
+        "),
     ]
     "#);
     Ok(())
@@ -112,13 +101,9 @@ fn file_deleted_in_worktree() -> anyhow::Result<()> {
 
     insta::assert_debug_snapshot!(actual, @r#"
     [
-        DiffHunk {
-            old_start: 1,
-            old_lines: 1,
-            new_start: 1,
-            new_lines: 0,
-            diff: "@@ -1,1 +1,0 @@\n-something\n",
-        },
+        DiffHunk("@@ -1,1 +1,0 @@
+        -something
+        "),
     ]
     "#);
     Ok(())
@@ -200,13 +185,10 @@ fn symlink_modified_in_worktree() -> anyhow::Result<()> {
 
     insta::assert_debug_snapshot!(actual, @r#"
     [
-        DiffHunk {
-            old_start: 1,
-            old_lines: 1,
-            new_start: 1,
-            new_lines: 1,
-            diff: "@@ -1,1 +1,1 @@\n-target-to-be-changed\n+changed-target\n",
-        },
+        DiffHunk("@@ -1,1 +1,1 @@
+        -target-to-be-changed
+        +changed-target
+        "),
     ]
     "#);
     Ok(())

--- a/crates/but-hunk-dependency/tests/hunk_dependency/query_workspace_ranges.rs
+++ b/crates/but-hunk-dependency/tests/hunk_dependency/query_workspace_ranges.rs
@@ -10,13 +10,10 @@ fn change_2_to_two_in_second_commit() -> anyhow::Result<()> {
                 "file",
                 [
                     HunkIntersection {
-                        hunk: DiffHunk {
-                            old_start: 2,
-                            old_lines: 1,
-                            new_start: 2,
-                            new_lines: 1,
-                            diff: "@@ -2,1 +2,1 @@\n-2\n+two\n",
-                        },
+                        hunk: DiffHunk("@@ -2,1 +2,1 @@
+                        -2
+                        +two
+                        "),
                         commit_intersections: [
                             StableHunkRange {
                                 change_type: Modification,
@@ -47,13 +44,10 @@ fn change_2_to_two_in_second_commit_after_file_rename() -> anyhow::Result<()> {
         missed_hunks: [
             (
                 "file-renamed",
-                DiffHunk {
-                    old_start: 2,
-                    old_lines: 1,
-                    new_start: 2,
-                    new_lines: 1,
-                    diff: "@@ -2,1 +2,1 @@\n-2\n+two\n",
-                },
+                DiffHunk("@@ -2,1 +2,1 @@
+                -2
+                +two
+                "),
             ),
         ],
     }
@@ -73,13 +67,10 @@ fn change_2_to_two_in_second_commit_after_shift_by_two() -> anyhow::Result<()> {
                 "file",
                 [
                     HunkIntersection {
-                        hunk: DiffHunk {
-                            old_start: 4,
-                            old_lines: 1,
-                            new_start: 4,
-                            new_lines: 1,
-                            diff: "@@ -4,1 +4,1 @@\n-2\n+two\n",
-                        },
+                        hunk: DiffHunk("@@ -4,1 +4,1 @@
+                        -2
+                        +two
+                        "),
                         commit_intersections: [
                             StableHunkRange {
                                 change_type: Modification,
@@ -111,13 +102,9 @@ fn add_single_line() -> anyhow::Result<()> {
                 "file",
                 [
                     HunkIntersection {
-                        hunk: DiffHunk {
-                            old_start: 6,
-                            old_lines: 0,
-                            new_start: 6,
-                            new_lines: 1,
-                            diff: "@@ -6,0 +6,1 @@\n+5.5\n",
-                        },
+                        hunk: DiffHunk("@@ -6,0 +6,1 @@
+                        +5.5
+                        "),
                         commit_intersections: [
                             StableHunkRange {
                                 change_type: Modification,
@@ -149,13 +136,9 @@ fn remove_single_line() -> anyhow::Result<()> {
                 "file",
                 [
                     HunkIntersection {
-                        hunk: DiffHunk {
-                            old_start: 5,
-                            old_lines: 1,
-                            new_start: 5,
-                            new_lines: 0,
-                            diff: "@@ -5,1 +5,0 @@\n-5\n",
-                        },
+                        hunk: DiffHunk("@@ -5,1 +5,0 @@
+                        -5
+                        "),
                         commit_intersections: [
                             StableHunkRange {
                                 change_type: Modification,

--- a/crates/but-hunk-dependency/tests/hunk_dependency/workspace_dependencies.rs
+++ b/crates/but-hunk-dependency/tests/hunk_dependency/workspace_dependencies.rs
@@ -531,13 +531,15 @@ fn complex_file_manipulation_with_uncommitted_changes() -> anyhow::Result<()> {
                 "file",
                 [
                     HunkIntersection {
-                        hunk: DiffHunk {
-                            old_start: 2,
-                            old_lines: 4,
-                            new_start: 2,
-                            new_lines: 3,
-                            diff: "@@ -2,4 +2,3 @@\n-e\n-1\n-2\n-3\n+updated line 3\n+updated line 4\n+updated line 5\n",
-                        },
+                        hunk: DiffHunk("@@ -2,4 +2,3 @@
+                        -e
+                        -1
+                        -2
+                        -3
+                        +updated line 3
+                        +updated line 4
+                        +updated line 5
+                        "),
                         commit_intersections: [
                             StableHunkRange {
                                 change_type: Modification,
@@ -561,13 +563,10 @@ fn complex_file_manipulation_with_uncommitted_changes() -> anyhow::Result<()> {
                 "file_2",
                 [
                     HunkIntersection {
-                        hunk: DiffHunk {
-                            old_start: 4,
-                            old_lines: 1,
-                            new_start: 4,
-                            new_lines: 1,
-                            diff: "@@ -4,1 +4,1 @@\n-d\n+updated d\n",
-                        },
+                        hunk: DiffHunk("@@ -4,1 +4,1 @@
+                        -d
+                        +updated d
+                        "),
                         commit_intersections: [
                             StableHunkRange {
                                 change_type: Addition,
@@ -697,13 +696,11 @@ fn complex_file_manipulation_multiple_hunks_with_uncommitted_changes() -> anyhow
                 "file",
                 [
                     HunkIntersection {
-                        hunk: DiffHunk {
-                            old_start: 3,
-                            old_lines: 1,
-                            new_start: 3,
-                            new_lines: 2,
-                            diff: "@@ -3,1 +3,2 @@\n-2\n+aaaaa\n+aaaaa\n",
-                        },
+                        hunk: DiffHunk("@@ -3,1 +3,2 @@
+                        -2
+                        +aaaaa
+                        +aaaaa
+                        "),
                         commit_intersections: [
                             StableHunkRange {
                                 change_type: Modification,
@@ -715,13 +712,11 @@ fn complex_file_manipulation_multiple_hunks_with_uncommitted_changes() -> anyhow
                         ],
                     },
                     HunkIntersection {
-                        hunk: DiffHunk {
-                            old_start: 7,
-                            old_lines: 2,
-                            new_start: 8,
-                            new_lines: 1,
-                            diff: "@@ -7,2 +8,1 @@\n-update 7\n-update 8\n+aaaaa\n",
-                        },
+                        hunk: DiffHunk("@@ -7,2 +8,1 @@
+                        -update 7
+                        -update 8
+                        +aaaaa
+                        "),
                         commit_intersections: [
                             StableHunkRange {
                                 change_type: Modification,
@@ -747,13 +742,11 @@ fn complex_file_manipulation_multiple_hunks_with_uncommitted_changes() -> anyhow
                         ],
                     },
                     HunkIntersection {
-                        hunk: DiffHunk {
-                            old_start: 10,
-                            old_lines: 1,
-                            new_start: 10,
-                            new_lines: 2,
-                            diff: "@@ -10,1 +10,2 @@\n-added at the bottom\n+update bottom\n+add another line\n",
-                        },
+                        hunk: DiffHunk("@@ -10,1 +10,2 @@
+                        -added at the bottom
+                        +update bottom
+                        +add another line
+                        "),
                         commit_intersections: [
                             StableHunkRange {
                                 change_type: Modification,
@@ -784,13 +777,10 @@ fn dependencies_ignore_merge_commits() -> anyhow::Result<()> {
                 "file",
                 [
                     HunkIntersection {
-                        hunk: DiffHunk {
-                            old_start: 8,
-                            old_lines: 1,
-                            new_start: 8,
-                            new_lines: 1,
-                            diff: "@@ -8,1 +8,1 @@\n-update line 8\n+update line 8 again\n",
-                        },
+                        hunk: DiffHunk("@@ -8,1 +8,1 @@
+                        -update line 8
+                        +update line 8 again
+                        "),
                         commit_intersections: [
                             StableHunkRange {
                                 change_type: Modification,
@@ -807,13 +797,10 @@ fn dependencies_ignore_merge_commits() -> anyhow::Result<()> {
         missed_hunks: [
             (
                 "file",
-                DiffHunk {
-                    old_start: 5,
-                    old_lines: 1,
-                    new_start: 5,
-                    new_lines: 1,
-                    diff: "@@ -5,1 +5,1 @@\n-update line 5\n+update line 5 again\n",
-                },
+                DiffHunk("@@ -5,1 +5,1 @@
+                -update line 5
+                +update line 5 again
+                "),
             ),
         ],
     }

--- a/crates/but-workspace/src/commit_engine/tree/tests.rs
+++ b/crates/but-workspace/src/commit_engine/tree/tests.rs
@@ -1,0 +1,243 @@
+mod to_additive_hunks {
+    use super::super::to_additive_hunks;
+    use crate::utils::hunk_header;
+
+    #[test]
+    fn rejected() {
+        let wth = vec![hunk_header("-1,10", "+1,10")];
+        insta::assert_debug_snapshot!(to_additive_hunks(
+            [
+                // rejected as old is out of bounds
+                hunk_header("-20,1", "+1,10"),
+                // rejected as new is out of bounds
+                hunk_header("+1,10", "+20,1"),
+                // rejected as it doesn't match any anchor point, nor does it match hunks without context
+                hunk_header("-0,0", "+2,10")
+            ],
+            &wth,
+            &wth,
+        ), @r#"
+        (
+            [],
+            [
+                HunkHeader("-20,1", "+1,10"),
+                HunkHeader("-1,10", "+20,1"),
+                HunkHeader("-0,0", "+2,10"),
+            ],
+        )
+        "#);
+    }
+
+    #[test]
+    fn only_selections() {
+        let wth = vec![hunk_header("-1,10", "+1,10")];
+        insta::assert_debug_snapshot!(to_additive_hunks(
+            [
+                hunk_header("-1,1", "+0,0"),
+                hunk_header("-5,2", "+0,0"),
+                hunk_header("-10,1", "+0,0")
+            ],
+            &wth,
+            &wth,
+        ), @r#"
+        (
+            [
+                HunkHeader("-1,1", "+1,0"),
+                HunkHeader("-5,2", "+1,0"),
+                HunkHeader("-10,1", "+1,0"),
+            ],
+            [],
+        )
+        "#);
+        insta::assert_debug_snapshot!(to_additive_hunks(
+            [
+                hunk_header("-0,0", "+1,1"),
+                hunk_header("-0,0", "+5,2"),
+                hunk_header("-0,0", "+10,1")
+            ],
+            &wth,
+            &wth,
+        ), @r#"
+        (
+            [
+                HunkHeader("-1,0", "+1,1"),
+                HunkHeader("-1,0", "+5,2"),
+                HunkHeader("-1,0", "+10,1"),
+            ],
+            [],
+        )
+        "#);
+        insta::assert_debug_snapshot!(to_additive_hunks(
+            [
+                hunk_header("-0,0", "+1,1"),
+                hunk_header("-5,2", "+0,0"),
+                hunk_header("-0,0", "+10,1")
+            ],
+            &wth,
+            &wth,
+        ), @r#"
+        (
+            [
+                HunkHeader("-1,0", "+1,1"),
+                HunkHeader("-5,2", "+2,0"),
+                HunkHeader("-7,0", "+10,1"),
+            ],
+            [],
+        )
+        "#);
+        insta::assert_debug_snapshot!(to_additive_hunks(
+            [
+                hunk_header("-1,1", "+0,0"),
+                hunk_header("-0,0", "+5,2"),
+                hunk_header("-10,1", "+0,0")
+            ],
+            &wth,
+            &wth,
+        ), @r#"
+        (
+            [
+                HunkHeader("-1,1", "+1,0"),
+                HunkHeader("-2,0", "+5,2"),
+                HunkHeader("-10,1", "+7,0"),
+            ],
+            [],
+        )
+        "#);
+    }
+
+    #[test]
+    fn selections_and_full_hunks() {
+        let wth = vec![
+            hunk_header("-1,10", "+1,10"),
+            hunk_header("-15,5", "+20,5"),
+            hunk_header("-25,5", "+40,5"),
+        ];
+        insta::assert_debug_snapshot!(to_additive_hunks(
+            [
+                // full match
+                hunk_header("-1,10", "+1,10"),
+                // partial match to same hunk
+                hunk_header("-15,2", "+0,0"),
+                hunk_header("-0,0", "+22,3"),
+                // Last hunk isn't used
+            ],
+            &wth,
+            &wth,
+        ), @r#"
+        (
+            [
+                HunkHeader("-1,10", "+1,10"),
+                HunkHeader("-15,2", "+20,0"),
+                HunkHeader("-17,0", "+22,3"),
+            ],
+            [],
+        )
+        "#);
+    }
+
+    #[test]
+    fn only_full_hunks() {
+        let wth = vec![
+            hunk_header("-1,10", "+1,10"),
+            hunk_header("-15,5", "+20,5"),
+            hunk_header("-25,5", "+40,5"),
+        ];
+        insta::assert_debug_snapshot!(to_additive_hunks(
+            [
+                // full match
+                hunk_header("-1,10", "+1,10"),
+                hunk_header("-15,5", "+20,5"),
+                // Last hunk isn't used
+            ],
+            &wth,
+            &wth,
+        ), @r#"
+        (
+            [
+                HunkHeader("-1,10", "+1,10"),
+                HunkHeader("-15,5", "+20,5"),
+            ],
+            [],
+        )
+        "#);
+    }
+
+    #[test]
+    fn worktree_hunks_without_context_lines() {
+        // diff --git a/file b/file
+        // index 190423f..b513cb5 100644
+        // --- a/file
+        // +++ b/file
+        // @@ -93,8 +93,10 @@
+        //  93
+        //  94
+        //  95
+        // -96
+        // +110
+        // +111
+        //  97
+        // +95
+        //  98
+        //  99
+        // -100
+        // +119
+        let wth = vec![hunk_header("-93,8", "+93,10")];
+
+        // diff --git a/file b/file
+        // index 190423f..b513cb5 100644
+        // --- a/file
+        // +++ b/file
+        // @@ -96 +96,2 @@
+        // -96
+        // +110
+        // +111
+        // @@ -97,0 +99 @@
+        // +95
+        // @@ -100 +102 @@
+        // -100
+        // +119
+        let wth0 = vec![
+            hunk_header("-96,1", "+96,2"),
+            hunk_header("-98,0", "+99,1"),
+            hunk_header("-100,1", "+102,1"),
+        ];
+
+        insta::assert_debug_snapshot!(to_additive_hunks(
+            [hunk_header("-96,1", "+0,0")],
+            &wth,
+            &wth0,
+        ), @r#"
+        (
+            [
+                HunkHeader("-96,1", "+96,0"),
+            ],
+            [],
+        )
+        "#);
+        insta::assert_debug_snapshot!(to_additive_hunks(
+            [hunk_header("-96,1", "+0,0"), hunk_header("-0,0", "+96,2")],
+            &wth,
+            &wth0,
+        ), @r#"
+        (
+            [
+                HunkHeader("-96,1", "+96,0"),
+                HunkHeader("-97,0", "+96,2"),
+            ],
+            [],
+        )
+        "#);
+        insta::assert_debug_snapshot!(to_additive_hunks(
+            [hunk_header("-0,0", "+96,2")],
+            &wth,
+            &wth0,
+        ), @r#"
+        (
+            [
+                HunkHeader("-96,0", "+96,2"),
+            ],
+            [],
+        )
+        "#);
+    }
+}

--- a/crates/but-workspace/src/discard/mod.rs
+++ b/crates/but-workspace/src/discard/mod.rs
@@ -44,7 +44,7 @@ pub mod ui {
 }
 
 mod file;
-mod hunk;
+pub(crate) mod hunk;
 
 #[cfg(unix)]
 fn locked_resource_at(

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -21,7 +21,7 @@
 //!   - Git doesn't have a notion of such a branch.
 //! * **DiffSpec**
 //!   - A type that identifies changes, either as whole file, or as hunks in the file.
-//!   - It doesn't specify if the change is in a commit, or in the worktree, so that information must provided separately.
+//!   - It doesn't specify if the change is in a commit, or in the worktree, so that information must be provided separately.
 
 use anyhow::{Context, Result};
 use author::Author;
@@ -637,5 +637,24 @@ impl TryFrom<&git2::Commit<'_>> for CommitData {
             message: commit.message_raw_bytes().into(),
             author: git2_signature_to_gix_signature(commit.author()),
         })
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod utils {
+    use crate::commit_engine::{HunkHeader, HunkRange};
+
+    pub fn range(start: u32, lines: u32) -> HunkRange {
+        HunkRange { start, lines }
+    }
+    pub fn hunk_header(old: &str, new: &str) -> HunkHeader {
+        let ((old_start, old_lines), (new_start, new_lines)) =
+            but_testsupport::hunk_header(old, new);
+        HunkHeader {
+            old_start,
+            old_lines,
+            new_start,
+            new_lines,
+        }
     }
 }

--- a/crates/but-workspace/tests/fixtures/scenario/all-file-types-renamed-and-modified.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/all-file-types-renamed-and-modified.sh
@@ -13,8 +13,8 @@ mkfifo fifo-should-be-ignored
 
 git add . && git commit -m "init"
 
-seq 5 9 >file
-seq 1 4 >executable
+seq 5 10 >file
+seq 1 5 >executable
 mv file file-renamed
 mv executable executable-renamed
 chmod +x executable-renamed

--- a/crates/but-workspace/tests/fixtures/scenario/plain-modifications.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/plain-modifications.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ### Description
-# An empty file that has 10 added lines, and a file with 10 lines that got emptied.
+# An empty file that has 10 added lines, and a file with 10 lines that got removed, and a modified file with all content changed.
 set -eu -o pipefail
 
 git init

--- a/crates/but-workspace/tests/workspace/commit_engine/amend_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/amend_commit.rs
@@ -26,10 +26,10 @@ fn all_changes_and_renames_to_topmost_commit_no_parent() -> anyhow::Result<()> {
     CreateCommitOutcome {
         rejected_specs: [],
         new_commit: Some(
-            Sha1(7d6c00efe8bf6abb4db3952325e0cf71add9a873),
+            Sha1(613bf3a2f7883b5b6317ced4fb6f5661d1315cec),
         ),
         changed_tree_pre_cherry_pick: Some(
-            Sha1(0236fb167942f3665aa348c514e8d272a6581ad5),
+            Sha1(e56fc9bacdd11ebe576b5d96d21127c423698126),
         ),
         references: [],
         rebase_output: None,
@@ -38,13 +38,13 @@ fn all_changes_and_renames_to_topmost_commit_no_parent() -> anyhow::Result<()> {
     ");
     let tree = visualize_tree(&repo, &outcome)?;
     insta::assert_snapshot!(tree, @r#"
-    0236fb1
-    ├── executable-renamed:100755:94ebaf9 "1\n2\n3\n4\n"
-    ├── file-renamed:100644:66f816c "5\n6\n7\n8\n9\n"
+    e56fc9b
+    ├── executable-renamed:100755:8a1218a "1\n2\n3\n4\n5\n"
+    ├── file-renamed:100644:c5c4315 "5\n6\n7\n8\n9\n10\n"
     └── link-renamed:120000:94e4e07 "other-nonexisting-target"
     "#);
     insta::assert_snapshot!(visualize_commit(&repo, &outcome)?, @r"
-    tree 0236fb167942f3665aa348c514e8d272a6581ad5
+    tree e56fc9bacdd11ebe576b5d96d21127c423698126
     author author <author@example.com> 946684800 +0000
     committer committer (From Env) <committer@example.com> 946771200 +0000
 
@@ -89,7 +89,7 @@ fn new_file_and_deletion_onto_merge_commit() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario("merge-with-two-branches-line-offset");
     // Rewrite the entire file, which is fine as we rewrite/amend the base-commit itself.
     write_sequence(&repo, "new-file", [(10, None)])?;
-    std::fs::remove_file(repo.workdir().expect("non-bare").join("file"))?;
+    std::fs::remove_file(repo.workdir_path("file").expect("non-bare"))?;
 
     let outcome = commit_whole_files_and_all_hunks_from_workspace(
         &repo,
@@ -109,7 +109,7 @@ fn make_a_file_empty() -> anyhow::Result<()> {
 
     let (repo, _tmp) = writable_scenario("merge-with-two-branches-line-offset");
     // Empty the file
-    std::fs::write(repo.workdir().expect("non-bare").join("file"), "")?;
+    std::fs::write(repo.workdir_path("file").expect("non-bare"), "")?;
     let outcome = commit_whole_files_and_all_hunks_from_workspace(
         &repo,
         Destination::AmendCommit(repo.rev_parse_single("merge")?.detach()),
@@ -129,7 +129,7 @@ fn new_file_and_deletion_onto_merge_commit_with_hunks() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario("merge-with-two-branches-line-offset");
     // Rewrite the entire file, which is fine as we rewrite/amend the base-commit itself.
     write_sequence(&repo, "new-file", [(10, None)])?;
-    std::fs::remove_file(repo.workdir().expect("non-bare").join("file"))?;
+    std::fs::remove_file(repo.workdir_path("file").expect("non-bare"))?;
 
     let outcome = but_workspace::commit_engine::create_commit(
         &repo,

--- a/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
@@ -1105,7 +1105,7 @@ mod utils {
         rela_path: &str,
         content: &str,
     ) -> std::io::Result<()> {
-        let work_dir = repo.workdir().expect("non-bare");
-        std::fs::write(work_dir.join(rela_path), content)
+        let work_path = repo.workdir_path(rela_path).expect("non-bare");
+        std::fs::write(work_path, content)
     }
 }

--- a/crates/but-workspace/tests/workspace/discard/file.rs
+++ b/crates/but-workspace/tests/workspace/discard/file.rs
@@ -547,10 +547,10 @@ D  link
 A  link-renamed
 ");
     insta::assert_snapshot!(visualize_index(&**repo.index()?), @r"
-100755:94ebaf9 executable-renamed
-100644:66f816c file-renamed
-120000:94e4e07 link-renamed
-");
+    100755:8a1218a executable-renamed
+    100644:c5c4315 file-renamed
+    120000:94e4e07 link-renamed
+    ");
     insta::assert_snapshot!(visualize_disk_tree_skip_dot_git(repo.workdir().unwrap())?, @r"
 .
 ├── .git:40755

--- a/crates/but-workspace/tests/workspace/discard/hunk.rs
+++ b/crates/but-workspace/tests/workspace/discard/hunk.rs
@@ -1,9 +1,7 @@
-use crate::discard::hunk::util::{
-    changed_file_in_worktree_with_hunks, hunk_header, previous_change_text,
-};
+use crate::discard::hunk::util::{changed_file_in_worktree_with_hunks, previous_change_text};
 use crate::utils::{
-    CONTEXT_LINES, read_only_in_memory_scenario, to_change_specs_all_hunks, visualize_index,
-    writable_scenario,
+    CONTEXT_LINES, hunk_header, read_only_in_memory_scenario, to_change_specs_all_hunks,
+    visualize_index, writable_scenario,
 };
 use bstr::{BString, ByteSlice};
 use but_core::UnifiedDiff;
@@ -416,16 +414,15 @@ fn from_selections_with_context() -> anyhow::Result<()> {
         "hunk-selection order doesn't matter, they can still be associated"
     );
     let actual = read_file_content()?;
-    // However, the order of old/new additions or removals do matter, as it affects the application order.
-    // Thus 8 & 11 are reversed compared to the above.
+    // The order of old/new additions or removals do matter also doesn't matter, the result is stable.
     insta::assert_snapshot!(actual, @r"
     1
     6
     7
     4
     5
-    11
     8
+    11
     9
     eleven
     12
@@ -829,7 +826,6 @@ mod util {
     use bstr::BString;
     use but_core::unified_diff::DiffHunk;
     use but_core::{TreeChange, UnifiedDiff};
-    use but_workspace::commit_engine::HunkHeader;
     use gix::prelude::ObjectIdExt;
 
     pub fn previous_change_text(
@@ -847,18 +843,6 @@ mod util {
             .detach()
             .data
             .into())
-    }
-
-    /// Choose a slightly more obvious, yet easy to type syntax than a function with 4 parameters.
-    pub fn hunk_header(old: &str, new: &str) -> HunkHeader {
-        let ((old_start, old_lines), (new_start, new_lines)) =
-            but_testsupport::hunk_header(old, new);
-        HunkHeader {
-            old_start,
-            old_lines,
-            new_start,
-            new_lines,
-        }
     }
 
     pub fn changed_file_in_worktree_with_hunks(

--- a/crates/but-workspace/tests/workspace/utils.rs
+++ b/crates/but-workspace/tests/workspace/utils.rs
@@ -2,7 +2,7 @@ use bstr::ByteSlice;
 use but_core::TreeStatus;
 use but_testsupport::gix_testtools;
 use but_testsupport::gix_testtools::{Creation, tempfile};
-use but_workspace::commit_engine::{Destination, DiffSpec};
+use but_workspace::commit_engine::{Destination, DiffSpec, HunkHeader};
 use gix::prelude::ObjectIdExt;
 
 pub const CONTEXT_LINES: u32 = 0;
@@ -89,6 +89,18 @@ pub fn to_change_specs_whole_file(changes: but_core::WorktreeChanges) -> Vec<Dif
         "fixture should contain actual changes to turn into requests"
     );
     out
+}
+
+pub fn diff_spec(
+    previous_path: Option<&str>,
+    path: &str,
+    hunks: impl IntoIterator<Item = HunkHeader>,
+) -> DiffSpec {
+    DiffSpec {
+        previous_path: previous_path.map(Into::into),
+        path: path.into(),
+        hunk_headers: hunks.into_iter().collect(),
+    }
 }
 
 /// Always use all the hunks.
@@ -277,4 +289,15 @@ pub fn write_local_config(repo: &gix::Repository) -> anyhow::Result<()> {
         |section| section.meta().source == gix::config::Source::Local,
     )?;
     Ok(())
+}
+
+/// Choose a slightly more obvious, yet easy to type syntax than a function with 4 parameters.
+pub fn hunk_header(old: &str, new: &str) -> HunkHeader {
+    let ((old_start, old_lines), (new_start, new_lines)) = but_testsupport::hunk_header(old, new);
+    HunkHeader {
+        old_start,
+        old_lines,
+        new_start,
+        new_lines,
+    }
 }


### PR DESCRIPTION
Add V3 facilities for discarding changes in the worktree or index, this time it's about hunks specifically.

Follow-up of #7807.

### Tasks

* [x]  **gitoxide informs about diff-filter changes** and this information is passed to the frontend
    - differentiate binary-to-text , otherwise it applies worktree conversions (which is fine). We ignore external diff programs anyway.
* [x] use latest `gix` from `main`
* [x] hunk-selections for committing
    - [x] trivial selections
    - [x] assure multiple selections per hunk actually work like they should (which won't work out of the box for sure)
    - [x] A UI-style selections with lots of one-liners - result should be the same no matter what (high-level)
    - [x] test for discarding only hunks that aren't matching, but commit the hunks that matched.
* [x] `but-cli` supports committing hunk headers

### Next PR

* https://github.com/gitbutlerapp/gitbutler/pull/7952#issue-2967230532
    - Why does it do the wrong thing once [these lines](https://github.com/gitbutlerapp/gitbutler/blob/92e722ddade85a195c7e7041317fbb3417467d56/crates/gitbutler-tauri/src/workspace.rs#L164-L167) are removed.
    - problem is that the passed workspace commit is already only having one parent only, even though it should have two.
          - Once that is clear, it should fail as it needs a base-substitute.
* **See what happens if one tries to commit these special cases** (i.e. the 'pretend there is  no index' changes)
* **Discard hunk logic** can probably use the context-window = 0 upgrade, right now splits are computed even though I doubt this is always correct.

