### PR TITLE
Sort updated refs to prevent flaky tests

### DIFF
--- a/crates/but-workspace/src/commit_engine/refs.rs
+++ b/crates/but-workspace/src/commit_engine/refs.rs
@@ -120,5 +120,8 @@ pub fn rewrite(
         }
     }
     repo.edit_references(ref_edits)?;
+    // Due to the way these are processed, they aren't stable.
+    // Make tests reproducible, hoping that soon we don't need hashmaps in the backend anymore.
+    updated_refs.sort_by(|a, b| a.reference.to_string().cmp(&b.reference.to_string()));
     Ok(())
 }

--- a/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
@@ -195,20 +195,6 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
         ),
         references: [
             UpdatedReference {
-                reference: Virtual(
-                    "s1-b/second",
-                ),
-                old_commit_id: Sha1(2abfa5cc3c7c48b8b9eabbd10c21b88347801f15),
-                new_commit_id: Sha1(189ac82eb44ddb97677d7d7b1859cf6f2e33a473),
-            },
-            UpdatedReference {
-                reference: Virtual(
-                    "s2-b/second",
-                ),
-                old_commit_id: Sha1(2abfa5cc3c7c48b8b9eabbd10c21b88347801f15),
-                new_commit_id: Sha1(189ac82eb44ddb97677d7d7b1859cf6f2e33a473),
-            },
-            UpdatedReference {
                 reference: Git(
                     FullName(
                         "refs/heads/another-tip",
@@ -222,6 +208,20 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
                     FullName(
                         "refs/heads/main",
                     ),
+                ),
+                old_commit_id: Sha1(2abfa5cc3c7c48b8b9eabbd10c21b88347801f15),
+                new_commit_id: Sha1(189ac82eb44ddb97677d7d7b1859cf6f2e33a473),
+            },
+            UpdatedReference {
+                reference: Virtual(
+                    "s1-b/second",
+                ),
+                old_commit_id: Sha1(2abfa5cc3c7c48b8b9eabbd10c21b88347801f15),
+                new_commit_id: Sha1(189ac82eb44ddb97677d7d7b1859cf6f2e33a473),
+            },
+            UpdatedReference {
+                reference: Virtual(
+                    "s2-b/second",
                 ),
                 old_commit_id: Sha1(2abfa5cc3c7c48b8b9eabbd10c21b88347801f15),
                 new_commit_id: Sha1(189ac82eb44ddb97677d7d7b1859cf6f2e33a473),
@@ -319,6 +319,22 @@ fn insert_commit_into_single_stack_with_signatures() -> anyhow::Result<()> {
         ),
         references: [
             UpdatedReference {
+                reference: Virtual(
+                    "",
+                ),
+                old_commit_id: Sha1(ecd67221705b069c4f46365a46c8f2cd8a97ec19),
+                new_commit_id: Sha1(3aec75308383b83d85a78a90308a618755a7b0f8),
+            },
+            UpdatedReference {
+                reference: Git(
+                    FullName(
+                        "refs/heads/first-commit",
+                    ),
+                ),
+                old_commit_id: Sha1(ecd67221705b069c4f46365a46c8f2cd8a97ec19),
+                new_commit_id: Sha1(3aec75308383b83d85a78a90308a618755a7b0f8),
+            },
+            UpdatedReference {
                 reference: Git(
                     FullName(
                         "refs/heads/main",
@@ -329,23 +345,7 @@ fn insert_commit_into_single_stack_with_signatures() -> anyhow::Result<()> {
             },
             UpdatedReference {
                 reference: Virtual(
-                    "",
-                ),
-                old_commit_id: Sha1(ecd67221705b069c4f46365a46c8f2cd8a97ec19),
-                new_commit_id: Sha1(3aec75308383b83d85a78a90308a618755a7b0f8),
-            },
-            UpdatedReference {
-                reference: Virtual(
                     "s1-b/init",
-                ),
-                old_commit_id: Sha1(ecd67221705b069c4f46365a46c8f2cd8a97ec19),
-                new_commit_id: Sha1(3aec75308383b83d85a78a90308a618755a7b0f8),
-            },
-            UpdatedReference {
-                reference: Git(
-                    FullName(
-                        "refs/heads/first-commit",
-                    ),
                 ),
                 old_commit_id: Sha1(ecd67221705b069c4f46365a46c8f2cd8a97ec19),
                 new_commit_id: Sha1(3aec75308383b83d85a78a90308a618755a7b0f8),


### PR DESCRIPTION
Turns out that the sorting issue doesn't come from `gitoxide`, so updating it didn't change anything.

Somehow I thought it had to be as it never really occurred on CI, but it seems it's related to something around hashmaps that may have been introduced more recently.

Follow-up to https://github.com/gitbutlerapp/gitbutler/pull/7902 which did flakily merge early.
