### PR TITLE
Refactor move commit file to use rebase engine

### DIFF
--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -32,7 +32,6 @@ use gitbutler_project::AUTO_TRACK_LIMIT_BYTES;
 use gitbutler_reference::{normalize_branch_name, Refname, RemoteRefname};
 use gitbutler_repo::{
     logging::{LogUntil, RepositoryExt as _},
-    rebase::cherry_rebase,
     RepositoryExt,
 };
 use gitbutler_repo_actions::RepoActionsExt;
@@ -1100,6 +1099,11 @@ pub fn is_remote_branch_mergeable(
 // and the rebase should be simple. if the "to" commit is above the "from" commit,
 // the changes need to be removed from the "from" commit, everything rebased,
 // then added to the "to" commit and everything above that rebased again.
+//
+// NB: It appears that this function is semi-broken when the "to" commit is above the "from" commit.
+// Ths changes are indeed removed from the "from" commit, but they end up in the workspace and not the "to" commit.
+// This was broken before the migration to the rebase engine.
+// The way the trees of "diffs to keep" and "diffs to amend" are computed with gitbutler_diff::write::hunks_onto_commit is incredibly sketchy
 pub(crate) fn move_commit_file(
     ctx: &CommandContext,
     stack_id: StackId,
@@ -1109,26 +1113,106 @@ pub(crate) fn move_commit_file(
 ) -> Result<git2::Oid> {
     let vb_state = ctx.project().virtual_branches();
 
-    let Some(mut target_stack) = vb_state.try_stack_in_workspace(stack_id)? else {
-        return Ok(to_commit_id); // this is wrong
-    };
-
     let default_target = vb_state.get_default_target()?;
 
-    let mut to_amend_oid = to_commit_id;
-    let mut amend_commit = ctx
-        .repo()
-        .find_commit(to_amend_oid)
-        .context("failed to find commit")?;
-
+    let mut stack = vb_state.get_stack_in_workspace(stack_id)?;
     let gix_repo = ctx.gix_repository()?;
+    let stack_context = ctx.to_stack_context()?;
+    let merge_base = stack.merge_base(&stack_context)?;
 
-    // find all the commits upstream from the target "to" commit
-    let mut upstream_commits = ctx.repo().l(
-        target_stack.head(&gix_repo)?,
-        LogUntil::Commit(amend_commit.id()),
-        false,
-    )?;
+    // first, let's get the from commit data and it's parent data
+    let from_commit = ctx
+        .repo()
+        .find_commit(from_commit_id)
+        .context("failed to find commit")?;
+    let from_tree = from_commit.tree().context("failed to find tree")?;
+    let from_parent = from_commit.parent(0).context("failed to find parent")?;
+    let from_parent_tree = from_parent.tree().context("failed to find parent tree")?;
+
+    // ok, what is the entire patch introduced in the "from" commit?
+    // we need to remove the parts of this patch that are in target_ownership (the parts we're moving)
+    // and then apply the rest to the parent tree of the "from" commit to
+    // create the new "from" commit without the changes we're moving
+    let from_commit_diffs = gitbutler_diff::trees(ctx.repo(), &from_parent_tree, &from_tree, true)
+        .context("failed to diff trees")?;
+
+    // filter from_commit_diffs to HashMap<filepath, Vec<GitHunk>> only for hunks NOT in target_ownership
+    // this is the patch parts we're keeping
+    let diffs_to_keep = from_commit_diffs
+        .iter()
+        .filter_map(|(filepath, file_diff)| {
+            let hunks = file_diff
+                .hunks
+                .iter()
+                .filter(|hunk| {
+                    !target_ownership.claims.iter().any(|file_ownership| {
+                        file_ownership.file_path.eq(filepath)
+                            && file_ownership.hunks.iter().any(|owned_hunk| {
+                                owned_hunk.start == hunk.new_start
+                                    && owned_hunk.end == hunk.new_start + hunk.new_lines
+                            })
+                    })
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            if hunks.is_empty() {
+                None
+            } else {
+                Some((filepath.clone(), hunks))
+            }
+        })
+        .collect::<HashMap<_, _>>();
+
+    // write our new tree and commit for the new "from" commit without the moved changes
+    let new_from_tree_id =
+        gitbutler_diff::write::hunks_onto_commit(ctx, from_parent.id(), &diffs_to_keep)?;
+    let new_from_tree = &ctx
+        .repo()
+        .find_tree(new_from_tree_id)
+        .with_context(|| "tree {new_from_tree_oid} not found")?;
+    let new_from_commit_oid = ctx
+        .repo()
+        .commit_with_signature(
+            None,
+            &from_commit.author(),
+            &from_commit.committer(),
+            &from_commit.message_bstr().to_str_lossy(),
+            new_from_tree,
+            &[&from_parent],
+            from_commit.gitbutler_headers(),
+        )
+        .context("commit failed")?;
+
+    // rebase swapping the from_commit_oid with the new_from_commit_oid
+    let mut steps = stack.as_rebase_steps(ctx, &gix_repo)?;
+    // replace the "from" commit in the rebase steps with the new "from" commit which has the moved changes removed
+    for step in steps.iter_mut() {
+        if let RebaseStep::Pick { commit_id, .. } = step {
+            if *commit_id == from_commit_id.to_gix() {
+                *commit_id = new_from_commit_oid.to_gix();
+            }
+        }
+    }
+    let mut rebase = but_rebase::Rebase::new(&gix_repo, merge_base.to_gix(), None)?;
+    rebase.steps(steps)?;
+    rebase.rebase_noops(false);
+    let outcome = rebase.rebase()?;
+    // ensure that the stack here has been updated.
+    stack.set_heads_from_rebase_output(ctx, outcome.references)?;
+
+    // Discover the new id of the commit to amend `to_commit_id` from the output of the first rebas
+    let to_commit_id = outcome
+        .commit_mapping
+        .iter()
+        .find(|(_base, old, _new)| old == &to_commit_id.to_gix())
+        .map(|(_base, _old, new)| new.to_git2())
+        .ok_or_else(|| anyhow!("failed to find the to_ammend_commit after the initial rebase"))?;
+
+    let to_commit = ctx
+        .repo()
+        .find_commit(to_commit_id)
+        .context("failed to find commit")?;
+    let to_commit_parents: Vec<_> = to_commit.parents().collect();
 
     // get a list of all the diffs across all the virtual branches
     let base_file_diffs = gitbutler_diff::workdir(ctx.repo(), default_target.sha)
@@ -1163,180 +1247,50 @@ pub(crate) fn move_commit_file(
             }
         })
         .collect::<HashMap<_, _>>();
-
-    // if we're not moving anything, return an error
-    if diffs_to_amend.is_empty() {
-        bail!("target ownership not found");
-    }
-
-    // is from_commit_oid in upstream_commits?
-    if !upstream_commits.contains(&from_commit_id) {
-        // this means that the "from" commit is _below_ the "to" commit in the history
-        // which makes things a little more complicated because in this case we need to
-        // remove the changes from the lower "from" commit, rebase everything, then add the changes
-        // to the _rebased_ version of the "to" commit that is above it.
-
-        // first, let's get the from commit data and it's parent data
-        let from_commit = ctx
-            .repo()
-            .find_commit(from_commit_id)
-            .context("failed to find commit")?;
-        let from_tree = from_commit.tree().context("failed to find tree")?;
-        let from_parent = from_commit.parent(0).context("failed to find parent")?;
-        let from_parent_tree = from_parent.tree().context("failed to find parent tree")?;
-
-        // ok, what is the entire patch introduced in the "from" commit?
-        // we need to remove the parts of this patch that are in target_ownership (the parts we're moving)
-        // and then apply the rest to the parent tree of the "from" commit to
-        // create the new "from" commit without the changes we're moving
-        let from_commit_diffs =
-            gitbutler_diff::trees(ctx.repo(), &from_parent_tree, &from_tree, true)
-                .context("failed to diff trees")?;
-
-        // filter from_commit_diffs to HashMap<filepath, Vec<GitHunk>> only for hunks NOT in target_ownership
-        // this is the patch parts we're keeping
-        let diffs_to_keep = from_commit_diffs
-            .iter()
-            .filter_map(|(filepath, file_diff)| {
-                let hunks = file_diff
-                    .hunks
-                    .iter()
-                    .filter(|hunk| {
-                        !target_ownership.claims.iter().any(|file_ownership| {
-                            file_ownership.file_path.eq(filepath)
-                                && file_ownership.hunks.iter().any(|owned_hunk| {
-                                    owned_hunk.start == hunk.new_start
-                                        && owned_hunk.end == hunk.new_start + hunk.new_lines
-                                })
-                        })
-                    })
-                    .cloned()
-                    .collect::<Vec<_>>();
-                if hunks.is_empty() {
-                    None
-                } else {
-                    Some((filepath.clone(), hunks))
-                }
-            })
-            .collect::<HashMap<_, _>>();
-
-        let repo = ctx.repo();
-
-        // write our new tree and commit for the new "from" commit without the moved changes
-        let new_from_tree_id =
-            gitbutler_diff::write::hunks_onto_commit(ctx, from_parent.id(), &diffs_to_keep)?;
-        let new_from_tree = &repo
-            .find_tree(new_from_tree_id)
-            .with_context(|| "tree {new_from_tree_oid} not found")?;
-        let new_from_commit_oid = ctx
-            .repo()
-            .commit_with_signature(
-                None,
-                &from_commit.author(),
-                &from_commit.committer(),
-                &from_commit.message_bstr().to_str_lossy(),
-                new_from_tree,
-                &[&from_parent],
-                from_commit.gitbutler_headers(),
-            )
-            .context("commit failed")?;
-
-        // rebase everything above the new "from" commit that has the moved changes removed
-        let new_head = match cherry_rebase(
-            ctx,
-            new_from_commit_oid,
-            from_commit_id,
-            target_stack.head(&gix_repo)?,
-        ) {
-            Ok(Some(new_head)) => new_head,
-            Ok(None) => bail!("no rebase was performed"),
-            Err(err) => return Err(err).context("rebase failed"),
-        };
-
-        // ok, now we need to identify which the new "to" commit is in the rebased history
-        // so we'll take a list of the upstream oids and find it simply based on location
-        // (since the order should not have changed in our simple rebase)
-        let old_upstream_commit_oids = ctx.repo().l(
-            target_stack.head(&gix_repo)?,
-            LogUntil::Commit(default_target.sha),
-            false,
-        )?;
-
-        let new_upstream_commit_oids =
-            ctx.repo()
-                .l(new_head, LogUntil::Commit(default_target.sha), false)?;
-
-        // find to_commit_oid offset in upstream_commits vector
-        let to_commit_offset = old_upstream_commit_oids
-            .iter()
-            .position(|c| *c == to_amend_oid)
-            .context("failed to find commit in old commits")?;
-
-        // find the new "to" commit in our new rebased upstream commits
-        to_amend_oid = *new_upstream_commit_oids
-            .get(to_commit_offset)
-            .context("failed to find commit in new commits")?;
-
-        // reset the "to" commit variable for writing the changes back to
-        amend_commit = ctx
-            .repo()
-            .find_commit(to_amend_oid)
-            .context("failed to find commit")?;
-
-        // reset the concept of what the upstream commits are to be the rebased ones
-        upstream_commits = ctx
-            .repo()
-            .l(new_head, LogUntil::Commit(amend_commit.id()), false)?;
-    }
-
-    // ok, now we will apply the moved changes to the "to" commit.
-    // if we were moving the changes down, we didn't need to rewrite the "from" commit
-    // because it will be rewritten with the upcoming rebase.
-    // if we were moving the changes "up" we've already rewritten the "from" commit
-
     // apply diffs_to_amend to the commit tree
     // and write a new commit with the changes we're moving
+    // let new_tree_oid =
+    //     gitbutler_diff::write::hunks_onto_commit(ctx, to_commit_id, &diffs_to_amend)?;
     let new_tree_oid =
-        gitbutler_diff::write::hunks_onto_commit(ctx, to_amend_oid, &diffs_to_amend)?;
+        gitbutler_diff::write::hunks_onto_tree(ctx, &to_commit.tree()?, &diffs_to_amend, true)?;
+
     let new_tree = ctx
         .repo()
         .find_tree(new_tree_oid)
         .context("failed to find new tree")?;
-    let parents: Vec<_> = amend_commit.parents().collect();
-    let commit_oid = ctx
+    let new_to_commit_oid = ctx
         .repo()
         .commit_with_signature(
             None,
-            &amend_commit.author(),
-            &amend_commit.committer(),
-            &amend_commit.message_bstr().to_str_lossy(),
+            &to_commit.author(),
+            &to_commit.committer(),
+            &to_commit.message_bstr().to_str_lossy(),
             &new_tree,
-            &parents.iter().collect::<Vec<_>>(),
-            amend_commit.gitbutler_headers(),
+            &to_commit_parents.iter().collect::<Vec<_>>(),
+            to_commit.gitbutler_headers(),
         )
         .context("failed to create commit")?;
 
-    // now rebase upstream commits, if needed
+    dbg!(&new_to_commit_oid);
 
-    // if there are no upstream commits (the "to" commit was the branch head), then we're done
-    if upstream_commits.is_empty() {
-        target_stack.set_stack_head(&vb_state, &gix_repo, commit_oid, None)?;
-        crate::integration::update_workspace_commit(&vb_state, ctx)?;
-        return Ok(commit_oid);
+    // another rebase
+    let mut steps = stack.as_rebase_steps(ctx, &gix_repo)?;
+    // replace the "to" commit in the rebase steps with the new "to" commit which has the moved changes added
+    for step in steps.iter_mut() {
+        if let RebaseStep::Pick { commit_id, .. } = step {
+            if *commit_id == to_commit_id.to_gix() {
+                *commit_id = new_to_commit_oid.to_gix();
+            }
+        }
     }
-
-    // otherwise, rebase the upstream commits onto the new commit
-    let last_commit = upstream_commits.first().cloned().unwrap();
-    let new_head = cherry_rebase(ctx, commit_oid, amend_commit.id(), last_commit)?;
-
-    // if that rebase worked, update the branch head and the gitbutler workspace
-    if let Some(new_head) = new_head {
-        target_stack.set_stack_head(&vb_state, &gix_repo, new_head, None)?;
-        crate::integration::update_workspace_commit(&vb_state, ctx)?;
-        Ok(commit_oid)
-    } else {
-        Err(anyhow!("rebase failed"))
-    }
+    let mut rebase = but_rebase::Rebase::new(&gix_repo, merge_base.to_gix(), None)?;
+    rebase.steps(steps)?;
+    rebase.rebase_noops(false);
+    let outcome = rebase.rebase()?;
+    stack.set_heads_from_rebase_output(ctx, outcome.references)?;
+    stack.set_stack_head(&vb_state, &gix_repo, outcome.top_commit.to_git2(), None)?;
+    // todo: maybe update the workspace commit here?
+    Ok(new_to_commit_oid)
 }
 
 // create and insert a blank commit (no tree change) either above or below a commit


### PR DESCRIPTION
It appears that this operation is broken in some of the cases, and this refactor neither fixes that breakage nor it introduces it