### PR TITLE
Toggling between v3 and v2 UI shouldn't screw up the workdir

### DIFF
--- a/apps/desktop/src/lib/config/appSettingsV2.ts
+++ b/apps/desktop/src/lib/config/appSettingsV2.ts
@@ -1,4 +1,7 @@
 import { listen, invoke } from '$lib/backend/ipc';
+const projectsService = getContext(ProjectsService);
+import { ProjectsService } from '$lib/project/projectsService';
+import { getContext } from '@gitbutler/shared/context';
 import { writable } from 'svelte/store';
 import type { Tauri } from '$lib/backend/tauri';
 
@@ -36,6 +39,10 @@ export class SettingsService {
 	}
 
 	async updateFeatureFlags(update: Partial<FeatureFlags>) {
+		// Doing a call to list_virtual_branches first to ensure the stack.tree properties are updated
+		await invoke<any>('list_virtual_branches', {
+			projectId: projectsService.getLastOpenedProject()
+		});
 		await invoke('update_feature_flags', { update });
 	}
 


### PR DESCRIPTION
Ideally we should do this for all projects. Let's first validate that this works