### PR TITLE
Fix incorrect indentation in diff view

### DIFF
--- a/packages/ui/src/lib/utils/diffParsing.ts
+++ b/packages/ui/src/lib/utils/diffParsing.ts
@@ -533,8 +533,8 @@ function toTokens(inputLine: string, parser: Parser | undefined): string[] {
 	const tokens: string[] = [];
 	highlighter.highlight((text, classNames) => {
 		const token = classNames
-			? `<span data-no-drag class=${classNames}>${sanitize(text)}</span>`
-			: sanitize(text);
+			? `<span class=${classNames}>${sanitize(text)}</span>`
+			: `<span>${sanitize(text)}</span>`;
 
 		tokens.push(token);
 	});


### PR DESCRIPTION
Tabs followed by a span meant the tabs were ignored.