### PR TITLE
Be much more thurourgh with invalidation tags

### DIFF
--- a/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
+++ b/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
@@ -1,7 +1,7 @@
 import { Code } from '$lib/backend/ipc';
 import { BaseBranch, type RemoteBranchInfo } from '$lib/baseBranch/baseBranch';
 import { showError } from '$lib/notifications/toasts';
-import { ReduxTag } from '$lib/state/tags';
+import { invalidatesList, providesList, ReduxTag } from '$lib/state/tags';
 import { parseRemoteUrl } from '$lib/url/gitUrl';
 import { plainToInstance } from 'class-transformer';
 import type { BackendApi } from '$lib/state/clientState.svelte';
@@ -134,7 +134,7 @@ function injectEndpoints(api: BackendApi) {
 					command: 'get_base_branch_data',
 					params: { projectId }
 				}),
-				providesTags: [ReduxTag.BaseBranchData]
+				providesTags: [providesList(ReduxTag.BaseBranchData)]
 			}),
 			fetchFromRemotes: build.mutation<void, { projectId: string; action?: string }>({
 				query: ({ projectId, action }) => ({
@@ -142,10 +142,10 @@ function injectEndpoints(api: BackendApi) {
 					params: { projectId, action: action ?? 'auto' }
 				}),
 				invalidatesTags: [
-					ReduxTag.BaseBranchData,
-					ReduxTag.Stacks,
-					ReduxTag.Commits,
-					ReduxTag.UpstreamIntegrationStatus
+					invalidatesList(ReduxTag.BaseBranchData),
+					invalidatesList(ReduxTag.Stacks),
+					invalidatesList(ReduxTag.Commits),
+					invalidatesList(ReduxTag.UpstreamIntegrationStatus)
 				],
 				transformErrorResponse: (error) => {
 					// This is good enough while we check the best way to handle this
@@ -160,14 +160,18 @@ function injectEndpoints(api: BackendApi) {
 					command: 'set_base_branch',
 					params: { projectId, branch, pushRemote }
 				}),
-				invalidatesTags: [ReduxTag.BaseBranchData, ReduxTag.Stacks, ReduxTag.Commits]
+				invalidatesTags: [
+					invalidatesList(ReduxTag.BaseBranchData),
+					invalidatesList(ReduxTag.Stacks),
+					invalidatesList(ReduxTag.Commits)
+				]
 			}),
 			push: build.mutation<void, { projectId: string; withForce?: boolean }>({
 				query: ({ projectId, withForce }) => ({
 					command: 'push_base_branch',
 					params: { projectId, withForce }
 				}),
-				invalidatesTags: [ReduxTag.BaseBranchData]
+				invalidatesTags: [invalidatesList(ReduxTag.BaseBranchData)]
 			}),
 			remoteBranches: build.query<RemoteBranchInfo[], { projectId: string }>({
 				query: ({ projectId }) => ({

--- a/apps/desktop/src/lib/forge/github/githubChecksMonitor.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubChecksMonitor.svelte.ts
@@ -1,6 +1,6 @@
 import { ghQuery } from '$lib/forge/github/ghQuery';
 import { type ChecksResult } from '$lib/forge/github/types';
-import { ReduxTag } from '$lib/state/tags';
+import { providesItem, ReduxTag } from '$lib/state/tags';
 import type { ChecksService } from '$lib/forge/interface/forgeChecksMonitor';
 import type { ChecksStatus } from '$lib/forge/interface/types';
 import type { QueryOptions } from '$lib/state/butlerModule';
@@ -72,10 +72,7 @@ function injectEndpoints(api: GitHubApi) {
 							ref
 						}
 					}),
-				providesTags: (_result, _error, args) => [
-					ReduxTag.Checks,
-					{ type: ReduxTag.Checks, id: args.stackId }
-				]
+				providesTags: (_result, _error, args) => [...providesItem(ReduxTag.Checks, args.stackId)]
 			})
 		})
 	});

--- a/apps/desktop/src/lib/forge/github/githubListingService.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubListingService.svelte.ts
@@ -1,7 +1,7 @@
 import { ghQuery } from '$lib/forge/github/ghQuery';
 import { ghResponseToInstance } from '$lib/forge/github/types';
 import { createSelectByIds } from '$lib/state/customSelectors';
-import { ReduxTag } from '$lib/state/tags';
+import { providesList, ReduxTag } from '$lib/state/tags';
 import { reactive } from '@gitbutler/shared/storeUtils';
 import { createEntityAdapter, type EntityState } from '@reduxjs/toolkit';
 import type { ForgeListingService } from '$lib/forge/interface/forgeListingService';
@@ -79,7 +79,7 @@ function injectEndpoints(api: GitHubApi) {
 					}
 					return result;
 				},
-				providesTags: [ReduxTag.PullRequests]
+				providesTags: [providesList(ReduxTag.PullRequests)]
 			})
 		})
 	});

--- a/apps/desktop/src/lib/forge/github/githubPrService.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubPrService.svelte.ts
@@ -10,7 +10,7 @@ import {
 	type DetailedPullRequest,
 	type PullRequest
 } from '$lib/forge/interface/types';
-import { ReduxTag } from '$lib/state/tags';
+import { providesItem, invalidatesItem, ReduxTag, invalidatesList } from '$lib/state/tags';
 import { sleep } from '$lib/utils/sleep';
 import { writable } from 'svelte/store';
 import type { PostHogWrapper } from '$lib/analytics/posthog';
@@ -113,7 +113,7 @@ function injectEndpoints(api: GitHubApi) {
 							extra: api.extra
 						})
 					),
-				providesTags: [ReduxTag.PullRequests]
+				providesTags: (_result, _error, args) => providesItem(ReduxTag.PullRequests, args.number)
 			}),
 			createPr: build.mutation<
 				CreatePrResult,
@@ -126,7 +126,7 @@ function injectEndpoints(api: GitHubApi) {
 						parameters: { head, base, title, body, draft },
 						extra: api.extra
 					}),
-				invalidatesTags: [ReduxTag.PullRequests]
+				invalidatesTags: (result) => [invalidatesItem(ReduxTag.PullRequests, result?.number)]
 			}),
 			mergePr: build.mutation<void, { number: number; method: MergeMethod }>({
 				queryFn: async ({ number, method: method }, api) => {
@@ -138,7 +138,7 @@ function injectEndpoints(api: GitHubApi) {
 					});
 					return { data: undefined };
 				},
-				invalidatesTags: [ReduxTag.PullRequests]
+				invalidatesTags: [invalidatesList(ReduxTag.PullRequests)]
 			}),
 			updatePr: build.mutation<
 				void,
@@ -165,7 +165,7 @@ function injectEndpoints(api: GitHubApi) {
 					});
 					return { data: undefined };
 				},
-				invalidatesTags: [ReduxTag.PullRequests]
+				invalidatesTags: [invalidatesList(ReduxTag.PullRequests)]
 			})
 		})
 	});

--- a/apps/desktop/src/lib/forge/github/githubRepoService.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubRepoService.svelte.ts
@@ -1,5 +1,5 @@
 import { ghQuery } from '$lib/forge/github/ghQuery';
-import { ReduxTag } from '$lib/state/tags';
+import { providesList, ReduxTag } from '$lib/state/tags';
 import type { RepoResult } from '$lib/forge/github/types';
 import type { ForgeRepoService, RepoDetailedInfo } from '$lib/forge/interface/forgeRepoService';
 import type { ReactiveResult } from '$lib/state/butlerModule';
@@ -34,7 +34,7 @@ function injectEndpoints(api: GitHubApi) {
 						action: 'get',
 						extra: api.extra
 					}),
-				providesTags: [ReduxTag.PullRequests]
+				providesTags: [providesList(ReduxTag.PullRequests)]
 			})
 		})
 	});

--- a/apps/desktop/src/lib/forge/github/githubRepoService.ts
+++ b/apps/desktop/src/lib/forge/github/githubRepoService.ts
@@ -1,5 +1,5 @@
 import { ghQuery } from '$lib/forge/github/ghQuery';
-import { ReduxTag } from '$lib/state/tags';
+import { providesList, ReduxTag } from '$lib/state/tags';
 import type { RepoResult } from '$lib/forge/github/types';
 import type { ForgeRepoService } from '$lib/forge/interface/forgeRepoService';
 import type { GitHubApi } from '$lib/state/clientState.svelte';
@@ -38,7 +38,7 @@ function injectEndpoints(api: GitHubApi) {
 						action: 'get',
 						extra: api.extra
 					}),
-				providesTags: [ReduxTag.PullRequests]
+				providesTags: [providesList(ReduxTag.PullRequests)]
 			})
 		})
 	});

--- a/apps/desktop/src/lib/forge/github/githubUserService.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubUserService.svelte.ts
@@ -1,5 +1,5 @@
 import { ghQuery } from '$lib/forge/github/ghQuery';
-import { ReduxTag } from '$lib/state/tags';
+import { providesList, ReduxTag } from '$lib/state/tags';
 import type { Tauri } from '$lib/backend/tauri';
 import type { GitHubApi } from '$lib/state/clientState.svelte';
 import type { RestEndpointMethodTypes } from '@octokit/rest';
@@ -45,7 +45,7 @@ function injectEndpoints(api: GitHubApi) {
 						action: 'getAuthenticated',
 						extra: api.extra
 					}),
-				providesTags: [ReduxTag.PullRequests]
+				providesTags: [providesList(ReduxTag.PullRequests)]
 			})
 		})
 	});

--- a/apps/desktop/src/lib/forge/github/issueService.ts
+++ b/apps/desktop/src/lib/forge/github/issueService.ts
@@ -1,5 +1,5 @@
 import { ghQuery } from '$lib/forge/github/ghQuery';
-import { ReduxTag } from '$lib/state/tags';
+import { invalidatesList, ReduxTag } from '$lib/state/tags';
 import type { CreateIssueResult } from '$lib/forge/github/types';
 import type { ForgeIssueService } from '$lib/forge/interface/forgeIssueService';
 import type { GitHubApi } from '$lib/state/clientState.svelte';
@@ -31,7 +31,7 @@ function injectEndpoints(api: GitHubApi) {
 						parameters: { title, body, labels },
 						extra: api.extra
 					}),
-				invalidatesTags: [ReduxTag.PullRequests]
+				invalidatesTags: [invalidatesList(ReduxTag.PullRequests)]
 			})
 		})
 	});

--- a/apps/desktop/src/lib/hunks/diffService.svelte.ts
+++ b/apps/desktop/src/lib/hunks/diffService.svelte.ts
@@ -1,4 +1,4 @@
-import { ReduxTag } from '$lib/state/tags';
+import { providesList, ReduxTag } from '$lib/state/tags';
 import type { TreeChange } from '$lib/hunks/change';
 import type { UnifiedDiff } from '$lib/hunks/diff';
 import type { ClientState } from '$lib/state/clientState.svelte';
@@ -37,7 +37,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'tree_change_diffs',
 					params: { projectId, change }
 				}),
-				providesTags: [ReduxTag.Diff]
+				providesTags: [providesList(ReduxTag.Diff)]
 			})
 		})
 	});

--- a/apps/desktop/src/lib/state/tags.ts
+++ b/apps/desktop/src/lib/state/tags.ts
@@ -15,3 +15,49 @@ export enum ReduxTag {
 	BaseBranchData = 'BaseBranchData',
 	UpstreamIntegrationStatus = 'UpstreamIntegrationStatus'
 }
+
+type Tag<T extends string | number> = {
+	type: ReduxTag;
+	id: T;
+};
+
+const LIST = 'LIST';
+
+// We always want to provide either, just the list or the list and the item.
+// This means that we can either invalidate all of them, or an individual item.
+
+export function providesList(tag: ReduxTag): Tag<typeof LIST> {
+	return { type: tag, id: LIST };
+}
+
+export function providesItem<T extends string | number>(
+	tag: ReduxTag,
+	id: T
+): [Tag<T>, Tag<typeof LIST>] {
+	return [
+		{ type: tag, id },
+		{ type: tag, id: LIST }
+	];
+}
+
+export function providesItems<T extends string | number>(
+	tag: ReduxTag,
+	ids: T[]
+): Tag<T | typeof LIST>[] {
+	const itemTags = ids.map((id) => ({ type: tag, id }));
+	return [...itemTags, { type: tag, id: LIST }];
+}
+
+export function invalidatesList(tag: ReduxTag): Tag<typeof LIST> {
+	return { type: tag, id: LIST };
+}
+
+export function invalidatesItem<
+	T extends string | number | undefined,
+	OutTag = Tag<T extends undefined ? typeof LIST : T>
+>(tag: ReduxTag, id: T): OutTag {
+	if (id === undefined) {
+		return { type: tag, id: LIST } as OutTag;
+	}
+	return { type: tag, id } as OutTag;
+}

--- a/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
+++ b/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
@@ -1,5 +1,5 @@
 import { ProjectsService } from '$lib/project/projectsService';
-import { ReduxTag } from '$lib/state/tags';
+import { invalidatesList, providesList, ReduxTag } from '$lib/state/tags';
 import { BranchService as CloudBranchService } from '@gitbutler/shared/branches/branchService';
 import { BranchStatus as CloudBranchStatus } from '@gitbutler/shared/branches/types';
 import { ProjectService as CloudProjectService } from '@gitbutler/shared/organizations/projectService';
@@ -112,7 +112,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: `upstream_integration_statuses`,
 					params: { projectId, targetCommitOid }
 				}),
-				providesTags: [ReduxTag.UpstreamIntegrationStatus]
+				providesTags: [providesList(ReduxTag.UpstreamIntegrationStatus)]
 			}),
 			integrateUpstream: build.mutation<
 				IntegrationOutcome,
@@ -127,10 +127,10 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					params: { projectId, resolutions, baseBranchResolution }
 				}),
 				invalidatesTags: [
-					ReduxTag.UpstreamIntegrationStatus,
-					ReduxTag.Stacks,
-					ReduxTag.StackBranches,
-					ReduxTag.StackInfo
+					invalidatesList(ReduxTag.UpstreamIntegrationStatus),
+					invalidatesList(ReduxTag.Stacks),
+					invalidatesList(ReduxTag.StackBranches),
+					invalidatesList(ReduxTag.StackInfo)
 				]
 			}),
 			resolveUpstreamIntegration: build.mutation<
@@ -141,7 +141,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: `resolve_upstream_integration`,
 					params: { projectId, resolutionApproach }
 				}),
-				invalidatesTags: [ReduxTag.UpstreamIntegrationStatus]
+				invalidatesTags: [invalidatesList(ReduxTag.UpstreamIntegrationStatus)]
 			})
 		})
 	});

--- a/apps/desktop/src/lib/worktree/worktreeService.svelte.ts
+++ b/apps/desktop/src/lib/worktree/worktreeService.svelte.ts
@@ -1,6 +1,6 @@
 import { hasTauriExtra } from '$lib/state/backendQuery';
 import { createSelectByIds } from '$lib/state/customSelectors';
-import { ReduxTag } from '$lib/state/tags';
+import { invalidatesList, providesList, ReduxTag } from '$lib/state/tags';
 import { createEntityAdapter, type EntityState } from '@reduxjs/toolkit';
 import type { TreeChange, WorktreeChanges } from '$lib/hunks/change';
 import type { ClientState } from '$lib/state/clientState.svelte';
@@ -56,7 +56,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 			getChanges: build.query<EntityState<TreeChange, string>, { projectId: string }>({
 				query: ({ projectId }) => ({ command: 'changes_in_worktree', params: { projectId } }),
 				/** Invalidating tags causes data to be refreshed. */
-				providesTags: [ReduxTag.WorktreeChanges],
+				providesTags: [providesList(ReduxTag.WorktreeChanges)],
 				/**
 				 * Sets up a subscription for changes to uncommitted changes until all consumers
 				 * of the query results have unsubscribed.
@@ -70,7 +70,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					const unsubscribe = lifecycleApi.extra.tauri.listen<WorktreeChanges>(
 						`project://${arg.projectId}/worktree_changes`,
 						(event) => {
-							lifecycleApi.dispatch(api.util.invalidateTags([ReduxTag.Diff]));
+							lifecycleApi.dispatch(api.util.invalidateTags([invalidatesList(ReduxTag.Diff)]));
 							lifecycleApi.updateCachedData(() =>
 								worktreeAdapter.addMany(worktreeAdapter.getInitialState(), event.payload.changes)
 							);


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#94ZZpqXS9`](https://gitbutler.com/cto/gitbutler-client-d443/reviews/94ZZpqXS9)

**Be much more thurourgh with invalidation tags**


This PR changes all invalidation to go through some helper functions.

These helper functions are technically superflous, but much more accuratly represent how we want our invalidations to behave.

When providing tags, we can either use `providesList` or `providesItem`. `providesItem` actually returns both the individual and the list tag. This means that if we invalidate the list, even individual getters get re-fetched. This is the desirable behaviour in our app.

1 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Be much more thurourgh with invalidation tags](https://gitbutler.com/cto/gitbutler-client-d443/reviews/94ZZpqXS9/commit/71c169dd-e6af-422c-b521-cf8b747e89b4) | ✅ | <img width="20" height="20" src="https://avatars.githubusercontent.com/u/35891811?v=4"> |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/cto/gitbutler-client-d443/reviews/94ZZpqXS9)_
<!-- GitButler Review Footer Boundary Bottom -->
