### PR TITLE
Sync the hell out of Project IDs, Stack IDs and redux results

### DIFF
--- a/apps/desktop/src/components/ReduxResult.svelte
+++ b/apps/desktop/src/components/ReduxResult.svelte
@@ -1,8 +1,9 @@
 <script lang="ts" module>
 	type A = unknown;
+	type B = string | undefined;
 </script>
 
-<script lang="ts" generics="A">
+<script lang="ts" generics="A, B extends string | undefined">
 	import Icon from '@gitbutler/ui/Icon.svelte';
 	import { isErrorlike } from '@gitbutler/ui/utils/typeguards';
 	import { QueryStatus } from '@reduxjs/toolkit/query';
@@ -14,39 +15,135 @@
 		error?: unknown;
 	};
 
-	type Props<A> = {
+	type BaseProps<A> = {
+		type: 'stack' | 'project' | 'optional-stack';
 		result: Result<A> | undefined;
-		children: Snippet<[A]>;
 		empty?: Snippet;
+		projectId: string;
 	};
 
-	const { result, children }: Props<A> = $props();
+	/**
+	 * Children depend on a the result of a RTK query, project ID and stack ID.
+	 */
+	type StackProps<A> = BaseProps<A> & {
+		type: 'stack';
+		stackId: string;
+		children: Snippet<[A, { stackId: string; projectId: string }]>;
+	};
 
-	let dataCopy: undefined | Result<A>['data'] = $state(result?.data);
+	/**
+	 * Children depend on a the result of a RTK query, project ID and an optional stack ID.
+	 *
+	 * @note Only use this if the stack ID is optional. If the stack ID is required, use the props of type `stack`.
+	 */
+	type OptionalStackProps<A> = BaseProps<A> & {
+		type: 'optional-stack';
+		stackId: string | undefined;
+		children: Snippet<[A, { stackId: string | undefined; projectId: string }]>;
+	};
+
+	/**
+	 * Children depend on a the result of a RTK query and project ID.
+	 */
+	type ProjectProps<A> = BaseProps<A> & {
+		type: 'project';
+		children: Snippet<[A, { projectId: string }]>;
+	};
+
+	type Props<A> = StackProps<A> | ProjectProps<A> | OptionalStackProps<A>;
+
+	let props: Props<A> = $props();
+
+	type CachedData =
+		| {
+				type: 'stack';
+				data: A;
+				stackId: string;
+				projectId: string;
+		  }
+		| {
+				type: 'project';
+				data: A;
+				projectId: string;
+		  }
+		| {
+				type: 'optional-stack';
+				data: A;
+				stackId: string | undefined;
+				projectId: string;
+		  };
 
 	/**
 	 * To prevent flickering when the input data changes for an already
 	 * rendered component we render the previous result until the next
 	 * result is ready.
 	 */
+	let cachedData = $state<CachedData | undefined>(undefined);
+
+	function setCachedData(data: A): CachedData {
+		switch (props.type) {
+			case 'stack': {
+				return {
+					type: 'stack',
+					data: data,
+					stackId: props.stackId,
+					projectId: props.projectId
+				};
+			}
+
+			case 'project': {
+				return {
+					type: 'project',
+					data: data,
+					projectId: props.projectId
+				};
+			}
+
+			case 'optional-stack': {
+				return {
+					type: 'optional-stack',
+					data: data,
+					stackId: props.stackId,
+					projectId: props.projectId
+				};
+			}
+		}
+	}
+
 	$effect(() => {
-		if (result?.data) dataCopy = result.data;
+		if (props.result?.data !== undefined) {
+			cachedData = setCachedData(props.result.data);
+		}
 	});
 </script>
 
-{#if dataCopy !== undefined}
-	{@render children(dataCopy)}
-{:else if result?.status === 'pending'}
+{#if cachedData !== undefined}
+	{#if cachedData.type === 'stack' && props.type === 'stack'}
+		{@render props.children(cachedData.data, {
+			stackId: cachedData.stackId,
+			projectId: cachedData.projectId
+		})}
+	{:else if cachedData.type === 'project' && props.type === 'project'}
+		{@render props.children(cachedData.data, {
+			projectId: cachedData.projectId
+		})}
+	{:else if cachedData.type === 'optional-stack' && props.type === 'optional-stack'}
+		{@render props.children(cachedData.data, {
+			stackId: cachedData.stackId,
+			projectId: cachedData.projectId
+		})}
+	{/if}
+{:else if props.result?.status === 'pending'}
 	<div class="loading-spinner">
 		<Icon name="spinner" />
 	</div>
-{:else if result?.status === 'rejected'}
-	{#if isErrorlike(result.error)}
-		{result.error.message}
+{:else if props.result?.status === 'rejected'}
+	{#if isErrorlike(props.result.error)}
+		{props.result.error.message}
 	{:else}
-		{String(result.error)}
+		{JSON.stringify(props.result.error)}
 	{/if}
-{:else if status === 'uninitialized'}
+{:else if props.result?.status === 'uninitialized'}
 	Uninitialized...
 {/if}
 

--- a/apps/desktop/src/components/v3/BranchCard.svelte
+++ b/apps/desktop/src/components/v3/BranchCard.svelte
@@ -78,7 +78,6 @@
 </script>
 
 <ReduxResult
-	type="stack"
 	{stackId}
 	{projectId}
 	result={combineResults(

--- a/apps/desktop/src/components/v3/BranchCard.svelte
+++ b/apps/desktop/src/components/v3/BranchCard.svelte
@@ -94,6 +94,7 @@
 		[branch, branches, branchDetails, commit, upstreamOnlyCommits, localAndRemoteCommits],
 		{ projectId, stackId }
 	)}
+		{@const branchName = branch.name}
 		{@const selected = selection.current?.branchName === branch.name}
 		{@const isNewBranch = !upstreamOnlyCommits.length && !localAndRemoteCommits.length}
 		{#if !first}

--- a/apps/desktop/src/components/v3/BranchCard.svelte
+++ b/apps/desktop/src/components/v3/BranchCard.svelte
@@ -78,6 +78,9 @@
 </script>
 
 <ReduxResult
+	type="stack"
+	{stackId}
+	{projectId}
 	result={combineResults(
 		branchResult.current,
 		branchesResult.current,
@@ -87,14 +90,10 @@
 		localAndRemoteCommits.current
 	)}
 >
-	{#snippet children([
-		branch,
-		branches,
-		branchDetails,
-		commit,
-		upstreamOnlyCommits,
-		localAndRemoteCommits
-	])}
+	{#snippet children(
+		[branch, branches, branchDetails, commit, upstreamOnlyCommits, localAndRemoteCommits],
+		{ projectId, stackId }
+	)}
 		{@const selected = selection.current?.branchName === branch.name}
 		{@const isNewBranch = !upstreamOnlyCommits.length && !localAndRemoteCommits.length}
 		{#if !first}

--- a/apps/desktop/src/components/v3/BranchCommitList.svelte
+++ b/apps/desktop/src/components/v3/BranchCommitList.svelte
@@ -54,8 +54,13 @@
 	);
 </script>
 
-<ReduxResult result={combineResults(upstreamOnlyCommits.current, localAndRemoteCommits.current)}>
-	{#snippet children([upstreamOnlyCommits, localAndRemoteCommits])}
+<ReduxResult
+	type="stack"
+	{stackId}
+	{projectId}
+	result={combineResults(upstreamOnlyCommits.current, localAndRemoteCommits.current)}
+>
+	{#snippet children([upstreamOnlyCommits, localAndRemoteCommits], { stackId })}
 		<div class="commit-list">
 			{#if upstreamTemplate}
 				{#each upstreamOnlyCommits as commit, i (commit.id)}

--- a/apps/desktop/src/components/v3/BranchCommitList.svelte
+++ b/apps/desktop/src/components/v3/BranchCommitList.svelte
@@ -55,7 +55,6 @@
 </script>
 
 <ReduxResult
-	type="stack"
 	{stackId}
 	{projectId}
 	result={combineResults(upstreamOnlyCommits.current, localAndRemoteCommits.current)}

--- a/apps/desktop/src/components/v3/BranchHeader.svelte
+++ b/apps/desktop/src/components/v3/BranchHeader.svelte
@@ -78,7 +78,7 @@
 	tabindex="0"
 	class:activated={isMenuOpenByMouse || isMenuOpenByBtn}
 >
-	<ReduxResult type="stack" {stackId} {projectId} result={topCommitResult.current}>
+	<ReduxResult {stackId} {projectId} result={topCommitResult.current}>
 		{#snippet children(commit)}
 			{@const branchType: CommitStateType = commit?.state.type ?? 'LocalOnly'}
 

--- a/apps/desktop/src/components/v3/BranchHeader.svelte
+++ b/apps/desktop/src/components/v3/BranchHeader.svelte
@@ -78,7 +78,7 @@
 	tabindex="0"
 	class:activated={isMenuOpenByMouse || isMenuOpenByBtn}
 >
-	<ReduxResult result={topCommitResult.current}>
+	<ReduxResult type="stack" {stackId} {projectId} result={topCommitResult.current}>
 		{#snippet children(commit)}
 			{@const branchType: CommitStateType = commit?.state.type ?? 'LocalOnly'}
 

--- a/apps/desktop/src/components/v3/BranchList.svelte
+++ b/apps/desktop/src/components/v3/BranchList.svelte
@@ -15,7 +15,7 @@
 	const branchesResult = $derived(stackService.branches(projectId, stackId));
 </script>
 
-<ReduxResult type="stack" {stackId} {projectId} result={branchesResult.current}>
+<ReduxResult {stackId} {projectId} result={branchesResult.current}>
 	{#snippet children(branches, { stackId, projectId })}
 		{#each branches as branch, i}
 			{@const first = i === 0}

--- a/apps/desktop/src/components/v3/BranchList.svelte
+++ b/apps/desktop/src/components/v3/BranchList.svelte
@@ -10,16 +10,13 @@
 		stackId: string;
 	};
 
-	const { projectId, stackId: unsyncedStackId }: Props = $props();
+	const { projectId, stackId }: Props = $props();
 	const [stackService] = inject(StackService);
-	const [stackId, branchesResult] = $derived([
-		unsyncedStackId,
-		stackService.branches(projectId, unsyncedStackId)
-	]);
+	const branchesResult = $derived(stackService.branches(projectId, stackId));
 </script>
 
-<ReduxResult result={branchesResult.current}>
-	{#snippet children(branches)}
+<ReduxResult type="stack" {stackId} {projectId} result={branchesResult.current}>
+	{#snippet children(branches, { stackId, projectId })}
 		{#each branches as branch, i}
 			{@const first = i === 0}
 			{@const last = i === branches.length - 1}

--- a/apps/desktop/src/components/v3/BranchView.svelte
+++ b/apps/desktop/src/components/v3/BranchView.svelte
@@ -63,7 +63,6 @@
 
 {#if branchName}
 	<ReduxResult
-		type="stack"
 		{stackId}
 		{projectId}
 		result={combineResults(

--- a/apps/desktop/src/components/v3/BranchView.svelte
+++ b/apps/desktop/src/components/v3/BranchView.svelte
@@ -62,8 +62,13 @@
 </script>
 
 {#if branchName}
-	<ReduxResult result={combineResults(branchResult.current, branchDetailsResult.current)}>
-		{#snippet children([branch, branchDetails])}
+	<ReduxResult
+		type="stack"
+		{stackId}
+		{projectId}
+		result={combineResults(branchResult.current, branchDetailsResult.current)}
+	>
+		{#snippet children([branch, branchDetails], { stackId, projectId })}
 			{@const hasCommits =
 				branchCommitsResult.current.data && branchCommitsResult.current.data.length > 0}
 			{@const remoteTrackingBranch = branchResult.current.data?.remoteTrackingBranch}

--- a/apps/desktop/src/components/v3/BranchView.svelte
+++ b/apps/desktop/src/components/v3/BranchView.svelte
@@ -66,12 +66,15 @@
 		type="stack"
 		{stackId}
 		{projectId}
-		result={combineResults(branchResult.current, branchDetailsResult.current)}
+		result={combineResults(
+			branchResult.current,
+			branchDetailsResult.current,
+			branchCommitsResult.current
+		)}
 	>
-		{#snippet children([branch, branchDetails], { stackId, projectId })}
-			{@const hasCommits =
-				branchCommitsResult.current.data && branchCommitsResult.current.data.length > 0}
-			{@const remoteTrackingBranch = branchResult.current.data?.remoteTrackingBranch}
+		{#snippet children([branch, branchDetails, branchCommits], { stackId, projectId })}
+			{@const hasCommits = branchCommits.length > 0}
+			{@const remoteTrackingBranch = branch.remoteTrackingBranch}
 			<Drawer {projectId} {stackId} splitView={hasCommits}>
 				{#snippet header()}
 					<div class="branch__header">
@@ -100,7 +103,7 @@
 							kind="outline"
 							tooltip="Copy branch name"
 							onclick={() => {
-								writeClipboard(branchName);
+								writeClipboard(branch.name);
 							}}
 						/>
 
@@ -143,7 +146,7 @@
 							</div>
 						</div>
 
-						<BranchReview {stackId} {projectId} {branchName} />
+						<BranchReview {stackId} {projectId} branchName={branch.name} />
 					</div>
 				{:else}
 					<div class="branch-view__empty-state">
@@ -165,7 +168,7 @@
 						<ChangedFiles
 							{projectId}
 							{stackId}
-							selectionId={{ type: 'branch', branchName, stackId }}
+							selectionId={{ type: 'branch', branchName: branch.name, stackId }}
 						/>
 					{/if}
 				{/snippet}

--- a/apps/desktop/src/components/v3/ChangedFiles.svelte
+++ b/apps/desktop/src/components/v3/ChangedFiles.svelte
@@ -44,7 +44,7 @@
 
 {#if changesResult}
 	<div class="changed-files">
-		<ReduxResult type="stack" {stackId} {projectId} result={changesResult.current}>
+		<ReduxResult {stackId} {projectId} result={changesResult.current}>
 			{#snippet children(changes, { stackId, projectId })}
 				<div class="changed-files__header" use:stickyHeader>
 					<div class="changed-files__header-left">

--- a/apps/desktop/src/components/v3/ChangedFiles.svelte
+++ b/apps/desktop/src/components/v3/ChangedFiles.svelte
@@ -44,8 +44,8 @@
 
 {#if changesResult}
 	<div class="changed-files">
-		<ReduxResult result={changesResult.current}>
-			{#snippet children(changes)}
+		<ReduxResult type="stack" {stackId} {projectId} result={changesResult.current}>
+			{#snippet children(changes, { stackId, projectId })}
 				<div class="changed-files__header" use:stickyHeader>
 					<div class="changed-files__header-left">
 						<h4 class="text-14 text-semibold">{headerTitle}</h4>

--- a/apps/desktop/src/components/v3/CommitView.svelte
+++ b/apps/desktop/src/components/v3/CommitView.svelte
@@ -103,7 +103,7 @@
 	}
 </script>
 
-<ReduxResult type="stack" {stackId} {projectId} result={commitResult.current}>
+<ReduxResult {stackId} {projectId} result={commitResult.current}>
 	{#snippet children(commit, env)}
 		{#if mode === 'edit'}
 			<Drawer projectId={env.projectId} stackId={env.stackId} title="Edit commit message">

--- a/apps/desktop/src/components/v3/CommitView.svelte
+++ b/apps/desktop/src/components/v3/CommitView.svelte
@@ -103,14 +103,14 @@
 	}
 </script>
 
-<ReduxResult result={commitResult.current}>
-	{#snippet children(commit)}
+<ReduxResult type="stack" {stackId} {projectId} result={commitResult.current}>
+	{#snippet children(commit, env)}
 		{#if mode === 'edit'}
-			<Drawer {projectId} {stackId} title="Edit commit message">
+			<Drawer projectId={env.projectId} stackId={env.stackId} title="Edit commit message">
 				<CommitMessageInput
 					bind:this={commitMessageInput}
-					{projectId}
-					{stackId}
+					projectId={env.projectId}
+					stackId={env.stackId}
 					action={editCommitMessage}
 					actionLabel="Save"
 					onCancel={() => setMode('view')}
@@ -120,7 +120,7 @@
 				/>
 			</Drawer>
 		{:else}
-			<Drawer {projectId} {stackId} splitView>
+			<Drawer projectId={env.projectId} stackId={env.stackId} splitView>
 				{#snippet header()}
 					<h3 class="text-13 text-semibold commit-view__header">
 						Commit
@@ -154,17 +154,17 @@
 				<div class="commit-view">
 					<CommitHeader {commit} class="text-14 text-semibold text-body" />
 					<CommitDetails
-						{projectId}
+						projectId={env.projectId}
 						{commit}
-						{stackId}
+						stackId={env.stackId}
 						onEditCommitMessage={() => setMode('edit')}
 					/>
 				</div>
 
 				{#snippet filesSplitView()}
 					<ChangedFiles
-						{projectId}
-						{stackId}
+						projectId={env.projectId}
+						stackId={env.stackId}
 						selectionId={{ type: 'commit', commitId: commitKey.commitId }}
 					/>
 				{/snippet}

--- a/apps/desktop/src/components/v3/SelectedChange.svelte
+++ b/apps/desktop/src/components/v3/SelectedChange.svelte
@@ -33,7 +33,7 @@
 	});
 </script>
 
-<ReduxResult type="project" {projectId} result={changeResult.current}>
+<ReduxResult {projectId} result={changeResult.current}>
 	{#snippet children(change, env)}
 		<div class="selected-change-item">
 			<FileListItemWrapper

--- a/apps/desktop/src/components/v3/SelectedChange.svelte
+++ b/apps/desktop/src/components/v3/SelectedChange.svelte
@@ -33,11 +33,17 @@
 	});
 </script>
 
-<ReduxResult result={changeResult.current}>
-	{#snippet children(change)}
+<ReduxResult type="project" {projectId} result={changeResult.current}>
+	{#snippet children(change, env)}
 		<div class="selected-change-item">
-			<FileListItemWrapper {selectedFile} {projectId} {change} isHeader listMode="list" />
-			<UnifiedDiffView {projectId} {change} selectable />
+			<FileListItemWrapper
+				{selectedFile}
+				projectId={env.projectId}
+				{change}
+				isHeader
+				listMode="list"
+			/>
+			<UnifiedDiffView projectId={env.projectId} {change} selectable />
 		</div>
 	{/snippet}
 </ReduxResult>

--- a/apps/desktop/src/components/v3/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/v3/UnifiedDiffView.svelte
@@ -156,7 +156,7 @@
 </script>
 
 <div class="diff-section" bind:this={viewport}>
-	<ReduxResult type="project" {projectId} result={diffResult.current}>
+	<ReduxResult {projectId} result={diffResult.current}>
 		{#snippet children(diff, env)}
 			{#if diff.type === 'Patch'}
 				{#each diff.subject.hunks as hunk}

--- a/apps/desktop/src/components/v3/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/v3/UnifiedDiffView.svelte
@@ -156,8 +156,8 @@
 </script>
 
 <div class="diff-section" bind:this={viewport}>
-	<ReduxResult result={diffResult.current}>
-		{#snippet children(diff)}
+	<ReduxResult type="project" {projectId} result={diffResult.current}>
+		{#snippet children(diff, env)}
 			{#if diff.type === 'Patch'}
 				{#each diff.subject.hunks as hunk}
 					{@const [staged, stagedLines] = getStageState(hunk)}
@@ -197,7 +197,7 @@
 						bind:this={contextMenu}
 						trigger={viewport}
 						projectPath={project.vscodePath}
-						{projectId}
+						projectId={env.projectId}
 						{change}
 						readonly={false}
 						unSelectHunk={(hunk) => updateStage(hunk, false, diff.subject.hunks)}

--- a/apps/desktop/src/components/v3/WorkspaceView.svelte
+++ b/apps/desktop/src/components/v3/WorkspaceView.svelte
@@ -7,7 +7,7 @@
 	import SelectionView from '$components/v3/SelectionView.svelte';
 	import WorktreeChanges from '$components/v3/WorktreeChanges.svelte';
 	import { focusable } from '$lib/focus/focusable.svelte';
-	import { UiState } from '$lib/state/uiState.svelte';
+	import { UiState, type GlobalProperty, type StackUiSelection } from '$lib/state/uiState.svelte';
 	import { inject } from '@gitbutler/shared/context';
 	import { type Snippet } from 'svelte';
 
@@ -17,14 +17,33 @@
 		right: Snippet<[{ viewportWidth: number }]>;
 	}
 
-	const { stackId, projectId, right }: Props = $props();
+	const { stackId: unsyncedStackId, projectId, right }: Props = $props();
 
 	const [uiState] = inject(UiState);
 	const projectUiState = $derived(uiState.project(projectId));
 	const drawerPage = $derived(projectUiState.drawerPage);
 	const drawerIsFullScreen = $derived(projectUiState.drawerFullScreen);
-	const selected = $derived(uiState.stack(stackId!).selection);
-	const branchName = $derived(selected.current?.branchName);
+
+	type SelectionInfo = {
+		selected: GlobalProperty<StackUiSelection | undefined> | undefined;
+		stackId: string | undefined;
+	};
+
+	let syncedData = $state<SelectionInfo>();
+
+	$effect(() => {
+		if (unsyncedStackId) {
+			syncedData = {
+				selected: uiState.stack(unsyncedStackId).selection,
+				stackId: unsyncedStackId
+			};
+		}
+	});
+
+	const stackId = $derived(syncedData?.stackId);
+	const branchName = $derived(syncedData?.selected?.current?.branchName);
+	const commitId = $derived(syncedData?.selected?.current?.commitId);
+	const upstream = $derived(!!syncedData?.selected?.current?.upstream);
 
 	const leftWidth = $derived(uiState.global.leftWidth);
 	const stacksViewWidth = $derived(uiState.global.stacksViewWidth);
@@ -61,15 +80,15 @@
 				<BranchView {stackId} {projectId} {branchName} />
 			{:else if drawerPage.current === 'review' && branchName}
 				<ReviewView {stackId} {projectId} {branchName} />
-			{:else if selected.current?.branchName && selected.current.commitId && stackId}
+			{:else if branchName && commitId && stackId}
 				<CommitView
 					{projectId}
 					{stackId}
 					commitKey={{
 						stackId,
-						branchName: selected.current.branchName,
-						commitId: selected.current.commitId,
-						upstream: !!selected.current.upstream
+						branchName,
+						commitId,
+						upstream
 					}}
 				/>
 			{/if}

--- a/apps/desktop/src/components/v3/WorkspaceView.svelte
+++ b/apps/desktop/src/components/v3/WorkspaceView.svelte
@@ -29,16 +29,14 @@
 		stackId: string | undefined;
 	};
 
-	let syncedData = $state<SelectionInfo>();
-
-	$effect(() => {
-		if (unsyncedStackId) {
-			syncedData = {
-				selected: uiState.stack(unsyncedStackId).selection,
-				stackId: unsyncedStackId
-			};
-		}
-	});
+	const syncedData = $derived<SelectionInfo | undefined>(
+		unsyncedStackId
+			? {
+					selected: uiState.stack(unsyncedStackId).selection,
+					stackId: unsyncedStackId
+				}
+			: undefined
+	);
 
 	const stackId = $derived(syncedData?.stackId);
 	const branchName = $derived(syncedData?.selected?.current?.branchName);

--- a/apps/desktop/src/components/v3/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/v3/WorktreeChanges.svelte
@@ -106,8 +106,8 @@
 	let isFooterSticky = $state(false);
 </script>
 
-<ReduxResult result={changesResult.current}>
-	{#snippet children(changes)}
+<ReduxResult type="optional-stack" {stackId} {projectId} result={changesResult.current}>
+	{#snippet children(changes, { stackId, projectId })}
 		<ScrollableContainer wide>
 			<div class="uncommitted-changes-wrap">
 				<div use:stickyHeader class="worktree-header">

--- a/apps/desktop/src/components/v3/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/v3/WorktreeChanges.svelte
@@ -106,7 +106,7 @@
 	let isFooterSticky = $state(false);
 </script>
 
-<ReduxResult type="optional-stack" {stackId} {projectId} result={changesResult.current}>
+<ReduxResult {stackId} {projectId} result={changesResult.current}>
 	{#snippet children(changes, { stackId, projectId })}
 		<ScrollableContainer wide>
 			<div class="uncommitted-changes-wrap">

--- a/apps/desktop/src/components/v3/stackTabs/StackTabs.svelte
+++ b/apps/desktop/src/components/v3/stackTabs/StackTabs.svelte
@@ -48,7 +48,7 @@
 <div class="tabs" bind:this={tabsEl}>
 	<div class="inner">
 		<div class="scroller" bind:this={scrollerEl} class:scrolled {onscroll}>
-			<ReduxResult type="project" {projectId} result={result.current}>
+			<ReduxResult {projectId} result={result.current}>
 				{#snippet children(result, env)}
 					{#if result.length > 0}
 						{#each result as tab, i (tab.branchNames[0])}

--- a/apps/desktop/src/components/v3/stackTabs/StackTabs.svelte
+++ b/apps/desktop/src/components/v3/stackTabs/StackTabs.svelte
@@ -48,8 +48,8 @@
 <div class="tabs" bind:this={tabsEl}>
 	<div class="inner">
 		<div class="scroller" bind:this={scrollerEl} class:scrolled {onscroll}>
-			<ReduxResult result={result.current}>
-				{#snippet children(result)}
+			<ReduxResult type="project" {projectId} result={result.current}>
+				{#snippet children(result, env)}
 					{#if result.length > 0}
 						{#each result as tab, i (tab.branchNames[0])}
 							{@const first = i === 0}
@@ -58,9 +58,9 @@
 
 							<StackTab
 								name={tab.branchNames[0]!}
-								{projectId}
+								projectId={env.projectId}
 								stackId={tab.id}
-								href={stackPath(projectId, tab.id)}
+								href={stackPath(env.projectId, tab.id)}
 								anchors={tab.branchNames.slice(1)}
 								{selected}
 								onNextTab={() => {

--- a/apps/desktop/src/lib/state/uiState.svelte.ts
+++ b/apps/desktop/src/lib/state/uiState.svelte.ts
@@ -15,14 +15,14 @@ export const uiStatePersistConfig = {
 	storage: storage
 };
 
+export type StackUiSelection = {
+	branchName: string;
+	commitId?: string;
+	upstream?: boolean;
+};
+
 type StackUiState = {
-	selection:
-		| {
-				branchName: string;
-				commitId?: string;
-				upstream?: boolean;
-		  }
-		| undefined;
+	selection: StackUiSelection | undefined;
 	activeSelectionId: SelectionId;
 };
 
@@ -175,7 +175,7 @@ type UiStateVariable = {
 type DefaultConfig = Record<string, UiStateValue>;
 
 /** Node type for global properties. */
-type GlobalProperty<T> = {
+export type GlobalProperty<T> = {
 	get(): Reactive<T>;
 	set(value: T): void;
 } & WritableReactive<T>;

--- a/apps/desktop/src/routes/[projectId]/workspace/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/workspace/+page.svelte
@@ -13,10 +13,10 @@
 
 {#if projectId}
 	{@const result = stackService.stackAt(projectId, 0)}
-	<ReduxResult result={result.current}>
-		{#snippet children(stack)}
+	<ReduxResult type="project" {projectId} result={result.current}>
+		{#snippet children(stack, env)}
 			{#if stack}
-				{goto(stackPath(projectId, stack.id))}
+				{goto(stackPath(env.projectId, stack.id))}
 			{:else}
 				{@const error = new Error(`No stacks found in project`)}
 				<SomethingWentWrong {error} />

--- a/apps/desktop/src/routes/[projectId]/workspace/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/workspace/+page.svelte
@@ -13,7 +13,7 @@
 
 {#if projectId}
 	{@const result = stackService.stackAt(projectId, 0)}
-	<ReduxResult type="project" {projectId} result={result.current}>
+	<ReduxResult {projectId} result={result.current}>
 		{#snippet children(stack, env)}
 			{#if stack}
 				{goto(stackPath(env.projectId, stack.id))}


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#6PJrQL8wI`](https://gitbutler.com/estib/gitbutler/reviews/6PJrQL8wI)

**Sync the hell out of Project IDs, Stack IDs and redux results**


In a nutshell, fine-grained reactivity is hard.

We have a combination of data that we get from the url parameters (e.g. project ID and stack ID) that we need to combine with API data (like branch names).

The issue is, that they get updated at different intervals and this can lead inconsistencies in the UI if not handled properly.
To address this, add a mechanism to ensure that the component re-renders only when all necessary data is available. 

By using reactive statements and combining results from different sources, we can maintain a smooth user experience while keeping the displayed information accurate and up-to-date.

5 commit series (version 2)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 5/5 | [Use the synchronized data in the branch views](https://gitbutler.com/estib/gitbutler/reviews/6PJrQL8wI/commit/a6165bff-ea91-48a4-bf47-e619877514e0) | ✅ | <img width="20" height="20" src="https://app.gitbutler.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MTc5OSwicHVyIjoiYmxvYl9pZCJ9fQ==--687bcccbc32853fc081271e42902a4f2fe2d0554/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJwbmciLCJyZXNpemVfdG9fbGltaXQiOlsyNTAsMjUwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--7ee67cd2edc36c03e1be048e50e661945f3999b0/96BE8547-FD64-407D-9769-7AB30DB85615.png"> |
| 4/5 | [Workspace view: Synchronize the selection data](https://gitbutler.com/estib/gitbutler/reviews/6PJrQL8wI/commit/a55b69e8-2f38-43ff-9f1f-8776cc0c5933) | ⚠️ | <img width="20" height="20" src="https://app.gitbutler.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MTc5OSwicHVyIjoiYmxvYl9pZCJ9fQ==--687bcccbc32853fc081271e42902a4f2fe2d0554/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJwbmciLCJyZXNpemVfdG9fbGltaXQiOlsyNTAsMjUwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--7ee67cd2edc36c03e1be048e50e661945f3999b0/96BE8547-FD64-407D-9769-7AB30DB85615.png"> |
| 3/5 | [UI State: Expose the types](https://gitbutler.com/estib/gitbutler/reviews/6PJrQL8wI/commit/29100e2b-1fe4-4b93-867d-307cd5c23475) | ✅ | <img width="20" height="20" src="https://app.gitbutler.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MTc5OSwicHVyIjoiYmxvYl9pZCJ9fQ==--687bcccbc32853fc081271e42902a4f2fe2d0554/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJwbmciLCJyZXNpemVfdG9fbGltaXQiOlsyNTAsMjUwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--7ee67cd2edc36c03e1be048e50e661945f3999b0/96BE8547-FD64-407D-9769-7AB30DB85615.png"> |
| 2/5 | [Adapt the redux result instances](https://gitbutler.com/estib/gitbutler/reviews/6PJrQL8wI/commit/5907b0ad-c1f9-4e60-958b-240a48f28f85) | ✅ | <img width="20" height="20" src="https://app.gitbutler.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MTc5OSwicHVyIjoiYmxvYl9pZCJ9fQ==--687bcccbc32853fc081271e42902a4f2fe2d0554/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJwbmciLCJyZXNpemVfdG9fbGltaXQiOlsyNTAsMjUwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--7ee67cd2edc36c03e1be048e50e661945f3999b0/96BE8547-FD64-407D-9769-7AB30DB85615.png"> |
| 1/5 | [Redux Resut: cache the stack ID and project ID as well](https://gitbutler.com/estib/gitbutler/reviews/6PJrQL8wI/commit/a53f3d45-1da3-49cb-982a-7896ea6137c2) | ✅ | <img width="20" height="20" src="https://app.gitbutler.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MTc5OSwicHVyIjoiYmxvYl9pZCJ9fQ==--687bcccbc32853fc081271e42902a4f2fe2d0554/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJwbmciLCJyZXNpemVfdG9fbGltaXQiOlsyNTAsMjUwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--7ee67cd2edc36c03e1be048e50e661945f3999b0/96BE8547-FD64-407D-9769-7AB30DB85615.png"> |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/estib/gitbutler/reviews/6PJrQL8wI)_
<!-- GitButler Review Footer Boundary Bottom -->
