### PR TITLE
fix multi-stack commits

### DIFF
--- a/crates/but-workspace/src/commit.rs
+++ b/crates/but-workspace/src/commit.rs
@@ -63,7 +63,7 @@ impl<'repo> WorkspaceCommit<'repo> {
         let author = gix::actor::Signature {
             name: "GitButler".into(),
             email: "gitbutler@gitbutler.com".into(),
-            time: gix::date::Time::now_local_or_utc(),
+            time: commit_time("GIT_COMMITTER_DATE"),
         };
         gix::objs::Commit {
             tree: gix::ObjectId::empty_tree(object_hash),
@@ -75,6 +75,15 @@ impl<'repo> WorkspaceCommit<'repo> {
             extra_headers: vec![],
         }
     }
+}
+
+/// Return the time of a commit as `now` unless the `overriding_variable_name` contains a parseable date,
+/// which is used instead.
+fn commit_time(overriding_variable_name: &str) -> gix::date::Time {
+    std::env::var(overriding_variable_name)
+        .ok()
+        .and_then(|time| gix::date::parse(&time, Some(std::time::SystemTime::now())).ok())
+        .unwrap_or_else(gix::date::Time::now_local_or_utc)
 }
 
 /// Query

--- a/crates/but-workspace/src/commit_engine/mod.rs
+++ b/crates/but-workspace/src/commit_engine/mod.rs
@@ -6,6 +6,7 @@ use bstr::BString;
 use but_core::RepositoryExt;
 use but_rebase::RebaseOutput;
 use but_rebase::commit::CommitterMode;
+use gitbutler_oxidize::OidExt;
 use gitbutler_project::access::WorktreeWritePermission;
 use gitbutler_stack::{StackId, VirtualBranchesHandle, VirtualBranchesState};
 use gix::prelude::ObjectIdExt as _;
@@ -21,6 +22,7 @@ pub mod reference_frame;
 mod refs;
 
 mod hunks;
+use crate::{StackEntry, WorkspaceCommit};
 pub use hunks::apply_hunks;
 
 /// Types for use in the frontend with serialization support.
@@ -415,7 +417,7 @@ pub fn create_commit_and_update_refs(
 
             let workspace_tip = frame
                 .workspace_tip
-                .filter(|tip| !commits_to_rebase.contains(tip));
+                .filter(|ws_tip| !commits_to_rebase.contains(ws_tip));
             let rebase = {
                 // Set commits leading up to the tip on top of the new commit, serving as base.
                 let mut builder = but_rebase::Rebase::new(repo, new_commit, Some(commit_in_graph))?;
@@ -426,13 +428,54 @@ pub fn create_commit_and_update_refs(
                     }
                 }))?;
                 if let Some(workspace_tip) = workspace_tip {
+                    // Special Hack (https://github.com/gitbutlerapp/gitbutler/pull/7976)
+                    // See if `branch_tip` isn't yet in the workspace-tip if it's a managed one, and if so, add it
+                    // so it's going to be re-merged.
+                    let wsc = WorkspaceCommit::from_id(workspace_tip.attach(repo))?;
+                    let commit_id = if wsc.is_managed() /* we can change the commit */
+                        && !wsc.inner.parents.contains(&branch_tip) /* the branch tip we know isn't yet merged */
+                        // but the tip is known to the workspace
+                        && vb.branches.values().any(|s| {
+                            s.head(repo)
+                                .is_ok_and(|head_id| head_id.to_gix() == branch_tip)
+                        }) {
+                        let mut stacks: Vec<_> = vb
+                            .branches
+                            .values()
+                            .filter(|stack| stack.in_workspace)
+                            .map(|stack| StackEntry::try_new(repo, stack))
+                            .collect::<Result<_, _>>()?;
+                        stacks.sort_by(|a, b| a.name().cmp(&b.name()));
+                        let new_wc = WorkspaceCommit::create_commit_from_vb_state(
+                            &stacks,
+                            repo.object_hash(),
+                        );
+                        repo.write_object(&new_wc)?.detach()
+                    } else {
+                        workspace_tip
+                    };
                     // We can assume the workspace tip is connected to a pick (or else the rebase will fail)
                     builder.steps([but_rebase::RebaseStep::Pick {
-                        commit_id: workspace_tip,
+                        commit_id,
                         new_message: None,
                     }])?;
+                    let mut outcome = builder.rebase()?;
+                    if commit_id != workspace_tip {
+                        let Some(rewritten_old) = outcome
+                            .commit_mapping
+                            .iter_mut()
+                            .find_map(|(_base, old, _new)| (old == &commit_id).then_some(old))
+                        else {
+                            bail!(
+                                "BUG: Needed to find modified {commit_id} to set it back its previous value, but couldn't find it"
+                            );
+                        };
+                        *rewritten_old = workspace_tip;
+                    }
+                    outcome
+                } else {
+                    builder.rebase()?
                 }
-                builder.rebase()?
             };
             refs::rewrite(
                 repo,

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -133,19 +133,23 @@ pub fn stacks(gb_dir: &Path, repo: &gix::Repository) -> Result<Vec<StackEntry>> 
         .list_stacks_in_workspace()?
         .into_iter()
         .sorted_by_key(|s| s.order)
-        .map(|stack| {
-            Ok(StackEntry {
-                id: stack.id,
-                branch_names: stack
-                    .heads(true)
-                    .into_iter()
-                    .rev()
-                    .map(Into::into)
-                    .collect(),
-                tip: stack.head(repo).map(|h| h.to_gix())?,
-            })
-        })
+        .map(|stack| StackEntry::try_new(repo, &stack))
         .collect()
+}
+
+impl StackEntry {
+    pub(crate) fn try_new(repo: &gix::Repository, stack: &Stack) -> anyhow::Result<Self> {
+        Ok(StackEntry {
+            id: stack.id,
+            branch_names: stack
+                .heads(true)
+                .into_iter()
+                .rev()
+                .map(Into::into)
+                .collect(),
+            tip: stack.head(repo).map(|h| h.to_gix())?,
+        })
+    }
 }
 
 /// Represents the pushable status for the current stack.

--- a/crates/but-workspace/tests/fixtures/generated-archives/.gitignore
+++ b/crates/but-workspace/tests/fixtures/generated-archives/.gitignore
@@ -24,3 +24,4 @@
 /deletion-addition-untracked.tar
 /mixed-hunk-modifications.tar
 /plain-modifications.tar
+/three-commits-with-line-offset-and-workspace-commit.tar

--- a/crates/but-workspace/tests/fixtures/scenario/three-commits-with-line-offset-and-workspace-commit.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/three-commits-with-line-offset-and-workspace-commit.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+### Description
+# A single branch with two commits. The first commit has 10 lines, the second adds
+# another 4 lines to the top of the file.
+# Large numbers are used make fuzzy-patch application harder.
+set -eu -o pipefail
+
+git init
+seq 10 >file
+git add . && git commit -m init && git tag first-commit
+
+{ seq 4; seq 10; } >file && git commit -am "insert 5 lines to the top"
+
+git commit -m $'GitButler Workspace Commit\n\njust a fake - only the subject matters right now' --allow-empty
+

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -1269,8 +1269,6 @@ pub(crate) fn move_commit_file(
         )
         .context("failed to create commit")?;
 
-    dbg!(&new_to_commit_oid);
-
     // another rebase
     let mut steps = stack.as_rebase_steps(ctx, &gix_repo)?;
     // replace the "to" commit in the rebase steps with the new "to" commit which has the moved changes added

--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -1,6 +1,5 @@
 use crate::error::Error;
 use crate::from_json::HexHash;
-use anyhow::Context;
 use but_hunk_dependency::ui::{
     hunk_dependencies_for_workspace_changes_by_worktree_dir, HunkDependencies,
 };
@@ -11,7 +10,7 @@ use gitbutler_command_context::CommandContext;
 use gitbutler_oplog::{OplogExt, SnapshotExt};
 use gitbutler_project as projects;
 use gitbutler_project::ProjectId;
-use gitbutler_stack::{StackId, VirtualBranchesHandle};
+use gitbutler_stack::StackId;
 use tauri::State;
 use tracing::instrument;
 
@@ -160,11 +159,6 @@ pub fn create_commit_from_worktree_changes(
         settings.get()?.context_lines,
         guard.write_permission(),
     );
-
-    let ctx = CommandContext::open(&project, settings.get()?.clone())?;
-    let vb_state = VirtualBranchesHandle::new(project.gb_dir());
-    gitbutler_branch_actions::update_workspace_commit(&vb_state, &ctx)
-        .context("failed to update gitbutler workspace")?;
 
     let _ = snapshot_tree.and_then(|snapshot_tree| {
         project.snapshot_commit_creation(


### PR DESCRIPTION
As follow-up to #7952, this PR is another attempt at fixing it.
Whereas #7952 applies a fix as post-process, let's try again and see if this can be correct from the start.

### Tasks

* [x] reproduction with additional debugging
    - From what we found out in our session with @krlvi, the integration commit as passed to the commit-engine already only has a single parent. If it had not, it would loudly fail with an error
      as the `base_substitute` must be set.
* [x] add test (with respective virtual-branches state)
* [x] fix it by detecting the case that not all heads are yet represented in the worktree commit, and rewrite the workspace commit to have it, then use the rebase engine as normal which does a proper merge.
    - make sure that failures don't actually make any change (probably automatic as no ref-rewrites would happen then)
- [x] double-check situation in the UI works as well, without the fix.

### The Problem

To reproduce the bug (with the previous fix unapplied), one has to be in a state where a new branch has been created, and now we attempt to create a new commit that new branch.

```
2025-04-04 18:05 +0800 GitButler         o [gitbutler/workspace] GitButler Workspace Commit
2025-04-04 18:04 +0800 Sebastian Thiel   o [dependent] [refs/gitbutler/Lane-4] left branch change
2025-03-26 14:25 +0800 Sebastian Thiel   o selection
2025-03-25 16:24 +0800 Sebastian Thiel   o some data for file
2025-03-25 10:01 +0800 Sebastian Thiel   o binary
2025-03-12 09:55 +0800 Sebastian Thiel   o tar added
2025-03-12 09:55 +0800 Sebastian Thiel   o edited in UI
2025-03-12 09:55 +0800 Sebastian Thiel   o [below-dependent] {origin/below-dependent} top commit
2025-02-25 20:31 +0100 Sebastian Thiel   o below middle below top
2025-02-27 19:56 +0100 Sebastian Thiel   o at A
2025-02-27 19:56 +0100 Sebastian Thiel   o below A
2025-02-27 19:56 +0100 Sebastian Thiel   o 2
2025-02-27 19:56 +0100 Sebastian Thiel   o 1
2025-02-24 18:53 +0100 Sebastian Thiel   o [new-branch] {origin/master} nested file
```

The current implementation isn't able to deal with that as it expect any head that is part of the worktree to already be merged into the worktree commit.