### PR TITLE
Render fewer branches at a time

### DIFF
--- a/apps/desktop/src/components/ChunkyList.svelte
+++ b/apps/desktop/src/components/ChunkyList.svelte
@@ -20,7 +20,7 @@
 		chunkSize?: number;
 	}
 
-	const { items, item, chunkSize = 100 }: Props = $props();
+	const { items, item, chunkSize = 20 }: Props = $props();
 
 	let chunkedItems: T[][] = [];
 	let displayedItems = $state<T[]>([]);


### PR DESCRIPTION
Reduce the initial count from 100 to 20. It will load more automatically if the screen size allows it.