### PR TITLE
Message editor: don't hide the buttons

### DIFF
--- a/apps/desktop/src/components/v3/CommitView.svelte
+++ b/apps/desktop/src/components/v3/CommitView.svelte
@@ -106,7 +106,13 @@
 <ReduxResult {stackId} {projectId} result={commitResult.current}>
 	{#snippet children(commit, env)}
 		{#if mode === 'edit'}
-			<Drawer projectId={env.projectId} stackId={env.stackId} title="Edit commit message">
+			<Drawer
+				projectId={env.projectId}
+				stackId={env.stackId}
+				title="Edit commit message"
+				disableScroll
+				minHeight={20}
+			>
 				<CommitMessageInput
 					bind:this={commitMessageInput}
 					projectId={env.projectId}

--- a/apps/desktop/src/components/v3/Drawer.svelte
+++ b/apps/desktop/src/components/v3/Drawer.svelte
@@ -17,6 +17,7 @@
 		extraActions?: Snippet;
 		children: Snippet;
 		filesSplitView?: Snippet;
+		disableScroll?: boolean;
 	};
 
 	const {
@@ -28,7 +29,8 @@
 		header,
 		extraActions,
 		children,
-		filesSplitView
+		filesSplitView,
+		disableScroll
 	}: Props = $props();
 
 	const [uiState] = inject(UiState);
@@ -42,6 +44,7 @@
 	const height = $derived(drawerIsFullScreen.current ? '100%' : heightRm);
 
 	const contentWidth = $derived(uiState.global.drawerSplitViewWidth.get());
+	const scrollable = $derived(!disableScroll);
 
 	let drawerDiv = $state<HTMLDivElement>();
 	let viewportEl = $state<HTMLElement>();
@@ -100,11 +103,17 @@
 				style:--custom-width={splitView ? `${contentWidth.current}rem` : 'auto'}
 			>
 				<div class="drawer__content-scroll" bind:this={viewportEl}>
-					<ConfigurableScrollableContainer>
+					{#if scrollable}
+						<ConfigurableScrollableContainer>
+							<div class="drawer__content">
+								{@render children()}
+							</div>
+						</ConfigurableScrollableContainer>
+					{:else}
 						<div class="drawer__content">
 							{@render children()}
 						</div>
-					</ConfigurableScrollableContainer>
+					{/if}
 
 					{#if splitView}
 						<div class="drawer__content-resizer">
@@ -250,9 +259,12 @@
 	}
 
 	.drawer__content-scroll {
+		display: flex;
+		flex-direction: column;
 		position: relative;
 		height: 100%;
 		width: var(--custom-width);
+		min-height: 0;
 	}
 
 	.drawer__files-split-view {

--- a/apps/desktop/src/components/v3/NewCommitView.svelte
+++ b/apps/desktop/src/components/v3/NewCommitView.svelte
@@ -97,7 +97,7 @@
 	}
 </script>
 
-<Drawer bind:this={drawer} {projectId} {stackId} title="Create commit">
+<Drawer bind:this={drawer} {projectId} {stackId} title="Create commit" disableScroll minHeight={20}>
 	<CommitMessageInput
 		bind:this={input}
 		{projectId}

--- a/apps/desktop/src/components/v3/ReviewView.svelte
+++ b/apps/desktop/src/components/v3/ReviewView.svelte
@@ -57,7 +57,14 @@
 	}
 </script>
 
-<Drawer bind:this={drawer} {projectId} {stackId} title={getTitleLabel()}>
+<Drawer
+	bind:this={drawer}
+	{projectId}
+	{stackId}
+	title={getTitleLabel()}
+	disableScroll
+	minHeight={20}
+>
 	<div class="submit-review__container">
 		<ReviewCreation bind:this={reviewCreation} {projectId} {stackId} {branchName} onClose={close} />
 

--- a/apps/desktop/src/components/v3/editor/MessageEditor.svelte
+++ b/apps/desktop/src/components/v3/editor/MessageEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import ConfigurableScrollableContainer from '$components/ConfigurableScrollableContainer.svelte';
 	import AiContextMenu from '$components/v3/editor/AIContextMenu.svelte';
 	import CommitSuggestions from '$components/v3/editor/commitSuggestions.svelte';
 	import { AIService } from '$lib/ai/service';
@@ -168,28 +169,34 @@
 			composer?.focus();
 		}}
 	>
-		<RichTextEditor
-			styleContext="client-editor"
-			namespace="CommitMessageEditor"
-			{placeholder}
-			bind:this={composer}
-			markdown={useRichText.current}
-			onError={(e) => showError('Editor error', e)}
-			initialText={initialValue}
-			onChange={debouncedHandleChange}
-			onKeyDown={handleKeyDown}
-			onFocus={() => (isEditorFocused = true)}
-			onBlur={() => (isEditorFocused = false)}
-			{disabled}
-		>
-			{#snippet plugins()}
-				<Formatter bind:this={formatter} />
-				<GhostTextPlugin
-					bind:this={suggestionsHandler.ghostTextComponent}
-					onSelection={(text) => suggestionsHandler.onAcceptSuggestion(text)}
-				/>
-			{/snippet}
-		</RichTextEditor>
+		<div class="message-editor__inner">
+			<ConfigurableScrollableContainer height="100%">
+				<div class="message-editor__wrapper">
+					<RichTextEditor
+						styleContext="client-editor"
+						namespace="CommitMessageEditor"
+						{placeholder}
+						bind:this={composer}
+						markdown={useRichText.current}
+						onError={(e) => showError('Editor error', e)}
+						initialText={initialValue}
+						onChange={debouncedHandleChange}
+						onKeyDown={handleKeyDown}
+						onFocus={() => (isEditorFocused = true)}
+						onBlur={() => (isEditorFocused = false)}
+						{disabled}
+					>
+						{#snippet plugins()}
+							<Formatter bind:this={formatter} />
+							<GhostTextPlugin
+								bind:this={suggestionsHandler.ghostTextComponent}
+								onSelection={(text) => suggestionsHandler.onAcceptSuggestion(text)}
+							/>
+						{/snippet}
+					</RichTextEditor>
+				</div>
+			</ConfigurableScrollableContainer>
+		</div>
 
 		<div class="message-editor__inner-toolbar">
 			<EmojiPickerButton onEmojiSelect={(emoji) => onEmojiSelect(emoji.unicode)} />
@@ -210,6 +217,7 @@
 		flex: 1;
 		background-color: var(--clr-bg-1);
 		overflow: auto;
+		min-height: 0;
 	}
 
 	.editor-header {
@@ -301,5 +309,21 @@
 		width: 1px;
 		height: 18px;
 		background-color: var(--clr-border-3);
+	}
+
+	.message-editor__inner {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+
+		overflow: hidden;
+		min-height: 0;
+	}
+
+	.message-editor__wrapper {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		min-height: 0;
 	}
 </style>


### PR DESCRIPTION
The buttons and other content is not hidden if the text editor content is too big to fit in the drawer.
Instead, make the content scrollable