### PR TITLE
let the people search their branches

### DIFF
--- a/apps/desktop/src/components/Branches.svelte
+++ b/apps/desktop/src/components/Branches.svelte
@@ -90,6 +90,7 @@
 	}
 
 	function openSearch() {
+		searching = true;
 		setTimeout(() => {
 			searchEl?.focus();
 		}, 0);


### PR DESCRIPTION
It seems we were not opening the search bar in the branches panel by accident. Now we do 👍

fixes #8048
