### PR TITLE
Fix commit message split when uncommitting

### DIFF
--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -10,6 +10,7 @@ import {
 	providesList,
 	ReduxTag
 } from '$lib/state/tags';
+import { splitMessage } from '$lib/utils/commitMessage';
 import { createEntityAdapter, type EntityState } from '@reduxjs/toolkit';
 import type { PostHogWrapper } from '$lib/analytics/posthog';
 import type { Commit, StackBranch, UpstreamCommit } from '$lib/branches/v3';
@@ -396,9 +397,10 @@ export class StackService {
 		const message = commit.data?.message;
 		if (message) {
 			const state = this.uiState.project(args.projectId);
-			const [title, description] = message.split('\n', 1);
-			state.commitDescription.set(title ? title.trim() : '');
-			state.commitDescription.set(description ? description.trim() : '');
+
+			const { title, description } = splitMessage(message);
+			state.commitTitle.set(title);
+			state.commitDescription.set(description);
 		}
 		return await this.api.endpoints.uncommit.mutate(args);
 	}

--- a/apps/desktop/src/lib/utils/commitMessage.ts
+++ b/apps/desktop/src/lib/utils/commitMessage.ts
@@ -1,10 +1,10 @@
-const commitMessageSplitRegExp = /(.*?)(?:\n+|$)(.*)/s;
-
 export function splitMessage(message: string) {
-	const matches = message.match(commitMessageSplitRegExp);
+	const splitIndex = message.indexOf('\n');
+	const title = splitIndex !== -1 ? message.substring(0, splitIndex) : message;
+	const description = splitIndex !== -1 ? message.substring(splitIndex + 1) : '';
 
 	return {
-		title: matches?.[1] || '',
-		description: matches?.[2] || ''
+		title: title.trim(),
+		description: description.trim()
 	};
 }


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#1lZK0SGPp`](https://cloud.staging.gitbutler.com/mtsgrd/gitbutler/reviews/1lZK0SGPp)

**Fix commit message split when uncommitting**


1 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Fix commit message split when uncommitting](https://cloud.staging.gitbutler.com/mtsgrd/gitbutler/reviews/1lZK0SGPp/commit/5c4ebb40-cc79-4269-a93f-ddd4181722a5) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://cloud.staging.gitbutler.com/mtsgrd/gitbutler/reviews/1lZK0SGPp)_
<!-- GitButler Review Footer Boundary Bottom -->
