### PR TITLE
v3: file context menu

### DIFF
--- a/apps/desktop/src/components/v3/FileContextMenu.svelte
+++ b/apps/desktop/src/components/v3/FileContextMenu.svelte
@@ -21,7 +21,7 @@
 	import type { Writable } from 'svelte/store';
 
 	type Props = {
-		isUnapplied: boolean;
+		isUncommitted: boolean;
 		trigger?: HTMLElement;
 		isBinary?: boolean;
 		unSelectChanges: (changes: TreeChange[]) => void;
@@ -41,7 +41,7 @@
 		);
 	}
 
-	const { trigger, isUnapplied, isBinary = false, unSelectChanges }: Props = $props();
+	const { trigger, isBinary = false, unSelectChanges, isUncommitted }: Props = $props();
 	const [stackService, project] = inject(StackService, Project);
 	const userSettings = getContextStoreBySymbol<Settings, Writable<Settings>>(SETTINGS);
 
@@ -85,7 +85,7 @@
 			<ContextMenuSection>
 				{#if item.changes.length > 0}
 					{@const changes = item.changes}
-					{#if !isUnapplied && !isBinary}
+					{#if !isBinary && isUncommitted}
 						<ContextMenuItem
 							label="Discard changes"
 							onclick={() => {

--- a/apps/desktop/src/components/v3/FileListItemWrapper.svelte
+++ b/apps/desktop/src/components/v3/FileListItemWrapper.svelte
@@ -5,6 +5,7 @@
 	import { draggableChips } from '$lib/dragging/draggable';
 	import { ChangeDropData } from '$lib/dragging/draggables';
 	import { getFilename } from '$lib/files/utils';
+	import { DiffService } from '$lib/hunks/diffService.svelte';
 	import { ChangeSelectionService } from '$lib/selection/changeSelection.svelte';
 	import { IdSelection } from '$lib/selection/idSelection.svelte';
 	import { key, type SelectionId } from '$lib/selection/key';
@@ -55,6 +56,7 @@
 	const stackId = $derived($stack?.id);
 	const idSelection = getContext(IdSelection);
 	const changeSelection = getContext(ChangeSelectionService);
+	const diffService = getContext(DiffService);
 
 	let contextMenu = $state<ReturnType<typeof FileContextMenu>>();
 	let draggableEl: HTMLDivElement | undefined = $state();
@@ -62,6 +64,10 @@
 	const selection = $derived(changeSelection.getById(change.path));
 	const indeterminate = $derived(selection.current && selection.current.type === 'partial');
 	const selectedChanges = $derived(idSelection.treeChanges(projectId, selectionId));
+	const diffResult = $derived(diffService.getDiff(projectId, change));
+
+	const isBinary = $derived(diffResult.current.data?.type === 'Binary');
+	const isUncommitted = $derived(selectionId.type === 'worktree');
 
 	function onCheck() {
 		if (selection.current) {
@@ -111,8 +117,8 @@
 	<FileContextMenu
 		bind:this={contextMenu}
 		trigger={draggableEl}
-		isUnapplied={false}
-		isBinary={false}
+		{isUncommitted}
+		{isBinary}
 		{unSelectChanges}
 	/>
 	{#if isHeader}

--- a/apps/desktop/src/lib/selection/idSelection.svelte.ts
+++ b/apps/desktop/src/lib/selection/idSelection.svelte.ts
@@ -93,9 +93,6 @@ export class IdSelection {
 	 */
 	treeChanges(projectId: string, params: SelectionId) {
 		const filePaths = this.values(params).map((fileSelection) => {
-			if (fileSelection.type !== 'worktree') {
-				throw new Error('???');
-			}
 			return fileSelection.path;
 		});
 


### PR DESCRIPTION
The file context menu now works for the branch and commit views

Getting the tree changes for committed content won't throw an error. Instead, just guard at the component level whether the changes are **discardable**