### PR TITLE
fix: Don't keep jumping to the start of the PR content

### DIFF
--- a/apps/desktop/src/components/BranchReview.svelte
+++ b/apps/desktop/src/components/BranchReview.svelte
@@ -64,7 +64,7 @@
 
 	let modal = $state<Modal>();
 	let confirmCreatePrModal = $state<ReturnType<typeof Modal>>();
-	let reviewCreation = $state<ReviewCreation>();
+	let reviewCreation = $state<ReturnType<typeof ReviewCreation>>();
 
 	syncPrToBr(
 		reactive(() => prNumber),
@@ -85,6 +85,8 @@
 		}
 		return 'Submit for review';
 	}
+
+	const ctaDisabled = $derived(reviewCreation ? !reviewCreation.imports.creationEnabled : false);
 </script>
 
 <Modal
@@ -122,9 +124,9 @@
 	{#snippet controls(close)}
 		<ReviewCreationControls
 			isSubmitting={!!reviewCreation?.imports.isLoading}
+			{ctaDisabled}
 			{canPublishBR}
 			{canPublishPR}
-			ctaDisabled={!reviewCreation?.createButtonEnabled().current}
 			onCancel={close}
 			onSubmit={async () => {
 				await reviewCreation?.createReview();

--- a/apps/desktop/src/components/PrTemplateSection.svelte
+++ b/apps/desktop/src/components/PrTemplateSection.svelte
@@ -11,9 +11,10 @@
 	interface Props {
 		templates: string[];
 		selectedTemplate: string | undefined;
+		disabled: boolean;
 	}
 
-	let { templates, selectedTemplate = $bindable() }: Props = $props();
+	let { templates, disabled, selectedTemplate = $bindable() }: Props = $props();
 
 	const forge = getContext(DefaultForgeFactory);
 	// TODO: Rename or refactor this service.
@@ -66,7 +67,7 @@
 		<Toggle
 			id="pr-template-toggle"
 			checked={!!selectedTemplate}
-			disabled={templates.length === 0}
+			disabled={templates.length === 0 || disabled}
 			onclick={handleToggle}
 		/>
 	</label>
@@ -76,7 +77,7 @@
 		placeholder={templates.length > 0 ? 'Choose template' : 'No PR templates found ¯\\_(ツ)_/¯'}
 		flex="1"
 		searchable
-		disabled={templates.length === 0 || !selectedTemplate}
+		disabled={templates.length === 0 || !selectedTemplate || disabled}
 		onselect={setTemplate}
 	>
 		{#snippet itemSnippet({ item, highlighted })}

--- a/apps/desktop/src/components/ReviewCreation.svelte
+++ b/apps/desktop/src/components/ReviewCreation.svelte
@@ -110,7 +110,6 @@
 	);
 
 	let titleInput = $state<ReturnType<typeof Textbox>>();
-	let descriptionInput = $state<ReturnType<typeof MessageEditor>>();
 
 	// Displays template select component when true.
 	let useTemplate = persisted(false, `use-template-${projectId}`);
@@ -157,12 +156,6 @@
 
 	$effect(() => {
 		prBody.init(projectId, branch?.description ?? '', commits, templateBody, branch?.name ?? '');
-	});
-
-	$effect(() => {
-		if (prBody.value !== undefined) {
-			descriptionInput?.setText(prBody.value);
-		}
 	});
 
 	async function pushIfNeeded(): Promise<string | undefined> {
@@ -347,12 +340,12 @@
 						prBody.reset();
 						firstToken = false;
 					}
-					prBody.append(token);
+					prBody.append(token, true);
 				}
 			});
 
 			if (description) {
-				prBody.set(description);
+				prBody.set(description, true);
 			}
 		} finally {
 			aiIsLoading = false;
@@ -388,7 +381,7 @@
 		onkeydown={(e: KeyboardEvent) => {
 			if (e.key === 'Enter' || e.key === 'Tab') {
 				e.preventDefault();
-				descriptionInput?.focus();
+				prBody.descriptionInput?.focus();
 			}
 		}}
 	/>
@@ -400,7 +393,7 @@
 
 	<!-- DESCRIPTION FIELD -->
 	<MessageEditor
-		bind:this={descriptionInput}
+		bind:this={prBody.descriptionInput}
 		{projectId}
 		disabled={isExecuting}
 		initialValue={prBody.value}

--- a/apps/desktop/src/components/v3/ReviewView.svelte
+++ b/apps/desktop/src/components/v3/ReviewView.svelte
@@ -19,7 +19,7 @@
 	const uiState = getContext(UiState);
 
 	let drawer = $state<ReturnType<typeof Drawer>>();
-	let reviewCreation = $state<ReviewCreation>();
+	let reviewCreation = $state<ReturnType<typeof ReviewCreation>>();
 
 	function close() {
 		uiState.project(projectId).drawerPage.current = 'branch';
@@ -55,6 +55,8 @@
 		}
 		return 'Submit for code review';
 	}
+
+	const ctaDisabled = $derived(reviewCreation ? !reviewCreation.imports.creationEnabled : false);
 </script>
 
 <Drawer
@@ -70,9 +72,9 @@
 
 		<ReviewCreationControls
 			isSubmitting={!!reviewCreation?.imports.isLoading}
+			{ctaDisabled}
 			{canPublishBR}
 			{canPublishPR}
-			ctaDisabled={!reviewCreation?.createButtonEnabled().current}
 			onCancel={close}
 			onSubmit={async () => {
 				await reviewCreation?.createReview();

--- a/apps/desktop/src/lib/forge/prContents.svelte.ts
+++ b/apps/desktop/src/lib/forge/prContents.svelte.ts
@@ -1,3 +1,4 @@
+import MessageEditor from '$components/v3/editor/MessageEditor.svelte';
 import { splitMessage } from '$lib/utils/commitMessage';
 import { getEphemeralStorageItem, setEphemeralStorageItem } from '@gitbutler/shared/persisted';
 import type { Commit } from '$lib/branches/v3';
@@ -102,6 +103,7 @@ export class ReactivePRBody {
 	private commits: Commit[] | undefined;
 	private templateBody: string | undefined;
 	private branchName: string | undefined;
+	private _descriptionInput = $state<ReturnType<typeof MessageEditor>>();
 
 	init(
 		projectId: string,
@@ -140,12 +142,23 @@ export class ReactivePRBody {
 		return this._value;
 	}
 
-	set(value: string | undefined) {
+	/**
+	 * Set the value of the PR body.
+	 *
+	 * @param flush - If true, the value will be set in the description input as well.
+	 */
+	set(value: string | undefined, flush?: boolean) {
 		if (!this.projectId || !this.branchName) {
 			throw new Error('ReactivePRBody not initialized');
 		}
 
-		this._value = value ?? '';
+		const newValue = value ?? '';
+
+		this._value = newValue;
+
+		if (flush) {
+			this._descriptionInput?.setText(newValue);
+		}
 
 		// Don't persist the default value
 		if (value !== this.getDefaultBody()) {
@@ -153,11 +166,19 @@ export class ReactivePRBody {
 		}
 	}
 
-	append(value: string) {
-		this.set(this._value + value);
+	append(value: string, flush?: boolean) {
+		this.set(this._value + value, flush);
 	}
 
 	reset() {
 		this.set(undefined);
+	}
+
+	get descriptionInput() {
+		return this._descriptionInput;
+	}
+
+	set descriptionInput(value: ReturnType<typeof MessageEditor> | undefined) {
+		this._descriptionInput = value;
 	}
 }


### PR DESCRIPTION
The caret would keep jumping at the beginning of the review creation modal description field, because there was an effect that would set the description value everytime the pr body would change.

This was dumb.

The motivation behind that was to be able to set the pr description content programatically for e.g. generating the description.

In order to do so now, though, we just let the set method optionally flush the value to the description input when programmatically setting the content

- Don't update the rich text content editor from an effect block
- Templates are tracked from within the class in order to track the updates to it