### PR TITLE
Refactor `useMutation` and prefer `mutate`

### DIFF
--- a/apps/desktop/src/components/AddSeriesModal.svelte
+++ b/apps/desktop/src/components/AddSeriesModal.svelte
@@ -32,14 +32,14 @@
 	const slugifiedRefName = $derived(createRefName && slugify(createRefName));
 	const generatedNameDiverges = $derived(!!createRefName && slugifiedRefName !== createRefName);
 
-	function addSeries() {
+	async function addSeries() {
 		if (!slugifiedRefName) {
 			error('No branch name provided');
 			createRefModal?.close();
 			return;
 		}
 
-		newBranch({
+		await newBranch({
 			projectId: project.id,
 			stackId: $stack.id,
 			request: {

--- a/apps/desktop/src/components/Board.svelte
+++ b/apps/desktop/src/components/Board.svelte
@@ -20,7 +20,6 @@
 	const vbranchService = getContext(VirtualBranchService);
 	const posthog = getContext(PostHogWrapper);
 	const stackService = getContext(StackService);
-	const [updateBranchOrder] = stackService.updateBranchOrder;
 
 	const error = vbranchService.error;
 	const branches = vbranchService.branches;
@@ -95,7 +94,7 @@
 			if (!dragged) {
 				return; // Something other than a lane was dropped.
 			}
-			updateBranchOrder({
+			stackService.updateBranchOrder({
 				projectId,
 				branches: sortedBranches.map((b, i) => ({ id: b.id, order: i }))
 			});

--- a/apps/desktop/src/components/BoardEmptyState.svelte
+++ b/apps/desktop/src/components/BoardEmptyState.svelte
@@ -14,7 +14,6 @@
 	const baseBranch = maybeGetContext(BaseBranch);
 	const userSettings = getContextStoreBySymbol<Settings, Writable<Settings>>(SETTINGS);
 	const stackService = getContext(StackService);
-	const [newStack] = stackService.newStack;
 
 	const project = getContext(Project);
 
@@ -48,8 +47,10 @@
 							class="empty-board__suggestions__link"
 							role="button"
 							tabindex="0"
-							onkeypress={async () => await newStack({ projectId: project.id, branch: {} })}
-							onclick={async () => await newStack({ projectId: project.id, branch: {} })}
+							onkeypress={async () =>
+								await stackService.newStackMutation({ projectId: project.id, branch: {} })}
+							onclick={async () =>
+								await stackService.newStackMutation({ projectId: project.id, branch: {} })}
 						>
 							<div class="empty-board__suggestions__link__icon">
 								<Icon name="add-new" />

--- a/apps/desktop/src/components/BranchDropzone.svelte
+++ b/apps/desktop/src/components/BranchDropzone.svelte
@@ -18,8 +18,6 @@
 	const { projectId }: Props = $props();
 
 	const stackService = getContext(StackService);
-	const [newStack] = stackService.newStack;
-
 	const handler = new NewStackDzHandler(stackService, projectId);
 </script>
 
@@ -55,7 +53,8 @@
 					<Button
 						kind="outline"
 						icon="plus-small"
-						onmousedown={async () => await newStack({ projectId, branch: {} })}>New branch</Button
+						onmousedown={async () => await stackService.newStackMutation({ projectId, branch: {} })}
+						>New branch</Button
 					>
 				</div>
 			</div>

--- a/apps/desktop/src/components/BranchLaneContextMenu.svelte
+++ b/apps/desktop/src/components/BranchLaneContextMenu.svelte
@@ -30,11 +30,6 @@
 	const prService = $derived(forge.current.prService);
 	const user = getContextStore(User);
 
-	const [updateStack] = stackService.updateStack;
-	const [newStack] = stackService.newStack;
-	const [unapplyWithoutSaving] = stackService.unapplyWithoutSaving;
-	const [unapply] = stackService.unapply;
-
 	let deleteBranchModal: Modal;
 	let allowRebasing = $state<boolean>();
 	let isDeleting = $state(false);
@@ -49,7 +44,7 @@
 	const allPrIds = $derived(stack.validSeries.map((series) => series.prNumber).filter(isDefined));
 
 	async function toggleAllowRebasing() {
-		updateStack({
+		await stackService.updateStack({
 			projectId,
 			branch: {
 				id: stack.id,
@@ -73,7 +68,7 @@
 		<ContextMenuItem
 			label="Unapply"
 			onclick={async () => {
-				await unapply({
+				await stackService.unapply({
 					projectId: projectId,
 					stackId: stack.id
 				});
@@ -85,7 +80,7 @@
 			label="Unapply and drop changes"
 			onclick={async () => {
 				if (commits.length === 0 && stack.files?.length === 0) {
-					await unapplyWithoutSaving({
+					await stackService.unapplyWithoutSaving({
 						projectId: projectId,
 						stackId: stack.id
 					});
@@ -111,7 +106,7 @@
 		<ContextMenuItem
 			label={`Create stack to the left`}
 			onclick={() => {
-				newStack({
+				stackService.newStackMutation({
 					projectId,
 					branch: { order: stack.order }
 				});
@@ -122,7 +117,7 @@
 		<ContextMenuItem
 			label={`Create stack to the right`}
 			onclick={() => {
-				newStack({
+				stackService.newStackMutation({
 					projectId,
 					branch: { order: stack.order + 1 }
 				});
@@ -154,7 +149,7 @@
 	onSubmit={async (close) => {
 		try {
 			isDeleting = true;
-			await unapplyWithoutSaving({
+			await stackService.unapplyWithoutSaving({
 				projectId,
 				stackId: stack.id
 			});

--- a/apps/desktop/src/components/BranchPreviewHeader.svelte
+++ b/apps/desktop/src/components/BranchPreviewHeader.svelte
@@ -38,8 +38,6 @@
 	);
 
 	const stackService = getContext(StackService);
-	const [createVirtualBranchFromBranch] = stackService.createVirtualBranchFromBranch;
-	const [deleteLocalBranchMutation] = stackService.deleteLocalBranch;
 
 	const mode = modeSerivce.mode;
 	const forgeBranch = $derived(upstream ? forge.current.branch(upstream) : undefined);
@@ -58,7 +56,7 @@
 	let deleteBranchModal = $state<Modal>();
 
 	async function createvBranchFromBranch(branch: string, remote?: string, prNumber?: number) {
-		await createVirtualBranchFromBranch({
+		await stackService.createVirtualBranchFromBranch({
 			projectId: project.id,
 			branch,
 			remote,
@@ -68,7 +66,7 @@
 	}
 
 	async function deleteLocalBranch(refname: string, givenName: string) {
-		await deleteLocalBranchMutation({
+		await stackService.deleteLocalBranch({
 			projectId: project.id,
 			refname,
 			givenName

--- a/apps/desktop/src/components/ChromeSidebar.svelte
+++ b/apps/desktop/src/components/ChromeSidebar.svelte
@@ -285,6 +285,7 @@
 			label="Global settings"
 			onclick={() => {
 				goto(newSettingsPath());
+				contextMenuEl?.close();
 			}}
 			keyboardShortcut="⌘,"
 		/>

--- a/apps/desktop/src/components/CommitCard.svelte
+++ b/apps/desktop/src/components/CommitCard.svelte
@@ -146,17 +146,17 @@
 	let isUpdating = $state(false);
 
 	async function submitCommitMessageModal() {
+		if (!stack) {
+			return;
+		}
 		isUpdating = true;
 		commit.description = description;
-
-		if (stack) {
-			await updateCommitMessage({
-				projectId: project.id,
-				stackId: stack.id,
-				commitId: commit.id,
-				message: description
-			});
-		}
+		await updateCommitMessage({
+			projectId: project.id,
+			stackId: stack.id,
+			commitId: commit.id,
+			message: description
+		});
 
 		commitMessageModal?.close();
 		isUpdating = false;

--- a/apps/desktop/src/components/CommitContextMenu.svelte
+++ b/apps/desktop/src/components/CommitContextMenu.svelte
@@ -47,12 +47,12 @@
 	const stackService = getContext(StackService);
 	const [insertBlankCommitMutation] = stackService.insertBlankCommit;
 
-	function insertBlankCommit(commitId: string, location: 'above' | 'below' = 'below') {
+	async function insertBlankCommit(commitId: string, location: 'above' | 'below' = 'below') {
 		if (!branch || !baseBranch) {
 			console.error('Unable to insert commit');
 			return;
 		}
-		insertBlankCommitMutation({
+		await insertBlankCommitMutation({
 			projectId: project.id,
 			stackId: branch.id,
 			commitOid: commitId,

--- a/apps/desktop/src/components/CommitDialog.svelte
+++ b/apps/desktop/src/components/CommitDialog.svelte
@@ -36,7 +36,6 @@
 	const commitMessage = persistedCommitMessage(projectId, $stack.id);
 	const runHooks = projectRunCommitHooks(projectId);
 	const stackService = getContext(StackService);
-	const [commitLegacy] = stackService.createCommitLegacy;
 
 	let commitMessageInput = $state<CommitMessageInput>();
 	let isCommitting = $state(false);
@@ -62,7 +61,12 @@
 					return; // Abort commit if hook failed.
 				}
 			}
-			await commitLegacy({ projectId, stackId: $stack.id, message: message.trim(), ownership });
+			await stackService.createCommitLegacy({
+				projectId,
+				stackId: $stack.id,
+				message: message.trim(),
+				ownership
+			});
 		} catch (err: unknown) {
 			showError('Failed to commit changes', err);
 			posthog.capture('Commit Failed', { error: err });

--- a/apps/desktop/src/components/CommitList.svelte
+++ b/apps/desktop/src/components/CommitList.svelte
@@ -67,7 +67,6 @@
 	const stack = getContextStore(BranchStack);
 	const lineManagerFactory = getContext(LineManagerFactory);
 	const stackService = getContext(StackService);
-	const [integrateUpstreamCommits] = stackService.integrateUpstreamCommits;
 
 	const forge = getContext(DefaultForgeFactory);
 
@@ -112,7 +111,7 @@
 	async function integrate(strategy?: SeriesIntegrationStrategy): Promise<void> {
 		isIntegratingCommits = true;
 		try {
-			await integrateUpstreamCommits({
+			await stackService.integrateUpstreamCommits({
 				projectId,
 				stackId: $stack.id,
 				seriesName: currentSeries.name,

--- a/apps/desktop/src/components/FileContextMenu.svelte
+++ b/apps/desktop/src/components/FileContextMenu.svelte
@@ -34,7 +34,6 @@
 	const project = getContext(Project);
 	const userSettings = getContextStoreBySymbol<Settings, Writable<Settings>>(SETTINGS);
 	const stackService = getContext(StackService);
-	const [unapplyFiles] = stackService.legacyUnapplyFiles;
 
 	let confirmationModal: ReturnType<typeof Modal> | undefined;
 	let contextMenu: ReturnType<typeof ContextMenu>;
@@ -54,7 +53,7 @@
 			toasts.error('Failed to discard changes');
 			return;
 		}
-		await unapplyFiles({ projectId, stackId, files: item.files });
+		await stackService.legacyUnapplyFiles({ projectId, stackId, files: item.files });
 		close();
 	}
 

--- a/apps/desktop/src/components/HunkContextMenu.svelte
+++ b/apps/desktop/src/components/HunkContextMenu.svelte
@@ -33,9 +33,6 @@
 	const stackService = getContext(StackService);
 	const userSettings = getContextStoreBySymbol<Settings, Writable<Settings>>(SETTINGS);
 
-	const [unapplyHunk] = stackService.legacyUnapplyHunk;
-	const [unapplyLines] = stackService.legacyUnapplyLines;
-
 	let contextMenu: ReturnType<typeof ContextMenu> | undefined;
 
 	function getDiscardLineLabel(
@@ -66,8 +63,8 @@
 			{#if item.hunk !== undefined && !readonly}
 				<ContextMenuItem
 					label="Discard hunk"
-					onclick={() => {
-						unapplyHunk({ projectId, hunk: item.hunk });
+					onclick={async () => {
+						stackService.legacyUnapplyHunk({ projectId, hunk: item.hunk });
 						contextMenu?.close();
 					}}
 				/>
@@ -75,8 +72,8 @@
 			{#if item.hunk !== undefined && (item.beforeLineNumber !== undefined || item.afterLineNumber !== undefined) && !readonly}
 				<ContextMenuItem
 					label={getDiscardLineLabel(item.beforeLineNumber, item.afterLineNumber)}
-					onclick={() => {
-						unapplyLines({
+					onclick={async () => {
+						stackService.legacyUnapplyLines({
 							projectId,
 							hunk: item.hunk,
 							linesToUnapply: [{ old: item.beforeLineNumber, new: item.afterLineNumber }]

--- a/apps/desktop/src/components/PullRequestCard.svelte
+++ b/apps/desktop/src/components/PullRequestCard.svelte
@@ -74,7 +74,6 @@
 	const baseBranch = $derived(baseBranchResponse.current.data);
 	const baseBranchRepoResponse = $derived(baseBranchService.repo(projectId));
 	const baseBranchRepo = $derived(baseBranchRepoResponse.current.data);
-	const [fetchFromRemotes] = baseBranchService.fetchFromRemotes;
 	const repoResult = $derived(repoService?.getInfo());
 	const repoInfo = $derived(repoResult?.current.data);
 
@@ -317,7 +316,7 @@
 							}
 
 							await Promise.all([
-								fetchFromRemotes({ projectId }),
+								baseBranchService.fetchFromRemotes(projectId),
 								vbranchService.refresh(),
 								baseBranchService.refreshBaseBranch(projectId)
 							]);

--- a/apps/desktop/src/components/PullRequestPreview.svelte
+++ b/apps/desktop/src/components/PullRequestPreview.svelte
@@ -25,8 +25,6 @@
 	const baseRepoResponse = $derived(baseBranchService.repo(project.id));
 	const baseRepo = $derived(baseRepoResponse.current.data);
 	const stackService = getContext(StackService);
-	const [createVirtualBranchFromBranch] = stackService.createVirtualBranchFromBranch;
-	const [fetchFromRemotes] = baseBranchService.fetchFromRemotes;
 
 	let inputRemoteName = $state<string>(pr.repoOwner || '');
 
@@ -60,8 +58,8 @@
 		try {
 			const remoteRef = 'refs/remotes/' + inputRemoteName + '/' + pr.sourceBranch;
 			await remotesService.addRemote(project.id, inputRemoteName, remoteUrl);
-			await fetchFromRemotes({ projectId: project.id });
-			await createVirtualBranchFromBranch({
+			await baseBranchService.fetchFromRemotes(project.id);
+			await stackService.createVirtualBranchFromBranch({
 				projectId: project.id,
 				branch: remoteRef,
 				remote: remoteRef,

--- a/apps/desktop/src/components/ReviewCreation.svelte
+++ b/apps/desktop/src/components/ReviewCreation.svelte
@@ -175,8 +175,8 @@
 				withForce: branchDetails?.pushStatus === 'unpushedCommitsRequiringForce'
 			});
 
-			if (pushResult.data) {
-				upstreamBranchName = getBranchNameFromRef(pushResult.data.refname, pushResult.data.remote);
+			if (pushResult) {
+				upstreamBranchName = getBranchNameFromRef(pushResult.refname, pushResult.remote);
 			}
 
 			if (firstPush) {
@@ -212,13 +212,12 @@
 		// Even if createButlerRequest is false, if we _cant_ create a PR, then
 		// We want to always create the BR, and vice versa.
 		if ((canPublishBR && $createButlerRequest) || !canPublishPR) {
-			const result = await publishBranch({
+			const reviewId = await publishBranch({
 				projectId,
 				stackId,
 				topBranch: branch.name,
 				user: $user
 			});
-			reviewId = result.data;
 			if (!reviewId) {
 				posthog.capture('Butler Review Creation Failed');
 				return;

--- a/apps/desktop/src/components/SyncButton.svelte
+++ b/apps/desktop/src/components/SyncButton.svelte
@@ -15,7 +15,6 @@
 
 	const [baseBranchService, branchService] = inject(BaseBranchService, BranchService);
 	const baseBranch = baseBranchService.baseBranch(projectId);
-	const [fetchFromRemotes] = baseBranchService.fetchFromRemotes;
 
 	const forge = getContext(DefaultForgeFactory);
 	const listingService = $derived(forge.current.listService);
@@ -37,10 +36,7 @@
 		e.stopPropagation();
 		loading = true;
 		try {
-			await fetchFromRemotes({
-				projectId,
-				action: 'modal'
-			});
+			await baseBranchService.fetchFromRemotes(projectId, 'modal');
 			await Promise.all([
 				listingService?.refresh(projectId),
 				baseBranch.current.refetch(),

--- a/apps/desktop/src/components/v3/CommitContextMenu.svelte
+++ b/apps/desktop/src/components/v3/CommitContextMenu.svelte
@@ -42,12 +42,12 @@
 	const stackService = getContext(StackService);
 	const [insertBlankCommitInBranch, commitInsertion] = stackService.insertBlankCommit;
 
-	function insertBlankCommit(commitId: string, location: 'above' | 'below' = 'below') {
+	async function insertBlankCommit(commitId: string, location: 'above' | 'below' = 'below') {
 		if (!stackId || !baseBranch) {
 			console.error('Unable to insert commit', { branchId: stackId, baseBranch });
 			return;
 		}
-		insertBlankCommitInBranch({
+		await insertBlankCommitInBranch({
 			projectId,
 			stackId,
 			commitOid: commitId,

--- a/apps/desktop/src/components/v3/CommitView.svelte
+++ b/apps/desktop/src/components/v3/CommitView.svelte
@@ -85,22 +85,12 @@
 			return;
 		}
 
-		const result = await updateCommitMessage({
+		const newCommitId = await updateCommitMessage({
 			projectId,
 			stackId,
 			commitId: commitKey.commitId,
 			message: commitMessage
 		});
-
-		if (!result.data) {
-			showToast({
-				message: `Update commit error`,
-				style: 'error'
-			});
-			return;
-		}
-
-		const newCommitId = result.data;
 
 		uiState.stack(stackId).selection.set({ branchName, commitId: newCommitId });
 		setMode('view');

--- a/apps/desktop/src/components/v3/FileContextMenu.svelte
+++ b/apps/desktop/src/components/v3/FileContextMenu.svelte
@@ -45,7 +45,6 @@
 	const [stackService, project] = inject(StackService, Project);
 	const userSettings = getContextStoreBySymbol<Settings, Writable<Settings>>(SETTINGS);
 
-	const [discardChanges] = stackService.discardChanges;
 	let confirmationModal: ReturnType<typeof Modal> | undefined;
 	let contextMenu: ReturnType<typeof ContextMenu>;
 	const projectId = $derived(project.id);
@@ -63,7 +62,7 @@
 			hunkHeaders: []
 		}));
 
-		await discardChanges({
+		await stackService.discardChanges({
 			projectId,
 			worktreeChanges
 		});

--- a/apps/desktop/src/components/v3/HunkContextMenu.svelte
+++ b/apps/desktop/src/components/v3/HunkContextMenu.svelte
@@ -37,7 +37,6 @@
 
 	const [stackService] = inject(StackService);
 	const userSettings = getContextStoreBySymbol<Settings, Writable<Settings>>(SETTINGS);
-	const [discardChanges] = stackService.discardChanges;
 
 	const filePath = $derived(change.path);
 	let contextMenu: ReturnType<typeof ContextMenu> | undefined;
@@ -57,7 +56,7 @@
 
 		unSelectHunk(item.hunk);
 
-		await discardChanges({
+		await stackService.discardChanges({
 			projectId,
 			worktreeChanges: [
 				{
@@ -76,7 +75,7 @@
 
 		unSelectHunk(item.hunk);
 
-		await discardChanges({
+		await stackService.discardChanges({
 			projectId,
 			worktreeChanges: [
 				{

--- a/apps/desktop/src/components/v3/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/v3/IntegrateUpstreamModal.svelte
@@ -97,8 +97,8 @@
 				projectId,
 				resolutionApproach: { type: baseResolutionApproach }
 			}).then((result) => {
-				if (result.data) {
-					targetCommitOid = result.data;
+				if (result) {
+					targetCommitOid = result;
 				}
 			});
 		}
@@ -116,16 +116,17 @@
 			baseResolutionApproach || 'hardReset'
 		);
 
-		await integrateUpstream({
-			projectId,
-			resolutions: Array.from(results.values()),
-			baseBranchResolution: baseResolution
-		});
-
-		await baseBranchService.refreshBaseBranch(projectId);
-		integratingUpstream = 'completed';
-
-		modal?.close();
+		try {
+			await integrateUpstream({
+				projectId,
+				resolutions: Array.from(results.values()),
+				baseBranchResolution: baseResolution
+			});
+		} finally {
+			await baseBranchService.refreshBaseBranch(projectId);
+			integratingUpstream = 'completed';
+			modal?.close();
+		}
 	}
 
 	export async function show() {

--- a/apps/desktop/src/components/v3/StackHeader.svelte
+++ b/apps/desktop/src/components/v3/StackHeader.svelte
@@ -13,7 +13,6 @@
 	}
 
 	const stackService = getContext(StackService);
-	const [updateStack] = stackService.updateStack;
 
 	const { onCollapseButtonClick, stack, projectId }: Props = $props();
 
@@ -30,7 +29,7 @@
 		isDefault={stack.selectedForChanges}
 		{onCollapseButtonClick}
 		onDefaultSet={async () => {
-			await updateStack({
+			await stackService.updateStack({
 				projectId,
 				branch: { id: stack.id, selected_for_changes: true }
 			});

--- a/apps/desktop/src/components/v3/stackTabs/StackTabMenu.svelte
+++ b/apps/desktop/src/components/v3/stackTabs/StackTabMenu.svelte
@@ -14,7 +14,6 @@
 	let { projectId, stackId, isOpen = $bindable() }: Props = $props();
 
 	const stackService = getContext(StackService);
-	const [unapply] = stackService.unapply;
 
 	let trigger = $state<HTMLElement>();
 	let contextMenu = $state<ContextMenu>();
@@ -54,7 +53,7 @@
 			label="Unapply Stack"
 			keyboardShortcut="$mod+X"
 			onclick={async () => {
-				await unapply({ projectId, stackId });
+				await stackService.unapply({ projectId, stackId });
 				contextMenu?.close();
 			}}
 		/>

--- a/apps/desktop/src/components/v3/stackTabs/StackTabNew.svelte
+++ b/apps/desktop/src/components/v3/stackTabs/StackTabNew.svelte
@@ -2,7 +2,6 @@
 	import RadioButton from '$components/RadioButton.svelte';
 	import dependentBranchSvg from '$components/v3/stackTabs/assets/dependent-branch.svg?raw';
 	import newStackSvg from '$components/v3/stackTabs/assets/new-stack.svg?raw';
-	import { showToast } from '$lib/notifications/toasts';
 	import { stackPath } from '$lib/routes/routes.svelte';
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { getContext } from '@gitbutler/shared/context';
@@ -45,21 +44,11 @@
 
 	async function addNew() {
 		if (createRefType === 'stack') {
-			const result = await createNewStack({
+			const stack = await createNewStack({
 				projectId,
 				branch: { name: createRefName }
 			});
-
-			if (!result.data) {
-				showToast({
-					message: 'Failed to create new stack',
-					style: 'error'
-				});
-				return;
-			}
-
-			const id = result.data.id;
-			goto(stackPath(projectId, id));
+			goto(stackPath(projectId, stack.id));
 			createRefModal?.close();
 		} else {
 			if (!stackId || !createRefName) {

--- a/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
+++ b/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
@@ -64,27 +64,30 @@ export default class BaseBranchService {
 		await this.api.endpoints.baseBranch.fetch({ projectId }, { forceRefetch: true });
 	}
 
-	get fetchFromRemotes() {
-		return this.api.endpoints.fetchFromRemotes.useMutation({
-			onError: (error, { action }) => {
-				const { code } = error;
-				if (code === Code.DefaultTargetNotFound) {
-					// Swallow this error since user should be taken to project setup page
-					return;
-				}
+	async fetchFromRemotes(projectId: string, action?: string) {
+		return await this.api.endpoints.fetchFromRemotes.mutate(
+			{ projectId, action },
+			{
+				onError: (error, { action }) => {
+					const { code } = error;
+					if (code === Code.DefaultTargetNotFound) {
+						// Swallow this error since user should be taken to project setup page
+						return;
+					}
 
-				if (code === Code.ProjectsGitAuth) {
-					showError('Failed to authenticate', error.message);
-					return;
-				}
+					if (code === Code.ProjectsGitAuth) {
+						showError('Failed to authenticate', error.message);
+						return;
+					}
 
-				if (action !== undefined) {
-					showError('Failed to fetch', error.message);
-				}
+					if (action !== undefined) {
+						showError('Failed to fetch', error.message);
+					}
 
-				console.error(error);
+					console.error(error);
+				}
 			}
-		});
+		);
 	}
 
 	async refreshRemotes(projectId: string) {

--- a/apps/desktop/src/lib/branches/dropHandler.ts
+++ b/apps/desktop/src/lib/branches/dropHandler.ts
@@ -23,7 +23,7 @@ export class BranchHunkDzHandler implements DropzoneHandler {
 
 	ondrop(data: HunkDropData) {
 		const newOwnership = `${data.hunk.filePath}:${data.hunk.id}`;
-		this.stackService.legacyUpdateBranchOwnershipMutation({
+		this.stackService.legacyUpdateBranchOwnership({
 			projectId: this.projectId,
 			stackId: this.stack.id,
 			ownership: (newOwnership + '\n' + this.stack.ownership).trim()
@@ -51,7 +51,7 @@ export class BranchFileDzHandler implements DropzoneHandler {
 
 	ondrop(data: FileDropData) {
 		const newOwnership = filesToOwnership(data.files);
-		this.stackService.legacyUpdateBranchOwnershipMutation({
+		this.stackService.legacyUpdateBranchOwnership({
 			projectId: this.projectId,
 			stackId: this.stackId,
 			ownership: (newOwnership + '\n' + this.ownership).trim()

--- a/apps/desktop/src/lib/commits/dropHandler.ts
+++ b/apps/desktop/src/lib/commits/dropHandler.ts
@@ -38,7 +38,7 @@ export class MoveCommitDzHandler implements DropzoneHandler {
 		);
 	}
 	ondrop(data: CommitDropData): void {
-		this.stackService.moveCommitMutation({
+		this.stackService.moveCommit({
 			projectId: this.projectId,
 			targetStackId: this.stack.id,
 			commitOid: data.commit.id,
@@ -72,14 +72,14 @@ export class AmendCommitWithChangeDzHandler implements DropzoneHandler {
 	}
 
 	async ondrop(data: ChangeDropData) {
-		const result = await this.trigger({
-			projectId: this.projectId,
-			stackId: this.stackId,
-			commitId: this.commit.id,
-			worktreeChanges: changesToDiffSpec(data)
-		});
-
-		this.onresult(result.data);
+		this.onresult(
+			await this.trigger({
+				projectId: this.projectId,
+				stackId: this.stackId,
+				commitId: this.commit.id,
+				worktreeChanges: changesToDiffSpec(data)
+			})
+		);
 	}
 }
 
@@ -215,10 +215,10 @@ export class SquashCommitDzHandler implements DropzoneHandler {
 		return true;
 	}
 
-	ondrop(data: unknown): void {
+	async ondrop(data: unknown) {
 		const { stackService, projectId, stackId, commit } = this.args;
 		if (data instanceof CommitDropData) {
-			stackService.squashCommitsMutation({
+			await stackService.squashCommits({
 				projectId,
 				stackId,
 				sourceCommitOids: [data.commit.id],

--- a/apps/desktop/src/lib/dragging/stackingReorderDropzoneManager.ts
+++ b/apps/desktop/src/lib/dragging/stackingReorderDropzoneManager.ts
@@ -30,7 +30,7 @@ export class ReorderCommitDzHandler implements DropzoneHandler {
 		return true;
 	}
 
-	ondrop(data: CommitDropData) {
+	async ondrop(data: CommitDropData) {
 		const stackOrder = buildNewStackOrder(
 			this.series,
 			this.currentSeries,
@@ -39,7 +39,7 @@ export class ReorderCommitDzHandler implements DropzoneHandler {
 		);
 
 		if (stackOrder) {
-			this.stackService.reorderStackMutation({
+			await this.stackService.reorderStack({
 				projectId: this.projectId,
 				stackId: data.stackId,
 				stackOrder

--- a/apps/desktop/src/lib/forge/github/githubPrService.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubPrService.svelte.ts
@@ -39,15 +39,15 @@ export class GitHubPrService implements ForgePrService {
 	}: CreatePullRequestArgs): Promise<PullRequest> {
 		this.loading.set(true);
 		const request = async () => {
-			const result = await this.api.endpoints.createPr.mutate({
-				head: upstreamName,
-				base: baseBranchName,
-				title,
-				body,
-				draft
-			});
-			if (!result.data) throw result.error;
-			return ghResponseToInstance(result.data);
+			return ghResponseToInstance(
+				await this.api.endpoints.createPr.mutate({
+					head: upstreamName,
+					base: baseBranchName,
+					title,
+					body,
+					draft
+				})
+			);
 		};
 
 		let attempts = 0;

--- a/apps/desktop/src/lib/forge/github/issueService.ts
+++ b/apps/desktop/src/lib/forge/github/issueService.ts
@@ -12,11 +12,7 @@ export class GitHubIssueService implements ForgeIssueService {
 	}
 
 	async create(title: string, body: string, labels: string[]) {
-		const result = await this.api.endpoints.create.mutate({ title, body, labels });
-		if (!result.data) {
-			return await Promise.reject(result.error);
-		}
-		return result.data;
+		return await this.api.endpoints.create.mutate({ title, body, labels });
 	}
 }
 

--- a/apps/desktop/src/lib/forge/gitlab/gitlabPrService.svelte.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlabPrService.svelte.ts
@@ -52,9 +52,8 @@ export class GitLabPrService implements ForgePrService {
 		while (attempts < 4) {
 			try {
 				const response = await request();
-				if (!response.data) throw response.error;
 				this.posthog?.capture('Gitlab MR Successful');
-				return response.data;
+				return response;
 			} catch (err: any) {
 				lastError = err;
 				attempts++;

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -169,11 +169,11 @@ export class StackService {
 	}
 
 	get updateStack() {
-		return this.api.endpoints.updateStack.useMutation();
+		return this.api.endpoints.updateStack.mutate;
 	}
 
 	get updateBranchOrder() {
-		return this.api.endpoints.updateBranchOrder.useMutation();
+		return this.api.endpoints.updateBranchOrder.mutate;
 	}
 
 	branches(projectId: string, stackId: string) {
@@ -336,7 +336,7 @@ export class StackService {
 	}
 
 	get createCommitLegacy() {
-		return this.api.endpoints.createCommitLegacy.useMutation();
+		return this.api.endpoints.createCommitLegacy.mutate;
 	}
 
 	commitChanges(projectId: string, commitId: string) {
@@ -409,23 +409,19 @@ export class StackService {
 	}
 
 	get unapply() {
-		return this.api.endpoints.unapply.useMutation();
+		return this.api.endpoints.unapply.mutate;
 	}
 
 	get unapplyWithoutSaving() {
-		return this.api.endpoints.unapplyWithoutSaving.useMutation();
+		return this.api.endpoints.unapplyWithoutSaving.mutate;
 	}
 
 	get publishBranch() {
 		return this.api.endpoints.publishBranch.useMutation();
 	}
 
-	get amendCommit() {
-		return this.api.endpoints.amendCommit.useMutation();
-	}
-
 	get discardChanges() {
-		return this.api.endpoints.discardChanges.useMutation();
+		return this.api.endpoints.discardChanges.mutate;
 	}
 
 	get updateBranchPrNumber() {
@@ -462,59 +458,47 @@ export class StackService {
 	}
 
 	get reorderStack() {
-		return this.api.endpoints.reorderStack.useMutation();
-	}
-
-	get reorderStackMutation() {
 		return this.api.endpoints.reorderStack.mutate;
 	}
 
 	get moveCommit() {
-		return this.api.endpoints.moveCommit.useMutation();
-	}
-
-	get moveCommitMutation() {
 		return this.api.endpoints.moveCommit.mutate;
 	}
 
 	get integrateUpstreamCommits() {
-		return this.api.endpoints.integrateUpstreamCommits.useMutation();
+		return this.api.endpoints.integrateUpstreamCommits.mutate;
 	}
 
 	get legacyUnapplyLines() {
-		return this.api.endpoints.legacyUnapplyLines.useMutation();
+		return this.api.endpoints.legacyUnapplyLines.mutate;
 	}
 
 	get legacyUnapplyHunk() {
-		return this.api.endpoints.legacyUnapplyHunk.useMutation();
+		return this.api.endpoints.legacyUnapplyHunk.mutate;
 	}
 
 	get legacyUnapplyFiles() {
-		return this.api.endpoints.legacyUnapplyFiles.useMutation();
+		return this.api.endpoints.legacyUnapplyFiles.mutate;
 	}
 
 	get legacyUpdateBranchOwnership() {
-		return this.api.endpoints.legacyUpdateBranchOwnership.useMutation();
-	}
-
-	get legacyUpdateBranchOwnershipMutation() {
 		return this.api.endpoints.legacyUpdateBranchOwnership.mutate;
 	}
 
 	get createVirtualBranchFromBranch() {
-		return this.api.endpoints.createVirtualBranchFromBranch.useMutation();
+		return this.api.endpoints.createVirtualBranchFromBranch.mutate;
 	}
 
 	get deleteLocalBranch() {
-		return this.api.endpoints.deleteLocalBranch.useMutation();
+		return this.api.endpoints.deleteLocalBranch.mutate;
 	}
 
 	get squashCommits() {
-		return this.api.endpoints.squashCommits.useMutation();
+		return this.api.endpoints.squashCommits.mutate;
 	}
 
-	get squashCommitsMutation() {
-		return this.api.endpoints.squashCommits.mutate;
+	get amendCommit() {
+		return this.api.endpoints.amendCommit.useMutation();
 	}
 
 	get amendCommitMutation() {
@@ -552,7 +536,7 @@ export class StackService {
 
 		const squashCommits = localCommits.slice(0, -1);
 
-		await this.squashCommitsMutation({
+		await this.squashCommits({
 			projectId,
 			stackId,
 			sourceCommitOids: squashCommits.map((commit) => commit.id),

--- a/apps/desktop/src/lib/state/butlerModule.ts
+++ b/apps/desktop/src/lib/state/butlerModule.ts
@@ -217,26 +217,13 @@ type QueryHooks<D extends CustomQuery<unknown>> = {
 export type CustomMutationResult<Definition extends MutationDefinition<any, any, string, any>> =
 	Prettify<MutationResultSelectorResult<Definition>>;
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-type NotNull = {};
-
-type MutationResult<Definition extends MutationDefinition<unknown, any, string, unknown>> =
-	| {
-			data: ResultTypeFrom<Definition>;
-			error: undefined;
-	  }
-	| {
-			error: NotNull;
-			data: undefined;
-	  };
-
 type CustomMutation<Definition extends MutationDefinition<any, any, string, any>> = readonly [
 	/**
 	 * Trigger the mutation with the given arguments.
 	 *
 	 * If awaited, the result will contain the mutation result.
 	 */
-	(args: QueryArgFrom<Definition>) => Promise<MutationResult<Definition>>,
+	(args: QueryArgFrom<Definition>) => Promise<NonNullable<ResultTypeFrom<Definition>>>,
 	/**
 	 * The reactive state of the mutation.
 	 *
@@ -258,5 +245,5 @@ type MutationHooks<Definition extends MutationDefinition<unknown, any, string, u
 	mutate: (
 		args: QueryArgFrom<Definition>,
 		options?: UseMutationHookParams<Definition>
-	) => Promise<MutationResult<Definition>>;
+	) => Promise<NonNullable<ResultTypeFrom<Definition>>>;
 };

--- a/apps/desktop/src/lib/state/customHooks.svelte.ts
+++ b/apps/desktop/src/lib/state/customHooks.svelte.ts
@@ -224,22 +224,16 @@ export function buildMutationHooks<Definitions extends EndpointDefinitions>({
 		const dispatch = getDispatch();
 
 		let promise =
-			$state<MutationActionCreatorResult<MutationDefinition<any, any, any, any, any>>>();
+			$state<MutationActionCreatorResult<MutationDefinition<unknown, any, any, unknown>>>();
 
 		async function triggerMutation(queryArg: unknown) {
 			preEffect?.(queryArg);
 			const dispatchResult = dispatch(initiate(queryArg, { fixedCacheKey }));
 			promise = dispatchResult;
-			const result = await promise;
-
-			if (!result.error) {
-				sideEffect?.(result.data, queryArg);
-			}
-
-			if (result.error && onError) {
-				onError(result.error, queryArg);
-			}
-
+			const result = await promise.unwrap().catch((error) => {
+				onError?.(error, queryArg);
+			});
+			sideEffect?.(result, queryArg);
 			return result;
 		}
 


### PR DESCRIPTION
Both mutate and the trigger of useMutation will now throw if an error occurs.

Also, we should prefer mutate over let [trigger] = something.useMutation() since they do the same work, but one is free of side effects.