### PR TITLE
Merge upstream commits into the stack details

### DIFF
--- a/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
+++ b/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
@@ -147,7 +147,7 @@ function injectEndpoints(api: BackendApi) {
 				invalidatesTags: [
 					invalidatesList(ReduxTag.BaseBranchData),
 					invalidatesList(ReduxTag.Stacks),
-					invalidatesList(ReduxTag.UpstreamCommits),
+					invalidatesList(ReduxTag.StackDetails),
 					invalidatesList(ReduxTag.UpstreamIntegrationStatus)
 				],
 				transformErrorResponse: (error) => {
@@ -166,7 +166,7 @@ function injectEndpoints(api: BackendApi) {
 				invalidatesTags: [
 					invalidatesList(ReduxTag.BaseBranchData),
 					invalidatesList(ReduxTag.Stacks),
-					invalidatesList(ReduxTag.UpstreamCommits)
+					invalidatesList(ReduxTag.StackDetails)
 				]
 			}),
 			push: build.mutation<void, { projectId: string; withForce?: boolean }>({

--- a/apps/desktop/src/lib/stacks/stack.ts
+++ b/apps/desktop/src/lib/stacks/stack.ts
@@ -1,4 +1,4 @@
-import type { Author, Commit } from '$lib/branches/v3';
+import type { Author, Commit, UpstreamCommit } from '$lib/branches/v3';
 
 /**
  * Return type of Tauri `stacks` command.
@@ -76,6 +76,10 @@ export type BranchDetails = {
 	 *  The commits contained in the branch, excluding the upstream commits.
 	 */
 	commits: Commit[];
+	/**
+	 * The commits that are only upstream.
+	 */
+	upstreamCommits: UpstreamCommit[];
 };
 
 export type StackDetails = {

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -666,7 +666,6 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				}),
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesList(ReduxTag.Checks),
-					invalidatesItem(ReduxTag.UpstreamCommits, args.stackId),
 					invalidatesItem(ReduxTag.PullRequests, args.stackId),
 					invalidatesItem(ReduxTag.StackDetails, args.stackId),
 					invalidatesList(ReduxTag.BranchListing)
@@ -895,7 +894,6 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				invalidatesTags: (_r, _e, args) => [
 					invalidatesList(ReduxTag.Stacks),
 					invalidatesItem(ReduxTag.StackDetails, args.stackId),
-					invalidatesItem(ReduxTag.UpstreamCommits, args.stackId),
 					invalidatesList(ReduxTag.BranchListing)
 				]
 			}),

--- a/apps/desktop/src/lib/state/tags.ts
+++ b/apps/desktop/src/lib/state/tags.ts
@@ -1,6 +1,5 @@
 export enum ReduxTag {
 	Diff = 'Diff',
-	UpstreamCommits = 'UpstreamCommits',
 	Stacks = 'Stacks',
 	StackDetails = 'StackDetails',
 	WorktreeChanges = 'WorktreeChanges',

--- a/apps/desktop/src/lib/testing/mockStackService.ts
+++ b/apps/desktop/src/lib/testing/mockStackService.ts
@@ -34,6 +34,7 @@ const BRANCH_DETAILS_A: BranchDetails = {
 	authors: [MOCK_AUTHOR_A],
 	isConflicted: false,
 	commits: [MOCK_COMMIT_A],
+	upstreamCommits: [MOCK_UPSTREAM_COMMIT_A],
 	remoteTrackingBranch: null,
 	description: null,
 	prNumber: null,

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -268,7 +268,6 @@ fn main() {
                     settings::update_feature_flags,
                     workspace::stacks,
                     workspace::stack_details,
-                    workspace::stack_branch_upstream_only_commits,
                     workspace::hunk_dependencies_for_workspace_changes,
                     workspace::create_commit_from_worktree_changes,
                     workspace::amend_commit_from_worktree_changes,

--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -41,22 +41,6 @@ pub fn stack_details(
     but_workspace::stack_details(&project.gb_dir(), stack_id, &ctx).map_err(Into::into)
 }
 
-#[tauri::command(async)]
-#[instrument(skip(projects, settings), err(Debug))]
-pub fn stack_branch_upstream_only_commits(
-    projects: State<'_, projects::Controller>,
-    settings: State<'_, AppSettingsWithDiskSync>,
-    project_id: ProjectId,
-    stack_id: String,
-    branch_name: String,
-) -> Result<Vec<but_workspace::UpstreamCommit>, Error> {
-    let project = projects.get(project_id)?;
-    let ctx = CommandContext::open(&project, settings.get()?.clone())?;
-    let repo = ctx.gix_repo()?;
-    but_workspace::stack_branch_upstream_only_commits(stack_id, branch_name, &ctx, &repo)
-        .map_err(Into::into)
-}
-
 /// Retrieve all changes in the workspace and associate them with commits in the Workspace of `project_id`.
 /// NOTE: right now there is no way to keep track of unassociated hunks.
 // TODO: This probably has to change a lot once it's clear how the UI is going to use it.


### PR DESCRIPTION
Add the information about the upstream commits to the stack details response.

We now care about one less endpoint.