### PR TITLE
Fix a bug in the canned branch name API

### DIFF
--- a/crates/gitbutler-stack/src/stack.rs
+++ b/crates/gitbutler-stack/src/stack.rs
@@ -397,7 +397,7 @@ impl Stack {
         Ok(reference)
     }
 
-    fn next_available_name(
+    pub fn next_available_name(
         repo: &gix::Repository,
         state: &VirtualBranchesHandle,
         mut name: String,

--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -218,5 +218,8 @@ pub fn canned_branch_name(
 ) -> Result<String, Error> {
     let project = projects.get(project_id)?;
     let ctx = CommandContext::open(&project, settings.get()?.clone())?;
-    gitbutler_stack::canned_branch_name(ctx.repo()).map_err(Into::into)
+    let template = gitbutler_stack::canned_branch_name(ctx.repo())?;
+    let state = VirtualBranchesHandle::new(ctx.project().gb_dir());
+    gitbutler_stack::Stack::next_available_name(&ctx.gix_repo()?, &state, template, false)
+        .map_err(Into::into)
 }


### PR DESCRIPTION
It was not returning unique names because the wrong function was called