### PR TITLE
Fix discard renamed files

### DIFF
--- a/apps/desktop/src/components/v3/FileContextMenu.svelte
+++ b/apps/desktop/src/components/v3/FileContextMenu.svelte
@@ -57,8 +57,9 @@
 
 	async function confirmDiscard(item: FileItem) {
 		const worktreeChanges: DiffSpec[] = item.changes.map((change) => ({
-			previousPathBytes: null,
-			pathBytes: change.path,
+			previousPathBytes:
+				change.status.type === 'Rename' ? change.status.subject.previousPathBytes : null,
+			pathBytes: change.pathBytes,
 			hunkHeaders: []
 		}));
 
@@ -69,7 +70,7 @@
 
 		unSelectChanges(item.changes);
 
-		contextMenu.close();
+		confirmationModal?.close();
 	}
 
 	export function open(e: MouseEvent, item: FileItem) {

--- a/apps/desktop/src/components/v3/HunkContextMenu.svelte
+++ b/apps/desktop/src/components/v3/HunkContextMenu.svelte
@@ -52,7 +52,7 @@
 
 	async function discardHunk(item: HunkContextItem) {
 		const previousPathBytes =
-			change.status.type === 'Rename' ? change.status.subject.previousPath : null;
+			change.status.type === 'Rename' ? change.status.subject.previousPathBytes : null;
 
 		unSelectHunk(item.hunk);
 
@@ -61,7 +61,7 @@
 			worktreeChanges: [
 				{
 					previousPathBytes,
-					pathBytes: change.path,
+					pathBytes: change.pathBytes,
 					hunkHeaders: [item.hunk]
 				}
 			]
@@ -71,7 +71,7 @@
 	async function discardHunkLines(item: HunkContextItem) {
 		if (item.selectedLines === undefined || item.selectedLines.length === 0) return;
 		const previousPathBytes =
-			change.status.type === 'Rename' ? change.status.subject.previousPath : null;
+			change.status.type === 'Rename' ? change.status.subject.previousPathBytes : null;
 
 		unSelectHunk(item.hunk);
 
@@ -80,7 +80,7 @@
 			worktreeChanges: [
 				{
 					previousPathBytes,
-					pathBytes: change.path,
+					pathBytes: change.pathBytes,
 					hunkHeaders: lineIdsToHunkHeaders(item.selectedLines, item.hunk.diff, 'discard')
 				}
 			]

--- a/apps/desktop/src/lib/commits/dropHandler.ts
+++ b/apps/desktop/src/lib/commits/dropHandler.ts
@@ -120,10 +120,10 @@ export class AmendCommitWithHunkDzHandler implements DropzoneHandler {
 			commitId: commit.id,
 			worktreeChanges: [
 				{
-					// TODO: We need the previous path bytes added here.
+					// TODO: We don't get prev path bytes in v2, but we're using
+					// the new api.
 					previousPathBytes: null,
-					// TODO: We need to change this to path bytes.
-					pathBytes: data.hunk.filePath,
+					pathBytes: data.hunk.filePath as any,
 					hunkHeaders: [
 						{
 							oldStart: data.hunk.oldStart,
@@ -233,7 +233,7 @@ function filesToDiffSpec(data: FileDropData): DiffSpec[] {
 	return data.files.map((file) => {
 		return {
 			previousPathBytes: null,
-			pathBytes: file.path, // Can we get the path in bytes here?
+			pathBytes: file.path as any, // Rust type is BString.
 			hunkHeaders: []
 		};
 	});
@@ -244,8 +244,8 @@ function changesToDiffSpec(data: ChangeDropData): DiffSpec[] {
 	const filePaths = data.filePaths;
 	return filePaths.map((filePath) => {
 		return {
-			previousPathBytes: null, // TODO: We need the previous path bytes added here.
-			pathBytes: filePath,
+			previousPathBytes: null,
+			pathBytes: filePath as any, // Rust type is Bstring.
 			hunkHeaders: []
 		};
 	});

--- a/apps/desktop/src/lib/hunks/change.ts
+++ b/apps/desktop/src/lib/hunks/change.ts
@@ -105,6 +105,7 @@ export type Modification = {
  */
 export type Rename = {
 	readonly previousPath: string;
+	readonly previousPathBytes: number[];
 	/** @private */
 	readonly previousState: ChangeState;
 	/** @private */

--- a/apps/desktop/src/lib/hunks/hunk.ts
+++ b/apps/desktop/src/lib/hunks/hunk.ts
@@ -59,9 +59,9 @@ export class HunkLock {
 
 export type DiffSpec = {
 	/** lossless version of `previous_path` if this was a rename. */
-	readonly previousPathBytes: string | null;
+	readonly previousPathBytes: number[] | null;
 	/** lossless version of `path`. */
-	readonly pathBytes: string;
+	readonly pathBytes: number[];
 	/** The headers of the hunks to use, or empty if all changes are to be used. */
 	readonly hunkHeaders: HunkHeader[];
 };


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#4UN1fxUUB`](https://cloud.staging.gitbutler.com/mtsgrd/gitbutler/reviews/4UN1fxUUB)

**Fix discard renamed files**


The previous path bytes were not supplied.

Also changes a few paths to path bytes. The api accepts both since the type is BString.

1 commit series (version 4)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Fix discard renamed files](https://cloud.staging.gitbutler.com/mtsgrd/gitbutler/reviews/4UN1fxUUB/commit/0d639189-7946-4225-abe2-a803ff831704) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://cloud.staging.gitbutler.com/mtsgrd/gitbutler/reviews/4UN1fxUUB)_
<!-- GitButler Review Footer Boundary Bottom -->
