### PR TITLE
Fix push status

### DIFF
--- a/apps/desktop/src/components/v3/BranchList.svelte
+++ b/apps/desktop/src/components/v3/BranchList.svelte
@@ -214,7 +214,7 @@
 				{/snippet}
 			</ReduxResult>
 		{/each}
-		<PushButton {projectId} {stackId} multipleBranches={branches.length > 0} />
+		<PushButton {projectId} {stackId} multipleBranches={branches.length > 1} />
 	{/snippet}
 </ReduxResult>
 

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -294,7 +294,7 @@ pub fn stack_details(
             .map(|_| branch.remote_reference(remote.as_str()));
 
         let mut branch_state = BranchState {
-            requires_force: requires_force(ctx, branch, &remote)?,
+            requires_force: dbg!(requires_force(ctx, branch, &remote))?,
             ..Default::default()
         };
 


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#4UN1fxUUB`](https://cloud.staging.gitbutler.com/mtsgrd/gitbutler/reviews/4UN1fxUUB)

**Fix discard renamed files**


The previous path bytes were not supplied.

Also changes a few paths to path bytes. The api accepts both since the type is BString.

1 commit series (version 4)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Fix discard renamed files](https://cloud.staging.gitbutler.com/mtsgrd/gitbutler/reviews/4UN1fxUUB/commit/0d639189-7946-4225-abe2-a803ff831704) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://cloud.staging.gitbutler.com/mtsgrd/gitbutler/reviews/4UN1fxUUB)_
<!-- GitButler Review Footer Boundary Bottom -->
