### PR TITLE
Add script for running tests without fixtures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,3 +84,9 @@ debug = true      # Enable debug symbols, for profiling
 codegen-units = 256
 lto = false
 opt-level = 3
+
+[profile.dev]
+incremental = true
+
+[profile.test]
+incremental = true

--- a/scripts/cargo-test.sh
+++ b/scripts/cargo-test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# This script runs deletes all generated fixtures before running the tests.
+# This prevents potentially incorrect passes or failures due to stale fixtures.
+# Especially considering that the time difference is negligible, this should be
+# the preferred way to run tests.
+#
+# Time to run tests without fixtures present:
+# ./scripts/cargo-test.sh  57.53s user 145.29s system 205% cpu 1:38.60 total
+# Time to run tests with fixtures present:
+# cargo test  46.74s user 176.52s system 288% cpu 1:17.31 total
+
+./scripts/delete-fixtures.sh
+
+echo "Running tests"
+cargo test $@

--- a/scripts/delete-fixtures.sh
+++ b/scripts/delete-fixtures.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Deleting fixtures"
+rm -rf crates/*/tests/fixtures/generated-do-not-edit


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#7WWz1yofA`](https://gitbutler.com/cto/gitbutler-client-d443/reviews/7WWz1yofA)

**Add script for running tests without fixtures**


Doing some testing, the performance gain of having the fixtures present is negligible. Especially when you consider how they can cause false positives AND false negatives, we should almost always clear them out before running the tests

1 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Add script for running tests without fixtures](https://gitbutler.com/cto/gitbutler-client-d443/reviews/7WWz1yofA/commit/61b1ac58-3ace-4b63-b975-66670eae6ab3) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/cto/gitbutler-client-d443/reviews/7WWz1yofA)_
<!-- GitButler Review Footer Boundary Bottom -->
