### PR TITLE
fix: workspace path validation logic & PR prompt

### DIFF
--- a/apps/desktop/src/lib/ai/prompts.ts
+++ b/apps/desktop/src/lib/ai/prompts.ts
@@ -141,7 +141,8 @@ Create a description for a pull request.
 Use the provided context, like the COMMIT_MESSAGES, PR_TEMPLATE, current TITLE and BODY.
 The list of commit messages is separated by this token: <###>.
 BE CONCISE.
-ONLY return the description.`
+ONLY return the description.
+Use the PR_TEMPLATE to format the description, if given.`
 	},
 	{
 		role: MessageRole.User,

--- a/apps/desktop/src/lib/routes/routes.svelte.ts
+++ b/apps/desktop/src/lib/routes/routes.svelte.ts
@@ -46,7 +46,11 @@ export function isIrcPath() {
 }
 
 export function isWorkspacePath() {
-	return isUrl<{ projectId: string; stackId?: string }>('/[projectId]/workspace/[stackId]');
+	const isStackUrl = isUrl<{ projectId: string; stackId?: string }>(
+		'/[projectId]/workspace/[stackId]'
+	);
+	const isWorkspaceUrl = isUrl<{ projectId: string }>('/[projectId]/workspace');
+	return isStackUrl ?? isWorkspaceUrl;
 }
 
 export function branchesPath(projectId: string) {


### PR DESCRIPTION
- Introduce a separate check for workspace URLs without a stack ID, to account for empty workspaces
- Improve the prompt for generating the PR descriptions so that the templates are respected