### PR TITLE
Support custom CSP (allowing custom GitLab/ Ollama hosts)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2985,6 +2985,7 @@ dependencies = [
  "but-settings",
  "but-workspace",
  "console-subscriber",
+ "dirs 6.0.0",
  "git2",
  "gitbutler-branch",
  "gitbutler-branch-actions",

--- a/crates/but-settings/assets/defaults.jsonc
+++ b/crates/but-settings/assets/defaults.jsonc
@@ -18,5 +18,10 @@
 	"featureFlags": {
 		// Enables the v3 design, as well as the purgatory mode (no uncommitted diff ownership assignments).
 		"v3": false
+	},
+	// Allows for additional "connect-src" hosts to be included. Requires app restart.
+	"extraCsp": {
+		// Additional hosts that the application can connect to.
+		"hosts": []
 	}
 }

--- a/crates/but-settings/src/app_settings.rs
+++ b/crates/but-settings/src/app_settings.rs
@@ -24,3 +24,10 @@ pub struct FeatureFlags {
     /// Enables the v3 design, as well as the purgatory mode (no uncommitted diff ownership assignments).
     pub v3: bool,
 }
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ExtraCsp {
+    /// Additional hosts that the application can connect to.
+    pub hosts: Vec<String>,
+}

--- a/crates/but-settings/src/lib.rs
+++ b/crates/but-settings/src/lib.rs
@@ -17,6 +17,8 @@ pub struct AppSettings {
     pub github_oauth_app: app_settings::GitHubOAuthAppSettings,
     /// Application feature flags.
     pub feature_flags: app_settings::FeatureFlags,
+    /// Allows for additional "connect-src" hosts to be included. Requires app restart.
+    pub extra_csp: app_settings::ExtraCsp,
 }
 
 impl Default for AppSettings {

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -80,6 +80,7 @@ but-core.workspace = true
 but-hunk-dependency.workspace = true
 open = "5"
 url = "2.5.4"
+dirs = "6.0.0"
 [target.'cfg(target_os = "macos")'.dependencies]
 tauri-plugin-trafficlights-positioner = { git = "https://github.com/gitbutlerapp/tauri-plugin-trafficlights-positioner", branch = "v2" }
 

--- a/crates/gitbutler-tauri/src/csp.rs
+++ b/crates/gitbutler-tauri/src/csp.rs
@@ -1,0 +1,34 @@
+use anyhow::Result;
+use but_settings::AppSettingsWithDiskSync;
+use tauri::utils::config::{Csp, CspDirectiveSources};
+
+/// Constructs a new CSP object with additional `connect-src` hosts as provided by the AppSettings.
+pub fn csp_with_extras(
+    csp: Option<Csp>,
+    settings: &AppSettingsWithDiskSync,
+) -> Result<Option<Csp>> {
+    let hosts = settings
+        .get()?
+        .clone()
+        .extra_csp
+        .hosts
+        .iter()
+        .filter_map(|host| url::Url::parse(host).ok())
+        .map(|h| h.to_string())
+        .collect::<Vec<_>>();
+
+    if hosts.is_empty() {
+        return Ok(csp); // noop
+    }
+
+    let new_csp = if let Some(Csp::DirectiveMap(mut map)) = csp {
+        if let Some(CspDirectiveSources::Inline(sources)) = map.get_mut("connect-src") {
+            sources.push_str(&format!(" {}", hosts.join(" ")));
+        }
+        Some(Csp::DirectiveMap(map))
+    } else {
+        None
+    };
+
+    Ok(new_csp)
+}

--- a/crates/gitbutler-tauri/src/lib.rs
+++ b/crates/gitbutler-tauri/src/lib.rs
@@ -45,6 +45,8 @@ pub mod diff;
 pub mod env;
 pub mod workspace;
 
+pub mod csp;
+
 /// Utility types that make it easier to transform data from the frontend to the backend.
 ///
 /// Note that these types *should not* be used to transfer anything to the frontend.

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -12,6 +12,7 @@
 )]
 
 use but_settings::AppSettingsWithDiskSync;
+use gitbutler_tauri::csp::csp_with_extras;
 use gitbutler_tauri::settings::SettingsStore;
 use gitbutler_tauri::{
     askpass, commands, config, diff, env, forge, github, logs, menu, modes, open, projects,
@@ -26,7 +27,7 @@ use tauri_plugin_store::StoreExt;
 fn main() {
     let performance_logging = std::env::var_os("GITBUTLER_PERFORMANCE_LOG").is_some();
     gitbutler_project::configure_git2();
-    let tauri_context = generate_context!();
+    let mut tauri_context = generate_context!();
     gitbutler_secret::secret::set_application_namespace(&tauri_context.config().identifier);
 
     let config_dir = dirs::config_dir()
@@ -35,6 +36,13 @@ fn main() {
     std::fs::create_dir_all(&config_dir).expect("failed to create config dir");
     let mut app_settings =
         AppSettingsWithDiskSync::new(config_dir.clone()).expect("failed to create app settings");
+
+    if let Ok(updated_csp) = csp_with_extras(
+        tauri_context.config().app.security.csp.as_ref().cloned(),
+        &app_settings,
+    ) {
+        tauri_context.config_mut().app.security.csp = updated_csp;
+    };
 
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()


### PR DESCRIPTION
This allows users to connect to custom GitLab or Ollama instances

This implements https://github.com/gitbutlerapp/gitbutler/issues/4714 
For issues https://github.com/gitbutlerapp/gitbutler/issues/8111 and https://github.com/gitbutlerapp/gitbutler/issues/8110 to be closed, documentation needs to be updated first for how the custom CSP is configured


Config can be found at:
OSX: `~/Library/Application\ Support/gitbutler/settings.json`
Linux: `~/.config/gitbutler/settings.json`
Windows: `C:\Users\<USERNAME>\AppData\Roaming\gitbutler\settings.json`

In addition to existing values add your custom domain as an "extraCsp" host
```
{ 
  "otherStuff" ... 

  "extraCsp": {
    "hosts": ["https://foo.example.com", "http://example.com", "http://example.com", "http://example.com:3003"]
  }
}
```
After updating this setting, the application needs to be restarted


Documentation:  https://docs.gitbutler.com/troubleshooting/custom-csp
