### PR TITLE
Adds a v3 API endpoint for listing the commits of the target branch

### DIFF
--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -285,6 +285,7 @@ fn main() {
                     workspace::amend_commit_from_worktree_changes,
                     workspace::discard_worktree_changes,
                     workspace::canned_branch_name,
+                    workspace::target_commits,
                     diff::changes_in_worktree,
                     diff::changes_in_commit,
                     diff::changes_in_branch,

--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -225,3 +225,22 @@ pub fn canned_branch_name(
     gitbutler_stack::Stack::next_available_name(&ctx.gix_repo()?, &state, template, false)
         .map_err(Into::into)
 }
+
+#[tauri::command(async)]
+#[instrument(skip(projects, settings), err(Debug))]
+pub fn target_commits(
+    projects: State<'_, projects::Controller>,
+    settings: State<'_, AppSettingsWithDiskSync>,
+    project_id: ProjectId,
+    last_commit_id: Option<HexHash>,
+    page_size: Option<usize>,
+) -> Result<Vec<but_workspace::Commit>, Error> {
+    let project = projects.get(project_id)?;
+    let ctx = CommandContext::open(&project, settings.get()?.clone())?;
+    but_workspace::log_target_first_parent(
+        &ctx,
+        last_commit_id.map(|id| id.into()),
+        page_size.unwrap_or(30),
+    )
+    .map_err(Into::into)
+}


### PR DESCRIPTION
Paginated.

Invoke like this to start with
```
		invoke('target_commits', {
			projectId: project.id,
		}).then((res) => {
			console.log('target_commits', res);
		});
```
and then to get another page
```
		invoke('target_commits', {
			projectId: project.id,
			lastCommitId: <LAST_SEEN_SHA>
		}).then((res) => {
			console.log('target_commits', res);
		});
```
By default the page size is 30, but `pageSize` can be passed for a different page size value