### PR TITLE
Add loading states for transitioning into edit mode

### DIFF
--- a/apps/desktop/src/components/CommitCard.svelte
+++ b/apps/desktop/src/components/CommitCard.svelte
@@ -21,6 +21,7 @@
 	import { UserService } from '$lib/user/userService';
 	import { openExternalUrl } from '$lib/utils/url';
 	import { getContext, maybeGetContext } from '@gitbutler/shared/context';
+	import AsyncButton from '@gitbutler/ui/AsyncButton.svelte';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import ContextMenu from '@gitbutler/ui/ContextMenu.svelte';
 	import Icon from '@gitbutler/ui/Icon.svelte';
@@ -179,7 +180,7 @@
 
 	async function editPatch() {
 		if (!canEdit()) return;
-		modeService!.enterEditMode(commit.id, stack!.id);
+		await modeService!.enterEditMode(commit.id, stack!.id);
 	}
 
 	async function handleEditPatch() {
@@ -213,7 +214,7 @@
 	{/snippet}
 </Modal>
 
-<Modal bind:this={conflictResolutionConfirmationModal} width="small" onSubmit={editPatch}>
+<Modal bind:this={conflictResolutionConfirmationModal} width="small">
 	{#snippet children()}
 		<div>
 			<p>It's generally better to start resolving conflicts from the bottom up.</p>
@@ -223,7 +224,13 @@
 	{/snippet}
 	{#snippet controls(close)}
 		<Button kind="outline" type="reset" onclick={close}>Cancel</Button>
-		<Button style="pop" type="submit">Yes</Button>
+		<AsyncButton
+			style="pop"
+			action={async () => {
+				await editPatch();
+				close();
+			}}>Yes</AsyncButton
+		>
 	{/snippet}
 </Modal>
 
@@ -245,7 +252,6 @@
 	commitUrl={showOpenInBrowser ? commitUrl : undefined}
 	onUncommitClick={undoCommit}
 	onEditMessageClick={openCommitMessageModal}
-	onPatchEditClick={handleEditPatch}
 />
 
 <div
@@ -427,13 +433,13 @@
 								>
 							{/if}
 							{#if canEdit()}
-								<Button size="tag" kind="outline" onclick={handleEditPatch}>
+								<AsyncButton size="tag" kind="outline" action={handleEditPatch} stopPropagation>
 									{#if conflicted}
 										Resolve conflicts
 									{:else}
 										Edit commit
 									{/if}
-								</Button>
+								</AsyncButton>
 							{/if}
 						</div>
 					{/if}

--- a/apps/desktop/src/components/CommitContextMenu.svelte
+++ b/apps/desktop/src/components/CommitContextMenu.svelte
@@ -22,7 +22,6 @@
 		isRemote: boolean;
 		onUncommitClick: (event: MouseEvent) => void;
 		onEditMessageClick: (event: MouseEvent) => void;
-		onPatchEditClick: (event: MouseEvent) => void;
 		onClose?: () => void;
 		onToggle?: (isOpen: boolean, isLeftClick: boolean) => void;
 	}
@@ -38,7 +37,6 @@
 		isRemote,
 		onUncommitClick,
 		onEditMessageClick,
-		onPatchEditClick,
 		onClose,
 		onToggle
 	}: Props = $props();
@@ -81,13 +79,6 @@
 				label="Edit commit message"
 				onclick={(e: MouseEvent) => {
 					onEditMessageClick(e);
-					menu?.close();
-				}}
-			/>
-			<ContextMenuItem
-				label="Edit commit"
-				onclick={(e: MouseEvent) => {
-					onPatchEditClick(e);
 					menu?.close();
 				}}
 			/>

--- a/apps/desktop/src/components/EditMode.svelte
+++ b/apps/desktop/src/components/EditMode.svelte
@@ -192,7 +192,6 @@
 
 		try {
 			await modeService.abortEditAndReturnToWorkspace();
-			await modeService.awaitNotEditing();
 			modeServiceAborting = 'completed';
 		} finally {
 			modeServiceAborting = 'inert';
@@ -204,7 +203,6 @@
 
 		try {
 			await modeService.saveEditAndReturnToWorkspace();
-			await modeService.awaitNotEditing();
 			modeServiceSaving = 'completed';
 		} finally {
 			modeServiceAborting = 'inert';

--- a/apps/desktop/src/components/v3/CommitContextMenu.svelte
+++ b/apps/desktop/src/components/v3/CommitContextMenu.svelte
@@ -20,7 +20,6 @@
 		commitUrl: string | undefined;
 		onUncommitClick: (event: MouseEvent) => void;
 		onEditMessageClick: (event: MouseEvent) => void;
-		onPatchEditClick: (event: MouseEvent) => void;
 		onToggle?: (isOpen: boolean, isLeftClick: boolean) => void;
 	}
 
@@ -35,7 +34,6 @@
 		commitUrl,
 		onUncommitClick,
 		onEditMessageClick,
-		onPatchEditClick,
 		onToggle
 	}: Props = $props();
 
@@ -74,15 +72,6 @@
 				disabled
 				onclick={(e: MouseEvent) => {
 					onEditMessageClick(e);
-					menu?.close();
-				}}
-			/>
-			<!-- TODO: Re-enable the option once it works -->
-			<ContextMenuItem
-				label="Edit commit"
-				disabled
-				onclick={(e: MouseEvent) => {
-					onPatchEditClick(e);
 					menu?.close();
 				}}
 			/>

--- a/apps/desktop/src/components/v3/CommitDetails.svelte
+++ b/apps/desktop/src/components/v3/CommitDetails.svelte
@@ -106,13 +106,13 @@
 				</AsyncButton>
 			{/if}
 
-			<Button size="tag" kind="outline" onclick={handleEditPatch}>
+			<AsyncButton size="tag" kind="outline" action={handleEditPatch}>
 				{#if isConflicted}
 					Resolve conflicts
 				{:else}
 					Edit commit
 				{/if}
-			</Button>
+			</AsyncButton>
 		</div>
 	{/if}
 

--- a/apps/desktop/src/components/v3/CommitRow.svelte
+++ b/apps/desktop/src/components/v3/CommitRow.svelte
@@ -56,7 +56,6 @@
 	const modeService = maybeGetContext(ModeService);
 
 	const conflicted = $derived(isCommit(commit) ? commit.hasConflicts : false);
-	const isAncestorMostConflicted = false; // TODO
 	const isUnapplied = false; // TODO
 	const branchRefName = undefined; // TODO
 
@@ -90,15 +89,7 @@
 
 	async function editPatch() {
 		if (!canEdit() || !branchRefName) return;
-		modeService!.enterEditMode(commit.id, stackId);
-	}
-
-	async function handleEditPatch() {
-		if (conflicted && !isAncestorMostConflicted) {
-			conflictResolutionConfirmationModal?.show();
-			return;
-		}
-		await editPatch();
+		await modeService!.enterEditMode(commit.id, stackId);
 	}
 
 	const commitShortSha = commit.id.substring(0, 7);
@@ -213,7 +204,6 @@
 	commitUrl={forge.current.commitUrl(commit.id)}
 	onUncommitClick={handleUncommit}
 	onEditMessageClick={openCommitMessageModal}
-	onPatchEditClick={handleEditPatch}
 	onToggle={(isOpen, isLeftClick) => {
 		if (isLeftClick) {
 			isOpenedByKebabButton = isOpen;

--- a/apps/desktop/src/components/v3/CommitView.svelte
+++ b/apps/desktop/src/components/v3/CommitView.svelte
@@ -51,8 +51,6 @@
 			? stackService.upstreamCommitById(projectId, commitKey)
 			: stackService.commitById(projectId, commitKey)
 	);
-	const conflicted = $derived((commitResult.current.data as Commit).hasConflicts);
-	const isAncestorMostConflicted = false; // TODO
 	const isUnapplied = false; // TODO
 	const branchRefName = undefined; // TODO
 
@@ -153,15 +151,7 @@
 
 	async function editPatch() {
 		if (!canEdit() || !branchRefName) return;
-		modeService!.enterEditMode(commitKey.commitId, stackId);
-	}
-
-	async function handleEditPatch() {
-		if (conflicted && !isAncestorMostConflicted) {
-			conflictResolutionConfirmationModal?.show();
-			return;
-		}
-		await editPatch();
+		await modeService!.enterEditMode(commitKey.commitId, stackId);
 	}
 </script>
 
@@ -266,7 +256,6 @@
 			commitUrl={forge.current.commitUrl(commit.id)}
 			onUncommitClick={handleUncommit}
 			onEditMessageClick={openCommitMessageModal}
-			onPatchEditClick={handleEditPatch}
 			onToggle={(isOpen) => {
 				isContextMenuOpen = isOpen;
 			}}

--- a/apps/desktop/src/components/v3/ConflictResolutionConfirmModal.svelte
+++ b/apps/desktop/src/components/v3/ConflictResolutionConfirmModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import AsyncButton from '@gitbutler/ui/AsyncButton.svelte';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import Modal from '@gitbutler/ui/Modal.svelte';
 
@@ -18,7 +19,7 @@
 	}
 </script>
 
-<Modal bind:this={modalEl} width="small" {onSubmit}>
+<Modal bind:this={modalEl} width="small">
 	{#snippet children()}
 		<div>
 			<p>It's generally better to start resolving conflicts from the bottom up.</p>
@@ -28,6 +29,12 @@
 	{/snippet}
 	{#snippet controls(close)}
 		<Button kind="outline" type="reset" onclick={close}>Cancel</Button>
-		<Button style="pop" type="submit">Yes</Button>
+		<AsyncButton
+			style="pop"
+			action={async () => {
+				await onSubmit();
+				close();
+			}}>Yes</AsyncButton
+		>
 	{/snippet}
 </Modal>

--- a/apps/desktop/src/lib/branches/virtualBranchService.ts
+++ b/apps/desktop/src/lib/branches/virtualBranchService.ts
@@ -66,7 +66,6 @@ export class VirtualBranchService {
 	async refresh() {
 		this.loading.set(true);
 		try {
-			await this.modeService.awaitNotEditing();
 			this.handlePayload(await this.listVirtualBranches());
 			await this.branchService.refresh(this.projectId);
 		} catch (err: unknown) {

--- a/apps/desktop/src/lib/mode/modeService.ts
+++ b/apps/desktop/src/lib/mode/modeService.ts
@@ -50,18 +50,21 @@ export class ModeService {
 			commitOid,
 			stackId
 		});
+		await this.awaitMode('Edit');
 	}
 
 	async abortEditAndReturnToWorkspace() {
 		await invoke('abort_edit_and_return_to_workspace', {
 			projectId: this.projectId
 		});
+		await this.awaitMode('OpenWorkspace');
 	}
 
 	async saveEditAndReturnToWorkspace() {
 		await invoke('save_edit_and_return_to_workspace', {
 			projectId: this.projectId
 		});
+		await this.awaitMode('OpenWorkspace');
 	}
 
 	async getInitialIndexState() {
@@ -74,10 +77,10 @@ export class ModeService {
 		}) as [RemoteFile, ConflictEntryPresence | undefined][];
 	}
 
-	async awaitNotEditing(): Promise<void> {
+	private async awaitMode(mode: Mode['type']): Promise<void> {
 		return await new Promise((resolve) => {
 			const unsubscribe = this.mode.subscribe((operatingMode) => {
-				if (operatingMode && operatingMode?.type !== 'Edit') {
+				if (operatingMode && operatingMode?.type === mode) {
 					resolve();
 
 					setTimeout(() => {


### PR DESCRIPTION

<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#1cdFH33sz`](https://gitbutler.com/cto/gitbutler-client-d443/reviews/1cdFH33sz)

**Add loading states for transitioning into edit mode**


1 commit series (version 4)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Add loading states for transitioning into edit mode](https://gitbutler.com/cto/gitbutler-client-d443/reviews/1cdFH33sz/commit/45a3bcb0-8ff7-4182-a5a6-d104032e5643) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/cto/gitbutler-client-d443/reviews/1cdFH33sz)_
<!-- GitButler Review Footer Boundary Bottom -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #8157 
- <kbd>&nbsp;2&nbsp;</kbd> #8156 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #8155 
<!-- GitButler Footer Boundary Bottom -->

