### PR TITLE
Remove debouncer plugin

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -5,7 +5,7 @@ import { defineConfig, type Plugin } from 'vitest/config';
 
 export default defineConfig({
 	plugins: [
-		debounceReload(),
+		process.env.IS_MATTIAS ? debounceReload() : undefined,
 		sentrySvelteKit({
 			adapter: 'other',
 			autoInstrument: {


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#4ac9hADCF`](https://gitbutler.com/cto/gitbutler-client-d443/reviews/4ac9hADCF)

**Remove debouncer plugin**


I’m pretty sure this is what is stopping edits in the UI library from reflecting in the UI. Either way it’s super anoying and only benefits people who run the dev build as their daily driver

1 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Remove debouncer plugin](https://gitbutler.com/cto/gitbutler-client-d443/reviews/4ac9hADCF/commit/ffbefc1f-1831-4bbd-8129-65af2078d14d) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/cto/gitbutler-client-d443/reviews/4ac9hADCF)_
<!-- GitButler Review Footer Boundary Bottom -->
