### PR TITLE
feat(ui): add option to disable dragging in diff hunks

### DIFF
--- a/apps/desktop/src/components/v3/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/v3/UnifiedDiffView.svelte
@@ -34,6 +34,7 @@
 	const projectState = $derived(uiState.project(projectId));
 	const drawerPage = $derived(projectState.drawerPage.current);
 	const isCommiting = $derived(drawerPage === 'new-commit');
+	const draggingDisabled = $derived(selectionId.type !== 'worktree');
 
 	const [changeSelection, idSelection, lineSelection] = inject(
 		ChangeSelectionService,
@@ -172,11 +173,14 @@
 		{#each diff.subject.hunks as hunk}
 			{@const [staged, stagedLines] = getStageState(hunk)}
 			<div
+				class="hunk-content"
 				use:draggableElement={{
-					data: new ChangeDropData(change, idSelection, selectionId)
+					data: new ChangeDropData(change, idSelection, selectionId),
+					disabled: draggingDisabled
 				}}
 			>
 				<HunkDiff
+					{draggingDisabled}
 					hideCheckboxes={!isCommiting}
 					filePath={change.path}
 					hunkStr={hunk.diff}
@@ -237,6 +241,10 @@
 		align-self: stretch;
 		overflow-x: hidden;
 		max-width: 100%;
+	}
+
+	.hunk-content {
+		user-select: text;
 	}
 	.hunk-content-warning {
 		margin-left: 8px;

--- a/packages/ui/src/lib/HunkDiff.svelte
+++ b/packages/ui/src/lib/HunkDiff.svelte
@@ -29,6 +29,7 @@
 		hideCheckboxes?: boolean;
 		selectedLines?: LineSelector[];
 		isHidden?: boolean;
+		draggingDisabled?: boolean;
 		whyHidden?: string;
 		onShowDiffClick?: () => void;
 		onChangeStage?: (staged: boolean) => void;
@@ -62,7 +63,8 @@
 		onCopySelection,
 		onQuoteSelection,
 		handleLineContextMenu,
-		clickOutsideExcludeElement
+		clickOutsideExcludeElement,
+		draggingDisabled
 	}: Props = $props();
 
 	const BORDER_WIDTH = 1;
@@ -92,7 +94,7 @@
 	style:font-variant-ligatures={diffLigatures ? 'common-ligatures' : 'none'}
 >
 	<table class="table__section">
-		<thead class="table__title">
+		<thead class="table__title" class:draggable={!draggingDisabled}>
 			<tr>
 				<th
 					bind:clientWidth={numberHeaderWidth}

--- a/packages/ui/src/lib/hunkDiff/HunkDiffRow.svelte
+++ b/packages/ui/src/lib/hunkDiff/HunkDiffRow.svelte
@@ -274,6 +274,10 @@
 	}
 
 	.table__row-header {
+		white-space: pre;
+		user-select: text;
+		-webkit-user-select: text;
+		cursor: text;
 		position: relative;
 	}
 

--- a/packages/ui/src/lib/utils/diffParsing.ts
+++ b/packages/ui/src/lib/utils/diffParsing.ts
@@ -533,8 +533,8 @@ function toTokens(inputLine: string, parser: Parser | undefined): string[] {
 	const tokens: string[] = [];
 	highlighter.highlight((text, classNames) => {
 		const token = classNames
-			? `<span class=${classNames}>${sanitize(text)}</span>`
-			: `<span>${sanitize(text)}</span>`;
+			? `<span data-no-drag class=${classNames}>${sanitize(text)}</span>`
+			: `<span data-no-drag>${sanitize(text)}</span>`;
 
 		tokens.push(token);
 	});


### PR DESCRIPTION
Set the `draggingDisabled` prop to control drag behavior in
HunkDiff and UnifiedDiffView components. This prevents drag actions
when selection type is not 'worktree', improving UX by avoiding
unintended drags in certain contexts.