### PR TITLE
Use the one vaugly correct commit message splitting function

### DIFF
--- a/apps/desktop/src/components/v3/CommitDetails.svelte
+++ b/apps/desktop/src/components/v3/CommitDetails.svelte
@@ -4,6 +4,7 @@
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { UiState } from '$lib/state/uiState.svelte';
 	import { UserService } from '$lib/user/userService';
+	import { splitMessage } from '$lib/utils/commitMessage';
 	import { inject } from '@gitbutler/shared/context';
 	import AsyncButton from '@gitbutler/ui/AsyncButton.svelte';
 	import Button from '@gitbutler/ui/Button.svelte';
@@ -36,7 +37,7 @@
 	const branchName = $derived(selected.current?.branchName);
 
 	const message = $derived(commit.message);
-	const description = $derived(message.slice(message.indexOf('\n') + 1).trim());
+	const description = $derived(splitMessage(message).description);
 	const isConflicted = $derived(isCommit(commit) && commit.hasConflicts);
 	const isUpstream = $derived(!isCommit(commit));
 

--- a/apps/desktop/src/components/v3/CommitHeader.svelte
+++ b/apps/desktop/src/components/v3/CommitHeader.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { splitMessage } from '$lib/utils/commitMessage';
 	import type { Commit, UpstreamCommit } from '$lib/branches/v3';
 
 	type Props = {
@@ -9,10 +10,7 @@
 
 	const { commit, row, class: className }: Props = $props();
 
-	const message = $derived(commit.message);
-	const indexOfNewLine = $derived(message.indexOf('\n'));
-	const endIndex = $derived(indexOfNewLine === -1 ? message.length : indexOfNewLine + 1);
-	const title = $derived(message.slice(0, endIndex).trim());
+	const title = $derived(splitMessage(commit.message).title);
 </script>
 
 <h3 class="{className} commit-title" class:row>

--- a/apps/desktop/src/components/v3/CommitMessageInput.svelte
+++ b/apps/desktop/src/components/v3/CommitMessageInput.svelte
@@ -7,6 +7,7 @@
 	import { AIService } from '$lib/ai/service';
 	import { projectAiGenEnabled } from '$lib/config/config';
 	import { UiState } from '$lib/state/uiState.svelte';
+	import { splitMessage } from '$lib/utils/commitMessage';
 	import { getContext } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import Textbox from '@gitbutler/ui/Textbox.svelte';
@@ -74,18 +75,11 @@
 		}
 	});
 
-	function splitTextMessage(generatedMessage: string) {
-		const splitText = generatedMessage.split('\n\n');
-		const title = splitText[0] ?? '';
-		const description = splitText.slice(1).join('\n\n');
-		return [title, description] as const;
-	}
-
 	let generatedText = $state<string>('');
 
 	$effect(() => {
 		if (generatedText) {
-			const [title, description] = splitTextMessage(generatedText);
+			const { title, description } = splitMessage(generatedText);
 			titleText.set(title);
 			descriptionText.set(description);
 			composer?.setText(description);

--- a/apps/desktop/src/components/v3/CommitView.svelte
+++ b/apps/desktop/src/components/v3/CommitView.svelte
@@ -18,6 +18,7 @@
 	import { showToast } from '$lib/notifications/toasts';
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { UiState } from '$lib/state/uiState.svelte';
+	import { splitMessage } from '$lib/utils/commitMessage';
 	import { inject } from '@gitbutler/shared/context';
 	import { getContext, maybeGetContext } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
@@ -94,22 +95,6 @@
 		setMode('view');
 	}
 
-	function getCommitTitile(message: string): string | undefined {
-		// Return undefined if there is no title
-		return message.split('\n').slice(0, 1).join('\n') || undefined;
-	}
-
-	function getCommitDescription(message: string): string | undefined {
-		// Return undefined if there is no description
-		const lines = message.split('\n');
-		for (let i = 1; i < lines.length; i++) {
-			if (lines[i]!.trim()) {
-				return lines.slice(i).join('\n');
-			}
-		}
-		return undefined;
-	}
-
 	function getCommitLabel(commit: Partial<Commit>) {
 		const commitType = commit ? getCommitType(commit as Commit) : 'unknown';
 
@@ -172,8 +157,8 @@
 					action={editCommitMessage}
 					actionLabel="Save"
 					onCancel={() => setMode('view')}
-					initialTitle={getCommitTitile(commit.message)}
-					initialMessage={getCommitDescription(commit.message)}
+					initialTitle={splitMessage(commit.message).title}
+					initialMessage={splitMessage(commit.message).description}
 					loading={messageUpdateResult.current.isLoading}
 					existingCommitId={commit.id}
 				/>


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#37oA7hpIU`](https://gitbutler.com/cto/gitbutler-client-d443/reviews/37oA7hpIU)

**Use the one vaugly correct commit message splitting function**


Fixes the issue where we were seeing the commit title twice

1 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Use the one vaugly correct commit message splitting function](https://gitbutler.com/cto/gitbutler-client-d443/reviews/37oA7hpIU/commit/9216834c-f62c-4193-86b7-cc0db0768c23) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/cto/gitbutler-client-d443/reviews/37oA7hpIU)_
<!-- GitButler Review Footer Boundary Bottom -->
