### PR TITLE
fix(ui): prevent drag on row header in HunkDiffRow

### DIFF
--- a/packages/ui/src/lib/hunkDiff/HunkDiffRow.svelte
+++ b/packages/ui/src/lib/hunkDiff/HunkDiffRow.svelte
@@ -203,7 +203,7 @@
 			});
 		}}
 	>
-		<div class="table__row-header">
+		<div data-no-drag class="table__row-header">
 			{#if row.isSelected}
 				<div
 					class="table__selected-row-overlay"


### PR DESCRIPTION
Add data-no-drag attribute to the row header div to disable drag
interactions.