### PR TITLE
fix: improve error handling and user feedback on commit failures

### DIFF
--- a/apps/desktop/src/components/v3/NewCommitView.svelte
+++ b/apps/desktop/src/components/v3/NewCommitView.svelte
@@ -147,6 +147,10 @@
 
 		const newId = response.newCommit;
 
+		if (response.pathsToRejectedChanges.length > 0) {
+			showError('Some changes were not committed', response.pathsToRejectedChanges.join('\n'));
+		}
+
 		uiState.project(projectId).drawerPage.set(undefined);
 		uiState.stack(finalStackId).selection.set({ branchName: finalBranchName, commitId: newId });
 		changeSelection.clear();


### PR DESCRIPTION
Add notification for rejected changes during commit to inform users
which files were not committed. 

Enhance parseError to better handle
string errors and provide more detailed error serialization for
promise rejections and unknown error types.