### PR TITLE
fix(ui): improve error message for rejected changes

### DIFF
--- a/apps/desktop/src/components/v3/NewCommitView.svelte
+++ b/apps/desktop/src/components/v3/NewCommitView.svelte
@@ -148,7 +148,10 @@
 		const newId = response.newCommit;
 
 		if (response.pathsToRejectedChanges.length > 0) {
-			showError('Some changes were not committed', response.pathsToRejectedChanges.join('\n'));
+			showError(
+				'Some changes were not committed',
+				`The following files were not committed becuase they are locked to another branch\n${response.pathsToRejectedChanges.join('\n')}`
+			);
 		}
 
 		uiState.project(projectId).drawerPage.set(undefined);


### PR DESCRIPTION
Update the error message shown when some changes are not committed
due to file locks. The new message clarifies that the files are locked
to another branch, helping users understand the cause of rejection.