### PR TITLE
fix: correct canPublishBR condition to check missing reviewId

### DIFF
--- a/apps/desktop/src/components/v3/CanPublishReviewPlugin.svelte
+++ b/apps/desktop/src/components/v3/CanPublishReviewPlugin.svelte
@@ -34,7 +34,7 @@
 	const pr = $derived(prResult?.current.data);
 
 	const canPublish = stackPublishingService.canPublish;
-	const canPublishBR = $derived(!!($canPublish && name && reviewId));
+	const canPublishBR = $derived(!!($canPublish && name && !reviewId));
 	const canPublishPR = $derived(!!(forge.current.authenticated && !pr));
 
 	const ctaLabel = $derived.by(() => {


### PR DESCRIPTION
Update canPublishBR derived store to require reviewId to be absent
instead of present. This fixes the logic determining if a user can
publish a review branch, ensuring the condition aligns with the intended
behavior of only allowing publishing when no reviewId exists.