### PR TITLE
Richard: Wrap the text around

### DIFF
--- a/apps/desktop/src/components/v3/editor/MessageEditor.svelte
+++ b/apps/desktop/src/components/v3/editor/MessageEditor.svelte
@@ -47,6 +47,12 @@
 	const rulerCountValue = uiState.global.rulerCountValue;
 	const wrapTextByRuler = uiState.global.wrapTextByRuler;
 
+	const wrapCountValue = $derived(
+		useRuler.current && wrapTextByRuler.current && !useRichText.current
+			? rulerCountValue.current
+			: undefined
+	);
+
 	let composer = $state<ReturnType<typeof RichTextEditor>>();
 	let formatter = $state<ReturnType<typeof Formatter>>();
 	let isEditorHovered = $state(false);
@@ -150,6 +156,7 @@
 						onFocus={() => (isEditorFocused = true)}
 						onBlur={() => (isEditorFocused = false)}
 						{disabled}
+						{wrapCountValue}
 					>
 						{#snippet plugins()}
 							<Formatter bind:this={formatter} />
@@ -224,12 +231,12 @@
 						max="500"
 						class="text-13 text-input message-textarea__ruler-input"
 						type="number"
-						oninput={(e) => {
+						onfocus={() => (isEditorFocused = true)}
+						onblur={(e) => {
 							const input = e.currentTarget as HTMLInputElement;
 							rulerCountValue.current = parseInt(input.value);
+							isEditorFocused = false;
 						}}
-						onfocus={() => (isEditorFocused = true)}
-						onblur={() => (isEditorFocused = false)}
 					/>
 				</div>
 			{/if}

--- a/packages/ui/src/lib/RichTextEditor.svelte
+++ b/packages/ui/src/lib/RichTextEditor.svelte
@@ -46,6 +46,7 @@
 		onKeyDown?: (event: KeyboardEvent | null) => boolean;
 		initialText?: string;
 		disabled?: boolean;
+		wrapCountValue?: number;
 	};
 
 	const {
@@ -60,7 +61,8 @@
 		onBlur,
 		onChange,
 		onKeyDown,
-		initialText
+		initialText,
+		wrapCountValue
 	}: Props = $props();
 
 	/** Standard configuration for our commit message editor. */
@@ -188,7 +190,7 @@
 		</div>
 
 		<EmojiPlugin bind:this={emojiPlugin} />
-		<OnChangePlugin {markdown} {onChange} />
+		<OnChangePlugin {markdown} {onChange} {wrapCountValue} />
 
 		{#if markdown}
 			<AutoFocusPlugin />

--- a/packages/ui/src/lib/richText/selection.ts
+++ b/packages/ui/src/lib/richText/selection.ts
@@ -184,5 +184,16 @@ export function setEditorText(editor: LexicalEditor, text: string) {
 		const paragraphNode = $createParagraphNode();
 		paragraphNode.append(textNode);
 		root.append(paragraphNode);
+
+		// Set the caret at the end of the text
+		const selection = $getSelection();
+		if ($isRangeSelection(selection)) {
+			selection.setTextNodeRange(
+				textNode,
+				textNode.getTextContentSize(),
+				textNode,
+				textNode.getTextContentSize()
+			);
+		}
 	});
 }


### PR DESCRIPTION
- Set caret at the end of the inserted text node to improve cursor placement.
- Implement text wrapping functionality when the auto-wrap option is enabled.