### PR TITLE
Fix: rename and delete branch modals

### DIFF
--- a/apps/desktop/src/components/DeleteBranchModal.svelte
+++ b/apps/desktop/src/components/DeleteBranchModal.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import { StackService } from '$lib/stacks/stackService.svelte';
+	import { inject } from '@gitbutler/shared/context';
+	import Button from '@gitbutler/ui/Button.svelte';
+	import Modal from '@gitbutler/ui/Modal.svelte';
+
+	type Props = {
+		projectId: string;
+		stackId: string;
+		branchName: string;
+	};
+
+	const { projectId, stackId, branchName }: Props = $props();
+	const [stackService] = inject(StackService);
+	const [removeBranch, branchRemovalOp] = stackService.removeBranch;
+
+	let modal = $state<Modal>();
+
+	export function show() {
+		modal?.show();
+	}
+</script>
+
+<Modal
+	bind:this={modal}
+	width="small"
+	title="Delete branch"
+	onSubmit={async (close) => {
+		await removeBranch({
+			projectId,
+			stackId,
+			branchName
+		});
+		close();
+	}}
+>
+	{#snippet children()}
+		Are you sure you want to delete <code class="code-string">{branchName}</code>?
+	{/snippet}
+	{#snippet controls(close)}
+		<Button kind="outline" onclick={close}>Cancel</Button>
+		<Button style="error" type="submit" loading={branchRemovalOp.current.isLoading}>Delete</Button>
+	{/snippet}
+</Modal>

--- a/apps/desktop/src/components/SeriesHeader.svelte
+++ b/apps/desktop/src/components/SeriesHeader.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
 	import AddSeriesModal from '$components/AddSeriesModal.svelte';
 	import BranchLabel from '$components/BranchLabel.svelte';
+	import BranchRenameModal from '$components/BranchRenameModal.svelte';
 	import BranchReview from '$components/BranchReview.svelte';
 	import BranchStatus from '$components/BranchStatus.svelte';
 	import CardOverlay from '$components/CardOverlay.svelte';
+	import DeleteBranchModal from '$components/DeleteBranchModal.svelte';
 	import Dropzone from '$components/Dropzone.svelte';
 	import SeriesDescription from '$components/SeriesDescription.svelte';
-	import SeriesHeaderContextMenu from '$components/SeriesHeaderContextMenu.svelte';
+	import SeriesHeaderContextMenuContents from '$components/SeriesHeaderContextMenuContents.svelte';
 	import SeriesHeaderStatusIcon from '$components/SeriesHeaderStatusIcon.svelte';
 	import { PromptService } from '$lib/ai/promptService';
 	import { AIService } from '$lib/ai/service';
@@ -66,7 +68,7 @@
 
 	let stackingAddSeriesModal = $state<ReturnType<typeof AddSeriesModal>>();
 	let kebabContextMenu = $state<ReturnType<typeof ContextMenu>>();
-	let branchContextMenu = $state<ReturnType<typeof SeriesHeaderContextMenu>>();
+	let branchContextMenu = $state<ReturnType<typeof SeriesHeaderContextMenuContents>>();
 	let kebabContextMenuTrigger = $state<HTMLButtonElement>();
 	let seriesHeaderEl = $state<HTMLDivElement>();
 	let seriesDescriptionEl = $state<HTMLTextAreaElement>();
@@ -197,6 +199,9 @@
 	closedStateSync(reactive(() => branch));
 
 	const dzHandler = $derived(new MoveCommitDzHandler(stackService, stack, projectId));
+
+	let renameBranchModal = $state<BranchRenameModal>();
+	let deleteBranchModal = $state<DeleteBranchModal>();
 </script>
 
 <AddSeriesModal bind:this={stackingAddSeriesModal} parentSeriesName={branch.name} />
@@ -212,7 +217,7 @@
 		}
 	}}
 >
-	<SeriesHeaderContextMenu
+	<SeriesHeaderContextMenuContents
 		{projectId}
 		stackId={stack.id}
 		bind:this={branchContextMenu}
@@ -230,8 +235,24 @@
 		{isPushed}
 		{pr}
 		{branchType}
+		showBranchRenameModal={() => renameBranchModal?.show()}
+		showDeleteBranchModal={() => deleteBranchModal?.show()}
 	/>
 </ContextMenu>
+
+<BranchRenameModal
+	{projectId}
+	stackId={stack.id}
+	branchName={branch.name}
+	bind:this={renameBranchModal}
+	{isPushed}
+/>
+<DeleteBranchModal
+	{projectId}
+	stackId={stack.id}
+	branchName={branch.name}
+	bind:this={deleteBranchModal}
+/>
 
 <div
 	role="article"
@@ -297,7 +318,7 @@
 						readonly={isPushed}
 						onDblClick={() => {
 							if (isPushed) {
-								branchContextMenu?.showSeriesRenameModal?.();
+								renameBranchModal?.show();
 							}
 						}}
 					/>

--- a/apps/desktop/src/components/v3/BranchCard.svelte
+++ b/apps/desktop/src/components/v3/BranchCard.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import BranchRenameModal from '$components/BranchRenameModal.svelte';
+	import DeleteBranchModal from '$components/DeleteBranchModal.svelte';
 	import BranchBadge from '$components/v3/BranchBadge.svelte';
 	import BranchDividerLine from '$components/v3/BranchDividerLine.svelte';
 	import BranchHeader from '$components/v3/BranchHeader.svelte';
@@ -49,6 +51,8 @@
 					[
 						{
 							onToggle: (open: boolean, isLeftClick: boolean) => void;
+							showBranchRenameModal: () => void;
+							showDeleteBranchModal: () => void;
 						}
 					]
 				>;
@@ -80,6 +84,16 @@
 	const selected = $derived(selection?.current?.branchName === branchName);
 
 	let contextMenu: ContextMenu | undefined = $state();
+	let renameBranchModal = $state<BranchRenameModal>();
+	let deleteBranchModal = $state<DeleteBranchModal>();
+
+	function showBranchRenameModal() {
+		renameBranchModal?.show();
+	}
+
+	function showDeleteBranchModal() {
+		deleteBranchModal?.show();
+	}
 </script>
 
 {#if args.type === 'stack-branch' && !args.first}
@@ -165,9 +179,24 @@
 			}}
 		>
 			{@render args.menu?.({
-				onToggle
+				onToggle,
+				showBranchRenameModal,
+				showDeleteBranchModal
 			})}
 		</ContextMenu>
+		<BranchRenameModal
+			{projectId}
+			stackId={args.stackId}
+			{branchName}
+			bind:this={renameBranchModal}
+			isPushed={!!args.trackingBranch}
+		/>
+		<DeleteBranchModal
+			{projectId}
+			stackId={args.stackId}
+			{branchName}
+			bind:this={deleteBranchModal}
+		/>
 	{:else if args.type === 'normal-branch'}
 		<BranchHeader
 			type="normal-branch"

--- a/apps/desktop/src/components/v3/BranchList.svelte
+++ b/apps/desktop/src/components/v3/BranchList.svelte
@@ -2,7 +2,7 @@
 	import CardOverlay from '$components/CardOverlay.svelte';
 	import Dropzone from '$components/Dropzone.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
-	import SeriesHeaderContextMenu from '$components/SeriesHeaderContextMenu.svelte';
+	import SeriesHeaderContextMenuContents from '$components/SeriesHeaderContextMenuContents.svelte';
 	import StackStickyButtons from '$components/StackStickyButtons.svelte';
 	import BranchCard from '$components/v3/BranchCard.svelte';
 	import BranchCommitList from '$components/v3/BranchCommitList.svelte';
@@ -309,11 +309,11 @@
 								{/snippet}
 							</BranchCommitList>
 						{/snippet}
-						{#snippet menu()}
+						{#snippet menu({ showDeleteBranchModal, showBranchRenameModal })}
 							{@const forgeBranch = branch.remoteTrackingBranch
 								? forge.current?.branch(branch.remoteTrackingBranch)
 								: undefined}
-							<SeriesHeaderContextMenu
+							<SeriesHeaderContextMenuContents
 								{projectId}
 								{stackId}
 								{branchType}
@@ -330,6 +330,8 @@
 									if (url) openExternalUrl(url);
 								}}
 								isPushed={!!branch.remoteTrackingBranch}
+								{showBranchRenameModal}
+								{showDeleteBranchModal}
 							/>
 						{/snippet}
 					</BranchCard>

--- a/apps/desktop/src/components/v3/BranchView.svelte
+++ b/apps/desktop/src/components/v3/BranchView.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+	import BranchRenameModal from '$components/BranchRenameModal.svelte';
 	import BranchReview from '$components/BranchReview.svelte';
+	import DeleteBranchModal from '$components/DeleteBranchModal.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
-	import SeriesHeaderContextMenu from '$components/SeriesHeaderContextMenu.svelte';
+	import SeriesHeaderContextMenuContents from '$components/SeriesHeaderContextMenuContents.svelte';
 	import BranchBadge from '$components/v3/BranchBadge.svelte';
 	import ChangedFiles from '$components/v3/ChangedFiles.svelte';
 	import Drawer from '$components/v3/Drawer.svelte';
@@ -57,6 +59,8 @@
 	let isContextMenuOpen = $state(false);
 
 	let newBranchModal = $state<ReturnType<typeof NewBranchModal>>();
+	let renameBranchModal = $state<BranchRenameModal>();
+	let deleteBranchModal = $state<DeleteBranchModal>();
 </script>
 
 <ReduxResult
@@ -173,7 +177,7 @@
 			testId={TestId.BranchHeaderContextMenu}
 			leftClickTrigger={kebabTrigger}
 		>
-			<SeriesHeaderContextMenu
+			<SeriesHeaderContextMenuContents
 				{projectId}
 				contextMenuEl={contextMenu}
 				{stackId}
@@ -191,8 +195,27 @@
 				}}
 				isPushed={!!branch.remoteTrackingBranch}
 				branchType={topCommit?.state.type || 'LocalOnly'}
+				showBranchRenameModal={() => {
+					renameBranchModal?.show();
+				}}
+				showDeleteBranchModal={() => {
+					deleteBranchModal?.show();
+				}}
 			/>
 		</ContextMenu>
+		<BranchRenameModal
+			{projectId}
+			{stackId}
+			branchName={branch.name}
+			bind:this={renameBranchModal}
+			isPushed={!!branch.remoteTrackingBranch}
+		/>
+		<DeleteBranchModal
+			{projectId}
+			{stackId}
+			branchName={branch.name}
+			bind:this={deleteBranchModal}
+		/>
 	{/snippet}
 </ReduxResult>
 


### PR DESCRIPTION
- Introduced a new `DeleteBranchModal` component for confirming and handling branch deletions.
- Improved user experience by providing a clear and safe method for branch removal.
- Moved modals out of the series context menu to allow for conditional injection.