### PR TITLE
e-branch-40

### DIFF
--- a/apps/desktop/src/components/v3/editor/MessageEditor.svelte
+++ b/apps/desktop/src/components/v3/editor/MessageEditor.svelte
@@ -74,7 +74,8 @@
 	let isEditorFocused = $state(false);
 	let fileUploadPlugin = $state<ReturnType<typeof FileUploadPlugin>>();
 	let uploadConfirmationModal = $state<ReturnType<typeof Modal>>();
-	const allowUploadFiles = persisted<boolean>(false, 'allowUploadFiles');
+	const doNotShowUploadWarning = persisted<boolean>(false, 'doNotShowUploadWarning');
+	let allowUploadOnce = $state<boolean>(false);
 
 	export async function getPlaintext(): Promise<string | undefined> {
 		return composer?.getPlaintext();
@@ -119,13 +120,22 @@
 			});
 		const settled = await Promise.allSettled(uploads);
 		const successful = settled.filter((result) => result.status === 'fulfilled');
+		const failed = settled.filter((result) => result.status === 'rejected');
+
+		if (failed.length > 0) {
+			console.error('File upload failed', failed);
+			showError('File upload failed', failed.map((result) => result.reason).join(', '));
+		}
+
+		allowUploadOnce = false;
+
 		return successful.map((result) => result.value);
 	}
 
 	async function handleDropFiles(
 		files: FileList | undefined
 	): Promise<DropFileResult[] | undefined> {
-		if ($allowUploadFiles) {
+		if ($doNotShowUploadWarning || allowUploadOnce) {
 			return onDropFiles(files);
 		}
 
@@ -143,7 +153,7 @@
 	}
 
 	function handleAttachFiles() {
-		if ($allowUploadFiles) {
+		if ($doNotShowUploadWarning) {
 			attachFiles();
 			return;
 		}
@@ -164,6 +174,7 @@
 	width="small"
 	bind:this={uploadConfirmationModal}
 	onSubmit={async (close) => {
+		allowUploadOnce = true;
 		await attachFiles();
 		close();
 	}}
@@ -196,7 +207,8 @@
 			<br />
 		{/if}
 		<div style="display: flex; align-items: center; gap: 4px">
-			<Checkbox small bind:checked={$allowUploadFiles} /> <span> Do not bring this up again </span>
+			<Checkbox small bind:checked={$doNotShowUploadWarning} />
+			<span> Do not bring this up again </span>
 		</div>
 	{/snippet}
 	{#snippet controls(close)}

--- a/packages/ui/src/lib/richText/plugins/FileUpload.svelte
+++ b/packages/ui/src/lib/richText/plugins/FileUpload.svelte
@@ -43,7 +43,7 @@
 	}
 
 	$effect(() => {
-		const unregidterDrop = editor.registerCommand(
+		const unregisterDrop = editor.registerCommand(
 			DROP_COMMAND,
 			(e) => {
 				e.preventDefault();
@@ -56,7 +56,7 @@
 			COMMAND_PRIORITY_CRITICAL
 		);
 
-		const unregidterPaste = editor.registerCommand(
+		const unregisterPaste = editor.registerCommand(
 			PASTE_COMMAND,
 			(e) => {
 				e.preventDefault();
@@ -71,8 +71,8 @@
 		);
 
 		return () => {
-			unregidterDrop();
-			unregidterPaste();
+			unregisterDrop();
+			unregisterPaste();
 		};
 	});
 


### PR DESCRIPTION
- Fix typo in unregister command variable names in FileUpload plugin.
- Replace allowUploadFiles flag with doNotShowUploadWarning for clearer upload warning control.
- Add allowUploadOnce state to allow a single upload after confirmation without disabling warnings.
- Reset allowUploadOnce after each upload attempt.
- Log and display errors for failed file uploads.
- Update UI checkbox to bind to doNotShowUploadWarning flag for better clarity.