### PR TITLE
MCP: vibe commit 

### DIFF
--- a/apps/desktop/src/lib/stacks/stack.ts
+++ b/apps/desktop/src/lib/stacks/stack.ts
@@ -51,6 +51,11 @@ export type BranchDetails = {
 	/** A unique identifier for the GitButler review associated with the branch, if any. */
 	readonly reviewId: string | null;
 	/**
+	 * This is the last commit in the branch, aka the tip of the branch.
+	 * If this is the only branch in the stack or the top-most branch, this is the tip of the stack.
+	 */
+	readonly tip: string;
+	/**
 	 * This is the base commit from the perspective of this branch.
 	 * If the branch is part of a stack and is on top of another branch, this is the head of the branch below it.
 	 * If this branch is at the bottom of the stack, this is the merge base of the stack.

--- a/apps/desktop/src/lib/testing/mockStackService.ts
+++ b/apps/desktop/src/lib/testing/mockStackService.ts
@@ -39,6 +39,7 @@ const BRANCH_DETAILS_A: BranchDetails = {
 	description: null,
 	prNumber: null,
 	reviewId: null,
+	tip: 'tip-commit-a',
 	baseCommit: 'base-commit-a'
 };
 

--- a/crates/but-cli/src/args.rs
+++ b/crates/but-cli/src/args.rs
@@ -62,6 +62,9 @@ pub enum Subcommands {
         /// The revspec to create the commit on top of, or the commit to amend to.
         #[clap(long)]
         parent: Option<String>,
+        /// A JSON specification of the changes to commit.
+        #[clap(long)]
+        diff_spec: Option<String>,
     },
     /// List all uncommitted working tree changes.
     Status {

--- a/crates/but-cli/src/command/mod.rs
+++ b/crates/but-cli/src/command/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, anyhow, bail};
 use but_core::UnifiedDiff;
-use but_workspace::commit_engine::HunkHeader;
+use but_workspace::commit_engine::{DiffSpec, HunkHeader};
 use gitbutler_project::Project;
 use gix::bstr::{BString, ByteSlice};
 use std::path::Path;
@@ -96,6 +96,16 @@ fn project_controller(
     }
     tracing::debug!("Using projects from '{}'", path.display());
     Ok(gitbutler_project::Controller::from_path(path))
+}
+
+pub fn parse_diff_spec(arg: &Option<String>) -> Result<Option<Vec<DiffSpec>>, anyhow::Error> {
+    arg.as_deref()
+        .map(|value| {
+            serde_json::from_str::<Vec<but_workspace::commit_engine::ui::DiffSpec>>(value)
+                .map(|diff_spec| diff_spec.into_iter().map(Into::into).collect())
+                .map_err(|e| anyhow!("Failed to parse diff_spec: {}", e))
+        })
+        .transpose()
 }
 
 mod commit;

--- a/crates/but-cli/src/main.rs
+++ b/crates/but-cli/src/main.rs
@@ -1,6 +1,7 @@
 //! A debug-CLI for making `but`-crates functionality available in real-world repositories.
 #![deny(rust_2018_idioms)]
 use anyhow::Result;
+use command::parse_diff_spec;
 
 mod args;
 use crate::command::{RepositoryOpenMode, repo_and_maybe_project};
@@ -47,8 +48,10 @@ fn main() -> Result<()> {
             parent,
             workspace_tip,
             stack_segment_ref,
+            diff_spec,
         } => {
             let (repo, project) = repo_and_maybe_project(&args, RepositoryOpenMode::Merge)?;
+            let diff_spec = parse_diff_spec(diff_spec)?;
             command::commit(
                 repo,
                 project,
@@ -64,6 +67,7 @@ fn main() -> Result<()> {
                 } else {
                     None
                 },
+                diff_spec,
             )
         }
         args::Subcommands::HunkDependency => command::diff::locks(&args.current_dir),

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { VERSION } from './shared/version.js';
 import * as chatMessages from './tools/chatMessages.js';
+import * as commit from './tools/client/commit.js';
 import * as status from './tools/client/status.js';
 import * as patchStacks from './tools/patchStacks.js';
 import * as projects from './tools/projects.js';
@@ -32,7 +33,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 			...projects.getProjectToolListings(),
 			...chatMessages.getChatMessageToolListings(),
 			...patchStacks.getPatchStackToolListing(),
-			...status.getStatusToolListing()
+			...status.getStatusToolListing(),
+			...commit.getCommitToolListing()
 		]
 	};
 });
@@ -47,7 +49,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 			projects.getProjectToolRequestHandler,
 			chatMessages.getChatMesssageToolRequestHandler,
 			patchStacks.getPatchStackToolRequestHandler,
-			status.getStatusToolRequestHandler
+			status.getStatusToolRequestHandler,
+			commit.getCommitToolRequestHandler
 		];
 
 		for (const handler of handlers) {

--- a/packages/mcp/src/shared/command.ts
+++ b/packages/mcp/src/shared/command.ts
@@ -14,11 +14,21 @@ export function hasGitButlerExecutable(): boolean {
  *
  * The command is executed synchronously, and the output is parsed using the provided schema.
  */
+export function executeGitButlerCommand(
+	projectDirectory: string,
+	args: string[],
+	schema: undefined
+): undefined;
 export function executeGitButlerCommand<T>(
 	projectDirectory: string,
 	args: string[],
 	schema: z.Schema<T>
-): T {
+): T;
+export function executeGitButlerCommand<T>(
+	projectDirectory: string,
+	args: string[],
+	schema: z.Schema<T> | undefined
+): T | undefined {
 	const executable = getGitButlerExecutable();
 
 	if (!executable) throw new Error('Command error: No executable configured');
@@ -33,6 +43,8 @@ export function executeGitButlerCommand<T>(
 	if (result.status !== 0) {
 		throw new Error(`Command error: ${result.stderr}`);
 	}
+
+	if (!schema) return undefined;
 
 	const parsed = JSON.parse(result.stdout);
 

--- a/packages/mcp/src/shared/entities/changes.ts
+++ b/packages/mcp/src/shared/entities/changes.ts
@@ -67,6 +67,8 @@ export const DiffHunkSchema = z.object({
 	diff: z.string()
 });
 
+export type DiffHunk = z.infer<typeof DiffHunkSchema>;
+
 export const PatchSchema = z.object({
 	hunks: z.array(DiffHunkSchema),
 	isResultOfBinaryToTextConversion: z.boolean(),

--- a/packages/mcp/src/shared/entities/stacks.ts
+++ b/packages/mcp/src/shared/entities/stacks.ts
@@ -2,7 +2,8 @@ import { z } from 'zod';
 
 export const StackSchema = z.object({
 	id: z.string({ description: 'The unique identifier for the stack. This is a UUID.' }),
-	branchNames: z.array(z.string())
+	branchNames: z.array(z.string()),
+	tip: z.string({ description: 'The commit ID of the tip of the stack.' })
 });
 
 export const StackListSchema = z.array(StackSchema);
@@ -22,6 +23,10 @@ export const BranchSchema = z.object({
 	archived: z.boolean({
 		description:
 			'Indicates whether the branch is part of this stack, but has already been integrated. In other words, the merge base of the stack is above this branch.'
+	}),
+	tip: z.string({
+		description:
+			'The commit ID of the tip of the branch. If this is the only branch in the stack or the top-most branch, this is the tip of the stack.'
 	}),
 	baseCommit: z.string({
 		description:

--- a/packages/mcp/src/tools/client/commit.ts
+++ b/packages/mcp/src/tools/client/commit.ts
@@ -1,0 +1,130 @@
+import { BaseParamsSchema, DiffSpec, getBranchRef } from './shared.js';
+import { listStackBranches, listStacks } from './status.js';
+import { executeGitButlerCommand, hasGitButlerExecutable } from '../../shared/command.js';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+const CommitParamsSchema = BaseParamsSchema.extend({
+	message: z.string({ description: 'The commit message' }),
+	all: z.boolean().optional().default(false),
+	filePaths: z.array(z.string()).optional().default([]),
+	branch: z.string({ description: 'The branch to commit to' })
+});
+
+type CommitParams = z.infer<typeof CommitParamsSchema>;
+
+/**
+ * Commit changes.
+ */
+function commit(params: CommitParams) {
+	const args = ['commit', '--message', params.message];
+
+	if (params.all) {
+		if (params.filePaths.length > 0) {
+			throw new Error('Cannot use --all and file paths together');
+		}
+	}
+
+	if (params.filePaths.length > 0) {
+		const diffSpec: DiffSpec[] = [];
+		for (const filePath of params.filePaths) {
+			diffSpec.push({
+				pathBytes: filePath,
+				hunkHeaders: []
+			});
+		}
+
+		const diffSpecJson = JSON.stringify(diffSpec);
+		args.push('--diff-spec', diffSpecJson);
+	}
+
+	const stacks = listStacks({ project_directory: params.project_directory });
+
+	if (stacks.length === 0) {
+		throw new Error('No stacks found');
+	}
+
+	for (const stack of stacks) {
+		if (stack.branchNames.includes(params.branch)) {
+			if (stack.branchNames.length === 1) {
+				// If this stack has only one branch, we can commit directly to it
+				const branchRef = getBranchRef(params.branch);
+				args.push('-s', branchRef);
+				args.push('--parent', stack.tip);
+				return executeGitButlerCommand(params.project_directory, args, undefined);
+			}
+
+			const stackBranches = listStackBranches({
+				project_directory: params.project_directory,
+				stack_id: stack.id
+			});
+			if (stackBranches.length === 0) {
+				throw new Error(`No branches found in stack ${stack.id}`);
+			}
+
+			const branch = stackBranches.find((b) => b.name === params.branch);
+			if (!branch) {
+				throw new Error(`Branch ${params.branch} not found in stack ${stack.id}`);
+			}
+
+			if (branch.archived) {
+				throw new Error(`Branch ${params.branch} is archived`);
+			}
+
+			const branchRef = getBranchRef(params.branch);
+			args.push('-s', branchRef);
+			args.push('--parent', branch.tip);
+			return executeGitButlerCommand(params.project_directory, args, undefined);
+		}
+	}
+
+	throw new Error(`Branch ${params.branch} not found in any stack`);
+}
+
+const TOOL_LISTINGS = [
+	{
+		name: 'commit',
+		description: 'Commit a set of changes to a specific branch in the GitButler project.',
+		inputSchema: zodToJsonSchema(CommitParamsSchema)
+	}
+] as const;
+
+type ToolName = (typeof TOOL_LISTINGS)[number]['name'];
+
+function isToolName(name: string): name is ToolName {
+	return TOOL_LISTINGS.some((tool) => tool.name === name);
+}
+
+export function getCommitToolListing() {
+	if (!hasGitButlerExecutable()) {
+		return [];
+	}
+
+	return TOOL_LISTINGS;
+}
+
+export async function getCommitToolRequestHandler(
+	toolName: string,
+	params: Record<string, unknown>
+): Promise<CallToolResult | null> {
+	if (!isToolName(toolName) || !hasGitButlerExecutable()) {
+		return null;
+	}
+
+	switch (toolName) {
+		case 'commit': {
+			try {
+				const parsedParams = CommitParamsSchema.parse(params);
+				commit(parsedParams);
+				return { content: [{ type: 'text', text: 'Commit successful' }] };
+			} catch (error: unknown) {
+				if (error instanceof Error) {
+					return { content: [{ type: 'text', text: `Error: ${error.message}` }], isError: true };
+				}
+
+				return { content: [{ type: 'text', text: `Error: ${String(error)}` }], isError: true };
+			}
+		}
+	}
+}

--- a/packages/mcp/src/tools/client/shared.ts
+++ b/packages/mcp/src/tools/client/shared.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+export const BaseParamsSchema = z.object({
+	project_directory: z.string({ description: 'The absolute path to the project directory' })
+});
+
+export function getBranchRef(branchName: string): string {
+	if (branchName.startsWith('refs/')) {
+		return branchName;
+	}
+	return `refs/heads/${branchName}`;
+}
+
+export type HunkHeader = {
+	oldStart: number;
+	oldLines: number;
+	newStart: number;
+	newLines: number;
+};
+
+export type DiffSpec = {
+	previousPathBytes?: string;
+	pathBytes: string;
+	hunkHeaders: HunkHeader[];
+};

--- a/packages/mcp/src/tools/client/status.ts
+++ b/packages/mcp/src/tools/client/status.ts
@@ -1,3 +1,4 @@
+import { BaseParamsSchema } from './shared.js';
 import { executeGitButlerCommand, hasGitButlerExecutable } from '../../shared/command.js';
 import { DiffHunk, UnifiedWorktreeChanges } from '../../shared/entities/changes.js';
 import {
@@ -8,10 +9,6 @@ import {
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
-
-const BaseParamsSchema = z.object({
-	project_directory: z.string({ description: 'The absolute path to the project directory' })
-});
 
 const StatusParamsSchema = BaseParamsSchema.extend({});
 
@@ -52,7 +49,7 @@ type ListStacksParams = z.infer<typeof ListStacksParamsSchema>;
 /**
  * Get the list of stacks of the current GitButler project.
  */
-function listStacks(params: ListStacksParams) {
+export function listStacks(params: ListStacksParams) {
 	const args = ['stacks'];
 
 	return executeGitButlerCommand(params.project_directory, args, StackListSchema);
@@ -67,7 +64,7 @@ type ListStackBranchesParams = z.infer<typeof ListStackBranchesParamsSchema>;
 /**
  * Get the branches of a stack.
  */
-function listStackBranches(params: ListStackBranchesParams) {
+export function listStackBranches(params: ListStackBranchesParams) {
 	const args = ['stack-branches', params.stack_id];
 
 	return executeGitButlerCommand(params.project_directory, args, BranchListSchema);

--- a/packages/mcp/src/tools/client/status.ts
+++ b/packages/mcp/src/tools/client/status.ts
@@ -1,5 +1,5 @@
 import { executeGitButlerCommand, hasGitButlerExecutable } from '../../shared/command.js';
-import { UnifiedWorktreeChanges } from '../../shared/entities/changes.js';
+import { DiffHunk, UnifiedWorktreeChanges } from '../../shared/entities/changes.js';
 import {
 	BranchCommitsSchema,
 	BranchListSchema,
@@ -19,7 +19,7 @@ type StatusParams = z.infer<typeof StatusParamsSchema>;
 
 type WorktreeDiffs = {
 	filePath: string;
-	hunkDiffs: string[];
+	hunks: DiffHunk[];
 };
 
 /**
@@ -38,8 +38,8 @@ function status(params: StatusParams) {
 	for (const change of unifiedWorktreeChanges.changes) {
 		if (change.diff.type === 'Patch') {
 			const filePath = change.treeChange.path;
-			const hunkDiffs = change.diff.subject.hunks.map((hunk) => hunk.diff);
-			result.push({ filePath, hunkDiffs });
+			const hunks = change.diff.subject.hunks;
+			result.push({ filePath, hunks });
 		}
 	}
 	return result;


### PR DESCRIPTION
### Description

- Update the type of the worktree diffs for improved accuracy  
- Implement commit tool for committing changes to a branch, including shared types and stack tip support  
- Add --diff-spec argument to commit command with parsing and integration  
- Add tip (last commit) field to stack and branch structures, updating serialization and construction logic  
- Refactor status tool to use shared base params and export utilities  
- Update stack and branch schemas to include tip property