### PR TITLE
Distribute the CLI

### DIFF
--- a/crates/gitbutler-tauri/inject-git-binaries.sh
+++ b/crates/gitbutler-tauri/inject-git-binaries.sh
@@ -11,14 +11,22 @@ TRIPLE=${TRIPLE_OVERRIDE:-$(rustc -vV | sed -n 's|host: ||p')}
 TARGET_ROOT="$ROOT/target/${TRIPLE_OVERRIDE:-}/release"
 CRATE_ROOT="$ROOT/crates/gitbutler-tauri"
 
-if [ -f "$TARGET_ROOT/gitbutler-git-askpass" ] && [ -f "$TARGET_ROOT/gitbutler-git-setsid" ]; then
+# BINARIES
+ASKPASS="gitbutler-git-askpass"
+SETSID="gitbutler-git-setsid"
+CLI="but-cli"
+
+
+if [ -f "$TARGET_ROOT/$ASKPASS" ] && [ -f "$TARGET_ROOT/$SETSID" ] && [ -f "$TARGET_ROOT/$CLI" ]; then
     log injecting gitbutler-git binaries into crates/gitbutler-tauri "(TRIPLE=${TRIPLE})"
-    cp -v "$TARGET_ROOT/gitbutler-git-askpass" "$CRATE_ROOT/gitbutler-git-askpass-${TRIPLE}"
-    cp -v "$TARGET_ROOT/gitbutler-git-setsid" "$CRATE_ROOT/gitbutler-git-setsid-${TRIPLE}"
-elif [ -f "$TARGET_ROOT/gitbutler-git-askpass.exe" ] && [ -f "$TARGET_ROOT/gitbutler-git-setsid.exe" ]; then
+    cp -v "$TARGET_ROOT/$ASKPASS" "$CRATE_ROOT/$ASKPASS-${TRIPLE}"
+    cp -v "$TARGET_ROOT/$SETSID" "$CRATE_ROOT/$SETSID-${TRIPLE}"
+    cp -v "$TARGET_ROOT/$CLI" "$CRATE_ROOT/$CLI-${TRIPLE}"
+elif [ -f "$TARGET_ROOT/$ASKPASS.exe" ] && [ -f "$TARGET_ROOT/$SETSID.exe" ] && [ -f "$TARGET_ROOT/$CLI.exe" ]; then
     log injecting gitbutler-git binaries into crates/gitbutler-tauri "(TRIPLE=${TRIPLE})"
-    cp -v "$TARGET_ROOT/gitbutler-git-askpass.exe" "$CRATE_ROOT/gitbutler-git-askpass-${TRIPLE}.exe"
-    cp -v "$TARGET_ROOT/gitbutler-git-setsid.exe" "$CRATE_ROOT/gitbutler-git-setsid-${TRIPLE}.exe"
+    cp -v "$TARGET_ROOT/$ASKPASS.exe" "$CRATE_ROOT/$ASKPASS-${TRIPLE}.exe"
+    cp -v "$TARGET_ROOT/$SETSID.exe" "$CRATE_ROOT/$SETSID-${TRIPLE}.exe"
+    cp -v "$TARGET_ROOT/$CLI.exe" "$CRATE_ROOT/$CLI-${TRIPLE}.exe"
 else
     log gitbutler-git binaries are not built
     exit 1

--- a/crates/gitbutler-tauri/tauri.conf.nightly.json
+++ b/crates/gitbutler-tauri/tauri.conf.nightly.json
@@ -13,7 +13,7 @@
 			"icons/nightly/icon.icns",
 			"icons/nightly/icon.ico"
 		],
-		"externalBin": ["gitbutler-git-setsid", "gitbutler-git-askpass"]
+		"externalBin": ["gitbutler-git-setsid", "gitbutler-git-askpass", "but-cli"]
 	},
 	"plugins": {
 		"updater": {

--- a/crates/gitbutler-tauri/tauri.conf.release.json
+++ b/crates/gitbutler-tauri/tauri.conf.release.json
@@ -13,7 +13,7 @@
 			"icons/icon.icns",
 			"icons/icon.ico"
 		],
-		"externalBin": ["gitbutler-git-setsid", "gitbutler-git-askpass"]
+		"externalBin": ["gitbutler-git-setsid", "gitbutler-git-askpass", "but-cli"]
 	},
 	"plugins": {
 		"updater": {


### PR DESCRIPTION
Even though the CLI alone is not fully designed for in-prod purposes, let’s start distributing it alonside the other binaries, to enable the usage of the MCP server.

We can keep building the CLI iteratively