### PR TITLE
feat(gitlabPrService): auto-remove source branch on MR creation

### DIFF
--- a/apps/desktop/src/lib/forge/gitlab/gitlabPrService.svelte.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlabPrService.svelte.ts
@@ -117,7 +117,8 @@ function injectEndpoints(api: GitLabApi) {
 					const upstreamProject = await api.Projects.show(upstreamProjectId);
 					const mr = await api.MergeRequests.create(forkProjectId, base, head, title, {
 						description: body,
-						targetProjectId: upstreamProject.id
+						targetProjectId: upstreamProject.id,
+						removeSourceBranch: true
 					});
 					return { data: mrToInstance(mr) };
 				},


### PR DESCRIPTION
Add removeSourceBranch option when creating merge requests to ensure the source branch is deleted automatically after the MR is merged. This helps with PR Stacks because every time the bottom merge request is merged, the next one in the stack will automatically change its target branch to main/master.

## 🧢 Changes

Add the `removeSourceBranch` option when creating merge requests to ensure
the source branch is deleted automatically after merging MR. This
helps with PR Stacks because every time the bottom merge request is merged, the next one in the stack will automatically change its target branch to main/master.

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->


## 📌 Todos

Unfortunately, I was not able to validate this change on my workstation. When I compile GitButler with `pnpm dev:desktop`, the "Create Pull Request" button is completely unresponsive with or without this PR applied.

