### PR TITLE
fix(stack): mark branch as having pushed commits if upstream exists

### DIFF
--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -350,6 +350,9 @@ pub fn stack_details(
         let commits = local_and_remote_commits(ctx, &repo, branch, &stack)?;
         let upstream_commits = upstream_only_commits(ctx, &repo, branch, &stack, Some(&commits))?;
 
+        // If there are commits in the remote, we can assume that commits have been pushed. *Like, literally*.
+        branch_state.has_pushed_commits |= !upstream_commits.is_empty();
+
         for commit in &commits {
             is_conflicted |= commit.has_conflicts;
             branch_state.is_dirty |= matches!(commit.state, CommitState::LocalOnly);


### PR DESCRIPTION
Update branch state to reflect pushed commits when remote commits are
present. This ensures the branch correctly indicates that commits have
been pushed if there are any upstream-only commits, improving the
accuracy of branch status reporting.