### PR TITLE
fix: update GitLab merge request prefix to '!'

### DIFF
--- a/apps/desktop/src/components/PullRequestCard.svelte
+++ b/apps/desktop/src/components/PullRequestCard.svelte
@@ -94,7 +94,7 @@
 			case 'github':
 				return ['Pull request', 'PR', '#'];
 			case 'gitlab':
-				return ['Merge request', 'MR', '#'];
+				return ['Merge request', 'MR', '!'];
 			default:
 				return ['Pull request', 'PR', '#'];
 		}


### PR DESCRIPTION
Change the prefix for GitLab merge requests from '#' to '!' in the   PullRequestCard component to correctly reflect markdown syntax.

## 🧢 Changes

In https://github.com/gitbutlerapp/gitbutler/pull/8221 the ability to distinguish UI elements by forge was introduced, but the correct MR symbol for GitLab is `!`.

## ☕️ Reasoning

If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: #8210 



<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
