### PR TITLE
Fix diffing between snapshots in v3

### DIFF
--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -900,6 +900,11 @@ fn tree_from_applied_vbranches(
     let snapshot_commit = repo.find_commit(git2_to_gix_object_id(snapshot_commit_id))?;
     let snapshot_tree = snapshot_commit.tree()?;
 
+    // If the `worktree` subtree is available, we should return that instead
+    if let Some(tree) = snapshot_tree.lookup_entry_by_path("worktree")? {
+        return Ok(tree.id().to_git2());
+    }
+
     let target_tree_entry = snapshot_tree
         .lookup_entry_by_path("target_tree")?
         .context("no entry at 'target_entry'")?;


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#7h0lTscIs`](https://gitbutler.com/cto/gitbutler-client-d443/reviews/7h0lTscIs)

**Fix diffing between snapshots in v3**


The old implementation would try to take all the branches and merge their tress to get a representation of the worktree.

This of course doesn’t work in v3. We now always write out this `worktree` subtree, so we might as well always look for it befrore falling back to the previous method of finding the state of the world

1 commit series (version 2)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Fix diffing between snapshots in v3](https://gitbutler.com/cto/gitbutler-client-d443/reviews/7h0lTscIs/commit/e089858f-7043-439f-b196-82e73e7dc8d2) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/cto/gitbutler-client-d443/reviews/7h0lTscIs)_
<!-- GitButler Review Footer Boundary Bottom -->
