### PR TITLE
fix(branchview): pass projectId and stackId explicitly to children

### DIFF
--- a/apps/desktop/src/components/v3/BranchView.svelte
+++ b/apps/desktop/src/components/v3/BranchView.svelte
@@ -110,11 +110,11 @@
 
 			{#snippet filesSplitView()}
 				<ReduxResult {projectId} {stackId} result={changesResult.current}>
-					{#snippet children(changes, env)}
+					{#snippet children(changes, { projectId, stackId })}
 						<ChangedFiles
 							title="All changed files"
-							projectId={env.projectId}
-							stackId={env.stackId}
+							{projectId}
+							{stackId}
 							selectionId={{ type: 'branch', stackId, branchName }}
 							{changes}
 						/>


### PR DESCRIPTION
Update BranchView component to pass projectId and stackId directly
to the children snippet instead of using the env object. This change
improves clarity and ensures the correct props are provided to the
ChangedFiles component, preventing potential issues with prop access.