### PR TITLE
Make stack id optional for pull request card

### DIFF
--- a/apps/desktop/src/components/BranchReview.svelte
+++ b/apps/desktop/src/components/BranchReview.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import BranchReviewButRequest from '$components/BranchReviewButRequest.svelte';
-	import PullRequestCard from '$components/PullRequestCard.svelte';
 	import ReviewCreation from '$components/ReviewCreation.svelte';
 	import ReviewCreationControls from '$components/ReviewCreationControls.svelte';
+	import StackedPullRequestCard from '$components/StackedPullRequestCard.svelte';
 	import CanPublishReviewPlugin from '$components/v3/CanPublishReviewPlugin.svelte';
 	import { SettingsService } from '$lib/config/appSettingsV2';
 	import { syncBrToPr } from '$lib/forge/brToPrSync.svelte';
@@ -123,7 +123,7 @@
 	{#if pr || (reviewId && allowedToPublishBR)}
 		<div class="status-cards">
 			{#if prNumber}
-				<PullRequestCard {projectId} {stackId} {branchName} poll />
+				<StackedPullRequestCard {projectId} {stackId} {branchName} {prNumber} poll />
 			{/if}
 			{#if reviewId && allowedToPublishBR}
 				<BranchReviewButRequest {reviewId} />

--- a/apps/desktop/src/components/ChecksPolling.svelte
+++ b/apps/desktop/src/components/ChecksPolling.svelte
@@ -7,7 +7,6 @@
 	import type { ComponentColorType } from '@gitbutler/ui/utils/colorTypes';
 
 	type Props = {
-		stackId: string;
 		branchName: string;
 		hasChecks?: boolean;
 		isFork?: boolean;
@@ -23,14 +22,7 @@
 		tooltip?: string;
 	};
 
-	let {
-		stackId,
-		branchName,
-		isFork,
-		isMerged,
-		hasChecks = $bindable(),
-		size = 'tag'
-	}: Props = $props();
+	let { branchName, isFork, isMerged, hasChecks = $bindable(), size = 'tag' }: Props = $props();
 
 	const [forge] = inject(DefaultForgeFactory);
 
@@ -67,7 +59,7 @@
 
 	const checksResult = $derived(
 		enabled
-			? checksService?.get(stackId, branchName, { subscriptionOptions: { pollingInterval } })
+			? checksService?.get(branchName, { subscriptionOptions: { pollingInterval } })
 			: undefined
 	);
 

--- a/apps/desktop/src/components/MergeButton.svelte
+++ b/apps/desktop/src/components/MergeButton.svelte
@@ -9,7 +9,6 @@
 	interface Props {
 		projectId: string;
 		onclick: (method: MergeMethod) => void;
-		loading?: boolean;
 		disabled?: boolean;
 		wide?: boolean;
 		tooltip?: string;
@@ -20,7 +19,6 @@
 	const {
 		projectId,
 		onclick,
-		loading = false,
 		disabled = false,
 		wide = false,
 		tooltip = '',
@@ -36,6 +34,7 @@
 	const action = persistedAction(projectId);
 
 	let dropDown: ReturnType<typeof DropDownButton> | undefined;
+	let loading = $state(false);
 
 	const labels = {
 		[MergeMethod.Merge]: 'Merge pull request',
@@ -46,10 +45,13 @@
 
 <DropDownButton
 	bind:this={dropDown}
-	onclick={(e) => {
-		e.preventDefault();
-		e.stopPropagation();
-		onclick?.($action);
+	onclick={async () => {
+		loading = true;
+		try {
+			await onclick?.($action);
+		} finally {
+			loading = false;
+		}
 	}}
 	{style}
 	{kind}

--- a/apps/desktop/src/components/PullRequestCard.svelte
+++ b/apps/desktop/src/components/PullRequestCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import ChecksPolling from '$components/ChecksPolling.svelte';
 	import PullRequestPolling from '$components/PullRequestPolling.svelte';
 	import { writeClipboard } from '$lib/backend/clipboard';
 	import { DefaultForgeFactory } from '$lib/forge/forgeFactory.svelte';
@@ -38,27 +39,17 @@
 		hasParent?: boolean;
 		baseIsTargetBranch?: boolean;
 		parentIsPushed?: boolean;
-		hasChecks?: boolean;
-		checks?: Snippet<[DetailedPullRequest]>;
 		button?: Snippet<
 			[{ pr: DetailedPullRequest; mergeStatus: ButtonStatus; reopenStatus: ButtonStatus }]
 		>;
 	}
 
-	const {
-		poll,
-		prNumber,
-		isPushed,
-		hasParent,
-		baseIsTargetBranch,
-		parentIsPushed,
-		hasChecks,
-		checks,
-		button
-	}: Props = $props();
+	const { poll, prNumber, isPushed, hasParent, baseIsTargetBranch, parentIsPushed, button }: Props =
+		$props();
 
 	let contextMenuEl = $state<ReturnType<typeof ContextMenu>>();
 	let container = $state<HTMLElement>();
+	let hasChecks = $state(false);
 
 	const forge = getContext(DefaultForgeFactory);
 	const prService = $derived(forge.current.prService);
@@ -228,7 +219,14 @@
 		<div class="text-12 pr-row">
 			{#if !pr.closedAt && forge.current.checks}
 				<div class="factoid">
-					{@render checks?.(pr)}
+					{#if pr.state === 'open'}
+						<ChecksPolling
+							branchName={pr.sourceBranch}
+							isFork={pr.fork}
+							isMerged={pr.merged}
+							bind:hasChecks
+						/>
+					{/if}
 				</div>
 				<span class="seperator">•</span>
 			{/if}

--- a/apps/desktop/src/components/SeriesHeader.svelte
+++ b/apps/desktop/src/components/SeriesHeader.svelte
@@ -340,7 +340,13 @@
 			<div class="branch-review-section">
 				<div class="branch-action__line" style:--bg-color={lineColor}></div>
 				<div class="branch-review-container">
-					<BranchReview {projectId} stackId={stack.id} branchName={branch.name}>
+					<BranchReview
+						{projectId}
+						stackId={stack.id}
+						branchName={branch.name}
+						prNumber={branch.prNumber || undefined}
+						reviewId={branch.reviewId || undefined}
+					>
 						{#snippet branchStatus()}
 							<BranchStatus
 								{mergedIncorrectly}

--- a/apps/desktop/src/components/StackedPullRequestCard.svelte
+++ b/apps/desktop/src/components/StackedPullRequestCard.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+	import ChecksPolling from '$components/ChecksPolling.svelte';
+	import MergeButton from '$components/MergeButton.svelte';
+	import PullRequestCard from '$components/PullRequestCard.svelte';
+	import BaseBranchService from '$lib/baseBranch/baseBranchService.svelte';
+	import { VirtualBranchService } from '$lib/branches/virtualBranchService';
+	import { DefaultForgeFactory } from '$lib/forge/forgeFactory.svelte';
+	import { StackService } from '$lib/stacks/stackService.svelte';
+	import { getContext } from '@gitbutler/shared/context';
+	import AsyncButton from '@gitbutler/ui/AsyncButton.svelte';
+	import type { MergeMethod } from '$lib/forge/interface/types';
+
+	interface Props {
+		projectId: string;
+		stackId: string;
+		branchName: string;
+		poll: boolean;
+		prNumber: number;
+	}
+
+	const { projectId, stackId, branchName, prNumber }: Props = $props();
+
+	const vbranchService = getContext(VirtualBranchService);
+	const baseBranchService = getContext(BaseBranchService);
+	const forge = getContext(DefaultForgeFactory);
+	const stackService = getContext(StackService);
+
+	// TODO: Make these props so we don't need `!`.
+	const repoService = $derived(forge.current.repoService);
+	const prService = $derived(forge.current.prService);
+
+	const branchResult = $derived(stackService.branchByName(projectId, stackId, branchName));
+	const branch = $derived(branchResult.current.data);
+	const branchDetailsResult = $derived(stackService.branchDetails(projectId, stackId, branchName));
+	const branchDetails = $derived(branchDetailsResult.current.data);
+	const isPushed = $derived(branchDetails?.pushStatus !== 'completelyUnpushed');
+	const prResult = $derived(branch?.prNumber ? prService?.get(branch?.prNumber) : undefined);
+	const pr = $derived(prResult?.current.data);
+
+	const parentResult = $derived(stackService.branchParentByName(projectId, stackId, branchName));
+	const parent = $derived(parentResult.current.data);
+	const hasParent = $derived(!!parent);
+	const parentBranchDetailsResult = $derived(
+		parent ? stackService.branchDetails(projectId, stackId, parent.name) : undefined
+	);
+	const parentBranchDetails = $derived(parentBranchDetailsResult?.current.data);
+	const parentIsPushed = $derived(parentBranchDetails?.pushStatus !== 'completelyUnpushed');
+	const childResult = $derived(stackService.branchChildByName(projectId, stackId, branchName));
+	const child = $derived(childResult.current.data);
+
+	const baseBranchResponse = $derived(baseBranchService.baseBranch(projectId));
+	const baseBranch = $derived(baseBranchResponse.current.data);
+	const baseBranchRepoResponse = $derived(baseBranchService.repo(projectId));
+	const baseBranchRepo = $derived(baseBranchRepoResponse.current.data);
+	const repoResult = $derived(repoService?.getInfo());
+	const repoInfo = $derived(repoResult?.current.data);
+
+	let shouldUpdateTargetBaseBranch = $state(false);
+	$effect(() => {
+		shouldUpdateTargetBaseBranch = repoInfo?.deleteBranchAfterMerge === false && !!child?.prNumber;
+	});
+
+	const baseIsTargetBranch = $derived.by(() => {
+		if (forge.current.name === 'gitlab') return true;
+		return pr
+			? baseBranch?.shortName === pr.baseBranch && baseBranchRepo?.hash === pr.baseRepo?.hash
+			: false;
+	});
+
+	const prUnit = $derived(prService?.unit.abbr);
+
+	let hasChecks = $state(false);
+
+	async function handleReopen() {
+		if (!pr) return;
+		await prService?.reopen(pr.number);
+	}
+
+	async function handleMerge(method: MergeMethod) {
+		if (!pr) return;
+		await prService?.merge(method, pr.number);
+
+		// In a stack, after merging, update the new bottom PR target
+		// base branch to master if necessary
+		if (baseBranch && shouldUpdateTargetBaseBranch && prService && child?.prNumber) {
+			const targetBase = baseBranch.branchName.replace(`${baseBranch.remoteName}/`, '');
+			await prService.update(child.prNumber, { targetBase });
+		}
+
+		await Promise.all([
+			baseBranchService.fetchFromRemotes(projectId),
+			vbranchService.refresh(),
+			baseBranchService.refreshBaseBranch(projectId)
+		]);
+	}
+</script>
+
+{#if pr}
+	<PullRequestCard
+		{branchName}
+		{prNumber}
+		{isPushed}
+		{hasParent}
+		{parentIsPushed}
+		{baseIsTargetBranch}
+		{hasChecks}
+		poll
+	>
+		{#snippet checks(pr)}
+			<ChecksPolling
+				{stackId}
+				branchName={pr.sourceBranch}
+				isFork={pr.fork}
+				isMerged={pr.merged}
+				bind:hasChecks
+			/>
+		{/snippet}
+		{#snippet button({ pr, mergeStatus, reopenStatus })}
+			{#if pr.state === 'open'}
+				<MergeButton
+					wide
+					{projectId}
+					disabled={mergeStatus.disabled}
+					tooltip={mergeStatus.tooltip}
+					onclick={handleMerge}
+				/>
+			{:else if !pr.merged}
+				<AsyncButton
+					kind="outline"
+					disabled={reopenStatus.disabled}
+					tooltip={reopenStatus.tooltip}
+					action={handleReopen}
+				>
+					{`Reopen ${prUnit}`}
+				</AsyncButton>
+			{/if}
+		{/snippet}
+	</PullRequestCard>
+{/if}
+
+<style lang="postcss">
+</style>

--- a/apps/desktop/src/components/StackedPullRequestCard.svelte
+++ b/apps/desktop/src/components/StackedPullRequestCard.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import ChecksPolling from '$components/ChecksPolling.svelte';
 	import MergeButton from '$components/MergeButton.svelte';
 	import PullRequestCard from '$components/PullRequestCard.svelte';
 	import BaseBranchService from '$lib/baseBranch/baseBranchService.svelte';
@@ -69,8 +68,6 @@
 
 	const prUnit = $derived(prService?.unit.abbr);
 
-	let hasChecks = $state(false);
-
 	async function handleReopen() {
 		if (!pr) return;
 		await prService?.reopen(pr.number);
@@ -103,18 +100,8 @@
 		{hasParent}
 		{parentIsPushed}
 		{baseIsTargetBranch}
-		{hasChecks}
 		poll
 	>
-		{#snippet checks(pr)}
-			<ChecksPolling
-				{stackId}
-				branchName={pr.sourceBranch}
-				isFork={pr.fork}
-				isMerged={pr.merged}
-				bind:hasChecks
-			/>
-		{/snippet}
 		{#snippet button({ pr, mergeStatus, reopenStatus })}
 			{#if pr.state === 'open'}
 				<MergeButton

--- a/apps/desktop/src/components/v3/BranchListingSidebarEntry.svelte
+++ b/apps/desktop/src/components/v3/BranchListingSidebarEntry.svelte
@@ -14,7 +14,7 @@
 		projectId: string;
 		branchListing: BranchListing;
 		prs: PullRequest[];
-		onclick: (listing: BranchListing) => void;
+		onclick: (args: { listing: BranchListing; pr?: PullRequest }) => void;
 	}
 
 	const { projectId, branchListing, prs, onclick }: Props = $props();
@@ -131,7 +131,7 @@
 		linesRemoved: branchListingDetails.linesRemoved
 	}}
 	onFirstSeen={() => (hasBeenSeen = true)}
-	onclick={() => onclick(branchListing)}
+	onclick={() => onclick({ listing: branchListing, pr: prs.at(0) })}
 	{selected}
 	{avatars}
 />

--- a/apps/desktop/src/components/v3/BranchView.svelte
+++ b/apps/desktop/src/components/v3/BranchView.svelte
@@ -91,7 +91,13 @@
 
 			{#if hasCommits}
 				<BranchDetails {branch}>
-					<BranchReview {stackId} {projectId} branchName={branch.name} />
+					<BranchReview
+						{stackId}
+						{projectId}
+						branchName={branch.name}
+						prNumber={branch.prNumber || undefined}
+						reviewId={branch.reviewId || undefined}
+					/>
 				</BranchDetails>
 			{:else}
 				<div class="branch-view__empty-state">

--- a/apps/desktop/src/components/v3/BranchesView.svelte
+++ b/apps/desktop/src/components/v3/BranchesView.svelte
@@ -89,7 +89,8 @@
 									if (listing.stack) {
 										branchesSelection.set({
 											stackId: listing.stack.id,
-											branchName: listing.stack.branches.at(0)
+											branchName: listing.stack.branches.at(0),
+											prNumber: pr?.number
 										});
 									} else {
 										branchesSelection.set({

--- a/apps/desktop/src/components/v3/BranchesView.svelte
+++ b/apps/desktop/src/components/v3/BranchesView.svelte
@@ -76,7 +76,7 @@
 								}
 							: undefined}
 						onclick={() => {
-							branchesSelection.set({ branchName: baseBranch.branchName });
+							branchesSelection.set({ branchName: baseBranch.shortName });
 						}}
 					/>
 				</BranchesListGroup>
@@ -85,14 +85,17 @@
 						{#if sidebarEntrySubject.type === 'branchListing'}
 							<BranchListingSidebarEntry
 								{projectId}
-								onclick={(listing) => {
+								onclick={({ listing, pr }) => {
 									if (listing.stack) {
 										branchesSelection.set({
 											stackId: listing.stack.id,
 											branchName: listing.stack.branches.at(0)
 										});
 									} else {
-										branchesSelection.set({ branchName: listing.name });
+										branchesSelection.set({
+											branchName: listing.name,
+											prNumber: pr?.number
+										});
 									}
 								}}
 								branchListing={sidebarEntrySubject.subject}
@@ -126,11 +129,12 @@
 						{projectId}
 						branchName={current.branchName}
 						stackId={current.stackId}
+						prNumber={current.prNumber}
 					/>
 				{/if}
 			</div>
 			<div class="branch-details" bind:this={rightDiv} style:width={rightWidth.current + 'rem'}>
-				{#if current.branchName === baseBranch.branchName}
+				{#if current.branchName === baseBranch.shortName}
 					<ReduxResult {projectId} result={baseBranchResult.current}>
 						{#snippet children(baseBranch)}
 							{@const branchName = baseBranch.branchName}

--- a/apps/desktop/src/components/v3/CanPublishReviewPlugin.svelte
+++ b/apps/desktop/src/components/v3/CanPublishReviewPlugin.svelte
@@ -6,31 +6,29 @@
 
 	type Props = {
 		projectId: string;
-		stackId: string;
+		stackId?: string;
 		branchName: string | undefined;
+		prNumber?: number;
+		reviewId?: string;
 	};
 
-	const { projectId, stackId, branchName }: Props = $props();
+	const { projectId, stackId, branchName, prNumber, reviewId }: Props = $props();
 
 	const forge = getContext(DefaultForgeFactory);
 	const stackService = getContext(StackService);
 	const stackPublishingService = getContext(StackPublishingService);
 
 	const branch = $derived(
-		branchName ? stackService.branchByName(projectId, stackId, branchName) : undefined
+		stackId && branchName ? stackService.branchByName(projectId, stackId, branchName) : undefined
 	);
 
 	const commits = $derived(
-		branchName ? stackService.commits(projectId, stackId, branchName) : undefined
+		stackId && branchName ? stackService.commits(projectId, stackId, branchName) : undefined
 	);
 	const branchEmpty = $derived(commits?.current.data ? commits.current.data.length === 0 : false);
-	const [prNumber, reviewId, name] = $derived(
-		branch?.current.data
-			? [branch.current.data.prNumber, branch.current.data.reviewId, branch.current.data.name]
-			: [null, null, undefined]
-	);
+	const name = $derived(branch?.current.data ? branch.current.data.name : undefined);
 	const prService = $derived(forge.current.prService);
-	const prResult = $derived(prNumber !== null ? prService?.get(prNumber) : undefined);
+	const prResult = $derived(prNumber ? prService?.get(prNumber) : undefined);
 	const pr = $derived(prResult?.current.data);
 
 	const canPublish = stackPublishingService.canPublish;

--- a/apps/desktop/src/components/v3/UnappliedBranchView.svelte
+++ b/apps/desktop/src/components/v3/UnappliedBranchView.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import PullRequestCard from '$components/PullRequestCard.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
 	import BranchDetails from '$components/v3/BranchDetails.svelte';
 	import ChangedFiles from '$components/v3/ChangedFiles.svelte';
@@ -14,9 +15,10 @@
 		projectId: string;
 		branchName: string;
 		stackId?: string;
+		prNumber?: number;
 	}
 
-	const { projectId, stackId, branchName }: Props = $props();
+	const { projectId, stackId, branchName, prNumber }: Props = $props();
 
 	const [stackService] = inject(StackService);
 
@@ -36,6 +38,7 @@
 	{#snippet children(branch, { stackId, projectId })}
 		{@const hasCommits = branch.commits.length > 0}
 		{@const remoteTrackingBranch = branch.remoteTrackingBranch}
+		{@const preferredPrNumber = branch.prNumber || prNumber}
 		<Drawer {projectId} {stackId}>
 			{#snippet header()}
 				<div class="branch__header">
@@ -69,9 +72,11 @@
 				/>
 			{/snippet}
 
-			{#if hasCommits}
-				<BranchDetails {branch} />
-			{/if}
+			<BranchDetails {branch}>
+				{#if preferredPrNumber}
+					<PullRequestCard {branchName} prNumber={preferredPrNumber} />
+				{/if}
+			</BranchDetails>
 
 			{#snippet filesSplitView()}
 				<ReduxResult {projectId} result={changesResult.current}>

--- a/apps/desktop/src/components/v3/UnappliedBranchView.svelte
+++ b/apps/desktop/src/components/v3/UnappliedBranchView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import PullRequestCard from '$components/PullRequestCard.svelte';
+	import BranchReview from '$components/BranchReview.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
 	import BranchDetails from '$components/v3/BranchDetails.svelte';
 	import ChangedFiles from '$components/v3/ChangedFiles.svelte';
@@ -74,7 +74,14 @@
 
 			<BranchDetails {branch}>
 				{#if preferredPrNumber}
-					<PullRequestCard {branchName} prNumber={preferredPrNumber} />
+					<!-- TODO(mattias): Use pr number from branch. -->
+					<BranchReview
+						{stackId}
+						{projectId}
+						{prNumber}
+						branchName={branch.name}
+						reviewId={branch.reviewId || undefined}
+					/>
 				{/if}
 			</BranchDetails>
 

--- a/apps/desktop/src/lib/forge/github/githubChecksMonitor.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubChecksMonitor.svelte.ts
@@ -15,10 +15,10 @@ export class GitHubChecksMonitor implements ChecksService {
 		this.api = injectEndpoints(gitHubApi);
 	}
 
-	get(stackId: string, branchName: string, options?: QueryOptions) {
+	get(branchName: string, options?: QueryOptions) {
 		const result = $derived(
 			this.api.endpoints.listChecks.useQuery(
-				{ stackId, ref: branchName },
+				{ ref: branchName },
 				{
 					transform: (result) => parseChecks(result),
 					...options
@@ -62,7 +62,7 @@ function parseChecks(data: ChecksResult): ChecksStatus | null {
 function injectEndpoints(api: GitHubApi) {
 	return api.injectEndpoints({
 		endpoints: (build) => ({
-			listChecks: build.query<ChecksResult, { stackId: string; ref: string }>({
+			listChecks: build.query<ChecksResult, { ref: string }>({
 				queryFn: async ({ ref }, api) =>
 					await ghQuery({
 						domain: 'checks',
@@ -72,7 +72,7 @@ function injectEndpoints(api: GitHubApi) {
 							ref
 						}
 					}),
-				providesTags: (_result, _error, args) => [...providesItem(ReduxTag.Checks, args.stackId)]
+				providesTags: (_result, _error, args) => [...providesItem(ReduxTag.Checks, args.ref)]
 			})
 		})
 	});

--- a/apps/desktop/src/lib/forge/github/githubPrService.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubPrService.svelte.ts
@@ -20,6 +20,7 @@ import type { GitHubApi } from '$lib/state/clientState.svelte';
 import type { StartQueryActionCreatorOptions } from '@reduxjs/toolkit/query';
 
 export class GitHubPrService implements ForgePrService {
+	readonly unit = { name: 'Pull request', abbr: 'PR', symbol: '#' };
 	loading = writable(false);
 	private api: ReturnType<typeof injectEndpoints>;
 

--- a/apps/desktop/src/lib/forge/gitlab/gitlabPrService.svelte.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlabPrService.svelte.ts
@@ -16,6 +16,7 @@ import type { GitLabApi } from '$lib/state/clientState.svelte';
 import type { StartQueryActionCreatorOptions } from '@reduxjs/toolkit/query';
 
 export class GitLabPrService implements ForgePrService {
+	readonly unit = { name: 'Merge request', abbr: 'MR', symbol: '!' };
 	loading = writable(false);
 	private api: ReturnType<typeof injectEndpoints>;
 

--- a/apps/desktop/src/lib/forge/interface/forgeChecksMonitor.ts
+++ b/apps/desktop/src/lib/forge/interface/forgeChecksMonitor.ts
@@ -2,5 +2,5 @@ import type { ChecksStatus } from '$lib/forge/interface/types';
 import type { QueryOptions, ReactiveResult } from '$lib/state/butlerModule';
 
 export interface ChecksService {
-	get(stackId: string, branch: string, options?: QueryOptions): ReactiveResult<ChecksStatus | null>;
+	get(branch: string, options?: QueryOptions): ReactiveResult<ChecksStatus | null>;
 }

--- a/apps/desktop/src/lib/forge/interface/forgePrService.ts
+++ b/apps/desktop/src/lib/forge/interface/forgePrService.ts
@@ -9,6 +9,7 @@ import type { StartQueryActionCreatorOptions } from '@reduxjs/toolkit/query';
 import type { Writable } from 'svelte/store';
 
 export interface ForgePrService {
+	readonly unit: { name: string; abbr: string; symbol: string };
 	loading: Writable<boolean>;
 	get(
 		prNumber: number,


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#1Lly1xURn`](https://cloud.staging.gitbutler.com/mtsgrd/gitbutler/reviews/1Lly1xURn)

**Make stack id optional for pull request card**


This way we can show them for unapplied branches.

2 commit series (version 3)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 2/2 | [Enable butler review without stack id](https://cloud.staging.gitbutler.com/mtsgrd/gitbutler/reviews/1Lly1xURn/commit/34652df5-c755-4b89-9a43-d9c65326d1a7) | ⏳ |  |
| 1/2 | [Make stack id optional for pull request card](https://cloud.staging.gitbutler.com/mtsgrd/gitbutler/reviews/1Lly1xURn/commit/6cee0ede-f742-47e9-88e7-d843247bf86f) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://cloud.staging.gitbutler.com/mtsgrd/gitbutler/reviews/1Lly1xURn)_
<!-- GitButler Review Footer Boundary Bottom -->
