### PR TITLE
fix-committing-to-second-empty-stack

### DIFF
--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -111,6 +111,8 @@ impl BranchManager<'_> {
         vb_state.set_stack(branch.clone())?;
         self.ctx.add_branch_reference(&branch)?;
 
+        update_workspace_commit(&vb_state, self.ctx)?;
+
         Ok(branch)
     }
 

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -81,7 +81,6 @@ pub(crate) fn get_workspace_head(ctx: &CommandContext) -> Result<git2::Oid> {
     let mut heads: Vec<git2::Commit<'_>> = stacks
         .iter()
         .filter_map(|stack| stack.head(&gix_repo).ok())
-        .filter(|h| h != &target.sha.to_gix())
         .filter_map(|h| repo.find_commit(h.to_git2()).ok())
         .collect();
 


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#7E9CGZzba`](https://gitbutler.com/cto/gitbutler-client-d443/reviews/7E9CGZzba)

**fix-committing-to-second-empty-stack**


2 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 2/2 | [Update workspace commit after creating empty branch](https://gitbutler.com/cto/gitbutler-client-d443/reviews/7E9CGZzba/commit/508a33e1-2483-4d4a-847e-79fe28cf8cda) | ⏳ |  |
| 1/2 | [Don't filter out heads that are the target sha](https://gitbutler.com/cto/gitbutler-client-d443/reviews/7E9CGZzba/commit/c7c23c53-4fc8-4a49-a953-4be7d186c7a4) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/cto/gitbutler-client-d443/reviews/7E9CGZzba)_
<!-- GitButler Review Footer Boundary Bottom -->
