### PR TITLE
feat(branches): improve last commit display in CurrentOriginCard

### DIFF
--- a/apps/desktop/src/components/v3/BranchesView.svelte
+++ b/apps/desktop/src/components/v3/BranchesView.svelte
@@ -65,11 +65,11 @@
 				<BranchesListGroup title="Current workspace target">
 					<!-- TODO: We need an API for `commitsCount`! -->
 					<CurrentOriginCard
-						originName="origin/master"
+						originName={baseBranch.branchName}
 						commitsAmount={13140}
 						lastCommit={lastCommit
 							? {
-									author: lastCommit.author.name || lastCommit.author.email,
+									author: lastCommit.author,
 									ago: getTimeAgo(lastCommit.createdAt, true),
 									branch: baseBranch.shortName,
 									sha: lastCommit.id.slice(0, 7)

--- a/apps/desktop/src/components/v3/branchesPage/CurrentOriginCard.svelte
+++ b/apps/desktop/src/components/v3/branchesPage/CurrentOriginCard.svelte
@@ -2,15 +2,23 @@
 	import BranchesCardTemplate from '$components/v3/branchesPage/BranchesCardTemplate.svelte';
 	import SeriesLabelsRow from '@gitbutler/ui/SeriesLabelsRow.svelte';
 	import Avatar from '@gitbutler/ui/avatar/Avatar.svelte';
+	import type { Author } from '$lib/commits/commit';
 
 	interface Props {
 		originName: string;
 		commitsAmount: number;
-		lastCommit?: { author?: string; ago: string; branch: string; sha: string };
+		lastCommit?: { author: Author; ago: string; branch: string; sha: string };
 		onclick: () => void;
 	}
 
 	const { originName, commitsAmount, lastCommit, onclick }: Props = $props();
+
+	const authorName = $derived(lastCommit?.author.name ?? lastCommit?.author.email ?? 'Unknown');
+	const authorAvatar = $derived(lastCommit?.author.gravatarUrl ?? '');
+
+	const fromOtherBranch = $derived(
+		lastCommit && originName.endsWith(lastCommit.branch) ? '' : `from ${lastCommit?.branch}`
+	);
 </script>
 
 <BranchesCardTemplate {onclick}>
@@ -18,15 +26,12 @@
 		<SeriesLabelsRow origin series={[originName]} />
 
 		<button type="button" class="workspace-target-card__about">
-			<Avatar
-				size="medium"
-				tooltip="origin"
-				srcUrl="https://avatars.githubusercontent.com/u/1?v=4"
-			/>
+			<Avatar size="medium" tooltip={authorName} srcUrl={authorAvatar} />
 			{#if lastCommit}
 				<p class="text-12 truncate workspace-target-card__text">
-					{lastCommit.author}
-					{lastCommit.ago} ago from {lastCommit.branch}
+					{authorName}
+					{lastCommit.ago}
+					{fromOtherBranch}
 				</p>
 			{/if}
 		</button>


### PR DESCRIPTION
Update CurrentOriginCard to use detailed author info of a stringDisplay author name and avatar dynamically based on last commit data.
Show branch origin context only when last commit is from a different branch.
Pass baseBranch.branchName as originName for accurate workspace target info.