### PR TITLE
improvements to locking information retrieval

### DIFF
--- a/apps/desktop/src/lib/dependencies/dependencies.ts
+++ b/apps/desktop/src/lib/dependencies/dependencies.ts
@@ -71,17 +71,19 @@ export type FileDependencies = {
 	 */
 	dependencies: HunkLocks[];
 };
-
 /**
  * Aggregates file dependencies from a collection of hunk dependencies.
  *
  * This function processes an array of `DiffDependency` objects and groups them
  * by file path, creating a list of `FileDependencies` where each file path
- * contains its associated hunk and lock dependencies.
+ * contains its associated hunk and lock dependencies. Additionally, it returns
+ * a list of all unique file paths encountered during the aggregation process.
  *
  * @param hunkDependencies - An object containing the diffs to process.
- * @returns An array of `FileDependencies` where each entry represents a file
- *          and its associated hunk and lock dependencies.
+ * @returns A tuple where:
+ *          - The first element is an array of unique file paths.
+ *          - The second element is an array of `FileDependencies` where each
+ *            entry represents a file and its associated hunk and lock dependencies.
  *
  * @example
  * const hunkDependencies = {
@@ -94,23 +96,29 @@ export type FileDependencies = {
  * const result = aggregateFileDependencies(hunkDependencies);
  * // result:
  * // [
- * //   {
- * //     path: 'file1.ts',
- * //     dependencies: [
- * //       { hunk: 'hunk1', locks: ['lock1'] },
- * //       { hunk: 'hunk3', locks: ['lock3'] }
- * //     ]
- * //   },
- * //   {
- * //     path: 'file2.ts',
- * //     dependencies: [
- * //       { hunk: 'hunk2', locks: ['lock2'] }
- * //     ]
- * //   }
+ * //   ['file1.ts', 'file2.ts'],
+ * //   [
+ * //     {
+ * //       path: 'file1.ts',
+ * //       dependencies: [
+ * //         { hunk: 'hunk1', locks: ['lock1'] },
+ * //         { hunk: 'hunk3', locks: ['lock3'] }
+ * //       ]
+ * //     },
+ * //     {
+ * //       path: 'file2.ts',
+ * //       dependencies: [
+ * //         { hunk: 'hunk2', locks: ['lock2'] }
+ * //       ]
+ * //     }
+ * //   ]
  * // ]
  */
-export function aggregateFileDependencies(hunkDependencies: HunkDependencies) {
-	return hunkDependencies.diffs.reduce<FileDependencies[]>(
+export function aggregateFileDependencies(
+	hunkDependencies: HunkDependencies
+): [string[], FileDependencies[]] {
+	const filePaths: string[] = [];
+	const fileDependencies = hunkDependencies.diffs.reduce<FileDependencies[]>(
 		(acc: FileDependencies[], diff: DiffDependency) => {
 			const [path, hunk, locks] = diff;
 			const exisitingDependency = acc.find((dep) => dep.path === path);
@@ -121,6 +129,8 @@ export function aggregateFileDependencies(hunkDependencies: HunkDependencies) {
 				});
 				return acc;
 			}
+
+			filePaths.push(path);
 
 			return [
 				...acc,
@@ -137,4 +147,6 @@ export function aggregateFileDependencies(hunkDependencies: HunkDependencies) {
 		},
 		[]
 	);
+
+	return [filePaths, fileDependencies];
 }

--- a/apps/desktop/src/lib/hunks/hunk.ts
+++ b/apps/desktop/src/lib/hunks/hunk.ts
@@ -1,3 +1,4 @@
+import { memoize } from '@gitbutler/shared/memoization';
 import {
 	lineIdKey,
 	parseHunk,
@@ -10,7 +11,6 @@ import { Transform, Type } from 'class-transformer';
 import type { HunkLocks } from '$lib/dependencies/dependencies';
 import type { Prettify } from '@gitbutler/shared/utils/typeUtils';
 import 'reflect-metadata';
-
 export class RemoteHunk {
 	diff!: string;
 	hash?: string;
@@ -153,6 +153,8 @@ function lineType(line: LineId): DeltaLineType | undefined {
 	return undefined;
 }
 
+const memoizedParseHunk = memoize(parseHunk);
+
 /**
  * Group the selected lines of a diff for the backend.
  *
@@ -165,7 +167,7 @@ export function extractLineGroups(lineIds: LineId[], diff: string): [DeltaLineGr
 	const lineGroups: DeltaLineGroup[] = [];
 	let currentGroup: DeltaLineGroup | undefined = undefined;
 	const lineKeys = new Set(lineIds.map((lineId) => lineIdKey(lineId)));
-	const parsedHunk = parseHunk(diff);
+	const parsedHunk = memoizedParseHunk(diff);
 
 	for (const section of parsedHunk.contentSections) {
 		for (const line of section.lines) {
@@ -349,7 +351,7 @@ export function getLineLocks(
 	}
 
 	const lineLocks: LineLock[] = [];
-	const parsedHunk = parseHunk(hunk.diff);
+	const parsedHunk = memoizedParseHunk(hunk.diff);
 
 	const locksContained = locks.filter((lock) => hunkContainsHunk(hunk, lock.hunk));
 

--- a/packages/shared/src/lib/memoization.test.ts
+++ b/packages/shared/src/lib/memoization.test.ts
@@ -1,0 +1,64 @@
+import { memoize } from '$lib/memoization';
+import { describe, it, expect, vi } from 'vitest';
+
+describe('memoize', () => {
+	it('should return the same result for the same arguments', () => {
+		const fn = vi.fn((a: number, b: number) => a + b);
+		const memoized = memoize(fn);
+
+		expect(memoized(1, 2)).toBe(3);
+		expect(memoized(1, 2)).toBe(3);
+		expect(fn).toHaveBeenCalledTimes(1);
+	});
+
+	it('should call the original function for different arguments', () => {
+		const fn = vi.fn((a: number, b: number) => a * b);
+		const memoized = memoize(fn);
+
+		expect(memoized(2, 3)).toBe(6);
+		expect(memoized(3, 2)).toBe(6);
+		expect(fn).toHaveBeenCalledTimes(2);
+	});
+
+	it('should work with functions returning objects', () => {
+		const fn = vi.fn((x: number) => ({ value: x }));
+		const memoized = memoize(fn);
+
+		const result1 = memoized(5);
+		const result2 = memoized(5);
+		expect(result1).toBe(result2);
+		expect(fn).toHaveBeenCalledTimes(1);
+	});
+
+	it('should handle no arguments', () => {
+		const fn = vi.fn(() => 42);
+		const memoized = memoize(fn);
+
+		expect(memoized()).toBe(42);
+		expect(memoized()).toBe(42);
+		expect(fn).toHaveBeenCalledTimes(1);
+	});
+
+	it('should cache based on argument values, not references', () => {
+		const fn = vi.fn((obj: { a: number }) => obj.a);
+		const memoized = memoize(fn);
+
+		expect(memoized({ a: 1 })).toBe(1);
+		expect(memoized({ a: 1 })).toBe(1);
+		expect(fn).toHaveBeenCalledTimes(1); // Because JSON.stringify({a:1}) === JSON.stringify({a:1})
+	});
+
+	it('should cache correctly for primitive and array arguments', () => {
+		const fn = vi.fn((arr: number[]) => arr.reduce((a, b) => a + b, 0));
+		const memoized = memoize(fn);
+
+		const arr = [1, 2, 3];
+		expect(memoized(arr)).toBe(6);
+		expect(memoized(arr)).toBe(6);
+		expect(fn).toHaveBeenCalledTimes(1);
+		expect(memoized([1, 2, 3])).toBe(6);
+		expect(fn).toHaveBeenCalledTimes(1);
+		expect(memoized([1, 2, 3, 4])).toBe(10);
+		expect(fn).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/shared/src/lib/memoization.ts
+++ b/packages/shared/src/lib/memoization.ts
@@ -1,0 +1,17 @@
+/**
+ * Memoizes a function to cache its results based on the arguments passed.
+ */
+export function memoize<T extends (...args: any[]) => any>(fn: T): T {
+	const cache = new Map<string, ReturnType<T>>();
+
+	return function (...args: Parameters<T>): ReturnType<T> {
+		const key = JSON.stringify(args);
+		if (cache.has(key)) {
+			return cache.get(key)!;
+		}
+
+		const result = fn(...args);
+		cache.set(key, result);
+		return result;
+	} as T;
+}


### PR DESCRIPTION
## 🧢 Changes

- Modified `aggregateFileDependencies` to return both unique file paths and aggregated dependencies.
- Updated `dependencyService` to handle the new response format with separate file paths and dependencies.
- Added a memoization utility function with comprehensive tests.
- Refactored `parseHunk` usage to utilize the memoized version for improved performance and cleaner code.

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->