### PR TITLE
fixes for splitmessage & commit shortcut in v2

### DIFF
--- a/apps/desktop/src/components/CommitMessageInput.svelte
+++ b/apps/desktop/src/components/CommitMessageInput.svelte
@@ -187,7 +187,11 @@
 			return;
 		}
 
-		if (commit && (e.ctrlKey || e.metaKey) && e.key === KeyName.Enter) commit();
+		if (commit && (e.ctrlKey || e.metaKey) && e.key === KeyName.Enter) {
+			commit();
+			return;
+		}
+
 		if (e.key === KeyName.Enter) {
 			e.preventDefault();
 

--- a/apps/desktop/src/lib/utils/commitMessage.test.ts
+++ b/apps/desktop/src/lib/utils/commitMessage.test.ts
@@ -57,4 +57,33 @@ I fancy coffee`;
 
 		expect(splitMessage(message)).toMatchObject({ title, description });
 	});
+
+	test('Only the new-lines in the beginning and end of the description are removed', () => {
+		const message = `Fixed all the bugs!
+
+
+
+
+
+Broke something else
+
+Made it better
+Got a dog
+
+I fancy coffee   
+
+
+
+`;
+
+		const title = 'Fixed all the bugs!';
+		const description = `Broke something else
+
+Made it better
+Got a dog
+
+I fancy coffee   `;
+
+		expect(splitMessage(message)).toMatchObject({ title, description });
+	});
 });

--- a/apps/desktop/src/lib/utils/commitMessage.ts
+++ b/apps/desktop/src/lib/utils/commitMessage.ts
@@ -1,10 +1,49 @@
+/**
+ * Splits a commit message into a title and description.
+ *
+ * The title is the first line of the message, and the description is everything from the
+ * next non-emptyline till the last non-empty line.
+ *
+ * Only the title will be trimmed, the description will keep its original formatting.
+ */
 export function splitMessage(message: string) {
-	const splitIndex = message.indexOf('\n');
-	const title = splitIndex !== -1 ? message.substring(0, splitIndex) : message;
-	const description = splitIndex !== -1 ? message.substring(splitIndex + 1) : '';
+	const lines = message.split('\n');
+	if (lines.length === 0) {
+		return { title: '', description: '' };
+	}
+
+	if (lines.length === 1) {
+		return { title: message.trim(), description: '' };
+	}
+
+	const title = lines[0]!.trim();
+	let description: string = '';
+
+	// Search for the first and last non-empty lines
+	// to determine the description.
+
+	let firstNonEmptyLine = -1;
+	let lastNonEmptyLine = -1;
+	for (let i = 1; i < lines.length; i++) {
+		const line = lines[i]!.trim();
+		if (line.length === 0) {
+			continue;
+		}
+
+		if (firstNonEmptyLine === -1) {
+			firstNonEmptyLine = i;
+		}
+		lastNonEmptyLine = i;
+	}
+
+	if (firstNonEmptyLine !== -1 && lastNonEmptyLine !== -1) {
+		description = lines.slice(firstNonEmptyLine, lastNonEmptyLine + 1).join('\n');
+	} else {
+		description = lines.slice(1).join('\n');
+	}
 
 	return {
-		title: title.trim(),
-		description: description.trim()
+		title,
+		description
 	};
 }


### PR DESCRIPTION
- Improved `splitMessage` to trim only the title while preserving the original description formatting, including internal newlines and spacing.
- Added a test to verify that the description's formatting remains unchanged.
- Fixed the commit message input to prevent further event handling after committing with Ctrl/Cmd+Enter, ensuring the commit action executes only once.

fixes https://github.com/gitbutlerapp/gitbutler/issues/5805