### PR TITLE
refactor(error): rename TitledError to NamedError for clarity

### DIFF
--- a/apps/desktop/src/hooks.client.ts
+++ b/apps/desktop/src/hooks.client.ts
@@ -1,4 +1,4 @@
-import { isTitledError } from '$lib/error/parser';
+import { isNamedError } from '$lib/error/parser';
 import { showError } from '$lib/notifications/toasts';
 import { captureException } from '@sentry/sveltekit';
 import { error as logErrorToFile } from '@tauri-apps/plugin-log';
@@ -34,8 +34,8 @@ function logError(error: unknown) {
 			}
 		});
 
-		if (isTitledError(error)) {
-			showError(error.title, error.error);
+		if (isNamedError(error)) {
+			showError(error.name, error.error);
 		} else {
 			showError('Unhandled exception', error);
 		}

--- a/apps/desktop/src/lib/error/parser.ts
+++ b/apps/desktop/src/lib/error/parser.ts
@@ -23,7 +23,7 @@ export function isParsedError(something: unknown): something is ParsedError {
 }
 
 export function parseError(error: unknown): ParsedError {
-	if (isTitledError(error)) {
+	if (isNamedError(error)) {
 		return parseError(error.error);
 	}
 
@@ -74,22 +74,22 @@ export function parseError(error: unknown): ParsedError {
 	return { parsedError: JSON.stringify(error, null, 2) };
 }
 
-export type TitledError = {
-	title: string;
+export type NamedError = {
+	name: string;
 	error: unknown;
 };
 
-export function isTitledError(error: unknown): error is TitledError {
+export function isNamedError(error: unknown): error is NamedError {
 	return (
 		typeof error === 'object' &&
 		error !== null &&
-		'title' in error &&
-		typeof error.title === 'string' &&
-		error.title.length > 0 &&
+		'name' in error &&
+		typeof error.name === 'string' &&
+		error.name.length > 0 &&
 		(error as any).error !== undefined
 	);
 }
 
-export function createTitledError(title: string, error: unknown): TitledError {
-	return { title, error };
+export function createNamedError(name: string, error: unknown): NamedError {
+	return { name, error };
 }

--- a/apps/desktop/src/lib/state/backendQuery.ts
+++ b/apps/desktop/src/lib/state/backendQuery.ts
@@ -1,7 +1,7 @@
 import { PostHogWrapper } from '$lib/analytics/posthog';
 import { isTauriCommandError, type TauriCommandError } from '$lib/backend/ipc';
 import { Tauri } from '$lib/backend/tauri';
-import { createTitledError, parseError } from '$lib/error/parser';
+import { createNamedError, parseError } from '$lib/error/parser';
 import { type BaseQueryApi, type QueryReturnValue } from '@reduxjs/toolkit/query';
 
 export type TauriBaseQueryFn = typeof tauriBaseQuery;
@@ -28,7 +28,7 @@ export async function tauriBaseQuery(
 			if (posthog && args.actionName) {
 				const title = `${args.actionName} Failed`;
 				posthog.capture(title, { error });
-				throw createTitledError(title, error);
+				throw createNamedError(title, error);
 			}
 		}
 
@@ -36,10 +36,10 @@ export async function tauriBaseQuery(
 		if (posthog && args.actionName) {
 			const title = `${args.actionName} Failed`;
 			posthog.capture(title, { error: newError });
-			throw createTitledError(title, newError);
+			throw createNamedError(title, newError);
 		}
 
-		throw createTitledError(title, newError);
+		throw createNamedError(title, newError);
 	}
 }
 


### PR DESCRIPTION
Rename all instances of TitledError to NamedError, changing the property
from "title" to "name" to better reflect the error structure.

The 'title' property seems to be swallowed by the error serialization by RTK