### PR TITLE
POC: Add information about file locking to the file list

### DIFF
--- a/apps/desktop/src/components/v3/FileDependenciesPlugin.svelte
+++ b/apps/desktop/src/components/v3/FileDependenciesPlugin.svelte
@@ -1,0 +1,98 @@
+<script lang="ts" module>
+	import type { FileDependencies } from '$lib/dependencies/dependencies';
+
+	export type FileDependencyData =
+		| {
+				type: 'multiple';
+				data: Map<string, FileDependencies>;
+		  }
+		| {
+				type: 'single';
+				data: FileDependencies;
+		  };
+</script>
+
+<script lang="ts">
+	import DependencyService from '$lib/dependencies/dependencyService.svelte';
+	import { StackService } from '$lib/stacks/stackService.svelte';
+	import { WorktreeService } from '$lib/worktree/worktreeService.svelte';
+	import { inject } from '@gitbutler/shared/context';
+
+	type BaseProps = {
+		type: 'single' | 'multiple';
+		projectId: string;
+		isCommitting: boolean;
+	};
+
+	type SingleFile = BaseProps & {
+		type: 'single';
+		filePath: string;
+	};
+
+	type MultipleFiles = BaseProps & {
+		type: 'multiple';
+		filePaths: string[];
+	};
+
+	type Props = SingleFile | MultipleFiles;
+
+	const props: Props = $props();
+
+	const [worktreeService, dependencyService, stackService] = inject(
+		WorktreeService,
+		DependencyService,
+		StackService
+	);
+
+	const stacks = $derived(stackService.stacks(props.projectId));
+	const hasMultipleStacks = $derived(stacks.current.data && stacks.current.data.length > 1);
+
+	const changesTimestamp = $derived(worktreeService.getChangesTimeStamp(props.projectId));
+	// For now, only show the file dependencies when committing, and there are multiple stacks applied
+	const canFetchDependencies = $derived(props.isCommitting && hasMultipleStacks);
+
+	const fileDependencies = $derived.by(() => {
+		// Derivation of the dependencies depends on the timestamp of the last time the file changes were updated.
+		if (changesTimestamp.current === undefined || !canFetchDependencies) return undefined;
+
+		switch (props.type) {
+			case 'single':
+				return dependencyService.fileDependencies(
+					props.projectId,
+					changesTimestamp.current,
+					props.filePath
+				);
+			case 'multiple':
+				return dependencyService.filesDependencies(
+					props.projectId,
+					changesTimestamp.current,
+					props.filePaths
+				);
+		}
+	});
+
+	export const imports = {
+		get deps(): FileDependencyData | undefined {
+			const data = fileDependencies?.current.data;
+			if (data === undefined) return undefined;
+
+			if (props.type === 'single' && !(data instanceof Map)) {
+				return {
+					type: 'single',
+					data
+				};
+			}
+			if (props.type === 'multiple' && data instanceof Map) {
+				return {
+					type: 'multiple',
+					data
+				};
+			}
+
+			// If the data is not in the expected format, throw an error.
+			throw new Error(
+				`Expected file dependencies to be in the format of ${props.type}, but got ${typeof data}`
+			);
+		}
+	};
+</script>

--- a/apps/desktop/src/components/v3/FileList.svelte
+++ b/apps/desktop/src/components/v3/FileList.svelte
@@ -9,6 +9,7 @@
 	import { chunk } from '$lib/utils/array';
 	import { sortLikeFileTree } from '$lib/worktree/changeTree';
 	import { getContext } from '@gitbutler/shared/context';
+	import type { FileDependencies } from '$lib/dependencies/dependencies';
 	import type { TreeChange } from '$lib/hunks/change';
 	import type { SelectionId } from '$lib/selection/key';
 
@@ -20,9 +21,18 @@
 		showCheckboxes?: boolean;
 		selectionId: SelectionId;
 		listActive: boolean;
+		fileDependencies?: Map<string, FileDependencies>;
 	};
 
-	const { projectId, changes, listMode, selectionId, showCheckboxes, listActive }: Props = $props();
+	const {
+		projectId,
+		changes,
+		listMode,
+		selectionId,
+		showCheckboxes,
+		listActive,
+		fileDependencies
+	}: Props = $props();
 
 	let currentDisplayIndex = $state(0);
 
@@ -65,6 +75,7 @@
 		onclick={(e) => {
 			selectFilesInList(e, change, visibleFiles, idSelection, true, idx, selectionId);
 		}}
+		locked={fileDependencies?.has(change.path)}
 	/>
 {/snippet}
 

--- a/apps/desktop/src/components/v3/FileListItemWrapper.svelte
+++ b/apps/desktop/src/components/v3/FileListItemWrapper.svelte
@@ -34,6 +34,7 @@
 		onclick?: (e: MouseEvent) => void;
 		onkeydown?: (e: KeyboardEvent) => void;
 		onCloseClick?: () => void;
+		locked?: boolean;
 	}
 
 	const {

--- a/apps/desktop/src/lib/dependencies/dependencies.ts
+++ b/apps/desktop/src/lib/dependencies/dependencies.ts
@@ -1,4 +1,6 @@
+import type { TreeChange } from '$lib/hunks/change';
 import type { DiffHunk } from '$lib/hunks/hunk';
+import type { SelectedFile } from '$lib/selection/changeSelection.svelte';
 
 export type CalculationError = {
 	/**
@@ -149,4 +151,66 @@ export function aggregateFileDependencies(
 	);
 
 	return [filePaths, fileDependencies];
+}
+
+/**
+ * Determine if a hunk is locked to a some other stack.
+ */
+function hunkIsLockedToOtherStack(fileDependency: HunkLocks[], currentStack: string): boolean {
+	return fileDependency.some((dependency) =>
+		dependency.locks.some((lock) => lock.stackId !== currentStack)
+	);
+}
+
+/**
+ * Retrieves a list of selectable files based on the provided changes, file dependencies, and stack ID.
+ *
+ * @param changes - An array of `TreeChange` objects representing the changes in the file tree.
+ *                  If undefined or empty, an empty array is returned.
+ * @param fileDependencies - A map where the keys are file paths and the values are `FileDependencies` objects.
+ *                           This is used to determine if a file is locked to a specific stack.
+ * @param stackId - The ID of the current stack. Will be used to determine locks to other stacks.
+ *
+ * @returns An array of `SelectedFile` objects representing the files that can be selected.
+ *          Files that are locked to other stacks are excluded from the result.
+ */
+export function getSelectableFiles(
+	changes: TreeChange[] | undefined,
+	fileDependencies: Map<string, FileDependencies> | undefined,
+	currentStack: string | undefined
+): SelectedFile[] {
+	if (!currentStack) {
+		// Should not happen, but just in case.
+		throw new Error('Current stack is undefined');
+	}
+
+	if (changes === undefined || changes.length === 0) {
+		// No changes
+		return [];
+	}
+	const selectedFiles: SelectedFile[] = [];
+
+	for (const change of changes) {
+		const fileDependency = fileDependencies?.get(change.path)?.dependencies;
+		if (
+			fileDependency &&
+			fileDependency.length > 0 &&
+			hunkIsLockedToOtherStack(fileDependency, currentStack)
+		) {
+			// The files are at least partially locked to other stacks,
+			// so we don't want to select them.
+
+			// TODO: Support partial selection of files and hunks.
+			continue;
+		}
+
+		const fullFile = {
+			path: change.path,
+			pathBytes: change.pathBytes,
+			type: 'full'
+		} as const;
+
+		selectedFiles.push(fullFile);
+	}
+	return selectedFiles;
 }

--- a/apps/desktop/src/lib/dependencies/dependencyService.svelte.ts
+++ b/apps/desktop/src/lib/dependencies/dependencyService.svelte.ts
@@ -3,7 +3,7 @@ import {
 	type FileDependencies,
 	type HunkDependencies
 } from '$lib/dependencies/dependencies';
-import { createSelectByIds } from '$lib/state/customSelectors';
+import { createSelectByIds, createSelectByIdsWithKey } from '$lib/state/customSelectors';
 import { createEntityAdapter, type EntityState } from '@reduxjs/toolkit';
 import type { BackendApi, ClientState } from '$lib/state/clientState.svelte';
 
@@ -28,8 +28,19 @@ export default class DependencyService {
 		return this.api.endpoints.dependencies.useQuery(
 			{ projectId, worktreeChangesKey },
 			{
-				transform: ({ fileDependencies }) =>
-					fileDependencySelectors.selectByIds(fileDependencies, filePaths)
+				transform: ({ fileDependencies }) => {
+					const keyedDepdendencies = fileDependencySelectors.createSelectByIdsWithKey(
+						fileDependencies,
+						filePaths
+					);
+					const dependecyMap = new Map<string, FileDependencies>();
+					for (const { key, value } of keyedDepdendencies) {
+						if (value) {
+							dependecyMap.set(key, value);
+						}
+					}
+					return dependecyMap;
+				}
 			}
 		);
 	}
@@ -68,5 +79,6 @@ const fileDependenciesAdapter = createEntityAdapter<FileDependencies, string>({
 
 const fileDependencySelectors = {
 	...fileDependenciesAdapter.getSelectors(),
-	selectByIds: createSelectByIds<FileDependencies>()
+	selectByIds: createSelectByIds<FileDependencies>(),
+	createSelectByIdsWithKey: createSelectByIdsWithKey<FileDependencies>()
 };

--- a/apps/desktop/src/lib/state/customSelectors.ts
+++ b/apps/desktop/src/lib/state/customSelectors.ts
@@ -28,6 +28,18 @@ export function createSelectByIds<T>() {
 	);
 }
 
+export function createSelectByIdsWithKey<T>() {
+	return createSelector(
+		[(state: EntityState<T, number | string>) => state, (state_, ids: string[]) => ids],
+		(state, ids) => {
+			return ids.map((id) => {
+				const entity = state.entities[id];
+				return { key: id, value: entity };
+			});
+		}
+	);
+}
+
 /**
  * The main purpose of this function is to enable selecting e.g. the
  * parent of a branch, or commit.


### PR DESCRIPTION
WIP

Right now, we don’t show files that are locked, but rather hunks and lines that are.

- We don’t have a design for displaying locked files
- We don’t whether a file is fully or only partially locked up until the point at which we load the hunks