### PR TITLE
teeny weeny fix: Make the BranchListing a type

### DIFF
--- a/apps/desktop/src/components/v3/BranchListingSidebarEntry.svelte
+++ b/apps/desktop/src/components/v3/BranchListingSidebarEntry.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import SidebarEntry from '$components/v3/SidebarEntry.svelte';
-	import { BranchListing, BranchListingDetails } from '$lib/branches/branchListing';
+	import { type BranchListing, BranchListingDetails } from '$lib/branches/branchListing';
 	import { BranchService } from '$lib/branches/branchService.svelte';
 	import { GitConfigService } from '$lib/config/gitConfigService';
 	import { UserService } from '$lib/user/userService';

--- a/apps/desktop/src/lib/branches/branchListing.ts
+++ b/apps/desktop/src/lib/branches/branchListing.ts
@@ -17,26 +17,26 @@ export type GroupedSidebarEntries = Record<
  * It is intended a summary that can be quickly retrieved and displayed in the UI.
  * For more detailed information, each branch can be queried individually for it's `BranchData`.
  */
-export class BranchListing {
+export type BranchListing = {
 	/** The name of the branch (e.g. `main`, `feature/branch`), excluding the remote name */
-	name!: string;
+	name: string;
 	/**
 	 * This is a list of remote that this branch can be found on (e.g. `origin`, `upstream` etc.).
 	 * If this branch is a local branch, this list will be empty.
 	 */
-	remotes!: string[];
+	remotes: string[];
 	/** The branch may or may not have a virtual branch associated with it */
 	stack?: StackReference | undefined;
 	/**
 	 * Timestamp in milliseconds since the branch was last updated.
 	 * This includes any commits, uncommited changes or even updates to the branch metadata (e.g. renaming).
 	 */
-	updatedAt!: string;
+	updatedAt: string;
 	/** The person who commited the head commit */
-	lastCommiter!: Author;
+	lastCommiter: Author;
 	/** Whether or not there is a local branch as part of the grouping */
-	hasLocal!: boolean;
-}
+	hasLocal: boolean;
+};
 
 /** Represents a reference to an associated virtual branch */
 export type StackReference = {


### PR DESCRIPTION
### Description

- Changed BranchListing from a value to a type for better type safety and clarity.