### PR TITLE
Don't rebase for change ids

### DIFF
--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -328,15 +328,7 @@ impl BranchManager<'_> {
             }
         }
 
-        // Do we need to rebase the branch on top of the default target?
-
-        let has_change_id = repo
-            .find_commit(stack.head_oid(&gix_repo)?.to_git2())?
-            .change_id()
-            .is_some();
-        // If the branch has no change ID for the head commit, we want to rebase it even if the base is the same
-        // This way stacking functionality which relies on change IDs will work as expected
-        if merge_base != default_target.sha || !has_change_id {
+        if merge_base != default_target.sha {
             let mut rebase_output = None;
             let new_head = if stack.allow_rebasing {
                 let gix_repo = self.ctx.gix_repo()?;


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#3TnhpHV8L`](https://gitbutler.com/cto/gitbutler-client-d443/reviews/3TnhpHV8L)

**Don't rebase for change ids**


This was relevant when we were using change ids for updating references, but we have since been enlightened and with the glory of the rebase engine, this is no longer needed.

1 commit series (version 2)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Don't rebase for change ids](https://gitbutler.com/cto/gitbutler-client-d443/reviews/3TnhpHV8L/commit/ff73d9bf-7ca7-428e-8d73-a211f2879e9a) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/cto/gitbutler-client-d443/reviews/3TnhpHV8L)_
<!-- GitButler Review Footer Boundary Bottom -->
