### PR TITLE
Use slugified name when creating new branch

### DIFF
--- a/apps/desktop/src/components/v3/stackTabs/StackTabNew.svelte
+++ b/apps/desktop/src/components/v3/stackTabs/StackTabNew.svelte
@@ -48,7 +48,7 @@
 		if (createRefType === 'stack') {
 			const stack = await createNewStack({
 				projectId,
-				branch: { name: createRefName }
+				branch: { name: slugifiedRefName }
 			});
 			// Why is there a timing thing going on here? Withou sleep you end
 			// up on stacks[0] after creating a new one.
@@ -56,17 +56,17 @@
 			goto(stackPath(projectId, stack.id));
 			createRefModal?.close();
 		} else {
-			if (!stackId || !createRefName) {
+			if (!stackId || !slugifiedRefName) {
 				// TODO: Add input validation.
 				return;
 			}
 			await createNewBranch({
 				projectId,
 				stackId,
-				request: { targetPatch: undefined, name: createRefName }
+				request: { targetPatch: undefined, name: slugifiedRefName }
 			});
 
-			uiState.stack(stackId).selection.set({ branchName: createRefName });
+			uiState.stack(stackId).selection.set({ branchName: slugifiedRefName });
 			createRefModal?.close();
 		}
 


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#0CsTC2gVo`](https://cloud.staging.gitbutler.com/mtsgrd/gitbutler/reviews/0CsTC2gVo)

**Use slugified name when creating new branch**


The commit function used to do this, but I see no reason we can't take
care of the conversion in the front end, and let the back end throw an
error if the parameter is invalid.

1 commit series (version 2)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Use slugified name when creating new branch](https://cloud.staging.gitbutler.com/mtsgrd/gitbutler/reviews/0CsTC2gVo/commit/cf501213-1f3d-4cee-98fb-49dc424f5b61) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://cloud.staging.gitbutler.com/mtsgrd/gitbutler/reviews/0CsTC2gVo)_
<!-- GitButler Review Footer Boundary Bottom -->
