### PR TITLE
fix(stack): correct heads filtering logic for archived refs

### DIFF
--- a/crates/gitbutler-stack/src/stack.rs
+++ b/crates/gitbutler-stack/src/stack.rs
@@ -786,7 +786,7 @@ impl Stack {
     }
 
     pub fn heads(&self, exclude_archived: bool) -> Vec<String> {
-        if exclude_archived {
+        if !exclude_archived {
             self.heads.iter().map(|h| h.name().clone()).collect()
         } else {
             self.heads


### PR DESCRIPTION
Invert condition in heads() to properly exclude archived refs when
exclude_archived is true. This fixes incorrect behavior where archived
heads were included despite the flag, ensuring accurate filtering.