### PR TITLE
MCP: Commit to empty stacks & type fixes

### DIFF
--- a/packages/mcp/src/shared/entities/stacks.ts
+++ b/packages/mcp/src/shared/entities/stacks.ts
@@ -1,8 +1,15 @@
 import { z } from 'zod';
 
+export const StackHeadInfoSchema = z.object({
+	name: z.string({ description: 'The name of the stack head.' }),
+	tip: z.string({ description: 'The commit ID of the tip of the stack head.' })
+});
+
 export const StackSchema = z.object({
 	id: z.string({ description: 'The unique identifier for the stack. This is a UUID.' }),
-	branchNames: z.array(z.string()),
+	heads: z.array(StackHeadInfoSchema, {
+		description: 'Information about the branches contained in the stack.'
+	}),
 	tip: z.string({ description: 'The commit ID of the tip of the stack.' })
 });
 

--- a/packages/mcp/src/tools/client/commit.ts
+++ b/packages/mcp/src/tools/client/commit.ts
@@ -46,12 +46,12 @@ function commit(params: CommitParams) {
 	}
 
 	for (const stack of stacks) {
-		if (stack.branchNames.includes(params.branch)) {
-			if (stack.branchNames.length === 1) {
+		const heads = stack.heads.map((h) => h.name);
+		if (heads.includes(params.branch)) {
+			if (heads.length === 1) {
 				// If this stack has only one branch, we can commit directly to it
 				const branchRef = getBranchRef(params.branch);
 				args.push('-s', branchRef);
-				args.push('--parent', stack.tip);
 				return executeGitButlerCommand(params.project_directory, args, undefined);
 			}
 
@@ -74,7 +74,6 @@ function commit(params: CommitParams) {
 
 			const branchRef = getBranchRef(params.branch);
 			args.push('-s', branchRef);
-			args.push('--parent', branch.tip);
 			return executeGitButlerCommand(params.project_directory, args, undefined);
 		}
 	}


### PR DESCRIPTION
- Infer reference frame stack segment when no specific stackId is provided during commit  
- Allow commits to empty branches by determining the correct commit location  
- Support passing branch names without full ref-name format in CLI  
- Remove the --parent argument from GitButler command arguments in commit.ts  
- Refactor StackSchema by adding StackHeadInfoSchema and replacing branchNames with heads array