### PR TITLE
MCP: fix the commit function & rename the cloud tools

### DIFF
--- a/packages/mcp/src/tools/chatMessages.ts
+++ b/packages/mcp/src/tools/chatMessages.ts
@@ -47,7 +47,7 @@ async function getChatMessagesForPatch(params: GetChatMessagesForPatchParams) {
 
 const TOOL_LISTINGS = [
 	{
-		name: 'get_chat_messages_for_patch',
+		name: 'cloud_get_chat_messages_for_patch',
 		description: 'Get all review chat messages for a given patch',
 		inputSchema: zodToJsonSchema(GetChatMessagesForPatchParamsSchema)
 	}
@@ -73,7 +73,7 @@ export async function getChatMesssageToolRequestHandler(
 	}
 
 	switch (toolName) {
-		case 'get_chat_messages_for_patch': {
+		case 'cloud_get_chat_messages_for_patch': {
 			const getChatMessagesParams = GetChatMessagesForPatchParamsSchema.parse(args);
 			const result = await getChatMessagesForPatch(getChatMessagesParams);
 			return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };

--- a/packages/mcp/src/tools/client/commit.ts
+++ b/packages/mcp/src/tools/client/commit.ts
@@ -1,4 +1,4 @@
-import { BaseParamsSchema, DiffSpec, getBranchRef } from './shared.js';
+import { BaseParamsSchema, DiffSpec } from './shared.js';
 import { listStackBranches, listStacks } from './status.js';
 import { executeGitButlerCommand, hasGitButlerExecutable } from '../../shared/command.js';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
@@ -8,7 +8,12 @@ import { zodToJsonSchema } from 'zod-to-json-schema';
 const CommitParamsSchema = BaseParamsSchema.extend({
 	message: z.string({ description: 'The commit message' }),
 	all: z.boolean().optional().default(false),
-	filePaths: z.array(z.string()).optional().default([]),
+	filePaths: z
+		.array(z.string(), {
+			description: 'The paths of files to commit. These have to be relative paths.'
+		})
+		.optional()
+		.default([]),
 	branch: z.string({ description: 'The branch to commit to' })
 });
 
@@ -50,8 +55,7 @@ function commit(params: CommitParams) {
 		if (heads.includes(params.branch)) {
 			if (heads.length === 1) {
 				// If this stack has only one branch, we can commit directly to it
-				const branchRef = getBranchRef(params.branch);
-				args.push('-s', branchRef);
+				args.push('-s', params.branch);
 				return executeGitButlerCommand(params.project_directory, args, undefined);
 			}
 
@@ -72,8 +76,7 @@ function commit(params: CommitParams) {
 				throw new Error(`Branch ${params.branch} is archived`);
 			}
 
-			const branchRef = getBranchRef(params.branch);
-			args.push('-s', branchRef);
+			args.push('-s', params.branch);
 			return executeGitButlerCommand(params.project_directory, args, undefined);
 		}
 	}

--- a/packages/mcp/src/tools/patchStacks.ts
+++ b/packages/mcp/src/tools/patchStacks.ts
@@ -98,19 +98,19 @@ async function getPatchCommit(params: GetPatchCommitParams) {
 
 const TOOL_LISTINGS = [
 	{
-		name: 'list_patch_stacks',
-		description: 'List all the patch stacks for a given project',
+		name: 'cloud_list_patch_stacks',
+		description: 'List all the patch stacks for a given project (from the GitButler cloud)',
 		inputSchema: zodToJsonSchema(GetProjectPatchStacksParamsSchema)
 	},
 	{
-		name: 'get_patch_stack',
-		description: 'Get a specific patch stack by UUID',
+		name: 'cloud_get_patch_stack',
+		description: 'Get a specific patch stack by UUID (from the GitButler cloud)',
 		inputSchema: zodToJsonSchema(GetPatchStackParamsSchema)
 	},
 	{
-		name: 'get_patch_commit',
+		name: 'cloud_get_patch_commit',
 		description:
-			'Get a specific patch commit by branch UUID and change ID. This includes information about the file changes',
+			'Get a specific patch commit by branch UUID and change ID (from the GitButler cloud, includes file changes)',
 		inputSchema: zodToJsonSchema(GetPatchCommitParamsSchema)
 	}
 ] as const;
@@ -135,17 +135,17 @@ export async function getPatchStackToolRequestHandler(
 	}
 
 	switch (toolName) {
-		case 'list_patch_stacks': {
+		case 'cloud_list_patch_stacks': {
 			const listPatchStacksParams = GetProjectPatchStacksParamsSchema.parse(args);
 			const result = await listAllPatchStacks(listPatchStacksParams);
 			return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
 		}
-		case 'get_patch_stack': {
+		case 'cloud_get_patch_stack': {
 			const getPatchStackParams = GetPatchStackParamsSchema.parse(args);
 			const result = await getPatchStack(getPatchStackParams);
 			return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
 		}
-		case 'get_patch_commit': {
+		case 'cloud_get_patch_commit': {
 			const getPatchCommitParams = GetPatchCommitParamsSchema.parse(args);
 			const result = await getPatchCommit(getPatchCommitParams);
 			return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };

--- a/packages/mcp/src/tools/projects.ts
+++ b/packages/mcp/src/tools/projects.ts
@@ -104,33 +104,38 @@ async function fullLookupProject(params: LookupProjectParams) {
 
 const TOOL_LISTINGS = [
 	{
-		name: 'list_projects',
-		description: 'List all the GitButler projects that are available',
+		name: 'cloud_list_projects',
+		description:
+			'List all the GitButler projects that are available (This refers to data in the GitButler cloud).',
 		inputSchema: zodToJsonSchema(ListProjectsParamsSchema)
 	},
 	{
-		name: 'get_project',
-		description: 'Get a specific GitButler project',
+		name: 'cloud_get_project',
+		description: 'Get a specific GitButler project (This refers to data in the GitButler cloud).',
 		inputSchema: zodToJsonSchema(GetProjectParamsSchema)
 	},
 	{
-		name: 'list_recently_interacted_projects',
-		description: 'List all the GitButler projects that have been recently interacted with',
+		name: 'cloud_list_recently_interacted_projects',
+		description:
+			'List all the GitButler projects that have been recently interacted with (This refers to data in the GitButler cloud).',
 		inputSchema: zodToJsonSchema(z.object({}))
 	},
 	{
-		name: 'list_recently_pushed_projects',
-		description: 'List all the GitButler projects that have been recently pushed to',
+		name: 'cloud_list_recently_pushed_projects',
+		description:
+			'List all the GitButler projects that have been recently pushed to (This refers to data in the GitButler cloud).',
 		inputSchema: zodToJsonSchema(z.object({}))
 	},
 	{
-		name: 'lookup_project',
-		description: 'Lookup a GitButler project by owner and repo, returning the project ID',
+		name: 'cloud_lookup_project',
+		description:
+			'Lookup a GitButler project by owner and repo, returning the project ID (This refers to data in the GitButler cloud).',
 		inputSchema: zodToJsonSchema(LookupProjectParamsSchema)
 	},
 	{
-		name: 'full_lookup_project',
-		description: 'Lookup a GitButler project by owner and repo, returning the full project object',
+		name: 'cloud_full_lookup_project',
+		description:
+			'Lookup a GitButler project by owner and repo, returning the full project object (This refers to data in the GitButler cloud).',
 		inputSchema: zodToJsonSchema(LookupProjectParamsSchema)
 	}
 ] as const;
@@ -157,30 +162,30 @@ export async function getProjectToolRequestHandler(
 	}
 
 	switch (toolName) {
-		case 'list_projects': {
+		case 'cloud_list_projects': {
 			const listProjectsParams = ListProjectsParamsSchema.parse(args);
 			const result = await listAllProjects(listProjectsParams);
 			return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
 		}
-		case 'get_project': {
+		case 'cloud_get_project': {
 			const getProjectParams = GetProjectParamsSchema.parse(args);
 			const result = await getProject(getProjectParams);
 			return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
 		}
-		case 'list_recently_interacted_projects': {
+		case 'cloud_list_recently_interacted_projects': {
 			const result = await listRecentlyInteractedProjects();
 			return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
 		}
-		case 'list_recently_pushed_projects': {
+		case 'cloud_list_recently_pushed_projects': {
 			const result = await listRecentlyPushedProjects();
 			return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
 		}
-		case 'lookup_project': {
+		case 'cloud_lookup_project': {
 			const lookupProjectParams = LookupProjectParamsSchema.parse(args);
 			const result = await lookupProject(lookupProjectParams);
 			return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
 		}
-		case 'full_lookup_project': {
+		case 'cloud_full_lookup_project': {
 			const lookupProjectParams = LookupProjectParamsSchema.parse(args);
 			const result = await fullLookupProject(lookupProjectParams);
 			return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };


### PR DESCRIPTION
### Description

- Fixed the commit function by removing `getBranchRef` usage and using `params.branch` directly.
- Renamed and updated descriptions for cloud-prefixed tools in chatMessages, patchStacks, and projects.