### PR TITLE
On workspace update list any conflicting files

### DIFF
--- a/apps/desktop/src/components/v3/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/v3/IntegrateUpstreamModal.svelte
@@ -233,6 +233,22 @@
 				</div>
 			</div>
 		{/if}
+		{#if branchStatuses.current?.type === 'updatesRequired' && branchStatuses.current?.worktreeConflicts.length > 0}
+			<div class="section">
+				<h3 class="text-14 text-semibold section-title">
+					<span>Conflicting uncommitted files</span><Badge
+						>{branchStatuses.current?.worktreeConflicts.length}</Badge
+					>
+				</h3>
+				<div class="scroll-wrap">
+					<ScrollableContainer maxHeight={pxToRem(268)}>
+						{#each branchStatuses.current?.worktreeConflicts as file}
+							<div>{file}</div>
+						{/each}
+					</ScrollableContainer>
+				</div>
+			</div>
+		{/if}
 
 		{#if base?.diverged}
 			<div class="target-divergence">

--- a/apps/desktop/src/lib/upstream/types.ts
+++ b/apps/desktop/src/lib/upstream/types.ts
@@ -52,6 +52,7 @@ export type StackStatusesWithBranchesV3 =
 	  }
 	| {
 			type: 'updatesRequired';
+			worktreeConflicts: string[];
 			subject: StackStatusInfoV3[];
 	  };
 

--- a/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
+++ b/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
@@ -49,6 +49,7 @@ export class UpstreamIntegrationService {
 
 			const stackStatusesWithBranches: StackStatusesWithBranchesV3 = {
 				type: 'updatesRequired',
+				worktreeConflicts: branchStatusesData.subject.worktreeConflicts,
 				subject: branchStatusesData.subject.statuses
 					.map((status) => {
 						const stack = stackData.find((appliedBranch) => appliedBranch.id === status[0]);


### PR DESCRIPTION
This affects v3 only and it is about showing any uncommitted changes that will conflict with the workspace update. 
It currently looks like this: 
<img width="608" alt="image" src="https://github.com/user-attachments/assets/a09c3e28-8ca8-456d-b210-9bb8d4fbb021" />

FYI @PavelLaptev 