### PR TITLE
Reproduce and fix #8213

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ generated-do-not-edit/
 
 # editors
 .idea
+$.idea
+$.zed
 
 .sentryclirc
 .DS_Store

--- a/crates/but-core/src/unified_diff.rs
+++ b/crates/but-core/src/unified_diff.rs
@@ -36,7 +36,11 @@ pub struct DiffHunk {
 
 impl std::fmt::Debug for DiffHunk {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, r#"DiffHunk("{}")"#, self.diff)
+        if f.alternate() {
+            write!(f, r#"DiffHunk("{}")"#, self.diff)
+        } else {
+            write!(f, r#"DiffHunk("{:?}")"#, self.diff)
+        }
     }
 }
 

--- a/crates/but-workspace/src/commit_engine/mod.rs
+++ b/crates/but-workspace/src/commit_engine/mod.rs
@@ -184,7 +184,7 @@ pub enum RejectionReason {
     /// This can happen if the target tree has an entry that isn't of the same type as the source worktree changes.
     UnsupportedTreeEntry,
     /// The DiffSpec points to an actual change, or a subset of that change using a file path and optionally hunks into that file.
-    /// However, at least one hunk was not fully contained..
+    /// However, at least one hunk was not fully contained.
     MissingDiffSpecAssociation,
 }
 

--- a/crates/but-workspace/src/commit_engine/tree/mod.rs
+++ b/crates/but-workspace/src/commit_engine/tree/mod.rs
@@ -162,11 +162,11 @@ fn apply_worktree_changes<'repo>(
     let base_tree = actual_base_tree.attach(repo).object()?.peel_to_tree()?;
     let mut base_tree_editor = base_tree.edit()?;
     let (mut pipeline, index) = repo.filter_pipeline(None)?;
-    let changes_with_hunks = changes
+    let has_changes_with_hunks = changes
         .iter()
         .filter_map(|c| c.as_ref().ok())
         .any(|c| !c.hunk_headers.is_empty());
-    let worktree_changes = changes_with_hunks
+    let worktree_changes = has_changes_with_hunks
         .then(|| but_core::diff::worktree_changes(repo).map(|wtc| wtc.changes))
         .transpose()?;
     let mut current_worktree = Vec::new();
@@ -346,9 +346,9 @@ pub(crate) fn worktree_file_to_git_in_buf(
 }
 
 /// Given `hunks_to_keep` (ascending hunks by starting line) and the set of `worktree_hunks_no_context`
-/// (worktree hunks without context), return `(hunks_to_commit, rejected_hunks)` where `hunks_to_commit` is the
-/// headers to drive the additive operation to create the buffer to commit, and `rejected_hunks` is the list of
-/// hunks from `hunks_to_keep` that couldn't be associated with `worktree_hunks_no_context` because they weren't actually included.
+/// (worktree hunks without context), return `(hunks_to_commit, rejected_hunks)`.
+/// `hunks_to_commit` is the headers to drive the additive operation to create the buffer to commit, and `rejected_hunks` is the list of
+/// hunks from `hunks_to_keep` that couldn't be associated with `worktree_hunks_no_context` because they weren't included.
 ///
 /// `worktree_hunks` is the hunks with a given amount of context, usually 3, and it's used to quickly select original hunks
 /// without selection.

--- a/crates/but-workspace/src/discard/file.rs
+++ b/crates/but-workspace/src/discard/file.rs
@@ -36,7 +36,7 @@ pub fn restore_state_to_worktree(
         crate::commit_engine::index::upsert_index_entry(
             index,
             rela_path,
-            &md,
+            Some(&md),
             state.id,
             state.kind.into(),
             gix::index::entry::Flags::UPDATE,

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -1239,8 +1239,6 @@ pub(crate) fn move_commit_file(
         )
         .context("failed to create commit")?;
 
-    dbg!(&new_to_commit_oid);
-
     // another rebase
     let mut steps = stack.as_rebase_steps(ctx, &gix_repo)?;
     // replace the "to" commit in the rebase steps with the new "to" commit which has the moved changes added

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/list.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/list.rs
@@ -76,7 +76,7 @@ fn two_vbranches_in_workspace_one_commit() -> Result<()> {
     assert_eq!(list.len(), 1, "only one of these is *not* applied");
 
     assert_equal(
-        dbg!(&list[0]),
+        &list[0],
         ExpectedBranchListing {
             identity: "virtual".into(),
             virtual_branch_given_name: Some("virtual"),

--- a/crates/gitbutler-stack/src/state.rs
+++ b/crates/gitbutler-stack/src/state.rs
@@ -154,7 +154,7 @@ impl VirtualBranchesHandle {
         refname: &str,
     ) -> Result<Option<Stack>> {
         let stacks = self.list_all_stacks()?;
-        Ok(dbg!(stacks.into_iter().find(|stack| {
+        Ok(stacks.into_iter().find(|stack| {
             if stack.in_workspace {
                 return false;
             }
@@ -168,7 +168,7 @@ impl VirtualBranchesHandle {
             }
 
             false
-        })))
+        }))
     }
 
     /// Gets the state of the given virtual branch.


### PR DESCRIPTION
Fixes #8213 .

### Tasks

* [x] reproduction
    - It doesn't trivially reproduce, at least not with deletions, strangely enough.
    - It doesn't reproduce even when doing it literally (in testing) as described in the issue
    - It trivially reproduces in app though.
    - **racy-git** is the reason tests can't easily reproduce it.
* [x] fix
* [x] validate UI works
