### PR TITLE
Add Integs for commit message update

### DIFF
--- a/apps/desktop/cypress/e2e/commitActions.cy.ts
+++ b/apps/desktop/cypress/e2e/commitActions.cy.ts
@@ -1,0 +1,73 @@
+import { clearCommandMocks, mockCommand } from './support';
+import { PROJECT_ID } from './support/mock/projects';
+import { MockStackService } from './support/mock/stacks';
+
+describe('Commit Actions', () => {
+	let mockStackService: MockStackService;
+	beforeEach(() => {
+		mockStackService = new MockStackService();
+		mockCommand('stack_details', (params) => mockStackService.getStackDetails(params));
+		mockCommand('update_commit_message', (params) => mockStackService.updateCommitMessage(params));
+	});
+
+	afterEach(() => {
+		clearCommandMocks();
+	});
+
+	it('Should rename a commit', () => {
+		const originalCommitMessage = 'Initial commit';
+
+		const newCommitMessageTitle = 'New commit message title';
+		const newCommitMessageBody = 'New commit message body';
+
+		cy.spy(mockStackService, 'updateCommitMessage').as('updateCommitMessageSpy');
+		cy.visit('/');
+
+		// Click on the first commit
+		cy.get('.commit-name').first().should('contain', originalCommitMessage).click();
+
+		// Should open the commit drawer
+		cy.get('.commit-view').first().should('contain', originalCommitMessage);
+
+		// Click on the edit message button
+		cy.getByTestId('commit-drawer-action-edit-message').should('contain', 'Edit message').click();
+
+		// Should open the commit rename drawer
+		cy.getByTestId('edit-commit-message-drawer').should('be.visible');
+
+		// Should have the original commit message, and be focused
+		cy.getByTestId('commit-drawer-title-input')
+			.should('have.value', originalCommitMessage)
+			.should('be.visible')
+			.should('be.enabled')
+			.should('be.focused')
+			.clear()
+			.type(newCommitMessageTitle); // Type the new commit message title
+
+		// Type in a description
+		cy.getByTestId('commit-drawer-description-input')
+			.should('be.visible')
+			.click()
+			.type(newCommitMessageBody); // Type the new commit message body
+
+		// Click on the save button
+		cy.getByTestId('commit-drawer-action-button')
+			.should('be.visible')
+			.should('be.enabled')
+			.should('contain', 'Save')
+			.click();
+
+		cy.getByTestId('edit-commit-message-drawer').should('not.exist');
+
+		cy.getByTestId('commit-drawer-title').should('contain', newCommitMessageTitle);
+		cy.getByTestId('commit-drawer-description').should('contain', newCommitMessageBody);
+
+		// Should call the update commit message function
+		cy.get('@updateCommitMessageSpy').should('be.calledWith', {
+			projectId: PROJECT_ID,
+			stackId: mockStackService.stackId,
+			commitOid: mockStackService.commitOid,
+			message: `${newCommitMessageTitle}\n\n${newCommitMessageBody}`
+		});
+	});
+});

--- a/apps/desktop/cypress/e2e/support/index.ts
+++ b/apps/desktop/cypress/e2e/support/index.ts
@@ -1,5 +1,6 @@
 import { getBaseBranchData, getRemoteBranches } from './mock/baseBranch';
 import { MOCK_BRANCH_LISTINGS } from './mock/branches';
+import { MOCK_TREE_CHANGES } from './mock/changes';
 import { MOCK_GIT_HEAD, MOCK_OPEN_WORKSPACE_MODE } from './mock/mode';
 import { getProject, isGetProjectArgs, listProjects } from './mock/projects';
 import { getSecret, isGetSecretArgs } from './mock/secrets';
@@ -96,6 +97,10 @@ Cypress.on('window:before:load', (win) => {
 		}
 
 		switch (command) {
+			case 'git_get_global_config':
+				return await Promise.resolve(undefined);
+			case 'changes_in_commit':
+				return MOCK_TREE_CHANGES;
 			case 'stack_details':
 				return MOCK_STACK_DETAILS;
 			case 'changes_in_worktree':
@@ -167,14 +172,7 @@ Cypress.on('window:before:unload', (win) => {
 declare global {
 	namespace Cypress {
 		interface Chainable {
-			/**
-			 * Mock the Tauri IPC calls.
-			 * @param command The command to mock.
-			 * @param cb The callback to call when the command is invoked.
-			 * @returns A function to clear the mock.
-			 */
-			mockIPC: (command: string, cb: MockCallback) => () => void;
-
+			getByTestId(testId: string): Chainable<JQuery<HTMLElement>>;
 			/**
 			 * Clear all mocks.
 			 */
@@ -195,6 +193,10 @@ Cypress.Commands.add('clearMocks', () => {
 	cy.window().then((win) => {
 		clearMocks(win);
 	});
+});
+
+Cypress.Commands.add('getByTestId', (testId: string) => {
+	return cy.get(`[data-testid="${testId}"]`);
 });
 
 beforeEach(() => {

--- a/apps/desktop/cypress/e2e/support/mock/changes.ts
+++ b/apps/desktop/cypress/e2e/support/mock/changes.ts
@@ -1,0 +1,10 @@
+import type { TreeChanges } from '$lib/hunks/change';
+
+export const MOCK_TREE_CHANGES: TreeChanges = {
+	changes: [],
+	stats: {
+		linesAdded: 0,
+		linesRemoved: 0,
+		filesChanged: 0
+	}
+};

--- a/apps/desktop/cypress/e2e/support/mock/stacks.ts
+++ b/apps/desktop/cypress/e2e/support/mock/stacks.ts
@@ -1,5 +1,6 @@
 import type { Author, Commit, CommitState, UpstreamCommit } from '$lib/branches/v3';
 import type { BranchDetails, Stack, StackDetails } from '$lib/stacks/stack';
+import type { InvokeArgs } from '@tauri-apps/api/core';
 
 export const MOCK_STACK_A_ID = '1234-123';
 
@@ -64,3 +65,98 @@ export const MOCK_STACK_DETAILS: StackDetails = {
 	branchDetails: [MOCK_BRANCH_DETAILS],
 	isConflicted: false
 };
+
+export type UpdateCommitMessageParams = {
+	projectId: string;
+	stackId: string;
+	commitOid: string;
+	message: string;
+};
+
+export function isUpdateCommitMessageParams(params: unknown): params is UpdateCommitMessageParams {
+	return (
+		typeof params === 'object' &&
+		params !== null &&
+		'projectId' in params &&
+		typeof params.projectId === 'string' &&
+		'stackId' in params &&
+		typeof params.stackId === 'string' &&
+		'commitOid' in params &&
+		typeof params.commitOid === 'string' &&
+		'message' in params &&
+		typeof params.message === 'string'
+	);
+}
+
+export type StackDetailsParams = {
+	projectId: string;
+	stackId: string;
+};
+
+export function isStackDetailsParams(params: unknown): params is StackDetailsParams {
+	return (
+		typeof params === 'object' &&
+		params !== null &&
+		'projectId' in params &&
+		typeof params.projectId === 'string' &&
+		'stackId' in params &&
+		typeof params.stackId === 'string'
+	);
+}
+
+/**
+ * *Ohhh, look at me, I'm a stack service!*
+ */
+export class MockStackService {
+	private stackDetails: Map<string, StackDetails>;
+	stackId: string = MOCK_STACK_A_ID;
+	commitOid: string = MOCK_COMMIT.id;
+
+	constructor() {
+		this.stackDetails = new Map<string, StackDetails>();
+
+		this.stackDetails.set(MOCK_STACK_A_ID, structuredClone(MOCK_STACK_DETAILS));
+	}
+
+	public getStackDetails(args: InvokeArgs | undefined): StackDetails {
+		if (!args || !isStackDetailsParams(args)) {
+			throw new Error('Invalid arguments for getStackDetails');
+		}
+		const { stackId } = args;
+		const stackDetails = this.stackDetails.get(stackId);
+		if (!stackDetails) {
+			throw new Error(`Stack with ID ${stackId} not found`);
+		}
+		return stackDetails;
+	}
+
+	public updateCommitMessage(args: InvokeArgs | undefined): string {
+		if (!args || !isUpdateCommitMessageParams(args)) {
+			throw new Error('Invalid arguments for renameCommit');
+		}
+		const { stackId, commitOid, message } = args;
+
+		const stackDetails = this.stackDetails.get(stackId);
+		if (!stackDetails) {
+			throw new Error(`Stack with ID ${stackId} not found`);
+		}
+
+		const editableDetails = structuredClone(stackDetails);
+
+		for (const branch of editableDetails.branchDetails) {
+			const commitIndex = branch.commits.findIndex((commit) => commit.id === commitOid);
+			if (commitIndex === -1) continue;
+			const commit = branch.commits[commitIndex]!;
+			const newId = '424242424242';
+			branch.commits[commitIndex] = {
+				...commit,
+				message,
+				id: newId
+			};
+			this.stackDetails.set(stackId, editableDetails);
+			return newId;
+		}
+
+		throw new Error(`Commit with ID ${commitOid} not found`);
+	}
+}

--- a/apps/desktop/src/components/v3/CommitDetails.svelte
+++ b/apps/desktop/src/components/v3/CommitDetails.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { isCommit, type Commit, type UpstreamCommit } from '$lib/branches/v3';
 	import { UiState } from '$lib/state/uiState.svelte';
+	import { TestId } from '$lib/testing/testIds';
 	import { UserService } from '$lib/user/userService';
 	import { splitMessage } from '$lib/utils/commitMessage';
 	import { inject } from '@gitbutler/shared/context';
@@ -21,7 +22,7 @@
 	const user = $derived(userService.user);
 
 	const message = $derived(commit.message);
-	const description = $derived(splitMessage(message).description);
+	const { description } = $derived(splitMessage(message));
 	const isUpstream = $derived(!isCommit(commit));
 
 	function getGravatarUrl(email: string, existingGravatarUrl: string): string {
@@ -54,7 +55,7 @@
 	{/if}
 
 	{#if description}
-		<p class="text-13 text-body commit-description">
+		<p data-testid={TestId.CommitDrawerDescription} class="text-13 text-body commit-description">
 			{@html marked(description)}
 		</p>
 	{/if}

--- a/apps/desktop/src/components/v3/CommitHeader.svelte
+++ b/apps/desktop/src/components/v3/CommitHeader.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { TestId } from '$lib/testing/testIds';
 	import { splitMessage } from '$lib/utils/commitMessage';
 
 	type Props = {
@@ -12,7 +13,7 @@
 	const title = $derived(splitMessage(commitMessage).title);
 </script>
 
-<h3 class="{className} commit-title" class:row>
+<h3 data-testid={TestId.CommitDrawerTitle} class="{className} commit-title" class:row>
 	{title}
 </h3>
 

--- a/apps/desktop/src/components/v3/CommitMessageEditor.svelte
+++ b/apps/desktop/src/components/v3/CommitMessageEditor.svelte
@@ -8,6 +8,7 @@
 	import { AIService } from '$lib/ai/service';
 	import { projectAiGenEnabled } from '$lib/config/config';
 	import { UiState } from '$lib/state/uiState.svelte';
+	import { TestId } from '$lib/testing/testIds';
 	import { splitMessage } from '$lib/utils/commitMessage';
 	import { getContext } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
@@ -151,6 +152,7 @@
 
 <div class="commit-message-wrap">
 	<MessageEditorInput
+		testId={TestId.CommitDrawerTitleInput}
 		bind:ref={titleInput}
 		value={titleText.current}
 		oninput={(e: Event) => {
@@ -173,6 +175,7 @@
 	/>
 
 	<MessageEditor
+		testId={TestId.CommitDrawerDescriptionInput}
 		bind:this={composer}
 		initialValue={descriptionText.current}
 		placeholder={'Your commit message'}
@@ -203,8 +206,13 @@
 	/>
 </div>
 <EditorFooter {onCancel}>
-	<Button style="pop" onclick={action} disabled={disabledAction} {loading} width={126}
-		>{actionLabel}</Button
+	<Button
+		testId={TestId.CommitDrawerActionButton}
+		style="pop"
+		onclick={action}
+		disabled={disabledAction}
+		{loading}
+		width={126}>{actionLabel}</Button
 	>
 </EditorFooter>
 

--- a/apps/desktop/src/components/v3/CommitView.svelte
+++ b/apps/desktop/src/components/v3/CommitView.svelte
@@ -17,6 +17,7 @@
 	import { showToast } from '$lib/notifications/toasts';
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { UiState } from '$lib/state/uiState.svelte';
+	import { TestId } from '$lib/testing/testIds';
 	import { splitMessage } from '$lib/utils/commitMessage';
 	import { inject } from '@gitbutler/shared/context';
 	import { getContext, maybeGetContext } from '@gitbutler/shared/context';
@@ -134,6 +135,7 @@
 		{@const isConflicted = isCommit(commit) && commit.hasConflicts}
 		{#if mode === 'edit'}
 			<Drawer
+				testId={TestId.EditCommitMessageDrawer}
 				projectId={env.projectId}
 				stackId={env.stackId}
 				title="Edit commit message"
@@ -217,6 +219,7 @@
 					/>
 					<CommitDetails {commit}>
 						<Button
+							testId={TestId.CommitDrawerActionEditMessage}
 							size="tag"
 							kind="outline"
 							icon="edit-small"

--- a/apps/desktop/src/components/v3/Drawer.svelte
+++ b/apps/desktop/src/components/v3/Drawer.svelte
@@ -19,6 +19,7 @@
 		children: Snippet;
 		filesSplitView?: Snippet;
 		disableScroll?: boolean;
+		testId?: string;
 	};
 
 	const {
@@ -31,7 +32,8 @@
 		kebabMenu,
 		children,
 		filesSplitView,
-		disableScroll
+		disableScroll,
+		testId
 	}: Props = $props();
 
 	const [uiState] = inject(UiState);
@@ -62,6 +64,7 @@
 </script>
 
 <div
+	data-testid={testId}
 	class="drawer"
 	bind:this={drawerDiv}
 	style:height

--- a/apps/desktop/src/components/v3/editor/MessageEditor.svelte
+++ b/apps/desktop/src/components/v3/editor/MessageEditor.svelte
@@ -8,7 +8,6 @@
 	import { uploadFiles } from '@gitbutler/shared/dom';
 	import { persisted } from '@gitbutler/shared/persisted';
 	import { UploadsService } from '@gitbutler/shared/uploads/uploadsService';
-	import { debouncePromise } from '@gitbutler/shared/utils/misc';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import Checkbox from '@gitbutler/ui/Checkbox.svelte';
 	import EmojiPickerButton from '@gitbutler/ui/EmojiPickerButton.svelte';
@@ -36,6 +35,7 @@
 		canUseAI: boolean;
 		aiIsLoading: boolean;
 		suggestionsHandler?: CommitSuggestions;
+		testId?: string;
 	}
 
 	let {
@@ -48,7 +48,8 @@
 		onAiButtonClick,
 		canUseAI,
 		aiIsLoading,
-		suggestionsHandler
+		suggestionsHandler,
+		testId
 	}: Props = $props();
 
 	const MIN_RULER_VALUE = 30;
@@ -91,8 +92,6 @@
 		onChange?.(text);
 		await suggestionsHandler?.onChange(textUpToAnchor, textAfterAnchor);
 	}
-
-	const debouncedHandleChange = debouncePromise(handleChange, 700);
 
 	function handleKeyDown(event: KeyboardEvent | null) {
 		if (event && onKeyDown?.(event)) {
@@ -251,6 +250,7 @@
 		onmouseleave={() => (isEditorHovered = false)}
 	>
 		<div
+			data-testid={testId}
 			role="presentation"
 			class="message-textarea__inner"
 			onclick={() => {
@@ -271,7 +271,7 @@
 						markdown={useRichText.current}
 						onError={(e) => showError('Editor error', e)}
 						initialText={initialValue}
-						onChange={debouncedHandleChange}
+						onChange={handleChange}
 						onKeyDown={handleKeyDown}
 						onFocus={() => (isEditorFocused = true)}
 						onBlur={() => (isEditorFocused = false)}

--- a/apps/desktop/src/components/v3/editor/MessageEditorInput.svelte
+++ b/apps/desktop/src/components/v3/editor/MessageEditorInput.svelte
@@ -5,6 +5,7 @@
 		showCount?: boolean;
 		oninput: (e: Event) => void;
 		onkeydown: (e: KeyboardEvent) => void;
+		testId?: string;
 	}
 
 	let {
@@ -12,7 +13,8 @@
 		value = $bindable(),
 		showCount = true,
 		oninput,
-		onkeydown
+		onkeydown,
+		testId
 	}: Props = $props();
 
 	let charsCount = $state(value.length);
@@ -21,6 +23,7 @@
 <!-- svelte-ignore a11y_autofocus -->
 <div class="message-editor-input">
 	<input
+		data-testid={testId}
 		bind:this={ref}
 		placeholder="Commit title"
 		class="text-14 text-semibold text-input"

--- a/apps/desktop/src/lib/testing/testIds.ts
+++ b/apps/desktop/src/lib/testing/testIds.ts
@@ -13,7 +13,14 @@ export enum TestId {
 	BranchHeaderContextMenu_CopyPRLink = 'branch-header-context-menu-copy-pr-link',
 	BranchHeaderRenameModal = 'branch-header-rename-modal',
 	BranchHeaderRenameModal_Warning = 'branch-header-rename-modal-warning',
-	BranchHeaderContextMenu_SquashAllCommits = 'branch-header-context-menu-squash-all-commits'
+	BranchHeaderContextMenu_SquashAllCommits = 'branch-header-context-menu-squash-all-commits',
+	EditCommitMessageDrawer = 'edit-commit-message-drawer',
+	CommitDrawerActionEditMessage = 'commit-drawer-action-edit-message',
+	CommitDrawerTitleInput = 'commit-drawer-title-input',
+	CommitDrawerDescriptionInput = 'commit-drawer-description-input',
+	CommitDrawerActionButton = 'commit-drawer-action-button',
+	CommitDrawerTitle = 'commit-drawer-title',
+	CommitDrawerDescription = 'commit-drawer-description'
 }
 
 export enum ElementId {


### PR DESCRIPTION
- Added new test IDs to the TestId enum and updated Svelte components for improved testability.
- Introduced Cypress tests and mocks specifically for commit message editing.
- Updated mock data and Cypress support files to support commit message update functionality.
- Performed minor refactors to enhance testability.