### PR TITLE
Add tests to commit action and remove unecessary API calls

### DIFF
--- a/apps/desktop/cypress/e2e/support/index.ts
+++ b/apps/desktop/cypress/e2e/support/index.ts
@@ -1,6 +1,6 @@
 import { getBaseBranchData, getRemoteBranches } from './mock/baseBranch';
 import { MOCK_BRANCH_LISTINGS } from './mock/branches';
-import { MOCK_TREE_CHANGES } from './mock/changes';
+import { MOCK_TREE_CHANGES, MOCK_UNIFIED_DIFF } from './mock/changes';
 import { MOCK_GIT_HEAD, MOCK_OPEN_WORKSPACE_MODE } from './mock/mode';
 import { getProject, isGetProjectArgs, listProjects } from './mock/projects';
 import { getSecret, isGetSecretArgs } from './mock/secrets';
@@ -100,6 +100,8 @@ Cypress.on('window:before:load', (win) => {
 		}
 
 		switch (command) {
+			case 'tree_change_diffs':
+				return MOCK_UNIFIED_DIFF;
 			case 'git_get_global_config':
 				return await Promise.resolve(undefined);
 			case 'changes_in_commit':

--- a/apps/desktop/cypress/e2e/support/mock/backend.ts
+++ b/apps/desktop/cypress/e2e/support/mock/backend.ts
@@ -1,0 +1,141 @@
+import { bytesToStr, isGetWorktreeChangesParams, MOCK_TREE_CHANGE_A } from './changes';
+import {
+	isCreateCommitParams,
+	isStackDetailsParams,
+	isUpdateCommitMessageParams,
+	MOCK_COMMIT,
+	MOCK_STACK_A_ID,
+	MOCK_STACK_DETAILS
+} from './stacks';
+import type { WorktreeChanges } from '$lib/hunks/change';
+import type { StackDetails } from '$lib/stacks/stack';
+import type { InvokeArgs } from '@tauri-apps/api/core';
+
+/**
+ * *Ooooh look at me, I'm a mock backend!*
+ */
+export default class MockBackend {
+	private stackDetails: Map<string, StackDetails>;
+	private worktreeChanges: WorktreeChanges;
+	stackId: string = MOCK_STACK_A_ID;
+	commitOid: string = MOCK_COMMIT.id;
+
+	constructor() {
+		this.stackDetails = new Map<string, StackDetails>();
+		this.worktreeChanges = { changes: [MOCK_TREE_CHANGE_A], ignoredChanges: [] };
+
+		this.stackDetails.set(MOCK_STACK_A_ID, structuredClone(MOCK_STACK_DETAILS));
+	}
+
+	public getStackDetails(args: InvokeArgs | undefined): StackDetails {
+		if (!args || !isStackDetailsParams(args)) {
+			throw new Error('Invalid arguments for getStackDetails');
+		}
+		const { stackId } = args;
+		const stackDetails = this.stackDetails.get(stackId);
+		if (!stackDetails) {
+			throw new Error(`Stack with ID ${stackId} not found`);
+		}
+		return stackDetails;
+	}
+
+	public updateCommitMessage(args: InvokeArgs | undefined): string {
+		if (!args || !isUpdateCommitMessageParams(args)) {
+			throw new Error('Invalid arguments for renameCommit');
+		}
+		const { stackId, commitOid, message } = args;
+
+		const stackDetails = this.stackDetails.get(stackId);
+		if (!stackDetails) {
+			throw new Error(`Stack with ID ${stackId} not found`);
+		}
+
+		const editableDetails = structuredClone(stackDetails);
+
+		for (const branch of editableDetails.branchDetails) {
+			const commitIndex = branch.commits.findIndex((commit) => commit.id === commitOid);
+			if (commitIndex === -1) continue;
+			const commit = branch.commits[commitIndex]!;
+			const newId = '424242424242';
+			branch.commits[commitIndex] = {
+				...commit,
+				message,
+				id: newId
+			};
+			this.stackDetails.set(stackId, editableDetails);
+			return newId;
+		}
+
+		throw new Error(`Commit with ID ${commitOid} not found`);
+	}
+
+	public getWorktreeChanges(args: InvokeArgs | undefined): WorktreeChanges {
+		if (!args || !isGetWorktreeChangesParams(args)) {
+			throw new Error('Invalid arguments for getWorktreeChanges');
+		}
+
+		return this.worktreeChanges;
+	}
+
+	public getWorktreeChangesFileNames(): string[] {
+		return this.worktreeChanges.changes
+			.map((change) => change.path)
+			.map((path) => path.split('/').pop()!);
+	}
+
+	public createCommit(args: InvokeArgs | undefined): {
+		newCommit: string;
+		pathsToRejectedChanges: string[];
+	} {
+		if (!args || !isCreateCommitParams(args)) {
+			throw new Error('Invalid arguments for createCommit' + JSON.stringify(args));
+		}
+
+		const { stackId, stackBranchName, message, worktreeChanges } = args;
+
+		const stackDetails = this.stackDetails.get(stackId);
+		if (!stackDetails) {
+			throw new Error(`Stack with ID ${stackId} not found`);
+		}
+
+		const editableDetails = structuredClone(stackDetails);
+
+		// Assume only full file changes are passed.
+		const remainingChanges = this.worktreeChanges.changes.filter((change) => {
+			return !worktreeChanges.some((c) => bytesToStr(c.pathBytes) === change.path);
+		});
+
+		this.worktreeChanges = {
+			...this.worktreeChanges,
+			changes: remainingChanges
+		};
+
+		const branch = editableDetails.branchDetails.find((b) => b.name === stackBranchName);
+
+		if (!branch) {
+			throw new Error(`Branch with name ${stackBranchName} not found`);
+		}
+
+		const topCommit = branch.commits[branch.commits.length - 1];
+		const parentIds = topCommit ? [topCommit.id] : [];
+
+		const newCommitId = 'new-commit-id';
+
+		branch.commits = [
+			{
+				...MOCK_COMMIT,
+				message,
+				parentIds,
+				createdAt: Date.now(),
+				id: newCommitId
+			},
+			...branch.commits
+		];
+
+		this.stackDetails.set(stackId, editableDetails);
+
+		const pathsToRejectedChanges: string[] = [];
+
+		return { newCommit: newCommitId, pathsToRejectedChanges };
+	}
+}

--- a/apps/desktop/cypress/e2e/support/mock/backend.ts
+++ b/apps/desktop/cypress/e2e/support/mock/backend.ts
@@ -1,4 +1,10 @@
-import { bytesToStr, isGetWorktreeChangesParams, MOCK_TREE_CHANGE_A } from './changes';
+import {
+	bytesToStr,
+	isGetDiffParams,
+	isGetWorktreeChangesParams,
+	MOCK_TREE_CHANGE_A,
+	MOCK_UNIFIED_DIFF
+} from './changes';
 import {
 	isCreateCommitParams,
 	isStackDetailsParams,
@@ -8,6 +14,7 @@ import {
 	MOCK_STACK_DETAILS
 } from './stacks';
 import type { WorktreeChanges } from '$lib/hunks/change';
+import type { UnifiedDiff } from '$lib/hunks/diff';
 import type { StackDetails } from '$lib/stacks/stack';
 import type { InvokeArgs } from '@tauri-apps/api/core';
 
@@ -137,5 +144,13 @@ export default class MockBackend {
 		const pathsToRejectedChanges: string[] = [];
 
 		return { newCommit: newCommitId, pathsToRejectedChanges };
+	}
+
+	public getDiff(args: InvokeArgs | undefined): UnifiedDiff {
+		if (!args || !isGetDiffParams(args)) {
+			throw new Error('Invalid arguments for getDiff');
+		}
+
+		return MOCK_UNIFIED_DIFF;
 	}
 }

--- a/apps/desktop/cypress/e2e/support/mock/changes.ts
+++ b/apps/desktop/cypress/e2e/support/mock/changes.ts
@@ -72,3 +72,33 @@ export function isGetWorktreeChangesParams(args: unknown): args is GetWorktreeCh
 		typeof args['projectId'] === 'string'
 	);
 }
+
+export type GetDiffParams = {
+	projectId: string;
+	change: TreeChange;
+};
+
+export function isTreeChange(args: unknown): args is TreeChange {
+	return (
+		typeof args === 'object' &&
+		args !== null &&
+		'path' in args &&
+		typeof args['path'] === 'string' &&
+		'status' in args &&
+		typeof args['status'] === 'object' &&
+		'pathBytes' in args &&
+		Array.isArray(args['pathBytes']) &&
+		args['pathBytes'].every((byte) => typeof byte === 'number')
+	);
+}
+
+export function isGetDiffParams(args: unknown): args is GetDiffParams {
+	return (
+		typeof args === 'object' &&
+		args !== null &&
+		'projectId' in args &&
+		typeof args['projectId'] === 'string' &&
+		'change' in args &&
+		isTreeChange(args['change'])
+	);
+}

--- a/apps/desktop/cypress/e2e/support/mock/changes.ts
+++ b/apps/desktop/cypress/e2e/support/mock/changes.ts
@@ -1,4 +1,5 @@
-import type { TreeChanges } from '$lib/hunks/change';
+import type { TreeChange, TreeChanges } from '$lib/hunks/change';
+import type { UnifiedDiff } from '$lib/hunks/diff';
 
 export const MOCK_TREE_CHANGES: TreeChanges = {
 	changes: [],
@@ -8,3 +9,66 @@ export const MOCK_TREE_CHANGES: TreeChanges = {
 		filesChanged: 0
 	}
 };
+
+export function strToBytes(str: string): number[] {
+	const bytes: number[] = [];
+	for (let i = 0; i < str.length; i++) {
+		bytes.push(str.charCodeAt(i));
+	}
+	return bytes;
+}
+
+export function bytesToStr(bytes: number[]): string {
+	const str: string[] = [];
+	for (let i = 0; i < bytes.length; i++) {
+		const byte = bytes[i]!;
+		if (byte === 0) {
+			break;
+		}
+		str.push(String.fromCharCode(byte));
+	}
+	return str.join('');
+}
+
+export const MOCK_TREE_CHANGE_A: TreeChange = {
+	path: '/path/to/projectA/fileA.txt',
+	pathBytes: strToBytes('/path/to/projectA/fileA.txt'),
+	status: {
+		type: 'Addition',
+		subject: {
+			state: {
+				id: 'addition-id',
+				kind: 'addition'
+			},
+			isUntracked: true
+		}
+	}
+};
+
+const MOCK_FILE_ADDITION_DIFF: string = `@@ -0,0 +1,3 @@
++Line 1
++Line 2
++Line 3`;
+
+export const MOCK_UNIFIED_DIFF: UnifiedDiff = {
+	type: 'Patch',
+	subject: {
+		isResultOfBinaryToTextConversion: false,
+		linesAdded: 3,
+		linesRemoved: 0,
+		hunks: [{ oldStart: 0, oldLines: 0, newStart: 1, newLines: 3, diff: MOCK_FILE_ADDITION_DIFF }]
+	}
+};
+
+export type GetWorktreeChangesParams = {
+	projectId: string;
+};
+
+export function isGetWorktreeChangesParams(args: unknown): args is GetWorktreeChangesParams {
+	return (
+		typeof args === 'object' &&
+		args !== null &&
+		'projectId' in args &&
+		typeof args['projectId'] === 'string'
+	);
+}

--- a/apps/desktop/src/components/v3/CommitRow.svelte
+++ b/apps/desktop/src/components/v3/CommitRow.svelte
@@ -3,6 +3,7 @@
 	import CommitLine from '$components/v3/CommitLine.svelte';
 	import ContextMenu from '$components/v3/ContextMenu.svelte';
 	import { type CommitStatusType } from '$lib/commits/commit';
+	import { TestId } from '$lib/testing/testIds';
 	import Icon from '@gitbutler/ui/Icon.svelte';
 	import { slide } from 'svelte/transition';
 	import type { Snippet } from 'svelte';
@@ -108,7 +109,7 @@
 		{lastBranch}
 	/>
 
-	<div class="commit-content">
+	<div data-testid={TestId.CommitRow} class="commit-content">
 		<!-- <button type="button" {onclick} tabindex="0"> -->
 		<div class="commit-name truncate">
 			<CommitHeader {commitMessage} row className="text-13 text-semibold" />

--- a/apps/desktop/src/components/v3/FileListItemWrapper.svelte
+++ b/apps/desktop/src/components/v3/FileListItemWrapper.svelte
@@ -8,6 +8,7 @@
 	import { ChangeSelectionService } from '$lib/selection/changeSelection.svelte';
 	import { IdSelection } from '$lib/selection/idSelection.svelte';
 	import { key, type SelectionId } from '$lib/selection/key';
+	import { TestId } from '$lib/testing/testIds';
 	import { computeChangeStatus } from '$lib/utils/fileStatus';
 	import { getContext } from '@gitbutler/shared/context';
 	import FileListItemV3 from '@gitbutler/ui/file/FileListItemV3.svelte';
@@ -116,6 +117,7 @@
 </script>
 
 <div
+	data-testid={TestId.UncommittedChanges_FileListItem}
 	use:stickyHeader={{
 		disabled: !isHeader
 	}}

--- a/apps/desktop/src/components/v3/NewCommitView.svelte
+++ b/apps/desktop/src/components/v3/NewCommitView.svelte
@@ -14,7 +14,6 @@
 	import { TestId } from '$lib/testing/testIds';
 	import { WorktreeService } from '$lib/worktree/worktreeService.svelte';
 	import { getContext, inject } from '@gitbutler/shared/context';
-	import { isDefined } from '@gitbutler/ui/utils/typeguards';
 
 	type Props = {
 		projectId: string;
@@ -39,17 +38,6 @@
 	const selectedCommitId = $derived(selected?.current?.commitId);
 
 	const selection = $derived(changeSelection.list());
-	const selectedPaths = $derived(selection.current.map((item) => item.path));
-	const selectedTreeChangesResponse = $derived(
-		worktreeService.getChangesById(projectId, selectedPaths)
-	);
-	const selectedTreeChanges = $derived(selectedTreeChangesResponse.current.data);
-	const selectedChangesResponse = $derived(
-		selectedTreeChanges ? diffService.getChanges(projectId, selectedTreeChanges) : undefined
-	);
-	const changeDiffs = $derived(
-		selectedChangesResponse?.current.map((item) => item.data).filter(isDefined) ?? []
-	);
 
 	const draftBranchName = $derived(uiState.global.draftBranchName.current);
 	const canCommit = $derived(
@@ -60,12 +48,20 @@
 	let input = $state<ReturnType<typeof CommitMessageEditor>>();
 	let drawer = $state<ReturnType<typeof Drawer>>();
 
-	function findHunkDiff(filePath: string, hunk: SelectedHunk): DiffHunk | undefined {
-		const file = changeDiffs.find((file) => file.path === filePath);
-		if (!file) return undefined;
-		if (file.diff.type !== 'Patch') return undefined;
+	async function findHunkDiff(filePath: string, hunk: SelectedHunk): Promise<DiffHunk | undefined> {
+		const treeChange = await worktreeService.fetchChange(projectId, filePath);
+		if (treeChange.data === undefined) {
+			throw new Error('Failed to fetch change');
+		}
+		const changeDiff = await diffService.fetchDiff(projectId, treeChange.data);
+		if (changeDiff.data === undefined) {
+			throw new Error('Failed to fetch diff');
+		}
+		const file = changeDiff.data;
 
-		const hunkDiff = file.diff.subject.hunks.find(
+		if (file.type !== 'Patch') return undefined;
+
+		const hunkDiff = file.subject.hunks.find(
 			(hunkDiff) =>
 				hunkDiff.oldStart === hunk.oldStart &&
 				hunkDiff.oldLines === hunk.oldLines &&
@@ -96,10 +92,6 @@
 			throw new Error('No branch selected!');
 		}
 
-		if (!selectedTreeChanges) {
-			throw new Error('No changes selected!');
-		}
-
 		const worktreeChanges: CreateCommitRequestWorktreeChanges[] = [];
 
 		for (const item of selection.current) {
@@ -120,7 +112,7 @@
 					}
 
 					if (hunk.type === 'partial') {
-						const hunkDiff = findHunkDiff(item.path, hunk);
+						const hunkDiff = await findHunkDiff(item.path, hunk);
 						if (!hunkDiff) {
 							throw new Error('Hunk not found while commiting');
 						}

--- a/apps/desktop/src/components/v3/NewCommitView.svelte
+++ b/apps/desktop/src/components/v3/NewCommitView.svelte
@@ -11,6 +11,7 @@
 		type CreateCommitRequestWorktreeChanges
 	} from '$lib/stacks/stackService.svelte';
 	import { UiState } from '$lib/state/uiState.svelte';
+	import { TestId } from '$lib/testing/testIds';
 	import { WorktreeService } from '$lib/worktree/worktreeService.svelte';
 	import { getContext, inject } from '@gitbutler/shared/context';
 	import { isDefined } from '@gitbutler/ui/utils/typeguards';
@@ -184,7 +185,15 @@
 	}
 </script>
 
-<Drawer bind:this={drawer} {projectId} {stackId} title="Create commit" disableScroll minHeight={20}>
+<Drawer
+	testId={TestId.NewCommitDrawer}
+	bind:this={drawer}
+	{projectId}
+	{stackId}
+	title="Create commit"
+	disableScroll
+	minHeight={20}
+>
 	<CommitMessageEditor
 		bind:this={input}
 		{projectId}

--- a/apps/desktop/src/components/v3/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/v3/WorktreeChanges.svelte
@@ -11,6 +11,7 @@
 	import { ChangeSelectionService, type SelectedFile } from '$lib/selection/changeSelection.svelte';
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { UiState } from '$lib/state/uiState.svelte';
+	import { TestId } from '$lib/testing/testIds';
 	import { WorktreeService } from '$lib/worktree/worktreeService.svelte';
 	import { inject } from '@gitbutler/shared/context';
 	import Badge from '@gitbutler/ui/Badge.svelte';
@@ -37,11 +38,12 @@
 	const drawerPage = $derived(projectState.drawerPage.get());
 	const isCommitting = $derived(drawerPage.current === 'new-commit');
 	const stackState = $derived(stackId ? uiState.stack(stackId) : undefined);
+
 	const defaultBranchResult = $derived(
 		stackId !== undefined ? stackService.defaultBranch(projectId, stackId) : undefined
 	);
-	const defaultBranch = $derived(defaultBranchResult?.current.data);
-	const defaultBranchName = $derived(defaultBranch?.name);
+	const defaultBranchName = $derived(defaultBranchResult?.current.data);
+
 	const selectedChanges = changeSelection.list();
 	const noChangesSelected = $derived(selectedChanges.current.length === 0);
 	const changesResult = $derived(worktreeService.getChanges(projectId));
@@ -131,7 +133,7 @@
 					<FileListMode bind:mode={listMode} persist="uncommitted" />
 				</div>
 				{#if changes.length > 0}
-					<div class="uncommitted-changes">
+					<div data-testid={TestId.UncommittedChanges_FileList} class="uncommitted-changes">
 						<FileList
 							selectionId={{ type: 'worktree' }}
 							showCheckboxes={isCommitting}
@@ -148,11 +150,12 @@
 						class:sticked={isFooterSticky}
 					>
 						<Button
+							testId={TestId.StartCommitButton}
 							kind={isCommitting ? 'outline' : 'solid'}
 							type="button"
 							size="cta"
 							wide
-							disabled={isCommitting}
+							disabled={isCommitting || !defaultBranchName}
 							onclick={startCommit}
 						>
 							Start a commit…

--- a/apps/desktop/src/lib/hunks/diffService.svelte.ts
+++ b/apps/desktop/src/lib/hunks/diffService.svelte.ts
@@ -21,6 +21,11 @@ export class DiffService {
 		return result;
 	}
 
+	async fetchDiff(projectId: string, change: TreeChange) {
+		const { getDiff } = this.api.endpoints;
+		return await getDiff.fetch({ projectId, change });
+	}
+
 	getChanges(projectId: string, changes: TreeChange[]) {
 		const args = changes.map((change) => ({ projectId, change }));
 		const { getDiff } = this.api.endpoints;

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -160,10 +160,10 @@ export class StackService {
 	}
 
 	defaultBranch(projectId: string, stackId: string) {
-		return this.api.endpoints.stackDetails.useQuery(
-			{ projectId, stackId },
+		return this.api.endpoints.stacks.useQuery(
+			{ projectId },
 			{
-				transform: ({ stackInfo }) => stackInfo.branchDetails[0]
+				transform: (stacks) => stackSelectors.selectById(stacks, stackId)?.heads[0]?.name
 			}
 		);
 	}

--- a/apps/desktop/src/lib/testing/testIds.ts
+++ b/apps/desktop/src/lib/testing/testIds.ts
@@ -20,7 +20,12 @@ export enum TestId {
 	CommitDrawerDescriptionInput = 'commit-drawer-description-input',
 	CommitDrawerActionButton = 'commit-drawer-action-button',
 	CommitDrawerTitle = 'commit-drawer-title',
-	CommitDrawerDescription = 'commit-drawer-description'
+	CommitDrawerDescription = 'commit-drawer-description',
+	UncommittedChanges_FileList = 'uncommitted-changes-file-list',
+	UncommittedChanges_FileListItem = 'uncommitted-changes-file-list-item',
+	StartCommitButton = 'start-commit-button',
+	CommitRow = 'commit-row',
+	NewCommitDrawer = 'new-commit-drawer'
 }
 
 export enum ElementId {

--- a/apps/desktop/src/lib/worktree/worktreeService.svelte.ts
+++ b/apps/desktop/src/lib/worktree/worktreeService.svelte.ts
@@ -30,6 +30,11 @@ export class WorktreeService {
 		return getChanges.useQueryState({ projectId }, { transform: (res) => selectById(res, path)! });
 	}
 
+	async fetchChange(projectId: string, path: string) {
+		const { getChanges } = this.api.endpoints;
+		return await getChanges.fetch({ projectId }, { transform: (res) => selectById(res, path)! });
+	}
+
 	/** Gets a set of changes by the given paths */
 	getChangesById(projectId: string, paths: string[]) {
 		const { getChanges } = this.api.endpoints;


### PR DESCRIPTION
### Description

- Updated defaultBranch query to use endpoint with projectId for data fetching.
- Refactored NewCommitView.svelte to use async fetch for hunk diffs, removed unused code, and improved error handling.
- Added fetchDiff method in diffService and fetchChange method in worktreeService for asynchronous data fetching.
- Added MockBackend and related mocks for Cypress commit action tests.
- Added test IDs for commit/file list UI and updated testIds enum.
- Extended MockBackend with getDiff and added relevant type guards and imports for improved type support.