### PR TITLE
feat(CommitHeader): add tooltip to display full commit message

### DIFF
--- a/apps/desktop/src/components/v3/CommitHeader.svelte
+++ b/apps/desktop/src/components/v3/CommitHeader.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { TestId } from '$lib/testing/testIds';
 	import { splitMessage } from '$lib/utils/commitMessage';
+	import Tooltip from '@gitbutler/ui/Tooltip.svelte';
 
 	type Props = {
 		row?: boolean;
@@ -13,9 +14,11 @@
 	const title = $derived(splitMessage(commitMessage).title);
 </script>
 
-<h3 data-testid={TestId.CommitDrawerTitle} class="{className} commit-title" class:row>
-	{title}
-</h3>
+<Tooltip text={title}>
+	<h3 data-testid={TestId.CommitDrawerTitle} class="{className} commit-title" class:row>
+		{title}
+	</h3>
+</Tooltip>
 
 <style>
 	.row {


### PR DESCRIPTION
## 🧢 Changes

Added a Tooltip instance to the CommitHeader component. This allows the commit title to be displayed when the user hovers over the commit in the list.

## ☕️ Reasoning

- Provides full commit title when title is truncated

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->

![Screenshot 2025-04-28 at 12 03 44 PM](https://github.com/user-attachments/assets/9a184ea9-c4da-4c3f-b612-ad736a9b6443)

