### PR TITLE
Debug: propagete missing askpass error instead of panic

### DIFF
--- a/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
+++ b/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
@@ -83,6 +83,10 @@ export default class BaseBranchService {
 					return;
 				}
 
+				if (code === Code.Unknown && error.message?.includes('cargo build -p gitbutler-git')) {
+					showError('Run `cargo build -p gitbutler-git`', error.message);
+				}
+
 				if (action !== undefined) {
 					showError('Failed to fetch', error.message);
 				}

--- a/crates/gitbutler-git/src/repository.rs
+++ b/crates/gitbutler-git/src/repository.rs
@@ -49,6 +49,8 @@ pub enum RepositoryError<
     AskpassDeviceMismatch,
     #[error("failed to perform askpass security check; executable mismatch")]
     AskpassExecutableMismatch,
+    #[error("Askpass Not found. Run `cargo build -p gitbutler-git` to get the binaries needed")]
+    AskpassExecutableNotFound,
 }
 
 /// Higher level errors that can occur when interacting with the CLI.
@@ -108,10 +110,9 @@ where
         .into_owned();
 
     let res = executor.stat(&askpath_path).await.map_err(Error::<E>::Exec);
-    debug_assert!(
-        res.is_ok(),
-        "Run `cargo build -p gitbutler-git` to get the binaries needed for this assertion to pass ({askpath_path:?} not found)"
-    );
+    if res.is_err() {
+        return Err(Error::<E>::AskpassExecutableNotFound);
+    }
     let askpath_stat = res?;
 
     #[cfg(unix)]


### PR DESCRIPTION
The `debug_assert!` panics, which means the requests the frontend makes will never get a response. Which messes up reactivity in the app in a confusing way.

This change makes the error get propagated to the frontend

Will show this error message instead of panic
<img width="493" alt="image" src="https://github.com/user-attachments/assets/56d743cd-0d09-4d10-bfdb-4d649974c8fa" />
