### PR TITLE
feat(CommitCard): add tooltip to commit title

### DIFF
--- a/apps/desktop/src/components/CommitCard.svelte
+++ b/apps/desktop/src/components/CommitCard.svelte
@@ -331,9 +331,11 @@
 				<span class="text-13 text-body text-semibold commit__empty-title">empty commit message</span
 				>
 			{:else}
-				<h5 class="text-13 text-body text-semibold commit__title" class:truncate={!showDetails}>
-					{commit.descriptionTitle}
-				</h5>
+				<Tooltip text={commit.descriptionTitle}>
+					<h5 class="text-13 text-body text-semibold commit__title" class:truncate={!showDetails}>
+						{commit.descriptionTitle}
+					</h5>
+				</Tooltip>
 
 				<div class="text-11 text-semibold commit__subtitle">
 					{#if commit.isSigned}


### PR DESCRIPTION
## 🧢 Changes

Adds a tooltip to the commit title in the CommitCard component (for V2)

## ☕️ Reasoning

For full context in the event of a truncated commit title.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->

![Screenshot 2025-04-28 at 3 03 46 PM](https://github.com/user-attachments/assets/a97a7623-a915-4fd8-b4cb-a7c92428e6a4)