### PR TITLE
Tame ref-updates

### DIFF
--- a/crates/but-workspace/src/commit_engine/mod.rs
+++ b/crates/but-workspace/src/commit_engine/mod.rs
@@ -435,7 +435,7 @@ pub fn create_commit_and_update_refs(
                         && !wsc.inner.parents.contains(&branch_tip) /* the branch tip we know isn't yet merged */
                         // but the tip is known to the workspace
                         && vb.branches.values().any(|s| {
-                        s.head(repo)
+                        s.head_oid(repo)
                             .is_ok_and(|head_id| head_id == branch_tip)
                     }) {
                         let mut stacks: Vec<_> = vb

--- a/crates/but-workspace/src/commit_engine/mod.rs
+++ b/crates/but-workspace/src/commit_engine/mod.rs
@@ -348,22 +348,57 @@ pub fn create_commit_and_update_refs(
         return Ok(out);
     };
 
-    let commit_to_find = match destination {
+    let (commit_to_find, is_amend) = match destination {
         Destination::NewCommit {
             parent_commit_id, ..
-        } => parent_commit_id,
-        Destination::AmendCommit(commit) => Some(commit),
+        } => (parent_commit_id, false),
+        Destination::AmendCommit(commit) => (Some(commit), true),
     };
 
     if let Some(commit_in_graph) = commit_to_find {
         let mut all_refs_by_id = gix::hashtable::HashMap::<_, Vec<_>>::default();
-        for (commit_id, git_reference) in repo
-            .references()?
-            .prefixed("refs/heads/")?
-            .chain(repo.references()?.prefixed("refs/gitbutler/")?)
-            .filter_map(Result::ok)
-            .filter_map(|r| r.try_id().map(|id| (id.detach(), r.inner.name)))
-        {
+        let mut checked_out_ref_name = None;
+        let checked_out_ref = repo.head_ref()?.and_then(|mut r| {
+            let id = r.peel_to_id_in_place().ok()?.detach();
+            checked_out_ref_name = Some(r.inner.name.clone());
+            Some((id, r.inner.name))
+        });
+        let (platform_storage, platform_storage_2);
+        let checked_out_and_gitbutler_refs =
+            checked_out_ref
+                .into_iter()
+                // TODO: remove this as `refs/gitbutler/` won't contain relevant refs anymore.
+                .chain({
+                    platform_storage_2 = repo.references()?;
+                    platform_storage_2
+                        .prefixed("refs/gitbutler/")?
+                        .filter_map(Result::ok)
+                        .filter_map(|r| r.try_id().map(|id| (id.detach(), r.inner.name)))
+                })
+                .chain(
+                    // When amending, we want to update all branches that pointed to the old commit to now point to the new commit.
+                    if is_amend {
+                        Box::new({
+                            platform_storage = repo.references()?;
+                            platform_storage
+                                .prefixed("refs/heads/")?
+                                .filter_map(Result::ok)
+                                .filter_map(|r| {
+                                    let is_checked_out = checked_out_ref_name.as_ref().is_some_and(
+                                        |checked_out_ref| checked_out_ref == &r.inner.name,
+                                    );
+                                    if is_checked_out {
+                                        None
+                                    } else {
+                                        r.try_id().map(|id| (id.detach(), r.inner.name))
+                                    }
+                                })
+                        }) as Box<dyn Iterator<Item = _>>
+                    } else {
+                        Box::new(std::iter::empty())
+                    },
+                );
+        for (commit_id, git_reference) in checked_out_and_gitbutler_refs {
             all_refs_by_id
                 .entry(commit_id)
                 .or_default()

--- a/crates/but-workspace/src/commit_engine/reference_frame.rs
+++ b/crates/but-workspace/src/commit_engine/reference_frame.rs
@@ -47,12 +47,12 @@ impl ReferenceFrame {
                     .context("Didn't find stack - was it deleted just now?")?;
                 Ok(ReferenceFrame {
                     workspace_tip: Some(head_id.detach()),
-                    branch_tip: Some(stack.head(repo)?),
+                    branch_tip: Some(stack.head_oid(repo)?),
                 })
             }
             InferenceMode::CommitIdInStack(commit_id) => {
                 for stack in vb.branches.values() {
-                    let stack_tip = stack.head(repo)?;
+                    let stack_tip = stack.head_oid(repo)?;
                     if stack_tip
                         .attach(repo)
                         .ancestors()

--- a/crates/but-workspace/src/commit_engine/refs.rs
+++ b/crates/but-workspace/src/commit_engine/refs.rs
@@ -35,7 +35,7 @@ pub fn rewrite(
                     continue; // Dont rewrite refs for other stacks
                 }
             }
-            if stack.head(repo)? == old {
+            if stack.head_oid(repo)? == old {
                 // Perhaps skip this - the head will be updated later in this call
                 // stack.set_stack_head_without_persisting(repo, new.to_git2(), None)?;
                 // Does it make sense to set stack tree in v3? I think not

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -140,7 +140,7 @@ impl StackEntry {
         Ok(StackEntry {
             id: stack.id,
             heads: stack_heads_info(stack, repo)?,
-            tip: stack.head(repo)?,
+            tip: stack.head_oid(repo)?,
         })
     }
 }

--- a/crates/but-workspace/tests/fixtures/scenario/three-commits-with-line-offset-and-workspace-commit.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/three-commits-with-line-offset-and-workspace-commit.sh
@@ -10,6 +10,6 @@ git init
 seq 10 >file
 git add . && git commit -m init && git tag first-commit
 
-{ seq 4; seq 10; } >file && git commit -am "insert 5 lines to the top"
+{ seq 4; seq 10; } >file && git commit -am "insert 5 lines to the top" && git branch feat1
 
 git commit -m $'GitButler Workspace Commit\n\njust a fake - only the subject matters right now' --allow-empty

--- a/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
@@ -110,8 +110,8 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
     // The HEAD reference was updated, along with all other tag-references that pointed to it.
     let new_commit = outcome.new_commit.expect("a new commit was created");
     insta::assert_snapshot!(visualize_commit_graph(&repo, new_commit)?, @r"
-    * 1c4bb33 (HEAD -> main, another-tip) third commit
-    * f1b87da (tag: tag-that-should-not-move) second commit
+    * 1c4bb33 (HEAD -> main) third commit
+    * f1b87da (tag: tag-that-should-not-move, another-tip) second commit
     * 0939187 initial commit
     ");
 
@@ -132,8 +132,8 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
     assure_no_worktree_changes(&repo)?;
     // The top commit has a different hash now thanks to amending.
     insta::assert_snapshot!(graph_commit_outcome(&repo, &outcome)?, @r"
-    * 2abfa5c (HEAD -> main, another-tip) third commit
-    * f1b87da (tag: tag-that-should-not-move) second commit
+    * 2abfa5c (HEAD -> main) third commit
+    * f1b87da (tag: tag-that-should-not-move, another-tip) second commit
     * 0939187 initial commit
     ");
 
@@ -197,15 +197,6 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
             UpdatedReference {
                 reference: Git(
                     FullName(
-                        "refs/heads/another-tip",
-                    ),
-                ),
-                old_commit_id: Sha1(2abfa5cc3c7c48b8b9eabbd10c21b88347801f15),
-                new_commit_id: Sha1(189ac82eb44ddb97677d7d7b1859cf6f2e33a473),
-            },
-            UpdatedReference {
-                reference: Git(
-                    FullName(
                         "refs/heads/main",
                     ),
                 ),
@@ -234,9 +225,9 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
     write_vrbranches_to_refs(&vb, &repo)?;
     // It updates stack heads and stack branch heads.
     insta::assert_snapshot!(graph_commit_outcome(&repo, &outcome)?, @r"
-    * 189ac82 (HEAD -> main, s2-b/second, s1-b/second, another-tip) fourth commit
+    * 189ac82 (HEAD -> main, s2-b/second, s1-b/second) fourth commit
     * 2abfa5c third commit
-    * f1b87da (tag: tag-that-should-not-move, s2-b/first, s1-b/first) second commit
+    * f1b87da (tag: tag-that-should-not-move, s2-b/first, s1-b/first, another-tip) second commit
     * 0939187 (s2-b/init, s1-b/init) initial commit
     ");
     insta::assert_snapshot!(visualize_tree(&repo, &outcome)?, @r#"
@@ -269,7 +260,7 @@ fn new_stack_receives_commit_and_adds_it_to_workspace_commit() -> anyhow::Result
     let workspace_commit_id = repo.rev_parse_single("@")?.detach();
     insta::assert_snapshot!(visualize_commit_graph(&repo, workspace_commit_id)?, @r"
     * 47c9e16 (HEAD -> main) GitButler Workspace Commit
-    * b451685 insert 5 lines to the top
+    * b451685 (feat1) insert 5 lines to the top
     * d15b5ae (tag: first-commit) init
     ");
 
@@ -312,7 +303,7 @@ fn new_stack_receives_commit_and_adds_it_to_workspace_commit() -> anyhow::Result
     *   7051951 (HEAD -> main) GitButler Workspace Commit
     |\  
     | * 00fbfba (s2/top) new file with 15 lines
-    * | b451685 (s1/top) insert 5 lines to the top
+    * | b451685 (s1/top, feat1) insert 5 lines to the top
     |/  
     * d15b5ae (tag: first-commit) init
     ");
@@ -611,8 +602,8 @@ fn insert_commit_into_single_stack_with_signatures() -> anyhow::Result<()> {
     let rewritten_head_id = repo.head_id()?.detach();
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
     * 3d1262e (HEAD -> main) insert 10 lines to the top
-    * 3aec753 (s1-b/init, first-commit) between initial and former first
-    * ecd6722 (tag: first-commit) init
+    * 3aec753 (s1-b/init) between initial and former first
+    * ecd6722 (tag: first-commit, first-commit) init
     ");
     insta::assert_snapshot!(but_testsupport::visualize_tree(rewritten_head_id.attach(&repo)), @r#"
     5fdd313
@@ -635,15 +626,6 @@ fn insert_commit_into_single_stack_with_signatures() -> anyhow::Result<()> {
             UpdatedReference {
                 reference: Virtual(
                     "",
-                ),
-                old_commit_id: Sha1(ecd67221705b069c4f46365a46c8f2cd8a97ec19),
-                new_commit_id: Sha1(3aec75308383b83d85a78a90308a618755a7b0f8),
-            },
-            UpdatedReference {
-                reference: Git(
-                    FullName(
-                        "refs/heads/first-commit",
-                    ),
                 ),
                 old_commit_id: Sha1(ecd67221705b069c4f46365a46c8f2cd8a97ec19),
                 new_commit_id: Sha1(3aec75308383b83d85a78a90308a618755a7b0f8),
@@ -710,8 +692,8 @@ fn insert_commit_into_single_stack_with_signatures() -> anyhow::Result<()> {
     let rewritten_head_id = repo.head_id()?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
     * 4b649eb (HEAD -> main) insert 10 lines to the top
-    * d26d789 (s1-b/init, first-commit) between initial and former first
-    * ecd6722 (tag: first-commit) init
+    * d26d789 (s1-b/init) between initial and former first
+    * ecd6722 (tag: first-commit, first-commit) init
     ");
     insta::assert_snapshot!(but_testsupport::visualize_tree(rewritten_head_id), @r#"
     683b451
@@ -879,8 +861,8 @@ fn insert_commits_into_workspace() -> anyhow::Result<()> {
     *   a97960f (HEAD -> merge) Merge branch 'A' into merge
     |\  
     | * 3538622 (A) add 10 to the beginning
-    * | 46991ae (s1-b/init, B) add 10 more lines at end
-    * | e81b470 add 10 to the end
+    * | 46991ae (s1-b/init) add 10 more lines at end
+    * | e81b470 (B) add 10 to the end
     |/  
     * 9cf2979 (main) init
     ");
@@ -1006,8 +988,8 @@ fn merge_commit_remains_unsigned_in_remerge() -> anyhow::Result<()> {
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
     *   595a255 (HEAD -> merge) Merge branch 'A' into merge
     |\  
-    | * 057f154 (s1-b/top, A) remove 5 lines from beginning
-    | * eede47d add 10 to the beginning
+    | * 057f154 (s1-b/top) remove 5 lines from beginning
+    | * eede47d (A) add 10 to the beginning
     * | 16fe86e (B) add 10 to the end
     |/  
     * 6074509 (main) init
@@ -1227,8 +1209,8 @@ fn commit_on_top_of_branch_in_workspace() -> anyhow::Result<()> {
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
     *   09ac476 (HEAD -> merge) Merge branch 'A' into merge
     |\  
-    | * 99f3a1c (s1-b/top, A) remove 5 lines from beginning
-    | * 7f389ed (s1-b/below-top) add 10 to the beginning
+    | * 99f3a1c (s1-b/top) remove 5 lines from beginning
+    | * 7f389ed (s1-b/below-top, A) add 10 to the beginning
     * | 91ef6f6 (s2-b/top, s2-b/below-top, B) add 10 to the end
     |/  
     * ff045ef (main) init
@@ -1315,10 +1297,10 @@ fn commit_on_top_of_branch_in_workspace() -> anyhow::Result<()> {
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
     *   098effd (HEAD -> merge) Merge branch 'A' into merge
     |\  
-    | * 99f3a1c (s1-b/top, A) remove 5 lines from beginning
-    | * 7f389ed (s1-b/below-top) add 10 to the beginning
-    * | 03e9b6f (s2-b/top, B) remove 5 lines from the end
-    * | 91ef6f6 (s2-b/below-top) add 10 to the end
+    | * 99f3a1c (s1-b/top) remove 5 lines from beginning
+    | * 7f389ed (s1-b/below-top, A) add 10 to the beginning
+    * | 03e9b6f (s2-b/top) remove 5 lines from the end
+    * | 91ef6f6 (s2-b/below-top, B) add 10 to the end
     |/  
     * ff045ef (main) init
     ");

--- a/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
@@ -258,7 +258,6 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
 /// https://github.com/gitbutlerapp/gitbutler/pull/7596 may affect the solution here, but
 /// it's not yet ready.
 #[test]
-#[ignore = "needs fixes"]
 fn new_stack_receives_commit_and_adds_it_to_workspace_commit() -> anyhow::Result<()> {
     assure_stable_env();
 
@@ -311,10 +310,10 @@ fn new_stack_receives_commit_and_adds_it_to_workspace_commit() -> anyhow::Result
     // head was updated to point to the new workspace commit.
     insta::assert_snapshot!(visualize_commit_graph(&repo, repo.head_id()?)?, @r"
     *   7051951 (HEAD -> main) GitButler Workspace Commit
-    |\
+    |\  
     | * 00fbfba (s2/top) new file with 15 lines
     * | b451685 (s1/top) insert 5 lines to the top
-    |/
+    |/  
     * d15b5ae (tag: first-commit) init
     ");
 

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -111,7 +111,7 @@ pub fn create_virtual_branch(
     Ok(StackEntry {
         id: stack.id,
         heads: stack_heads_info(&stack, &repo)?,
-        tip: stack.head(&repo)?,
+        tip: stack.head_oid(&repo)?,
     })
 }
 

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -82,7 +82,7 @@ fn go_back_to_integration(ctx: &CommandContext, default_target: &Target) -> Resu
     for branch in &virtual_branches {
         // merge this branches tree with our tree
         let branch_tree_id = git2_to_gix_object_id(
-            repo.find_commit(branch.head(&gix_repo)?.to_git2())
+            repo.find_commit(branch.head_oid(&gix_repo)?.to_git2())
                 .context("failed to find branch head")?
                 .tree_id(),
         );

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -298,7 +298,7 @@ fn branch_group_to_branch(
     // If there is a virtual branch let's get it's head. Alternatively, pick the first local branch and use it's head.
     // If there are no local branches, pick the first remote branch.
     let head_commit = if let Some(vbranch) = virtual_branch {
-        Some(vbranch.head(repo)?.attach(repo))
+        Some(vbranch.head_oid(repo)?.attach(repo))
     } else if let Some(mut branch) = local_branches.into_iter().next() {
         branch.peel_to_id_in_place_packed(packed).ok()
     } else if let Some(mut branch) = remote_branches.into_iter().next() {

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -289,11 +289,11 @@ impl BranchManager<'_> {
 
         let gix_repo = repo.to_gix()?;
         let merge_base = repo
-            .merge_base(default_target.sha, stack.head(&gix_repo)?.to_git2())
+            .merge_base(default_target.sha, stack.head_oid(&gix_repo)?.to_git2())
             .context(format!(
                 "failed to find merge base between {} and {}",
                 default_target.sha,
-                stack.head(&gix_repo)?
+                stack.head_oid(&gix_repo)?
             ))?;
 
         // Branch is out of date, merge or rebase it
@@ -331,7 +331,7 @@ impl BranchManager<'_> {
         // Do we need to rebase the branch on top of the default target?
 
         let has_change_id = repo
-            .find_commit(stack.head(&gix_repo)?.to_git2())?
+            .find_commit(stack.head_oid(&gix_repo)?.to_git2())?
             .change_id()
             .is_some();
         // If the branch has no change ID for the head commit, we want to rebase it even if the base is the same
@@ -351,7 +351,7 @@ impl BranchManager<'_> {
             } else {
                 gitbutler_merge_commits(
                     repo,
-                    repo.find_commit(stack.head(&gix_repo)?.to_git2())?,
+                    repo.find_commit(stack.head_oid(&gix_repo)?.to_git2())?,
                     repo.find_commit(default_target.sha)?,
                     &stack.name,
                     default_target.branch.branch(),
@@ -378,7 +378,8 @@ impl BranchManager<'_> {
 
         {
             if let Some(wip_commit_to_unapply) = &stack.not_in_workspace_wip_change_id {
-                let potential_wip_commit = repo.find_commit(stack.head(&gix_repo)?.to_git2())?;
+                let potential_wip_commit =
+                    repo.find_commit(stack.head_oid(&gix_repo)?.to_git2())?;
 
                 // Don't try to undo commit if its conflicted
                 if !potential_wip_commit.is_conflicted() {
@@ -387,7 +388,7 @@ impl BranchManager<'_> {
                             stack = crate::undo_commit::undo_commit(
                                 self.ctx,
                                 stack.id,
-                                stack.head(&gix_repo)?.to_git2(),
+                                stack.head_oid(&gix_repo)?.to_git2(),
                                 perm,
                             )?;
                         }

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
@@ -77,7 +77,9 @@ impl BranchManager<'_> {
             let workspace_base = gix_repo
                 .find_commit(workspace_base(self.ctx, perm.read_permission())?)?
                 .tree_id()?;
-            let stack_head = gix_repo.find_commit(stack.head(&gix_repo)?)?.tree_id()?;
+            let stack_head = gix_repo
+                .find_commit(stack.head_oid(&gix_repo)?)?
+                .tree_id()?;
 
             let mut merge = gix_repo.merge_trees(
                 stack_head,
@@ -95,7 +97,7 @@ impl BranchManager<'_> {
                 .context("failed to checkout tree")?;
         } else {
             let gix_repo = self.ctx.gix_repo()?;
-            let head = stack.head(&gix_repo)?;
+            let head = stack.head_oid(&gix_repo)?;
             let head = repo.find_commit(head.to_git2())?;
 
             // If there are uncommited changes, we should make a wip commit.
@@ -128,7 +130,7 @@ impl BranchManager<'_> {
                                 .collect::<Vec<(PathBuf, Vec<VirtualBranchHunk>)>>();
                             let tree_oid = gitbutler_diff::write::hunks_onto_oid(
                                 self.ctx,
-                                stack.head(&gix_repo)?.to_git2(),
+                                stack.head_oid(&gix_repo)?.to_git2(),
                                 files,
                             )?;
                             let mut merge = gix_repo.merge_trees(
@@ -184,7 +186,7 @@ impl BranchManager<'_> {
         // Build wip tree as either any uncommitted changes or an empty tree
         let vbranch_wip_tree = repo.find_tree(stack.tree(self.ctx)?)?;
         let vbranch_head_tree = repo
-            .find_commit(stack.head(&repo.to_gix()?)?.to_git2())?
+            .find_commit(stack.head_oid(&repo.to_gix()?)?.to_git2())?
             .tree()?;
 
         let tree = if vbranch_head_tree.id() != vbranch_wip_tree.id() {
@@ -201,7 +203,7 @@ impl BranchManager<'_> {
         // Commit wip commit
         let committer = gitbutler_repo::signature(SignaturePurpose::Committer)?;
         let author = gitbutler_repo::signature(SignaturePurpose::Author)?;
-        let parent = stack.head(&gix_repo)?;
+        let parent = stack.head_oid(&gix_repo)?;
         let parent = repo.find_commit(parent.to_git2())?;
 
         let commit_headers = CommitHeadersV2::new();

--- a/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
@@ -66,7 +66,7 @@ pub fn integrate_upstream_commits_for_series(
     let integrate_upstream_context = IntegrateUpstreamContext {
         repo,
         target_branch_head: default_target.sha,
-        branch_head: stack.head(&gix_repo)?.to_git2(),
+        branch_head: stack.head_oid(&gix_repo)?.to_git2(),
         branch_tree: stack.tree(ctx)?,
         branch_name: subject_branch.name(),
         branch_full_name: subject_branch.full_name()?,

--- a/crates/gitbutler-branch-actions/src/dependencies.rs
+++ b/crates/gitbutler-branch-actions/src/dependencies.rs
@@ -82,7 +82,7 @@ fn get_commits_to_process<'a>(
 ) -> Result<impl Iterator<Item = git2::Oid> + 'a, anyhow::Error> {
     let commit_ids = repo
         .l(
-            stack.head(gix_repo)?.to_git2(),
+            stack.head_oid(gix_repo)?.to_git2(),
             LogUntil::Commit(*target_sha),
             false,
         )

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -52,7 +52,7 @@ pub(crate) fn get_workspace_head(ctx: &CommandContext) -> Result<git2::Oid> {
     let merge_tree_id = git2_to_gix_object_id(repo.find_commit(target.sha)?.tree_id());
     for stack in stacks.iter_mut() {
         stack.migrate_change_ids(ctx).ok(); // If it fails thats ok - best effort migration
-        let branch_head = repo.find_commit(stack.head(&gix_repo)?.to_git2())?;
+        let branch_head = repo.find_commit(stack.head_oid(&gix_repo)?.to_git2())?;
         let branch_tree_id =
             git2_to_gix_object_id(repo.find_real_tree(&branch_head, Default::default())?.id());
 
@@ -80,7 +80,7 @@ pub(crate) fn get_workspace_head(ctx: &CommandContext) -> Result<git2::Oid> {
     let gix_repo = repo.to_gix()?;
     let mut heads: Vec<git2::Commit<'_>> = stacks
         .iter()
-        .filter_map(|stack| stack.head(&gix_repo).ok())
+        .filter_map(|stack| stack.head_oid(&gix_repo).ok())
         .filter_map(|h| repo.find_commit(h.to_git2()).ok())
         .collect();
 
@@ -192,9 +192,9 @@ pub fn update_workspace_commit(
             message.push_str(format!(" ({})", &branch.refname()?).as_str());
             message.push('\n');
 
-            if branch.head(&gix_repo)? != target.sha.to_gix() {
+            if branch.head_oid(&gix_repo)? != target.sha.to_gix() {
                 message.push_str("   branch head: ");
-                message.push_str(&branch.head(&gix_repo)?.to_string());
+                message.push_str(&branch.head_oid(&gix_repo)?.to_string());
                 message.push('\n');
             }
             for file in &branch.ownership.claims {
@@ -249,7 +249,7 @@ pub fn update_workspace_commit(
     // finally, update the refs/gitbutler/ heads to the states of the current virtual branches
     for branch in &virtual_branches {
         let wip_tree = repo.find_tree(branch.tree(ctx)?)?;
-        let mut branch_head = repo.find_commit(branch.head(&gix_repo)?.to_git2())?;
+        let mut branch_head = repo.find_commit(branch.head_oid(&gix_repo)?.to_git2())?;
         let head_tree = branch_head.tree()?;
 
         // create a wip commit if there is wip
@@ -378,7 +378,7 @@ fn verify_head_is_clean(ctx: &CommandContext, perm: &mut WorktreeWritePermission
 
     // rebasing the extra commits onto the new branch
     let gix_repo = ctx.repo().to_gix()?;
-    let mut head = new_branch.head(&gix_repo)?.to_git2();
+    let mut head = new_branch.head_oid(&gix_repo)?.to_git2();
     for commit in extra_commits {
         let new_branch_head = ctx
             .repo()

--- a/crates/gitbutler-branch-actions/src/move_commits.rs
+++ b/crates/gitbutler-branch-actions/src/move_commits.rs
@@ -90,7 +90,7 @@ fn get_source_branch_diffs(
     source_stack: &gitbutler_stack::Stack,
 ) -> Result<BranchStatus> {
     let repo = ctx.repo();
-    let source_stack_head = repo.find_commit(source_stack.head(&repo.to_gix()?)?.to_git2())?;
+    let source_stack_head = repo.find_commit(source_stack.head_oid(&repo.to_gix()?)?.to_git2())?;
     let source_stack_head_tree = source_stack_head.tree()?;
     let uncommitted_changes_tree = repo.find_tree(source_stack.tree(ctx)?)?;
 

--- a/crates/gitbutler-branch-actions/src/reorder.rs
+++ b/crates/gitbutler-branch-actions/src/reorder.rs
@@ -45,9 +45,11 @@ pub fn reorder_stack(
     let default_target_commit = repo
         .find_reference(&default_target.branch.to_string())?
         .peel_to_commit()?;
-    let old_head = repo.find_commit(stack.head(&gix_repo)?.to_git2())?;
-    let merge_base =
-        repo.merge_base(default_target_commit.id(), stack.head(&gix_repo)?.to_git2())?;
+    let old_head = repo.find_commit(stack.head_oid(&gix_repo)?.to_git2())?;
+    let merge_base = repo.merge_base(
+        default_target_commit.id(),
+        stack.head_oid(&gix_repo)?.to_git2(),
+    )?;
 
     let mut steps: Vec<RebaseStep> = Vec::new();
     for series in new_order.series.iter().rev() {

--- a/crates/gitbutler-branch-actions/src/squash.rs
+++ b/crates/gitbutler-branch-actions/src/squash.rs
@@ -59,7 +59,7 @@ fn do_squash_commits(
     let default_target = vb_state.get_default_target()?;
     let merge_base = ctx
         .repo()
-        .merge_base(stack.head(&gix_repo)?.to_git2(), default_target.sha)?;
+        .merge_base(stack.head_oid(&gix_repo)?.to_git2(), default_target.sha)?;
 
     // =========== Step 1: Reorder
 
@@ -104,7 +104,7 @@ fn do_squash_commits(
     // stack was updated by reorder_stack, therefore it is reloaded
     let mut stack = vb_state.get_stack_in_workspace(stack_id)?;
     let branch_commit_oids = ctx.repo().l(
-        stack.head(&gix_repo)?.to_git2(),
+        stack.head_oid(&gix_repo)?.to_git2(),
         LogUntil::Commit(merge_base),
         false,
     )?;

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -169,9 +169,10 @@ pub fn push_stack(ctx: &CommandContext, stack_id: StackId, with_force: bool) -> 
 
     let repo = ctx.repo();
     let default_target = state.get_default_target()?;
-    let merge_base = repo.find_commit(
-        repo.merge_base(stack.head(&repo.to_gix()?)?.to_git2(), default_target.sha)?,
-    )?;
+    let merge_base = repo.find_commit(repo.merge_base(
+        stack.head_oid(&repo.to_gix()?)?.to_git2(),
+        default_target.sha,
+    )?)?;
     // let merge_base: CommitOrChangeId = merge_base.into();
 
     // First fetch, because we dont want to push integrated series

--- a/crates/gitbutler-branch-actions/src/status.rs
+++ b/crates/gitbutler-branch-actions/src/status.rs
@@ -215,7 +215,7 @@ pub fn get_applied_status_cached(
     for (vbranch, files) in &mut hunks_by_branch {
         vbranch.set_tree(gitbutler_diff::write::hunks_onto_oid(
             ctx,
-            vbranch.head(&repo)?.to_git2(),
+            vbranch.head_oid(&repo)?.to_git2(),
             files,
         )?);
         vb_state

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -324,7 +324,7 @@ fn get_stack_status(
         });
     }
 
-    let stack_head = repo.find_commit(stack.head(gix_repo)?.to_git2())?;
+    let stack_head = repo.find_commit(stack.head_oid(gix_repo)?.to_git2())?;
 
     let tree_status;
     if ctx.app_settings().feature_flags.v3 {
@@ -381,7 +381,7 @@ pub fn upstream_integration_statuses(
 
     let heads = stacks_in_workspace
         .iter()
-        .map(|stack| stack.head(&gix_repo))
+        .map(|stack| stack.head_oid(&gix_repo))
         .chain(Some(Ok(new_target.id().to_gix())))
         .collect::<Result<Vec<_>>>()?;
 
@@ -693,7 +693,7 @@ fn compute_resolutions(
                     // then rebase the tree ontop of that. If the tree ends
                     // up conflicted, commit the tree.
                     let target_commit =
-                        repo.find_commit(branch_stack.head(context.gix_repo)?.to_git2())?;
+                        repo.find_commit(branch_stack.head_oid(context.gix_repo)?.to_git2())?;
                     let top_branch = branch_stack.heads.last().context("top branch not found")?;
 
                     // These two go into the merge commit message.

--- a/crates/gitbutler-branch-actions/tests/reorder.rs
+++ b/crates/gitbutler-branch-actions/tests/reorder.rs
@@ -332,7 +332,7 @@ fn conflicting_reorder_stack() -> Result<()> {
     // Verify the initial order
     assert_eq!(commits[1].msgs(), vec!["commit 2", "commit 1"]);
     assert_eq!(commits[1].conflicted(), vec![false, false]); // no conflicts
-    assert_eq!(file(&ctx, test.stack.head(&repo.to_gix()?)?), "y\n"); // y is the last version
+    assert_eq!(file(&ctx, test.stack.head_oid(&repo.to_gix()?)?), "y\n"); // y is the last version
     assert!(commits[1].timestamps().windows(2).all(|w| w[0] >= w[1])); // commit timestamps in descending order
 
     // Reorder the stack in a way that will cause a conflict
@@ -350,7 +350,7 @@ fn conflicting_reorder_stack() -> Result<()> {
     // Verify that the commits are now in the updated order
     assert_eq!(commits[1].msgs(), vec!["commit 1", "commit 2"]); // swapped
     assert_eq!(commits[1].conflicted(), vec![false, true]); // bottom commit is now conflicted
-    assert_eq!(file(&ctx, test.stack.head(&repo.to_gix()?)?), "x\n"); // x is the last version
+    assert_eq!(file(&ctx, test.stack.head_oid(&repo.to_gix()?)?), "x\n"); // x is the last version
     assert!(commits[1].timestamps().windows(2).all(|w| w[0] >= w[1])); // commit timestamps in descending order
 
     let commit_1_prime = repo.find_commit(commits[1].ids()[0])?;
@@ -384,7 +384,7 @@ fn conflicting_reorder_stack() -> Result<()> {
     // Verify that the commits are now in the updated order
     assert_eq!(commits[1].msgs(), vec!["commit 2", "commit 1"]); // swapped
     assert_eq!(commits[1].conflicted(), vec![false, false]); // conflicts are gone
-    assert_eq!(file(&ctx, test.stack.head(&repo.to_gix()?)?), "y\n"); // y is the last version again
+    assert_eq!(file(&ctx, test.stack.head_oid(&repo.to_gix()?)?), "y\n"); // y is the last version again
     assert!(commits[1].timestamps().windows(2).all(|w| w[0] >= w[1])); // commit timestamps in descending order
 
     let commit_2_prime_prime = repo.find_commit(commits[1].ids()[0])?;

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -452,7 +452,7 @@ fn prepare_snapshot(
 
         // let's get all the commits between the branch head and the target
         let mut revwalk = repo.revwalk()?;
-        revwalk.push(stack.head(&gix_repo)?.to_git2())?;
+        revwalk.push(stack.head_oid(&gix_repo)?.to_git2())?;
         revwalk.hide(default_target_commit.id())?;
 
         // If the references are out of sync, now is a good time to update them

--- a/crates/gitbutler-repo-actions/src/repository.rs
+++ b/crates/gitbutler-repo-actions/src/repository.rs
@@ -84,7 +84,7 @@ impl RepoActionsExt for CommandContext {
         let (should_write, with_force) =
             match self.repo().find_reference(&stack.refname()?.to_string()) {
                 Ok(reference) => match reference.target() {
-                    Some(head_oid) => Ok((head_oid != stack.head(&gix_repo)?.to_git2(), true)),
+                    Some(head_oid) => Ok((head_oid != stack.head_oid(&gix_repo)?.to_git2(), true)),
                     None => Ok((true, true)),
                 },
                 Err(err) => match err.code() {
@@ -98,7 +98,7 @@ impl RepoActionsExt for CommandContext {
             self.repo()
                 .reference(
                     &stack.refname()?.to_string(),
-                    stack.head(&gix_repo)?.to_git2(),
+                    stack.head_oid(&gix_repo)?.to_git2(),
                     with_force,
                     "new vbranch",
                 )

--- a/crates/gitbutler-stack/src/stack.rs
+++ b/crates/gitbutler-stack/src/stack.rs
@@ -210,11 +210,10 @@ impl Stack {
         self.try_into()
     }
 
-    // TODO: derive this from the last head
     pub fn head_oid(&self, repo: &gix::Repository) -> Result<gix::ObjectId> {
         self.heads
             .last()
-            .map(|head| head.head_oid(repo))
+            .map(|branch| branch.head_oid(repo))
             .ok_or_else(|| anyhow!("Stack is uninitialized"))?
     }
 

--- a/crates/gitbutler-stack/src/stack.rs
+++ b/crates/gitbutler-stack/src/stack.rs
@@ -211,7 +211,7 @@ impl Stack {
     }
 
     // TODO: derive this from the last head
-    pub fn head(&self, repo: &gix::Repository) -> Result<gix::ObjectId> {
+    pub fn head_oid(&self, repo: &gix::Repository) -> Result<gix::ObjectId> {
         self.heads
             .last()
             .map(|head| head.head_oid(repo))
@@ -226,7 +226,7 @@ impl Stack {
     pub fn tree(&self, ctx: &CommandContext) -> Result<git2::Oid> {
         if ctx.app_settings().feature_flags.v3 {
             ctx.gix_repo()?
-                .find_commit(self.head(&ctx.gix_repo()?)?)?
+                .find_commit(self.head_oid(&ctx.gix_repo()?)?)?
                 .tree()
                 .map(|tree| tree.id.to_git2())
                 .map_err(Into::into)
@@ -292,7 +292,7 @@ impl Stack {
     pub fn commits(&self, ctx: &CommandContext) -> Result<Vec<git2::Oid>> {
         let repo = ctx.repo();
         let stack_commits = repo.l(
-            self.head(&repo.to_gix()?)?.to_git2(),
+            self.head_oid(&repo.to_gix()?)?.to_git2(),
             LogUntil::Commit(self.merge_base(ctx)?.to_git2()),
             false,
         )?;
@@ -324,7 +324,7 @@ impl Stack {
         let virtual_branch_state = VirtualBranchesHandle::new(ctx.project().gb_dir());
         let target = virtual_branch_state.get_default_target()?;
         let gix_repo = ctx.gix_repo()?;
-        let merge_base = gix_repo.merge_base(self.head(&gix_repo)?, target.sha.to_gix())?;
+        let merge_base = gix_repo.merge_base(self.head_oid(&gix_repo)?, target.sha.to_gix())?;
         Ok(merge_base.detach())
     }
 
@@ -374,7 +374,7 @@ impl Stack {
         let head = if self.heads.is_empty() {
             self.head
         } else {
-            self.head(&repo)?.to_git2()
+            self.head_oid(&repo)?.to_git2()
         };
         let commit = ctx.repo().find_commit(head)?;
 
@@ -457,7 +457,7 @@ impl Stack {
         validate_target(
             new_head.head_oid(&gix_repo)?.to_git2(),
             ctx.repo(),
-            self.head(&gix_repo)?.to_git2(),
+            self.head_oid(&gix_repo)?.to_git2(),
             &state,
         )?;
         let updated_heads = add_head(

--- a/crates/gitbutler-stack/src/stack_branch.rs
+++ b/crates/gitbutler-stack/src/stack_branch.rs
@@ -143,14 +143,17 @@ impl StackBranch {
         }
     }
 
-    /// This will update the commit that this points to (the virtual reference in virtual_branches.toml) as well as update of create a real git reference.
-    /// If this points to a change id, it's a noop operation. In practice, moving forward, new CommitOrChangeId entries will always be CommitId and ChangeId may only appear in deserialized data.
-    pub fn set_head<T>(&mut self, head: T, repo: &gix::Repository) -> Result<Option<BString>>
+    /// This will update the commit that real git reference points to, so it points to `target`,
+    /// as well as the cached data in this instance.
+    /// Returns the full reference name like `refs/heads/name`.
+    /// If this points to a change id, it's a noop operation. In practice, moving forward, new
+    /// `CommitOrChangeId` entries will always be CommitId and ChangeId may only appear in deserialized data.
+    pub fn set_head<T>(&mut self, target: T, repo: &gix::Repository) -> Result<Option<BString>>
     where
         T: Into<CommitOrChangeId> + Clone,
     {
-        let refname = self.set_real_reference(repo, &head)?;
-        self.head = head.into();
+        let refname = self.set_real_reference(repo, &target)?;
+        self.head = target.into();
         Ok(refname)
     }
 

--- a/crates/gitbutler-stack/src/stack_branch.rs
+++ b/crates/gitbutler-stack/src/stack_branch.rs
@@ -317,7 +317,7 @@ impl StackBranch {
         let head_commit = commit_by_oid_or_change_id(
             &self.head,
             repo,
-            stack.head(&gix_repo)?.to_git2(),
+            stack.head_oid(&gix_repo)?.to_git2(),
             merge_base,
         );
         if head_commit.is_err() {
@@ -331,7 +331,7 @@ impl StackBranch {
 
         // Find the previous head in the stack - if it is not archived, use it as base
         // Otherwise use the merge base
-        let stack_head = stack.head(&gix_repo)?.to_git2();
+        let stack_head = stack.head_oid(&gix_repo)?.to_git2();
         let previous_head = stack
             .branch_predacessor(self)
             .filter(|predacessor| !predacessor.archived)

--- a/crates/gitbutler-stack/src/state.rs
+++ b/crates/gitbutler-stack/src/state.rs
@@ -290,7 +290,7 @@ impl VirtualBranchesHandle {
             if branch.not_in_workspace_wip_change_id.is_some() {
                 continue; // Skip branches that have a WIP commit
             }
-            if let Ok(branch_head) = branch.head(&gix_repo).map(|h| h.to_git2()) {
+            if let Ok(branch_head) = branch.head_oid(&gix_repo).map(|h| h.to_git2()) {
                 if repo.find_commit(branch_head).is_err() {
                     // if the head commit cant be found, we can GC the branch
                     to_remove.push(branch.id);

--- a/crates/gitbutler-stack/tests/mod.rs
+++ b/crates/gitbutler-stack/tests/mod.rs
@@ -66,7 +66,7 @@ fn add_series_top_base() -> Result<()> {
     let (ctx, _temp_dir) = command_ctx("multiple-commits")?;
     let mut test_ctx = test_ctx(&ctx)?;
     let merge_base = ctx.repo().find_commit(ctx.repo().merge_base(
-        test_ctx.stack.head(&ctx.gix_repo()?)?.to_git2(),
+        test_ctx.stack.head_oid(&ctx.gix_repo()?)?.to_git2(),
         test_ctx.default_target.sha,
     )?)?;
     let reference = StackBranch::new(
@@ -640,7 +640,7 @@ fn set_stack_head() -> Result<()> {
         branches.first().unwrap().head_oid(&ctx.gix_repo()?)?.into()
     );
     assert_eq!(
-        test_ctx.stack.head(&ctx.gix_repo()?)?,
+        test_ctx.stack.head_oid(&ctx.gix_repo()?)?,
         test_ctx.other_commits.last().unwrap().id().to_gix()
     );
     Ok(())
@@ -818,13 +818,13 @@ fn test_ctx(ctx: &CommandContext) -> Result<TestContext> {
     let target = handle.get_default_target()?;
     let gix_repo = ctx.gix_repo()?;
     let mut branch_commits = ctx.repo().log(
-        stack.head(&gix_repo)?.to_git2(),
+        stack.head_oid(&gix_repo)?.to_git2(),
         LogUntil::Commit(target.sha),
         false,
     )?;
     branch_commits.reverse();
     let mut other_commits = ctx.repo().log(
-        other_stack.head(&gix_repo)?.to_git2(),
+        other_stack.head_oid(&gix_repo)?.to_git2(),
         LogUntil::Commit(target.sha),
         false,
     )?;

--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -138,10 +138,6 @@ pub fn create_commit_from_worktree_changes(
         guard.write_permission(),
     );
 
-    // let vb_state = VirtualBranchesHandle::new(project.gb_dir());
-    // gitbutler_branch_actions::update_workspace_commit(&vb_state, &ctx)
-    //     .context("failed to update gitbutler workspace")?;
-
     let _ = snapshot_tree.and_then(|snapshot_tree| {
         ctx.snapshot_commit_creation(
             snapshot_tree,

--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -260,7 +260,7 @@ pub fn stash_into_branch(
         perm,
     )?;
 
-    let parent_commit_id = stack.head(&repo)?;
+    let parent_commit_id = stack.head_oid(&repo)?;
     let branch_name = stack.derived_name()?;
 
     let outcome = commit_engine::create_commit_and_update_refs_with_project(

--- a/crates/gitbutler-workspace/src/branch_trees.rs
+++ b/crates/gitbutler-workspace/src/branch_trees.rs
@@ -47,7 +47,7 @@ pub fn checkout_branch_trees<'a>(
         let gix_repo = ctx.gix_repo_for_merging()?;
         let heads = stacks
             .iter()
-            .map(|b| b.head(&gix_repo))
+            .map(|b| b.head_oid(&gix_repo))
             .collect::<Result<Vec<_>>>()?;
         let merge_base_tree_id = gix_repo
             .merge_base_octopus(heads)?
@@ -101,7 +101,7 @@ impl WorkspaceState {
             .list_stacks_in_workspace()?
             .iter()
             .map(|stack| -> Result<git2::Oid> {
-                let head = stack.head(&repo.to_gix()?)?.to_git2();
+                let head = stack.head_oid(&repo.to_gix()?)?.to_git2();
                 let commit = repo.find_commit(head)?;
                 let tree = repo.find_real_tree(&commit, Default::default())?;
                 Ok(tree.id())
@@ -253,7 +253,7 @@ pub fn compute_updated_branch_head(
     compute_updated_branch_head_for_commits(
         repo,
         gix_repo,
-        stack.head(&repo.to_gix()?)?.to_git2(),
+        stack.head_oid(&repo.to_gix()?)?.to_git2(),
         stack.tree(ctx)?,
         new_head,
     )

--- a/crates/gitbutler-workspace/src/lib.rs
+++ b/crates/gitbutler-workspace/src/lib.rs
@@ -26,7 +26,7 @@ pub fn workspace_base(
     let stacks = vb_state.list_stacks_in_workspace()?;
     let stack_heads = stacks
         .iter()
-        .map(|b| b.head(&gix_repo))
+        .map(|b| b.head_oid(&gix_repo))
         .collect::<Result<Vec<_>>>()?;
     let merge_base_id = gix_repo
         .merge_base_octopus([stack_heads, vec![target_branch_commit]].concat())?

--- a/crates/gitbutler-workspace/tests/branch_trees.rs
+++ b/crates/gitbutler-workspace/tests/branch_trees.rs
@@ -60,7 +60,7 @@ mod compute_updated_branch_head {
             compute_updated_branch_head(r, &r.to_gix().unwrap(), &stack, head.id(), &ctx).unwrap();
 
         let r = &test_repository.repository;
-        assert_eq!(head.to_gix(), stack.head(&r.to_gix().unwrap()).unwrap());
+        assert_eq!(head.to_gix(), stack.head_oid(&r.to_gix().unwrap()).unwrap());
         assert_eq!(tree, stack.tree(&ctx).unwrap());
     }
 


### PR DESCRIPTION
When using the commit-engine, references pointed to any old commit are updated to the new commit.
However, this also is done for references 'outside' of the workspace, and ideally we reign that in to only happen when a reference is known to be 'inside' of the workspace.

### Tasks

* [x] 'real-world' emulating test
    - Update checked-out branch
    - branches in virtual-branches.toml
* [x] fix it