### PR TITLE
test: add option to skip trimming commit message titles

### DIFF
--- a/apps/desktop/src/components/CommitMessageInput.svelte
+++ b/apps/desktop/src/components/CommitMessageInput.svelte
@@ -68,7 +68,7 @@
 	let isTitleFocused = $state(true);
 	let isDescriptionFocused = $state(false);
 
-	const { title, description } = $derived(splitMessage(commitMessage));
+	const { title, description } = $derived(splitMessage(commitMessage, true));
 
 	$effect(() => {
 		valid = !!title;

--- a/apps/desktop/src/lib/utils/commitMessage.test.ts
+++ b/apps/desktop/src/lib/utils/commitMessage.test.ts
@@ -27,6 +27,20 @@ describe.concurrent('#splitMessage', () => {
 		});
 	});
 
+	test('Titles are trimmed by default', () => {
+		const message = '   Fixed all the bugs!   \nActually maybe not...';
+		const title = 'Fixed all the bugs!';
+		const description = 'Actually maybe not...';
+		expect(splitMessage(message)).toMatchObject({ title, description });
+	});
+
+	test('If specified, titles are not trimmed', () => {
+		const message = '   Fixed all the bugs!   \nActually maybe not...';
+		const title = '   Fixed all the bugs!   ';
+		const description = 'Actually maybe not...';
+		expect(splitMessage(message, true)).toMatchObject({ title, description });
+	});
+
 	test('When provided a commit message with multiple newline, it returns a title and description', () => {
 		const message = 'Fixed all the bugs!\n\nActually maybe not...';
 

--- a/apps/desktop/src/lib/utils/commitMessage.ts
+++ b/apps/desktop/src/lib/utils/commitMessage.ts
@@ -4,19 +4,19 @@
  * The title is the first line of the message, and the description is everything from the
  * next non-emptyline till the last non-empty line.
  *
- * Only the title will be trimmed, the description will keep its original formatting.
+ * Only the title will be trimmed (unless otherwise specified), the description will keep its original formatting.
  */
-export function splitMessage(message: string) {
+export function splitMessage(message: string, skipTrimming: boolean = false) {
 	const lines = message.split('\n');
 	if (lines.length === 0) {
 		return { title: '', description: '' };
 	}
 
 	if (lines.length === 1) {
-		return { title: message.trim(), description: '' };
+		return { title: skipTrimming ? message : message.trim(), description: '' };
 	}
 
-	const title = lines[0]!.trim();
+	const title = skipTrimming ? lines[0]! : lines[0]!.trim();
 	let description: string = '';
 
 	// Search for the first and last non-empty lines


### PR DESCRIPTION
Add a skipTrimming parameter to splitMessage to allow titles to be
returned without trimming whitespace. Update tests to verify default
trimming behavior and the new option. This improves flexibility when
parsing commit messages with intentional leading or trailing spaces
in titles.