### PR TITLE
Update commit_changes to support tree changes along side commit changes

### DIFF
--- a/apps/desktop/src/components/v3/FileListItemWrapper.svelte
+++ b/apps/desktop/src/components/v3/FileListItemWrapper.svelte
@@ -4,6 +4,7 @@
 	import { draggableChips } from '$lib/dragging/draggable';
 	import { ChangeDropData } from '$lib/dragging/draggables';
 	import { getFilename } from '$lib/files/utils';
+	import { previousPathBytesFromTreeChange, type TreeChange } from '$lib/hunks/change';
 	import { ChangeSelectionService } from '$lib/selection/changeSelection.svelte';
 	import { IdSelection } from '$lib/selection/idSelection.svelte';
 	import { key, type SelectionId } from '$lib/selection/key';
@@ -13,7 +14,6 @@
 	import FileListItemV3 from '@gitbutler/ui/file/FileListItemV3.svelte';
 	import FileViewHeader from '@gitbutler/ui/file/FileViewHeader.svelte';
 	import { stickyHeader } from '@gitbutler/ui/utils/stickyHeader';
-	import type { TreeChange } from '$lib/hunks/change';
 	import type { Rename } from '$lib/hunks/change';
 	import type { UnifiedDiff } from '$lib/hunks/diff';
 
@@ -88,7 +88,8 @@
 			changeSelection.add({
 				type: 'full',
 				path,
-				pathBytes
+				pathBytes,
+				previousPathBytes: previousPathBytesFromTreeChange(change)
 			});
 		}
 	}

--- a/apps/desktop/src/components/v3/NewCommitView.svelte
+++ b/apps/desktop/src/components/v3/NewCommitView.svelte
@@ -98,6 +98,7 @@
 			if (item.type === 'full') {
 				worktreeChanges.push({
 					pathBytes: item.pathBytes,
+					previousPathBytes: item.previousPathBytes,
 					hunkHeaders: []
 				});
 				continue;
@@ -123,6 +124,7 @@
 				}
 				worktreeChanges.push({
 					pathBytes: item.pathBytes,
+					previousPathBytes: item.previousPathBytes,
 					hunkHeaders
 				});
 				continue;

--- a/apps/desktop/src/components/v3/TreeListFolder.svelte
+++ b/apps/desktop/src/components/v3/TreeListFolder.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { countLeafNodes, getAllChanges, nodePath, type TreeNode } from '$lib/files/filetreeV3';
+	import { previousPathBytesFromTreeChange } from '$lib/hunks/change';
 	import { ChangeSelectionService } from '$lib/selection/changeSelection.svelte';
 	import { getContext } from '@gitbutler/shared/context';
 	import FolderListItem from '@gitbutler/ui/file/FolderListItem.svelte';
@@ -37,7 +38,8 @@
 				selectionService.add({
 					type: 'full',
 					path: change.path,
-					pathBytes: change.pathBytes
+					pathBytes: change.pathBytes,
+					previousPathBytes: previousPathBytesFromTreeChange(change)
 				});
 			} else {
 				selectionService.remove(change.path);

--- a/apps/desktop/src/components/v3/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/v3/UnifiedDiffView.svelte
@@ -8,6 +8,7 @@
 	import DependencyService from '$lib/dependencies/dependencyService.svelte';
 	import { draggableChips } from '$lib/dragging/draggable';
 	import { ChangeDropData } from '$lib/dragging/draggables';
+	import { previousPathBytesFromTreeChange, type TreeChange } from '$lib/hunks/change';
 	import { canBePartiallySelected, getLineLocks, type DiffHunk } from '$lib/hunks/hunk';
 	import { Project } from '$lib/project/project';
 	import { isWorkspacePath } from '$lib/routes/routes.svelte';
@@ -24,7 +25,6 @@
 	import { getContextStoreBySymbol, inject } from '@gitbutler/shared/context';
 	import EmptyStatePlaceholder from '@gitbutler/ui/EmptyStatePlaceholder.svelte';
 	import HunkDiff from '@gitbutler/ui/HunkDiff.svelte';
-	import type { TreeChange } from '$lib/hunks/change';
 	import type { UnifiedDiff } from '$lib/hunks/diff';
 	import type { LineId } from '@gitbutler/ui/utils/diffParsing';
 
@@ -67,7 +67,8 @@
 	const selection = $derived(changeSelectionResult.current);
 	const pathData = $derived({
 		path: change.path,
-		pathBytes: change.pathBytes
+		pathBytes: change.pathBytes,
+		previousPathBytes: previousPathBytesFromTreeChange(change)
 	});
 
 	const changesTimestamp = $derived(worktreeService.getChangesTimeStamp(projectId));

--- a/apps/desktop/src/components/v3/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/v3/WorktreeChanges.svelte
@@ -8,6 +8,7 @@
 	import { createCommitStore } from '$lib/commits/contexts';
 	import { Focusable, FocusManager } from '$lib/focus/focusManager.svelte';
 	import { focusable } from '$lib/focus/focusable.svelte';
+	import { previousPathBytesFromTreeChange } from '$lib/hunks/change';
 	import { ChangeSelectionService, type SelectedFile } from '$lib/selection/changeSelection.svelte';
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { UiState } from '$lib/state/uiState.svelte';
@@ -72,10 +73,13 @@
 
 	function selectEverything() {
 		const affectedPaths =
-			changesResult.current.data?.map((c) => [c.path, c.pathBytes] as const) ?? [];
-		const files: SelectedFile[] = affectedPaths.map(([path, pathBytes]) => ({
+			changesResult.current.data?.map(
+				(c) => [c.path, c.pathBytes, previousPathBytesFromTreeChange(c)] as const
+			) ?? [];
+		const files: SelectedFile[] = affectedPaths.map(([path, pathBytes, previousPathBytes]) => ({
 			path,
 			pathBytes,
+			previousPathBytes,
 			type: 'full'
 		}));
 		changeSelection.addMany(files);

--- a/apps/desktop/src/components/v3/unifiedDiffLineSelection.svelte.ts
+++ b/apps/desktop/src/components/v3/unifiedDiffLineSelection.svelte.ts
@@ -1,4 +1,4 @@
-import { type TreeChange } from '$lib/hunks/change';
+import { previousPathBytesFromTreeChange, type TreeChange } from '$lib/hunks/change';
 import { leftJoinBy, outerJoinBy } from '$lib/utils/array';
 import { isDefined } from '@gitbutler/ui/utils/typeguards';
 import type { DiffHunk } from '$lib/hunks/hunk';
@@ -21,7 +21,8 @@ export default class LineSelection {
 		this.change
 			? {
 					path: this.change.path,
-					pathBytes: this.change.pathBytes
+					pathBytes: this.change.pathBytes,
+					previousPathBytes: previousPathBytesFromTreeChange(this.change)
 				}
 			: undefined
 	);

--- a/apps/desktop/src/lib/hunks/change.ts
+++ b/apps/desktop/src/lib/hunks/change.ts
@@ -25,6 +25,13 @@ export type TreeChange = {
 	readonly status: Status;
 };
 
+export function previousPathBytesFromTreeChange(treeChange: TreeChange): number[] | null {
+	if (treeChange.status.type === 'Rename') {
+		return treeChange.status.subject.previousPathBytes;
+	}
+	return null;
+}
+
 export type TreeStats = {
 	/** The total amount of lines added. */
 	readonly linesAdded: number;

--- a/apps/desktop/src/lib/selection/changeSelection.svelte.ts
+++ b/apps/desktop/src/lib/selection/changeSelection.svelte.ts
@@ -37,6 +37,7 @@ export type SelectedHunk = FullySelectedHunk | PartiallySelectedHunk;
 type FileHeader = {
 	path: string;
 	pathBytes: number[];
+	previousPathBytes: number[] | null;
 };
 
 export type FullySelectedFile = FileHeader & {

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -38,7 +38,7 @@ export type CreateCommitRequest = {
 	parentId: string | undefined;
 	stackBranchName: string;
 	worktreeChanges: {
-		previousPathBytes?: number[];
+		previousPathBytes: number[] | null;
 		pathBytes: number[];
 		hunkHeaders: HunkHeader[];
 	}[];


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#52gwwJfTm`](https://gitbutler.com/cto/gitbutler-client-d443/reviews/52gwwJfTm)

**Update commit_changes to support tree changes along side commit changes**


Given that the tauri type are `thing | null` I’ve gone ahead and used that throughout

1 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Update commit_changes to support tree changes along side commit changes](https://gitbutler.com/cto/gitbutler-client-d443/reviews/52gwwJfTm/commit/94f7ac02-3db2-45a6-b894-3c30163a8a6b) | ✅ | <img width="20" height="20" src="https://avatars.githubusercontent.com/u/35891811?v=4"> |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/cto/gitbutler-client-d443/reviews/52gwwJfTm)_
<!-- GitButler Review Footer Boundary Bottom -->
