### PR TITLE
Test the stackless commit & 'your commit goes here' badge

### DIFF
--- a/apps/desktop/cypress/e2e/commitActions.cy.ts
+++ b/apps/desktop/cypress/e2e/commitActions.cy.ts
@@ -5,12 +5,14 @@ import { MOCK_STACK_A_ID } from './support/mock/stacks';
 
 describe('Commit Actions', () => {
 	let mockBackend: MockBackend;
+
 	beforeEach(() => {
 		mockBackend = new MockBackend();
 		mockCommand('stack_details', (params) => mockBackend.getStackDetails(params));
 		mockCommand('update_commit_message', (params) => mockBackend.updateCommitMessage(params));
 		mockCommand('changes_in_worktree', (params) => mockBackend.getWorktreeChanges(params));
 		mockCommand('tree_change_diffs', (params) => mockBackend.getDiff(params));
+		mockCommand('changes_in_commit', (params) => mockBackend.getCommitChanges(params));
 		mockCommand('create_commit_from_worktree_changes', (params) =>
 			mockBackend.createCommit(params)
 		);
@@ -31,6 +33,7 @@ describe('Commit Actions', () => {
 		const newCommitMessageBody = 'New commit message body';
 
 		cy.spy(mockBackend, 'updateCommitMessage').as('updateCommitMessageSpy');
+		cy.spy(mockBackend, 'getDiff').as('getDiffSpy');
 
 		// Click on the first commit
 		cy.getByTestId('commit-row').first().should('contain', originalCommitMessage).click();
@@ -78,6 +81,9 @@ describe('Commit Actions', () => {
 			commitOid: mockBackend.commitOid,
 			message: `${newCommitMessageTitle}\n\n${newCommitMessageBody}`
 		});
+
+		// Should never get the diff information, because there are no partial changes being committed.
+		expect(mockBackend.getDiff).to.have.callCount(0);
 	});
 
 	it('Should be able to commit', () => {
@@ -107,6 +113,9 @@ describe('Commit Actions', () => {
 		// Should open the new commit drawer
 		cy.getByTestId('new-commit-drawer').should('be.visible');
 
+		// Should have the "Your commit goes here" text
+		cy.getByTestId('your-commit-goes-here').should('be.visible').should('have.class', 'first');
+
 		// Should have selected the file
 		cy.getByTestId('uncommitted-changes-file-list-item')
 			.first()
@@ -135,7 +144,101 @@ describe('Commit Actions', () => {
 		cy.getByTestId('commit-drawer-title').should('contain', newCommitMessage);
 		cy.getByTestId('commit-drawer-description').should('contain', newCommitMessageBody);
 
-		// Should never get the diff information, becase there are no partial changes being commmitted.
-		cy.get('@getDiffSpy').should('not.be.called');
+		// Should never get the diff information, because there are no partial changes being committed.
+		expect(mockBackend.getDiff).to.have.callCount(0);
+	});
+});
+
+describe('Commit Actions with no stacks', () => {
+	let mockBackend: MockBackend;
+
+	beforeEach(() => {
+		mockBackend = new MockBackend({ initalStacks: [] });
+		mockCommand('stacks', () => mockBackend.getStacks());
+		mockCommand('create_virtual_branch', () => mockBackend.createBranch());
+		mockCommand('canned_branch_name', () => mockBackend.getCannedBranchName());
+		mockCommand('stack_details', (params) => mockBackend.getStackDetails(params));
+		mockCommand('update_commit_message', (params) => mockBackend.updateCommitMessage(params));
+		mockCommand('changes_in_worktree', (params) => mockBackend.getWorktreeChanges(params));
+		mockCommand('tree_change_diffs', (params) => mockBackend.getDiff(params));
+		mockCommand('changes_in_commit', (params) => mockBackend.getCommitChanges(params));
+		mockCommand('create_commit_from_worktree_changes', (params) =>
+			mockBackend.createCommit(params)
+		);
+
+		cy.visit('/');
+
+		cy.url().should('include', `/${PROJECT_ID}/workspace`);
+	});
+
+	afterEach(() => {
+		clearCommandMocks();
+	});
+
+	it('Should be able to commit even without a stack present', () => {
+		const newCommitMessage = 'New commit message';
+		const newCommitMessageBody = 'New commit message body';
+
+		// spies
+		cy.spy(mockBackend, 'getDiff').as('getDiffSpy');
+		cy.spy(mockBackend, 'createBranch').as('createBranchSpy');
+
+		// There should be uncommitted changes
+		cy.getByTestId('uncommitted-changes-file-list').should('be.visible');
+
+		const fileNames = mockBackend.getWorktreeChangesFileNames();
+
+		expect(fileNames).to.have.length(1);
+
+		const fileName = fileNames[0]!;
+
+		cy.getByTestId('uncommitted-changes-file-list-item')
+			.first()
+			.should('be.visible')
+			.should('contain', fileName);
+
+		// Click on the commit button
+		cy.getByTestId('start-commit-button').should('be.visible').should('be.enabled').click();
+
+		// Should open the new commit drawer
+		cy.getByTestId('new-commit-drawer').should('be.visible');
+
+		// Should display the draft stack
+		cy.getByTestId('stack-draft').should('be.visible');
+		cy.getByTestId('stack-draft').should('contain', mockBackend.cannedBranchName);
+
+		// Should have the "Your commit goes here" text
+		cy.getByTestId('your-commit-goes-here').should('be.visible').should('have.class', 'draft');
+
+		// Should have selected the file
+		cy.getByTestId('uncommitted-changes-file-list-item')
+			.first()
+			.get('input[type="checkbox"]')
+			.should('be.checked');
+
+		// Type in a commit message
+		cy.getByTestId('commit-drawer-title-input')
+			.should('be.visible')
+			.should('be.enabled')
+			.type(newCommitMessage); // Type the new commit message
+
+		// Type in a description
+		cy.getByTestId('commit-drawer-description-input')
+			.should('be.visible')
+			.click()
+			.type(newCommitMessageBody); // Type the new commit message body
+
+		// Click on the commit button
+		cy.getByTestId('commit-drawer-action-button').should('be.visible').should('be.enabled').click();
+
+		// Should display the commit rows
+		cy.getByTestId('commit-row').should('have.length', 1);
+
+		// Should commit and select the new commit
+		cy.getByTestId('commit-drawer-title').should('contain', newCommitMessage);
+		cy.getByTestId('commit-drawer-description').should('contain', newCommitMessageBody);
+
+		// Should never get the diff information, because there are no partial changes being committed.
+		expect(mockBackend.getDiff).to.have.callCount(0);
 	});
 });

--- a/apps/desktop/cypress/e2e/support/mock/backend.ts
+++ b/apps/desktop/cypress/e2e/support/mock/backend.ts
@@ -1,5 +1,6 @@
 import {
 	bytesToStr,
+	isGetCommitChangesParams,
 	isGetDiffParams,
 	isGetWorktreeChangesParams,
 	MOCK_TREE_CHANGE_A,
@@ -9,29 +10,60 @@ import {
 	isCreateCommitParams,
 	isStackDetailsParams,
 	isUpdateCommitMessageParams,
+	MOCK_BRAND_NEW_BRANCH_NAME,
 	MOCK_COMMIT,
 	MOCK_STACK_A_ID,
-	MOCK_STACK_DETAILS
+	MOCK_STACK_BRAND_NEW,
+	MOCK_STACK_BRAND_NEW_ID,
+	MOCK_STACK_DETAILS,
+	MOCK_STACK_DETAILS_BRAND_NEW,
+	MOCK_STACKS
 } from './stacks';
-import type { WorktreeChanges } from '$lib/hunks/change';
+import type { TreeChange, TreeChanges, WorktreeChanges } from '$lib/hunks/change';
 import type { UnifiedDiff } from '$lib/hunks/diff';
-import type { StackDetails } from '$lib/stacks/stack';
+import type { Stack, StackDetails } from '$lib/stacks/stack';
 import type { InvokeArgs } from '@tauri-apps/api/core';
+
+export type MockBackendOptions = {
+	initalStacks?: Stack[];
+};
 
 /**
  * *Ooooh look at me, I'm a mock backend!*
  */
 export default class MockBackend {
+	private stacks: Stack[];
 	private stackDetails: Map<string, StackDetails>;
+	private commitChanges: Map<string, TreeChange[]>;
 	private worktreeChanges: WorktreeChanges;
 	stackId: string = MOCK_STACK_A_ID;
+	renamedCommitId: string = '424242424242';
 	commitOid: string = MOCK_COMMIT.id;
+	cannedBranchName = MOCK_BRAND_NEW_BRANCH_NAME;
 
-	constructor() {
+	constructor(private options: MockBackendOptions = {}) {
+		this.stacks = options.initalStacks ?? MOCK_STACKS;
 		this.stackDetails = new Map<string, StackDetails>();
+		this.commitChanges = new Map<string, TreeChange[]>();
 		this.worktreeChanges = { changes: [MOCK_TREE_CHANGE_A], ignoredChanges: [] };
 
 		this.stackDetails.set(MOCK_STACK_A_ID, structuredClone(MOCK_STACK_DETAILS));
+		this.stackDetails.set(MOCK_STACK_BRAND_NEW_ID, structuredClone(MOCK_STACK_DETAILS_BRAND_NEW));
+		this.commitChanges.set(MOCK_COMMIT.id, []);
+		this.commitChanges.set(this.renamedCommitId, []);
+	}
+
+	public getStacks(): Stack[] {
+		return this.stacks;
+	}
+
+	public getCannedBranchName(): string {
+		return this.cannedBranchName ?? 'super-cool-branch-name';
+	}
+
+	public createBranch(): Stack {
+		this.stacks.push(MOCK_STACK_BRAND_NEW);
+		return MOCK_STACK_BRAND_NEW;
 	}
 
 	public getStackDetails(args: InvokeArgs | undefined): StackDetails {
@@ -63,7 +95,7 @@ export default class MockBackend {
 			const commitIndex = branch.commits.findIndex((commit) => commit.id === commitOid);
 			if (commitIndex === -1) continue;
 			const commit = branch.commits[commitIndex]!;
-			const newId = '424242424242';
+			const newId = this.renamedCommitId;
 			branch.commits[commitIndex] = {
 				...commit,
 				message,
@@ -108,9 +140,17 @@ export default class MockBackend {
 		const editableDetails = structuredClone(stackDetails);
 
 		// Assume only full file changes are passed.
-		const remainingChanges = this.worktreeChanges.changes.filter((change) => {
-			return !worktreeChanges.some((c) => bytesToStr(c.pathBytes) === change.path);
-		});
+		const remainingChanges: TreeChange[] = [];
+		const committedChanges: TreeChange[] = [];
+
+		for (const change of this.worktreeChanges.changes) {
+			const isCommitted = worktreeChanges.some((c) => bytesToStr(c.pathBytes) === change.path);
+			if (isCommitted) {
+				committedChanges.push(change);
+			} else {
+				remainingChanges.push(change);
+			}
+		}
 
 		this.worktreeChanges = {
 			...this.worktreeChanges,
@@ -140,6 +180,7 @@ export default class MockBackend {
 		];
 
 		this.stackDetails.set(stackId, editableDetails);
+		this.commitChanges.set(newCommitId, committedChanges);
 
 		const pathsToRejectedChanges: string[] = [];
 
@@ -152,5 +193,27 @@ export default class MockBackend {
 		}
 
 		return MOCK_UNIFIED_DIFF;
+	}
+
+	public getCommitChanges(args: InvokeArgs | undefined): TreeChanges {
+		if (!args || !isGetCommitChangesParams(args)) {
+			throw new Error('Invalid arguments for getCommitChanges');
+		}
+
+		const { commitId } = args;
+		const changes = this.commitChanges.get(commitId);
+
+		if (!changes) {
+			throw new Error(`No changes found for commit with ID ${commitId}`);
+		}
+
+		return {
+			changes,
+			stats: {
+				linesAdded: 0,
+				linesRemoved: 0,
+				filesChanged: changes.length
+			}
+		};
 	}
 }

--- a/apps/desktop/cypress/e2e/support/mock/changes.ts
+++ b/apps/desktop/cypress/e2e/support/mock/changes.ts
@@ -102,3 +102,19 @@ export function isGetDiffParams(args: unknown): args is GetDiffParams {
 		isTreeChange(args['change'])
 	);
 }
+
+export type GetCommitChangesParams = {
+	projectId: string;
+	commitId: string;
+};
+
+export function isGetCommitChangesParams(args: unknown): args is GetCommitChangesParams {
+	return (
+		typeof args === 'object' &&
+		args !== null &&
+		'projectId' in args &&
+		typeof args['projectId'] === 'string' &&
+		'commitId' in args &&
+		typeof args['commitId'] === 'string'
+	);
+}

--- a/apps/desktop/cypress/e2e/support/mock/stacks.ts
+++ b/apps/desktop/cypress/e2e/support/mock/stacks.ts
@@ -15,6 +15,21 @@ export const MOCK_STACK_A: Stack = {
 	tip: '1234123'
 };
 
+export const MOCK_BRAND_NEW_BRANCH_NAME = 'super-cool-branch-name';
+
+export const MOCK_STACK_BRAND_NEW_ID = 'empty-stack';
+
+export const MOCK_STACK_BRAND_NEW: Stack = {
+	id: MOCK_STACK_BRAND_NEW_ID,
+	heads: [
+		{
+			name: MOCK_BRAND_NEW_BRANCH_NAME,
+			tip: '1234123'
+		}
+	],
+	tip: '1234123'
+};
+
 export const MOCK_STACKS: Stack[] = [MOCK_STACK_A];
 
 export const MOCK_AUTHOR: Author = {
@@ -59,8 +74,32 @@ export const MOCK_BRANCH_DETAILS: BranchDetails = {
 	isRemoteHead: false
 };
 
+export const MOCK_BRANCH_DETAILS_BRAND_NEW: BranchDetails = {
+	name: MOCK_BRAND_NEW_BRANCH_NAME,
+	remoteTrackingBranch: null,
+	description: 'A mock branch for testing',
+	prNumber: null,
+	reviewId: null,
+	tip: '1234123',
+	baseCommit: 'base-sha',
+	pushStatus: 'completelyUnpushed',
+	lastUpdatedAt: Date.now(),
+	authors: [],
+	isConflicted: false,
+	commits: [],
+	upstreamCommits: [],
+	isRemoteHead: false
+};
+
+export const MOCK_STACK_DETAILS_BRAND_NEW: StackDetails = {
+	derivedName: MOCK_BRAND_NEW_BRANCH_NAME,
+	pushStatus: 'completelyUnpushed',
+	branchDetails: [MOCK_BRANCH_DETAILS_BRAND_NEW],
+	isConflicted: false
+};
+
 export const MOCK_STACK_DETAILS: StackDetails = {
-	derivedName: 'mock-branch',
+	derivedName: 'branch-a',
 	pushStatus: 'completelyUnpushed',
 	branchDetails: [MOCK_BRANCH_DETAILS],
 	isConflicted: false

--- a/apps/desktop/src/components/v3/CommitGoesHere.svelte
+++ b/apps/desktop/src/components/v3/CommitGoesHere.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { TestId } from '$lib/testing/testIds';
 	import Badge from '@gitbutler/ui/Badge.svelte';
 
 	type Props = {
@@ -14,6 +15,7 @@
 
 {#snippet indicator(args?: { last?: boolean; first?: boolean; draft?: boolean })}
 	<div
+		data-testid={TestId.YourCommitGoesHere}
 		class="indicator"
 		class:first={args?.first}
 		class:last={args?.last}

--- a/apps/desktop/src/components/v3/StackDraft.svelte
+++ b/apps/desktop/src/components/v3/StackDraft.svelte
@@ -4,6 +4,7 @@
 	import CommitGoesHere from '$components/v3/CommitGoesHere.svelte';
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { UiState } from '$lib/state/uiState.svelte';
+	import { TestId } from '$lib/testing/testIds';
 	import { inject } from '@gitbutler/shared/context';
 
 	type Props = {
@@ -32,7 +33,7 @@
 	const branchName = $derived(draftBranchName.current || newName);
 </script>
 
-<div class="stack-draft">
+<div data-testid={TestId.StackDraft} class="stack-draft">
 	<BranchCard type="draft-branch" {projectId} {branchName}>
 		{#snippet header()}
 			<BranchHeader

--- a/apps/desktop/src/components/v3/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/v3/WorktreeChanges.svelte
@@ -159,7 +159,7 @@
 							type="button"
 							size="cta"
 							wide
-							disabled={isCommitting || !defaultBranchName}
+							disabled={isCommitting || defaultBranchResult?.current.isLoading}
 							onclick={startCommit}
 						>
 							Start a commit…

--- a/apps/desktop/src/lib/testing/testIds.ts
+++ b/apps/desktop/src/lib/testing/testIds.ts
@@ -25,7 +25,9 @@ export enum TestId {
 	UncommittedChanges_FileListItem = 'uncommitted-changes-file-list-item',
 	StartCommitButton = 'start-commit-button',
 	CommitRow = 'commit-row',
-	NewCommitDrawer = 'new-commit-drawer'
+	NewCommitDrawer = 'new-commit-drawer',
+	StackDraft = 'stack-draft',
+	YourCommitGoesHere = 'your-commit-goes-here'
 }
 
 export enum ElementId {


### PR DESCRIPTION
- Add tests for committing with no stacks present and update commit actions for stackless and 'your commit goes here' scenarios  
- Update mock backend and mock data to support new test scenarios  
- Add type guards and types for new mock API parameters  
- Add test IDs to 'your commit goes here' indicator and stack draft container  
- Update testIds enum and fix commit button disabled logic in WorktreeChanges.svelte