### PR TITLE
fix(mock): allow previousPathBytes to be null in stacks mock

### DIFF
--- a/apps/desktop/cypress/e2e/support/mock/stacks.ts
+++ b/apps/desktop/cypress/e2e/support/mock/stacks.ts
@@ -180,7 +180,7 @@ export function isCreateCommitRequestWorktreeChanges(
 		something !== null &&
 		((Array.isArray((something as any).previousPathBytes) &&
 			(something as any).previousPathBytes.every((byte: any) => typeof byte === 'number')) ||
-			(something as any)['previousPathBytes'] === undefined) &&
+			(something as any)['previousPathBytes'] === null) &&
 		'pathBytes' in something &&
 		Array.isArray(something['pathBytes']) &&
 		something['pathBytes'].every((byte) => typeof byte === 'number') &&


### PR DESCRIPTION
Update validation logic in stacks mock to accept null for
previousPathBytes instead of undefined. This change aligns the
mock data with updated application behavior where previousPathBytes
can be explicitly set to null, improving test accuracy and
preventing false validation failures.