### PR TITLE
backend exposes workspace commit merge-failures to frontend

### DIFF
--- a/apps/desktop/src/components/v3/NewCommitView.svelte
+++ b/apps/desktop/src/components/v3/NewCommitView.svelte
@@ -145,7 +145,7 @@
 		if (response.pathsToRejectedChanges.length > 0) {
 			showError(
 				'Some changes were not committed',
-				`The following files were not committed becuase they are locked to another branch\n${response.pathsToRejectedChanges.join('\n')}`
+				`The following files were not committed becuase they are locked to another branch\n${response.pathsToRejectedChanges.map(([_reason, path]) => path).join('\n')}`
 			);
 		}
 

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -94,6 +94,22 @@ export interface BranchPushResult {
 	remote: string;
 }
 
+type RejectionReason =
+	| 'NoEffectiveChanges'
+	| 'CherryPickMergeConflict'
+	| 'WorkspaceMergeConflict'
+	| 'WorktreeFileMissingForObjectConversion'
+	| 'FileToLargeOrBinary'
+	| 'PathNotFoundInBaseTree'
+	| 'UnsupportedDirectoryEntry'
+	| 'UnsupportedTreeEntry'
+	| 'MissingDiffSpecAssociation';
+
+export type CreateCommitOutcome = {
+	newCommit: string;
+	pathsToRejectedChanges: [RejectionReason, string][];
+};
+
 export class StackService {
 	private api: ReturnType<typeof injectEndpoints>;
 
@@ -793,7 +809,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				]
 			}),
 			createCommit: build.mutation<
-				{ newCommit: string; pathsToRejectedChanges: string[] },
+				CreateCommitOutcome,
 				{ projectId: string } & CreateCommitRequest
 			>({
 				query: ({ projectId, ...commitData }) => ({

--- a/crates/but-workspace/src/commit_engine/mod.rs
+++ b/crates/but-workspace/src/commit_engine/mod.rs
@@ -159,7 +159,8 @@ pub struct CreateCommitOutcome {
 }
 
 /// Provide a description of why a [`DiffSpec`] was rejected for application to the tree of a commit.
-#[derive(Default, Debug, Copy, Clone, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 pub enum RejectionReason {
     /// All changes were applied, but they didn't end up effectively change the tree to something differing from the target tree.
     /// This means the changes were a no-op.


### PR DESCRIPTION
The idea is that top-level merge-conflicts are observable, and we match the diffspecs against them. This allows the frontend to respond to it.

Related to #8331.

### Tasks

* [x] reproduce
* [x] backend exposes a new rejection reason with diffspecs for merge failure
* [x] frontend type is aware of rejection reasons
