### PR TITLE
fix: remove unused variables and simplify edit permission logic

### DIFF
--- a/apps/desktop/src/components/v3/CommitView.svelte
+++ b/apps/desktop/src/components/v3/CommitView.svelte
@@ -52,8 +52,6 @@
 			? stackService.upstreamCommitById(projectId, commitKey)
 			: stackService.commitById(projectId, commitKey)
 	);
-	const isUnapplied = false; // TODO
-	const branchRefName = undefined; // TODO
 
 	const changesResult = $derived(stackService.commitChanges(projectId, commitKey.commitId));
 
@@ -118,14 +116,11 @@
 	}
 
 	function canEdit() {
-		if (isUnapplied) return false;
-		if (!modeService) return false;
-
-		return true;
+		return modeService !== undefined;
 	}
 
 	async function editPatch() {
-		if (!canEdit() || !branchRefName) return;
+		if (!canEdit()) return;
 		await modeService!.enterEditMode(commitKey.commitId, stackId);
 	}
 </script>


### PR DESCRIPTION
Remove the unused isUnapplied and branchRefName variables from CommitView.svelte
to clean up the code. Simplify the canEdit function by directly checking for the
presence of modeService, improving readability. Update editPatch to rely solely
on canEdit, removing the unnecessary branchRefName check. These changes reduce
dead code and clarify the conditions for enabling edit mode.