### PR TITLE
Add tests for the upstream integration modal & add the 'delete branch' check box

### DIFF
--- a/apps/desktop/cypress/e2e/support/index.ts
+++ b/apps/desktop/cypress/e2e/support/index.ts
@@ -179,7 +179,13 @@ type TestIdValues = `${TestId}`;
 declare global {
 	namespace Cypress {
 		interface Chainable {
-			getByTestId(testId: TestIdValues): Chainable<JQuery<HTMLElement>>;
+			/**
+			 * Get an element by its data-testid attribute.
+			 *
+			 * @param testId - The data-testid value to search for.
+			 * @param containingText - Optional text content to filter the elements by.
+			 */
+			getByTestId(testId: TestIdValues, containingText?: string): Chainable<JQuery<HTMLElement>>;
 			/**
 			 * Clear all mocks.
 			 */
@@ -202,7 +208,10 @@ Cypress.Commands.add('clearMocks', () => {
 	});
 });
 
-Cypress.Commands.add('getByTestId', (testId: TestIdValues) => {
+Cypress.Commands.add('getByTestId', (testId: TestIdValues, containingText?: string) => {
+	if (containingText) {
+		return cy.contains(`[data-testid="${testId}"]`, containingText);
+	}
 	return cy.get(`[data-testid="${testId}"]`);
 });
 

--- a/apps/desktop/cypress/e2e/support/mock/backend.ts
+++ b/apps/desktop/cypress/e2e/support/mock/backend.ts
@@ -1,3 +1,4 @@
+import { getBaseBranchData } from './baseBranch';
 import {
 	bytesToStr,
 	isGetCommitChangesParams,
@@ -20,9 +21,11 @@ import {
 	MOCK_STACK_DETAILS_BRAND_NEW,
 	MOCK_STACKS
 } from './stacks';
+import { MOCK_BRANCH_STATUSES_RESPONSE } from './upstreamIntegration';
 import type { TreeChange, TreeChanges, WorktreeChanges } from '$lib/hunks/change';
 import type { UnifiedDiff } from '$lib/hunks/diff';
 import type { Stack, StackDetails } from '$lib/stacks/stack';
+import type { BranchStatusesResponse } from '$lib/upstream/types';
 import type { InvokeArgs } from '@tauri-apps/api/core';
 
 export type MockBackendOptions = {
@@ -36,10 +39,10 @@ type CommitId = string;
  * *Ooooh look at me, I'm a mock backend!*
  */
 export default class MockBackend {
-	private stacks: Stack[];
-	private stackDetails: Map<StackId, StackDetails>;
-	private commitChanges: Map<CommitId, TreeChange[]>;
-	private worktreeChanges: WorktreeChanges;
+	protected stacks: Stack[];
+	protected stackDetails: Map<StackId, StackDetails>;
+	protected commitChanges: Map<CommitId, TreeChange[]>;
+	protected worktreeChanges: WorktreeChanges;
 	stackId: string = MOCK_STACK_A_ID;
 	renamedCommitId: string = '424242424242';
 	commitOid: string = MOCK_COMMIT.id;
@@ -246,5 +249,13 @@ export default class MockBackend {
 		}
 
 		throw new Error(`Commit with ID ${commitOid} not found`);
+	}
+
+	public getBaseBranchData(): unknown {
+		return getBaseBranchData();
+	}
+
+	public getUpstreamIntegrationStatuses(): BranchStatusesResponse {
+		return MOCK_BRANCH_STATUSES_RESPONSE;
 	}
 }

--- a/apps/desktop/cypress/e2e/support/mock/backend.ts
+++ b/apps/desktop/cypress/e2e/support/mock/backend.ts
@@ -21,11 +21,11 @@ import {
 	MOCK_STACK_DETAILS_BRAND_NEW,
 	MOCK_STACKS
 } from './stacks';
-import { MOCK_BRANCH_STATUSES_RESPONSE } from './upstreamIntegration';
+import { MOCK_BRANCH_STATUSES_RESPONSE, MOCK_INTEGRATION_OUTCOME } from './upstreamIntegration';
 import type { TreeChange, TreeChanges, WorktreeChanges } from '$lib/hunks/change';
 import type { UnifiedDiff } from '$lib/hunks/diff';
 import type { Stack, StackDetails } from '$lib/stacks/stack';
-import type { BranchStatusesResponse } from '$lib/upstream/types';
+import type { BranchStatusesResponse, IntegrationOutcome } from '$lib/upstream/types';
 import type { InvokeArgs } from '@tauri-apps/api/core';
 
 export type MockBackendOptions = {
@@ -257,5 +257,9 @@ export default class MockBackend {
 
 	public getUpstreamIntegrationStatuses(): BranchStatusesResponse {
 		return MOCK_BRANCH_STATUSES_RESPONSE;
+	}
+
+	public integrateUpstream(_args: InvokeArgs | undefined): IntegrationOutcome {
+		return MOCK_INTEGRATION_OUTCOME;
 	}
 }

--- a/apps/desktop/cypress/e2e/support/mock/baseBranch.ts
+++ b/apps/desktop/cypress/e2e/support/mock/baseBranch.ts
@@ -10,20 +10,20 @@ const MOCK_AUTHOR = {
 	name: 'Author Name'
 };
 
-const MOCK_RECENT_COMMITS = [
-	{
-		id: 'abc123',
-		author: MOCK_AUTHOR,
-		description: 'Initial commit',
-		createdAt: new Date('2023-01-01T00:00:00Z').getTime(),
-		changeId: '1',
-		isSigned: false,
-		parentIds: [],
-		conflicted: false,
-		prev: undefined,
-		next: undefined
-	}
-];
+const MOCK_COMMIT = {
+	id: 'abc123',
+	author: MOCK_AUTHOR,
+	description: 'Initial commit',
+	createdAt: new Date('2023-01-01T00:00:00Z').getTime(),
+	changeId: '1',
+	isSigned: false,
+	parentIds: [],
+	conflicted: false,
+	prev: undefined,
+	next: undefined
+};
+
+const MOCK_RECENT_COMMITS = [MOCK_COMMIT];
 
 const MOCK_BASE_BRANCH_DATA = {
 	branchName: 'origin/main',
@@ -45,4 +45,18 @@ const MOCK_BASE_BRANCH_DATA = {
 
 export function getBaseBranchData() {
 	return MOCK_BASE_BRANCH_DATA;
+}
+
+export function getBaseBranchBehindData() {
+	return {
+		...MOCK_BASE_BRANCH_DATA,
+		behind: 1,
+		upstreamCommits: [
+			{
+				...MOCK_COMMIT,
+				id: 'upstream-commit-id',
+				description: 'Upstream commit'
+			}
+		]
+	};
 }

--- a/apps/desktop/cypress/e2e/support/mock/stacks.ts
+++ b/apps/desktop/cypress/e2e/support/mock/stacks.ts
@@ -38,17 +38,29 @@ export const MOCK_AUTHOR: Author = {
 	gravatarUrl: 'https://avatars.githubusercontent.com/u/35891811?v=4'
 };
 
-export const MOCK_COMMIT_STATE: CommitState = { type: 'LocalOnly' };
+export const MOCK_COMMIT_STATE_LOCAL: CommitState = { type: 'LocalOnly' };
+export const MOCK_COMMIT_STATE_INTEGRATED: CommitState = { type: 'Integrated' };
+export const MOCK_COMMIT_STATE_LOCAL_AND_REMOTE_DIVERGED: CommitState = {
+	type: 'LocalAndRemote',
+	subject: 'remote-commit'
+};
 
 export const MOCK_COMMIT: Commit = {
 	id: '1234123',
 	parentIds: ['parent-sha'],
 	message: 'Initial commit',
 	hasConflicts: false,
-	state: MOCK_COMMIT_STATE,
+	state: MOCK_COMMIT_STATE_LOCAL,
 	createdAt: 1714000000000,
 	author: MOCK_AUTHOR
 };
+
+export function createCommit(override: Partial<Commit>): Commit {
+	return {
+		...MOCK_COMMIT,
+		...override
+	};
+}
 
 export const MOCK_UPSTREAM_COMMIT: UpstreamCommit = {
 	id: 'upstream-sha',

--- a/apps/desktop/cypress/e2e/support/mock/upstreamIntegration.ts
+++ b/apps/desktop/cypress/e2e/support/mock/upstreamIntegration.ts
@@ -1,5 +1,10 @@
-import type { BranchStatusesResponse } from '$lib/upstream/types';
+import type { BranchStatusesResponse, IntegrationOutcome } from '$lib/upstream/types';
 
 export const MOCK_BRANCH_STATUSES_RESPONSE: BranchStatusesResponse = {
 	type: 'upToDate'
+};
+
+export const MOCK_INTEGRATION_OUTCOME: IntegrationOutcome = {
+	archivedBranches: [],
+	reviewIdsToClose: []
 };

--- a/apps/desktop/cypress/e2e/support/scenarios/partialllyIntegratedBranches.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/partialllyIntegratedBranches.ts
@@ -65,13 +65,13 @@ const MOCK_BRANCH_DETAILS_B: BranchDetails = {
 	name: MOCK_STACK_B_ID,
 	tip: '1234123',
 	remoteTrackingBranch: `origin/${MOCK_STACK_B_ID}`,
-	pushStatus: 'unpushedCommits',
+	pushStatus: 'integrated',
 	commits: [
-		createCommit({ id: '1234123', message: 'Commit 1 (B)' }),
+		createCommit({ id: '1234123', message: 'Commit 1 (B)', state: MOCK_COMMIT_STATE_INTEGRATED }),
 		createCommit({
 			id: '456456456',
 			message: 'Commit 2 (B)',
-			state: { type: 'LocalAndRemote', subject: '456456456' }
+			state: MOCK_COMMIT_STATE_INTEGRATED
 		})
 	]
 };
@@ -93,7 +93,7 @@ const MOCK_BRANCH_DETAILS_B_D: BranchDetails = {
 
 const MOCK_STACK_DETAILS_B: StackDetails = {
 	derivedName: MOCK_STACK_B_ID,
-	pushStatus: 'unpushedCommits',
+	pushStatus: 'integrated',
 	branchDetails: [MOCK_BRANCH_DETAILS_B, MOCK_BRANCH_DETAILS_B_D],
 	isConflicted: false
 };
@@ -136,10 +136,10 @@ const MOCK_BRANCH_STATUSES_RESPONSE: BranchStatusesResponse = {
 			[
 				MOCK_STACK_B_ID,
 				{
-					treeStatus: { type: 'saflyUpdatable' },
+					treeStatus: { type: 'empty' },
 					branchStatuses: [
 						{ name: 'branch-d', status: { type: 'integrated' } },
-						{ name: MOCK_STACK_B_ID, status: { type: 'saflyUpdatable' } }
+						{ name: MOCK_STACK_B_ID, status: { type: 'integrated' } }
 					]
 				}
 			],

--- a/apps/desktop/cypress/e2e/support/scenarios/partialllyIntegratedBranches.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/partialllyIntegratedBranches.ts
@@ -1,0 +1,183 @@
+import MockBackend from '../mock/backend';
+import { getBaseBranchBehindData } from '../mock/baseBranch';
+import { createCommit, MOCK_BRANCH_DETAILS, MOCK_COMMIT_STATE_INTEGRATED } from '../mock/stacks';
+import type { BranchDetails, Stack, StackDetails } from '$lib/stacks/stack';
+import type { BranchStatusesResponse } from '$lib/upstream/types';
+
+const MOCK_STACK_A_ID = 'stack-a-id';
+const MOCK_STACK_B_ID = 'stack-b-id';
+const MOCK_STACK_C_ID = 'stack-c-id';
+
+const MOCK_STACK_A: Stack = {
+	id: MOCK_STACK_A_ID,
+	heads: [{ name: MOCK_STACK_A_ID, tip: '1234123' }],
+	tip: '1234123'
+};
+
+const MOCK_STACK_B: Stack = {
+	id: MOCK_STACK_B_ID,
+	heads: [
+		{ name: MOCK_STACK_B_ID, tip: '1234123' },
+		{ name: 'branch-d', tip: '456456456' }
+	],
+	tip: '1234123'
+};
+
+const MOCK_STACK_C: Stack = {
+	id: MOCK_STACK_C_ID,
+	heads: [
+		{ name: MOCK_STACK_C_ID, tip: '1234123' },
+		{ name: 'branch-e', tip: '456456456' }
+	],
+	tip: '1234123'
+};
+
+const MOCK_BRANCH_DETAILS_A: BranchDetails = {
+	...MOCK_BRANCH_DETAILS,
+	name: MOCK_STACK_A_ID,
+	tip: '1234123',
+	remoteTrackingBranch: `origin/${MOCK_STACK_A_ID}`,
+	pushStatus: 'unpushedCommits',
+	commits: [
+		createCommit({ id: '1234123', message: 'Commit 1' }),
+		createCommit({
+			id: '456456456',
+			message: 'Commit 2',
+			state: { type: 'LocalAndRemote', subject: '77888777888' }
+		}),
+		createCommit({
+			id: '789789789',
+			message: 'Commit 3',
+			state: { type: 'LocalAndRemote', subject: '789789789' }
+		})
+	]
+};
+
+const MOCK_STACK_DETAILS_A: StackDetails = {
+	derivedName: MOCK_STACK_A_ID,
+	pushStatus: 'unpushedCommits',
+	branchDetails: [MOCK_BRANCH_DETAILS_A],
+	isConflicted: false
+};
+
+const MOCK_BRANCH_DETAILS_B: BranchDetails = {
+	...MOCK_BRANCH_DETAILS,
+	name: MOCK_STACK_B_ID,
+	tip: '1234123',
+	remoteTrackingBranch: `origin/${MOCK_STACK_B_ID}`,
+	pushStatus: 'unpushedCommits',
+	commits: [
+		createCommit({ id: '1234123', message: 'Commit 1 (B)' }),
+		createCommit({
+			id: '456456456',
+			message: 'Commit 2 (B)',
+			state: { type: 'LocalAndRemote', subject: '456456456' }
+		})
+	]
+};
+
+const MOCK_BRANCH_DETAILS_B_D: BranchDetails = {
+	...MOCK_BRANCH_DETAILS,
+	name: 'branch-d',
+	tip: '456456456',
+	remoteTrackingBranch: 'origin/branch-d',
+	pushStatus: 'integrated',
+	commits: [
+		createCommit({
+			id: '456456456',
+			message: 'Commit 1 (branch-d)',
+			state: MOCK_COMMIT_STATE_INTEGRATED
+		})
+	]
+};
+
+const MOCK_STACK_DETAILS_B: StackDetails = {
+	derivedName: MOCK_STACK_B_ID,
+	pushStatus: 'unpushedCommits',
+	branchDetails: [MOCK_BRANCH_DETAILS_B, MOCK_BRANCH_DETAILS_B_D],
+	isConflicted: false
+};
+
+const MOCK_BRANCH_DETAILS_C: BranchDetails = {
+	...MOCK_BRANCH_DETAILS,
+	name: MOCK_STACK_C_ID,
+	tip: '1234123',
+	remoteTrackingBranch: `origin/${MOCK_STACK_C_ID}`,
+	pushStatus: 'integrated',
+	commits: [
+		createCommit({ id: '1234123', message: 'Commit 1 (C)', state: MOCK_COMMIT_STATE_INTEGRATED }),
+		createCommit({
+			id: '456456456',
+			message: 'Commit 2 (C)',
+			state: MOCK_COMMIT_STATE_INTEGRATED
+		})
+	]
+};
+
+const MOCK_STACK_DETAILS_C: StackDetails = {
+	derivedName: MOCK_STACK_C_ID,
+	pushStatus: 'unpushedCommits',
+	branchDetails: [MOCK_BRANCH_DETAILS_C],
+	isConflicted: false
+};
+
+const MOCK_BRANCH_STATUSES_RESPONSE: BranchStatusesResponse = {
+	type: 'updatesRequired',
+	subject: {
+		worktreeConflicts: [],
+		statuses: [
+			[
+				MOCK_STACK_A_ID,
+				{
+					treeStatus: { type: 'saflyUpdatable' },
+					branchStatuses: [{ name: MOCK_STACK_A_ID, status: { type: 'saflyUpdatable' } }]
+				}
+			],
+			[
+				MOCK_STACK_B_ID,
+				{
+					treeStatus: { type: 'saflyUpdatable' },
+					branchStatuses: [
+						{ name: 'branch-d', status: { type: 'integrated' } },
+						{ name: MOCK_STACK_B_ID, status: { type: 'saflyUpdatable' } }
+					]
+				}
+			],
+			[
+				MOCK_STACK_C_ID,
+				{
+					treeStatus: { type: 'empty' },
+					branchStatuses: [{ name: MOCK_STACK_C_ID, status: { type: 'integrated' } }]
+				}
+			]
+		]
+	}
+};
+
+/**
+ * This is a mock backend for the following scenario:
+ *
+ * There are multiple stacks in the workspace.
+ * Some of the stacks are fully integrated, while others are partially integrated.
+ *
+ * The base branch is one commit behind.
+ */
+export default class PartiallyIntegratedBranches extends MockBackend {
+	constructor() {
+		super();
+		this.stacks = [MOCK_STACK_A, MOCK_STACK_B, MOCK_STACK_C];
+		this.stackId = MOCK_STACK_A_ID;
+		this.stackDetails = new Map<string, StackDetails>();
+		this.stackDetails.set(MOCK_STACK_A_ID, MOCK_STACK_DETAILS_A);
+		this.stackDetails.set(MOCK_STACK_B_ID, MOCK_STACK_DETAILS_B);
+		this.stackDetails.set(MOCK_STACK_C_ID, MOCK_STACK_DETAILS_C);
+	}
+
+	public getBaseBranchData() {
+		return getBaseBranchBehindData();
+	}
+
+	public getUpstreamIntegrationStatuses(): BranchStatusesResponse {
+		return MOCK_BRANCH_STATUSES_RESPONSE;
+	}
+}

--- a/apps/desktop/cypress/e2e/upstreamIntegration.cy.ts
+++ b/apps/desktop/cypress/e2e/upstreamIntegration.cy.ts
@@ -1,0 +1,90 @@
+import { clearCommandMocks, mockCommand } from './support';
+import { PROJECT_ID } from './support/mock/projects';
+import PartiallyIntegratedBranches from './support/scenarios/partialllyIntegratedBranches';
+
+describe('Upstream Integration', () => {
+	let mockBackend: PartiallyIntegratedBranches;
+
+	beforeEach(() => {
+		mockBackend = new PartiallyIntegratedBranches();
+		mockCommand('stacks', () => mockBackend.getStacks());
+		mockCommand('stack_details', (params) => mockBackend.getStackDetails(params));
+		mockCommand('get_base_branch_data', () => mockBackend.getBaseBranchData());
+		mockCommand('upstream_integration_statuses', () =>
+			mockBackend.getUpstreamIntegrationStatuses()
+		);
+		mockCommand('integrate_upstream', (params) => mockBackend.integrateUpstream(params));
+
+		cy.visit('/');
+
+		cy.url({ timeout: 3000 }).should('include', `/workspace/${mockBackend.stackId}`);
+	});
+
+	afterEach(() => {
+		clearCommandMocks();
+	});
+
+	it('Should open the upstream integration modal', () => {
+		// The first stack should be shown in the workspace
+		cy.getByTestId('branch-header')
+			.first()
+			.should('be.visible')
+			.should('contain', mockBackend.stackId);
+
+		// Click on the "Integrate Upstream Commits" button
+		cy.getByTestId('integrate-upstream-commits-button').click();
+
+		// The modal should be visible
+		cy.getByTestId('integrate-upstream-commits-modal').should('be.visible');
+
+		// The modal should contain the three stacks
+		cy.getByTestId('integrate-upstream-commits-modal')
+			.getByTestId('integrate-upstream-series-row')
+			.should('have.length', 3);
+	});
+
+	it('Should correctly delete the integrated stacks', () => {
+		// spy
+		cy.spy(mockBackend, 'integrateUpstream').as('integrateUpstream');
+
+		// Click on the "Integrate Upstream Commits" button
+		cy.getByTestId('integrate-upstream-commits-button').click();
+
+		// The modal should be visible
+		cy.getByTestId('integrate-upstream-commits-modal').should('be.visible');
+
+		// Click on the "Delete" button for the first stack
+		cy.getByTestId('integrate-upstream-series-row', 'Delete all local branches')
+			.first()
+			.find('input[type="checkbox"]')
+			.uncheck();
+
+		// Integrate the sh*t out of the upstream
+		cy.getByTestId('integrate-upstream-action-button').click();
+		cy.getByTestId('integrate-upstream-commits-modal').should('not.exist');
+
+		cy.get('@integrateUpstream').should('have.been.calledWithMatch', {
+			projectId: PROJECT_ID,
+			resolutions: [
+				{
+					branchId: 'stack-a-id',
+					approach: { type: 'rebase' },
+					deleteIntegratedBranches: true
+				},
+				{
+					branchId: 'stack-b-id',
+					approach: { type: 'delete' },
+					deleteIntegratedBranches: false
+				},
+				{
+					branchId: 'stack-c-id',
+					approach: {
+						type: 'delete'
+					},
+					deleteIntegratedBranches: true
+				}
+			],
+			branchResolution: undefined
+		});
+	});
+});

--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -8,6 +8,7 @@
 	import { Project } from '$lib/project/project';
 	import { ProjectsService } from '$lib/project/projectsService';
 	import { ircPath, projectPath } from '$lib/routes/routes.svelte';
+	import { TestId } from '$lib/testing/testIds';
 	import { getContext, maybeGetContext } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import Icon from '@gitbutler/ui/Icon.svelte';
@@ -66,7 +67,11 @@
 		<div class="chrome-left-buttons" class:macos={platformName === 'macos'}>
 			<SyncButton {projectId} size="button" disabled={actionsDisabled} />
 			{#if upstreamCommits > 0}
-				<Button style="pop" onclick={openModal} disabled={!selectedProjectId || actionsDisabled}
+				<Button
+					testId={TestId.IntegrateUpstreamCommitsButton}
+					style="pop"
+					onclick={openModal}
+					disabled={!selectedProjectId || actionsDisabled}
 					>{upstreamCommits} upstream commits</Button
 				>
 			{/if}

--- a/apps/desktop/src/components/v3/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/v3/IntegrateUpstreamModal.svelte
@@ -84,9 +84,9 @@
 					{
 						branchId: status.stack.id,
 						approach: defaultApproach,
-						deleteIntegratedBranches: false // TODO: Take input from the UI
+						deleteIntegratedBranches: true
 					}
-				];
+				] as const;
 			})
 		);
 
@@ -207,6 +207,7 @@
 {#snippet stackStatus(stack: Stack, stackStatus: StackStatus)}
 	{@const branchShouldBeDeletedMap = getBranchShouldBeDeletedMap(stack.id, stackStatus)}
 	<IntegrationSeriesRow
+		testId={TestId.IntegrateUpstreamSeriesRow}
 		series={integrationRowSeries(stackStatus)}
 		{branchShouldBeDeletedMap}
 		updateBranchShouldBeDeletedMap={(_, shouldBeDeleted) =>
@@ -344,6 +345,7 @@
 		<div class="controls">
 			<Button onclick={() => modal?.close()} kind="outline">Cancel</Button>
 			<Button
+				testId={TestId.IntegrateUpstreamActionButton}
 				wide
 				type="submit"
 				style="pop"

--- a/apps/desktop/src/components/v3/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/v3/IntegrateUpstreamModal.svelte
@@ -4,6 +4,7 @@
 	import BaseBranchService from '$lib/baseBranch/baseBranchService.svelte';
 	import { DefaultForgeFactory } from '$lib/forge/forgeFactory.svelte';
 	import { type Stack } from '$lib/stacks/stack';
+	import { TestId } from '$lib/testing/testIds';
 	import {
 		getBaseBranchResolution,
 		type BaseBranchResolutionApproach,
@@ -208,7 +209,14 @@
 	</IntegrationSeriesRow>
 {/snippet}
 
-<Modal bind:this={modal} {onClose} width={520} noPadding onSubmit={integrate}>
+<Modal
+	testId={TestId.IntegrateUpstreamCommitsModal}
+	bind:this={modal}
+	{onClose}
+	width={520}
+	noPadding
+	onSubmit={integrate}
+>
 	<ScrollableContainer maxHeight={'70vh'}>
 		{#if base}
 			<div class="section">

--- a/apps/desktop/src/lib/testing/testIds.ts
+++ b/apps/desktop/src/lib/testing/testIds.ts
@@ -33,7 +33,9 @@ export enum TestId {
 	CommitMenuButton = 'commit-menu-btn',
 	UncommitMenuButton = 'uncommit-menu-btn',
 	IntegrateUpstreamCommitsButton = 'integrate-upstream-commits-button',
-	IntegrateUpstreamCommitsModal = 'integrate-upstream-commits-modal'
+	IntegrateUpstreamCommitsModal = 'integrate-upstream-commits-modal',
+	IntegrateUpstreamSeriesRow = 'integrate-upstream-series-row',
+	IntegrateUpstreamActionButton = 'integrate-upstream-action-button'
 }
 
 export enum ElementId {

--- a/apps/desktop/src/lib/testing/testIds.ts
+++ b/apps/desktop/src/lib/testing/testIds.ts
@@ -31,7 +31,9 @@ export enum TestId {
 	StackDraft = 'stack-draft',
 	YourCommitGoesHere = 'your-commit-goes-here',
 	CommitMenuButton = 'commit-menu-btn',
-	UncommitMenuButton = 'uncommit-menu-btn'
+	UncommitMenuButton = 'uncommit-menu-btn',
+	IntegrateUpstreamCommitsButton = 'integrate-upstream-commits-button',
+	IntegrateUpstreamCommitsModal = 'integrate-upstream-commits-modal'
 }
 
 export enum ElementId {

--- a/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
+++ b/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
@@ -110,7 +110,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				{ projectId: string; targetCommitOid?: string }
 			>({
 				query: ({ projectId, targetCommitOid }) => ({
-					command: `upstream_integration_statuses`,
+					command: 'upstream_integration_statuses',
 					params: { projectId, targetCommitOid }
 				}),
 				providesTags: [providesList(ReduxTag.UpstreamIntegrationStatus)]
@@ -124,7 +124,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				}
 			>({
 				query: ({ projectId, resolutions, baseBranchResolution }) => ({
-					command: `integrate_upstream`,
+					command: 'integrate_upstream',
 					params: { projectId, resolutions, baseBranchResolution }
 				}),
 				invalidatesTags: [

--- a/packages/ui/src/lib/IntegrationSeriesRow.svelte
+++ b/packages/ui/src/lib/IntegrationSeriesRow.svelte
@@ -13,6 +13,7 @@
 	};
 
 	export interface Props {
+		testId?: string;
 		series: Branch[];
 		branchShouldBeDeletedMap: BranchShouldBeDeletedMap;
 		updateBranchShouldBeDeletedMap: (branchName: string[], shouldBeDeleted: boolean) => void;
@@ -24,8 +25,13 @@
 	import Checkbox from '$lib/Checkbox.svelte';
 	import Icon from '$lib/Icon.svelte';
 	import SeriesIcon from '$lib/SeriesIcon.svelte';
-	const { series, children, updateBranchShouldBeDeletedMap, branchShouldBeDeletedMap }: Props =
-		$props();
+	const {
+		testId,
+		series,
+		children,
+		updateBranchShouldBeDeletedMap,
+		branchShouldBeDeletedMap
+	}: Props = $props();
 
 	const allSeriesAreIntegrated = series.every((branch) => branch.status === 'integrated');
 </script>
@@ -56,7 +62,7 @@
 	</div>
 {/snippet}
 
-<div class="integration-series-item no-select">
+<div data-testid={testId} class="integration-series-item no-select">
 	{#if series.length > 1}
 		<div class="series-header" class:integrated={allSeriesAreIntegrated}>
 			<div class="series-header-row">

--- a/packages/ui/src/lib/IntegrationSeriesRow.svelte
+++ b/packages/ui/src/lib/IntegrationSeriesRow.svelte
@@ -8,16 +8,26 @@
 		status: BranchStatus;
 	};
 
+	export type BranchShouldBeDeletedMap = {
+		[branchName: string]: boolean;
+	};
+
 	export interface Props {
 		series: Branch[];
+		branchShouldBeDeletedMap: BranchShouldBeDeletedMap;
+		updateBranchShouldBeDeletedMap: (branchName: string[], shouldBeDeleted: boolean) => void;
 		children?: Snippet;
 	}
 </script>
 
 <script lang="ts">
+	import Checkbox from '$lib/Checkbox.svelte';
 	import Icon from '$lib/Icon.svelte';
 	import SeriesIcon from '$lib/SeriesIcon.svelte';
-	const { series, children }: Props = $props();
+	const { series, children, updateBranchShouldBeDeletedMap, branchShouldBeDeletedMap }: Props =
+		$props();
+
+	const allSeriesAreIntegrated = series.every((branch) => branch.status === 'integrated');
 </script>
 
 {#snippet stackBranch({ name, status }: Branch, isLast: boolean)}
@@ -48,11 +58,32 @@
 
 <div class="integration-series-item no-select">
 	{#if series.length > 1}
-		<div class="series-header">
-			<div class="name-label-wrap">
-				<SeriesIcon single={false} outlined />
+		<div class="series-header" class:integrated={allSeriesAreIntegrated}>
+			<div class="series-header-row">
+				<div class="name-label-wrap">
+					<SeriesIcon single={false} outlined />
 
-				<span class="series-label text-12 text-semibold truncate"> Stack branches </span>
+					<span class="series-label text-12 text-semibold truncate"> Stack branches </span>
+				</div>
+
+				{#if allSeriesAreIntegrated}
+					{@const atLeastSomeWillBeDeleted = series.some(
+						(branch) => branchShouldBeDeletedMap[branch.name]
+					)}
+					<div class="integrated-label-wrap">
+						<span class="integrated-label text-12">Delete all local branches</span>
+						<Checkbox
+							checked={atLeastSomeWillBeDeleted}
+							onchange={(e) => {
+								const shouldBeDeleted = e.currentTarget.checked;
+								updateBranchShouldBeDeletedMap(
+									series.map((branch) => branch.name),
+									shouldBeDeleted
+								);
+							}}
+						/>
+					</div>
+				{/if}
 			</div>
 
 			{#if children}
@@ -74,14 +105,30 @@
 				<span class="text-12 text-semibold truncate">
 					{branch.name}
 				</span>
+
 				{#if branch.status}
-					<span class="status-badge text-10 text-semibold">
-						{#if branch.status === 'conflicted'}
-							Conflicted
-						{:else if branch.status === 'integrated'}
-							Integrated
+					<div class="branch-status-info">
+						<span class="status-badge text-10 text-semibold">
+							{#if branch.status === 'conflicted'}
+								Conflicted
+							{:else if branch.status === 'integrated'}
+								Integrated
+							{/if}
+						</span>
+
+						{#if branch.status === 'integrated'}
+							<div class="integrated-label-wrap">
+								<span class="integrated-label text-12">Delete local branch</span>
+								<Checkbox
+									checked={branchShouldBeDeletedMap[branch.name]}
+									onchange={(e) => {
+										const shouldBeDeleted = e.currentTarget.checked;
+										updateBranchShouldBeDeletedMap([branch.name], shouldBeDeleted);
+									}}
+								/>
+							</div>
 						{/if}
-					</span>
+					</div>
 				{/if}
 			</div>
 
@@ -130,6 +177,13 @@
 			color: var(--clr-text-2);
 		}
 
+		.series-header-row {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			flex: 1;
+		}
+
 		/* NAME LABEL */
 		.name-label-wrap {
 			flex: 1;
@@ -137,6 +191,13 @@
 			align-items: center;
 			gap: 10px;
 			overflow: hidden;
+		}
+
+		.branch-status-info {
+			flex: 1;
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
 		}
 
 		.select {
@@ -166,7 +227,7 @@
 	.integrated-label-wrap {
 		display: flex;
 		align-items: center;
-		gap: 4px;
+		gap: 8px;
 		padding-left: 6px;
 		margin-right: 2px;
 		color: var(--clr-text-2);

--- a/packages/ui/src/stories/IntegrationSeriesRow/IntegrationSeriesRow.stories.svelte
+++ b/packages/ui/src/stories/IntegrationSeriesRow/IntegrationSeriesRow.stories.svelte
@@ -4,32 +4,67 @@
 	} from '$lib/IntegrationSeriesRow.svelte';
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 
-	const items = [
+	// eslint-disable-next-line func-style
+	const updateBranchShouldBeDeletedMap = (branchName: string[], shouldBeDeleted: boolean) => {
+		// Mock function to update the branch deletion status
+		// eslint-disable-next-line no-console
+		console.log(`Branches ${branchName.join(',')} should be deleted: ${shouldBeDeleted}`);
+	};
+	const items: SeriesProps[] = [
 		{
 			series: [
 				{ name: 'feature/add-user-auth', status: 'integrated' },
-				{ name: 'feature/update-user-profile' },
+				{ name: 'feature/update-user-profile', status: 'clear' },
 				{ name: 'feature/create-payment-gateway', status: 'conflicted' },
 				{ name: 'feature/improve-dashboard', status: 'integrated' },
-				{ name: 'feature/add-user-notifications' }
-			]
+				{ name: 'feature/add-user-notifications', status: 'clear' }
+			],
+			branchShouldBeDeletedMap: {
+				'feature/add-user-auth': true,
+				'feature/update-user-profile': false,
+				'feature/create-payment-gateway': false,
+				'feature/improve-dashboard': true,
+				'feature/add-user-notifications': false
+			},
+			updateBranchShouldBeDeletedMap
 		},
-		{ series: [{ name: 'feature/add-user-auth', status: 'integrated' }] },
+		{
+			series: [{ name: 'feature/add-user-auth', status: 'integrated' }],
+			branchShouldBeDeletedMap: {
+				'feature/add-user-auth': true
+			},
+			updateBranchShouldBeDeletedMap
+		},
 		{
 			series: [
 				{ name: 'feature/add-user-auth', status: 'integrated' },
-				{ name: 'feature/update-user-profile' },
+				{ name: 'feature/update-user-profile', status: 'clear' },
 				{ name: 'feature/create-payment-gateway', status: 'conflicted' },
 				{ name: 'feature/improve-dashboard', status: 'integrated' },
-				{ name: 'feature/add-user-notifications' },
+				{ name: 'feature/add-user-notifications', status: 'clear' },
 				{ name: 'feature/optimize-search', status: 'conflicted' },
 				{ name: 'feature/refactor-api', status: 'integrated' },
-				{ name: 'feature/fix-bug-123' },
+				{ name: 'feature/fix-bug-123', status: 'clear' },
+				{ name: 'feature/add-analytics-tracking', status: 'integrated' },
+				{ name: 'feature/add-multi-language-support', status: 'conflicted' },
 				{ name: 'feature/add-analytics-tracking', status: 'conflicted' },
 				{ name: 'feature/add-multi-language-support', status: 'integrated' }
-			]
+			],
+			branchShouldBeDeletedMap: {
+				'feature/add-user-auth': true,
+				'feature/update-user-profile': false,
+				'feature/create-payment-gateway': false,
+				'feature/improve-dashboard': true,
+				'feature/add-user-notifications': false,
+				'feature/optimize-search': false,
+				'feature/refactor-api': true,
+				'feature/fix-bug-123': false,
+				'feature/add-analytics-tracking': false,
+				'feature/add-multi-language-support': true
+			},
+			updateBranchShouldBeDeletedMap
 		}
-	] as SeriesProps[];
+	];
 
 	const { Story } = defineMeta({
 		title: 'List items / Integration Series Row'


### PR DESCRIPTION
### Description

- Added comprehensive Cypress tests for the upstream integration modal, including new scenarios for partially integrated branches.
- Updated mock backend and utilities to support upstream integration testing.
- Introduced test IDs for upstream integration button, modal, and integration rows to improve test targeting.
- Added a "delete branch" checkbox control in IntegrationSeriesRow and integration modals, supporting individual and bulk branch deletion.
- Fixed command string formatting in the upstream integration service.
- Enhanced Cypress utility `getByTestId` to filter by optional text content for more flexible selectors.
- Updated Storybook stories to demonstrate the new branch deletion UI and logic.