### PR TITLE
Re-use terminal environment

### DIFF
--- a/crates/but-core/src/cmd.rs
+++ b/crates/but-core/src/cmd.rs
@@ -1,26 +1,98 @@
+use bstr::BStr;
 use std::ffi::OsString;
+use std::path::PathBuf;
+use std::process::Stdio;
 
-/// Prepare `program` for invocation with a Git-compatible shell to help it pick up more of the usual environment.
+/// Prepare `program` for invocation with a Git-compatible shell to help it pick up more of the usual environment on Windows.
 ///
 /// On Windows, this specifically uses the Git-bundled shell, further increasing compatibility.
-pub fn prepare_with_shell(program: impl Into<OsString>) -> gix::command::Prepare {
-    let login_shell = std::env::var_os("SHELL");
-    // if login shell is set and it is a POSIX shell, use it, otherwise use the default shell
-    let shell_program = login_shell
-        .filter(|s| {
-            let s = s.to_string_lossy();
-            s.ends_with("/sh") || s.ends_with("/bash") || s.ends_with("/zsh")
-        })
-        .unwrap_or_else(|| gix::path::env::shell().into());
+pub fn prepare_with_shell_on_windows(program: impl Into<OsString>) -> gix::command::Prepare {
+    if cfg!(windows) {
+        gix::command::prepare(program)
+            // On Windows, this means a shell will always be used.
+            .command_may_be_shell_script_disallow_manual_argument_splitting()
+            // force using a shell, we want access to additional programs here
+            .with_shell()
+            // We know `program` is a path, so quote it.
+            .with_quoted_command()
+    } else {
+        gix::command::prepare(program)
+    }
+}
 
-    gix::command::prepare(program)
-        // On Windows, this means a shell will always be used.
-        .command_may_be_shell_script_disallow_manual_argument_splitting()
-        // On Windows, this yields the Git-bundled `sh.exe`, which is what we want.
-        // Only use a login shell here if it is a POSIX one.
-        .with_shell_program(shell_program)
-        // force using a shell, we want access to additional programs here
-        .with_shell()
-        // We know `program` is a path, so quote it.
-        .with_quoted_command()
+/// Launch the login shell and try to extract their environment variables, or `None` if the shell couldn't be determined,
+/// or if it couldn't be launched, or if the environment extraction failed.
+pub fn extract_interactive_login_shell_environment() -> Option<Vec<(OsString, OsString)>> {
+    let shell_path: PathBuf = std::env::var_os("SHELL")?.into();
+    let stdout = std::process::Command::new(shell_path)
+        .args(["-i", "-l", "-c", "env"])
+        .stderr(Stdio::null())
+        .output()
+        .ok()?
+        .stdout;
+
+    let vars = parse_key_value_pairs(stdout.as_slice());
+    (!vars.is_empty()).then_some(vars)
+}
+
+/// Parse `a=b\n` input and convert these into OsStrings for later consumption
+fn parse_key_value_pairs<'a>(input: impl Into<&'a BStr>) -> Vec<(OsString, OsString)> {
+    use bstr::ByteSlice;
+    let mut out = Vec::new();
+    for line in input.into().lines() {
+        let mut tokens = line.splitn(2, |b| b == &b'=');
+        let (key, value) = (tokens.next(), tokens.next());
+        match (key, value) {
+            (Some(key), Some(value)) => {
+                out.push((
+                    gix::path::from_byte_slice(key).into(),
+                    gix::path::from_byte_slice(value).into(),
+                ));
+            }
+            _ => continue,
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod extract_login_shell_command {
+    use super::parse_key_value_pairs;
+    use std::ffi::OsString;
+
+    #[test]
+    fn parse_key_value_pairs_various_inputs() {
+        let one_line_missing_newline = "a=b";
+        assert_eq!(
+            parse_key_value_pairs(one_line_missing_newline),
+            osvec(Some(("a", "b")))
+        );
+
+        let value_with_equal_sign = "a=b=c";
+        assert_eq!(
+            parse_key_value_pairs(value_with_equal_sign),
+            osvec(Some(("a", "b=c")))
+        );
+
+        let multi_line = "a=b\nkey=value\n";
+        assert_eq!(
+            parse_key_value_pairs(multi_line),
+            osvec([("a", "b"), ("key", "value")])
+        );
+
+        let multi_line_missing_trailing_newline = "a=b\nkey=value";
+        assert_eq!(
+            parse_key_value_pairs(multi_line_missing_trailing_newline),
+            osvec([("a", "b"), ("key", "value")])
+        );
+    }
+
+    fn osvec(
+        pairs: impl IntoIterator<Item = (&'static str, &'static str)>,
+    ) -> Vec<(OsString, OsString)> {
+        pairs
+            .into_iter()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect()
+    }
 }

--- a/crates/but-core/tests/core/cmd.rs
+++ b/crates/but-core/tests/core/cmd.rs
@@ -1,0 +1,16 @@
+mod extract_login_shell_environment {
+    use but_core::cmd::extract_interactive_login_shell_environment;
+
+    #[test]
+    fn no_panic() {
+        // cannot expect anything, except that invoking it shouldn't panic.
+        let res = extract_interactive_login_shell_environment();
+        if let Some(vars) = res {
+            assert_ne!(
+                vars.len(),
+                0,
+                "There is never 'no' variables, or else there is `None`"
+            );
+        }
+    }
+}

--- a/crates/but-core/tests/core/main.rs
+++ b/crates/but-core/tests/core/main.rs
@@ -1,3 +1,4 @@
+mod cmd;
 mod commit;
 mod diff;
 mod json_samples;

--- a/crates/but-rebase/src/commit.rs
+++ b/crates/but-rebase/src/commit.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, anyhow, bail};
 use bstr::{BString, ByteSlice};
-use but_core::cmd::prepare_with_shell;
+use but_core::cmd::prepare_with_shell_on_windows;
 use but_core::{GitConfigSettings, RepositoryExt};
 use gitbutler_error::error::Code;
 use gix::objs::WriteTo;
@@ -121,8 +121,8 @@ pub fn sign_buffer(repo: &gix::Repository, buffer: &[u8]) -> anyhow::Result<BStr
                 |program| Cow::Owned(program.into_owned().into()),
             );
 
-        let cmd =
-            prepare_with_shell(gpg_program.into_owned()).args(["-Y", "sign", "-n", "git", "-f"]);
+        let cmd = prepare_with_shell_on_windows(gpg_program.into_owned())
+            .args(["-Y", "sign", "-n", "git", "-f"]);
 
         // Write the key to a temp file. This is needs to be created in the
         // same scope where its used; IE: in the command, otherwise the
@@ -179,7 +179,7 @@ pub fn sign_buffer(repo: &gix::Repository, buffer: &[u8]) -> anyhow::Result<BStr
                 |program| Cow::Owned(program.into_owned().into()),
             );
 
-        let mut cmd = into_command(prepare_with_shell(gpg_program.as_ref()).args([
+        let mut cmd = into_command(prepare_with_shell_on_windows(gpg_program.as_ref()).args([
             "--status-fd=2",
             "-bsau",
             signing_key,


### PR DESCRIPTION
Try to acquire the login shell (`$SHELL`) environment and apply it to the parent process so we can use the Git shell (usually `sh`) to run helper programs like GPG.
That should significantly reduce the time it takes to invoke, as using `$SHELL` can add 100ms and more, something that accumulates when doing rebases or rewrites of a stack.
Additionally, this will make GPG work on more Unix systems (like mine).

Fixes #8238.
Fixes #4750.

### Tasks

* [x] global environment acquisition
* [x] test with posix shell
* [x] test with non-POSIX shell: `fish`
    - it works implicitly, as we know `fish` supports `-c` which seems quite universal

### Follow-Up issues

* #8345 
* #5661 

### Notes for the reviewer

* On Unix systems, a shell isn't used anymore, which is similar to how Git does it. On Windows, a Git shell is used to provide GPG from the programs that Git ships with.
* On Unix, GPG will now basically work out of the box, so it should be possible to change the behaviour of `gitbutler.signCommits`.