### PR TITLE
fix: use current mode instead of saved state for defaultIndex

### DIFF
--- a/apps/desktop/src/components/v3/FileListMode.svelte
+++ b/apps/desktop/src/components/v3/FileListMode.svelte
@@ -21,7 +21,7 @@
 </script>
 
 <SegmentControl
-	defaultIndex={$saved === 'list' ? 0 : 1}
+	defaultIndex={mode === 'list' ? 0 : 1}
 	onselect={(id) => {
 		// TODO: Refactor SegmentControl.
 		$saved = id as Mode;


### PR DESCRIPTION
Update FileListMode.svelte to set SegmentControl defaultIndex based
on the current mode prop. The saved state will only update the mode when the persisted variable updates