### PR TITLE
Add tests for the file list modes & add some auto collapse logic for the tree view

### DIFF
--- a/apps/desktop/cypress/e2e/fileTree.cy.ts
+++ b/apps/desktop/cypress/e2e/fileTree.cy.ts
@@ -1,0 +1,55 @@
+import { clearCommandMocks, mockCommand } from './support';
+import LotsOfFileChanges from './support/scenarios/lotsOfFileChanges';
+
+describe('File Tree', () => {
+	let mockBackend: LotsOfFileChanges;
+	beforeEach(() => {
+		mockBackend = new LotsOfFileChanges();
+		mockCommand('stacks', () => mockBackend.getStacks());
+		mockCommand('stack_details', (params) => mockBackend.getStackDetails(params));
+		mockCommand('changes_in_worktree', (params) => mockBackend.getWorktreeChanges(params));
+
+		cy.visit('/');
+
+		cy.url({ timeout: 3000 }).should('include', `/workspace/${mockBackend.stackId}`);
+	});
+
+	afterEach(() => {
+		clearCommandMocks();
+	});
+
+	it('Should be able to toggle the file tree view - Uncommitted changes', () => {
+		// There should be uncommitted changes
+		cy.getByTestId('uncommitted-changes-file-list').should('be.visible');
+
+		// All files should be visible
+		cy.getByTestId('uncommitted-changes-file-list-item').should(
+			'have.length',
+			mockBackend.getWorktreeChangesFileNames().length
+		);
+
+		// The uncommitted changes header should be visible,
+		// and the file list mode should be selected
+		cy.getByTestId('uncommitted-changes-header')
+			.should('be.visible')
+			.within(() => {
+				cy.get('#list').should('be.visible').should('have.attr', 'aria-selected', 'true');
+
+				// Click the tree view button
+				cy.get('#tree').should('be.visible').should('have.attr', 'aria-selected', 'false').click();
+			});
+
+		// There should be collapsed file tree
+		cy.getByTestId('uncommitted-changes-file-list').within(() => {
+			cy.getByTestId('file-list-tree-folder').should(
+				'have.length',
+				mockBackend.getWorktreeChangesTopLevelDirs().length
+			);
+
+			cy.getByTestId('uncommitted-changes-file-list-item').should(
+				'have.length',
+				mockBackend.getWorktreeChangesTopLevelFiles().length
+			);
+		});
+	});
+});

--- a/apps/desktop/cypress/e2e/support/mock/backend.ts
+++ b/apps/desktop/cypress/e2e/support/mock/backend.ts
@@ -22,6 +22,7 @@ import {
 	MOCK_STACKS
 } from './stacks';
 import { MOCK_BRANCH_STATUSES_RESPONSE, MOCK_INTEGRATION_OUTCOME } from './upstreamIntegration';
+import { isDefined } from '@gitbutler/ui/utils/typeguards';
 import type { TreeChange, TreeChanges, WorktreeChanges } from '$lib/hunks/change';
 import type { UnifiedDiff } from '$lib/hunks/diff';
 import type { Stack, StackDetails } from '$lib/stacks/stack';
@@ -127,6 +128,28 @@ export default class MockBackend {
 		return this.worktreeChanges.changes
 			.map((change) => change.path)
 			.map((path) => path.split('/').pop()!);
+	}
+
+	public getWorktreeChangesTopLevelDirs(): string[] {
+		return this.worktreeChanges.changes
+			.map((change) => {
+				const listed = change.path.split('/');
+				if (listed.length < 2) return undefined;
+				return listed[0];
+			})
+			.filter(isDefined)
+			.filter((dir, index, self) => self.indexOf(dir) === index);
+	}
+
+	public getWorktreeChangesTopLevelFiles(): string[] {
+		return this.worktreeChanges.changes
+			.map((change) => {
+				const listed = change.path.split('/');
+				if (listed.length > 1) return undefined;
+				return listed[0];
+			})
+			.filter(isDefined)
+			.filter((file, index, self) => self.indexOf(file) === index);
 	}
 
 	public createCommit(args: InvokeArgs | undefined): {

--- a/apps/desktop/cypress/e2e/support/mock/changes.ts
+++ b/apps/desktop/cypress/e2e/support/mock/changes.ts
@@ -137,3 +137,98 @@ export function isUndoCommitParams(args: unknown): args is UndoCommitParams {
 		typeof args['stackId'] === 'string'
 	);
 }
+
+export const MOCK_TREE_CHANGE_ADDITION: TreeChange = {
+	path: '/mock/addition.txt',
+	pathBytes: strToBytes('/mock/addition.txt'),
+	status: {
+		type: 'Addition',
+		subject: {
+			state: { id: 'addition-id', kind: 'addition' },
+			isUntracked: false
+		}
+	}
+};
+
+export function createMockAdditionTreeChange(props: Partial<TreeChange>): TreeChange {
+	const path = props.path ?? MOCK_TREE_CHANGE_ADDITION.path;
+	const pathBytes = props.pathBytes ?? strToBytes(path);
+	return {
+		...MOCK_TREE_CHANGE_ADDITION,
+		...props,
+		path,
+		pathBytes
+	};
+}
+
+export const MOCK_TREE_CHANGE_DELETION: TreeChange = {
+	path: '/mock/deletion.txt',
+	pathBytes: strToBytes('/mock/deletion.txt'),
+	status: {
+		type: 'Deletion',
+		subject: {
+			previousState: { id: 'deletion-prev-id', kind: 'deletion' }
+		}
+	}
+};
+
+export function createMockDeletionTreeChange(props: Partial<TreeChange>): TreeChange {
+	const path = props.path ?? MOCK_TREE_CHANGE_DELETION.path;
+	const pathBytes = props.pathBytes ?? strToBytes(path);
+	return {
+		...MOCK_TREE_CHANGE_DELETION,
+		...props,
+		path,
+		pathBytes
+	};
+}
+
+export const MOCK_TREE_CHANGE_MODIFICATION: TreeChange = {
+	path: '/mock/modification.txt',
+	pathBytes: strToBytes('/mock/modification.txt'),
+	status: {
+		type: 'Modification',
+		subject: {
+			previousState: { id: 'mod-prev-id', kind: 'mod-prev' },
+			state: { id: 'mod-id', kind: 'mod' },
+			flags: null
+		}
+	}
+};
+
+export function createMockModificationTreeChange(props: Partial<TreeChange>): TreeChange {
+	const path = props.path ?? MOCK_TREE_CHANGE_MODIFICATION.path;
+	const pathBytes = props.pathBytes ?? strToBytes(path);
+	return {
+		...MOCK_TREE_CHANGE_MODIFICATION,
+		...props,
+		path,
+		pathBytes
+	};
+}
+
+export const MOCK_TREE_CHANGE_RENAME: TreeChange = {
+	path: '/mock/renamed.txt',
+	pathBytes: strToBytes('/mock/renamed.txt'),
+	status: {
+		type: 'Rename',
+		subject: {
+			previousPath: '/mock/oldname.txt',
+			previousPathBytes: strToBytes('/mock/oldname.txt'),
+			previousState: { id: 'rename-prev-id', kind: 'rename-prev' },
+			state: { id: 'rename-id', kind: 'rename' },
+			flags: null
+		}
+	}
+};
+
+export function createMockRenameTreeChange(props: Partial<TreeChange>): TreeChange {
+	const path = props.path ?? MOCK_TREE_CHANGE_RENAME.path;
+	const pathBytes = props.pathBytes ?? strToBytes(path);
+	return {
+		...MOCK_TREE_CHANGE_RENAME,
+		...props,
+		path,
+		pathBytes
+	};
+}

--- a/apps/desktop/cypress/e2e/support/scenarios/lotsOfFileChanges.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/lotsOfFileChanges.ts
@@ -1,0 +1,94 @@
+import MockBackend from '../mock/backend';
+import {
+	createMockAdditionTreeChange,
+	createMockDeletionTreeChange,
+	createMockModificationTreeChange
+} from '../mock/changes';
+import type { TreeChange } from '$lib/hunks/change';
+
+const FILE_PATHS = [
+	'fileA.txt',
+	'fileB.txt',
+	'dir1/fileA.txt',
+	'dir1/fileB.txt',
+	'dir1/fileC.txt',
+	'dir1/fileD.txt',
+	'dir1/fileE.txt',
+	'dir1/fileF.txt',
+	'dir1/fileG.txt',
+	'dir1/fileH.txt',
+	'dir1/fileI.txt',
+	'dir1/fileJ.txt',
+	'dir1/fileK.txt',
+	'dir2/fileE.txt',
+	'dir2/fileF.txt',
+	'dir1/subdir1/fileG.txt',
+	'dir1/subdir1/fileH.txt',
+	'dir2/subdir2/fileI.txt',
+	'dir2/subdir2/fileJ.txt',
+	'dir3/fileK.txt',
+	'dir3/fileL.txt',
+	'dir3/subdir3/fileM.txt',
+	'dir3/subdir3/fileN.txt',
+	'dir4/fileO.txt',
+	'dir4/fileP.txt',
+	'dir4/subdir4/fileQ.txt',
+	'dir4/subdir4/fileR.txt',
+	'dir5/fileS.txt',
+	'dir5/fileT.txt',
+	'dir5/subdir5/fileU.txt',
+	'dir5/subdir5/fileV.txt',
+	'dir1/subdir1/deep/fileW.txt',
+	'dir2/subdir2/deep/fileX.txt',
+	'dir3/subdir3/deep/fileY.txt',
+	'dir4/subdir4/deep/fileZ.txt',
+	'dir5/subdir5/deep/fileAA.txt',
+	'dir1/subdir1/deep/deeper/fileAB.txt',
+	'dir2/subdir2/deep/deeper/fileAC.txt',
+	'dir3/subdir3/deep/deeper/fileAD.txt',
+	'dir4/subdir4/deep/deeper/fileAE.txt',
+	'dir5/subdir5/deep/deeper/fileAF.txt',
+	'dir1/subdir1/deep/deeper/deepest/fileAG.txt',
+	'dir2/subdir2/deep/deeper/deepest/fileAH.txt',
+	'dir3/subdir3/deep/deeper/deepest/fileAI.txt',
+	'dir4/subdir4/deep/deeper/deepest/fileAJ.txt',
+	'dir5/subdir5/deep/deeper/deepest/fileAK.txt',
+	'dir6/fileAL.txt',
+	'dir6/subdir6/fileAM.txt',
+	'dir6/subdir6/deep/fileAN.txt',
+	'dir6/subdir6/deep/deeper/fileAO.txt',
+	'dir6/subdir6/deep/deeper/deepest/fileAP.txt',
+	'dir7/fileAQ.txt',
+	'dir7/subdir7/fileAR.txt',
+	'dir7/subdir7/deep/fileAS.txt',
+	'dir7/subdir7/deep/deeper/fileAT.txt',
+	'dir7/subdir7/deep/deeper/deepest/fileAU.txt',
+	'dir8/fileAV.txt',
+	'dir8/subdir8/fileAW.txt',
+	'dir8/subdir8/deep/fileAX.txt',
+	'dir8/subdir8/deep/deeper/fileAY.txt',
+	'dir8/subdir8/deep/deeper/deepest/fileAZ.txt'
+];
+
+const treeChangeGenerators = [
+	createMockAdditionTreeChange,
+	createMockDeletionTreeChange,
+	createMockModificationTreeChange
+];
+
+const MOCK_FILE_TREE_CHANGES: TreeChange[] = FILE_PATHS.map((path) => {
+	const randomGeneratorIndex = Math.floor(Math.random() * treeChangeGenerators.length);
+	const randomGenerator = treeChangeGenerators[randomGeneratorIndex]!;
+	return randomGenerator({ path });
+});
+
+export default class LotsOfFileChanges extends MockBackend {
+	constructor() {
+		super();
+
+		this.worktreeChanges = {
+			changes: MOCK_FILE_TREE_CHANGES,
+			ignoredChanges: []
+		};
+	}
+}

--- a/apps/desktop/src/components/v3/FileListMode.svelte
+++ b/apps/desktop/src/components/v3/FileListMode.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { TestId } from '$lib/testing/testIds';
 	import { persisted } from '@gitbutler/shared/persisted';
 	import Segment from '@gitbutler/ui/segmentControl/Segment.svelte';
 	import SegmentControl from '@gitbutler/ui/segmentControl/SegmentControl.svelte';
@@ -28,6 +29,6 @@
 	}}
 	size="small"
 >
-	<Segment id="list" icon="list-view" />
-	<Segment id="tree" icon="tree-view" />
+	<Segment id="list" testId={TestId.FileListModeOption} icon="list-view" />
+	<Segment id="tree" testId={TestId.FileListModeOption} icon="tree-view" />
 </SegmentControl>

--- a/apps/desktop/src/components/v3/FileTreeNode.svelte
+++ b/apps/desktop/src/components/v3/FileTreeNode.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
 	import Self from '$components/v3/FileTreeNode.svelte';
 	import TreeListFolder from '$components/v3/TreeListFolder.svelte';
+	import { TestId } from '$lib/testing/testIds';
 	import type { TreeNode } from '$lib/files/filetreeV3';
 	import type { TreeChange } from '$lib/hunks/change';
 	import type { Snippet } from 'svelte';
+
+	const CHILD_THRESHOLD_FOR_AUTO_EXPAND = 10;
+	const DEPTH_THRESHOLD_FOR_AUTO_EXPAND = 3;
 
 	type Props = {
 		node: TreeNode;
@@ -11,29 +15,57 @@
 		showCheckboxes?: boolean;
 		changes: TreeChange[];
 		depth?: number;
+		initiallyCollapsed?: boolean;
 		fileTemplate: Snippet<[TreeChange, number, number]>;
 	};
 
-	let { node, isRoot = false, showCheckboxes, changes, depth = 0, fileTemplate }: Props = $props();
+	let {
+		node,
+		isRoot = false,
+		showCheckboxes,
+		changes,
+		depth = 0,
+		fileTemplate,
+		initiallyCollapsed
+	}: Props = $props();
+
+	const notSoDeep = $derived(depth < DEPTH_THRESHOLD_FOR_AUTO_EXPAND);
+	const hasAFewChildren = $derived(
+		(node.kind === 'dir' || isRoot) && node.children.length <= CHILD_THRESHOLD_FOR_AUTO_EXPAND
+	);
+	const isProbablyFine = $derived(notSoDeep && hasAFewChildren);
+	const defaultIsExpanded = $derived(
+		initiallyCollapsed ?? (isProbablyFine || node.kind === 'file')
+	);
+
+	let actionableIsExpanded = $state<boolean>();
 
 	// Local state to track whether the folder is expanded
-	let isExpanded = $state(true);
+	const isExpanded = $derived(actionableIsExpanded ?? defaultIsExpanded);
 
 	// Handler for toggling the folder
 	function handleToggle() {
-		isExpanded = !isExpanded;
+		actionableIsExpanded = !isExpanded;
 	}
 </script>
 
 {#if isRoot}
 	<!-- Node is a root and should only render children! -->
-	{#each node.children as childNode}
-		<Self {depth} node={childNode} {showCheckboxes} {changes} {fileTemplate} />
+	{#each node.children as childNode (childNode.name)}
+		<Self
+			{depth}
+			node={childNode}
+			{showCheckboxes}
+			{changes}
+			{fileTemplate}
+			initiallyCollapsed={!hasAFewChildren}
+		/>
 	{/each}
 {:else if node.kind === 'file'}
 	{@render fileTemplate(node.change, node.index, depth)}
 {:else}
 	<TreeListFolder
+		testId={TestId.FileListTreeFolder}
 		{depth}
 		{isExpanded}
 		showCheckbox={showCheckboxes}
@@ -42,7 +74,7 @@
 	/>
 
 	{#if isExpanded}
-		{#each node.children as childNode}
+		{#each node.children as childNode (childNode.name)}
 			<Self depth={depth + 1} node={childNode} {showCheckboxes} {changes} {fileTemplate} />
 		{/each}
 	{/if}

--- a/apps/desktop/src/components/v3/TreeListFolder.svelte
+++ b/apps/desktop/src/components/v3/TreeListFolder.svelte
@@ -12,9 +12,10 @@
 		isExpanded?: boolean;
 		onclick?: (e: MouseEvent) => void;
 		ontoggle?: (expanded: boolean) => void;
+		testId?: string;
 	};
 
-	const { node, depth, showCheckbox, isExpanded, onclick, ontoggle }: Props = $props();
+	const { node, depth, showCheckbox, isExpanded, onclick, ontoggle, testId }: Props = $props();
 
 	const selectionService = getContext(ChangeSelectionService);
 	const selection = $derived(selectionService.getByPrefix(nodePath(node)));
@@ -49,6 +50,7 @@
 </script>
 
 <FolderListItem
+	{testId}
 	name={node.name}
 	{depth}
 	{isExpanded}

--- a/apps/desktop/src/components/v3/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/v3/WorktreeChanges.svelte
@@ -117,7 +117,11 @@
 				class="uncommitted-changes-wrap"
 				use:focusable={{ id: Focusable.UncommittedChanges, parentId: Focusable.WorkspaceLeft }}
 			>
-				<div use:stickyHeader class="worktree-header">
+				<div
+					data-testid={TestId.UncommittedChanges_Header}
+					use:stickyHeader
+					class="worktree-header"
+				>
 					<div class="worktree-header__general">
 						{#if isCommitting}
 							<Checkbox

--- a/apps/desktop/src/lib/testing/testIds.ts
+++ b/apps/desktop/src/lib/testing/testIds.ts
@@ -25,6 +25,7 @@ export enum TestId {
 	CommitDrawerDescription = 'commit-drawer-description',
 	UncommittedChanges_FileList = 'uncommitted-changes-file-list',
 	UncommittedChanges_FileListItem = 'uncommitted-changes-file-list-item',
+	UncommittedChanges_Header = 'uncommitted-changes-header',
 	StartCommitButton = 'start-commit-button',
 	CommitRow = 'commit-row',
 	NewCommitDrawer = 'new-commit-drawer',
@@ -35,7 +36,9 @@ export enum TestId {
 	IntegrateUpstreamCommitsButton = 'integrate-upstream-commits-button',
 	IntegrateUpstreamCommitsModal = 'integrate-upstream-commits-modal',
 	IntegrateUpstreamSeriesRow = 'integrate-upstream-series-row',
-	IntegrateUpstreamActionButton = 'integrate-upstream-action-button'
+	IntegrateUpstreamActionButton = 'integrate-upstream-action-button',
+	FileListModeOption = 'file-list-mode-option',
+	FileListTreeFolder = 'file-list-tree-folder'
 }
 
 export enum ElementId {

--- a/packages/ui/src/lib/file/FolderListItem.svelte
+++ b/packages/ui/src/lib/file/FolderListItem.svelte
@@ -18,6 +18,7 @@
 		ontoggle?: (expanded: boolean) => void;
 		onclick?: (e: MouseEvent) => void;
 		onkeydown?: (e: KeyboardEvent) => void;
+		testId?: string;
 	}
 
 	let {
@@ -30,7 +31,8 @@
 		oncheck,
 		ontoggle,
 		onclick,
-		onkeydown
+		onkeydown,
+		testId
 	}: Props = $props();
 
 	let isFolderExpanded = $state(isExpanded);
@@ -41,6 +43,7 @@
 </script>
 
 <div
+	data-testid={testId}
 	class="folder-list-item"
 	role="presentation"
 	tabindex="-1"

--- a/packages/ui/src/lib/segmentControl/Segment.svelte
+++ b/packages/ui/src/lib/segmentControl/Segment.svelte
@@ -6,6 +6,7 @@
 	import type { Snippet } from 'svelte';
 
 	interface SegmentProps {
+		testId?: string;
 		id: string;
 		onselect?: (id: string) => void;
 		disabled?: boolean;
@@ -13,7 +14,7 @@
 		icon?: keyof typeof iconsJson;
 	}
 
-	const { id, onselect, children, disabled, icon }: SegmentProps = $props();
+	const { id, onselect, children, disabled, icon, testId }: SegmentProps = $props();
 
 	const context = getContext<SegmentContext>('SegmentControl');
 	const index = context.setIndex();
@@ -39,6 +40,7 @@
 </script>
 
 <button
+	data-testid={testId}
 	type="button"
 	bind:this={elRef}
 	{id}


### PR DESCRIPTION
### Description

- Added Cypress tests for toggling between list and tree view modes in the file list.
- Created a new mock scenario with many file changes to simulate addition, deletion, modification, and renaming.
- Enhanced mock backend with helpers for top-level directories/files and typeguards for file tree testing.
- Introduced new test IDs for file list and tree components to improve test reliability.
- Improved file tree node expansion logic with auto-collapse based on depth and child count.
- Updated components to use keyed each blocks and pass testId props for better test targeting.