### PR TITLE
ci: improve Cypress caching in FE integration workflow

### DIFF
--- a/.github/workflows/test-client-fe-integration.yml
+++ b/.github/workflows/test-client-fe-integration.yml
@@ -3,10 +3,6 @@ name: Client Frontend Integration Tests
 on:
   pull_request:
     branches: [master]
-    paths:
-      - 'apps/desktop/**'
-      - 'packages/shared/**'
-      - 'packages/ui/**'
   workflow_dispatch:
     inputs:
       sha:
@@ -42,6 +38,7 @@ jobs:
         uses: cypress-io/github-action@v6
         with:
           install: false
+          cache-key: ${{ runner.os }}-cypress-${{ hashFiles('pnpm-lock.yaml') }}
           start: pnpm --dir apps/desktop preview
           wait-on: 'http://localhost:1420'
           command: pnpm --dir apps/desktop cy:ci


### PR DESCRIPTION
Remove path filters to run tests on all pull requests targeting master.
Add cache-key for Cypress dependencies to speed up CI by reusing cached
installations based on pnpm-lock.yaml changes.