### PR TITLE
Encode BitBucket's branch url "dest" parameter (#8220)

### DIFF
--- a/apps/desktop/src/lib/forge/bitbucket/bitbucketBranch.ts
+++ b/apps/desktop/src/lib/forge/bitbucket/bitbucketBranch.ts
@@ -6,6 +6,6 @@ export class BitBucketBranch implements ForgeBranch {
 		if (fork) {
 			name = `${fork}:${name}`;
 		}
-		this.url = `${baseUrl}/branch/${name}?dest=${baseBranch}`;
+		this.url = `${baseUrl}/branch/${name}?dest=${encodeURIComponent(baseBranch)}`;
 	}
 }


### PR DESCRIPTION
## 🧢 Changes
Add encoding for BitBucket's branch url "dest" parameter

## ☕️ Reasoning
BitBucket expects the value encoded, so that branch names with "/" or other special symbols do not break the full url

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

-->

## 🎫 Affected issues

Fixes: #8220 

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
