### PR TITLE
fix(gitlab): Swap `head` and `base` in GitLabPrService

### DIFF
--- a/apps/desktop/src/lib/forge/gitlab/gitlabPrService.svelte.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlabPrService.svelte.ts
@@ -38,8 +38,8 @@ export class GitLabPrService implements ForgePrService {
 
 		const request = async () => {
 			return await this.api.endpoints.createPr.mutate({
-				head: baseBranchName,
-				base: upstreamName,
+				head: upstreamName,
+				base: baseBranchName,
 				title,
 				body,
 				draft


### PR DESCRIPTION
## 🧢 Changes

- Swaps the `head` and `base` parameters in the `createPr` mutation.

## ☕️ Reasoning

- To correctly set the branch names when creating a new merge request on GitLab.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
