### PR TITLE
fix(UI): Remove duplicate "Delete local branch" option in Integrate Upstream modal

### DIFF
--- a/apps/desktop/src/components/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/IntegrateUpstreamModal.svelte
@@ -22,7 +22,6 @@
 	import { getContext } from '@gitbutler/shared/context';
 	import Badge from '@gitbutler/ui/Badge.svelte';
 	import Button from '@gitbutler/ui/Button.svelte';
-	import Checkbox from '@gitbutler/ui/Checkbox.svelte';
 	import IntegrationSeriesRow, {
 		type BranchShouldBeDeletedMap
 	} from '@gitbutler/ui/IntegrationSeriesRow.svelte';
@@ -228,25 +227,6 @@
 					</SelectItem>
 				{/snippet}
 			</Select>
-		{:else if stackFullyIntegrated(stackStatus) && results.get(stack.id)}
-			<label class="delete-branch-checkbox">
-				<span style="white-space: nowrap" class="text-12">
-					{#if series.length > 1}
-						Delete all local branches
-					{:else}
-						Delete local branch
-					{/if}
-				</span>
-				<Checkbox
-					small
-					checked={results.get(stack.id)!.deleteIntegratedBranches}
-					onchange={(e: Event & { currentTarget: EventTarget & HTMLInputElement }) => {
-						const isChecked = e.currentTarget.checked;
-						const result = results.get(stack.id)!;
-						results.set(stack.id, { ...result, deleteIntegratedBranches: isChecked });
-					}}
-				/>
-			</label>
 		{/if}
 	</IntegrationSeriesRow>
 {/snippet}
@@ -374,14 +354,6 @@
 		gap: 14px;
 		border-bottom: 1px solid var(--clr-border-2);
 		background-color: var(--clr-theme-warn-bg);
-	}
-
-	.delete-branch-checkbox {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-		color: var(--clr-text-2);
-		margin-right: 2px;
 	}
 
 	.target-icon {


### PR DESCRIPTION
## 🧢 Changes

- Removed redundant rendering logic for the "Delete local branch" option within the `IntegrateUpstreamModal.svelte` component.

## ☕️ Reasoning

When the Integrate Upstream modal displayed a single branch that was already integrated, the UI would incorrectly show the "Delete local branch" text and checkbox twice.

This happened because:
1. The `IntegrationSeriesRow.svelte` component correctly renders this UI element internally when `series.length === 1` and the branch status is `'integrated'`.
2. The `IntegrateUpstreamModal.svelte` component was *also* rendering the same UI element within the child content (`{#snippet stackStatus...}`) it passed to `IntegrationSeriesRow` under the same conditions (`stackFullyIntegrated(stackStatus)` being true and `series.length === 1`).

This commit removes the redundant rendering from the child content in `IntegrateUpstreamModal.svelte`, ensuring the option is only displayed once by the `IntegrationSeriesRow` component itself.

## 🖼️ 
Before
![Screenshot 2025-04-30 at 11 13 59 AM](https://github.com/user-attachments/assets/a5fc0f4e-0aae-4cf1-aba5-d609a471e9f3)

After
![Screenshot 2025-04-30 at 11 23 16 AM](https://github.com/user-attachments/assets/3ec88a0f-5b06-4f5b-aec1-8c0bbf8a8399)
