### PR TITLE
feat(ui): apply text styles from settings to MessageEditor

### DIFF
--- a/apps/desktop/src/components/v3/editor/MessageEditor.svelte
+++ b/apps/desktop/src/components/v3/editor/MessageEditor.svelte
@@ -3,8 +3,9 @@
 	import MessageEditorRuler from '$components/v3/editor/MessageEditorRuler.svelte';
 	import CommitSuggestions from '$components/v3/editor/commitSuggestions.svelte';
 	import { showError } from '$lib/notifications/toasts';
+	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import { UiState } from '$lib/state/uiState.svelte';
-	import { getContext } from '@gitbutler/shared/context';
+	import { getContext, getContextStoreBySymbol } from '@gitbutler/shared/context';
 	import { uploadFiles } from '@gitbutler/shared/dom';
 	import { persisted } from '@gitbutler/shared/persisted';
 	import { UploadsService } from '@gitbutler/shared/uploads/uploadsService';
@@ -57,6 +58,7 @@
 
 	const uiState = getContext(UiState);
 	const uploadsService = getContext(UploadsService);
+	const userSettings = getContextStoreBySymbol<Settings>(SETTINGS);
 
 	const useRichText = uiState.global.useRichText;
 	const useRuler = uiState.global.useRuler;
@@ -217,6 +219,9 @@
 	style:--lexical-input-client-text-wrap={useRuler.current && !useRichText.current
 		? 'nowrap'
 		: 'normal'}
+	style:--code-block-font={$userSettings.diffFont}
+	style:--code-block-tab-size={$userSettings.tabSize}
+	style:--code-block-ligatures={$userSettings.diffLigatures ? 'common-ligatures' : 'normal'}
 >
 	<div class="editor-header">
 		<div class="editor-tabs">

--- a/packages/ui/src/lib/HunkDiff.svelte
+++ b/packages/ui/src/lib/HunkDiff.svelte
@@ -147,6 +147,7 @@
 				clearLineSelection={() => clearLineSelection?.(filePath)}
 				{wrapText}
 				{tabSize}
+				{diffFont}
 				{inlineUnifiedDiffs}
 				{selectedLines}
 				{lineLocks}

--- a/packages/ui/src/lib/richText/css/standard-theme.css
+++ b/packages/ui/src/lib/richText/css/standard-theme.css
@@ -3,7 +3,8 @@
 }
 
 .lexical-container.plain-text {
-	--fontfamily-default: var(--fontfamily-mono);
+	--fontfamily-default: var(--code-block-font, var(--fontfamily-mono));
+	font-variant-ligatures: var(--code-block-ligatures, normal);
 }
 
 /* text alignment */
@@ -108,9 +109,10 @@
 .StandardTheme__textCode {
 	background-color: var(--clr-theme-ntrl-soft);
 	padding: 2px 3px;
-	font-family: var(--fontfamily-mono);
+	font-family: var(--code-block-font, var(--fontfamily-mono));
 	font-size: 96%;
 	border-radius: var(--radius-s);
+	font-variant-ligatures: var(--code-block-ligatures, normal);
 }
 
 .StandardTheme__hashtag {
@@ -152,7 +154,7 @@
 /* CODE */
 .StandardTheme__code {
 	background-color: var(--clr-bg-1);
-	font-family: var(--fontfamily-mono);
+	font-family: var(--code-block-font, var(--fontfamily-mono));
 	display: block;
 	padding: 8px 8px 8px 46px;
 	line-height: 1.53;
@@ -161,9 +163,10 @@
 	margin-bottom: var(--markdown-generic-bottom-margin);
 	overflow-x: auto;
 	position: relative;
-	tab-size: 2;
+	tab-size: var(--code-block-tab-size, 2);
 	border-radius: var(--radius-m);
 	border: 1px solid var(--clr-border-2);
+	font-variant-ligatures: var(--code-block-ligatures, normal);
 }
 
 .StandardTheme__code:before {


### PR DESCRIPTION
## 🧢 Changes

- Passed user diff settings (font family, tab size, ligatures) from `MessageEditor.svelte` down to the CSS layer using CSS custom properties (`--code-block-font`, `--code-block-tab-size`, `--code-block-ligatures`).
- Updated `standard-theme.css` to consume these new custom properties for code blocks (`.StandardTheme__code`), inline code (`.StandardTheme__textCode`), and the plain text container (`.lexical-container.plain-text`). Sensible defaults are provided in case the properties are not set.

## ☕️ Reasoning

To apply a consistent visual representation of text styling across components.