### PR TITLE
fix(FileListItemV3): selected item had empty context menu

### DIFF
--- a/packages/ui/src/lib/file/FileListItemV3.svelte
+++ b/packages/ui/src/lib/file/FileListItemV3.svelte
@@ -97,7 +97,6 @@
 	oncontextmenu={(e) => {
 		if (oncontextmenu) {
 			e.preventDefault();
-			e.stopPropagation();
 			oncontextmenu(e);
 		}
 	}}


### PR DESCRIPTION
Still debugging – problem exists, but existing solution not working.

## 🧢 Changes

## ☕️ Reasoning

- Was causing the selected file list item (V3 only) to have an empty context menu.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
