### PR TITLE
fix(PullRequestCard): check permissions for merge pull request button state

### DIFF
--- a/apps/desktop/src/components/PullRequestCard.svelte
+++ b/apps/desktop/src/components/PullRequestCard.svelte
@@ -87,9 +87,11 @@
 		if (isPushed && hasParent && !parentIsPushed) {
 			tooltip = 'Remote parent branch seems to have been deleted';
 		} else if (!baseIsTargetBranch) {
-			tooltip = name + 'is not next in stack';
+			tooltip = name + ' is not next in stack';
 		} else if (prLoading) {
 			tooltip = 'Reloading pull request data';
+		} else if (!pr?.permissions?.canMerge) {
+			tooltip = name + ' requires push permissions';
 		} else if (pr?.draft) {
 			tooltip = name + ' is a draft';
 		} else if (pr?.mergeableState === 'blocked') {

--- a/apps/desktop/src/lib/forge/gitlab/types.ts
+++ b/apps/desktop/src/lib/forge/gitlab/types.ts
@@ -29,7 +29,10 @@ export function detailedMrToInstance(data: ExpandedMergeRequestSchema): Detailed
 		state: data.state === 'opened' ? 'open' : 'closed',
 		fork: false, // seems hard to get
 		reviewers,
-		commentsCount: data.user_notes_count
+		commentsCount: data.user_notes_count,
+		permissions: {
+			canMerge: data.user.can_merge
+		}
 	};
 }
 

--- a/apps/desktop/src/lib/forge/interface/types.ts
+++ b/apps/desktop/src/lib/forge/interface/types.ts
@@ -28,6 +28,10 @@ export interface PullRequest {
 	reviewers: { srcUrl: string; name: string }[];
 }
 
+export interface PullRequestPermissions {
+	canMerge?: boolean;
+}
+
 export interface DetailedPullRequest {
 	id: number;
 	title: string;
@@ -51,6 +55,7 @@ export interface DetailedPullRequest {
 	baseBranch: string;
 	reviewers: { srcUrl: string; name: string }[];
 	commentsCount: number;
+	permissions?: PullRequestPermissions;
 }
 
 export type ChecksStatus = {


### PR DESCRIPTION
## 🧢 Changes

1.  **Fetch Repository Permissions:**
    *   Modified the `getPr` query function within `apps/desktop/src/lib/forge/github/githubPrService.svelte.ts` to fetch repository details (using the GitHub `repos.get` API endpoint via `ghQuery`) in addition to the pull request details.
2.  **Update Data Types:**
    *   Introduced a unified `permissions: { canMerge?: boolean }` field to the shared `DetailedPullRequest` type.
    *   Populated `canMerge` by inferring from repository `push` access for GitHub and using the direct `user.can_merge` flag for GitLab.
4.  **Update UI Logic:**
    *   Added a check: `!pr?.permissions?.canMerge` to control merge button state.
    *   Updated the corresponding tooltip to inform the user about the missing permission: `'{name} requires push permissions'`.

## ☕️ Reasoning

Previously, the "Merge pull request" button in `PullRequestCard.svelte` could be enabled even if the current user lacked the necessary permissions (e.g., `push` access) on the upstream GitHub/GitLab repository. This occurred because the button's enabled state was determined solely by the technical mergeability status (`mergeable`, `mergeableState`) reported by the GitHub API for the PR, combined with local GitButler stack conditions. It did not account for the user's specific permissions on the target repository.

![Screenshot 2025-04-30 at 2 05 45 PM](https://github.com/user-attachments/assets/e7027cec-4f96-4356-b291-85fbd1f851a2)
