### PR TITLE
Support inserting of a blank commit in an empty stack

### DIFF
--- a/apps/desktop/src/components/SeriesHeaderContextMenuContents.svelte
+++ b/apps/desktop/src/components/SeriesHeaderContextMenuContents.svelte
@@ -70,6 +70,7 @@
 	async function setAIConfigurationValid() {
 		aiConfigurationValid = await aiService.validateConfiguration();
 	}
+	const [insertBlankCommitInBranch, commitInsertion] = stackService.insertBlankCommit;
 </script>
 
 {#if isTopBranch}
@@ -105,6 +106,19 @@
 	/>
 </ContextMenuSection>
 <ContextMenuSection>
+	<ContextMenuItem
+		label="Add empty commit"
+		onclick={async () => {
+			await insertBlankCommitInBranch({
+				projectId,
+				stackId,
+				commitOid: undefined,
+				offset: -1
+			});
+			contextMenuEl?.close();
+		}}
+		disabled={commitInsertion.current.isLoading}
+	/>
 	<ContextMenuItem
 		label="Squash all commits"
 		testId={TestId.BranchHeaderContextMenu_SquashAllCommits}

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -936,7 +936,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 			}),
 			insertBlankCommit: build.mutation<
 				void,
-				{ projectId: string; stackId: string; commitOid: string; offset: number }
+				{ projectId: string; stackId: string; commitOid: string | undefined; offset: number }
 			>({
 				query: ({ projectId, stackId, commitOid, offset }) => ({
 					command: 'insert_blank_commit',

--- a/crates/but-workspace/src/integrated.rs
+++ b/crates/but-workspace/src/integrated.rs
@@ -116,6 +116,14 @@ impl<'repo, 'cache, 'graph> IsCommitIntegrated<'repo, 'cache, 'graph> {
 
         let merge_tree_id = merge_output.tree.write()?.detach();
 
+        let parent_tree = commit.parents().next().map(|c| c.tree_id());
+        if let Some(parent_tree) = parent_tree {
+            // if the commit tree is the same as its the parent tree, it must be an empty commit, so dont classify it as integrated
+            if commit.tree_id() == parent_tree {
+                return Ok(false);
+            }
+        }
+
         // if the merge_tree is the same as the new_target_tree and there are no files (uncommitted changes)
         // then the vbranch is fully merged
         Ok(merge_tree_id == self.upstream_tree_id)


### PR DESCRIPTION
Adds support for injecting an empty commit even when the stack/branch is empty
<img width="491" alt="image" src="https://github.com/user-attachments/assets/7f1dd205-8a4f-4c8e-a67f-448558db0df6" />
