### PR TITLE
Only display keyboard shortcuts in V3 (#8153)

### DIFF
--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -44,6 +44,7 @@ fn main() {
     ) {
         tauri_context.config_mut().app.security.csp = updated_csp;
     };
+    let settings_for_menu = app_settings.clone();
 
     inherit_interactive_login_shell_environment();
 
@@ -300,7 +301,7 @@ fn main() {
                     #[cfg(debug_assertions)]
                     env::env_vars,
                 ])
-                .menu(menu::build)
+                .menu(move |handle| menu::build(handle, &settings_for_menu))
                 .on_window_event(|window, event| match event {
                     #[cfg(target_os = "macos")]
                     tauri::WindowEvent::CloseRequested { .. } => {


### PR DESCRIPTION
Fixes #8153.

### Caveats

* The menu is only built at startup, and not updated afterwards. Hence dynamic switching between V2 and V3 leaves the menu in a stale state, either showing the keyboard shortcuts menu item where it should not, or not showing it where it should.
  That's deemed acceptable in the transition period.
