### PR TITLE
fix(client): prevent using --all with file paths together

### DIFF
--- a/packages/mcp/src/tools/client/commit.ts
+++ b/packages/mcp/src/tools/client/commit.ts
@@ -18,6 +18,14 @@ function populateDiffSpec(
 	},
 	args: string[]
 ) {
+	if (params.all) {
+		if (params.filePaths.length > 0) {
+			throw new Error('Cannot use --all and file paths together');
+		}
+
+		return;
+	}
+
 	const diffSpec: DiffSpec[] = [];
 	for (const filePath of params.filePaths) {
 		diffSpec.push({
@@ -58,12 +66,6 @@ function commit(params: CommitParams, amendParams?: AmendCommitParams) {
 		args.push('--amend', '--parent', amendParams.commitId);
 	} else {
 		args.push('--message', params.message);
-	}
-
-	if (params.all) {
-		if (params.filePaths.length > 0) {
-			throw new Error('Cannot use --all and file paths together');
-		}
 	}
 
 	populateDiffSpec(params, args);


### PR DESCRIPTION
Add a check to throw an error if both --all and file paths are provided
simultaneously. This enforces correct usage and avoids ambiguous commit
behavior. The validation is moved earlier to simplify the flow and
prevent unnecessary processing when the conflict occurs.