### PR TITLE
CLI: Option to use JSON for the commit output

### DIFF
--- a/crates/but-cli/src/main.rs
+++ b/crates/but-cli/src/main.rs
@@ -68,6 +68,7 @@ fn main() -> Result<()> {
                     None
                 },
                 diff_spec,
+                args.json,
             )
         }
         args::Subcommands::HunkDependency => command::diff::locks(&args.current_dir),


### PR DESCRIPTION
### Description

- Refactor commit function for better maintainability.
- Add `use_json` parameter to commit functions to support JSON output.
- Enable JSON output mode via `args.json` CLI flag.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #8383 
- <kbd>&nbsp;1&nbsp;</kbd> #8382 👈 
<!-- GitButler Footer Boundary Bottom -->

