### PR TITLE
feat(mcp): add CreateCommitOutcomeSchema and rejection summary handling for commit outcome

### DIFF
--- a/packages/mcp/src/shared/entities/stacks.ts
+++ b/packages/mcp/src/shared/entities/stacks.ts
@@ -86,3 +86,29 @@ export const BranchCommitsSchema = z.object({
 	localAndRemote: z.array(CommitSchema),
 	upstreamCommits: z.array(UpstreamCommitSchema)
 });
+
+export const RejectedChangesSchema = z.tuple([
+	z.enum([
+		'NoEffectiveChanges',
+		'CherryPickMergeConflict',
+		'WorkspaceMergeConflict',
+		'WorktreeFileMissingForObjectConversion',
+		'FileToLargeOrBinary',
+		'PathNotFoundInBaseTree',
+		'UnsupportedDirectoryEntry',
+		'UnsupportedTreeEntry',
+		'MissingDiffSpecAssociation'
+	]),
+	z.string({ description: 'The path to the file that could not be committed.' })
+]);
+
+export const CreateCommitOutcomeSchema = z.object({
+	newCommitId: z
+		.string({
+			description: 'The commit ID of the new commit. Null if the commit failed to be created.'
+		})
+		.nullable(),
+	pathsToRejectedChanges: z.array(RejectedChangesSchema, {
+		description: 'The paths to the files that could not be committed, and the reason why.'
+	})
+});


### PR DESCRIPTION
### Description

- Added `CreateCommitOutcomeSchema` to the MCP module.
- Implemented rejection summary handling for commit outcomes.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #8383 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #8382 
<!-- GitButler Footer Boundary Bottom -->

