### PR TITLE
MCP: Fix the commit outcome typing

### DIFF
--- a/packages/mcp/src/shared/entities/stacks.ts
+++ b/packages/mcp/src/shared/entities/stacks.ts
@@ -103,7 +103,7 @@ export const RejectedChangesSchema = z.tuple([
 ]);
 
 export const CreateCommitOutcomeSchema = z.object({
-	newCommitId: z
+	newCommit: z
 		.string({
 			description: 'The commit ID of the new commit. Null if the commit failed to be created.'
 		})

--- a/packages/mcp/src/tools/client/commit.ts
+++ b/packages/mcp/src/tools/client/commit.ts
@@ -67,15 +67,15 @@ type CreateCommitOutcome = z.infer<typeof CreateCommitOutcomeSchema>;
 
 function interpretOutcome(outcome: CreateCommitOutcome, action: 'created' | 'amend'): string {
 	// Success
-	if (outcome.newCommitId !== null && outcome.pathsToRejectedChanges.length === 0) {
-		return `Commit successfully ${action} with ID ${outcome.newCommitId}`;
+	if (outcome.newCommit !== null && outcome.pathsToRejectedChanges.length === 0) {
+		return `Commit successfully ${action} with ID ${outcome.newCommit}`;
 	}
 
 	// Created commit but some changes were rejected
-	if (outcome.newCommitId !== null && outcome.pathsToRejectedChanges.length > 0) {
+	if (outcome.newCommit !== null && outcome.pathsToRejectedChanges.length > 0) {
 		const rejectionMessages = createRejectionSummary(outcome);
 
-		return `Commit successfully ${amendCommit} with ID ${outcome.newCommitId}, but some changes were rejected: ${rejectionMessages}`;
+		return `Commit successfully ${amendCommit} with ID ${outcome.newCommit}, but some changes were rejected: ${rejectionMessages}`;
 	}
 
 	// No commit created


### PR DESCRIPTION
### Description

- Renamed `newCommitId` to `newCommit` in `CreateCommitOutcomeSchema` for consistency.
- Updated usage of `newCommitId` to `newCommit` in `interpretOutcome` and related logic.
<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#16TGgAkFs`](https://gitbutler.com/estib/gitbutler/reviews/16TGgAkFs)

**MCP: Create branches**


Add tools for creating branches or adding them to a stack

2 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 2/2 | [refactor: update usage of newCommitId to newCommit in interpretOutcome and related logic](https://gitbutler.com/estib/gitbutler/reviews/16TGgAkFs/commit/4ea74f70-e4f9-4ba9-a812-ab2d3d1eab2a) | ⏳ |  |
| 1/2 | [refactor: rename newCommitId to newCommit in CreateCommitOutcomeSchema for consistency](https://gitbutler.com/estib/gitbutler/reviews/16TGgAkFs/commit/75709e7a-3b96-47c4-904d-49812399c750) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/estib/gitbutler/reviews/16TGgAkFs)_
<!-- GitButler Review Footer Boundary Bottom -->
