### PR TITLE
Add `simple` flag to HunkDependency CLI and expose simple dependency output

### DIFF
--- a/crates/but-cli/src/args.rs
+++ b/crates/but-cli/src/args.rs
@@ -100,7 +100,11 @@ pub enum Subcommands {
     },
     /// Return the dependencies of worktree changes with the commits that last changed them.
     #[clap(visible_alias = "dep")]
-    HunkDependency,
+    HunkDependency {
+        /// Whether to show the dependencies in the ui format.
+        #[clap(long, default_value_t = false)]
+        simple: bool,
+    },
     /// Returns the list of stacks that are currently part of the GitButler workspace.
     Stacks,
     /// Return all stack branches related to the given `id`.

--- a/crates/but-cli/src/main.rs
+++ b/crates/but-cli/src/main.rs
@@ -71,7 +71,9 @@ fn main() -> Result<()> {
                 args.json,
             )
         }
-        args::Subcommands::HunkDependency => command::diff::locks(&args.current_dir),
+        args::Subcommands::HunkDependency { simple } => {
+            command::diff::locks(&args.current_dir, *simple, args.json)
+        }
         args::Subcommands::Status {
             unified_diff,
             context_lines,

--- a/crates/but-hunk-dependency/src/ui.rs
+++ b/crates/but-hunk-dependency/src/ui.rs
@@ -40,7 +40,7 @@ pub struct HunkDependencies {
 
 impl HunkDependencies {
     /// Calculate all hunk dependencies using a preparepd [`crate::WorkspaceRanges`].
-    fn try_from_workspace_ranges(
+    pub fn try_from_workspace_ranges(
         repo: &gix::Repository,
         ranges: crate::WorkspaceRanges,
         worktree_changes: Vec<but_core::TreeChange>,


### PR DESCRIPTION
- Adds a `simple` flag to the `HunkDependency` subcommand in the CLI.
- Updates the CLI logic to process and display hunk dependencies in a simplified format when the flag is set.
- Makes the `try_from_workspace_ranges` function public in the `but-hunk-dependency` crate for use in the CLI.