### PR TITLE
linux build improvements

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -92,7 +92,7 @@ jobs:
         platform:
           - macos-13 # [macOs, x64]
           - macos-latest # [macOs, ARM64]
-          - ubuntu-24.04 # [linux, x64]
+          - ubuntu-22.04 # [linux, x64]
           - windows-latest # [windows, x64]
 
     runs-on: ${{ matrix.platform }}
@@ -163,22 +163,15 @@ jobs:
         run: |
           sudo apt update;
           sudo apt install -y \
+            libwebkit2gtk-4.1-dev \
             build-essential \
             curl \
             wget \
             file \
+            libxdo-dev \
             libssl-dev \
-            libgtk-3-dev \
-            libappindicator3-dev \
+            libayatana-appindicator3-dev \
             librsvg2-dev;
-
-          sudo apt install -y \
-            libwebkit2gtk-4.1-0=2.44.0-2 \
-            libwebkit2gtk-4.1-dev=2.44.0-2 \
-            libjavascriptcoregtk-4.1-0=2.44.0-2 \
-            libjavascriptcoregtk-4.1-dev=2.44.0-2 \
-            gir1.2-javascriptcoregtk-4.1=2.44.0-2 \
-            gir1.2-webkit2-4.1=2.44.0-2;
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
This is a research PR which could even be merged if the experiment is successful.

Try to see how low we can get when building a Tauri App.

### Prerequisites
* [x] learn about minimal support version of Ubuntu/Debian for Tauri 2
    - Seems to be 22.04

### Tasks

* [x] try CI build with Ubuntu 22
* [x] try to release on Ubuntu 22 locally (by running relevant CI steps and try build)
    - works
* [x] make local build available for testing: https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.12.9
* [x] offer *untested* (or only locally tested) CI changes that might need to be reverted.

### ~~Optional Tasks~~

No need to try to bypass available runner images as the lowest bound is determined by Gtk4.1.

* [ ] See how Docker works on GitHub to build and extract artefacts
* [ ] Try to build on Ubuntu 20 (locally)
* [ ] possibly setup a Dockerfile to build a release binary and package it as
    * [ ] .deb
    * [ ] AppImage

Related to https://github.com/gitbutlerapp/gitbutler/issues/7671#issuecomment-2850618406.

### Notes for the Reviewer

> [!WARNING]
> This may have to be reverted as it could fail the publishing. With that in mind, I think it has good chances to work given my local testing.