### PR TITLE
feat(cli): add support for branch description when creating branches

### DIFF
--- a/crates/but-cli/src/args.rs
+++ b/crates/but-cli/src/args.rs
@@ -120,6 +120,11 @@ pub enum Subcommands {
         /// If this is set, a branch will be created with the given name.
         #[clap(long, short = 'b')]
         branch_name: Option<String>,
+        /// Optional. The description of the branch to create.
+        ///
+        /// This is the place where some metadata about the branch can be stored.
+        #[clap(long, short = 'd')]
+        description: Option<String>,
     },
     /// Returns all commits for the branch with the given `name` in the stack with the given `id`.
     StackBranchCommits { id: String, name: String },

--- a/crates/but-cli/src/main.rs
+++ b/crates/but-cli/src/main.rs
@@ -89,10 +89,18 @@ fn main() -> Result<()> {
             *unified_diff,
         ),
         args::Subcommands::Stacks => command::stacks::list(&args.current_dir, args.json),
-        args::Subcommands::StackBranches { id, branch_name } => match (branch_name, id) {
-            (Some(branch_name), maybe_id) => {
-                command::stacks::create_branch(maybe_id, branch_name, &args.current_dir, args.json)
-            }
+        args::Subcommands::StackBranches {
+            id,
+            branch_name,
+            description,
+        } => match (branch_name, id) {
+            (Some(branch_name), maybe_id) => command::stacks::create_branch(
+                maybe_id,
+                branch_name,
+                description,
+                &args.current_dir,
+                args.json,
+            ),
             (None, Some(id)) => command::stacks::branches(id, &args.current_dir, args.json),
             (None, None) => {
                 bail!(


### PR DESCRIPTION
Adds an optional `description` parameter to the CLI for branch creation, updates command logic to handle and pass the description.