### PR TITLE
docs: clarify branch matching criteria in copilot guide

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,13 +23,28 @@ The packages are:
 
 - Use GitButler tools
 - The MCP tools require the absolute path to the repository
-- When told to 'figure out the commits' follow these steps:
-  1. List the file changes
-  2. List the stacks
-  3. Figure out, based on the changes and whether there are any applied stacks/branches:
-  4. Create a plan for the commits. For that, take a look at the `Create a commit plan` section below.
-  5. Execute the plan, and commit the changes as previously determined.
 - Don't use any other git commands
+
+### Absorb
+
+When told to 'absorb' follow these steps:
+
+1. If there were any instructions given, take them into account.
+2. List the file changes
+3. Get the hunk dependencies
+4. For all files that depend on a **single** commit, amend the file onto that commit.
+5. If there are no dependencies, list the stacks. Based on the stack branch names and descriptions, determine the best branch to commit the changes to.
+6. List the commits in the branch determined in the previous step, and then determine the best commit to amend the changes to based on the description. Update the description if needed.
+
+### Figure out the commits
+
+When told to 'figure out the commits' follow these steps:
+
+1. List the file changes
+2. List the stacks
+3. Figure out, based on the changes and whether there are any applied stacks/branches:
+4. Create a plan for the commits. For that, take a look at the `Create a commit plan` section below.
+5. Always execute the plan, and commit the changes as previously determined unless otherwise directed.
 
 ### Creating a commit plan
 
@@ -40,7 +55,7 @@ Follow this instructions when creating a commit plan:
    - Groups are good, but prefer to have smaller commits than larger ones.
    - Granularity is good.
 2. Determine if any branches should be created
-   - If there are any stacks with branches, take a look at the branch names and match them with the file changes.
+   - If there are any stacks with branches, take a look at the branch names and descriptions and match them with the file changes.
    - Create multiple branches if needed. You can tell if multiple branches are needed if the file changes span multiple projects in the monorepo.
 3. Determine the commits
    - For each group of file changes, determine the commit message. Be descriptive and explain what the changes are.


### PR DESCRIPTION
Update instructions to match branch names and descriptions with file
changes.