### PR TITLE
Add tests and update logic for deeply nested file tree changes in desktop app

### DIFF
--- a/apps/desktop/cypress/e2e/fileTree.cy.ts
+++ b/apps/desktop/cypress/e2e/fileTree.cy.ts
@@ -1,7 +1,8 @@
 import { clearCommandMocks, mockCommand } from './support';
 import LotsOfFileChanges from './support/scenarios/lotsOfFileChanges';
+import SomeDeeplyNestedChanges from './support/scenarios/someDeeplyNestedChanges';
 
-describe('File Tree', () => {
+describe('File Tree - multiple file changes', () => {
 	let mockBackend: LotsOfFileChanges;
 	beforeEach(() => {
 		mockBackend = new LotsOfFileChanges();
@@ -49,6 +50,59 @@ describe('File Tree', () => {
 			cy.getByTestId('file-list-item').should(
 				'have.length',
 				mockBackend.getWorktreeChangesTopLevelFiles().length
+			);
+		});
+	});
+});
+
+describe('File Tree - some file changes', () => {
+	let mockBackend: SomeDeeplyNestedChanges;
+	beforeEach(() => {
+		mockBackend = new SomeDeeplyNestedChanges();
+		mockCommand('stacks', () => mockBackend.getStacks());
+		mockCommand('stack_details', (params) => mockBackend.getStackDetails(params));
+		mockCommand('changes_in_worktree', (params) => mockBackend.getWorktreeChanges(params));
+
+		cy.visit('/');
+
+		cy.url({ timeout: 3000 }).should('include', `/workspace/${mockBackend.stackId}`);
+	});
+
+	afterEach(() => {
+		clearCommandMocks();
+	});
+
+	it('Should be able to toggle the file tree view - Uncommitted changes', () => {
+		// There should be uncommitted changes
+		cy.getByTestId('uncommitted-changes-file-list').should('be.visible');
+
+		// All files should be visible
+		cy.getByTestId('file-list-item').should(
+			'have.length',
+			mockBackend.getWorktreeChangesFileNames().length
+		);
+
+		// The uncommitted changes header should be visible,
+		// and the file list mode should be selected
+		cy.getByTestId('uncommitted-changes-header')
+			.should('be.visible')
+			.within(() => {
+				cy.get('#list').should('be.visible').should('have.attr', 'aria-selected', 'true');
+
+				// Click the tree view button
+				cy.get('#tree').should('be.visible').should('have.attr', 'aria-selected', 'false').click();
+			});
+
+		// There should be an expanded file tree
+		cy.getByTestId('uncommitted-changes-file-list').within(() => {
+			cy.getByTestId('file-list-tree-folder').should(
+				'have.length',
+				mockBackend.getWorktreeChangesTopLevelDirs().length
+			);
+
+			cy.getByTestId('file-list-item').should(
+				'have.length',
+				mockBackend.getWorktreeChangesFileNames().length
 			);
 		});
 	});

--- a/apps/desktop/cypress/e2e/support/scenarios/someDeeplyNestedChanges.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/someDeeplyNestedChanges.ts
@@ -1,0 +1,41 @@
+import MockBackend from '../mock/backend';
+import {
+	createMockAdditionTreeChange,
+	createMockDeletionTreeChange,
+	createMockModificationTreeChange
+} from '../mock/changes';
+import type { TreeChange } from '$lib/hunks/change';
+
+const FILE_PATHS = [
+	'dir1/subdir1/deep/deeper/deepest/fileAG.txt',
+	'dir2/subdir2/deep/deeper/deepest/fileAH.txt',
+	'dir3/subdir3/deep/deeper/deepest/fileAI.txt',
+	'dir4/subdir4/deep/deeper/deepest/fileAJ.txt',
+	'dir5/subdir5/deep/deeper/deepest/fileAK.txt'
+];
+
+const treeChangeGenerators = [
+	createMockAdditionTreeChange,
+	createMockDeletionTreeChange,
+	createMockModificationTreeChange
+];
+
+const MOCK_FILE_TREE_CHANGES: TreeChange[] = FILE_PATHS.map((path) => {
+	const randomGeneratorIndex = Math.floor(Math.random() * treeChangeGenerators.length);
+	const randomGenerator = treeChangeGenerators[randomGeneratorIndex]!;
+	return randomGenerator({ path });
+});
+
+/**
+ * Mock backend for a scenario with only some deeply nested file changes.
+ */
+export default class SomeDeeplyNestedChanges extends MockBackend {
+	constructor() {
+		super();
+
+		this.worktreeChanges = {
+			changes: MOCK_FILE_TREE_CHANGES,
+			ignoredChanges: []
+		};
+	}
+}

--- a/apps/desktop/src/components/v3/FileTreeNode.svelte
+++ b/apps/desktop/src/components/v3/FileTreeNode.svelte
@@ -6,8 +6,7 @@
 	import type { TreeChange } from '$lib/hunks/change';
 	import type { Snippet } from 'svelte';
 
-	const CHILD_THRESHOLD_FOR_AUTO_EXPAND = 10;
-	const DEPTH_THRESHOLD_FOR_AUTO_EXPAND = 3;
+	const CHILD_THRESHOLD_FOR_AUTO_EXPAND = 8;
 
 	type Props = {
 		node: TreeNode;
@@ -15,7 +14,7 @@
 		showCheckboxes?: boolean;
 		changes: TreeChange[];
 		depth?: number;
-		initiallyCollapsed?: boolean;
+		initiallyExpanded?: boolean;
 		fileTemplate: Snippet<[TreeChange, number, number]>;
 	};
 
@@ -26,16 +25,14 @@
 		changes,
 		depth = 0,
 		fileTemplate,
-		initiallyCollapsed
+		initiallyExpanded
 	}: Props = $props();
 
-	const notSoDeep = $derived(depth < DEPTH_THRESHOLD_FOR_AUTO_EXPAND);
 	const hasAFewChildren = $derived(
 		(node.kind === 'dir' || isRoot) && node.children.length <= CHILD_THRESHOLD_FOR_AUTO_EXPAND
 	);
-	const isProbablyFine = $derived(notSoDeep && hasAFewChildren);
 	const defaultIsExpanded = $derived(
-		initiallyCollapsed ?? (isProbablyFine || node.kind === 'file')
+		initiallyExpanded ?? (hasAFewChildren || node.kind === 'file')
 	);
 
 	let actionableIsExpanded = $state<boolean>();
@@ -58,7 +55,7 @@
 			{showCheckboxes}
 			{changes}
 			{fileTemplate}
-			initiallyCollapsed={!hasAFewChildren}
+			initiallyExpanded={hasAFewChildren}
 		/>
 	{/each}
 {:else if node.kind === 'file'}


### PR DESCRIPTION
- Add scenario and test for deeply nested file changes in Cypress
- Update FileTreeNode.svelte auto-expand logic and props
- Adjust thresholds and improve expand/collapse behavior for nested directories