### PR TITLE
feat(StackView): remove unnecessary div and styles

### DIFF
--- a/apps/desktop/src/components/v3/BranchesView.svelte
+++ b/apps/desktop/src/components/v3/BranchesView.svelte
@@ -92,6 +92,11 @@
 	{#snippet children(baseBranch)}
 		{@const lastCommit = baseBranch.recentCommits.at(0)}
 		{@const current = branchesState.current}
+		{@const inWorkspaceOrTargetBranch =
+			current.inWorkspace || current.branchName === baseBranch.shortName}
+		{@const isStackOrNormalBranchPreview =
+			current.stackId || (current.branchName && current.branchName !== baseBranch.shortName)}
+
 		<div class="branches-view" use:focusable={{ id: Focusable.Branches }}>
 			<div class="branch-list" bind:this={leftDiv} style:width={leftWidth.current + 'rem'}>
 				<BranchesListGroup title="Current workspace target">
@@ -192,7 +197,7 @@
 			</div>
 
 			<div class="branches-sideview">
-				{#if !current.inWorkspace}
+				{#if !inWorkspaceOrTargetBranch}
 					<div class="branches-actions">
 						{#if !current.isTarget}
 							<AsyncButton
@@ -222,10 +227,8 @@
 				<div
 					class={[
 						'branch-details',
-						current.stackId || (current.branchName && current.branchName !== baseBranch.shortName)
-							? 'dotted-container dotted-pattern'
-							: undefined,
-						current.inWorkspace ? 'rounded-container' : undefined
+						isStackOrNormalBranchPreview ? 'dotted-container dotted-pattern' : '',
+						inWorkspaceOrTargetBranch ? 'rounded-container' : ''
 					]}
 					bind:this={rightDiv}
 					style:width={rightWidth.current + 'rem'}
@@ -295,9 +298,7 @@
 		flex-direction: column;
 		position: relative;
 		flex: 1;
-
 		border: 1px solid var(--clr-border-2);
-		border-radius: var(--radius-ml);
 		overflow: hidden;
 	}
 

--- a/apps/desktop/src/components/v3/StackView.svelte
+++ b/apps/desktop/src/components/v3/StackView.svelte
@@ -11,13 +11,5 @@
 </script>
 
 <ConfigurableScrollableContainer wide>
-	<div class="inner">
-		<BranchList {projectId} {stackId} />
-	</div>
+	<BranchList {projectId} {stackId} />
 </ConfigurableScrollableContainer>
-
-<style>
-	.inner {
-		padding: 14px;
-	}
-</style>

--- a/apps/desktop/src/components/v3/WorkspaceView.svelte
+++ b/apps/desktop/src/components/v3/WorkspaceView.svelte
@@ -136,9 +136,8 @@
 						bind:width={tabsWidth}
 					/>
 					<div
-						class="contents"
+						class={['contents', stacks.length > 0 ? 'contents_stack dotted-pattern' : '']}
 						class:rounded={tabsWidth! <= (remToPx(stacksViewWidth.current - 0.5) as number)}
-						class:dotted-pattern={stacks.length > 0}
 					>
 						{@render stack()}
 					</div>
@@ -212,7 +211,11 @@
 		border: 1px solid var(--clr-border-2);
 	}
 
+	/* MODIFIERS */
 	.rounded {
 		border-radius: 0 var(--radius-ml) var(--radius-ml) var(--radius-ml);
+	}
+	.contents_stack {
+		padding: 12px;
 	}
 </style>


### PR DESCRIPTION
The changes in this commit remove an unnecessary `div` element and its associated styles from the `StackView` component. This simplifies the component's structure and reduces unnecessary markup.

The main changes are:

- Removed the `<div class="inner">` element and its contents.
- Removed the `.inner` styles from the component's CSS.

These changes improve the overall code readability and maintainability of the `StackView` component.