### PR TITLE
fix remerge issue in rebase-engine

### DIFF
--- a/crates/but-rebase/tests/fixtures/rebase.sh
+++ b/crates/but-rebase/tests/fixtures/rebase.sh
@@ -31,3 +31,19 @@ git init three-branches-merged
   git checkout main
   git merge A B C
 )
+
+git init merge-in-the-middle
+(cd merge-in-the-middle
+  seq 50 60 >file && git add . && git commit -m "base" && git tag base
+  git branch B
+
+  git checkout -b A
+  { seq 10; seq 50 60; } >file && git add . && git commit -m "A: 10 lines on top"
+  git branch with-inner-merge
+
+  git checkout B
+  seq 10 >new-file && git add . && git commit -m "C: new file with 10 lines"
+
+  git checkout with-inner-merge && git merge --no-ff B
+  echo seq 10 >'added-after-with-inner-merge' && git add . && git commit -m "on top of inner merge"
+)


### PR DESCRIPTION
Previously, when moving a merge commit down in the stack, the rebase engine would try to figure out which
of the parents of the merge-commit it should replace. For that to work, the respective parent would have to
be encountered already.

However, that doesn't happen when moving a merge-commit down in the branch.

### Tasks

* [x] reproduce
* [x] fix
* [ ] ~~refactor: remove `base_substitute`~~.
* [x] test GUI
