### PR TITLE
Automatically move broken projects.json out of the way to allow app-startup

### DIFF
--- a/crates/gitbutler-tauri/src/projects.rs
+++ b/crates/gitbutler-tauri/src/projects.rs
@@ -54,15 +54,18 @@ pub mod commands {
         projects: State<'_, Controller>,
     ) -> Result<Vec<ProjectForFrontend>, Error> {
         let open_projects = window_state.open_projects();
-        projects.list().map_err(Into::into).map(|projects| {
-            projects
-                .into_iter()
-                .map(|project| ProjectForFrontend {
-                    is_open: open_projects.contains(&project.id),
-                    inner: project,
-                })
-                .collect()
-        })
+        projects
+            .assure_app_can_startup_or_fix_it(projects.list())
+            .map_err(Into::into)
+            .map(|projects| {
+                projects
+                    .into_iter()
+                    .map(|project| ProjectForFrontend {
+                        is_open: open_projects.contains(&project.id),
+                        inner: project,
+                    })
+                    .collect()
+            })
     }
 
     /// This trigger is the GUI telling us that the project with `id` is now displayed.


### PR DESCRIPTION
### Tasks

* [x] reproduce issue (manual testing)
* [x] fix it by moving file out of the way, and informing the user with an error

Fixes #8346 .