### PR TITLE
basic head-info

### DIFF
--- a/crates/but-workspace/src/branch.rs
+++ b/crates/but-workspace/src/branch.rs
@@ -515,6 +515,19 @@ pub struct Stack {
     pub stash_status: Option<StashStatus>,
 }
 
+impl Stack {
+    /// Return the name of the top-most [`StackSegment`].
+    ///
+    /// It is `None` if this branch is the top-most stack segment and the `ref_name` wasn't pointing to
+    /// a commit anymore that was reached by our rev-walk.
+    /// This can happen if the ref is deleted, or if it was advanced by other means.
+    pub fn name(&self) -> Option<&gix::refs::FullNameRef> {
+        self.segments
+            .first()
+            .and_then(|name| name.ref_name.as_ref().map(|name| name.as_ref()))
+    }
+}
+
 /// A list of all commits
 #[derive(Debug, Clone)]
 pub struct BranchCommit {

--- a/crates/but-workspace/src/branch_details.rs
+++ b/crates/but-workspace/src/branch_details.rs
@@ -1,0 +1,220 @@
+use crate::head_info::function::workspace_data_of_default_workspace_branch;
+use crate::ui::{CommitState, PushStatus};
+use crate::{state_handle, ui};
+use anyhow::{Context, bail};
+use but_core::RefMetadata;
+use gitbutler_command_context::CommandContext;
+use gitbutler_error::error::Code;
+use gitbutler_oxidize::OidExt;
+use gix::remote::Direction;
+use std::collections::HashSet;
+use std::path::Path;
+
+/// Returns information about the current state of a branch.
+pub fn branch_details(
+    gb_dir: &Path,
+    branch_name: &str,
+    remote: Option<&str>,
+    ctx: &CommandContext,
+) -> anyhow::Result<ui::BranchDetails> {
+    let state = state_handle(gb_dir);
+    let repository = ctx.repo();
+
+    let default_target = state.get_default_target()?;
+
+    let (branch, is_remote_head) = match remote {
+        None => repository
+            .find_branch(branch_name, git2::BranchType::Local)
+            .map(|b| (b, false)),
+        Some(remote) => repository
+            .find_branch(
+                format!("{remote}/{branch_name}").as_str(),
+                git2::BranchType::Remote,
+            )
+            .map(|b| (b, true)),
+    }
+    .context(format!("Could not find branch {branch_name}"))
+    .context(Code::BranchNotFound)?;
+
+    let Some(branch_oid) = branch.get().target() else {
+        bail!("Branch points to nothing");
+    };
+    let upstream = branch.upstream().ok();
+    let upstream_oid = upstream.as_ref().and_then(|u| u.get().target());
+
+    let push_status = match upstream.as_ref() {
+        Some(upstream) => {
+            if upstream.get().target() == branch.get().target() {
+                PushStatus::NothingToPush
+            } else {
+                PushStatus::UnpushedCommits
+            }
+        }
+        None => PushStatus::CompletelyUnpushed,
+    };
+
+    let merge_bases = repository.merge_bases(branch_oid, default_target.sha)?;
+    let Some(base_commit) = merge_bases.last() else {
+        bail!("Failed to find merge base");
+    };
+
+    let mut revwalk = repository.revwalk()?;
+    revwalk.push(branch_oid)?;
+    revwalk.hide(default_target.sha)?;
+    revwalk.simplify_first_parent()?;
+
+    let commits = revwalk
+        .filter_map(|oid| repository.find_commit(oid.ok()?).ok())
+        .collect::<Vec<_>>();
+
+    let upstream_commits = if let Some(upstream_oid) = upstream_oid {
+        let mut revwalk = repository.revwalk()?;
+        revwalk.push(upstream_oid)?;
+        revwalk.hide(branch_oid)?;
+        revwalk.hide(default_target.sha)?;
+        revwalk.simplify_first_parent()?;
+        revwalk
+            .filter_map(|oid| repository.find_commit(oid.ok()?).ok())
+            .collect::<Vec<_>>()
+    } else {
+        vec![]
+    };
+
+    let mut authors = HashSet::new();
+
+    let commits = commits
+        .into_iter()
+        .map(|commit| {
+            let author: ui::Author = commit.author().into();
+            let commiter: ui::Author = commit.committer().into();
+            authors.insert(author.clone());
+            authors.insert(commiter);
+            ui::Commit {
+                id: commit.id().to_gix(),
+                parent_ids: commit.parent_ids().map(|id| id.to_gix()).collect(),
+                message: commit.message().unwrap_or_default().into(),
+                has_conflicts: false,
+                state: CommitState::LocalAndRemote(commit.id().to_gix()),
+                created_at: u128::try_from(commit.time().seconds()).unwrap_or(0) * 1000,
+                author,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let upstream_commits = upstream_commits
+        .into_iter()
+        .map(|commit| {
+            let author: ui::Author = commit.author().into();
+            let commiter: ui::Author = commit.committer().into();
+            authors.insert(author.clone());
+            authors.insert(commiter);
+            ui::UpstreamCommit {
+                id: commit.id().to_gix(),
+                message: commit.message().unwrap_or_default().into(),
+                created_at: u128::try_from(commit.time().seconds()).unwrap_or(0) * 1000,
+                author,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    Ok(ui::BranchDetails {
+        name: branch_name.into(),
+        remote_tracking_branch: upstream
+            .as_ref()
+            .and_then(|upstream| upstream.get().name())
+            .map(Into::into),
+        description: None,
+        pr_number: None,
+        review_id: None,
+        base_commit: base_commit.to_gix(),
+        push_status,
+        last_updated_at: commits
+            .first()
+            .map(|c| c.created_at)
+            .or(upstream_commits.first().map(|c| c.created_at)),
+        authors: authors.into_iter().collect(),
+        is_conflicted: false,
+        commits,
+        upstream_commits,
+        tip: branch_oid.to_gix(),
+        is_remote_head,
+    })
+}
+
+/// Returns information about the current state of a branch identified by its `name`.
+/// This branch is assumed to not be in the workspace, but it will still be assumed to want to integrate with the workspace target reference if set.
+///
+/// ### Implementation
+#[allow(unused_variables)]
+pub fn branch_details_v3(
+    repo: &gix::Repository,
+    name: &gix::refs::FullNameRef,
+    meta: &impl RefMetadata,
+) -> anyhow::Result<ui::BranchDetails> {
+    let integration_ref_name = workspace_data_of_default_workspace_branch(meta)?
+        .context(
+            "TODO: cannot run in non-workspace mode yet.\
+        It would need a way to deal with limiting the commit traversal",
+        )?
+        .target_ref
+        .context("TODO: a target to integrate with is currently needed for a workspace commit")?;
+    let mut integration_ref = repo
+        .find_reference(&integration_ref_name)
+        .context("The branch to integrate with must be present")?;
+    let integration_ref_target_id = integration_ref.peel_to_id_in_place()?;
+
+    let mut branch = repo.find_reference(name)?;
+    let branch_target_id = branch.peel_to_id_in_place()?;
+
+    let mut remote_tracking_branch = repo
+        .branch_remote_tracking_ref_name(name, Direction::Fetch)
+        .transpose()?
+        .and_then(|remote_tracking_ref| repo.find_reference(remote_tracking_ref.as_ref()).ok());
+    let remote_tracking_target_id = remote_tracking_branch
+        .as_mut()
+        .map(|remote_ref| remote_ref.peel_to_id_in_place())
+        .transpose()?;
+    let push_status = remote_tracking_target_id
+        .map(|remote_target_id| {
+            if remote_target_id == branch_target_id {
+                PushStatus::NothingToPush
+            } else {
+                PushStatus::UnpushedCommits
+            }
+        })
+        .unwrap_or(PushStatus::CompletelyUnpushed);
+
+    let meta = meta.branch(name)?;
+    let meta: &but_core::ref_metadata::Branch = &meta;
+
+    let base_commit = {
+        let cache = repo.commit_graph_if_enabled()?;
+        let mut graph = repo.revision_graph(cache.as_ref());
+        let merge_bases = repo.merge_bases_many_with_graph(
+            branch_target_id,
+            &[integration_ref_target_id.detach()],
+            &mut graph,
+        )?;
+        // TODO: have a test that shows why this must/should be last. Then maybe make it easy to do
+        //       the right thing whenever the mergebase with the integration branch is needed.
+        merge_bases.last().map(|id| id.detach())
+    };
+
+    todo!()
+    // Ok(ui::BranchDetails {
+    //     name: name.as_bstr().into(),
+    //     remote_tracking_branch: remote_tracking_branch.map(|b| b.name().as_bstr().to_owned()),
+    //     description: meta.description.clone(),
+    //     pr_number: meta.review.pull_request,
+    //     review_id: meta.review.review_id.clone(),
+    //     base_commit: todo!(),
+    //     push_status,
+    //     last_updated_at: todo!(),
+    //     authors: todo!(),
+    //     is_conflicted: todo!(),
+    //     commits: todo!(),
+    //     upstream_commits: todo!(),
+    //     tip: branch_target_id.detach(),
+    //     is_remote_head: name.category() == Some(Category::RemoteBranch),
+    // })
+}

--- a/crates/but-workspace/src/head_info.rs
+++ b/crates/but-workspace/src/head_info.rs
@@ -20,6 +20,7 @@ pub(crate) mod function {
     use but_core::ref_metadata::ValueInfo;
     use gix::prelude::ReferenceExt;
     use gix::revision::walk::Sorting;
+    use tracing::instrument;
 
     /// Gather information about the current `HEAD` and the workspace that might be associated with it, based on data in `repo` and `meta`.
     ///
@@ -28,6 +29,7 @@ pub(crate) mod function {
     /// ### Performance
     ///
     /// Make sure the `repo` is initialized with a decently sized Object cache so querying the same commit multiple times will be cheap(er).
+    #[instrument(level = tracing::Level::DEBUG, skip(repo, meta), err(Debug))]
     pub fn head_info(
         repo: &gix::Repository,
         meta: &impl but_core::RefMetadata,

--- a/crates/but-workspace/src/head_info.rs
+++ b/crates/but-workspace/src/head_info.rs
@@ -16,7 +16,6 @@ pub struct Options {
 pub(crate) mod function {
     use crate::HeadInfo;
     use crate::branch::{RefLocation, Stack, StackSegment};
-    use bstr::ByteSlice;
     use but_core::ref_metadata::ValueInfo;
     use gix::prelude::ReferenceExt;
     use gix::revision::walk::Sorting;
@@ -225,7 +224,7 @@ pub(crate) mod function {
     }
 
     // Fetch non-default workspace information, but only if reference at `name` seems to be a workspace reference.
-    fn workspace_data_of_workspace_branch(
+    pub fn workspace_data_of_workspace_branch(
         meta: &impl but_core::RefMetadata,
         name: &gix::refs::FullNameRef,
     ) -> anyhow::Result<Option<but_core::ref_metadata::Workspace>> {
@@ -241,7 +240,19 @@ pub(crate) mod function {
         })
     }
 
+    /// Like [`workspace_data_of_workspace_branch()`], but it will try the name of the default GitButler workspace branch.
+    pub fn workspace_data_of_default_workspace_branch(
+        meta: &impl but_core::RefMetadata,
+    ) -> anyhow::Result<Option<but_core::ref_metadata::Workspace>> {
+        workspace_data_of_workspace_branch(
+            meta,
+            "refs/heads/gitbutler/workspace"
+                .try_into()
+                .expect("statically known"),
+        )
+    }
+
     fn is_gitbutler_workspace_ref(name: &gix::refs::FullNameRef) -> bool {
-        name.shorten().starts_with_str("gitbutler/workspace/")
+        name.as_bstr() == "refs/heads/gitbutler/workspace"
     }
 }

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -22,16 +22,15 @@
 //! * **DiffSpec**
 //!   - A type that identifies changes, either as whole file, or as hunks in the file.
 //!   - It doesn't specify if the change is in a commit, or in the worktree, so that information must be provided separately.
+use std::path::Path;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
 use but_core::RefMetadata;
 use gitbutler_command_context::CommandContext;
-use gitbutler_error::error::Code;
 use gitbutler_oxidize::OidExt;
 use gitbutler_stack::VirtualBranchesHandle;
-use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
-use std::path::Path;
 
 mod integrated;
 
@@ -78,6 +77,12 @@ pub use stacks::{
     stack_details, stack_heads_info, stacks, stacks_v3,
 };
 
+mod virtual_branches_metadata;
+pub use virtual_branches_metadata::VirtualBranchesTomlMetadata;
+
+mod branch_details;
+pub use branch_details::{branch_details, branch_details_v3};
+
 /// Information about where the user is currently looking at.
 #[derive(Debug, Clone)]
 pub struct HeadInfo {
@@ -90,9 +95,6 @@ pub struct HeadInfo {
     pub target_ref: Option<gix::refs::FullName>,
 }
 
-mod virtual_branches_metadata;
-pub use virtual_branches_metadata::VirtualBranchesTomlMetadata;
-
 /// A representation of the commit that is the tip of the workspace, i.e., usually what `HEAD` points to,
 /// possibly in its managed form in which it merges two or more stacks together, and we can rewrite it at will.
 pub struct WorkspaceCommit<'repo> {
@@ -102,7 +104,6 @@ pub struct WorkspaceCommit<'repo> {
     pub inner: gix::objs::Commit,
 }
 
-use crate::ui::{CommitState, PushStatus};
 /// An ID uniquely identifying stacks.
 pub use gitbutler_stack::StackId;
 
@@ -131,137 +132,6 @@ fn id_from_name_v2_to_v3(
             "{name:?} didn't have a stack-id even though \
         it was supposed to be in virtualbranches.toml"
         )
-    })
-}
-
-/// Returns information about the current state of a branch.
-pub fn branch_details(
-    gb_dir: &Path,
-    branch_name: &str,
-    remote: Option<&str>,
-    ctx: &CommandContext,
-) -> Result<ui::BranchDetails> {
-    let state = state_handle(gb_dir);
-    let repository = ctx.repo();
-
-    let default_target = state.get_default_target()?;
-
-    let (branch, is_remote_head) = match remote {
-        None => repository
-            .find_branch(branch_name, git2::BranchType::Local)
-            .map(|b| (b, false)),
-        Some(remote) => repository
-            .find_branch(
-                format!("{remote}/{branch_name}").as_str(),
-                git2::BranchType::Remote,
-            )
-            .map(|b| (b, true)),
-    }
-    .context(format!("Could not find branch {branch_name}"))
-    .context(Code::BranchNotFound)?;
-
-    let Some(branch_oid) = branch.get().target() else {
-        bail!("Branch points to nothing");
-    };
-    let upstream = branch.upstream().ok();
-    let upstream_oid = upstream.as_ref().and_then(|u| u.get().target());
-
-    let push_status = match upstream.as_ref() {
-        Some(upstream) => {
-            if upstream.get().target() == branch.get().target() {
-                PushStatus::NothingToPush
-            } else {
-                PushStatus::UnpushedCommits
-            }
-        }
-        None => PushStatus::CompletelyUnpushed,
-    };
-
-    let merge_bases = repository.merge_bases(branch_oid, default_target.sha)?;
-    let Some(base_commit) = merge_bases.last() else {
-        bail!("Failed to find merge base");
-    };
-
-    let mut revwalk = repository.revwalk()?;
-    revwalk.push(branch_oid)?;
-    revwalk.hide(default_target.sha)?;
-    revwalk.simplify_first_parent()?;
-
-    let commits = revwalk
-        .filter_map(|oid| repository.find_commit(oid.ok()?).ok())
-        .collect::<Vec<_>>();
-
-    let upstream_commits = if let Some(upstream_oid) = upstream_oid {
-        let mut revwalk = repository.revwalk()?;
-        revwalk.push(upstream_oid)?;
-        revwalk.hide(branch_oid)?;
-        revwalk.hide(default_target.sha)?;
-        revwalk.simplify_first_parent()?;
-        revwalk
-            .filter_map(|oid| repository.find_commit(oid.ok()?).ok())
-            .collect::<Vec<_>>()
-    } else {
-        vec![]
-    };
-
-    let mut authors = HashSet::new();
-
-    let commits = commits
-        .into_iter()
-        .map(|commit| {
-            let author: ui::Author = commit.author().into();
-            let commiter: ui::Author = commit.committer().into();
-            authors.insert(author.clone());
-            authors.insert(commiter);
-            ui::Commit {
-                id: commit.id().to_gix(),
-                parent_ids: commit.parent_ids().map(|id| id.to_gix()).collect(),
-                message: commit.message().unwrap_or_default().into(),
-                has_conflicts: false,
-                state: CommitState::LocalAndRemote(commit.id().to_gix()),
-                created_at: u128::try_from(commit.time().seconds()).unwrap_or(0) * 1000,
-                author,
-            }
-        })
-        .collect::<Vec<_>>();
-
-    let upstream_commits = upstream_commits
-        .into_iter()
-        .map(|commit| {
-            let author: ui::Author = commit.author().into();
-            let commiter: ui::Author = commit.committer().into();
-            authors.insert(author.clone());
-            authors.insert(commiter);
-            ui::UpstreamCommit {
-                id: commit.id().to_gix(),
-                message: commit.message().unwrap_or_default().into(),
-                created_at: u128::try_from(commit.time().seconds()).unwrap_or(0) * 1000,
-                author,
-            }
-        })
-        .collect::<Vec<_>>();
-
-    Ok(ui::BranchDetails {
-        name: branch_name.into(),
-        remote_tracking_branch: upstream
-            .as_ref()
-            .and_then(|upstream| upstream.get().name())
-            .map(Into::into),
-        description: None,
-        pr_number: None,
-        review_id: None,
-        base_commit: base_commit.to_gix(),
-        push_status,
-        last_updated_at: commits
-            .first()
-            .map(|c| c.created_at)
-            .or(upstream_commits.first().map(|c| c.created_at)),
-        authors: authors.into_iter().collect(),
-        is_conflicted: false,
-        commits,
-        upstream_commits,
-        tip: branch_oid.to_gix(),
-        is_remote_head,
     })
 }
 
@@ -318,7 +188,7 @@ pub fn log_target_first_parent(
             parent_ids: commit.parent_ids().map(|id| id.detach()).collect(),
             message: commit.message_raw_sloppy().into(),
             has_conflicts: false,
-            state: CommitState::LocalAndRemote(commit.id),
+            state: ui::CommitState::LocalAndRemote(commit.id),
             created_at: u128::try_from(commit.time()?.seconds)? * 1000,
             author: commit.author()?.into(),
         });

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -24,19 +24,14 @@
 //!   - It doesn't specify if the change is in a commit, or in the worktree, so that information must be provided separately.
 
 use anyhow::{Context, Result, bail};
-use bstr::BString;
+use but_core::RefMetadata;
 use gitbutler_command_context::CommandContext;
-use gitbutler_commit::commit_ext::CommitExt;
 use gitbutler_error::error::Code;
-use gitbutler_id::id::Id;
-use gitbutler_oxidize::{ObjectIdExt, OidExt, git2_signature_to_gix_signature};
-use gitbutler_stack::{Stack, StackBranch, VirtualBranchesHandle};
-use integrated::IsCommitIntegrated;
-use itertools::Itertools;
+use gitbutler_oxidize::OidExt;
+use gitbutler_stack::VirtualBranchesHandle;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::Path;
-use std::str::FromStr;
 
 mod integrated;
 
@@ -76,6 +71,13 @@ pub use head_info::function::head_info;
 /// High level Stack funtions that use primitives from this crate (`but-workspace`)
 pub mod stack_ext;
 
+/// Functions related to retrieving stack information.
+mod stacks;
+pub use stacks::{
+    stack_branch_local_and_remote_commits, stack_branch_upstream_only_commits, stack_branches,
+    stack_details, stack_heads_info, stacks, stacks_v3,
+};
+
 /// Information about where the user is currently looking at.
 #[derive(Debug, Clone)]
 pub struct HeadInfo {
@@ -113,264 +115,22 @@ pub enum StacksFilter {
     #[default]
     InWorkspace,
     /// Show only unapplied stacks
+    // TODO: figure out where this is used. V2 maybe? If so, it can be removed eventually.
     Unapplied,
 }
 
-/// Returns the list of branch information for the branches in a stack.
-pub fn stack_heads_info(stack: &Stack, repo: &gix::Repository) -> Result<Vec<ui::StackHeadInfo>> {
-    let branches = stack
-        .branches()
-        .into_iter()
-        .rev()
-        .filter_map(|branch| {
-            let tip = branch.head_oid(repo).ok()?;
-            Some(ui::StackHeadInfo {
-                name: branch.name().to_owned().into(),
-                tip,
-            })
-        })
-        .collect::<Vec<_>>();
-
-    Ok(branches)
-}
-
-/// Returns the list of stacks that are currently part of the workspace.
-/// If there are no applied stacks, the returned Vec is empty.
-/// If the GitButler state file in the provided path is missing or invalid, an error is returned.
-///
-/// - `gb_dir`: The path to the GitButler state for the project. Normally this is `.git/gitbutler` in the project's repository.
-pub fn stacks(
-    ctx: &CommandContext,
-    gb_dir: &Path,
-    repo: &gix::Repository,
-    filter: StacksFilter,
-) -> Result<Vec<ui::StackEntry>> {
-    let state = state_handle(gb_dir);
-
-    let stacks = match filter {
-        StacksFilter::All => state.list_all_stacks()?,
-        StacksFilter::InWorkspace => state
-            .list_all_stacks()?
-            .into_iter()
-            .filter(|s| s.in_workspace)
-            .collect(),
-        StacksFilter::Unapplied => state
-            .list_all_stacks()?
-            .into_iter()
-            .filter(|s| !s.in_workspace)
-            .collect(),
-    };
-
-    let stacks = stacks
-        .into_iter()
-        .filter_map(|mut stack| stack.migrate_change_ids(ctx).ok().map(|()| stack))
-        .filter(|s| s.is_initialized());
-
-    stacks
-        .sorted_by_key(|s| s.order)
-        .map(|stack| ui::StackEntry::try_new(repo, &stack))
-        .collect()
-}
-
-fn try_from_stack_v3(
-    repo: &gix::Repository,
-    stack: branch::Stack,
-) -> anyhow::Result<ui::StackEntry> {
-    let heads = stack.segments.into_iter().map(|segment| {
-        let ref_name = segment
-            .ref_name
-            .expect("This type can't represent this state and it shouldn't have to");
-        ui::StackHeadInfo {
-            tip: repo
-                .find_reference(ref_name.as_ref())
-                .ok()
-                .and_then(|r| r.try_id())
-                .map(|id| id.detach())
-                .unwrap_or(repo.object_hash().null()),
-            name: ref_name.into(),
-        }
-    });
-    Ok(ui::StackEntry {
-        id: Default::default(), // TODO: have a global evil mapping from ref-names to IDs
-        heads: heads.collect(),
-        tip: stack.tip.unwrap_or(repo.object_hash().null()),
-    })
-}
-
-/// Returns the list of stacks that pass `filter`.
-///
-/// Use `repo` and `meta` to read branches data
-// TODO: Let the UI get all stacks at once.
-pub fn stacks_v3(
-    repo: &gix::Repository,
-    meta: &impl but_core::RefMetadata,
-    filter: StacksFilter,
-) -> Result<Vec<ui::StackEntry>> {
-    let info = crate::head_info(
-        repo,
-        meta,
-        head_info::Options {
-            // TODO: set this to a good value for the UI to not slow down, and also a value that forces us to re-investigate this.
-            stack_commit_limit: 100,
-        },
-    )?;
-
-    info.stacks
-        .into_iter()
-        .filter_map(|stack| match filter {
-            StacksFilter::All | StacksFilter::InWorkspace => Some(try_from_stack_v3(repo, stack)),
-            // TODO: get all stacks, not just the applied ones. These are only by inspection of metadata.
-            StacksFilter::Unapplied => None,
-        })
-        .collect::<Result<_, _>>()
-}
-
-/// Determines if a force push is required to push a branch to its remote.
-fn requires_force(ctx: &CommandContext, branch: &StackBranch, remote: &str) -> Result<bool> {
-    let upstream = branch.remote_reference(remote);
-
-    let reference = match ctx.repo().refname_to_id(&upstream) {
-        Ok(reference) => reference,
-        Err(err) if err.code() == git2::ErrorCode::NotFound => return Ok(false),
-        Err(other) => return Err(other).context("failed to find upstream reference"),
-    };
-
-    let upstream_commit = ctx
-        .repo()
-        .find_commit(reference)
-        .context("failed to find upstream commit")?;
-
-    let branch_head = branch.head_oid(&ctx.gix_repo()?)?;
-    let merge_base = ctx
-        .repo()
-        .merge_base(upstream_commit.id(), branch_head.to_git2())?;
-
-    Ok(merge_base != upstream_commit.id())
-}
-
-/// Returns information about the current state of a stack.
-/// If the stack is not found, an error is returned.
-///
-/// - `gb_dir`: The path to the GitButler state for the project. Normally this is `.git/gitbutler` in the project's repository.
-/// - `stack_id`: The ID of the stack to get information about.
-/// - `ctx`: The command context for the project.
-pub fn stack_details(
-    gb_dir: &Path,
-    stack_id: StackId,
-    ctx: &CommandContext,
-) -> Result<ui::StackDetails> {
-    #[derive(Debug, Default)]
-    struct BranchState {
-        is_integrated: bool,
-        is_dirty: bool,
-        requires_force: bool,
-        has_pushed_commits: bool,
-    }
-
-    impl From<BranchState> for PushStatus {
-        fn from(state: BranchState) -> Self {
-            match (
-                state.is_integrated,
-                state.is_dirty,
-                state.requires_force,
-                state.has_pushed_commits,
-            ) {
-                (true, _, _, _) => PushStatus::Integrated,
-                (_, true, _, false) => PushStatus::CompletelyUnpushed,
-                (_, _, true, _) => PushStatus::UnpushedCommitsRequiringForce,
-                (_, true, _, _) => PushStatus::UnpushedCommits,
-                (_, false, _, _) => PushStatus::NothingToPush,
-            }
-        }
-    }
-
-    let state = state_handle(gb_dir);
-    let mut stack = state.get_stack(stack_id)?;
-    let branches = stack.branches();
-    let branches = branches.iter().filter(|b| !b.archived);
-    let repo = ctx.gix_repo()?;
-    let remote = state
-        .get_default_target()
-        .context("failed to get default target")?
-        .push_remote_name();
-
-    let mut stack_state = BranchState::default();
-    let mut stack_is_conflicted = false;
-    let mut branch_details = vec![];
-    let mut current_base = stack.merge_base(ctx)?;
-
-    for branch in branches {
-        let upstream_reference = ctx
-            .repo()
-            .find_reference(&branch.remote_reference(remote.as_str()))
-            .ok()
-            .map(|_| branch.remote_reference(remote.as_str()));
-
-        let mut branch_state = BranchState {
-            requires_force: requires_force(ctx, branch, &remote)?,
-            ..Default::default()
-        };
-
-        let mut is_conflicted = false;
-        let mut authors = HashSet::new();
-        let commits = local_and_remote_commits(ctx, &repo, branch, &stack)?;
-        let upstream_commits = upstream_only_commits(ctx, &repo, branch, &stack, Some(&commits))?;
-
-        // If there are commits in the remote, we can assume that commits have been pushed. *Like, literally*.
-        branch_state.has_pushed_commits |= !upstream_commits.is_empty();
-
-        for commit in &commits {
-            is_conflicted |= commit.has_conflicts;
-            branch_state.is_dirty |= matches!(commit.state, ui::CommitState::LocalOnly);
-            branch_state.has_pushed_commits |=
-                matches!(commit.state, CommitState::LocalAndRemote(_));
-            authors.insert(commit.author.clone());
-        }
-
-        // We can assume that if the child-most commit is integrated, the whole branch is integrated
-        branch_state.is_integrated = matches!(
-            commits.first().map(|c| &c.state),
-            Some(CommitState::Integrated)
-        );
-
-        stack_is_conflicted |= is_conflicted;
-        stack_state.is_dirty |= branch_state.is_dirty;
-        stack_state.requires_force |= branch_state.requires_force;
-        stack_state.has_pushed_commits |= branch_state.has_pushed_commits;
-
-        // If all branches are integrated, the stack is integrated
-        stack_state.is_integrated &= branch_state.is_integrated;
-
-        branch_details.push(ui::BranchDetails {
-            name: branch.name().to_owned().into(),
-            remote_tracking_branch: upstream_reference.map(Into::into),
-            description: branch.description.clone(),
-            pr_number: branch.pr_number,
-            review_id: branch.review_id.clone(),
-            tip: branch.head_oid(&repo)?,
-            base_commit: current_base,
-            push_status: branch_state.into(),
-            last_updated_at: commits.first().map(|c| c.created_at),
-            authors: authors.into_iter().collect(),
-            is_conflicted,
-            commits,
-            upstream_commits,
-            is_remote_head: false,
-        });
-
-        current_base = branch.head_oid(&repo)?;
-    }
-
-    stack.migrate_change_ids(ctx).ok(); // If it fails thats ok - best effort migration
-    branch_details.reverse();
-
-    let push_status = stack_state.into();
-
-    Ok(ui::StackDetails {
-        derived_name: stack.derived_name()?,
-        push_status,
-        branch_details,
-        is_conflicted: stack_is_conflicted,
+/// Get a stable `StackId` for the given `name`. It's fetched from `meta`, assuming it's backed by a toml file
+/// and assuming that `name` is stored there as applied or unapplied branch.
+fn id_from_name_v2_to_v3(
+    name: &gix::refs::FullNameRef,
+    meta: &VirtualBranchesTomlMetadata,
+) -> Result<StackId> {
+    let ref_meta = meta.branch(name)?;
+    ref_meta.stack_id().with_context(|| {
+        format!(
+            "{name:?} didn't have a stack-id even though \
+        it was supposed to be in virtualbranches.toml"
+        )
     })
 }
 
@@ -514,249 +274,6 @@ pub fn common_merge_base_with_target_branch(gb_dir: &Path) -> Result<gix::Object
         .to_gix())
 }
 
-/// Represents a branch in a [`Stack`]. It contains commits derived from the local pseudo branch and it's respective remote
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Branch {
-    /// The name of the branch.
-    #[serde(with = "gitbutler_serde::bstring_lossy")]
-    pub name: BString,
-    /// Upstream reference, e.g. `refs/remotes/origin/base-branch-improvements`
-    #[serde(with = "gitbutler_serde::bstring_opt_lossy")]
-    pub remote_tracking_branch: Option<BString>,
-    /// Description of the branch.
-    /// Can include arbitrary utf8 data, eg. markdown etc.
-    pub description: Option<String>,
-    /// The pull(merge) request associated with the branch, or None if no such entity has not been created.
-    pub pr_number: Option<usize>,
-    /// A unique identifier for the GitButler review associated with the branch, if any.
-    pub review_id: Option<String>,
-    /// Indicates that the branch was previously part of a stack but it has since been integrated.
-    /// In other words, the merge base of the stack is now above this branch.
-    /// This would occur when the branch has been merged at the remote and the workspace has been updated with that change.
-    /// An archived branch will not have any commits associated with it.
-    pub archived: bool,
-    /// This is the last commit in the branch, aka the tip of the branch.
-    /// If this is the only branch in the stack or the top-most branch, this is the tip of the stack.
-    #[serde(with = "gitbutler_serde::object_id")]
-    pub tip: gix::ObjectId,
-    /// This is the base commit from the perspective of this branch.
-    /// If the branch is part of a stack and is on top of another branch, this is the head of the branch below it.
-    /// If this branch is at the bottom of the stack, this is the merge base of the stack.
-    #[serde(with = "gitbutler_serde::object_id")]
-    pub base_commit: gix::ObjectId,
-}
-
-/// Returns the branches that belong to a particular [`gitbutler_stack::Stack`]
-/// The entries are ordered from newest to oldest.
-pub fn stack_branches(stack_id: String, ctx: &CommandContext) -> Result<Vec<Branch>> {
-    let state = state_handle(&ctx.project().gb_dir());
-    let remote = state
-        .get_default_target()
-        .context("failed to get default target")?
-        .push_remote_name();
-
-    let mut stack_branches = vec![];
-    let mut stack = state.get_stack(Id::from_str(&stack_id)?)?;
-    let mut current_base = stack.merge_base(ctx)?;
-    let repo = ctx.gix_repo()?;
-    for internal in stack.branches() {
-        let upstream_reference = ctx
-            .repo()
-            .find_reference(&internal.remote_reference(remote.as_str()))
-            .ok()
-            .map(|_| internal.remote_reference(remote.as_str()));
-        let result = Branch {
-            name: internal.name().to_owned().into(),
-            remote_tracking_branch: upstream_reference.map(Into::into),
-            description: internal.description.clone(),
-            pr_number: internal.pr_number,
-            review_id: internal.review_id.clone(),
-            archived: internal.archived,
-            tip: internal.head_oid(&repo)?,
-            base_commit: current_base,
-        };
-        current_base = internal.head_oid(&repo)?;
-        stack_branches.push(result);
-    }
-    stack.migrate_change_ids(ctx).ok(); // If it fails thats ok - best effort migration
-    stack_branches.reverse();
-    Ok(stack_branches)
-}
-
-/// Returns a list of commits beloning to this branch. Ordered from newest to oldest (child-most to parent-most).
-///
-/// These are the commits that are currently part of the workspace (applied).
-/// Created from the local pseudo branch (head currently stored in the TOML file)
-///
-/// When there is only one branch in the stack, this includes the commits
-/// from the tip of the stack to the merge base with the trunk / target branch (not including the merge base).
-///
-/// When there are multiple branches in the stack, this includes the commits from the branch head to the next branch in the stack.
-///
-/// In either case, this is effectively a list of commits that in the working copy which may or may not have been pushed to the remote.
-pub fn stack_branch_local_and_remote_commits(
-    stack_id: String,
-    branch_name: String,
-    ctx: &CommandContext,
-    repo: &gix::Repository,
-) -> Result<Vec<ui::Commit>> {
-    let state = state_handle(&ctx.project().gb_dir());
-    let stack = state.get_stack(Id::from_str(&stack_id)?)?;
-
-    let branches = stack.branches();
-    let branch = branches
-        .iter()
-        .find(|b| b.name() == &branch_name)
-        .ok_or_else(|| anyhow::anyhow!("Could not find branch {:?}", branch_name))?;
-    if branch.archived {
-        return Ok(vec![]);
-    }
-    local_and_remote_commits(ctx, repo, branch, &stack)
-}
-
-/// Returns a fift of commits belonging to this branch. Ordered from newest to oldest (child-most to parent-most).
-///
-/// These are the commits that exist **only** on the upstream branch. Ordered from newest to oldest.
-/// Created from the tip of the local tracking branch eg. refs/remotes/origin/my-branch -> refs/heads/my-branch
-///
-/// This does **not** include the commits that are in the commits list (local)
-/// This is effectively the list of commits that are on the remote branch but are not in the working copy.
-pub fn stack_branch_upstream_only_commits(
-    stack_id: String,
-    branch_name: String,
-    ctx: &CommandContext,
-    repo: &gix::Repository,
-) -> Result<Vec<ui::UpstreamCommit>> {
-    let state = state_handle(&ctx.project().gb_dir());
-    let stack = state.get_stack(Id::from_str(&stack_id)?)?;
-
-    let branches = stack.branches();
-    let branch = branches
-        .iter()
-        .find(|b| b.name() == &branch_name)
-        .with_context(|| format!("Could not find branch {branch_name:?}"))?;
-    if branch.archived {
-        return Ok(vec![]);
-    }
-    upstream_only_commits(ctx, repo, branch, &stack, None)
-}
-
-fn upstream_only_commits(
-    ctx: &CommandContext,
-    repo: &gix::Repository,
-    stack_branch: &gitbutler_stack::StackBranch,
-    stack: &Stack,
-    current_local_and_remote_commits: Option<&Vec<ui::Commit>>,
-) -> Result<Vec<ui::UpstreamCommit>> {
-    let branch_commits = stack_branch.commits(ctx, stack)?;
-
-    let local_and_remote = if let Some(current_local_and_remote) = current_local_and_remote_commits
-    {
-        current_local_and_remote
-    } else {
-        &local_and_remote_commits(ctx, repo, stack_branch, stack)?
-    };
-
-    // Upstream only
-    let mut upstream_only = vec![];
-    for commit in branch_commits.upstream_only.iter() {
-        let matches_known_commit = local_and_remote.iter().any(|c| {
-            // If the id matches verbatim or if there is a known remote_id (in the case of LocalAndRemote) that matchies
-            c.id == commit.id().to_gix() || matches!(&c.state, CommitState::LocalAndRemote(remote_id) if remote_id == &commit.id().to_gix())
-        });
-        // Ignore commits that strictly speaking are remote only, but they match a known local commit (rebase etc)
-        if !matches_known_commit {
-            let created_at = u128::try_from(commit.time().seconds())? * 1000;
-            let upstream_commit = ui::UpstreamCommit {
-                id: commit.id().to_gix(),
-                message: commit.message_bstr().into(),
-                created_at,
-                author: commit.author().into(),
-            };
-            upstream_only.push(upstream_commit);
-        }
-    }
-    upstream_only.reverse();
-
-    Ok(upstream_only)
-}
-
-fn local_and_remote_commits(
-    ctx: &CommandContext,
-    repo: &gix::Repository,
-    stack_branch: &gitbutler_stack::StackBranch,
-    stack: &Stack,
-) -> Result<Vec<ui::Commit>> {
-    let state = state_handle(&ctx.project().gb_dir());
-    let default_target = state
-        .get_default_target()
-        .context("failed to get default target")?;
-    let cache = repo.commit_graph_if_enabled()?;
-    let mut graph = repo.revision_graph(cache.as_ref());
-    let mut check_commit = IsCommitIntegrated::new(ctx, &default_target, repo, &mut graph)?;
-
-    let branch_commits = stack_branch.commits(ctx, stack)?;
-    let mut local_and_remote: Vec<ui::Commit> = vec![];
-    let mut is_integrated = false;
-
-    let remote_commit_data = branch_commits
-        .remote_commits
-        .iter()
-        .filter_map(|commit| {
-            let data = CommitData::try_from(commit).ok()?;
-            Some((data, commit.id()))
-        })
-        .collect::<HashMap<_, _>>();
-
-    // Local and remote
-    // Reverse first instead of later, so that we catch the first integrated commit
-    for commit in branch_commits.clone().local_commits.iter().rev() {
-        if !is_integrated {
-            is_integrated = check_commit.is_integrated(commit)?;
-        }
-        let copied_from_remote_id = CommitData::try_from(commit)
-            .ok()
-            .and_then(|data| remote_commit_data.get(&data).copied());
-
-        let state = if is_integrated {
-            CommitState::Integrated
-        } else {
-            // Can we find this as a remote commit by any of these options:
-            // - the commit is copied from a remote commit
-            // - the commit has an identical sha as the remote commit (the no brainer case)
-            // - the commit has a change id that matches a remote commit
-            if let Some(remote_id) = copied_from_remote_id {
-                CommitState::LocalAndRemote(remote_id.to_gix())
-            } else if let Some(remote_id) = branch_commits
-                .remote_commits
-                .iter()
-                .find(|c| c.id() == commit.id() || c.change_id() == commit.change_id())
-                .map(|c| c.id())
-            {
-                CommitState::LocalAndRemote(remote_id.to_gix())
-            } else {
-                CommitState::LocalOnly
-            }
-        };
-
-        let created_at = u128::try_from(commit.time().seconds())? * 1000;
-
-        let api_commit = ui::Commit {
-            id: commit.id().to_gix(),
-            parent_ids: commit.parents().map(|p| p.id().to_gix()).collect(),
-            message: commit.message_bstr().into(),
-            has_conflicts: commit.is_conflicted(),
-            state,
-            created_at,
-            author: commit.author().into(),
-        };
-        local_and_remote.push(api_commit);
-    }
-
-    Ok(local_and_remote)
-}
-
 /// Return a list of commits on the target branch
 /// Starts either from the target branch or from the provided commit id, up to the limit provided.
 ///
@@ -811,26 +328,6 @@ pub fn log_target_first_parent(
 
 fn state_handle(gb_state_path: &Path) -> VirtualBranchesHandle {
     VirtualBranchesHandle::new(gb_state_path)
-}
-
-/// The commit-data we can use for comparison to see which remote-commit was used to craete
-/// a local commit from.
-/// Note that trees can't be used for comparison as these are typically rebased.
-#[derive(Debug, Hash, Eq, PartialEq)]
-pub(crate) struct CommitData {
-    message: BString,
-    author: gix::actor::Signature,
-}
-
-impl TryFrom<&git2::Commit<'_>> for CommitData {
-    type Error = anyhow::Error;
-
-    fn try_from(commit: &git2::Commit<'_>) -> std::result::Result<Self, Self::Error> {
-        Ok(CommitData {
-            message: commit.message_raw_bytes().into(),
-            author: git2_signature_to_gix_signature(commit.author()),
-        })
-    }
 }
 
 #[cfg(test)]

--- a/crates/but-workspace/src/stacks.rs
+++ b/crates/but-workspace/src/stacks.rs
@@ -1,0 +1,577 @@
+use crate::integrated::IsCommitIntegrated;
+use crate::ui::{CommitState, PushStatus};
+use crate::{
+    StacksFilter, VirtualBranchesTomlMetadata, branch, head_info, id_from_name_v2_to_v3,
+    state_handle, ui,
+};
+use anyhow::Context;
+use bstr::BString;
+use but_core::RefMetadata;
+use gitbutler_command_context::CommandContext;
+use gitbutler_commit::commit_ext::CommitExt;
+use gitbutler_id::id::Id;
+use gitbutler_oxidize::{ObjectIdExt, OidExt, git2_signature_to_gix_signature};
+use gitbutler_stack::{Stack, StackBranch, StackId};
+use itertools::Itertools;
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::str::FromStr;
+
+/// Returns the list of branch information for the branches in a stack.
+pub fn stack_heads_info(
+    stack: &Stack,
+    repo: &gix::Repository,
+) -> anyhow::Result<Vec<ui::StackHeadInfo>> {
+    let branches = stack
+        .branches()
+        .into_iter()
+        .rev()
+        .filter_map(|branch| {
+            let tip = branch.head_oid(repo).ok()?;
+            Some(ui::StackHeadInfo {
+                name: branch.name().to_owned().into(),
+                tip,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    Ok(branches)
+}
+
+/// Returns the list of stacks that are currently part of the workspace.
+/// If there are no applied stacks, the returned Vec is empty.
+/// If the GitButler state file in the provided path is missing or invalid, an error is returned.
+///
+/// - `gb_dir`: The path to the GitButler state for the project. Normally this is `.git/gitbutler` in the project's repository.
+pub fn stacks(
+    ctx: &CommandContext,
+    gb_dir: &Path,
+    repo: &gix::Repository,
+    filter: StacksFilter,
+) -> anyhow::Result<Vec<ui::StackEntry>> {
+    let state = state_handle(gb_dir);
+
+    let stacks = match filter {
+        StacksFilter::All => state.list_all_stacks()?,
+        StacksFilter::InWorkspace => state
+            .list_all_stacks()?
+            .into_iter()
+            .filter(|s| s.in_workspace)
+            .collect(),
+        StacksFilter::Unapplied => state
+            .list_all_stacks()?
+            .into_iter()
+            .filter(|s| !s.in_workspace)
+            .collect(),
+    };
+
+    let stacks = stacks
+        .into_iter()
+        .filter_map(|mut stack| stack.migrate_change_ids(ctx).ok().map(|()| stack))
+        .filter(|s| s.is_initialized());
+
+    stacks
+        .sorted_by_key(|s| s.order)
+        .map(|stack| ui::StackEntry::try_new(repo, &stack))
+        .collect()
+}
+
+fn try_from_stack_v3(
+    repo: &gix::Repository,
+    stack: branch::Stack,
+    meta: &VirtualBranchesTomlMetadata,
+) -> anyhow::Result<ui::StackEntry> {
+    let name = stack
+        .name()
+        .expect("Every V2/V3 stack has a name as long as it's in a gitbutler workspace")
+        .to_owned();
+    let heads = stack.segments.into_iter().map(|segment| {
+        let ref_name = segment
+            .ref_name
+            .expect("This type can't represent this state and it shouldn't have to");
+        ui::StackHeadInfo {
+            tip: repo
+                .find_reference(ref_name.as_ref())
+                .ok()
+                .and_then(|r| r.try_id())
+                .map(|id| id.detach())
+                .unwrap_or(repo.object_hash().null()),
+            name: ref_name.into(),
+        }
+    });
+    Ok(ui::StackEntry {
+        id: id_from_name_v2_to_v3(name.as_ref(), meta)?,
+        heads: heads.collect(),
+        tip: stack.tip.unwrap_or(repo.object_hash().null()),
+    })
+}
+
+/// Returns the list of stacks that pass `filter`, in unspecified order.
+///
+/// Use `repo` and `meta` to read branches data
+// TODO: See if the UI can migrate to `head_info()` or a variant of it so the information is only called once.
+pub fn stacks_v3(
+    repo: &gix::Repository,
+    meta: &VirtualBranchesTomlMetadata,
+    filter: StacksFilter,
+) -> anyhow::Result<Vec<ui::StackEntry>> {
+    // TODO: See if this works at all once VirtualBranches.toml isn't the backing anymore.
+    //       Probably needs to change, maybe even alongside the notion of 'unapplied'.
+    //       In future, unapplied stacks could just be stacks, either with one segment, or multiple ones - any branch with another branch
+    //       found while traversing its commits to some base becomes a stack in that very sense.
+    fn unapplied_stacks(
+        repo: &gix::Repository,
+        meta: &VirtualBranchesTomlMetadata,
+        applied_stacks: &[branch::Stack],
+    ) -> anyhow::Result<Vec<ui::StackEntry>> {
+        let mut out = Vec::new();
+        for item in meta.iter() {
+            let (ref_name, ref_meta) = item?;
+            if !ref_meta.is::<but_core::ref_metadata::Branch>() {
+                continue;
+            };
+            let is_applied = applied_stacks.iter().any(|stack| {
+                stack.segments.iter().any(|segment| {
+                    segment
+                        .ref_name
+                        .as_ref()
+                        .is_some_and(|name| name == &ref_name)
+                })
+            });
+            if is_applied {
+                continue;
+            }
+
+            let reference = repo.find_reference(ref_name.as_ref())?;
+            let tip = reference
+                .try_id()
+                .with_context(|| format!("Encountered symbolic reference: {ref_name}"))?
+                .detach();
+            out.push(ui::StackEntry {
+                id: id_from_name_v2_to_v3(ref_name.as_ref(), meta)?,
+                // TODO: this is just a simulation and such a thing doesn't really exist in the V3 world, let's see how it goes.
+                //       Thus, we just pass ourselves as first segment, similar to having no other segments.
+                heads: vec![ui::StackHeadInfo {
+                    name: ref_name.into(),
+                    tip,
+                }],
+                tip,
+            })
+        }
+        Ok(out)
+    }
+
+    let info = crate::head_info(
+        repo,
+        meta,
+        head_info::Options {
+            // TODO: set this to a good value for the UI to not slow down, and also a value that forces us to re-investigate this.
+            stack_commit_limit: 100,
+        },
+    )?;
+
+    fn into_ui_stacks(
+        repo: &gix::Repository,
+        stacks: Vec<branch::Stack>,
+        meta: &VirtualBranchesTomlMetadata,
+    ) -> Vec<ui::StackEntry> {
+        stacks
+            .into_iter()
+            .filter_map(|stack| try_from_stack_v3(repo, stack, meta).ok())
+            .collect()
+    }
+
+    let unapplied_stacks = unapplied_stacks(repo, meta, &info.stacks)?;
+    Ok(match filter {
+        StacksFilter::InWorkspace => into_ui_stacks(repo, info.stacks, meta),
+        StacksFilter::All => {
+            let mut all_stacks = unapplied_stacks;
+            all_stacks.extend(into_ui_stacks(repo, info.stacks, meta));
+            all_stacks
+        }
+        StacksFilter::Unapplied => unapplied_stacks,
+    })
+}
+
+/// Returns information about the current state of a stack.
+/// If the stack is not found, an error is returned.
+///
+/// - `gb_dir`: The path to the GitButler state for the project. Normally this is `.git/gitbutler` in the project's repository.
+/// - `stack_id`: The ID of the stack to get information about.
+/// - `ctx`: The command context for the project.
+pub fn stack_details(
+    gb_dir: &Path,
+    stack_id: StackId,
+    ctx: &CommandContext,
+) -> anyhow::Result<ui::StackDetails> {
+    /// Determines if a force push is required to push a branch to its remote.
+    fn requires_force(
+        ctx: &CommandContext,
+        branch: &StackBranch,
+        remote: &str,
+    ) -> anyhow::Result<bool> {
+        let upstream = branch.remote_reference(remote);
+
+        let reference = match ctx.repo().refname_to_id(&upstream) {
+            Ok(reference) => reference,
+            Err(err) if err.code() == git2::ErrorCode::NotFound => return Ok(false),
+            Err(other) => return Err(other).context("failed to find upstream reference"),
+        };
+
+        let upstream_commit = ctx
+            .repo()
+            .find_commit(reference)
+            .context("failed to find upstream commit")?;
+
+        let branch_head = branch.head_oid(&ctx.gix_repo()?)?;
+        let merge_base = ctx
+            .repo()
+            .merge_base(upstream_commit.id(), branch_head.to_git2())?;
+
+        Ok(merge_base != upstream_commit.id())
+    }
+
+    #[derive(Debug, Default)]
+    struct BranchState {
+        is_integrated: bool,
+        is_dirty: bool,
+        requires_force: bool,
+        has_pushed_commits: bool,
+    }
+
+    impl From<BranchState> for PushStatus {
+        fn from(state: BranchState) -> Self {
+            match (
+                state.is_integrated,
+                state.is_dirty,
+                state.requires_force,
+                state.has_pushed_commits,
+            ) {
+                (true, _, _, _) => PushStatus::Integrated,
+                (_, true, _, false) => PushStatus::CompletelyUnpushed,
+                (_, _, true, _) => PushStatus::UnpushedCommitsRequiringForce,
+                (_, true, _, _) => PushStatus::UnpushedCommits,
+                (_, false, _, _) => PushStatus::NothingToPush,
+            }
+        }
+    }
+
+    let state = state_handle(gb_dir);
+    let mut stack = state.get_stack(stack_id)?;
+    let branches = stack.branches();
+    let branches = branches.iter().filter(|b| !b.archived);
+    let repo = ctx.gix_repo()?;
+    let remote = state
+        .get_default_target()
+        .context("failed to get default target")?
+        .push_remote_name();
+
+    let mut stack_state = BranchState::default();
+    let mut stack_is_conflicted = false;
+    let mut branch_details = vec![];
+    let mut current_base = stack.merge_base(ctx)?;
+
+    for branch in branches {
+        let upstream_reference = ctx
+            .repo()
+            .find_reference(&branch.remote_reference(remote.as_str()))
+            .ok()
+            .map(|_| branch.remote_reference(remote.as_str()));
+
+        let mut branch_state = BranchState {
+            requires_force: requires_force(ctx, branch, &remote)?,
+            ..Default::default()
+        };
+
+        let mut is_conflicted = false;
+        let mut authors = HashSet::new();
+        let commits = local_and_remote_commits(ctx, &repo, branch, &stack)?;
+        let upstream_commits = upstream_only_commits(ctx, &repo, branch, &stack, Some(&commits))?;
+
+        // If there are commits in the remote, we can assume that commits have been pushed. *Like, literally*.
+        branch_state.has_pushed_commits |= !upstream_commits.is_empty();
+
+        for commit in &commits {
+            is_conflicted |= commit.has_conflicts;
+            branch_state.is_dirty |= matches!(commit.state, ui::CommitState::LocalOnly);
+            branch_state.has_pushed_commits |=
+                matches!(commit.state, CommitState::LocalAndRemote(_));
+            authors.insert(commit.author.clone());
+        }
+
+        // We can assume that if the child-most commit is integrated, the whole branch is integrated
+        branch_state.is_integrated = matches!(
+            commits.first().map(|c| &c.state),
+            Some(CommitState::Integrated)
+        );
+
+        stack_is_conflicted |= is_conflicted;
+        stack_state.is_dirty |= branch_state.is_dirty;
+        stack_state.requires_force |= branch_state.requires_force;
+        stack_state.has_pushed_commits |= branch_state.has_pushed_commits;
+
+        // If all branches are integrated, the stack is integrated
+        stack_state.is_integrated &= branch_state.is_integrated;
+
+        branch_details.push(ui::BranchDetails {
+            name: branch.name().to_owned().into(),
+            remote_tracking_branch: upstream_reference.map(Into::into),
+            description: branch.description.clone(),
+            pr_number: branch.pr_number,
+            review_id: branch.review_id.clone(),
+            tip: branch.head_oid(&repo)?,
+            base_commit: current_base,
+            push_status: branch_state.into(),
+            last_updated_at: commits.first().map(|c| c.created_at),
+            authors: authors.into_iter().collect(),
+            is_conflicted,
+            commits,
+            upstream_commits,
+            is_remote_head: false,
+        });
+
+        current_base = branch.head_oid(&repo)?;
+    }
+
+    stack.migrate_change_ids(ctx).ok(); // If it fails thats ok - best effort migration
+    branch_details.reverse();
+
+    let push_status = stack_state.into();
+
+    Ok(ui::StackDetails {
+        derived_name: stack.derived_name()?,
+        push_status,
+        branch_details,
+        is_conflicted: stack_is_conflicted,
+    })
+}
+
+/// Return the branches that belong to a particular [`gitbutler_stack::Stack`]
+/// The entries are ordered from newest to oldest.
+pub fn stack_branches(stack_id: String, ctx: &CommandContext) -> anyhow::Result<Vec<ui::Branch>> {
+    let state = state_handle(&ctx.project().gb_dir());
+    let remote = state
+        .get_default_target()
+        .context("failed to get default target")?
+        .push_remote_name();
+
+    let mut stack_branches = vec![];
+    let mut stack = state.get_stack(Id::from_str(&stack_id)?)?;
+    let mut current_base = stack.merge_base(ctx)?;
+    let repo = ctx.gix_repo()?;
+    for internal in stack.branches() {
+        let upstream_reference = ctx
+            .repo()
+            .find_reference(&internal.remote_reference(remote.as_str()))
+            .ok()
+            .map(|_| internal.remote_reference(remote.as_str()));
+        let result = ui::Branch {
+            name: internal.name().to_owned().into(),
+            remote_tracking_branch: upstream_reference.map(Into::into),
+            description: internal.description.clone(),
+            pr_number: internal.pr_number,
+            review_id: internal.review_id.clone(),
+            archived: internal.archived,
+            tip: internal.head_oid(&repo)?,
+            base_commit: current_base,
+        };
+        current_base = internal.head_oid(&repo)?;
+        stack_branches.push(result);
+    }
+    stack.migrate_change_ids(ctx).ok(); // If it fails thats ok - best effort migration
+    stack_branches.reverse();
+    Ok(stack_branches)
+}
+
+/// Returns a list of commits beloning to this branch. Ordered from newest to oldest (child-most to parent-most).
+///
+/// These are the commits that are currently part of the workspace (applied).
+/// Created from the local pseudo branch (head currently stored in the TOML file)
+///
+/// When there is only one branch in the stack, this includes the commits
+/// from the tip of the stack to the merge base with the trunk / target branch (not including the merge base).
+///
+/// When there are multiple branches in the stack, this includes the commits from the branch head to the next branch in the stack.
+///
+/// In either case, this is effectively a list of commits that in the working copy which may or may not have been pushed to the remote.
+pub fn stack_branch_local_and_remote_commits(
+    stack_id: String,
+    branch_name: String,
+    ctx: &CommandContext,
+    repo: &gix::Repository,
+) -> anyhow::Result<Vec<ui::Commit>> {
+    let state = state_handle(&ctx.project().gb_dir());
+    let stack = state.get_stack(Id::from_str(&stack_id)?)?;
+
+    let branches = stack.branches();
+    let branch = branches
+        .iter()
+        .find(|b| b.name() == &branch_name)
+        .ok_or_else(|| anyhow::anyhow!("Could not find branch {:?}", branch_name))?;
+    if branch.archived {
+        return Ok(vec![]);
+    }
+    local_and_remote_commits(ctx, repo, branch, &stack)
+}
+
+/// Returns a fift of commits belonging to this branch. Ordered from newest to oldest (child-most to parent-most).
+///
+/// These are the commits that exist **only** on the upstream branch. Ordered from newest to oldest.
+/// Created from the tip of the local tracking branch eg. refs/remotes/origin/my-branch -> refs/heads/my-branch
+///
+/// This does **not** include the commits that are in the commits list (local)
+/// This is effectively the list of commits that are on the remote branch but are not in the working copy.
+pub fn stack_branch_upstream_only_commits(
+    stack_id: String,
+    branch_name: String,
+    ctx: &CommandContext,
+    repo: &gix::Repository,
+) -> anyhow::Result<Vec<ui::UpstreamCommit>> {
+    let state = state_handle(&ctx.project().gb_dir());
+    let stack = state.get_stack(Id::from_str(&stack_id)?)?;
+
+    let branches = stack.branches();
+    let branch = branches
+        .iter()
+        .find(|b| b.name() == &branch_name)
+        .with_context(|| format!("Could not find branch {branch_name:?}"))?;
+    if branch.archived {
+        return Ok(vec![]);
+    }
+    upstream_only_commits(ctx, repo, branch, &stack, None)
+}
+
+fn upstream_only_commits(
+    ctx: &CommandContext,
+    repo: &gix::Repository,
+    stack_branch: &StackBranch,
+    stack: &Stack,
+    current_local_and_remote_commits: Option<&Vec<ui::Commit>>,
+) -> anyhow::Result<Vec<ui::UpstreamCommit>> {
+    let branch_commits = stack_branch.commits(ctx, stack)?;
+
+    let local_and_remote = if let Some(current_local_and_remote) = current_local_and_remote_commits
+    {
+        current_local_and_remote
+    } else {
+        &local_and_remote_commits(ctx, repo, stack_branch, stack)?
+    };
+
+    // Upstream only
+    let mut upstream_only = vec![];
+    for commit in branch_commits.upstream_only.iter() {
+        let matches_known_commit = local_and_remote.iter().any(|c| {
+            // If the id matches verbatim or if there is a known remote_id (in the case of LocalAndRemote) that matchies
+            c.id == commit.id().to_gix() || matches!(&c.state, CommitState::LocalAndRemote(remote_id) if remote_id == &commit.id().to_gix())
+        });
+        // Ignore commits that strictly speaking are remote only, but they match a known local commit (rebase etc)
+        if !matches_known_commit {
+            let created_at = u128::try_from(commit.time().seconds())? * 1000;
+            let upstream_commit = ui::UpstreamCommit {
+                id: commit.id().to_gix(),
+                message: commit.message_bstr().into(),
+                created_at,
+                author: commit.author().into(),
+            };
+            upstream_only.push(upstream_commit);
+        }
+    }
+    upstream_only.reverse();
+
+    Ok(upstream_only)
+}
+
+fn local_and_remote_commits(
+    ctx: &CommandContext,
+    repo: &gix::Repository,
+    stack_branch: &gitbutler_stack::StackBranch,
+    stack: &Stack,
+) -> anyhow::Result<Vec<ui::Commit>> {
+    let state = state_handle(&ctx.project().gb_dir());
+    let default_target = state
+        .get_default_target()
+        .context("failed to get default target")?;
+    let cache = repo.commit_graph_if_enabled()?;
+    let mut graph = repo.revision_graph(cache.as_ref());
+    let mut check_commit = IsCommitIntegrated::new(ctx, &default_target, repo, &mut graph)?;
+
+    let branch_commits = stack_branch.commits(ctx, stack)?;
+    let mut local_and_remote: Vec<ui::Commit> = vec![];
+    let mut is_integrated = false;
+
+    let remote_commit_data = branch_commits
+        .remote_commits
+        .iter()
+        .filter_map(|commit| {
+            let data = CommitData::try_from(commit).ok()?;
+            Some((data, commit.id()))
+        })
+        .collect::<HashMap<_, _>>();
+
+    // Local and remote
+    // Reverse first instead of later, so that we catch the first integrated commit
+    for commit in branch_commits.clone().local_commits.iter().rev() {
+        if !is_integrated {
+            is_integrated = check_commit.is_integrated(commit)?;
+        }
+        let copied_from_remote_id = CommitData::try_from(commit)
+            .ok()
+            .and_then(|data| remote_commit_data.get(&data).copied());
+
+        let state = if is_integrated {
+            CommitState::Integrated
+        } else {
+            // Can we find this as a remote commit by any of these options:
+            // - the commit is copied from a remote commit
+            // - the commit has an identical sha as the remote commit (the no brainer case)
+            // - the commit has a change id that matches a remote commit
+            if let Some(remote_id) = copied_from_remote_id {
+                CommitState::LocalAndRemote(remote_id.to_gix())
+            } else if let Some(remote_id) = branch_commits
+                .remote_commits
+                .iter()
+                .find(|c| c.id() == commit.id() || c.change_id() == commit.change_id())
+                .map(|c| c.id())
+            {
+                CommitState::LocalAndRemote(remote_id.to_gix())
+            } else {
+                CommitState::LocalOnly
+            }
+        };
+
+        let created_at = u128::try_from(commit.time().seconds())? * 1000;
+
+        let api_commit = ui::Commit {
+            id: commit.id().to_gix(),
+            parent_ids: commit.parents().map(|p| p.id().to_gix()).collect(),
+            message: commit.message_bstr().into(),
+            has_conflicts: commit.is_conflicted(),
+            state,
+            created_at,
+            author: commit.author().into(),
+        };
+        local_and_remote.push(api_commit);
+    }
+
+    Ok(local_and_remote)
+}
+
+/// The commit-data we can use for comparison to see which remote-commit was used to craete
+/// a local commit from.
+/// Note that trees can't be used for comparison as these are typically rebased.
+#[derive(Debug, Hash, Eq, PartialEq)]
+pub(crate) struct CommitData {
+    message: BString,
+    author: gix::actor::Signature,
+}
+
+impl TryFrom<&git2::Commit<'_>> for CommitData {
+    type Error = anyhow::Error;
+
+    fn try_from(commit: &git2::Commit<'_>) -> std::result::Result<Self, Self::Error> {
+        Ok(CommitData {
+            message: commit.message_raw_bytes().into(),
+            author: git2_signature_to_gix_signature(commit.author()),
+        })
+    }
+}

--- a/crates/but-workspace/src/ui.rs
+++ b/crates/but-workspace/src/ui.rs
@@ -237,3 +237,36 @@ pub struct StackDetails {
     /// Whether the stack is conflicted.
     pub is_conflicted: bool,
 }
+
+/// Represents a branch in a [`Stack`]. It contains commits derived from the local pseudo branch and it's respective remote
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Branch {
+    /// The name of the branch.
+    #[serde(with = "gitbutler_serde::bstring_lossy")]
+    pub name: BString,
+    /// Upstream reference, e.g. `refs/remotes/origin/base-branch-improvements`
+    #[serde(with = "gitbutler_serde::bstring_opt_lossy")]
+    pub remote_tracking_branch: Option<BString>,
+    /// Description of the branch.
+    /// Can include arbitrary utf8 data, eg. markdown etc.
+    pub description: Option<String>,
+    /// The pull(merge) request associated with the branch, or None if no such entity has not been created.
+    pub pr_number: Option<usize>,
+    /// A unique identifier for the GitButler review associated with the branch, if any.
+    pub review_id: Option<String>,
+    /// Indicates that the branch was previously part of a stack but it has since been integrated.
+    /// In other words, the merge base of the stack is now above this branch.
+    /// This would occur when the branch has been merged at the remote and the workspace has been updated with that change.
+    /// An archived branch will not have any commits associated with it.
+    pub archived: bool,
+    /// This is the last commit in the branch, aka the tip of the branch.
+    /// If this is the only branch in the stack or the top-most branch, this is the tip of the stack.
+    #[serde(with = "gitbutler_serde::object_id")]
+    pub tip: gix::ObjectId,
+    /// This is the base commit from the perspective of this branch.
+    /// If the branch is part of a stack and is on top of another branch, this is the head of the branch below it.
+    /// If this branch is at the bottom of the stack, this is the merge base of the stack.
+    #[serde(with = "gitbutler_serde::object_id")]
+    pub base_commit: gix::ObjectId,
+}

--- a/crates/but-workspace/src/virtual_branches_metadata.rs
+++ b/crates/but-workspace/src/virtual_branches_metadata.rs
@@ -63,7 +63,7 @@ impl Snapshot {
 ///
 /// The idea is that it's forgiving and easy to use, while helping to eventually migrate to a database.
 pub struct VirtualBranchesTomlMetadata {
-    // What is currently in memory for query or edits.
+    // What is currently in memory for query or editing.
     snapshot: Snapshot,
 }
 
@@ -440,6 +440,13 @@ pub struct VBTomlMetadataHandle<T> {
     // other storage backends like database may have similar handles to avoid searches by name.
     stack_id: RefCell<Option<StackId>>,
     value: T,
+}
+
+impl<T> VBTomlMetadataHandle<T> {
+    /// Return the stack_id of the underlying stack if there is one.
+    pub fn stack_id(&self) -> Option<StackId> {
+        *self.stack_id.borrow()
+    }
 }
 
 impl<T> AsRef<FullNameRef> for VBTomlMetadataHandle<T> {

--- a/crates/but-workspace/tests/workspace/branch_details.rs
+++ b/crates/but-workspace/tests/workspace/branch_details.rs
@@ -1,0 +1,112 @@
+/// All tests have a workspace present.
+mod with_workspace {
+    use crate::utils::read_only_in_memory_scenario;
+    use but_core::RefMetadata;
+    use but_core::ref_metadata::{Branch, Workspace};
+    use but_testsupport::visualize_commit_graph;
+    use gix::refs::{FullName, FullNameRef};
+    use std::any::Any;
+    use std::ops::{Deref, DerefMut};
+
+    fn refname(short_name: &str) -> gix::refs::FullName {
+        format!("refs/heads/{short_name}").try_into().unwrap()
+    }
+
+    #[test]
+    #[ignore = "TBD"]
+    fn merge_with_two_branches() -> anyhow::Result<()> {
+        let repo = read_only_in_memory_scenario("merge-with-two-branches-line-offset")?;
+        insta::assert_snapshot!(visualize_commit_graph(&repo, "HEAD")?, @r"
+        *   2a6d103 (HEAD -> merge) Merge branch 'A' into merge
+        |\  
+        | * 7f389ed (A) add 10 to the beginning
+        * | 91ef6f6 (B) add 10 to the end
+        |/  
+        * ff045ef (main) init
+        ");
+        let store = WorkspaceStore::with_target("A");
+        insta::assert_debug_snapshot!(
+            but_workspace::branch_details_v3(&repo, refname("A").as_ref(), &store).unwrap(),
+            @r"",
+        );
+        Ok(())
+    }
+
+    struct WorkspaceStore {
+        workspace: but_core::ref_metadata::Workspace,
+    }
+
+    impl WorkspaceStore {
+        pub fn with_target(short_name: &str) -> Self {
+            WorkspaceStore {
+                workspace: but_core::ref_metadata::Workspace {
+                    ref_info: Default::default(),
+                    stacks: vec![],
+                    target_ref: Some(refname(short_name)),
+                },
+            }
+        }
+    }
+
+    struct NullHandle<T> {
+        inner: T,
+        name: FullName,
+    }
+
+    impl<T> but_core::ref_metadata::ValueInfo for NullHandle<T> {
+        fn is_default(&self) -> bool {
+            false
+        }
+    }
+
+    impl<T> Deref for NullHandle<T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            &self.inner
+        }
+    }
+
+    impl<T> DerefMut for NullHandle<T> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.inner
+        }
+    }
+
+    impl<T> AsRef<FullNameRef> for NullHandle<T> {
+        fn as_ref(&self) -> &FullNameRef {
+            self.name.as_ref()
+        }
+    }
+
+    impl RefMetadata for WorkspaceStore {
+        type Handle<T> = NullHandle<T>;
+
+        fn iter(&self) -> impl Iterator<Item = anyhow::Result<(FullName, Box<dyn Any>)>> + '_ {
+            std::iter::empty()
+        }
+
+        fn workspace(&self, ref_name: &FullNameRef) -> anyhow::Result<Self::Handle<Workspace>> {
+            Ok(NullHandle {
+                inner: self.workspace.clone(),
+                name: ref_name.into(),
+            })
+        }
+
+        fn branch(&self, _ref_name: &FullNameRef) -> anyhow::Result<Self::Handle<Branch>> {
+            unreachable!()
+        }
+
+        fn set_workspace(&mut self, _value: &Self::Handle<Workspace>) -> anyhow::Result<()> {
+            unreachable!()
+        }
+
+        fn set_branch(&mut self, _value: &Self::Handle<Branch>) -> anyhow::Result<()> {
+            unreachable!()
+        }
+
+        fn remove(&mut self, _ref_name: &FullNameRef) -> anyhow::Result<bool> {
+            unreachable!()
+        }
+    }
+}

--- a/crates/but-workspace/tests/workspace/main.rs
+++ b/crates/but-workspace/tests/workspace/main.rs
@@ -1,3 +1,4 @@
+mod branch_details;
 mod commit_engine;
 mod head_info;
 mod ref_metadata;

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -419,7 +419,7 @@ pub struct BranchListingFilter {
 
 /// Represents a branch that exists for the repository
 /// This also combines the concept of a remote, local and virtual branch in order to provide a unified interface for the UI
-/// Branch entry is not meant to contain all of the data a branch can have (e.g. full commit history, all files and diffs, etc.).
+/// Branch entry is not meant to contain all the data a branch can have (e.g. full commit history, all files and diffs, etc.).
 /// It is intended a summary that can be quickly retrieved and displayed in the UI.
 /// For more detailed information, each branch can be queried individually for it's `BranchData`.
 #[derive(Debug, Clone, Serialize, PartialEq)]


### PR DESCRIPTION
A first implementation of `head_info()` to provide information about where the user currently is.
It presents the world as a workspace with stacks, even though technically it might not exist.`

Follow-up on #7596.

* [x] prevent non-workspace cases (or assure that the new system doesn't get to show them)
    - [x] figure out how it knows that one moved away from GitButler workspace
        - `operating_mode()` is called when the workspace branch changes, which tells the UI it's not on the right branch. So no need to alter the current implementation.
* [ ] `heads_info` with workspace cases - reflect what's currently possible
* [x] research on how to Integrate new `heads_info()` with current API interface
    - [x] move UI types into `ui` modules
    - [x] check if current data is sufficient to provide all that's needed to current API
        -  ~~`get_base_branch_data()`~~ (skipped), `stacks()`, `stack_details()`
* [ ] implement intermediate V3 versions of these functions 
    - [x] `stacks_v3()`
        - [ ] basic test (needs heads-info test setup)
    - [ ] `branch_details_v3()`
    - [ ] `stack_details_v3()`
* [ ] make use of `stacks_v3` and `stack_details_v3()` in tauri

## Notes for the Reviewer

* This is a transitory PR that replaces VirtualBranchesToml with the RefMetadata trait to prepare the code to transition to other data stores.
* The code is clearly transitory while `StackId`  is still a thing - in the new world stacks or stack-segments are referred to by their reference name or by their index in the parent-list of the top-level merge commit (if there is one).
* Ideally, one the UI will be able to make just one `heads_info` call, and can consume the data directly (even though it may have been processed to further facilitate consumption).
* `branch_details()` already works on references
* `BranchDetails` are probably the data structure of choice for the UI, and it's just the question if there is stack information or not.
* There is no notion of using stacks in branch listings outside of what we are currently looking at, i.e. where `HEAD` is. Thus, for this we will probably keep using branch details of sort.

## Next PR

- intermediate V3 version of `get_base_branch_data()`.

## Conversion check

Does the new types have enough information to provide what's needed to the UI?

### Stack
- `stack_id` (deprecated, maybe emulated with workaround to map an index to an id maybe)
- `heads`
    - `name` ✓
    - `tip` ✓

### Stack Details
- derived_name ✓ (stack name, top-most branch in stack)
- push_status (enum) (derived)
- is_conflicted (has a conflicting commit somewhere) (derived)
- branch details
    - name ✓
    - remote_tracking_branch ✓ (from `Stack::upstream`, but it's deduced seemingly)
    - description ✓
    - pr_number ✓
    - review_id ✓
    - tip ✓
    - base_commit (derived)
    - push_status: (derived with remote tracking branch)
    - last_updated_at (from RefInfo::updated_at ✓)
    - authors: Vec<Author> ✓
    - is_conflicted ✓
    - commits: Vec<Commit> ✓
    - upstream_commits: Vec<UpstreamCommit> ✓
    - is_remote_head ✓

### Commit 
- id ✓
- parent_ids ✓
- message ✓
- has_conflicts ✓
- state: CommitState (derived)
- created_at ✓
- author: Author ✓

### CommitState

All derived once the commit-analysis is done

- LocalOnly (derived)
- LocalAndRemote(id) (derived)
- Integrated (derived)

### UpstreamCommit

- id ✓
- message ✓
- created_at ✓
- author ✓

### Author

- name ✓
- email ✓
- gravatar_url ✓


### Follow Up Tasks

* [ ] first non-workspace cases
    - [ ] merge commit
    - [ ] merge commit stacked
    - [ ] stacks and ambiguous stack references (i.e. lots of empty stack segments)

### Next PRs

* head-info, stacks and details API with key scenarios
* graph-based integration checks with target and remote
* integration checking with target
* integration checking with remote tracking branch

### Known Shortcomings (for now)

* ⚠️One probably wants to show all refs at a position (or indicate there are more) ⚠️
* ⚠️ rebase engine needs a way to know which parent to rewrite if there are two parents pointing to the same commit in a starting configuration with two stacks at the same commit. Alternatively, `create_commit` would have to create a workspace commit, which seems worse than adding a WS commit in the moment there are two stacks.
* ⚠️ **merge conflicts** are created from either cherry-picks or normal merges (legacy?), but cherry-pick would need to know that to either choose the auto-resolution. That's OK as long as the 'old' merge-commit isn't run as it would create a semantically different tree-setup in the conflicted commit.
* ⚠️ **commit listing** are ambiguous
    - Certain less common but possible branch configuration make ambiguous to assign commits to one branch or another. It won't be super trivial to make this work right.
* ⚠️Even though Git does not list *namespaced references*, `tig` will happily list everything. `set reference-format = hide:other` fixes this though
* empty commits aren't specifically highlighted when rebasing, or handled or prevented. The UI could detect that and show them.
* Moving hunks or files will need multi-branch rebases with merge-commit handling. This can be added to the rebase engine as we know it today. This will also enable worktree-updates.
* reordering in such a way that only heads a moved and nothing else happens (in terms of commit rewrites) probably wouldn't work yet in `but-rebase`.
* Index adjustments (tree to disk index) lack a lot of tests, particularly those for automatic conflict removal.
* if changes are added to the wrong spot, then they may apply cleanly *and* yield different results after merging, so the worktree differs from what's in Git. This is where hunk-dependencies/auto-hunk-splitting comes into play.
* Right now sub-hunks can't be selected as they won't match when it tries to find exact matches. However, that check could be changed to a 'contains' or 'is-included' to allow sub-hunks. Maybe this doesn't naturally work though or do the right thing.
* Workspace commits with a single branch will get signed if they were signed before. This shouldn't be a real problem, and ideally it will go away soon enough.


### For follow-up PRs

In any order (probably)

* Rebase-engine with insert empty commit (below and above, insert as first parent support)
* What happens in Git if one rebases non-linear branches? Can it retain the structure?
    - Rebase engine probably has to learn to re-schedule picks (and remember the base, a feature useful for multi-stacks as well, which then wouldn't need a special case anymore)
* move file out of commit into worktree (uncommit something)
* per-hunk exclusion if hunk didn't match (right now it rejects the whole file)
* run hooks on an index created from the tree that would be committed.
* move hunks from one commit into another


### Out of scope

* **hunk-dependencies**
    - These should be added once the commit-engine is feature-complete, the idea is that the UI can function well enough without them as a baseline.
* **atomic object writes**
    - In theory, new objects should only be written to disk if they actually end up in a tree. For instance, if a change is rejected, the object associated with it shouldn't be in the object database.
    - However, even though implementing this with the in-memory object feature is very possible, it feels like an optimization for another day. In general, I really think only objects that end up in a tree should actually be written, so that the implementation doesn't have to rely on `git gc` to cleanup.







