### PR TITLE
Reference uncommited changes tree directly

### DIFF
--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -131,23 +131,10 @@ fn find_or_create_base_commit<'a>(
     Ok(repository.find_commit(base)?)
 }
 
-fn commit_uncommited_changes(ctx: &CommandContext, parent: git2::Oid) -> Result<()> {
+fn commit_uncommited_changes(ctx: &CommandContext) -> Result<()> {
     let repository = ctx.repo();
-    let author_signature = signature(SignaturePurpose::Author)?;
-    let committer_signature = signature(SignaturePurpose::Committer)?;
-    let parent = repository.find_commit(parent)?;
-
     let uncommited_changes = repository.create_wd_tree(0)?;
-    let uncommited_changes_commit = repository.commit(
-        None,
-        &author_signature,
-        &committer_signature,
-        "Conflict base",
-        &uncommited_changes,
-        &[&parent],
-    )?;
-
-    repository.reference(UNCOMMITED_CHANGES_REF, uncommited_changes_commit, true, "")?;
+    repository.reference(UNCOMMITED_CHANGES_REF, uncommited_changes.id(), true, "")?;
     Ok(())
 }
 
@@ -226,7 +213,7 @@ pub(crate) fn enter_edit_mode(
         bail!("Can not enter edit mode for a reference which does not have a cooresponding virtual branch")
     }
 
-    commit_uncommited_changes(ctx, commit.id())?;
+    commit_uncommited_changes(ctx)?;
     write_edit_mode_metadata(ctx, &edit_mode_metadata).context("Failed to persist metadata")?;
     checkout_edit_branch(ctx, commit).context("Failed to checkout edit branch")?;
 


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#5fSvHqE4w`](https://gitbutler.com/cto/gitbutler-client-d443/reviews/5fSvHqE4w)

**Reference uncommited changes tree directly**


1 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Reference uncommited changes tree directly](https://gitbutler.com/cto/gitbutler-client-d443/reviews/5fSvHqE4w/commit/a4190a77-2ce5-41ce-9787-e4e503d092c9) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/cto/gitbutler-client-d443/reviews/5fSvHqE4w)_
<!-- GitButler Review Footer Boundary Bottom -->
