### PR TITLE
fix(ui): enable text selection in UnifiedDiffView hunks

### DIFF
--- a/apps/desktop/src/components/v3/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/v3/UnifiedDiffView.svelte
@@ -209,7 +209,7 @@
 				fileDependencies?.current.data?.dependencies ?? []
 			)}
 			<div
-				class="hunk-content no-select"
+				class="hunk-content"
 				use:draggableChips={{
 					label: hunk.diff.split('\n')[0],
 					data: new HunkDropDataV3(change, hunk, uncommittedChange),
@@ -310,5 +310,9 @@
 	.hunk-placehoder {
 		border: 1px solid var(--clr-border-3);
 		border-radius: var(--radius-m);
+	}
+
+	.hunk-content {
+		user-select: text;
 	}
 </style>


### PR DESCRIPTION
Remove the no-select class from hunk-content to allow users to
select and copy text within diff hunks. Add explicit user-select:
text style to hunk-content to ensure that this still 