### PR TITLE
Refactor IntegrateUpstreamModal result management

### DIFF
--- a/apps/desktop/src/components/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/IntegrateUpstreamModal.svelte
@@ -53,7 +53,7 @@
 
 	let modal = $state<Modal>();
 	let integratingUpstream = $state<OperationState>('inert');
-	let results = new SvelteMap<string, Resolution>();
+	const results = new SvelteMap<string, Resolution>();
 	let statuses = $state<StackStatusInfo[]>([]);
 	let baseResolutionApproach = $state<BaseBranchResolutionApproach | undefined>();
 	let targetCommitOid = $state<string | undefined>(undefined);
@@ -70,20 +70,15 @@
 		statusesTmp.sort(sortStatusInfo);
 
 		// Side effect, refresh results
-		results = new SvelteMap(
-			statusesTmp.map((status) => {
-				const defaultApproach = getResolutionApproach(status);
-
-				return [
-					status.stack.id,
-					{
-						branchId: status.stack.id,
-						approach: defaultApproach,
-						deleteIntegratedBranches: true
-					}
-				];
-			})
-		);
+		results.clear();
+		for (const status of statusesTmp) {
+			const defaultApproach = getResolutionApproach(status);
+			results.set(status.stack.id, {
+				branchId: status.stack.id,
+				approach: defaultApproach,
+				deleteIntegratedBranches: true
+			});
+		}
 
 		statuses = statusesTmp;
 	});

--- a/apps/desktop/src/components/v3/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/v3/IntegrateUpstreamModal.svelte
@@ -52,7 +52,7 @@
 
 	let modal = $state<Modal>();
 	let integratingUpstream = $state<OperationState>('inert');
-	let results = new SvelteMap<string, Resolution>();
+	const results = new SvelteMap<string, Resolution>();
 	let statuses = $state<StackStatusInfoV3[]>([]);
 	let baseResolutionApproach = $state<BaseBranchResolutionApproach | undefined>();
 	let targetCommitOid = $state<string | undefined>(undefined);
@@ -75,20 +75,14 @@
 		statusesTmp.sort(sortStatusInfoV3);
 
 		// Side effect, refresh results
-		results = new SvelteMap(
-			statusesTmp.map((status) => {
-				const defaultApproach = getResolutionApproachV3(status);
-
-				return [
-					status.stack.id,
-					{
-						branchId: status.stack.id,
-						approach: defaultApproach,
-						deleteIntegratedBranches: true
-					}
-				] as const;
-			})
-		);
+		results.clear();
+		for (const status of statusesTmp) {
+			results.set(status.stack.id, {
+				branchId: status.stack.id,
+				approach: getResolutionApproachV3(status),
+				deleteIntegratedBranches: true
+			});
+		}
 
 		statuses = statusesTmp;
 	});


### PR DESCRIPTION
Refactor the way the `results` map is managed in both modal components to use `clear()` and `set()` instead of reassigning a new map. This improves state management and aligns with Svelte best practices.