### PR TITLE
errors: Errors in Tauri and GitHub shuold use the expected Redux format

### DIFF
--- a/apps/desktop/cypress/e2e/errorHandling.cy.ts
+++ b/apps/desktop/cypress/e2e/errorHandling.cy.ts
@@ -1,0 +1,156 @@
+import { clearCommandMocks, mockCommand } from './support';
+import MockBackend from './support/mock/backend';
+
+describe('Error handling - commit actions', () => {
+	let mockBackend: MockBackend;
+
+	const UPDATE_COMMIT_ERROR_MESSAGE = 'Error updating commit message';
+	const COMMIT_ERROR_MESSAGE = 'Error creating commit';
+	const COMMIT_UNDO_ERROR_MESSAGE = 'Error undoing commit';
+
+	beforeEach(() => {
+		mockBackend = new MockBackend();
+		mockCommand('stack_details', (params) => mockBackend.getStackDetails(params));
+		mockCommand('update_commit_message', () => {
+			throw new Error(UPDATE_COMMIT_ERROR_MESSAGE);
+		});
+		mockCommand('changes_in_worktree', (params) => mockBackend.getWorktreeChanges(params));
+		mockCommand('tree_change_diffs', (params) => mockBackend.getDiff(params));
+		mockCommand('changes_in_commit', (params) => mockBackend.getCommitChanges(params));
+		mockCommand('create_commit_from_worktree_changes', () => {
+			throw new Error(COMMIT_ERROR_MESSAGE);
+		});
+		mockCommand('undo_commit', () => {
+			throw new Error(COMMIT_UNDO_ERROR_MESSAGE);
+		});
+
+		cy.visit('/');
+
+		cy.url({ timeout: 3000 }).should('include', `/workspace/${mockBackend.stackId}`);
+	});
+
+	afterEach(() => {
+		clearCommandMocks();
+	});
+
+	it('Failing to rename a commit should fail gracefully', () => {
+		const originalCommitMessage = 'Initial commit';
+
+		const newCommitMessageTitle = 'New commit message title';
+		const newCommitMessageBody = 'New commit message body';
+
+		cy.spy(mockBackend, 'getDiff').as('getDiffSpy');
+
+		// Click on the first commit
+		cy.getByTestId('commit-row').first().should('contain', originalCommitMessage).click();
+
+		// Should open the commit drawer
+		cy.get('.commit-view').first().should('contain', originalCommitMessage);
+
+		// Click on the edit message button
+		cy.getByTestId('commit-drawer-action-edit-message').should('contain', 'Edit message').click();
+
+		// Should open the commit rename drawer
+		cy.getByTestId('edit-commit-message-drawer').should('be.visible');
+
+		// Should have the original commit message, and be focused
+		cy.getByTestId('commit-drawer-title-input')
+			.should('have.value', originalCommitMessage)
+			.should('be.visible')
+			.should('be.enabled')
+			.should('be.focused')
+			.clear()
+			.type(newCommitMessageTitle); // Type the new commit message title
+
+		// Type in a description
+		cy.getByTestId('commit-drawer-description-input')
+			.should('be.visible')
+			.click()
+			.type(newCommitMessageBody); // Type the new commit message body
+
+		// Click on the save button
+		cy.getByTestId('commit-drawer-action-button')
+			.should('be.visible')
+			.should('be.enabled')
+			.should('contain', 'Save')
+			.click();
+
+		// Should show the error message
+		cy.getByTestId('toast-info-message')
+			.should('be.visible')
+			.should('contain', UPDATE_COMMIT_ERROR_MESSAGE);
+
+		// Should never get the diff information, because there are no partial changes being committed.
+		expect(mockBackend.getDiff).to.have.callCount(0);
+	});
+
+	it('Failing to commit should fail gracefully', () => {
+		const newCommitMessage = 'New commit message';
+		const newCommitMessageBody = 'New commit message body';
+
+		// spies
+		cy.spy(mockBackend, 'getDiff').as('getDiffSpy');
+
+		// There should be uncommitted changes
+		cy.getByTestId('uncommitted-changes-file-list').should('be.visible');
+
+		const fileNames = mockBackend.getWorktreeChangesFileNames();
+
+		expect(fileNames).to.have.length(1);
+
+		const fileName = fileNames[0]!;
+
+		cy.getByTestId('file-list-item').first().should('be.visible').should('contain', fileName);
+
+		// Click on the commit button
+		cy.getByTestId('start-commit-button').should('be.visible').should('be.enabled').click();
+
+		// Should open the new commit drawer
+		cy.getByTestId('new-commit-drawer').should('be.visible');
+
+		// Should have the "Your commit goes here" text
+		cy.getByTestId('your-commit-goes-here').should('be.visible').should('have.class', 'first');
+
+		// Should have selected the file
+		cy.getByTestId('file-list-item').first().get('input[type="checkbox"]').should('be.checked');
+
+		// Type in a commit message
+		cy.getByTestId('commit-drawer-title-input')
+			.should('be.visible')
+			.should('be.enabled')
+			.type(newCommitMessage); // Type the new commit message
+
+		// Type in a description
+		cy.getByTestId('commit-drawer-description-input')
+			.should('be.visible')
+			.click()
+			.type(newCommitMessageBody); // Type the new commit message body
+
+		// Click on the commit button
+		cy.getByTestId('commit-drawer-action-button').should('be.visible').should('be.enabled').click();
+
+		// Should show the error message
+		cy.getByTestId('toast-info-message')
+			.should('be.visible')
+			.should('contain', COMMIT_ERROR_MESSAGE);
+
+		// Should never get the diff information, because there are no partial changes being committed.
+		expect(mockBackend.getDiff).to.have.callCount(0);
+	});
+
+	it('Failing to uncommit should fail graceful', () => {
+		// Click on the first commit
+		cy.getByTestId('commit-row').first().click();
+
+		// Should open the commit drawer
+		cy.getByTestId('commit-drawer').first().should('be.visible');
+
+		// Click on the uncommit button
+		cy.getByTestId('commit-drawer-action-uncommit').click();
+
+		// Should show the error message
+		cy.getByTestId('toast-info-message')
+			.should('be.visible')
+			.should('contain', COMMIT_UNDO_ERROR_MESSAGE);
+	});
+});

--- a/apps/desktop/cypress/e2e/support/index.ts
+++ b/apps/desktop/cypress/e2e/support/index.ts
@@ -237,6 +237,12 @@ Cypress.Commands.add('selectText', (element: Cypress.Chainable<JQuery<HTMLElemen
 	cy.document().trigger('selectionchange');
 });
 
+Cypress.on('uncaught:exception', () => {
+	// Returning false here prevents Cypress from
+	// failing the test.
+	return false;
+});
+
 beforeEach(() => {
 	cy.viewport('macbook-11');
 });

--- a/apps/desktop/src/components/InfoMessage.svelte
+++ b/apps/desktop/src/components/InfoMessage.svelte
@@ -27,6 +27,7 @@
 		error?: string | undefined;
 		title?: Snippet;
 		content?: Snippet;
+		testId?: string;
 	}
 
 	const {
@@ -43,7 +44,8 @@
 		shadow = false,
 		error = undefined,
 		title,
-		content
+		content,
+		testId
 	}: Props = $props();
 
 	const iconMap: { [Key in MessageStyle]: IconName } = {
@@ -74,6 +76,7 @@
 </script>
 
 <div
+	data-testid={testId}
 	class="info-message {style}"
 	class:has-border={outlined}
 	class:has-background={filled}

--- a/apps/desktop/src/components/ToastController.svelte
+++ b/apps/desktop/src/components/ToastController.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import InfoMessage from '$components/InfoMessage.svelte';
 	import { dismissToast, toastStore } from '$lib/notifications/toasts';
+	import { TestId } from '$lib/testing/testIds';
 	import Markdown from '@gitbutler/ui/markdown/Markdown.svelte';
 	import { slide } from 'svelte/transition';
 </script>
@@ -9,6 +10,7 @@
 	{#each $toastStore as toast (toast.id)}
 		<div transition:slide={{ duration: 170 }}>
 			<InfoMessage
+				testId={TestId.ToastInfoMessage}
 				style={toast.style ?? 'neutral'}
 				secondaryLabel="Dismiss"
 				error={toast.error}

--- a/apps/desktop/src/lib/backend/ipc.ts
+++ b/apps/desktop/src/lib/backend/ipc.ts
@@ -11,7 +11,7 @@ export enum Code {
 	ProjectMissing = 'errors.projects.missing'
 }
 
-export type TauriCommandError = { message: string; code?: string };
+export type TauriCommandError = { name: string; message: string; code?: string };
 
 export function isTauriCommandError(something: unknown): something is TauriCommandError {
 	return (

--- a/apps/desktop/src/lib/forge/github/ghQuery.ts
+++ b/apps/desktop/src/lib/forge/github/ghQuery.ts
@@ -63,13 +63,10 @@ export async function ghQuery<
 			: 'GitHub API error';
 
 		if (isErrorlike(err)) {
-			throw { name: title, message: err.message };
+			return { error: { name: title, message: err.message } };
 		}
 
-		throw {
-			name: title,
-			message: String(err)
-		};
+		return { error: { name: title, message: String(err) } };
 	}
 }
 
@@ -89,7 +86,9 @@ export type GhArgs<
 	extra: unknown;
 };
 
-export type GhResponse<T> = { data: T };
+export type GhResponse<T> =
+	| { data: T; error?: never }
+	| { error: { name: string; message: string }; data?: never };
 /**
  * Response type for `ghQuery` inferred from octokit.js.
  */

--- a/apps/desktop/src/lib/forge/github/githubListingService.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubListingService.svelte.ts
@@ -69,6 +69,10 @@ function injectEndpoints(api: GitHubApi) {
 						'required'
 					);
 
+					if (result.error) {
+						return { error: result.error };
+					}
+
 					return {
 						data: prAdapter.addMany(
 							prAdapter.getInitialState(),

--- a/apps/desktop/src/lib/forge/github/types.ts
+++ b/apps/desktop/src/lib/forge/github/types.ts
@@ -39,6 +39,9 @@ export type DetailedGitHubPullRequestWithPermissions = DetailedGitHubPullRequest
 export function parseGitHubDetailedPullRequest(
 	response: GhResponse<DetailedGitHubPullRequestWithPermissions>
 ): GhResponse<DetailedPullRequest> {
+	if (response.error) {
+		return response;
+	}
 	const data = response.data;
 
 	const reviewers =

--- a/apps/desktop/src/lib/state/backendQuery.ts
+++ b/apps/desktop/src/lib/state/backendQuery.ts
@@ -11,7 +11,9 @@ export async function tauriBaseQuery(
 	api: BaseQueryApi
 ): Promise<QueryReturnValue<unknown, TauriCommandError, undefined>> {
 	if (!hasTauriExtra(api.extra)) {
-		return { error: { message: 'Redux dependency Tauri not found!' } };
+		return {
+			error: { name: 'Failed to execute Tauri query', message: 'Redux dependency Tauri not found!' }
+		};
 	}
 
 	const posthog = hasPosthogExtra(api.extra) ? api.extra.posthog : undefined;
@@ -31,12 +33,14 @@ export async function tauriBaseQuery(
 		if (isTauriCommandError(error)) {
 			const newMessage =
 				`command: ${args.command}\nparams: ${JSON.stringify(args.params)})\n\n` + error.message;
-			throw { name, message: newMessage, code: error.code };
-		} else if (isErrorlike(error)) {
-			throw { name, message: error.message };
-		} else {
-			throw { name, message: String(error) };
+			return { error: { name, message: newMessage, code: error.code } };
 		}
+
+		if (isErrorlike(error)) {
+			return { error: { name, message: error.message } };
+		}
+
+		return { error: { name, message: String(error) } };
 	}
 }
 

--- a/apps/desktop/src/lib/testing/testIds.ts
+++ b/apps/desktop/src/lib/testing/testIds.ts
@@ -42,7 +42,8 @@ export enum TestId {
 	StackTab = 'stack-tab',
 	BranchChangedFileList = 'branch-changed-file-list',
 	UnifiedDiffView = 'unified-diff-view',
-	UnifiedDiffViewLockWarning = 'unified-diff-view-lock-warning'
+	UnifiedDiffViewLockWarning = 'unified-diff-view-lock-warning',
+	ToastInfoMessage = 'toast-info-message'
 }
 
 export enum ElementId {


### PR DESCRIPTION
Redux expects that the shape of the return values from the base query comes as an object shape with data (if successful) or error (if failed).

### Description

- Improved error handling and types for GitHub and Tauri IPC integration, including adding `name` to error types and refactoring functions to return error objects instead of throwing.
- Updated all related services and utilities to handle and propagate errors consistently using the expected Redux format.
- Added Cypress end-to-end tests covering error scenarios in commit actions (renaming, creating, undoing commits).
- Enhanced Cypress support to prevent test failures on uncaught exceptions.
- Added `testId` support for toast info messages to improve testability.