### PR TITLE
fix(desktop): update MessageEditor to use console.warn for editor errors

### DIFF
--- a/apps/desktop/src/components/v3/editor/MessageEditor.svelte
+++ b/apps/desktop/src/components/v3/editor/MessageEditor.svelte
@@ -272,7 +272,7 @@
 						{placeholder}
 						bind:this={composer}
 						markdown={useRichText.current}
-						onError={(e) => showError('Editor error', e)}
+						onError={(e) => console.warn('Editor error', e)}
 						initialText={initialValue}
 						onChange={handleChange}
 						onKeyDown={handleKeyDown}


### PR DESCRIPTION
- Change error handler to use console.warn instead of showError for editor errors
- Keeps error reporting in the console for easier debugging without user interruption