### PR TITLE
Enable commit re-ordering in v3

### DIFF
--- a/apps/desktop/src/components/SeriesList.svelte
+++ b/apps/desktop/src/components/SeriesList.svelte
@@ -38,7 +38,10 @@
 
 	const stackingReorderDropzoneManagerFactory = getContext(StackingReorderDropzoneManagerFactory);
 	const stackingReorderDropzoneManager = $derived(
-		stackingReorderDropzoneManagerFactory.build(stack)
+		stackingReorderDropzoneManagerFactory.build(
+			stack.id,
+			stack.validSeries.map((s) => ({ name: s.name, commitIds: s.patches.map((p) => p.id) }))
+		)
 	);
 </script>
 
@@ -60,8 +63,11 @@
 					projectId,
 					stack.id,
 					stackService,
-					currentSeries,
-					nonArchivedValidSeries,
+					currentSeries.name,
+					nonArchivedValidSeries.map((s) => ({
+						name: s.name,
+						commitIds: s.patches.map((p) => p.id)
+					})),
 					'top'
 				)}
 				<div>

--- a/apps/desktop/src/components/v3/BranchCommitList.svelte
+++ b/apps/desktop/src/components/v3/BranchCommitList.svelte
@@ -13,6 +13,7 @@
 		branchName: string;
 		selectedCommitId?: string;
 		empty?: Snippet;
+		beforeLocalAndRemote?: Snippet;
 		upstreamTemplate?: Snippet<
 			[
 				{
@@ -44,6 +45,7 @@
 		branchName,
 		selectedCommitId,
 		empty,
+		beforeLocalAndRemote,
 		localAndRemoteTemplate,
 		upstreamTemplate
 	}: Props = $props();
@@ -77,6 +79,7 @@
 			{/if}
 
 			{#if localAndRemoteTemplate}
+				{@render beforeLocalAndRemote?.()}
 				{#each localAndRemoteCommits as commit, i (commit.id)}
 					{@const first = i === 0}
 					{@const last = i === localAndRemoteCommits.length - 1}


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#5pzygqNJH`](https://cloud.staging.gitbutler.com/mtsgrd/gitbutler/reviews/5pzygqNJH)

**Three unrelated small changes**


- fix closing of commit context menus
- removed unused var in eslint config
- upgrade svelte npm packages

1 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Enable commit re-ordering in v3](https://cloud.staging.gitbutler.com/mtsgrd/gitbutler/reviews/5pzygqNJH/commit/ff54f7be-73e0-400d-9b6e-d760d16003a6) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://cloud.staging.gitbutler.com/mtsgrd/gitbutler/reviews/5pzygqNJH)_
<!-- GitButler Review Footer Boundary Bottom -->
