### PR TITLE
Richard fix: text wrapping

### DIFF
--- a/packages/ui/src/lib/richText/plugins/onChange.svelte
+++ b/packages/ui/src/lib/richText/plugins/onChange.svelte
@@ -40,9 +40,31 @@
 	}
 
 	/**
+	 * Splits a given word into chunks of specified length and appends a dash ('-') to all but the last chunk.
+	 *
+	 * @param word - The word to be split into chunks.
+	 * @param wrap - The maximum length of each chunk (the actual chunk size will be wrap - 1 to leave space for the dash).
+	 * @returns An array of string chunks, with dashes appended to all but the last chunk.
+	 * @throws Error if the word cannot be split into chunks.
+	 */
+	function wrapWord(word: string, wrap: number): string[] {
+		// Split the word into chunks of length wrap - 1
+		// to leave space for the dash.
+		const chunks = word.match(new RegExp(`.{1,${wrap - 1}}`, 'g'));
+		if (chunks) {
+			// Append a dash to all but the last chunk.
+			for (let i = 0; i < chunks.length - 1; i++) {
+				chunks[i] += '-';
+			}
+			return chunks;
+		}
+		throw new Error('Failed to wrap word');
+	}
+
+	/**
 	 * Wraps the text to a given length
 	 *
-	 * Doesn't break words, but will break lines
+	 * Doesn't break words, but will break lines unless the word is longer than the wrap length.
 	 */
 	function wrapText(text: string, wrap: number): string {
 		const lines = text.split('\n');
@@ -52,6 +74,19 @@
 				const words = line.split(' ');
 				let currentLine = '';
 				for (const word of words) {
+					if (word.length >= wrap) {
+						if (currentLine.length > 0) {
+							buffer.push(currentLine);
+							currentLine = '';
+						}
+						// If the word is longer than the wrap, we need to break it
+						const chunks = wrapWord(word, wrap);
+						buffer.push(...chunks);
+						continue;
+					}
+
+					// If the sum of the current line, a space, and the word is greater than the wrap,
+					// we need to break the line.
 					if (currentLine.length + word.length + 1 > wrap) {
 						buffer.push(currentLine);
 						currentLine = '';


### PR DESCRIPTION
The UI would freeze because it would basically fall into a endless loop of trying to wrap the words around when there would be a word larger than the wrap value.

This is no longer the case.

Instead, the word will be broken only if it alone surpases the wrap value.