### PR TITLE
Clear selection when branch not tound

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,6 +799,7 @@ dependencies = [
  "gitbutler-cherry-pick",
  "gitbutler-command-context",
  "gitbutler-commit",
+ "gitbutler-error",
  "gitbutler-fs",
  "gitbutler-id",
  "gitbutler-oxidize",

--- a/apps/desktop/src/components/ReduxResult.svelte
+++ b/apps/desktop/src/components/ReduxResult.svelte
@@ -27,6 +27,7 @@
 		projectId: string;
 		children: Snippet<[A, Env<B>]>;
 		error?: Snippet<[unknown]>;
+		onerror?: (err: unknown) => void;
 	} & (B extends undefined ? { stackId?: B } : { stackId: B });
 
 	const props: Props<A, B> = $props();
@@ -37,6 +38,7 @@
 	};
 
 	let cache: Display | undefined;
+
 	const display = $derived.by<Display>(() => {
 		const env = { projectId: props.projectId, stackId: props.stackId as B };
 		if (props.result?.error) {
@@ -50,6 +52,12 @@
 			} else {
 				return { result: props.result, env };
 			}
+		}
+	});
+
+	$effect(() => {
+		if (props.onerror && display.result?.error !== undefined) {
+			props.onerror(display.result.error);
 		}
 	});
 </script>

--- a/apps/desktop/src/components/v3/BranchView.svelte
+++ b/apps/desktop/src/components/v3/BranchView.svelte
@@ -22,9 +22,10 @@
 		stackId: string;
 		projectId: string;
 		branchName: string;
+		onerror?: (err: unknown) => void;
 	}
 
-	const { stackId, projectId, branchName }: Props = $props();
+	const { stackId, projectId, branchName, onerror }: Props = $props();
 
 	const [stackService] = inject(StackService);
 
@@ -43,6 +44,7 @@
 <ReduxResult
 	{stackId}
 	{projectId}
+	{onerror}
 	result={combineResults(branchesResult.current, branchResult.current, topCommitResult.current)}
 >
 	{#snippet children([branches, branch, topCommit], { stackId, projectId })}
@@ -110,7 +112,7 @@
 
 			{#snippet filesSplitView()}
 				{@const changesResult = stackService.branchChanges({ projectId, stackId, branchName })}
-				<ReduxResult {projectId} {stackId} result={changesResult.current}>
+				<ReduxResult {projectId} {stackId} result={changesResult.current} {onerror}>
 					{#snippet children(changes, { projectId, stackId })}
 						<ChangedFiles
 							testId={TestId.BranchChangedFileList}

--- a/apps/desktop/src/components/v3/BranchesViewBranch.svelte
+++ b/apps/desktop/src/components/v3/BranchesViewBranch.svelte
@@ -15,9 +15,10 @@
 		branchName: string;
 		remote?: string;
 		isTopBranch?: boolean;
+		onerror?: (error: unknown) => void;
 	};
 
-	const { projectId, stackId, branchName, remote, isTopBranch = true }: Props = $props();
+	const { projectId, stackId, branchName, remote, isTopBranch = true, onerror }: Props = $props();
 
 	const stackService = getContext(StackService);
 	const branchResult = $derived(
@@ -31,7 +32,7 @@
 	const branchesState = $derived(projectState.branchesSelection);
 </script>
 
-<ReduxResult result={branchResult.current} {projectId} {stackId}>
+<ReduxResult result={branchResult.current} {projectId} {stackId} {onerror}>
 	{#snippet children(branch, env)}
 		<BranchCard type="normal-branch" projectId={env.projectId} branchName={branch.name}>
 			{#snippet header()}

--- a/apps/desktop/src/components/v3/BranchesViewStack.svelte
+++ b/apps/desktop/src/components/v3/BranchesViewStack.svelte
@@ -8,19 +8,20 @@
 	type Props = {
 		projectId: string;
 		stackId: string;
+		onerror: (err: unknown) => void;
 	};
 
-	const { projectId, stackId }: Props = $props();
+	const { projectId, stackId, onerror }: Props = $props();
 
 	const stackService = getContext(StackService);
 
 	const stackResult = $derived(stackService.allStackById(projectId, stackId));
 </script>
 
-<ReduxResult result={stackResult.current} {projectId} {stackId}>
+<ReduxResult result={stackResult.current} {projectId} {stackId} {onerror}>
 	{#snippet children(stack, { stackId, projectId })}
 		{#each getStackBranchNames(stack) as branchName, idx}
-			<BranchesViewBranch {projectId} {stackId} {branchName} isTopBranch={idx === 0} />
+			<BranchesViewBranch {projectId} {stackId} {branchName} isTopBranch={idx === 0} {onerror} />
 		{/each}
 	{/snippet}
 </ReduxResult>

--- a/apps/desktop/src/components/v3/UnappliedBranchView.svelte
+++ b/apps/desktop/src/components/v3/UnappliedBranchView.svelte
@@ -19,9 +19,10 @@
 		stackId?: string;
 		remote?: string;
 		prNumber?: number;
+		onerror?: (err: unknown) => void;
 	}
 
-	const { projectId, stackId, branchName, remote, prNumber }: Props = $props();
+	const { projectId, stackId, branchName, remote, prNumber, onerror }: Props = $props();
 
 	const [stackService] = inject(StackService, BaseBranchService);
 
@@ -34,7 +35,7 @@
 	let headerMenuContext = $state<BranchHeaderContextItem>();
 </script>
 
-<ReduxResult {projectId} result={branchResult.current}>
+<ReduxResult {projectId} result={branchResult.current} {onerror}>
 	{#snippet children(branch, { stackId, projectId })}
 		{@const hasCommits = branch.commits.length > 0}
 		{@const remoteTrackingBranch = branch.remoteTrackingBranch}

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -144,7 +144,6 @@
 		reactive(() => uiStateSlice),
 		clientState.dispatch
 	);
-	(window as any)['uiState'] = uiState;
 	setContext(UiState, uiState);
 
 	const stackService = new StackService(clientState['backendApi'], forgeFactory, uiState);

--- a/crates/but-workspace/Cargo.toml
+++ b/crates/but-workspace/Cargo.toml
@@ -18,6 +18,7 @@ gitbutler-id.workspace = true
 gix = { workspace = true, features = ["worktree-mutation"] }
 gitbutler-stack.workspace = true
 gitbutler-command-context.workspace = true
+gitbutler-error.workspace = true
 gitbutler-oxidize.workspace = true
 gitbutler-cherry-pick.workspace = true
 gitbutler-project.workspace = true

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -27,6 +27,7 @@ use anyhow::{Context, Result, bail};
 use bstr::BString;
 use gitbutler_command_context::CommandContext;
 use gitbutler_commit::commit_ext::CommitExt;
+use gitbutler_error::error::Code;
 use gitbutler_id::id::Id;
 use gitbutler_oxidize::{ObjectIdExt, OidExt, git2_signature_to_gix_signature};
 use gitbutler_stack::{Stack, StackBranch, VirtualBranchesHandle};
@@ -395,7 +396,9 @@ pub fn branch_details(
                 git2::BranchType::Remote,
             )
             .map(|b| (b, true)),
-    }?;
+    }
+    .context(format!("Could not find branch {branch_name}"))
+    .context(Code::BranchNotFound)?;
 
     let Some(branch_oid) = branch.get().target() else {
         bail!("Branch points to nothing");

--- a/crates/gitbutler-error/src/error.rs
+++ b/crates/gitbutler-error/src/error.rs
@@ -134,6 +134,7 @@ pub enum Code {
     CommitMergeConflictFailure,
     ProjectMissing,
     AuthorMissing,
+    BranchNotFound,
 }
 
 impl std::fmt::Display for Code {
@@ -147,6 +148,7 @@ impl std::fmt::Display for Code {
             Code::CommitMergeConflictFailure => "errors.commit.merge_conflict_failure",
             Code::AuthorMissing => "errors.git.author_missing",
             Code::ProjectMissing => "errors.projects.missing",
+            Code::BranchNotFound => "errors.branch.notfound",
         };
         f.write_str(code)
     }

--- a/crates/gitbutler-stack/src/state.rs
+++ b/crates/gitbutler-stack/src/state.rs
@@ -176,7 +176,7 @@ impl VirtualBranchesHandle {
     /// Errors if the file cannot be read or written.
     pub fn get_stack_in_workspace(&self, id: StackId) -> Result<Stack> {
         self.try_stack_in_workspace(id)?
-            .ok_or_else(|| anyhow!("branch with ID {id} not found"))
+            .ok_or_else(|| anyhow!("branch with ID {id} not found").context(Code::BranchNotFound))
     }
 
     /// Gets the state of the given virtual branch.
@@ -184,7 +184,7 @@ impl VirtualBranchesHandle {
     /// Errors if the file cannot be read or written.
     pub fn get_stack(&self, id: StackId) -> Result<Stack> {
         self.try_stack(id)?
-            .ok_or_else(|| anyhow!("branch with ID {id} not found"))
+            .ok_or_else(|| anyhow!("branch with ID {id} not found").context(Code::BranchNotFound))
     }
 
     /// Gets the state of the given virtual branch returning `Some(branch)` or `None`


### PR DESCRIPTION
Adds Code::BranchNotFound to the error context of `brach_details` and
`stack_details`, and clears the selection on the branches page if and
when it happens.