### PR TITLE
basic head-info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,6 +816,7 @@ dependencies = [
  "gitbutler-id",
  "gitbutler-oxidize",
  "gitbutler-project",
+ "gitbutler-reference",
  "gitbutler-repo",
  "gitbutler-serde",
  "gitbutler-stack",

--- a/apps/desktop/src/lib/config/appSettingsV2.ts
+++ b/apps/desktop/src/lib/config/appSettingsV2.ts
@@ -80,6 +80,8 @@ export type TelemetrySettings = {
 export type FeatureFlags = {
 	/** Enables the v3 design, as well as the purgatory mode (no uncommitted diff ownership assignments). */
 	v3: boolean;
+	/** Enable the usage of the V3 workspace API */
+	ws3: boolean;
 };
 
 export type Fetch = {

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -268,6 +268,10 @@
 		'v 3': () => {
 			settingsService.updateFeatureFlags({ v3: !$settingsStore?.featureFlags.v3 });
 		},
+		// Toggle v3 workspace APIs on/off
+		'w s 3': () => {
+			settingsService.updateFeatureFlags({ ws3: !$settingsStore?.featureFlags.ws3 });
+		},
 		// This is a debug tool to learn about environment variables actually present - only available if the backend is in debug mode.
 		'e n v': async () => {
 			let env = await invoke('env_vars');

--- a/crates/but-cli/src/args.rs
+++ b/crates/but-cli/src/args.rs
@@ -1,3 +1,4 @@
+use gitbutler_stack::StackId;
 use std::path::PathBuf;
 
 #[derive(Debug, clap::Parser)]
@@ -107,6 +108,11 @@ pub enum Subcommands {
     },
     /// Returns the list of stacks that are currently part of the GitButler workspace.
     Stacks,
+    /// Returns the list of stacks that are currently part of the GitButler workspace.
+    StackDetails {
+        /// The ID of the stack to list details for.
+        id: StackId,
+    },
     /// Return all stack branches related to the given `id`.
     StackBranches {
         /// The ID of the stack to list branches from.

--- a/crates/but-cli/src/args.rs
+++ b/crates/but-cli/src/args.rs
@@ -120,7 +120,7 @@ pub enum Subcommands {
         /// If creating a branch, this is optionally the stack to which the branch will be added.
         /// If no ID is present while creating a branch, a new stack will be created that will
         /// contain the brand new branch.
-        id: Option<String>,
+        id: Option<StackId>,
         /// Optional. The name of the branch to create.
         ///
         /// If this is set, a branch will be created with the given name.
@@ -133,7 +133,7 @@ pub enum Subcommands {
         description: Option<String>,
     },
     /// Returns all commits for the branch with the given `name` in the stack with the given `id`.
-    StackBranchCommits { id: String, name: String },
+    StackBranchCommits { id: StackId, name: String },
 }
 
 #[cfg(test)]

--- a/crates/but-cli/src/command/mod.rs
+++ b/crates/but-cli/src/command/mod.rs
@@ -117,6 +117,7 @@ pub mod diff;
 pub mod stacks {
     use std::{path::Path, str::FromStr};
 
+    use crate::command::{debug_print, project_from_path};
     use but_settings::AppSettings;
     use but_workspace::{
         stack_branch_local_and_remote_commits, stack_branch_upstream_only_commits, stack_branches,
@@ -124,8 +125,7 @@ pub mod stacks {
     };
     use gitbutler_command_context::CommandContext;
     use gitbutler_id::id::Id;
-
-    use crate::command::{debug_print, project_from_path};
+    use gitbutler_stack::StackId;
 
     /// A collection of all the commits that are part of a branch.
     #[derive(Debug, Clone, serde::Serialize)]
@@ -149,6 +149,12 @@ pub mod stacks {
         } else {
             debug_print(stacks)
         }
+    }
+
+    pub fn details(id: StackId, current_dir: &Path) -> anyhow::Result<()> {
+        let project = project_from_path(current_dir)?;
+        let ctx = CommandContext::open(&project, AppSettings::default())?;
+        debug_print(but_workspace::stack_details(&project.gb_dir(), id, &ctx)?)
     }
 
     pub fn branches(id: &str, current_dir: &Path, use_json: bool) -> anyhow::Result<()> {

--- a/crates/but-cli/src/command/mod.rs
+++ b/crates/but-cli/src/command/mod.rs
@@ -244,7 +244,11 @@ pub mod stacks {
         let project = project_from_path(current_dir)?;
         // Enable v3 feature flags for the command context
         let app_settings = AppSettings {
-            feature_flags: but_settings::app_settings::FeatureFlags { v3: true },
+            feature_flags: but_settings::app_settings::FeatureFlags {
+                v3: true,
+                // Keep this off until it caught up at least.
+                ws3: false,
+            },
             ..AppSettings::default()
         };
 

--- a/crates/but-cli/src/main.rs
+++ b/crates/but-cli/src/main.rs
@@ -89,6 +89,7 @@ fn main() -> Result<()> {
             *unified_diff,
         ),
         args::Subcommands::Stacks => command::stacks::list(&args.current_dir, args.json),
+        args::Subcommands::StackDetails { id } => command::stacks::details(*id, &args.current_dir),
         args::Subcommands::StackBranches {
             id,
             branch_name,

--- a/crates/but-cli/src/main.rs
+++ b/crates/but-cli/src/main.rs
@@ -96,13 +96,13 @@ fn main() -> Result<()> {
             description,
         } => match (branch_name, id) {
             (Some(branch_name), maybe_id) => command::stacks::create_branch(
-                maybe_id,
+                *maybe_id,
                 branch_name,
-                description,
+                description.as_deref(),
                 &args.current_dir,
                 args.json,
             ),
-            (None, Some(id)) => command::stacks::branches(id, &args.current_dir, args.json),
+            (None, Some(id)) => command::stacks::branches(*id, &args.current_dir, args.json),
             (None, None) => {
                 bail!(
                     "You must provide a stack ID to list branches. Use `--branch-name` to create a new branch."
@@ -110,7 +110,7 @@ fn main() -> Result<()> {
             }
         },
         args::Subcommands::StackBranchCommits { id, name } => {
-            command::stacks::branch_commits(id, name, &args.current_dir, args.json)
+            command::stacks::branch_commits(*id, name, &args.current_dir, args.json)
         }
     }
 }

--- a/crates/but-settings/assets/defaults.jsonc
+++ b/crates/but-settings/assets/defaults.jsonc
@@ -17,7 +17,9 @@
 	},
 	"featureFlags": {
 		// Enables the v3 design, as well as the purgatory mode (no uncommitted diff ownership assignments).
-		"v3": false
+		"v3": false,
+		/// Enable the usage of V3 workspace APIs.
+		"ws3": false
 	},
 	// Allows for additional "connect-src" hosts to be included. Requires app restart.
 	"extraCsp": {

--- a/crates/but-settings/src/api.rs
+++ b/crates/but-settings/src/api.rs
@@ -16,6 +16,7 @@ pub struct TelemetryUpdate {
 /// Update request for [`crate::app_settings::FeatureFlags`].
 pub struct FeatureFlagsUpdate {
     pub v3: Option<bool>,
+    pub ws3: Option<bool>,
 }
 
 /// Mutation, immediately followed by writing everything to disk.
@@ -40,10 +41,16 @@ impl AppSettingsWithDiskSync {
         settings.save()
     }
 
-    pub fn update_feature_flags(&self, update: FeatureFlagsUpdate) -> Result<()> {
+    pub fn update_feature_flags(
+        &self,
+        FeatureFlagsUpdate { v3, ws3 }: FeatureFlagsUpdate,
+    ) -> Result<()> {
         let mut settings = self.get_mut_enforce_save()?;
-        if let Some(v3) = update.v3 {
+        if let Some(v3) = v3 {
             settings.feature_flags.v3 = v3;
+        }
+        if let Some(ws3) = ws3 {
+            settings.feature_flags.ws3 = ws3;
         }
         settings.save()
     }

--- a/crates/but-settings/src/app_settings.rs
+++ b/crates/but-settings/src/app_settings.rs
@@ -23,6 +23,8 @@ pub struct GitHubOAuthAppSettings {
 pub struct FeatureFlags {
     /// Enables the v3 design, as well as the purgatory mode (no uncommitted diff ownership assignments).
     pub v3: bool,
+    /// Enable the usage of V3 workspace APIs.
+    pub ws3: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/but-testsupport/src/lib.rs
+++ b/crates/but-testsupport/src/lib.rs
@@ -108,6 +108,15 @@ pub fn visualize_commit_graph(
     Ok(log.stdout.to_str().expect("no illformed UTF-8").to_string())
 }
 
+/// Produce a graph of all commits reachable from all refs.
+pub fn visualize_commit_graph_all(repo: &gix::Repository) -> std::io::Result<String> {
+    let log = git(repo)
+        .args(["log", "--oneline", "--graph", "--decorate", "--all"])
+        .output()?;
+    assert!(log.status.success());
+    Ok(log.stdout.to_str().expect("no illformed UTF-8").to_string())
+}
+
 /// Run a condensed status on `repo`.
 pub fn git_status(repo: &gix::Repository) -> std::io::Result<String> {
     let out = git(repo).args(["status", "--porcelain"]).output()?;

--- a/crates/but-workspace/Cargo.toml
+++ b/crates/but-workspace/Cargo.toml
@@ -46,3 +46,4 @@ but-core = { workspace = true, features = ["testing"] }
 # TODO: remove once `gitbutler-repo` isn't needed anymore.
 gitbutler-commit = { workspace = true, features = ["testing"] }
 regex = "1.11.1"
+gitbutler-reference.workspace = true

--- a/crates/but-workspace/src/branch_details.rs
+++ b/crates/but-workspace/src/branch_details.rs
@@ -223,7 +223,7 @@ pub fn branch_details_v3(
         pr_number: meta.review.pull_request,
         review_id: meta.review.review_id.clone(),
         base_commit,
-        last_updated_at: meta.ref_info.updated_at.map(|d| d.seconds as u128 * 1_000),
+        last_updated_at: meta.ref_info.updated_at.map(|d| d.seconds as i128 * 1_000),
         authors: authors
             .into_iter()
             .sorted_by(|a, b| a.name.cmp(&b.name).then_with(|| a.email.cmp(&b.email)))
@@ -263,7 +263,7 @@ fn upstream_commits(
             ui::UpstreamCommit {
                 id: commit.id().to_gix(),
                 message: commit.message().unwrap_or_default().into(),
-                created_at: u128::try_from(commit.time().seconds()).unwrap_or(0) * 1000,
+                created_at: i128::from(commit.time().seconds()) * 1000,
                 author,
             }
         })
@@ -297,7 +297,7 @@ fn local_commits(
                 message: commit.message().unwrap_or_default().into(),
                 has_conflicts: false,
                 state: CommitState::LocalAndRemote(commit.id().to_gix()),
-                created_at: u128::try_from(commit.time().seconds()).unwrap_or(0) * 1000,
+                created_at: i128::from(commit.time().seconds()) * 1000,
                 author,
             }
         })

--- a/crates/but-workspace/src/branch_details.rs
+++ b/crates/but-workspace/src/branch_details.rs
@@ -1,12 +1,14 @@
 use crate::head_info::function::workspace_data_of_default_workspace_branch;
-use crate::ui::{CommitState, PushStatus};
+use crate::ui::{CommitState, PushStatus, UpstreamCommit};
 use crate::{state_handle, ui};
 use anyhow::{Context, bail};
 use but_core::RefMetadata;
 use gitbutler_command_context::CommandContext;
 use gitbutler_error::error::Code;
-use gitbutler_oxidize::OidExt;
+use gitbutler_oxidize::{ObjectIdExt, OidExt};
+use gix::reference::Category;
 use gix::remote::Direction;
+use itertools::Itertools;
 use std::collections::HashSet;
 use std::path::Path;
 
@@ -65,64 +67,20 @@ pub fn branch_details(
         bail!("Failed to find merge base");
     };
 
-    let mut revwalk = repository.revwalk()?;
-    revwalk.push(branch_oid)?;
-    revwalk.hide(default_target.sha)?;
-    revwalk.simplify_first_parent()?;
-
-    let commits = revwalk
-        .filter_map(|oid| repository.find_commit(oid.ok()?).ok())
-        .collect::<Vec<_>>();
-
-    let upstream_commits = if let Some(upstream_oid) = upstream_oid {
-        let mut revwalk = repository.revwalk()?;
-        revwalk.push(upstream_oid)?;
-        revwalk.hide(branch_oid)?;
-        revwalk.hide(default_target.sha)?;
-        revwalk.simplify_first_parent()?;
-        revwalk
-            .filter_map(|oid| repository.find_commit(oid.ok()?).ok())
-            .collect::<Vec<_>>()
-    } else {
-        vec![]
-    };
-
     let mut authors = HashSet::new();
-
-    let commits = commits
-        .into_iter()
-        .map(|commit| {
-            let author: ui::Author = commit.author().into();
-            let commiter: ui::Author = commit.committer().into();
-            authors.insert(author.clone());
-            authors.insert(commiter);
-            ui::Commit {
-                id: commit.id().to_gix(),
-                parent_ids: commit.parent_ids().map(|id| id.to_gix()).collect(),
-                message: commit.message().unwrap_or_default().into(),
-                has_conflicts: false,
-                state: CommitState::LocalAndRemote(commit.id().to_gix()),
-                created_at: u128::try_from(commit.time().seconds()).unwrap_or(0) * 1000,
-                author,
-            }
+    let commits = local_commits(repository, default_target.sha, branch_oid, &mut authors)?;
+    let upstream_commits = upstream_oid
+        .map(|upstream_oid| {
+            upstream_commits(
+                repository,
+                upstream_oid,
+                default_target.sha,
+                branch_oid,
+                &mut authors,
+            )
         })
-        .collect::<Vec<_>>();
-
-    let upstream_commits = upstream_commits
-        .into_iter()
-        .map(|commit| {
-            let author: ui::Author = commit.author().into();
-            let commiter: ui::Author = commit.committer().into();
-            authors.insert(author.clone());
-            authors.insert(commiter);
-            ui::UpstreamCommit {
-                id: commit.id().to_gix(),
-                message: commit.message().unwrap_or_default().into(),
-                created_at: u128::try_from(commit.time().seconds()).unwrap_or(0) * 1000,
-                author,
-            }
-        })
-        .collect::<Vec<_>>();
+        .transpose()?
+        .unwrap_or_default();
 
     Ok(ui::BranchDetails {
         name: branch_name.into(),
@@ -152,76 +110,196 @@ pub fn branch_details(
 /// This branch is assumed to not be in the workspace, but it will still be assumed to want to integrate with the workspace target reference if set.
 ///
 /// ### Implementation
-#[allow(unused_variables)]
+///
+/// Note that the following fields aren't computed or are only partially computed.
+///
+/// - `push_status` - `Integrated` variant is not computed for now (but it's considered valuable to have so could be done later).
+/// - `is_conflicted` - bogus value (true)
 pub fn branch_details_v3(
     repo: &gix::Repository,
     name: &gix::refs::FullNameRef,
     meta: &impl RefMetadata,
 ) -> anyhow::Result<ui::BranchDetails> {
-    let integration_ref_name = workspace_data_of_default_workspace_branch(meta)?
+    let integration_branch_name = workspace_data_of_default_workspace_branch(meta)?
         .context(
             "TODO: cannot run in non-workspace mode yet.\
         It would need a way to deal with limiting the commit traversal",
         )?
         .target_ref
         .context("TODO: a target to integrate with is currently needed for a workspace commit")?;
-    let mut integration_ref = repo
-        .find_reference(&integration_ref_name)
+    let mut integration_branch = repo
+        .find_reference(&integration_branch_name)
         .context("The branch to integrate with must be present")?;
-    let integration_ref_target_id = integration_ref.peel_to_id_in_place()?;
+    let integration_branch_id = integration_branch.peel_to_id_in_place()?;
 
     let mut branch = repo.find_reference(name)?;
-    let branch_target_id = branch.peel_to_id_in_place()?;
+    let branch_id = branch.peel_to_id_in_place()?;
 
     let mut remote_tracking_branch = repo
         .branch_remote_tracking_ref_name(name, Direction::Fetch)
         .transpose()?
         .and_then(|remote_tracking_ref| repo.find_reference(remote_tracking_ref.as_ref()).ok());
-    let remote_tracking_target_id = remote_tracking_branch
+    let remote_tracking_branch_id = remote_tracking_branch
         .as_mut()
-        .map(|remote_ref| remote_ref.peel_to_id_in_place())
+        .map(|r| r.peel_to_id_in_place())
         .transpose()?;
-    let push_status = remote_tracking_target_id
-        .map(|remote_target_id| {
-            if remote_target_id == branch_target_id {
-                PushStatus::NothingToPush
-            } else {
-                PushStatus::UnpushedCommits
-            }
-        })
-        .unwrap_or(PushStatus::CompletelyUnpushed);
 
     let meta = meta.branch(name)?;
     let meta: &but_core::ref_metadata::Branch = &meta;
 
+    let cache = repo.commit_graph_if_enabled()?;
+    let mut graph = repo.revision_graph(cache.as_ref());
     let base_commit = {
-        let cache = repo.commit_graph_if_enabled()?;
-        let mut graph = repo.revision_graph(cache.as_ref());
         let merge_bases = repo.merge_bases_many_with_graph(
-            branch_target_id,
-            &[integration_ref_target_id.detach()],
+            branch_id,
+            &[integration_branch_id.detach()],
             &mut graph,
         )?;
         // TODO: have a test that shows why this must/should be last. Then maybe make it easy to do
         //       the right thing whenever the mergebase with the integration branch is needed.
-        merge_bases.last().map(|id| id.detach())
+        merge_bases
+            .last()
+            .map(|id| id.detach())
+            .with_context(|| format!("No merge-base found between {name} and the integration branch {integration_branch_name}", name = name.as_bstr()))?
     };
 
-    todo!()
-    // Ok(ui::BranchDetails {
-    //     name: name.as_bstr().into(),
-    //     remote_tracking_branch: remote_tracking_branch.map(|b| b.name().as_bstr().to_owned()),
-    //     description: meta.description.clone(),
-    //     pr_number: meta.review.pull_request,
-    //     review_id: meta.review.review_id.clone(),
-    //     base_commit: todo!(),
-    //     push_status,
-    //     last_updated_at: todo!(),
-    //     authors: todo!(),
-    //     is_conflicted: todo!(),
-    //     commits: todo!(),
-    //     upstream_commits: todo!(),
-    //     tip: branch_target_id.detach(),
-    //     is_remote_head: name.category() == Some(Category::RemoteBranch),
-    // })
+    let mut authors = HashSet::new();
+    let (commits, upstream_commits) = {
+        let repo = git2::Repository::open(repo.path())?;
+
+        let commits = local_commits(
+            &repo,
+            integration_branch_id.to_git2(),
+            branch_id.to_git2(),
+            &mut authors,
+        )?;
+
+        let upstream_commits = if let Some(remote_tracking_branch) = remote_tracking_branch.as_mut()
+        {
+            let remote_id = remote_tracking_branch.peel_to_id_in_place()?;
+            upstream_commits(
+                &repo,
+                remote_id.to_git2(),
+                integration_branch_id.to_git2(),
+                branch_id.to_git2(),
+                &mut authors,
+            )?
+        } else {
+            Vec::new()
+        };
+        (commits, upstream_commits)
+    };
+
+    let is_remote_head = name.category() == Some(Category::RemoteBranch);
+    let push_status = match remote_tracking_branch_id {
+        Some(remote_tracking_branch_id) => {
+            let merge_base =
+                repo.merge_base_with_graph(branch_id, remote_tracking_branch_id, &mut graph)?;
+            if merge_base == remote_tracking_branch_id {
+                if merge_base == branch_id {
+                    PushStatus::NothingToPush
+                } else {
+                    PushStatus::UnpushedCommits
+                }
+            } else {
+                PushStatus::UnpushedCommitsRequiringForce
+            }
+        }
+        None => {
+            if is_remote_head {
+                // Make remotes appears neutral, like there is nothing to do.
+                PushStatus::NothingToPush
+            } else {
+                // likely that no remote tracking branch existed in the first place.
+                PushStatus::CompletelyUnpushed
+            }
+        }
+    };
+
+    Ok(ui::BranchDetails {
+        name: name.as_bstr().into(),
+        remote_tracking_branch: remote_tracking_branch.map(|b| b.name().as_bstr().to_owned()),
+        description: meta.description.clone(),
+        pr_number: meta.review.pull_request,
+        review_id: meta.review.review_id.clone(),
+        base_commit,
+        last_updated_at: meta.ref_info.updated_at.map(|d| d.seconds as u128 * 1_000),
+        authors: authors
+            .into_iter()
+            .sorted_by(|a, b| a.name.cmp(&b.name).then_with(|| a.email.cmp(&b.email)))
+            .collect(),
+        commits,
+        upstream_commits,
+        tip: branch_id.detach(),
+        is_remote_head,
+        push_status,
+        // Should be initialized, but this type is re-used in StackDetails where these are set so we can't indicate it.
+        is_conflicted: true,
+    })
+}
+
+/// Traverse all commits that are reachable from the first parent of `upstream_id`, but not in `integration_branch_id` nor in `branch_id`.
+/// While at it, collect the commiter and author of each commit into `authors`.
+fn upstream_commits(
+    repository: &git2::Repository,
+    upstream_id: git2::Oid,
+    integration_branch_id: git2::Oid,
+    branch_id: git2::Oid,
+    authors: &mut HashSet<ui::Author>,
+) -> anyhow::Result<Vec<UpstreamCommit>> {
+    let mut revwalk = repository.revwalk()?;
+    revwalk.push(upstream_id)?;
+    revwalk.hide(branch_id)?;
+    revwalk.hide(integration_branch_id)?;
+    revwalk.simplify_first_parent()?;
+    Ok(revwalk
+        .filter_map(Result::ok)
+        .filter_map(|oid| repository.find_commit(oid).ok())
+        .map(|commit| {
+            let author: ui::Author = commit.author().into();
+            let commiter: ui::Author = commit.committer().into();
+            authors.insert(author.clone());
+            authors.insert(commiter);
+            ui::UpstreamCommit {
+                id: commit.id().to_gix(),
+                message: commit.message().unwrap_or_default().into(),
+                created_at: u128::try_from(commit.time().seconds()).unwrap_or(0) * 1000,
+                author,
+            }
+        })
+        .collect())
+}
+
+/// Traverse all commits that are reachable from the first parent of `branch_id`, but not in `integration_branch`, and store all
+/// commit authors and committers in `authors` while at it.
+fn local_commits(
+    repository: &git2::Repository,
+    integration_branch_id: git2::Oid,
+    branch_id: git2::Oid,
+    authors: &mut HashSet<ui::Author>,
+) -> anyhow::Result<Vec<ui::Commit>> {
+    let mut revwalk = repository.revwalk()?;
+    revwalk.push(branch_id)?;
+    revwalk.hide(integration_branch_id)?;
+    revwalk.simplify_first_parent()?;
+
+    Ok(revwalk
+        .filter_map(Result::ok)
+        .filter_map(|oid| repository.find_commit(oid).ok())
+        .map(|commit| {
+            let author: ui::Author = commit.author().into();
+            let commiter: ui::Author = commit.committer().into();
+            authors.insert(author.clone());
+            authors.insert(commiter);
+            ui::Commit {
+                id: commit.id().to_gix(),
+                parent_ids: commit.parent_ids().map(|id| id.to_gix()).collect(),
+                message: commit.message().unwrap_or_default().into(),
+                has_conflicts: false,
+                state: CommitState::LocalAndRemote(commit.id().to_gix()),
+                created_at: u128::try_from(commit.time().seconds()).unwrap_or(0) * 1000,
+                author,
+            }
+        })
+        .collect())
 }

--- a/crates/but-workspace/src/commit.rs
+++ b/crates/but-workspace/src/commit.rs
@@ -93,8 +93,9 @@ impl WorkspaceCommit<'_> {
     /// once another branch is added to the workspace.
     pub fn is_managed(&self) -> bool {
         let message = gix::objs::commit::MessageRef::from_bytes(&self.message);
-        message.title == Self::GITBUTLER_INTEGRATION_COMMIT_TITLE
-            || message.title == Self::GITBUTLER_WORKSPACE_COMMIT_TITLE
+        let title = message.title.trim().as_bstr();
+        title == Self::GITBUTLER_INTEGRATION_COMMIT_TITLE
+            || title == Self::GITBUTLER_WORKSPACE_COMMIT_TITLE
     }
 }
 

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -78,9 +78,10 @@ pub mod stack_ext;
 
 /// Functions related to retrieving stack information.
 mod stacks;
+// TODO: _v3 versions are specifically for the UI, so import them into `ui` instead.
 pub use stacks::{
     stack_branch_local_and_remote_commits, stack_branch_upstream_only_commits, stack_branches,
-    stack_details, stack_heads_info, stacks, stacks_v3,
+    stack_details, stack_details_v3, stack_heads_info, stacks, stacks_v3,
 };
 
 mod virtual_branches_metadata;

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -50,6 +50,7 @@ pub use head::{head, merge_worktree_with_workspace};
 mod relapath;
 
 /// 🚧utilities for applying and unapplying branches 🚧.
+/// Ignore the name of this module; it's just a place to put code by now.
 pub mod branch;
 
 /// 🚧Deal with worktree changes 🚧.

--- a/crates/but-workspace/src/stack_ext.rs
+++ b/crates/but-workspace/src/stack_ext.rs
@@ -18,7 +18,7 @@ impl StackExt for gitbutler_stack::Stack {
         repo: &gix::Repository,
     ) -> anyhow::Result<Vec<RebaseStep>> {
         let mut steps: Vec<RebaseStep> = Vec::new();
-        for branch in crate::stack_branches(self.id.to_string(), ctx)? {
+        for branch in crate::stack_branches(self.id, ctx)? {
             if branch.archived {
                 continue;
             }
@@ -29,7 +29,7 @@ impl StackExt for gitbutler_stack::Stack {
             };
             steps.push(reference_step);
             let commits = crate::stack_branch_local_and_remote_commits(
-                self.id.to_string(),
+                self.id,
                 branch.name.to_string(),
                 ctx,
                 repo,

--- a/crates/but-workspace/src/stacks.rs
+++ b/crates/but-workspace/src/stacks.rs
@@ -464,7 +464,7 @@ fn upstream_only_commits(
         });
         // Ignore commits that strictly speaking are remote only, but they match a known local commit (rebase etc)
         if !matches_known_commit {
-            let created_at = u128::try_from(commit.time().seconds())? * 1000;
+            let created_at = i128::from(commit.time().seconds()) * 1000;
             let upstream_commit = ui::UpstreamCommit {
                 id: commit.id().to_gix(),
                 message: commit.message_bstr().into(),
@@ -537,7 +537,7 @@ fn local_and_remote_commits(
             }
         };
 
-        let created_at = u128::try_from(commit.time().seconds())? * 1000;
+        let created_at = i128::from(commit.time().seconds()) * 1000;
 
         let api_commit = ui::Commit {
             id: commit.id().to_gix(),

--- a/crates/but-workspace/src/stacks.rs
+++ b/crates/but-workspace/src/stacks.rs
@@ -212,7 +212,7 @@ pub fn stack_details(
     ) -> anyhow::Result<bool> {
         let upstream = branch.remote_reference(remote);
 
-        let reference = match ctx.repo().refname_to_id(&upstream) {
+        let upstream_reference = match ctx.repo().refname_to_id(&upstream) {
             Ok(reference) => reference,
             Err(err) if err.code() == git2::ErrorCode::NotFound => return Ok(false),
             Err(other) => return Err(other).context("failed to find upstream reference"),
@@ -220,7 +220,7 @@ pub fn stack_details(
 
         let upstream_commit = ctx
             .repo()
-            .find_commit(reference)
+            .find_commit(upstream_reference)
             .context("failed to find upstream commit")?;
 
         let branch_head = branch.head_oid(&ctx.gix_repo()?)?;
@@ -493,7 +493,7 @@ fn local_and_remote_commits(
         .context("failed to get default target")?;
     let cache = repo.commit_graph_if_enabled()?;
     let mut graph = repo.revision_graph(cache.as_ref());
-    let mut check_commit = IsCommitIntegrated::new(ctx, &default_target, repo, &mut graph)?;
+    let mut check_commit = IsCommitIntegrated::new(ctx.repo(), &default_target, repo, &mut graph)?;
 
     let branch_commits = stack_branch.commits(ctx, stack)?;
     let mut local_and_remote: Vec<ui::Commit> = vec![];

--- a/crates/but-workspace/src/stacks.rs
+++ b/crates/but-workspace/src/stacks.rs
@@ -348,6 +348,7 @@ pub fn stack_details(
 
 /// Return the branches that belong to a particular [`gitbutler_stack::Stack`]
 /// The entries are ordered from newest to oldest.
+// TODO: `stack_id` probably wants to be a real StackId, and at some point a V3 stack index.
 pub fn stack_branches(stack_id: String, ctx: &CommandContext) -> anyhow::Result<Vec<ui::Branch>> {
     let state = state_handle(&ctx.project().gb_dir());
     let remote = state

--- a/crates/but-workspace/src/ui.rs
+++ b/crates/but-workspace/src/ui.rs
@@ -210,7 +210,7 @@ impl std::fmt::Debug for UpstreamCommit {
 }
 
 /// Represents the pushable status for the current stack.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Copy, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum PushStatus {
     /// Can push, but there are no changes to be pushed

--- a/crates/but-workspace/src/ui.rs
+++ b/crates/but-workspace/src/ui.rs
@@ -150,7 +150,7 @@ pub struct Commit {
     /// Note that remote only commits in the context of a branch are expressed with the [`UpstreamCommit`] struct instead of this.
     pub state: CommitState,
     /// Commit creation time in Epoch milliseconds.
-    pub created_at: u128,
+    pub created_at: i128,
     /// The author of the commit.
     pub author: Author,
 }
@@ -164,7 +164,7 @@ impl TryFrom<gix::Commit<'_>> for Commit {
             message: commit.message_raw_sloppy().into(),
             has_conflicts: false,
             state: CommitState::LocalAndRemote(commit.id),
-            created_at: u128::try_from(commit.time()?.seconds)? * 1000,
+            created_at: i128::from(commit.time()?.seconds) * 1000,
             author: commit.author()?.into(),
         })
     }
@@ -193,7 +193,7 @@ pub struct UpstreamCommit {
     #[serde(with = "gitbutler_serde::bstring_lossy")]
     pub message: BString,
     /// Commit creation time in Epoch milliseconds.
-    pub created_at: u128,
+    pub created_at: i128,
     /// The author of the commit.
     pub author: Author,
 }
@@ -254,7 +254,7 @@ pub struct BranchDetails {
     /// The pushable status for the branch.
     pub push_status: PushStatus,
     /// Last time, the branch was updated in Epoch milliseconds.
-    pub last_updated_at: Option<u128>,
+    pub last_updated_at: Option<i128>,
     /// All authors of the commits in the branch.
     pub authors: Vec<Author>,
     /// Whether the branch is conflicted.

--- a/crates/but-workspace/src/virtual_branches_metadata.rs
+++ b/crates/but-workspace/src/virtual_branches_metadata.rs
@@ -86,6 +86,14 @@ impl VirtualBranchesTomlMetadata {
     }
 }
 
+/// Mostly used in testing, and it's fine as it's intermediate, and we are very practical here.
+impl VirtualBranchesTomlMetadata {
+    /// Return a mutable snapshot of the underlying data. Useful for testing mainly.
+    pub fn data_mut(&mut self) -> &mut VirtualBranchesState {
+        &mut self.snapshot.content
+    }
+}
+
 // Emergency-behaviour in case the application winds down, we don't want data-loss (at least a chance).
 impl Drop for VirtualBranchesTomlMetadata {
     fn drop(&mut self) {

--- a/crates/but-workspace/tests/fixtures/generated-archives/.gitignore
+++ b/crates/but-workspace/tests/fixtures/generated-archives/.gitignore
@@ -25,4 +25,5 @@
 /mixed-hunk-modifications.tar
 /plain-modifications.tar
 /three-commits-with-line-offset-and-workspace-commit.tar
-/with_remotes_no_workspace.tar
+/with-remotes-no-workspace.tar
+/with-remotes-and-workspace.tar

--- a/crates/but-workspace/tests/fixtures/generated-archives/.gitignore
+++ b/crates/but-workspace/tests/fixtures/generated-archives/.gitignore
@@ -25,3 +25,4 @@
 /mixed-hunk-modifications.tar
 /plain-modifications.tar
 /three-commits-with-line-offset-and-workspace-commit.tar
+/with_remotes_no_workspace.tar

--- a/crates/but-workspace/tests/fixtures/scenario/with-remotes-and-workspace.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/with-remotes-and-workspace.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+### General Description
+
+# Various directories with different scenarios for testing stack information *with* a workspace commit,
+# and of course with a remote and a branch to integrate with.
+set -eu -o pipefail
+
+function set_author() {
+  local author=${1:?Author}
+
+  unset GIT_AUTHOR_NAME
+  unset GIT_AUTHOR_EMAIL
+
+  git config user.name $author
+  git config user.email $author@example.com
+}
+
+
+# can only be called once per test setup
+function create_workspace_commit_once() {
+  local workspace_commit_subject="GitButler Workspace Commit"
+
+  if [ $# == 1 ]; then
+    local current_branch=$(git rev-parse --abbrev-ref HEAD)
+    if [[ "$current_branch" != "$1" ]]; then
+      echo "BUG: Must assure the current branch is the branch passed as argument: $current_branch != $1"
+      return 42
+    fi
+  fi
+
+  git checkout -b gitbutler/workspace
+  if [ $# == 1 ] || [ $# == 0 ]; then
+    git commit --allow-empty -m "$workspace_commit_subject"
+  else
+    git merge -m "$workspace_commit_subject" "${@}"
+  fi
+}
+
+git init remote
+(cd remote
+  touch file
+  git add . && git commit -m init-integration
+
+  git checkout -b A
+  touch file-in-A && git add . && git commit -m "new file in A"
+  echo change >file-in-A && git commit -am "change in A"
+
+  git checkout main
+)
+
+# The remote has a new commit, but is fast-forwardable
+git clone remote remote-advanced-ff
+(cd remote-advanced-ff
+  git checkout -b A origin/A
+  git reset --hard @~1
+
+  create_workspace_commit_once A
+)

--- a/crates/but-workspace/tests/fixtures/scenario/with-remotes-no-workspace.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/with-remotes-no-workspace.sh
@@ -27,14 +27,14 @@ git init remote
   git checkout main
 )
 
-# The remote has a new commit, but is fast-forwardable
+# The remote has a new commit, but is fast-forwardable.
 git clone remote remote-tracking-advanced-ff
 (cd remote-tracking-advanced-ff
   git checkout -b A origin/A
   git reset --hard @~1
 )
 
-# The remote has a new commit, but is fast-forwardable
+# The remote has a new commit, and local has a new commit in an unreconcilable way.
 cp -R remote-tracking-advanced-ff remote-diverged
 (cd remote-diverged
   set_author local-user

--- a/crates/but-workspace/tests/fixtures/scenario/with_remotes_no_workspace.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/with_remotes_no_workspace.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+### General Description
+
+# Various directories with different scenarios for testing stack information without a workspace commit available.
+set -eu -o pipefail
+
+function set_author() {
+  local author=${1:?Author}
+
+  unset GIT_AUTHOR_NAME
+  unset GIT_AUTHOR_EMAIL
+
+  git config user.name $author
+  git config user.email $author@example.com
+}
+
+git init remote
+(cd remote
+  touch file
+  git add . && git commit -m init-integration
+
+  git checkout -b A
+  touch file-in-A && git add . && git commit -m "new file in A"
+  echo change >file-in-A && git commit -am "change in A"
+
+  git checkout main
+)
+
+# The remote has a new commit, but is fast-forwardable
+git clone remote remote-tracking-advanced-ff
+(cd remote-tracking-advanced-ff
+  git checkout -b A origin/A
+  git reset --hard @~1
+)
+
+# The remote has a new commit, but is fast-forwardable
+cp -R remote-tracking-advanced-ff remote-diverged
+(cd remote-diverged
+  set_author local-user
+  echo other-change >file-in-A && git commit -am "local change in A"
+)
+
+git clone remote nothing-to-push
+(cd nothing-to-push
+  git checkout -b A origin/A
+)

--- a/crates/but-workspace/tests/workspace/branch_details.rs
+++ b/crates/but-workspace/tests/workspace/branch_details.rs
@@ -70,7 +70,7 @@ mod with_workspace {
     #[test]
     fn nothing_to_push() -> anyhow::Result<()> {
         let repo =
-            read_only_in_memory_scenario_named("with_remotes_no_workspace", "nothing-to-push")?;
+            read_only_in_memory_scenario_named("with-remotes-no-workspace", "nothing-to-push")?;
 
         insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
         * 89cc2d3 (HEAD -> A, origin/A) change in A
@@ -120,7 +120,7 @@ mod with_workspace {
     #[test]
     fn remote_tracking_advanced_ff() -> anyhow::Result<()> {
         let repo = read_only_in_memory_scenario_named(
-            "with_remotes_no_workspace",
+            "with-remotes-no-workspace",
             "remote-tracking-advanced-ff",
         )?;
         insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
@@ -199,7 +199,7 @@ mod with_workspace {
     #[test]
     fn remote_tracking_diverged() -> anyhow::Result<()> {
         let repo =
-            read_only_in_memory_scenario_named("with_remotes_no_workspace", "remote-diverged")?;
+            read_only_in_memory_scenario_named("with-remotes-no-workspace", "remote-diverged")?;
         insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
         * 1a265a4 (HEAD -> A) local change in A
         | * 89cc2d3 (origin/A) change in A

--- a/crates/but-workspace/tests/workspace/branch_details.rs
+++ b/crates/but-workspace/tests/workspace/branch_details.rs
@@ -1,19 +1,22 @@
 /// All tests have a workspace present.
 mod with_workspace {
-    use crate::utils::read_only_in_memory_scenario;
+    use crate::utils::{read_only_in_memory_scenario, read_only_in_memory_scenario_named};
     use but_core::RefMetadata;
-    use but_core::ref_metadata::{Branch, Workspace};
-    use but_testsupport::visualize_commit_graph;
+    use but_core::ref_metadata::{Branch, RefInfo, Review, Workspace};
+    use but_testsupport::{visualize_commit_graph, visualize_commit_graph_all};
     use gix::refs::{FullName, FullNameRef};
     use std::any::Any;
     use std::ops::{Deref, DerefMut};
 
     fn refname(short_name: &str) -> gix::refs::FullName {
-        format!("refs/heads/{short_name}").try_into().unwrap()
+        if short_name.contains("/") {
+            format!("refs/remotes/{short_name}").try_into().unwrap()
+        } else {
+            format!("refs/heads/{short_name}").try_into().unwrap()
+        }
     }
 
     #[test]
-    #[ignore = "TBD"]
     fn merge_with_two_branches() -> anyhow::Result<()> {
         let repo = read_only_in_memory_scenario("merge-with-two-branches-line-offset")?;
         insta::assert_snapshot!(visualize_commit_graph(&repo, "HEAD")?, @r"
@@ -24,38 +27,276 @@ mod with_workspace {
         |/  
         * ff045ef (main) init
         ");
-        let store = WorkspaceStore::with_target("A");
+        let store = WorkspaceStore::default()
+            .with_target("B")
+            .with_named_branch("A");
         insta::assert_debug_snapshot!(
             but_workspace::branch_details_v3(&repo, refname("A").as_ref(), &store).unwrap(),
-            @r"",
+            @r#"
+        BranchDetails {
+            name: "refs/heads/A",
+            remote_tracking_branch: None,
+            description: Some(
+                "A: description",
+            ),
+            pr_number: Some(
+                42,
+            ),
+            review_id: Some(
+                "uuid",
+            ),
+            tip: Sha1(7f389eda1b366f3d56ecc1300b3835727c3309b6),
+            base_commit: Sha1(ff045efb99e8ee865f0fcded16ffbfff689aa667),
+            push_status: CompletelyUnpushed,
+            last_updated_at: Some(
+                56000,
+            ),
+            authors: [
+                author <author@example.com>,
+                committer <committer@example.com>,
+            ],
+            is_conflicted: true,
+            commits: [
+                Commit(7f389ed, "add 10 to the beginning"),
+            ],
+            upstream_commits: [],
+            is_remote_head: false,
+        }
+        "#,
         );
         Ok(())
     }
 
+    #[test]
+    fn nothing_to_push() -> anyhow::Result<()> {
+        let repo =
+            read_only_in_memory_scenario_named("with_remotes_no_workspace", "nothing-to-push")?;
+
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        * 89cc2d3 (HEAD -> A, origin/A) change in A
+        * d79bba9 new file in A
+        * c166d42 (origin/main, origin/HEAD, main) init-integration
+        ");
+        let store = WorkspaceStore::default()
+            .with_target("main")
+            .with_named_branch("A");
+        insta::assert_debug_snapshot!(but_workspace::branch_details_v3(&repo, refname("A").as_ref(), &store).unwrap(), @r#"
+        BranchDetails {
+            name: "refs/heads/A",
+            remote_tracking_branch: Some(
+                "refs/remotes/origin/A",
+            ),
+            description: Some(
+                "A: description",
+            ),
+            pr_number: Some(
+                42,
+            ),
+            review_id: Some(
+                "uuid",
+            ),
+            tip: Sha1(89cc2d303514654e9cab2d05b9af08b420a740c1),
+            base_commit: Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
+            push_status: NothingToPush,
+            last_updated_at: Some(
+                56000,
+            ),
+            authors: [
+                author <author@example.com>,
+                committer <committer@example.com>,
+            ],
+            is_conflicted: true,
+            commits: [
+                Commit(89cc2d3, "change in A"),
+                Commit(d79bba9, "new file in A"),
+            ],
+            upstream_commits: [],
+            is_remote_head: false,
+        }
+        "#);
+        Ok(())
+    }
+
+    #[test]
+    fn remote_tracking_advanced_ff() -> anyhow::Result<()> {
+        let repo = read_only_in_memory_scenario_named(
+            "with_remotes_no_workspace",
+            "remote-tracking-advanced-ff",
+        )?;
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        * 89cc2d3 (origin/A) change in A
+        * d79bba9 (HEAD -> A) new file in A
+        * c166d42 (origin/main, origin/HEAD, main) init-integration
+        ");
+
+        let store = WorkspaceStore::default()
+            .with_target("main")
+            .with_named_branch("A");
+        insta::assert_debug_snapshot!(but_workspace::branch_details_v3(&repo, refname("A").as_ref(), &store).unwrap(), @r#"
+        BranchDetails {
+            name: "refs/heads/A",
+            remote_tracking_branch: Some(
+                "refs/remotes/origin/A",
+            ),
+            description: Some(
+                "A: description",
+            ),
+            pr_number: Some(
+                42,
+            ),
+            review_id: Some(
+                "uuid",
+            ),
+            tip: Sha1(d79bba960b112dbd25d45921c47eeda22288022b),
+            base_commit: Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
+            push_status: UnpushedCommitsRequiringForce,
+            last_updated_at: Some(
+                56000,
+            ),
+            authors: [
+                author <author@example.com>,
+                committer <committer@example.com>,
+            ],
+            is_conflicted: true,
+            commits: [
+                Commit(d79bba9, "new file in A"),
+            ],
+            upstream_commits: [
+                UpstreamCommit(89cc2d3, "change in A"),
+            ],
+            is_remote_head: false,
+        }
+        "#);
+
+        // Remote tracking branches are OK to use as well.
+        insta::assert_debug_snapshot!(but_workspace::branch_details_v3(&repo, refname("origin/A").as_ref(), &store).unwrap(), @r#"
+        BranchDetails {
+            name: "refs/remotes/origin/A",
+            remote_tracking_branch: None,
+            description: None,
+            pr_number: None,
+            review_id: None,
+            tip: Sha1(89cc2d303514654e9cab2d05b9af08b420a740c1),
+            base_commit: Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
+            push_status: NothingToPush,
+            last_updated_at: None,
+            authors: [
+                author <author@example.com>,
+                committer <committer@example.com>,
+            ],
+            is_conflicted: true,
+            commits: [
+                Commit(89cc2d3, "change in A"),
+                Commit(d79bba9, "new file in A"),
+            ],
+            upstream_commits: [],
+            is_remote_head: true,
+        }
+        "#);
+        Ok(())
+    }
+
+    #[test]
+    fn remote_tracking_diverged() -> anyhow::Result<()> {
+        let repo =
+            read_only_in_memory_scenario_named("with_remotes_no_workspace", "remote-diverged")?;
+        insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+        * 1a265a4 (HEAD -> A) local change in A
+        | * 89cc2d3 (origin/A) change in A
+        |/  
+        * d79bba9 new file in A
+        * c166d42 (origin/main, origin/HEAD, main) init-integration
+        ");
+
+        let store = WorkspaceStore::default()
+            .with_target("main")
+            .with_named_branch("A");
+        insta::assert_debug_snapshot!(but_workspace::branch_details_v3(&repo, refname("A").as_ref(), &store).unwrap(), @r#"
+        BranchDetails {
+            name: "refs/heads/A",
+            remote_tracking_branch: Some(
+                "refs/remotes/origin/A",
+            ),
+            description: Some(
+                "A: description",
+            ),
+            pr_number: Some(
+                42,
+            ),
+            review_id: Some(
+                "uuid",
+            ),
+            tip: Sha1(1a265a4374e58a2d5fc015d8ce3ce92025702273),
+            base_commit: Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
+            push_status: UnpushedCommitsRequiringForce,
+            last_updated_at: Some(
+                56000,
+            ),
+            authors: [
+                author <author@example.com>,
+                committer <committer@example.com>,
+                local-user <local-user@example.com>,
+            ],
+            is_conflicted: true,
+            commits: [
+                Commit(1a265a4, "local change in A"),
+                Commit(d79bba9, "new file in A"),
+            ],
+            upstream_commits: [
+                UpstreamCommit(89cc2d3, "change in A"),
+            ],
+            is_remote_head: false,
+        }
+        "#);
+        Ok(())
+    }
+
+    #[derive(Default)]
     struct WorkspaceStore {
-        workspace: but_core::ref_metadata::Workspace,
+        workspace: Workspace,
+        branches: Vec<(FullName, but_core::ref_metadata::Branch)>,
     }
 
     impl WorkspaceStore {
-        pub fn with_target(short_name: &str) -> Self {
-            WorkspaceStore {
-                workspace: but_core::ref_metadata::Workspace {
-                    ref_info: Default::default(),
-                    stacks: vec![],
-                    target_ref: Some(refname(short_name)),
+        pub fn with_target(mut self, short_name: &str) -> Self {
+            self.workspace = but_core::ref_metadata::Workspace {
+                ref_info: Default::default(),
+                stacks: vec![],
+                target_ref: Some(refname(short_name)),
+            };
+            self
+        }
+
+        pub fn with_branch(mut self, short_name: &str, branch: Branch) -> Self {
+            self.branches.push((refname(short_name), branch));
+            self
+        }
+
+        pub fn with_named_branch(self, short_name: &str) -> Self {
+            let branch = Branch {
+                ref_info: RefInfo {
+                    created_at: None,
+                    updated_at: Some(gix::date::Time::new(56, 0)),
                 },
-            }
+                description: Some(format!("{short_name}: description")),
+                review: Review {
+                    pull_request: Some(42),
+                    review_id: Some("uuid".into()),
+                },
+            };
+            self.with_branch(short_name, branch)
         }
     }
 
     struct NullHandle<T> {
         inner: T,
+        is_default: bool,
         name: FullName,
     }
 
     impl<T> but_core::ref_metadata::ValueInfo for NullHandle<T> {
         fn is_default(&self) -> bool {
-            false
+            self.is_default
         }
     }
 
@@ -89,12 +330,29 @@ mod with_workspace {
         fn workspace(&self, ref_name: &FullNameRef) -> anyhow::Result<Self::Handle<Workspace>> {
             Ok(NullHandle {
                 inner: self.workspace.clone(),
+                is_default: false,
                 name: ref_name.into(),
             })
         }
 
-        fn branch(&self, _ref_name: &FullNameRef) -> anyhow::Result<Self::Handle<Branch>> {
-            unreachable!()
+        fn branch(&self, ref_name: &FullNameRef) -> anyhow::Result<Self::Handle<Branch>> {
+            let mut is_default = true;
+            let inner = self
+                .branches
+                .iter()
+                .find_map(|(name, branch)| {
+                    (name.as_ref() == ref_name).then(|| {
+                        is_default = false;
+                        branch
+                    })
+                })
+                .cloned()
+                .unwrap_or_default();
+            Ok(NullHandle {
+                inner,
+                is_default: true,
+                name: ref_name.into(),
+            })
         }
 
         fn set_workspace(&mut self, _value: &Self::Handle<Workspace>) -> anyhow::Result<()> {

--- a/crates/but-workspace/tests/workspace/head_info.rs
+++ b/crates/but-workspace/tests/workspace/head_info.rs
@@ -17,6 +17,7 @@ fn untracked() -> anyhow::Result<()> {
             Stack {
                 index: 0,
                 tip: None,
+                base: None,
                 segments: [
                     StackSegment {
                         ref_name: Some(
@@ -28,8 +29,7 @@ fn untracked() -> anyhow::Result<()> {
                             AtHead,
                         ),
                         commits_unique_from_tip: [],
-                        commits_unintegratd_local: [],
-                        commits_unintegrated_upstream: [],
+                        commits_unique_in_remote_tracking_branch: [],
                         remote_tracking_ref_name: None,
                         metadata: None,
                     },
@@ -87,6 +87,7 @@ fn single_branch() -> anyhow::Result<()> {
                 tip: Some(
                     Sha1(b5743a3aa79957bcb7f654d7d4ad11d995ad5303),
                 ),
+                base: None,
                 segments: [
                     StackSegment {
                         ref_name: Some(
@@ -98,49 +99,13 @@ fn single_branch() -> anyhow::Result<()> {
                             AtHead,
                         ),
                         commits_unique_from_tip: [
-                            BranchCommit {
-                                id: Sha1(b5743a3aa79957bcb7f654d7d4ad11d995ad5303),
-                                title: "10\n",
-                                committed_date: Time {
-                                    seconds: 946771200,
-                                    offset: 0,
-                                },
-                            },
-                            BranchCommit {
-                                id: Sha1(344e3209e344c1eb90bedb4b00b4d4999a84406c),
-                                title: "9\n",
-                                committed_date: Time {
-                                    seconds: 946771200,
-                                    offset: 0,
-                                },
-                            },
-                            BranchCommit {
-                                id: Sha1(599c271e8734e58a96b3a22666704c2a72623f7f),
-                                title: "8\n",
-                                committed_date: Time {
-                                    seconds: 946771200,
-                                    offset: 0,
-                                },
-                            },
-                            BranchCommit {
-                                id: Sha1(05f069b1c601c098170571bc9fab6966606f8b51),
-                                title: "7\n",
-                                committed_date: Time {
-                                    seconds: 946771200,
-                                    offset: 0,
-                                },
-                            },
-                            BranchCommit {
-                                id: Sha1(c4f2a356d6ed7250bab3dd7c58e1922b95f288c5),
-                                title: "6\n",
-                                committed_date: Time {
-                                    seconds: 946771200,
-                                    offset: 0,
-                                },
-                            },
+                            LocalCommit(b5743a3, "10\n", local),
+                            LocalCommit(344e320, "9\n", local),
+                            LocalCommit(599c271, "8\n", local),
+                            LocalCommit(05f069b, "7\n", local),
+                            LocalCommit(c4f2a35, "6\n", local),
                         ],
-                        commits_unintegratd_local: [],
-                        commits_unintegrated_upstream: [],
+                        commits_unique_in_remote_tracking_branch: [],
                         remote_tracking_ref_name: None,
                         metadata: None,
                     },
@@ -173,6 +138,7 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
                 tip: Some(
                     Sha1(b5743a3aa79957bcb7f654d7d4ad11d995ad5303),
                 ),
+                base: None,
                 segments: [
                     StackSegment {
                         ref_name: Some(
@@ -184,17 +150,9 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
                             AtHead,
                         ),
                         commits_unique_from_tip: [
-                            BranchCommit {
-                                id: Sha1(b5743a3aa79957bcb7f654d7d4ad11d995ad5303),
-                                title: "10\n",
-                                committed_date: Time {
-                                    seconds: 946771200,
-                                    offset: 0,
-                                },
-                            },
+                            LocalCommit(b5743a3, "10\n", local),
                         ],
-                        commits_unintegratd_local: [],
-                        commits_unintegrated_upstream: [],
+                        commits_unique_in_remote_tracking_branch: [],
                         remote_tracking_ref_name: None,
                         metadata: None,
                     },
@@ -208,33 +166,11 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
                             AtHead,
                         ),
                         commits_unique_from_tip: [
-                            BranchCommit {
-                                id: Sha1(344e3209e344c1eb90bedb4b00b4d4999a84406c),
-                                title: "9\n",
-                                committed_date: Time {
-                                    seconds: 946771200,
-                                    offset: 0,
-                                },
-                            },
-                            BranchCommit {
-                                id: Sha1(599c271e8734e58a96b3a22666704c2a72623f7f),
-                                title: "8\n",
-                                committed_date: Time {
-                                    seconds: 946771200,
-                                    offset: 0,
-                                },
-                            },
-                            BranchCommit {
-                                id: Sha1(05f069b1c601c098170571bc9fab6966606f8b51),
-                                title: "7\n",
-                                committed_date: Time {
-                                    seconds: 946771200,
-                                    offset: 0,
-                                },
-                            },
+                            LocalCommit(344e320, "9\n", local),
+                            LocalCommit(599c271, "8\n", local),
+                            LocalCommit(05f069b, "7\n", local),
                         ],
-                        commits_unintegratd_local: [],
-                        commits_unintegrated_upstream: [],
+                        commits_unique_in_remote_tracking_branch: [],
                         remote_tracking_ref_name: None,
                         metadata: None,
                     },
@@ -248,33 +184,11 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
                             AtHead,
                         ),
                         commits_unique_from_tip: [
-                            BranchCommit {
-                                id: Sha1(c4f2a356d6ed7250bab3dd7c58e1922b95f288c5),
-                                title: "6\n",
-                                committed_date: Time {
-                                    seconds: 946771200,
-                                    offset: 0,
-                                },
-                            },
-                            BranchCommit {
-                                id: Sha1(44c12cef1e9fa109b2516079cb1f849049af3cbf),
-                                title: "5\n",
-                                committed_date: Time {
-                                    seconds: 946771200,
-                                    offset: 0,
-                                },
-                            },
-                            BranchCommit {
-                                id: Sha1(c584dbe79d5ef9d630d006957b3b657cee1e80df),
-                                title: "4\n",
-                                committed_date: Time {
-                                    seconds: 946771200,
-                                    offset: 0,
-                                },
-                            },
+                            LocalCommit(c4f2a35, "6\n", local),
+                            LocalCommit(44c12ce, "5\n", local),
+                            LocalCommit(c584dbe, "4\n", local),
                         ],
-                        commits_unintegratd_local: [],
-                        commits_unintegrated_upstream: [],
+                        commits_unique_in_remote_tracking_branch: [],
                         remote_tracking_ref_name: None,
                         metadata: None,
                     },
@@ -288,25 +202,10 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
                             AtHead,
                         ),
                         commits_unique_from_tip: [
-                            BranchCommit {
-                                id: Sha1(281da9454d5b41844d28e453e80b24925a7c8c7a),
-                                title: "3\n",
-                                committed_date: Time {
-                                    seconds: 946771200,
-                                    offset: 0,
-                                },
-                            },
-                            BranchCommit {
-                                id: Sha1(12995d783f3ac841a1774e9433ee8e4c1edac576),
-                                title: "2\n",
-                                committed_date: Time {
-                                    seconds: 946771200,
-                                    offset: 0,
-                                },
-                            },
+                            LocalCommit(281da94, "3\n", local),
+                            LocalCommit(12995d7, "2\n", local),
                         ],
-                        commits_unintegratd_local: [],
-                        commits_unintegrated_upstream: [],
+                        commits_unique_in_remote_tracking_branch: [],
                         remote_tracking_ref_name: None,
                         metadata: None,
                     },
@@ -320,17 +219,9 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
                             AtHead,
                         ),
                         commits_unique_from_tip: [
-                            BranchCommit {
-                                id: Sha1(3d57fc18d679a1ba45bc7f79e394a5e2606719ee),
-                                title: "1\n",
-                                committed_date: Time {
-                                    seconds: 946771200,
-                                    offset: 0,
-                                },
-                            },
+                            LocalCommit(3d57fc1, "1\n", local),
                         ],
-                        commits_unintegratd_local: [],
-                        commits_unintegrated_upstream: [],
+                        commits_unique_in_remote_tracking_branch: [],
                         remote_tracking_ref_name: None,
                         metadata: None,
                     },

--- a/crates/but-workspace/tests/workspace/head_info/mod.rs
+++ b/crates/but-workspace/tests/workspace/head_info/mod.rs
@@ -1,6 +1,9 @@
 use crate::head_info::utils::read_only_in_memory_scenario;
 use but_workspace::head_info;
 
+/// All tests that use a workspace commit for a fully managed, explicit workspace.
+mod with_workspace_commit;
+
 #[test]
 fn untracked() -> anyhow::Result<()> {
     let (repo, meta) = read_only_in_memory_scenario("unborn-untracked")?;
@@ -9,6 +12,7 @@ fn untracked() -> anyhow::Result<()> {
         &*meta,
         head_info::Options {
             stack_commit_limit: 5,
+            expensive_commit_info: true,
         },
     )?;
     insta::assert_debug_snapshot!(&info, @r#"
@@ -20,17 +24,11 @@ fn untracked() -> anyhow::Result<()> {
                 base: None,
                 segments: [
                     StackSegment {
-                        ref_name: Some(
-                            FullName(
-                                "refs/heads/main",
-                            ),
-                        ),
-                        ref_location: Some(
-                            AtHead,
-                        ),
+                        ref_name: "refs/heads/main",
+                        remote_tracking_ref_name: "None",
+                        ref_location: "AtHead",
                         commits_unique_from_tip: [],
                         commits_unique_in_remote_tracking_branch: [],
-                        remote_tracking_ref_name: None,
                         metadata: None,
                     },
                 ],
@@ -46,13 +44,7 @@ fn untracked() -> anyhow::Result<()> {
 #[test]
 fn detached() -> anyhow::Result<()> {
     let (repo, meta) = read_only_in_memory_scenario("one-commit-detached")?;
-    let info = but_workspace::head_info(
-        &repo,
-        &*meta,
-        head_info::Options {
-            stack_commit_limit: 0,
-        },
-    )?;
+    let info = but_workspace::head_info(&repo, &*meta, head_info::Options::default())?;
     insta::assert_debug_snapshot!(&info, @r"
     HeadInfo {
         stacks: [],
@@ -67,7 +59,14 @@ fn single_branch() -> anyhow::Result<()> {
     let (repo, meta) = read_only_in_memory_scenario("single-branch-10-commits")?;
     let stack_commit_limit = 5;
 
-    let info = but_workspace::head_info(&repo, &*meta, head_info::Options { stack_commit_limit })?;
+    let info = but_workspace::head_info(
+        &repo,
+        &*meta,
+        head_info::Options {
+            stack_commit_limit,
+            expensive_commit_info: true,
+        },
+    )?;
 
     assert_eq!(
         info.stacks[0].segments.len(),
@@ -90,14 +89,9 @@ fn single_branch() -> anyhow::Result<()> {
                 base: None,
                 segments: [
                     StackSegment {
-                        ref_name: Some(
-                            FullName(
-                                "refs/heads/main",
-                            ),
-                        ),
-                        ref_location: Some(
-                            AtHead,
-                        ),
+                        ref_name: "refs/heads/main",
+                        remote_tracking_ref_name: "None",
+                        ref_location: "AtHead",
                         commits_unique_from_tip: [
                             LocalCommit(b5743a3, "10\n", local),
                             LocalCommit(344e320, "9\n", local),
@@ -106,7 +100,6 @@ fn single_branch() -> anyhow::Result<()> {
                             LocalCommit(c4f2a35, "6\n", local),
                         ],
                         commits_unique_in_remote_tracking_branch: [],
-                        remote_tracking_ref_name: None,
                         metadata: None,
                     },
                 ],
@@ -127,6 +120,7 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
         &*meta,
         head_info::Options {
             stack_commit_limit: 0,
+            expensive_commit_info: true,
         },
     )?;
 
@@ -141,88 +135,58 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
                 base: None,
                 segments: [
                     StackSegment {
-                        ref_name: Some(
-                            FullName(
-                                "refs/heads/main",
-                            ),
-                        ),
-                        ref_location: Some(
-                            AtHead,
-                        ),
+                        ref_name: "refs/heads/main",
+                        remote_tracking_ref_name: "None",
+                        ref_location: "AtHead",
                         commits_unique_from_tip: [
                             LocalCommit(b5743a3, "10\n", local),
                         ],
                         commits_unique_in_remote_tracking_branch: [],
-                        remote_tracking_ref_name: None,
                         metadata: None,
                     },
                     StackSegment {
-                        ref_name: Some(
-                            FullName(
-                                "refs/heads/nine",
-                            ),
-                        ),
-                        ref_location: Some(
-                            AtHead,
-                        ),
+                        ref_name: "refs/heads/nine",
+                        remote_tracking_ref_name: "None",
+                        ref_location: "AtHead",
                         commits_unique_from_tip: [
                             LocalCommit(344e320, "9\n", local),
                             LocalCommit(599c271, "8\n", local),
                             LocalCommit(05f069b, "7\n", local),
                         ],
                         commits_unique_in_remote_tracking_branch: [],
-                        remote_tracking_ref_name: None,
                         metadata: None,
                     },
                     StackSegment {
-                        ref_name: Some(
-                            FullName(
-                                "refs/heads/six",
-                            ),
-                        ),
-                        ref_location: Some(
-                            AtHead,
-                        ),
+                        ref_name: "refs/heads/six",
+                        remote_tracking_ref_name: "None",
+                        ref_location: "AtHead",
                         commits_unique_from_tip: [
                             LocalCommit(c4f2a35, "6\n", local),
                             LocalCommit(44c12ce, "5\n", local),
                             LocalCommit(c584dbe, "4\n", local),
                         ],
                         commits_unique_in_remote_tracking_branch: [],
-                        remote_tracking_ref_name: None,
                         metadata: None,
                     },
                     StackSegment {
-                        ref_name: Some(
-                            FullName(
-                                "refs/heads/three",
-                            ),
-                        ),
-                        ref_location: Some(
-                            AtHead,
-                        ),
+                        ref_name: "refs/heads/three",
+                        remote_tracking_ref_name: "None",
+                        ref_location: "AtHead",
                         commits_unique_from_tip: [
                             LocalCommit(281da94, "3\n", local),
                             LocalCommit(12995d7, "2\n", local),
                         ],
                         commits_unique_in_remote_tracking_branch: [],
-                        remote_tracking_ref_name: None,
                         metadata: None,
                     },
                     StackSegment {
-                        ref_name: Some(
-                            FullName(
-                                "refs/heads/one",
-                            ),
-                        ),
-                        ref_location: Some(
-                            AtHead,
-                        ),
+                        ref_name: "refs/heads/one",
+                        remote_tracking_ref_name: "None",
+                        ref_location: "AtHead",
                         commits_unique_from_tip: [
                             LocalCommit(3d57fc1, "1\n", local),
                         ],
                         commits_unique_in_remote_tracking_branch: [],
-                        remote_tracking_ref_name: None,
                         metadata: None,
                     },
                 ],
@@ -246,7 +210,17 @@ mod utils {
         gix::Repository,
         std::mem::ManuallyDrop<VirtualBranchesTomlMetadata>,
     )> {
-        let repo = crate::utils::read_only_in_memory_scenario(name)?;
+        named_read_only_in_memory_scenario(name, "")
+    }
+
+    pub fn named_read_only_in_memory_scenario(
+        script: &str,
+        name: &str,
+    ) -> anyhow::Result<(
+        gix::Repository,
+        std::mem::ManuallyDrop<VirtualBranchesTomlMetadata>,
+    )> {
+        let repo = crate::utils::read_only_in_memory_scenario_named(script, name)?;
         let meta = VirtualBranchesTomlMetadata::from_path(
             repo.path()
                 .join(".git")

--- a/crates/but-workspace/tests/workspace/head_info/with_workspace_commit.rs
+++ b/crates/but-workspace/tests/workspace/head_info/with_workspace_commit.rs
@@ -1,0 +1,86 @@
+#[test]
+fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
+    let (repo, meta) = read_only_in_memory_scenario("remote-advanced-ff")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * fb27086 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | * 89cc2d3 (origin/A) change in A
+    |/  
+    * d79bba9 (A) new file in A
+    * c166d42 (origin/main, origin/HEAD, main) init-integration
+    ");
+
+    // TODO: set metadata
+    let info = head_info(
+        &repo,
+        &*meta,
+        head_info::Options {
+            stack_commit_limit: 0,
+            expensive_commit_info: true,
+        },
+    )?;
+    insta::assert_debug_snapshot!(info, @r#"
+    HeadInfo {
+        stacks: [
+            Stack {
+                index: 0,
+                tip: Some(
+                    Sha1(d79bba960b112dbd25d45921c47eeda22288022b),
+                ),
+                base: Some(
+                    Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
+                ),
+                segments: [
+                    StackSegment {
+                        ref_name: "refs/heads/A",
+                        remote_tracking_ref_name: "None",
+                        ref_location: "ReachableFromWorkspaceCommit",
+                        commits_unique_from_tip: [
+                            LocalCommit(d79bba9, "new file in A\n", local/remote(identity)),
+                        ],
+                        commits_unique_in_remote_tracking_branch: [
+                            RemoteCommit(89cc2d3, "change in A\n",
+                        ],
+                        metadata: None,
+                    },
+                ],
+                stash_status: None,
+            },
+        ],
+        target_ref: Some(
+            FullName(
+                "refs/remotes/origin/main",
+            ),
+        ),
+    }
+    "#);
+    Ok(())
+}
+
+mod utils {
+    use crate::head_info::utils::named_read_only_in_memory_scenario;
+    use but_workspace::VirtualBranchesTomlMetadata;
+
+    pub fn read_only_in_memory_scenario(
+        name: &str,
+    ) -> anyhow::Result<(
+        gix::Repository,
+        std::mem::ManuallyDrop<VirtualBranchesTomlMetadata>,
+    )> {
+        let (repo, mut meta) =
+            named_read_only_in_memory_scenario("with-remotes-and-workspace", name)?;
+        let vb = meta.data_mut();
+        vb.default_target = Some(gitbutler_stack::Target {
+            // For simplicity, we stick to the defaults.
+            branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
+            // Not required
+            remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
+            sha: git2::Oid::zero(),
+            push_remote_name: None,
+        });
+        Ok((repo, meta))
+    }
+}
+
+use but_testsupport::visualize_commit_graph_all;
+use but_workspace::head_info;
+use utils::read_only_in_memory_scenario;

--- a/crates/but-workspace/tests/workspace/utils.rs
+++ b/crates/but-workspace/tests/workspace/utils.rs
@@ -27,11 +27,19 @@ fn writable_scenario_inner(
 
 /// Provide a scenario but assure the returned repository will write objects to memory.
 pub fn read_only_in_memory_scenario(name: &str) -> anyhow::Result<gix::Repository> {
-    let root = gix_testtools::scripted_fixture_read_only(format!("scenario/{name}.sh"))
+    read_only_in_memory_scenario_named(name, "")
+}
+
+/// Provide a scenario but assure the returned repository will write objects to memory, in a subdirectory `dirname`.
+pub fn read_only_in_memory_scenario_named(
+    script_name: &str,
+    dirname: &str,
+) -> anyhow::Result<gix::Repository> {
+    let root = gix_testtools::scripted_fixture_read_only(format!("scenario/{script_name}.sh"))
         .map_err(anyhow::Error::from_boxed)?;
     let mut options = gix::open::Options::isolated();
     options.permissions.env = gix::open::permissions::Environment::all();
-    let repo = gix::open_opts(root, options)?.with_object_memory();
+    let repo = gix::open_opts(root.join(dirname), options)?.with_object_memory();
     Ok(repo)
 }
 

--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -31,7 +31,7 @@ pub fn stacks(
 ) -> Result<Vec<StackEntry>, Error> {
     let project = projects.get(project_id)?;
     let ctx = CommandContext::open(&project, settings.get()?.clone())?;
-    let repo = ctx.gix_repo()?;
+    let repo = ctx.gix_repo_for_merging_non_persisting()?;
     if ctx.app_settings().feature_flags.ws3 {
         let meta = ref_metadata_toml(ctx.project())?;
         but_workspace::stacks_v3(&repo, &meta, filter.unwrap_or_default())
@@ -52,7 +52,7 @@ pub fn stack_details(
     let project = projects.get(project_id)?;
     let ctx = CommandContext::open(&project, settings.get()?.clone())?;
     if ctx.app_settings().feature_flags.ws3 {
-        let repo = ctx.gix_repo()?;
+        let repo = ctx.gix_repo_for_merging_non_persisting()?;
         let meta = ref_metadata_toml(ctx.project())?;
         but_workspace::stack_details_v3(stack_id, &repo, &meta)
     } else {
@@ -73,7 +73,7 @@ pub fn branch_details(
     let project = projects.get(project_id)?;
     let ctx = CommandContext::open(&project, settings.get()?.clone())?;
     if ctx.app_settings().feature_flags.ws3 {
-        let repo = ctx.gix_repo()?;
+        let repo = ctx.gix_repo_for_merging_non_persisting()?;
         let meta = ref_metadata_toml(ctx.project())?;
         let ref_name: gix::refs::FullName = match remote {
             None => {

--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -9,13 +9,13 @@ use but_hunk_dependency::ui::{
 use but_settings::AppSettingsWithDiskSync;
 use but_workspace::commit_engine::StackSegmentId;
 use but_workspace::MoveChangesResult;
-use but_workspace::{commit_engine, ui::StackEntry};
+use but_workspace::{commit_engine, ui::StackEntry, VirtualBranchesTomlMetadata};
 use gitbutler_branch_actions::{update_workspace_commit, BranchManagerExt};
 use gitbutler_command_context::CommandContext;
 use gitbutler_oplog::entry::{OperationKind, SnapshotDetails};
 use gitbutler_oplog::{OplogExt, SnapshotExt};
 use gitbutler_project as projects;
-use gitbutler_project::ProjectId;
+use gitbutler_project::{Project, ProjectId};
 use gitbutler_stack::{StackId, VirtualBranchesHandle};
 use serde::Serialize;
 use tauri::State;
@@ -32,8 +32,13 @@ pub fn stacks(
     let project = projects.get(project_id)?;
     let ctx = CommandContext::open(&project, settings.get()?.clone())?;
     let repo = ctx.gix_repo()?;
-    but_workspace::stacks(&ctx, &project.gb_dir(), &repo, filter.unwrap_or_default())
-        .map_err(Into::into)
+    if ctx.app_settings().feature_flags.ws3 {
+        let meta = ref_metadata_toml(ctx.project())?;
+        but_workspace::stacks_v3(&repo, &meta, filter.unwrap_or_default())
+    } else {
+        but_workspace::stacks(&ctx, &project.gb_dir(), &repo, filter.unwrap_or_default())
+    }
+    .map_err(Into::into)
 }
 
 #[tauri::command(async)]
@@ -46,7 +51,14 @@ pub fn stack_details(
 ) -> Result<but_workspace::ui::StackDetails, Error> {
     let project = projects.get(project_id)?;
     let ctx = CommandContext::open(&project, settings.get()?.clone())?;
-    but_workspace::stack_details(&project.gb_dir(), stack_id, &ctx).map_err(Into::into)
+    if ctx.app_settings().feature_flags.ws3 {
+        let repo = ctx.gix_repo()?;
+        let meta = ref_metadata_toml(ctx.project())?;
+        but_workspace::stack_details_v3(stack_id, &repo, &meta)
+    } else {
+        but_workspace::stack_details(&project.gb_dir(), stack_id, &ctx)
+    }
+    .map_err(Into::into)
 }
 
 #[tauri::command(async)]
@@ -60,7 +72,28 @@ pub fn branch_details(
 ) -> Result<but_workspace::ui::BranchDetails, Error> {
     let project = projects.get(project_id)?;
     let ctx = CommandContext::open(&project, settings.get()?.clone())?;
-    but_workspace::branch_details(&project.gb_dir(), branch_name, remote, &ctx).map_err(Into::into)
+    if ctx.app_settings().feature_flags.ws3 {
+        let repo = ctx.gix_repo()?;
+        let meta = ref_metadata_toml(ctx.project())?;
+        let ref_name: gix::refs::FullName = match remote {
+            None => {
+                format!("refs/heads/{branch_name}")
+            }
+            Some(remote) => {
+                format!("refs/remotes/{remote}/{branch_name}")
+            }
+        }
+        .try_into()
+        .map_err(anyhow::Error::from)?;
+        but_workspace::branch_details_v3(&repo, ref_name.as_ref(), &meta)
+    } else {
+        but_workspace::branch_details(&project.gb_dir(), branch_name, remote, &ctx)
+    }
+    .map_err(Into::into)
+}
+
+fn ref_metadata_toml(project: &Project) -> anyhow::Result<VirtualBranchesTomlMetadata> {
+    VirtualBranchesTomlMetadata::from_path(project.gb_dir().join("virtual_branches.toml"))
 }
 
 /// Retrieve all changes in the workspace and associate them with commits in the Workspace of `project_id`.


### PR DESCRIPTION
A first implementation of `head_info()` to provide information about where the user currently is.
It presents the world as a workspace with stacks, even though technically it might not exist.`

Follow-up on #8422.

* [x] prevent non-workspace cases (or assure that the new system doesn't get to show them)
    - [x] figure out how it knows that one moved away from GitButler workspace
        - `operating_mode()` is called when the workspace branch changes, which tells the UI it's not on the right branch. So no need to alter the current implementation.
* [ ] `heads_info` with workspace cases - reflect what's currently possible
    - [ ] determine if local commits are integrated
* [x] research on how to Integrate new `heads_info()` with current API interface
    - [x] move UI types into `ui` modules
    - [x] check if current data is sufficient to provide all that's needed to current API
        -  ~~`get_base_branch_data()`~~ (skipped), `stacks()`, `stack_details()`
* [ ] implement intermediate V3 versions of these functions 
    - [x] `stacks_v3()`
        - [ ] basic test (needs heads-info test setup)
    - [x] `branch_details_v3()`
    - [x] `stack_details_v3()`
        - [ ] basic test derived from `head_info`, particularly tests for the push status.
* [x] make use of `stacks_v3` and `stack_details_v3()` in tauri via feature toggle

## Notable changes to the Datamodel

* Upstream commits can also be integrated. This would happen if the local tracking branch has not caught up to them, and all of them are integrated. This also means that everything local could be unintegrated, but upstream-only commits are integrated, something that can happen if everything is diverged. If both disagree, it's unclear what to do.

## Notes for the Reviewer

* This is a transitory PR that replaces VirtualBranchesToml with the RefMetadata trait to prepare the code to transition to other data stores.
* The code is clearly transitory while `StackId`  is still a thing - in the new world stacks or stack-segments are referred to by their reference name or by their index in the parent-list of the top-level merge commit (if there is one).
* Ideally, one the UI will be able to make just one `heads_info` call, and can consume the data directly (even though it may have been processed to further facilitate consumption).
* `branch_details()` already works on references
* `BranchDetails` are probably the data structure of choice for the UI, and it's just the question if there is stack information or not.
* There is no notion of using stacks in branch listings outside of what we are currently looking at, i.e. where `HEAD` is. Thus, for this we will probably keep using branch details of sort.

## Next PR

- intermediate V3 version of `get_base_branch_data()`.

### Follow Up Tasks

* [ ] first non-workspace cases
    - [ ] merge commit
    - [ ] merge commit stacked
    - [ ] stacks and ambiguous stack references (i.e. lots of empty stack segments)

### Next PRs

* head-info, stacks and details API with key scenarios
* graph-based integration checks with target and remote
* **use `hide()` in places where merge-commits are used as boundary.**
    - This shouldn't be a major problem for simple topologies, but is certainly an issue for more complex ones.
* integration checking with target
* integration checking with remote tracking branch

### Known Shortcomings (for now)

* ⚠️ `first_parent_only` maybe a good simplification for display, but I wonder if there are side-effects like us not seeing commits that could participate in commit-status check.
* ⚠️ Commit-classification is hacky and undertested  right now⚠️
* One probably wants to show all refs at a position (or indicate there are more)
* ⚠️ rebase engine needs a way to know which parent to rewrite if there are two parents pointing to the same commit in a starting configuration with two stacks at the same commit. Alternatively, `create_commit` would have to create a workspace commit, which seems worse than adding a WS commit in the moment there are two stacks.
* ⚠️ **merge conflicts** are created from either cherry-picks or normal merges (legacy?), but cherry-pick would need to know that to either choose the auto-resolution. That's OK as long as the 'old' merge-commit isn't run as it would create a semantically different tree-setup in the conflicted commit.
* ⚠️ **commit listing** are ambiguous
    - Certain less common but possible branch configuration make ambiguous to assign commits to one branch or another. It won't be super trivial to make this work right.
* ⚠️Even though Git does not list *namespaced references*, `tig` will happily list everything. `set reference-format = hide:other` fixes this though
* empty commits aren't specifically highlighted when rebasing, or handled or prevented. The UI could detect that and show them.
* Moving hunks or files will need multi-branch rebases with merge-commit handling. This can be added to the rebase engine as we know it today. This will also enable worktree-updates.
* reordering in such a way that only heads a moved and nothing else happens (in terms of commit rewrites) probably wouldn't work yet in `but-rebase`.
* Index adjustments (tree to disk index) lack a lot of tests, particularly those for automatic conflict removal.
* if changes are added to the wrong spot, then they may apply cleanly *and* yield different results after merging, so the worktree differs from what's in Git. This is where hunk-dependencies/auto-hunk-splitting comes into play.
* Right now sub-hunks can't be selected as they won't match when it tries to find exact matches. However, that check could be changed to a 'contains' or 'is-included' to allow sub-hunks. Maybe this doesn't naturally work though or do the right thing.
* Workspace commits with a single branch will get signed if they were signed before. This shouldn't be a real problem, and ideally it will go away soon enough.


### For follow-up PRs

In any order (probably)

* Rebase-engine with insert empty commit (below and above, insert as first parent support)
* What happens in Git if one rebases non-linear branches? Can it retain the structure?
    - Rebase engine probably has to learn to re-schedule picks (and remember the base, a feature useful for multi-stacks as well, which then wouldn't need a special case anymore)
* ~~move file out of commit into worktree (uncommit something)~~
* ~~per-hunk exclusion if hunk didn't match (right now it rejects the whole file)~~
* run hooks on an index created from the tree that would be committed.
* move hunks from one commit into another


### Out of scope

* **hunk-dependencies**
    - These should be added once the commit-engine is feature-complete, the idea is that the UI can function well enough without them as a baseline.
* **atomic object writes**
    - In theory, new objects should only be written to disk if they actually end up in a tree. For instance, if a change is rejected, the object associated with it shouldn't be in the object database.
    - However, even though implementing this with the in-memory object feature is very possible, it feels like an optimization for another day. In general, I really think only objects that end up in a tree should actually be written, so that the implementation doesn't have to rely on `git gc` to cleanup.


<details><summary>Archive</summary>


## Conversion check

Does the new types have enough information to provide what's needed to the UI?

### Stack
- `stack_id` (deprecated, maybe emulated with workaround to map an index to an id maybe)
- `heads`
    - `name` ✓
    - `tip` ✓

### Stack Details
- derived_name ✓ (stack name, top-most branch in stack)
- push_status (enum) (derived)
- is_conflicted (has a conflicting commit somewhere) (derived)
- branch details
    - name ✓
    - remote_tracking_branch ✓ (from `Stack::upstream`, but it's deduced seemingly)
    - description ✓
    - pr_number ✓
    - review_id ✓
    - tip ✓
    - base_commit (derived)
    - push_status: (derived with remote tracking branch)
    - last_updated_at (from RefInfo::updated_at ✓)
    - authors: Vec<Author> ✓
    - is_conflicted ✓
    - commits: Vec<Commit> ✓
    - upstream_commits: Vec<UpstreamCommit> ✓
    - is_remote_head ✓

### Commit 
- id ✓
- parent_ids ✓
- message ✓
- has_conflicts ✓
- state: CommitState (derived)
- created_at ✓
- author: Author ✓

### CommitState

All derived once the commit-analysis is done

- LocalOnly (derived)
- LocalAndRemote(id) (derived)
- Integrated (derived)

### UpstreamCommit

- id ✓
- message ✓
- created_at ✓
- author ✓

### Author

- name ✓
- email ✓
- gravatar_url ✓

</details>




