### PR TITLE
Fix selecting a remote commit

### DIFF
--- a/apps/desktop/src/components/v3/BranchesViewBranch.svelte
+++ b/apps/desktop/src/components/v3/BranchesViewBranch.svelte
@@ -52,7 +52,8 @@
 					onclick={() => {
 						branchesState.current = {
 							branchName,
-							stackId: env.stackId
+							stackId: env.stackId,
+							remote
 						};
 					}}
 				/>
@@ -72,7 +73,8 @@
 							branchesState.set({
 								stackId: env.stackId,
 								branchName: branch.name,
-								commitId: commit.id
+								commitId: commit.id,
+								remote
 							});
 						}}
 						lastCommit={idx === branch.upstreamCommits.length - 1 && branch.commits.length === 0}
@@ -92,7 +94,8 @@
 							branchesState.set({
 								stackId: env.stackId,
 								branchName: branch.name,
-								commitId: commit.id
+								commitId: commit.id,
+								remote
 							});
 						}}
 						lastCommit={idx === branch.commits.length - 1}


### PR DESCRIPTION
We were not passing along the remote information to the selection
object.