### PR TITLE
feat(forge): add temporary workaround for GitLab domain

### DIFF
--- a/apps/desktop/src/lib/forge/forgeFactory.svelte.ts
+++ b/apps/desktop/src/lib/forge/forgeFactory.svelte.ts
@@ -93,7 +93,11 @@ export class DefaultForgeFactory implements Reactive<Forge> {
 				authenticated: !!githubAuthenticated
 			});
 		}
-		if (domain === GITLAB_DOMAIN || domain.startsWith(GITLAB_SUB_DOMAIN + '.')) {
+		if (
+			domain === GITLAB_DOMAIN ||
+			domain.startsWith(GITLAB_SUB_DOMAIN + '.') ||
+			domain.startsWith('xy' + GITLAB_SUB_DOMAIN + '.') // Temporary workaround until we have foerge overrides implemented
+		) {
 			const { gitLabClient, gitLabApi, posthog } = this.params;
 			return new GitLab({
 				...baseParams,


### PR DESCRIPTION
Adds a temporary workaround to handle a specific GitLab domain
that does not match the standard pattern. This is a temporary
solution until a more robust override mechanism is implemented
for the Forge integration.