### PR TITLE
Refactor but-workspace DiffSpec type

### DIFF
--- a/crates/but-cli/src/command/mod.rs
+++ b/crates/but-cli/src/command/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, anyhow, bail};
 use but_core::UnifiedDiff;
-use but_workspace::commit_engine::{DiffSpec, HunkHeader};
+use but_workspace::{DiffSpec, HunkHeader};
 use gitbutler_project::Project;
 use gix::bstr::{BString, ByteSlice};
 use std::path::Path;
@@ -101,8 +101,8 @@ fn project_controller(
 pub fn parse_diff_spec(arg: &Option<String>) -> Result<Option<Vec<DiffSpec>>, anyhow::Error> {
     arg.as_deref()
         .map(|value| {
-            serde_json::from_str::<Vec<but_workspace::commit_engine::ui::DiffSpec>>(value)
-                .map(|diff_spec| diff_spec.into_iter().map(Into::into).collect())
+            serde_json::from_str::<Vec<but_workspace::DiffSpec>>(value)
+                .map(|diff_spec| diff_spec.into_iter().collect())
                 .map_err(|e| anyhow!("Failed to parse diff_spec: {}", e))
         })
         .transpose()
@@ -313,9 +313,9 @@ pub(crate) fn discard_change(
         &path,
         previous_path.as_ref(),
     )?;
-    let spec = but_workspace::commit_engine::DiffSpec {
-        previous_path,
-        path,
+    let spec = but_workspace::DiffSpec {
+        previous_path_bytes: previous_path,
+        path_bytes: path,
         hunk_headers,
     };
     debug_print(but_workspace::discard_workspace_changes(

--- a/crates/but-cli/src/command/mod.rs
+++ b/crates/but-cli/src/command/mod.rs
@@ -320,7 +320,7 @@ pub(crate) fn discard_change(
     };
     debug_print(but_workspace::discard_workspace_changes(
         &repo,
-        Some(spec.into()),
+        Some(spec),
         UI_CONTEXT_LINES,
     )?)
 }

--- a/crates/but-workspace/src/commit_engine/hunks.rs
+++ b/crates/but-workspace/src/commit_engine/hunks.rs
@@ -1,4 +1,4 @@
-use crate::commit_engine::{HunkHeader, HunkRange};
+use crate::{HunkHeader, commit_engine::HunkRange};
 use anyhow::Context;
 use bstr::{BStr, BString, ByteSlice};
 use but_core::unified_diff::DiffHunk;

--- a/crates/but-workspace/src/commit_engine/tree/mod.rs
+++ b/crates/but-workspace/src/commit_engine/tree/mod.rs
@@ -1,6 +1,5 @@
-use crate::commit_engine::{
-    Destination, DiffSpec, HunkHeader, MoveSourceCommit, RejectionReason, apply_hunks,
-};
+use crate::commit_engine::{Destination, MoveSourceCommit, RejectionReason, apply_hunks};
+use crate::{DiffSpec, HunkHeader};
 use bstr::{BStr, ByteSlice};
 use but_core::{RepositoryExt, UnifiedDiff};
 use gix::filter::plumbing::pipeline::convert::ToGitOutcome;
@@ -114,7 +113,7 @@ pub fn create_tree(
                 if !unresolved_conflicts.is_empty() {
                     for change in changes.iter_mut().filter(|c| {
                         c.as_ref().ok().is_some_and(|change| {
-                            unresolved_conflicts.contains(&change.path.as_bstr())
+                            unresolved_conflicts.contains(&change.path_bytes.as_bstr())
                         })
                     }) {
                         into_err_spec(change, RejectionReason::CherryPickMergeConflict);
@@ -178,21 +177,25 @@ fn apply_worktree_changes<'repo>(
             Ok(change) => change,
             Err(_) => continue,
         };
-        let path = work_dir.join(gix::path::from_bstr(change_request.path.as_bstr()));
+        let path = work_dir.join(gix::path::from_bstr(change_request.path_bytes.as_bstr()));
         let md = match gix::index::fs::Metadata::from_path_no_follow(&path) {
             Ok(md) => md,
             Err(err) if gix::fs::io_err::is_not_found(err.kind(), err.raw_os_error()) => {
-                base_tree_editor.remove(change_request.path.as_bstr())?;
+                base_tree_editor.remove(change_request.path_bytes.as_bstr())?;
                 continue;
             }
             Err(err) => return Err(err.into()),
         };
         // NOTE: See copy below!
-        if let Some(previous_path) = change_request.previous_path.as_ref().map(|p| p.as_bstr()) {
+        if let Some(previous_path) = change_request
+            .previous_path_bytes
+            .as_ref()
+            .map(|p| p.as_bstr())
+        {
             base_tree_editor.remove(previous_path)?;
         }
         if change_request.hunk_headers.is_empty() {
-            let rela_path = change_request.path.as_bstr();
+            let rela_path = change_request.path_bytes.as_bstr();
             match pipeline.worktree_file_to_object(rela_path, &index)? {
                 Some((id, kind, _fs_metadata)) => {
                     base_tree_editor.upsert(rela_path, kind, id)?;
@@ -204,9 +207,12 @@ fn apply_worktree_changes<'repo>(
             }
         } else if let Some(worktree_changes) = &worktree_changes {
             let Some(worktree_change) = worktree_changes.iter().find(|c| {
-                c.path == change_request.path
+                c.path == change_request.path_bytes
                     && c.previous_path()
-                        == change_request.previous_path.as_ref().map(|p| p.as_bstr())
+                        == change_request
+                            .previous_path_bytes
+                            .as_ref()
+                            .map(|p| p.as_bstr())
             }) else {
                 into_err_spec(possible_change, RejectionReason::NoEffectiveChanges);
                 continue;
@@ -262,7 +268,7 @@ fn apply_worktree_changes<'repo>(
                 .previous_state_and_path()
                 .map(|(state, maybe_path)| (Some(state), maybe_path))
                 .unwrap_or_default();
-            let base_rela_path = previous_path.unwrap_or(change_request.path.as_bstr());
+            let base_rela_path = previous_path.unwrap_or(change_request.path_bytes.as_bstr());
             let current_entry_kind = if md.is_symlink() {
                 EntryKind::Link
             } else if md.is_file() {
@@ -307,7 +313,7 @@ fn apply_worktree_changes<'repo>(
             )?;
             let blob_with_selected_patches = repo.write_blob(base_with_patches.as_slice())?;
             base_tree_editor.upsert(
-                change_request.path.as_bstr(),
+                change_request.path_bytes.as_bstr(),
                 current_entry_kind,
                 blob_with_selected_patches,
             )?;

--- a/crates/but-workspace/src/commit_engine/ui.rs
+++ b/crates/but-workspace/src/commit_engine/ui.rs
@@ -1,52 +1,7 @@
 #![allow(missing_docs)]
-use crate::commit_engine::{HunkHeader, RejectionReason};
-use bstr::BString;
+use crate::commit_engine::RejectionReason;
 use gitbutler_serde::BStringForFrontend;
-use serde::{Deserialize, Serialize};
-
-/// The JSON serializable type of [super::DiffSpec].
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DiffSpec {
-    /// lossless version of `previous_path` if this was a rename.
-    pub previous_path_bytes: Option<BString>,
-    /// lossless version of `path`.
-    pub path_bytes: BString,
-    /// The headers of the hunks to use, or empty if all changes are to be used.
-    pub hunk_headers: Vec<HunkHeader>,
-}
-
-impl From<DiffSpec> for super::DiffSpec {
-    fn from(
-        DiffSpec {
-            path_bytes,
-            hunk_headers,
-            previous_path_bytes,
-        }: DiffSpec,
-    ) -> Self {
-        super::DiffSpec {
-            previous_path: previous_path_bytes,
-            path: path_bytes,
-            hunk_headers,
-        }
-    }
-}
-
-impl From<super::DiffSpec> for DiffSpec {
-    fn from(
-        super::DiffSpec {
-            path,
-            hunk_headers,
-            previous_path,
-        }: super::DiffSpec,
-    ) -> Self {
-        DiffSpec {
-            previous_path_bytes: previous_path,
-            path_bytes: path,
-            hunk_headers,
-        }
-    }
-}
+use serde::Serialize;
 
 /// The JSON serializable type of [super::CreateCommitOutcome].
 // TODO(ST): this type should contain mappings from old to new commits so that the UI knows what state to update, maybe.
@@ -74,7 +29,7 @@ impl From<super::CreateCommitOutcome> for CreateCommitOutcome {
         CreateCommitOutcome {
             paths_to_rejected_changes: rejected_specs
                 .into_iter()
-                .map(|(reason, spec)| (reason, spec.path.into()))
+                .map(|(reason, spec)| (reason, spec.path_bytes.into()))
                 .collect(),
             new_commit,
         }

--- a/crates/but-workspace/src/tree_manipulation/hunk/mod.rs
+++ b/crates/but-workspace/src/tree_manipulation/hunk/mod.rs
@@ -1,4 +1,4 @@
-use crate::commit_engine::{HunkHeader, HunkRange};
+use crate::{HunkHeader, commit_engine::HunkRange};
 use anyhow::Context;
 
 #[derive(Debug, Copy, Clone)]

--- a/crates/but-workspace/src/tree_manipulation/mod.rs
+++ b/crates/but-workspace/src/tree_manipulation/mod.rs
@@ -1,7 +1,8 @@
 //! Utility types related to discarding changes in the worktree.
 
-use crate::commit_engine::DiffSpec;
 use std::ops::{Deref, DerefMut};
+
+use crate::DiffSpec;
 
 /// A specification of what should be discarded, either changes to the whole file, or a portion of it.
 /// Note that these must match an actual worktree change, but also may only partially match them if individual ranges are chosen
@@ -53,7 +54,7 @@ pub(super) mod function;
 #[allow(missing_docs)]
 pub mod ui {
     /// A specification of which worktree-change to discard.
-    pub type DiscardSpec = crate::commit_engine::ui::DiffSpec;
+    pub type DiscardSpec = crate::DiffSpec;
 }
 
 mod file;

--- a/crates/but-workspace/src/tree_manipulation/mod.rs
+++ b/crates/but-workspace/src/tree_manipulation/mod.rs
@@ -1,40 +1,5 @@
 //! Utility types related to discarding changes in the worktree.
 
-use std::ops::{Deref, DerefMut};
-
-use crate::DiffSpec;
-
-/// A specification of what should be discarded, either changes to the whole file, or a portion of it.
-/// Note that these must match an actual worktree change, but also may only partially match them if individual ranges are chosen
-/// for removal.
-#[derive(Debug, Default, Clone, PartialEq)]
-pub struct DiscardSpec(DiffSpec);
-impl From<DiffSpec> for DiscardSpec {
-    fn from(value: DiffSpec) -> Self {
-        DiscardSpec(value)
-    }
-}
-
-impl Deref for DiscardSpec {
-    type Target = DiffSpec;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for DiscardSpec {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl From<DiscardSpec> for DiffSpec {
-    fn from(value: DiscardSpec) -> Self {
-        value.0
-    }
-}
-
 pub(crate) trait RelaPath {
     fn rela_path(&self) -> &bstr::BStr;
 }
@@ -51,11 +16,6 @@ impl RelaPath for gix::diff::index::ChangeRef<'_, '_> {
 }
 
 pub(super) mod function;
-#[allow(missing_docs)]
-pub mod ui {
-    /// A specification of which worktree-change to discard.
-    pub type DiscardSpec = crate::DiffSpec;
-}
 
 mod file;
 pub(crate) mod hunk;

--- a/crates/but-workspace/tests/workspace/commit_engine/amend_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/amend_commit.rs
@@ -4,7 +4,7 @@ use crate::utils::{
     writable_scenario_with_ssh_key, write_local_config, write_sequence,
 };
 use but_testsupport::assure_stable_env;
-use but_workspace::commit_engine::{Destination, DiffSpec, HunkHeader};
+use but_workspace::{DiffSpec, HunkHeader, commit_engine::Destination};
 
 #[test]
 fn all_changes_and_renames_to_topmost_commit_no_parent() -> anyhow::Result<()> {
@@ -152,13 +152,13 @@ fn new_file_and_deletion_onto_merge_commit_with_hunks() -> anyhow::Result<()> {
         None,
         vec![
             DiffSpec {
-                previous_path: None,
-                path: "file".into(),
+                previous_path_bytes: None,
+                path_bytes: "file".into(),
                 hunk_headers: vec![],
             },
             DiffSpec {
-                previous_path: None,
-                path: "new-file".into(),
+                previous_path_bytes: None,
+                path_bytes: "new-file".into(),
                 hunk_headers: vec![HunkHeader {
                     old_start: 1,
                     old_lines: 0,

--- a/crates/but-workspace/tests/workspace/commit_engine/new_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/new_commit.rs
@@ -5,8 +5,8 @@ use crate::utils::{
     write_sequence,
 };
 use but_testsupport::assure_stable_env;
-use but_workspace::commit_engine;
-use commit_engine::{Destination, DiffSpec};
+use but_workspace::{DiffSpec, commit_engine};
+use commit_engine::Destination;
 use gix::prelude::ObjectIdExt;
 
 mod with_refs_update {}
@@ -106,8 +106,8 @@ fn from_unborn_head_with_selection() -> anyhow::Result<()> {
         destination,
         None,
         vec![DiffSpec {
-            previous_path: None,
-            path: "not-yet-tracked".into(),
+            previous_path_bytes: None,
+            path_bytes: "not-yet-tracked".into(),
             hunk_headers: vec![hunk_header("-1,0", "+1,1")],
         }],
         CONTEXT_LINES,
@@ -130,8 +130,8 @@ fn from_unborn_head_with_selection() -> anyhow::Result<()> {
         destination.clone(),
         None,
         vec![DiffSpec {
-            previous_path: None,
-            path: "also-untracked".into(),
+            previous_path_bytes: None,
+            path_bytes: "also-untracked".into(),
             // Take 3 lines in the middle, instead of 10
             hunk_headers: vec![hunk_header("-0,0", "+4,3")],
         }],
@@ -155,8 +155,8 @@ fn from_unborn_head_with_selection() -> anyhow::Result<()> {
         destination,
         None,
         vec![DiffSpec {
-            previous_path: None,
-            path: "also-untracked".into(),
+            previous_path_bytes: None,
+            path_bytes: "also-untracked".into(),
             // Take 3 lines in the middle, instead of 10, but line by line like the UI would select it.
             hunk_headers: vec![
                 hunk_header("-0,0", "+4,1"),
@@ -837,8 +837,8 @@ fn commit_whole_file_to_conflicting_position() -> anyhow::Result<()> {
             (
                 CherryPickMergeConflict,
                 DiffSpec {
-                    previous_path: None,
-                    path: "file",
+                    previous_path_bytes: None,
+                    path_bytes: "file",
                     hunk_headers: [],
                 },
             ),
@@ -892,8 +892,8 @@ fn commit_whole_file_to_conflicting_position_one_unconflicting_file_remains() ->
             (
                 CherryPickMergeConflict,
                 DiffSpec {
-                    previous_path: None,
-                    path: "file",
+                    previous_path_bytes: None,
+                    path_bytes: "file",
                     hunk_headers: [],
                 },
             ),
@@ -1074,7 +1074,7 @@ fn validate_no_change_on_noop() -> anyhow::Result<()> {
 
     let repo = read_only_in_memory_scenario("two-commits-with-line-offset")?;
     let specs = vec![DiffSpec {
-        path: "file".into(),
+        path_bytes: "file".into(),
         ..Default::default()
     }];
     let outcome = commit_engine::create_commit(
@@ -1100,8 +1100,8 @@ fn validate_no_change_on_noop() -> anyhow::Result<()> {
             (
                 NoEffectiveChanges,
                 DiffSpec {
-                    previous_path: None,
-                    path: "file",
+                    previous_path_bytes: None,
+                    path_bytes: "file",
                     hunk_headers: [],
                 },
             ),

--- a/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
@@ -9,7 +9,8 @@ use crate::utils::{
     worktree_changes_with_diffs, writable_scenario, writable_scenario_with_ssh_key, write_sequence,
 };
 use but_testsupport::{assure_stable_env, visualize_commit_graph};
-use but_workspace::commit_engine::{Destination, DiffSpec, ReferenceFrame, StackSegmentId};
+use but_workspace::DiffSpec;
+use but_workspace::commit_engine::{Destination, ReferenceFrame, StackSegmentId};
 use gitbutler_stack::VirtualBranchesState;
 use gix::prelude::ObjectIdExt;
 use gix::refs::transaction::PreviousValue;
@@ -368,8 +369,8 @@ fn first_partial_commit_to_tip_from_unborn_head() -> anyhow::Result<()> {
         },
         None,
         vec![DiffSpec {
-            previous_path: None,
-            path: "not-yet-tracked".into(),
+            previous_path_bytes: None,
+            path_bytes: "not-yet-tracked".into(),
             // Add the first two lines
             hunk_headers: vec![hunk_header("-0,0", "+1,2")],
         }],
@@ -424,8 +425,8 @@ fn first_partial_commit_to_tip_from_unborn_head() -> anyhow::Result<()> {
         },
         None,
         vec![DiffSpec {
-            previous_path: None,
-            path: "not-yet-tracked".into(),
+            previous_path_bytes: None,
+            path_bytes: "not-yet-tracked".into(),
             // Add the last line
             hunk_headers: vec![hunk_header("-0,0", "+4,1")],
         }],
@@ -492,20 +493,20 @@ fn first_partial_commit_to_tip_from_unborn_head() -> anyhow::Result<()> {
         None,
         vec![
             DiffSpec {
-                previous_path: None,
-                path: "not-yet-tracked".into(),
+                previous_path_bytes: None,
+                path_bytes: "not-yet-tracked".into(),
                 // Add the remainder
                 hunk_headers: vec![hunk_header("-3,0", "+3,1")],
             },
             DiffSpec {
-                previous_path: None,
-                path: "other-untracked-non-racy".into(),
+                previous_path_bytes: None,
+                path_bytes: "other-untracked-non-racy".into(),
                 // Add the first line
                 hunk_headers: vec![hunk_header("-0,0", "+1,1")],
             },
             DiffSpec {
-                previous_path: None,
-                path: "other-untracked-added-as-whole".into(),
+                previous_path_bytes: None,
+                path_bytes: "other-untracked-added-as-whole".into(),
                 // Add the only line
                 hunk_headers: vec![hunk_header("-0,0", "+1,1")],
             },
@@ -938,8 +939,8 @@ fn insert_commits_into_workspace_with_conflict() -> anyhow::Result<()> {
         (
             WorkspaceMergeConflict,
             DiffSpec {
-                previous_path: None,
-                path: "file",
+                previous_path_bytes: None,
+                path_bytes: "file",
                 hunk_headers: [],
             },
         ),
@@ -1061,8 +1062,8 @@ fn workspace_commit_with_merge_conflict() -> anyhow::Result<()> {
                 (
                     WorkspaceMergeConflict,
                     DiffSpec {
-                        previous_path: None,
-                        path: "file",
+                        previous_path_bytes: None,
+                        path_bytes: "file",
                         hunk_headers: [
                             HunkHeader("-1,10", "+1,0"),
                             HunkHeader("-12,0", "+2,10"),
@@ -1431,8 +1432,8 @@ fn commit_on_top_of_branch_in_workspace() -> anyhow::Result<()> {
         },
         None,
         vec![DiffSpec {
-            previous_path: None,
-            path: "file".into(),
+            previous_path_bytes: None,
+            path_bytes: "file".into(),
             // Remove 5 lines from the end.
             hunk_headers: vec![hunk_header("-22,5", "+0,0")],
         }],

--- a/crates/but-workspace/tests/workspace/tree_manipulation/file.rs
+++ b/crates/but-workspace/tests/workspace/tree_manipulation/file.rs
@@ -1022,33 +1022,30 @@ D submodule
 
 mod util {
     use crate::utils::to_change_specs_whole_file;
-    use but_workspace::{DiffSpec, tree_manipulation::DiscardSpec};
+    use but_workspace::DiffSpec;
 
-    pub fn file_to_spec(name: &str) -> DiscardSpec {
+    pub fn file_to_spec(name: &str) -> DiffSpec {
         DiffSpec {
             previous_path_bytes: None,
             path_bytes: name.into(),
             hunk_headers: vec![],
         }
-        .into()
     }
 
-    pub fn renamed_file_to_spec(previous: &str, name: &str) -> DiscardSpec {
+    pub fn renamed_file_to_spec(previous: &str, name: &str) -> DiffSpec {
         DiffSpec {
             previous_path_bytes: Some(previous.into()),
             path_bytes: name.into(),
             hunk_headers: vec![],
         }
-        .into()
     }
 
     pub fn worktree_changes_to_discard_specs(
         repo: &gix::Repository,
-    ) -> impl Iterator<Item = DiscardSpec> {
+    ) -> impl Iterator<Item = DiffSpec> {
         to_change_specs_whole_file(
             but_core::diff::worktree_changes(repo).expect("worktree changes never fail"),
         )
         .into_iter()
-        .map(Into::into)
     }
 }

--- a/crates/but-workspace/tests/workspace/tree_manipulation/file.rs
+++ b/crates/but-workspace/tests/workspace/tree_manipulation/file.rs
@@ -1022,13 +1022,12 @@ D submodule
 
 mod util {
     use crate::utils::to_change_specs_whole_file;
-    use but_workspace::commit_engine::DiffSpec;
-    use but_workspace::tree_manipulation::DiscardSpec;
+    use but_workspace::{DiffSpec, tree_manipulation::DiscardSpec};
 
     pub fn file_to_spec(name: &str) -> DiscardSpec {
         DiffSpec {
-            previous_path: None,
-            path: name.into(),
+            previous_path_bytes: None,
+            path_bytes: name.into(),
             hunk_headers: vec![],
         }
         .into()
@@ -1036,8 +1035,8 @@ mod util {
 
     pub fn renamed_file_to_spec(previous: &str, name: &str) -> DiscardSpec {
         DiffSpec {
-            previous_path: Some(previous.into()),
-            path: name.into(),
+            previous_path_bytes: Some(previous.into()),
+            path_bytes: name.into(),
             hunk_headers: vec![],
         }
         .into()

--- a/crates/but-workspace/tests/workspace/tree_manipulation/hunk.rs
+++ b/crates/but-workspace/tests/workspace/tree_manipulation/hunk.rs
@@ -8,8 +8,7 @@ use crate::utils::{
 use bstr::{BString, ByteSlice};
 use but_core::UnifiedDiff;
 use but_testsupport::{git_status, visualize_disk_tree_skip_dot_git};
-use but_workspace::commit_engine::{DiffSpec, HunkHeader};
-use but_workspace::discard_workspace_changes;
+use but_workspace::{DiffSpec, HunkHeader, discard_workspace_changes};
 
 #[test]
 fn dropped_hunks() -> anyhow::Result<()> {
@@ -21,8 +20,8 @@ fn dropped_hunks() -> anyhow::Result<()> {
     hunks_to_discard.insert(0, hunk_header("-1,1", "+1,0"));
 
     let discard_spec = DiffSpec {
-        previous_path: None,
-        path: change.path,
+        previous_path_bytes: None,
+        path_bytes: change.path,
         hunk_headers: hunks_to_discard,
     };
     let dropped = discard_workspace_changes(&repo, Some(discard_spec.into()), CONTEXT_LINES)?;
@@ -31,8 +30,8 @@ fn dropped_hunks() -> anyhow::Result<()> {
     [
         DiscardSpec(
             DiffSpec {
-                previous_path: None,
-                path: "file",
+                previous_path_bytes: None,
+                path_bytes: "file",
                 hunk_headers: [
                     HunkHeader("-1,1", "+1,0"),
                     HunkHeader("-10,1", "+13,3"),
@@ -66,8 +65,8 @@ fn non_modifications_trigger_error() -> anyhow::Result<()> {
             &repo,
             Some(
                 DiffSpec {
-                    previous_path: None,
-                    path: file_name.into(),
+                    previous_path_bytes: None,
+                    path_bytes: file_name.into(),
                     hunk_headers: vec![hunk],
                 }
                 .into(),
@@ -146,8 +145,8 @@ fn from_end() -> anyhow::Result<()> {
             .expect("there is always one change if the file is only modified");
         let discarded_patch = std::mem::take(&mut last_hunk.diff);
         let discard_spec = DiffSpec {
-            previous_path: None,
-            path: change.path.clone(),
+            previous_path_bytes: None,
+            path_bytes: change.path.clone(),
             hunk_headers: vec![last_hunk.into()],
         };
         let dropped = discard_workspace_changes(&repo, Some(discard_spec.into()), CONTEXT_LINES)?;
@@ -217,8 +216,8 @@ fn from_beginning() -> anyhow::Result<()> {
         let mut first_hun_hunk = hunks.remove(0);
         let discarded_patch = std::mem::take(&mut first_hun_hunk.diff);
         let discard_spec = DiffSpec {
-            previous_path: None,
-            path: change.path.clone(),
+            previous_path_bytes: None,
+            path_bytes: change.path.clone(),
             hunk_headers: vec![first_hun_hunk.into()],
         };
         let dropped = discard_workspace_changes(&repo, Some(discard_spec.into()), CONTEXT_LINES)?;
@@ -279,8 +278,8 @@ fn from_selections() -> anyhow::Result<()> {
     "#);
 
     let discard_spec = DiffSpec {
-        previous_path: None,
-        path: change.path.clone(),
+        previous_path_bytes: None,
+        path_bytes: change.path.clone(),
         hunk_headers: vec![
             // Split first hunk into two yielding
             // '+1\n+3\n+4\n'
@@ -365,8 +364,8 @@ fn from_selections_with_context() -> anyhow::Result<()> {
     let read_file_content = || std::fs::read(&filepath).map(BString::from);
     let original_file_content = read_file_content()?;
     let mut discard_spec = DiffSpec {
-        previous_path: None,
-        path: change.path.clone(),
+        previous_path_bytes: None,
+        path_bytes: change.path.clone(),
         hunk_headers: vec![
             // Discard 2,3, keeping 1,4
             hunk_header("-1,14", "+2,2"),
@@ -462,8 +461,8 @@ fn hunk_removal_of_additions_single_line() -> anyhow::Result<()> {
     ");
 
     let discard_spec = DiffSpec {
-        previous_path: None,
-        path: change.path.clone(),
+        previous_path_bytes: None,
+        path_bytes: change.path.clone(),
         hunk_headers: vec![
             // Anchor at the old hunk, and redefine change to discard in the new hunk,
             // effectively discarding only line 5.
@@ -516,8 +515,8 @@ fn hunk_removal_of_removal_single_line() -> anyhow::Result<()> {
     ");
 
     let discard_spec = DiffSpec {
-        previous_path: None,
-        path: change.path.clone(),
+        previous_path_bytes: None,
+        path_bytes: change.path.clone(),
         hunk_headers: vec![
             // Anchor at the new hunk, and redefine change to discard in the old hunk,
             // effectively keeping only line 5.
@@ -571,8 +570,8 @@ fn hunk_removal_of_modifications() -> anyhow::Result<()> {
     ");
 
     let discard_spec = DiffSpec {
-        previous_path: None,
-        path: change.path.clone(),
+        previous_path_bytes: None,
+        path_bytes: change.path.clone(),
         hunk_headers: vec![
             // Anchor at the new hunk, and redefine change to discard in the old hunk,
             // effectively keeping only line 5.

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -19,8 +19,7 @@ use crate::{
     VirtualBranchesExt,
 };
 use anyhow::{bail, Context, Result};
-use but_workspace::commit_engine::DiffSpec;
-use but_workspace::{commit_engine, stack_heads_info, ui};
+use but_workspace::{commit_engine, stack_heads_info, ui, DiffSpec};
 use gitbutler_branch::{BranchCreateRequest, BranchUpdateRequest};
 use gitbutler_command_context::CommandContext;
 use gitbutler_diff::DiffByPathMap;

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/amend.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/amend.rs
@@ -1,4 +1,4 @@
-use but_workspace::commit_engine::{DiffSpec, HunkHeader};
+use but_workspace::{DiffSpec, HunkHeader};
 use gitbutler_branch::{BranchCreateRequest, BranchUpdateRequest};
 use gitbutler_branch_actions::list_commit_files;
 
@@ -53,8 +53,8 @@ fn forcepush_allowed() -> anyhow::Result<()> {
         fs::write(repo.path().join("file2.txt"), "content2").unwrap();
         // let to_amend: BranchOwnershipClaims = "file2.txt:1-2".parse().unwrap();
         let to_amend = vec![DiffSpec {
-            previous_path: None,
-            path: "file2.txt".into(),
+            previous_path_bytes: None,
+            path_bytes: "file2.txt".into(),
             hunk_headers: vec![HunkHeader {
                 old_start: 1,
                 old_lines: 0,
@@ -118,8 +118,8 @@ fn forcepush_forbidden() {
         fs::write(repo.path().join("file2.txt"), "content2").unwrap();
         // let to_amend: BranchOwnershipClaims = "file2.txt:1-2".parse().unwrap();
         let to_amend = vec![DiffSpec {
-            previous_path: None,
-            path: "file2.txt".into(),
+            previous_path_bytes: None,
+            path_bytes: "file2.txt".into(),
             hunk_headers: vec![HunkHeader {
                 old_start: 1,
                 old_lines: 0,
@@ -170,8 +170,8 @@ fn non_locked_hunk() -> anyhow::Result<()> {
         fs::write(repo.path().join("file2.txt"), "content2").unwrap();
         // let to_amend: BranchOwnershipClaims = "file2.txt:1-2".parse().unwrap();
         let to_amend = vec![DiffSpec {
-            previous_path: None,
-            path: "file2.txt".into(),
+            previous_path_bytes: None,
+            path_bytes: "file2.txt".into(),
             hunk_headers: vec![HunkHeader {
                 old_start: 1,
                 old_lines: 0,
@@ -235,8 +235,8 @@ fn locked_hunk() -> anyhow::Result<()> {
         fs::write(repo.path().join("file.txt"), "more content").unwrap();
         // let to_amend: BranchOwnershipClaims = "file.txt:1-2".parse().unwrap();
         let to_amend = vec![DiffSpec {
-            previous_path: None,
-            path: "file.txt".into(),
+            previous_path_bytes: None,
+            path_bytes: "file.txt".into(),
             hunk_headers: vec![HunkHeader {
                 old_start: 1,
                 old_lines: 1,
@@ -296,8 +296,8 @@ fn non_existing_ownership() {
         // amend non existing hunk
         // let to_amend: BranchOwnershipClaims = "file2.txt:1-2".parse().unwrap();
         let to_amend = vec![DiffSpec {
-            previous_path: None,
-            path: "file2.txt".into(),
+            previous_path_bytes: None,
+            path_bytes: "file2.txt".into(),
             hunk_headers: vec![HunkHeader {
                 old_start: 1,
                 old_lines: 0,
@@ -309,7 +309,7 @@ fn non_existing_ownership() {
             gitbutler_branch_actions::amend(ctx, stack_entry.id, commit_oid, to_amend)
                 .unwrap_err()
                 .to_string(),
-            r#"Failed to amend with commit engine. Rejected specs: [(NoEffectiveChanges, DiffSpec { previous_path: None, path: "file2.txt", hunk_headers: [HunkHeader("-1,0", "+1,1")] })]"#,
+            r#"Failed to amend with commit engine. Rejected specs: [(NoEffectiveChanges, DiffSpec { previous_path_bytes: None, path_bytes: "file2.txt", hunk_headers: [HunkHeader("-1,0", "+1,1")] })]"#,
         );
     }
 }

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -1,8 +1,8 @@
 pub mod commands {
     use anyhow::{anyhow, Context};
     use but_settings::AppSettingsWithDiskSync;
-    use but_workspace::commit_engine::ui::DiffSpec;
     use but_workspace::ui::StackEntry;
+    use but_workspace::DiffSpec;
     use gitbutler_branch::{BranchCreateRequest, BranchUpdateRequest};
     use gitbutler_branch_actions::branch_upstream_integration::IntegrationStrategy;
     use gitbutler_branch_actions::internal::StackListResult;
@@ -373,12 +373,7 @@ pub mod commands {
         let project = projects.get(project_id)?;
         let ctx = CommandContext::open(&project, settings.get()?.clone())?;
         let commit_oid = git2::Oid::from_str(&commit_id).map_err(|e| anyhow!(e))?;
-        let oid = gitbutler_branch_actions::amend(
-            &ctx,
-            stack_id,
-            commit_oid,
-            worktree_changes.into_iter().map(Into::into).collect(),
-        )?;
+        let oid = gitbutler_branch_actions::amend(&ctx, stack_id, commit_oid, worktree_changes)?;
         emit_vbranches(&windows, project_id, ctx.app_settings());
         Ok(oid.to_string())
     }

--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -204,8 +204,8 @@ pub fn discard_worktree_changes(
     projects: State<'_, projects::Controller>,
     settings: State<'_, AppSettingsWithDiskSync>,
     project_id: ProjectId,
-    worktree_changes: Vec<but_workspace::tree_manipulation::ui::DiscardSpec>,
-) -> Result<Vec<but_workspace::tree_manipulation::ui::DiscardSpec>, Error> {
+    worktree_changes: Vec<but_workspace::DiffSpec>,
+) -> Result<Vec<but_workspace::DiffSpec>, Error> {
     let project = projects.get(project_id)?;
     let repo = but_core::open_repo(project.worktree_path())?;
     let ctx = CommandContext::open(&project, settings.get()?.clone())?;
@@ -217,15 +217,13 @@ pub fn discard_worktree_changes(
     );
     let refused = but_workspace::discard_workspace_changes(
         &repo,
-        worktree_changes
-            .into_iter()
-            .map(but_workspace::tree_manipulation::DiscardSpec::from),
+        worktree_changes,
         settings.get()?.context_lines,
     )?;
     if !refused.is_empty() {
         tracing::warn!(?refused, "Failed to discard at least one hunk");
     }
-    Ok(refused.into_iter().map(|change| change.into()).collect())
+    Ok(refused)
 }
 
 /// This API allows the user to quickly "stash" a bunch of uncommitted changes - getting them out of the worktree.


### PR DESCRIPTION
Move DiffSpec and HunkHeader to the root of the but-workspace crate.
Remove the commit_engine::ui versions of the DiffSpec type since it was
Identical