### PR TITLE
Remove commit status label for now

### DIFF
--- a/apps/desktop/src/components/v3/CommitView.svelte
+++ b/apps/desktop/src/components/v3/CommitView.svelte
@@ -11,7 +11,7 @@
 	import ConflictResolutionConfirmModal from '$components/v3/ConflictResolutionConfirmModal.svelte';
 	import Drawer from '$components/v3/Drawer.svelte';
 	import KebabButton from '$components/v3/KebabButton.svelte';
-	import { getCommitLabel, isLocalAndRemoteCommit } from '$components/v3/lib';
+	import { isLocalAndRemoteCommit } from '$components/v3/lib';
 	import { writeClipboard } from '$lib/backend/clipboard';
 	import { isCommit } from '$lib/branches/v3';
 	import { CommitStatus, type CommitKey } from '$lib/commits/commit';
@@ -140,7 +140,6 @@
 		{:else}
 			<Drawer testId={TestId.CommitDrawer} projectId={env.projectId} stackId={env.stackId}>
 				{#snippet header()}
-					{@const label = getCommitLabel(commit)}
 					<div class="commit-view__header text-13">
 						{#if isLocalAndRemoteCommit(commit)}
 							{@const commitState = commit.state}
@@ -148,7 +147,6 @@
 								commitStatus={commitState.type}
 								diverged={commitState.type === 'LocalAndRemote' &&
 									commit.id !== commitState.subject}
-								tooltip={label}
 								width={24}
 							/>
 						{:else}
@@ -161,8 +159,6 @@
 						{/if}
 
 						<div class="commit-view__header-title text-13">
-							<span class="text-semibold">{getCommitLabel(commit)} commit:</span>
-
 							<Tooltip text="Copy commit SHA">
 								<button
 									type="button"

--- a/apps/desktop/src/components/v3/UnappliedCommitView.svelte
+++ b/apps/desktop/src/components/v3/UnappliedCommitView.svelte
@@ -5,7 +5,6 @@
 	import CommitHeader from '$components/v3/CommitHeader.svelte';
 	import CommitLine from '$components/v3/CommitLine.svelte';
 	import Drawer from '$components/v3/Drawer.svelte';
-	import { getCommitLabel } from '$components/v3/lib';
 	import { writeClipboard } from '$lib/backend/clipboard';
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { TestId } from '$lib/testing/testIds';
@@ -27,7 +26,6 @@
 
 <ReduxResult {projectId} result={commitResult.current}>
 	{#snippet children(commit)}
-		{@const label = getCommitLabel(commit)}
 		{@const commitState = commit.state}
 		<Drawer {projectId}>
 			{#snippet header()}
@@ -35,14 +33,9 @@
 					<CommitLine
 						commitStatus={commitState.type}
 						diverged={commitState.type === 'LocalAndRemote' && commitState.subject !== commit.id}
-						tooltip={label}
 						width={24}
 					/>
 					<div class="commit-view__header-title text-13">
-						<span class="text-semibold">
-							{label}
-						</span>
-
 						<Tooltip text="Copy commit SHA">
 							<button
 								type="button"

--- a/apps/desktop/src/components/v3/lib.ts
+++ b/apps/desktop/src/components/v3/lib.ts
@@ -92,18 +92,3 @@ export function getBranchStatusLabelAndColor(pushStatus: PushStatus): {
 			return { label: 'Unknown', color: colorMap.Error };
 	}
 }
-
-export function getCommitLabel(commit: Partial<Commit>) {
-	const commitType = commit ? getCommitType(commit as Commit) : 'unknown';
-
-	switch (commitType) {
-		case 'local':
-			return 'Unpushed';
-		case 'upstream':
-			return 'Upstream';
-		case 'local-and-remote':
-			return 'Pushed';
-		case 'diverged':
-			return 'Diverged';
-	}
-}


### PR DESCRIPTION
Reading "pushed commit" for a commit on e.g. master is not helpful.
Removing these descriptions until we can provide something more
accurate.

![image](https://github.com/user-attachments/assets/3c5c9bed-fcdf-4869-8fab-07dc70d9f8ff)
