### PR TITLE
feat: add review creation state management

### DIFF
--- a/apps/desktop/src/components/ReviewCreation.svelte
+++ b/apps/desktop/src/components/ReviewCreation.svelte
@@ -134,11 +134,13 @@
 		});
 	});
 
+	let isCreatingReview = $state<boolean>(false);
 	const isExecuting = $derived(
 		branchPublishing.current.isLoading ||
 			PRNumberUpdate.current.isLoading ||
 			stackPush.current.isLoading ||
-			aiIsLoading
+			aiIsLoading ||
+			isCreatingReview
 	);
 
 	const canPublishBR = $derived(!!($canPublish && branch?.name && !branch.reviewId));
@@ -191,6 +193,9 @@
 		if (!branch) return;
 		if (!$user) return;
 
+		isCreatingReview = true;
+		await tick();
+
 		const upstreamBranchName = await pushIfNeeded();
 
 		let reviewId: string | undefined;
@@ -229,6 +234,7 @@
 		prBody.reset();
 		prTitle.reset();
 
+		isCreatingReview = false;
 		onClose();
 	}
 


### PR DESCRIPTION
Introduce `isCreatingReview` state to track the review creation 
process. Update the `isExecuting` derived state to include 
`isCreatingReview`, ensuring accurate loading status during 
review creation. Set `isCreatingReview` to true when starting 
the review and reset it to false upon completion. This improves 
user feedback and prevents multiple submissions during the 
creation process.