### PR TITLE
Improve dragging changes

### DIFF
--- a/apps/desktop/src/components/v3/FileList.svelte
+++ b/apps/desktop/src/components/v3/FileList.svelte
@@ -55,6 +55,7 @@
 	<FileListItemWrapper
 		{selectionId}
 		{change}
+		allChanges={changes}
 		{projectId}
 		{listActive}
 		{listMode}

--- a/apps/desktop/src/components/v3/FileListItemWrapper.svelte
+++ b/apps/desktop/src/components/v3/FileListItemWrapper.svelte
@@ -20,6 +20,7 @@
 	interface Props {
 		projectId: string;
 		change: TreeChange;
+		allChanges?: TreeChange[];
 		diff?: UnifiedDiff;
 		selectionId: SelectionId;
 		selected?: boolean;
@@ -38,6 +39,7 @@
 
 	const {
 		change,
+		allChanges,
 		diff,
 		selectionId,
 		projectId,
@@ -123,7 +125,7 @@
 	use:draggableChips={{
 		label: getFilename(change.path),
 		filePath: change.path,
-		data: new ChangeDropData(change, idSelection, selectionId),
+		data: new ChangeDropData(change, idSelection, allChanges ?? [change], selectionId),
 		viewportId: 'board-viewport',
 		selector: '.selected-draggable',
 		disabled: showCheckbox,

--- a/apps/desktop/src/lib/commits/dropHandler.ts
+++ b/apps/desktop/src/lib/commits/dropHandler.ts
@@ -353,11 +353,13 @@ function filesToDiffSpec(data: FileDropData): DiffSpec[] {
 
 /** Helper function that converts `ChangeDropData` to `DiffSpec`. */
 function changesToDiffSpec(data: ChangeDropData): DiffSpec[] {
-	const filePaths = data.filePaths;
-	return filePaths.map((filePath) => {
+	const changes = data.changes;
+	return changes.map((change) => {
+		const previousPathBytes =
+			change.status.type === 'Rename' ? change.status.subject.previousPathBytes : null;
 		return {
-			previousPathBytes: null,
-			pathBytes: filePath as any, // Rust type is Bstring.
+			previousPathBytes,
+			pathBytes: change.pathBytes,
 			hunkHeaders: []
 		};
 	});

--- a/apps/desktop/src/lib/dragging/draggables.ts
+++ b/apps/desktop/src/lib/dragging/draggables.ts
@@ -43,6 +43,7 @@ export class ChangeDropData {
 		 * dragged.
 		 */
 		private selection: IdSelection,
+		private allChanges: TreeChange[],
 		readonly selectionId: SelectionId
 	) {}
 
@@ -61,6 +62,11 @@ export class ChangeDropData {
 		} else {
 			return [this.change.path];
 		}
+	}
+
+	get changes(): TreeChange[] {
+		const paths = this.filePaths;
+		return this.allChanges.filter((change) => paths.includes(change.path));
 	}
 
 	get isCommitted(): boolean {


### PR DESCRIPTION
Immprove dragging the changes such, that the actual change types are used.

This enables:
- Correctly amending renamed files into commits
- Corretctly selecting files when dragging files to start a commit


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#1dm0ov7gi`](https://cloud.staging.gitbutler.com/estib/gitbutler-792c/reviews/1dm0ov7gi)

**Remove unneeded derives in services**


- Added support for an optional `allChanges` prop in `FileListItemWrapper` to enable dragging multiple files.
- Refactored the `changesToDiffSpec` function to use the `changes` array from `ChangeDropData` instead of the `filePaths` array.

2 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 2/2 | [refactor: update changesToDiffSpec to use changes array](https://cloud.staging.gitbutler.com/estib/gitbutler-792c/reviews/1dm0ov7gi/commit/28d9f8bf-2680-4770-abbf-a8f1872b33a9) | ⏳ |  |
| 1/2 | [feat: add support for allChanges in FileListItemWrapper](https://cloud.staging.gitbutler.com/estib/gitbutler-792c/reviews/1dm0ov7gi/commit/9675e5d9-72f2-4251-9539-c8cfed8fbeae) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://cloud.staging.gitbutler.com/estib/gitbutler-792c/reviews/1dm0ov7gi)_
<!-- GitButler Review Footer Boundary Bottom -->
