### PR TITLE
Unified diff: Locks are shown independent of the stack

### DIFF
--- a/apps/desktop/cypress/e2e/support/scenarios/branchesWithChanges.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/branchesWithChanges.ts
@@ -39,6 +39,7 @@ const MOCK_STACK_B: Stack = {
 };
 
 const MOCK_FILE_D = 'fileD.txt';
+const MOCK_FILE_J = 'fileJ.txt';
 
 const MOCK_BRANCH_B_CHANGES: TreeChange[] = [
 	createMockAdditionTreeChange({ path: MOCK_FILE_D }),
@@ -69,7 +70,8 @@ const MOCK_STACK_DETAILS_C = createMockStackDetails({
 });
 
 const MOCK_UNCOMMITTED_CHANGES: TreeChange[] = [
-	createMockModificationTreeChange({ path: MOCK_FILE_D }) // Depends on the changes in the stack B
+	createMockModificationTreeChange({ path: MOCK_FILE_D }), // Depends on the changes in the stack B
+	createMockAdditionTreeChange({ path: MOCK_FILE_J })
 ];
 
 const MOCK_FILE_D_MODIFICATION_DIFF_HUNKS: DiffHunk[] = [
@@ -93,6 +95,24 @@ const MOCK_FILE_D_MODIFICATION = createMockUnifiedDiffPatch(
 	MOCK_FILE_D_MODIFICATION_DIFF_HUNKS,
 	2,
 	3
+);
+
+const BIG_DIFF_THRESHOLD = 2501;
+
+const MOCK_FILE_J_MODIFICATION_DIFF_HUNKS: DiffHunk[] = [
+	{
+		oldStart: 0,
+		oldLines: 0,
+		newStart: 1,
+		newLines: BIG_DIFF_THRESHOLD,
+		diff: `@@ -0,0 +1,${BIG_DIFF_THRESHOLD} @@\n${Array.from({ length: BIG_DIFF_THRESHOLD }, (_, i) => `+line ${i + 1}`).join('\n')}`
+	}
+];
+
+const MOCK_FILE_J_MODIFICATION = createMockUnifiedDiffPatch(
+	MOCK_FILE_J_MODIFICATION_DIFF_HUNKS,
+	BIG_DIFF_THRESHOLD,
+	0
 );
 
 const MOCK_DIFF_DEPENDENCY: DiffDependency[] = [
@@ -134,6 +154,8 @@ const MOCK_DIFF_DEPENDENCY: DiffDependency[] = [
  * Three branches with file changes.
  */
 export default class BranchesWithChanges extends MockBackend {
+	bigFileName = MOCK_FILE_J;
+
 	constructor() {
 		super();
 
@@ -163,6 +185,7 @@ export default class BranchesWithChanges extends MockBackend {
 		this.branchChanges.set(MOCK_STACK_C_ID, stackCChanges);
 
 		this.unifiedDiffs.set(MOCK_FILE_D, MOCK_FILE_D_MODIFICATION);
+		this.unifiedDiffs.set(MOCK_FILE_J, MOCK_FILE_J_MODIFICATION);
 		this.hunkDependencies = {
 			diffs: MOCK_DIFF_DEPENDENCY,
 			errors: []

--- a/apps/desktop/cypress/e2e/unifiedDiffView.cy.ts
+++ b/apps/desktop/cypress/e2e/unifiedDiffView.cy.ts
@@ -89,4 +89,40 @@ describe('Unified Diff View', () => {
 		// The tooltip should be visible
 		cy.getByTestId('unified-diff-view-lock-warning').should('be.visible');
 	});
+
+	it.only('should hide big diffs by default', () => {
+		// There should be uncommitted changes
+		cy.getByTestId('uncommitted-changes-file-list').should('be.visible');
+
+		// All files should be visible
+		cy.getByTestId('file-list-item').should(
+			'have.length',
+			mockBackend.getWorktreeChangesFileNames().length
+		);
+
+		// Open bif file diff
+		cy.getByTestId('uncommitted-changes-file-list').within(() => {
+			const fileName = mockBackend.bigFileName;
+			cy.getByTestId('file-list-item', fileName).click();
+		});
+
+		cy.getByTestId('unified-diff-view').within(() => {
+			// The diff should not be visible
+			cy.get('table').should('not.exist');
+		});
+
+		// The large diff message should be visible
+		cy.getByTestId('large-diff-message')
+			.should('be.visible')
+			.within(() => {
+				// The large diff message should be visible
+				cy.getByTestId('large-diff-message-button').click();
+			});
+
+		// The diff should be visible
+		cy.getByTestId('unified-diff-view').within(() => {
+			// The diff should be visible
+			cy.get('table').should('be.visible');
+		});
+	});
 });

--- a/apps/desktop/cypress/e2e/unifiedDiffView.cy.ts
+++ b/apps/desktop/cypress/e2e/unifiedDiffView.cy.ts
@@ -79,15 +79,14 @@ describe('Unified Diff View', () => {
 		cy.getByTestId('unified-diff-view')
 			.should('be.visible')
 			.within(() => {
-				// TODO(mattias): Get help from estib in fixing this test.
 				// The line locks shold be visible
-				// cy.get('[data-testid="hunk-line-locking-info"]')
-				// 	.should('have.length', 5)
-				// 	.first()
-				// 	.trigger('mouseenter');
+				cy.get('[data-testid="hunk-line-locking-info"]')
+					.should('have.length', 5)
+					.first()
+					.trigger('mouseenter');
 			});
 
 		// The tooltip should be visible
-		// cy.getByTestId('unified-diff-view-lock-warning').should('be.visible');
+		cy.getByTestId('unified-diff-view-lock-warning').should('be.visible');
 	});
 });

--- a/apps/desktop/src/components/LargeDiffMessage.svelte
+++ b/apps/desktop/src/components/LargeDiffMessage.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { TestId } from '$lib/testing/testIds';
 	import Button from '@gitbutler/ui/Button.svelte';
 
 	interface Props {
@@ -13,9 +14,9 @@
 	}
 </script>
 
-<div class="large-diff-message" class:frame-box={showFrame}>
+<div data-testid={TestId.LargeDiffMessage} class="large-diff-message" class:frame-box={showFrame}>
 	<p class="text-13">Change hidden as large diffs may slow down the UI</p>
-	<Button kind="outline" onclick={show}>Show anyways</Button>
+	<Button testId={TestId.LargeDiffMessageButton} kind="outline" onclick={show}>Show anyways</Button>
 </div>
 
 <style>

--- a/apps/desktop/src/components/v3/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/v3/UnifiedDiffView.svelte
@@ -11,7 +11,6 @@
 	import { previousPathBytesFromTreeChange, type TreeChange } from '$lib/hunks/change';
 	import { canBePartiallySelected, getLineLocks, type DiffHunk } from '$lib/hunks/hunk';
 	import { Project } from '$lib/project/project';
-	import { isWorkspacePath } from '$lib/routes/routes.svelte';
 	import {
 		ChangeSelectionService,
 		type PartiallySelectedFile
@@ -46,11 +45,6 @@
 	const stacks = $derived(stackService.stacks(projectId));
 	const hasMultipleStacks = $derived(stacks.current.data && stacks.current.data.length > 1);
 
-	const workspacesParams = $derived(isWorkspacePath());
-
-	// This is the stack ID that's being viewed. Not **necessarily** the stack ID associated with
-	// the change and diff in question.
-	const viewingStackId = $derived(workspacesParams?.stackId);
 	const isCommiting = $derived(drawerPage === 'new-commit');
 
 	const uncommittedChange = $derived(selectionId.type === 'worktree');
@@ -204,7 +198,6 @@
 		{#each diff.subject.hunks as hunk}
 			{@const [staged, stagedLines] = getStageState(hunk)}
 			{@const [fullyLocked, lineLocks] = getLineLocks(
-				viewingStackId,
 				hunk,
 				fileDependencies?.current.data?.dependencies ?? []
 			)}

--- a/apps/desktop/src/lib/hunks/hunk.test.ts
+++ b/apps/desktop/src/lib/hunks/hunk.test.ts
@@ -308,7 +308,7 @@ describe('getLineLocks', () => {
 		}
 	];
 	test('returns line locks for lines covered by locks', () => {
-		const [fullyLocked, lineLocks] = getLineLocks('stack2', hunk, locks);
+		const [fullyLocked, lineLocks] = getLineLocks(hunk, locks);
 		expect(fullyLocked).toBe(true);
 		expect(lineLocks).toEqual([
 			{ oldLine: 2, newLine: undefined, locks: [{ stackId: 'stack1', commitId: 'commit1' }] },
@@ -322,7 +322,7 @@ describe('getLineLocks', () => {
 				locks: [{ stackId: 'stack2', commitId: 'commit2' }]
 			}
 		];
-		const [fullyLocked, lineLocks] = getLineLocks('stack1', hunk, noLocks);
+		const [fullyLocked, lineLocks] = getLineLocks(hunk, noLocks);
 		expect(fullyLocked).toBe(false);
 		expect(lineLocks).toEqual([]);
 	});
@@ -338,7 +338,7 @@ describe('getLineLocks', () => {
 			}
 		];
 		// Only line 3 is locked, lines 2 and 4 are not
-		const [fullyLocked, lineLocks] = getLineLocks('stack2', partialHunk, partialLocks);
+		const [fullyLocked, lineLocks] = getLineLocks(partialHunk, partialLocks);
 		expect(fullyLocked).toBe(false);
 		expect(lineLocks).toEqual([
 			{ oldLine: 3, newLine: undefined, locks: [{ stackId: 'stack1', commitId: 'commit1' }] },

--- a/apps/desktop/src/lib/hunks/hunk.ts
+++ b/apps/desktop/src/lib/hunks/hunk.ts
@@ -342,14 +342,9 @@ export function hunkContainsLine(hunk: DiffHunk, line: LineId): boolean {
  * Get the line locks for a hunk.
  */
 export function getLineLocks(
-	stackId: string | undefined,
 	hunk: DiffHunk,
 	locks: HunkLocks[]
 ): [boolean, LineLock[] | undefined] {
-	if (stackId === undefined) {
-		return [false, undefined];
-	}
-
 	const lineLocks: LineLock[] = [];
 	const parsedHunk = memoizedParseHunk(hunk.diff);
 
@@ -373,10 +368,7 @@ export function getLineLocks(
 			}
 
 			// Filter out locks to the current stack ID
-			const locks = hunkLocks
-				.map((lock) => lock.locks)
-				.flat()
-				.filter((lock) => lock.stackId !== stackId);
+			const locks = hunkLocks.map((lock) => lock.locks).flat();
 
 			if (locks.length === 0) {
 				hunkIsFullyLocked = false;

--- a/apps/desktop/src/lib/testing/testIds.ts
+++ b/apps/desktop/src/lib/testing/testIds.ts
@@ -59,7 +59,9 @@ export enum TestId {
 	UnappliedBranchDrawer = 'unapplied-branch-drawer',
 	DeleteLocalBranchConfirmationModal = 'delete-local-branch-confirmation-modal',
 	DeleteLocalBranchConfirmationModal_Cancel = 'delete-local-branch-confirmation-modal-cancel',
-	DeleteLocalBranchConfirmationModal_Delete = 'delete-local-branch-confirmation-modal-delete'
+	DeleteLocalBranchConfirmationModal_Delete = 'delete-local-branch-confirmation-modal-delete',
+	LargeDiffMessage = 'large-diff-message',
+	LargeDiffMessageButton = 'large-diff-message-button'
 }
 
 export enum ElementId {


### PR DESCRIPTION
Since we no longer have stacks tied to pages, we no longer can (or shold) hide the locks dependeing on which stack you’re viewing.

- Display the locks independently of the stack
- Re-enable the tests

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #8499 
- <kbd>&nbsp;1&nbsp;</kbd> #8497 👈 
<!-- GitButler Footer Boundary Bottom -->

