### PR TITLE
hide the large diffs

### DIFF
--- a/apps/desktop/cypress/e2e/support/scenarios/branchesWithChanges.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/branchesWithChanges.ts
@@ -39,6 +39,7 @@ const MOCK_STACK_B: Stack = {
 };
 
 const MOCK_FILE_D = 'fileD.txt';
+const MOCK_FILE_J = 'fileJ.txt';
 
 const MOCK_BRANCH_B_CHANGES: TreeChange[] = [
 	createMockAdditionTreeChange({ path: MOCK_FILE_D }),
@@ -69,7 +70,8 @@ const MOCK_STACK_DETAILS_C = createMockStackDetails({
 });
 
 const MOCK_UNCOMMITTED_CHANGES: TreeChange[] = [
-	createMockModificationTreeChange({ path: MOCK_FILE_D }) // Depends on the changes in the stack B
+	createMockModificationTreeChange({ path: MOCK_FILE_D }), // Depends on the changes in the stack B
+	createMockAdditionTreeChange({ path: MOCK_FILE_J })
 ];
 
 const MOCK_FILE_D_MODIFICATION_DIFF_HUNKS: DiffHunk[] = [
@@ -93,6 +95,24 @@ const MOCK_FILE_D_MODIFICATION = createMockUnifiedDiffPatch(
 	MOCK_FILE_D_MODIFICATION_DIFF_HUNKS,
 	2,
 	3
+);
+
+const BIG_DIFF_THRESHOLD = 2501;
+
+const MOCK_FILE_J_MODIFICATION_DIFF_HUNKS: DiffHunk[] = [
+	{
+		oldStart: 0,
+		oldLines: 0,
+		newStart: 1,
+		newLines: BIG_DIFF_THRESHOLD,
+		diff: `@@ -0,0 +1,${BIG_DIFF_THRESHOLD} @@\n${Array.from({ length: BIG_DIFF_THRESHOLD }, (_, i) => `+line ${i + 1}`).join('\n')}`
+	}
+];
+
+const MOCK_FILE_J_MODIFICATION = createMockUnifiedDiffPatch(
+	MOCK_FILE_J_MODIFICATION_DIFF_HUNKS,
+	BIG_DIFF_THRESHOLD,
+	0
 );
 
 const MOCK_DIFF_DEPENDENCY: DiffDependency[] = [
@@ -134,6 +154,8 @@ const MOCK_DIFF_DEPENDENCY: DiffDependency[] = [
  * Three branches with file changes.
  */
 export default class BranchesWithChanges extends MockBackend {
+	bigFileName = MOCK_FILE_J;
+
 	constructor() {
 		super();
 
@@ -163,6 +185,7 @@ export default class BranchesWithChanges extends MockBackend {
 		this.branchChanges.set(MOCK_STACK_C_ID, stackCChanges);
 
 		this.unifiedDiffs.set(MOCK_FILE_D, MOCK_FILE_D_MODIFICATION);
+		this.unifiedDiffs.set(MOCK_FILE_J, MOCK_FILE_J_MODIFICATION);
 		this.hunkDependencies = {
 			diffs: MOCK_DIFF_DEPENDENCY,
 			errors: []

--- a/apps/desktop/cypress/e2e/unifiedDiffView.cy.ts
+++ b/apps/desktop/cypress/e2e/unifiedDiffView.cy.ts
@@ -89,4 +89,40 @@ describe('Unified Diff View', () => {
 		// The tooltip should be visible
 		cy.getByTestId('unified-diff-view-lock-warning').should('be.visible');
 	});
+
+	it.only('should hide big diffs by default', () => {
+		// There should be uncommitted changes
+		cy.getByTestId('uncommitted-changes-file-list').should('be.visible');
+
+		// All files should be visible
+		cy.getByTestId('file-list-item').should(
+			'have.length',
+			mockBackend.getWorktreeChangesFileNames().length
+		);
+
+		// Open bif file diff
+		cy.getByTestId('uncommitted-changes-file-list').within(() => {
+			const fileName = mockBackend.bigFileName;
+			cy.getByTestId('file-list-item', fileName).click();
+		});
+
+		cy.getByTestId('unified-diff-view').within(() => {
+			// The diff should not be visible
+			cy.get('table').should('not.exist');
+		});
+
+		// The large diff message should be visible
+		cy.getByTestId('large-diff-message')
+			.should('be.visible')
+			.within(() => {
+				// The large diff message should be visible
+				cy.getByTestId('large-diff-message-button').click();
+			});
+
+		// The diff should be visible
+		cy.getByTestId('unified-diff-view').within(() => {
+			// The diff should be visible
+			cy.get('table').should('be.visible');
+		});
+	});
 });

--- a/apps/desktop/src/components/LargeDiffMessage.svelte
+++ b/apps/desktop/src/components/LargeDiffMessage.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { TestId } from '$lib/testing/testIds';
 	import Button from '@gitbutler/ui/Button.svelte';
 
 	interface Props {
@@ -13,9 +14,9 @@
 	}
 </script>
 
-<div class="large-diff-message" class:frame-box={showFrame}>
+<div data-testid={TestId.LargeDiffMessage} class="large-diff-message" class:frame-box={showFrame}>
 	<p class="text-13">Change hidden as large diffs may slow down the UI</p>
-	<Button kind="outline" onclick={show}>Show anyways</Button>
+	<Button testId={TestId.LargeDiffMessageButton} kind="outline" onclick={show}>Show anyways</Button>
 </div>
 
 <style>

--- a/apps/desktop/src/lib/testing/testIds.ts
+++ b/apps/desktop/src/lib/testing/testIds.ts
@@ -59,7 +59,9 @@ export enum TestId {
 	UnappliedBranchDrawer = 'unapplied-branch-drawer',
 	DeleteLocalBranchConfirmationModal = 'delete-local-branch-confirmation-modal',
 	DeleteLocalBranchConfirmationModal_Cancel = 'delete-local-branch-confirmation-modal-cancel',
-	DeleteLocalBranchConfirmationModal_Delete = 'delete-local-branch-confirmation-modal-delete'
+	DeleteLocalBranchConfirmationModal_Delete = 'delete-local-branch-confirmation-modal-delete',
+	LargeDiffMessage = 'large-diff-message',
+	LargeDiffMessageButton = 'large-diff-message-button'
 }
 
 export enum ElementId {


### PR DESCRIPTION
### Description

- Implemented hiding of large diffs in UnifiedDiffView
- Added mock data and test cases in Cypress to handle large diffs
- Added test IDs for large diff message and its button

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #8499 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #8497 
<!-- GitButler Footer Boundary Bottom -->

