### PR TITLE
Show locks dependeing on the active branch

### DIFF
--- a/apps/desktop/cypress/e2e/support/scenarios/branchesWithChanges.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/branchesWithChanges.ts
@@ -154,6 +154,7 @@ const MOCK_DIFF_DEPENDENCY: DiffDependency[] = [
  * Three branches with file changes.
  */
 export default class BranchesWithChanges extends MockBackend {
+	dependsOnStack = MOCK_STACK_B_ID;
 	bigFileName = MOCK_FILE_J;
 
 	constructor() {

--- a/apps/desktop/cypress/e2e/unifiedDiffView.cy.ts
+++ b/apps/desktop/cypress/e2e/unifiedDiffView.cy.ts
@@ -88,9 +88,20 @@ describe('Unified Diff View', () => {
 
 		// The tooltip should be visible
 		cy.getByTestId('unified-diff-view-lock-warning').should('be.visible');
+
+		// Select the stack that the file belongs to
+		cy.getByTestId('branch-header', mockBackend.dependsOnStack).should('be.visible').click();
+
+		// The unified diff view should be visible
+		cy.getByTestId('unified-diff-view')
+			.should('be.visible')
+			.within(() => {
+				// The line locks should not be visible
+				cy.get('[data-testid="hunk-line-locking-info"]').should('not.exist');
+			});
 	});
 
-	it.only('should hide big diffs by default', () => {
+	it('should hide big diffs by default', () => {
 		// There should be uncommitted changes
 		cy.getByTestId('uncommitted-changes-file-list').should('be.visible');
 

--- a/apps/desktop/src/components/v3/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/v3/UnifiedDiffView.svelte
@@ -48,6 +48,7 @@
 	const drawerPage = $derived(projectState.drawerPage.current);
 	const stacks = $derived(stackService.stacks(projectId));
 	const hasMultipleStacks = $derived(stacks.current.data && stacks.current.data.length > 1);
+	const activeStackId = $derived(projectState.stackId.current);
 
 	const isCommiting = $derived(drawerPage === 'new-commit');
 
@@ -203,6 +204,7 @@
 			{@const linesModified = diff.subject.linesAdded + diff.subject.linesRemoved}
 			{@const [staged, stagedLines] = getStageState(hunk)}
 			{@const [fullyLocked, lineLocks] = getLineLocks(
+				activeStackId,
 				hunk,
 				fileDependencies?.current.data?.dependencies ?? []
 			)}

--- a/apps/desktop/src/lib/hunks/hunk.test.ts
+++ b/apps/desktop/src/lib/hunks/hunk.test.ts
@@ -308,7 +308,7 @@ describe('getLineLocks', () => {
 		}
 	];
 	test('returns line locks for lines covered by locks', () => {
-		const [fullyLocked, lineLocks] = getLineLocks(hunk, locks);
+		const [fullyLocked, lineLocks] = getLineLocks('stack2', hunk, locks);
 		expect(fullyLocked).toBe(true);
 		expect(lineLocks).toEqual([
 			{ oldLine: 2, newLine: undefined, locks: [{ stackId: 'stack1', commitId: 'commit1' }] },
@@ -322,7 +322,7 @@ describe('getLineLocks', () => {
 				locks: [{ stackId: 'stack2', commitId: 'commit2' }]
 			}
 		];
-		const [fullyLocked, lineLocks] = getLineLocks(hunk, noLocks);
+		const [fullyLocked, lineLocks] = getLineLocks('stack1', hunk, noLocks);
 		expect(fullyLocked).toBe(false);
 		expect(lineLocks).toEqual([]);
 	});
@@ -338,7 +338,7 @@ describe('getLineLocks', () => {
 			}
 		];
 		// Only line 3 is locked, lines 2 and 4 are not
-		const [fullyLocked, lineLocks] = getLineLocks(partialHunk, partialLocks);
+		const [fullyLocked, lineLocks] = getLineLocks('stack2', partialHunk, partialLocks);
 		expect(fullyLocked).toBe(false);
 		expect(lineLocks).toEqual([
 			{ oldLine: 3, newLine: undefined, locks: [{ stackId: 'stack1', commitId: 'commit1' }] },

--- a/apps/desktop/src/lib/hunks/hunk.ts
+++ b/apps/desktop/src/lib/hunks/hunk.ts
@@ -342,9 +342,14 @@ export function hunkContainsLine(hunk: DiffHunk, line: LineId): boolean {
  * Get the line locks for a hunk.
  */
 export function getLineLocks(
+	stackId: string | undefined,
 	hunk: DiffHunk,
 	locks: HunkLocks[]
 ): [boolean, LineLock[] | undefined] {
+	if (stackId === undefined) {
+		return [false, undefined];
+	}
+
 	const lineLocks: LineLock[] = [];
 	const parsedHunk = memoizedParseHunk(hunk.diff);
 
@@ -368,7 +373,10 @@ export function getLineLocks(
 			}
 
 			// Filter out locks to the current stack ID
-			const locks = hunkLocks.map((lock) => lock.locks).flat();
+			const locks = hunkLocks
+				.map((lock) => lock.locks)
+				.flat()
+				.filter((lock) => lock.stackId !== stackId);
 
 			if (locks.length === 0) {
 				hunkIsFullyLocked = false;


### PR DESCRIPTION
- Updated unified diff view tests to support stack-based locking  
- Included active stack ID in UnifiedDiffView component  
- Modified hunk tests to incorporate stack ID  
- Implemented stack ID filtering in getLineLocks function