### PR TITLE
ui-fixes-54

### DIFF
--- a/apps/desktop/src/components/v3/BranchHeader.svelte
+++ b/apps/desktop/src/components/v3/BranchHeader.svelte
@@ -25,7 +25,6 @@
 		readonly: boolean;
 		iconName: keyof typeof iconsJson;
 		lineColor: string;
-		isCommitting?: boolean;
 		activated?: boolean;
 	} & (
 		| { type: 'draft-branch' }
@@ -49,7 +48,6 @@
 				reviewId?: string;
 				pushStatus: PushStatus;
 				lastUpdatedAt?: number;
-				isCommitting: boolean;
 				isConflicted: boolean;
 				contextMenu?: typeof BranchHeaderContextMenu;
 				onclick: () => void;
@@ -63,16 +61,8 @@
 		  }
 	);
 
-	let {
-		projectId,
-		branchName,
-		readonly,
-		iconName,
-		lineColor,
-		isCommitting,
-		activated,
-		...args
-	}: Props = $props();
+	let { projectId, branchName, readonly, iconName, lineColor, activated, ...args }: Props =
+		$props();
 
 	const [stackService, uiState, changeSelectionService] = inject(
 		StackService,
@@ -125,7 +115,6 @@
 			role="button"
 			class="branch-header"
 			class:new-branch={args.isNewBranch}
-			class:is-committing={isCommitting}
 			class:selected={args.selected}
 			onclick={args.onclick}
 			onkeypress={args.onclick}
@@ -296,9 +285,6 @@
 		&.new-branch {
 			border-bottom: none;
 			border-radius: var(--radius-ml);
-		}
-		&.is-committing {
-			border-radius: var(--radius-ml) var(--radius-ml) 0 0;
 		}
 	}
 

--- a/apps/desktop/src/components/v3/BranchHeader.svelte
+++ b/apps/desktop/src/components/v3/BranchHeader.svelte
@@ -316,7 +316,7 @@
 		top: 14px;
 		left: 0;
 		width: 4px;
-		height: 20px;
+		height: calc(100% - 28px);
 		border-radius: 0 var(--radius-ml) var(--radius-ml) 0;
 		background-color: var(--branch-selected-element-bg);
 		transition: transform var(--transition-fast);

--- a/apps/desktop/src/components/v3/BranchList.svelte
+++ b/apps/desktop/src/components/v3/BranchList.svelte
@@ -198,7 +198,6 @@
 											{stackId}
 											{lineColor}
 											{iconName}
-											{isCommitting}
 											{selected}
 											{isNewBranch}
 											{pushStatus}

--- a/apps/desktop/src/components/v3/BranchesViewBranch.svelte
+++ b/apps/desktop/src/components/v3/BranchesViewBranch.svelte
@@ -45,7 +45,6 @@
 					iconName={pushStatusToIcon(branch.pushStatus)}
 					lineColor={getColorFromBranchType(pushStatusToColor(branch.pushStatus))}
 					trackingBranch={branch.remoteTrackingBranch || undefined}
-					isCommitting={false}
 					readonly
 					selected={branchesState.current.branchName === branch.name &&
 						branchesState.current.stackId === env.stackId &&

--- a/apps/desktop/src/components/v3/CommitHeader.svelte
+++ b/apps/desktop/src/components/v3/CommitHeader.svelte
@@ -4,27 +4,18 @@
 	import Tooltip from '@gitbutler/ui/Tooltip.svelte';
 
 	type Props = {
-		row?: boolean;
+		truncate?: boolean;
 		commitMessage: string;
 		className?: string;
 	};
 
-	const { commitMessage, row, className }: Props = $props();
+	const { commitMessage, truncate, className }: Props = $props();
 
 	const title = $derived(splitMessage(commitMessage).title);
 </script>
 
 <Tooltip text={title}>
-	<h3 data-testid={TestId.CommitDrawerTitle} class="{className} commit-title" class:row>
+	<h3 data-testid={TestId.CommitDrawerTitle} class="{className} commit-title" class:truncate>
 		{title}
 	</h3>
 </Tooltip>
-
-<style>
-	.row {
-		text-align: left;
-		text-overflow: ellipsis;
-		overflow: hidden;
-		white-space: nowrap;
-	}
-</style>

--- a/apps/desktop/src/components/v3/CommitHeader.svelte
+++ b/apps/desktop/src/components/v3/CommitHeader.svelte
@@ -12,10 +12,22 @@
 	const { commitMessage, truncate, className }: Props = $props();
 
 	const title = $derived(splitMessage(commitMessage).title);
+
+	function getTitle() {
+		if (title) {
+			return title;
+		}
+		return 'Empty commit. Drag changes here';
+	}
 </script>
 
-<Tooltip text={title}>
-	<h3 data-testid={TestId.CommitDrawerTitle} class="{className} commit-title" class:truncate>
-		{title}
+<Tooltip text={getTitle()}>
+	<h3
+		data-testid={TestId.CommitDrawerTitle}
+		class="{className} commit-title"
+		class:truncate
+		class:text-clr3={!title}
+	>
+		{getTitle()}
 	</h3>
 </Tooltip>

--- a/apps/desktop/src/components/v3/CommitRow.svelte
+++ b/apps/desktop/src/components/v3/CommitRow.svelte
@@ -122,7 +122,7 @@
 		{/if}
 
 		<div class="commit-name truncate">
-			<CommitHeader {commitMessage} row className="text-13 text-semibold" />
+			<CommitHeader {commitMessage} truncate className="text-13 text-semibold" />
 		</div>
 
 		{#if !args.disableCommitActions}

--- a/apps/desktop/src/components/v3/CommitRow.svelte
+++ b/apps/desktop/src/components/v3/CommitRow.svelte
@@ -126,7 +126,9 @@
 		</div>
 
 		{#if !args.disableCommitActions}
-			{@render menu?.({ rightClickTrigger: container })}
+			<div class="commit-menu">
+				{@render menu?.({ rightClickTrigger: container })}
+			</div>
 		{/if}
 	</div>
 </div>
@@ -142,6 +144,10 @@
 		&:hover,
 		&.menu-shown {
 			background-color: var(--clr-bg-1-muted);
+
+			& .commit-menu {
+				display: flex;
+			}
 		}
 
 		&:not(.last) {
@@ -194,6 +200,10 @@
 		display: flex;
 		color: var(--clr-theme-err-element);
 		margin-right: 4px;
+	}
+
+	.commit-menu {
+		display: none;
 	}
 
 	/* MODIFIERS */

--- a/apps/desktop/src/components/v3/CommitRow.svelte
+++ b/apps/desktop/src/components/v3/CommitRow.svelte
@@ -126,9 +126,7 @@
 		</div>
 
 		{#if !args.disableCommitActions}
-			<div class="commit-menu">
-				{@render menu?.({ rightClickTrigger: container })}
-			</div>
+			{@render menu?.({ rightClickTrigger: container })}
 		{/if}
 	</div>
 </div>
@@ -144,10 +142,6 @@
 		&:hover,
 		&.menu-shown {
 			background-color: var(--clr-bg-1-muted);
-
-			& .commit-menu {
-				display: flex;
-			}
 		}
 
 		&:not(.last) {
@@ -200,10 +194,6 @@
 		display: flex;
 		color: var(--clr-theme-err-element);
 		margin-right: 4px;
-	}
-
-	.commit-menu {
-		display: none;
 	}
 
 	/* MODIFIERS */

--- a/apps/desktop/src/components/v3/FileList.svelte
+++ b/apps/desktop/src/components/v3/FileList.svelte
@@ -9,7 +9,7 @@
 	import { chunk } from '$lib/utils/array';
 	import { sortLikeFileTree } from '$lib/worktree/changeTree';
 	import { getContext } from '@gitbutler/shared/context';
-	import type { TreeChange } from '$lib/hunks/change';
+	import type { TreeChange, Modification } from '$lib/hunks/change';
 	import type { SelectionId } from '$lib/selection/key';
 
 	type Props = {
@@ -52,6 +52,7 @@
 </script>
 
 {#snippet fileTemplate(change: TreeChange, idx: number, depth: number = 0)}
+	{@const isExecutable = (change.status.subject as Modification).flags}
 	<FileListItemWrapper
 		{selectionId}
 		{change}
@@ -60,6 +61,7 @@
 		{listActive}
 		{listMode}
 		{depth}
+		executable={!!isExecutable}
 		showCheckbox={showCheckboxes}
 		isLast={idx === visibleFiles.length - 1}
 		selected={idSelection.has(change.path, selectionId)}

--- a/apps/desktop/src/components/v3/FileListItemWrapper.svelte
+++ b/apps/desktop/src/components/v3/FileListItemWrapper.svelte
@@ -31,6 +31,7 @@
 		linesAdded?: number;
 		linesRemoved?: number;
 		depth?: number;
+		executable?: boolean;
 		showCheckbox?: boolean;
 		onclick?: (e: MouseEvent) => void;
 		onkeydown?: (e: KeyboardEvent) => void;
@@ -49,6 +50,7 @@
 		isLast,
 		listMode,
 		depth,
+		executable,
 		showCheckbox,
 		onclick,
 		onkeydown,
@@ -147,6 +149,7 @@
 			linesAdded={lineChangesStat?.added}
 			linesRemoved={lineChangesStat?.removed}
 			fileStatusTooltip={previousTooltipText}
+			{executable}
 			oncontextmenu={(e) => {
 				e.stopPropagation();
 				e.preventDefault();
@@ -168,6 +171,7 @@
 			{indeterminate}
 			{isLast}
 			{depth}
+			{executable}
 			draggable={!showCheckbox}
 			{onkeydown}
 			locked={false}

--- a/apps/desktop/src/components/v3/KebabButton.svelte
+++ b/apps/desktop/src/components/v3/KebabButton.svelte
@@ -14,6 +14,7 @@
 	const { flat, activated, contextElement, onclick, oncontext }: Props = $props();
 
 	let visible = $state(false);
+	let isContextElementFocused = $state(false);
 	let buttonElement = $state<HTMLElement>();
 
 	function onMouseEnter() {
@@ -22,6 +23,22 @@
 	}
 
 	function onMouseLeave() {
+		if (!flat) return;
+		visible = false;
+	}
+
+	function onFocus() {
+		if (!flat) return;
+		if (isContextElementFocused) return;
+		isContextElementFocused = true;
+		visible = true;
+	}
+	function onBlur() {
+		if (!flat) return;
+		if (isContextElementFocused) {
+			isContextElementFocused = false;
+			return;
+		}
 		visible = false;
 	}
 
@@ -41,10 +58,14 @@
 			contextElement.addEventListener('contextmenu', onContextMenu);
 			contextElement.addEventListener('mouseenter', onMouseEnter);
 			contextElement.addEventListener('mouseleave', onMouseLeave);
+			contextElement.addEventListener('focus', onFocus);
+			contextElement.addEventListener('blur', onBlur);
 			return () => {
 				contextElement.removeEventListener('contextmenu', onContextMenu);
 				contextElement.removeEventListener('mouseenter', onMouseEnter);
 				contextElement.removeEventListener('mouseleave', onMouseLeave);
+				contextElement.removeEventListener('focus', onFocus);
+				contextElement.removeEventListener('blur', onBlur);
 			};
 		}
 	});
@@ -55,7 +76,7 @@
 		bind:this={buttonElement}
 		type="button"
 		class="branch-menu-btn"
-		class:visible
+		class:visible={visible || isContextElementFocused}
 		class:activated
 		onclick={onClick}
 		data-testid={TestId.KebabMenuButton}
@@ -78,15 +99,17 @@
 		display: flex;
 		padding: 0 4px;
 		color: var(--clr-text-1);
-		opacity: 0;
+		display: none;
 
 		&.visible {
+			display: flex;
 			opacity: 0.5;
 		}
 
 		&.activated,
-		&:hover {
-			opacity: 1;
+		&:hover,
+		&:focus-within {
+			display: flex;
 		}
 	}
 </style>

--- a/apps/desktop/src/components/v3/MultiStackView.svelte
+++ b/apps/desktop/src/components/v3/MultiStackView.svelte
@@ -182,6 +182,7 @@
 			display: flex;
 			align-items: center;
 			gap: 6px;
+			overflow: hidden;
 		}
 
 		& .actions {

--- a/apps/desktop/src/components/v3/SelectedChange.svelte
+++ b/apps/desktop/src/components/v3/SelectedChange.svelte
@@ -7,6 +7,7 @@
 	import { combineResults } from '$lib/state/helpers';
 	import { WorktreeService } from '$lib/worktree/worktreeService.svelte';
 	import { inject } from '@gitbutler/shared/context';
+	import type { Modification } from '$lib/hunks/change';
 	import type { SelectedFile } from '$lib/selection/key';
 
 	type Props = {
@@ -46,6 +47,7 @@
 {#if diffResult?.current}
 	<ReduxResult {projectId} result={combineResults(changeResult.current, diffResult.current)}>
 		{#snippet children([change, diff], env)}
+			{@const isExecutable = (change.status.subject as Modification).flags}
 			<div class="selected-change-item">
 				<FileListItemWrapper
 					selectionId={selectedFile}
@@ -53,6 +55,7 @@
 					{change}
 					{diff}
 					isHeader
+					executable={!!isExecutable}
 					listMode="list"
 					{onCloseClick}
 				/>

--- a/packages/ui/src/lib/file/ExecutableLabel.svelte
+++ b/packages/ui/src/lib/file/ExecutableLabel.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	import Badge from '$lib/Badge.svelte';
+	import Tooltip from '$lib/Tooltip.svelte';
+</script>
+
+<Tooltip text="Executable">
+	<Badge kind="soft" style="neutral" size="icon">Ex</Badge>
+</Tooltip>

--- a/packages/ui/src/lib/file/FileListItemV3.svelte
+++ b/packages/ui/src/lib/file/FileListItemV3.svelte
@@ -4,6 +4,7 @@
 	import Checkbox from '$lib/Checkbox.svelte';
 	import Icon from '$lib/Icon.svelte';
 	import Tooltip from '$lib/Tooltip.svelte';
+	import ExecutableLabel from '$lib/file/ExecutableLabel.svelte';
 	import FileIndent from '$lib/file/FileIndent.svelte';
 	import FileName from '$lib/file/FileName.svelte';
 	import FileStatusBadge from '$lib/file/FileStatusBadge.svelte';
@@ -31,6 +32,7 @@
 		lockText?: string;
 		listActive?: boolean;
 		isLast?: boolean;
+		executable?: boolean;
 		oncheck?: (
 			e: Event & {
 				currentTarget: EventTarget & HTMLInputElement;
@@ -65,6 +67,7 @@
 		listActive,
 		listMode,
 		depth,
+		executable,
 		oncheck,
 		onclick,
 		ondblclick,
@@ -159,6 +162,10 @@
 					<Icon name="warning-small" color="error" />
 				</div>
 			</Tooltip>
+		{/if}
+
+		{#if executable}
+			<ExecutableLabel />
 		{/if}
 
 		{#if fileStatus}

--- a/packages/ui/src/lib/file/FileViewHeader.svelte
+++ b/packages/ui/src/lib/file/FileViewHeader.svelte
@@ -2,6 +2,7 @@
 	import Badge from '$lib/Badge.svelte';
 	import Button from '$lib/Button.svelte';
 	import Icon from '$lib/Icon.svelte';
+	import ExecutableLabel from '$lib/file/ExecutableLabel.svelte';
 	import FileName from '$lib/file/FileName.svelte';
 	import FileStatusBadge from '$lib/file/FileStatusBadge.svelte';
 	import LineChangeStats from '$lib/file/LineChangeStats.svelte';
@@ -16,6 +17,7 @@
 		linesAdded?: number;
 		linesRemoved?: number;
 		conflicted?: boolean;
+		executable?: boolean;
 		oncontextmenu?: (e: MouseEvent) => void;
 		oncloseclick?: () => void;
 	}
@@ -28,7 +30,8 @@
 		draggable = true,
 		linesAdded = 0,
 		linesRemoved = 0,
-		conflicted = false,
+		conflicted,
+		executable,
 		oncontextmenu,
 		oncloseclick
 	}: Props = $props();
@@ -60,6 +63,10 @@
 
 	<div class="file-header__statuses">
 		<LineChangeStats added={linesAdded} removed={linesRemoved} />
+
+		{#if executable}
+			<ExecutableLabel />
+		{/if}
 
 		{#if fileStatus}
 			<FileStatusBadge tooltip={fileStatusTooltip} status={fileStatus} style="full" />


### PR DESCRIPTION
- Refactored the "truncate" prop
- Fixed the commit menu to show on hover
- Handled the empty commit placeholder
- Emphasized the branch select indicator
- Truncated the branches view title if it's too narrow
- Fixed the branch header bottom border-radius
- Added executable status