### PR TITLE
sc-fix-plain-text-mode

### DIFF
--- a/apps/desktop/src/components/v3/CommitView.svelte
+++ b/apps/desktop/src/components/v3/CommitView.svelte
@@ -15,6 +15,7 @@
 	import { writeClipboard } from '$lib/backend/clipboard';
 	import { isCommit } from '$lib/branches/v3';
 	import { CommitStatus, type CommitKey } from '$lib/commits/commit';
+	import CommitMessageFormatter from '$lib/commits/commitMessageFormatter';
 	import { DefaultForgeFactory } from '$lib/forge/forgeFactory.svelte';
 	import { ModeService } from '$lib/mode/modeService';
 	import { showToast } from '$lib/notifications/toasts';
@@ -85,11 +86,13 @@
 			return;
 		}
 
+		const formattedMessage = CommitMessageFormatter.formatForCommit(commitMessage);
+
 		const newCommitId = await updateCommitMessage({
 			projectId,
 			stackId,
 			commitId: commitKey.commitId,
-			message: commitMessage
+			message: formattedMessage
 		});
 
 		uiState.stack(stackId).selection.set({ branchName, commitId: newCommitId });

--- a/apps/desktop/src/components/v3/NewCommitView.svelte
+++ b/apps/desktop/src/components/v3/NewCommitView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import CommitMessageEditor from '$components/v3/CommitMessageEditor.svelte';
 	import Drawer from '$components/v3/Drawer.svelte';
+	import CommitMessageFormatter from '$lib/commits/commitMessageFormatter';
 	import { DiffService } from '$lib/hunks/diffService.svelte';
 	import { lineIdsToHunkHeaders, type DiffHunk, type HunkHeader } from '$lib/hunks/hunk';
 	import { showError, showToast } from '$lib/notifications/toasts';
@@ -173,8 +174,10 @@
 			return;
 		}
 
+		const formattedMessage = CommitMessageFormatter.formatForCommit(message);
+
 		try {
-			await createCommit(message);
+			await createCommit(formattedMessage);
 		} catch (err: unknown) {
 			showError('Failed to commit', err);
 		}

--- a/apps/desktop/src/lib/commits/commitMessageFormatter.ts
+++ b/apps/desktop/src/lib/commits/commitMessageFormatter.ts
@@ -1,0 +1,289 @@
+/**
+ * Message formatting utilities for GitButler commit messages.
+ *
+ * This module handles the formatting and parsing of commit messages,
+ * allowing for a standardized format in the Git repository while providing
+ * UI-friendly versions for editing.
+ */
+
+class CommitMessageFormatter {
+	/**
+	 * Wrap a line of text at 72 characters, preserving list items and quotes.
+	 * @param {string} line - The line to wrap
+	 * @param {string|null} leading - String to prepend to lines after the first
+	 * @param {number|null} indent - Number of spaces to indent
+	 * @returns {string} The wrapped text
+	 */
+	static wrapLine(
+		line: string,
+		leading: string | null = null,
+		indent: number | null = null
+	): string {
+		const leadingSpaces = line.length - line.trimStart().length;
+		// We use `as string[]` to tell TypeScript these are all strings
+		const words = line.split(/\s+/).filter(Boolean) as string[];
+		let lines = 0;
+
+		let result = '';
+		let currentLine = '';
+
+		if (leadingSpaces > 0) {
+			result += ' '.repeat(leadingSpaces);
+		}
+
+		let currentIndent = '';
+		if (indent !== null) {
+			currentIndent = ' '.repeat(indent);
+		}
+
+		for (let j = 0; j < words.length; j++) {
+			const word = words[j];
+
+			if (!word) {
+				continue;
+			}
+
+			if (currentLine === '') {
+				currentLine = word;
+			} else if (currentLine.length + word.length + 1 > 72) {
+				// Line would be too long, start a new line
+				if (lines > 0 && leading !== null) {
+					result += leading;
+				}
+				result += currentLine;
+				result += '\n';
+				result += currentIndent;
+				lines += 1;
+				currentLine = word;
+			} else {
+				// Add word to current line
+				currentLine += ' ' + word;
+			}
+
+			// If this is the last word and we're not at the end of the input
+			if (j === words.length - 1) {
+				if (lines > 0 && leading !== null) {
+					result += leading;
+				}
+				result += currentLine.trimEnd();
+				currentLine = '';
+			}
+		}
+
+		return result;
+	}
+
+	/**
+	 * Turn a multi-line quote into a single line
+	 * @param {string} paragraph - The paragraph to unwrap
+	 * @returns {string} Unwrapped text
+	 */
+	static quoteUnwrap(paragraph: string): string {
+		let result = '';
+		const lines = paragraph.split('\n');
+
+		for (let j = 0; j < lines.length; j++) {
+			let line = lines[j] || '';
+
+			// preserve indentation of first line
+			if (j === 0) {
+				const leadingSpaces = line.length - line.trimStart().length;
+				result += ' '.repeat(leadingSpaces);
+			}
+
+			line = line.trim();
+
+			if (line.startsWith('>') && j > 0) {
+				result += line.replace(/^>\s*/, '').trim();
+			} else {
+				result += line;
+			}
+			result += ' ';
+		}
+
+		return result.trimEnd();
+	}
+
+	/**
+	 * Process bullet points in a paragraph
+	 * @param {string} paragraph - The paragraph to process
+	 * @returns {string} Processed text
+	 */
+	static bulletUnwrap(paragraph: string): string {
+		const possibleBullets = ['*', '-', '+'];
+
+		let result = '';
+		const lines = paragraph.split('\n');
+
+		for (let j = 0; j < lines.length; j++) {
+			const line = lines[j] || '';
+
+			// if it starts with any of the possible bullets, start a new line
+			if (possibleBullets.some((bullet) => line.trim().startsWith(bullet))) {
+				if (j > 0) {
+					result = result.trimEnd();
+					result += '\n';
+				}
+				result += line;
+			} else {
+				// it's a continuation of the last bullet
+				result += line.trim();
+			}
+
+			result += ' ';
+		}
+
+		return result.trimEnd();
+	}
+
+	/**
+	 * Basic paragraph unwrapping
+	 * @param {string} paragraph - The paragraph to unwrap
+	 * @returns {string} Unwrapped text
+	 */
+	static simpleUnwrap(paragraph: string): string {
+		let result = '';
+		const lines = paragraph.split('\n');
+		const trailerRegex = /^[!-9;-~]+:\s*.+$/;
+
+		// Process each line in the paragraph
+		for (let j = 0; j < lines.length; j++) {
+			const line = lines[j] || '';
+
+			// if it's a trailer (RFC 822 grammar), add it to the result
+			if (trailerRegex.test(line.trim())) {
+				result += line;
+				result += '\n';
+			} else {
+				result += line;
+				result += ' ';
+			}
+		}
+
+		return result.trimEnd();
+	}
+
+	/**
+	 * Format a user-provided message for storage in a commit.
+	 * @param {string} message - The message to format
+	 * @returns {string} Formatted message for commit storage
+	 */
+	static formatForCommit(message: string): string {
+		// Split the message into paragraphs
+		const paragraphs = message.split('\n\n');
+
+		if (paragraphs.length === 0) {
+			return '';
+		}
+
+		// Keep the first line as is, this is the subject line
+		let result = paragraphs[0] || '';
+		result += '\n\n';
+
+		let codeBlock = false;
+
+		// Format the rest of the message with hard wrapping text paragraphs at 72 chars
+		if (paragraphs.length > 1) {
+			// Process remaining paragraphs
+			for (let i = 1; i < paragraphs.length; i++) {
+				const paragraph = paragraphs[i] || '';
+				const lines = paragraph.split('\n');
+
+				// Process each line in the paragraph
+				for (let x = 0; x < lines.length; x++) {
+					const line = lines[x] || '';
+
+					if (line.startsWith('```')) {
+						codeBlock = !codeBlock;
+						result += line;
+					} else if (codeBlock || line.length <= 72) {
+						result += line;
+					} else {
+						// is this a list item or quote?
+						const isListItem = line.trim().startsWith('* ');
+						const isQuote = line.trim().startsWith('> ');
+
+						if (isListItem || isQuote) {
+							const leadingSpaces = line.length - line.trimStart().length;
+
+							if (isListItem) {
+								result += this.wrapLine(line, null, leadingSpaces + 2);
+							} else {
+								result += this.wrapLine(line, '> ', leadingSpaces);
+							}
+						} else {
+							result += this.wrapLine(line, null, null);
+						}
+					}
+
+					if (x < lines.length - 1) {
+						result += '\n';
+					}
+				}
+
+				result += '\n\n';
+			}
+		}
+
+		return result.trimEnd();
+	}
+
+	/**
+	 * Parse a commit message back into its user-editable form.
+	 * @param {string} formattedMessage - The formatted message to parse
+	 * @returns {string} Message in user-editable form
+	 */
+	static parseForUi(formattedMessage: string): string {
+		// Split the message into paragraphs
+		const paragraphs = formattedMessage.split('\n\n');
+
+		if (paragraphs.length === 0) {
+			return '';
+		}
+
+		let codeBlock = false;
+
+		// Keep the first line as is, this is the subject line
+		let result = paragraphs[0] || '';
+		result += '\n\n';
+
+		if (paragraphs.length > 1) {
+			// Process remaining paragraphs
+			for (let i = 1; i < paragraphs.length; i++) {
+				const paragraph = paragraphs[i] || '';
+
+				// is this a list item or quote?
+				const isListItem = paragraph.trim().startsWith('* ');
+				const isQuote = paragraph.trim().startsWith('>');
+				const startsCodeBlock = paragraph.trim().startsWith('```');
+				const endsCodeBlock = paragraph.trim().endsWith('```');
+
+				if (startsCodeBlock) {
+					codeBlock = !codeBlock;
+				}
+
+				if (codeBlock) {
+					result += paragraph;
+				} else if (isListItem) {
+					result += this.bulletUnwrap(paragraph);
+				} else if (isQuote) {
+					result += this.quoteUnwrap(paragraph);
+				} else {
+					result += this.simpleUnwrap(paragraph);
+				}
+
+				if (endsCodeBlock) {
+					codeBlock = !codeBlock;
+				}
+
+				if (i < paragraphs.length - 1) {
+					result += '\n\n';
+				}
+			}
+		}
+
+		return result.trimEnd();
+	}
+}
+
+export default CommitMessageFormatter;

--- a/apps/desktop/src/lib/utils/commitMessage.ts
+++ b/apps/desktop/src/lib/utils/commitMessage.ts
@@ -1,3 +1,5 @@
+import CommitMessageFormatter from '$lib/commits/commitMessageFormatter';
+
 /**
  * Splits a commit message into a title and description.
  *
@@ -5,15 +7,23 @@
  * next non-emptyline till the last non-empty line.
  *
  * Only the title will be trimmed (unless otherwise specified), the description will keep its original formatting.
+ *
+ * This will also unformat a message from the Git email RFC format
+ * (remove hard wraps at 72 char, etc)
  */
 export function splitMessage(message: string, skipTrimming: boolean = false) {
-	const lines = message.split('\n');
+	let unformattedMessage = CommitMessageFormatter.parseForUi(message);
+
+	const lines = unformattedMessage.split('\n');
 	if (lines.length === 0) {
 		return { title: '', description: '' };
 	}
 
 	if (lines.length === 1) {
-		return { title: skipTrimming ? message : message.trim(), description: '' };
+		return {
+			title: skipTrimming ? unformattedMessage : unformattedMessage.trim(),
+			description: ''
+		};
 	}
 
 	const title = skipTrimming ? lines[0]! : lines[0]!.trim();


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#9kPcDBoQA`](https://gitbutler.com/schacon/gitbutler/reviews/9kPcDBoQA)

**sc-fix-plain-text-mode**


More or less implements this:

https://www.notion.so/gitbutler/Commit-Message-Manifesto-Two-1ab5a4bfdeac8072a722d7889ee38fde


- Remove ruler and wrapping UI elements to rely on dynamic CSS wrapping for plain text mode.
- Implement automatic formatting of commit messages before saving, wrapping at 72 characters and indenting bullets for better terminal `git log` display.
- Add a new class to handle formatting and unformatting of commit messages, ensuring proper serialization.
- Unformat commit messages when editing to allow smooth rewrapping of paragraphs during text modifications.

3 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 3/3 | [unformat commit messages when editing](https://gitbutler.com/schacon/gitbutler/reviews/9kPcDBoQA/commit/ccfcd2d7-ef26-45b3-872f-b7f8b467f601) | ⏳ |  |
| 2/3 | [format commit messages before saving](https://gitbutler.com/schacon/gitbutler/reviews/9kPcDBoQA/commit/05b93cc9-0549-49b4-b28a-65fdc3d614eb) | ⏳ |  |
| 1/3 | [remove ruler and wrapping UI elements](https://gitbutler.com/schacon/gitbutler/reviews/9kPcDBoQA/commit/735300d6-7090-45b9-94b0-c809b0a09e1c) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/schacon/gitbutler/reviews/9kPcDBoQA)_
<!-- GitButler Review Footer Boundary Bottom -->
