### PR TITLE
Commit message edition fixes and test

### DIFF
--- a/apps/desktop/cypress/e2e/errorHandling.cy.ts
+++ b/apps/desktop/cypress/e2e/errorHandling.cy.ts
@@ -59,7 +59,6 @@ describe('Error handling - commit actions', () => {
 			.should('have.value', originalCommitMessage)
 			.should('be.visible')
 			.should('be.enabled')
-			.should('be.focused')
 			.clear()
 			.type(newCommitMessageTitle); // Type the new commit message title
 

--- a/apps/desktop/cypress/e2e/support/mock/backend.ts
+++ b/apps/desktop/cypress/e2e/support/mock/backend.ts
@@ -133,13 +133,14 @@ export default class MockBackend {
 			const commitIndex = branch.commits.findIndex((commit) => commit.id === commitOid);
 			if (commitIndex === -1) continue;
 			const commit = branch.commits[commitIndex]!;
-			const newId = this.renamedCommitId;
+			const newId = this.renamedCommitId + message;
 			branch.commits[commitIndex] = {
 				...commit,
 				message,
 				id: newId
 			};
 			this.stackDetails.set(stackId, editableDetails);
+			this.commitChanges.set(newId, []);
 			return newId;
 		}
 
@@ -226,7 +227,7 @@ export default class MockBackend {
 		const topCommit = branch.commits[branch.commits.length - 1];
 		const parentIds = topCommit ? [topCommit.id] : [];
 
-		const newCommitId = 'new-commit-id';
+		const newCommitId = 'new-commit-id' + message;
 
 		branch.commits = [
 			{

--- a/apps/desktop/cypress/e2e/unifiedDiffView.cy.ts
+++ b/apps/desktop/cypress/e2e/unifiedDiffView.cy.ts
@@ -25,13 +25,15 @@ describe('Unified Diff View', () => {
 
 	it('should open the unified diff view when clicking on a file and show the dependency locks', () => {
 		// There should be uncommitted changes
-		cy.getByTestId('uncommitted-changes-file-list').should('be.visible');
-
-		// // All files should be visible
-		// cy.getByTestId('file-list-item').should(
-		// 	'have.length',
-		// 	mockBackend.getWorktreeChangesFileNames().length
-		// );
+		cy.getByTestId('uncommitted-changes-file-list')
+			.should('be.visible')
+			.within(() => {
+				// All files should be visible
+				cy.getByTestId('file-list-item').should(
+					'have.length',
+					mockBackend.getWorktreeChangesFileNames().length
+				);
+			});
 
 		// Stack with branch should be opened by default
 		cy.getByTestId('branch-header').should('contain', mockBackend.stackId);

--- a/apps/desktop/src/components/v3/CommitMessageEditor.svelte
+++ b/apps/desktop/src/components/v3/CommitMessageEditor.svelte
@@ -75,6 +75,7 @@
 
 		if (isDefined(initialMessage)) {
 			descriptionText.current = initialMessage;
+			composer?.setText(initialMessage);
 		}
 	});
 
@@ -173,7 +174,6 @@
 			}
 		}}
 	/>
-
 	<MessageEditor
 		testId={TestId.CommitDrawerDescriptionInput}
 		bind:this={composer}

--- a/apps/desktop/src/components/v3/CommitView.svelte
+++ b/apps/desktop/src/components/v3/CommitView.svelte
@@ -121,6 +121,7 @@
 	{#snippet children(commit, env)}
 		{@const isConflicted = isCommit(commit) && commit.hasConflicts}
 		{#if projectState.editingCommitMessage.current}
+			{@const parsedMessage = splitMessage(commit.message)}
 			<Drawer
 				testId={TestId.EditCommitMessageDrawer}
 				projectId={env.projectId}
@@ -136,8 +137,8 @@
 					action={editCommitMessage}
 					actionLabel="Save"
 					onCancel={() => setMode('view')}
-					initialTitle={splitMessage(commit.message).title}
-					initialMessage={splitMessage(commit.message).description}
+					initialTitle={parsedMessage.title}
+					initialMessage={parsedMessage.description}
 					loading={messageUpdateResult.current.isLoading}
 					existingCommitId={commit.id}
 				/>

--- a/apps/desktop/src/components/v3/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/v3/WorktreeChanges.svelte
@@ -107,34 +107,30 @@
 
 <ReduxResult {stackId} {projectId} result={changesResult.current}>
 	{#snippet children(changes, { stackId, projectId })}
-		<ScrollableContainer wide>
-			<div
-				class="uncommitted-changes-wrap"
-				use:focusable={{ id: Focusable.UncommittedChanges, parentId: Focusable.WorkspaceLeft }}
-			>
-				<div
-					data-testid={TestId.UncommittedChanges_Header}
-					use:stickyHeader
-					class="worktree-header"
-				>
-					<div class="worktree-header__general">
-						{#if isCommitting}
-							<Checkbox
-								checked={filesPartiallySelected || filesFullySelected}
-								indeterminate={filesPartiallySelected}
-								small
-								onchange={toggleGlobalCheckbox}
-							/>
+		<div
+			class="uncommitted-changes-wrap"
+			use:focusable={{ id: Focusable.UncommittedChanges, parentId: Focusable.WorkspaceLeft }}
+		>
+			<div data-testid={TestId.UncommittedChanges_Header} use:stickyHeader class="worktree-header">
+				<div class="worktree-header__general">
+					{#if isCommitting}
+						<Checkbox
+							checked={filesPartiallySelected || filesFullySelected}
+							indeterminate={filesPartiallySelected}
+							small
+							onchange={toggleGlobalCheckbox}
+						/>
+					{/if}
+					<div class="worktree-header__title truncate">
+						<h3 class="text-14 text-semibold truncate">Uncommitted</h3>
+						{#if changes.length > 0}
+							<Badge>{changes.length}</Badge>
 						{/if}
-						<div class="worktree-header__title truncate">
-							<h3 class="text-14 text-semibold truncate">Uncommitted</h3>
-							{#if changes.length > 0}
-								<Badge>{changes.length}</Badge>
-							{/if}
-						</div>
 					</div>
-					<FileListMode bind:mode={listMode} persist="uncommitted" />
 				</div>
+				<FileListMode bind:mode={listMode} persist="uncommitted" />
+			</div>
+			<ScrollableContainer autoScroll={false}>
 				{#if changes.length > 0}
 					<div data-testid={TestId.UncommittedChanges_FileList} class="uncommitted-changes">
 						<FileList
@@ -177,8 +173,8 @@
 						<WorktreeTipsFooter />
 					</div>
 				{/if}
-			</div>
-		</ScrollableContainer>
+			</ScrollableContainer>
+		</div>
 	{/snippet}
 </ReduxResult>
 


### PR DESCRIPTION
- Added tests for committing multiple times and editing commit messages  
- Updated mock backend to support commit message changes  
- Synchronized initial message with composer in CommitMessageEditor  
- Refactored CommitView to use parsed commit messages  
- Ensured uncommitted changes header remains at the top