### PR TITLE
feat(settings): add autoFetchIntervalMinutes to mock settings

### DIFF
--- a/apps/desktop/cypress/e2e/support/mock/settings.ts
+++ b/apps/desktop/cypress/e2e/support/mock/settings.ts
@@ -13,5 +13,8 @@ export const MOCK_FEATURE_FLAGS: FeatureFlags = {
 export const MOCK_APP_SETTINGS: AppSettings = {
 	onboardingComplete: true,
 	telemetry: MOCK_TELEMETRY_SETINGS,
-	featureFlags: MOCK_FEATURE_FLAGS
+	featureFlags: MOCK_FEATURE_FLAGS,
+	fetch: {
+		autoFetchIntervalMinutes: 15
+	}
 };


### PR DESCRIPTION
Include autoFetchIntervalMinutes with a default value of 15 in the
mock app settings to simulate fetch behavior during tests. This change
improves test coverage for features relying on fetch intervals.