### PR TITLE
Fix big diff performance bottleneck

### DIFF
--- a/packages/ui/src/lib/hunkDiff/HunkDiffBody.svelte
+++ b/packages/ui/src/lib/hunkDiff/HunkDiffBody.svelte
@@ -14,6 +14,7 @@
 		type Row,
 		SectionType
 	} from '$lib/utils/diffParsing';
+	import { intersectionObserver } from '$lib/utils/intersectionObserver';
 	import type { LineSelectionParams } from '$lib/hunkDiff/lineSelection.svelte';
 	import type { Snippet } from 'svelte';
 
@@ -123,6 +124,7 @@
 
 	const showingExtraColumn = $derived(staged !== undefined && !hideCheckboxes);
 	const commentNumericColSpan = $derived(showingExtraColumn ? 3 : 2);
+
 	const commentRows = $derived.by(() => {
 		if (!comment) return undefined;
 		return generateRows(
@@ -141,6 +143,32 @@
 	});
 
 	const commentRow = $derived(commentRows?.[0]);
+
+	/* TODO: Move utility function from `apps/desktop` into this UI library. */
+	function chunk<T>(arr: T[], size: number) {
+		return Array.from({ length: Math.ceil(arr.length / size) }, (_v, i) =>
+			arr.slice(i * size, i * size + size)
+		);
+	}
+
+	/* Number of lines grouped together for intersection observer purposes. */
+	const chunkLength = 5;
+	/* The assumed height of a row, used to set height before rows have rendered. */
+	const defaultChunkHeight = 18;
+
+	const chunkedRows = $derived(chunk(renderRows, chunkLength));
+
+	/* Bound array of booleans used to control rendering of rows. */
+	let chunkVisibility = $state<boolean[]>([]);
+	/* Bound array of chunk heights, for accurate scrolling. */
+	let chunkHeight = $state<number[]>([]);
+
+	$effect(() => {
+		if (chunkedRows) {
+			chunkVisibility.length = chunkedRows.length;
+			chunkHeight.length = chunkedRows.length;
+		}
+	});
 </script>
 
 <tbody
@@ -162,29 +190,61 @@
 			</td>
 		</tr>
 	{/if}
-
-	{#each renderRows as row, idx (lineIdKey( { oldLine: row.beforeLineNumber, newLine: row.afterLineNumber } ))}
-		<HunkDiffRow
-			{minWidth}
-			{idx}
-			{row}
-			{clickable}
-			{lineSelection}
-			{tabSize}
-			{wrapText}
-			{diffFont}
-			{numberHeaderWidth}
-			{onQuoteSelection}
-			{onCopySelection}
-			clearLineSelection={handleClearSelection}
-			{hoveringOverTable}
-			staged={getStageState(row)}
-			{hideCheckboxes}
-			{handleLineContextMenu}
-			{lockWarning}
-		/>
-	{/each}
 </tbody>
+
+{#each chunkedRows as renderRows, i}
+	<tbody
+		onmouseenter={() => (hoveringOverTable = true)}
+		onmouseleave={() => (hoveringOverTable = false)}
+		ontouchstart={(ev) => lineSelection.onTouchStart(ev)}
+		ontouchmove={(ev) => lineSelection.onTouchMove(ev)}
+		ontouchend={() => lineSelection.onEnd()}
+		bind:clientHeight={chunkHeight[i]}
+		use:clickOutside={{
+			handler: handleClearSelection,
+			excludeElement: clickOutsideExcludeElement
+		}}
+		use:intersectionObserver={{
+			callback: (entries) => {
+				chunkVisibility[i] = !!entries?.isIntersecting;
+			},
+			options: { threshold: 0 }
+		}}
+	>
+		{#if chunkVisibility[i]}
+			{#each renderRows as row, idx (lineIdKey( { oldLine: row.beforeLineNumber, newLine: row.afterLineNumber } ))}
+				<HunkDiffRow
+					{minWidth}
+					{idx}
+					{row}
+					{clickable}
+					{lineSelection}
+					{tabSize}
+					{wrapText}
+					{diffFont}
+					{numberHeaderWidth}
+					{onQuoteSelection}
+					{onCopySelection}
+					clearLineSelection={handleClearSelection}
+					{hoveringOverTable}
+					staged={getStageState(row)}
+					{hideCheckboxes}
+					{handleLineContextMenu}
+					{lockWarning}
+				/>
+			{/each}
+		{:else}
+			<tr>
+				<td
+					style:height={chunkHeight[i]
+						? chunkHeight[i] + 'px'
+						: chunkLength * defaultChunkHeight + 'px'}
+				>
+				</td>
+			</tr>
+		{/if}
+	</tbody>
+{/each}
 
 <style lang="postcss">
 	tbody {


### PR DESCRIPTION
By grouping rows together and using an intersection observer we can
selectively render only what's on on screen.