### PR TITLE
fix(commit-message-editor): swap Enter and Tab key behaviors with modifiers

### DIFF
--- a/apps/desktop/src/components/v3/CommitMessageEditor.svelte
+++ b/apps/desktop/src/components/v3/CommitMessageEditor.svelte
@@ -150,15 +150,15 @@
 			projectState.commitTitle.current = input.value;
 		}}
 		onkeydown={(e: KeyboardEvent) => {
-			if (e.key === 'Enter' || e.key === 'Tab') {
-				e.preventDefault();
-				composer?.focus();
-				return;
-			}
-
 			if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
 				e.preventDefault();
 				action();
+				return;
+			}
+
+			if (e.key === 'Enter' || e.key === 'Tab') {
+				e.preventDefault();
+				composer?.focus();
 				return;
 			}
 		}}


### PR DESCRIPTION
Change the keydown handler to trigger the commit action only when Enter is
pressed with Ctrl or Meta keys. Pressing Enter or Tab without modifiers now
moves focus to the composer. 