### PR TITLE
Review flow integs

### DIFF
--- a/apps/desktop/cypress/e2e/review.cy.ts
+++ b/apps/desktop/cypress/e2e/review.cy.ts
@@ -1,0 +1,66 @@
+import { clearCommandMocks, mockCommand } from './support';
+import { PROJECT_ID } from './support/mock/projects';
+import BranchesWithChanges from './support/scenarios/branchesWithChanges';
+
+describe('Review', () => {
+	let mockBackend: BranchesWithChanges;
+
+	beforeEach(() => {
+		mockBackend = new BranchesWithChanges();
+
+		mockCommand('stacks', () => mockBackend.getStacks());
+		mockCommand('stack_details', (params) => mockBackend.getStackDetails(params));
+		mockCommand('changes_in_branch', (args) => mockBackend.getBranchChanges(args));
+		mockCommand('changes_in_worktree', (params) => mockBackend.getWorktreeChanges(params));
+		mockCommand('tree_change_diffs', (params) => mockBackend.getDiff(params));
+		mockCommand('hunk_dependencies_for_workspace_changes', (params) =>
+			mockBackend.getHunkDependencies(params)
+		);
+		mockCommand('get_base_branch_data', () => mockBackend.getBaseBranchData());
+		mockCommand('get_available_review_templates', () => mockBackend.getAvailableReviewTemplates());
+		mockCommand('push_stack', (params) => mockBackend.pushStack(params));
+
+		cy.visit('/');
+
+		cy.url({ timeout: 3000 }).should('include', `/${PROJECT_ID}/workspace`);
+	});
+
+	afterEach(() => {
+		clearCommandMocks();
+	});
+
+	it('should be able to open a GitHub pull request', () => {
+		const prTitle = 'Test PR Title';
+		const prDescription = 'Test PR Description';
+
+		// The branch should be applied. Click it.
+		cy.getByTestId('branch-header', mockBackend.stackId).should('be.visible').click();
+
+		// The Create Branch Review button should be visible.
+		// Click it.
+		cy.getByTestId('branch-drawer-create-review-button').should('be.visible').click();
+
+		// The Review Drawer should be visible.
+		cy.getByTestId('review-drawer').should('be.visible');
+
+		// Since this branch has a single commit, the commit message should be pre-filled.
+		// Update both.
+		cy.getByTestId('review-drawer-title-input')
+			.should('be.visible')
+			.should('be.enabled')
+			.should('have.value', mockBackend.commitTitle)
+			.clear()
+			.type(prTitle);
+
+		cy.getByTestId('review-drawer-description-input')
+			.should('be.visible')
+			.should('contain', mockBackend.commitMessage)
+			.click()
+			.clear()
+			.type(prDescription);
+
+		// The Create Review button should be visible.
+		// Click it.
+		cy.getByTestId('review-drawer-create-button').should('be.visible').should('be.enabled').click();
+	});
+});

--- a/apps/desktop/cypress/e2e/review.cy.ts
+++ b/apps/desktop/cypress/e2e/review.cy.ts
@@ -19,6 +19,8 @@ describe('Review', () => {
 		mockCommand('get_base_branch_data', () => mockBackend.getBaseBranchData());
 		mockCommand('get_available_review_templates', () => mockBackend.getAvailableReviewTemplates());
 		mockCommand('push_stack', (params) => mockBackend.pushStack(params));
+		mockCommand('list_remotes', (params) => mockBackend.listRemotes(params));
+		mockCommand('update_branch_pr_number', (params) => mockBackend.updateBranchPrNumber(params));
 
 		cy.visit('/');
 
@@ -30,6 +32,57 @@ describe('Review', () => {
 	});
 
 	it('should be able to open a GitHub pull request', () => {
+		cy.intercept(
+			{
+				method: 'POST',
+				url: 'https://api.github.com/repos/example/repo/pulls'
+			},
+			{
+				statusCode: 201,
+				body: {
+					number: 42
+				}
+			}
+		).as('createPullRequest');
+
+		cy.intercept(
+			{
+				method: 'GET',
+				url: 'https://api.github.com/repos/example/repo'
+			},
+			{
+				statusCode: 200
+			}
+		).as('getRepo');
+
+		cy.intercept(
+			{
+				method: 'GET',
+				url: 'https://api.github.com/repos/example/repo/pulls/42'
+			},
+			{
+				statusCode: 200,
+				body: {
+					number: 42,
+					state: 'open'
+				}
+			}
+		).as('getPullRequest');
+
+		cy.intercept(
+			{
+				method: 'GET',
+				url: 'https://api.github.com/repos/example/repo/commits/check-runs'
+			},
+			{
+				statusCode: 200,
+				body: {
+					total_count: 0,
+					check_runs: []
+				}
+			}
+		).as('getChecks');
+
 		const prTitle = 'Test PR Title';
 		const prDescription = 'Test PR Description';
 
@@ -62,5 +115,8 @@ describe('Review', () => {
 		// The Create Review button should be visible.
 		// Click it.
 		cy.getByTestId('review-drawer-create-button').should('be.visible').should('be.enabled').click();
+
+		// The PR card should be visible.
+		cy.getByTestId('stacked-pull-request-card').should('be.visible');
 	});
 });

--- a/apps/desktop/cypress/e2e/support/mock/backend.ts
+++ b/apps/desktop/cypress/e2e/support/mock/backend.ts
@@ -18,6 +18,7 @@ import {
 	isDeleteLocalBranchParams,
 	isGetTargetCommitsParams,
 	isIntegrateUpstreamCommitsParams,
+	isPushStackParams,
 	isStackDetailsParams,
 	isUpdateCommitMessageParams,
 	MOCK_BRAND_NEW_BRANCH_NAME,
@@ -37,6 +38,7 @@ import type { HunkDependencies } from '$lib/dependencies/dependencies';
 import type { TreeChange, TreeChanges, WorktreeChanges } from '$lib/hunks/change';
 import type { UnifiedDiff } from '$lib/hunks/diff';
 import type { BranchDetails, Stack, StackDetails } from '$lib/stacks/stack';
+import type { BranchPushResult } from '$lib/stacks/stackService.svelte';
 import type { BranchStatusesResponse, IntegrationOutcome } from '$lib/upstream/types';
 import type { InvokeArgs } from '@tauri-apps/api/core';
 
@@ -454,5 +456,22 @@ export default class MockBackend {
 		}
 
 		// Do nothing for now
+	}
+
+	public getAvailableReviewTemplates(): string[] {
+		return [];
+	}
+
+	public pushStack(args: InvokeArgs | undefined): BranchPushResult {
+		if (!args || !isPushStackParams(args)) {
+			throw new Error('Invalid arguments for pushStack');
+		}
+
+		// Do nothing for now
+
+		return {
+			refname: `refs/heads/${args.stackId}`,
+			remote: 'idk'
+		};
 	}
 }

--- a/apps/desktop/cypress/e2e/support/mock/baseBranch.ts
+++ b/apps/desktop/cypress/e2e/support/mock/baseBranch.ts
@@ -28,9 +28,9 @@ const MOCK_RECENT_COMMITS = [MOCK_COMMIT];
 const MOCK_BASE_BRANCH_DATA = {
 	branchName: 'origin/main',
 	remoteName: 'origin',
-	remoteUrl: 'https://example.com/repo.git',
+	remoteUrl: 'https://github.com/example/repo.git',
 	pushRemoteName: 'origin',
-	pushRemoteUrl: 'https://example.com/repo.git',
+	pushRemoteUrl: null,
 	baseSha: 'abc123',
 	currentSha: 'abc123',
 	behind: 0,

--- a/apps/desktop/cypress/e2e/support/mock/stacks.ts
+++ b/apps/desktop/cypress/e2e/support/mock/stacks.ts
@@ -346,3 +346,27 @@ export function isPushStackParams(params: unknown): params is PushStackParams {
 		typeof params.withForce === 'boolean'
 	);
 }
+
+export type UpdateBranchPRNumberParams = {
+	projectId: string;
+	stackId: string;
+	branchName: string;
+	prNumber: number;
+};
+
+export function isUpdateBranchPRNumberParams(
+	params: unknown
+): params is UpdateBranchPRNumberParams {
+	return (
+		typeof params === 'object' &&
+		params !== null &&
+		'projectId' in params &&
+		typeof params.projectId === 'string' &&
+		'stackId' in params &&
+		typeof params.stackId === 'string' &&
+		'branchName' in params &&
+		typeof params.branchName === 'string' &&
+		'prNumber' in params &&
+		typeof params.prNumber === 'number'
+	);
+}

--- a/apps/desktop/cypress/e2e/support/mock/stacks.ts
+++ b/apps/desktop/cypress/e2e/support/mock/stacks.ts
@@ -79,7 +79,7 @@ export function createMockUpstreamCommit(override: Partial<UpstreamCommit>): Ups
 export const MOCK_BRANCH_DETAILS: BranchDetails = {
 	name: 'branch-a',
 	remoteTrackingBranch: null,
-	description: 'A mock branch for testing',
+	description: null,
 	prNumber: null,
 	reviewId: null,
 	tip: '1234123',
@@ -96,7 +96,7 @@ export const MOCK_BRANCH_DETAILS: BranchDetails = {
 export const MOCK_BRANCH_DETAILS_BRAND_NEW: BranchDetails = {
 	name: MOCK_BRAND_NEW_BRANCH_NAME,
 	remoteTrackingBranch: null,
-	description: 'A mock branch for testing',
+	description: null,
 	prNumber: null,
 	reviewId: null,
 	tip: '1234123',
@@ -325,5 +325,24 @@ export function isIntegrateUpstreamCommitsParams(
 			(params as any).strategy === 'merge' ||
 			(params as any).strategy === 'rebase' ||
 			(params as any).strategy === 'hardreset')
+	);
+}
+
+export type PushStackParams = {
+	projectId: string;
+	stackId: string;
+	withForce: boolean;
+};
+
+export function isPushStackParams(params: unknown): params is PushStackParams {
+	return (
+		typeof params === 'object' &&
+		params !== null &&
+		'projectId' in params &&
+		typeof params.projectId === 'string' &&
+		'stackId' in params &&
+		typeof params.stackId === 'string' &&
+		'withForce' in params &&
+		typeof params.withForce === 'boolean'
 	);
 }

--- a/apps/desktop/cypress/e2e/support/scenarios/branchesWithChanges.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/branchesWithChanges.ts
@@ -5,7 +5,7 @@ import {
 	createMockModificationTreeChange,
 	createMockUnifiedDiffPatch
 } from '../mock/changes';
-import { createMockBranchDetails, createMockStackDetails } from '../mock/stacks';
+import { createMockBranchDetails, createMockCommit, createMockStackDetails } from '../mock/stacks';
 import type { DiffDependency } from '$lib/dependencies/dependencies';
 import type { TreeChange } from '$lib/hunks/change';
 import type { DiffHunk } from '$lib/hunks/hunk';
@@ -27,9 +27,18 @@ const MOCK_BRANCH_A_CHANGES: TreeChange[] = [
 	createMockDeletionTreeChange({ path: 'fileC.txt' })
 ];
 
+const MOCK_COMMIT_TITLE = 'Initial commit';
+const MOCK_COMMIT_MESSAGE = 'This is a test commit';
+
+const MOCK_COMMIT_IN_BRANCH_A = createMockCommit({
+	message: `${MOCK_COMMIT_TITLE}\n\n${MOCK_COMMIT_MESSAGE}`
+});
+
 const MOCK_STACK_DETAILS_A = createMockStackDetails({
 	derivedName: MOCK_STACK_A_ID,
-	branchDetails: [createMockBranchDetails({ name: MOCK_STACK_A_ID })]
+	branchDetails: [
+		createMockBranchDetails({ name: MOCK_STACK_A_ID, commits: [MOCK_COMMIT_IN_BRANCH_A] })
+	]
 });
 
 const MOCK_STACK_B: Stack = {
@@ -154,6 +163,8 @@ const MOCK_DIFF_DEPENDENCY: DiffDependency[] = [
  * Three branches with file changes.
  */
 export default class BranchesWithChanges extends MockBackend {
+	commitTitle = MOCK_COMMIT_TITLE;
+	commitMessage = MOCK_COMMIT_MESSAGE;
 	dependsOnStack = MOCK_STACK_B_ID;
 	bigFileName = MOCK_FILE_J;
 

--- a/apps/desktop/src/components/BranchReview.svelte
+++ b/apps/desktop/src/components/BranchReview.svelte
@@ -10,6 +10,7 @@
 	import { syncPrToBr } from '$lib/forge/prToBrSync.svelte';
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { UiState } from '$lib/state/uiState.svelte';
+	import { TestId } from '$lib/testing/testIds';
 	import { getContext } from '@gitbutler/shared/context';
 	import { reactive } from '@gitbutler/shared/reactiveUtils.svelte';
 	import Button from '@gitbutler/ui/Button.svelte';
@@ -148,6 +149,7 @@
 
 	{#if showCreateButton}
 		<Button
+			testId={TestId.BranchDrawerCreateReviewButton}
 			onclick={() => {
 				if ($settingsStore?.featureFlags.v3) {
 					uiState.project(projectId).drawerPage.current = 'review';

--- a/apps/desktop/src/components/PullRequestCard.svelte
+++ b/apps/desktop/src/components/PullRequestCard.svelte
@@ -32,6 +32,7 @@
 	};
 
 	interface Props {
+		testId?: string;
 		branchName: string;
 		poll?: boolean;
 		prNumber: number;
@@ -44,8 +45,16 @@
 		>;
 	}
 
-	const { poll, prNumber, isPushed, hasParent, baseIsTargetBranch, parentIsPushed, button }: Props =
-		$props();
+	const {
+		testId,
+		poll,
+		prNumber,
+		isPushed,
+		hasParent,
+		baseIsTargetBranch,
+		parentIsPushed,
+		button
+	}: Props = $props();
 
 	let contextMenuEl = $state<ReturnType<typeof ContextMenu>>();
 	let container = $state<HTMLElement>();
@@ -176,6 +185,7 @@
 	</ContextMenu>
 
 	<div
+		data-testid={testId}
 		bind:this={container}
 		role="article"
 		class="review-card pr-card"

--- a/apps/desktop/src/components/ReviewCreation.svelte
+++ b/apps/desktop/src/components/ReviewCreation.svelte
@@ -30,6 +30,7 @@
 	import { ProjectsService } from '$lib/project/projectsService';
 	import { RemotesService } from '$lib/remotes/remotesService';
 	import { StackService } from '$lib/stacks/stackService.svelte';
+	import { TestId } from '$lib/testing/testIds';
 	import { parseRemoteUrl } from '$lib/url/gitUrl';
 	import { UserService } from '$lib/user/userService';
 	import { getBranchNameFromRef } from '$lib/utils/branch';
@@ -382,6 +383,7 @@
 <!-- MAIN FIELDS -->
 <div class="pr-content">
 	<Textbox
+		testId={TestId.ReviewTitleInput}
 		autofocus
 		size="large"
 		placeholder="PR title"
@@ -410,6 +412,7 @@
 
 	<!-- DESCRIPTION FIELD -->
 	<MessageEditor
+		testId={TestId.ReviewDescriptionInput}
 		bind:this={prBody.descriptionInput}
 		{projectId}
 		disabled={isExecuting}

--- a/apps/desktop/src/components/ReviewCreationControls.svelte
+++ b/apps/desktop/src/components/ReviewCreationControls.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { TestId } from '$lib/testing/testIds';
 	import { persisted } from '@gitbutler/shared/persisted';
 	import AsyncButton from '@gitbutler/ui/AsyncButton.svelte';
 	import Button from '@gitbutler/ui/Button.svelte';
@@ -44,6 +45,7 @@
 	<div class="submit-review-actions__general">
 		<Button kind="outline" disabled={isSubmitting} onclick={onCancel}>Cancel</Button>
 		<AsyncButton
+			testId={TestId.ReviewCreateButton}
 			width={166}
 			style="pop"
 			action={async () => onSubmit()}

--- a/apps/desktop/src/components/StackedPullRequestCard.svelte
+++ b/apps/desktop/src/components/StackedPullRequestCard.svelte
@@ -5,6 +5,7 @@
 	import { VirtualBranchService } from '$lib/branches/virtualBranchService';
 	import { DefaultForgeFactory } from '$lib/forge/forgeFactory.svelte';
 	import { StackService } from '$lib/stacks/stackService.svelte';
+	import { TestId } from '$lib/testing/testIds';
 	import { getContext } from '@gitbutler/shared/context';
 	import AsyncButton from '@gitbutler/ui/AsyncButton.svelte';
 	import type { MergeMethod } from '$lib/forge/interface/types';
@@ -94,6 +95,7 @@
 
 {#if pr}
 	<PullRequestCard
+		testId={TestId.StackedPullRequestCard}
 		{branchName}
 		{prNumber}
 		{isPushed}

--- a/apps/desktop/src/components/v3/ReviewView.svelte
+++ b/apps/desktop/src/components/v3/ReviewView.svelte
@@ -6,6 +6,7 @@
 	import { StackPublishingService } from '$lib/history/stackPublishingService';
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { UiState } from '$lib/state/uiState.svelte';
+	import { TestId } from '$lib/testing/testIds';
 	import { getContext } from '@gitbutler/shared/context';
 
 	type Props = {
@@ -58,7 +59,14 @@
 	const ctaDisabled = $derived(reviewCreation ? !reviewCreation.imports.creationEnabled : false);
 </script>
 
-<Drawer {projectId} {stackId} title={getTitleLabel()} disableScroll minHeight={28}>
+<Drawer
+	testId={TestId.ReviewDrawer}
+	{projectId}
+	{stackId}
+	title={getTitleLabel()}
+	disableScroll
+	minHeight={28}
+>
 	<div class="submit-review__container">
 		<ReviewCreation bind:this={reviewCreation} {projectId} {stackId} {branchName} onClose={close} />
 

--- a/apps/desktop/src/lib/forge/github/types.ts
+++ b/apps/desktop/src/lib/forge/github/types.ts
@@ -16,7 +16,7 @@ export type CreateIssueResult = RestEndpointMethodTypes['issues']['create']['res
 export type UpdateResult = RestEndpointMethodTypes['pulls']['update']['response']['data'];
 
 export type PullRequestListItem =
-	| RestEndpointMethodTypes['pulls']['create']['response']['data']
+	| CreatePrResult
 	| RestEndpointMethodTypes['pulls']['list']['response']['data'][number];
 
 export type ChecksResult = RestEndpointMethodTypes['checks']['listForRef']['response']['data'];

--- a/apps/desktop/src/lib/testing/testIds.ts
+++ b/apps/desktop/src/lib/testing/testIds.ts
@@ -68,7 +68,8 @@ export enum TestId {
 	ReviewDrawer = 'review-drawer',
 	ReviewTitleInput = 'review-drawer-title-input',
 	ReviewDescriptionInput = 'review-drawer-description-input',
-	ReviewCreateButton = 'review-drawer-create-button'
+	ReviewCreateButton = 'review-drawer-create-button',
+	StackedPullRequestCard = 'stacked-pull-request-card'
 }
 
 export enum ElementId {

--- a/apps/desktop/src/lib/testing/testIds.ts
+++ b/apps/desktop/src/lib/testing/testIds.ts
@@ -63,7 +63,12 @@ export enum TestId {
 	LargeDiffMessage = 'large-diff-message',
 	LargeDiffMessageButton = 'large-diff-message-button',
 	UpstreamCommitsAccordion = 'upstream-commits-accordion',
-	UpstreamCommitsIntegrateButton = 'upstream-commits-integrate-button'
+	UpstreamCommitsIntegrateButton = 'upstream-commits-integrate-button',
+	BranchDrawerCreateReviewButton = 'branch-drawer-create-review-button',
+	ReviewDrawer = 'review-drawer',
+	ReviewTitleInput = 'review-drawer-title-input',
+	ReviewDescriptionInput = 'review-drawer-description-input',
+	ReviewCreateButton = 'review-drawer-create-button'
 }
 
 export enum ElementId {

--- a/packages/ui/src/lib/Textbox.svelte
+++ b/packages/ui/src/lib/Textbox.svelte
@@ -8,6 +8,7 @@
 	interface Props {
 		element?: HTMLElement;
 		id?: string;
+		testId?: string;
 		type?: inputType;
 		icon?: keyof typeof iconsJson;
 		size?: 'default' | 'large';
@@ -40,6 +41,7 @@
 	let {
 		element = $bindable(),
 		id,
+		testId,
 		type = 'text',
 		icon,
 		value = $bindable(),
@@ -130,6 +132,7 @@
 
 		<input
 			{id}
+			data-testid={testId}
 			{readonly}
 			{required}
 			{placeholder}


### PR DESCRIPTION
- Added Cypress E2E tests for review creation flow and GitHub pull request opening  
- Updated mock backend to support pushStack, review templates, new commands, and PR number updates  
- Introduced testId props to review creation UI components, PullRequestCard, and StackedPullRequestCard for improved testing  
- Updated PullRequestListItem type to include CreatePrResult for GitHub PRs