### PR TITLE
Fix bug in focus tracking

### DIFF
--- a/apps/desktop/src/components/v3/WorkspaceView.svelte
+++ b/apps/desktop/src/components/v3/WorkspaceView.svelte
@@ -54,12 +54,7 @@
 		if (focusGroup.current === Focusable.UncommittedChanges && worktreeSelection.entries.size > 0) {
 			return { type: 'worktree' };
 		}
-		if (
-			focusGroup.current !== Focusable.UncommittedChanges &&
-			currentSelection &&
-			stackId &&
-			branchName
-		) {
+		if (currentSelection && stackId && branchName) {
 			if (currentSelection.commitId) {
 				const selectionId = { type: 'commit', commitId: currentSelection.commitId } as const;
 				if (idSelection.hasItems(selectionId)) return selectionId;


### PR DESCRIPTION
Show commit selection even when focus is on uncommitted changes, if
there are no changes in the worktree.