### PR TITLE
feat: refactor upstream status fetching and stack retrieval

### DIFF
--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -130,6 +130,15 @@ export class StackService {
 		);
 	}
 
+	async fetchStacks(projectId: string) {
+		return await this.api.endpoints.stacks.fetch(
+			{ projectId },
+			{
+				transform: (stacks) => stackSelectors.selectAll(stacks)
+			}
+		);
+	}
+
 	stackAt(projectId: string, index: number) {
 		return this.api.endpoints.stacks.useQuery(
 			{ projectId },


### PR DESCRIPTION
Add fetchStacks method to stackService for direct stack fetching with
transformation. Refactor upstreamStatuses in upstreamIntegrationService
to be async and fetch data directly instead of using reactive queries.
Update IntegrateUpstreamModal to handle async upstream status fetching
and remove reactive derived state. These changes improve data fetching
clarity and simplify status handling logic.