### PR TITLE
UI fixes 57: Redesign draggable chip element for the commit component

### DIFF
--- a/apps/desktop/src/components/v3/BranchList.svelte
+++ b/apps/desktop/src/components/v3/BranchList.svelte
@@ -37,7 +37,7 @@
 		SquashCommitDzHandler,
 		type DzCommitData
 	} from '$lib/commits/dropHandler';
-	import { draggableCommit } from '$lib/dragging/draggable';
+	import { draggableCommitV3 } from '$lib/dragging/draggable';
 	import {
 		ReorderCommitDzHandler,
 		StackingReorderDropzoneManagerFactory
@@ -368,13 +368,13 @@
 														<CardOverlay {hovered} {activated} {label} />
 													{/snippet}
 													<div
-														use:draggableCommit={{
+														use:draggableCommitV3={{
 															disabled: false,
 															label: commit.message.split('\n')[0],
 															sha: commit.id.slice(0, 7),
 															date: getTimeAgo(commit.createdAt),
 															authorImgUrl: undefined,
-															commitType: 'LocalAndRemote',
+															commitType: commit.state.type,
 															data: new CommitDropData(
 																stackId,
 																{

--- a/apps/desktop/src/lib/dragging/draggable.ts
+++ b/apps/desktop/src/lib/dragging/draggable.ts
@@ -1,3 +1,4 @@
+import { getColorFromCommitState } from '$components/v3/lib';
 import { type CommitStatusType } from '$lib/commits/commit';
 import { FileDropData, ChangeDropData, type DropData } from '$lib/dragging/draggables';
 import { dropzoneRegistry } from '$lib/dragging/dropzone';
@@ -246,7 +247,7 @@ function setupDragHandlers(
 //// COMMIT DRAGGABLE ////
 //////////////////////////
 
-export function createCommitElement(
+function createCommitElement(
 	commitType: CommitStatusType | undefined,
 	label: string | undefined,
 	sha: string | undefined,
@@ -285,6 +286,51 @@ export function draggableCommit(
 	function createClone(opts: DraggableConfig) {
 		if (opts.disabled) return;
 		return createCommitElement(opts.commitType, opts.label, opts.sha, opts.date, opts.authorImgUrl);
+	}
+	return setupDragHandlers(node, initialOpts, createClone, {
+		handlerWidth: true
+	});
+}
+
+/////////////////////////////
+//// COMMIT DRAGGABLE V3 ////
+/////////////////////////////
+
+function createCommitElementV3(
+	commitType: CommitStatusType | undefined,
+	label: string | undefined
+): HTMLDivElement {
+	const commitColor = getColorFromCommitState(commitType || 'LocalOnly', false);
+
+	const cardEl = createElement('div', [
+		'draggable-commit-v3',
+		commitType === 'LocalOnly' || commitType === 'Integrated' || commitType === 'Base'
+			? 'draggable-commit-v3-local'
+			: 'draggable-commit-v3-remote'
+	]);
+
+	cardEl.style.setProperty('--commit-color', commitColor);
+
+	const commitIndicationEl = createElement('div', ['draggable-commit-v3-indicator']);
+	const labelEl = createElement(
+		'div',
+		['truncate', 'text-13', 'text-semibold'],
+		label || 'Empty commit'
+	);
+
+	cardEl.appendChild(commitIndicationEl);
+	cardEl.appendChild(labelEl);
+
+	return cardEl;
+}
+
+export function draggableCommitV3(
+	node: HTMLElement,
+	initialOpts: DraggableConfig | NonDraggableConfig
+) {
+	function createClone(opts: DraggableConfig) {
+		if (opts.disabled) return;
+		return createCommitElementV3(opts.commitType, opts.label);
 	}
 	return setupDragHandlers(node, initialOpts, createClone, {
 		handlerWidth: true

--- a/apps/desktop/src/styles/draggable.css
+++ b/apps/desktop/src/styles/draggable.css
@@ -67,7 +67,7 @@
 	}
 }
 
-/* File drag */
+/* FILE DRAG */
 .dragchip-file-container {
 	position: relative;
 	display: flex;
@@ -174,6 +174,55 @@
 	}
 }
 
+/* COMMIT DRAG CARD V3 */
+.draggable-commit-v3 {
+	position: relative;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	background-color: var(--clr-bg-1);
+	border-radius: var(--radius-m);
+	border: 1px solid var(--clr-border-2);
+	padding: 0 10px;
+	max-width: 240px;
+	height: 36px;
+	overflow: hidden;
+
+	&::before {
+		z-index: 1;
+		content: '';
+		position: absolute;
+		top: 0;
+		left: 14px;
+		width: 2px;
+		height: 100%;
+		background-color: var(--commit-color);
+	}
+}
+
+.draggable-commit-v3-indicator {
+	z-index: 2;
+	flex-shrink: 0;
+	width: 10px;
+	height: 10px;
+	background-color: var(--commit-color);
+	outline: 3px solid var(--clr-bg-1);
+}
+
+.draggable-commit-v3-local {
+	& .draggable-commit-v3-indicator {
+		border-radius: 50%;
+	}
+}
+
+.draggable-commit-v3-remote {
+	& .draggable-commit-v3-indicator {
+		border-radius: 2px;
+		transform: rotate(45deg) scale(0.9);
+	}
+}
+
+/* OTHER */
 .dragging {
 	opacity: 0.5;
 }


### PR DESCRIPTION
- Redesigned the draggable chip element for the commit component

Before:
<img width="552" alt="image" src="https://github.com/user-attachments/assets/67e9eb4d-2f06-4184-8017-942fdb1f6475" />

After:
![image.png](https://app.gitbutler.com/uploads/1a4c2cfb-8c66-4f16-b517-5ee4995f9e8c)