### PR TITLE
Add two global variables for console debugging

### DIFF
--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -48,6 +48,7 @@
 	import { RemotesService } from '$lib/remotes/remotesService';
 	import { setSecretsService } from '$lib/secrets/secretsService';
 	import { ChangeSelectionService } from '$lib/selection/changeSelection.svelte';
+	import { IdSelection } from '$lib/selection/idSelection.svelte';
 	import { SETTINGS, loadUserSettings } from '$lib/settings/userSettings';
 	import { ShortcutService } from '$lib/shortcuts/shortcutService.svelte';
 	import { StackService } from '$lib/stacks/stackService.svelte';
@@ -155,6 +156,7 @@
 	const cloudUserService = new CloudUserService(data.cloud, appState.appDispatch);
 	const cloudProjectService = new CloudProjectService(data.cloud, appState.appDispatch);
 	const dependecyService = new DependencyService(clientState.backendApi);
+	const idSelection = new IdSelection(worktreeService, stackService);
 
 	const cloudBranchService = new CloudBranchService(data.cloud, appState.appDispatch);
 	const cloudPatchService = new CloudPatchCommitService(data.cloud, appState.appDispatch);
@@ -233,6 +235,7 @@
 	setContext(DiffService, diffService);
 	setContext(UploadsService, data.uploadsService);
 	setContext(DependencyService, dependecyService);
+	setContext(IdSelection, idSelection);
 
 	setNameNormalizationServiceContext(new IpcNameNormalizationService(invoke));
 
@@ -275,6 +278,10 @@
 			console.log('Also written to window.tauriEnv');
 		}
 	});
+
+	/** These are made available on the window object for easier debugging. */
+	(window as any)['uiState'] = uiState;
+	(window as any)['idSelection'] = idSelection;
 </script>
 
 <svelte:window

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -35,11 +35,9 @@
 	import { projectCloudSync } from '$lib/project/projectCloudSync.svelte';
 	import { ProjectService } from '$lib/project/projectService';
 	import { getSecretsService } from '$lib/secrets/secretsService';
-	import { IdSelection } from '$lib/selection/idSelection.svelte';
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { UpstreamIntegrationService } from '$lib/upstream/upstreamIntegrationService';
 	import { debounce } from '$lib/utils/debounce';
-	import { WorktreeService } from '$lib/worktree/worktreeService.svelte';
 	import { BranchService as CloudBranchService } from '@gitbutler/shared/branches/branchService';
 	import { LatestBranchLookupService } from '@gitbutler/shared/branches/latestBranchLookupService';
 	import { getContext } from '@gitbutler/shared/context';
@@ -143,10 +141,6 @@
 
 	const focusManager = new FocusManager();
 	setContext(FocusManager, focusManager);
-
-	const worktreeService = getContext(WorktreeService);
-	const idSelection = new IdSelection(worktreeService, stackService);
-	setContext(IdSelection, idSelection);
 
 	let intervalId: any;
 


### PR DESCRIPTION
Having access to `uiState` and `idSelection` from the console makes
debugging certain things a bit more convenient.

I tried to think of risks related to doing this, but could not come up
with any. We should perhaps just avoid using these for testing
purposes, it's better to test public interfaces.