### PR TITLE
Fix deduplication error in creating new stack

### DIFF
--- a/crates/gitbutler-branch-actions/tests/extra/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/extra/mod.rs
@@ -274,8 +274,8 @@ fn create_branch_in_the_middle() -> Result<()> {
     stacks.sort_by_key(|b| b.order);
     assert_eq!(stacks.len(), 3);
     assert_eq!(stacks[0].name, "Lane");
-    assert_eq!(stacks[1].name, "Lane 2");
-    assert_eq!(stacks[2].name, "Lane 1");
+    assert_eq!(stacks[1].name, "Lane-2");
+    assert_eq!(stacks[2].name, "Lane-1");
 
     Ok(())
 }

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/references.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/references.rs
@@ -69,7 +69,7 @@ mod create_virtual_branch {
         assert_eq!(branches[0].id, stack_entry_1.id);
         assert_eq!(branches[0].name, "name");
         assert_eq!(branches[1].id, stack_entry_2.id);
-        assert_eq!(branches[1].name, "name 1");
+        assert_eq!(branches[1].name, "name-1");
 
         let refnames = repo
             .references()
@@ -175,7 +175,7 @@ mod update_virtual_branch {
         assert_eq!(branches[0].id, stack_entry_1.id);
         assert_eq!(branches[0].name, "name");
         assert_eq!(branches[1].id, stack_entry_2.id);
-        assert_eq!(branches[1].name, "name 1");
+        assert_eq!(branches[1].name, "name-1");
 
         let refnames = repo
             .references()

--- a/crates/gitbutler-branch/src/dedup.rs
+++ b/crates/gitbutler-branch/src/dedup.rs
@@ -1,5 +1,5 @@
 pub fn dedup(existing: &[&str], new: &str) -> String {
-    dedup_fmt(existing, new, " ")
+    dedup_fmt(existing, new, "-")
 }
 
 /// Makes sure that _new_ is not in _existing_ by adding a number to it.
@@ -33,16 +33,16 @@ mod tests {
     fn test_dedup() {
         for (existing, new, expected) in [
             (vec!["bar", "baz"], "foo", "foo"),
-            (vec!["foo", "bar", "baz"], "foo", "foo 1"),
-            (vec!["foo", "foo 2"], "foo", "foo 3"),
-            (vec!["foo", "foo 1", "foo 2"], "foo", "foo 3"),
-            (vec!["foo", "foo 1", "foo 2"], "foo 1", "foo 1 1"),
-            (vec!["foo", "foo 1", "foo 2"], "foo 2", "foo 2 1"),
-            (vec!["foo", "foo 1", "foo 2"], "foo 3", "foo 3"),
-            (vec!["foo 2"], "foo", "foo 3"),
-            (vec!["foo", "foo 1", "foo 2", "foo 4"], "foo", "foo 5"),
-            (vec!["foo", "foo 0"], "foo", "foo 1"),
-            (vec!["foo 0"], "foo", "foo 1"),
+            (vec!["foo", "bar", "baz"], "foo", "foo-1"),
+            (vec!["foo", "foo-2"], "foo", "foo-3"),
+            (vec!["foo", "foo-1", "foo-2"], "foo", "foo-3"),
+            (vec!["foo", "foo-1", "foo-2"], "foo-1", "foo-1-1"),
+            (vec!["foo", "foo-1", "foo-2"], "foo-2", "foo-2-1"),
+            (vec!["foo", "foo-1", "foo-2"], "foo-3", "foo-3"),
+            (vec!["foo-2"], "foo", "foo-3"),
+            (vec!["foo", "foo-1", "foo-2", "foo-4"], "foo", "foo-5"),
+            (vec!["foo", "foo-0"], "foo", "foo-1"),
+            (vec!["foo-0"], "foo", "foo-1"),
         ] {
             assert_eq!(dedup(&existing, new), expected);
         }


### PR DESCRIPTION
If say branch `test` is taken we want to deduplicate to `test-1`
rather than `test 1`, since the latter is not a valid ref. 