### PR TITLE
fix the selection for hunk lines

### DIFF
--- a/packages/ui/src/lib/hunkDiff/HunkDiffRow.svelte
+++ b/packages/ui/src/lib/hunkDiff/HunkDiffRow.svelte
@@ -116,6 +116,7 @@
 {#snippet countColumn(side: CountColumnSide)}
 	{@const deltaLine = isDeltaLine(row.type)}
 	<td
+		data-testid="hunk-count-column"
 		class="table__numberColumn"
 		data-no-drag
 		class:diff-line-deletion={row.type === SectionType.RemovedLines}


### PR DESCRIPTION
### Description

- Fixed the unified diff line selection logic for partial hunk selection.
- Corrected the determination of whether a file fully selected.
- Added a data-testid attribute to the hunk count column to improve E2E testing.