### PR TITLE
fix(desktop): update CanPublishReviewPlugin and PublishButton for improved prop typing and tooltip logic

### DIFF
--- a/apps/desktop/src/components/v3/CanPublishReviewPlugin.svelte
+++ b/apps/desktop/src/components/v3/CanPublishReviewPlugin.svelte
@@ -8,8 +8,8 @@
 		projectId: string;
 		stackId?: string;
 		branchName: string | undefined;
-		prNumber?: number;
-		reviewId?: string;
+		prNumber: number | undefined;
+		reviewId: string | undefined;
 	};
 
 	const { projectId, stackId, branchName, prNumber, reviewId }: Props = $props();
@@ -33,7 +33,7 @@
 
 	const canPublish = stackPublishingService.canPublish;
 	const canPublishBR = $derived(!!($canPublish && name && !reviewId));
-	const canPublishPR = $derived(!!(forge.current.authenticated && !pr));
+	const canPublishPR = $derived(forge.current.authenticated && !pr);
 
 	const ctaLabel = $derived.by(() => {
 		if (canPublishBR && canPublishPR) {

--- a/apps/desktop/src/components/v3/PublishButton.svelte
+++ b/apps/desktop/src/components/v3/PublishButton.svelte
@@ -58,6 +58,8 @@
 	);
 
 	const branchName = $derived(branchToReview?.name);
+	const prNumber = $derived(branchToReview?.prNumber ?? undefined);
+	const reviewId = $derived(branchToReview?.reviewId ?? undefined);
 
 	const canPublishBR = $derived(!!canPublishReviewPlugin?.imports.canPublishBR);
 	const canPublishPR = $derived(!!canPublishReviewPlugin?.imports.canPublishPR);
@@ -75,7 +77,7 @@
 		uiState.project(projectId).drawerPage.set('review');
 	}
 
-	function getPushTooltip() {
+	const tooltip = $derived.by(() => {
 		if (!branchName) {
 			return 'No available branches';
 		}
@@ -85,10 +87,17 @@
 		} else {
 			return branches.length > 1 ? `Create for ${branchName}` : undefined;
 		}
-	}
+	});
 </script>
 
-<CanPublishReviewPlugin {projectId} {stackId} {branchName} bind:this={canPublishReviewPlugin} />
+<CanPublishReviewPlugin
+	{projectId}
+	{stackId}
+	{branchName}
+	{prNumber}
+	{reviewId}
+	bind:this={canPublishReviewPlugin}
+/>
 
 {#if canPublish && !branchEmpty}
 	<div class="publish-button" style:flex>
@@ -96,7 +105,7 @@
 			style="neutral"
 			wide
 			disabled={!branchName || hasConflicts}
-			tooltip={getPushTooltip()}
+			{tooltip}
 			tooltipPosition="top"
 			onclick={publish}
 		>


### PR DESCRIPTION
- Make prNumber and reviewId props explicitly `number | undefined` and `string | undefined` in CanPublishReviewPlugin
- Refactor PublishButton to pass prNumber and reviewId props, and improve tooltip logic
- Adjust canPublishPR logic for clarity
- Update usage of CanPublishReviewPlugin in PublishButton for new props and tooltip binding