### PR TITLE
Better FE Error on nonexclusive project access

### DIFF
--- a/apps/desktop/src/lib/backend/ipc.ts
+++ b/apps/desktop/src/lib/backend/ipc.ts
@@ -8,7 +8,8 @@ export enum Code {
 	ProjectsGitAuth = 'errors.projects.git.auth',
 	DefaultTargetNotFound = 'errors.projects.default_target.not_found',
 	CommitSigningFailed = 'errors.commit.signing_failed',
-	ProjectMissing = 'errors.projects.missing'
+	ProjectMissing = 'errors.projects.missing',
+	NonexclusiveAccess = 'errors.projects.nonexclusive.access'
 }
 
 export type TauriCommandError = { name: string; message: string; code?: string };

--- a/crates/gitbutler-error/src/error.rs
+++ b/crates/gitbutler-error/src/error.rs
@@ -135,6 +135,7 @@ pub enum Code {
     ProjectMissing,
     AuthorMissing,
     BranchNotFound,
+    NonexclusiveAccess,
 }
 
 impl std::fmt::Display for Code {
@@ -149,6 +150,7 @@ impl std::fmt::Display for Code {
             Code::AuthorMissing => "errors.git.author_missing",
             Code::ProjectMissing => "errors.projects.missing",
             Code::BranchNotFound => "errors.branch.notfound",
+            Code::NonexclusiveAccess => "errors.projects.nonexclusive.access",
         };
         f.write_str(code)
     }

--- a/crates/gitbutler-tauri/src/window.rs
+++ b/crates/gitbutler-tauri/src/window.rs
@@ -93,6 +93,7 @@ pub(crate) mod state {
         }
     }
     use event::ChangeForFrontend;
+    use gitbutler_error::error::Code;
 
     struct State {
         /// The id of the project displayed by the window.
@@ -160,7 +161,9 @@ pub(crate) mod state {
                     return Ok(());
                 }
             }
-            let exclusive_access = project.try_exclusive_access()?;
+            let exclusive_access = project
+                .try_exclusive_access()
+                .context(Code::NonexclusiveAccess)?;
             let handler = handler_from_app(&self.app_handle)?;
             let worktree_dir = project.path.clone();
             let project_id = project.id;


### PR DESCRIPTION
This way it's possible for the UI to correctly explain what's going on.

### Tasks

* [x] backend makes lock-error distinguishable
* [x] frontend uses this new Code variant
