### PR TITLE
Create a new stack from dropped files

### DIFF
--- a/apps/desktop/src/components/v3/MultiStackOfflaneDropzone.svelte
+++ b/apps/desktop/src/components/v3/MultiStackOfflaneDropzone.svelte
@@ -2,7 +2,8 @@
 	import Dropzone from '$components/Dropzone.svelte';
 	import { OutsideLaneDzHandler } from '$lib/stacks/dropHandler';
 	import { StackService } from '$lib/stacks/stackService.svelte';
-	import { getContext } from '@gitbutler/shared/context';
+	import { UiState } from '$lib/state/uiState.svelte';
+	import { inject } from '@gitbutler/shared/context';
 
 	interface Props {
 		projectId: string;
@@ -10,8 +11,8 @@
 
 	const { projectId }: Props = $props();
 
-	const stackService = getContext(StackService);
-	const dzHandler = $derived(new OutsideLaneDzHandler(stackService, projectId));
+	const [stackService, uiState] = inject(StackService, UiState);
+	const dzHandler = $derived(new OutsideLaneDzHandler(stackService, projectId, uiState));
 </script>
 
 <div class="hidden-dropzone">
@@ -105,7 +106,7 @@
 		align-items: center;
 		justify-content: center;
 		gap: 10px;
-		padding: 20px 30px;
+		min-height: 240px;
 		min-width: 240px;
 
 		/* SVG ANIMATION */

--- a/apps/desktop/src/lib/commits/dropHandler.ts
+++ b/apps/desktop/src/lib/commits/dropHandler.ts
@@ -1,3 +1,4 @@
+import { changesToDiffSpec } from '$lib/commits/utils';
 import {
 	ChangeDropData,
 	FileDropData,
@@ -518,20 +519,6 @@ function filesToDiffSpec(data: FileDropData): DiffSpec[] {
 		return {
 			previousPathBytes: null,
 			pathBytes: file.path as any, // Rust type is BString.
-			hunkHeaders: []
-		};
-	});
-}
-
-/** Helper function that converts `ChangeDropData` to `DiffSpec`. */
-function changesToDiffSpec(data: ChangeDropData): DiffSpec[] {
-	const changes = data.changes;
-	return changes.map((change) => {
-		const previousPathBytes =
-			change.status.type === 'Rename' ? change.status.subject.previousPathBytes : null;
-		return {
-			previousPathBytes,
-			pathBytes: change.pathBytes,
 			hunkHeaders: []
 		};
 	});

--- a/apps/desktop/src/lib/commits/utils.ts
+++ b/apps/desktop/src/lib/commits/utils.ts
@@ -1,4 +1,6 @@
 import type { DetailedCommit } from '$lib/commits/commit';
+import type { ChangeDropData } from '$lib/dragging/draggables';
+import type { DiffSpec } from '$lib/hunks/hunk';
 
 type DivergenceResult =
 	| { type: 'localDiverged'; commit: DetailedCommit }
@@ -31,4 +33,18 @@ export function findLastDivergentCommit(
 	}
 
 	return { type: 'notDiverged' };
+}
+
+/** Helper function that converts `ChangeDropData` to `DiffSpec`. */
+export function changesToDiffSpec(data: ChangeDropData): DiffSpec[] {
+	const changes = data.changes;
+	return changes.map((change) => {
+		const previousPathBytes =
+			change.status.type === 'Rename' ? change.status.subject.previousPathBytes : null;
+		return {
+			previousPathBytes,
+			pathBytes: change.pathBytes,
+			hunkHeaders: []
+		};
+	});
 }

--- a/apps/desktop/src/lib/stacks/dropHandler.ts
+++ b/apps/desktop/src/lib/stacks/dropHandler.ts
@@ -1,7 +1,13 @@
 import { filesToOwnership } from '$lib/branches/ownership';
+import { changesToDiffSpec } from '$lib/commits/utils';
 import { ChangeDropData, FileDropData, HunkDropData } from '$lib/dragging/draggables';
+import { showError } from '$lib/notifications/toasts';
 import type { DropzoneHandler } from '$lib/dragging/handler';
-import type { StackService } from '$lib/stacks/stackService.svelte';
+import type {
+	CreateCommitRequestWorktreeChanges,
+	StackService
+} from '$lib/stacks/stackService.svelte';
+import type { UiState } from '$lib/state/uiState.svelte';
 
 /** Handler that creates a new stack from files or hunks. */
 export class NewStackDzHandler implements DropzoneHandler {
@@ -31,19 +37,145 @@ export class NewStackDzHandler implements DropzoneHandler {
 	}
 }
 
+const STUB_COMMIT_MESSAGE = 'New commit';
 /** Handler when drop changes on a special outside lanes dropzone. */
 export class OutsideLaneDzHandler implements DropzoneHandler {
 	constructor(
 		private stackService: StackService,
-		private projectId: string
+		private projectId: string,
+		private readonly uiState: UiState
 	) {}
 
 	accepts(data: unknown) {
-		return data instanceof ChangeDropData && !data.isCommitted;
+		if (!(data instanceof ChangeDropData)) return false;
+		if (data.selectionId.type === 'branch') return false;
+		if (data.selectionId.type === 'commit' && data.stackId === undefined) return false;
+		return true;
 	}
 
-	ondrop(data: HunkDropData | FileDropData) {
-		// TODO: Implement logic
-		console.warn('Outside lane drop', data);
+	async ondrop(data: ChangeDropData) {
+		switch (data.selectionId.type) {
+			case 'branch': {
+				// This should never happen, but just in case
+				console.warn('Moving changes from a branch to a new stack is not supported');
+				break;
+			}
+			case 'commit': {
+				const { stack, outcome, branchName } = await this.createNewStackAndCommit();
+
+				const sourceStackId = data.stackId;
+				const sourceCommitId = data.selectionId.commitId;
+				if (sourceStackId) {
+					await this.moveChangesToNewCommit(
+						stack.id,
+						outcome.newCommit,
+						sourceStackId,
+						sourceCommitId,
+						branchName,
+						data
+					);
+				} else {
+					// Should not happen, but just in case
+					throw new Error('Change drop data must specify the source stackId');
+				}
+				break;
+			}
+			case 'worktree': {
+				const worktreeChanges = changesToWorktreeChanges(data);
+				const { stack, outcome, branchName } = await this.createNewStackAndCommit(worktreeChanges);
+
+				this.uiState.stack(stack.id).selection.set({
+					branchName,
+					commitId: outcome.newCommit
+				});
+
+				break;
+			}
+		}
 	}
+
+	/**
+	 * Moves the changes from the source commit to the new commit in the new stack.
+	 */
+	private async moveChangesToNewCommit(
+		destinationStackId: string,
+		destinationCommitId: string,
+		sourceStackId: string,
+		sourceCommitId: string,
+		branchName: string,
+		data: ChangeDropData
+	) {
+		const { replacedCommits } = await this.stackService.moveChangesBetweenCommits({
+			projectId: this.projectId,
+			destinationStackId: destinationStackId,
+			destinationCommitId: destinationCommitId,
+			sourceStackId,
+			sourceCommitId,
+			changes: changesToDiffSpec(data)
+		});
+
+		const newCommitId = replacedCommits.find(([before]) => before === destinationCommitId)?.[1];
+		if (!newCommitId) {
+			// This happend only if something went wrong
+			throw new Error('No new commit id found for the moved changes');
+		}
+
+		this.uiState.stack(destinationStackId).selection.set({
+			branchName,
+			commitId: newCommitId
+		});
+		this.uiState.project(this.projectId).stackId.set(destinationStackId);
+	}
+
+	/**
+	 * Creates a new stack and stub commit into it.
+	 */
+	private async createNewStackAndCommit(
+		worktreeChanges: CreateCommitRequestWorktreeChanges[] = []
+	) {
+		const stack = await this.stackService.newStackMutation({
+			projectId: this.projectId,
+			branch: {}
+		});
+		const branchName = stack.heads[0]?.name;
+		if (!branchName) {
+			// This should never happen, but just in case
+			throw new Error('No branch name found for the new stack');
+		}
+		const outcome = await this.stackService.createCommitMutation({
+			projectId: this.projectId,
+			stackId: stack.id,
+			stackBranchName: branchName,
+			parentId: undefined,
+			message: STUB_COMMIT_MESSAGE,
+			worktreeChanges
+		});
+
+		if (outcome.pathsToRejectedChanges.length > 0) {
+			showError(
+				'Some changes were not committed',
+				'The following files were not committed becuase they are locked to another branch:\n' +
+					outcome.pathsToRejectedChanges.map(([_reason, path]) => path).join('\n')
+			);
+		}
+		return { stack, outcome, branchName };
+	}
+}
+
+/**
+ * Converts a `ChangeDropData` object into an array of `CreateCommitRequestWorktreeChanges`.
+ */
+function changesToWorktreeChanges(changes: ChangeDropData): CreateCommitRequestWorktreeChanges[] {
+	const worktreeChanges: CreateCommitRequestWorktreeChanges[] = [];
+	for (const change of changes.changes) {
+		const previousPathBytes =
+			change.status.type === 'Rename' ? change.status.subject.previousPathBytes : null;
+		worktreeChanges.push({
+			pathBytes: change.pathBytes,
+			previousPathBytes,
+			hunkHeaders: []
+		});
+	}
+
+	return worktreeChanges;
 }


### PR DESCRIPTION
### Description

- Implement drag-and-drop functionality to create a new stack from dropped files.
- Automatically commit the changes after creating the new stack.
- Share common utility functions across components.
- Invalidate commit changes after moving files to ensure consistency.
- Update UI and styling for the MultiStackOfflaneDropzone component to support the new outside lane dropzone logic.