### PR TITLE
follow-up for `ref-info`: more reliability

### DIFF
--- a/apps/desktop/cypress/e2e/support/index.ts
+++ b/apps/desktop/cypress/e2e/support/index.ts
@@ -122,7 +122,7 @@ Cypress.on('window:before:load', (win) => {
 				return MOCK_OPEN_WORKSPACE_MODE;
 			case 'set_project_active':
 				// Do nothing
-				return await Promise.resolve();
+				return await Promise.resolve(true);
 			case 'fetch_from_remotes':
 				// Do nothing
 				return await Promise.resolve();

--- a/apps/desktop/src/lib/backend/ipc.ts
+++ b/apps/desktop/src/lib/backend/ipc.ts
@@ -8,8 +8,7 @@ export enum Code {
 	ProjectsGitAuth = 'errors.projects.git.auth',
 	DefaultTargetNotFound = 'errors.projects.default_target.not_found',
 	CommitSigningFailed = 'errors.commit.signing_failed',
-	ProjectMissing = 'errors.projects.missing',
-	NonexclusiveAccess = 'errors.projects.nonexclusive.access'
+	ProjectMissing = 'errors.projects.missing'
 }
 
 export type TauriCommandError = { name: string; message: string; code?: string };

--- a/apps/desktop/src/lib/project/projectsService.ts
+++ b/apps/desktop/src/lib/project/projectsService.ts
@@ -40,9 +40,10 @@ export class ProjectsService {
 		this.projects.set(await this.loadAll());
 	}
 
-	async setActiveProject(projectId: string): Promise<void> {
-		await invoke('set_project_active', { id: projectId });
+	async setActiveProject(projectId: string): Promise<boolean> {
+		const is_exclusive = await invoke<boolean>('set_project_active', { id: projectId });
 		await this.reload();
+		return is_exclusive;
 	}
 
 	async getProject(projectId: string, noValidation?: boolean) {

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -13,7 +13,6 @@
 	import TryV3Modal from '$components/TryV3Modal.svelte';
 	import IrcPopups from '$components/v3/IrcPopups.svelte';
 	import NotOnGitButlerBranchV3 from '$components/v3/NotOnGitButlerBranch.svelte';
-	import { Code, isTauriCommandError } from '$lib/backend/ipc';
 	import { BaseBranch } from '$lib/baseBranch/baseBranch';
 	import BaseBranchService from '$lib/baseBranch/baseBranchService.svelte';
 	import { BranchService } from '$lib/branches/branchService.svelte';
@@ -259,16 +258,14 @@
 	async function setActiveProjectOrRedirect() {
 		// Optimistically assume the project is viewable
 		try {
-			await projectsService.setActiveProject(projectId);
-		} catch (error: unknown) {
-			if (isTauriCommandError(error) && error.code === Code.NonexclusiveAccess) {
+			const is_first_window_on_project = await projectsService.setActiveProject(projectId);
+			if (!is_first_window_on_project) {
 				showInfo(
 					'Just FYI, this project is already open in another window',
 					'There might be some unexpected behavior if you open it in multiple windows'
 				);
-
-				return;
 			}
+		} catch (error: unknown) {
 			showError('Failed to set the project active', error);
 		}
 	}

--- a/crates/but-cli/src/args.rs
+++ b/crates/but-cli/src/args.rs
@@ -133,6 +133,11 @@ pub enum Subcommands {
         /// The ID of the stack to list details for.
         id: StackId,
     },
+    /// Returns everything we know about the given ref, or `HEAD`.
+    RefInfo {
+        /// The name of the ref to get workspace information for.
+        ref_name: Option<String>,
+    },
     /// Return all stack branches related to the given `id`.
     StackBranches {
         /// The ID of the stack to list branches from.

--- a/crates/but-cli/src/command/mod.rs
+++ b/crates/but-cli/src/command/mod.rs
@@ -422,6 +422,26 @@ pub async fn watch(args: &super::Args) -> anyhow::Result<()> {
     Ok(())
 }
 
+pub fn ref_info(args: &super::Args, ref_name: Option<&str>) -> anyhow::Result<()> {
+    let (repo, project) = repo_and_maybe_project(args, RepositoryOpenMode::General)?;
+    let opts = but_workspace::ref_info::Options {
+        stack_commit_limit: 0,
+        expensive_commit_info: true,
+    };
+
+    let project = project.with_context(|| {
+        format!(
+            "Currently there must be an official project so we have metadata: {project_dir}",
+            project_dir = args.current_dir.display()
+        )
+    })?;
+    let meta = ref_metadata_toml(&project)?;
+    debug_print(match ref_name {
+        None => but_workspace::head_info(&repo, &meta, opts),
+        Some(ref_name) => but_workspace::ref_info(repo.find_reference(ref_name)?, &meta, opts),
+    }?)
+}
+
 fn indices_or_headers_to_hunk_headers(
     repo: &gix::Repository,
     indices_or_headers: Option<IndicesOrHeaders<'_>>,

--- a/crates/but-cli/src/main.rs
+++ b/crates/but-cli/src/main.rs
@@ -101,6 +101,7 @@ async fn main() -> Result<()> {
         args::Subcommands::StackDetails { id } => {
             command::stacks::details(*id, &args.current_dir, args.v3)
         }
+        args::Subcommands::RefInfo { ref_name } => command::ref_info(&args, ref_name.as_deref()),
         args::Subcommands::HunkAssignments => {
             command::assignment::hunk_assignments(&args.current_dir, args.json)
         }

--- a/crates/but-workspace/src/branch.rs
+++ b/crates/but-workspace/src/branch.rs
@@ -495,16 +495,6 @@ pub fn remove_branch_from_workspace(
 // TODO: move this to the crate root once the 'old' implementation isn't used anymore.
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct Stack {
-    /// The index into the parents-array of its [`WorkspaceCommit`](crate::WorkspaceCommit), but for our
-    /// purposes just a way to refer to the stack.
-    ///
-    /// The actual index is dependent on the order in which they are merged into the workspace commit,
-    /// if the stack is merged at all.
-    // TODO: find a way to map this to (or provide) legacy StackIDs
-    pub index: usize,
-    /// The commit that the tip of the stack is pointing to.
-    /// It is `None` if there is no commit as this repository is newly initialized, or no `base` is available.
-    pub tip: Option<gix::ObjectId>,
     /// If there is an integration branch, we know a base commit shared with the integration branch from
     /// which we branched off.
     /// Otherwise, it's the merge-base of all stacks in the current workspace.
@@ -524,6 +514,10 @@ pub struct Stack {
 }
 
 impl Stack {
+    /// Return the tip of the stack, which is either the first commit of the first segment or `None` if this is an unborn branch.
+    pub fn tip(&self) -> Option<gix::ObjectId> {
+        self.segments.first().and_then(|name| name.tip())
+    }
     /// Return the name of the top-most [`StackSegment`].
     ///
     /// It is `None` if this branch is the top-most stack segment and the `ref_name` wasn't pointing to

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -72,7 +72,7 @@ mod commit;
 ///
 /// Note that many of these types should eventually end up in the crate root.
 pub mod ref_info;
-pub use ref_info::function::{ref_info, ref_info_at};
+pub use ref_info::function::{head_info, ref_info};
 
 /// High level Stack funtions that use primitives from this crate (`but-workspace`)
 pub mod stack_ext;

--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::indexing_slicing)]
 
-/// Options for the [`head_info()`](crate::ref_info) call.
+/// Options for the [`ref_info()`](crate::ref_info) call.
 #[derive(Default, Debug, Copy, Clone)]
 pub struct Options {
     /// The maximum amount of commits to list *per stack*. Note that a [`StackSegment`](crate::branch::StackSegment) will always have a single commit, if available,

--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -30,7 +30,9 @@ pub(crate) mod function {
     use but_core::ref_metadata::ValueInfo;
     use gitbutler_oxidize::ObjectIdExt as _;
     use gix::prelude::{ObjectIdExt, ReferenceExt};
+    use gix::refs::Category;
     use gix::revision::walk::Sorting;
+    use gix::trace;
     use std::collections::hash_map::Entry;
     use std::collections::{HashMap, HashSet};
     use tracing::instrument;
@@ -38,8 +40,8 @@ pub(crate) mod function {
     /// Gather information about the current `HEAD` and the workspace that might be associated with it, based on data in `repo` and `meta`.
     /// Use `options` to further configure the call.
     ///
-    /// For details, see [`ref_info_at()`].
-    pub fn ref_info(
+    /// For details, see [`ref_info()`].
+    pub fn head_info(
         repo: &gix::Repository,
         meta: &impl but_core::RefMetadata,
         opts: super::Options,
@@ -52,8 +54,6 @@ pub(crate) mod function {
                     target_ref: workspace_data_of_workspace_branch(meta, ref_name.as_ref())?
                         .and_then(|ws| ws.target_ref),
                     stacks: vec![Stack {
-                        index: 0,
-                        tip: None,
                         base: None,
                         segments: vec![StackSegment {
                             commits_unique_from_tip: vec![],
@@ -76,7 +76,7 @@ pub(crate) mod function {
             }
             gix::head::Kind::Symbolic(name) => name.attach(repo),
         };
-        ref_info_at(existing_ref, meta, opts)
+        ref_info(existing_ref, meta, opts)
     }
 
     /// Gather information about the commit at `existing_ref` and the workspace that might be associated with it,
@@ -89,31 +89,36 @@ pub(crate) mod function {
     /// Make sure the `repo` is initialized with a decently sized Object cache so querying the same commit multiple times will be cheap(er).
     /// Also, **IMPORTANT**, it must use in-memory objects to avoid leaking objects generated during test-merges to disk!
     #[instrument(level = tracing::Level::DEBUG, skip(meta), err(Debug))]
-    pub fn ref_info_at(
+    pub fn ref_info(
         mut existing_ref: gix::Reference<'_>,
         meta: &impl but_core::RefMetadata,
-        super::Options {
-            stack_commit_limit,
-            expensive_commit_info,
-        }: super::Options,
+        opts: super::Options,
     ) -> anyhow::Result<RefInfo> {
         let ws_data = workspace_data_of_workspace_branch(meta, existing_ref.name())?;
-        let (workspace_ref_name, target_ref) = if let Some(data) = ws_data {
+        let (workspace_ref_name, target_ref, stored_workspace_stacks) = if let Some(ws_data) =
+            ws_data
+        {
             // TODO: figure out what to do with workspace information, consolidate it with what's there as well
             //       to know which branch is where.
-            (Some(existing_ref.name().to_owned()), data.target_ref)
+            (
+                Some(existing_ref.name().to_owned()),
+                ws_data.target_ref,
+                Some(ws_data.stacks),
+            )
         } else {
             // We'd want to assure we don't overcount commits even if we are handed a non-workspace ref, so we always have to
             // search for known workspaces.
             // Do get the first known target ref for now.
+            let ws_data_iter = meta
+                .iter()
+                .filter_map(Result::ok)
+                .filter_map(|(ref_name, item)| {
+                    item.downcast::<but_core::ref_metadata::Workspace>()
+                        .ok()
+                        .map(|ws| (ref_name, ws))
+                });
             let mut target_refs =
-                meta.iter()
-                    .filter_map(Result::ok)
-                    .filter_map(|(ref_name, item)| {
-                        item.downcast::<but_core::ref_metadata::Workspace>()
-                            .ok()
-                            .and_then(|ws| ws.target_ref.map(|target| (ref_name, target)))
-                    });
+                ws_data_iter.map(|(ref_name, ws)| (ref_name, ws.target_ref, ws.stacks));
             let first_target = target_refs.next();
             if target_refs.next().is_some() {
                 bail!(
@@ -121,9 +126,23 @@ pub(crate) mod function {
                 )
             }
             first_target
-                .map(|(a, b)| (Some(a), Some(b)))
+                .map(|(a, b, c)| (Some(a), b, Some(c)))
                 .unwrap_or_default()
         };
+        let repo = existing_ref.repo;
+        // If there are multiple choices for a ref that points to a commit we encounter, use one of these.
+        let mut preferred_ref_names = stored_workspace_stacks
+            .as_ref()
+            .map(|stacks| {
+                stacks
+                    .iter()
+                    .flat_map(|stack| stack.branches.iter().map(|b| b.ref_name.as_ref()))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let target_remote_symbolic_name = target_ref
+            .as_ref()
+            .and_then(|rn| extract_remote_name(rn.as_ref(), &repo.remote_names()));
 
         let ref_commit = existing_ref.peel_to_commit()?;
         let ref_commit = crate::WorkspaceCommit {
@@ -138,17 +157,17 @@ pub(crate) mod function {
             .transpose()?;
         let cache = repo.commit_graph_if_enabled()?;
         let mut graph = repo.revision_graph(cache.as_ref());
-        let base: Option<_> = if target_ref_id.is_none() {
-            repo.merge_base_octopus_with_graph(ref_commit.parents.iter().cloned(), &mut graph)?
-                .into()
-        } else {
-            None
-        };
         let mut boundary = gix::hashtable::HashSet::default();
         let mut stacks = if ref_commit.is_managed() {
+            let base: Option<_> = if target_ref_id.is_none() {
+                repo.merge_base_octopus_with_graph(ref_commit.parents.iter().cloned(), &mut graph)?
+                    .into()
+            } else {
+                None
+            };
             // The commits we have already associated with a stack segment.
             let mut stacks = Vec::new();
-            for (index, commit_id) in ref_commit.parents.iter().enumerate() {
+            for commit_id in ref_commit.parents.iter() {
                 let tip = *commit_id;
                 let base = base
                     .map(Ok)
@@ -161,16 +180,19 @@ pub(crate) mod function {
                 boundary.extend(base);
                 let segments = collect_stack_segments(
                     tip.attach(repo),
-                    refs_by_id
-                        .get(&tip)
-                        .and_then(|refs| refs.first().map(|r| r.as_ref())),
+                    refs_by_id.get(&tip).and_then(|refs| {
+                        refs.iter()
+                            .find(|rn| preferred_ref_names.iter().any(|orn| *orn == rn.as_ref()))
+                            .or_else(|| refs.first())
+                            .map(|rn| rn.as_ref())
+                    }),
                     Some(RefLocation::ReachableFromWorkspaceCommit),
                     &boundary,
-                    // TODO: get from workspace information maybe?
-                    &[], /* preferred refs */
-                    stack_commit_limit,
+                    &preferred_ref_names,
+                    opts.stack_commit_limit,
                     &refs_by_id,
                     meta,
+                    target_remote_symbolic_name.as_deref(),
                 )?;
 
                 boundary.extend(segments.iter().flat_map(|segment| {
@@ -183,8 +205,6 @@ pub(crate) mod function {
                 }));
 
                 stacks.push(Stack {
-                    index,
-                    tip: Some(tip),
                     segments,
                     base,
                     // TODO: but as part of the commits.
@@ -199,11 +219,64 @@ pub(crate) mod function {
                 .map(|target_id| repo.merge_base_with_graph(target_id, tip, &mut graph))
                 .transpose()?
                 .map(|base| base.detach());
+            if let Some((workspace_ref, base)) = workspace_ref_name
+                .as_ref()
+                .filter(|workspace_ref| workspace_ref.as_ref() != existing_ref.name())
+                .zip(base)
+            {
+                let workspace_contains_ref_tip =
+                    walk_commits(repo, workspace_ref.as_ref(), base)?.contains(&*tip);
+                if workspace_contains_ref_tip {
+                    // To assure the stack is counted consistently even when queried alone, redo the query.
+                    // This should be avoided (i.e., the caller should consume the 'highest value'
+                    // refs if possible, but that's not always the case.
+                    let mut info = ref_info(repo.find_reference(workspace_ref)?, meta, opts)?;
+                    if let Some((stack_index, segment_index)) = info
+                        .stacks
+                        .iter()
+                        .enumerate()
+                        .find_map(|(stack_index, stack)| {
+                            stack.segments.iter().enumerate().find_map(
+                                |(segment_index, segment)| {
+                                    segment
+                                        .ref_name
+                                        .as_ref()
+                                        .is_some_and(|rn| rn.as_ref() == existing_ref.name())
+                                        .then_some((stack_index, segment_index))
+                                },
+                            )
+                        })
+                    {
+                        let mut curr_stack_idx = 0;
+                        info.stacks.retain(|_| {
+                            let retain = curr_stack_idx == stack_index;
+                            curr_stack_idx += 1;
+                            retain
+                        });
+                        let mut curr_segment_idx = 0;
+                        info.stacks[0].segments.retain(|_| {
+                            let retain = curr_segment_idx >= segment_index;
+                            curr_segment_idx += 1;
+                            retain
+                        });
+                    } else {
+                        // TODO: a test for that, is it even desirable?
+                        info.stacks.clear();
+                        trace::warn!(
+                            "Didn't find {ref_name} in ref-info, even though commit {tip} is reachable from {workspace_ref}",
+                            ref_name = existing_ref.name().as_bstr(),
+                        );
+                    }
+                    return Ok(info);
+                }
+            }
             let boundary = {
                 let mut hs = gix::hashtable::HashSet::default();
                 hs.extend(base);
                 hs
             };
+
+            preferred_ref_names.push(existing_ref.name());
             let segments = collect_stack_segments(
                 tip,
                 Some(existing_ref.name()),
@@ -218,16 +291,15 @@ pub(crate) mod function {
                         }
                     }
                 }),
-                &boundary,                         /* boundary commits */
-                &[existing_ref.name().to_owned()], /* preferred refs */
-                stack_commit_limit,
+                &boundary, /* boundary commits */
+                &preferred_ref_names,
+                opts.stack_commit_limit,
                 &refs_by_id,
                 meta,
+                target_remote_symbolic_name.as_deref(),
             )?;
 
             vec![Stack {
-                index: 0,
-                tip: Some(tip.detach()),
                 // TODO: compute base if target-ref is available, but only if this isn't the target ref!
                 base,
                 segments,
@@ -235,7 +307,51 @@ pub(crate) mod function {
             }]
         };
 
-        if expensive_commit_info {
+        if let Some(ws_stacks) = stored_workspace_stacks.as_ref() {
+            // Stacks that are genuinely reachable we have ot show.
+            // Empty ones are special as they don't have their own commits and aren't distinguishable
+            // by traversing a workspace commit. For this, we have workspace metadata to tell us what is what.
+            for stack in stacks
+                .iter_mut()
+                .filter(|stack| stack.name() != Some(existing_ref.name()))
+            {
+                // Find all empty segments that aren't listed in our workspace stacks metadata, and remove them.
+                let desired_stack_segments = ws_stacks.iter().find(|ws_stack| {
+                    ws_stack
+                        .branches
+                        .first()
+                        .is_some_and(|branch| Some(branch.ref_name.as_ref()) == stack.name())
+                });
+                let num_segments_to_keep = stack
+                    .segments
+                    .iter()
+                    .enumerate()
+                    .rev()
+                    .by_ref()
+                    .take_while(|(_idx, segment)| segment.commits_unique_from_tip.is_empty())
+                    .take_while(|(_idx, segment)| {
+                        segment
+                            .ref_name
+                            .as_ref()
+                            .zip(desired_stack_segments)
+                            .is_none_or(|(srn, desired_stack)| {
+                                // We don't let the desired order matter, just that an empty segment is (not) mentioned.
+                                desired_stack
+                                    .branches
+                                    .iter()
+                                    .all(|branch| &branch.ref_name != srn)
+                            })
+                    })
+                    .map(|t| t.0)
+                    .last();
+                if let Some(keep) = num_segments_to_keep {
+                    // Empty stacks are OK for now….
+                    stack.segments.drain(keep..);
+                }
+            }
+        }
+
+        if opts.expensive_commit_info {
             populate_commit_info(target_ref.as_ref(), &mut stacks, repo, &mut graph)?;
         }
 
@@ -270,6 +386,35 @@ pub(crate) mod function {
             .collect())
     }
 
+    fn lookup_remote_tracking_branch(
+        repo: &gix::Repository,
+        ref_name: &gix::refs::FullNameRef,
+    ) -> anyhow::Result<Option<gix::refs::FullName>> {
+        Ok(repo
+            .branch_remote_tracking_ref_name(ref_name, gix::remote::Direction::Fetch)
+            .transpose()?
+            .map(|rn| rn.into_owned()))
+    }
+
+    fn extract_remote_name(
+        ref_name: &gix::refs::FullNameRef,
+        remotes: &gix::remote::Names<'_>,
+    ) -> Option<String> {
+        let (category, shorthand_name) = ref_name.category_and_short_name()?;
+        if !matches!(category, Category::RemoteBranch) {
+            return None;
+        }
+
+        let longest_remote = remotes
+            .iter()
+            .rfind(|reference_name| shorthand_name.starts_with(reference_name))
+            .ok_or(anyhow::anyhow!(
+                "Failed to find remote branch's corresponding remote"
+            ))
+            .ok()?;
+        Some(longest_remote.to_string())
+    }
+
     /// For each stack in `stacks`, and for each stack segment within it, check if a remote tracking branch is available
     /// and existing. Then find its commits and fill in commit-information of the commits that are reachable by the stack tips as well.
     ///
@@ -284,20 +429,6 @@ pub(crate) mod function {
         repo: &'repo gix::Repository,
         merge_graph: &mut MergeBaseCommitGraph<'repo, '_>,
     ) -> anyhow::Result<()> {
-        fn find_remote_ref_tip(
-            repo: &gix::Repository,
-            ref_name: &gix::refs::FullNameRef,
-        ) -> anyhow::Result<Option<gix::ObjectId>> {
-            let Some(remote_ref_name) = repo
-                .branch_remote_tracking_ref_name(ref_name, gix::remote::Direction::Fetch)
-                .transpose()?
-            else {
-                return Ok(None);
-            };
-
-            try_refname_to_id(repo, remote_ref_name.as_ref())
-        }
-
         #[derive(Hash, Clone, Eq, PartialEq)]
         enum ChangeIdOrCommitData {
             ChangeId(String),
@@ -308,107 +439,118 @@ pub(crate) mod function {
         }
         let mut boundary = gix::hashtable::HashSet::default();
         let mut ambiguous_commits = HashSet::<ChangeIdOrCommitData>::new();
+        // NOTE: The check for similarity is currently run across all remote branches in the stack.
+        //       Further, this doesn't handle reorderings/topology differences at all, it's just there or not.
         let mut similarity_lut = HashMap::<ChangeIdOrCommitData, gix::ObjectId>::new();
         let git2_repo = git2::Repository::open(repo.path())?;
         for stack in stacks {
             boundary.clear();
             boundary.extend(stack.base);
 
-            let segments_with_remote_ref_tips: Vec<_> = stack
+            let segments_with_remote_ref_tips_and_base: Vec<_> = stack
                 .segments
                 .iter()
                 .enumerate()
                 .map(|(index, segment)| {
-                    (
-                        index,
-                        segment.ref_name.as_ref().and_then(|ref_name| {
-                            find_remote_ref_tip(repo, ref_name.as_ref()).ok().flatten()
-                        }),
-                    )
+                    let remote_ref_tip =
+                        segment
+                            .remote_tracking_ref_name
+                            .as_ref()
+                            .and_then(|remote_ref_name| {
+                                try_refname_to_id(repo, remote_ref_name.as_ref())
+                                    .ok()
+                                    .flatten()
+                            });
+                    (index, remote_ref_tip)
                 })
                 .collect();
             // Start the remote commit collection on the segment with the first remote,
-            // and stop commit-status handling at the first segment which has a remote (as it would be a new starting point.
-            let segments_with_remote_ref_tips_and_base: Vec<_> = segments_with_remote_ref_tips
-                .iter()
-                // TODO: a test for this: remote_ref_tip selects the start, and the base is always the next start's tip or the stack base.
-                .filter_map(|(index, remote_ref_tip)| {
-                    remote_ref_tip.and_then(|tip| {
-                        segments_with_remote_ref_tips
-                            .get((index + 1)..)
-                            .and_then(|slice| {
-                                slice.iter().find_map(|(index, remote_ref_tip)| {
-                                    remote_ref_tip.and_then(|_| stack.segments[*index].tip())
-                                })
-                            })
-                            .or(stack.base)
-                            .map(|base| (index, tip, base))
-                    })
-                })
-                .collect();
-
-            for (segment_index, remote_ref_tip, base) in segments_with_remote_ref_tips_and_base {
-                boundary.insert(base);
-
-                let segment = &mut stack.segments[*segment_index];
-                let local_commit_ids: gix::hashtable::HashSet = segment
-                    .commits_unique_from_tip
+            // and stop commit-status handling at the first segment which has a remote (as it would be a new starting point).
+            let segments_with_remote_ref_tips_and_base: Vec<_> =
+                segments_with_remote_ref_tips_and_base
                     .iter()
-                    .map(|c| c.id)
+                    // TODO: a test for this: remote_ref_tip selects the start, and the base is always the next start's tip or the stack base.
+                    .map(|(index, remote_ref_tip)| {
+                        let remote_ref_tip_and_base = remote_ref_tip.and_then(|remote_ref_tip| {
+                            segments_with_remote_ref_tips_and_base
+                                .get((index + 1)..)
+                                .and_then(|slice| {
+                                    slice.iter().find_map(|(index, remote_ref_tip)| {
+                                        remote_ref_tip.and_then(|_| stack.segments[*index].tip())
+                                    })
+                                })
+                                .or(stack.base)
+                                .map(|base| (remote_ref_tip, base))
+                        });
+                        (index, remote_ref_tip_and_base)
+                    })
                     .collect();
 
-                let mut insert_or_expell_ambiguous = |k: ChangeIdOrCommitData, v: gix::ObjectId| {
-                    if ambiguous_commits.contains(&k) {
-                        return;
-                    }
-                    match similarity_lut.entry(k) {
-                        Entry::Occupied(ambiguous) => {
-                            ambiguous_commits.insert(ambiguous.key().clone());
-                            ambiguous.remove();
-                        }
-                        Entry::Vacant(entry) => {
-                            entry.insert(v);
-                        }
-                    }
-                };
+            for (segment_index, remote_ref_tip_and_base) in segments_with_remote_ref_tips_and_base {
+                let segment = &mut stack.segments[*segment_index];
+                if let Some((remote_ref_tip, base_for_remote)) = remote_ref_tip_and_base {
+                    boundary.insert(base_for_remote);
 
-                for info in remote_ref_tip
-                    .attach(repo)
-                    .ancestors()
-                    .first_parent_only()
-                    .sorting(Sorting::BreadthFirst)
-                    // TODO: boundary should be 'hide'.
-                    .selected(|commit_id_to_yield| !boundary.contains(commit_id_to_yield))?
-                {
-                    let info = info?;
-                    // Don't break, maybe the local commits are reachable through multiple avenues.
-                    if local_commit_ids.contains(&info.id) {
-                        for local_commit in &mut segment.commits_unique_from_tip {
-                            local_commit.relation =
-                                LocalCommitRelation::LocalAndRemote(local_commit.id);
-                        }
-                    } else {
-                        let commit = but_core::Commit::from_id(info.id())?;
-                        let has_conflicts = commit.is_conflicted();
-                        if let Some(hdr) = commit.headers() {
+                    let local_commit_ids: gix::hashtable::HashSet = segment
+                        .commits_unique_from_tip
+                        .iter()
+                        .map(|c| c.id)
+                        .collect();
+
+                    let mut insert_or_expell_ambiguous =
+                        |k: ChangeIdOrCommitData, v: gix::ObjectId| {
+                            if ambiguous_commits.contains(&k) {
+                                return;
+                            }
+                            match similarity_lut.entry(k) {
+                                Entry::Occupied(ambiguous) => {
+                                    ambiguous_commits.insert(ambiguous.key().clone());
+                                    ambiguous.remove();
+                                }
+                                Entry::Vacant(entry) => {
+                                    entry.insert(v);
+                                }
+                            }
+                        };
+
+                    for info in remote_ref_tip
+                        .attach(repo)
+                        .ancestors()
+                        .first_parent_only()
+                        .sorting(Sorting::BreadthFirst)
+                        // TODO: boundary should be 'hide'.
+                        .selected(|commit_id_to_yield| !boundary.contains(commit_id_to_yield))?
+                    {
+                        let info = info?;
+                        // Don't break, maybe the local commits are reachable through multiple avenues.
+                        if local_commit_ids.contains(&info.id) {
+                            for local_commit in &mut segment.commits_unique_from_tip {
+                                local_commit.relation =
+                                    LocalCommitRelation::LocalAndRemote(local_commit.id);
+                            }
+                        } else {
+                            let commit = but_core::Commit::from_id(info.id())?;
+                            let has_conflicts = commit.is_conflicted();
+                            if let Some(hdr) = commit.headers() {
+                                insert_or_expell_ambiguous(
+                                    ChangeIdOrCommitData::ChangeId(hdr.change_id),
+                                    commit.id.detach(),
+                                );
+                            }
                             insert_or_expell_ambiguous(
-                                ChangeIdOrCommitData::ChangeId(hdr.change_id),
+                                ChangeIdOrCommitData::CommitData {
+                                    author: commit.author.clone(),
+                                    message: commit.message.clone(),
+                                },
                                 commit.id.detach(),
                             );
+                            segment.commits_unique_in_remote_tracking_branch.push(
+                                branch::RemoteCommit {
+                                    inner: commit.into(),
+                                    has_conflicts,
+                                },
+                            );
                         }
-                        insert_or_expell_ambiguous(
-                            ChangeIdOrCommitData::CommitData {
-                                author: commit.author.clone(),
-                                message: commit.message.clone(),
-                            },
-                            commit.id.detach(),
-                        );
-                        segment.commits_unique_in_remote_tracking_branch.push(
-                            branch::RemoteCommit {
-                                inner: commit.into(),
-                                has_conflicts,
-                            },
-                        );
                     }
                 }
 
@@ -429,6 +571,7 @@ pub(crate) mod function {
                                 LocalCommitRelation::LocalAndRemote(*remote_commit_id);
                         }
                     }
+                    local_commit.has_conflicts = commit.is_conflicted();
                 }
             }
 
@@ -480,6 +623,7 @@ pub(crate) mod function {
     /// `ref_location` it the location of `tip_ref`
     /// `preferred_refs` is an arbitrarily sorted array of names that should be used in the returned segments if they are encountered during the traversal
     /// *and* there are more than one ref pointing to it.
+    /// `symbolic_remote_name` is used to infer the name of the remote tracking ref in case `tip_ref` doesn't have a remote configured.
     ///
     /// Note that `boundary_commits` are sorted so binary-search can be used to quickly check membership.
     ///
@@ -495,10 +639,11 @@ pub(crate) mod function {
         tip_ref: Option<&gix::refs::FullNameRef>,
         ref_location: Option<RefLocation>,
         boundary_commits: &gix::hashtable::HashSet,
-        preferred_refs: &[gix::refs::FullName],
+        preferred_refs: &[&gix::refs::FullNameRef],
         mut limit: usize,
         refs_by_id: &RefsById,
         meta: &impl but_core::RefMetadata,
+        symbolic_remote_name: Option<&str>,
     ) -> anyhow::Result<Vec<StackSegment>> {
         let mut out = Vec::new();
         let mut segment = Some(StackSegment {
@@ -529,7 +674,7 @@ pub(crate) mod function {
             if let Some(refs) = refs_by_id.get(&info.id) {
                 let ref_at_commit = refs
                     .iter()
-                    .find(|rn| preferred_refs.iter().any(|orn| orn == *rn))
+                    .find(|rn| preferred_refs.iter().any(|orn| *orn == rn.as_ref()))
                     .or_else(|| refs.first())
                     .map(|rn| rn.to_owned());
                 if ref_at_commit.as_ref().map(|rn| rn.as_ref()) == tip_ref {
@@ -556,10 +701,26 @@ pub(crate) mod function {
         }
         out.extend(segment);
 
+        let repo = tip.repo;
         for segment in out.iter_mut() {
             let Some(ref_name) = segment.ref_name.as_ref() else {
                 continue;
             };
+            segment.remote_tracking_ref_name =
+                lookup_remote_tracking_branch(repo, ref_name.as_ref())?.or_else(|| {
+                    let symbolic_remote_name = symbolic_remote_name?;
+                    // Deduce the ref-name as fallback.
+                    // TODO: remove this - this is only required to support legacy repos that
+                    //       didn't setup normal Git remotes.
+                    // let remote_name = target_
+                    let remote_tracking_ref_name = format!(
+                        "refs/remotes/{symbolic_remote_name}/{short_name}",
+                        short_name = ref_name.shorten()
+                    );
+                    repo.find_reference(&remote_tracking_ref_name)
+                        .ok()
+                        .map(|remote_ref| remote_ref.name().to_owned())
+                });
             let branch_info = meta.branch(ref_name.as_ref())?;
             if !branch_info.is_default() {
                 segment.metadata = Some((*branch_info).clone())

--- a/crates/but-workspace/src/virtual_branches_metadata.rs
+++ b/crates/but-workspace/src/virtual_branches_metadata.rs
@@ -13,6 +13,7 @@ use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
+#[derive(Debug)]
 struct Snapshot {
     /// The time at which the `content` was changed, before it was written to disk.
     changed_at: Option<Instant>,
@@ -62,6 +63,7 @@ impl Snapshot {
 /// that is possibly written multiple times. It will write itself on drop only, and log write failures.
 ///
 /// The idea is that it's forgiving and easy to use, while helping to eventually migrate to a database.
+#[derive(Debug)]
 pub struct VirtualBranchesTomlMetadata {
     // What is currently in memory for query or editing.
     snapshot: Snapshot,

--- a/crates/but-workspace/tests/fixtures/generated-archives/.gitignore
+++ b/crates/but-workspace/tests/fixtures/generated-archives/.gitignore
@@ -27,3 +27,4 @@
 /three-commits-with-line-offset-and-workspace-commit.tar
 /with-remotes-no-workspace.tar
 /with-remotes-and-workspace.tar
+/with-conflict.tar

--- a/crates/but-workspace/tests/fixtures/scenario/with-conflict.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/with-conflict.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+git init
+# A repository with a normal and an artificial conflicting commit
+echo content >file && git add . && git commit -m "init"
+git tag normal
+
+conflict_files_id=$(git hash-object -wt blob --stdin <<EOF
+ancestorEntries = [ "a-one", "a-two" ]
+ourEntries = [ "o-one", "o-two" ]
+theirEntries = [ "t-one", "t-two" ]
+EOF
+)
+
+empty_blob=$(git hash-object -wt blob /dev/null)
+git update-index --index-info <<EOF
+100644 blob $empty_blob	.auto-resolution/file
+100644 blob $empty_blob	.conflict-base-0/file
+100644 blob $conflict_files_id	.conflict-files
+100644 blob $empty_blob	.conflict-side-0/file
+100644 blob $empty_blob	.conflict-side-1/file
+100644 blob $empty_blob	README.txt
+EOF
+
+conflict_tree=$(git write-tree)
+
+conflict_commit=$(git hash-object -wt commit --stdin <<EOF
+tree $conflict_tree
+parent $(git rev-parse HEAD)
+author GitButler <gitbutler@gitbutler.com> 1730625617 +0100
+committer Sebastian Thiel <sebastian.thiel@icloud.com> 1736343261 +0100
+gitbutler-headers-version 2
+gitbutler-change-id 0f74c342-1cd3-4408-b965-6c2dfac89857
+gitbutler-conflicted 2
+
+GitButler WIP Commit
+
+
+EOF
+)
+git reset --hard $conflict_commit
+git tag conflicted
+

--- a/crates/but-workspace/tests/fixtures/scenario/with-remotes-and-workspace.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/with-remotes-and-workspace.sh
@@ -57,3 +57,27 @@ git clone remote remote-advanced-ff
 
   create_workspace_commit_once A
 )
+
+# There are multiple stacked branches that could lead towards a shared stack.
+git clone remote multiple-stacks-with-shared-segment
+(cd multiple-stacks-with-shared-segment
+  git checkout -b A origin/A
+  git reset --hard @~1
+
+set -x
+  git checkout -b B-on-A
+  echo >new-in-B && git add . && git commit -am "add new file in B-on-A"
+
+  git checkout -b C-on-A A
+  echo >new-in-C && git add . && git commit -am "add new file in C-on-A"
+
+  create_workspace_commit_once B-on-A C-on-A
+)
+
+# A single lane directly at the base of the target branch (origin/main)
+git clone remote empty-workspace-with-branch-below
+(cd empty-workspace-with-branch-below
+   git checkout -b unrelated
+
+  create_workspace_commit_once unrelated
+)

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit.rs
@@ -1,9 +1,12 @@
-use but_workspace::{ref_info, ref_info_at};
+use bstr::ByteSlice;
+use but_testsupport::{visualize_commit_graph, visualize_commit_graph_all};
+use but_workspace::{head_info, ref_info};
+use gitbutler_stack::StackId;
 use pretty_assertions::assert_eq;
 
 #[test]
 fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
-    let (repo, mut meta) = read_only_in_memory_scenario("remote-advanced-ff")?;
+    let (mut repo, mut meta) = read_only_in_memory_scenario("remote-advanced-ff")?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
     * fb27086 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     | * 89cc2d3 (origin/A) change in A
@@ -12,17 +15,16 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
     * c166d42 (origin/main, origin/HEAD, main) init-integration
     ");
 
-    // Needs a branch for workspace to 'fake-exists'.
-    add_workspace(&mut meta);
+    // Needs a branch for workspace implied by a branch with metadata.
+    add_stack(
+        &mut meta,
+        StackId::from_number_for_testing(1),
+        "A",
+        StackState::InWorkspace,
+    );
     // We can look at a workspace ref directly (via HEAD)
-    let info = ref_info(
-        &repo,
-        &*meta,
-        ref_info::Options {
-            stack_commit_limit: 0,
-            expensive_commit_info: true,
-        },
-    )?;
+    let opts = standard_options();
+    let info = head_info(&repo, &*meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
         workspace_ref_name: Some(
@@ -32,17 +34,196 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
-                index: 0,
-                tip: Some(
-                    Sha1(d79bba960b112dbd25d45921c47eeda22288022b),
-                ),
                 base: Some(
                     Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
                 ),
                 segments: [
                     StackSegment {
                         ref_name: "refs/heads/A",
+                        remote_tracking_ref_name: "refs/remotes/origin/A",
+                        ref_location: "ReachableFromWorkspaceCommit",
+                        commits_unique_from_tip: [
+                            LocalCommit(d79bba9, "new file in A\n", local/remote(identity)),
+                        ],
+                        commits_unique_in_remote_tracking_branch: [
+                            RemoteCommit(89cc2d3, "change in A\n",
+                        ],
+                        metadata: Some(
+                            Branch {
+                                ref_info: RefInfo { created_at: None, updated_at: "1970-01-01 00:00:00 +0000" },
+                                description: None,
+                                review: Review { pull_request: None, review_id: None },
+                            },
+                        ),
+                    },
+                ],
+                stash_status: None,
+            },
+        ],
+        target_ref: Some(
+            FullName(
+                "refs/remotes/origin/main",
+            ),
+        ),
+    }
+    "#);
+
+    let expected_info = info;
+
+    let at = repo.find_reference("refs/heads/A")?;
+    let info = ref_info(at, &*meta, opts)?;
+    assert_eq!(
+        info, expected_info,
+        "Information doesn't change just because the starting point is different"
+    );
+
+    // Remove remote configuration to have it deduce the remote.
+    // This is from the times when GB wouldn't set up Git remotes, so it's for backward compatibility.
+    repo.config_snapshot_mut()
+        .remove_section("branch", info.stacks[0].name().unwrap().shorten().as_bstr());
+
+    let at = repo.find_reference("refs/heads/A")?;
+    let info = ref_info(at, &*meta, opts)?;
+    assert_eq!(
+        info, expected_info,
+        "Information doesn't change, the remote is inferred"
+    );
+    Ok(())
+}
+
+#[test]
+fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario("multiple-stacks-with-shared-segment")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   820f2b3 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * 4e5484a (B-on-A) add new file in B-on-A
+    * | 5f37dbf (C-on-A) add new file in C-on-A
+    |/  
+    | * 89cc2d3 (origin/A) change in A
+    |/  
+    * d79bba9 (A) new file in A
+    * c166d42 (origin/main, origin/HEAD, main) init-integration
+    ");
+
+    add_stack(
+        &mut meta,
+        StackId::from_number_for_testing(1),
+        "C-on-A",
+        StackState::InWorkspace,
+    );
+
+    let opts = standard_options();
+    let info = head_info(&repo, &*meta, opts)?;
+
+    // The shared "A" segment is only used in the first stack, despite reachable from both.
+    // The first stack which reaches the shared segment claims it.
+    insta::assert_debug_snapshot!(info, @r#"
+    RefInfo {
+        workspace_ref_name: Some(
+            FullName(
+                "refs/heads/gitbutler/workspace",
+            ),
+        ),
+        stacks: [
+            Stack {
+                base: Some(
+                    Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
+                ),
+                segments: [
+                    StackSegment {
+                        ref_name: "refs/heads/C-on-A",
                         remote_tracking_ref_name: "None",
+                        ref_location: "ReachableFromWorkspaceCommit",
+                        commits_unique_from_tip: [
+                            LocalCommit(5f37dbf, "add new file in C-on-A\n", local),
+                        ],
+                        commits_unique_in_remote_tracking_branch: [],
+                        metadata: Some(
+                            Branch {
+                                ref_info: RefInfo { created_at: None, updated_at: "1970-01-01 00:00:00 +0000" },
+                                description: None,
+                                review: Review { pull_request: None, review_id: None },
+                            },
+                        ),
+                    },
+                    StackSegment {
+                        ref_name: "refs/heads/A",
+                        remote_tracking_ref_name: "refs/remotes/origin/A",
+                        ref_location: "ReachableFromWorkspaceCommit",
+                        commits_unique_from_tip: [
+                            LocalCommit(d79bba9, "new file in A\n", local/remote(identity)),
+                        ],
+                        commits_unique_in_remote_tracking_branch: [
+                            RemoteCommit(89cc2d3, "change in A\n",
+                        ],
+                        metadata: None,
+                    },
+                ],
+                stash_status: None,
+            },
+            Stack {
+                base: Some(
+                    Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
+                ),
+                segments: [
+                    StackSegment {
+                        ref_name: "refs/heads/B-on-A",
+                        remote_tracking_ref_name: "None",
+                        ref_location: "ReachableFromWorkspaceCommit",
+                        commits_unique_from_tip: [
+                            LocalCommit(4e5484a, "add new file in B-on-A\n", local),
+                        ],
+                        commits_unique_in_remote_tracking_branch: [],
+                        metadata: None,
+                    },
+                ],
+                stash_status: None,
+            },
+        ],
+        target_ref: Some(
+            FullName(
+                "refs/remotes/origin/main",
+            ),
+        ),
+    }
+    "#);
+
+    let c_info = ref_info(repo.find_reference("C-on-A")?, &*meta, opts)?;
+
+    // A partial workspace is provided, but the entire workspace is known.
+    insta::assert_debug_snapshot!(c_info, @r#"
+    RefInfo {
+        workspace_ref_name: Some(
+            FullName(
+                "refs/heads/gitbutler/workspace",
+            ),
+        ),
+        stacks: [
+            Stack {
+                base: Some(
+                    Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
+                ),
+                segments: [
+                    StackSegment {
+                        ref_name: "refs/heads/C-on-A",
+                        remote_tracking_ref_name: "None",
+                        ref_location: "ReachableFromWorkspaceCommit",
+                        commits_unique_from_tip: [
+                            LocalCommit(5f37dbf, "add new file in C-on-A\n", local),
+                        ],
+                        commits_unique_in_remote_tracking_branch: [],
+                        metadata: Some(
+                            Branch {
+                                ref_info: RefInfo { created_at: None, updated_at: "1970-01-01 00:00:00 +0000" },
+                                description: None,
+                                review: Review { pull_request: None, review_id: None },
+                            },
+                        ),
+                    },
+                    StackSegment {
+                        ref_name: "refs/heads/A",
+                        remote_tracking_ref_name: "refs/remotes/origin/A",
                         ref_location: "ReachableFromWorkspaceCommit",
                         commits_unique_from_tip: [
                             LocalCommit(d79bba9, "new file in A\n", local/remote(identity)),
@@ -63,28 +244,362 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
         ),
     }
     "#);
+    assert_eq!(info.stacks[0], c_info.stacks[0]);
 
-    let expected_info = info;
+    let b_info = ref_info(repo.find_reference("B-on-A")?, &*meta, opts)?;
 
-    let at = repo.find_reference("refs/heads/A")?;
-    let info = ref_info_at(
-        at,
-        &*meta,
-        ref_info::Options {
-            stack_commit_limit: 0,
-            expensive_commit_info: true,
-        },
-    )?;
+    // It's like the stack is part of the workspace, so "A" is only used once.
+    insta::assert_debug_snapshot!(b_info, @r#"
+    RefInfo {
+        workspace_ref_name: Some(
+            FullName(
+                "refs/heads/gitbutler/workspace",
+            ),
+        ),
+        stacks: [
+            Stack {
+                base: Some(
+                    Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
+                ),
+                segments: [
+                    StackSegment {
+                        ref_name: "refs/heads/B-on-A",
+                        remote_tracking_ref_name: "None",
+                        ref_location: "ReachableFromWorkspaceCommit",
+                        commits_unique_from_tip: [
+                            LocalCommit(4e5484a, "add new file in B-on-A\n", local),
+                        ],
+                        commits_unique_in_remote_tracking_branch: [],
+                        metadata: None,
+                    },
+                ],
+                stash_status: None,
+            },
+        ],
+        target_ref: Some(
+            FullName(
+                "refs/remotes/origin/main",
+            ),
+        ),
+    }
+    "#);
+
     assert_eq!(
-        info, expected_info,
-        "Information doesn't change just because the starting point is different"
+        info.stacks[1].segments, b_info.stacks[0].segments,
+        "It's like the stack is part of the workspace, so 'A' is only used once."
     );
+
+    let a_info = ref_info(repo.find_reference("A")?, &*meta, opts)?;
+
+    // We can also show segments that are part of the stack (like homing in on them), as long as they are in a workspace.
+    insta::assert_debug_snapshot!(a_info, @r#"
+    RefInfo {
+        workspace_ref_name: Some(
+            FullName(
+                "refs/heads/gitbutler/workspace",
+            ),
+        ),
+        stacks: [
+            Stack {
+                base: Some(
+                    Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
+                ),
+                segments: [
+                    StackSegment {
+                        ref_name: "refs/heads/A",
+                        remote_tracking_ref_name: "refs/remotes/origin/A",
+                        ref_location: "ReachableFromWorkspaceCommit",
+                        commits_unique_from_tip: [
+                            LocalCommit(d79bba9, "new file in A\n", local/remote(identity)),
+                        ],
+                        commits_unique_in_remote_tracking_branch: [
+                            RemoteCommit(89cc2d3, "change in A\n",
+                        ],
+                        metadata: None,
+                    },
+                ],
+                stash_status: None,
+            },
+        ],
+        target_ref: Some(
+            FullName(
+                "refs/remotes/origin/main",
+            ),
+        ),
+    }
+    "#);
     Ok(())
+}
+
+#[test]
+fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario("empty-workspace-with-branch-below")?;
+    insta::assert_snapshot!(visualize_commit_graph(&repo, "HEAD")?, @r"
+    * c7276fa (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * c166d42 (origin/main, origin/HEAD, unrelated, main) init-integration
+    ");
+
+    add_stack(
+        &mut meta,
+        StackId::from_number_for_testing(1),
+        "unrelated",
+        StackState::InWorkspace,
+    );
+
+    let opts = standard_options();
+    let info = head_info(&repo, &*meta, opts)?;
+    // Active branches we should see, but only "unrelated",
+    // not any other branch that happens to point at that commit.
+    insta::assert_debug_snapshot!(info, @r#"
+    RefInfo {
+        workspace_ref_name: Some(
+            FullName(
+                "refs/heads/gitbutler/workspace",
+            ),
+        ),
+        stacks: [
+            Stack {
+                base: Some(
+                    Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
+                ),
+                segments: [
+                    StackSegment {
+                        ref_name: "refs/heads/unrelated",
+                        remote_tracking_ref_name: "None",
+                        ref_location: "ReachableFromWorkspaceCommit",
+                        commits_unique_from_tip: [],
+                        commits_unique_in_remote_tracking_branch: [],
+                        metadata: Some(
+                            Branch {
+                                ref_info: RefInfo { created_at: None, updated_at: "1970-01-01 00:00:00 +0000" },
+                                description: None,
+                                review: Review { pull_request: None, review_id: None },
+                            },
+                        ),
+                    },
+                ],
+                stash_status: None,
+            },
+        ],
+        target_ref: Some(
+            FullName(
+                "refs/remotes/origin/main",
+            ),
+        ),
+    }
+    "#);
+
+    // Change the stack to be inactive, so it's not considered to be part of the workspace.
+    add_stack(
+        &mut meta,
+        StackId::from_number_for_testing(1),
+        "unrelated",
+        StackState::Inactive,
+    );
+
+    let info = head_info(&repo, &*meta, opts)?;
+    // Now there should be no stack, it's an empty workspace.
+    insta::assert_debug_snapshot!(info, @r#"
+    RefInfo {
+        workspace_ref_name: Some(
+            FullName(
+                "refs/heads/gitbutler/workspace",
+            ),
+        ),
+        stacks: [
+            Stack {
+                base: Some(
+                    Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
+                ),
+                segments: [],
+                stash_status: None,
+            },
+        ],
+        target_ref: Some(
+            FullName(
+                "refs/remotes/origin/main",
+            ),
+        ),
+    }
+    "#);
+
+    // But if it's requested directly, we should see it nonetheless.
+    let info = ref_info(repo.find_reference("unrelated")?, &*meta, opts)?;
+    insta::assert_debug_snapshot!(info, @r#"
+    RefInfo {
+        workspace_ref_name: Some(
+            FullName(
+                "refs/heads/gitbutler/workspace",
+            ),
+        ),
+        stacks: [
+            Stack {
+                base: Some(
+                    Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
+                ),
+                segments: [
+                    StackSegment {
+                        ref_name: "refs/heads/unrelated",
+                        remote_tracking_ref_name: "None",
+                        ref_location: "OutsideOfWorkspace",
+                        commits_unique_from_tip: [],
+                        commits_unique_in_remote_tracking_branch: [],
+                        metadata: Some(
+                            Branch {
+                                ref_info: RefInfo { created_at: None, updated_at: "1970-01-01 00:00:00 +0000" },
+                                description: None,
+                                review: Review { pull_request: None, review_id: None },
+                            },
+                        ),
+                    },
+                ],
+                stash_status: None,
+            },
+        ],
+        target_ref: Some(
+            FullName(
+                "refs/remotes/origin/main",
+            ),
+        ),
+    }
+    "#);
+    Ok(())
+}
+
+mod legacy {
+    mod stack_details {
+        use crate::ref_info::with_workspace_commit::read_only_in_memory_scenario;
+        use crate::ref_info::with_workspace_commit::utils::{StackState, add_stack};
+        use but_testsupport::visualize_commit_graph_all;
+        use gitbutler_stack::StackId;
+
+        #[test]
+        fn multiple_branches_with_shared_segment_automatically_know_containing_workspace()
+        -> anyhow::Result<()> {
+            let (repo, mut meta) =
+                read_only_in_memory_scenario("multiple-stacks-with-shared-segment")?;
+            insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+            *   820f2b3 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+            |\  
+            | * 4e5484a (B-on-A) add new file in B-on-A
+            * | 5f37dbf (C-on-A) add new file in C-on-A
+            |/  
+            | * 89cc2d3 (origin/A) change in A
+            |/  
+            * d79bba9 (A) new file in A
+            * c166d42 (origin/main, origin/HEAD, main) init-integration
+            ");
+
+            let b_stack_id = add_stack(
+                &mut meta,
+                StackId::from_number_for_testing(1),
+                "B-on-A",
+                StackState::InWorkspace,
+            );
+            let actual = but_workspace::stack_details_v3(b_stack_id, &repo, &meta)?;
+            insta::assert_debug_snapshot!(actual, @r#"
+            StackDetails {
+                derived_name: "B-on-A",
+                push_status: UnpushedCommits,
+                branch_details: [
+                    BranchDetails {
+                        name: "B-on-A",
+                        remote_tracking_branch: None,
+                        description: None,
+                        pr_number: None,
+                        review_id: None,
+                        tip: Sha1(4e5484ac0f1da1909414b1e16bd740c1a3599509),
+                        base_commit: Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
+                        push_status: UnpushedCommits,
+                        last_updated_at: Some(
+                            0,
+                        ),
+                        authors: [
+                            author <author@example.com>,
+                        ],
+                        is_conflicted: false,
+                        commits: [
+                            Commit(4e5484a, "add new file in B-on-A"),
+                        ],
+                        upstream_commits: [],
+                        is_remote_head: false,
+                    },
+                ],
+                is_conflicted: false,
+            }
+            "#);
+
+            let c_stack_id = add_stack(
+                &mut meta,
+                StackId::from_number_for_testing(2),
+                "C-on-A",
+                StackState::InWorkspace,
+            );
+            let actual = but_workspace::stack_details_v3(c_stack_id, &repo, &meta)?;
+            insta::assert_debug_snapshot!(actual, @r#"
+            StackDetails {
+                derived_name: "C-on-A",
+                push_status: UnpushedCommits,
+                branch_details: [
+                    BranchDetails {
+                        name: "C-on-A",
+                        remote_tracking_branch: None,
+                        description: None,
+                        pr_number: None,
+                        review_id: None,
+                        tip: Sha1(5f37dbfd4b1c3d2ee75f216665ab4edf44c843cb),
+                        base_commit: Sha1(d79bba960b112dbd25d45921c47eeda22288022b),
+                        push_status: UnpushedCommits,
+                        last_updated_at: Some(
+                            0,
+                        ),
+                        authors: [
+                            author <author@example.com>,
+                        ],
+                        is_conflicted: false,
+                        commits: [
+                            Commit(5f37dbf, "add new file in C-on-A"),
+                        ],
+                        upstream_commits: [],
+                        is_remote_head: false,
+                    },
+                    BranchDetails {
+                        name: "A",
+                        remote_tracking_branch: Some(
+                            "refs/remotes/origin/A",
+                        ),
+                        description: None,
+                        pr_number: None,
+                        review_id: None,
+                        tip: Sha1(d79bba960b112dbd25d45921c47eeda22288022b),
+                        base_commit: Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
+                        push_status: CompletelyUnpushed,
+                        last_updated_at: None,
+                        authors: [
+                            author <author@example.com>,
+                        ],
+                        is_conflicted: false,
+                        commits: [
+                            Commit(d79bba9, "new file in A"),
+                        ],
+                        upstream_commits: [
+                            UpstreamCommit(89cc2d3, "change in A"),
+                        ],
+                        is_remote_head: false,
+                    },
+                ],
+                is_conflicted: false,
+            }
+            "#);
+            Ok(())
+        }
+    }
 }
 
 mod utils {
     use crate::ref_info::utils::named_read_only_in_memory_scenario;
     use but_workspace::VirtualBranchesTomlMetadata;
+    use gitbutler_stack::StackId;
 
     pub fn read_only_in_memory_scenario(
         name: &str,
@@ -106,26 +621,40 @@ mod utils {
         Ok((repo, meta))
     }
 
+    pub enum StackState {
+        InWorkspace,
+        Inactive,
+    }
+
     // Add parameters as needed.
-    pub fn add_workspace(meta: &mut VirtualBranchesTomlMetadata) {
-        meta.data_mut().branches.insert(
-            but_workspace::StackId::generate(),
-            gitbutler_stack::Stack::new_with_just_heads(
-                vec![gitbutler_stack::StackBranch::new_with_zero_head(
-                    "name is not important, needs branch for workspace to exist".into(),
-                    None,
-                    None,
-                    None,
-                    true,
-                )],
-                0,
-                0,
-                false,
-            ),
+    pub fn add_stack(
+        meta: &mut VirtualBranchesTomlMetadata,
+        stack_id: StackId,
+        stack_name: &str,
+        state: StackState,
+    ) -> StackId {
+        let mut stack = gitbutler_stack::Stack::new_with_just_heads(
+            vec![gitbutler_stack::StackBranch::new_with_zero_head(
+                stack_name.into(),
+                None,
+                None,
+                None,
+                true,
+            )],
+            0,
+            0,
+            match state {
+                StackState::InWorkspace => true,
+                StackState::Inactive => false,
+            },
         );
+        stack.id = stack_id;
+        meta.data_mut().branches.insert(stack_id, stack);
+        meta.data();
+        stack_id
     }
 }
-
-use crate::ref_info::with_workspace_commit::utils::add_workspace;
-use but_testsupport::visualize_commit_graph_all;
-use utils::read_only_in_memory_scenario;
+use crate::ref_info::utils::standard_options;
+use crate::ref_info::with_workspace_commit::utils::StackState;
+use utils::add_stack;
+pub use utils::read_only_in_memory_scenario;

--- a/crates/but-workspace/tests/workspace/ref_metadata.rs
+++ b/crates/but-workspace/tests/workspace/ref_metadata.rs
@@ -164,236 +164,80 @@ mod virtual_branches_toml {
                     .clone()
             })
             .collect::<Vec<_>>();
-        insta::assert_debug_snapshot!(branches, @r"
+        insta::assert_debug_snapshot!(branches, @r#"
         [
             Branch {
-                ref_info: RefInfo {
-                    created_at: None,
-                    updated_at: Some(
-                        Time {
-                            seconds: 1740394757,
-                            offset: 0,
-                        },
-                    ),
-                },
+                ref_info: RefInfo { created_at: None, updated_at: "2025-02-24 10:59:17 +0000" },
                 description: None,
-                review: Review {
-                    pull_request: Some(
-                        12,
-                    ),
-                    review_id: None,
-                },
+                review: Review { pull_request: 12, review_id: None },
             },
             Branch {
-                ref_info: RefInfo {
-                    created_at: None,
-                    updated_at: Some(
-                        Time {
-                            seconds: 1740394727,
-                            offset: 0,
-                        },
-                    ),
-                },
+                ref_info: RefInfo { created_at: None, updated_at: "2025-02-24 10:58:47 +0000" },
                 description: None,
-                review: Review {
-                    pull_request: None,
-                    review_id: None,
-                },
+                review: Review { pull_request: None, review_id: None },
             },
             Branch {
-                ref_info: RefInfo {
-                    created_at: None,
-                    updated_at: Some(
-                        Time {
-                            seconds: 1740394727,
-                            offset: 0,
-                        },
-                    ),
-                },
+                ref_info: RefInfo { created_at: None, updated_at: "2025-02-24 10:58:47 +0000" },
                 description: None,
-                review: Review {
-                    pull_request: None,
-                    review_id: None,
-                },
+                review: Review { pull_request: None, review_id: None },
             },
             Branch {
-                ref_info: RefInfo {
-                    created_at: None,
-                    updated_at: Some(
-                        Time {
-                            seconds: 1740394727,
-                            offset: 0,
-                        },
-                    ),
-                },
+                ref_info: RefInfo { created_at: None, updated_at: "2025-02-24 10:58:47 +0000" },
                 description: None,
-                review: Review {
-                    pull_request: None,
-                    review_id: None,
-                },
+                review: Review { pull_request: None, review_id: None },
             },
             Branch {
-                ref_info: RefInfo {
-                    created_at: None,
-                    updated_at: Some(
-                        Time {
-                            seconds: 1740394727,
-                            offset: 0,
-                        },
-                    ),
-                },
+                ref_info: RefInfo { created_at: None, updated_at: "2025-02-24 10:58:47 +0000" },
                 description: None,
-                review: Review {
-                    pull_request: None,
-                    review_id: None,
-                },
+                review: Review { pull_request: None, review_id: None },
             },
             Branch {
-                ref_info: RefInfo {
-                    created_at: None,
-                    updated_at: Some(
-                        Time {
-                            seconds: 1740394670,
-                            offset: 0,
-                        },
-                    ),
-                },
+                ref_info: RefInfo { created_at: None, updated_at: "2025-02-24 10:57:50 +0000" },
                 description: None,
-                review: Review {
-                    pull_request: None,
-                    review_id: None,
-                },
+                review: Review { pull_request: None, review_id: None },
             },
             Branch {
-                ref_info: RefInfo {
-                    created_at: None,
-                    updated_at: Some(
-                        Time {
-                            seconds: 1740394670,
-                            offset: 0,
-                        },
-                    ),
-                },
+                ref_info: RefInfo { created_at: None, updated_at: "2025-02-24 10:57:50 +0000" },
                 description: None,
-                review: Review {
-                    pull_request: None,
-                    review_id: None,
-                },
+                review: Review { pull_request: None, review_id: None },
             },
             Branch {
-                ref_info: RefInfo {
-                    created_at: None,
-                    updated_at: Some(
-                        Time {
-                            seconds: 1740394670,
-                            offset: 0,
-                        },
-                    ),
-                },
+                ref_info: RefInfo { created_at: None, updated_at: "2025-02-24 10:57:50 +0000" },
                 description: None,
-                review: Review {
-                    pull_request: None,
-                    review_id: None,
-                },
+                review: Review { pull_request: None, review_id: None },
             },
             Branch {
-                ref_info: RefInfo {
-                    created_at: None,
-                    updated_at: Some(
-                        Time {
-                            seconds: 1740394670,
-                            offset: 0,
-                        },
-                    ),
-                },
+                ref_info: RefInfo { created_at: None, updated_at: "2025-02-24 10:57:50 +0000" },
                 description: None,
-                review: Review {
-                    pull_request: None,
-                    review_id: None,
-                },
+                review: Review { pull_request: None, review_id: None },
             },
             Branch {
-                ref_info: RefInfo {
-                    created_at: None,
-                    updated_at: Some(
-                        Time {
-                            seconds: 1740394670,
-                            offset: 0,
-                        },
-                    ),
-                },
+                ref_info: RefInfo { created_at: None, updated_at: "2025-02-24 10:57:50 +0000" },
                 description: None,
-                review: Review {
-                    pull_request: None,
-                    review_id: None,
-                },
+                review: Review { pull_request: None, review_id: None },
             },
             Branch {
-                ref_info: RefInfo {
-                    created_at: None,
-                    updated_at: Some(
-                        Time {
-                            seconds: 1740394670,
-                            offset: 0,
-                        },
-                    ),
-                },
+                ref_info: RefInfo { created_at: None, updated_at: "2025-02-24 10:57:50 +0000" },
                 description: None,
-                review: Review {
-                    pull_request: None,
-                    review_id: None,
-                },
+                review: Review { pull_request: None, review_id: None },
             },
             Branch {
-                ref_info: RefInfo {
-                    created_at: None,
-                    updated_at: Some(
-                        Time {
-                            seconds: 1740394788,
-                            offset: 0,
-                        },
-                    ),
-                },
+                ref_info: RefInfo { created_at: None, updated_at: "2025-02-24 10:59:48 +0000" },
                 description: None,
-                review: Review {
-                    pull_request: None,
-                    review_id: None,
-                },
+                review: Review { pull_request: None, review_id: None },
             },
             Branch {
-                ref_info: RefInfo {
-                    created_at: None,
-                    updated_at: Some(
-                        Time {
-                            seconds: 1740394788,
-                            offset: 0,
-                        },
-                    ),
-                },
+                ref_info: RefInfo { created_at: None, updated_at: "2025-02-24 10:59:48 +0000" },
                 description: None,
-                review: Review {
-                    pull_request: None,
-                    review_id: None,
-                },
+                review: Review { pull_request: None, review_id: None },
             },
             Branch {
-                ref_info: RefInfo {
-                    created_at: None,
-                    updated_at: Some(
-                        Time {
-                            seconds: 1740394801,
-                            offset: 0,
-                        },
-                    ),
-                },
+                ref_info: RefInfo { created_at: None, updated_at: "2025-02-24 11:00:01 +0000" },
                 description: None,
-                review: Review {
-                    pull_request: None,
-                    review_id: None,
-                },
+                review: Review { pull_request: None, review_id: None },
             },
         ]
-        ");
+        "#);
 
         let toml_path = store.path().to_owned();
         assert!(toml_path.exists(), "the file is still present");
@@ -745,21 +589,13 @@ mod virtual_branches_toml {
             ws.is_default(),
             "it's empty, so no difference to a default one"
         );
-        insta::assert_debug_snapshot!(ws.deref(), @r"
+        insta::assert_debug_snapshot!(ws.deref(), @r#"
         Workspace {
-            ref_info: RefInfo {
-                created_at: Some(
-                    Time {
-                        seconds: 1675176957,
-                        offset: 0,
-                    },
-                ),
-                updated_at: None,
-            },
+            ref_info: RefInfo { created_at: "2023-01-31 14:55:57 +0000", updated_at: None },
             stacks: [],
             target_ref: None,
         }
-        ");
+        "#);
 
         drop(store);
         assert!(

--- a/crates/gitbutler-error/src/error.rs
+++ b/crates/gitbutler-error/src/error.rs
@@ -135,7 +135,6 @@ pub enum Code {
     ProjectMissing,
     AuthorMissing,
     BranchNotFound,
-    NonexclusiveAccess,
 }
 
 impl std::fmt::Display for Code {
@@ -150,7 +149,6 @@ impl std::fmt::Display for Code {
             Code::AuthorMissing => "errors.git.author_missing",
             Code::ProjectMissing => "errors.projects.missing",
             Code::BranchNotFound => "errors.branch.notfound",
-            Code::NonexclusiveAccess => "errors.projects.nonexclusive.access",
         };
         f.write_str(code)
     }

--- a/crates/gitbutler-id/src/id.rs
+++ b/crates/gitbutler-id/src/id.rs
@@ -35,6 +35,10 @@ impl<T> Id<T> {
     pub fn generate() -> Self {
         Id(Uuid::new_v4(), PhantomData)
     }
+    /// Create a new ID that is stable. Only useful for testing so IDs are stable.
+    pub fn from_number_for_testing(stable_id: u128) -> Self {
+        Id(Uuid::from_u128(stable_id), PhantomData)
+    }
 }
 
 impl<T> Default for Id<T> {

--- a/crates/gitbutler-tauri/src/env.rs
+++ b/crates/gitbutler-tauri/src/env.rs
@@ -1,7 +1,5 @@
-use std::collections::BTreeMap;
-
 #[cfg(debug_assertions)]
 #[tauri::command(async)]
-pub fn env_vars() -> BTreeMap<String, String> {
+pub fn env_vars() -> std::collections::BTreeMap<String, String> {
     std::env::vars().collect()
 }


### PR DESCRIPTION
There are still a lot of fatal flaws resulting in errors and even panics. These should be fixed and it should 'generally' be working.
Write critical tests only.

Follow-up on #8571

## Tasks

* [x] handle empty workspace
* [x] remove possibilities of panics
* [x] is-conflicted
* [x] remove integer index from `Stack`
* ~~traversal utilities?~~ not for now, keep it simple, but well-tested
* [x] use workspace stack info to select empty refs
    - [x] **deal with newly created refs (without commit), also doesn't show if there is only one of these**
* [ ] deal with `archived` flag
* [ ] **branch listing merge-base is different from the new one - fix it if possible**
* [x] remove `tip` and make it a function
* [ ] more tests
    - [ ] head-info for different levels of similarity
    - [ ] for `stacks_v3()`
    - [ ] for `branch_details_v3()`
    - [x] for `stack_details_v3()`

## Possible Tasks

* [ ] V3 of `get_branch_listing_details()`

## Notable changes to the Datamodel

* Upstream commits can also be integrated. This would happen if the local tracking branch has not caught up to them, and all of them are integrated. This also means that everything local could be unintegrated, but upstream-only commits are integrated, something that can happen if everything is diverged. If both disagree, it's unclear what to do.

## Notes for the Reviewer

* This is a transitory PR that replaces VirtualBranchesToml with the RefMetadata trait to prepare the code to transition to other data stores.
* The code is clearly transitory while `StackId`  is still a thing - in the new world stacks or stack-segments are referred to by their reference name or by their index in the parent-list of the top-level merge commit (if there is one).
* Ideally, one the UI will be able to make just one `heads_info` call, and can consume the data directly (even though it may have been processed to further facilitate consumption).
* `branch_details()` already works on references
* `BranchDetails` are probably the data structure of choice for the UI, and it's just the question if there is stack information or not.
* There is no notion of using stacks in branch listings outside of what we are currently looking at, i.e. where `HEAD` is. Thus, for this we will probably keep using branch details of sort.

## Next PR

- intermediate V3 version of `get_base_branch_data()`.

### Follow Up Tasks

* [ ] first non-workspace cases
    - [ ] merge commit
    - [ ] merge commit stacked
    - [ ] stacks and ambiguous stack references (i.e. lots of empty stack segments)

### Next PRs

* head-info, stacks and details API with key scenarios
* graph-based integration checks with target and remote
* **use `hide()` in places where merge-commits are used as boundary.**
    - This shouldn't be a major problem for simple topologies, but is certainly an issue for more complex ones.
* integration checking with target
* integration checking with remote tracking branch

### Known Shortcomings (for now)

* ⚠️ `first_parent_only` maybe a good simplification for display, but I wonder if there are side-effects like us not seeing commits that could participate in commit-status check.
* ⚠️ Commit-classification is hacky and undertested  right now⚠️
* One probably wants to show all refs at a position (or indicate there are more)
* ⚠️ rebase engine needs a way to know which parent to rewrite if there are two parents pointing to the same commit in a starting configuration with two stacks at the same commit. Alternatively, `create_commit` would have to create a workspace commit, which seems worse than adding a WS commit in the moment there are two stacks.
* ⚠️ **merge conflicts** are created from either cherry-picks or normal merges (legacy?), but cherry-pick would need to know that to either choose the auto-resolution. That's OK as long as the 'old' merge-commit isn't run as it would create a semantically different tree-setup in the conflicted commit.
* ⚠️ **commit listing** are ambiguous
    - Certain less common but possible branch configuration make ambiguous to assign commits to one branch or another. It won't be super trivial to make this work right.
* ⚠️Even though Git does not list *namespaced references*, `tig` will happily list everything. `set reference-format = hide:other` fixes this though
* empty commits aren't specifically highlighted when rebasing, or handled or prevented. The UI could detect that and show them.
* Moving hunks or files will need multi-branch rebases with merge-commit handling. This can be added to the rebase engine as we know it today. This will also enable worktree-updates.
* reordering in such a way that only heads a moved and nothing else happens (in terms of commit rewrites) probably wouldn't work yet in `but-rebase`.
* Index adjustments (tree to disk index) lack a lot of tests, particularly those for automatic conflict removal.
* if changes are added to the wrong spot, then they may apply cleanly *and* yield different results after merging, so the worktree differs from what's in Git. This is where hunk-dependencies/auto-hunk-splitting comes into play.
* Right now sub-hunks can't be selected as they won't match when it tries to find exact matches. However, that check could be changed to a 'contains' or 'is-included' to allow sub-hunks. Maybe this doesn't naturally work though or do the right thing.
* Workspace commits with a single branch will get signed if they were signed before. This shouldn't be a real problem, and ideally it will go away soon enough.


### For follow-up PRs

In any order (probably)

* Rebase-engine with insert empty commit (below and above, insert as first parent support)
* What happens in Git if one rebases non-linear branches? Can it retain the structure?
    - Rebase engine probably has to learn to re-schedule picks (and remember the base, a feature useful for multi-stacks as well, which then wouldn't need a special case anymore)
* ~~move file out of commit into worktree (uncommit something)~~
* ~~per-hunk exclusion if hunk didn't match (right now it rejects the whole file)~~
* run hooks on an index created from the tree that would be committed.
* move hunks from one commit into another


### Out of scope

* **hunk-dependencies**
    - These should be added once the commit-engine is feature-complete, the idea is that the UI can function well enough without them as a baseline.
* **atomic object writes**
    - In theory, new objects should only be written to disk if they actually end up in a tree. For instance, if a change is rejected, the object associated with it shouldn't be in the object database.
    - However, even though implementing this with the in-memory object feature is very possible, it feels like an optimization for another day. In general, I really think only objects that end up in a tree should actually be written, so that the implementation doesn't have to rely on `git gc` to cleanup.


