### PR TITLE
pretty-conflicts

### DIFF
--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -338,8 +338,18 @@ pub(crate) fn save_and_return_to_workspace(
         #[allow(deprecated)]
         checkout_branch_trees(ctx, perm)?;
     }
+
     update_workspace_commit(&vb_state, ctx)?;
-    list_virtual_branches(ctx, perm)?;
+
+    // Currently if the index goes wonky then files don't appear quite right.
+    // This just makes sure the index is all good.
+    let mut index = repository.index()?;
+    index.read_tree(&repository.head()?.peel_to_tree()?)?;
+    index.write()?;
+
+    if !ctx.app_settings().feature_flags.v3 {
+        list_virtual_branches(ctx, perm)?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#17xMEZxtT`](https://gitbutler.com/cto/gitbutler-client-d443/reviews/17xMEZxtT)

**pretty-conflicts**


2 commit series (version 4)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 2/2 | [Have correct cache invalidations for edit mode transtions](https://gitbutler.com/cto/gitbutler-client-d443/reviews/17xMEZxtT/commit/269f714e-b37e-47c9-aaf7-9721ca380e99) | ⏳ |  |
| 1/2 | [Better reflect conflicted states in the v3 frontend](https://gitbutler.com/cto/gitbutler-client-d443/reviews/17xMEZxtT/commit/ed338ceb-6ca0-4d39-8458-5026c57854eb) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/cto/gitbutler-client-d443/reviews/17xMEZxtT)_
<!-- GitButler Review Footer Boundary Bottom -->
