### PR TITLE
fix and test that the right hunk context menu options are visible

### DIFF
--- a/apps/desktop/cypress/e2e/unifiedDiffView.cy.ts
+++ b/apps/desktop/cypress/e2e/unifiedDiffView.cy.ts
@@ -142,6 +142,104 @@ describe('Unified Diff View', () => {
 			cy.get('table').should('be.visible');
 		});
 	});
+
+	it('should display the correct option in the hunk context menu for the branch changes', () => {
+		// Select a branch
+		cy.getByTestId('branch-header', mockBackend.stackId).should('be.visible').click();
+
+		// The branch drawer should be opened.
+		// Open a file from the list changes.
+		cy.getByTestId('branch-drawer')
+			.should('be.visible')
+			.within(() => {
+				cy.getByTestId('file-list-item').should('have.length', 3).first().click();
+			});
+
+		// The unified diff view should be opened.
+		cy.getByTestId('unified-diff-view')
+			.should('be.visible')
+			.within(() => {
+				// Right click on the first hunk
+				cy.get('[data-testid="hunk-count-column"]').first().rightclick();
+			});
+
+		// The hunk context menu should be opened
+		cy.getByTestId('hunk-context-menu')
+			.should('be.visible')
+			.within(() => {
+				// The discard change option should be visible
+				cy.getByTestId('hunk-context-menu-discard-change').should('not.exist');
+				// The discard lines option should be visible
+				cy.getByTestId('hunk-context-menu-discard-lines').should('not.exist');
+				// The open in editor option should be visible
+				cy.getByTestId('hunk-context-menu-open-in-editor').should('be.visible');
+			});
+	});
+
+	it('should display the correct option in the hunk context menu for the uncommitted changes', () => {
+		// There should be uncommitted changes
+		cy.getByTestId('uncommitted-changes-file-list').should('be.visible');
+
+		// All files should be visible
+		cy.getByTestId('file-list-item').should(
+			'have.length',
+			mockBackend.getWorktreeChangesFileNames().length
+		);
+
+		// Open bif file diff
+		cy.getByTestId('uncommitted-changes-file-list').within(() => {
+			cy.getByTestId('file-list-item').first().click();
+		});
+
+		cy.getByTestId('unified-diff-view').within(() => {
+			// Right click on the first hunk
+			cy.get('[data-testid="hunk-count-column"]').first().rightclick();
+		});
+
+		// The hunk context menu should be opened
+		cy.getByTestId('hunk-context-menu')
+			.should('be.visible')
+			.within(() => {
+				// The discard change option should be visible
+				cy.getByTestId('hunk-context-menu-discard-change').should('be.visible');
+				// The open in editor option should be visible
+				cy.getByTestId('hunk-context-menu-open-in-editor').should('be.visible');
+			});
+	});
+
+	it('should display the correct option in the hunk context menu for the uncommitted changes with selected lines', () => {
+		// There should be uncommitted changes
+		cy.getByTestId('uncommitted-changes-file-list').should('be.visible');
+
+		// All files should be visible
+		cy.getByTestId('file-list-item').should(
+			'have.length',
+			mockBackend.getWorktreeChangesFileNames().length
+		);
+
+		// Open bif file diff
+		cy.getByTestId('uncommitted-changes-file-list').within(() => {
+			cy.getByTestId('file-list-item').first().click();
+		});
+
+		cy.getByTestId('unified-diff-view').within(() => {
+			// Select the first line in the hunk
+			// and then right click on it.
+			cy.get('[data-is-delta-line=true]').first().click().rightclick();
+		});
+
+		// The hunk context menu should be opened
+		cy.getByTestId('hunk-context-menu')
+			.should('be.visible')
+			.within(() => {
+				// The discard change option should be visible
+				cy.getByTestId('hunk-context-menu-discard-change').should('be.visible');
+				// The discard lines option should be visible
+				cy.getByTestId('hunk-context-menu-discard-lines').should('be.visible');
+				// The open in editor option should be visible
+				cy.getByTestId('hunk-context-menu-open-in-editor').should('be.visible');
+			});
+	});
 });
 
 describe('Unified Diff View with complex hunks', () => {

--- a/apps/desktop/src/components/v3/HunkContextMenu.svelte
+++ b/apps/desktop/src/components/v3/HunkContextMenu.svelte
@@ -17,6 +17,7 @@
 	import { IrcService } from '$lib/irc/ircService.svelte';
 	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import { StackService } from '$lib/stacks/stackService.svelte';
+	import { TestId } from '$lib/testing/testIds';
 	import { getEditorUri, openExternalUrl } from '$lib/utils/url';
 	import { getContextStoreBySymbol, inject } from '@gitbutler/shared/context';
 	import ContextMenu from '@gitbutler/ui/ContextMenu.svelte';
@@ -31,11 +32,11 @@
 		projectId: string;
 		change: TreeChange;
 		projectPath: string | undefined;
-		readonly: boolean;
+		discardable: boolean;
 		unSelectHunk: (hunk: DiffHunk) => void;
 	}
 
-	const { trigger, projectId, change, projectPath, readonly, unSelectHunk }: Props = $props();
+	const { trigger, projectId, change, projectPath, discardable, unSelectHunk }: Props = $props();
 
 	const [stackService, ircService] = inject(StackService, IrcService);
 
@@ -102,12 +103,13 @@
 	}
 </script>
 
-<ContextMenu bind:this={contextMenu} rightClickTrigger={trigger}>
+<ContextMenu testId={TestId.HunkContextMenu} bind:this={contextMenu} rightClickTrigger={trigger}>
 	{#snippet children(item)}
 		{#if isHunkContextItem(item)}
 			<ContextMenuSection>
-				{#if !readonly}
+				{#if discardable}
 					<ContextMenuItem
+						testId={TestId.HunkContextMenu_DiscardChange}
 						label="Discard change"
 						onclick={() => {
 							discardHunk(item);
@@ -115,8 +117,9 @@
 						}}
 					/>
 				{/if}
-				{#if item.selectedLines !== undefined && item.selectedLines.length > 0 && !readonly}
+				{#if item.selectedLines !== undefined && item.selectedLines.length > 0 && discardable}
 					<ContextMenuItem
+						testId={TestId.HunkContextMenu_DiscardLines}
 						label={getDiscardLineLabel(item)}
 						onclick={() => {
 							discardHunkLines(item);
@@ -150,6 +153,7 @@
 				{/if}
 				{#if item.beforeLineNumber !== undefined || item.afterLineNumber !== undefined}
 					<ContextMenuItem
+						testId={TestId.HunkContextMenu_OpenInEditor}
 						label="Open in {$userSettings.defaultCodeEditor.displayName}"
 						onclick={() => {
 							if (projectPath) {

--- a/apps/desktop/src/components/v3/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/v3/UnifiedDiffView.svelte
@@ -296,7 +296,7 @@
 			projectPath={project.vscodePath}
 			{projectId}
 			{change}
-			{readonly}
+			discardable={uncommittedChange}
 			unSelectHunk={(hunk) => unselectHunk(hunk, diff.subject.hunks)}
 		/>
 	{:else if diff.type === 'TooLarge'}

--- a/apps/desktop/src/lib/testing/testIds.ts
+++ b/apps/desktop/src/lib/testing/testIds.ts
@@ -76,7 +76,11 @@ export enum TestId {
 	ReviewCreateButton = 'review-drawer-create-button',
 	ReviewCancelButton = 'review-drawer-cancel-button',
 	StackedPullRequestCard = 'stacked-pull-request-card',
-	BranchDrawer = 'branch-drawer'
+	BranchDrawer = 'branch-drawer',
+	HunkContextMenu = 'hunk-context-menu',
+	HunkContextMenu_DiscardChange = 'hunk-context-menu-discard-change',
+	HunkContextMenu_DiscardLines = 'hunk-context-menu-discard-lines',
+	HunkContextMenu_OpenInEditor = 'hunk-context-menu-open-in-editor'
 }
 
 export enum ElementId {

--- a/packages/ui/src/lib/hunkDiff/HunkDiffRow.svelte
+++ b/packages/ui/src/lib/hunkDiff/HunkDiffRow.svelte
@@ -117,6 +117,7 @@
 	{@const deltaLine = isDeltaLine(row.type)}
 	<td
 		data-testid="hunk-count-column"
+		data-is-delta-line={deltaLine}
 		class="table__numberColumn"
 		data-no-drag
 		class:diff-line-deletion={row.type === SectionType.RemovedLines}


### PR DESCRIPTION
### Description

- The ablity to discard hunks is limited to uncommitted changes
- Added Cypress tests to verify the visibility of the correct hunk context menu options in UnifiedDiffView.