### PR TITLE
fix: Start review through the publish buttons

### DIFF
--- a/apps/desktop/cypress/e2e/review.cy.ts
+++ b/apps/desktop/cypress/e2e/review.cy.ts
@@ -203,4 +203,70 @@ describe('Review', () => {
 			cy.getByTestId('stacked-pull-request-card').should('be.visible');
 		}
 	});
+
+	it('should be able to create multiple pull requests from the publish buttons', () => {
+		const stacks = mockBackend.getStacks();
+		expect(stacks).to.have.length(3);
+
+		for (const stack of stacks) {
+			const prTitle = 'Test PR Title' + stack.id;
+			const prDescription = 'Test PR Description' + stack.id;
+
+			// Scroll the publish buttons into view
+			cy.get('[data-testid-stackid="' + stack.id + '"]')
+				.should('exist')
+				.scrollIntoView()
+				.within(() => {
+					cy.getByTestId('stack-publish-button').should('be.visible').click();
+				});
+
+			// The Review Drawer should be visible.
+			cy.getByTestId('review-drawer').should('be.visible');
+
+			// Since this branch has a single commit, the commit message should be pre-filled.
+			// Update both.
+			cy.getByTestId('review-drawer-title-input')
+				.should('be.visible')
+				.should('be.enabled')
+				.should('have.value', mockBackend.getCommitTitle(stack.id))
+				.clear()
+				.type(prTitle);
+
+			cy.getByTestId('review-drawer-description-input')
+				.should('be.visible')
+				.should('contain', mockBackend.getCommitMessage(stack.id))
+				.click()
+				.clear()
+				.type(prDescription);
+
+			// Cancel the creation of the review.
+			cy.getByTestId('review-drawer-cancel-button').should('be.visible').click();
+
+			// The Review Drawer should not be visible.
+			cy.getByTestId('review-drawer').should('not.exist');
+
+			// Reopen the Review Drawer.
+			cy.getByTestId('branch-drawer-create-review-button').should('be.visible').click();
+
+			// The inputs should be persisted
+			cy.getByTestId('review-drawer-title-input')
+				.should('be.visible')
+				.should('be.enabled')
+				.should('have.value', prTitle);
+
+			cy.getByTestId('review-drawer-description-input')
+				.should('be.visible')
+				.should('contain', prDescription);
+
+			// The Create Review button should be visible.
+			// Click it.
+			cy.getByTestId('review-drawer-create-button')
+				.should('be.visible')
+				.should('be.enabled')
+				.click();
+
+			// The PR card should be visible.
+			cy.getByTestId('stacked-pull-request-card').should('be.visible');
+		}
+	});
 });

--- a/apps/desktop/src/components/v3/MultiStackView.svelte
+++ b/apps/desktop/src/components/v3/MultiStackView.svelte
@@ -119,6 +119,7 @@
 						bind:clientWidth={laneWidths[i]}
 						bind:clientHeight={lineHights[i]}
 						data-testid={TestId.Stack}
+						data-testid-stackid={stack.id}
 						data-testid-stack={stack.heads.at(0)?.name}
 						use:intersectionObserver={{
 							callback: (entry) => {

--- a/apps/desktop/src/components/v3/PublishButton.svelte
+++ b/apps/desktop/src/components/v3/PublishButton.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import CanPublishReviewPlugin from '$components/v3/CanPublishReviewPlugin.svelte';
 	import { UiState } from '$lib/state/uiState.svelte';
+	import { TestId } from '$lib/testing/testIds';
 	import { getContext } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import type { BranchDetails } from '$lib/stacks/stack';
@@ -74,6 +75,7 @@
 		if (!branchName) return;
 
 		uiState.stack(stackId).selection.set({ branchName });
+		uiState.project(projectId).stackId.set(stackId);
 		uiState.project(projectId).drawerPage.set('review');
 	}
 
@@ -102,6 +104,7 @@
 {#if canPublish && !branchEmpty}
 	<div class="publish-button" style:flex>
 		<Button
+			testId={TestId.StackPublishButton}
 			style="neutral"
 			wide
 			disabled={!branchName || hasConflicts}

--- a/apps/desktop/src/components/v3/PushButton.svelte
+++ b/apps/desktop/src/components/v3/PushButton.svelte
@@ -5,6 +5,7 @@
 		stackRequiresForcePush
 	} from '$lib/stacks/stack';
 	import { StackService } from '$lib/stacks/stackService.svelte';
+	import { TestId } from '$lib/testing/testIds';
 	import { UserService } from '$lib/user/userService';
 	import { getContext } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
@@ -66,6 +67,7 @@
 
 <div class="push-button" class:use-flex={!flex} style:flex>
 	<Button
+		testId={TestId.StackPushButton}
 		style="neutral"
 		wide
 		{loading}

--- a/apps/desktop/src/lib/testing/testIds.ts
+++ b/apps/desktop/src/lib/testing/testIds.ts
@@ -80,7 +80,9 @@ export enum TestId {
 	HunkContextMenu = 'hunk-context-menu',
 	HunkContextMenu_DiscardChange = 'hunk-context-menu-discard-change',
 	HunkContextMenu_DiscardLines = 'hunk-context-menu-discard-lines',
-	HunkContextMenu_OpenInEditor = 'hunk-context-menu-open-in-editor'
+	HunkContextMenu_OpenInEditor = 'hunk-context-menu-open-in-editor',
+	StackPushButton = 'stack-push-button',
+	StackPublishButton = 'stack-publish-button'
 }
 
 export enum ElementId {


### PR DESCRIPTION
The publish button at the bottom of the stack didn’t correctly select the stack that was intended to be published

