### PR TITLE
Don't branch file changes if there's nothing selected

### DIFF
--- a/apps/desktop/src/components/v3/FileList.svelte
+++ b/apps/desktop/src/components/v3/FileList.svelte
@@ -156,13 +156,15 @@
 	 * - Anonymous
 	 */
 	async function branchChanges() {
+		const selectedFiles = idSelection.values(selectionId);
+		if (selectedFiles.length === 0) return;
+
 		showToast({
 			style: 'neutral',
 			title: 'Creating a branch and commit...',
 			message: 'This may take a few seconds.'
 		});
 
-		const selectedFiles = idSelection.values(selectionId);
 		const selectedChanges: CreateCommitRequestWorktreeChanges[] = [];
 		const treeChanges = changes.filter((change) =>
 			selectedFiles.some((file) => file.path === change.path)


### PR DESCRIPTION
If there are no file changes selected, don’t trigger the branching macro