### PR TITLE
Implement support for allocating uncommitted changes to lanes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,10 +734,12 @@ dependencies = [
  "but-hunk-dependency",
  "but-workspace",
  "gitbutler-command-context",
+ "gitbutler-fs",
  "gitbutler-stack",
  "gix",
  "itertools",
  "serde",
+ "toml",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3025,6 +3025,7 @@ dependencies = [
  "anyhow",
  "backtrace",
  "but-core",
+ "but-hunk-assignment",
  "but-hunk-dependency",
  "but-settings",
  "but-workspace",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,6 +725,23 @@ name = "but-debugging"
 version = "0.0.0"
 
 [[package]]
+name = "but-hunk-assignment"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "bstr",
+ "but-core",
+ "but-hunk-dependency",
+ "but-workspace",
+ "gitbutler-command-context",
+ "gitbutler-stack",
+ "gix",
+ "itertools",
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "but-hunk-dependency"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ but-testsupport = { path = "crates/but-testsupport" }
 but-rebase = { path = "crates/but-rebase" }
 but-core = { path = "crates/but-core" }
 but-workspace = { path = "crates/but-workspace" }
+but-hunk-assignment = { path = "crates/but-hunk-assignment" }
 but-hunk-dependency = { path = "crates/but-hunk-dependency" }
 but-status = { path = "crates/but-status" }
 

--- a/apps/desktop/src/lib/hunks/diffService.svelte.ts
+++ b/apps/desktop/src/lib/hunks/diffService.svelte.ts
@@ -1,6 +1,7 @@
 import { providesList, ReduxTag } from '$lib/state/tags';
 import type { TreeChange } from '$lib/hunks/change';
 import type { UnifiedDiff } from '$lib/hunks/diff';
+import type { HunkAssignment } from '$lib/hunks/hunk';
 import type { ClientState } from '$lib/state/clientState.svelte';
 
 export type ChangeDiff = {
@@ -18,6 +19,15 @@ export class DiffService {
 	getDiff(projectId: string, change: TreeChange) {
 		const { getDiff } = this.api.endpoints;
 		return getDiff.useQuery({ projectId, change });
+	}
+
+	hunkAssignments(projectId: string) {
+		const { hunkAssignments } = this.api.endpoints;
+		return hunkAssignments.useQuery({ projectId });
+	}
+
+	assignHunk() {
+		return this.api.endpoints.assignHunk.mutate;
 	}
 
 	async fetchDiff(projectId: string, change: TreeChange) {
@@ -57,6 +67,20 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					params: { projectId, change }
 				}),
 				providesTags: [providesList(ReduxTag.Diff)]
+			}),
+			hunkAssignments: build.query<HunkAssignment[], { projectId: string }>({
+				query: ({ projectId }) => ({
+					command: 'hunk_assignments',
+					params: { projectId }
+				}),
+				providesTags: [providesList(ReduxTag.HunkAssignments)]
+			}),
+			assignHunk: build.mutation<void, { projectId: string; assignment: HunkAssignment }>({
+				query: ({ projectId, assignment }) => ({
+					command: 'assign_hunk',
+					params: { projectId, assignment }
+				}),
+				invalidatesTags: [providesList(ReduxTag.HunkAssignments)]
 			})
 		})
 	});

--- a/apps/desktop/src/lib/hunks/hunk.ts
+++ b/apps/desktop/src/lib/hunks/hunk.ts
@@ -84,6 +84,29 @@ export type HunkHeader = {
 	readonly newLines: number;
 };
 
+/**
+ * Represents a loose association between a hunk and a stack.
+ * A hunk being assigned to a stack means that upon unapplying the stack,
+ * the associated hunks will be dumped into a WIP commit and unapplid together with the stack.
+ *
+ * The hunk assignments are set by the user but also the backednd reconciles those assignments
+ * with the workspace hunks when they are updated on disk.
+ *
+ * Additionally, the hunk dependencies (locking) affects what assignment is possible.
+ */
+export type HunkAssignment = {
+	/** The hunk that is being assigned. Together with path_bytes, this identifies the hunk.
+	 * If the file is binary, or too large to load, this will be None and in this case the path name is the only identity.
+	 */
+	readonly hunkHeader: HunkHeader;
+	/** The file path of the hunk. Used for display. */
+	readonly path: string;
+	/** The file path of the hunk in bytes. Used to correctly communicate to the backed when creating new assignments */
+	readonly pathBytes: number[];
+	/** The stack to which the hunk is assigned. If None, the hunk is not assigned to any stack (i.e. it belongs in the unassigned area */
+	readonly stackId: string | null;
+};
+
 type DeltaLineGroup = {
 	type: DeltaLineType;
 	lines: LineId[];

--- a/apps/desktop/src/lib/state/tags.ts
+++ b/apps/desktop/src/lib/state/tags.ts
@@ -1,5 +1,6 @@
 export enum ReduxTag {
 	Diff = 'Diff',
+	HunkAssignments = 'HunkAssignments',
 	Stacks = 'Stacks',
 	StackDetails = 'StackDetails',
 	WorktreeChanges = 'WorktreeChanges',

--- a/crates/but-hunk-assignment/Cargo.toml
+++ b/crates/but-hunk-assignment/Cargo.toml
@@ -19,7 +19,9 @@ but-core.workspace = true
 but-hunk-dependency.workspace = true
 gitbutler-command-context.workspace = true
 gitbutler-stack.workspace = true
+gitbutler-fs.workspace = true
 bstr.workspace = true
+toml.workspace = true
 
 [dev-dependencies]
 uuid.workspace = true

--- a/crates/but-hunk-assignment/Cargo.toml
+++ b/crates/but-hunk-assignment/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "but-hunk-assignment"
+version = "0.0.0"
+edition = "2024"
+authors = ["GitButler <gitbutler@gitbutler.com>"]
+publish = false
+
+
+[lib]
+doctest = false
+
+[dependencies]
+anyhow = "1.0.98"
+itertools = "0.14.0"
+serde.workspace = true
+gix = { workspace = true, features = [] }
+but-workspace.workspace = true
+but-core.workspace = true
+but-hunk-dependency.workspace = true
+gitbutler-command-context.workspace = true
+gitbutler-stack.workspace = true
+bstr.workspace = true
+
+[dev-dependencies]
+uuid.workspace = true

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -68,9 +68,14 @@ impl HunkAssignment {
 
 /// Returns the current hunk assignments for the workspace.
 pub fn assignments(ctx: &CommandContext) -> Result<Vec<HunkAssignment>> {
-    let state = state::AssignmentsHandle::new(&ctx.project().gb_dir());
-    let assignments = state.assignments()?;
-    Ok(assignments)
+    // TODO: Use a dirty bit set in the file watcher to indicate when reconcilation is needed.
+    if true {
+        reconcile(ctx)
+    } else {
+        let state = state::AssignmentsHandle::new(&ctx.project().gb_dir());
+        let assignments = state.assignments()?;
+        Ok(assignments)
+    }
 }
 
 /// Sets the assignment for a hunk. It must be already present in the current assignments, errors out if it isn't.
@@ -109,8 +114,7 @@ pub fn assign(ctx: &CommandContext, new_assignment: HunkAssignment) -> Result<Ve
 /// If a stack is no longer present in the workspace (either unapplied or deleted), any assignments to it are removed.
 ///
 /// This needs to be ran only after the worktree has changed.
-/// TODO: When listing, we can reffer to a dirty bit to know if we need to run this.
-pub fn reconcile(ctx: &CommandContext) -> Result<Vec<HunkAssignment>> {
+fn reconcile(ctx: &CommandContext) -> Result<Vec<HunkAssignment>> {
     let state = state::AssignmentsHandle::new(&ctx.project().gb_dir());
     let previous_assignments = state.assignments()?;
     let repo = &ctx.gix_repo()?;

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -1,0 +1,352 @@
+//!
+//!
+//! Hunk - File, range
+//!
+//! HunkAssignment - None or Some(Stack in workspace)
+//!
+//! reconcile_assignments - takes worktree changes (Vec<TreeChange>) + current assignments (Vec<HunkAssignment>)
+//! returns updated assignments (Vec<HunkAssignment>)
+//!
+//! set_assignments
+
+use std::cmp::Ordering;
+
+use anyhow::Result;
+use bstr::BString;
+use but_core::{TreeChange, UnifiedDiff};
+use but_workspace::{HunkHeader, StackId};
+use gitbutler_command_context::CommandContext;
+
+#[derive(Debug, Clone)]
+pub struct HunkAssignment {
+    /// The hunk that is being assigned. Together with path_bytes, this identifies the hunk.
+    /// If the file is binary, or too large to load, this will be None and in this case the path name is the only identity.
+    pub hunk_header: Option<HunkHeader>,
+    /// The file path of the hunk.
+    pub path_bytes: BString,
+    /// The stack to which the hunk is assigned. If None, the hunk is not assigned to any stack.
+    pub stack_id: Option<StackId>,
+}
+
+impl PartialEq for HunkAssignment {
+    fn eq(&self, other: &Self) -> bool {
+        self.hunk_header == other.hunk_header && self.path_bytes == other.path_bytes
+    }
+}
+
+impl HunkAssignment {
+    /// Whether there is overlap between the two hunks.
+    fn intersects(&self, other: HunkAssignment) -> bool {
+        if self == &other {
+            return true;
+        }
+        if self.path_bytes != other.path_bytes {
+            return false;
+        }
+        if self.hunk_header == other.hunk_header {
+            return true;
+        }
+        if let (Some(header), Some(other_header)) = (self.hunk_header, other.hunk_header) {
+            if header.new_start >= other_header.new_start
+                && header.new_start < other_header.new_start + other_header.new_lines
+            {
+                return true;
+            }
+            if other_header.new_start >= header.new_start
+                && other_header.new_start < header.new_start + header.new_lines
+            {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+/// Reconciles the current hunk assignments with the current worktree changes.
+/// It takes  the current hunk assignments as well as the current worktree changes, producing a new set of hunk assignments.
+///
+/// Inside, fuzzy matching is performed, such that hunks that were previously assigned
+/// and now in they have been modified in the worktree are still assigned to the same stack.
+///
+/// If a hunk was deleted in the worktree, it is removed from the assignments list.
+/// If a completely new hunk is added it is accounted for with a HunkAssignment with stack_id None.
+///
+/// If a stack is no longer present in the workspace (either unapplied or deleted), any assignments to it are removed.
+///
+/// This needs to be ran only after the worktree has changed.
+/// TODO: When listing, we can reffer to a dirty bit to know if we need to run this.
+/// TODO: Conside hunk locking as well
+pub fn reconcile(
+    ctx: &CommandContext,
+    worktree_changes: Vec<TreeChange>,
+    applied_stacks: Vec<StackId>,
+    previous_assignments: Vec<HunkAssignment>,
+) -> Result<Vec<HunkAssignment>> {
+    let repo = &ctx.gix_repo()?;
+    let context_lines = ctx.app_settings().context_lines;
+    let mut new_assignments = vec![];
+    for change in worktree_changes {
+        let diff = change.unified_diff(repo, context_lines)?;
+        new_assignments.extend(reconcile_assignments(
+            diff_to_assignments(diff, change.path),
+            &previous_assignments,
+            &applied_stacks,
+        )?);
+    }
+    // TODO: Respect hunk-stack dependencies
+    Ok(new_assignments)
+}
+
+fn reconcile_assignments(
+    worktree_assignments: Vec<HunkAssignment>,
+    previous_assignments: &[HunkAssignment],
+    applied_stacks: &[StackId],
+) -> Result<Vec<HunkAssignment>> {
+    let mut new_assignments = vec![];
+    for mut worktree_entry in worktree_assignments {
+        let intersecting = previous_assignments
+            .iter()
+            .filter(|current_entry| current_entry.intersects(worktree_entry.clone()))
+            .collect::<Vec<_>>();
+
+        // If the worktree hunk intersects with exactly one previous assignment, then it inherits the stack_id assignment from it, but only if the stack is still applied.
+        // If the worktree hunk does not interesect with any previous assingment then it remains, "unassigned", i.e. with stack_id None
+        // If the worktree hunk intersects with more that one one previous assignment there is special handling
+        match intersecting.len().cmp(&1) {
+            Ordering::Less => {
+                // No intersection - do nothing, the None assignment is kept
+            }
+            Ordering::Equal => {
+                // One intersection - assign the stack id if the stack is still in the applied list
+                if let Some(stack_id) = intersecting[0].stack_id {
+                    if applied_stacks.contains(&stack_id) {
+                        worktree_entry.stack_id = intersecting[0].stack_id;
+                    }
+                }
+            }
+            Ordering::Greater => {
+                // More than one intersection - pick the one with the most lines
+                worktree_entry.stack_id = intersecting
+                    .iter()
+                    .max_by_key(|x| x.hunk_header.as_ref().map(|h| h.new_lines))
+                    .and_then(|x| x.stack_id);
+            }
+        }
+        new_assignments.push(worktree_entry);
+    }
+    Ok(new_assignments)
+}
+
+fn diff_to_assignments(diff: UnifiedDiff, path: BString) -> Vec<HunkAssignment> {
+    match diff {
+        but_core::UnifiedDiff::Binary => vec![HunkAssignment {
+            hunk_header: None,
+            path_bytes: path,
+            stack_id: None,
+        }],
+        but_core::UnifiedDiff::TooLarge { .. } => vec![HunkAssignment {
+            hunk_header: None,
+            path_bytes: path,
+            stack_id: None,
+        }],
+        but_core::UnifiedDiff::Patch {
+            hunks,
+            is_result_of_binary_to_text_conversion,
+            ..
+        } => {
+            if is_result_of_binary_to_text_conversion {
+                vec![HunkAssignment {
+                    hunk_header: None,
+                    path_bytes: path,
+                    stack_id: None,
+                }]
+            } else {
+                hunks
+                    .iter()
+                    .map(|hunk| HunkAssignment {
+                        hunk_header: Some(hunk.into()),
+                        path_bytes: path.clone(),
+                        stack_id: None,
+                    })
+                    .collect()
+            }
+        }
+    }
+}
+
+/// Sets the assignment for a hunk. It must be already present in the current assignments, errors out if it isn't.
+/// If the stack is not in the list of applied stacks, it errors out.
+/// Returns the updated assignments list.
+/// TODO: Conside hunk locking as well
+pub fn set_assignment(
+    applied_stacks: Vec<StackId>,
+    mut previous_assignments: Vec<HunkAssignment>,
+    new_assignment: HunkAssignment,
+) -> Result<Vec<HunkAssignment>> {
+    if let Some(stack_id) = new_assignment.stack_id {
+        if !applied_stacks.contains(&stack_id) {
+            return Err(anyhow::anyhow!("No such stack in the workspace"));
+        }
+    }
+    if !previous_assignments.contains(&new_assignment) {
+        return Err(anyhow::anyhow!("Hunk not found in current assignments"));
+    }
+    if let Some(found) = previous_assignments
+        .iter_mut()
+        .find(|x| **x == new_assignment)
+    {
+        found.stack_id = new_assignment.stack_id;
+    }
+    Ok(previous_assignments)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bstr::BString;
+    use but_workspace::{HunkHeader, StackId};
+
+    fn ass(path: &str, start: u32, end: u32, stack_id: Option<usize>) -> HunkAssignment {
+        HunkAssignment {
+            hunk_header: Some(HunkHeader {
+                old_start: 0,
+                old_lines: 0,
+                new_start: start,
+                new_lines: end,
+            }),
+            path_bytes: BString::from(path),
+            stack_id: stack_id.map(id),
+        }
+    }
+    fn id(num: usize) -> StackId {
+        StackId::from(
+            uuid::Uuid::parse_str(&format!("00000000-0000-0000-0000-00000000000{}", num % 10))
+                .unwrap(),
+        )
+    }
+
+    #[test]
+    fn test_reconcile_exact_match_and_no_intersection() {
+        let previous_assignments = vec![ass("foo.rs", 10, 15, Some(1))];
+        let worktree_assignments = vec![ass("foo.rs", 10, 15, None), ass("foo.rs", 16, 20, None)];
+        let applied_stacks = vec![id(1), id(2)];
+        let result =
+            reconcile_assignments(worktree_assignments, &previous_assignments, &applied_stacks)
+                .unwrap();
+        assert_eq!(
+            result,
+            vec![ass("foo.rs", 10, 15, Some(1)), ass("foo.rs", 16, 20, None)]
+        );
+    }
+
+    #[test]
+    fn test_reconcile_exact_match_unapplied_branch_unassigns() {
+        let previous_assignments = vec![ass("foo.rs", 10, 15, Some(1))];
+        let worktree_assignments = vec![ass("foo.rs", 10, 15, None)];
+        let applied_stacks = vec![id(2)];
+        let result =
+            reconcile_assignments(worktree_assignments, &previous_assignments, &applied_stacks)
+                .unwrap();
+        assert_eq!(result, vec![ass("foo.rs", 10, 15, None)]);
+    }
+
+    #[test]
+    fn test_reconcile_with_overlap_preserves_assignment() {
+        let previous_assignments = vec![ass("foo.rs", 10, 15, Some(1))];
+        let worktree_assignments = vec![ass("foo.rs", 12, 17, None)];
+        let applied_stacks = vec![id(1)];
+        let result =
+            reconcile_assignments(worktree_assignments, &previous_assignments, &applied_stacks)
+                .unwrap();
+        assert_eq!(result, vec![ass("foo.rs", 12, 17, Some(1))]);
+    }
+
+    #[test]
+    fn test_double_overlap_picks_the_bigger_previous_assignment() {
+        let previous_assignments = vec![
+            ass("foo.rs", 5, 15, Some(1)),
+            ass("foo.rs", 17, 25, Some(2)),
+        ];
+        let applied_stacks = vec![id(1), id(2)];
+        let worktree_assignments = vec![ass("foo.rs", 5, 18, None)];
+        let result =
+            reconcile_assignments(worktree_assignments, &previous_assignments, &applied_stacks)
+                .unwrap();
+        assert_eq!(result, vec![ass("foo.rs", 5, 18, Some(1))]);
+    }
+
+    #[test]
+    fn test_set_assignment_success() {
+        let applied_stacks = vec![id(1), id(2)];
+        let previous_assignments =
+            vec![ass("foo.rs", 10, 15, None), ass("bar.rs", 20, 25, Some(1))];
+
+        // Assign foo.rs:10 to stack 2
+        let new_assignment = ass("foo.rs", 10, 15, Some(2));
+        let updated = set_assignment(
+            applied_stacks.clone(),
+            previous_assignments.clone(),
+            new_assignment.clone(),
+        )
+        .unwrap();
+
+        // Should update the stack_id for foo.rs:10
+        let found = updated.iter().find(|h| **h == new_assignment).unwrap();
+        assert_eq!(found.stack_id, Some(id(2)));
+
+        // Other assignments should remain unchanged
+        let other = updated
+            .iter()
+            .find(|h| **h == ass("bar.rs", 20, 25, Some(1)))
+            .unwrap();
+        assert_eq!(other.stack_id, Some(id(1)));
+    }
+
+    #[test]
+    fn test_set_assignment_stack_not_applied() {
+        let applied_stacks = vec![id(1), id(2)];
+        let previous_assignments =
+            vec![ass("foo.rs", 10, 15, None), ass("bar.rs", 20, 25, Some(1))];
+
+        // Assign foo.rs:10 to stack 3 (not applied)
+        let new_assignment = ass("foo.rs", 10, 15, Some(3));
+        let result = set_assignment(
+            applied_stacks.clone(),
+            previous_assignments.clone(),
+            new_assignment.clone(),
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_set_assignment_hunk_not_found() {
+        let applied_stacks = vec![id(1), id(2)];
+        let previous_assignments =
+            vec![ass("foo.rs", 10, 15, None), ass("bar.rs", 20, 25, Some(1))];
+
+        // Assign baz.rs:30 to stack 2 (not found)
+        let new_assignment = ass("baz.rs", 30, 35, Some(2));
+        let result = set_assignment(
+            applied_stacks.clone(),
+            previous_assignments.clone(),
+            new_assignment.clone(),
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_hunk_assignment_partial_eq() {
+        let hunk1 = ass("foo.rs", 10, 15, Some(1));
+        let hunk2 = ass("foo.rs", 10, 15, Some(2));
+        assert_eq!(hunk1, hunk2);
+    }
+
+    #[test]
+    fn test_hunk_assignment_partial_eq_different_path() {
+        let hunk1 = ass("foo.rs", 10, 15, Some(1));
+        let hunk2 = ass("bar.rs", 10, 15, Some(2));
+        assert_ne!(hunk1, hunk2);
+    }
+}

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -22,6 +22,7 @@ use gitbutler_stack::VirtualBranchesHandle;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct HunkAssignment {
     /// The hunk that is being assigned. Together with path_bytes, this identifies the hunk.
     /// If the file is binary, or too large to load, this will be None and in this case the path name is the only identity.

--- a/crates/but-hunk-assignment/src/state.rs
+++ b/crates/but-hunk-assignment/src/state.rs
@@ -1,0 +1,49 @@
+/// The name of the file holding our state, useful for watching for changes.
+const FILE_NAME: &str = "hunk-assignment.toml";
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use gitbutler_fs::read_toml_file_or_default;
+use serde::{Deserialize, Serialize};
+
+use crate::HunkAssignment;
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct HunkAssignments {
+    pub assignments: Vec<HunkAssignment>,
+}
+
+pub(crate) struct AssignmentsHandle {
+    /// The path to the file containing the hunk assignment state.
+    file_path: PathBuf,
+}
+
+impl AssignmentsHandle {
+    pub fn new(base_path: &Path) -> Self {
+        let file_path = base_path.join(FILE_NAME);
+        Self { file_path }
+    }
+
+    pub fn assignments(&self) -> Result<Vec<HunkAssignment>> {
+        let val = self.read_file()?;
+        Ok(val.assignments)
+    }
+
+    pub fn set_assignments(&self, assignments: Vec<HunkAssignment>) -> Result<()> {
+        let mut val = self.read_file()?;
+        val.assignments = assignments;
+        self.write_file(val)
+    }
+
+    /// Reads and parses the state file.
+    ///
+    /// If the file does not exist, it will be created.
+    fn read_file(&self) -> Result<HunkAssignments> {
+        read_toml_file_or_default(&self.file_path)
+    }
+
+    fn write_file(&self, assignments: HunkAssignments) -> Result<()> {
+        gitbutler_fs::write(&self.file_path, toml::to_string(&assignments)?)
+    }
+}

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -122,6 +122,17 @@ pub struct HunkHeader {
     pub new_lines: u32,
 }
 
+impl From<&but_core::unified_diff::DiffHunk> for HunkHeader {
+    fn from(hunk: &but_core::unified_diff::DiffHunk) -> Self {
+        Self {
+            old_start: hunk.old_start,
+            old_lines: hunk.old_lines,
+            new_start: hunk.new_start,
+            new_lines: hunk.new_lines,
+        }
+    }
+}
+
 impl HunkHeader {
     /// Returns the hunk header with the old and new ranges swapped.
     ///

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -77,6 +77,7 @@ but-settings.workspace = true
 but-workspace.workspace = true
 but-core.workspace = true
 but-hunk-dependency.workspace = true
+but-hunk-assignment.workspace = true
 open = "5"
 url = "2.5.4"
 dirs = "6.0.0"

--- a/crates/gitbutler-tauri/src/diff.rs
+++ b/crates/gitbutler-tauri/src/diff.rs
@@ -6,6 +6,7 @@ use but_core::{
     ui::{TreeChange, TreeChanges, WorktreeChanges},
     Commit,
 };
+use but_hunk_assignment::HunkAssignment;
 use but_workspace::StackId;
 use gitbutler_command_context::CommandContext;
 use gitbutler_oxidize::{ObjectIdExt, OidExt};
@@ -164,4 +165,31 @@ pub fn changes_in_worktree(
     Ok(but_core::diff::ui::worktree_changes_by_worktree_dir(
         project.path,
     )?)
+}
+
+#[tauri::command(async)]
+#[instrument(skip(projects, settings), err(Debug))]
+pub fn assignments(
+    projects: tauri::State<'_, gitbutler_project::Controller>,
+    settings: tauri::State<'_, but_settings::AppSettingsWithDiskSync>,
+    project_id: ProjectId,
+) -> anyhow::Result<Vec<HunkAssignment>, Error> {
+    let project = projects.get(project_id)?;
+    let ctx = CommandContext::open(&project, settings.get()?.clone())?;
+    let assignments = but_hunk_assignment::assignments(&ctx)?;
+    Ok(assignments)
+}
+
+#[tauri::command(async)]
+#[instrument(skip(projects, settings), err(Debug))]
+pub fn assign(
+    projects: tauri::State<'_, gitbutler_project::Controller>,
+    settings: tauri::State<'_, but_settings::AppSettingsWithDiskSync>,
+    project_id: ProjectId,
+    assignment: HunkAssignment,
+) -> anyhow::Result<Vec<HunkAssignment>, Error> {
+    let project = projects.get(project_id)?;
+    let ctx = CommandContext::open(&project, settings.get()?.clone())?;
+    let assignments = but_hunk_assignment::assign(&ctx, assignment)?;
+    Ok(assignments)
 }

--- a/crates/gitbutler-tauri/src/diff.rs
+++ b/crates/gitbutler-tauri/src/diff.rs
@@ -169,7 +169,7 @@ pub fn changes_in_worktree(
 
 #[tauri::command(async)]
 #[instrument(skip(projects, settings), err(Debug))]
-pub fn assignments(
+pub fn hunk_assignments(
     projects: tauri::State<'_, gitbutler_project::Controller>,
     settings: tauri::State<'_, but_settings::AppSettingsWithDiskSync>,
     project_id: ProjectId,
@@ -182,14 +182,14 @@ pub fn assignments(
 
 #[tauri::command(async)]
 #[instrument(skip(projects, settings), err(Debug))]
-pub fn assign(
+pub fn assign_hunk(
     projects: tauri::State<'_, gitbutler_project::Controller>,
     settings: tauri::State<'_, but_settings::AppSettingsWithDiskSync>,
     project_id: ProjectId,
     assignment: HunkAssignment,
-) -> anyhow::Result<Vec<HunkAssignment>, Error> {
+) -> anyhow::Result<(), Error> {
     let project = projects.get(project_id)?;
     let ctx = CommandContext::open(&project, settings.get()?.clone())?;
-    let assignments = but_hunk_assignment::assign(&ctx, assignment)?;
-    Ok(assignments)
+    but_hunk_assignment::assign(&ctx, assignment)?;
+    Ok(())
 }

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -298,6 +298,8 @@ fn main() {
                     diff::commit_details,
                     diff::changes_in_branch,
                     diff::tree_change_diffs,
+                    diff::assignments,
+                    diff::assign,
                     // `env_vars` is only supposed to be avaialble in debug mode, not in production.
                     #[cfg(debug_assertions)]
                     env::env_vars,

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -298,8 +298,8 @@ fn main() {
                     diff::commit_details,
                     diff::changes_in_branch,
                     diff::tree_change_diffs,
-                    diff::assignments,
-                    diff::assign,
+                    diff::hunk_assignments,
+                    diff::assign_hunk,
                     // `env_vars` is only supposed to be avaialble in debug mode, not in production.
                     #[cfg(debug_assertions)]
                     env::env_vars,


### PR DESCRIPTION
- [x] Initial type definition of hunk assignment to a lane
- [x] API for listing hunk assignments
- [x] API for creating a new assignment
- [x] Handling of file system changes
- [x] Handling of hunk dependencies (locks)
- [x] Persistence
- [ ] Handling of "unapply branch" containing assigned hunks
- [ ] Performance: Use a dirty bit signal from the file system watcher to make the "list assignments" endpoint *not* reconcile when it's not needed
- [x] Add "locked" to the assignment type (useful to the UI)
- [ ] Report to the UI when the assign_hunk operation rejects an operation due locking / branch dependency
- [x] UI: Types
- [x] UI: Service methods
- [ ] User interface for displaying assignments correctly
- [ ] User interface for creating assignments
- [ ] Explore UX for creating commits from within a lane

Related to https://github.com/gitbutlerapp/gitbutler/issues/8637