### PR TITLE
ui-updates-62

### DIFF
--- a/apps/desktop/src/components/ReduxResult.svelte
+++ b/apps/desktop/src/components/ReduxResult.svelte
@@ -26,6 +26,7 @@
 		result: Result<A> | undefined;
 		projectId: string;
 		children: Snippet<[A, Env<B>]>;
+		loading?: Snippet<[]>;
 		error?: Snippet<[unknown]>;
 		onerror?: (err: unknown) => void;
 	} & (B extends undefined ? { stackId?: B } : { stackId: B });
@@ -77,19 +78,26 @@
 	{#if props.error}
 		{@render props.error(display.result.error)}
 	{/if}
+{:else if display.result?.status === 'pending' || display.result?.status === 'uninitialized'}
+	{#if props.loading}
+		{@render props.loading()}
+	{:else}
+		<div class="text-12 loading-spinner">
+			<Icon name="spinner" />
+			<span>{display.result?.status}</span>
+		</div>
+	{/if}
 {:else if display.result?.data !== undefined}
 	{@render props.children(display.result.data, display.env)}
-{:else if display.result?.status === 'pending'}
-	<div class="loading-spinner">
-		<Icon name="spinner" />
-	</div>
-{:else if display.result?.status === 'uninitialized'}
-	Uninitialized...
 {/if}
 
 <style>
 	.loading-spinner {
+		display: flex;
+		align-items: center;
+		gap: 8px;
 		z-index: var(--z-lifted);
 		position: relative;
+		color: var(--clr-text-2);
 	}
 </style>

--- a/apps/desktop/src/components/v3/MultiStackOfflaneDropzone.svelte
+++ b/apps/desktop/src/components/v3/MultiStackOfflaneDropzone.svelte
@@ -4,6 +4,7 @@
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { UiState } from '$lib/state/uiState.svelte';
 	import { inject } from '@gitbutler/shared/context';
+	import { preventTransitionOnMount } from '@gitbutler/ui/utils/preventTransitionOnMount';
 
 	interface Props {
 		projectId: string;
@@ -20,14 +21,13 @@
 		{#snippet overlay({ hovered, activated })}
 			<div class="hidden-dropzone__lane" class:activated class:hovered>
 				<div class="hidden-dropzone__content">
-					<div>
+					<div use:preventTransitionOnMount class="hidden-dropzone__svg">
 						<svg
 							xmlns="http://www.w3.org/2000/svg"
 							width="72"
 							height="97"
 							viewBox="0 0 72 97"
 							fill="none"
-							class="hidden-dropzone__svg"
 						>
 							<g class="hidden-dropzone__svg__plus-list">
 								<path
@@ -75,7 +75,7 @@
 						</svg>
 					</div>
 
-					<p class="hidden-dropzone__label text-13 text-body">
+					<p use:preventTransitionOnMount class="hidden-dropzone__label text-13 text-body">
 						Drag and drop files<br />to create a new branch.
 					</p>
 				</div>

--- a/apps/desktop/src/components/v3/WorkspaceView.svelte
+++ b/apps/desktop/src/components/v3/WorkspaceView.svelte
@@ -133,31 +133,34 @@
 		{/if}
 	</div>
 
-	<ReduxResult {projectId} result={stacksResult?.current}>
-		{#snippet children(stacks)}
-			<div
-				class="stacks-view-wrap"
-				bind:this={stacksViewEl}
-				style:width={stacksViewWidth.current + 'rem'}
-				use:focusable={{ id: Focusable.WorkspaceRight, parentId: Focusable.Workspace }}
-			>
+	<div
+		class="stacks-view-wrap"
+		bind:this={stacksViewEl}
+		style:width={stacksViewWidth.current + 'rem'}
+		use:focusable={{ id: Focusable.WorkspaceRight, parentId: Focusable.Workspace }}
+	>
+		<ReduxResult {projectId} result={stacksResult?.current}>
+			{#snippet loading()}
+				<div class="stacks-view-skeleton"></div>
+			{/snippet}
+
+			{#snippet children(stacks)}
 				<MultiStackView
 					{projectId}
 					{stacks}
 					selectedId={stackId}
 					active={focusGroup.current !== Focusable.UncommittedChanges}
 				/>
-
-				<Resizer
-					viewport={stacksViewEl}
-					direction="left"
-					minWidth={16}
-					borderRadius="ml"
-					onWidth={(value) => uiState.global.stacksViewWidth.set(value)}
-				/>
-			</div>
-		{/snippet}
-	</ReduxResult>
+			{/snippet}
+		</ReduxResult>
+		<Resizer
+			viewport={stacksViewEl}
+			direction="left"
+			minWidth={16}
+			borderRadius="ml"
+			onWidth={(value) => uiState.global.stacksViewWidth.set(value)}
+		/>
+	</div>
 </div>
 
 <style>
@@ -201,5 +204,13 @@
 		overflow-x: hidden;
 		gap: 8px;
 		min-width: 320px;
+	}
+
+	/* SKELETON LOADING */
+	.stacks-view-skeleton {
+		width: 100%;
+		height: 100%;
+		border-radius: var(--radius-ml);
+		border: 1px solid var(--clr-border-2);
 	}
 </style>

--- a/apps/desktop/src/components/v3/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/v3/WorktreeChanges.svelte
@@ -119,23 +119,24 @@
 	let listFooterHeight = $state(0);
 </script>
 
-<ReduxResult {stackId} {projectId} result={changesResult.current}>
-	{#snippet children(changes, { stackId, projectId })}
-		<Dropzone handlers={[uncommitDzHandler]} maxHeight>
-			{#snippet overlay({ hovered, activated })}
-				<CardOverlay {hovered} {activated} label="Uncommit changes" />
-			{/snippet}
-			<div
-				class="uncommitted-changes-wrap"
-				use:focusable={{ id: Focusable.UncommittedChanges, parentId: Focusable.WorkspaceLeft }}
-			>
-				<ScrollableContainer
-					autoScroll={false}
-					padding={{
-						top: listHeaderHeight,
-						bottom: listFooterHeight
-					}}
-				>
+<Dropzone handlers={[uncommitDzHandler]} maxHeight>
+	{#snippet overlay({ hovered, activated })}
+		<CardOverlay {hovered} {activated} label="Uncommit changes" />
+	{/snippet}
+
+	<div
+		class="uncommitted-changes-wrap"
+		use:focusable={{ id: Focusable.UncommittedChanges, parentId: Focusable.WorkspaceLeft }}
+	>
+		<ScrollableContainer
+			autoScroll={false}
+			padding={{
+				top: listHeaderHeight,
+				bottom: listFooterHeight
+			}}
+		>
+			<ReduxResult {stackId} {projectId} result={changesResult.current}>
+				{#snippet children(changes, { stackId, projectId })}
 					<div
 						data-testid={TestId.UncommittedChanges_Header}
 						use:stickyHeader
@@ -202,11 +203,11 @@
 							<WorktreeTipsFooter />
 						</div>
 					{/if}
-				</ScrollableContainer>
-			</div>
-		</Dropzone>
-	{/snippet}
-</ReduxResult>
+				{/snippet}
+			</ReduxResult>
+		</ScrollableContainer>
+	</div>
+</Dropzone>
 
 <style>
 	.uncommitted-changes-wrap {

--- a/packages/ui/src/lib/scroll/Scrollbar.svelte
+++ b/packages/ui/src/lib/scroll/Scrollbar.svelte
@@ -276,6 +276,7 @@
 	}
 </script>
 
+<!-- {#if mounted} -->
 <div
 	bind:this={track}
 	data-remove-from-draggable
@@ -308,6 +309,8 @@
 	></div>
 </div>
 
+<!-- {/if} -->
+
 <style>
 	.scrollbar-track {
 		position: absolute;
@@ -331,9 +334,6 @@
 		background-color: var(--clr-scale-ntrl-0);
 		opacity: 0;
 		will-change: transform, opacity;
-		transition:
-			opacity 0.2s,
-			transform 0.15s;
 	}
 
 	/* modify vertical scrollbar */
@@ -353,9 +353,13 @@
 	}
 
 	/* MODIFIERS */
+
 	.show-scrollbar {
 		& .scrollbar-thumb {
 			opacity: 0.15;
+			transition:
+				opacity 0.2s,
+				transform 0.15s;
 		}
 	}
 

--- a/packages/ui/src/lib/utils/preventTransitionOnMount.ts
+++ b/packages/ui/src/lib/utils/preventTransitionOnMount.ts
@@ -1,0 +1,19 @@
+export function preventTransitionOnMount(node: HTMLElement) {
+	// cunstruct class styles
+
+	// run timer to prevent transition on mount
+	function runTimer() {
+		node.classList.add('h-no-transition');
+		setTimeout(() => {
+			node.classList.remove('h-no-transition');
+		}, 100);
+	}
+
+	runTimer();
+
+	return {
+		destroy() {
+			node.classList.remove('h-no-transition');
+		}
+	};
+}

--- a/packages/ui/src/styles/utility/helpers.css
+++ b/packages/ui/src/styles/utility/helpers.css
@@ -92,7 +92,6 @@ pre {
 }
 
 /* STICKY HEADER */
-
 .h-sticky-header {
 	position: sticky;
 	z-index: var(--z-lifted);
@@ -112,4 +111,9 @@ pre {
 
 .h-sticky-header_sticked-bottom {
 	border-top: 1px solid var(--clr-border-2);
+}
+
+/* NO TRANSITION ON MOUNT */
+.h-no-transition {
+	transition: none !important;
 }


### PR DESCRIPTION
- Added a `loading` snippet to the `ReduxResult` component
- Combined the `pending` and `uninitialized` conditions in `ReduxResult`, showing the difference only for labels
- Restructured the components hierarchy in `ReduxResult` to prevent content shift if sections are loading data and still empty
- Fixed an issue to prevent CSS transitions from firing on mount