### PR TITLE
Remove TryV3Modal import and usage from the global desktop layout and add

### DIFF
--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -14,7 +14,6 @@
 	import ShareIssueModal from '$components/ShareIssueModal.svelte';
 	import SwitchThemeMenuAction from '$components/SwitchThemeMenuAction.svelte';
 	import ToastController from '$components/ToastController.svelte';
-	import TryV3Modal from '$components/TryV3Modal.svelte';
 	import ZoomInOutMenuAction from '$components/ZoomInOutMenuAction.svelte';
 	import LineSelection from '$components/v3/unifiedDiffLineSelection.svelte';
 	import { PromptService as AIPromptService } from '$lib/ai/promptService';
@@ -301,7 +300,6 @@
 	{/if}
 	{@render children()}
 </div>
-<TryV3Modal />
 <Toaster />
 <ShareIssueModal bind:this={shareIssueModal} />
 <ToastController />

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -9,6 +9,7 @@
 	import NotOnGitButlerBranch from '$components/NotOnGitButlerBranch.svelte';
 	import ProblemLoadingRepo from '$components/ProblemLoadingRepo.svelte';
 	import ProjectSettingsMenuAction from '$components/ProjectSettingsMenuAction.svelte';
+	import TryV3Modal from '$components/TryV3Modal.svelte';
 	import IrcPopups from '$components/v3/IrcPopups.svelte';
 	import { Code, isTauriCommandError } from '$lib/backend/ipc';
 	import { BaseBranch } from '$lib/baseBranch/baseBranch';
@@ -303,6 +304,8 @@
 		setActiveProjectOrRedirect();
 	});
 </script>
+
+<TryV3Modal />
 
 <!-- forces components to be recreated when projectId changes -->
 {#key projectId}


### PR DESCRIPTION
it to the project-specific layout.

That way the popup only appears after the successful onboarding of a 
project.