### PR TITLE
fix(ui): move rtl direction to first path element in FileName

### DIFF
--- a/packages/ui/src/lib/file/FileName.svelte
+++ b/packages/ui/src/lib/file/FileName.svelte
@@ -85,11 +85,10 @@
 
 	.file-name__path--first,
 	.file-name__path--last {
-		direction: rtl;
 		min-width: 2ch;
 	}
-
 	.file-name__path--first {
 		flex: 1;
+		direction: rtl;
 	}
 </style>


### PR DESCRIPTION
Shift the 'direction: rtl' style from both first and last path elements to
only the first path element in FileName.svelte.


This allows trailing punctuation to be rendered at the beginning.

Fixes #8611 