### PR TITLE
commit-messages-staleness-p1

### DIFF
--- a/apps/desktop/cypress/e2e/commitActions.cy.ts
+++ b/apps/desktop/cypress/e2e/commitActions.cy.ts
@@ -535,6 +535,54 @@ describe('Commit Actions with lots of uncommitted changes', () => {
 
 			cy.getByTestId('commit-row', commitTitle).should('be.visible');
 		}
+
+		// Start editing the commits and cancel
+		for (let i = TIMES; i < TIMES * 2; i++) {
+			const commitTitle = `Commit title ${i + 1}`;
+			const commitDescription = `Commit description ${i + 1}`;
+
+			const newCommitTitle = `New commit title ${i + 1}`;
+			const newCommitDescription = `New commit description ${i + 1}`;
+
+			// Click on the first commit
+			cy.getByTestId('commit-row', commitTitle).should('contain', commitTitle).click();
+
+			// Should open the commit drawer
+			cy.get('.commit-view').first().should('contain', commitTitle);
+
+			// Click on the edit message button
+			cy.getByTestId('commit-drawer-action-edit-message').should('contain', 'Edit message').click();
+
+			// Should open the commit rename drawer
+			cy.getByTestId('edit-commit-message-drawer').should('be.visible');
+
+			// Should have the original commit message, and be focused
+			cy.getByTestId('commit-drawer-title-input')
+				.should('have.value', commitTitle)
+				.should('be.visible')
+				.should('be.enabled')
+				.clear()
+				.type(newCommitTitle); // Type the new commit message title
+
+			// Type in a description
+			cy.getByTestId('commit-drawer-description-input')
+				.should('be.visible')
+				.should('contain', commitDescription)
+				.click()
+				.clear()
+				.type(newCommitDescription); // Type the new commit message body
+
+			// Click on the save button
+			cy.getByTestId('commit-drawer-cancel-button')
+				.should('be.visible')
+				.should('be.enabled')
+				.click();
+
+			cy.getByTestId('edit-commit-message-drawer').should('not.exist');
+
+			cy.getByTestId('commit-drawer-title').should('contain', commitTitle);
+			cy.getByTestId('commit-drawer-description').should('contain', commitDescription);
+		}
 	});
 });
 

--- a/apps/desktop/src/components/v3/CommitMessageEditor.svelte
+++ b/apps/desktop/src/components/v3/CommitMessageEditor.svelte
@@ -147,7 +147,7 @@
 		value={effectiveTitleValue}
 		oninput={(e: Event) => {
 			const input = e.currentTarget as HTMLInputElement;
-			projectState.commitTitle.current = input.value;
+			titleText.current = input.value;
 		}}
 		onkeydown={(e: KeyboardEvent) => {
 			if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {

--- a/apps/desktop/src/components/v3/CommitView.svelte
+++ b/apps/desktop/src/components/v3/CommitView.svelte
@@ -118,6 +118,12 @@
 		if (!canEdit()) return;
 		await modeService!.enterEditMode(commitKey.commitId, stackId);
 	}
+
+	function cancelEdit() {
+		setMode('view');
+		commitTitle.current = '';
+		commitDescription.current = '';
+	}
 </script>
 
 <ReduxResult {stackId} {projectId} result={commitResult.current} {onerror}>
@@ -139,7 +145,7 @@
 					stackId={env.stackId}
 					action={() => editCommitMessage()}
 					actionLabel="Save"
-					onCancel={() => setMode('view')}
+					onCancel={cancelEdit}
 					initialTitle={parsedMessage.title}
 					initialMessage={parsedMessage.description}
 					loading={messageUpdateResult.current.isLoading}

--- a/apps/desktop/src/components/v3/NewCommitView.svelte
+++ b/apps/desktop/src/components/v3/NewCommitView.svelte
@@ -240,6 +240,8 @@
 
 	function cancel() {
 		drawer?.onClose();
+		projectState.commitTitle.set('');
+		projectState.commitDescription.set('');
 	}
 </script>
 

--- a/apps/desktop/src/components/v3/editor/EditorFooter.svelte
+++ b/apps/desktop/src/components/v3/editor/EditorFooter.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { TestId } from '$lib/testing/testIds';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import { type Snippet } from 'svelte';
 
@@ -12,7 +13,9 @@
 </script>
 
 <div class="editor-footer">
-	<Button kind="outline" style="neutral" onclick={onCancel}>{CancelButtonLabel}</Button>
+	<Button testId={TestId.CommitDrawerCancelButton} kind="outline" style="neutral" onclick={onCancel}
+		>{CancelButtonLabel}</Button
+	>
 	{@render children()}
 </div>
 

--- a/apps/desktop/src/lib/testing/testIds.ts
+++ b/apps/desktop/src/lib/testing/testIds.ts
@@ -28,6 +28,7 @@ export enum TestId {
 	CommitDrawerTitleInput = 'commit-drawer-title-input',
 	CommitDrawerDescriptionInput = 'commit-drawer-description-input',
 	CommitDrawerActionButton = 'commit-drawer-action-button',
+	CommitDrawerCancelButton = 'commit-drawer-cancel-button',
 	CommitDrawerTitle = 'commit-drawer-title',
 	CommitDrawerDescription = 'commit-drawer-description',
 	UncommittedChanges_FileList = 'uncommitted-changes-file-list',


### PR DESCRIPTION
- Clear commit title and description fields on cancel actions in NewCommitView and CommitView to prevent stale input data.
- Update commit title state handling in the editor component.
- Instrument the cancel button in the commit message editor for better testing.
- Extend tests to cover clearing cached commit messages when editing is canceled.