### PR TITLE
update `gix` to fix index-worktree rename tracking performance issue for when there is a lot of new files.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,7 +3169,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.72.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "gix-actor 0.35.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-attributes 0.26.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3240,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.35.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "gix-date 0.10.2 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3271,7 +3271,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.26.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "gix-glob 0.20.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3297,7 +3297,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.14"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "thiserror 2.0.12",
 ]
@@ -3314,7 +3314,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "thiserror 2.0.12",
 ]
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.6.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "gix-path 0.10.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3347,7 +3347,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "gix-chunk 0.4.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3360,7 +3360,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.45.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -3380,7 +3380,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -3392,7 +3392,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3423,7 +3423,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.10.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "itoa 1.0.15",
@@ -3436,7 +3436,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.52.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "gix-attributes 0.26.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3459,7 +3459,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.14.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "gix-discover 0.40.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3494,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.40.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "dunce",
@@ -3523,7 +3523,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.42.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -3543,7 +3543,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.19.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -3577,7 +3577,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "fastrand",
@@ -3602,7 +3602,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.20.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -3626,7 +3626,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.18.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "faster-hex",
  "gix-features 0.42.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3649,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.8.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "gix-hash 0.18.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "hashbrown 0.14.5",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "gix-glob 0.20.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3713,7 +3713,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.40.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -3752,7 +3752,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "17.1.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "gix-tempfile 17.1.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3762,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.27.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "gix-actor 0.35.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3774,7 +3774,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.5.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3798,7 +3798,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.20.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bitflags 2.9.1",
  "gix-commitgraph 0.28.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3834,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.49.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "gix-actor 0.35.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3855,7 +3855,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.69.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "arc-swap",
  "gix-date 0.10.2 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3876,7 +3876,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.59.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "clru",
  "gix-chunk 0.4.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3897,7 +3897,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -3908,7 +3908,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -3933,7 +3933,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.18"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "gix-trace 0.1.12 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3946,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -3960,7 +3960,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -3972,7 +3972,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.50.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -4009,7 +4009,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4040,7 +4040,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.52.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "gix-actor 0.35.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-features 0.42.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4061,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.30.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "gix-hash 0.18.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4074,7 +4074,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.34.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -4107,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.20.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "gix-commitgraph 0.28.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-date 0.10.2 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4133,7 +4133,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bitflags 2.9.1",
  "gix-path 0.10.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4145,7 +4145,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.4.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "gix-hash 0.18.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4157,7 +4157,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "filetime",
@@ -4179,7 +4179,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "gix-config",
@@ -4208,7 +4208,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "17.1.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "dashmap",
  "gix-fs 0.15.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4251,7 +4251,7 @@ checksum = "7c396a2036920c69695f760a65e7f2677267ccf483f25046977d87e4cb2665f7"
 [[package]]
 name = "gix-trace"
 version = "0.1.12"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "tracing-core",
 ]
@@ -4259,7 +4259,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.47.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -4295,7 +4295,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.46.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bitflags 2.9.1",
  "gix-commitgraph 0.28.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4311,7 +4311,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "gix-features 0.42.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4335,7 +4335,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4355,7 +4355,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "thiserror 2.0.12",
@@ -4383,7 +4383,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.41.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "gix-attributes 0.26.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4402,7 +4402,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#fd49eeeb850ea3c3956ca15be2bf4e04a3d319ad"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#309421424fa02037f7609fc4ca0c03a99909cdb6"
 dependencies = [
  "bstr",
  "gix-features 0.42.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -9767,7 +9767,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
This is more of an issue in `gitoxide` which is just too slow for such cases, after all there isn't any deletion that it could use, yet the runtime blows up.

The fixed version of `gix` does a pre-analysis to catch such cases to do nearly no work at all (if there is nothing to work on anyway).
