### PR TITLE
Commit stale messages: Edit with a vengance

### DIFF
--- a/apps/desktop/cypress/e2e/commitActions.cy.ts
+++ b/apps/desktop/cypress/e2e/commitActions.cy.ts
@@ -196,6 +196,53 @@ describe('Commit Actions', () => {
 		expect(mockBackend.getDiff).to.have.callCount(0);
 	});
 
+	it('If nothing is changed, it should call the edit commit message function with the same message', () => {
+		const originalCommitMessage = 'Initial commit';
+
+		cy.spy(mockBackend, 'updateCommitMessage').as('updateCommitMessageSpy');
+		cy.spy(mockBackend, 'getDiff').as('getDiffSpy');
+
+		// Click on the first commit
+		cy.getByTestId('commit-row').first().should('contain', originalCommitMessage).click();
+
+		// Should open the commit drawer
+		cy.get('.commit-view').first().should('contain', originalCommitMessage);
+
+		// Click on the edit message button
+		cy.getByTestId('commit-drawer-action-edit-message').should('contain', 'Edit message').click();
+
+		// Should open the commit rename drawer
+		cy.getByTestId('edit-commit-message-drawer').should('be.visible');
+
+		// Should have the original commit message, and be focused
+		cy.getByTestId('commit-drawer-title-input')
+			.should('have.value', originalCommitMessage)
+			.should('be.visible')
+			.should('be.enabled');
+
+		// Click on the save button
+		cy.getByTestId('commit-drawer-action-button')
+			.should('be.visible')
+			.should('be.enabled')
+			.should('contain', 'Save')
+			.click();
+
+		cy.getByTestId('edit-commit-message-drawer').should('not.exist');
+
+		cy.getByTestId('commit-drawer-title').should('contain', originalCommitMessage);
+		cy.getByTestId('commit-drawer-description').should('not.exist');
+
+		// Should call the update commit message function
+		cy.get('@updateCommitMessageSpy').should('be.calledWith', {
+			projectId: PROJECT_ID,
+			stackId: mockBackend.stackId,
+			commitOid: mockBackend.commitOid,
+			message: originalCommitMessage
+		});
+
+		expect(mockBackend.getDiff).to.have.callCount(0);
+	});
+
 	it('Should be able to rename a commit from the context menu', () => {
 		const originalCommitMessage = 'Initial commit';
 
@@ -377,7 +424,7 @@ describe('Commit Actions with lots of uncommitted changes', () => {
 	});
 
 	it('should be able to commit a bunch of times in a row and edit their message', () => {
-		const TIMES = 2;
+		const TIMES = 3;
 		for (let i = 0; i < TIMES; i++) {
 			// Click commit button
 			cy.getByTestId('start-commit-button').should('be.visible').should('be.enabled').click();
@@ -421,6 +468,7 @@ describe('Commit Actions with lots of uncommitted changes', () => {
 			// Type in a description
 			cy.getByTestId('commit-drawer-description-input')
 				.should('be.visible')
+				.should('contain', '')
 				.click()
 				.type(commitDescription); // Type the new commit message body
 
@@ -524,6 +572,7 @@ describe('Commit Actions with lots of uncommitted changes', () => {
 			// Type in a description
 			cy.getByTestId('commit-drawer-description-input')
 				.should('be.visible')
+				.should('contain', '')
 				.click()
 				.type(commitDescription); // Type the new commit message body
 
@@ -572,7 +621,7 @@ describe('Commit Actions with lots of uncommitted changes', () => {
 				.clear()
 				.type(newCommitDescription); // Type the new commit message body
 
-			// Click on the save button
+			// Click on the cancel button
 			cy.getByTestId('commit-drawer-cancel-button')
 				.should('be.visible')
 				.should('be.enabled')
@@ -582,6 +631,120 @@ describe('Commit Actions with lots of uncommitted changes', () => {
 
 			cy.getByTestId('commit-drawer-title').should('contain', commitTitle);
 			cy.getByTestId('commit-drawer-description').should('contain', commitDescription);
+		}
+
+		let lastInputTitle: string | undefined = undefined;
+		let lastInputDescription: string | undefined = undefined;
+
+		// Start creating a commit and cancel
+		for (let i = TIMES * 2; i < TIMES * 3; i++) {
+			// Click commit button
+			cy.getByTestId('start-commit-button').should('be.visible').should('be.enabled').click();
+
+			// There should only be one 'Your commit goes here' text
+			cy.getByTestId('your-commit-goes-here')
+				.should('have.length', 1)
+				.should('be.visible')
+				.should('have.class', 'first');
+
+			// Unstage all files
+			cy.getByTestId('uncommitted-changes-header')
+				.should('be.visible')
+				.within(() => {
+					cy.get('input[type="checkbox"]').should('be.visible').click();
+				});
+
+			// Stage the file
+			cy.getByTestId('uncommitted-changes-file-list')
+				.should('be.visible')
+				.within(() => {
+					cy.getByTestId('file-list-item')
+						.first()
+						.scrollIntoView()
+						.should('be.visible')
+						.within(() => {
+							cy.get('input[type="checkbox"]').should('be.visible').click();
+						});
+				});
+
+			const commitTitle = `Commit title ${i + 1}`;
+			const commitDescription = `Commit description ${i + 1}`;
+
+			// Type in a commit message
+			cy.getByTestId('commit-drawer-title-input')
+				.should('be.visible')
+				.should('be.enabled')
+				.should('have.value', lastInputTitle ?? '')
+				.clear()
+				.type(commitTitle); // Type the new commit message
+
+			lastInputTitle = commitTitle;
+
+			// Type in a description
+			cy.getByTestId('commit-drawer-description-input')
+				.should('be.visible')
+				.should('contain', lastInputDescription ?? '')
+				.click()
+				.clear()
+				.type(commitDescription); // Type the new commit message body
+
+			lastInputDescription = commitDescription;
+
+			// Click on the cancel button
+			cy.getByTestId('commit-drawer-cancel-button')
+				.should('be.visible')
+				.should('be.enabled')
+				.click();
+
+			cy.getByTestId('commit-row', commitTitle).should('not.exist');
+		}
+
+		// Edit the commit messages
+		for (let i = TIMES; i < TIMES * 2; i++) {
+			const commitTitle = `Commit title ${i + 1}`;
+			const commitDescription = `Commit description ${i + 1}`;
+
+			const newCommitTitle = `New commit title ${i + 1}`;
+			const newCommitDescription = `New commit description ${i + 1}`;
+
+			// Click on the first commit
+			cy.getByTestId('commit-row', commitTitle).should('contain', commitTitle).click();
+
+			// Should open the commit drawer
+			cy.get('.commit-view').first().should('contain', commitTitle);
+
+			// Click on the edit message button
+			cy.getByTestId('commit-drawer-action-edit-message').should('contain', 'Edit message').click();
+
+			// Should open the commit rename drawer
+			cy.getByTestId('edit-commit-message-drawer').should('be.visible');
+
+			// Should have the original commit message, and be focused
+			cy.getByTestId('commit-drawer-title-input')
+				.should('have.value', commitTitle)
+				.should('be.visible')
+				.should('be.enabled')
+				.clear()
+				.type(newCommitTitle); // Type the new commit message title
+
+			// Type in a description
+			cy.getByTestId('commit-drawer-description-input')
+				.should('be.visible')
+				.should('contain', commitDescription)
+				.click()
+				.clear()
+				.type(newCommitDescription); // Type the new commit message body
+
+			// Edit the commit message
+			cy.getByTestId('commit-drawer-action-button')
+				.should('be.visible')
+				.should('be.enabled')
+				.click();
+
+			cy.getByTestId('edit-commit-message-drawer').should('not.exist');
+
+			cy.getByTestId('commit-drawer-title').should('contain', newCommitTitle);
+			cy.getByTestId('commit-drawer-description').should('contain', newCommitDescription);
 		}
 	});
 });

--- a/apps/desktop/src/components/v3/NewCommitView.svelte
+++ b/apps/desktop/src/components/v3/NewCommitView.svelte
@@ -224,8 +224,15 @@
 
 	const [createNewStack, newStackResult] = stackService.newStack;
 
+	function getMessage(): string {
+		if (projectState.commitDescription.current) {
+			return projectState.commitTitle.current + '\n\n' + projectState.commitDescription.current;
+		}
+		return projectState.commitTitle.current;
+	}
+
 	async function handleCommitCreation() {
-		const message = input?.getMessage();
+		const message = getMessage();
 		if (!message) {
 			showToast({ message: 'Commit message is required', style: 'error' });
 			return;
@@ -240,8 +247,6 @@
 
 	function cancel() {
 		drawer?.onClose();
-		projectState.commitTitle.set('');
-		projectState.commitDescription.set('');
 	}
 </script>
 
@@ -263,5 +268,13 @@
 		onCancel={cancel}
 		disabledAction={!canCommit}
 		loading={commitCreation.current.isLoading || newStackResult.current.isLoading}
+		title={projectState.commitTitle.current}
+		description={projectState.commitDescription.current}
+		setTitle={(title: string) => {
+			projectState.commitTitle.set(title);
+		}}
+		setDescription={(description: string) => {
+			projectState.commitDescription.set(description);
+		}}
 	/>
 </Drawer>


### PR DESCRIPTION
Only new commit messages will be cached. There’s no point to caching the 
message editions.
