### PR TITLE
fix(e2e): wait for element to be displayed before clicking

### DIFF
--- a/apps/desktop/e2e/tests/add-project.spec.ts
+++ b/apps/desktop/e2e/tests/add-project.spec.ts
@@ -9,6 +9,8 @@ describe('Project', () => {
 	});
 
 	it('should add a local project', async () => {
+		await browser.setTimeout({ pageLoad: 10000 });
+
 		await findAndClick('button[data-testid="analytics-continue"]');
 
 		const dirInput = await $('input[data-testid="test-directory-path"]');


### PR DESCRIPTION
Add a wait condition to ensure the element is displayed before
checking if it is clickable and performing a click action. This
improves test reliability by reducing flakiness caused by timing
issues in the UI rendering.