### PR TITLE
V3 modal copy updates

### DIFF
--- a/apps/desktop/src/components/TryV3Modal.svelte
+++ b/apps/desktop/src/components/TryV3Modal.svelte
@@ -40,12 +40,11 @@
 		<div class="modal-content">
 			<div class="modal-description">
 				<h2 class="text-16 text-bold">GitButler has a new, updated UI!</h2>
-				<p class="text-13 text-body">If you’re not in the middle of something, give it a try!</p>
 				<p class="text-13 text-body">
-					In an upcoming release, v3 will become the default, and we’d love to know what you think.
-					Leave your thoughts in the app, on <Link href="https://discord.gg/MmFkmaJ42D"
-						>Discord</Link
-					>, or create a <Link
+					In an upcoming release, this will be the default, so we'd love to know what you think!
+				</p>
+				<p class="text-13 text-body">
+					Ping us on <Link href="https://discord.gg/MmFkmaJ42D">Discord</Link>, or create a <Link
 						href="https://github.com/gitbutlerapp/gitbutler/issues/new?template=BLANK_ISSUE"
 						>GitHub issue</Link
 					>.
@@ -53,8 +52,16 @@
 			</div>
 
 			<div class="modal-content__notes text-12 text-body">
-				<p>Toggle this setting under 'Experimental' in ⚙️ global settings.</p>
-				<p class="text-clr2">A restart may be needed for the change to take effect.</p>
+				<p>This can also be toggled this under 'Experimental' in ⚙️ global settings.</p>
+
+				<p class="text-clr2">Known issues:</p>
+				<ul class="text-clr2">
+					<li>- A restart may be needed for the change to fully take effect</li>
+					<li>
+						- It is currently not possible to assign uncommitted changes to a lane
+						<Link href="https://github.com/gitbutlerapp/gitbutler/issues/8637">GitHub Issue</Link>
+					</li>
+				</ul>
 			</div>
 		</div>
 	</div>

--- a/apps/desktop/src/components/v3/profileSettings/ExperimentalSettings.svelte
+++ b/apps/desktop/src/components/v3/profileSettings/ExperimentalSettings.svelte
@@ -6,6 +6,7 @@
 	import SectionCard from '@gitbutler/ui/SectionCard.svelte';
 	import Textbox from '@gitbutler/ui/Textbox.svelte';
 	import Toggle from '@gitbutler/ui/Toggle.svelte';
+	import Link from '@gitbutler/ui/link/Link.svelte';
 
 	const settingsService = getContext(SettingsService);
 	const settingsStore = settingsService.appSettings;
@@ -26,7 +27,22 @@
 			V3 Design
 		{/snippet}
 		{#snippet caption()}
-			Enable the new V3 User Interface.
+			<p>Enable the new V3 User Interface.</p>
+			<p>
+				Share your feedback on <Link href="https://discord.gg/MmFkmaJ42D">Discord</Link>, or create
+				a <Link href="https://github.com/gitbutlerapp/gitbutler/issues/new?template=BLANK_ISSUE"
+					>GitHub issue</Link
+				>.
+			</p>
+
+			<p class="text-clr2">Known issues:</p>
+			<ul class="text-clr2">
+				<li>- A restart may be needed for the change to fully take effect</li>
+				<li>
+					- It is currently not possible to assign uncommitted changes to a lane
+					<Link href="https://github.com/gitbutlerapp/gitbutler/issues/8637">GitHub Issue</Link>
+				</li>
+			</ul>
 		{/snippet}
 
 		{#snippet actions()}


### PR DESCRIPTION
@PavelLaptev I updated the copy - do you approve of the way the design looks like before releasing? 

<img width="449" alt="Screenshot 2025-05-19 at 19 31 19" src="https://github.com/user-attachments/assets/ff056854-938c-4e4f-8dce-c83fe3d6001d" />
<img width="888" alt="Screenshot 2025-05-19 at 19 31 43" src="https://github.com/user-attachments/assets/640d8913-55b5-4781-8ff8-456615135d01" />
