### PR TITLE
Remove hello in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,4 +137,3 @@ Want to show your support? Add a GitButler badge to your project's README:
 ```
 
 [![BADGE][s6]][l6]
-hello


### PR DESCRIPTION
## 🧢 Changes

Remove unused "hello" text at end of README.md

This "hello" text got implemented in https://github.com/gitbutlerapp/gitbutler/pull/8610/files
