### PR TITLE
add AiCredentialCheck component

### DIFF
--- a/apps/desktop/src/components/AiCredentialCheck.svelte
+++ b/apps/desktop/src/components/AiCredentialCheck.svelte
@@ -81,14 +81,14 @@
 			const summarizePromise = aiService.summarizeCommit({
 				diffInput: testDiff,
 				useEmojiStyle: false,
-				useBriefStyle: true
+				useBriefStyle: false
 			});
 
 			console.log('Waiting for AI response...');
 			const aiResult = await Promise.race([
 				summarizePromise,
 				new Promise<string>((_, reject) =>
-					setTimeout(() => reject(new Error('AI response timed out after 15 seconds')), 15000)
+					setTimeout(() => reject(new Error('AI response timed out after 8 seconds')), 8000)
 				)
 			]);
 

--- a/apps/desktop/src/components/AiCredentialCheck.svelte
+++ b/apps/desktop/src/components/AiCredentialCheck.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import InfoMessage from '$components/InfoMessage.svelte';
-	import { AIService, GitAIConfigKey, KeyOption, type DiffInput } from '$lib/ai/service';
-	import { ModelKind, MessageRole, type Prompt } from '$lib/ai/types';
+	import { AIService, type DiffInput } from '$lib/ai/service';
+	import { ModelKind } from '$lib/ai/types';
 	import { UserService } from '$lib/user/userService';
 	import { getContext } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
@@ -287,7 +287,7 @@
 	</Button>
 
 	<div class="debug-toggle">
-		<button class="text-12 debug-button" onclick={toggleDebug}>
+		<button type="button" class="text-12 debug-button" onclick={toggleDebug}>
 			{showDebug ? 'Hide' : 'Show'} Debug Info
 		</button>
 	</div>

--- a/apps/desktop/src/components/AiCredentialCheck.svelte
+++ b/apps/desktop/src/components/AiCredentialCheck.svelte
@@ -1,0 +1,270 @@
+<script lang="ts">
+	import InfoMessage from '$components/InfoMessage.svelte';
+	import { AIService, GitAIConfigKey, KeyOption, type DiffInput } from '$lib/ai/service';
+	import { ModelKind, MessageRole, type Prompt } from '$lib/ai/types';
+	import { UserService } from '$lib/user/userService';
+	import { getContext } from '@gitbutler/shared/context';
+	import Button from '@gitbutler/ui/Button.svelte';
+	import Icon from '@gitbutler/ui/Icon.svelte';
+	import Link from '@gitbutler/ui/link/Link.svelte';
+	import { slide } from 'svelte/transition';
+
+	const aiService = getContext(AIService);
+	const userService = getContext(UserService);
+	const user = userService.user;
+
+	let testing = $state(false);
+	let result = $state<string | null>(null);
+	let error = $state<string | null>(null);
+	let modelKind = $state<ModelKind | undefined>();
+	let isUsingButlerAPI = $state(false);
+	let debugInfo = $state<string | null>(null);
+	let showDebug = $state(false);
+
+	// Simple test diff for commit message generation
+	const testDiff: DiffInput[] = [
+		{
+			filePath: 'example.js',
+			diff: `@@ -1,3 +1,5 @@
+ function hello() {
+-  return "Hello World";
++  // Add a greeting with the current time
++  const now = new Date();
++  return \`Hello World! The time is \${now.toLocaleTimeString()}\`;
+ }`
+		}
+	];
+
+	async function testAiCredentials() {
+		testing = true;
+		result = null;
+		error = null;
+		debugInfo = null;
+
+		try {
+			// Get current model kind
+			modelKind = await aiService.getModelKind();
+			console.log(`Testing AI credentials for model kind: ${modelKind}`);
+			debugInfo = `Model kind: ${modelKind}`;
+
+			// Check if using GitButler API
+			isUsingButlerAPI = await aiService.usingGitButlerAPI();
+			console.log(`Using GitButler API: ${isUsingButlerAPI}`);
+			debugInfo += `, Using GB API: ${isUsingButlerAPI}`;
+
+			// Check if configuration is valid
+			const isConfigValid = await aiService.validateConfiguration();
+			console.log(`Configuration valid: ${isConfigValid}`);
+			debugInfo += `, Config valid: ${isConfigValid}`;
+
+			if (!isConfigValid) {
+				if (modelKind === ModelKind.OpenAI || modelKind === ModelKind.Anthropic) {
+					if (isUsingButlerAPI && !$user) {
+						throw new Error("Please sign in to use GitButler's AI API");
+					} else {
+						throw new Error('Please provide a valid API key for your selected AI service');
+					}
+				} else if (modelKind === ModelKind.Ollama) {
+					// Get Ollama configuration for more detailed error
+					const endpoint = await aiService.getOllamaEndpoint();
+					const model = await aiService.getOllamaModelName();
+					throw new Error(
+						`Please check Ollama configuration: endpoint=${endpoint}, model=${model}`
+					);
+				}
+			}
+
+			console.log('Testing AI with commit message generation');
+			debugInfo += `, Testing commit message generation`;
+
+			// Use the summarizeCommit method with a timeout
+			const summarizePromise = aiService.summarizeCommit({
+				diffInput: testDiff,
+				useEmojiStyle: false,
+				useBriefStyle: true
+			});
+
+			console.log('Waiting for AI response...');
+			const aiResult = await Promise.race([
+				summarizePromise,
+				new Promise<string>((_, reject) =>
+					setTimeout(() => reject(new Error('AI response timed out after 15 seconds')), 15000)
+				)
+			]);
+
+			// Set the result (handling undefined case)
+			result = aiResult || null;
+
+			console.log('Received commit message:', result);
+			debugInfo += `, Received commit message: ${result?.substring(0, 30)}${result && result.length > 30 ? '...' : ''}`;
+
+			// If result is empty or undefined, show an error
+			if (!result || result.trim() === '') {
+				throw new Error('Received empty response from AI service');
+			}
+		} catch (e) {
+			console.error('AI credential check error:', e);
+			error = e instanceof Error ? e.message : 'Unknown error occurred';
+			debugInfo += `, Error: ${error}`;
+		} finally {
+			testing = false;
+		}
+	}
+
+	function toggleDebug() {
+		showDebug = !showDebug;
+	}
+</script>
+
+<div class="ai-credential-check">
+	{#if result || error}
+		<div transition:slide={{ duration: 250 }}>
+			<InfoMessage style={error ? 'warning' : 'success'} filled outlined={false}>
+				{#snippet title()}
+					{#if error}
+						AI credential check failed
+					{:else}
+						AI credential check passed
+					{/if}
+				{/snippet}
+
+				{#snippet content()}
+					<div class="result-content" transition:slide={{ duration: 250 }}>
+						{#if error}
+							<div class="text-12 text-body error-text">
+								<i class="result-icon">
+									<Icon name="error-small" color="error" />
+								</i>
+								{error}
+							</div>
+
+							{#if (modelKind === ModelKind.OpenAI || modelKind === ModelKind.Anthropic) && isUsingButlerAPI && !$user}
+								<div class="text-12 text-body help-text">
+									<span> Please sign in to use GitButler's AI API. </span>
+								</div>
+							{:else if modelKind === ModelKind.OpenAI || modelKind === ModelKind.Anthropic}
+								<div class="text-12 text-body help-text">
+									<span> Please check your API key or try GitButler's API. </span>
+								</div>
+							{:else if modelKind === ModelKind.Ollama}
+								<div class="text-12 text-body help-text">
+									<span>
+										Please check your Ollama endpoint and model configuration.
+										<br />
+										Make sure Ollama is running locally and accessible.
+										<br />
+										<Link href="https://ollama.ai">Learn more about Ollama</Link>
+									</span>
+								</div>
+							{/if}
+						{:else}
+							<div class="text-12 text-body success-text">
+								<i class="result-icon">
+									<Icon name="success-small" color="success" />
+								</i>
+								<div class="ai-response">
+									<strong>Sample commit message:</strong>
+									<pre>{result}</pre>
+								</div>
+							</div>
+						{/if}
+
+						{#if showDebug && debugInfo}
+							<div class="debug-info text-12">
+								<hr />
+								<div>Debug info: {debugInfo}</div>
+							</div>
+						{/if}
+					</div>
+				{/snippet}
+			</InfoMessage>
+		</div>
+	{/if}
+	<Button style="pop" wide icon="ai" disabled={testing} onclick={testAiCredentials}>
+		{#if testing}
+			Testing AI connection...
+		{:else if result || error}
+			Test again
+		{:else}
+			Test AI connection
+		{/if}
+	</Button>
+
+	<div class="debug-toggle">
+		<button class="text-12 debug-button" on:click={toggleDebug}>
+			{showDebug ? 'Hide' : 'Show'} Debug Info
+		</button>
+	</div>
+</div>
+
+<style>
+	.ai-credential-check {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+	}
+
+	.result-content {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		margin-top: 4px;
+	}
+
+	.result-icon {
+		display: flex;
+		align-items: flex-start;
+		margin-right: 6px;
+	}
+
+	.error-text,
+	.success-text {
+		display: flex;
+		align-items: flex-start;
+	}
+
+	.help-text {
+		margin-top: 6px;
+		margin-left: 18px;
+	}
+
+	.ai-response {
+		max-height: 100px;
+		overflow-y: auto;
+		word-break: break-word;
+	}
+
+	.ai-response pre {
+		margin: 8px 0 0 0;
+		padding: 8px;
+		background-color: var(--clr-bg-1);
+		border-radius: 4px;
+		font-family: var(--font-mono);
+		white-space: pre-wrap;
+		font-size: 12px;
+	}
+
+	.debug-toggle {
+		display: flex;
+		justify-content: flex-end;
+	}
+
+	.debug-button {
+		background: none;
+		border: none;
+		color: var(--clr-text-3);
+		cursor: pointer;
+		padding: 4px 8px;
+		text-decoration: underline;
+		font-size: 11px;
+	}
+
+	.debug-info {
+		margin-top: 8px;
+		color: var(--clr-text-3);
+		white-space: pre-wrap;
+		word-break: break-word;
+		font-family: monospace;
+		font-size: 11px;
+	}
+</style>

--- a/apps/desktop/src/components/v3/profileSettings/AiSettings.svelte
+++ b/apps/desktop/src/components/v3/profileSettings/AiSettings.svelte
@@ -37,6 +37,7 @@
 	let diffLengthLimit: number | undefined = $state();
 	let ollamaEndpoint: string | undefined = $state();
 	let ollamaModel: string | undefined = $state();
+	let lmStudioEndpoint: string | undefined = $state();
 
 	async function setConfiguration(key: GitAIConfigKey, value: string | undefined) {
 		if (!initialized) return;
@@ -63,6 +64,8 @@
 
 		ollamaEndpoint = await aiService.getOllamaEndpoint();
 		ollamaModel = await aiService.getOllamaModelName();
+
+		lmStudioEndpoint = await aiService.getLMStudioEndpoint();
 
 		// Ensure reactive declarations have finished running before we set initialized to true
 		await tick();
@@ -148,6 +151,9 @@
 		setConfiguration(GitAIConfigKey.OllamaModelName, ollamaModel);
 	});
 	run(() => {
+		setConfiguration(GitAIConfigKey.LMStudioEndpoint, lmStudioEndpoint);
+	});
+	run(() => {
 		if (form) form.modelKind.value = modelKind;
 	});
 </script>
@@ -155,7 +161,7 @@
 <p class="text-13 text-body ai-settings__text">
 	GitButler supports multiple providers for its AI powered features. We currently support models
 	from OpenAI and Anthropic either proxied through the GitButler API, or in a bring your own key
-	configuration.
+	configuration. We also support local models through Ollama and LM Studio.
 </p>
 
 <form class="git-radio" bind:this={form} onchange={(e) => onFormChange(e.currentTarget)}>
@@ -331,6 +337,31 @@
 			</InfoMessage>
 		</SectionCard>
 	{/if}
+
+	<SectionCard
+		roundedTop={false}
+		roundedBottom={modelKind !== ModelKind.LMStudio}
+		orientation="row"
+		labelFor="lmstudio"
+		bottomBorder={modelKind !== ModelKind.LMStudio}
+	>
+		{#snippet title()}
+			LM Studio
+		{/snippet}
+		{#snippet actions()}
+			<RadioButton name="modelKind" id="lmstudio" value={ModelKind.LMStudio} />
+		{/snippet}
+	</SectionCard>
+	{#if modelKind === ModelKind.LMStudio}
+		<SectionCard roundedTop={false} topDivider>
+			<Textbox
+				label="Server URL"
+				bind:value={lmStudioEndpoint}
+				placeholder="http://127.0.0.1:1234"
+			/>
+		</SectionCard>
+	{/if}
+
 	<!-- AI credential check -->
 	<SectionCard roundedTop={false} topDivider>
 		<AiCredentialCheck />

--- a/apps/desktop/src/components/v3/profileSettings/AiSettings.svelte
+++ b/apps/desktop/src/components/v3/profileSettings/AiSettings.svelte
@@ -302,10 +302,10 @@
 
 	<SectionCard
 		roundedTop={false}
-		roundedBottom={modelKind !== ModelKind.Ollama}
+		roundedBottom={false}
 		orientation="row"
 		labelFor="ollama"
-		bottomBorder={modelKind !== ModelKind.Ollama}
+		bottomBorder={true}
 	>
 		{#snippet title()}
 			Ollama 🦙
@@ -315,7 +315,7 @@
 		{/snippet}
 	</SectionCard>
 	{#if modelKind === ModelKind.Ollama}
-		<SectionCard roundedTop={false} topDivider>
+		<SectionCard roundedTop={false} roundedBottom={false} topDivider>
 			<Textbox label="Endpoint" bind:value={ollamaEndpoint} placeholder="http://127.0.0.1:11434" />
 
 			<Textbox label="Model" bind:value={ollamaModel} placeholder="llama3" />
@@ -340,10 +340,10 @@
 
 	<SectionCard
 		roundedTop={false}
-		roundedBottom={modelKind !== ModelKind.LMStudio}
+		roundedBottom={false}
 		orientation="row"
 		labelFor="lmstudio"
-		bottomBorder={modelKind !== ModelKind.LMStudio}
+		bottomBorder={false}
 	>
 		{#snippet title()}
 			LM Studio
@@ -353,7 +353,7 @@
 		{/snippet}
 	</SectionCard>
 	{#if modelKind === ModelKind.LMStudio}
-		<SectionCard roundedTop={false} topDivider>
+		<SectionCard roundedTop={false} roundedBottom={false} topDivider>
 			<Textbox
 				label="Server URL"
 				bind:value={lmStudioEndpoint}

--- a/apps/desktop/src/components/v3/profileSettings/AiSettings.svelte
+++ b/apps/desktop/src/components/v3/profileSettings/AiSettings.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import AIPromptEdit from '$components/AIPromptEdit.svelte';
+	import AiCredentialCheck from '$components/AiCredentialCheck.svelte';
 	import AuthorizationBanner from '$components/AuthorizationBanner.svelte';
 	import InfoMessage from '$components/InfoMessage.svelte';
 	import Section from '$components/Section.svelte';
@@ -330,6 +331,10 @@
 			</InfoMessage>
 		</SectionCard>
 	{/if}
+	<!-- AI credential check -->
+	<SectionCard roundedTop={false} topDivider>
+		<AiCredentialCheck />
+	</SectionCard>
 </form>
 
 <Spacer />

--- a/apps/desktop/src/lib/ai/butlerClient.ts
+++ b/apps/desktop/src/lib/ai/butlerClient.ts
@@ -12,15 +12,12 @@ function splitPromptMessagesIfNecessary(
 	modelKind: ModelKind,
 	prompt: Prompt
 ): [Prompt, string | undefined] {
-	switch (modelKind) {
-		case ModelKind.Anthropic: {
-			const [messages, system] = splitPromptMessages(prompt);
-			return [messageParamToPrompt(messages), system];
-		}
-		case ModelKind.OpenAI:
-		case ModelKind.Ollama:
-			return [prompt, undefined];
+	if (modelKind === ModelKind.Anthropic) {
+		const [messages, system] = splitPromptMessages(prompt);
+		return [messageParamToPrompt(messages), system];
 	}
+
+	return [prompt, undefined];
 }
 
 export class ButlerAIClient implements AIClient {

--- a/apps/desktop/src/lib/ai/lmStudioClient.ts
+++ b/apps/desktop/src/lib/ai/lmStudioClient.ts
@@ -1,0 +1,125 @@
+import {
+	SHORT_DEFAULT_BRANCH_TEMPLATE,
+	SHORT_DEFAULT_COMMIT_TEMPLATE,
+	SHORT_DEFAULT_PR_TEMPLATE
+} from '$lib/ai/prompts';
+import type { Prompt, AIClient, AIEvalOptions } from '$lib/ai/types';
+
+const DEFAULT_MAX_TOKENS = -1; // -1 means no limit
+const DEFAULT_TEMPERATURE = 0.7;
+
+/**
+ * LMStudioClient implements the AIClient interface for LM Studio servers.
+ * LM Studio provides an OpenAI-compatible API at the /v1/chat/completions endpoint.
+ */
+export class LMStudioClient implements AIClient {
+	defaultCommitTemplate = SHORT_DEFAULT_COMMIT_TEMPLATE;
+	defaultBranchTemplate = SHORT_DEFAULT_BRANCH_TEMPLATE;
+	defaultPRTemplate = SHORT_DEFAULT_PR_TEMPLATE;
+
+	private baseUrl: string;
+
+	constructor(endpoint: string) {
+		// Format the base URL to ensure it ends with /v1
+		this.baseUrl = endpoint.endsWith('/v1')
+			? endpoint
+			: endpoint.endsWith('/')
+				? `${endpoint}v1`
+				: `${endpoint}/v1`;
+	}
+
+	async evaluate(prompt: Prompt, options?: AIEvalOptions): Promise<string> {
+		try {
+			// Validate input
+			if (!prompt || !Array.isArray(prompt) || prompt.length === 0) {
+				throw new Error('Invalid prompt: must be a non-empty array');
+			}
+
+			// Format messages for the API
+			const messages = prompt.map((msg) => ({
+				role: msg.role.toLowerCase(),
+				content: msg.content
+			}));
+
+			console.log('Sending request to LM Studio:', {
+				url: `${this.baseUrl}/chat/completions`,
+				messages: messages.length,
+				max_tokens: options?.maxTokens ?? DEFAULT_MAX_TOKENS
+			});
+
+			// Determine if we should stream the response
+			const shouldStream = options?.onToken !== undefined;
+
+			// Make request to the LM Studio API
+			const response = await fetch(`${this.baseUrl}/chat/completions`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({
+					model: 'default', // LM Studio will use whatever model is currently loaded
+					messages: messages,
+					temperature: DEFAULT_TEMPERATURE,
+					max_tokens: options?.maxTokens ?? DEFAULT_MAX_TOKENS,
+					stream: shouldStream
+				})
+			});
+
+			if (!response.ok) {
+				const errorText = await response.text();
+				throw new Error(`LM Studio API error (${response.status}): ${errorText}`);
+			}
+
+			// Handle streaming response
+			if (shouldStream) {
+				const reader = response.body?.getReader();
+				if (!reader) {
+					throw new Error('Failed to get reader from response');
+				}
+
+				let result = '';
+				const decoder = new TextDecoder();
+
+				while (true) {
+					const { done, value } = await reader.read();
+					if (done) break;
+
+					const chunk = decoder.decode(value, { stream: true });
+					const lines = chunk
+						.split('\n')
+						.filter((line) => line.trim() !== '' && line.trim() !== 'data: [DONE]');
+
+					for (const line of lines) {
+						if (!line.startsWith('data:')) continue;
+
+						try {
+							const jsonStr = line.slice(5).trim();
+							if (jsonStr) {
+								const json = JSON.parse(jsonStr);
+								const token = json.choices[0]?.delta?.content || '';
+								if (token) {
+									options?.onToken?.(token);
+									result += token;
+								}
+							}
+						} catch (e) {
+							console.warn('Error parsing streaming JSON', e);
+						}
+					}
+				}
+
+				return result;
+			}
+			// Handle non-streaming response
+			else {
+				const json = await response.json();
+				return json.choices[0]?.message?.content || '';
+			}
+		} catch (error) {
+			console.error('Error calling LM Studio API:', error);
+			throw new Error(
+				`Failed to communicate with LM Studio server: ${error instanceof Error ? error.message : String(error)}`
+			);
+		}
+	}
+}

--- a/apps/desktop/src/lib/ai/lmStudioClient.ts
+++ b/apps/desktop/src/lib/ai/lmStudioClient.ts
@@ -41,12 +41,6 @@ export class LMStudioClient implements AIClient {
 				content: msg.content
 			}));
 
-			console.log('Sending request to LM Studio:', {
-				url: `${this.baseUrl}/chat/completions`,
-				messages: messages.length,
-				max_tokens: options?.maxTokens ?? DEFAULT_MAX_TOKENS
-			});
-
 			// Determine if we should stream the response
 			const shouldStream = options?.onToken !== undefined;
 

--- a/apps/desktop/src/lib/ai/types.ts
+++ b/apps/desktop/src/lib/ai/types.ts
@@ -4,7 +4,8 @@ import type { Persisted } from '@gitbutler/shared/persisted';
 export enum ModelKind {
 	OpenAI = 'openai',
 	Anthropic = 'anthropic',
-	Ollama = 'ollama'
+	Ollama = 'ollama',
+	LMStudio = 'lmstudio'
 }
 
 // https://platform.openai.com/docs/models


### PR DESCRIPTION
This adds two things - a testing component for our AI services so you can make sure your credentials or choice works when you're in the settings screen (rather than trying it out or trying to debug it later). The other is a new provider, [LM Studio](https://lmstudio.ai/), another local model provider.

![CleanShot 2025-05-20 at 16 38 35@2x](https://github.com/user-attachments/assets/8a0001ea-c34b-4d8f-8f06-c49f462b753f)


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#3KV1rVL9Z`](https://gitbutler.com/schacon/gitbutler/reviews/3KV1rVL9Z)

**add AiCredentialCheck component**


This component trys out any selected AI option and runs a test to let 
you know if your AI stuff is configured correctly. Should show a fake 
test commit message that is actually generated from the AI provider 
currently selected, or show error messages if something is not working.

5 commit series (version 11)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 5/5 | [fix node linter](https://gitbutler.com/schacon/gitbutler/reviews/3KV1rVL9Z/commit/efb4b782-d9a3-441e-baec-c896a7b6dd62) | ⏳ |  |
| 4/5 | [fix ai options styles](https://gitbutler.com/schacon/gitbutler/reviews/3KV1rVL9Z/commit/691afd43-dfaa-419d-8ea0-90822868ca9e) | ⏳ |  |
| 3/5 | [make AiCredentialCheck output stream](https://gitbutler.com/schacon/gitbutler/reviews/3KV1rVL9Z/commit/ec8178aa-e026-476a-95cf-ee4340e79ddc) | ⏳ |  |
| 2/5 | [add LM Studio as another local endpoint option](https://gitbutler.com/schacon/gitbutler/reviews/3KV1rVL9Z/commit/3859c47e-07ad-488a-bd14-8be3d242c21c) | ⏳ |  |
| 1/5 | [add AiCredentialCheck component](https://gitbutler.com/schacon/gitbutler/reviews/3KV1rVL9Z/commit/19ca5c15-7abc-42cf-97c6-6f6eefad6bb3) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/schacon/gitbutler/reviews/3KV1rVL9Z)_
<!-- GitButler Review Footer Boundary Bottom -->
