### PR TITLE
Serialize editor messages onblur rather than onchange

### DIFF
--- a/apps/desktop/src/components/v3/NewCommitView.svelte
+++ b/apps/desktop/src/components/v3/NewCommitView.svelte
@@ -224,15 +224,11 @@
 
 	const [createNewStack, newStackResult] = stackService.newStack;
 
-	function getMessage(): string {
-		if (projectState.commitDescription.current) {
-			return projectState.commitTitle.current + '\n\n' + projectState.commitDescription.current;
-		}
-		return projectState.commitTitle.current;
-	}
+	async function handleCommitCreation(title: string, description: string) {
+		projectState.commitTitle.set(title);
+		projectState.commitDescription.set(description);
 
-	async function handleCommitCreation() {
-		const message = getMessage();
+		const message = description ? title + '\n\n' + description : title;
 		if (!message) {
 			showToast({ message: 'Commit message is required', style: 'error' });
 			return;
@@ -242,6 +238,15 @@
 			await createCommit(message);
 		} catch (err: unknown) {
 			showError('Failed to commit', err);
+		}
+	}
+
+	function handleMessageUpdate(title?: string, description?: string) {
+		if (typeof title === 'string') {
+			projectState.commitTitle.set(title);
+		}
+		if (typeof description === 'string') {
+			projectState.commitDescription.set(description);
 		}
 	}
 
@@ -264,17 +269,12 @@
 		{projectId}
 		{stackId}
 		actionLabel="Create commit"
-		action={handleCommitCreation}
+		action={({ title, description }) => handleCommitCreation(title, description)}
+		onChange={({ title, description }) => handleMessageUpdate(title, description)}
 		onCancel={cancel}
 		disabledAction={!canCommit}
 		loading={commitCreation.current.isLoading || newStackResult.current.isLoading}
 		title={projectState.commitTitle.current}
 		description={projectState.commitDescription.current}
-		setTitle={(title: string) => {
-			projectState.commitTitle.set(title);
-		}}
-		setDescription={(description: string) => {
-			projectState.commitDescription.set(description);
-		}}
 	/>
 </Drawer>

--- a/apps/desktop/src/components/v3/editor/MessageEditorInput.svelte
+++ b/apps/desktop/src/components/v3/editor/MessageEditorInput.svelte
@@ -3,7 +3,8 @@
 		ref: HTMLInputElement | undefined;
 		value: string;
 		showCount?: boolean;
-		oninput: (e: Event) => void;
+		oninput?: (e: Event) => void;
+		onchange?: (value: string) => void;
 		onkeydown: (e: KeyboardEvent) => void;
 		testId?: string;
 	}
@@ -13,6 +14,7 @@
 		value = $bindable(),
 		showCount = true,
 		oninput,
+		onchange,
 		onkeydown,
 		testId
 	}: Props = $props();
@@ -33,8 +35,9 @@
 		oninput={(e: Event) => {
 			const input = e.currentTarget as HTMLInputElement;
 			charsCount = input.value.length;
-			oninput(e);
+			oninput?.(e);
 		}}
+		onchange={(e) => onchange?.(e.currentTarget.value)}
 		{onkeydown}
 	/>
 	{#if charsCount > 0 && showCount}

--- a/packages/ui/src/lib/richText/plugins/onChange.svelte
+++ b/packages/ui/src/lib/richText/plugins/onChange.svelte
@@ -11,6 +11,8 @@
 	import { getMarkdownString } from '$lib/richText/markdown';
 	import { getEditorTextAfterAnchor, getEditorTextUpToAnchor } from '$lib/richText/selection';
 	import {
+		BLUR_COMMAND,
+		COMMAND_PRIORITY_NORMAL,
 		$getRoot as getRoot,
 		$getSelection as getSelection,
 		$isRangeSelection as isRangeSelection
@@ -36,17 +38,10 @@
 	}
 
 	$effect(() => {
-		return editor.registerUpdateListener(
-			({ editorState, dirtyElements, dirtyLeaves, prevEditorState, tags }) => {
-				if (
-					tags.has('history-merge') ||
-					(dirtyElements.size === 0 && dirtyLeaves.size === 0) ||
-					prevEditorState.isEmpty()
-				) {
-					return;
-				}
-
-				editorState.read(() => {
+		return editor.registerCommand(
+			BLUR_COMMAND,
+			() => {
+				editor.read(() => {
 					const currentText = getCurrentText();
 					if (currentText === text) {
 						return;
@@ -62,7 +57,9 @@
 					const textAfterAnchor = getEditorTextAfterAnchor(selection);
 					onChange?.(text, textUpToAnchor, textAfterAnchor);
 				});
-			}
+				return false;
+			},
+			COMMAND_PRIORITY_NORMAL
 		);
 	});
 


### PR DESCRIPTION
Serializing into markdown on each keystroke has some likely limits in 
terms of document length.
<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#9J45eKlFs`](https://cloud.staging.gitbutler.com/mtsgrd/gitbutler/reviews/9J45eKlFs)

**on-blur**


1 commit series (version 2)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Serialize editor message onblur rather than onchange](https://cloud.staging.gitbutler.com/mtsgrd/gitbutler/reviews/9J45eKlFs/commit/7d58451b-447a-4bda-9552-3586863520a5) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://cloud.staging.gitbutler.com/mtsgrd/gitbutler/reviews/9J45eKlFs)_
<!-- GitButler Review Footer Boundary Bottom -->
