### PR TITLE
fix: Branch files should not be draggable

### DIFF
--- a/apps/desktop/src/components/v3/FileListItemWrapper.svelte
+++ b/apps/desktop/src/components/v3/FileListItemWrapper.svelte
@@ -122,6 +122,7 @@
 	}
 
 	const conflict = $derived(conflictEntries ? conflictEntries.entries[change.path] : undefined);
+	const draggableDisabled = $derived(showCheckbox || selectionId.type === 'branch');
 </script>
 
 <div
@@ -138,7 +139,7 @@
 		data: new ChangeDropData(change, idSelection, allChanges ?? [change], selectionId, stackId),
 		viewportId: 'board-viewport',
 		selector: '.selected-draggable',
-		disabled: showCheckbox,
+		disabled: draggableDisabled,
 		chipType: 'file'
 	}}
 >

--- a/apps/desktop/src/lib/commits/dropHandler.ts
+++ b/apps/desktop/src/lib/commits/dropHandler.ts
@@ -132,6 +132,7 @@ export class AmendCommitWithChangeDzHandler implements DropzoneHandler {
 	accepts(data: unknown): boolean {
 		if (!(data instanceof ChangeDropData)) return false;
 		if (this.commit.hasConflicts) return false;
+		if (data.selectionId.type === 'branch') return false;
 		if (data.selectionId.type === 'commit' && data.selectionId.commitId === this.commit.id)
 			return false;
 		return true;


### PR DESCRIPTION
Files from the branches view should not be draggable, as they are meerly an immutable aggregation of the changes