### PR TITLE
fix: Text editor shortcut

### DIFF
--- a/apps/desktop/src/components/v3/CommitMessageEditor.svelte
+++ b/apps/desktop/src/components/v3/CommitMessageEditor.svelte
@@ -200,7 +200,7 @@
 
 			if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
 				e.preventDefault();
-				action({ title, description });
+				emitAction();
 				return true;
 			}
 


### PR DESCRIPTION
Reenable the ability to commit, edit message, submit pt, etc through command + enter