### PR TITLE
ref-info: more reliability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,6 +681,7 @@ dependencies = [
  "gitbutler-commit",
  "gitbutler-filemonitor",
  "gitbutler-id",
+ "gitbutler-operating-modes",
  "gitbutler-project",
  "gitbutler-stack",
  "gix",

--- a/crates/but-cli/Cargo.toml
+++ b/crates/but-cli/Cargo.toml
@@ -27,6 +27,7 @@ but-hunk-assignment.workspace = true
 gitbutler-branch-actions.workspace = true
 gitbutler-branch.workspace = true
 gitbutler-id.workspace = true
+gitbutler-operating-modes.workspace = true
 
 gitbutler-commit = { workspace = true, optional = true, features = ["testing"] }
 

--- a/crates/but-cli/src/args.rs
+++ b/crates/but-cli/src/args.rs
@@ -112,6 +112,8 @@ pub enum Subcommands {
         simple: bool,
     },
     Watch,
+    #[clap(visible_alias = "operating-mode", alias = "opmode")]
+    OpMode,
     /// Returns the current hunk assignments
     HunkAssignments,
     AssignHunk {

--- a/crates/but-cli/src/args.rs
+++ b/crates/but-cli/src/args.rs
@@ -130,10 +130,17 @@ pub enum Subcommands {
         #[clap(long, short = 'w')]
         workspace_only: bool,
     },
-    /// Returns the list of stacks that are currently part of the GitButler workspace.
+    /// Returns details about a stack, as identified by StackID.
+    ///
+    /// As StackIDs are going away, BranchDetails would be the part that remains.
     StackDetails {
         /// The ID of the stack to list details for.
         id: StackId,
+    },
+    /// Returns detailed
+    BranchDetails {
+        /// A resolvable reference name.
+        ref_name: String,
     },
     /// Returns everything we know about the given ref, or `HEAD`.
     RefInfo {

--- a/crates/but-cli/src/command/mod.rs
+++ b/crates/but-cli/src/command/mod.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, anyhow, bail};
 use but_core::UnifiedDiff;
+use but_settings::AppSettings;
 use but_workspace::{DiffSpec, HunkHeader, VirtualBranchesTomlMetadata};
 use gitbutler_project::{Project, ProjectId};
 use gix::bstr::{BString, ByteSlice};
@@ -116,6 +117,7 @@ pub fn parse_diff_spec(arg: &Option<String>) -> Result<Option<Vec<DiffSpec>>, an
 mod commit;
 use crate::command::discard_change::IndicesOrHeaders;
 pub use commit::commit;
+use gitbutler_command_context::CommandContext;
 
 pub mod diff;
 
@@ -420,6 +422,14 @@ pub async fn watch(args: &super::Args) -> anyhow::Result<()> {
         debug_print(event).ok();
     }
     Ok(())
+}
+
+pub fn operating_mode(args: &super::Args) -> anyhow::Result<()> {
+    let (_repo, project) = repo_and_maybe_project(args, RepositoryOpenMode::General)?;
+    let project = project.context("Couldn't find GitButler project in directory")?;
+    let ctx = CommandContext::open(&project, AppSettings::default())?;
+
+    debug_print(gitbutler_operating_modes::operating_mode(&ctx))
 }
 
 pub fn ref_info(args: &super::Args, ref_name: Option<&str>) -> anyhow::Result<()> {

--- a/crates/but-cli/src/main.rs
+++ b/crates/but-cli/src/main.rs
@@ -24,6 +24,7 @@ async fn main() -> Result<()> {
     let _op_span = tracing::info_span!("cli-op").entered();
 
     match &args.cmd {
+        args::Subcommands::OpMode => command::operating_mode(&args),
         args::Subcommands::DiscardChange {
             hunk_indices,
             hunk_headers,

--- a/crates/but-cli/src/main.rs
+++ b/crates/but-cli/src/main.rs
@@ -99,6 +99,9 @@ async fn main() -> Result<()> {
         args::Subcommands::Stacks { workspace_only } => {
             command::stacks::list(&args.current_dir, args.json, args.v3, *workspace_only)
         }
+        args::Subcommands::BranchDetails { ref_name } => {
+            command::stacks::branch_details(ref_name, &args.current_dir, args.v3)
+        }
         args::Subcommands::StackDetails { id } => {
             command::stacks::details(*id, &args.current_dir, args.v3)
         }

--- a/crates/but-workspace/src/branch.rs
+++ b/crates/but-workspace/src/branch.rs
@@ -748,11 +748,13 @@ pub struct StackSegment {
     pub commits_unique_from_tip: Vec<LocalCommit>,
     /// Commits that are reachable from the remote-tracking branch associated with this branch,
     /// but are not reachable from this branch or duplicated by a commit in it.
+    /// Note that commits that are also similar to commits in `commits_unique_from_tip` are pruned, and not present here.
     ///
     /// Note that remote commits along with their remote tracking branch should always retain a shared history
     /// with the local tracking branch. If these diverge, we can represent this in data, but currently there is
     /// no derived value to make this visible explicitly.
     // TODO: review this - should branch divergence be a thing? Rare, but not impossible.
+    //       We linearize these, pretending a simpler history than there actually is.
     pub commits_unique_in_remote_tracking_branch: Vec<RemoteCommit>,
     /// Metadata with additional information, or `None` if nothing was present.
     ///

--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -513,7 +513,7 @@ pub(crate) mod function {
                             }
                         };
 
-                    for info in remote_ref_tip
+                    'remote_branch_traversal: for info in remote_ref_tip
                         .attach(repo)
                         .ancestors()
                         .first_parent_only()
@@ -524,10 +524,8 @@ pub(crate) mod function {
                         let info = info?;
                         // Don't break, maybe the local commits are reachable through multiple avenues.
                         if local_commit_ids.contains(&info.id) {
-                            for local_commit in &mut segment.commits_unique_from_tip {
-                                local_commit.relation =
-                                    LocalCommitRelation::LocalAndRemote(local_commit.id);
-                            }
+                            // TODO: could we break out here? Only if there is only one forkpoint. There can probably be geometries that make this wrong.
+                            break 'remote_branch_traversal;
                         } else {
                             let commit = but_core::Commit::from_id(info.id())?;
                             let has_conflicts = commit.is_conflicted();
@@ -557,22 +555,35 @@ pub(crate) mod function {
                 // Find duplicates harder by change-ids by commit-data.
                 for local_commit in &mut segment.commits_unique_from_tip {
                     let commit = but_core::Commit::from_id(local_commit.id.attach(repo))?;
-                    if let Some(hdr) = commit.headers() {
-                        if let Some(remote_commit_id) = similarity_lut
-                            .get(&ChangeIdOrCommitData::ChangeId(hdr.change_id))
-                            .or_else(|| {
-                                similarity_lut.get(&ChangeIdOrCommitData::CommitData {
-                                    author: commit.author.clone(),
-                                    message: commit.message.clone(),
-                                })
+                    if let Some(remote_commit_id) = commit
+                        .headers()
+                        .and_then(|hdr| {
+                            similarity_lut.get(&ChangeIdOrCommitData::ChangeId(hdr.change_id))
+                        })
+                        .or_else(|| {
+                            similarity_lut.get(&ChangeIdOrCommitData::CommitData {
+                                author: commit.author.clone(),
+                                message: commit.message.clone(),
                             })
-                        {
-                            local_commit.relation =
-                                LocalCommitRelation::LocalAndRemote(*remote_commit_id);
-                        }
+                        })
+                    {
+                        local_commit.relation =
+                            LocalCommitRelation::LocalAndRemote(*remote_commit_id);
                     }
                     local_commit.has_conflicts = commit.is_conflicted();
                 }
+
+                // Prune upstream commits so they don't show if they are considered locally available as well.
+                // This is kind of 'wrong', and we can hope that code doesn't rely on upstream commits.
+                segment
+                    .commits_unique_in_remote_tracking_branch
+                    .retain(|remote_commit| {
+                        let remote_commit_is_shared_in_local = segment
+                            .commits_unique_from_tip
+                            .iter()
+                            .any(|c| matches!(c.relation,  LocalCommitRelation::LocalAndRemote(rid) if rid == remote_commit.id));
+                        !remote_commit_is_shared_in_local
+                    });
             }
 
             // Finally, check for integration into the target if available.

--- a/crates/but-workspace/src/stacks.rs
+++ b/crates/but-workspace/src/stacks.rs
@@ -146,7 +146,9 @@ pub fn stacks_v3(
                 continue;
             }
 
-            let reference = repo.find_reference(ref_name.as_ref())?;
+            let Some(reference) = repo.try_find_reference(ref_name.as_ref())? else {
+                continue;
+            };
             let tip = reference
                 .try_id()
                 .with_context(|| format!("Encountered symbolic reference: {ref_name}"))?

--- a/crates/but-workspace/src/ui.rs
+++ b/crates/but-workspace/src/ui.rs
@@ -127,6 +127,22 @@ pub enum CommitState {
     Integrated,
 }
 
+impl CommitState {
+    fn display(&self, id: gix::ObjectId) -> &'static str {
+        match self {
+            CommitState::LocalOnly => "local",
+            CommitState::LocalAndRemote(remote_id) => {
+                if *remote_id == id {
+                    "local/remote(identity)"
+                } else {
+                    "local/remote(similarity)"
+                }
+            }
+            CommitState::Integrated => "integrated",
+        }
+    }
+}
+
 /// Commit that is a part of a [`StackBranch`](gitbutler_stack::StackBranch) and, as such, containing state derived in relation to the specific branch.
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -174,9 +190,10 @@ impl std::fmt::Debug for Commit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Commit({short_hex}, {message:?})",
+            "Commit({short_hex}, {message:?}, {state})",
             short_hex = self.id.to_hex_with_len(7),
-            message = self.message.trim().as_bstr()
+            message = self.message.trim().as_bstr(),
+            state = self.state.display(self.id)
         )
     }
 }

--- a/crates/but-workspace/tests/fixtures/scenario/with-remotes-and-workspace.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/with-remotes-and-workspace.sh
@@ -81,3 +81,28 @@ git clone remote empty-workspace-with-branch-below
 
   create_workspace_commit_once unrelated
 )
+
+# There are multiple stacked branches that could lead towards a shared stack.
+git clone remote target-ahead-remote-rewritten
+(cd target-ahead-remote-rewritten
+  git checkout -b origin/main
+  git commit -m "target ahead" --allow-empty
+
+  git checkout -b A main
+  git commit --allow-empty -m "shared local/remote"
+
+  (git checkout -b new-origin
+    # a remote commit that looks like a local commit by message
+    git commit --allow-empty -m "shared by name"
+    git commit --allow-empty -m "unique remote"
+    mv .git/refs/heads/new-origin .git/refs/remotes/origin/A
+  )
+  git checkout A
+
+  git commit --allow-empty -m "unique local"
+  # a local commit that looks like a remote commit by message
+  git commit --allow-empty -m "shared by name"
+  git commit --allow-empty -m "unique local tip"
+
+  create_workspace_commit_once A
+)

--- a/crates/but-workspace/tests/workspace/branch_details.rs
+++ b/crates/but-workspace/tests/workspace/branch_details.rs
@@ -55,7 +55,7 @@ mod with_workspace {
                 author <author@example.com>,
                 committer <committer@example.com>,
             ],
-            is_conflicted: true,
+            is_conflicted: false,
             commits: [
                 Commit(7f389ed, "add 10 to the beginning"),
             ],
@@ -105,7 +105,7 @@ mod with_workspace {
                 author <author@example.com>,
                 committer <committer@example.com>,
             ],
-            is_conflicted: true,
+            is_conflicted: false,
             commits: [
                 Commit(89cc2d3, "change in A"),
                 Commit(d79bba9, "new file in A"),
@@ -157,7 +157,7 @@ mod with_workspace {
                 author <author@example.com>,
                 committer <committer@example.com>,
             ],
-            is_conflicted: true,
+            is_conflicted: false,
             commits: [
                 Commit(d79bba9, "new file in A"),
             ],
@@ -184,7 +184,7 @@ mod with_workspace {
                 author <author@example.com>,
                 committer <committer@example.com>,
             ],
-            is_conflicted: true,
+            is_conflicted: false,
             commits: [
                 Commit(89cc2d3, "change in A"),
                 Commit(d79bba9, "new file in A"),
@@ -237,7 +237,7 @@ mod with_workspace {
                 committer <committer@example.com>,
                 local-user <local-user@example.com>,
             ],
-            is_conflicted: true,
+            is_conflicted: false,
             commits: [
                 Commit(1a265a4, "local change in A"),
                 Commit(d79bba9, "new file in A"),

--- a/crates/but-workspace/tests/workspace/branch_details.rs
+++ b/crates/but-workspace/tests/workspace/branch_details.rs
@@ -57,7 +57,7 @@ mod with_workspace {
             ],
             is_conflicted: false,
             commits: [
-                Commit(7f389ed, "add 10 to the beginning"),
+                Commit(7f389ed, "add 10 to the beginning", local/remote(identity)),
             ],
             upstream_commits: [],
             is_remote_head: false,
@@ -107,8 +107,8 @@ mod with_workspace {
             ],
             is_conflicted: false,
             commits: [
-                Commit(89cc2d3, "change in A"),
-                Commit(d79bba9, "new file in A"),
+                Commit(89cc2d3, "change in A", local/remote(identity)),
+                Commit(d79bba9, "new file in A", local/remote(identity)),
             ],
             upstream_commits: [],
             is_remote_head: false,
@@ -159,7 +159,7 @@ mod with_workspace {
             ],
             is_conflicted: false,
             commits: [
-                Commit(d79bba9, "new file in A"),
+                Commit(d79bba9, "new file in A", local/remote(identity)),
             ],
             upstream_commits: [
                 UpstreamCommit(89cc2d3, "change in A"),
@@ -186,8 +186,8 @@ mod with_workspace {
             ],
             is_conflicted: false,
             commits: [
-                Commit(89cc2d3, "change in A"),
-                Commit(d79bba9, "new file in A"),
+                Commit(89cc2d3, "change in A", local/remote(identity)),
+                Commit(d79bba9, "new file in A", local/remote(identity)),
             ],
             upstream_commits: [],
             is_remote_head: true,
@@ -239,8 +239,8 @@ mod with_workspace {
             ],
             is_conflicted: false,
             commits: [
-                Commit(1a265a4, "local change in A"),
-                Commit(d79bba9, "new file in A"),
+                Commit(1a265a4, "local change in A", local/remote(identity)),
+                Commit(d79bba9, "new file in A", local/remote(identity)),
             ],
             upstream_commits: [
                 UpstreamCommit(89cc2d3, "change in A"),

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit.rs
@@ -467,6 +467,146 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
 }
 
 mod legacy {
+    mod stacks {
+        use crate::ref_info::with_workspace_commit::read_only_in_memory_scenario;
+        use crate::ref_info::with_workspace_commit::utils::{StackState, add_stack};
+        use but_testsupport::visualize_commit_graph_all;
+        use but_workspace::{StacksFilter, stacks_v3};
+        use gitbutler_stack::StackId;
+
+        #[test]
+        fn multiple_branches_with_shared_segment_automatically_know_containing_workspace()
+        -> anyhow::Result<()> {
+            let (repo, mut meta) =
+                read_only_in_memory_scenario("multiple-stacks-with-shared-segment")?;
+
+            add_stack(
+                &mut meta,
+                StackId::from_number_for_testing(1),
+                "B-on-A",
+                StackState::InWorkspace,
+            );
+            add_stack(
+                &mut meta,
+                StackId::from_number_for_testing(2),
+                "C-on-A",
+                StackState::Inactive,
+            );
+            add_stack(
+                &mut meta,
+                StackId::from_number_for_testing(3),
+                "does-not-exist-inactive",
+                StackState::Inactive,
+            );
+            add_stack(
+                &mut meta,
+                StackId::from_number_for_testing(4),
+                "does-not-exist-active",
+                StackState::InWorkspace,
+            );
+            insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+            *   820f2b3 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+            |\  
+            | * 4e5484a (B-on-A) add new file in B-on-A
+            * | 5f37dbf (C-on-A) add new file in C-on-A
+            |/  
+            | * 89cc2d3 (origin/A) change in A
+            |/  
+            * d79bba9 (A) new file in A
+            * c166d42 (origin/main, origin/HEAD, main) init-integration
+            ");
+            let actual = stacks_v3(&repo, &meta, StacksFilter::All)?;
+            insta::assert_debug_snapshot!(actual, @r#"
+            [
+                StackEntry {
+                    id: 00000000-0000-0000-0000-000000000002,
+                    heads: [
+                        StackHeadInfo {
+                            name: "C-on-A",
+                            tip: Sha1(5f37dbfd4b1c3d2ee75f216665ab4edf44c843cb),
+                        },
+                        StackHeadInfo {
+                            name: "A",
+                            tip: Sha1(d79bba960b112dbd25d45921c47eeda22288022b),
+                        },
+                    ],
+                    tip: Sha1(5f37dbfd4b1c3d2ee75f216665ab4edf44c843cb),
+                },
+                StackEntry {
+                    id: 00000000-0000-0000-0000-000000000001,
+                    heads: [
+                        StackHeadInfo {
+                            name: "B-on-A",
+                            tip: Sha1(4e5484ac0f1da1909414b1e16bd740c1a3599509),
+                        },
+                    ],
+                    tip: Sha1(4e5484ac0f1da1909414b1e16bd740c1a3599509),
+                },
+            ]
+            "#);
+
+            let actual = stacks_v3(&repo, &meta, StacksFilter::InWorkspace)?;
+            // It lists both still as both are reachable from a workspace commit, so clearly in the workspace.
+            insta::assert_debug_snapshot!(actual, @r#"
+            [
+                StackEntry {
+                    id: 00000000-0000-0000-0000-000000000002,
+                    heads: [
+                        StackHeadInfo {
+                            name: "C-on-A",
+                            tip: Sha1(5f37dbfd4b1c3d2ee75f216665ab4edf44c843cb),
+                        },
+                        StackHeadInfo {
+                            name: "A",
+                            tip: Sha1(d79bba960b112dbd25d45921c47eeda22288022b),
+                        },
+                    ],
+                    tip: Sha1(5f37dbfd4b1c3d2ee75f216665ab4edf44c843cb),
+                },
+                StackEntry {
+                    id: 00000000-0000-0000-0000-000000000001,
+                    heads: [
+                        StackHeadInfo {
+                            name: "B-on-A",
+                            tip: Sha1(4e5484ac0f1da1909414b1e16bd740c1a3599509),
+                        },
+                    ],
+                    tip: Sha1(4e5484ac0f1da1909414b1e16bd740c1a3599509),
+                },
+            ]
+            "#);
+
+            let actual = stacks_v3(&repo, &meta, StacksFilter::Unapplied)?;
+            // nothing reachable
+            insta::assert_debug_snapshot!(actual, @"[]");
+
+            add_stack(
+                &mut meta,
+                StackId::from_number_for_testing(5),
+                "main",
+                StackState::Inactive,
+            );
+
+            let actual = stacks_v3(&repo, &meta, StacksFilter::Unapplied)?;
+            // Still nothing reachable
+            insta::assert_debug_snapshot!(actual, @r#"
+            [
+                StackEntry {
+                    id: 00000000-0000-0000-0000-000000000005,
+                    heads: [
+                        StackHeadInfo {
+                            name: "main",
+                            tip: Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
+                        },
+                    ],
+                    tip: Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
+                },
+            ]
+            "#);
+            Ok(())
+        }
+    }
+
     mod stack_details {
         use crate::ref_info::with_workspace_commit::read_only_in_memory_scenario;
         use crate::ref_info::with_workspace_commit::utils::{StackState, add_stack};


### PR DESCRIPTION
There are still a lot of fatal flaws resulting in errors and even panics. These should be fixed and it should 'generally' be working.
Write critical tests only.

Follow-up on #8590

## Tasks

* [ ] deal with `archived` flag
* [x] **branch listing merge-base is different from the new one - fix it if possible**
    - it matches the current implementation of the branch listing
    - [ ] see if that also matches for unapplied **stacks**!
* [x] fix "merge base not found" in "docs"
* [x] fix "commit identity issue" and remote commit duplication
* [ ] more tests
    - [ ] head-info for different levels of similarity
    - [x] for `stacks_v3()`
    - [ ] for `branch_details_v3()`
    - [x] for `stack_details_v3()`

## Possible Tasks

* [ ] A test for: commit in branch A has "foo" added, now try to create a commit with the removal of "foo" in branch B
* [ ] V3 of `get_branch_listing_details()`

## Notable changes to the Datamodel

* Upstream commits can also be integrated. This would happen if the local tracking branch has not caught up to them, and all of them are integrated. This also means that everything local could be unintegrated, but upstream-only commits are integrated, something that can happen if everything is diverged. If both disagree, it's unclear what to do.

## Notes for the Reviewer

* This is a transitory PR that replaces VirtualBranchesToml with the RefMetadata trait to prepare the code to transition to other data stores.
* The code is clearly transitory while `StackId`  is still a thing - in the new world stacks or stack-segments are referred to by their reference name or by their index in the parent-list of the top-level merge commit (if there is one).
* Ideally, one the UI will be able to make just one `heads_info` call, and can consume the data directly (even though it may have been processed to further facilitate consumption).
* `branch_details()` already works on references
* `BranchDetails` are probably the data structure of choice for the UI, and it's just the question if there is stack information or not.
* There is no notion of using stacks in branch listings outside of what we are currently looking at, i.e. where `HEAD` is. Thus, for this we will probably keep using branch details of sort.

## Next PR

- intermediate V3 version of `get_base_branch_data()`.

### Follow Up Tasks

* [ ] first non-workspace cases
    - [ ] merge commit
    - [ ] merge commit stacked
    - [ ] stacks and ambiguous stack references (i.e. lots of empty stack segments)

### Next PRs

* head-info, stacks and details API with key scenarios
* graph-based integration checks with target and remote
* **use `hide()` in places where merge-commits are used as boundary.**
    - This shouldn't be a major problem for simple topologies, but is certainly an issue for more complex ones.
* integration checking with target
* integration checking with remote tracking branch

### Known Shortcomings (for now)

* ⚠️ `first_parent_only` maybe a good simplification for display, but I wonder if there are side-effects like us not seeing commits that could participate in commit-status check.
* ⚠️ Commit-classification is hacky and undertested  right now⚠️
* One probably wants to show all refs at a position (or indicate there are more)
* ⚠️ rebase engine needs a way to know which parent to rewrite if there are two parents pointing to the same commit in a starting configuration with two stacks at the same commit. Alternatively, `create_commit` would have to create a workspace commit, which seems worse than adding a WS commit in the moment there are two stacks.
* ⚠️ **merge conflicts** are created from either cherry-picks or normal merges (legacy?), but cherry-pick would need to know that to either choose the auto-resolution. That's OK as long as the 'old' merge-commit isn't run as it would create a semantically different tree-setup in the conflicted commit.
* ⚠️ **commit listing** are ambiguous
    - Certain less common but possible branch configuration make ambiguous to assign commits to one branch or another. It won't be super trivial to make this work right.
* ⚠️Even though Git does not list *namespaced references*, `tig` will happily list everything. `set reference-format = hide:other` fixes this though
* empty commits aren't specifically highlighted when rebasing, or handled or prevented. The UI could detect that and show them.
* Moving hunks or files will need multi-branch rebases with merge-commit handling. This can be added to the rebase engine as we know it today. This will also enable worktree-updates.
* reordering in such a way that only heads a moved and nothing else happens (in terms of commit rewrites) probably wouldn't work yet in `but-rebase`.
* Index adjustments (tree to disk index) lack a lot of tests, particularly those for automatic conflict removal.
* if changes are added to the wrong spot, then they may apply cleanly *and* yield different results after merging, so the worktree differs from what's in Git. This is where hunk-dependencies/auto-hunk-splitting comes into play.
* Right now sub-hunks can't be selected as they won't match when it tries to find exact matches. However, that check could be changed to a 'contains' or 'is-included' to allow sub-hunks. Maybe this doesn't naturally work though or do the right thing.
* Workspace commits with a single branch will get signed if they were signed before. This shouldn't be a real problem, and ideally it will go away soon enough.


### For follow-up PRs

In any order (probably)

* Rebase-engine with insert empty commit (below and above, insert as first parent support)
* What happens in Git if one rebases non-linear branches? Can it retain the structure?
    - Rebase engine probably has to learn to re-schedule picks (and remember the base, a feature useful for multi-stacks as well, which then wouldn't need a special case anymore)
* ~~move file out of commit into worktree (uncommit something)~~
* ~~per-hunk exclusion if hunk didn't match (right now it rejects the whole file)~~
* run hooks on an index created from the tree that would be committed.
* move hunks from one commit into another


### Out of scope

* **hunk-dependencies**
    - These should be added once the commit-engine is feature-complete, the idea is that the UI can function well enough without them as a baseline.
* **atomic object writes**
    - In theory, new objects should only be written to disk if they actually end up in a tree. For instance, if a change is rejected, the object associated with it shouldn't be in the object database.
    - However, even though implementing this with the in-memory object feature is very possible, it feels like an optimization for another day. In general, I really think only objects that end up in a tree should actually be written, so that the implementation doesn't have to rely on `git gc` to cleanup.


