### PR TITLE
fix: update loading condition for base branch response

### DIFF
--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -284,7 +284,7 @@
 
 	{#if !project}
 		<p>Project not found!</p>
-	{:else if baseBranchResponse.current.isLoading}
+	{:else if baseBranchResponse.current.isLoading && !baseBranch}
 		<FullviewLoading />
 	{:else if !baseBranch}
 		<NoBaseBranch />


### PR DESCRIPTION
Don’t flicker between the loading screen and the workspace view. If there is any basebranch data, show it.

This is achieved by correctly separating the different data states:
- Loading & no data
- Loading & data (updating)
- Not loading & no data (missing base branch)
- Not loading & data (s’all good maaaan)