### PR TITLE
feat: do not send origin header to Ollama

### DIFF
--- a/apps/desktop/src/lib/ai/ollamaClient.ts
+++ b/apps/desktop/src/lib/ai/ollamaClient.ts
@@ -53,7 +53,10 @@ export class OllamaClient implements AIClient {
 		private modelName: string
 	) {
 		this.ollama = new Ollama({
-			host: this.endpoint
+			host: this.endpoint,
+			headers: {
+				origin: ''
+			}
 		});
 	}
 


### PR DESCRIPTION

## 🧢 Changes
Do not send Origin header to Ollama endpoint. There seem to be a way to remove Origin header, by setting it's value to an empty string.

## ☕️ Reasoning
Currently the request to Ollama contains `Origin: null` header, which is not accepted by Ollama server (server responds with 403).


## 🎫 Affected issues

Fixes:
- https://github.com/gitbutlerapp/gitbutler/issues/8078
- https://github.com/gitbutlerapp/gitbutler/issues/5862


<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
