### PR TITLE
fix(ui): add hover and touch event handlers to HunkDiffBody

### DIFF
--- a/packages/ui/src/lib/hunkDiff/HunkDiffBody.svelte
+++ b/packages/ui/src/lib/hunkDiff/HunkDiffBody.svelte
@@ -245,6 +245,11 @@
 
 {#each chunkedRows as chunk, chunkIdx}
 	<tbody
+		onmouseenter={() => (hoveringOverTable = true)}
+		onmouseleave={() => (hoveringOverTable = false)}
+		ontouchstart={(ev) => lineSelection.onTouchStart(ev)}
+		ontouchmove={(ev) => lineSelection.onTouchMove(ev)}
+		ontouchend={() => lineSelection.onEnd()}
 		bind:clientHeight={chunkHeight[chunkIdx]}
 		use:clickOutside={{
 			handler: handleClearSelection,


### PR DESCRIPTION
Add mouse enter and leave events to track hovering state over table
rows. Implement touch event handlers to support touch-based line
selection interactions.