### PR TITLE
ui-fixes-70

### DIFF
--- a/apps/desktop/src/components/CommitFailedFileEntry.svelte
+++ b/apps/desktop/src/components/CommitFailedFileEntry.svelte
@@ -1,0 +1,210 @@
+<script lang="ts">
+	import ReduxResult from '$components/ReduxResult.svelte';
+	import DependencyService from '$lib/dependencies/dependencyService.svelte';
+	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
+	import { type RejectionReason } from '$lib/stacks/stackService.svelte';
+	import { StackService } from '$lib/stacks/stackService.svelte';
+	import { inject } from '@gitbutler/shared/context';
+	import { getContext } from '@gitbutler/shared/context';
+	import { getContextStoreBySymbol } from '@gitbutler/shared/context';
+	import HunkDiff from '@gitbutler/ui/HunkDiff.svelte';
+	import Icon from '@gitbutler/ui/Icon.svelte';
+	import Tooltip from '@gitbutler/ui/Tooltip.svelte';
+
+	import FileName from '@gitbutler/ui/file/FileName.svelte';
+
+	type Props = {
+		path: string;
+		reason: RejectionReason;
+		projectId: string;
+		changesTimestamp: number | undefined;
+	};
+
+	const { path, reason, projectId, changesTimestamp }: Props = $props();
+
+	const stackService = getContext(StackService);
+	const userSettings = getContextStoreBySymbol<Settings>(SETTINGS);
+	const [dependencyService] = inject(DependencyService);
+
+	let isFolded = $state(true);
+
+	function reasonRelatedToDependencyInfo(reason: RejectionReason): boolean {
+		return reason === 'cherryPickMergeConflict' || reason === 'workspaceMergeConflict';
+	}
+</script>
+
+{#if reasonRelatedToDependencyInfo(reason) && changesTimestamp !== undefined}
+	<!-- In some cases, the dependency information is relevant to the cause of commit rejection.
+	 Show the relevant diff locks in that case. -->
+	{@const fileDependencies = dependencyService.fileDependencies(projectId, changesTimestamp, path)}
+	<div class="commit-failed__file-entry">
+		<button
+			type="button"
+			class="commit-failed__file-entry__header clickable"
+			onclick={() => (isFolded = !isFolded)}
+		>
+			<FileName filePath={path} textSize="13" />
+
+			<div class="commit-failed__file-entry__header__unfold-action">
+				<span class="text-12 text-semibold"
+					>{isFolded ? 'Show' : 'Hide'}
+					hunks ({#if fileDependencies.current.data}
+						{fileDependencies.current.data.dependencies.length}
+					{:else}
+						0
+					{/if})</span
+				>
+
+				<Icon name={isFolded ? 'chevron-down' : 'chevron-up'} />
+			</div>
+		</button>
+
+		{#if !isFolded}
+			<div class="commit-failed__file-entry-dependencies">
+				<ReduxResult {projectId} result={fileDependencies.current}>
+					{#snippet children(fileDependencies)}
+						{#each fileDependencies.dependencies as dependency, i}
+							<HunkDiff
+								filePath="test.tsx"
+								tabSize={$userSettings.tabSize}
+								wrapText={$userSettings.wrapText}
+								diffFont={$userSettings.diffFont}
+								diffLigatures={$userSettings.diffLigatures}
+								diffContrast={$userSettings.diffContrast}
+								inlineUnifiedDiffs={$userSettings.inlineUnifiedDiffs}
+								hunkStr={dependency.hunk.diff}
+								draggingDisabled
+							/>
+
+							<div class="text-12 commit-failed__file-entry__dependency-locks">
+								<div class="commit-failed__file-entry__dependency-locks__label">
+									<Icon name="locked" />
+									<span class="text-clr2">Depends on:</span>
+								</div>
+								<div class="commit-failed__file-entry__dependency-locks__content">
+									{#each dependency.locks as lock}
+										{@const brnachesResult = stackService.branches(projectId, lock.stackId)}
+										{@const branch = brnachesResult.current.data}
+										{@const commitBranch = branch?.find((b) =>
+											b.commits.some((c) => c.id === lock.commitId)
+										)}
+										{@const branchName = commitBranch?.name || 'Unknown branch'}
+										{@const commitMessage = commitBranch?.commits.find(
+											(c) => c.id === lock.commitId
+										)}
+										{@const commitTitle =
+											commitMessage?.message.split('\n')[0] || 'No commit message provided'}
+										<p class="text-body commit-failed__file-entry-dependency-lock">
+											<i class="commit-failed__text-icon"><Icon name="branch-small" /></i>
+											<span class="text-semibold">{branchName}</span>
+											<i class="text-clr2">in commit</i>
+											<i class="commit-failed__text-icon"><Icon name="commit" /></i>
+											<Tooltip text={commitTitle}>
+												<span class="commit-failed__tooltip-text text-semibold h-dotted-underline"
+													>{lock.commitId.substring(0, 7)}</span
+												>
+											</Tooltip>
+										</p>
+									{/each}
+								</div>
+							</div>
+
+							{#if i < fileDependencies.dependencies.length - 1}
+								<hr class="commit-failed__file-entry-divider" />
+							{/if}
+						{/each}
+					{/snippet}
+				</ReduxResult>
+			</div>
+		{/if}
+	</div>
+{:else}
+	<div class="commit-failed__file-entry">
+		<div class="commit-failed__file-entry__header">
+			<FileName filePath={path} textSize="13" />
+		</div>
+	</div>
+{/if}
+
+<style lang="postcss">
+	.commit-failed__file-entry__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 12px 10px;
+		gap: 8px;
+
+		&:hover {
+			.commit-failed__file-entry__header__unfold-action {
+				opacity: 1;
+			}
+		}
+	}
+
+	.commit-failed__file-entry__header__unfold-action {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		color: var(--clr-text-2);
+		text-wrap: nowrap;
+		opacity: 0.7;
+		transition: opacity var(--transition-fast);
+	}
+
+	.commit-failed__text-icon {
+		display: inline-flex;
+		align-items: center;
+		margin-right: 1px;
+		gap: 4px;
+		transform: translateY(4px);
+		color: var(--clr-text-2);
+	}
+
+	.commit-failed__file-entry-dependencies {
+		display: flex;
+		flex-direction: column;
+		padding: 0 12px 12px;
+		gap: 10px;
+	}
+
+	/* File entry */
+	.commit-failed__file-entry {
+		display: flex;
+		flex-direction: column;
+		border: 1px solid var(--clr-border-2);
+		border-radius: var(--radius-m);
+	}
+
+	.commit-failed__file-entry-divider {
+		margin: 6px -12px;
+		border: 0;
+		border-top: 1px solid var(--clr-border-2);
+	}
+
+	.commit-failed__file-entry__dependency-locks {
+		display: flex;
+		flex-direction: column;
+		padding: 12px;
+		gap: 5px;
+		border: 1px solid var(--clr-border-2);
+		border-radius: var(--radius-m);
+	}
+
+	.commit-failed__file-entry__dependency-locks__label {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		color: var(--clr-theme-warn-element);
+	}
+
+	.commit-failed__file-entry__dependency-locks__content {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	/* MODIFIERS */
+	.clickable {
+		cursor: pointer;
+	}
+</style>

--- a/apps/desktop/src/components/CommitFailedModalContent.svelte
+++ b/apps/desktop/src/components/CommitFailedModalContent.svelte
@@ -1,21 +1,22 @@
 <script lang="ts">
+	import CommitFailedFileEntry from '$components/CommitFailedFileEntry.svelte';
 	import ConfigurableScrollableContainer from '$components/ConfigurableScrollableContainer.svelte';
-	import ReduxResult from '$components/ReduxResult.svelte';
-	import DependencyService from '$lib/dependencies/dependencyService.svelte';
 	import { REJECTTION_REASONS, type RejectionReason } from '$lib/stacks/stackService.svelte';
 	import { WorktreeService } from '$lib/worktree/worktreeService.svelte';
 	import { inject } from '@gitbutler/shared/context';
-	import HunkDiffBody from '@gitbutler/ui/hunkDiff/HunkDiffBody.svelte';
-	import { parseHunk } from '@gitbutler/ui/utils/diffParsing';
+	import Icon from '@gitbutler/ui/Icon.svelte';
+	import ModalHeader from '@gitbutler/ui/ModalHeader.svelte';
+	import Tooltip from '@gitbutler/ui/Tooltip.svelte';
 	import type { CommitFailedModalState } from '$lib/state/uiState.svelte';
 
 	type Props = {
 		data: CommitFailedModalState;
+		oncloseclick?: () => void;
 	};
 
-	const { data }: Props = $props();
+	const { data, oncloseclick }: Props = $props();
 
-	const [worktreeService, dependencyService] = inject(WorktreeService, DependencyService);
+	const [worktreeService] = inject(WorktreeService);
 
 	type ReasonGroup = {
 		reason: RejectionReason;
@@ -66,80 +67,48 @@
 		return result;
 	}
 
-	function reasonRelatedToDependencyInfo(reason: RejectionReason): boolean {
-		return reason === 'cherryPickMergeConflict' || reason === 'workspaceMergeConflict';
-	}
-
 	const changesTimestamp = $derived(worktreeService.getChangesTimeStamp(data.projectId));
 
 	const groupedData = groupByReason(data);
 </script>
 
-{#snippet fileEntry(path: string, reason: RejectionReason)}
-	{#if reasonRelatedToDependencyInfo(reason) && changesTimestamp.current !== undefined}
-		<!-- In some cases, the dependency information is relevant to the cause of commit rejection.
-		 Show the relevant diff locks in that case. -->
-		{@const fileDependencies = dependencyService.fileDependencies(
-			data.projectId,
-			changesTimestamp.current,
-			path
-		)}
-		<div class="commit-failed__file-entry">
-			<p class="text-13 text-semibold">{path}</p>
-			<div class="commit-failed__file-entry-dependencies">
-				<ReduxResult projectId={data.projectId} result={fileDependencies.current}>
-					{#snippet children(fileDependencies)}
-						{#each fileDependencies.dependencies as dependency}
-							{@const hunk = parseHunk(dependency.hunk.diff)}
-							<div class="commit-failed__file-entry-dependencies-diff">
-								<table class="table__section">
-									<HunkDiffBody content={hunk.contentSections} filePath={path} />
-								</table>
-							</div>
-							Depends on:
-							<br />
-							{#each dependency.locks as lock}
-								<div class="commit-failed__file-entry-dependency-lock">
-									<p>Stack Id {lock.stackId}</p>
-									<p>Commit Id {lock.commitId}</p>
-								</div>
-							{/each}
-						{/each}
-					{/snippet}
-				</ReduxResult>
-			</div>
-		</div>
-	{:else}
-		<!-- If the dependency information is not relevant, just display the path -->
-		<p class="text-13 text-semibold">{path}</p>
-	{/if}
-{/snippet}
-
 <div class="commit-failed__wrapper">
-	<div class="commit-failed__description">
-		{#if data.newCommitId}
-			<p>
-				A commit could be created with SHA <b>{data.newCommitId.substring(0, 7)}</b>
-				in branch <b>{data.targetBranchName}</b> but some changes could not be fully committed:
-			</p>
-		{:else}
-			<p>Commit could not be created because of the following reasons:</p>
-		{/if}
-	</div>
 	<ConfigurableScrollableContainer>
-		<div class="commit-failed">
+		<ModalHeader type={data.newCommitId ? 'warning' : 'error'} closeButton {oncloseclick} sticky
+			>{data.newCommitId
+				? 'Some changes were not committed'
+				: 'Failed to create commit'}</ModalHeader
+		>
+		<div class="commit-failed__content">
+			<div class="text-13 commit-failed__description">
+				{#if data.newCommitId}
+					Commit <i class="commit-failed__text-icon"><Icon name="commit" /></i>
+					<Tooltip text={data.commitTitle ? data.commitTitle : 'No commit title provided'}
+						><span class="h-dotted-underline text-semibold">{data.newCommitId.substring(0, 7)}</span
+						></Tooltip
+					> was created, but some changes weren't fully committed:
+				{:else}
+					Commit could not be created because of the following reasons:
+				{/if}
+			</div>
+
 			<div class="commit-failed__reasons">
 				{#each groupedData as { reason, paths, reasonReadable } (reason)}
-					<div class="commit-failed__reason">
-						<p class="text-bold text-14">
-							{reasonReadable}
-						</p>
+					<hr class="commit-failed__reasons-divider" />
 
-						<div class="commit-failed__reason-file-list">
-							{#each paths as path (path)}
-								{@render fileEntry(path, reason)}
-							{/each}
-						</div>
+					<p class="text-13">
+						Cause: <span class="text-bold">{reasonReadable}</span>
+					</p>
+
+					<div class="commit-failed__reason-file-list">
+						{#each paths as path (path)}
+							<CommitFailedFileEntry
+								{path}
+								{reason}
+								projectId={data.projectId}
+								changesTimestamp={changesTimestamp.current}
+							/>
+						{/each}
 					</div>
 				{/each}
 			</div>
@@ -151,59 +120,41 @@
 	.commit-failed__wrapper {
 		display: flex;
 		flex-direction: column;
-		height: 320px;
-
-		gap: 32px;
+		/* max-height: 620px; */
+		overflow: hidden;
 	}
 
-	.commit-failed {
+	.commit-failed__content {
 		display: flex;
 		flex-direction: column;
-
-		gap: 32px;
+		padding: 0 16px 16px 16px;
+		gap: 16px;
 	}
 
+	.commit-failed__text-icon {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		transform: translateY(4px);
+		color: var(--clr-text-2);
+	}
+
+	/* Groups */
 	.commit-failed__reasons {
 		display: flex;
 		flex-direction: column;
-		gap: 8px;
+		gap: 16px;
 	}
 
-	.commit-failed__reason {
-		display: flex;
-		flex-direction: column;
-		gap: 4px;
+	.commit-failed__reasons-divider {
+		margin: 0 -16px;
+		border: 0;
+		border-top: 1px solid var(--clr-border-2);
 	}
 
 	.commit-failed__reason-file-list {
 		display: flex;
 		flex-direction: column;
-
-		padding-left: 8px;
 		gap: 8px;
-	}
-
-	.commit-failed__file-entry {
-		display: flex;
-		flex-direction: column;
-
-		gap: 4px;
-	}
-
-	.commit-failed__file-entry-dependencies-diff {
-		overflow: hidden;
-		border: 1px solid var(--clr-diff-count-border);
-		border-radius: var(--radius-m);
-	}
-
-	.table__section {
-		width: 100%;
-		border-collapse: separate;
-		border-spacing: 0;
-	}
-
-	.commit-failed__file-entry-dependency-lock {
-		display: flex;
-		gap: 4px;
 	}
 </style>

--- a/apps/desktop/src/components/CommitFailedModalContent.svelte
+++ b/apps/desktop/src/components/CommitFailedModalContent.svelte
@@ -2,6 +2,7 @@
 	import CommitFailedFileEntry from '$components/CommitFailedFileEntry.svelte';
 	import ConfigurableScrollableContainer from '$components/ConfigurableScrollableContainer.svelte';
 	import { REJECTTION_REASONS, type RejectionReason } from '$lib/stacks/stackService.svelte';
+	import { TestId } from '$lib/testing/testIds';
 	import { WorktreeService } from '$lib/worktree/worktreeService.svelte';
 	import { inject } from '@gitbutler/shared/context';
 	import Icon from '@gitbutler/ui/Icon.svelte';
@@ -70,15 +71,24 @@
 	const changesTimestamp = $derived(worktreeService.getChangesTimeStamp(data.projectId));
 
 	const groupedData = groupByReason(data);
+
+	let isScrollTopVisible = $state(true);
 </script>
 
 <div class="commit-failed__wrapper">
-	<ConfigurableScrollableContainer>
-		<ModalHeader type={data.newCommitId ? 'warning' : 'error'} closeButton {oncloseclick} sticky
-			>{data.newCommitId
-				? 'Some changes were not committed'
-				: 'Failed to create commit'}</ModalHeader
-		>
+	<ModalHeader
+		sticky={!isScrollTopVisible}
+		type={data.newCommitId ? 'warning' : 'error'}
+		closeButton
+		{oncloseclick}
+		closeButtonTestId={TestId.GlobalModalActionButton}
+		>{data.newCommitId ? 'Some changes were not committed' : 'Failed to create commit'}</ModalHeader
+	>
+	<ConfigurableScrollableContainer
+		onscrollTop={(visible) => {
+			isScrollTopVisible = visible;
+		}}
+	>
 		<div class="commit-failed__content">
 			<div class="text-13 commit-failed__description">
 				{#if data.newCommitId}

--- a/apps/desktop/src/components/GlobalModal.svelte
+++ b/apps/desktop/src/components/GlobalModal.svelte
@@ -22,7 +22,7 @@
 					props: {
 						testId: TestId.GlobalModal_CommitFailed,
 						closeButton: true,
-						width: 'large',
+						width: 540,
 						noPadding: true
 					}
 				};
@@ -47,7 +47,6 @@
 		{...modalProps.props}
 		onClose={() => uiState.global.modal.set(undefined)}
 		onSubmit={(close) => close()}
-		width={540}
 	>
 		{#if modalProps.state.type === 'commit-failed'}
 			<CommitFailedModalContent data={modalProps.state} oncloseclick={() => modal?.close()} />

--- a/apps/desktop/src/components/GlobalModal.svelte
+++ b/apps/desktop/src/components/GlobalModal.svelte
@@ -3,7 +3,6 @@
 	import { UiState, type GlobalModalState } from '$lib/state/uiState.svelte';
 	import { TestId } from '$lib/testing/testIds';
 	import { inject } from '@gitbutler/shared/context';
-	import Button from '@gitbutler/ui/Button.svelte';
 	import Modal, { type ModalProps } from '@gitbutler/ui/Modal.svelte';
 
 	const [uiState] = inject(UiState);
@@ -11,8 +10,6 @@
 	type ModalData = {
 		state: GlobalModalState;
 		props: Omit<ModalProps, 'children'>;
-
-		actionButtonLabel: string;
 	};
 
 	function mapModalStateToProps(modalState: GlobalModalState | undefined): ModalData | null {
@@ -24,14 +21,10 @@
 					state: modalState,
 					props: {
 						testId: TestId.GlobalModal_CommitFailed,
-						title: modalState.newCommitId
-							? 'Some changes were not committed'
-							: 'Failed to create commit',
-						type: modalState.newCommitId ? 'warning' : 'error',
 						closeButton: true,
-						width: 'large'
-					},
-					actionButtonLabel: modalState.newCommitId ? 'Oh ok' : 'Well, that sucks'
+						width: 'large',
+						noPadding: true
+					}
 				};
 			}
 		}
@@ -54,15 +47,10 @@
 		{...modalProps.props}
 		onClose={() => uiState.global.modal.set(undefined)}
 		onSubmit={(close) => close()}
+		width={540}
 	>
 		{#if modalProps.state.type === 'commit-failed'}
-			<CommitFailedModalContent data={modalProps.state} />
+			<CommitFailedModalContent data={modalProps.state} oncloseclick={() => modal?.close()} />
 		{/if}
-
-		{#snippet controls()}
-			<Button testId={TestId.GlobalModalActionButton} style="neutral" type="submit"
-				>{modalProps.actionButtonLabel}</Button
-			>
-		{/snippet}
 	</Modal>
 {/if}

--- a/apps/desktop/src/components/HunkDiff.svelte
+++ b/apps/desktop/src/components/HunkDiff.svelte
@@ -538,7 +538,7 @@
 	}
 
 	.table__title {
-		user-select: none;
+		user-select: text;
 	}
 
 	.draggable {

--- a/apps/desktop/src/components/v3/ChangedFiles.svelte
+++ b/apps/desktop/src/components/v3/ChangedFiles.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import ConfigurableScrollableContainer from '$components/ConfigurableScrollableContainer.svelte';
 	import FileList from '$components/v3/FileList.svelte';
 	import FileListMode from '$components/v3/FileListMode.svelte';
 	import emptyFolderSvg from '$lib/assets/empty-state/empty-folder.svg?raw';
 	import Badge from '@gitbutler/ui/Badge.svelte';
 	import EmptyStatePlaceholder from '@gitbutler/ui/EmptyStatePlaceholder.svelte';
-	import { stickyHeader } from '@gitbutler/ui/utils/stickyHeader';
 	import type { ConflictEntriesObj } from '$lib/files/conflicts';
 	import type { TreeChange } from '$lib/hunks/change';
 	import type { SelectionId } from '$lib/selection/key';
@@ -32,9 +32,11 @@
 	}: Props = $props();
 
 	let listMode: 'list' | 'tree' = $state('tree');
+
+	let scrollTopIsVisible = $state(true);
 </script>
 
-<div class="changed-files__header" use:stickyHeader>
+<div class="changed-files__header" class:sticked={!scrollTopIsVisible}>
 	<div class="changed-files__header-left">
 		<h4 class="text-14 text-semibold truncate">{title}</h4>
 		<Badge>{changes.length}</Badge>
@@ -42,16 +44,23 @@
 	<FileListMode bind:mode={listMode} persist="committed" />
 </div>
 {#if changes.length > 0}
-	<FileList
-		{selectionId}
-		{projectId}
-		{stackId}
-		{changes}
-		{listMode}
-		{active}
-		{conflictEntries}
-		{draggableFiles}
-	/>
+	<ConfigurableScrollableContainer
+		zIndex="var(--z-floating)"
+		onscrollTop={(visible) => {
+			scrollTopIsVisible = visible;
+		}}
+	>
+		<FileList
+			{selectionId}
+			{projectId}
+			{stackId}
+			{changes}
+			{listMode}
+			{active}
+			{conflictEntries}
+			{draggableFiles}
+		/>
+	</ConfigurableScrollableContainer>
 {:else}
 	<EmptyStatePlaceholder image={emptyFolderSvg} width={180} gap={4}>
 		{#snippet caption()}
@@ -60,7 +69,7 @@
 	</EmptyStatePlaceholder>
 {/if}
 
-<style>
+<style lang="postcss">
 	.changed-files__header {
 		display: flex;
 		align-items: center;
@@ -68,6 +77,10 @@
 		padding: 10px 10px 10px 14px;
 		gap: 8px;
 		background-color: var(--clr-bg-1);
+
+		&.sticked {
+			border-bottom: 1px solid var(--clr-border-2);
+		}
 	}
 
 	.changed-files__header-left {

--- a/apps/desktop/src/components/v3/Drawer.svelte
+++ b/apps/desktop/src/components/v3/Drawer.svelte
@@ -143,9 +143,9 @@
 
 				{#if splitView && filesSplitView}
 					<div class="drawer__files-split-view">
-						<ConfigurableScrollableContainer zIndex="var(--z-floating)">
-							{@render filesSplitView()}
-						</ConfigurableScrollableContainer>
+						<!-- <ConfigurableScrollableContainer zIndex="var(--z-floating)"> -->
+						{@render filesSplitView()}
+						<!-- </ConfigurableScrollableContainer> -->
 					</div>
 				{/if}
 			</div>

--- a/apps/desktop/src/components/v3/Drawer.svelte
+++ b/apps/desktop/src/components/v3/Drawer.svelte
@@ -143,7 +143,7 @@
 
 				{#if splitView && filesSplitView}
 					<div class="drawer__files-split-view">
-						<ConfigurableScrollableContainer>
+						<ConfigurableScrollableContainer zIndex="var(--z-floating)">
 							{@render filesSplitView()}
 						</ConfigurableScrollableContainer>
 					</div>

--- a/apps/desktop/src/components/v3/NewCommitView.svelte
+++ b/apps/desktop/src/components/v3/NewCommitView.svelte
@@ -229,6 +229,7 @@
 				projectId,
 				targetBranchName: finalBranchName,
 				newCommitId: newId ?? undefined,
+				commitTitle: projectState.commitTitle.current,
 				pathsToRejectedChanges
 			});
 		}

--- a/apps/desktop/src/lib/stacks/macros.ts
+++ b/apps/desktop/src/lib/stacks/macros.ts
@@ -82,6 +82,7 @@ export default class StackMacros {
 				projectId: this.projectId,
 				targetBranchName: branchName,
 				newCommitId: outcome.newCommit ?? undefined,
+				commitTitle: message ?? STUB_COMMIT_MESSAGE,
 				pathsToRejectedChanges
 			});
 		}

--- a/apps/desktop/src/lib/state/uiState.svelte.ts
+++ b/apps/desktop/src/lib/state/uiState.svelte.ts
@@ -56,6 +56,7 @@ export type CommitFailedModalState = BaseGlobalModalState & {
 	projectId: string;
 	targetBranchName: string;
 	newCommitId: string | undefined;
+	commitTitle: string | undefined;
 	pathsToRejectedChanges: Record<string, RejectionReason>;
 };
 

--- a/apps/desktop/src/lib/utils/theme.ts
+++ b/apps/desktop/src/lib/utils/theme.ts
@@ -1,9 +1,7 @@
 import { getCurrentWindow, type Theme } from '@tauri-apps/api/window';
-import { writable, type Writable } from 'svelte/store';
+import { type Writable } from 'svelte/store';
 import type { Settings } from '$lib/settings/userSettings';
 const appWindow = getCurrentWindow();
-
-export const theme = writable('dark');
 
 let systemTheme: string | null;
 let selectedTheme: string | undefined;

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -322,7 +322,6 @@
 		display: flex;
 		height: 100%;
 		cursor: default;
-		user-select: none;
 	}
 
 	.drag-region {

--- a/packages/ui/src/lib/HunkDiff.svelte
+++ b/packages/ui/src/lib/HunkDiff.svelte
@@ -186,7 +186,6 @@
 		border-collapse: separate;
 		border-spacing: 0;
 		font-family: var(--diff-font);
-		user-select: none;
 	}
 
 	thead {

--- a/packages/ui/src/lib/Modal.svelte
+++ b/packages/ui/src/lib/Modal.svelte
@@ -32,8 +32,7 @@
 </script>
 
 <script lang="ts" generics="T extends undefined | any = any">
-	import Button from '$lib/Button.svelte';
-	import Icon from '$lib/Icon.svelte';
+	import ModalHeader from '$lib/ModalHeader.svelte';
 	import { focusTrap } from '$lib/utils/focusTrap';
 	import { portal } from '$lib/utils/portal';
 	import { pxToRem } from '$lib/utils/pxToRem';
@@ -139,29 +138,9 @@
 			}}
 		>
 			{#if title}
-				<div class="modal__header">
-					{#if type === 'warning'}
-						<Icon name="warning" color="warning" />
-					{/if}
-
-					{#if type === 'error'}
-						<Icon name="error" color="error" />
-					{/if}
-
-					{#if type === 'success'}
-						<Icon name="success" color="success" />
-					{/if}
-
-					<h2 class="text-14 text-semibold">
-						{title}
-					</h2>
-
-					{#if closeButton}
-						<div class="close-btn">
-							<Button type="button" kind="ghost" icon="cross" onclick={close}></Button>
-						</div>
-					{/if}
-				</div>
+				<ModalHeader {type} {closeButton} oncloseclick={close}>
+					{title}
+				</ModalHeader>
 			{/if}
 
 			<div class="modal__body text-13 text-body" class:no-padding={noPadding}>
@@ -214,35 +193,19 @@
 	.modal-form {
 		display: flex;
 		flex-direction: column;
-
 		max-height: calc(100vh - 80px);
-
 		overflow: hidden;
 		border: 1px solid var(--clr-border-2);
 		border-radius: var(--radius-l);
 		background-color: var(--clr-bg-1);
 		box-shadow: var(--fx-shadow-l);
-	}
-
-	.modal__header {
-		display: flex;
-		position: relative;
-		align-items: center;
-		padding: 16px;
-		padding-bottom: 0;
-		gap: 8px;
-	}
-
-	.close-btn {
-		position: absolute;
-		top: 10px;
-		right: 10px;
+		user-select: text;
 	}
 
 	.modal__body {
 		display: flex;
 		flex-direction: column;
-		padding: 16px;
+		padding: 0 16px 16px 16px;
 		overflow: hidden;
 		line-height: 160%;
 

--- a/packages/ui/src/lib/Modal.svelte
+++ b/packages/ui/src/lib/Modal.svelte
@@ -11,6 +11,7 @@
 		closeButton?: boolean;
 		noPadding?: boolean;
 		defaultItem?: T;
+		preventCloseOnClickOutside?: boolean;
 		/**
 		 * Callback to be called when the modal is closed.
 		 *
@@ -46,6 +47,7 @@
 		closeButton,
 		onClose,
 		onClickOutside,
+		preventCloseOnClickOutside,
 		children,
 		controls,
 		onSubmit,
@@ -111,8 +113,10 @@
 		use:portal={'body'}
 		class="modal-container {isClosing ? 'closing' : 'open'}"
 		class:open
-		onmousedown={(e) => {
+		onclick={(e) => {
 			e.stopPropagation();
+
+			if (preventCloseOnClickOutside) return;
 
 			if (e.target === e.currentTarget) {
 				onClickOutside?.();
@@ -148,7 +152,7 @@
 						<Icon name="success" color="success" />
 					{/if}
 
-					<h2 class="text-14 text-bold">
+					<h2 class="text-14 text-semibold">
 						{title}
 					</h2>
 

--- a/packages/ui/src/lib/ModalHeader.svelte
+++ b/packages/ui/src/lib/ModalHeader.svelte
@@ -2,26 +2,28 @@
 	import Button from '$lib/Button.svelte';
 	import Icon from '$lib/Icon.svelte';
 	import { type ModalType } from '$lib/Modal.svelte';
-	import { stickyHeader } from '@gitbutler/ui/utils/stickyHeader';
 	import { type Snippet } from 'svelte';
 
 	interface Props {
 		type?: ModalType;
 		closeButton?: boolean;
 		sticky?: boolean;
+		closeButtonTestId?: string;
 		children: Snippet;
 		oncloseclick?: () => void;
 	}
 
-	const { type = 'info', closeButton, sticky, children, oncloseclick }: Props = $props();
+	const {
+		type = 'info',
+		closeButton,
+		sticky,
+		closeButtonTestId,
+		children,
+		oncloseclick
+	}: Props = $props();
 </script>
 
-<div
-	class="modal__header"
-	use:stickyHeader={{
-		disabled: !sticky
-	}}
->
+<div class="modal__header" class:sticky>
 	{#if type === 'warning'}
 		<Icon name="warning" color="warning" />
 	{/if}
@@ -40,7 +42,13 @@
 
 	{#if closeButton}
 		<div class="close-btn">
-			<Button type="button" kind="ghost" icon="cross" onclick={oncloseclick}></Button>
+			<Button
+				type="button"
+				testId={closeButtonTestId}
+				kind="ghost"
+				icon="cross"
+				onclick={oncloseclick}
+			></Button>
 		</div>
 	{/if}
 </div>
@@ -53,6 +61,10 @@
 		padding: 16px;
 		gap: 8px;
 		background-color: var(--clr-bg-1);
+
+		&.sticky {
+			border-bottom: 1px solid var(--clr-border-2);
+		}
 	}
 
 	.close-btn {

--- a/packages/ui/src/lib/ModalHeader.svelte
+++ b/packages/ui/src/lib/ModalHeader.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	import Button from '$lib/Button.svelte';
+	import Icon from '$lib/Icon.svelte';
+	import { type ModalType } from '$lib/Modal.svelte';
+	import { stickyHeader } from '@gitbutler/ui/utils/stickyHeader';
+	import { type Snippet } from 'svelte';
+
+	interface Props {
+		type?: ModalType;
+		closeButton?: boolean;
+		sticky?: boolean;
+		children: Snippet;
+		oncloseclick?: () => void;
+	}
+
+	const { type = 'info', closeButton, sticky, children, oncloseclick }: Props = $props();
+</script>
+
+<div
+	class="modal__header"
+	use:stickyHeader={{
+		disabled: !sticky
+	}}
+>
+	{#if type === 'warning'}
+		<Icon name="warning" color="warning" />
+	{/if}
+
+	{#if type === 'error'}
+		<Icon name="error" color="error" />
+	{/if}
+
+	{#if type === 'success'}
+		<Icon name="success" color="success" />
+	{/if}
+
+	<h2 class="text-14 text-semibold">
+		{@render children()}
+	</h2>
+
+	{#if closeButton}
+		<div class="close-btn">
+			<Button type="button" kind="ghost" icon="cross" onclick={oncloseclick}></Button>
+		</div>
+	{/if}
+</div>
+
+<style lang="postcss">
+	.modal__header {
+		display: flex;
+		position: relative;
+		align-items: center;
+		padding: 16px;
+		gap: 8px;
+		background-color: var(--clr-bg-1);
+	}
+
+	.close-btn {
+		position: absolute;
+		top: 10px;
+		right: 10px;
+	}
+</style>

--- a/packages/ui/src/lib/file/FileName.svelte
+++ b/packages/ui/src/lib/file/FileName.svelte
@@ -17,7 +17,7 @@
 	});
 </script>
 
-<div role="presentation" class="file-name">
+<div class="file-name">
 	<FileIcon fileName={fileNameAndPath.filename} size={16} />
 	<span class="text-{textSize} text-semibold file-name__name truncate">
 		{fileNameAndPath.filename}

--- a/packages/ui/src/lib/scroll/ScrollableContainer.svelte
+++ b/packages/ui/src/lib/scroll/ScrollableContainer.svelte
@@ -54,6 +54,35 @@
 	let scrollTopVisible = $state<boolean>(true);
 	let scrollEndVisible = $state<boolean>(true);
 
+	// Function to check scroll position and update visibility states
+	function checkScrollPosition() {
+		if (!viewport) return;
+
+		const { scrollTop, scrollHeight, clientHeight } = viewport;
+		const threshold = 1; // Small threshold to account for sub-pixel scrolling
+
+		// Check if we're at the top
+		const atTop = scrollTop <= threshold;
+		scrollTopVisible = atTop;
+
+		// Check if we're at the bottom
+		const atBottom = scrollTop + clientHeight >= scrollHeight - threshold;
+		scrollEndVisible = atBottom;
+	}
+
+	// Handle scroll events
+	function handleScroll(e: Event) {
+		checkScrollPosition();
+		onscroll?.(e);
+	}
+
+	// Check initial position when viewport is available
+	$effect(() => {
+		if (viewport) {
+			checkScrollPosition();
+		}
+	});
+
 	$effect(() => {
 		if (scrollTopVisible) {
 			onscrollTop?.(true);
@@ -76,7 +105,7 @@
 		bind:this={viewport}
 		use:useAutoScroll={{ enabled: autoScroll }}
 		bind:offsetHeight={viewportHeight}
-		{onscroll}
+		onscroll={handleScroll}
 		class="viewport hide-native-scrollbar"
 		style="padding-top: {top}px; padding-bottom: {bottom}px;"
 		style:height

--- a/packages/ui/src/lib/utils/stickyHeader.ts
+++ b/packages/ui/src/lib/utils/stickyHeader.ts
@@ -13,25 +13,57 @@ export function stickyHeader(
 
 	if (disabled) return;
 
-	node.classList.add('h-sticky-header');
-	node.classList.add(`h-sticky-header_${align}`);
+	// Base sticky positioning
+	node.style.position = 'sticky';
+	node.style.zIndex = 'var(--z-lifted)';
 
-	const stickyClass = `h-sticky-header_sticked-${align}`;
+	if (align === 'top') {
+		node.style.top = '-1px';
+	} else {
+		node.style.bottom = '-1px';
+	}
 
-	intersectionObserver(node, {
+	function applyStickyStyles() {
+		if (unstyled) return;
+
+		if (align === 'top') {
+			node.style.borderBottom = '1px solid var(--clr-border-2)';
+		} else {
+			node.style.borderTop = '1px solid var(--clr-border-2)';
+		}
+	}
+
+	function removeStickyStyles() {
+		if (unstyled) return;
+
+		if (align === 'top') {
+			node.style.removeProperty('border-bottom');
+		} else {
+			node.style.removeProperty('border-top');
+		}
+	}
+
+	const cleanup = intersectionObserver(node, {
 		callback: (entry) => {
-			if (entry?.isIntersecting) {
-				if (!unstyled) node.classList.toggle(stickyClass, false);
-				onStick?.(false);
+			const isStuck = !entry?.isIntersecting;
+			if (isStuck) {
+				applyStickyStyles();
 			} else {
-				if (!unstyled) node.classList.toggle(stickyClass, true);
-				onStick?.(true);
+				removeStickyStyles();
 			}
+			onStick?.(isStuck);
 		},
 		options: {
 			root: null,
-			rootMargin: `-1px`,
+			rootMargin: '-1px',
 			threshold: 1
 		}
 	});
+
+	return {
+		destroy() {
+			cleanup?.destroy();
+			removeStickyStyles();
+		}
+	};
 }

--- a/packages/ui/src/styles/utility/helpers.css
+++ b/packages/ui/src/styles/utility/helpers.css
@@ -95,32 +95,14 @@ pre {
 	}
 }
 
-/* STICKY HEADER */
-.h-sticky-header {
-	z-index: var(--z-lifted);
-	position: sticky;
-}
-
-.h-sticky-header_top {
-	top: -1px;
-}
-
-.h-sticky-header_bottom {
-	bottom: -1px;
-}
-
-.h-sticky-header_sticked-top {
-	border-bottom: 1px solid var(--clr-border-2);
-}
-
-.h-sticky-header_sticked-bottom {
-	border-top: 1px solid var(--clr-border-2);
-}
-
 /* NO TRANSITION ON MOUNT */
 .h-no-transition {
 	transition: none !important;
 	& * {
 		transition: none !important;
 	}
+}
+
+.h-dotted-underline {
+	text-decoration: underline dotted;
 }


### PR DESCRIPTION
### Description

- Fix ability to select text in the table title  
- Remove unused "theme" variable  
- Add `preventCloseOnClickOutside` prop to Modal to control closing behavior on outside clicks  
- Update modal heading style from text-bold to text-semibold  
- Fix header overlapping scrollbar issue  
- Replace stickyHeader utility with scroll visibility tracking for improved header/footer stickiness  
- Disable ConfigurableScrollableContainer in Drawer to resolve split view layout issues