### PR TITLE
fix(ui): remove clickOutside directive to fix selection issues

### DIFF
--- a/packages/ui/src/lib/hunkDiff/HunkDiffBody.svelte
+++ b/packages/ui/src/lib/hunkDiff/HunkDiffBody.svelte
@@ -187,59 +187,13 @@
 </script>
 
 {#if commentRow}
-	<tbody
-		onmouseenter={() => (hoveringOverTable = true)}
-		onmouseleave={() => (hoveringOverTable = false)}
-		ontouchstart={(ev) => lineSelection.onTouchStart(ev)}
-		ontouchmove={(ev) => lineSelection.onTouchMove(ev)}
-		ontouchend={() => lineSelection.onEnd()}
-		use:clickOutside={{
-			handler: handleClearSelection,
-			excludeElement: clickOutsideExcludeElement
-		}}
-	>
+	<tbody>
 		<tr>
 			<td class="diff-comment__number-column" colspan={commentNumericColSpan}>comment</td>
 			<td style="--tab-size: {tabSize};" class="diff-comment">
 				{@html commentRow.tokens.join('')}
 			</td>
 		</tr>
-	</tbody>
-{/if}
-
-<!-- Render always the first row if there's any. -->
-<!-- This is needed in order for the header dimensions to be calculated correctly -->
-{#if firstRow}
-	<tbody
-		onmouseenter={() => (hoveringOverTable = true)}
-		onmouseleave={() => (hoveringOverTable = false)}
-		ontouchstart={(ev) => lineSelection.onTouchStart(ev)}
-		ontouchmove={(ev) => lineSelection.onTouchMove(ev)}
-		ontouchend={() => lineSelection.onEnd()}
-		use:clickOutside={{
-			handler: handleClearSelection,
-			excludeElement: clickOutsideExcludeElement
-		}}
-	>
-		<HunkDiffRow
-			{minWidth}
-			idx={0}
-			row={firstRow}
-			{clickable}
-			{lineSelection}
-			{tabSize}
-			{wrapText}
-			{diffFont}
-			{numberHeaderWidth}
-			{onQuoteSelection}
-			{onCopySelection}
-			clearLineSelection={handleClearSelection}
-			{hoveringOverTable}
-			staged={getStageState(firstRow)}
-			{hideCheckboxes}
-			{handleLineContextMenu}
-			{lockWarning}
-		/>
 	</tbody>
 {/if}
 
@@ -262,6 +216,30 @@
 			options: { threshold: 0 }
 		}}
 	>
+		<!-- Render always the first row if there's any. -->
+		<!-- This is needed in order for the header dimensions to be calculated correctly -->
+		{#if firstRow}
+			<HunkDiffRow
+				{minWidth}
+				idx={0}
+				row={firstRow}
+				{clickable}
+				{lineSelection}
+				{tabSize}
+				{wrapText}
+				{diffFont}
+				{numberHeaderWidth}
+				{onQuoteSelection}
+				{onCopySelection}
+				clearLineSelection={handleClearSelection}
+				{hoveringOverTable}
+				staged={getStageState(firstRow)}
+				{hideCheckboxes}
+				{handleLineContextMenu}
+				{lockWarning}
+			/>
+		{/if}
+
 		{#if chunkVisibility[chunkIdx]}
 			{#each chunk as row, idx (lineIdKey( { oldLine: row.beforeLineNumber, newLine: row.afterLineNumber } ))}
 				{@const rowIdx = getRowIndex(chunkIdx, idx)}


### PR DESCRIPTION
Remove the use of the clickOutside action and related excludeElement
property in HunkDiffBody.svelte. 

This is needed since the hunks are now split by virtual sections.