### PR TITLE
fix(desktop): use params.branchName instead of branchName

### DIFF
--- a/apps/desktop/src/components/ReviewCreation.svelte
+++ b/apps/desktop/src/components/ReviewCreation.svelte
@@ -293,7 +293,7 @@
 			}
 
 			// Find the index of the current branch so we know where we want to point the pr.
-			const currentIndex = branches.findIndex((b) => b.name === branchName);
+			const currentIndex = branches.findIndex((b) => b.name === params.branchName);
 			if (currentIndex === -1) {
 				throw new Error('Branch index not found.');
 			}


### PR DESCRIPTION
Update branch index lookup in ReviewCreation component to use
params.branchName instead of branchName variable. 

This is needed to ensure the closure branch name is used