### PR TITLE
fix: File list view mode segment control

### DIFF
--- a/apps/desktop/cypress/e2e/fileTree.cy.ts
+++ b/apps/desktop/cypress/e2e/fileTree.cy.ts
@@ -94,4 +94,65 @@ describe('File Tree - some file changes', () => {
 			);
 		});
 	});
+
+	it('Correctly remembers the file tree view state', () => {
+		// There should be uncommitted changes
+		cy.getByTestId('uncommitted-changes-file-list').should('be.visible');
+
+		// All files should be visible
+		cy.getByTestId('file-list-item').should(
+			'have.length',
+			mockBackend.getWorktreeChangesFileNames().length
+		);
+
+		// The uncommitted changes header should be visible,
+		// and the file list mode should be selected
+		cy.getByTestId('uncommitted-changes-header')
+			.should('be.visible')
+			.within(() => {
+				cy.get('#list').should('be.visible').should('have.attr', 'aria-selected', 'true');
+
+				// Click the tree view button
+				cy.get('#tree').should('be.visible').should('have.attr', 'aria-selected', 'false').click();
+			});
+
+		// There should be an expanded file tree
+		cy.getByTestId('uncommitted-changes-file-list').within(() => {
+			cy.getByTestId('file-list-tree-folder').should(
+				'have.length',
+				mockBackend.getWorktreeChangesTopLevelDirs().length
+			);
+
+			cy.getByTestId('file-list-item').should(
+				'have.length',
+				mockBackend.getWorktreeChangesFileNames().length
+			);
+		});
+
+		// Click on the branches view
+		cy.getByTestId('navigation-branches-button').should('be.visible').click();
+
+		// Click the workspace button
+		cy.getByTestId('navigation-workspace-button').should('be.visible').click();
+
+		// There should be an expanded file tree
+		cy.getByTestId('uncommitted-changes-file-list').within(() => {
+			cy.getByTestId('file-list-tree-folder').should(
+				'have.length',
+				mockBackend.getWorktreeChangesTopLevelDirs().length
+			);
+
+			cy.getByTestId('file-list-item').should(
+				'have.length',
+				mockBackend.getWorktreeChangesFileNames().length
+			);
+		});
+
+		// The file tree view should still be selected
+		cy.getByTestId('uncommitted-changes-header')
+			.should('be.visible')
+			.within(() => {
+				cy.get('#tree').should('be.visible').should('have.attr', 'aria-selected', 'true');
+			});
+	});
 });

--- a/apps/desktop/src/components/v3/FileListMode.svelte
+++ b/apps/desktop/src/components/v3/FileListMode.svelte
@@ -15,7 +15,7 @@
 	let saved = persisted<Mode | undefined>(undefined, persist);
 
 	$effect(() => {
-		if ($saved) {
+		if ($saved !== undefined && $saved !== mode) {
 			mode = $saved;
 		}
 	});

--- a/packages/ui/src/lib/segmentControl/Segment.svelte
+++ b/packages/ui/src/lib/segmentControl/Segment.svelte
@@ -26,16 +26,12 @@
 
 	let elRef = $state<HTMLButtonElement>();
 	let isFocused = $state(false);
-	let isSelected = $state(false);
+	const isSelected = $derived(index === $selectedSegmentIndex);
 
 	$effect(() => {
 		if (elRef && isFocused) {
 			elRef.focus();
 		}
-	});
-
-	$effect(() => {
-		isSelected = $selectedSegmentIndex === index;
 	});
 
 	onMount(() => {

--- a/packages/ui/src/lib/segmentControl/SegmentControl.svelte
+++ b/packages/ui/src/lib/segmentControl/SegmentControl.svelte
@@ -27,6 +27,10 @@
 
 	let selectedSegmentIndex = writable(defaultIndex);
 
+	$effect(() => {
+		$selectedSegmentIndex = defaultIndex;
+	});
+
 	const context: SegmentContext = {
 		selectedSegmentIndex,
 		setIndex: () => {


### PR DESCRIPTION
- Synchronize selected segment with defaultIndex in SegmentControl to ensure UI consistency.
- Update FileListMode only when the saved value differs to prevent redundant updates.
- Replace manual isSelected state with a derived store based on selectedSegmentIndex for better reactivity.
- Add tests to verify that the file tree mode segment control stays synced with the persisted value.

fixes: https://github.com/gitbutlerapp/gitbutler/issues/8758