### PR TITLE
fix: Disable techno-mode for the hunk diffs

### DIFF
--- a/packages/ui/src/lib/hunkDiff/HunkDiffBody.svelte
+++ b/packages/ui/src/lib/hunkDiff/HunkDiffBody.svelte
@@ -197,6 +197,38 @@
 	</tbody>
 {/if}
 
+<!-- Render always the first row if there's any. -->
+<!-- This is needed in order for the header dimensions to be calculated correctly -->
+{#if firstRow}
+	<tbody
+		onmouseenter={() => (hoveringOverTable = true)}
+		onmouseleave={() => (hoveringOverTable = false)}
+		ontouchstart={(ev) => lineSelection.onTouchStart(ev)}
+		ontouchmove={(ev) => lineSelection.onTouchMove(ev)}
+		ontouchend={() => lineSelection.onEnd()}
+	>
+		<HunkDiffRow
+			{minWidth}
+			idx={0}
+			row={firstRow}
+			{clickable}
+			{lineSelection}
+			{tabSize}
+			{wrapText}
+			{diffFont}
+			{numberHeaderWidth}
+			{onQuoteSelection}
+			{onCopySelection}
+			clearLineSelection={handleClearSelection}
+			{hoveringOverTable}
+			staged={getStageState(firstRow)}
+			{hideCheckboxes}
+			{handleLineContextMenu}
+			{lockWarning}
+		/>
+	</tbody>
+{/if}
+
 {#each chunkedRows as chunk, chunkIdx}
 	<tbody
 		onmouseenter={() => (hoveringOverTable = true)}
@@ -216,30 +248,6 @@
 			options: { threshold: 0 }
 		}}
 	>
-		<!-- Render always the first row if there's any. -->
-		<!-- This is needed in order for the header dimensions to be calculated correctly -->
-		{#if firstRow}
-			<HunkDiffRow
-				{minWidth}
-				idx={0}
-				row={firstRow}
-				{clickable}
-				{lineSelection}
-				{tabSize}
-				{wrapText}
-				{diffFont}
-				{numberHeaderWidth}
-				{onQuoteSelection}
-				{onCopySelection}
-				clearLineSelection={handleClearSelection}
-				{hoveringOverTable}
-				staged={getStageState(firstRow)}
-				{hideCheckboxes}
-				{handleLineContextMenu}
-				{lockWarning}
-			/>
-		{/if}
-
 		{#if chunkVisibility[chunkIdx]}
 			{#each chunk as row, idx (lineIdKey( { oldLine: row.beforeLineNumber, newLine: row.afterLineNumber } ))}
 				{@const rowIdx = getRowIndex(chunkIdx, idx)}


### PR DESCRIPTION
It seems that the hunk diffs were incorrectly virtualized in some recent changes, mistakenly adding the first line multiple times

This led to a wonky scroll experience in the application.
This is now fixed