### PR TITLE
feat: Uncommit from file context menu

### DIFF
--- a/apps/desktop/src/components/v3/FileListItemWrapper.svelte
+++ b/apps/desktop/src/components/v3/FileListItemWrapper.svelte
@@ -74,7 +74,6 @@
 	const selection = $derived(changeSelection.getById(change.path));
 	const indeterminate = $derived(selection.current && selection.current.type === 'partial');
 	const selectedChanges = $derived(idSelection.treeChanges(projectId, selectionId));
-	const isUncommitted = $derived(selectionId?.type === 'worktree');
 
 	const previousTooltipText = $derived(
 		(change.status.subject as Rename).previousPath
@@ -147,8 +146,10 @@
 >
 	<FileContextMenu
 		bind:this={contextMenu}
+		{projectId}
+		{stackId}
 		trigger={draggableEl}
-		{isUncommitted}
+		{selectionId}
 		{unSelectChanges}
 	/>
 

--- a/apps/desktop/src/lib/commits/dropHandler.ts
+++ b/apps/desktop/src/lib/commits/dropHandler.ts
@@ -1,4 +1,4 @@
-import { changesToDiffSpec } from '$lib/commits/utils';
+import { dropDataToDiffSpec } from '$lib/commits/utils';
 import {
 	ChangeDropData,
 	FileDropData,
@@ -150,7 +150,7 @@ export class AmendCommitWithChangeDzHandler implements DropzoneHandler {
 						destinationCommitId: this.commit.id,
 						sourceStackId,
 						sourceCommitId,
-						changes: changesToDiffSpec(data)
+						changes: dropDataToDiffSpec(data)
 					});
 
 					// Update the project state to point to the new commit if needed.
@@ -171,7 +171,7 @@ export class AmendCommitWithChangeDzHandler implements DropzoneHandler {
 						stackId: this.stackId,
 						branchName: this.branchName,
 						commitId: this.commit.id,
-						worktreeChanges: changesToDiffSpec(data)
+						worktreeChanges: dropDataToDiffSpec(data)
 					})
 				);
 		}
@@ -212,7 +212,7 @@ export class UncommitDzHandler implements DropzoneHandler {
 							projectId: this.projectId,
 							stackId,
 							commitId,
-							changes: changesToDiffSpec(data)
+							changes: dropDataToDiffSpec(data)
 						});
 
 						// Update the project state to point to the new commit if needed.

--- a/apps/desktop/src/lib/commits/utils.ts
+++ b/apps/desktop/src/lib/commits/utils.ts
@@ -1,5 +1,6 @@
 import type { DetailedCommit } from '$lib/commits/commit';
 import type { ChangeDropData } from '$lib/dragging/draggables';
+import type { TreeChange } from '$lib/hunks/change';
 import type { DiffSpec } from '$lib/hunks/hunk';
 
 type DivergenceResult =
@@ -34,10 +35,8 @@ export function findLastDivergentCommit(
 
 	return { type: 'notDiverged' };
 }
-
-/** Helper function that converts `ChangeDropData` to `DiffSpec`. */
-export function changesToDiffSpec(data: ChangeDropData): DiffSpec[] {
-	const changes = data.changes;
+/** Helper function that turns tree changes into a diff spec */
+export function changesToDiffSpec(changes: TreeChange[]): DiffSpec[] {
 	return changes.map((change) => {
 		const previousPathBytes =
 			change.status.type === 'Rename' ? change.status.subject.previousPathBytes : null;
@@ -47,4 +46,9 @@ export function changesToDiffSpec(data: ChangeDropData): DiffSpec[] {
 			hunkHeaders: []
 		};
 	});
+}
+/** Helper function that converts `ChangeDropData` to `DiffSpec`. */
+export function dropDataToDiffSpec(data: ChangeDropData): DiffSpec[] {
+	const changes = data.changes;
+	return changesToDiffSpec(changes);
 }

--- a/apps/desktop/src/lib/stacks/dropHandler.ts
+++ b/apps/desktop/src/lib/stacks/dropHandler.ts
@@ -1,5 +1,5 @@
 import { filesToOwnership } from '$lib/branches/ownership';
-import { changesToDiffSpec } from '$lib/commits/utils';
+import { dropDataToDiffSpec } from '$lib/commits/utils';
 import { ChangeDropData, FileDropData, HunkDropData } from '$lib/dragging/draggables';
 import StackMacros from '$lib/stacks/macros';
 import type { DropzoneHandler } from '$lib/dragging/handler';
@@ -79,7 +79,7 @@ export class OutsideLaneDzHandler implements DropzoneHandler {
 						sourceStackId,
 						sourceCommitId,
 						branchName,
-						changesToDiffSpec(data)
+						dropDataToDiffSpec(data)
 					);
 				} else {
 					// Should not happen, but just in case


### PR DESCRIPTION
**Add the ability to uncommit files from the context menu**
 
- Remove unused isUncommitted prop from FileListItemWrapper and pass projectId
  and stackId to FileContextMenu for better context handling.
- Add selectionId, projectId, and stackId props to FileContextMenu for improved
  state management and enable derived isUncommitted inside the component.
- Implement "Uncommit changes" menu item in FileContextMenu when selection is a
  commit and stackId is present, allowing users to uncommit changes and update
  UI state accordingly.
- Replace changesToDiffSpec with dropDataToDiffSpec in dropHandler for accurate
  diff spec conversion on drag-and-drop operations.
- Inject UiState into FileContextMenu to synchronize stack selection state after
  uncommit actions.