### PR TITLE
Implement force intgrate branches flag for workspace update

### DIFF
--- a/apps/desktop/cypress/e2e/upstreamIntegration.cy.ts
+++ b/apps/desktop/cypress/e2e/upstreamIntegration.cy.ts
@@ -69,19 +69,22 @@ describe('Upstream Integration', () => {
 				{
 					branchId: 'stack-a-id',
 					approach: { type: 'rebase' },
-					deleteIntegratedBranches: true
+					deleteIntegratedBranches: true,
+					forceIntegratedBranches: []
 				},
 				{
 					branchId: 'stack-b-id',
 					approach: { type: 'delete' },
-					deleteIntegratedBranches: false
+					deleteIntegratedBranches: false,
+					forceIntegratedBranches: []
 				},
 				{
 					branchId: 'stack-c-id',
 					approach: {
 						type: 'delete'
 					},
-					deleteIntegratedBranches: true
+					deleteIntegratedBranches: true,
+					forceIntegratedBranches: []
 				}
 			],
 			branchResolution: undefined

--- a/apps/desktop/src/components/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/IntegrateUpstreamModal.svelte
@@ -76,7 +76,8 @@
 			results.set(status.stack.id, {
 				branchId: status.stack.id,
 				approach: defaultApproach,
-				deleteIntegratedBranches: true
+				deleteIntegratedBranches: true,
+				forceIntegratedBranches: []
 			});
 		}
 

--- a/apps/desktop/src/components/v3/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/v3/IntegrateUpstreamModal.svelte
@@ -78,7 +78,8 @@
 			results.set(status.stack.id, {
 				branchId: status.stack.id,
 				approach: getResolutionApproachV3(status),
-				deleteIntegratedBranches: true
+				deleteIntegratedBranches: true,
+				forceIntegratedBranches: []
 			});
 		}
 

--- a/apps/desktop/src/lib/upstream/types.ts
+++ b/apps/desktop/src/lib/upstream/types.ts
@@ -64,6 +64,7 @@ export type Resolution = {
 	branchId: string;
 	approach: ResolutionApproach;
 	deleteIntegratedBranches: boolean;
+	forceIntegratedBranches: string[];
 };
 
 export type BaseBranchResolutionApproach = 'rebase' | 'merge' | 'hardReset';

--- a/crates/gitbutler-cli/src/command/mod.rs
+++ b/crates/gitbutler-cli/src/command/mod.rs
@@ -60,6 +60,7 @@ pub mod workspace {
                 branch_id: b.id,
                 approach,
                 delete_integrated_branches: false,
+                force_integrated_branches: vec![],
             })
             .collect();
         gitbutler_branch_actions::integrate_upstream(&ctx, &resolutions, None)?;


### PR DESCRIPTION
This is applicable for the times when a branch was squash merged and GitButler cant detect that it was merged but the GitHub API knows about it