### PR TITLE
Integration modal: Force the integration state

### DIFF
--- a/apps/desktop/cypress/e2e/upstreamIntegration.cy.ts
+++ b/apps/desktop/cypress/e2e/upstreamIntegration.cy.ts
@@ -14,6 +14,16 @@ describe('Upstream Integration', () => {
 			mockBackend.getUpstreamIntegrationStatuses()
 		);
 		mockCommand('integrate_upstream', (params) => mockBackend.integrateUpstream(params));
+		cy.intercept(
+			{
+				method: 'GEt',
+				url: 'https://api.github.com/repos/example/repo/pulls'
+			},
+			{
+				statusCode: 200,
+				body: []
+			}
+		).as('listPullRequests');
 
 		cy.visit('/');
 

--- a/apps/desktop/src/lib/forge/github/githubListingService.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubListingService.svelte.ts
@@ -42,13 +42,9 @@ export class GitHubListingService implements ForgeListingService {
 	}
 
 	filterByBranch(projectId: string, branchName: string[]) {
-		const result = $derived(
-			this.api.endpoints.listPrs.useQueryState(projectId, {
-				transform: (result) => prSelectors.selectByIds(result, branchName)
-			})
-		);
-		const data = $derived(result.current.data);
-		return reactive(() => data || []);
+		return this.api.endpoints.listPrs.useQueryState(projectId, {
+			transform: (result) => prSelectors.selectByIds(result, branchName)
+		});
 	}
 
 	async refresh(projectId: string): Promise<void> {

--- a/apps/desktop/src/lib/forge/gitlab/gitlabListingService.svelte.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlabListingService.svelte.ts
@@ -42,13 +42,9 @@ export class GitLabListingService implements ForgeListingService {
 	}
 
 	filterByBranch(projectId: string, branchName: string[]) {
-		const result = $derived(
-			this.api.endpoints.listPrs.useQueryState(projectId, {
-				transform: (result) => prSelectors.selectByIds(result, branchName)
-			})
-		);
-		const data = $derived(result.current.data);
-		return reactive(() => data || []);
+		return this.api.endpoints.listPrs.useQueryState(projectId, {
+			transform: (result) => prSelectors.selectByIds(result, branchName)
+		});
 	}
 
 	async refresh(projectId: string): Promise<void> {

--- a/apps/desktop/src/lib/forge/interface/forgeListingService.ts
+++ b/apps/desktop/src/lib/forge/interface/forgeListingService.ts
@@ -1,10 +1,9 @@
 import type { PullRequest } from '$lib/forge/interface/types';
 import type { ReactiveResult } from '$lib/state/butlerModule';
-import type { Reactive } from '@gitbutler/shared/storeUtils';
 
 export interface ForgeListingService {
 	list(projectId: string, pollingInterval?: number): ReactiveResult<PullRequest[]>;
 	getByBranch(projectId: string, branchName: string): ReactiveResult<PullRequest>;
-	filterByBranch(projectId: string, branchName: string[]): Reactive<PullRequest[]>;
+	filterByBranch(projectId: string, branchName: string[]): ReactiveResult<PullRequest[]>;
 	refresh(projectId: string): Promise<void>;
 }


### PR DESCRIPTION
- Simplified `filterByBranch` implementation in forge services for improved readability and reduced complexity.
- Updated `filterByBranch` to return query state directly with a transform function.
- Added detection of merged PRs on integration branches to inform the backend accordingly.