### PR TITLE
improve submodule worktree changes

### DIFF
--- a/crates/but-core/tests/core/diff/worktree_changes.rs
+++ b/crates/but-core/tests/core/diff/worktree_changes.rs
@@ -303,6 +303,47 @@ fn submodule_added_in_unborn() -> Result<()> {
 }
 
 #[test]
+fn submodule_changes_ignored_in_configuration() -> Result<()> {
+    let repo = repo("submodule-changed-head-ignore-all")?;
+    let actual = diff::worktree_changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    WorktreeChanges {
+        changes: [
+            TreeChange {
+                path: ".gitmodules",
+                status: Modification {
+                    previous_state: ChangeState {
+                        id: Sha1(46f8c8b821d79a888a1ea0b30ec9f5d7e90821b0),
+                        kind: Blob,
+                    },
+                    state: ChangeState {
+                        id: Sha1(0000000000000000000000000000000000000000),
+                        kind: Blob,
+                    },
+                    flags: None,
+                },
+            },
+        ],
+        ignored_changes: [],
+    }
+    "#);
+    Ok(())
+}
+
+#[test]
+fn submodule_changes_set_to_all_in_config_but_has_uncommittable_changes() -> Result<()> {
+    let repo = repo("submodule-changed-worktree-ignore-none")?;
+    let actual = diff::worktree_changes(&repo)?;
+    insta::assert_debug_snapshot!(actual, @r#"
+    WorktreeChanges {
+        changes: [],
+        ignored_changes: [],
+    }
+    "#);
+    Ok(())
+}
+
+#[test]
 fn submodule_changed_head() -> Result<()> {
     let repo = repo("submodule-changed-head")?;
     let actual = diff::worktree_changes(&repo)?;

--- a/crates/but-core/tests/fixtures/worktree-changes.sh
+++ b/crates/but-core/tests/fixtures/worktree-changes.sh
@@ -224,6 +224,21 @@ git init submodule-changed-head
   )
 )
 
+cp -Rv submodule-changed-head submodule-changed-head-ignore-all
+(cd submodule-changed-head-ignore-all
+  echo $'\tignore = all\n' >>.gitmodules
+)
+
+git init submodule-changed-worktree-ignore-none
+(cd submodule-changed-worktree-ignore-none
+  git submodule add ../modified-in-index submodule
+  git commit -m "init"
+  (cd submodule
+    echo change >>modified
+  )
+  echo $'\tignore = none\n' >>.gitmodules && git commit -am "update .gitmodules"
+)
+
 git init case-folding-worktree-changes
 (cd case-folding-worktree-changes
   git config core.ignorecase false


### PR DESCRIPTION
Fixes #8792.

### Tasks

* [x] do show ignored submodules by forcing our configuration override.
* [x] assure uncommittable changes aren't shown if submodule configuration is set to `ignore = none`.
