### PR TITLE
fix(review): Branch is used as the default PR titile

### DIFF
--- a/apps/desktop/cypress/e2e/review.cy.ts
+++ b/apps/desktop/cypress/e2e/review.cy.ts
@@ -38,6 +38,17 @@ describe('Review', () => {
 		cy.intercept(
 			{
 				method: 'GET',
+				url: 'https://api.github.com/repos/example/repo/pulls'
+			},
+			{
+				statusCode: 200,
+				body: []
+			}
+		).as('listPullRequests');
+
+		cy.intercept(
+			{
+				method: 'GET',
 				url: 'https://api.github.com/repos/example/repo'
 			},
 			{

--- a/apps/desktop/cypress/e2e/support/scenarios/branchesWithChanges.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/branchesWithChanges.ts
@@ -63,10 +63,20 @@ const MOCK_COMMIT_IN_BRANCH_B = createMockCommit({
 	message: `${MOCK_COMMIT_TITLE_B}\n\n${MOCK_COMMIT_MESSAGE_B}`
 });
 
+const MOCK_COMMIT_TITLE_B_2 = 'Also second commit';
+const MOCK_COMMIT_MESSAGE_B_2 = 'This is another test commit, but with a different title';
+const MOCK_COMMIT_IN_BRANCH_B_2 = createMockCommit({
+	id: '1234123-2',
+	message: `${MOCK_COMMIT_TITLE_B_2}\n\n${MOCK_COMMIT_MESSAGE_B_2}`
+});
+
 const MOCK_STACK_DETAILS_B = createMockStackDetails({
 	derivedName: MOCK_STACK_B_ID,
 	branchDetails: [
-		createMockBranchDetails({ name: MOCK_STACK_B_ID, commits: [MOCK_COMMIT_IN_BRANCH_B] })
+		createMockBranchDetails({
+			name: MOCK_STACK_B_ID,
+			commits: [MOCK_COMMIT_IN_BRANCH_B, MOCK_COMMIT_IN_BRANCH_B_2]
+		})
 	]
 });
 
@@ -287,7 +297,7 @@ export default class BranchesWithChanges extends MockBackend {
 			return MOCK_COMMIT_TITLE_A;
 		}
 		if (stackId === MOCK_STACK_B_ID) {
-			return MOCK_COMMIT_TITLE_B;
+			return MOCK_STACK_B_ID;
 		}
 		if (stackId === MOCK_STACK_C_ID) {
 			return MOCK_COMMIT_TITLE_C;
@@ -301,7 +311,7 @@ export default class BranchesWithChanges extends MockBackend {
 			return MOCK_COMMIT_MESSAGE_A;
 		}
 		if (stackId === MOCK_STACK_B_ID) {
-			return MOCK_COMMIT_MESSAGE_B;
+			return '';
 		}
 		if (stackId === MOCK_STACK_C_ID) {
 			return MOCK_COMMIT_MESSAGE_C;

--- a/apps/desktop/src/components/ReviewCreation.svelte
+++ b/apps/desktop/src/components/ReviewCreation.svelte
@@ -139,12 +139,19 @@
 	const canPublishPR = $derived(!!(forge.current.authenticated && !pr));
 
 	function getDefaultTitle(commits: Commit[]): string {
-		if (commits.length > 0) {
+		if (commits.length === 1) {
 			const commitMessage = commits[0]!.message;
 			const { title } = splitMessage(commitMessage);
 			return title;
 		}
 		return branchName;
+	}
+
+	function getDefaultBody(commits: Commit[]): string {
+		if (commits.length === 1) {
+			return splitMessage(commits[0]!.message).description;
+		}
+		return '';
 	}
 
 	const prTitle = $derived(
@@ -159,7 +166,7 @@
 		new PrPersistedStore({
 			cacheKey: 'prbody' + projectId + '_' + branchName,
 			commits,
-			defaultFn: (commits) => splitMessage(commits[0]!.message).description
+			defaultFn: getDefaultBody
 		})
 	);
 

--- a/apps/desktop/src/lib/forge/prContents.ts
+++ b/apps/desktop/src/lib/forge/prContents.ts
@@ -62,10 +62,8 @@ export class PrPersistedStore {
 	}
 
 	setDefault(commits: Commit[]) {
-		if (commits.length === 1) {
-			this._default = this.args.defaultFn(commits);
-			this.dispatchCurrent();
-		}
+		this._default = this.args.defaultFn(commits);
+		this.dispatchCurrent();
 	}
 
 	get default() {


### PR DESCRIPTION
Change default PR title logic to use branch name when multiple commits
are present, instead of always using the first commit's title. 
Add a new function to derive the default PR body from a single commit's description,
returning empty for multiple commits. Update persisted store to always
set default body regardless of commit count. Adjust test mocks to include
multiple commits and update expected titles and messages accordingly.
Add API intercept for pull requests in Cypress tests to improve test
stability. These changes enhance PR creation UX by providing more
accurate default titles and bodies based on commit context.