### PR TITLE
ref-info: more correctness

### DIFF
--- a/crates/but-testing/src/args.rs
+++ b/crates/but-testing/src/args.rs
@@ -144,6 +144,9 @@ pub enum Subcommands {
     },
     /// Returns everything we know about the given ref, or `HEAD`.
     RefInfo {
+        /// Perform all possible computations.
+        #[clap(long, short = 'e')]
+        expensive: bool,
         /// The name of the ref to get workspace information for.
         ref_name: Option<String>,
     },

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -464,11 +464,11 @@ pub fn operating_mode(args: &super::Args) -> anyhow::Result<()> {
     debug_print(gitbutler_operating_modes::operating_mode(&ctx))
 }
 
-pub fn ref_info(args: &super::Args, ref_name: Option<&str>) -> anyhow::Result<()> {
+pub fn ref_info(args: &super::Args, ref_name: Option<&str>, expensive: bool) -> anyhow::Result<()> {
     let (repo, project) = repo_and_maybe_project(args, RepositoryOpenMode::General)?;
     let opts = but_workspace::ref_info::Options {
         stack_commit_limit: 0,
-        expensive_commit_info: true,
+        expensive_commit_info: expensive,
     };
 
     let project = project.with_context(|| {

--- a/crates/but-testing/src/main.rs
+++ b/crates/but-testing/src/main.rs
@@ -105,7 +105,10 @@ async fn main() -> Result<()> {
         args::Subcommands::StackDetails { id } => {
             command::stacks::details(*id, &args.current_dir, args.v3)
         }
-        args::Subcommands::RefInfo { ref_name } => command::ref_info(&args, ref_name.as_deref()),
+        args::Subcommands::RefInfo {
+            ref_name,
+            expensive,
+        } => command::ref_info(&args, ref_name.as_deref(), *expensive),
         args::Subcommands::HunkAssignments => {
             command::assignment::hunk_assignments(&args.current_dir, args.json)
         }

--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -231,10 +231,9 @@ pub(crate) mod function {
                 .map(|base| base.detach());
             // If we have a workspace, then we have to use that as the basis for our traversal to assure
             // the commits and stacks are assigned consistently.
-            if let Some((workspace_ref, base)) = workspace_ref_name
+            if let Some(workspace_ref) = workspace_ref_name
                 .as_ref()
                 .filter(|workspace_ref| workspace_ref.as_ref() != existing_ref.name())
-                .zip(base)
             {
                 let workspace_contains_ref_tip =
                     walk_commits(repo, workspace_ref.as_ref(), base)?.contains(&*tip);
@@ -246,6 +245,7 @@ pub(crate) mod function {
                     // To assure the stack is counted consistently even when queried alone, redo the query.
                     // This should be avoided (i.e., the caller should consume the 'highest value'
                     // refs if possible, but that's not always the case.
+                    // TODO(perf): add 'focus' to `opts` so it doesn't do expensive computations for stacks we drop later.
                     let mut info = ref_info(repo.find_reference(workspace_ref)?, meta, opts)?;
                     if let Some((stack_index, segment_index)) = info
                         .stacks
@@ -299,7 +299,7 @@ pub(crate) mod function {
                 Some(match workspace_ref_name.as_ref().zip(target_ref_id) {
                     None => RefLocation::OutsideOfWorkspace,
                     Some((ws_ref, target_id)) => {
-                        let ws_commits = walk_commits(repo, ws_ref.as_ref(), target_id)?;
+                        let ws_commits = walk_commits(repo, ws_ref.as_ref(), Some(target_id))?;
                         if ws_commits.contains(&*tip) {
                             RefLocation::ReachableFromWorkspaceCommit
                         } else {
@@ -501,15 +501,6 @@ pub(crate) mod function {
         // With this, the tip can also be missing, and we still have a somewhat expected order.
         // Besides, it's easier to work with.
         let serialized_virtual_segments = {
-            let all_stack_commits: gix::hashtable::HashSet<_> = unordered
-                .iter()
-                .flat_map(|s| {
-                    s.segments
-                        .iter()
-                        .flat_map(|s| s.commits_unique_from_tip.iter().map(|c| c.id))
-                        .chain(s.base)
-                })
-                .collect();
             let mut v = Vec::new();
             for (is_stack_tip, existing_ws_ref) in ordered.iter().flat_map(|ws_stack| {
                 ws_stack
@@ -524,9 +515,7 @@ pub(crate) mod function {
             }) {
                 let mut existing_ws_ref = existing_ws_ref?;
                 let id = existing_ws_ref.peel_to_id_in_place()?.detach();
-                if all_stack_commits.contains(&id) {
-                    v.push((is_stack_tip, id, existing_ws_ref.inner.name));
-                }
+                v.push((is_stack_tip, id, existing_ws_ref.inner.name));
             }
             v
         };
@@ -665,7 +654,7 @@ pub(crate) mod function {
     fn walk_commits(
         repo: &gix::Repository,
         from: &gix::refs::FullNameRef,
-        hide: gix::ObjectId,
+        hide: Option<gix::ObjectId>,
     ) -> anyhow::Result<gix::hashtable::HashSet<gix::ObjectId>> {
         let Some(from_id) = repo
             .try_find_reference(from)?
@@ -677,7 +666,7 @@ pub(crate) mod function {
             .ancestors()
             .sorting(Sorting::BreadthFirst)
             // TODO: use 'hide()'
-            .with_boundary(Some(hide))
+            .with_boundary(hide)
             .all()?
             .filter_map(Result::ok)
             .map(|info| info.id)

--- a/crates/but-workspace/tests/fixtures/scenario/with-remotes-and-workspace.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/with-remotes-and-workspace.sh
@@ -19,6 +19,12 @@ function set_author() {
 function setup_target_to_match_main() {
   mkdir -p .git/refs/remotes/origin
   cp .git/refs/heads/main .git/refs/remotes/origin/
+
+  cat <<EOF >>.git/config
+[remote "origin"]
+	url = ./fake/local/path/which-is-fine-as-we-dont-fetch-or-push
+	fetch = +refs/heads/*:refs/remotes/origin/*
+EOF
 }
 
 
@@ -55,7 +61,6 @@ function create_workspace_commit_aggressively() {
     fi
   fi
 
-set -x
   git checkout -b gitbutler/workspace main
   if [ $# == 1 ] || [ $# == 0 ]; then
     git commit --allow-empty -m "$workspace_commit_subject"
@@ -191,6 +196,12 @@ git init two-branches-one-advanced-two-parent-ws-commit
   git commit -m "change" --allow-empty
 
   create_workspace_commit_aggressively lane advanced-lane
+)
+
+cp -R two-branches-one-advanced-two-parent-ws-commit two-branches-one-advanced-two-parent-ws-commit-advanced-fully-pushed
+(cd two-branches-one-advanced-two-parent-ws-commit-advanced-fully-pushed
+  # This works without an official remote setup as we go by name as fallback.
+  cp .git/refs/heads/advanced-lane .git/refs/remotes/origin/advanced-lane
 )
 
 git init two-branches-one-advanced-ws-commit-on-top-of-stack

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/legacy.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/legacy.rs
@@ -249,7 +249,7 @@ mod stack_details {
                     ],
                     is_conflicted: false,
                     commits: [
-                        Commit(d79bba9, "new file in A", local),
+                        Commit(d79bba9, "new file in A", local/remote(identity)),
                     ],
                     upstream_commits: [
                         UpstreamCommit(89cc2d3, "change in A"),

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -43,7 +43,7 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         ref_location: "ReachableFromWorkspaceCommit",
                         commits_unique_from_tip: [
-                            LocalCommit(d79bba9, "new file in A\n", local),
+                            LocalCommit(d79bba9, "new file in A\n", local/remote(identity)),
                         ],
                         commits_unique_in_remote_tracking_branch: [
                             RemoteCommit(89cc2d3, "change in A\n",
@@ -138,7 +138,7 @@ fn target_ahead_remote_rewritten() -> anyhow::Result<()> {
                             LocalCommit(d5d3a92, "unique local tip\n", local),
                             LocalCommit(6ffd040, "shared by name\n", local/remote(similarity)),
                             LocalCommit(4cd56ab, "unique local\n", local),
-                            LocalCommit(872c22f, "shared local/remote\n", local),
+                            LocalCommit(872c22f, "shared local/remote\n", local/remote(identity)),
                         ],
                         commits_unique_in_remote_tracking_branch: [
                             RemoteCommit(50d31c8, "unique remote\n",
@@ -660,6 +660,60 @@ fn single_commit_but_two_branches_both_in_ws_commit() -> anyhow::Result<()> {
 }
 
 #[test]
+fn single_commit_pushed_but_two_branches_both_in_ws_commit() -> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario(
+        "two-branches-one-advanced-two-parent-ws-commit-advanced-fully-pushed",
+    )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   335d6f2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    |\  
+    | * cbc6713 (origin/advanced-lane, advanced-lane) change
+    |/  
+    * fafd9d0 (origin/main, main, lane) init
+    ");
+
+    // For complexity, we also don't set up any branch metadata, only 'something' to get the target ref.
+    add_workspace(&mut meta);
+    let opts = standard_options();
+    let info = head_info(&repo, &*meta, opts)?;
+    insta::assert_debug_snapshot!(info, @r#"
+    RefInfo {
+        workspace_ref_name: Some(
+            FullName(
+                "refs/heads/gitbutler/workspace",
+            ),
+        ),
+        stacks: [
+            Stack {
+                base: Some(
+                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                ),
+                segments: [
+                    StackSegment {
+                        ref_name: "refs/heads/advanced-lane",
+                        remote_tracking_ref_name: "refs/remotes/origin/advanced-lane",
+                        ref_location: "ReachableFromWorkspaceCommit",
+                        commits_unique_from_tip: [
+                            LocalCommit(cbc6713, "change\n", local/remote(identity)),
+                        ],
+                        commits_unique_in_remote_tracking_branch: [],
+                        metadata: None,
+                    },
+                ],
+                stash_status: None,
+            },
+        ],
+        target_ref: Some(
+            FullName(
+                "refs/remotes/origin/main",
+            ),
+        ),
+    }
+    "#);
+    Ok(())
+}
+
+#[test]
 fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<()> {
     let (repo, mut meta) =
         read_only_in_memory_scenario("two-branches-one-advanced-ws-commit-on-top-of-stack")?;
@@ -960,7 +1014,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         ref_location: "ReachableFromWorkspaceCommit",
                         commits_unique_from_tip: [
-                            LocalCommit(d79bba9, "new file in A\n", local),
+                            LocalCommit(d79bba9, "new file in A\n", local/remote(identity)),
                         ],
                         commits_unique_in_remote_tracking_branch: [
                             RemoteCommit(89cc2d3, "change in A\n",
@@ -1034,7 +1088,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         ref_location: "ReachableFromWorkspaceCommit",
                         commits_unique_from_tip: [
-                            LocalCommit(d79bba9, "new file in A\n", local),
+                            LocalCommit(d79bba9, "new file in A\n", local/remote(identity)),
                         ],
                         commits_unique_in_remote_tracking_branch: [
                             RemoteCommit(89cc2d3, "change in A\n",
@@ -1118,7 +1172,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         ref_location: "ReachableFromWorkspaceCommit",
                         commits_unique_from_tip: [
-                            LocalCommit(d79bba9, "new file in A\n", local),
+                            LocalCommit(d79bba9, "new file in A\n", local/remote(identity)),
                         ],
                         commits_unique_in_remote_tracking_branch: [
                             RemoteCommit(89cc2d3, "change in A\n",
@@ -1214,15 +1268,7 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
                 "refs/heads/gitbutler/workspace",
             ),
         ),
-        stacks: [
-            Stack {
-                base: Some(
-                    Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
-                ),
-                segments: [],
-                stash_status: None,
-            },
-        ],
+        stacks: [],
         target_ref: Some(
             FullName(
                 "refs/remotes/origin/main",
@@ -1367,7 +1413,15 @@ mod utils {
         Inactive,
     }
 
-    // Add parameters as needed.
+    pub fn add_workspace(meta: &mut VirtualBranchesTomlMetadata) {
+        add_stack(
+            meta,
+            StackId::from_number_for_testing(u128::MAX),
+            "definitely outside of the workspace just to have it",
+            StackState::Inactive,
+        );
+    }
+
     pub fn add_stack(
         meta: &mut VirtualBranchesTomlMetadata,
         stack_id: StackId,
@@ -1421,6 +1475,8 @@ mod utils {
     }
 }
 use crate::ref_info::utils::standard_options;
-use crate::ref_info::with_workspace_commit::utils::{StackState, add_stack_with_segments};
+use crate::ref_info::with_workspace_commit::utils::{
+    StackState, add_stack_with_segments, add_workspace,
+};
 use utils::add_stack;
 pub use utils::read_only_in_memory_scenario;

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -821,7 +821,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
     * da83717 (origin/main) disjoint remote target
     ");
 
-    for (idx, name) in ["advanced-lane", "lane"].into_iter().enumerate() {
+    for (idx, name) in ["lane", "advanced-lane"].into_iter().enumerate() {
         add_stack(
             &mut meta,
             StackId::from_number_for_testing(idx as u128),
@@ -831,6 +831,154 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
     }
 
     let opts = standard_options();
+    let info = head_info(&repo, &*meta, opts)?;
+    insta::assert_debug_snapshot!(info, @r#"
+    RefInfo {
+        workspace_ref_name: Some(
+            FullName(
+                "refs/heads/gitbutler/workspace",
+            ),
+        ),
+        stacks: [
+            Stack {
+                base: None,
+                segments: [
+                    StackSegment {
+                        ref_name: "refs/heads/lane",
+                        remote_tracking_ref_name: "None",
+                        ref_location: "ReachableFromWorkspaceCommit",
+                        commits_unique_from_tip: [],
+                        commits_unique_in_remote_tracking_branch: [],
+                        metadata: Some(
+                            Branch {
+                                ref_info: RefInfo { created_at: None, updated_at: "1970-01-01 00:00:00 +0000" },
+                                description: None,
+                                review: Review { pull_request: None, review_id: None },
+                            },
+                        ),
+                    },
+                ],
+                stash_status: None,
+            },
+            Stack {
+                base: None,
+                segments: [
+                    StackSegment {
+                        ref_name: "refs/heads/advanced-lane",
+                        remote_tracking_ref_name: "None",
+                        ref_location: "ReachableFromWorkspaceCommit",
+                        commits_unique_from_tip: [
+                            LocalCommit(cbc6713, "change\n", local),
+                        ],
+                        commits_unique_in_remote_tracking_branch: [],
+                        metadata: Some(
+                            Branch {
+                                ref_info: RefInfo { created_at: None, updated_at: "1970-01-01 00:00:00 +0000" },
+                                description: None,
+                                review: Review { pull_request: None, review_id: None },
+                            },
+                        ),
+                    },
+                ],
+                stash_status: None,
+            },
+        ],
+        target_ref: Some(
+            FullName(
+                "refs/remotes/origin/main",
+            ),
+        ),
+    }
+    "#);
+
+    let info = ref_info(repo.find_reference("advanced-lane")?, &*meta, opts)?;
+    insta::assert_debug_snapshot!(info, @r#"
+    RefInfo {
+        workspace_ref_name: Some(
+            FullName(
+                "refs/heads/gitbutler/workspace",
+            ),
+        ),
+        stacks: [
+            Stack {
+                base: None,
+                segments: [
+                    StackSegment {
+                        ref_name: "refs/heads/advanced-lane",
+                        remote_tracking_ref_name: "None",
+                        ref_location: "ReachableFromWorkspaceCommit",
+                        commits_unique_from_tip: [
+                            LocalCommit(cbc6713, "change\n", local),
+                        ],
+                        commits_unique_in_remote_tracking_branch: [],
+                        metadata: Some(
+                            Branch {
+                                ref_info: RefInfo { created_at: None, updated_at: "1970-01-01 00:00:00 +0000" },
+                                description: None,
+                                review: Review { pull_request: None, review_id: None },
+                            },
+                        ),
+                    },
+                ],
+                stash_status: None,
+            },
+        ],
+        target_ref: Some(
+            FullName(
+                "refs/remotes/origin/main",
+            ),
+        ),
+    }
+    "#);
+
+    let info = ref_info(repo.find_reference("lane")?, &*meta, opts)?;
+    insta::assert_debug_snapshot!(info, @r#"
+    RefInfo {
+        workspace_ref_name: Some(
+            FullName(
+                "refs/heads/gitbutler/workspace",
+            ),
+        ),
+        stacks: [
+            Stack {
+                base: None,
+                segments: [
+                    StackSegment {
+                        ref_name: "refs/heads/lane",
+                        remote_tracking_ref_name: "None",
+                        ref_location: "ReachableFromWorkspaceCommit",
+                        commits_unique_from_tip: [],
+                        commits_unique_in_remote_tracking_branch: [],
+                        metadata: Some(
+                            Branch {
+                                ref_info: RefInfo { created_at: None, updated_at: "1970-01-01 00:00:00 +0000" },
+                                description: None,
+                                review: Review { pull_request: None, review_id: None },
+                            },
+                        ),
+                    },
+                ],
+                stash_status: None,
+            },
+        ],
+        target_ref: Some(
+            FullName(
+                "refs/remotes/origin/main",
+            ),
+        ),
+    }
+    "#);
+
+    meta.data_mut().branches.clear();
+    for (idx, name) in ["advanced-lane", "lane"].into_iter().enumerate() {
+        add_stack(
+            &mut meta,
+            StackId::from_number_for_testing(idx as u128),
+            name,
+            StackState::InWorkspace,
+        );
+    }
+
     let info = head_info(&repo, &*meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {


### PR DESCRIPTION
There are still a lot of fatal flaws resulting in errors and even panics. These should be fixed and it should 'generally' be working.
Write critical tests only.

Follow-up on #8730.

## Tasks

* [x] reproduce and fix segment-duplicates (see `docs` repo, and strange as it was fixed already)
* [ ] deal with `archived` flag
* [ ] more tests for unapplied stacks and branch listings.
* [x] **detection of pushed commits (see image below)**
* [ ] try normal workflow once, including the integration of a branch and its archival


## Possible Tasks

* [ ] A test for: commit in branch A has "foo" added, now try to create a commit with the removal of "foo" in branch B
* [ ] V3 of `get_branch_listing_details()`

## Notable changes to the Datamodel

* Upstream commits can also be integrated. This would happen if the local tracking branch has not caught up to them, and all of them are integrated. This also means that everything local could be unintegrated, but upstream-only commits are integrated, something that can happen if everything is diverged. If both disagree, it's unclear what to do.

## Notes for the Reviewer

* This is a transitory PR that replaces VirtualBranchesToml with the RefMetadata trait to prepare the code to transition to other data stores.
* The code is clearly transitory while `StackId`  is still a thing - in the new world stacks or stack-segments are referred to by their reference name or by their index in the parent-list of the top-level merge commit (if there is one).
* Ideally, one the UI will be able to make just one `heads_info` call, and can consume the data directly (even though it may have been processed to further facilitate consumption).
* `branch_details()` already works on references
* `BranchDetails` are probably the data structure of choice for the UI, and it's just the question if there is stack information or not.
* There is no notion of using stacks in branch listings outside of what we are currently looking at, i.e. where `HEAD` is. Thus, for this we will probably keep using branch details of sort.

## Next PR

- intermediate V3 version of `get_base_branch_data()`.

### Follow Up Tasks

* [ ] first non-workspace cases
    - [ ] merge commit
    - [ ] merge commit stacked
    - [ ] stacks and ambiguous stack references (i.e. lots of empty stack segments)

### Next PRs

* head-info, stacks and details API with key scenarios
* graph-based integration checks with target and remote
* **use `hide()` in places where merge-commits are used as boundary.**
    - This shouldn't be a major problem for simple topologies, but is certainly an issue for more complex ones.
* integration checking with target
* integration checking with remote tracking branch

### Known Shortcomings (for now)

* ⚠️ `first_parent_only` maybe a good simplification for display, but I wonder if there are side-effects like us not seeing commits that could participate in commit-status check.
* ⚠️ Commit-classification is hacky and undertested  right now⚠️
* One probably wants to show all refs at a position (or indicate there are more)
* ⚠️ rebase engine needs a way to know which parent to rewrite if there are two parents pointing to the same commit in a starting configuration with two stacks at the same commit. Alternatively, `create_commit` would have to create a workspace commit, which seems worse than adding a WS commit in the moment there are two stacks.
* ⚠️ **merge conflicts** are created from either cherry-picks or normal merges (legacy?), but cherry-pick would need to know that to either choose the auto-resolution. That's OK as long as the 'old' merge-commit isn't run as it would create a semantically different tree-setup in the conflicted commit.
* ⚠️ **commit listing** are ambiguous
    - Certain less common but possible branch configuration make ambiguous to assign commits to one branch or another. It won't be super trivial to make this work right.
* ⚠️Even though Git does not list *namespaced references*, `tig` will happily list everything. `set reference-format = hide:other` fixes this though
* empty commits aren't specifically highlighted when rebasing, or handled or prevented. The UI could detect that and show them.
* Moving hunks or files will need multi-branch rebases with merge-commit handling. This can be added to the rebase engine as we know it today. This will also enable worktree-updates.
* reordering in such a way that only heads a moved and nothing else happens (in terms of commit rewrites) probably wouldn't work yet in `but-rebase`.
* Index adjustments (tree to disk index) lack a lot of tests, particularly those for automatic conflict removal.
* if changes are added to the wrong spot, then they may apply cleanly *and* yield different results after merging, so the worktree differs from what's in Git. This is where hunk-dependencies/auto-hunk-splitting comes into play.
* Right now sub-hunks can't be selected as they won't match when it tries to find exact matches. However, that check could be changed to a 'contains' or 'is-included' to allow sub-hunks. Maybe this doesn't naturally work though or do the right thing.
* Workspace commits with a single branch will get signed if they were signed before. This shouldn't be a real problem, and ideally it will go away soon enough.


### For follow-up PRs

In any order (probably)

* Rebase-engine with insert empty commit (below and above, insert as first parent support)
* What happens in Git if one rebases non-linear branches? Can it retain the structure?
    - Rebase engine probably has to learn to re-schedule picks (and remember the base, a feature useful for multi-stacks as well, which then wouldn't need a special case anymore)
* ~~move file out of commit into worktree (uncommit something)~~
* ~~per-hunk exclusion if hunk didn't match (right now it rejects the whole file)~~
* run hooks on an index created from the tree that would be committed.
* move hunks from one commit into another


### Out of scope

* **hunk-dependencies**
    - These should be added once the commit-engine is feature-complete, the idea is that the UI can function well enough without them as a baseline.
* **atomic object writes**
    - In theory, new objects should only be written to disk if they actually end up in a tree. For instance, if a change is rejected, the object associated with it shouldn't be in the object database.
    - However, even though implementing this with the in-memory object feature is very possible, it feels like an optimization for another day. In general, I really think only objects that end up in a tree should actually be written, so that the implementation doesn't have to rely on `git gc` to cleanup.


