### PR TITLE
avoid panics when calculating hunk dependencies.

### DIFF
--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -195,8 +195,8 @@ impl HunkAssignment {
     }
 }
 
-#[instrument(skip(ctx), err(Debug))]
 /// Returns the current hunk assignments for the workspace.
+#[instrument(skip(ctx), err(Debug))]
 pub fn assignments(
     ctx: &mut CommandContext,
     set_assignment_from_locks: bool,

--- a/crates/but-hunk-dependency/src/lib.rs
+++ b/crates/but-hunk-dependency/src/lib.rs
@@ -133,6 +133,7 @@ use but_core::{TreeChange, UnifiedDiff};
 use gitbutler_oxidize::{ObjectIdExt, OidExt};
 use gitbutler_repo::logging::{LogUntil, RepositoryExt};
 use gix::prelude::ObjectIdExt as _;
+use gix::trace;
 pub use input::{InputCommit, InputDiffHunk, InputFile, InputStack};
 
 mod ranges;
@@ -187,7 +188,11 @@ pub fn tree_changes_to_input_files(
     for change in changes {
         let diff = change.unified_diff(repo, 0)?;
         let UnifiedDiff::Patch { hunks, .. } = diff else {
-            unreachable!("Test repos don't have file-size issue")
+            trace::warn!(
+                "Skipping change at '{}' as it doesn't have hunks to calculate dependencies for (binary/too large)",
+                change.path
+            );
+            continue;
         };
         let change_type = change.status.kind();
         files.push(InputFile {


### PR DESCRIPTION
These are now part of workspace changes (which might be a problem by itself), but until that can be changed, let's be sure it fails more gracefully by making these failures optional.

Thus, no panics, and failures to get hunks are non-fatal, while being logged.

This fixes a panic for me that prevented worktree changes to show up.