### PR TITLE
feat: add configurable options to svelte comment injector

### DIFF
--- a/packages/svelte-comment-injector/README.md
+++ b/packages/svelte-comment-injector/README.md
@@ -25,10 +25,30 @@ Add the preprocessor to your Svelte configuration:
 
 ```js
 // svelte.config.js
-import svelteDevtoolsComment from 'svelte-devtools-comment';
+import svelteInjectComment from 'svelte-devtools-comment';
 
 export default {
-	preprocess: [svelteDevtoolsComment()]
+	preprocess: [svelteInjectComment()]
+	// ...rest of your config
+};
+```
+
+## 🛠️ Configuration
+
+You can customize the comment format by passing options to the preprocessor:
+
+```js
+// svelte.config.js
+import svelteInjectComment from 'svelte-devtools-comment';
+
+export default {
+	preprocess: [
+		svelteInjectComment({
+			enabled: true, // Enable or disable the comment injection
+			showEndComment: true, // Show the end comment
+			showFullPath: false // Show the full path in the comment
+		})
+	]
 	// ...rest of your config
 };
 ```

--- a/packages/svelte-comment-injector/src/index.ts
+++ b/packages/svelte-comment-injector/src/index.ts
@@ -1,21 +1,36 @@
 import path from 'path';
 
+interface svelteInjectOptions {
+	enabled?: boolean;
+	showEndComment?: boolean;
+	showFullPath?: boolean;
+}
+
 /**
  * Svelte preprocessor that injects HTML comments at the start and end of each component — in dev only.
  */
-export default function svelteDevtoolsComment() {
-	const isDev = process.env.NODE_ENV === 'development';
+export default function svelteInjectComment(options: svelteInjectOptions = {}) {
+	const {
+		enabled = process.env.NODE_ENV === 'development',
+		showEndComment = true,
+		showFullPath = false
+	} = options;
 
 	return {
-		markup({ content, filename }: { content: string; filename?: string }) {
-			if (!isDev) return { code: content };
+		markup({ content, filename }: { content: string; filename?: string }): { code: string } {
+			if (!enabled || !filename) return { code: content };
 
-			const file = filename ? path.basename(filename) : 'Unknown.svelte';
-			const start = `{@html '<!-- Begin ${file} -->'}`;
-			const end = `{@html '<!-- End ${file} -->'}`;
+			const filePath = showFullPath
+				? filename.replace(process.cwd() + '/', '')
+				: path.basename(filename);
+
+			const startComment = `{@html '<!-- Begin ${filePath} -->'}`;
+			const endComment = `{@html '<!-- End ${filePath} -->'}`;
 
 			// Inject start after the opening script/style blocks, and end at the bottom
-			const injected = `${start}\n${content}\n${end}`;
+			const injected = showEndComment
+				? `${startComment}\n${content}\n${endComment}`
+				: `${startComment}\n${content}`;
 			return { code: injected };
 		}
 	};


### PR DESCRIPTION
Introduce options to enable/disable injection, toggle end comment,
and choose between full path or filename in injected comments.
Update README with usage and configuration details to improve
flexibility and developer control during development.