### PR TITLE
Swap the order in which the applied branches is read

### DIFF
--- a/apps/desktop/src/components/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/IntegrateUpstreamModal.svelte
@@ -122,8 +122,8 @@
 	// Fetch the reviews for the applied branches
 	$effect(() => {
 		if (
-			filteredReviews === undefined &&
 			appliedBranches !== undefined &&
+			filteredReviews === undefined &&
 			forgeListingService !== undefined
 		) {
 			if (appliedBranches.length === 0) {


### PR DESCRIPTION
It seems like the order in which the reactive values is read affects the way in which the effects run.

Ensure first that there are some applied branches and then the rest of the information