### PR TITLE
ref-info: normal workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3302,7 +3302,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.72.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "gix-actor 0.35.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-attributes 0.26.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3373,7 +3373,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.35.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "gix-date 0.10.2 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3404,7 +3404,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.26.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "gix-glob 0.20.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3430,7 +3430,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.14"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "thiserror 2.0.12",
 ]
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "thiserror 2.0.12",
 ]
@@ -3455,7 +3455,7 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.6.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "gix-path 0.10.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3480,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "gix-chunk 0.4.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3493,7 +3493,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.45.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -3513,7 +3513,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -3525,7 +3525,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3556,7 +3556,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.10.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "itoa 1.0.15",
@@ -3569,7 +3569,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.52.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "gix-attributes 0.26.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3592,7 +3592,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.14.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "gix-discover 0.40.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3627,7 +3627,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.40.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "dunce",
@@ -3656,7 +3656,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.42.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -3676,7 +3676,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.19.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -3710,7 +3710,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "fastrand",
@@ -3735,7 +3735,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.20.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -3759,7 +3759,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.18.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "faster-hex",
  "gix-features 0.42.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3782,7 +3782,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.8.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "gix-hash 0.18.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "hashbrown 0.14.5",
@@ -3805,7 +3805,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "gix-glob 0.20.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.40.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -3885,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "17.1.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "gix-tempfile 17.1.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.27.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "gix-actor 0.35.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3907,7 +3907,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.5.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3931,7 +3931,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.20.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bitflags 2.9.1",
  "gix-commitgraph 0.28.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3967,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.49.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "gix-actor 0.35.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3988,7 +3988,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.69.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "arc-swap",
  "gix-date 0.10.2 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4009,7 +4009,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.59.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "clru",
  "gix-chunk 0.4.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4030,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4041,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4066,7 +4066,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.18"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "gix-trace 0.1.12 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4079,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -4093,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4105,7 +4105,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.50.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -4142,7 +4142,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4173,7 +4173,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.52.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "gix-actor 0.35.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-features 0.42.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4194,7 +4194,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.30.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "gix-hash 0.18.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4207,7 +4207,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.34.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -4240,7 +4240,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.20.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "gix-commitgraph 0.28.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-date 0.10.2 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4266,7 +4266,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bitflags 2.9.1",
  "gix-path 0.10.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4278,7 +4278,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.4.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "gix-hash 0.18.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4290,7 +4290,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "filetime",
@@ -4312,7 +4312,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "gix-config",
@@ -4341,7 +4341,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "17.1.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "dashmap",
  "gix-fs 0.15.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4384,7 +4384,7 @@ checksum = "7c396a2036920c69695f760a65e7f2677267ccf483f25046977d87e4cb2665f7"
 [[package]]
 name = "gix-trace"
 version = "0.1.12"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "tracing-core",
 ]
@@ -4392,7 +4392,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.47.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -4428,7 +4428,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.46.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bitflags 2.9.1",
  "gix-commitgraph 0.28.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4444,7 +4444,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "gix-features 0.42.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4468,7 +4468,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4488,7 +4488,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "thiserror 2.0.12",
@@ -4516,7 +4516,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.41.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "gix-attributes 0.26.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4535,7 +4535,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#874cc388e1e6af558e7cab4e9238f447e8c122e1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#249bf9a2add29caa339c5f9783dd63f87a718c6e"
 dependencies = [
  "bstr",
  "gix-features 0.42.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -5310,9 +5310,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02000660d30638906021176af16b17498bd0d12813dbfe7b276d8bc7f3c0806"
+checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -5325,9 +5325,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c30758ddd7188629c6713fc45d1188af4f44c90582311d0c8d8c9907f60c48"
+checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10005,7 +10005,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/but-workspace/tests/fixtures/scenario/with-remotes-and-workspace.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/with-remotes-and-workspace.sh
@@ -252,6 +252,28 @@ git init three-branches-one-advanced-ws-commit-advanced-fully-pushed-empty-depen
   create_workspace_commit_once advanced-lane
 )
 
+git init two-dependent-branches-first-merge-no-ff
+(cd two-dependent-branches-first-merge-no-ff
+  git commit -m "init" --allow-empty
+  setup_target_to_match_main
+
+  git checkout -b A
+  echo a >a && git add a && git commit -m "change in A"
+  remote_tracking_caught_up A
+
+  git checkout -b B-on-A
+  echo b >b && git add b && git commit -m "change in B"
+  remote_tracking_caught_up B-on-A
+
+  create_workspace_commit_once B-on-A
+
+  tick
+  git checkout -b new-origin-main main && git merge --no-ff A
+  setup_remote_tracking new-origin-main main 'move'
+
+  git checkout gitbutler/workspace
+)
+
 git init two-dependent-branches-rebased-with-remotes
 (cd two-dependent-branches-rebased-with-remotes
   git commit -m "init" --allow-empty

--- a/crates/but-workspace/tests/fixtures/scenario/with-remotes-and-workspace.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/with-remotes-and-workspace.sh
@@ -282,6 +282,12 @@ git init two-dependent-branches-rebased-with-remotes
   setup_remote_tracking future-remote-B B-on-A 'move'
 )
 
+cp -R two-dependent-branches-rebased-with-remotes two-dependent-branches-rebased-explicit-remote-in-extra-segment
+(cd two-dependent-branches-rebased-explicit-remote-in-extra-segment
+  # This officially 'claims' the remote 'origin/A' so it's not deduced anymore.
+  git branch base-of-A origin/A
+)
+
 git init two-branches-one-advanced-ws-commit-on-top-of-stack
 (cd two-branches-one-advanced-ws-commit-on-top-of-stack
   git commit -m "init" --allow-empty

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -273,6 +273,92 @@ fn two_dependent_branches_rebased_explicit_remote_in_extra_segment() -> anyhow::
 }
 
 #[test]
+fn two_dependent_branches_first_merged_no_ff() -> anyhow::Result<()> {
+    let (repo, mut meta) =
+        read_only_in_memory_scenario("two-dependent-branches-first-merge-no-ff")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   a455fe7 (origin/main) Merge branch 'A' into new-origin-main
+    |\  
+    | | * 4a62dfc (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | | * de11c03 (origin/B-on-A, B-on-A) change in B
+    | |/  
+    | * 0ee3a9e (origin/A, A) change in A
+    |/  
+    * fafd9d0 (main) init
+    ");
+
+    add_stack_with_segments(
+        &mut meta,
+        StackId::from_number_for_testing(0),
+        "B-on-A",
+        StackState::InWorkspace,
+        &["A"],
+    );
+
+    let opts = standard_options();
+    // TODO: needs one integrated commit 'change in A'.
+    let info = head_info(&repo, &*meta, opts)?;
+    insta::assert_debug_snapshot!(info, @r#"
+    RefInfo {
+        workspace_ref_name: Some(
+            FullName(
+                "refs/heads/gitbutler/workspace",
+            ),
+        ),
+        stacks: [
+            Stack {
+                base: Some(
+                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                ),
+                segments: [
+                    StackSegment {
+                        ref_name: "refs/heads/B-on-A",
+                        remote_tracking_ref_name: "refs/remotes/origin/B-on-A",
+                        ref_location: "ReachableFromWorkspaceCommit",
+                        commits_unique_from_tip: [
+                            LocalCommit(de11c03, "change in B\n", local/remote(identity)),
+                        ],
+                        commits_unique_in_remote_tracking_branch: [],
+                        metadata: Some(
+                            Branch {
+                                ref_info: RefInfo { created_at: None, updated_at: "1970-01-01 00:00:00 +0000" },
+                                description: None,
+                                review: Review { pull_request: None, review_id: None },
+                            },
+                        ),
+                    },
+                    StackSegment {
+                        ref_name: "refs/heads/A",
+                        remote_tracking_ref_name: "refs/remotes/origin/A",
+                        ref_location: "ReachableFromWorkspaceCommit",
+                        commits_unique_from_tip: [
+                            LocalCommit(0ee3a9e, "change in A\n", integrated),
+                        ],
+                        commits_unique_in_remote_tracking_branch: [],
+                        metadata: Some(
+                            Branch {
+                                ref_info: RefInfo { created_at: None, updated_at: "1970-01-01 00:00:00 +0000" },
+                                description: None,
+                                review: Review { pull_request: None, review_id: None },
+                            },
+                        ),
+                    },
+                ],
+                stash_status: None,
+            },
+        ],
+        target_ref: Some(
+            FullName(
+                "refs/remotes/origin/main",
+            ),
+        ),
+    }
+    "#);
+
+    Ok(())
+}
+
+#[test]
 fn target_ahead_remote_rewritten() -> anyhow::Result<()> {
     let (repo, mut meta) = read_only_in_memory_scenario("target-ahead-remote-rewritten")?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
@@ -1417,7 +1503,9 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
         ),
         stacks: [
             Stack {
-                base: None,
+                base: Some(
+                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                ),
                 segments: [
                     StackSegment {
                         ref_name: "refs/heads/lane",
@@ -1437,7 +1525,9 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 stash_status: None,
             },
             Stack {
-                base: None,
+                base: Some(
+                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                ),
                 segments: [
                     StackSegment {
                         ref_name: "refs/heads/advanced-lane",
@@ -1477,7 +1567,9 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
         ),
         stacks: [
             Stack {
-                base: None,
+                base: Some(
+                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                ),
                 segments: [
                     StackSegment {
                         ref_name: "refs/heads/advanced-lane",
@@ -1517,7 +1609,9 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
         ),
         stacks: [
             Stack {
-                base: None,
+                base: Some(
+                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                ),
                 segments: [
                     StackSegment {
                         ref_name: "refs/heads/lane",
@@ -1565,7 +1659,9 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
         ),
         stacks: [
             Stack {
-                base: None,
+                base: Some(
+                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                ),
                 segments: [
                     StackSegment {
                         ref_name: "refs/heads/advanced-lane",
@@ -1587,7 +1683,9 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 stash_status: None,
             },
             Stack {
-                base: None,
+                base: Some(
+                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                ),
                 segments: [
                     StackSegment {
                         ref_name: "refs/heads/lane",

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -92,6 +92,90 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
 }
 
 #[test]
+fn two_dependent_branches_rebased_with_remotes() -> anyhow::Result<()> {
+    let (repo, mut meta) =
+        read_only_in_memory_scenario("two-dependent-branches-rebased-with-remotes")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * e26f4fd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 31b3f92 (B-on-A) change in B
+    * 51db0ec (A) change after push
+    | * ec39463 (origin/B-on-A) change in B
+    |/  
+    * 807f596 (origin/A) change in A
+    * fafd9d0 (origin/main, main) init
+    ");
+
+    add_stack_with_segments(
+        &mut meta,
+        StackId::from_number_for_testing(0),
+        "B-on-A",
+        StackState::InWorkspace,
+        &["A"],
+    );
+
+    let opts = standard_options();
+    let info = head_info(&repo, &*meta, opts)?;
+    insta::assert_debug_snapshot!(info, @r#"
+    RefInfo {
+        workspace_ref_name: Some(
+            FullName(
+                "refs/heads/gitbutler/workspace",
+            ),
+        ),
+        stacks: [
+            Stack {
+                base: Some(
+                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                ),
+                segments: [
+                    StackSegment {
+                        ref_name: "refs/heads/B-on-A",
+                        remote_tracking_ref_name: "refs/remotes/origin/B-on-A",
+                        ref_location: "ReachableFromWorkspaceCommit",
+                        commits_unique_from_tip: [
+                            LocalCommit(31b3f92, "change in B\n", local/remote(similarity)),
+                        ],
+                        commits_unique_in_remote_tracking_branch: [],
+                        metadata: Some(
+                            Branch {
+                                ref_info: RefInfo { created_at: None, updated_at: "1970-01-01 00:00:00 +0000" },
+                                description: None,
+                                review: Review { pull_request: None, review_id: None },
+                            },
+                        ),
+                    },
+                    StackSegment {
+                        ref_name: "refs/heads/A",
+                        remote_tracking_ref_name: "refs/remotes/origin/A",
+                        ref_location: "ReachableFromWorkspaceCommit",
+                        commits_unique_from_tip: [
+                            LocalCommit(51db0ec, "change after push\n", local),
+                            LocalCommit(807f596, "change in A\n", local/remote(identity)),
+                        ],
+                        commits_unique_in_remote_tracking_branch: [],
+                        metadata: Some(
+                            Branch {
+                                ref_info: RefInfo { created_at: None, updated_at: "1970-01-01 00:00:00 +0000" },
+                                description: None,
+                                review: Review { pull_request: None, review_id: None },
+                            },
+                        ),
+                    },
+                ],
+                stash_status: None,
+            },
+        ],
+        target_ref: Some(
+            FullName(
+                "refs/remotes/origin/main",
+            ),
+        ),
+    }
+    "#);
+    Ok(())
+}
+
+#[test]
 fn target_ahead_remote_rewritten() -> anyhow::Result<()> {
     let (repo, mut meta) = read_only_in_memory_scenario("target-ahead-remote-rewritten")?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
@@ -1001,6 +1085,86 @@ fn single_commit_pushed_ws_commit_empty_dependant() -> anyhow::Result<()> {
                     StackSegment {
                         ref_name: "refs/heads/advanced-lane",
                         remote_tracking_ref_name: "refs/remotes/origin/advanced-lane",
+                        ref_location: "ReachableFromWorkspaceCommit",
+                        commits_unique_from_tip: [
+                            LocalCommit(cbc6713, "change\n", local/remote(identity)),
+                        ],
+                        commits_unique_in_remote_tracking_branch: [],
+                        metadata: Some(
+                            Branch {
+                                ref_info: RefInfo { created_at: None, updated_at: "1970-01-01 00:00:00 +0000" },
+                                description: None,
+                                review: Review { pull_request: None, review_id: None },
+                            },
+                        ),
+                    },
+                ],
+                stash_status: None,
+            },
+        ],
+        target_ref: Some(
+            FullName(
+                "refs/remotes/origin/main",
+            ),
+        ),
+    }
+    "#);
+    Ok(())
+}
+
+#[test]
+fn two_branches_stracked_with_remotes() -> anyhow::Result<()> {
+    let (repo, mut meta) =
+        read_only_in_memory_scenario("two-dependent-branches-with-one-commit-with-remotes")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 9b3cfd4 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 788ad06 (origin/on-top-of-lane, on-top-of-lane) change on top
+    * cbc6713 (origin/lane, lane) change
+    * fafd9d0 (origin/main, main) init
+    ");
+
+    add_stack_with_segments(
+        &mut meta,
+        StackId::from_number_for_testing(0),
+        "on-top-of-lane",
+        StackState::InWorkspace,
+        &["lane"],
+    );
+
+    let opts = standard_options();
+    let info = head_info(&repo, &*meta, opts)?;
+    insta::assert_debug_snapshot!(info, @r#"
+    RefInfo {
+        workspace_ref_name: Some(
+            FullName(
+                "refs/heads/gitbutler/workspace",
+            ),
+        ),
+        stacks: [
+            Stack {
+                base: Some(
+                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                ),
+                segments: [
+                    StackSegment {
+                        ref_name: "refs/heads/on-top-of-lane",
+                        remote_tracking_ref_name: "refs/remotes/origin/on-top-of-lane",
+                        ref_location: "ReachableFromWorkspaceCommit",
+                        commits_unique_from_tip: [
+                            LocalCommit(788ad06, "change on top\n", local/remote(identity)),
+                        ],
+                        commits_unique_in_remote_tracking_branch: [],
+                        metadata: Some(
+                            Branch {
+                                ref_info: RefInfo { created_at: None, updated_at: "1970-01-01 00:00:00 +0000" },
+                                description: None,
+                                review: Review { pull_request: None, review_id: None },
+                            },
+                        ),
+                    },
+                    StackSegment {
+                        ref_name: "refs/heads/lane",
+                        remote_tracking_ref_name: "refs/remotes/origin/lane",
                         ref_location: "ReachableFromWorkspaceCommit",
                         commits_unique_from_tip: [
                             LocalCommit(cbc6713, "change\n", local/remote(identity)),


### PR DESCRIPTION
There are still a lot of fatal flaws resulting in errors and even panics. These should be fixed and it should 'generally' be working.
Write critical tests only.

Follow-up on #8815.

## Tasks

* [ ] try normal workflow once, including the integration of a branch and its archival
    - [ ] figure out what should happen after merge (is that the archived flag?)
* [ ] deal with `archived` flag
* [ ] more tests for unapplied stacks and branch listings
    - [ ] `apply` and `unapply` testing)
* [x] ‼️update to `gix` on `main`

## Possible Tasks

* [ ] a single branch can be applied multiple times and will then show up multiple times as parent to the workspace commit
* [ ] A test for: commit in branch A has "foo" added, now try to create a commit with the removal of "foo" in branch B
* [ ] V3 of `get_branch_listing_details()`

## Notable changes to the Datamodel

* Upstream commits can also be integrated. This would happen if the local tracking branch has not caught up to them, and all of them are integrated. This also means that everything local could be unintegrated, but upstream-only commits are integrated, something that can happen if everything is diverged. If both disagree, it's unclear what to do.

## Notes for the Reviewer

* This is a transitory PR that replaces VirtualBranchesToml with the RefMetadata trait to prepare the code to transition to other data stores.
* The code is clearly transitory while `StackId`  is still a thing - in the new world stacks or stack-segments are referred to by their reference name or by their index in the parent-list of the top-level merge commit (if there is one).
* Ideally, one the UI will be able to make just one `heads_info` call, and can consume the data directly (even though it may have been processed to further facilitate consumption).
* `branch_details()` already works on references
* `BranchDetails` are probably the data structure of choice for the UI, and it's just the question if there is stack information or not.
* There is no notion of using stacks in branch listings outside of what we are currently looking at, i.e. where `HEAD` is. Thus, for this we will probably keep using branch details of sort.

## Next PR

- intermediate V3 version of `get_base_branch_data()`.

### Follow Up Tasks

* [ ] first non-workspace cases
    - [ ] merge commit
    - [ ] merge commit stacked
    - [ ] stacks and ambiguous stack references (i.e. lots of empty stack segments)

### Next PRs

* head-info, stacks and details API with key scenarios
* graph-based integration checks with target and remote
* **use `hide()` in places where merge-commits are used as boundary.**
    - This shouldn't be a major problem for simple topologies, but is certainly an issue for more complex ones.
* integration checking with target
* integration checking with remote tracking branch

### Known Shortcomings (for now)

* ⚠️ `first_parent_only` maybe a good simplification for display, but I wonder if there are side-effects like us not seeing commits that could participate in commit-status check.
* ⚠️ Commit-classification is hacky and undertested  right now⚠️
* One probably wants to show all refs at a position (or indicate there are more)
* ⚠️ rebase engine needs a way to know which parent to rewrite if there are two parents pointing to the same commit in a starting configuration with two stacks at the same commit. Alternatively, `create_commit` would have to create a workspace commit, which seems worse than adding a WS commit in the moment there are two stacks.
* ⚠️ **merge conflicts** are created from either cherry-picks or normal merges (legacy?), but cherry-pick would need to know that to either choose the auto-resolution. That's OK as long as the 'old' merge-commit isn't run as it would create a semantically different tree-setup in the conflicted commit.
* ⚠️ **commit listing** are ambiguous
    - Certain less common but possible branch configuration make ambiguous to assign commits to one branch or another. It won't be super trivial to make this work right.
* ⚠️Even though Git does not list *namespaced references*, `tig` will happily list everything. `set reference-format = hide:other` fixes this though
* empty commits aren't specifically highlighted when rebasing, or handled or prevented. The UI could detect that and show them.
* Moving hunks or files will need multi-branch rebases with merge-commit handling. This can be added to the rebase engine as we know it today. This will also enable worktree-updates.
* reordering in such a way that only heads a moved and nothing else happens (in terms of commit rewrites) probably wouldn't work yet in `but-rebase`.
* Index adjustments (tree to disk index) lack a lot of tests, particularly those for automatic conflict removal.
* if changes are added to the wrong spot, then they may apply cleanly *and* yield different results after merging, so the worktree differs from what's in Git. This is where hunk-dependencies/auto-hunk-splitting comes into play.
* Right now sub-hunks can't be selected as they won't match when it tries to find exact matches. However, that check could be changed to a 'contains' or 'is-included' to allow sub-hunks. Maybe this doesn't naturally work though or do the right thing.
* Workspace commits with a single branch will get signed if they were signed before. This shouldn't be a real problem, and ideally it will go away soon enough.


### For follow-up PRs

In any order (probably)

* Rebase-engine with insert empty commit (below and above, insert as first parent support)
* What happens in Git if one rebases non-linear branches? Can it retain the structure?
    - Rebase engine probably has to learn to re-schedule picks (and remember the base, a feature useful for multi-stacks as well, which then wouldn't need a special case anymore)
* ~~move file out of commit into worktree (uncommit something)~~
* ~~per-hunk exclusion if hunk didn't match (right now it rejects the whole file)~~
* run hooks on an index created from the tree that would be committed.
* move hunks from one commit into another


### Out of scope

* **hunk-dependencies**
    - These should be added once the commit-engine is feature-complete, the idea is that the UI can function well enough without them as a baseline.
* **atomic object writes**
    - In theory, new objects should only be written to disk if they actually end up in a tree. For instance, if a change is rejected, the object associated with it shouldn't be in the object database.
    - However, even though implementing this with the in-memory object feature is very possible, it feels like an optimization for another day. In general, I really think only objects that end up in a tree should actually be written, so that the implementation doesn't have to rely on `git gc` to cleanup.



