### PR TITLE
fix(integrate-upstream): simplify loading condition in modal buttons

### DIFF
--- a/apps/desktop/src/components/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/IntegrateUpstreamModal.svelte
@@ -356,9 +356,7 @@
 				type="submit"
 				style="pop"
 				disabled={isDivergedResolved || !branchStatuses}
-				loading={integratingUpstream === 'loading' ||
-					!branchStatuses ||
-					filteredReviews === undefined}>Update workspace</Button
+				loading={integratingUpstream === 'loading' || !branchStatuses}>Update workspace</Button
 			>
 		</div>
 	{/snippet}

--- a/apps/desktop/src/components/v3/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/v3/IntegrateUpstreamModal.svelte
@@ -396,9 +396,7 @@
 				wide
 				style="pop"
 				disabled={isDivergedResolved || !branchStatuses}
-				loading={integratingUpstream === 'loading' ||
-					!branchStatuses ||
-					filteredReviews === undefined}
+				loading={integratingUpstream === 'loading' || !branchStatuses}
 				onclick={async (e) => {
 					await integrate(e);
 				}}


### PR DESCRIPTION
Remove unnecessary check for filteredReviews being undefined in the
loading state of the Update workspace buttons.