### PR TITLE
Fix Spelling error in Forge form

### DIFF
--- a/apps/desktop/src/components/ForgeForm.svelte
+++ b/apps/desktop/src/components/ForgeForm.svelte
@@ -90,8 +90,8 @@
 		</Select>
 	{:else}
 		<p class="text-13">
-			We have determiend that you are currently using <code>{$determinedForgeType}</code>. We
-			currently do not support overriding an automatically determiend forge type.
+			We have determined that you are currently using <code>{$determinedForgeType}</code>. We
+			currently do not support overriding an automatically determined forge type.
 		</p>
 	{/if}
 </SectionCard>


### PR DESCRIPTION
## 🧢 Changes

This pull request fixes a typo in the `ForgeForm.svelte` file. The word "determiend" has been corrected to "determined" in two places.