### PR TITLE
Implement a reload signal that can be consumed in the frontend and reload the workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,7 @@ dependencies = [
  "gitbutler-branch",
  "gitbutler-branch-actions",
  "gitbutler-command-context",
+ "gitbutler-filemonitor",
  "gitbutler-operating-modes",
  "gitbutler-oplog",
  "gitbutler-oxidize",

--- a/crates/but-action/Cargo.toml
+++ b/crates/but-action/Cargo.toml
@@ -27,6 +27,7 @@ gitbutler-oplog.workspace = true
 gitbutler-oxidize.workspace = true
 gitbutler-project.workspace = true
 gitbutler-reference.workspace = true
+gitbutler-filemonitor.workspace = true
 but-core.workspace = true
 but-db.workspace = true
 but-workspace.workspace = true

--- a/crates/but-action/src/simple.rs
+++ b/crates/but-action/src/simple.rs
@@ -62,6 +62,7 @@ pub fn handle_changes(
         ),
     )?;
 
+    gitbutler_filemonitor::send_reload_signal(&ctx.project().gb_dir());
     response
 }
 

--- a/crates/gitbutler-filemonitor/src/events.rs
+++ b/crates/gitbutler-filemonitor/src/events.rs
@@ -13,6 +13,7 @@ pub enum InternalEvent {
     ProjectFilesChange(ProjectId, Vec<PathBuf>),
     // Triggered on change in the `.git/gitbutler` directory
     GitButlerOplogChange(ProjectId),
+    ReloadSignal(ProjectId),
 }
 
 impl Display for InternalEvent {
@@ -38,6 +39,7 @@ impl Display for InternalEvent {
                 )
             }
             InternalEvent::CalculateVirtualBranches(pid) => write!(f, "VirtualBranch({})", pid),
+            InternalEvent::ReloadSignal(project_id) => write!(f, "ReloadSignal({})", project_id),
         }
     }
 }
@@ -55,5 +57,15 @@ fn comma_separated_paths(paths: &[PathBuf]) -> String {
         format!("{listing} […{remaining} more]")
     } else {
         listing
+    }
+}
+
+pub const RELOAD_SIGNAL_FILE: &str = "butler_signal";
+
+/// Creates a signal file intended to trigger a reload of the workspace.
+pub fn send_reload_signal(gb_dir: &std::path::Path) {
+    let file_path = gb_dir.join(RELOAD_SIGNAL_FILE);
+    if let Err(e) = std::fs::File::create(&file_path) {
+        tracing::warn!("Failed to create reload signal file: {e}");
     }
 }

--- a/crates/gitbutler-filemonitor/src/lib.rs
+++ b/crates/gitbutler-filemonitor/src/lib.rs
@@ -6,4 +6,5 @@ mod events;
 
 pub use events::InternalEvent;
 mod file_monitor;
+pub use events::send_reload_signal;
 pub use file_monitor::spawn;

--- a/crates/gitbutler-tauri/src/window.rs
+++ b/crates/gitbutler-tauri/src/window.rs
@@ -67,6 +67,11 @@ pub(crate) mod state {
                         payload: serde_json::json!(&changes),
                         project_id,
                     },
+                    Change::ReloadSignal(project_id) => ChangeForFrontend {
+                        name: format!("project://{}/reload", project_id),
+                        payload: serde_json::json!({}),
+                        project_id,
+                    },
                 }
             }
         }

--- a/crates/gitbutler-watcher/src/events.rs
+++ b/crates/gitbutler-watcher/src/events.rs
@@ -52,4 +52,5 @@ pub enum Change {
         project_id: ProjectId,
         changes: but_hunk_assignment::WorktreeChanges,
     },
+    ReloadSignal(ProjectId),
 }

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -83,6 +83,11 @@ impl Handler {
                 self.calculate_virtual_branches(&ctx, None)
                     .context("failed to handle virtual branch event")
             }
+
+            InternalEvent::ReloadSignal(project_id) => {
+                // This is a signal to reload the app, so we just emit an event.
+                self.emit_app_event(Change::ReloadSignal(project_id))
+            }
         }
     }
 


### PR DESCRIPTION
In the frontend we can do something like
```ts

	import { listen } from '$lib/backend/ipc';
	import { ClientState } from '$lib/state/clientState.svelte';
	import { getContext } from '@gitbutler/shared/context';
	const clientState = getContext(ClientState);
	$effect(() => {
		const unsubscribe = listen(`project://${projectId}/reload`, (event) => {
			clientState.backendApi.util.resetApiState();
		});
		return () => unsubscribe();
	});
```

However, it seems like `clientState.backendApi.util.resetApiState();` does not seem to work, so skipping this for now