### PR TITLE
butler-actions-reverting

### DIFF
--- a/apps/desktop/src/components/v3/ActionLog.svelte
+++ b/apps/desktop/src/components/v3/ActionLog.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import ReduxResult from '$components/ReduxResult.svelte';
+	import ActionLogFilesChanged from '$components/v3/ActionLogFilesChanged.svelte';
 	import ActionLogItem from '$components/v3/ActionLogMcpItem.svelte';
 	import ActionService from '$lib/actions/actionService.svelte';
 	import { inject } from '@gitbutler/shared/context';
@@ -46,14 +47,29 @@
 							{@const lastInPage = i === actions.actions.length - 1}
 							{@const last = lastInPage && page === pages.at(-1)!}
 							{@const p = previous(pi, i, lastInPage, last)}
-							{#if action.action.type === 'mcpAction' && (!p || p.action.type === 'mcpAction')}
+							{#if action.action.type === 'mcpAction'}
 								<ActionLogItem
 									{projectId}
 									action={action as ButlerAction & { action: { type: 'mcpAction' } }}
 									{last}
 									{loadNextPage}
+								/>
+							{/if}
+							{#if p}
+								{@const after =
+									action.action.type === 'mcpAction'
+										? action.action.subject.snapshotBefore
+										: action.action.subject.snapshot}
+								{@const before =
+									p.action.type === 'mcpAction'
+										? p.action.subject.snapshotAfter
+										: p.action.subject.snapshot}
+								<ActionLogFilesChanged
+									{projectId}
+									{before}
+									{after}
 									{selectionId}
-									previous={p as (ButlerAction & { action: { type: 'mcpAction' } }) | undefined}
+									timestamp={action.createdAt}
 								/>
 							{/if}
 						{/each}

--- a/apps/desktop/src/components/v3/ActionLog.svelte
+++ b/apps/desktop/src/components/v3/ActionLog.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import ReduxResult from '$components/ReduxResult.svelte';
-	import ActionLogItem from '$components/v3/ActionLogItem.svelte';
+	import ActionLogItem from '$components/v3/ActionLogMcpItem.svelte';
 	import ActionService from '$lib/actions/actionService.svelte';
 	import { inject } from '@gitbutler/shared/context';
 	import { untrack } from 'svelte';
+	import type { ButlerAction } from '$lib/actions/types';
 	import type { SelectionId } from '$lib/selection/key';
 
 	type Props = {
@@ -44,14 +45,17 @@
 						{#each actions.actions as action, i (action.id)}
 							{@const lastInPage = i === actions.actions.length - 1}
 							{@const last = lastInPage && page === pages.at(-1)!}
-							<ActionLogItem
-								{projectId}
-								{action}
-								{last}
-								{loadNextPage}
-								{selectionId}
-								previous={previous(pi, i, lastInPage, last)}
-							/>
+							{@const p = previous(pi, i, lastInPage, last)}
+							{#if action.action.type === 'mcpAction' && (!p || p.action.type === 'mcpAction')}
+								<ActionLogItem
+									{projectId}
+									action={action as ButlerAction & { action: { type: 'mcpAction' } }}
+									{last}
+									{loadNextPage}
+									{selectionId}
+									previous={p as (ButlerAction & { action: { type: 'mcpAction' } }) | undefined}
+								/>
+							{/if}
 						{/each}
 					{/snippet}
 				</ReduxResult>

--- a/apps/desktop/src/components/v3/ActionLog.svelte
+++ b/apps/desktop/src/components/v3/ActionLog.svelte
@@ -2,6 +2,7 @@
 	import ReduxResult from '$components/ReduxResult.svelte';
 	import ActionLogFilesChanged from '$components/v3/ActionLogFilesChanged.svelte';
 	import ActionLogItem from '$components/v3/ActionLogMcpItem.svelte';
+	import ActionLogRevertItem from '$components/v3/ActionLogRevertItem.svelte';
 	import ActionService from '$lib/actions/actionService.svelte';
 	import { inject } from '@gitbutler/shared/context';
 	import { untrack } from 'svelte';
@@ -51,6 +52,13 @@
 								<ActionLogItem
 									{projectId}
 									action={action as ButlerAction & { action: { type: 'mcpAction' } }}
+									{last}
+									{loadNextPage}
+								/>
+							{:else}
+								<ActionLogRevertItem
+									{projectId}
+									action={action as ButlerAction & { action: { type: 'revertAction' } }}
 									{last}
 									{loadNextPage}
 								/>

--- a/apps/desktop/src/components/v3/ActionLogFilesChanged.svelte
+++ b/apps/desktop/src/components/v3/ActionLogFilesChanged.svelte
@@ -1,0 +1,209 @@
+<script lang="ts">
+	import ReduxResult from '$components/ReduxResult.svelte';
+	import DataContextMenu from '$components/v3/DataContextMenu.svelte';
+	import FileList from '$components/v3/FileList.svelte';
+	import { snapshotChangesFocusableId } from '$lib/focus/focusManager.svelte';
+	import { focusable } from '$lib/focus/focusable.svelte';
+	import { HistoryService } from '$lib/history/history';
+	import { OplogService } from '$lib/history/oplogService.svelte';
+	import { getContext } from '@gitbutler/shared/context';
+	import Button from '@gitbutler/ui/Button.svelte';
+	import Icon from '@gitbutler/ui/Icon.svelte';
+	import TimeAgo from '@gitbutler/ui/TimeAgo.svelte';
+	import { getContext as svelteGetContext, untrack } from 'svelte';
+	import type { SelectionId } from '$lib/selection/key';
+	import type { Writable } from 'svelte/store';
+
+	type Props = {
+		projectId: string;
+		before: string;
+		after: string;
+		timestamp: string;
+		selectionId: SelectionId;
+	};
+
+	const { projectId, before, after, timestamp, selectionId }: Props = $props();
+
+	const oplogService = getContext(OplogService);
+	const historyService = getContext(HistoryService);
+
+	const focusableId = $derived(snapshotChangesFocusableId(before, after));
+	const focusableIds = svelteGetContext<Writable<string[]>>('snapshot-focusables');
+
+	async function restore(id: string) {
+		await historyService.restoreSnapshot(projectId, id);
+		// In some cases, restoring the snapshot doesnt update the UI correctly
+		// Until we have that figured out, we need to reload the page.
+		location.reload();
+	}
+
+	// Include the id in the radio group
+	$effect(() => {
+		if (focusableId) {
+			$focusableIds = [...untrack(() => $focusableIds), focusableId];
+			return () => {
+				$focusableIds = untrack(() => $focusableIds).filter((id) => id !== focusableId);
+			};
+		}
+	});
+
+	const changes = $derived(
+		oplogService.diffWorktree({
+			projectId,
+			before,
+			after
+		})
+	);
+
+	let showPreviousActions = $state(false);
+	let showPreviousActionsTarget = $state<HTMLElement>();
+</script>
+
+<ReduxResult {projectId} result={changes.current}>
+	{#snippet children(changes, { projectId: _projectId })}
+		{#if changes.changes.length > 0 && focusableId}
+			<DataContextMenu
+				bind:open={showPreviousActions}
+				items={[
+					[
+						{
+							label: 'Revert to before',
+							onclick: async () => await restore(before)
+						},
+						{
+							label: 'Revert to after',
+							onclick: async () => await restore(after)
+						}
+					]
+				]}
+				target={showPreviousActionsTarget}
+			/>
+
+			<div class="action-item" use:focusable={{ id: focusableId }}>
+				<div class="action-item__robot">
+					<Icon name="robot" />
+				</div>
+				<div class="action-item__content">
+					<div class="action-item__content__header">
+						<div>
+							<p class="text-13 text-bold">Files changed</p>
+							<span class="text-13 text-greyer"
+								><TimeAgo date={new Date(timestamp)} addSuffix /></span
+							>
+						</div>
+						<div bind:this={showPreviousActionsTarget}>
+							<Button
+								icon="kebab"
+								size="tag"
+								kind="outline"
+								onclick={() => (showPreviousActions = true)}
+							/>
+						</div>
+					</div>
+
+					<div class="action-item__content__metadata">
+						<FileList
+							{projectId}
+							changes={changes.changes}
+							listMode="list"
+							draggableFiles={false}
+							selectionId={{
+								type: 'snapshot',
+								before,
+								after
+							}}
+							active={selectionId.type === 'snapshot' &&
+								selectionId.before === before &&
+								selectionId.after === after}
+						/>
+					</div>
+				</div>
+			</div>
+		{/if}
+	{/snippet}
+</ReduxResult>
+
+<style lang="postcss">
+	.action-item__robot {
+		padding: 4px 6px;
+		border: 1px solid var(--clr-border-2);
+
+		border-radius: var(--radius-m);
+		background-color: var(--clr-bg-2);
+	}
+
+	.action-item {
+		display: flex;
+
+		align-items: flex-start;
+
+		gap: 14px;
+	}
+
+	.action-item__content__header {
+		display: flex;
+		align-items: flex-start;
+
+		> div:first-of-type {
+			flex-grow: 1;
+		}
+
+		> div {
+			display: flex;
+			flex-wrap: wrap;
+
+			align-items: center;
+			gap: 8px;
+		}
+	}
+
+	.action-item__content {
+		display: flex;
+
+		flex-grow: 1;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.action-item__content__metadata {
+		width: 100%;
+
+		margin-top: 4px;
+
+		border: 1px solid var(--clr-border-2);
+		border-radius: var(--radius-m);
+	}
+
+	.outcome-item {
+		display: flex;
+
+		padding: 12px;
+		gap: 8px;
+
+		border-bottom: 1px solid var(--clr-border-2);
+
+		&:last-child {
+			border-bottom: none;
+		}
+	}
+
+	.text-grey {
+		color: var(--clr-text-2);
+	}
+
+	.text-darkgrey {
+		color: var(--clr-core-ntrl-20);
+		text-decoration-color: var(--clr-core-ntrl-20);
+	}
+
+	.text-greyer {
+		color: var(--clr-text-3);
+	}
+
+	.pill {
+		padding: 2px 6px;
+		border: 1px solid var(--clr-border-2);
+		border-radius: 99px;
+		background-color: var(--clr-bg-2);
+	}
+</style>

--- a/apps/desktop/src/components/v3/ActionLogMcpItem.svelte
+++ b/apps/desktop/src/components/v3/ActionLogMcpItem.svelte
@@ -19,9 +19,9 @@
 
 	type Props = {
 		projectId: string;
-		action: ButlerAction;
+		action: ButlerAction & { action: { type: 'mcpAction' } };
 		last: boolean;
-		previous: ButlerAction | undefined;
+		previous: (ButlerAction & { action: { type: 'mcpAction' } }) | undefined;
 		loadNextPage: () => void;
 		selectionId: SelectionId;
 	};
@@ -42,14 +42,19 @@
 		previous
 			? oplogService.diffWorktree({
 					projectId,
-					before: previous.snapshotAfter,
-					after: action.snapshotBefore
+					before: previous.action.subject.snapshotAfter,
+					after: action.action.subject.snapshotBefore
 				})
 			: undefined
 	);
 
 	const focusableId = $derived(
-		previous ? snapshotChangesFocusableId(previous.snapshotAfter, action.snapshotBefore) : undefined
+		previous
+			? snapshotChangesFocusableId(
+					previous.action.subject.snapshotAfter,
+					action.action.subject.snapshotBefore
+				)
+			: undefined
 	);
 	const focusableIds = svelteGetContext<Writable<string[]>>('snapshot-focusables');
 
@@ -95,11 +100,11 @@
 		[
 			{
 				label: 'Revert to before',
-				onclick: async () => await restore(action.snapshotBefore)
+				onclick: async () => await restore(action.action.subject.snapshotBefore)
 			},
 			{
 				label: 'Revert to after',
-				onclick: async () => await restore(action.snapshotAfter)
+				onclick: async () => await restore(action.action.subject.snapshotAfter)
 			}
 		]
 	]}
@@ -118,18 +123,20 @@
 				<span class="text-13 text-greyer"
 					><TimeAgo date={new Date(action.createdAt)} addSuffix /></span
 				>
-				<Tooltip text={action.externalPrompt}><div class="pill text-12">Prompt</div></Tooltip>
+				<Tooltip text={action.action.subject.externalPrompt}
+					><div class="pill text-12">Prompt</div></Tooltip
+				>
 			</div>
 			<div bind:this={showActionsTarget}>
 				<Button icon="kebab" size="tag" kind="outline" onclick={() => (showActions = true)} />
 			</div>
 		</div>
 		<span class="text-14 text-darkgrey">
-			<Markdown content={action.externalSummary} />
+			<Markdown content={action.action.subject.externalSummary} />
 		</span>
-		{#if action.response && action.response.updatedBranches.length > 0}
+		{#if action.action.subject.response && action.action.subject.response.updatedBranches.length > 0}
 			<div class="action-item__content__metadata">
-				{@render outcome(action.response)}
+				{@render outcome(action.action.subject.response)}
 			</div>
 		{/if}
 		{#if last}
@@ -148,11 +155,11 @@
 						[
 							{
 								label: 'Revert to before',
-								onclick: async () => await restore(previous.snapshotAfter)
+								onclick: async () => await restore(previous.action.subject.snapshotAfter)
 							},
 							{
 								label: 'Revert to after',
-								onclick: async () => await restore(action.snapshotBefore)
+								onclick: async () => await restore(action.action.subject.snapshotBefore)
 							}
 						]
 					]}
@@ -189,12 +196,12 @@
 								draggableFiles={false}
 								selectionId={{
 									type: 'snapshot',
-									before: previous.snapshotAfter,
-									after: action.snapshotBefore
+									before: previous.action.subject.snapshotAfter,
+									after: action.action.subject.snapshotBefore
 								}}
 								active={selectionId.type === 'snapshot' &&
-									selectionId.before === previous.snapshotAfter &&
-									selectionId.after === action.snapshotBefore}
+									selectionId.before === previous.action.subject.snapshotAfter &&
+									selectionId.after === action.action.subject.snapshotBefore}
 							/>
 						</div>
 					</div>

--- a/apps/desktop/src/lib/actions/actionService.svelte.ts
+++ b/apps/desktop/src/lib/actions/actionService.svelte.ts
@@ -11,6 +11,10 @@ export default class ActionService {
 	listActions(projectId: string, page: number = 1, pageSize: number = 10) {
 		return this.api.endpoints.listActions.useQuery({ projectId, page, pageSize });
 	}
+
+	get revertSnapshot() {
+		return this.api.endpoints.actionsRevertSnapshot.useMutation();
+	}
 }
 
 function injectEndpoints(api: ClientState['backendApi']) {
@@ -23,6 +27,15 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				query: ({ projectId, page, pageSize }) => ({
 					command: 'list_actions',
 					params: { projectId, page, pageSize }
+				})
+			}),
+			actionsRevertSnapshot: build.mutation<
+				void,
+				{ projectId: string; snapshot: string; description: string }
+			>({
+				query: ({ projectId, snapshot, description }) => ({
+					command: 'actions_revert_snapshot',
+					params: { projectId, snapshot, description }
 				})
 			})
 		})

--- a/apps/desktop/src/lib/actions/types.ts
+++ b/apps/desktop/src/lib/actions/types.ts
@@ -13,11 +13,9 @@ export type Outcome = {
 export type ActionHandler = 'handleChangesSimple';
 
 /** Represents a snapshot of an automatic action taken by a GitButler automation.  */
-export type ButlerAction = {
+export type ButlerMcpAction = {
 	/** UUID identifier of the action */
 	id: string;
-	/** The time when the action was performed. */
-	createdAt: number;
 	/** A description of the change that was made and why it was made - i.e. the information that can be obtained from the caller. */
 	externalSummary: string;
 	/** The prompt used that triggered this thingy stuff figgure it out yourself */
@@ -34,6 +32,28 @@ export type ButlerAction = {
 	response: Outcome | null;
 	/** An error message if the action failed. */
 	error: string | null;
+};
+
+export type ButlerRevertAction = {
+	id: string;
+	snapshot: string;
+	description: string;
+};
+
+type Action =
+	| {
+			type: 'mcpAction';
+			subject: ButlerMcpAction;
+	  }
+	| {
+			type: 'revertAction';
+			subject: ButlerRevertAction;
+	  };
+
+export type ButlerAction = {
+	id: string;
+	createdAt: string;
+	action: Action;
 };
 
 export type ActionListing = {

--- a/crates/but-action/src/lib.rs
+++ b/crates/but-action/src/lib.rs
@@ -18,6 +18,7 @@ mod action;
 mod simple;
 pub use action::ActionListing;
 pub use action::list_actions;
+pub use action::revert;
 use strum::EnumString;
 
 pub fn handle_changes(

--- a/crates/but-action/src/simple.rs
+++ b/crates/but-action/src/simple.rs
@@ -52,7 +52,7 @@ pub fn handle_changes(
 
     crate::action::persist_action(
         ctx,
-        crate::action::ButlerAction::new(
+        crate::action::ButlerAction::new_mcp(
             crate::ActionHandler::HandleChangesSimple,
             external_prompt,
             change_summary.to_owned(),

--- a/crates/but-db/migrations/2025-05-30-112246_butler_actions/up.sql
+++ b/crates/but-db/migrations/2025-05-30-112246_butler_actions/up.sql
@@ -2,5 +2,3 @@
 ALTER TABLE `butler_actions` DROP COLUMN `external_prompt`;
 ALTER TABLE `butler_actions` ADD COLUMN `external_summary` TEXT NOT NULL;
 ALTER TABLE `butler_actions` ADD COLUMN `external_prompt` TEXT;
-
-

--- a/crates/but-db/migrations/2025-06-03-204936_enumey_butler_actions/down.sql
+++ b/crates/but-db/migrations/2025-06-03-204936_enumey_butler_actions/down.sql
@@ -1,0 +1,24 @@
+-- This file should undo anything in `up.sql`
+
+-- Add back the created_at column to butler_mcp_actions
+ALTER TABLE `butler_mcp_actions` ADD COLUMN created_at TIMESTAMP;
+
+-- Populate the created_at column from the new butler_actions table
+UPDATE `butler_mcp_actions` 
+SET created_at = (
+    SELECT created_at 
+    FROM butler_actions 
+    WHERE butler_actions.mcp_action_id = butler_mcp_actions.id
+);
+
+-- Recreate the old index on butler_mcp_actions.created_at
+CREATE INDEX `idx_butler_actions_created_at` ON `butler_mcp_actions`(`created_at`);
+
+-- Drop the new butler_actions table (this also drops its index)
+DROP TABLE IF EXISTS `butler_actions`;
+
+-- Drop the butler_revert_actions table
+DROP TABLE IF EXISTS `butler_revert_actions`;
+
+-- Rename butler_mcp_actions back to butler_actions
+ALTER TABLE `butler_mcp_actions` RENAME TO `butler_actions`;

--- a/crates/but-db/migrations/2025-06-03-204936_enumey_butler_actions/up.sql
+++ b/crates/but-db/migrations/2025-06-03-204936_enumey_butler_actions/up.sql
@@ -1,0 +1,33 @@
+-- Your SQL goes here
+
+-- Rename `butler_actions` to `butler_mcp_actions`
+ALTER TABLE `butler_actions` RENAME TO `butler_mcp_actions`;
+
+-- Drop old index that is not going to be needed
+DROP INDEX IF EXISTS idx_butler_actions_created_at;
+
+-- Create table `butler_revert_actions` which has a `snapshot` property which is a string
+CREATE TABLE `butler_revert_actions` (
+    id TEXT PRIMARY KEY,
+    snapshot TEXT NOT NULL,
+    description TEXT NOT NULL
+);
+
+-- Create new `butler_actions` table which has two optional FKs to `butler_mcp_actions` and `butler_revert_actions`, an auto-incrementing ID, and a `created_at` timestamp which has an index
+CREATE TABLE `butler_actions` (
+    id TEXT PRIMARY KEY,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    mcp_action_id TEXT,
+    revert_action_id TEXT,
+    FOREIGN KEY (mcp_action_id) REFERENCES butler_mcp_actions(id),
+    FOREIGN KEY (revert_action_id) REFERENCES butler_revert_actions(id)
+);
+
+CREATE INDEX idx_butler_actions_new_created_at ON butler_actions(created_at);
+
+-- For each existing butler_mcp_actions row, create a butler_actions row with the same id and created_at, mcp_action_id set to id, revert_action_id set to NULL
+INSERT INTO butler_actions (id, created_at, mcp_action_id, revert_action_id)
+SELECT id, created_at, id, NULL FROM butler_mcp_actions;
+
+-- Remove the created_at column from butler_mcp_actions
+ALTER TABLE `butler_mcp_actions` DROP COLUMN created_at;

--- a/crates/but-db/src/butler_actions.rs
+++ b/crates/but-db/src/butler_actions.rs
@@ -1,20 +1,20 @@
+use diesel::SelectableHelper;
 use diesel::dsl::count_star;
-use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl, associations::HasTable};
+use diesel::{Connection, ExpressionMethods, QueryDsl, RunQueryDsl, associations::HasTable};
 
 use crate::schema::butler_actions::dsl::butler_actions;
+use crate::schema::{butler_mcp_actions, butler_revert_actions};
 use crate::{DbHandle, schema::butler_actions as schema};
 
-use diesel::prelude::{Insertable, Queryable, Selectable};
+use diesel::prelude::{Associations, Insertable, Queryable, Selectable};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable, Insertable)]
-#[diesel(table_name = crate::schema::butler_actions)]
+#[diesel(table_name = crate::schema::butler_mcp_actions)]
 #[diesel(check_for_backend(diesel::sqlite::Sqlite))]
-pub struct ButlerAction {
+pub struct ButlerMcpAction {
     /// UUID identifier of the action.
     pub id: String,
-    /// The time when the action was performed.
-    pub created_at: chrono::NaiveDateTime,
     /// The prompt that was used to generate the changes that were made, if applicable
     pub external_prompt: Option<String>,
     /// A description of the change that was made and why it was made - i.e. the information that can be obtained from the caller.
@@ -33,6 +33,41 @@ pub struct ButlerAction {
     pub error: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable, Insertable)]
+#[diesel(table_name = crate::schema::butler_revert_actions)]
+#[diesel(check_for_backend(diesel::sqlite::Sqlite))]
+pub struct ButlerRevertAction {
+    /// UUID identifier of the action.
+    pub id: String,
+    /// The snapshot representing the revert
+    pub snapshot: String,
+    /// A description of what was undone
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable, Insertable, Associations)]
+#[diesel(table_name = crate::schema::butler_actions)]
+#[diesel(check_for_backend(diesel::sqlite::Sqlite))]
+#[diesel(belongs_to(ButlerRevertAction, foreign_key = revert_action_id))]
+#[diesel(belongs_to(ButlerMcpAction, foreign_key = mcp_action_id))]
+pub struct ButlerAction {
+    /// UUID identifier of the action.
+    pub id: String,
+    /// When it was created
+    pub created_at: chrono::NaiveDateTime,
+    /// Optional butler mcp action
+    pub mcp_action_id: Option<String>,
+    /// Optional butler revert action
+    pub revert_action_id: Option<String>,
+}
+
+pub struct FilledButlerAction {
+    pub id: String,
+    pub created_at: chrono::NaiveDateTime,
+    pub mcp_action: Option<ButlerMcpAction>,
+    pub revert_action: Option<ButlerRevertAction>,
+}
+
 impl DbHandle {
     pub fn butler_actions(&mut self) -> ButlerActionsHandle {
         ButlerActionsHandle { db: self }
@@ -44,20 +79,77 @@ pub struct ButlerActionsHandle<'a> {
 }
 
 impl ButlerActionsHandle<'_> {
-    pub fn insert(&mut self, action: ButlerAction) -> anyhow::Result<()> {
-        diesel::insert_into(butler_actions)
-            .values(&action)
-            .execute(&mut self.db.conn)?;
-        Ok(())
+    pub fn insert(&mut self, filled_action: FilledButlerAction) -> anyhow::Result<()> {
+        self.db.conn.transaction(|conn| {
+            // Insert the MCP action if it exists
+            let mcp_action_id = if let Some(mcp_action) = filled_action.mcp_action {
+                diesel::insert_into(butler_mcp_actions::table)
+                    .values(&mcp_action)
+                    .execute(conn)?;
+                Some(mcp_action.id)
+            } else {
+                None
+            };
+
+            // Insert the revert action if it exists
+            let revert_action_id = if let Some(revert_action) = filled_action.revert_action {
+                diesel::insert_into(butler_revert_actions::table)
+                    .values(&revert_action)
+                    .execute(conn)?;
+                Some(revert_action.id)
+            } else {
+                None
+            };
+
+            // Create and insert the main butler_action with the appropriate foreign keys
+            let butler_action = ButlerAction {
+                id: filled_action.id,
+                created_at: filled_action.created_at,
+                mcp_action_id,
+                revert_action_id,
+            };
+
+            diesel::insert_into(butler_actions)
+                .values(&butler_action)
+                .execute(conn)?;
+
+            Ok(())
+        })
     }
 
-    pub fn list(&mut self, page: i64, page_size: i64) -> anyhow::Result<(i64, Vec<ButlerAction>)> {
+    pub fn list(
+        &mut self,
+        page: i64,
+        page_size: i64,
+    ) -> anyhow::Result<(i64, Vec<FilledButlerAction>)> {
         let offset = (page - 1) * page_size;
         let actions = butler_actions::table()
+            .left_join(butler_mcp_actions::table)
+            .left_join(butler_revert_actions::table)
             .order(schema::created_at.desc())
             .limit(page_size)
             .offset(offset)
-            .load::<ButlerAction>(&mut self.db.conn)?;
+            .select((
+                ButlerAction::as_select(),
+                Option::<ButlerMcpAction>::as_select(),
+                Option::<ButlerRevertAction>::as_select(),
+            ))
+            .load::<(
+                ButlerAction,
+                Option<ButlerMcpAction>,
+                Option<ButlerRevertAction>,
+            )>(&mut self.db.conn)?;
+
+        let actions = actions
+            .into_iter()
+            .map(|(action, mcp, revert)| FilledButlerAction {
+                id: action.id,
+                created_at: action.created_at,
+                mcp_action: mcp,
+                revert_action: revert,
+            })
+            .collect();
+
         let total = butler_actions::table()
             .select(count_star())
             .first::<i64>(&mut self.db.conn)?;

--- a/crates/but-db/src/lib.rs
+++ b/crates/but-db/src/lib.rs
@@ -9,7 +9,7 @@ const FILE_NAME: &str = "but.sqlite";
 mod hunk_assignments;
 pub use hunk_assignments::HunkAssignment;
 mod butler_actions;
-pub use butler_actions::ButlerAction;
+pub use butler_actions::{ButlerMcpAction, ButlerRevertAction, FilledButlerAction};
 mod schema;
 
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};

--- a/crates/but-db/src/schema.rs
+++ b/crates/but-db/src/schema.rs
@@ -8,10 +8,35 @@ diesel::table! {
     }
 }
 
+diesel::allow_tables_to_appear_in_same_query!(
+    butler_actions,
+    butler_revert_actions,
+    butler_mcp_actions
+);
+
+diesel::joinable!(butler_actions -> butler_revert_actions (revert_action_id));
+diesel::joinable!(butler_actions -> butler_mcp_actions (mcp_action_id));
+
 diesel::table! {
     butler_actions (id) {
         id -> Text,
         created_at -> Timestamp,
+        mcp_action_id -> Nullable<Text>,
+        revert_action_id -> Nullable<Text>,
+    }
+}
+
+diesel::table! {
+    butler_revert_actions (id) {
+        id -> Text,
+        snapshot -> Text,
+        description -> Text
+    }
+}
+
+diesel::table! {
+    butler_mcp_actions (id) {
+        id -> Text,
         external_prompt -> Nullable<Text>,
         external_summary -> Text,
         handler -> Text,

--- a/crates/gitbutler-tauri/src/action.rs
+++ b/crates/gitbutler-tauri/src/action.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::{error::Error, from_json::HexHash};
 use gitbutler_command_context::CommandContext;
 use gitbutler_project::ProjectId;
 use tracing::instrument;
@@ -15,6 +15,23 @@ pub fn list_actions(
     let project = projects.get(project_id)?;
     let ctx = &mut CommandContext::open(&project, settings.get()?.clone())?;
     but_action::list_actions(ctx, page, page_size).map_err(|e| Error::from(anyhow::anyhow!(e)))
+}
+
+#[tauri::command(async)]
+#[instrument(skip(projects, settings), err(Debug))]
+pub fn actions_revert_snapshot(
+    projects: tauri::State<'_, gitbutler_project::Controller>,
+    settings: tauri::State<'_, but_settings::AppSettingsWithDiskSync>,
+    project_id: ProjectId,
+    snapshot: HexHash,
+    description: &str,
+) -> anyhow::Result<(), Error> {
+    let project = projects.get(project_id)?;
+    let mut ctx = CommandContext::open(&project, settings.get()?.clone())?;
+    let mut guard = ctx.project().exclusive_worktree_access();
+    but_action::revert(&mut ctx, *snapshot, description, guard.write_permission())
+        .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
+    Ok(())
 }
 
 #[tauri::command(async)]

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -286,6 +286,7 @@ fn main() {
                     settings::update_feature_flags,
                     action::list_actions,
                     action::handle_changes,
+                    action::actions_revert_snapshot,
                     cli::install_cli,
                     cli::cli_path,
                     workspace::stacks,


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#7s97f2H4D`](https://gitbutler.com/cto/gitbutler-client-d443/reviews/7s97f2H4D)

**butler-actions-reverting**


3 commit series (version 3)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 3/3 | [Frontend for reverts](https://gitbutler.com/cto/gitbutler-client-d443/reviews/7s97f2H4D/commit/3a39464a-7530-45e1-9892-f9c5cdb80092) | ⏳ |  |
| 2/3 | [Split files changed and the action itself](https://gitbutler.com/cto/gitbutler-client-d443/reviews/7s97f2H4D/commit/1e665cfd-bf79-4bda-819a-45febcba03f3) | ⏳ |  |
| 1/3 | [Restructure butler actions to have other types in an enum](https://gitbutler.com/cto/gitbutler-client-d443/reviews/7s97f2H4D/commit/21ab6c6c-544d-4119-9024-09848bc68eb1) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/cto/gitbutler-client-d443/reviews/7s97f2H4D)_
<!-- GitButler Review Footer Boundary Bottom -->
