### PR TITLE
Test combine results

### DIFF
--- a/apps/desktop/src/lib/state/helpers.test.ts
+++ b/apps/desktop/src/lib/state/helpers.test.ts
@@ -1,0 +1,122 @@
+import { combineResults } from '$lib/state/helpers';
+import { QueryStatus } from '@reduxjs/toolkit/query';
+import { describe, expect, test } from 'vitest';
+import type { CustomResult } from '$lib/state/butlerModule';
+
+describe.concurrent('combineResults', () => {
+	test('when passed one result, keep the same status', () => {
+		const fulfilled = {
+			data: 'foo',
+			error: undefined,
+			status: QueryStatus.fulfilled
+		} as CustomResult<any>;
+		const pending = {
+			data: undefined,
+			error: undefined,
+			status: QueryStatus.pending
+		} as CustomResult<any>;
+		const rejected = {
+			data: undefined,
+			error: 'failure!',
+			status: QueryStatus.rejected
+		} as CustomResult<any>;
+		const uninitialized = {
+			data: undefined,
+			error: undefined,
+			status: QueryStatus.uninitialized
+		} as CustomResult<any>;
+		expect(combineResults(fulfilled)).toEqual({ ...fulfilled, data: ['foo'] });
+		expect(combineResults(pending)).toEqual(pending);
+		expect(combineResults(rejected)).toEqual(rejected);
+		expect(combineResults(uninitialized)).toEqual(uninitialized);
+	});
+
+	test('rejected takes precidence over all', () => {
+		const fulfilled = {
+			data: 'foo',
+			error: undefined,
+			status: QueryStatus.fulfilled
+		} as CustomResult<any>;
+		const pending = {
+			data: undefined,
+			error: undefined,
+			status: QueryStatus.pending
+		} as CustomResult<any>;
+		const rejected = {
+			data: undefined,
+			error: 'failure!',
+			status: QueryStatus.rejected
+		} as CustomResult<any>;
+		const uninitialized = {
+			data: undefined,
+			error: undefined,
+			status: QueryStatus.uninitialized
+		} as CustomResult<any>;
+		expect(combineResults(fulfilled, pending, rejected, uninitialized)).toEqual(rejected);
+	});
+
+	test('uninitialized takes precidence over fufilled and pending', () => {
+		const fulfilled = {
+			data: 'foo',
+			error: undefined,
+			status: QueryStatus.fulfilled
+		} as CustomResult<any>;
+		const pending = {
+			data: undefined,
+			error: undefined,
+			status: QueryStatus.pending
+		} as CustomResult<any>;
+		const uninitialized = {
+			data: undefined,
+			error: undefined,
+			status: QueryStatus.uninitialized
+		} as CustomResult<any>;
+		expect(combineResults(fulfilled, pending, uninitialized)).toEqual(uninitialized);
+	});
+
+	test('pending takes precidence over fufilled', () => {
+		const fulfilled = {
+			data: 'foo',
+			error: undefined,
+			status: QueryStatus.fulfilled
+		} as CustomResult<any>;
+		const pending = {
+			data: undefined,
+			error: undefined,
+			status: QueryStatus.pending
+		} as CustomResult<any>;
+		expect(combineResults(fulfilled, pending)).toEqual(pending);
+	});
+
+	test('multiple fufilled combines results in order', () => {
+		const a = {
+			data: 'a',
+			error: undefined,
+			status: QueryStatus.fulfilled
+		} as CustomResult<any>;
+		const b = {
+			data: 'b',
+			error: undefined,
+			status: QueryStatus.fulfilled
+		} as CustomResult<any>;
+		const c = {
+			data: 'c',
+			error: undefined,
+			status: QueryStatus.fulfilled
+		} as CustomResult<any>;
+
+		expect(combineResults(a, b, c)).toEqual({
+			data: ['a', 'b', 'c'],
+			error: undefined,
+			status: QueryStatus.fulfilled
+		});
+	});
+
+	test('combining zero results returns uninitalized', () => {
+		expect(combineResults()).toEqual({
+			data: undefined,
+			error: undefined,
+			status: QueryStatus.uninitialized
+		});
+	});
+});

--- a/apps/desktop/src/lib/state/helpers.ts
+++ b/apps/desktop/src/lib/state/helpers.ts
@@ -33,8 +33,16 @@ export function isMutationDefinition(
 export function combineResults<T extends [...CustomResult<any>[]]>(
 	...results: T
 ): CustomResult<CustomQuery<{ [K in keyof T]: Exclude<T[K]['data'], undefined> }>> {
+	if (results.length === 0) {
+		return {
+			status: QueryStatus.uninitialized,
+			error: undefined,
+			data: undefined
+		} as CustomResult<CustomQuery<{ [K in keyof T]: Exclude<T[K]['data'], undefined> }>>;
+	}
+
 	const data = results.every((r) => r.data !== undefined) ? results.map((r) => r.data) : undefined;
-	const error = results.find((r) => r.error);
+	const error = results.find((r) => r.error)?.error;
 	const status = (results.find((r) => r.status === QueryStatus.rejected) ||
 		results.find((r) => r.status === QueryStatus.uninitialized) ||
 		results.find((r) => r.status === QueryStatus.pending) ||


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#0z1sOG5IT`](https://gitbutler.com/cto/gitbutler-client-d443/reviews/0z1sOG5IT)

**Test combine results**


This fixes at two errors:

When no results were passed, an error was caused

Not correctly passing the error through

Now when you pass zero results as an input, it returns an uninitialized result as the outcome.

I also noticed when testing, that the output error property was getting set to the entire result that contained the error, which is probably where a handful of [object Object]s might have come from.

1 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Test combine results](https://gitbutler.com/cto/gitbutler-client-d443/reviews/0z1sOG5IT/commit/1ade7726-d659-465a-aad4-0cfd8ddbdfcf) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/cto/gitbutler-client-d443/reviews/0z1sOG5IT)_
<!-- GitButler Review Footer Boundary Bottom -->
