### PR TITLE
Fix pushing when making PRs

### DIFF
--- a/apps/desktop/src/components/ReviewCreation.svelte
+++ b/apps/desktop/src/components/ReviewCreation.svelte
@@ -31,6 +31,7 @@
 	import { showError, showToast } from '$lib/notifications/toasts';
 	import { ProjectsService } from '$lib/project/projectsService';
 	import { RemotesService } from '$lib/remotes/remotesService';
+	import { requiresPush } from '$lib/stacks/stack';
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { TestId } from '$lib/testing/testIds';
 	import { parseRemoteUrl } from '$lib/url/gitUrl';
@@ -89,10 +90,8 @@
 		branchParent ? stackService.branchDetails(projectId, stackId, branchParent.name) : undefined
 	);
 	const branchParentDetails = $derived(branchParentDetailsResult?.current.data);
-	const branchDetailsResult = $derived(
-		branchParent ? stackService.branchDetails(projectId, stackId, branchName) : undefined
-	);
-	const branchDetails = $derived(branchDetailsResult?.current.data);
+	const branchDetailsResult = $derived(stackService.branchDetails(projectId, stackId, branchName));
+	const branchDetails = $derived(branchDetailsResult.current.data);
 	const commitsResult = $derived(stackService.commits(projectId, stackId, branchName));
 	const commits = $derived(commitsResult.current.data || []);
 
@@ -109,7 +108,7 @@
 	const createPullRequest = persisted<boolean>(true, 'createPullRequest');
 
 	const pushBeforeCreate = $derived(
-		!forgeBranch || commits.some((c) => c.state.type === 'LocalOnly')
+		!forgeBranch || (branchDetails ? requiresPush(branchDetails.pushStatus) : true)
 	);
 
 	let titleInput = $state<ReturnType<typeof Textbox>>();

--- a/apps/desktop/src/lib/stacks/stack.ts
+++ b/apps/desktop/src/lib/stacks/stack.ts
@@ -186,10 +186,14 @@ export function stackHasConflicts(stack: StackDetails): boolean {
 }
 
 export function stackHasUnpushedCommits(stack: StackDetails): boolean {
+	return requiresPush(stack.pushStatus);
+}
+
+export function requiresPush(status: PushStatus): boolean {
 	return (
-		stack.pushStatus === 'unpushedCommits' ||
-		stack.pushStatus === 'unpushedCommitsRequiringForce' ||
-		stack.pushStatus === 'completelyUnpushed'
+		status === 'unpushedCommits' ||
+		status === 'unpushedCommitsRequiringForce' ||
+		status === 'completelyUnpushed'
 	);
 }
 


### PR DESCRIPTION

<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#9drAnWJQm`](https://gitbutler.com/cto/gitbutler-client-d443/reviews/9drAnWJQm)

**Fix pushing when making PRs**


There were a handful of problems that this fixes

branchDetailsResult was only ever set when it has a parent branch. This was causing us to try regularly pushing in some scenarios when force push was required

pushBeforeCreate used an incorrect commit based heuristic that missed some diverged scenarios. It now uses the branchDetails and the stackHashUnpushedCommits function

1 commit series (version 2)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Fix pushing when making PRs](https://gitbutler.com/cto/gitbutler-client-d443/reviews/9drAnWJQm/commit/387d1f86-9cd0-4bcc-861c-15ea73316469) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/cto/gitbutler-client-d443/reviews/9drAnWJQm)_
<!-- GitButler Review Footer Boundary Bottom -->
