### PR TITLE
Implement stable IDs for HunkAssignment

### DIFF
--- a/apps/desktop/src/lib/hunks/hunk.ts
+++ b/apps/desktop/src/lib/hunks/hunk.ts
@@ -95,6 +95,13 @@ export type HunkHeader = {
  * Additionally, the hunk dependencies (locking) affects what assignment is possible.
  */
 export type HunkAssignment = {
+	/**
+	 * A stable identifier for the hunk assignment.
+	 *   - When a new hunk is first observed (from the uncommitted changes), it is assigned a new id.
+	 *   - If a hunk is modified (i.e. it has gained or lost lines), the UUID remains the same.
+	 *   - If two or more hunks become merged (due to edits causing the contexts to overlap), the id of the hunk with the most lines is adopted.
+	 */
+	readonly id: string | null;
 	/** The hunk that is being assigned. Together with path_bytes, this identifies the hunk.
 	 * If the file is binary, or too large to load, this will be None and in this case the path name is the only identity.
 	 */

--- a/crates/but-db/migrations/2025-06-03-111503_hunk_assignments/down.sql
+++ b/crates/but-db/migrations/2025-06-03-111503_hunk_assignments/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+
+ALTER TABLE `hunk_assignments` DROP COLUMN `id`;
+

--- a/crates/but-db/migrations/2025-06-03-111503_hunk_assignments/up.sql
+++ b/crates/but-db/migrations/2025-06-03-111503_hunk_assignments/up.sql
@@ -1,0 +1,4 @@
+-- Your SQL goes here
+
+ALTER TABLE `hunk_assignments` ADD COLUMN `id` TEXT;
+

--- a/crates/but-db/src/hunk_assignments.rs
+++ b/crates/but-db/src/hunk_assignments.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 #[diesel(table_name = crate::schema::hunk_assignments)]
 #[diesel(check_for_backend(diesel::sqlite::Sqlite))]
 pub struct HunkAssignment {
+    pub id: Option<String>,
     pub hunk_header: Option<String>,
     pub path: String,
     pub path_bytes: Vec<u8>,

--- a/crates/but-db/src/schema.rs
+++ b/crates/but-db/src/schema.rs
@@ -1,5 +1,6 @@
 diesel::table! {
     hunk_assignments (path, hunk_header) {
+        id -> Nullable<Text>,
         hunk_header -> Nullable<Text>,
         path -> Text,
         path_bytes -> Binary,

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -187,12 +187,12 @@ impl HunkAssignment {
         }
         if let (Some(header), Some(other_header)) = (self.hunk_header, other.hunk_header) {
             if header.new_start >= other_header.new_start
-                && header.new_start < other_header.new_start + other_header.new_lines
+                && header.new_start <= other_header.new_start + other_header.new_lines
             {
                 return true;
             }
             if other_header.new_start >= header.new_start
-                && other_header.new_start < header.new_start + header.new_lines
+                && other_header.new_start <= header.new_start + header.new_lines
             {
                 return true;
             }

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -28,8 +28,10 @@ use uuid::Uuid;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct HunkAssignment {
-    /// An optional identifier for a hunk assignment. This is useful when a hunk is modified -
-    /// The path + hunk_header are now different, but it is useful to the UI to have a stable identifier.
+    /// A stable identifier for the hunk assignment.
+    ///   - When a new hunk is first observed (from the uncommitted changes), it is assigned a new id.
+    ///   - If a hunk is modified (i.e. it has gained or lost lines), the UUID remains the same.
+    ///   - If two or more hunks become merged (due to edits causing the contexts to overlap), the id of the hunk with the most lines is adopted.
     pub id: Option<Uuid>,
     /// The hunk that is being assigned. Together with path_bytes, this identifies the hunk.
     /// If the file is binary, or too large to load, this will be None and in this case the path name is the only identity.

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -356,11 +356,12 @@ fn hunk_dependency_assignments(
     Ok(assignments)
 }
 
+/// This also generates a UUID for the assignment
 fn diff_to_assignments(diff: UnifiedDiff, path: BString) -> Vec<HunkAssignment> {
     let path_str = path.to_str_lossy();
     match diff {
         but_core::UnifiedDiff::Binary => vec![HunkAssignment {
-            id: None,
+            id: Some(Uuid::new_v4()),
             hunk_header: None,
             path: path_str.into(),
             path_bytes: path,
@@ -368,7 +369,7 @@ fn diff_to_assignments(diff: UnifiedDiff, path: BString) -> Vec<HunkAssignment> 
             hunk_locks: vec![],
         }],
         but_core::UnifiedDiff::TooLarge { .. } => vec![HunkAssignment {
-            id: None,
+            id: Some(Uuid::new_v4()),
             hunk_header: None,
             path: path_str.into(),
             path_bytes: path,
@@ -383,7 +384,7 @@ fn diff_to_assignments(diff: UnifiedDiff, path: BString) -> Vec<HunkAssignment> 
             // If there are no hunks, then the assignment is for the whole file
             if is_result_of_binary_to_text_conversion || hunks.is_empty() {
                 vec![HunkAssignment {
-                    id: None,
+                    id: Some(Uuid::new_v4()),
                     hunk_header: None,
                     path: path_str.into(),
                     path_bytes: path,
@@ -394,7 +395,7 @@ fn diff_to_assignments(diff: UnifiedDiff, path: BString) -> Vec<HunkAssignment> 
                 hunks
                     .iter()
                     .map(|hunk| HunkAssignment {
-                        id: None,
+                        id: Some(Uuid::new_v4()),
                         hunk_header: Some(hunk.into()),
                         path: path_str.clone().into(),
                         path_bytes: path.clone(),

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -9,8 +9,8 @@
 //!
 //! set_assignments
 
+mod reconcile;
 mod state;
-use std::cmp::Ordering;
 
 use anyhow::Result;
 use bstr::{BString, ByteSlice};
@@ -20,6 +20,7 @@ use but_workspace::{HunkHeader, StackId};
 use gitbutler_command_context::CommandContext;
 use gitbutler_stack::VirtualBranchesHandle;
 use itertools::Itertools;
+use reconcile::MultipleOverlapping;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 use uuid::Uuid;
@@ -201,16 +202,6 @@ impl HunkAssignment {
     }
 }
 
-/// Returns the current hunk assignments for the workspace.
-#[instrument(skip(ctx), err(Debug))]
-pub fn assignments(
-    ctx: &mut CommandContext,
-    set_assignment_from_locks: bool,
-    worktree_changes: Option<Vec<but_core::TreeChange>>,
-) -> Result<Vec<HunkAssignment>> {
-    reconcile(ctx, set_assignment_from_locks, worktree_changes)
-}
-
 /// Sets the assignment for a hunk. It must be already present in the current assignments, errors out if it isn't.
 /// If the stack is not in the list of applied stacks, it errors out.
 /// Returns the updated assignments list.
@@ -231,11 +222,11 @@ pub fn assign(
         requests.clone(),
     )?;
     let deps_assignments = hunk_dependency_assignments(ctx, None)?;
-    let assignments_considering_deps = reconcile_assignments(
+    let assignments_considering_deps = reconcile::assignments(
         new_assignments,
         &deps_assignments,
         &applied_stacks,
-        MultiDepsResolution::SetNone, // If there is double locking, move the hunk to the Uncommitted section
+        MultipleOverlapping::SetNone, // If there is double locking, move the hunk to the Uncommitted section
         true,
     )?;
     state::set_assignments(ctx, assignments_considering_deps.clone())?;
@@ -261,6 +252,8 @@ pub fn assign(
     Ok(rejections)
 }
 
+/// Returns the current hunk assignments for the workspace.
+///
 /// Reconciles the current hunk assignments with the current worktree changes.
 /// It takes  the current hunk assignments as well as the current worktree changes, producing a new set of hunk assignments.
 ///
@@ -278,7 +271,8 @@ pub fn assign(
 /// This needs to be ran only after the worktree has changed.
 ///
 /// If `worktree_changes` is `None`, they will be fetched automatically.
-fn reconcile(
+#[instrument(skip(ctx), err(Debug))]
+pub fn assignments(
     ctx: &mut CommandContext,
     set_assignment_from_locks: bool,
     worktree_changes: Option<Vec<but_core::TreeChange>>,
@@ -298,101 +292,28 @@ fn reconcile(
 
     let deps_assignments = hunk_dependency_assignments(ctx, Some(worktree_changes.clone()))?;
 
-    let mut new_assignments = vec![];
+    let mut reconciled = vec![];
     for change in worktree_changes {
         let diff = change.unified_diff(repo, context_lines)?;
         let assignments_from_worktree = diff_to_assignments(diff, change.path);
-        let assignments_considering_previous = reconcile_assignments(
+        let assignments_considering_previous = reconcile::assignments(
             assignments_from_worktree,
             &previous_assignments,
             &applied_stacks,
-            MultiDepsResolution::SetMostLines,
+            MultipleOverlapping::SetMostLines,
             true,
         )?;
-        let assignments_considering_deps = reconcile_assignments(
+        let assignments_considering_deps = reconcile::assignments(
             assignments_considering_previous,
             &deps_assignments,
             &applied_stacks,
-            MultiDepsResolution::SetNone, // If there is double locking, move the hunk to the Uncommitted section
+            MultipleOverlapping::SetNone, // If there is double locking, move the hunk to the Uncommitted section
             !set_assignment_from_locks, // If we are not setting assignments from locks, we do not want to update unassigned hunks here
         )?;
-        new_assignments.extend(assignments_considering_deps);
+        reconciled.extend(assignments_considering_deps);
     }
-    state::set_assignments(ctx, new_assignments.clone())?;
-    Ok(new_assignments)
-}
-
-enum MultiDepsResolution {
-    SetNone,
-    SetMostLines,
-}
-
-fn reconcile_assignments(
-    current_assignments: Vec<HunkAssignment>,
-    previous_assignments: &[HunkAssignment],
-    applied_stacks: &[StackId],
-    multi_deps_resolution: MultiDepsResolution,
-    update_unassigned: bool,
-) -> Result<Vec<HunkAssignment>> {
-    let mut new_assignments = vec![];
-    for mut current_assignment in current_assignments {
-        let intersecting = previous_assignments
-            .iter()
-            .filter(|current_entry| current_entry.intersects(current_assignment.clone()))
-            .collect::<Vec<_>>();
-
-        // If the worktree hunk intersects with exactly one previous assignment, then it inherits the stack_id assignment from it, but only if the stack is still applied.
-        // If the worktree hunk does not interesect with any previous assingment then it remains, "unassigned", i.e. with stack_id None
-        // If the worktree hunk intersects with more that one one previous assignment there is special handling
-        match intersecting.len().cmp(&1) {
-            Ordering::Less => {
-                // No intersection - do nothing, the None assignment is kept
-            }
-            Ordering::Equal => {
-                // One intersection - assign the stack id if the stack is still in the applied list
-                if let Some(stack_id) = intersecting[0].stack_id {
-                    if applied_stacks.contains(&stack_id) {
-                        if update_unassigned && current_assignment.stack_id.is_none() {
-                            // In the case where there was no assignment but a hunk lock was detected, we dont want to automatically assign the hunk to the lane where it depends
-                            current_assignment.stack_id = intersecting[0].stack_id;
-                        }
-                        current_assignment.hunk_locks = intersecting[0].hunk_locks.clone();
-                        if intersecting[0].id.is_some() {
-                            current_assignment.id = intersecting[0].id;
-                        }
-                    }
-                }
-            }
-            Ordering::Greater => {
-                match multi_deps_resolution {
-                    MultiDepsResolution::SetNone => {
-                        current_assignment.stack_id = None;
-                    }
-                    MultiDepsResolution::SetMostLines => {
-                        // More than one intersection - pick the one with the most lines
-                        current_assignment.stack_id = intersecting
-                            .iter()
-                            .max_by_key(|x| x.hunk_header.as_ref().map(|h| h.new_lines))
-                            .and_then(|x| x.stack_id);
-                    }
-                }
-
-                if intersecting[0].id.is_some() {
-                    current_assignment.id = intersecting[0].id; // Use the id of the first intersecting assignment as the id for the new assignment
-                }
-
-                // Inherit all locks from the intersecting assignments
-                let all_locks = intersecting
-                    .iter()
-                    .flat_map(|i| i.hunk_locks.clone())
-                    .unique()
-                    .collect::<Vec<_>>();
-                current_assignment.hunk_locks = all_locks;
-            }
-        }
-        new_assignments.push(current_assignment);
-    }
-    Ok(new_assignments)
+    state::set_assignments(ctx, reconciled.clone())?;
+    Ok(reconciled)
 }
 
 fn hunk_dependency_assignments(
@@ -511,48 +432,62 @@ fn set_assignment(
 
 #[cfg(test)]
 mod tests {
+    use crate::reconcile::MultipleOverlapping;
+
     use super::*;
     use bstr::BString;
     use but_workspace::{HunkHeader, StackId};
 
-    fn ass(
-        path: &str,
-        start: u32,
-        end: u32,
-        stack_id: Option<usize>,
-        id: Option<usize>,
-    ) -> HunkAssignment {
-        HunkAssignment {
-            id: id.map(sequential_id),
-            hunk_header: Some(HunkHeader {
-                old_start: 0,
-                old_lines: 0,
-                new_start: start,
-                new_lines: end,
-            }),
-            path: path.to_string(),
-            path_bytes: BString::from(path),
-            stack_id: stack_id.map(sequential_stack_id),
-            hunk_locks: vec![],
+    impl HunkAssignment {
+        pub fn new(
+            path: &str,
+            start: u32,
+            end: u32,
+            stack_id: Option<usize>,
+            id: Option<usize>,
+        ) -> HunkAssignment {
+            HunkAssignment {
+                id: id.map(id_seq),
+                hunk_header: Some(HunkHeader {
+                    old_start: 0,
+                    old_lines: 0,
+                    new_start: start,
+                    new_lines: end,
+                }),
+                path: path.to_string(),
+                path_bytes: BString::from(path),
+                stack_id: stack_id.map(stack_id_seq),
+                hunk_locks: vec![],
+            }
         }
-    }
-    fn ass_req(path: &str, start: u32, end: u32, stack_id: Option<usize>) -> HunkAssignmentRequest {
-        HunkAssignmentRequest {
-            hunk_header: Some(HunkHeader {
-                old_start: 0,
-                old_lines: 0,
-                new_start: start,
-                new_lines: end,
-            }),
-            path_bytes: BString::from(path),
-            stack_id: stack_id.map(sequential_stack_id),
-        }
-    }
-    fn sequential_stack_id(num: usize) -> StackId {
-        StackId::from(sequential_id(num))
     }
 
-    fn sequential_id(num: usize) -> Uuid {
+    impl HunkAssignmentRequest {
+        pub fn new(
+            path: &str,
+            start: u32,
+            end: u32,
+            stack_id: Option<usize>,
+        ) -> HunkAssignmentRequest {
+            HunkAssignmentRequest {
+                hunk_header: Some(HunkHeader {
+                    old_start: 0,
+                    old_lines: 0,
+                    new_start: start,
+                    new_lines: end,
+                }),
+                path_bytes: BString::from(path),
+                stack_id: stack_id.map(stack_id_seq),
+            }
+        }
+    }
+
+    fn stack_id_seq(num: usize) -> StackId {
+        StackId::from(id_seq(num))
+    }
+
+    fn id_seq(num: usize) -> Uuid {
+        assert!(num < 10);
         uuid::Uuid::parse_str(&format!("00000000-0000-0000-0000-00000000000{}", num % 10)).unwrap()
     }
 
@@ -575,134 +510,158 @@ mod tests {
 
     #[test]
     fn test_intersection() {
-        assert!(!ass("foo.rs", 10, 5, None, None).intersects(ass("foo.rs", 16, 5, None, None)));
-        assert!(ass("foo.rs", 10, 6, None, None).intersects(ass("foo.rs", 16, 5, None, None)));
-        assert!(ass("foo.rs", 10, 7, None, None).intersects(ass("foo.rs", 16, 5, None, None)));
+        assert!(
+            !HunkAssignment::new("foo.rs", 10, 5, None, None)
+                .intersects(HunkAssignment::new("foo.rs", 16, 5, None, None))
+        );
+        assert!(
+            HunkAssignment::new("foo.rs", 10, 6, None, None)
+                .intersects(HunkAssignment::new("foo.rs", 16, 5, None, None))
+        );
+        assert!(
+            HunkAssignment::new("foo.rs", 10, 7, None, None)
+                .intersects(HunkAssignment::new("foo.rs", 16, 5, None, None))
+        );
     }
 
     #[test]
     fn test_reconcile_exact_match_and_no_intersection() {
-        let previous_assignments = vec![ass("foo.rs", 10, 5, Some(1), Some(1))];
+        let previous_assignments = vec![HunkAssignment::new("foo.rs", 10, 5, Some(1), Some(1))];
         let worktree_assignments = vec![
-            ass("foo.rs", 10, 5, None, None),
-            ass("foo.rs", 20, 5, None, None),
+            HunkAssignment::new("foo.rs", 10, 5, None, None),
+            HunkAssignment::new("foo.rs", 20, 5, None, None),
         ];
-        let applied_stacks = vec![sequential_stack_id(1), sequential_stack_id(2)];
-        let result = reconcile_assignments(
+        let applied_stacks = vec![stack_id_seq(1), stack_id_seq(2)];
+        let result = reconcile::assignments(
             worktree_assignments,
             &previous_assignments,
             &applied_stacks,
-            MultiDepsResolution::SetMostLines,
+            MultipleOverlapping::SetMostLines,
             true,
         )
         .unwrap();
         assert_eq(
             result,
             vec![
-                ass("foo.rs", 10, 5, Some(1), Some(1)),
-                ass("foo.rs", 20, 5, None, None),
+                HunkAssignment::new("foo.rs", 10, 5, Some(1), Some(1)),
+                HunkAssignment::new("foo.rs", 20, 5, None, None),
             ],
         );
     }
 
     #[test]
     fn test_reconcile_exact_match_unapplied_branch_unassigns() {
-        let previous_assignments = vec![ass("foo.rs", 10, 5, Some(1), Some(1))];
-        let worktree_assignments = vec![ass("foo.rs", 10, 5, None, Some(1))];
-        let applied_stacks = vec![sequential_stack_id(2)];
-        let result = reconcile_assignments(
+        let previous_assignments = vec![HunkAssignment::new("foo.rs", 10, 5, Some(1), Some(1))];
+        let worktree_assignments = vec![HunkAssignment::new("foo.rs", 10, 5, None, Some(1))];
+        let applied_stacks = vec![stack_id_seq(2)];
+        let result = reconcile::assignments(
             worktree_assignments,
             &previous_assignments,
             &applied_stacks,
-            MultiDepsResolution::SetMostLines,
+            MultipleOverlapping::SetMostLines,
             true,
         )
         .unwrap();
-        assert_eq(result, vec![ass("foo.rs", 10, 5, None, Some(1))]);
+        assert_eq(
+            result,
+            vec![HunkAssignment::new("foo.rs", 10, 5, None, Some(1))],
+        );
     }
 
     #[test]
     fn test_reconcile_with_overlap_preserves_assignment() {
-        let previous_assignments = vec![ass("foo.rs", 10, 5, Some(1), Some(1))];
-        let worktree_assignments = vec![ass("foo.rs", 12, 7, None, Some(1))];
-        let applied_stacks = vec![sequential_stack_id(1)];
-        let result = reconcile_assignments(
+        let previous_assignments = vec![HunkAssignment::new("foo.rs", 10, 5, Some(1), Some(1))];
+        let worktree_assignments = vec![HunkAssignment::new("foo.rs", 12, 7, None, Some(1))];
+        let applied_stacks = vec![stack_id_seq(1)];
+        let result = reconcile::assignments(
             worktree_assignments,
             &previous_assignments,
             &applied_stacks,
-            MultiDepsResolution::SetMostLines,
+            MultipleOverlapping::SetMostLines,
             true,
         )
         .unwrap();
-        assert_eq(result, vec![ass("foo.rs", 12, 7, Some(1), Some(1))]);
+        assert_eq(
+            result,
+            vec![HunkAssignment::new("foo.rs", 12, 7, Some(1), Some(1))],
+        );
     }
 
     #[test]
     fn test_double_overlap_picks_the_bigger_previous_assignment() {
         let previous_assignments = vec![
-            ass("foo.rs", 1, 15, Some(1), Some(1)),
-            ass("foo.rs", 17, 20, Some(2), Some(2)),
+            HunkAssignment::new("foo.rs", 1, 15, Some(1), Some(1)),
+            HunkAssignment::new("foo.rs", 17, 20, Some(2), Some(2)),
         ];
-        let applied_stacks = vec![sequential_stack_id(1), sequential_stack_id(2)];
-        let worktree_assignments = vec![ass("foo.rs", 5, 18, None, None)];
-        let result = reconcile_assignments(
+        let applied_stacks = vec![stack_id_seq(1), stack_id_seq(2)];
+        let worktree_assignments = vec![HunkAssignment::new("foo.rs", 5, 18, None, None)];
+        let result = reconcile::assignments(
             worktree_assignments,
             &previous_assignments,
             &applied_stacks,
-            MultiDepsResolution::SetMostLines,
+            MultipleOverlapping::SetMostLines,
             true,
         )
         .unwrap();
-        assert_eq(result, vec![ass("foo.rs", 5, 18, Some(2), Some(1))]);
+        assert_eq(
+            result,
+            vec![HunkAssignment::new("foo.rs", 5, 18, Some(2), Some(1))],
+        );
     }
 
     #[test]
     fn test_double_overlap_unassigns() {
         let previous_assignments = vec![
-            ass("foo.rs", 5, 15, Some(1), Some(1)),
-            ass("foo.rs", 17, 25, Some(2), Some(2)),
+            HunkAssignment::new("foo.rs", 5, 15, Some(1), Some(1)),
+            HunkAssignment::new("foo.rs", 17, 25, Some(2), Some(2)),
         ];
-        let applied_stacks = vec![sequential_stack_id(1), sequential_stack_id(2)];
-        let worktree_assignments = vec![ass("foo.rs", 5, 18, None, None)];
-        let result = reconcile_assignments(
+        let applied_stacks = vec![stack_id_seq(1), stack_id_seq(2)];
+        let worktree_assignments = vec![HunkAssignment::new("foo.rs", 5, 18, None, None)];
+        let result = reconcile::assignments(
             worktree_assignments,
             &previous_assignments,
             &applied_stacks,
-            MultiDepsResolution::SetNone,
+            MultipleOverlapping::SetNone,
             true,
         )
         .unwrap();
-        assert_eq(result, vec![ass("foo.rs", 5, 18, None, Some(1))]);
+        assert_eq(
+            result,
+            vec![HunkAssignment::new("foo.rs", 5, 18, None, Some(1))],
+        );
     }
 
     #[test]
     fn test_reconcile_not_updating_unassigned() {
-        let previous_assignments = vec![ass("foo.rs", 10, 15, Some(1), None)];
-        let worktree_assignments = vec![ass("foo.rs", 12, 17, Some(2), None)];
-        let applied_stacks = vec![sequential_stack_id(1)];
-        let result = reconcile_assignments(
+        let previous_assignments = vec![HunkAssignment::new("foo.rs", 10, 15, Some(1), None)];
+        let worktree_assignments = vec![HunkAssignment::new("foo.rs", 12, 17, Some(2), None)];
+        let applied_stacks = vec![stack_id_seq(1)];
+        let result = reconcile::assignments(
             worktree_assignments,
             &previous_assignments,
             &applied_stacks,
-            MultiDepsResolution::SetMostLines,
+            MultipleOverlapping::SetMostLines,
             false,
         )
         .unwrap();
         // TODO: This is actually broken
-        assert_eq!(result, vec![ass("foo.rs", 12, 17, Some(1), None)]);
+        assert_eq!(
+            result,
+            vec![HunkAssignment::new("foo.rs", 12, 17, Some(1), None)]
+        );
     }
 
     #[test]
     fn test_set_assignment_success() {
-        let applied_stacks = vec![sequential_stack_id(1), sequential_stack_id(2)];
+        let applied_stacks = vec![stack_id_seq(1), stack_id_seq(2)];
         let previous_assignments = vec![
-            ass("foo.rs", 10, 15, None, None),
-            ass("bar.rs", 20, 25, Some(1), None),
+            HunkAssignment::new("foo.rs", 10, 15, None, None),
+            HunkAssignment::new("bar.rs", 20, 25, Some(1), None),
         ];
 
         // Assign foo.rs:10 to stack 2
-        let new_assignment_req = ass_req("foo.rs", 10, 15, Some(2));
-        let new_assignment = ass("foo.rs", 10, 15, Some(2), None);
+        let new_assignment_req = HunkAssignmentRequest::new("foo.rs", 10, 15, Some(2));
+        let new_assignment = HunkAssignment::new("foo.rs", 10, 15, Some(2), None);
         let updated = set_assignment(
             &applied_stacks,
             previous_assignments.clone(),
@@ -712,26 +671,26 @@ mod tests {
 
         // Should update the stack_id for foo.rs:10
         let found = updated.iter().find(|h| **h == new_assignment).unwrap();
-        assert_eq!(found.stack_id, Some(sequential_stack_id(2)));
+        assert_eq!(found.stack_id, Some(stack_id_seq(2)));
 
         // Other assignments should remain unchanged
         let other = updated
             .iter()
-            .find(|h| **h == ass("bar.rs", 20, 25, Some(1), None))
+            .find(|h| **h == HunkAssignment::new("bar.rs", 20, 25, Some(1), None))
             .unwrap();
-        assert_eq!(other.stack_id, Some(sequential_stack_id(1)));
+        assert_eq!(other.stack_id, Some(stack_id_seq(1)));
     }
 
     #[test]
     fn test_set_assignment_stack_not_applied() {
-        let applied_stacks = vec![sequential_stack_id(1), sequential_stack_id(2)];
+        let applied_stacks = vec![stack_id_seq(1), stack_id_seq(2)];
         let previous_assignments = vec![
-            ass("foo.rs", 10, 15, None, None),
-            ass("bar.rs", 20, 25, Some(1), None),
+            HunkAssignment::new("foo.rs", 10, 15, None, None),
+            HunkAssignment::new("bar.rs", 20, 25, Some(1), None),
         ];
 
         // Assign foo.rs:10 to stack 3 (not applied)
-        let new_assignment = ass_req("foo.rs", 10, 15, Some(3));
+        let new_assignment = HunkAssignmentRequest::new("foo.rs", 10, 15, Some(3));
         let result = set_assignment(
             &applied_stacks,
             previous_assignments.clone(),
@@ -743,14 +702,14 @@ mod tests {
 
     #[test]
     fn test_set_assignment_hunk_not_found() {
-        let applied_stacks = vec![sequential_stack_id(1), sequential_stack_id(2)];
+        let applied_stacks = vec![stack_id_seq(1), stack_id_seq(2)];
         let previous_assignments = vec![
-            ass("foo.rs", 10, 15, None, None),
-            ass("bar.rs", 20, 25, Some(1), None),
+            HunkAssignment::new("foo.rs", 10, 15, None, None),
+            HunkAssignment::new("bar.rs", 20, 25, Some(1), None),
         ];
 
         // Assign baz.rs:30 to stack 2 (not found)
-        let new_assignment = ass_req("baz.rs", 30, 35, Some(2));
+        let new_assignment = HunkAssignmentRequest::new("baz.rs", 30, 35, Some(2));
         let result = set_assignment(
             &applied_stacks,
             previous_assignments.clone(),
@@ -762,15 +721,15 @@ mod tests {
 
     #[test]
     fn test_hunk_assignment_partial_eq() {
-        let hunk1 = ass("foo.rs", 10, 15, Some(1), Some(3));
-        let hunk2 = ass("foo.rs", 10, 15, Some(2), Some(4));
+        let hunk1 = HunkAssignment::new("foo.rs", 10, 15, Some(1), Some(3));
+        let hunk2 = HunkAssignment::new("foo.rs", 10, 15, Some(2), Some(4));
         assert_eq!(hunk1, hunk2);
     }
 
     #[test]
     fn test_hunk_assignment_partial_eq_different_path() {
-        let hunk1 = ass("foo.rs", 10, 15, Some(1), None);
-        let hunk2 = ass("bar.rs", 10, 15, Some(2), None);
+        let hunk1 = HunkAssignment::new("foo.rs", 10, 15, Some(1), None);
+        let hunk2 = HunkAssignment::new("bar.rs", 10, 15, Some(2), None);
         assert_ne!(hunk1, hunk2);
     }
 }

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -605,7 +605,7 @@ mod tests {
         .unwrap();
         assert_eq(
             result,
-            vec![HunkAssignment::new("foo.rs", 5, 18, Some(2), Some(1))],
+            vec![HunkAssignment::new("foo.rs", 5, 18, Some(2), Some(2))],
         );
     }
 
@@ -627,7 +627,7 @@ mod tests {
         .unwrap();
         assert_eq(
             result,
-            vec![HunkAssignment::new("foo.rs", 5, 18, None, Some(1))],
+            vec![HunkAssignment::new("foo.rs", 5, 18, None, Some(2))],
         );
     }
 

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -227,7 +227,7 @@ pub fn assign(
         &deps_assignments,
         &applied_stacks,
         MultipleOverlapping::SetNone, // If there is double locking, move the hunk to the Uncommitted section
-        true,
+        false, // Dependencies should not update the assignment request if it is attemptint to set to None
     )?;
     state::set_assignments(ctx, assignments_considering_deps.clone())?;
 
@@ -308,7 +308,7 @@ pub fn assignments(
             &deps_assignments,
             &applied_stacks,
             MultipleOverlapping::SetNone, // If there is double locking, move the hunk to the Uncommitted section
-            !set_assignment_from_locks, // If we are not setting assignments from locks, we do not want to update unassigned hunks here
+            set_assignment_from_locks,
         )?;
         reconciled.extend(assignments_considering_deps);
     }

--- a/crates/but-hunk-assignment/src/reconcile.rs
+++ b/crates/but-hunk-assignment/src/reconcile.rs
@@ -1,0 +1,80 @@
+use std::cmp::Ordering;
+
+use anyhow::Result;
+use but_workspace::StackId;
+use itertools::Itertools;
+
+use crate::HunkAssignment;
+
+pub enum MultipleOverlapping {
+    SetNone,
+    SetMostLines,
+}
+
+pub(crate) fn assignments(
+    new: Vec<HunkAssignment>,
+    old: &[HunkAssignment],
+    applied_stack_ids: &[StackId],
+    multiple_overlapping_resolution: MultipleOverlapping,
+    update_unassigned: bool,
+) -> Result<Vec<HunkAssignment>> {
+    let mut reconciled = vec![];
+    for mut new_assignment in new {
+        let intersecting = old
+            .iter()
+            .filter(|current_entry| current_entry.intersects(new_assignment.clone()))
+            .collect::<Vec<_>>();
+
+        // If the worktree hunk intersects with exactly one previous assignment, then it inherits the stack_id assignment from it, but only if the stack is still applied.
+        // If the worktree hunk does not interesect with any previous assingment then it remains, "unassigned", i.e. with stack_id None
+        // If the worktree hunk intersects with more that one one previous assignment there is special handling
+        match intersecting.len().cmp(&1) {
+            Ordering::Less => {
+                // No intersection - do nothing, the None assignment is kept
+            }
+            Ordering::Equal => {
+                // One intersection - assign the stack id if the stack is still in the applied list
+                if let Some(stack_id) = intersecting[0].stack_id {
+                    if applied_stack_ids.contains(&stack_id) {
+                        if update_unassigned && new_assignment.stack_id.is_none() {
+                            // In the case where there was no assignment but a hunk lock was detected, we dont want to automatically assign the hunk to the lane where it depends
+                            new_assignment.stack_id = intersecting[0].stack_id;
+                        }
+                        new_assignment.hunk_locks = intersecting[0].hunk_locks.clone();
+                        if intersecting[0].id.is_some() {
+                            new_assignment.id = intersecting[0].id;
+                        }
+                    }
+                }
+            }
+            Ordering::Greater => {
+                match multiple_overlapping_resolution {
+                    MultipleOverlapping::SetNone => {
+                        new_assignment.stack_id = None;
+                    }
+                    MultipleOverlapping::SetMostLines => {
+                        // More than one intersection - pick the one with the most lines
+                        new_assignment.stack_id = intersecting
+                            .iter()
+                            .max_by_key(|x| x.hunk_header.as_ref().map(|h| h.new_lines))
+                            .and_then(|x| x.stack_id);
+                    }
+                }
+
+                if intersecting[0].id.is_some() {
+                    new_assignment.id = intersecting[0].id; // Use the id of the first intersecting assignment as the id for the new assignment
+                }
+
+                // Inherit all locks from the intersecting assignments
+                let all_locks = intersecting
+                    .iter()
+                    .flat_map(|i| i.hunk_locks.clone())
+                    .unique()
+                    .collect::<Vec<_>>();
+                new_assignment.hunk_locks = all_locks;
+            }
+        }
+        reconciled.push(new_assignment);
+    }
+    Ok(reconciled)
+}

--- a/crates/but-hunk-assignment/src/reconcile.rs
+++ b/crates/but-hunk-assignment/src/reconcile.rs
@@ -2,13 +2,41 @@ use std::cmp::Ordering;
 
 use anyhow::Result;
 use but_workspace::StackId;
-use itertools::Itertools;
 
 use crate::HunkAssignment;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MultipleOverlapping {
     SetNone,
     SetMostLines,
+}
+
+impl HunkAssignment {
+    fn set_from(&mut self, other: &Self, applied_stack_ids: &[StackId], update_unassigned: bool) {
+        // Always override the locks with the from the other assignment
+        self.hunk_locks = other.hunk_locks.clone();
+        // Override the id only if the other assignment has an id
+        if other.id.is_some() {
+            self.id = other.id;
+        }
+        // Override the stack_id only if the current assignment has a stack_id or if update_unassigned is true
+        match self.stack_id {
+            Some(_) => {
+                self.stack_id = other.stack_id;
+            }
+            None => {
+                if update_unassigned {
+                    self.stack_id = other.stack_id;
+                }
+            }
+        }
+        // If the self.stack_id is set, ensure that it is a value that is still in the applied_stack_ids. If not, reset it to None.
+        if let Some(stack_id) = self.stack_id {
+            if !applied_stack_ids.contains(&stack_id) {
+                self.stack_id = None;
+            }
+        }
+    }
 }
 
 pub(crate) fn assignments(
@@ -25,53 +53,26 @@ pub(crate) fn assignments(
             .filter(|current_entry| current_entry.intersects(new_assignment.clone()))
             .collect::<Vec<_>>();
 
-        // If the worktree hunk intersects with exactly one previous assignment, then it inherits the stack_id assignment from it, but only if the stack is still applied.
-        // If the worktree hunk does not interesect with any previous assingment then it remains, "unassigned", i.e. with stack_id None
-        // If the worktree hunk intersects with more that one one previous assignment there is special handling
         match intersecting.len().cmp(&1) {
             Ordering::Less => {
                 // No intersection - do nothing, the None assignment is kept
             }
             Ordering::Equal => {
-                // One intersection - assign the stack id if the stack is still in the applied list
-                if let Some(stack_id) = intersecting[0].stack_id {
-                    if applied_stack_ids.contains(&stack_id) {
-                        if update_unassigned && new_assignment.stack_id.is_none() {
-                            // In the case where there was no assignment but a hunk lock was detected, we dont want to automatically assign the hunk to the lane where it depends
-                            new_assignment.stack_id = intersecting[0].stack_id;
-                        }
-                        new_assignment.hunk_locks = intersecting[0].hunk_locks.clone();
-                        if intersecting[0].id.is_some() {
-                            new_assignment.id = intersecting[0].id;
-                        }
-                    }
-                }
+                new_assignment.set_from(intersecting[0], applied_stack_ids, update_unassigned);
             }
             Ordering::Greater => {
-                match multiple_overlapping_resolution {
-                    MultipleOverlapping::SetNone => {
-                        new_assignment.stack_id = None;
-                    }
-                    MultipleOverlapping::SetMostLines => {
-                        // More than one intersection - pick the one with the most lines
-                        new_assignment.stack_id = intersecting
-                            .iter()
-                            .max_by_key(|x| x.hunk_header.as_ref().map(|h| h.new_lines))
-                            .and_then(|x| x.stack_id);
-                    }
-                }
-
-                if intersecting[0].id.is_some() {
-                    new_assignment.id = intersecting[0].id; // Use the id of the first intersecting assignment as the id for the new assignment
-                }
-
-                // Inherit all locks from the intersecting assignments
-                let all_locks = intersecting
+                // Pick the hunk with the most lines to adopt the assignment info from.
+                let biggest_hunk = intersecting
                     .iter()
-                    .flat_map(|i| i.hunk_locks.clone())
-                    .unique()
-                    .collect::<Vec<_>>();
-                new_assignment.hunk_locks = all_locks;
+                    .max_by_key(|h| h.hunk_header.as_ref().map(|h| h.new_lines));
+                if let Some(other) = biggest_hunk {
+                    new_assignment.set_from(other, applied_stack_ids, update_unassigned);
+                }
+
+                if multiple_overlapping_resolution == MultipleOverlapping::SetNone {
+                    // If requested, reset stack_id to none on multiple overlapping
+                    new_assignment.stack_id = None;
+                }
             }
         }
         reconciled.push(new_assignment);


### PR DESCRIPTION
A stable identifier for a hunk assignment.
  - When a new hunk is first observed (from the uncommitted changes), it is assigned a new id.
  - If a hunk is modified (i.e. it has gained or lost lines), the UUID remains the same.
  - If two or more hunks become merged (due to edits causing the contexts to overlap), the id of the hunk with the most lines is adopted.


This also fixes a bug where the system will automatically assign changes due to hunk locks