### PR TITLE
Remove hunkSelectionId

### DIFF
--- a/apps/desktop/src/lib/selection/entityAdapters.ts
+++ b/apps/desktop/src/lib/selection/entityAdapters.ts
@@ -27,15 +27,19 @@ export const hunkAssignmentAdapter = createEntityAdapter<HunkAssignment, string>
 	selectId: (c) => compositeKey(c)
 });
 
+/**
+ * There may be at most one HunkSelection for each HunkAssignment. As such, we
+ * use an `assignmentId` which cooresponds to a given HunkAssignment both as a
+ * foreign key, but also the primary identifier of a HunkSelection.
+ */
 export type HunkSelection = {
-	hunkSelectionId: string;
+	assignmentId: string;
 	stackId: string | null;
 	path: string;
-	assignmentId: string;
 	changeId: string;
 	lines: LineId[];
 };
 
 export const hunkSelectionAdapter = createEntityAdapter<HunkSelection, string>({
-	selectId: (c) => c.hunkSelectionId
+	selectId: (c) => c.assignmentId
 });

--- a/apps/desktop/src/lib/selection/uncommitted.ts
+++ b/apps/desktop/src/lib/selection/uncommitted.ts
@@ -19,6 +19,8 @@ import type { LineId } from '@gitbutler/ui/utils/diffParsing';
  * In this slice we manage a few related concepts, 1) tree changes, 2) hunk
  * assignments, and 3) hunk selections, with the intended outcome that it
  * should be easy to manage checkboxes.
+ *
+ * A hunk selection will always have an associated hunk assignment.
  */
 export const uncommittedSlice = createSlice({
 	name: 'uncommitted',
@@ -84,7 +86,6 @@ export const uncommittedSlice = createSlice({
 					throw new Error(`Expected to find assignment: ${key} `);
 				}
 				state.hunkSelection = hunkSelectionAdapter.addOne(state.hunkSelection, {
-					hunkSelectionId: key,
 					stackId: stackId,
 					path: assignment.path,
 					assignmentId: key,
@@ -134,7 +135,7 @@ export const uncommittedSlice = createSlice({
 						} else {
 							state.hunkSelection = hunkSelectionAdapter.removeOne(
 								state.hunkSelection,
-								selection.hunkSelectionId
+								selection.assignmentId
 							);
 						}
 					}
@@ -153,7 +154,6 @@ export const uncommittedSlice = createSlice({
 			);
 			if (assignment) {
 				state.hunkSelection = hunkSelectionAdapter.upsertOne(state.hunkSelection, {
-					hunkSelectionId: key,
 					stackId: stackId,
 					path: assignment.path,
 					assignmentId: key,
@@ -180,7 +180,6 @@ export const uncommittedSlice = createSlice({
 			for (const assignment of assignments) {
 				const key = hunkAssignmentAdapter.selectId(assignment);
 				state.hunkSelection = hunkSelectionAdapter.upsertOne(state.hunkSelection, {
-					hunkSelectionId: key,
 					stackId: stackId,
 					path: assignment.path,
 					assignmentId: key,
@@ -212,7 +211,6 @@ export const uncommittedSlice = createSlice({
 			for (const assignment of assignments) {
 				const key = hunkAssignmentAdapter.selectId(assignment);
 				state.hunkSelection = hunkSelectionAdapter.upsertOne(state.hunkSelection, {
-					hunkSelectionId: key,
 					stackId: stackId,
 					path: assignment.path,
 					assignmentId: key,
@@ -230,7 +228,7 @@ export const uncommittedSlice = createSlice({
 			);
 			state.hunkSelection = hunkSelectionAdapter.removeMany(
 				state.hunkSelection,
-				selections.map((s) => s.hunkSelectionId)
+				selections.map((s) => s.assignmentId)
 			);
 		}
 	}

--- a/apps/desktop/src/lib/selection/uncommitted.ts
+++ b/apps/desktop/src/lib/selection/uncommitted.ts
@@ -146,18 +146,17 @@ export const uncommittedSlice = createSlice({
 			state,
 			action: PayloadAction<{ stackId: string | null; path: string; hunkHeader: string | null }>
 		) {
-			const { stackId, path, hunkHeader } = action.payload;
 			const key = compositeKey(action.payload);
 			const assignment = uncommittedSelectors.hunkAssignments.selectById(
 				state.hunkAssignments,
-				compositeKey({ stackId, path, hunkHeader })
+				key
 			);
 			if (assignment) {
 				state.hunkSelection = hunkSelectionAdapter.upsertOne(state.hunkSelection, {
-					stackId: stackId,
+					stackId: action.payload.stackId,
 					path: assignment.path,
 					assignmentId: key,
-					changeId: `${stackId}::${assignment.path}`,
+					changeId: `${action.payload.stackId}::${assignment.path}`,
 					lines: []
 				});
 			}


### PR DESCRIPTION

<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#3bRgzIRwj`](https://gitbutler.com/cto/gitbutler-client-d443/reviews/3bRgzIRwj)

**Remove hunkSelectionId**


An observation that I had was that the hunkSelectionId was always, and must always be the same as the assignmentId. Given this relationship, it seems reasonable that we drop the hunkSelectionId and work only with the assignmentId.

2 commit series (version 6)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 2/2 | [Only create composite key once in `checkHunk`](https://gitbutler.com/cto/gitbutler-client-d443/reviews/3bRgzIRwj/commit/6562c2c9-b7b7-4556-8ef1-86459f8959b4) | ⏳ |  |
| 1/2 | [Remove hunkSelectionId](https://gitbutler.com/cto/gitbutler-client-d443/reviews/3bRgzIRwj/commit/0132c43e-dae6-4b5b-a726-f3e198e6cc78) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/cto/gitbutler-client-d443/reviews/3bRgzIRwj)_
<!-- GitButler Review Footer Boundary Bottom -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #8915 
- <kbd>&nbsp;2&nbsp;</kbd> #8914 
- <kbd>&nbsp;1&nbsp;</kbd> #8908 👈 
<!-- GitButler Footer Boundary Bottom -->

