### PR TITLE
Use a copy of state in `worktreeChanges`

### DIFF
--- a/apps/desktop/src/lib/selection/uncommittedService.svelte.ts
+++ b/apps/desktop/src/lib/selection/uncommittedService.svelte.ts
@@ -90,11 +90,10 @@ export class UncommittedService {
 	 * Gathers data for creating a commit, based on what hunks are selected.
 	 */
 	async worktreeChanges(projectId: string, stackId?: string) {
+		const state = structuredClone(this.state);
+
 		const key = `${stackId || null}::`;
-		const selection = uncommittedSelectors.hunkSelection.selectByPrefix(
-			this.state.hunkSelection,
-			key
-		);
+		const selection = uncommittedSelectors.hunkSelection.selectByPrefix(state.hunkSelection, key);
 
 		const pathGroups = selection.reduce<Record<string, HunkSelection[]>>((acc, item) => {
 			const key = `${item.path}`;
@@ -108,11 +107,11 @@ export class UncommittedService {
 		const worktreeChanges: DiffSpec[] = [];
 		for (const [path, selection] of Object.entries(pathGroups)) {
 			const hunkHeaders: HunkHeader[] = [];
-			const change = uncommittedSelectors.treeChanges.selectById(this.state.treeChanges, path)!;
+			const change = uncommittedSelectors.treeChanges.selectById(state.treeChanges, path)!;
 			for (const { lines, assignmentId } of selection) {
 				// We want to use `null` to commit from unassigned changes if new stack was created.
 				const assignment = uncommittedSelectors.hunkAssignments.selectById(
-					this.state.hunkAssignments,
+					state.hunkAssignments,
 					assignmentId
 				)!;
 


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#9q6Jkd7DL`](https://gitbutler.com/cto/gitbutler-client-d443/reviews/9q6Jkd7DL)

**Use a copy of state in `worktreeChanges`**


Inside an asynchronous function, external values can change during any time and await happens. As such, it makes sense to clone the state before we start to make sure everything remains consistent as the function works.

This means that any changes to selection, or any changes on disk won’t be picked up while this function is working, but changes not getting picked up feels like a more consistent behaviour than having state potentially change whilst the function is working. 

1 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Use a copy of state in `worktreeChanges`](https://gitbutler.com/cto/gitbutler-client-d443/reviews/9q6Jkd7DL/commit/4f5603c7-f0e1-4469-96d4-c178204fcb0b) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/cto/gitbutler-client-d443/reviews/9q6Jkd7DL)_
<!-- GitButler Review Footer Boundary Bottom -->
