### PR TITLE
investigate a ligher `git2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6530,15 +6530,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "openssl-src"
-version = "300.5.0+3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6546,7 +6537,6 @@ checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,7 @@ gix = { git = "https://github.com/GitoxideLabs/gitoxide", branch = "main", versi
 ] }
 gix-testtools = "0.16.1"
 insta = "1.43.1"
-git2 = { version = "0.20.0", features = [
-    "vendored-openssl",
+git2 = { version = "0.20.0", default-features = false, features = [
     "vendored-libgit2",
 ] }
 uuid = { version = "1.17.0", features = ["v4", "serde"] }


### PR DESCRIPTION
This is more of a quick research spike, not for merge. Motivated by a converstaion yesterday, a "what-if" so to say.
If it was merged, this should improve compile times for everyone. Unfortunately, that only removes `openssl-sys` from the tree,
but probably it also won't compile HTTPS related things.

With this PR, one will remove openssl-src from the tree.

```
  32,33d31
< │   │       ├── openssl-src v300.5.0+3.5.0
< │   │       │   └── cc v1.2.23 (*)
```

However, `openssl-sys` is still unconditionally pulled in. The `src` is probably just due to the vendoring being disabled.

### Tasks

* [x] Minimize features used by `git2`

If one wanted to complete this, one would now have to delete

https://github.com/gitbutlerapp/gitbutler/blob/00724047cd926f40f94d39821f2171a6cefb50ec/crates/gitbutler-repo-actions/src/repository.rs#L283-L316

and remove support for non-git-binary flows.

These are probably a feature, but **it would be great to have information on which flows people actually use**.
In theory, this is needed to make GitButler a standalone client, but achieving this with full compatibility is hard, as SSH in particular is incredibly complex
if it should be fully compatible.

### Conclusion

There is no way to remove `openssl-sys` while `libgit2` is pulled in.
In theory, we can stop doing so once `gitoxide` learns to:

* reset worktrees
* create trees from an index and better index manipulation
* (ahead-behind)
* optionally: fetch and push

The above would also mean that all old code has to be gone, or be ported to `gitoxide`.

> [!IMPORTANT]
> My recommendation is to prepare this by seeing if supporting only the binary for fetching is the way to go - after all, pushing is only ever done with the binary so the currently implementation isn't complete at all.
