### PR TITLE
Pass whole headers about

### DIFF
--- a/apps/desktop/src/components/v3/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/v3/UnifiedDiffView.svelte
@@ -119,7 +119,7 @@
 						{@const selection = uncommittedService.hunkCheckStatus(
 							stackId || null,
 							change.path,
-							hunk.newStart.toString()
+							hunk
 						)}
 						{@const [fullyLocked, lineLocks] = getLineLocks(
 							activeStackId,
@@ -159,48 +159,26 @@
 								onLineClick={(p) => {
 									if (fullyLocked) return;
 									if (!canBePartiallySelected(diff.subject)) {
-										uncommittedService.checkHunk(
-											stackId || null,
-											change.path,
-											hunk.newStart.toString()
-										);
+										uncommittedService.checkHunk(stackId || null, change.path, hunk);
 									}
 									if (!linesInclude(p.newLine, p.oldLine, selection.current.lines)) {
-										uncommittedService.checkLine(
-											stackId || null,
-											change.path,
-											hunk.newStart.toString(),
-											{
-												newLine: p.newLine,
-												oldLine: p.oldLine
-											}
-										);
+										uncommittedService.checkLine(stackId || null, change.path, hunk, {
+											newLine: p.newLine,
+											oldLine: p.oldLine
+										});
 									} else {
-										uncommittedService.uncheckLine(
-											stackId || null,
-											change.path,
-											hunk.newStart.toString(),
-											{
-												newLine: p.newLine,
-												oldLine: p.oldLine
-											}
-										);
+										uncommittedService.uncheckLine(stackId || null, change.path, hunk, {
+											newLine: p.newLine,
+											oldLine: p.oldLine
+										});
 									}
 								}}
 								onChangeStage={(selected) => {
 									if (fullyLocked || !selectable) return;
 									if (selected) {
-										uncommittedService.checkHunk(
-											stackId || null,
-											change.path,
-											hunk.newStart.toString()
-										);
+										uncommittedService.checkHunk(stackId || null, change.path, hunk);
 									} else {
-										uncommittedService.uncheckHunk(
-											stackId || null,
-											change.path,
-											hunk.newStart.toString()
-										);
+										uncommittedService.uncheckHunk(stackId || null, change.path, hunk);
 									}
 								}}
 								handleLineContextMenu={(params) => {
@@ -237,7 +215,7 @@
 					{change}
 					discardable={isUncommittedChange}
 					unSelectHunk={(hunk) => {
-						uncommittedService.uncheckHunk(stackId || null, change.path, hunk.newStart.toString());
+						uncommittedService.uncheckHunk(stackId || null, change.path, hunk);
 					}}
 				/>
 			{:else if diff.type === 'TooLarge'}

--- a/apps/desktop/src/lib/commits/dropHandler.ts
+++ b/apps/desktop/src/lib/commits/dropHandler.ts
@@ -60,7 +60,7 @@ export class StartCommitDzHandler implements DropzoneHandler {
 				uncommittedService.checkFile(null, change.path);
 			}
 		} else if (data instanceof HunkDropDataV3) {
-			uncommittedService.checkHunk(stackId, data.change.path, data.hunk.newStart.toString());
+			uncommittedService.checkHunk(stackId, data.change.path, data.hunk);
 		}
 
 		projectState.drawerPage.set('new-commit');

--- a/apps/desktop/src/lib/hunks/dropHandler.ts
+++ b/apps/desktop/src/lib/hunks/dropHandler.ts
@@ -40,7 +40,7 @@ export class AssignmentDropHandler implements DropzoneHandler {
 			const assignment = this.uncommittedService.getAssignmentByHeader(
 				data.stackId,
 				data.change.path,
-				`${data.hunk.newStart}`
+				data.hunk
 			).current!;
 			await this.diffService.assignHunk({
 				projectId: this.projectId,

--- a/apps/desktop/src/lib/selection/entityAdapters.ts
+++ b/apps/desktop/src/lib/selection/entityAdapters.ts
@@ -11,7 +11,7 @@ import type { LineId } from '@gitbutler/ui/utils/diffParsing';
 export function compositeKey(args: {
 	stackId: string | null;
 	path: string;
-	hunkHeader: string | HunkHeader | null;
+	hunkHeader: HunkHeader | null;
 }) {
 	if (typeof args.hunkHeader === 'string' || args.hunkHeader === null) {
 		return `${args.stackId}::${args.path}::${args.hunkHeader}`;

--- a/apps/desktop/src/lib/selection/uncommitted.ts
+++ b/apps/desktop/src/lib/selection/uncommitted.ts
@@ -10,7 +10,7 @@ import { createSelectByPrefix, createSelectNotIn } from '$lib/state/customSelect
 import { isDefined } from '@gitbutler/ui/utils/typeguards';
 import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import type { TreeChange } from '$lib/hunks/change';
-import type { HunkAssignment } from '$lib/hunks/hunk';
+import type { HunkAssignment, HunkHeader } from '$lib/hunks/hunk';
 import type { LineId } from '@gitbutler/ui/utils/diffParsing';
 
 /**
@@ -65,7 +65,7 @@ export const uncommittedSlice = createSlice({
 			action: PayloadAction<{
 				stackId: string | null;
 				path: string;
-				hunkHeader: string;
+				hunkHeader: HunkHeader;
 				line: LineId;
 			}>
 		) {
@@ -99,7 +99,7 @@ export const uncommittedSlice = createSlice({
 			action: PayloadAction<{
 				stackId: string | null;
 				path: string;
-				hunkHeader: string;
+				hunkHeader: HunkHeader;
 				line: LineId;
 			}>
 		) {
@@ -144,7 +144,7 @@ export const uncommittedSlice = createSlice({
 		},
 		checkHunk(
 			state,
-			action: PayloadAction<{ stackId: string | null; path: string; hunkHeader: string | null }>
+			action: PayloadAction<{ stackId: string | null; path: string; hunkHeader: HunkHeader | null }>
 		) {
 			const key = compositeKey(action.payload);
 			const assignment = uncommittedSelectors.hunkAssignments.selectById(
@@ -163,7 +163,7 @@ export const uncommittedSlice = createSlice({
 		},
 		uncheckHunk(
 			state,
-			action: PayloadAction<{ stackId: string | null; path: string; hunkHeader: string | null }>
+			action: PayloadAction<{ stackId: string | null; path: string; hunkHeader: HunkHeader | null }>
 		) {
 			const key = compositeKey(action.payload);
 			state.hunkSelection = hunkSelectionAdapter.removeOne(state.hunkSelection, key);
@@ -293,7 +293,7 @@ const selectByPath = createSelector(
 const hunkCheckStatus = createSelector(
 	[
 		selectHunkSelection,
-		(_, hunkId: { stackId: string | null; path: string; hunkHeader: string }) => {
+		(_, hunkId: { stackId: string | null; path: string; hunkHeader: HunkHeader }) => {
 			return hunkId;
 		}
 	],

--- a/apps/desktop/src/lib/selection/uncommittedService.svelte.ts
+++ b/apps/desktop/src/lib/selection/uncommittedService.svelte.ts
@@ -206,7 +206,7 @@ export class UncommittedService {
 	getAssignmentByHeader(
 		stackId: string | null,
 		path: string,
-		hunkHeader: string
+		hunkHeader: HunkHeader
 	): Reactive<HunkAssignment | undefined> {
 		const assignments = $derived(
 			uncommittedSelectors.hunkAssignments.selectById(
@@ -217,7 +217,7 @@ export class UncommittedService {
 		return reactive(() => assignments);
 	}
 
-	hunkCheckStatus(stackId: string | null, path: string, header: string) {
+	hunkCheckStatus(stackId: string | null, path: string, header: HunkHeader) {
 		const result = $derived(
 			uncommittedSelectors.hunkSelection.hunkCheckStatus(this.state, {
 				stackId,
@@ -257,19 +257,19 @@ export class UncommittedService {
 		return reactive(() => result);
 	}
 
-	checkLine(stackId: string | null, path: string, hunkHeader: string, line: LineId) {
+	checkLine(stackId: string | null, path: string, hunkHeader: HunkHeader, line: LineId) {
 		this.dispatch(uncommittedActions.checkLine({ stackId, path, hunkHeader, line }));
 	}
 
-	uncheckLine(stackId: string | null, path: string, header: string, line: LineId) {
+	uncheckLine(stackId: string | null, path: string, header: HunkHeader, line: LineId) {
 		this.dispatch(uncommittedActions.uncheckLine({ stackId, path, hunkHeader: header, line }));
 	}
 
-	checkHunk(stackId: string | null, path: string, header: string) {
+	checkHunk(stackId: string | null, path: string, header: HunkHeader) {
 		this.dispatch(uncommittedActions.checkHunk({ stackId, path, hunkHeader: header }));
 	}
 
-	uncheckHunk(stackId: string | null, path: string, header: string) {
+	uncheckHunk(stackId: string | null, path: string, header: HunkHeader) {
 		this.dispatch(uncommittedActions.uncheckHunk({ stackId, path, hunkHeader: header }));
 	}
 


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #8915 
- <kbd>&nbsp;2&nbsp;</kbd> #8914 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #8908 
<!-- GitButler Footer Boundary Bottom -->

<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#5of0b7nxx`](https://gitbutler.com/cto/gitbutler-client-d443/reviews/5of0b7nxx)

**Pass whole headers about**


Given that the hunk header is used to generate the stable key, it felt a little unsafe to have a load of locations trying to serialize it correctly. It would mean that if we ever decided we needed more than just the newStart we’d have to change all the locations where they get serialized.

This changes all of these to take a proper HunkHeader so it can be serialized exactly in the compositeKey function

1 commit series (version 4)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Pass whole headers about](https://gitbutler.com/cto/gitbutler-client-d443/reviews/5of0b7nxx/commit/348774fd-3126-45cf-88c9-0e91677b8bac) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/cto/gitbutler-client-d443/reviews/5of0b7nxx)_
<!-- GitButler Review Footer Boundary Bottom -->
