### PR TITLE
Suppress updater offline error

### DIFF
--- a/apps/desktop/src/lib/updater/updater.ts
+++ b/apps/desktop/src/lib/updater/updater.ts
@@ -175,7 +175,7 @@ function isOffline(err: any): boolean {
 	return (
 		typeof err === 'string' &&
 		(err.includes('Could not fetch a valid release') ||
-			err.includes('error sending request for') ||
+			err.includes('error sending request') ||
 			err.includes('Network Error'))
 	);
 }


### PR DESCRIPTION
Looks like the error reported from Tauri has changed. Would be great if
we had a more reliable way of suppressing it.