### PR TITLE
Fix slowness of file item :hover effects

### DIFF
--- a/apps/desktop/src/components/v3/FileListItemWrapper.svelte
+++ b/apps/desktop/src/components/v3/FileListItemWrapper.svelte
@@ -179,8 +179,11 @@
 
 <style lang="postcss">
 	.filelistitem-wrapper {
-		display: flex;
-		flex-direction: column;
+		/* We have two nested divs for one file, but a block within a block
+		   seems fine. It seems we cannot have them both be flex boxes, it
+		   makes any :hover css trigger excessive layout passes, thus making
+		   the interface super slow. */
+		display: block;
 	}
 	.filelistitem-header {
 		z-index: var(--z-lifted);

--- a/apps/desktop/src/components/v3/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/v3/WorktreeChanges.svelte
@@ -228,10 +228,7 @@
 	}
 
 	.uncommitted-changes {
-		display: flex;
-		flex: 1;
-		flex-direction: column;
-		width: 100%;
+		display: block;
 	}
 
 	.start-commit {


### PR DESCRIPTION
Seems like a flex div within a flex div was making the :hover effect
on uncommitted files really slow.
