### PR TITLE
Update to the latest version of `gix` for unified-diff fix.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1305,7 +1305,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3425,7 +3425,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.72.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "gix-actor 0.35.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-attributes 0.26.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3496,7 +3496,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.35.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "gix-date 0.10.2 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3527,7 +3527,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.26.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "gix-glob 0.20.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3553,7 +3553,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.14"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "thiserror 2.0.12",
 ]
@@ -3570,7 +3570,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "thiserror 2.0.12",
 ]
@@ -3578,7 +3578,7 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.6.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "gix-path 0.10.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3603,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "gix-chunk 0.4.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3616,7 +3616,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.45.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -3636,7 +3636,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -3648,7 +3648,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3679,7 +3679,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.10.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "itoa 1.0.15",
@@ -3692,7 +3692,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.52.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "gix-attributes 0.26.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3715,7 +3715,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.14.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "gix-discover 0.40.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3750,7 +3750,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.40.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "dunce",
@@ -3779,7 +3779,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.42.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -3799,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.19.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "fastrand",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.20.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -3882,7 +3882,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.18.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "faster-hex",
  "gix-features 0.42.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3905,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.8.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "gix-hash 0.18.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "hashbrown 0.14.5",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "gix-glob 0.20.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3969,7 +3969,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.40.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -4008,7 +4008,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "17.1.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "gix-tempfile 17.1.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.27.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "gix-actor 0.35.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4030,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.5.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4054,7 +4054,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.20.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bitflags 2.9.1",
  "gix-commitgraph 0.28.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4090,7 +4090,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.49.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "gix-actor 0.35.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4111,7 +4111,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.69.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "arc-swap",
  "gix-date 0.10.2 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4132,7 +4132,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.59.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "clru",
  "gix-chunk 0.4.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4153,7 +4153,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4164,7 +4164,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4189,7 +4189,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.18"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "gix-trace 0.1.12 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4202,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -4216,7 +4216,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4228,7 +4228,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.50.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -4265,7 +4265,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4296,7 +4296,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.52.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "gix-actor 0.35.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-features 0.42.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4317,7 +4317,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.30.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "gix-hash 0.18.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4330,7 +4330,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.34.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -4363,7 +4363,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.20.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "gix-commitgraph 0.28.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-date 0.10.2 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bitflags 2.9.1",
  "gix-path 0.10.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4401,7 +4401,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.4.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "gix-hash 0.18.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4413,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "filetime",
@@ -4435,7 +4435,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "gix-config",
@@ -4464,7 +4464,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "17.1.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "dashmap",
  "gix-fs 0.15.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4507,7 +4507,7 @@ checksum = "7c396a2036920c69695f760a65e7f2677267ccf483f25046977d87e4cb2665f7"
 [[package]]
 name = "gix-trace"
 version = "0.1.12"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "tracing-core",
 ]
@@ -4515,7 +4515,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.47.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -4551,7 +4551,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.46.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bitflags 2.9.1",
  "gix-commitgraph 0.28.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4567,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "gix-features 0.42.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4591,7 +4591,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4611,7 +4611,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "thiserror 2.0.12",
@@ -4639,7 +4639,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.41.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "gix-attributes 0.26.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4658,7 +4658,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#92febae025165c55e596d58511b1634fb6580b9c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#08e7777454bdce466363321fce7b168d425bb833"
 dependencies = [
  "bstr",
  "gix-features 0.42.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -10244,7 +10244,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
This update includes a fix to the way hunks are merged into one by context.

### Tasks

* [x] [fix in `gix-diff`](https://github.com/GitoxideLabs/gitoxide/pull/2043/commits/0d102f4bdf1450f9c5f8d4176707c73b499bd665)
* [x] validate in GB-UI

The hunk was 'joined' and a commit could be created.

<img width="830" alt="Screenshot 2025-06-11 at 06 42 20" src="https://github.com/user-attachments/assets/d5db5f64-06a5-4f07-9f04-437512d49054" />

Indeed, the "hunks must be in order" error related to the overlap in context lines, causing a sanity check to fail.

For posterity, the issue was in an untested condition copied over from `imara-diff` - the issue we see here is a test for this, and removing the special-case fixed the issue. I also checked in `imara-diff@master` where this issue was also fixed similarly as part of the ongoing 0.2 work.