### PR TITLE
more-mcp-internal-changes

### DIFF
--- a/crates/but/src/mcp_internal/commit.rs
+++ b/crates/but/src/mcp_internal/commit.rs
@@ -5,6 +5,7 @@ use but_workspace::commit_engine::StackSegmentId;
 use rmcp::schemars;
 use serde::{Deserialize, Serialize};
 
+/// Commit changes to the repository.
 pub fn commit(
     project_dir: &Path,
     commit_message: String,
@@ -65,6 +66,55 @@ pub fn commit(
         &repo,
         &project,
         None,
+        destination,
+        None,
+        changes,
+        0, /* context-lines */
+        guard.write_permission(),
+    )?;
+
+    Ok(outcome.into())
+}
+
+/// Amend an existing commit in the repository.
+pub fn amend(
+    project_dir: &Path,
+    commit_message: String,
+    diff_spec: Vec<DiffSpec>,
+    commit_id: String,
+    branch_name: String,
+) -> anyhow::Result<but_workspace::commit_engine::ui::CreateCommitOutcome> {
+    let changes: Vec<but_workspace::DiffSpec> = diff_spec.into_iter().map(Into::into).collect();
+    let (repo, project) = crate::mcp_internal::project::repo_and_maybe_project(
+        project_dir,
+        crate::mcp_internal::project::RepositoryOpenMode::Merge,
+    )?;
+
+    let project = project.ok_or_else(|| {
+        anyhow::anyhow!(
+            "No project found in the specified directory: {}",
+            project_dir.display()
+        )
+    })?;
+
+    let commit_id = resolve_parent_id(&repo, &commit_id)?;
+
+    let stack_id = gitbutler_stack::VirtualBranchesHandle::new(project.gb_dir())
+        .list_stacks_in_workspace()?
+        .iter()
+        .find(|s| s.heads(false).contains(&branch_name))
+        .map(|s| s.id);
+
+    let destination = but_workspace::commit_engine::Destination::AmendCommit {
+        commit_id,
+        new_message: Some(commit_message),
+    };
+
+    let mut guard = project.exclusive_worktree_access();
+    let outcome = but_workspace::commit_engine::create_commit_and_update_refs_with_project(
+        &repo,
+        &project,
+        stack_id,
         destination,
         None,
         changes,

--- a/crates/but/src/mcp_internal/mod.rs
+++ b/crates/but/src/mcp_internal/mod.rs
@@ -28,9 +28,8 @@ impl Mcp {
         Self {}
     }
 
-    #[tool(
-        description = "Get the status of a project. This contains information about the branches applied and uncommitted file changes."
-    )]
+    #[tool(description = "Get the status of a project.
+        This contains information about the branches applied, uncommitted file changes and any uncommitted changes assigned to the branches .")]
     pub fn project_status(
         &self,
         #[tool(aggr)] params: ProjectStatusParams,
@@ -44,9 +43,8 @@ impl Mcp {
         )?]))
     }
 
-    #[tool(
-        description = "Commit changes to the repository. Applies the given diff spec and creates a commit with the provided message."
-    )]
+    #[tool(description = "Commit changes to the repository.
+        Applies the given diff spec and creates a commit with the provided message.")]
     pub fn commit(
         &self,
         #[tool(aggr)] params: CommitParams,
@@ -66,9 +64,8 @@ impl Mcp {
         )?]))
     }
 
-    #[tool(
-        description = "Amend an existing commit in the repository. Updates the commit message and file changes for the specified commit."
-    )]
+    #[tool(description = "Amend an existing commit in the repository.
+        Updates the commit message and file changes for the specified commit.")]
     pub fn amend(&self, #[tool(aggr)] params: AmendParams) -> Result<CallToolResult, rmcp::Error> {
         let project_path = std::path::PathBuf::from(&params.current_working_directory);
         let outcome = crate::mcp_internal::commit::amend(
@@ -105,13 +102,14 @@ pub struct CommitParams {
     pub message: String,
 
     #[schemars(
-        description = "The list of files paths (and optionally their previous paths) to commit. If the previous path is provided, it indicates a rename operation."
+        description = "The list of files paths (and optionally their previous paths) to commit.
+        If the previous path is provided, it indicates a rename operation."
     )]
     pub diff_spec: Vec<crate::mcp_internal::commit::DiffSpec>,
 
-    #[schemars(
-        description = "Optional parent commit id. If provided, the commit will be created as a child of this commit. Otherwise, it will be created on top of the specified branch."
-    )]
+    #[schemars(description = "Optional parent commit id.
+        If provided, the commit will be created as a child of this commit.
+        Otherwise, it will be created on top of the specified branch.")]
     pub parent_id: Option<String>,
 
     #[schemars(description = "The branch name to commit to")]
@@ -128,13 +126,13 @@ pub struct AmendParams {
     pub message: String,
 
     #[schemars(
-        description = "The list of file paths (and optionally their previous paths) to include in the amended commit. If the previous path is provided, it indicates a rename operation."
+        description = "The list of file paths (and optionally their previous paths) to include in the amended commit.
+        If the previous path is provided, it indicates a rename operation."
     )]
     pub diff_spec: Vec<crate::mcp_internal::commit::DiffSpec>,
 
-    #[schemars(
-        description = "The commit id of the commit to amend. This is the commit that will be modified with the new message and changes."
-    )]
+    #[schemars(description = "The commit id of the commit to amend. 
+        This is the commit that will be modified with the new message and changes.")]
     pub commit_id: String,
 
     #[schemars(description = "The branch name to amend the commit on")]
@@ -145,7 +143,9 @@ pub struct AmendParams {
 impl ServerHandler for Mcp {
     fn get_info(&self) -> ServerInfo {
         ServerInfo {
-            instructions: Some("This is the GitButler MCP server. This provides tools and other context resources that allow you to interact with your project's version control. If enabled, these are the tools that should be used for any Git operations".into()),
+            instructions: Some("This is the GitButler MCP server.
+            This provides tools and other context resources that allow you to interact with your project's version control.
+            If enabled, these are the tools that should be used for any Git operations".into()),
             capabilities: ServerCapabilities::builder().enable_tools().build(),
             server_info: Implementation {
                 name: "GitButler MCP Server".into(),


### PR DESCRIPTION
- Added amend functionality to `mcp_internal` for updating existing commits with new messages and file changes.
- Exposed amend functionality via a new `AmendParams` struct in the tool interface.
- Enhanced project status tool to include hunk assignment information in its results.
- Updated documentation and function signatures to reflect these changes.