### PR TITLE
fix-unselect-hunks-on-commit-cancel

### DIFF
--- a/apps/desktop/cypress/e2e/unifiedDiffView.cy.ts
+++ b/apps/desktop/cypress/e2e/unifiedDiffView.cy.ts
@@ -375,4 +375,51 @@ describe('Unified Diff View with complex hunks', () => {
 			worktreeChanges: mockBackend.expectedWorktreeChangesLong
 		});
 	});
+
+	it('should unselect all when canceling the commit', () => {
+		// There should be uncommitted changes
+		cy.getByTestId('uncommitted-changes-file-list').should('be.visible');
+
+		// Click on start a commit
+		cy.getByTestId('start-commit-button').click();
+
+		// Unstage everything
+		cy.getByTestId('uncommitted-changes-header').within(() => {
+			cy.get('input[type="checkbox"]').should('be.checked').click();
+		});
+
+		// All files should be visible
+		cy.getByTestId('file-list-item').should(
+			'have.length',
+			mockBackend.getWorktreeChangesFileNames().length
+		);
+
+		// Open big file diff
+		cy.getByTestId('uncommitted-changes-file-list').within(() => {
+			const fileName = mockBackend.complexHunkFileName;
+			cy.getByTestId('file-list-item', fileName).click();
+		});
+
+		cy.getByTestId('unified-diff-view').within(() => {
+			// The diff should be visible
+			cy.get('table').should('be.visible');
+
+			for (const lineSelector of mockBackend.hunkLineSelectorsComplex) {
+				cy.get(lineSelector).within(() => {
+					cy.get('[data-testid="hunk-count-column"]').first().click({ force: true });
+				});
+			}
+		});
+
+		cy.getByTestId('commit-drawer-cancel-button').should('be.visible').click();
+
+		cy.getByTestId('unified-diff-view').within(() => {
+			// The diff should be visible
+			cy.get('table').should('be.visible');
+
+			for (const lineSelector of mockBackend.hunkLineSelectorsComplex) {
+				cy.get(lineSelector).should('be.visible').should('have.attr', 'data-test-staged', 'false');
+			}
+		});
+	});
 });

--- a/apps/desktop/src/components/v3/NewCommitView.svelte
+++ b/apps/desktop/src/components/v3/NewCommitView.svelte
@@ -207,6 +207,7 @@
 	function cancel(args: { title: string; description: string }) {
 		projectState.commitTitle.set(args.title);
 		projectState.commitDescription.set(args.description);
+		uncommittedService.uncheckAll(null);
 		drawer?.onClose();
 	}
 </script>

--- a/packages/ui/src/lib/hunkDiff/HunkDiffRow.svelte
+++ b/packages/ui/src/lib/hunkDiff/HunkDiffRow.svelte
@@ -152,6 +152,7 @@
 	id={getHunkLineId(row.encodedLineId)}
 	class="table__row"
 	class:selected={row.isSelected}
+	data-test-staged={staged}
 	data-no-drag
 	style="--diff-font: {diffFont};"
 >


### PR DESCRIPTION
- Unstage all hunks when canceling a commit by calling uncommittedService.uncheckAll(null) in NewCommitView.svelte  
- Add data-test-staged attribute to HunkDiffRow.svelte to improve testability  
- Add Cypress test in unifiedDiffView.cy.ts to verify all hunks are unstaged when canceling a commit