### PR TITLE
unified-diff-deselect-single-line

### DIFF
--- a/apps/desktop/cypress/e2e/support/scenarios/complexHunks.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/complexHunks.ts
@@ -605,6 +605,35 @@ export default class ComplexHunks extends MockBackend {
 		}
 	];
 
+	expectedHunkDeselectOneLine = [
+		{
+			pathBytes: [
+				99, 111, 109, 109, 105, 116, 83, 117, 103, 103, 101, 115, 116, 105, 111, 110, 115, 46, 115,
+				118, 101, 108, 116, 101, 46, 116, 115
+			],
+			previousPathBytes: null,
+			hunkHeaders: [
+				{ oldStart: 0, oldLines: 0, newStart: 55, newLines: 4 },
+				{ oldStart: 0, oldLines: 0, newStart: 65, newLines: 1 },
+				{ oldStart: 0, oldLines: 0, newStart: 72, newLines: 1 },
+				{ oldStart: 60, oldLines: 3, newStart: 0, newLines: 0 },
+				{ oldStart: 0, oldLines: 0, newStart: 79, newLines: 1 },
+				{ oldStart: 0, oldLines: 0, newStart: 82, newLines: 6 },
+				{ oldStart: 0, oldLines: 0, newStart: 93, newLines: 6 },
+				{ oldStart: 75, oldLines: 3, newStart: 0, newLines: 0 },
+				{ oldStart: 0, oldLines: 0, newStart: 104, newLines: 1 },
+				{ oldStart: 0, oldLines: 0, newStart: 107, newLines: 6 },
+				{
+					oldStart: 84,
+					oldLines: 29,
+					newStart: 117,
+					newLines: 51,
+					diff: '@@ -84,29 +117,51 @@\n \t\t\tthis.suggest(true);\n \t\t\treturn true;\n \t\t}\n+\n+\t\t// return things\n \t\treturn false;\n \t}\n \n+\t/**\n+\t * Accepts the current AI suggestion and marks it as selected to avoid redundant suggestions.\n+\t * @param text - The accepted suggestion text.\n+\t */\n \tonAcceptSuggestion(text: string) {\n \t\tthis.lasSelectedGhostText = text;\n \t}\n \n+\t/**\n+\t * Gets whether AI suggestions on type are currently enabled.\n+\t */\n \tget suggestOnType() {\n \t\treturn this._suggestOnType.current;\n \t}\n \n+\t/**\n+\t * Toggles the AI suggestions on type feature on or off.\n+\t */\n \ttoggleSuggestOnType() {\n \t\tthis._suggestOnType.current = !this._suggestOnType.current;\n \t}\n \n+\t/**\n+\t * Gets the current ghost text component instance.\n+\t */\n \tget ghostTextComponent(): ReturnType<typeof GhostTextPlugin> | undefined {\n \t\treturn this._ghostTextComponent;\n \t}\n \n+\t/**\n+\t * Sets the ghost text component instance for displaying suggestions.\n+\t * @param value - The ghost text component instance.\n+\t */\n \tset ghostTextComponent(value: ReturnType<typeof GhostTextPlugin>) {\n \t\tthis._ghostTextComponent = value;\n \t}\n \n+\t/**\n+\t * Clears all internal state, including input text, last message, and resets the ghost text component.\n+\t */\n \tclear() {\n \t\tthis.textUpToAnchor = undefined;\n \t\tthis.textAfterAnchor = undefined;\n'
+				}
+			]
+		}
+	];
+
 	constructor() {
 		super();
 

--- a/apps/desktop/src/lib/selection/uncommittedService.svelte.ts
+++ b/apps/desktop/src/lib/selection/uncommittedService.svelte.ts
@@ -252,8 +252,16 @@ export class UncommittedService {
 		this.dispatch(uncommittedActions.checkLine({ stackId, path, hunkHeader, line }));
 	}
 
-	uncheckLine(stackId: string | null, path: string, header: HunkHeader, line: LineId) {
-		this.dispatch(uncommittedActions.uncheckLine({ stackId, path, hunkHeader: header, line }));
+	uncheckLine(
+		stackId: string | null,
+		path: string,
+		header: HunkHeader,
+		line: LineId,
+		allLinesInHunk: LineId[]
+	) {
+		this.dispatch(
+			uncommittedActions.uncheckLine({ stackId, path, hunkHeader: header, line, allLinesInHunk })
+		);
 	}
 
 	checkHunk(stackId: string | null, path: string, header: HunkHeader) {


### PR DESCRIPTION
### Description

- Updated unified diff selection logic to support deselecting a single line within a fully selected hunk.
- Modified reducer and service to handle new uncheckLine signature that processes all lines in a hunk.
- Enhanced Cypress tests to accurately test single line deselection in unified diffs.