### PR TITLE
Fix invalidation of branch changes when amending commits

### DIFF
--- a/apps/desktop/src/components/CommitList.svelte
+++ b/apps/desktop/src/components/CommitList.svelte
@@ -219,7 +219,6 @@
 						stackService,
 						projectId,
 						stackId,
-						branchName: currentSeries.branchName,
 						commit: dzCommit,
 						okWithForce: true
 					})}
@@ -233,7 +232,6 @@
 						stackService,
 						projectId,
 						stackId,
-						branchName: currentSeries.branchName,
 						commit: dzCommit,
 						// TODO: Use correct value!
 						okWithForce: true,

--- a/apps/desktop/src/components/v3/BranchCommitList.svelte
+++ b/apps/desktop/src/components/v3/BranchCommitList.svelte
@@ -324,7 +324,6 @@
 					stackService,
 					projectId,
 					stackId,
-					branchName,
 					commit: dzCommit,
 					// TODO: Use correct value!
 					okWithForce: true,

--- a/apps/desktop/src/lib/commits/dropHandler.ts
+++ b/apps/desktop/src/lib/commits/dropHandler.ts
@@ -154,7 +154,6 @@ export class AmendCommitWithChangeDzHandler implements DropzoneHandler {
 					await this.trigger({
 						projectId: this.projectId,
 						stackId: this.stackId,
-						branchName: this.branchName,
 						commitId: this.commit.id,
 						worktreeChanges: diffSpec
 					})
@@ -261,7 +260,6 @@ export class AmendCommitWithHunkDzHandler implements DropzoneHandler {
 			okWithForce: boolean;
 			projectId: string;
 			stackId: string;
-			branchName: string;
 			commit: DzCommitData;
 			uiState: UiState;
 		}
@@ -292,8 +290,7 @@ export class AmendCommitWithHunkDzHandler implements DropzoneHandler {
 	}
 
 	async ondrop(data: HunkDropData | HunkDropDataV3): Promise<void> {
-		const { stackService, projectId, stackId, branchName, commit, okWithForce, uiState } =
-			this.args;
+		const { stackService, projectId, stackId, commit, okWithForce, uiState } = this.args;
 		if (!okWithForce && commit.isRemote) return;
 
 		if (data instanceof HunkDropData) {
@@ -334,7 +331,6 @@ export class AmendCommitWithHunkDzHandler implements DropzoneHandler {
 			stackService.amendCommitMutation({
 				projectId,
 				stackId,
-				branchName,
 				commitId: commit.id,
 				worktreeChanges: [
 					{
@@ -397,7 +393,6 @@ export class AmendCommitWithHunkDzHandler implements DropzoneHandler {
 			stackService.amendCommitMutation({
 				projectId,
 				stackId,
-				branchName,
 				commitId: commit.id,
 				worktreeChanges: [
 					{
@@ -429,7 +424,6 @@ export class AmendCommitDzHandler implements DropzoneHandler {
 			okWithForce: boolean;
 			projectId: string;
 			stackId: string;
-			branchName: string;
 			commit: DzCommitData;
 		}
 	) {}
@@ -447,12 +441,11 @@ export class AmendCommitDzHandler implements DropzoneHandler {
 	}
 
 	ondrop(data: FileDropData): void {
-		const { stackService, projectId, stackId, branchName, commit } = this.args;
+		const { stackService, projectId, stackId, commit } = this.args;
 		if (data.file instanceof LocalFile) {
 			stackService.amendCommitMutation({
 				projectId,
 				stackId,
-				branchName,
 				commitId: commit.id,
 				worktreeChanges: filesToDiffSpec(data)
 			});

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -989,9 +989,8 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'changes_in_branch',
 					params: { projectId, stackId, branchName, remote }
 				}),
-				providesTags: (_result, _error, { branchName }) => [
-					...providesItem(ReduxTag.BranchChanges, branchName)
-				],
+				providesTags: (_result, _error, { stackId }) =>
+					stackId ? providesItem(ReduxTag.BranchChanges, stackId) : [],
 				transformResponse(rsp: TreeChanges) {
 					return changesAdapter.addMany(changesAdapter.getInitialState(), rsp.changes);
 				}
@@ -1039,19 +1038,18 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				{
 					projectId: string;
 					stackId: string;
-					branchName: string; // Provided only for invalidating `BranchDetails`.
 					commitId: string;
 					worktreeChanges: DiffSpec[];
 				}
 			>({
-				query: ({ projectId, stackId, branchName: _, commitId, worktreeChanges }) => ({
+				query: ({ projectId, stackId, commitId, worktreeChanges }) => ({
 					command: 'amend_virtual_branch',
 					params: { projectId, stackId, commitId, worktreeChanges },
 					actionName: 'Amend Commit'
 				}),
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesList(ReduxTag.WorktreeChanges),
-					invalidatesItem(ReduxTag.BranchChanges, args.branchName),
+					invalidatesItem(ReduxTag.BranchChanges, args.stackId),
 					invalidatesItem(ReduxTag.StackDetails, args.stackId)
 				]
 			}),
@@ -1143,6 +1141,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				}),
 				invalidatesTags(_result, _error, arg) {
 					return [
+						invalidatesItem(ReduxTag.BranchChanges, arg.stackId),
 						invalidatesItem(ReduxTag.StackDetails, arg.stackId),
 						invalidatesList(ReduxTag.WorktreeChanges)
 					];

--- a/apps/desktop/src/lib/state/tags.ts
+++ b/apps/desktop/src/lib/state/tags.ts
@@ -1,3 +1,4 @@
+// TODO: Refactor this enum into an object conataining invalidation rules.
 export enum ReduxTag {
 	Diff = 'Diff',
 	HunkAssignments = 'HunkAssignments',
@@ -5,6 +6,11 @@ export enum ReduxTag {
 	StackDetails = 'StackDetails',
 	WorktreeChanges = 'WorktreeChanges',
 	CommitChanges = 'CommitChanges',
+	/**
+	 * Use stack id when invalidating this tag since invalidating just one
+	 * branch in a stack is rarely what you want, and unapplied branches
+	 * should not require much invalidation.
+	 */
 	BranchChanges = 'BranchChanges',
 	PullRequests = 'PullRequests',
 	GitLabPullRequests = 'GitLabPullRequests',


### PR DESCRIPTION
Adds invalidation to one api call, and changes the cache parameter from
branch name to stack id. It rarely makes sense to just invalidate one
branch since e.g. amends can affect the whole stack.

It should be noted we don't yet have any way to invalidate branch 
changes when it changes on disk rather than through gitbutler.
