### PR TITLE
propagate telemetry distinct id to backend on login/logout

### DIFF
--- a/apps/desktop/cypress/e2e/support/index.ts
+++ b/apps/desktop/cypress/e2e/support/index.ts
@@ -144,6 +144,9 @@ Cypress.on('window:before:load', (win) => {
 				return getProject(args);
 			case 'list_projects':
 				return listProjects();
+			case 'update_telemetry_distinct_id':
+				return await Promise.resolve();
+
 			case 'plugin:updater|check':
 				return null;
 			case 'get_user':

--- a/apps/desktop/src/components/AppUpdater.test.ts
+++ b/apps/desktop/src/components/AppUpdater.test.ts
@@ -1,6 +1,7 @@
 import AppUpdater from '$components/AppUpdater.svelte';
 import { PostHogWrapper } from '$lib/analytics/posthog';
 import { Tauri } from '$lib/backend/tauri';
+import { getSettingsdServiceMock } from '$lib/testing/mockSettingsdService';
 import { UpdaterService } from '$lib/updater/updater';
 import { render, screen } from '@testing-library/svelte';
 import { expect, test, describe, vi, beforeEach, afterEach } from 'vitest';
@@ -10,7 +11,9 @@ describe('AppUpdater', () => {
 	let tauri: Tauri;
 	let updater: UpdaterService;
 	let context: Map<any, any>;
-	const posthog = new PostHogWrapper();
+	const MockSettingsService = getSettingsdServiceMock();
+	const settingsService = new MockSettingsService();
+	const posthog = new PostHogWrapper(settingsService);
 
 	beforeEach(() => {
 		vi.useFakeTimers();

--- a/apps/desktop/src/components/MetricsReporter.test.ts
+++ b/apps/desktop/src/components/MetricsReporter.test.ts
@@ -6,6 +6,7 @@ import MetricsReporter, {
 import { PostHogWrapper } from '$lib/analytics/posthog';
 import { ProjectMetrics } from '$lib/metrics/projectMetrics';
 import { ProjectService } from '$lib/project/projectService';
+import { getSettingsdServiceMock } from '$lib/testing/mockSettingsdService';
 import { render } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
 import { assert, test, describe, vi, beforeEach, afterEach } from 'vitest';
@@ -22,7 +23,10 @@ describe('MetricsReporter', () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
 		projectMetrics = new ProjectMetrics();
-		posthog = new PostHogWrapper();
+		const MockSettingsService = getSettingsdServiceMock();
+		const settingsService = new MockSettingsService();
+		posthog = new PostHogWrapper(settingsService);
+
 		projectService = { project: writable(undefined), projectId: PROJECT_ID };
 		context = new Map([
 			[PostHogWrapper as object, posthog as any],

--- a/apps/desktop/src/lib/analytics/posthog.ts
+++ b/apps/desktop/src/lib/analytics/posthog.ts
@@ -1,11 +1,12 @@
 import { PostHog, posthog } from 'posthog-js';
+import type { SettingsService } from '$lib/config/appSettingsV2';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import { PUBLIC_POSTHOG_API_KEY } from '$env/static/public';
 
 export class PostHogWrapper {
 	private _instance: PostHog | void = undefined;
 
-	constructor() {}
+	constructor(private settingsService: SettingsService) {}
 
 	capture(...args: Parameters<typeof posthog.capture>) {
 		this._instance?.capture(...args);
@@ -29,17 +30,20 @@ export class PostHogWrapper {
 		});
 	}
 
-	setPostHogUser(params: { id: number; email?: string; name?: string }) {
+	async setPostHogUser(params: { id: number; email?: string; name?: string }) {
 		const { id, email, name } = params;
-		this._instance?.identify(`user_${id}`, {
+		const distinctId = `user_${id}`;
+		this._instance?.identify(distinctId, {
 			email,
 			name
 		});
+		this.settingsService.updateTelemetryDistinctId(distinctId);
 	}
 
-	resetPostHog() {
+	async resetPostHog() {
 		this._instance?.capture('logout');
 		this._instance?.reset();
+		await this.settingsService.updateTelemetryDistinctId(null);
 	}
 
 	/**

--- a/apps/desktop/src/lib/forge/forgeFactory.test.ts
+++ b/apps/desktop/src/lib/forge/forgeFactory.test.ts
@@ -4,13 +4,16 @@ import { GitHub } from '$lib/forge/github/github';
 import { GitLab } from '$lib/forge/gitlab/gitlab';
 import { ProjectMetrics } from '$lib/metrics/projectMetrics';
 import { type GitHubApi } from '$lib/state/clientState.svelte';
+import { getSettingsdServiceMock } from '$lib/testing/mockSettingsdService';
 import { expect, test, describe } from 'vitest';
 import type { GitHubClient } from '$lib/forge/github/githubClient';
 import type { GitLabClient } from '$lib/forge/gitlab/gitlabClient.svelte';
 import type { ThunkDispatch, UnknownAction } from '@reduxjs/toolkit';
 
 describe.concurrent('DefaultforgeFactory', () => {
-	const posthog = new PostHogWrapper();
+	const MockSettingsService = getSettingsdServiceMock();
+	const settingsService = new MockSettingsService();
+	const posthog = new PostHogWrapper(settingsService);
 	const projectMetrics = new ProjectMetrics();
 	const gitHubApi: GitHubApi = {
 		endpoints: {},

--- a/apps/desktop/src/lib/forge/github/githubListingService.svelte.test.ts
+++ b/apps/desktop/src/lib/forge/github/githubListingService.svelte.test.ts
@@ -2,6 +2,7 @@ import { PostHogWrapper } from '$lib/analytics/posthog';
 import { GitHub } from '$lib/forge/github/github';
 import { ProjectMetrics } from '$lib/metrics/projectMetrics';
 import { setupMockGitHubApi } from '$lib/testing/mockGitHubApi.svelte';
+import { getSettingsdServiceMock } from '$lib/testing/mockSettingsdService';
 import { type RestEndpointMethodTypes } from '@octokit/rest';
 import { flushSync } from 'svelte';
 import { test, describe, vi, beforeEach, expect } from 'vitest';
@@ -15,7 +16,9 @@ describe('GitHubListingService', () => {
 
 	let gh: GitHub;
 	let projectMetrics: ProjectMetrics;
-	const posthog = new PostHogWrapper();
+	const MockSettingsService = getSettingsdServiceMock();
+	const settingsService = new MockSettingsService();
+	const posthog = new PostHogWrapper(settingsService);
 
 	vi.useFakeTimers();
 

--- a/apps/desktop/src/lib/testing/mockSettingsdService.ts
+++ b/apps/desktop/src/lib/testing/mockSettingsdService.ts
@@ -1,0 +1,9 @@
+import { vi } from 'vitest';
+
+export function getSettingsdServiceMock() {
+	const SettingsServiceMock = vi.fn();
+
+	SettingsServiceMock.prototype.updateTelemetryDistinctId = vi.fn();
+
+	return SettingsServiceMock;
+}

--- a/apps/desktop/src/lib/updater/updater.test.ts
+++ b/apps/desktop/src/lib/updater/updater.test.ts
@@ -1,5 +1,6 @@
 import { PostHogWrapper } from '$lib/analytics/posthog';
 import { Tauri } from '$lib/backend/tauri';
+import { getSettingsdServiceMock } from '$lib/testing/mockSettingsdService';
 import { UPDATE_INTERVAL_MS, UpdaterService } from '$lib/updater/updater';
 import { get } from 'svelte/store';
 import { expect, test, describe, vi, beforeEach, afterEach } from 'vitest';
@@ -12,7 +13,9 @@ import type { Update } from '@tauri-apps/plugin-updater';
 describe('Updater', () => {
 	let tauri: Tauri;
 	let updater: UpdaterService;
-	const posthog = new PostHogWrapper();
+	const MockSettingsService = getSettingsdServiceMock();
+	const settingsService = new MockSettingsService();
+	const posthog = new PostHogWrapper(settingsService);
 
 	beforeEach(() => {
 		vi.useFakeTimers();

--- a/apps/desktop/src/lib/user/userService.ts
+++ b/apps/desktop/src/lib/user/userService.ts
@@ -44,7 +44,7 @@ export class UserService {
 			const user = plainToInstance(User, userData);
 			this.tokenMemoryService.setToken(user.access_token);
 			this.user.set(user);
-			this.posthog.setPostHogUser({ id: user.id, email: user.email, name: user.name });
+			await this.posthog.setPostHogUser({ id: user.id, email: user.email, name: user.name });
 			setSentryUser(user);
 			return user;
 		}
@@ -81,7 +81,7 @@ export class UserService {
 		await this.clearUser();
 		this.user.set(undefined);
 		this.tokenMemoryService.setToken(undefined);
-		this.posthog.resetPostHog();
+		await this.posthog.resetPostHog();
 		resetSentry();
 	}
 


### PR DESCRIPTION
- Update PostHogWrapper to accept SettingsService and propagate distinct id
- Make setPostHogUser and resetPostHog async and update userService accordingly
- Refactor service initialization in +layout.ts to support new analytics flow

<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#0JM654HcE`](https://gitbutler.com/estib/gitbutler/reviews/0JM654HcE)

**propagate telemetry distinct id to backend on login/logout**


- Update PostHogWrapper to accept SettingsService and propagate distinct id
- Make setPostHogUser and resetPostHog async and update userService accordingly
- Refactor service initialization in +layout.ts to support new analytics flow


1 commit series (version 3)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [propagate telemetry distinct id to backend on login/logout](https://gitbutler.com/estib/gitbutler/reviews/0JM654HcE/commit/ebf47572-4f5c-4435-8739-236f1677ebae) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/estib/gitbutler/reviews/0JM654HcE)_
<!-- GitButler Review Footer Boundary Bottom -->
