### PR TITLE
fix(tauri): add settings::update_telemetry_distinct_id command to backend

### DIFF
--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -284,6 +284,7 @@ fn main() {
                     settings::update_onboarding_complete,
                     settings::update_telemetry,
                     settings::update_feature_flags,
+                    settings::update_telemetry_distinct_id,
                     action::list_actions,
                     action::handle_changes,
                     cli::install_cli,


### PR DESCRIPTION
Adds the `settings::update_telemetry_distinct_id` command to the Tauri backend command list, enabling the backend to receive and update the telemetry distinct id for analytics purposes.

<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#4CDNwWitV`](https://gitbutler.com/estib/gitbutler/reviews/4CDNwWitV)

****


Adds the `settings::update_telemetry_distinct_id` command to the Tauri backend command list, enabling the backend to receive and update the telemetry distinct id for analytics purposes.


1 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [fix(tauri): add settings::update_telemetry_distinct_id command to backend](https://gitbutler.com/estib/gitbutler/reviews/4CDNwWitV/commit/75e25d6d-a3b2-4d9c-b0d8-8386e717d8e0) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/estib/gitbutler/reviews/4CDNwWitV)_
<!-- GitButler Review Footer Boundary Bottom -->
