### PR TITLE
gb client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,6 +760,7 @@ dependencies = [
  "gitbutler-serde",
  "gitbutler-stack",
  "gix",
+ "reqwest 0.12.18",
  "schemars 0.9.0",
  "serde",
  "serde-error",

--- a/crates/but-action/Cargo.toml
+++ b/crates/but-action/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1.0.98"
 chrono = "0.4.41"
 uuid = { workspace = true }
 strum = { version = "0.27", features = ["derive"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 gix.workspace = true
 gitbutler-command-context.workspace = true
 gitbutler-stack.workspace = true

--- a/crates/but-action/src/gb_client.rs
+++ b/crates/but-action/src/gb_client.rs
@@ -55,6 +55,75 @@ pub struct OpenAIStructuredOutputResponse<T> {
     pub response: Option<T>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(tag = "role")]
+#[serde(rename_all = "lowercase")]
+pub enum AnthropicChatCompletionMessage {
+    System(ChatMessage),
+    User(ChatMessage),
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+struct AnthropicStructuredOutputInternal {
+    /// The type of model to use.
+    /// This should be set to "anthropic".
+    /// TODO: Not sure if this is the best way of expessing this
+    model_kind: String,
+    /// The list of messages to be completed.
+    pub messages: Vec<AnthropicChatCompletionMessage>,
+    /// The maximum number of tokens to generate in the completion.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+    /// The temperature to use for sampling.
+    /// From 0.0 to 2.0, where lower values make the output more deterministic and higher values make it more random.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    /// The schema for the response format, described as a JSON Schema object.
+    pub json_schema: serde_json::Value,
+    /// The available tools for the llm to call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<Tool>>,
+}
+
+impl From<&AnthropicStructuredOutput> for AnthropicStructuredOutputInternal {
+    fn from(value: &AnthropicStructuredOutput) -> Self {
+        Self {
+            model_kind: "anthropic".to_string(),
+            messages: value.messages.clone(),
+            max_tokens: value.max_tokens,
+            temperature: value.temperature,
+            json_schema: value.json_schema.clone(),
+            tools: value.tools.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct AnthropicStructuredOutput {
+    /// The system message to use for the model.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system: Option<String>,
+    /// The list of messages to be completed.
+    pub messages: Vec<AnthropicChatCompletionMessage>,
+    /// The maximum number of tokens to generate in the completion.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+    /// The temperature to use for sampling.
+    /// From 0.0 to 2.0, where lower values make the output more deterministic and higher values make it more random.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    /// The schema for the response format, described as a JSON Schema object.
+    pub json_schema: serde_json::Value,
+    /// The available tools for the llm to call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<Tool>>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct AnthropicStructuredOutputResponse<T> {
+    pub response: Option<T>,
+}
+
 pub struct GBClient {
     client: Client,
     token: String,
@@ -122,6 +191,7 @@ impl GBClient {
         self.post_json("evaluate_prompt/structured", body).await
     }
 
+    /// Sends a structured output request to the GB API using Open AI
     pub async fn open_ai_structured_output<TResp>(
         &self,
         request: &OpenAIStructuredOutput,
@@ -130,6 +200,18 @@ impl GBClient {
         TResp: DeserializeOwned,
     {
         self.structured_output(request).await
+    }
+
+    /// Sends a structured output request to the GB API using Anthropic
+    pub async fn anthropic_structured_output<TResp>(
+        &self,
+        request: &AnthropicStructuredOutput,
+    ) -> Result<AnthropicStructuredOutputResponse<TResp>, reqwest::Error>
+    where
+        TResp: DeserializeOwned,
+    {
+        let internal_request: AnthropicStructuredOutputInternal = request.into();
+        self.structured_output(&internal_request).await
     }
 }
 
@@ -196,6 +278,72 @@ pub async fn commit_message_open_ai(
 
     let response: OpenAIStructuredOutputResponse<CommitMessage> =
         client.open_ai_structured_output(&request).await?;
+
+    response
+        .response
+        .map(|cm| cm.commit_message)
+        .ok_or_else(|| anyhow::anyhow!("No commit message returned from the AI model"))
+}
+
+pub fn commit_message_blocking_anthropic(
+    api_key: &str,
+    external_summary: &str,
+    external_prompt: &str,
+    diff: &str,
+) -> anyhow::Result<String> {
+    let api_key_owned = api_key.to_string();
+    let change_summary_owned = external_summary.to_string();
+    let external_prompt_owned = external_prompt.to_string();
+    let diff_owned = diff.to_string();
+
+    std::thread::spawn(move || {
+        tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(commit_message_anthropic(
+                &api_key_owned,
+                &change_summary_owned,
+                &external_prompt_owned,
+                &diff_owned,
+            ))
+    })
+    .join()
+    .unwrap()
+}
+
+pub async fn commit_message_anthropic(
+    api_key: &str,
+    external_summary: &str,
+    external_prompt: &str,
+    diff: &str,
+) -> anyhow::Result<String> {
+    let system_message =
+        "You are a version control assistant that helps with Git branch committing.".to_string();
+    let user_message = format!(
+        "Extract the git commit data from the prompt, summary and diff output. Return the commit message. Determine from this AI prompt, summary and diff output what the git commit data should be.\n\n{}\n\nHere is the data:\n\nPrompt: {}\n\nSummary: {}\n\nDiff:\n```\n{}\n```\n\n",
+        "Default commit message instructions", external_prompt, external_summary, diff
+    );
+
+    let client = GBClient::new(
+        "https://app.gitbutler.com/api".to_string(),
+        api_key.to_string(),
+    );
+
+    let schema = schema_for!(CommitMessage);
+    let json_schema = serde_json::to_value(schema).unwrap();
+
+    let request = AnthropicStructuredOutput {
+        system: Some(system_message),
+        messages: vec![AnthropicChatCompletionMessage::User(ChatMessage {
+            content: user_message,
+        })],
+        max_tokens: None,
+        temperature: None,
+        json_schema,
+        tools: None,
+    };
+
+    let response: AnthropicStructuredOutputResponse<CommitMessage> =
+        client.anthropic_structured_output(&request).await?;
 
     response
         .response

--- a/crates/but-action/src/gb_client.rs
+++ b/crates/but-action/src/gb_client.rs
@@ -1,0 +1,211 @@
+use reqwest::{
+    Client,
+    header::{CONTENT_TYPE, HeaderMap, HeaderValue},
+};
+use schemars::{JsonSchema, schema_for};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+
+#[derive(Debug, Serialize, Deserialize, Default, Clone, PartialEq)]
+pub struct ChatMessage {
+    /// The contents of the developer message.
+    pub content: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default, Clone, PartialEq)]
+pub struct Tool {
+    /// The name of the tool to call.
+    /// Should be unique within the context of the chat completion.
+    pub name: String,
+    /// The description of the tool.
+    /// This should be a human-readable description of what the tool does. The more detailed the better.
+    pub description: String,
+    /// The JSON schema for the tool's input parameters.
+    pub parameters: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(tag = "role")]
+#[serde(rename_all = "lowercase")]
+pub enum OpenAIChatCompletionMessage {
+    System(ChatMessage),
+    User(ChatMessage),
+    Assistant(ChatMessage),
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct OpenAIStructuredOutput {
+    /// The list of messages to be completed.
+    pub messages: Vec<OpenAIChatCompletionMessage>,
+    /// The maximum number of tokens to generate in the completion.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+    /// The temperature to use for sampling.
+    /// From 0.0 to 2.0, where lower values make the output more deterministic and higher values make it more random.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    /// The schema for the response format, described as a JSON Schema object.
+    pub json_schema: serde_json::Value,
+    /// The available tools for the llm to call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<Tool>>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct OpenAIStructuredOutputResponse<T> {
+    pub response: Option<T>,
+}
+
+pub struct GBClient {
+    client: Client,
+    token: String,
+    base_url: String,
+}
+
+impl GBClient {
+    pub fn new(base_url: String, token: String) -> Self {
+        let client = Client::builder()
+            .user_agent("gb-client/1.0")
+            .build()
+            .expect("Failed to create HTTP client");
+        GBClient {
+            base_url,
+            client,
+            token,
+        }
+    }
+    async fn post_json<TReq, TResp>(&self, url: &str, body: &TReq) -> Result<TResp, reqwest::Error>
+    where
+        TReq: Serialize + ?Sized,
+        TResp: DeserializeOwned,
+    {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        headers.insert("X-Auth-Token", HeaderValue::from_str(&self.token).unwrap());
+
+        let url = format!("{}/{}", self.base_url, url);
+
+        let resp_result = self
+            .client
+            .post(&url)
+            .json(body)
+            .headers(headers)
+            .send()
+            .await;
+
+        match resp_result {
+            Ok(resp) => {
+                if resp.status().is_success() {
+                    let json = resp.json::<TResp>().await?;
+                    Ok(json)
+                } else {
+                    println!("Request failed:");
+                    println!("  Status: {}", resp.status());
+                    let err = resp.error_for_status_ref().unwrap_err();
+                    let text = resp.text().await?;
+                    println!("  Error: {}", text);
+                    Err(err)
+                }
+            }
+            Err(err) => {
+                eprintln!("Request error:");
+                eprintln!("  Error: {}", err);
+                Err(err)
+            }
+        }
+    }
+
+    async fn structured_output<TReq, TResp>(&self, body: &TReq) -> Result<TResp, reqwest::Error>
+    where
+        TReq: Serialize + ?Sized,
+        TResp: DeserializeOwned,
+    {
+        self.post_json("evaluate_prompt/structured", body).await
+    }
+
+    pub async fn open_ai_structured_output<TResp>(
+        &self,
+        request: &OpenAIStructuredOutput,
+    ) -> Result<OpenAIStructuredOutputResponse<TResp>, reqwest::Error>
+    where
+        TResp: DeserializeOwned,
+    {
+        self.structured_output(request).await
+    }
+}
+
+pub fn commit_message_blocking_open_ai(
+    api_key: &str,
+    external_summary: &str,
+    external_prompt: &str,
+    diff: &str,
+) -> anyhow::Result<String> {
+    let api_key_owned = api_key.to_string();
+    let change_summary_owned = external_summary.to_string();
+    let external_prompt_owned = external_prompt.to_string();
+    let diff_owned = diff.to_string();
+
+    std::thread::spawn(move || {
+        tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(commit_message_open_ai(
+                &api_key_owned,
+                &change_summary_owned,
+                &external_prompt_owned,
+                &diff_owned,
+            ))
+    })
+    .join()
+    .unwrap()
+}
+
+pub async fn commit_message_open_ai(
+    api_key: &str,
+    external_summary: &str,
+    external_prompt: &str,
+    diff: &str,
+) -> anyhow::Result<String> {
+    let system_message =
+        "You are a version control assistant that helps with Git branch committing.".to_string();
+    let user_message = format!(
+        "Extract the git commit data from the prompt, summary and diff output. Return the commit message. Determine from this AI prompt, summary and diff output what the git commit data should be.\n\n{}\n\nHere is the data:\n\nPrompt: {}\n\nSummary: {}\n\nDiff:\n```\n{}\n```\n\n",
+        "Default commit message instructions", external_prompt, external_summary, diff
+    );
+
+    let client = GBClient::new(
+        "https://app.gitbutler.com/api".to_string(),
+        api_key.to_string(),
+    );
+
+    let schema = schema_for!(CommitMessage);
+    let json_schema = serde_json::to_value(schema).unwrap();
+
+    let request = OpenAIStructuredOutput {
+        messages: vec![
+            OpenAIChatCompletionMessage::System(ChatMessage {
+                content: system_message,
+            }),
+            OpenAIChatCompletionMessage::User(ChatMessage {
+                content: user_message,
+            }),
+        ],
+        max_tokens: None,
+        temperature: None,
+        json_schema,
+        tools: None,
+    };
+
+    let response: OpenAIStructuredOutputResponse<CommitMessage> =
+        client.open_ai_structured_output(&request).await?;
+
+    response
+        .response
+        .map(|cm| cm.commit_message)
+        .ok_or_else(|| anyhow::anyhow!("No commit message returned from the AI model"))
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[schemars(deny_unknown_fields)]
+pub struct CommitMessage {
+    pub commit_message: String,
+}

--- a/crates/but-action/src/lib.rs
+++ b/crates/but-action/src/lib.rs
@@ -14,6 +14,7 @@ use gitbutler_stack::{Target, VirtualBranchesHandle};
 use serde::{Deserialize, Serialize};
 
 mod action;
+mod gb_client;
 mod generate;
 mod simple;
 pub use action::ActionListing;

--- a/crates/but-action/src/simple.rs
+++ b/crates/but-action/src/simple.rs
@@ -138,8 +138,15 @@ fn handle_changes_simple_inner(
     let commit_message = if std::env::var("OPENAI_API_KEY").is_ok() {
         // TODO: Provide diff string
         commit_message_blocking(change_summary, &external_prompt.unwrap_or_default(), "")?
-    } else if let Ok(gb_api_key) = std::env::var("GB_API_KEY") {
+    } else if let Ok(gb_api_key) = std::env::var("GB_API_KEY_OPENAI") {
         gb_client::commit_message_blocking_open_ai(
+            &gb_api_key,
+            change_summary,
+            &external_prompt.unwrap_or_default(),
+            "",
+        )?
+    } else if let Ok(gb_api_key) = std::env::var("GB_API_KEY_ANTHROPIC") {
+        gb_client::commit_message_blocking_anthropic(
             &gb_api_key,
             change_summary,
             &external_prompt.unwrap_or_default(),

--- a/crates/but-action/src/simple.rs
+++ b/crates/but-action/src/simple.rs
@@ -139,6 +139,8 @@ fn handle_changes_simple_inner(
         // TODO: Provide diff string
         commit_message_blocking(change_summary, &external_prompt.unwrap_or_default(), "")?
     } else if let Ok(gb_api_key) = std::env::var("GB_API_KEY_OPENAI") {
+        // TODO: Obviously, this should not be the way that we pass in the API key AND decide to use OpenAI,
+        // but it'f goof enough for now.
         gb_client::commit_message_blocking_open_ai(
             &gb_api_key,
             change_summary,
@@ -146,6 +148,7 @@ fn handle_changes_simple_inner(
             "",
         )?
     } else if let Ok(gb_api_key) = std::env::var("GB_API_KEY_ANTHROPIC") {
+        // TODO: Obviously, [read above comment]
         gb_client::commit_message_blocking_anthropic(
             &gb_api_key,
             change_summary,

--- a/crates/but-action/src/simple.rs
+++ b/crates/but-action/src/simple.rs
@@ -12,7 +12,9 @@ use gitbutler_oxidize::OidExt;
 use gitbutler_project::access::WorktreeWritePermission;
 use gitbutler_stack::VirtualBranchesHandle;
 
-use crate::{Outcome, default_target_setting_if_none, generate::commit_message_blocking};
+use crate::{
+    Outcome, default_target_setting_if_none, gb_client, generate::commit_message_blocking,
+};
 /// This is a GitButler automation which allows easy handling of uncommitted changes in a repository.
 /// At a high level, it will:
 ///   - Checkout GitButler's workspace branch if not already checked out
@@ -136,6 +138,13 @@ fn handle_changes_simple_inner(
     let commit_message = if std::env::var("OPENAI_API_KEY").is_ok() {
         // TODO: Provide diff string
         commit_message_blocking(change_summary, &external_prompt.unwrap_or_default(), "")?
+    } else if let Ok(gb_api_key) = std::env::var("GB_API_KEY") {
+        gb_client::commit_message_blocking_open_ai(
+            &gb_api_key,
+            change_summary,
+            &external_prompt.unwrap_or_default(),
+            "",
+        )?
     } else {
         change_summary.to_string()
     };


### PR DESCRIPTION
Create a GitButler API client on the Rust side, and let it send beautiful requests to the AI endpoint.

- Implement the structured output generation for Open AI and Anthropic
- Add an easy way to test it out

### How to test

**OpenAI Proxy**
```
GB_API_KEY_OPENAI=<YOUR-GITBUTLER-API-KEY> but -C <YOUR-REPOSITORY> actions handle-changes -d "<A-BEAUTIFUL-MESSAGE>"
```

**Anthropic Proxy**
```
GB_API_KEY_OPENAI=<YOUR-GITBUTLER-API-KEY> but -C <YOUR-REPOSITORY> actions handle-changes -d "<A-BEAUTIFUL-MESSAGE>"
```
⚠️ **NOTE** At the moment of this PR, the [Anthropic API seems to be down](https://status.anthropic.com/) so I could not fully test that this works as well, but I'll check later again