### PR TITLE
GB Client, tool calling

### DIFF
--- a/crates/but-action/src/gb_client.rs
+++ b/crates/but-action/src/gb_client.rs
@@ -7,6 +7,8 @@ use reqwest::{
 use schemars::{JsonSchema, schema_for};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
+use crate::serialize::StringOrObject;
+
 #[derive(Debug, Serialize, Deserialize, Default, Clone, PartialEq)]
 pub struct ChatMessage {
     /// The contents of the developer message.
@@ -99,11 +101,50 @@ pub struct OpenAIStructuredOutputResponse<T> {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct AntrhopicToolResult {
+    /// The type of the content.
+    /// This should be set to "tool_result" for tool results.
+    #[serde(rename = "type")]
+    pub constent_type: String,
+    /// The ID of the tool call that this message is responding to.
+    pub tool_use_id: String,
+    /// The result of the tool call.
+    pub content: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct AnthropicUserChatMessage {
+    /// The contents of the user message.
+    /// This can be a string or a tool result object.
+    pub content: StringOrObject<Vec<AntrhopicToolResult>>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct AnthropicToolCall {
+    /// The ID of the tool call.
+    pub id: String,
+    /// The type of the tool call.
+    /// This should be set to "tool_use" for tool calls.
+    #[serde(rename = "type")]
+    pub call_type: String,
+    /// The name of the function to call.
+    pub name: String,
+    /// The input parameters for the tool call.
+    pub input: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct AnthropicAssistantChatMessage {
+    /// The contents of the developer message.
+    pub content: Option<Vec<AnthropicToolCall>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(tag = "role")]
 #[serde(rename_all = "lowercase")]
 pub enum AnthropicChatCompletionMessage {
-    System(ChatMessage),
-    User(ChatMessage),
+    Assistant(AnthropicAssistantChatMessage),
+    User(AnthropicUserChatMessage),
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
@@ -164,7 +205,10 @@ pub struct AnthropicStructuredOutput {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct AnthropicStructuredOutputResponse<T> {
+    /// The response in the format specified by the json_schema.
     pub response: Option<T>,
+    /// The tool calls made by the model, if any.
+    pub tool_calls: Option<Vec<AnthropicToolCall>>,
 }
 
 pub struct GBClient {
@@ -457,25 +501,91 @@ pub async fn commit_message_anthropic(
         api_key.to_string(),
     );
 
-    let schema = schema_for!(CommitMessage);
-    let json_schema = serde_json::to_value(schema).unwrap();
+    let commit_message_schema = schema_for!(CommitMessage);
+    let json_schema = serde_json::to_value(commit_message_schema).unwrap();
+
+    let commit_context_params_schema = schema_for!(GetCommitContextParams);
+
+    let tool = Tool {
+        name: "get_commit_context".to_string(),
+        description: "Get the commit context based on the prompt".to_string(),
+        parameters: serde_json::to_value(commit_context_params_schema).unwrap(),
+    };
 
     let request = AnthropicStructuredOutput {
         system: Some(system_message),
-        messages: vec![AnthropicChatCompletionMessage::User(ChatMessage {
-            content: user_message,
-        })],
+        messages: vec![AnthropicChatCompletionMessage::User(
+            AnthropicUserChatMessage {
+                content: StringOrObject::String(user_message),
+            },
+        )],
         max_tokens: None,
         temperature: None,
         json_schema,
-        tools: None,
+        tools: Some(vec![tool]),
     };
 
-    let response: AnthropicStructuredOutputResponse<CommitMessage> =
-        client.anthropic_structured_output(&request).await?;
+    let mut request = request;
 
-    response
-        .response
-        .map(|cm| cm.commit_message)
-        .ok_or_else(|| anyhow::anyhow!("No commit message returned from the AI model"))
+    // This is the function calling loop.
+    // - If we get tool calls, we handle them and continue the loop with the updated request.
+    // - We break if we get a commit message response.
+    // - If we get no response and no tool calls, we break with an error.
+    loop {
+        let response: AnthropicStructuredOutputResponse<CommitMessage> =
+            client.anthropic_structured_output(&request).await?;
+
+        // If there are tool calls, handle them first
+        if let Some(tool_calls) = response.tool_calls {
+            // For now, only handle "get_commit_context"
+            let mut new_messages = request.messages.clone();
+            for tool_call in tool_calls {
+                if tool_call.call_type == "tool_use" {
+                    match tool_call.name.as_str() {
+                        "get_commit_context" => {
+                            // Add the tool call result as an assistant message
+                            new_messages.push(AnthropicChatCompletionMessage::Assistant(
+                                AnthropicAssistantChatMessage {
+                                    content: Some(vec![tool_call.clone()]),
+                                },
+                            ));
+
+                            let params: GetCommitContextParams =
+                                serde_json::from_value(tool_call.input)?;
+                            let result = get_commit_context(&params);
+
+                            // Add the tool call result as a user message (Anthropic format)
+                            new_messages.push(AnthropicChatCompletionMessage::User(
+                                AnthropicUserChatMessage {
+                                    content: StringOrObject::Object(vec![AntrhopicToolResult {
+                                        constent_type: "tool_result".to_string(),
+                                        tool_use_id: tool_call.id,
+                                        content: result,
+                                    }]),
+                                },
+                            ));
+                        }
+                        _ => {
+                            // TODO: Handle unknown tool calls gracefully
+                            return Err(anyhow::anyhow!("Unknown tool call: {}", tool_call.name));
+                        }
+                    }
+                }
+            }
+            // Update the request with the new messages
+            request.messages = new_messages;
+            // Continue the loop to send the updated request
+            continue;
+        }
+
+        // If we have a commit message, return it
+        if let Some(cm) = response.response {
+            return Ok(cm.commit_message);
+        }
+
+        // No response and no tool calls, break with error
+        break Err(anyhow::anyhow!(
+            "No commit message or tool calls returned from the AI model"
+        ));
+    }
 }

--- a/crates/but-action/src/gb_client.rs
+++ b/crates/but-action/src/gb_client.rs
@@ -1,3 +1,5 @@
+use std::vec;
+
 use reqwest::{
     Client,
     header::{CONTENT_TYPE, HeaderMap, HeaderValue},
@@ -23,13 +25,51 @@ pub struct Tool {
     pub parameters: serde_json::Value,
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct OpenAIFunction {
+    /// The name of the function to call.
+    pub name: String,
+    /// Stringified JSON object of the function's parameters.
+    pub arguments: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct OpenAIToolCall {
+    /// The ID of the tool call.
+    pub id: String,
+    /// The type of the tool call.
+    /// This should be set to "function" for function calls.
+    #[serde(rename = "type")]
+    call_type: String,
+    /// The name and parameters of the function to call.
+    function: OpenAIFunction,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default, Clone, PartialEq)]
+pub struct OpenAIAssistantChatMessage {
+    /// The contents of the developer message.
+    pub content: Option<String>,
+    /// The tool calls made by the model, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<OpenAIToolCall>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default, Clone, PartialEq)]
+pub struct OpenAIToolResultChatMessage {
+    /// The ID of the tool call that this message is responding to.
+    pub tool_call_id: String,
+    /// The contents of the developer message.
+    pub content: String,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(tag = "role")]
 #[serde(rename_all = "lowercase")]
 pub enum OpenAIChatCompletionMessage {
     System(ChatMessage),
     User(ChatMessage),
-    Assistant(ChatMessage),
+    Assistant(OpenAIAssistantChatMessage),
+    Tool(OpenAIToolResultChatMessage),
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
@@ -52,7 +92,10 @@ pub struct OpenAIStructuredOutput {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct OpenAIStructuredOutputResponse<T> {
+    /// The response in the format specified by the json_schema.
     pub response: Option<T>,
+    /// The tool calls made by the model, if any.
+    pub tool_calls: Option<Vec<OpenAIToolCall>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -215,6 +258,25 @@ impl GBClient {
     }
 }
 
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[schemars(deny_unknown_fields)]
+pub struct CommitMessage {
+    pub commit_message: String,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[schemars(deny_unknown_fields)]
+pub struct GetCommitContextParams {
+    pub prompt: String,
+}
+
+fn get_commit_context(params: &GetCommitContextParams) -> String {
+    println!("Getting commit context for prompt: {}", params.prompt);
+    "Make the commit message description should be written as a haiku poem.".to_string()
+}
+
 pub fn commit_message_blocking_open_ai(
     api_key: &str,
     external_summary: &str,
@@ -258,31 +320,98 @@ pub async fn commit_message_open_ai(
         api_key.to_string(),
     );
 
-    let schema = schema_for!(CommitMessage);
-    let json_schema = serde_json::to_value(schema).unwrap();
+    let commit_message_schema = schema_for!(CommitMessage);
+    let json_schema = serde_json::to_value(commit_message_schema).unwrap();
+
+    let commit_context_params_schema = schema_for!(GetCommitContextParams);
+
+    let tool = Tool {
+        name: "get_commit_context".to_string(),
+        description: "Get the commit context based on the prompt".to_string(),
+        parameters: serde_json::to_value(commit_context_params_schema).unwrap(),
+    };
+
+    let messages = vec![
+        OpenAIChatCompletionMessage::System(ChatMessage {
+            content: system_message,
+        }),
+        OpenAIChatCompletionMessage::User(ChatMessage {
+            content: user_message,
+        }),
+    ];
 
     let request = OpenAIStructuredOutput {
-        messages: vec![
-            OpenAIChatCompletionMessage::System(ChatMessage {
-                content: system_message,
-            }),
-            OpenAIChatCompletionMessage::User(ChatMessage {
-                content: user_message,
-            }),
-        ],
+        messages,
         max_tokens: None,
         temperature: None,
         json_schema,
-        tools: None,
+        tools: Some(vec![tool]),
     };
 
-    let response: OpenAIStructuredOutputResponse<CommitMessage> =
-        client.open_ai_structured_output(&request).await?;
+    let mut request = request;
 
-    response
-        .response
-        .map(|cm| cm.commit_message)
-        .ok_or_else(|| anyhow::anyhow!("No commit message returned from the AI model"))
+    // This is the function calling loop.
+    // - If we get tool calls, we handle them and continue the loop with the updated request.
+    // - We brake if we get a commit message response.
+    // - If we get no response and no tool calls, we break with an error.
+    loop {
+        let response: OpenAIStructuredOutputResponse<CommitMessage> =
+            client.open_ai_structured_output(&request).await?;
+
+        // If there are tool calls, handle them first
+        if let Some(tool_calls) = response.tool_calls {
+            // For now, only handle "get_commit_context"
+            let mut new_messages = request.messages.clone();
+            for tool_call in tool_calls {
+                if tool_call.call_type == "function" {
+                    match tool_call.function.name.as_str() {
+                        "get_commit_context" => {
+                            let params: GetCommitContextParams =
+                                serde_json::from_str(&tool_call.function.arguments)?;
+                            let result = get_commit_context(&params);
+
+                            // Add the tool call result as an assistant message
+                            new_messages.push(OpenAIChatCompletionMessage::Assistant(
+                                OpenAIAssistantChatMessage {
+                                    content: None,
+                                    tool_calls: Some(vec![tool_call.clone()]),
+                                },
+                            ));
+
+                            // Add the tool response as a user message
+                            new_messages.push(OpenAIChatCompletionMessage::Tool(
+                                OpenAIToolResultChatMessage {
+                                    tool_call_id: tool_call.id,
+                                    content: result,
+                                },
+                            ));
+                        }
+                        _ => {
+                            // TODO: Handle unknown tool calls gracefully
+                            return Err(anyhow::anyhow!(
+                                "Unknown tool call: {}",
+                                tool_call.function.name
+                            ));
+                        }
+                    }
+                }
+            }
+            // Update the request with the new messages
+            request.messages = new_messages;
+            // Continue the loop to send the updated request
+            continue;
+        }
+
+        // If we have a commit message, return it
+        if let Some(cm) = response.response {
+            return Ok(cm.commit_message);
+        }
+
+        // No response and no tool calls, break with error
+        break Err(anyhow::anyhow!(
+            "No commit message or tool calls returned from the AI model"
+        ));
+    }
 }
 
 pub fn commit_message_blocking_anthropic(
@@ -349,11 +478,4 @@ pub async fn commit_message_anthropic(
         .response
         .map(|cm| cm.commit_message)
         .ok_or_else(|| anyhow::anyhow!("No commit message returned from the AI model"))
-}
-
-#[derive(Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-#[schemars(deny_unknown_fields)]
-pub struct CommitMessage {
-    pub commit_message: String,
 }

--- a/crates/but-action/src/lib.rs
+++ b/crates/but-action/src/lib.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 mod action;
 mod gb_client;
 mod generate;
+mod serialize;
 mod simple;
 pub use action::ActionListing;
 pub use action::list_actions;

--- a/crates/but-action/src/serialize.rs
+++ b/crates/but-action/src/serialize.rs
@@ -1,0 +1,74 @@
+use serde::de::{self, MapAccess, Visitor};
+use serde::{Deserialize, Serialize};
+use serde::{Deserializer, Serializer};
+use std::fmt;
+
+/// A type that can be serialized as either a string or an object.
+/// This is useful for APIs that accept both forms.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StringOrObject<T> {
+    String(String),
+    Object(T),
+}
+
+impl<T> Serialize for StringOrObject<T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            StringOrObject::String(s) => serializer.serialize_str(s),
+            StringOrObject::Object(obj) => obj.serialize(serializer),
+        }
+    }
+}
+
+impl<'de, T> Deserialize<'de> for StringOrObject<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct StringOrObjectVisitor<T>(std::marker::PhantomData<T>);
+
+        impl<'de, T> Visitor<'de> for StringOrObjectVisitor<T>
+        where
+            T: Deserialize<'de>,
+        {
+            type Value = StringOrObject<T>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a string or an object")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(StringOrObject::String(value.to_owned()))
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(StringOrObject::String(value))
+            }
+
+            fn visit_map<M>(self, map: M) -> Result<Self::Value, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                let obj = T::deserialize(de::value::MapAccessDeserializer::new(map))?;
+                Ok(StringOrObject::Object(obj))
+            }
+        }
+
+        deserializer.deserialize_any(StringOrObjectVisitor(std::marker::PhantomData))
+    }
+}


### PR DESCRIPTION
Add the ability to perform tool calling.

How it works is in the following way:
1. We submit a request, while advertising the available tools.
2. The LLM *decides* whether it needs to do a tool call to accomplish the task.
3. If a tools is identified, it returns a tool name and the set of parameters to pass to it.
4. The client executes that call, and passes the result in a subsequent request.
5. The LLM returns the result.

Steps 2-4 can be repeated as many times as possible.


### Changes

- Add function call support and tool call handling to the Rust GB client for OpenAI and Anthropic models.
- Introduce new types to represent function calls, tool calls, and tool results for structured model interaction.
- Extend chat message variants to include assistant messages with tool calls and tool result messages.
- Implement a function calling loop in the client to dynamically handle tool calls until a commit message is produced.
- Add JSON schemas and tooling support for improved commit message generation with context.
- Introduce StringOrObject<T> enum for flexible API input handling, supporting both strings and objects.
- Implement handling for the "get_commit_context" tool to fetch additional context dynamically during completion generation.