### PR TITLE
stable-hunk-assignments

### DIFF
--- a/apps/desktop/src/lib/selection/entityAdapters.ts
+++ b/apps/desktop/src/lib/selection/entityAdapters.ts
@@ -53,6 +53,7 @@ export const hunkAssignmentAdapter = createEntityAdapter<HunkAssignment, string>
  * foreign key, but also the primary identifier of a HunkSelection.
  */
 export type HunkSelection = {
+	stableId: string | null;
 	assignmentId: string;
 	stackId: string | null;
 	path: string;

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -314,6 +314,8 @@ pub fn assignments_with_fallback(
     )
     .map(|a| (a, None))
     .unwrap_or_else(|e| (worktree_assignments, Some(e)));
+
+    state::set_assignments(ctx, reconciled.0.clone())?;
     Ok(reconciled)
 }
 

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -235,7 +235,7 @@ pub fn assign(
     // Reconcile worktree with the persisted assignments
     let persisted_assignments = state::assignments(ctx)?;
     let with_worktree = reconcile::assignments(
-        worktree_assignments.clone(),
+        &worktree_assignments,
         &persisted_assignments,
         &applied_stacks,
         MultipleOverlapping::SetMostLines,
@@ -244,7 +244,7 @@ pub fn assign(
 
     // Reconcile with the requested changes
     let with_requests = reconcile::assignments(
-        with_worktree,
+        &with_worktree,
         &requests_to_assignments(requests.clone()),
         &applied_stacks,
         MultipleOverlapping::SetMostLines,
@@ -254,7 +254,7 @@ pub fn assign(
     // Reconcile with hunk locks
     let lock_assignments = hunk_dependency_assignments(ctx, Some(worktree_changes.clone()))?;
     let with_locks = reconcile::assignments(
-        with_requests,
+        &with_requests,
         &lock_assignments,
         &applied_stacks,
         MultipleOverlapping::SetNone,
@@ -352,7 +352,7 @@ fn reconcile_with_worktree_and_locks(
 
     let persisted_assignments = state::assignments(ctx)?;
     let with_worktree = reconcile::assignments(
-        worktree_assignments.clone(),
+        worktree_assignments,
         &persisted_assignments,
         &applied_stacks,
         MultipleOverlapping::SetMostLines,
@@ -361,7 +361,7 @@ fn reconcile_with_worktree_and_locks(
 
     let lock_assignments = hunk_dependency_assignments(ctx, Some(worktree_changes.clone()))?;
     let with_locks = reconcile::assignments(
-        with_worktree,
+        &with_worktree,
         &lock_assignments,
         &applied_stacks,
         MultipleOverlapping::SetNone,
@@ -643,7 +643,7 @@ mod tests {
         ];
         let applied_stacks = vec![stack_id_seq(1), stack_id_seq(2)];
         let result = reconcile::assignments(
-            worktree_assignments,
+            &worktree_assignments,
             &previous_assignments,
             &applied_stacks,
             MultipleOverlapping::SetMostLines,
@@ -665,7 +665,7 @@ mod tests {
         let worktree_assignments = vec![HunkAssignment::new("foo.rs", 10, 5, None, Some(1))];
         let applied_stacks = vec![stack_id_seq(2)];
         let result = reconcile::assignments(
-            worktree_assignments,
+            &worktree_assignments,
             &previous_assignments,
             &applied_stacks,
             MultipleOverlapping::SetMostLines,
@@ -684,7 +684,7 @@ mod tests {
         let worktree_assignments = vec![HunkAssignment::new("foo.rs", 12, 7, None, Some(1))];
         let applied_stacks = vec![stack_id_seq(1)];
         let result = reconcile::assignments(
-            worktree_assignments,
+            &worktree_assignments,
             &previous_assignments,
             &applied_stacks,
             MultipleOverlapping::SetMostLines,
@@ -706,7 +706,7 @@ mod tests {
         let applied_stacks = vec![stack_id_seq(1), stack_id_seq(2)];
         let worktree_assignments = vec![HunkAssignment::new("foo.rs", 5, 18, None, None)];
         let result = reconcile::assignments(
-            worktree_assignments,
+            &worktree_assignments,
             &previous_assignments,
             &applied_stacks,
             MultipleOverlapping::SetMostLines,
@@ -728,7 +728,7 @@ mod tests {
         let applied_stacks = vec![stack_id_seq(1), stack_id_seq(2)];
         let worktree_assignments = vec![HunkAssignment::new("foo.rs", 5, 18, None, None)];
         let result = reconcile::assignments(
-            worktree_assignments,
+            &worktree_assignments,
             &previous_assignments,
             &applied_stacks,
             MultipleOverlapping::SetNone,
@@ -747,7 +747,7 @@ mod tests {
         let worktree_assignments = vec![HunkAssignment::new("foo.rs", 12, 17, Some(2), None)];
         let applied_stacks = vec![stack_id_seq(1)];
         let result = reconcile::assignments(
-            worktree_assignments,
+            &worktree_assignments,
             &previous_assignments,
             &applied_stacks,
             MultipleOverlapping::SetMostLines,

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -194,16 +194,8 @@ impl HunkAssignment {
             return true;
         }
         if let (Some(header), Some(other_header)) = (self.hunk_header, other.hunk_header) {
-            if header.new_start >= other_header.new_start
-                && header.new_start <= other_header.new_start + other_header.new_lines
-            {
-                return true;
-            }
-            if other_header.new_start >= header.new_start
-                && other_header.new_start <= header.new_start + header.new_lines
-            {
-                return true;
-            }
+            return header.old_range().intersects(other_header.old_range())
+                && header.new_range().intersects(other_header.new_range());
         }
         false
     }
@@ -559,8 +551,8 @@ mod tests {
             HunkAssignment {
                 id: id.map(id_seq),
                 hunk_header: Some(HunkHeader {
-                    old_start: 0,
-                    old_lines: 0,
+                    old_start: start,
+                    old_lines: end,
                     new_start: start,
                     new_lines: end,
                 }),
@@ -583,8 +575,8 @@ mod tests {
         ) -> HunkAssignmentRequest {
             HunkAssignmentRequest {
                 hunk_header: Some(HunkHeader {
-                    old_start: 0,
-                    old_lines: 0,
+                    old_start: start,
+                    old_lines: end,
                     new_start: start,
                     new_lines: end,
                 }),
@@ -627,12 +619,12 @@ mod tests {
                 .intersects(HunkAssignment::new("foo.rs", 16, 5, None, None))
         );
         assert!(
-            HunkAssignment::new("foo.rs", 10, 6, None, None)
-                .intersects(HunkAssignment::new("foo.rs", 16, 5, None, None))
+            !HunkAssignment::new("foo.rs", 10, 6, None, None) // Lines 10 to 15
+                .intersects(HunkAssignment::new("foo.rs", 16, 5, None, None)) // Lines 16 to 20
         );
         assert!(
-            HunkAssignment::new("foo.rs", 10, 7, None, None)
-                .intersects(HunkAssignment::new("foo.rs", 16, 5, None, None))
+            HunkAssignment::new("foo.rs", 10, 7, None, None) // Lines 10 to 16
+                .intersects(HunkAssignment::new("foo.rs", 16, 5, None, None)) // Lines 16 to 20
         );
     }
 

--- a/crates/but-hunk-assignment/src/reconcile.rs
+++ b/crates/but-hunk-assignment/src/reconcile.rs
@@ -2,6 +2,7 @@ use std::cmp::Ordering;
 
 use anyhow::Result;
 use but_workspace::StackId;
+use itertools::Itertools;
 
 use crate::HunkAssignment;
 
@@ -81,8 +82,11 @@ pub(crate) fn assignments(
                     new_assignment.set_from(other, applied_stack_ids, update_unassigned);
                 }
 
-                if multiple_overlapping_resolution == MultipleOverlapping::SetNone {
-                    // If requested, reset stack_id to none on multiple overlapping
+                // If requested, reset stack_id to none on multiple overlapping
+                let unique_stack_ids = intersecting.iter().filter_map(|a| a.stack_id).unique();
+                if multiple_overlapping_resolution == MultipleOverlapping::SetNone
+                    && unique_stack_ids.count() > 1
+                {
                     new_assignment.stack_id = None;
                 }
             }

--- a/crates/but-hunk-assignment/src/reconcile.rs
+++ b/crates/but-hunk-assignment/src/reconcile.rs
@@ -51,14 +51,15 @@ impl HunkAssignment {
 }
 
 pub(crate) fn assignments(
-    new: Vec<HunkAssignment>,
+    new: &[HunkAssignment],
     old: &[HunkAssignment],
     applied_stack_ids: &[StackId],
     multiple_overlapping_resolution: MultipleOverlapping,
     update_unassigned: bool,
 ) -> Result<Vec<HunkAssignment>> {
     let mut reconciled = vec![];
-    for mut new_assignment in new {
+    for new_assignment in new {
+        let mut new_assignment = new_assignment.clone();
         let intersecting = old
             .iter()
             .filter(|current_entry| current_entry.intersects(new_assignment.clone()))


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#0WzfFoejj`](https://gitbutler.com/cto/gitbutler-client-d443/reviews/0WzfFoejj)

**stable-hunk-assignments**


5 commit series (version 2)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 5/5 | [Use the new stable ID in the uncommited retain function](https://gitbutler.com/cto/gitbutler-client-d443/reviews/0WzfFoejj/commit/6dac1c08-afcd-4d4c-8f19-0e592eaebfa8) | ⏳ |  |
| 4/5 | [Update the intersects logic to cover both the before and after](https://gitbutler.com/cto/gitbutler-client-d443/reviews/0WzfFoejj/commit/b535c78b-0a20-4739-bcb0-02ed578555b4) | ⏳ |  |
| 3/5 | [Persist assignments after requesting them](https://gitbutler.com/cto/gitbutler-client-d443/reviews/0WzfFoejj/commit/c631bf31-6b93-437d-a348-dcfc847de82d) | ⏳ |  |
| 2/5 | [Only unset assignment if there are multiple stack ids that overlap](https://gitbutler.com/cto/gitbutler-client-d443/reviews/0WzfFoejj/commit/aa61f093-08f5-4132-a2f9-48c51c675ae4) | ⏳ |  |
| 1/5 | [Pass a slice for both new and old](https://gitbutler.com/cto/gitbutler-client-d443/reviews/0WzfFoejj/commit/ce67447c-ba6c-4d7c-b760-e7a948db84d7) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/cto/gitbutler-client-d443/reviews/0WzfFoejj)_
<!-- GitButler Review Footer Boundary Bottom -->
