### PR TITLE
Simplify dropzone code a bit

### DIFF
--- a/apps/desktop/src/components/CommitCard.svelte
+++ b/apps/desktop/src/components/CommitCard.svelte
@@ -11,7 +11,7 @@
 	import { createCommitStore } from '$lib/commits/contexts';
 	import { CommitDropData } from '$lib/commits/dropHandler';
 	import { draggableCommit } from '$lib/dragging/draggable';
-	import { NON_DRAGGABLE } from '$lib/dragging/draggables';
+	import { DropzoneRegistry } from '$lib/dragging/registry';
 	import { RemoteFile } from '$lib/files/file';
 	import { FileService } from '$lib/files/fileService';
 	import { ModeService } from '$lib/mode/modeService';
@@ -72,6 +72,7 @@
 	const modeService = maybeGetContext(ModeService);
 	const fileService = getContext(FileService);
 	const stackService = getContext(StackService);
+	const dropzoneRegistry = getContext(DropzoneRegistry);
 
 	const [updateCommitMessage] = stackService.updateCommitMessage;
 
@@ -267,15 +268,15 @@
 	onkeyup={onKeyup}
 	role="button"
 	tabindex="0"
-	use:draggableCommit={isDraggable && stack
-		? {
-				disabled: false,
-				label: commit.descriptionTitle,
-				sha: commitShortSha,
-				date: getTimeAgo(commit.createdAt),
-				authorImgUrl: authorImgUrl,
-				commitType: type,
-				data: new CommitDropData(
+	use:draggableCommit={{
+		disabled: !isDraggable || !stack,
+		label: commit.descriptionTitle,
+		sha: commitShortSha,
+		date: getTimeAgo(commit.createdAt),
+		authorImgUrl: authorImgUrl,
+		commitType: type,
+		data: stack
+			? new CommitDropData(
 					stack.id,
 					{
 						id: commit.id,
@@ -285,10 +286,11 @@
 					},
 					isHeadCommit,
 					currentSeries?.name
-				),
-				viewportId: 'board-viewport'
-			}
-		: NON_DRAGGABLE}
+				)
+			: undefined,
+		viewportId: 'board-viewport',
+		dropzoneRegistry
+	}}
 >
 	{#if lines}
 		<div>

--- a/apps/desktop/src/components/Dropzone.svelte
+++ b/apps/desktop/src/components/Dropzone.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
 	import { dropzone, type HoverArgs } from '$lib/dragging/dropzone';
+	import { DropzoneRegistry } from '$lib/dragging/registry';
+	import { getContext } from '@gitbutler/shared/context';
 	import type { DropzoneHandler } from '$lib/dragging/handler';
 	import type { Snippet } from 'svelte';
+
+	const dropzoneRegistry = getContext(DropzoneRegistry);
 
 	interface Props {
 		disabled?: boolean;
@@ -60,7 +64,8 @@
 		onHoverEnd,
 		onActivationStart,
 		onActivationEnd,
-		target: '.dropzone-target'
+		target: '.dropzone-target',
+		registry: dropzoneRegistry
 	}}
 	class:fill-height={fillHeight}
 	class:max-height={maxHeight}
@@ -81,6 +86,7 @@
 		display: flex;
 		flex-grow: 1;
 		flex-direction: column;
+		background-color: red;
 	}
 
 	.max-height {

--- a/apps/desktop/src/components/FileListItemWrapper.svelte
+++ b/apps/desktop/src/components/FileListItemWrapper.svelte
@@ -6,6 +6,7 @@
 	import { getCommitStore } from '$lib/commits/contexts';
 	import { draggableChips, type DraggableConfig } from '$lib/dragging/draggable';
 	import { FileDropData } from '$lib/dragging/draggables';
+	import { DropzoneRegistry } from '$lib/dragging/registry';
 	import { LocalFile } from '$lib/files/file';
 	import { type AnyFile } from '$lib/files/file';
 	import { getLockText } from '$lib/files/lock';
@@ -43,6 +44,7 @@
 	const selectedOwnership: Writable<SelectedOwnership> | undefined =
 		maybeGetContextStore(SelectedOwnership);
 	const fileIdSelection = getContext(FileIdSelection);
+	const dropzoneRegistry = getContext(DropzoneRegistry);
 	const commit = getCommitStore();
 
 	// TODO: Refactor this into something more meaningful.
@@ -91,7 +93,8 @@
 				disabled: !draggable,
 				viewportId: 'board-viewport',
 				selector: '.selected-draggable',
-				chipType: 'file'
+				chipType: 'file',
+				dropzoneRegistry
 			};
 			if (chips) {
 				chips.update(config);

--- a/apps/desktop/src/components/HunkViewer.svelte
+++ b/apps/desktop/src/components/HunkViewer.svelte
@@ -6,6 +6,7 @@
 	import { SelectedOwnership } from '$lib/branches/ownership';
 	import { draggableChips } from '$lib/dragging/draggable';
 	import { HunkDropData } from '$lib/dragging/draggables';
+	import { DropzoneRegistry } from '$lib/dragging/registry';
 	import { type Hunk } from '$lib/hunks/hunk';
 	import { Project } from '$lib/project/project';
 	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
@@ -46,6 +47,7 @@
 	const userSettings = getContextStoreBySymbol<Settings>(SETTINGS);
 	const stack = maybeGetContextStore(BranchStack);
 	const project = getContext(Project);
+	const dropzoneRegistry = getContext(DropzoneRegistry);
 
 	let alwaysShow = $state(false);
 	let viewport = $state<HTMLDivElement>();
@@ -83,7 +85,8 @@
 			label: section.hunk.diff.split('\n')[0],
 			data: new HunkDropData($stack?.id || '', section.hunk, section.hunk.lockedTo, commitId),
 			disabled: draggingDisabled,
-			chipType: 'hunk'
+			chipType: 'hunk',
+			dropzoneRegistry
 		}}
 	>
 		{#if linesModified > 2500 && !alwaysShow}

--- a/apps/desktop/src/components/v3/BranchCard.svelte
+++ b/apps/desktop/src/components/v3/BranchCard.svelte
@@ -7,9 +7,7 @@
 	import BranchHeaderContextMenu from '$components/v3/BranchHeaderContextMenu.svelte';
 	import PrNumberUpdater from '$components/v3/PrNumberUpdater.svelte';
 	import ReviewView from '$components/v3/ReviewView.svelte';
-	import { MoveCommitDzHandler, StartCommitDzHandler } from '$lib/commits/dropHandler';
-	import { assignmentEnabled } from '$lib/config/uiFeatureFlags';
-	import { UncommittedService } from '$lib/selection/uncommittedService.svelte';
+	import { MoveCommitDzHandler } from '$lib/commits/dropHandler';
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { UiState } from '$lib/state/uiState.svelte';
 	import { TestId } from '$lib/testing/testIds';
@@ -78,11 +76,7 @@
 
 	let { projectId, branchName, expand, active, lineColor, readonly, ...args }: Props = $props();
 
-	const [uiState, stackService, uncommittedService] = inject(
-		UiState,
-		StackService,
-		UncommittedService
-	);
+	const [uiState, stackService] = inject(UiState, StackService);
 
 	const [updateName, nameUpdate] = stackService.updateBranchName;
 
@@ -125,17 +119,10 @@
 >
 	{#if args.type === 'stack-branch'}
 		{@const moveHandler = new MoveCommitDzHandler(stackService, args.stackId, projectId)}
-		{@const startCommitHandler = new StartCommitDzHandler({
-			uiState,
-			uncommittedService,
-			stackId: args.stackId,
-			projectId,
-			branchName
-		})}
 		{#if !args.prNumber}
 			<PrNumberUpdater {projectId} stackId={args.stackId} {branchName} />
 		{/if}
-		<Dropzone handlers={$assignmentEnabled ? [moveHandler] : [moveHandler, startCommitHandler]}>
+		<Dropzone handlers={[moveHandler]}>
 			{#snippet overlay({ hovered, activated, handler })}
 				{@const label = handler instanceof MoveCommitDzHandler ? 'Move here' : 'Start commit'}
 				<CardOverlay {hovered} {activated} {label} />

--- a/apps/desktop/src/components/v3/BranchCommitList.svelte
+++ b/apps/desktop/src/components/v3/BranchCommitList.svelte
@@ -21,12 +21,12 @@
 		SquashCommitDzHandler
 	} from '$lib/commits/dropHandler';
 	import { draggableCommitV3 } from '$lib/dragging/draggable';
+	import { DropzoneRegistry } from '$lib/dragging/registry';
 	import {
 		ReorderCommitDzFactory,
 		ReorderCommitDzHandler
 	} from '$lib/dragging/stackingReorderDropzoneManager';
 	import { DefaultForgeFactory } from '$lib/forge/forgeFactory.svelte';
-	import { IdSelection } from '$lib/selection/idSelection.svelte';
 	import { StackService, type SeriesIntegrationStrategy } from '$lib/stacks/stackService.svelte';
 	import { combineResults } from '$lib/state/helpers';
 	import { UiState } from '$lib/state/uiState.svelte';
@@ -92,12 +92,12 @@
 		handleEditPatch
 	}: Props = $props();
 
-	const [stackService, uiState, forge, baseBranchService] = inject(
+	const [stackService, uiState, forge, baseBranchService, dropzoneRegistry] = inject(
 		StackService,
 		UiState,
 		DefaultForgeFactory,
 		BaseBranchService,
-		IdSelection
+		DropzoneRegistry
 	);
 	const [integrateUpstreamCommits, upstreamIntegration] = stackService.integrateUpstreamCommits;
 
@@ -357,7 +357,8 @@
 								false,
 								branchName
 							),
-							viewportId: 'board-viewport'
+							viewportId: 'board-viewport',
+							dropzoneRegistry
 						}}
 					>
 						<CommitRow

--- a/apps/desktop/src/components/v3/BranchList.svelte
+++ b/apps/desktop/src/components/v3/BranchList.svelte
@@ -12,7 +12,6 @@
 	import NewBranchModal from '$components/v3/NewBranchModal.svelte';
 	import PushButton from '$components/v3/PushButton.svelte';
 	import { getColorFromCommitState, getIconFromCommitState } from '$components/v3/lib';
-	import { assignmentEnabled } from '$lib/config/uiFeatureFlags';
 	import { StackingReorderDropzoneManagerFactory } from '$lib/dragging/stackingReorderDropzoneManager';
 	import { ModeService } from '$lib/mode/modeService';
 	import { StackService } from '$lib/stacks/stackService.svelte';
@@ -23,16 +22,14 @@
 	import Modal from '@gitbutler/ui/Modal.svelte';
 	import { QueryStatus } from '@reduxjs/toolkit/query';
 	import type { CommitStatusType } from '$lib/commits/commit';
-	import type { Snippet } from 'svelte';
 
 	type Props = {
 		projectId: string;
 		stackId: string;
 		focusedStackId?: string;
-		assignments: Snippet;
 	};
 
-	const { projectId, stackId, focusedStackId, assignments }: Props = $props();
+	const { projectId, stackId, focusedStackId }: Props = $props();
 	const [stackService, uiState, modeService] = inject(StackService, UiState, ModeService);
 
 	const branchesResult = $derived(stackService.branches(projectId, stackId));
@@ -115,9 +112,6 @@
 			)}
 			<ScrollableContainer>
 				<div class="branches-wrapper">
-					{#if $assignmentEnabled}
-						{@render assignments()}
-					{/if}
 					{#each branches as branch, i}
 						{@const branchName = branch.name}
 						{@const localAndRemoteCommits = stackService.commits(projectId, stackId, branchName)}

--- a/apps/desktop/src/components/v3/Drawer.svelte
+++ b/apps/desktop/src/components/v3/Drawer.svelte
@@ -233,6 +233,7 @@
 		position: relative;
 		flex: 1;
 		flex-direction: column;
+		align-items: stretch;
 		overflow: hidden;
 
 		&.files-split-view {
@@ -291,7 +292,6 @@
 		position: relative;
 		flex-direction: column;
 		width: var(--custom-width);
-		height: 100%;
 	}
 
 	.drawer__files-split-view {

--- a/apps/desktop/src/components/v3/FileListItemWrapper.svelte
+++ b/apps/desktop/src/components/v3/FileListItemWrapper.svelte
@@ -4,6 +4,7 @@
 	import { conflictEntryHint } from '$lib/conflictEntryPresence';
 	import { draggableChips } from '$lib/dragging/draggable';
 	import { ChangeDropData } from '$lib/dragging/draggables';
+	import { DropzoneRegistry } from '$lib/dragging/registry';
 	import { getFilename } from '$lib/files/utils';
 	import { type TreeChange } from '$lib/hunks/change';
 	import { IdSelection } from '$lib/selection/idSelection.svelte';
@@ -65,6 +66,7 @@
 
 	const idSelection = getContext(IdSelection);
 	const uncommittedService = getContext(UncommittedService);
+	const dropzoneRegistry = getContext(DropzoneRegistry);
 
 	let contextMenu = $state<ReturnType<typeof FileContextMenu>>();
 	let draggableEl: HTMLDivElement | undefined = $state();
@@ -123,7 +125,8 @@
 		viewportId: 'board-viewport',
 		selector: '.selected-draggable',
 		disabled: draggableDisabled,
-		chipType: 'file'
+		chipType: 'file',
+		dropzoneRegistry
 	}}
 >
 	<FileContextMenu

--- a/apps/desktop/src/components/v3/profileSettings/ExperimentalSettings.svelte
+++ b/apps/desktop/src/components/v3/profileSettings/ExperimentalSettings.svelte
@@ -1,11 +1,6 @@
 <script lang="ts">
 	import { SettingsService } from '$lib/config/appSettingsV2';
-	import {
-		assignmentEnabled,
-		confettiEnabled,
-		ircEnabled,
-		ircServer
-	} from '$lib/config/uiFeatureFlags';
+	import { confettiEnabled, ircEnabled, ircServer } from '$lib/config/uiFeatureFlags';
 	import { User } from '$lib/user/user';
 	import { getContext, getContextStore } from '@gitbutler/shared/context';
 	import SectionCard from '@gitbutler/ui/SectionCard.svelte';
@@ -56,23 +51,6 @@
 				id="v3Design"
 				checked={$settingsStore?.featureFlags.v3}
 				onclick={() => settingsService.updateFeatureFlags({ v3: !$settingsStore?.featureFlags.v3 })}
-			/>
-		{/snippet}
-	</SectionCard>
-
-	<SectionCard labelFor="assignments" roundedTop={false} roundedBottom={false} orientation="row">
-		{#snippet title()}
-			Assign uncommitted changes
-		{/snippet}
-		{#snippet caption()}
-			When enabled you can assign uncommitted changes to branches (stacks).
-		{/snippet}
-
-		{#snippet actions()}
-			<Toggle
-				id="assignments"
-				checked={$assignmentEnabled}
-				onclick={() => assignmentEnabled.set(!$assignmentEnabled)}
 			/>
 		{/snippet}
 	</SectionCard>

--- a/apps/desktop/src/lib/config/uiFeatureFlags.ts
+++ b/apps/desktop/src/lib/config/uiFeatureFlags.ts
@@ -11,7 +11,6 @@ export const confettiEnabled = persisted(false, 'experimental-confetti');
 export const workspaceSwapPanels = persisted<
 	'dont-swap-panels' | 'swap-middle-to-right' | 'swap-middle-to-left'
 >('dont-swap-panels', 'workspace-swap-panels');
-export const assignmentEnabled = persisted(false, 'experimental-assignment');
 
 export const ircEnabled = persistWithExpiration(false, 'feature-irc', 1440 * 30);
 export const ircServer = persistWithExpiration('', 'feature-irc-server', 1440 * 30);

--- a/apps/desktop/src/lib/dragging/dropzone.ts
+++ b/apps/desktop/src/lib/dragging/dropzone.ts
@@ -1,4 +1,5 @@
 import type { DropzoneHandler } from '$lib/dragging/handler';
+import type { DropzoneRegistry } from '$lib/dragging/registry';
 
 export type HoverArgs = {
 	handler?: DropzoneHandler;
@@ -12,6 +13,7 @@ export interface DropzoneConfiguration {
 	onHoverStart: (args: HoverArgs) => void;
 	onHoverEnd: () => void;
 	target: string;
+	registry: DropzoneRegistry;
 }
 
 export class Dropzone {
@@ -68,13 +70,13 @@ export class Dropzone {
 	}
 
 	deactivate() {
-		if (this.registered) {
-			this.unregisterListeners();
-		}
+		if (this.registered) this.unregisterListeners();
+
+		if (this.activated) this.configuration.onActivationEnd();
 		this.activated = false;
+
+		if (this.hovered) this.configuration.onHoverEnd();
 		this.hovered = false;
-		this.configuration.onActivationEnd();
-		this.configuration.onHoverEnd();
 	}
 
 	private registerListeners() {
@@ -128,8 +130,6 @@ export class Dropzone {
 	}
 }
 
-export const dropzoneRegistry = new Map<HTMLElement, Dropzone>();
-
 export function dropzone(node: HTMLElement, configuration: DropzoneConfiguration) {
 	let instance: Dropzone | undefined;
 
@@ -141,7 +141,7 @@ export function dropzone(node: HTMLElement, configuration: DropzoneConfiguration
 		}
 
 		instance = new Dropzone(config, node);
-		dropzoneRegistry.set(node, instance);
+		configuration.registry.set(node, instance);
 	}
 
 	function cleanup() {
@@ -149,7 +149,7 @@ export function dropzone(node: HTMLElement, configuration: DropzoneConfiguration
 			instance.deactivate();
 			instance = undefined;
 		}
-		dropzoneRegistry.delete(node);
+		configuration.registry.delete(node);
 	}
 
 	setup(configuration);

--- a/apps/desktop/src/lib/dragging/registry.ts
+++ b/apps/desktop/src/lib/dragging/registry.ts
@@ -1,0 +1,20 @@
+import type { Dropzone } from '$lib/dragging/dropzone';
+
+/**
+ * This class was bascially only created in order to facilitate injection.
+ */
+export class DropzoneRegistry {
+	private map = new Map<HTMLElement, Dropzone>();
+	get(key: HTMLElement) {
+		return this.map.get(key);
+	}
+	set(key: HTMLElement, value: Dropzone) {
+		this.map.set(key, value);
+	}
+	delete(key: HTMLElement) {
+		this.map.delete(key);
+	}
+	values() {
+		return this.map.values();
+	}
+}

--- a/apps/desktop/src/lib/focus/focusManager.svelte.ts
+++ b/apps/desktop/src/lib/focus/focusManager.svelte.ts
@@ -13,6 +13,7 @@ export enum DefinedFocusable {
 	Drawer = 'drawer',
 	Branches = 'branches',
 	Stack = 'stack',
+	Preview = 'preview',
 	// Only one of these can be in the dom at any given time.
 	ChangedFiles = 'changed-files'
 }
@@ -21,7 +22,7 @@ export function stackFocusableId(stackId: string) {
 	return `${DefinedFocusable.Stack}:${stackId}`;
 }
 
-export function uncommittedFocusableId(stackId: string) {
+export function uncommittedFocusableId(stackId?: string) {
 	return `${DefinedFocusable.UncommittedChanges}:${stackId}`;
 }
 

--- a/apps/desktop/src/lib/hunks/hunk.ts
+++ b/apps/desktop/src/lib/hunks/hunk.ts
@@ -423,11 +423,11 @@ export function hunkContainsLine(hunk: DiffHunk, line: LineId): boolean {
  * Get the line locks for a hunk.
  */
 export function getLineLocks(
-	stackId: string | undefined,
+	excludeStackId: string | undefined,
 	hunk: DiffHunk,
 	locks: HunkLocks[]
 ): [boolean, LineLock[] | undefined] {
-	if (stackId === undefined) {
+	if (excludeStackId === undefined) {
 		return [false, undefined];
 	}
 
@@ -457,7 +457,7 @@ export function getLineLocks(
 			const locks = hunkLocks
 				.map((lock) => lock.locks)
 				.flat()
-				.filter((lock) => lock.stackId !== stackId);
+				.filter((lock) => lock.stackId !== excludeStackId);
 
 			if (locks.length === 0) {
 				hunkIsFullyLocked = false;

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -32,6 +32,7 @@
 	import { GitConfigService } from '$lib/config/gitConfigService';
 	import { ircEnabled, ircServer } from '$lib/config/uiFeatureFlags';
 	import DependencyService from '$lib/dependencies/dependencyService.svelte';
+	import { DropzoneRegistry } from '$lib/dragging/registry';
 	import { FileService } from '$lib/files/fileService';
 	import { ButRequestDetailsService } from '$lib/forge/butRequestDetailsService';
 	import { DefaultForgeFactory } from '$lib/forge/forgeFactory.svelte';
@@ -234,6 +235,7 @@
 	setContext(UploadsService, data.uploadsService);
 	setContext(DependencyService, dependecyService);
 	setContext(IdSelection, idSelection);
+	setContext(DropzoneRegistry, new DropzoneRegistry());
 
 	setNameNormalizationServiceContext(new IpcNameNormalizationService(invoke));
 

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -21,7 +21,6 @@
 	import { VirtualBranchService } from '$lib/branches/virtualBranchService';
 	import { SettingsService } from '$lib/config/appSettingsV2';
 	import { showHistoryView } from '$lib/config/config';
-	import { assignmentEnabled } from '$lib/config/uiFeatureFlags';
 	import { StackingReorderDropzoneManagerFactory } from '$lib/dragging/stackingReorderDropzoneManager';
 	import { UncommitedFilesWatcher } from '$lib/files/watcher';
 	import { FocusManager } from '$lib/focus/focusManager.svelte';
@@ -303,9 +302,7 @@
 					changes: worktreeData.rawChanges,
 					// If assignments are not enabled we override the stack id to prevent
 					// files from becoming hidden when toggling on/off.
-					assignments: $assignmentEnabled
-						? worktreeData.hunkAssignments
-						: worktreeData.hunkAssignments.map((a) => ({ ...a, stackId: null }))
+					assignments: worktreeData.hunkAssignments
 				});
 			});
 		}


### PR DESCRIPTION
Trying to figure out why dropzones sometimes malfunction, but it is hard
to understand what goes wrong without a bit of cleanup.

One of the bigger changes here is that we make the dropzone registry
another dependency that is given to the dropzone svelte action. The main
reason for doing this is we avoid declaring a static map. It is also
nice to stay consistent with the preferred way of managing dependencies.
