### PR TITLE
Improve worktreeChanges function

### DIFF
--- a/apps/desktop/cypress/e2e/support/scenarios/complexHunks.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/complexHunks.ts
@@ -566,12 +566,6 @@ export default class ComplexHunks extends MockBackend {
 					newLines: 1
 				},
 				{
-					oldStart: 60,
-					oldLines: 3,
-					newStart: 0,
-					newLines: 0
-				},
-				{
 					oldStart: 0,
 					oldLines: 0,
 					newStart: 79,
@@ -584,12 +578,6 @@ export default class ComplexHunks extends MockBackend {
 					newLines: 3
 				},
 				{
-					oldStart: 77,
-					oldLines: 1,
-					newStart: 0,
-					newLines: 0
-				},
-				{
 					oldStart: 0,
 					oldLines: 0,
 					newStart: 104,
@@ -600,6 +588,18 @@ export default class ComplexHunks extends MockBackend {
 					oldLines: 0,
 					newStart: 107,
 					newLines: 6
+				},
+				{
+					oldStart: 60,
+					oldLines: 3,
+					newStart: 0,
+					newLines: 0
+				},
+				{
+					oldStart: 77,
+					oldLines: 1,
+					newStart: 0,
+					newLines: 0
 				}
 			]
 		}
@@ -616,13 +616,13 @@ export default class ComplexHunks extends MockBackend {
 				{ oldStart: 0, oldLines: 0, newStart: 55, newLines: 4 },
 				{ oldStart: 0, oldLines: 0, newStart: 65, newLines: 1 },
 				{ oldStart: 0, oldLines: 0, newStart: 72, newLines: 1 },
-				{ oldStart: 60, oldLines: 3, newStart: 0, newLines: 0 },
 				{ oldStart: 0, oldLines: 0, newStart: 79, newLines: 1 },
 				{ oldStart: 0, oldLines: 0, newStart: 82, newLines: 6 },
 				{ oldStart: 0, oldLines: 0, newStart: 93, newLines: 6 },
-				{ oldStart: 75, oldLines: 3, newStart: 0, newLines: 0 },
 				{ oldStart: 0, oldLines: 0, newStart: 104, newLines: 1 },
 				{ oldStart: 0, oldLines: 0, newStart: 107, newLines: 6 },
+				{ oldStart: 60, oldLines: 3, newStart: 0, newLines: 0 },
+				{ oldStart: 75, oldLines: 3, newStart: 0, newLines: 0 },
 				{
 					oldStart: 84,
 					oldLines: 29,

--- a/apps/desktop/src/components/v3/NewCommitView.svelte
+++ b/apps/desktop/src/components/v3/NewCommitView.svelte
@@ -122,17 +122,15 @@
 			throw new Error('No branch selected!');
 		}
 
-		const worktreeChanges = (await uncommittedService.worktreeChanges(projectId, stackId)).concat(
-			await uncommittedService.worktreeChanges(projectId, undefined)
-		);
+		const worktreeChanges = await uncommittedService.worktreeChanges(projectId, stackId);
 
 		const preHookFailed = await runPreHook(worktreeChanges);
 		if (preHookFailed) return;
 
 		const response = await createCommitInStack({
 			projectId,
-			stackId: finalStackId,
 			parentId: selectedCommitId,
+			stackId: finalStackId,
 			message: message,
 			stackBranchName: finalBranchName,
 			worktreeChanges

--- a/apps/desktop/src/lib/hunks/hunk.ts
+++ b/apps/desktop/src/lib/hunks/hunk.ts
@@ -473,3 +473,14 @@ export function getLineLocks(
 
 	return [hunkIsFullyLocked, lineLocks];
 }
+
+/**
+ * Order hunk headers from the top of a file to the bottom.
+ */
+export function orderHeaders(a: HunkHeader, b: HunkHeader): number {
+	const old = a.oldStart - b.oldStart;
+	if (old === 0) {
+		return a.newStart - b.newStart;
+	}
+	return old;
+}


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#2KMEFpEFW`](https://gitbutler.com/cto/gitbutler-client-d443/reviews/2KMEFpEFW)

**Improve worktreeChanges function**


This commit contains two changes.

It adapts the function to better represent the intended behaviour, now if you pass a stackId it will still return any unassigned selections

Sorts hunk headers. Hunk headers need to be ordered from the top of a file to the bottom. This adds in an ordering function to help us do that

1 commit series (version 2)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Improve worktreeChanges function](https://gitbutler.com/cto/gitbutler-client-d443/reviews/2KMEFpEFW/commit/2e662302-bfb0-4fac-8830-4606d88b200d) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/cto/gitbutler-client-d443/reviews/2KMEFpEFW)_
<!-- GitButler Review Footer Boundary Bottom -->
