### PR TITLE
Dim other lanes when committing

### DIFF
--- a/apps/desktop/cypress/e2e/unifiedDiffView.cy.ts
+++ b/apps/desktop/cypress/e2e/unifiedDiffView.cy.ts
@@ -25,7 +25,7 @@ describe('Unified Diff View', () => {
 		clearCommandMocks();
 	});
 
-	it('should open the unified diff view when clicking on a file and show the dependency locks', () => {
+	it.only('should open the unified diff view when clicking on a file and show the dependency locks', () => {
 		// There should be uncommitted changes
 		cy.getByTestId('uncommitted-changes-file-list')
 			.should('be.visible')
@@ -94,8 +94,11 @@ describe('Unified Diff View', () => {
 		// The tooltip should be visible
 		cy.getByTestId('unified-diff-view-lock-warning').should('be.visible');
 
+		// Cancel the commit.
+		cy.getByTestId('commit-drawer-cancel-button').scrollIntoView().should('be.visible').click();
+
 		// Select the stack that the file belongs to
-		cy.getByTestId('branch-header', mockBackend.dependsOnStack)
+		cy.get(`[data-id="${mockBackend.dependsOnStack}"]`)
 			.scrollIntoView()
 			.should('be.visible')
 			.click();

--- a/apps/desktop/src/components/v3/StackView.svelte
+++ b/apps/desktop/src/components/v3/StackView.svelte
@@ -53,9 +53,13 @@
 		StackService
 	);
 	const projectState = $derived(uiState.project(projectId));
-	const exclusiveAction = $derived(projectState.exclusiveAction.current);
-	const isCommitting = $derived(
-		exclusiveAction?.type === 'commit' && exclusiveAction.stackId === stack.id
+
+	const action = $derived(projectState.exclusiveAction.current);
+	const isCommitting = $derived(action?.type === 'commit' && action.stackId === stack.id);
+
+	// If the user is making a commit to a different lane we dim this one.
+	const dimmed = $derived(
+		action?.type === 'commit' && action.stackId !== undefined && action.stackId !== stack.id
 	);
 
 	const branchesResult = $derived(stackService.branches(projectId, stack.id));
@@ -124,6 +128,7 @@
 	}}
 	<div
 		class="stack-view-wrapper dotted-pattern"
+		class:dimmed
 		data-id={stack.id}
 		data-testid={TestId.Stack}
 		data-testid-stackid={stack.id}
@@ -317,6 +322,9 @@
 		flex-shrink: 0;
 		overflow: hidden;
 
+		&.dimmed {
+			opacity: 0.5;
+		}
 		&:first-child {
 			border-left: 1px solid var(--clr-border-2);
 		}
@@ -328,6 +336,10 @@
 		flex-shrink: 0;
 		flex-direction: column;
 		border-right: 1px solid var(--clr-border-2);
+	}
+
+	.dimmed .stack-view {
+		pointer-events: none;
 	}
 
 	.assigned-changes-empty__text {


### PR DESCRIPTION
We might want to cancel the commit if you click on a dimmed lane, but 
for now let's start with this.
