### PR TITLE
Add structured logging to MCP server startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -45,4 +45,9 @@ gitbutler-secret.workspace = true
 colored = "3.0.0"
 serde_json = "1.0.140"
 tracing.workspace = true
+tracing-subscriber = { version = "0.3", features = [
+    "env-filter",
+    "std",
+    "fmt",
+] }
 dirs-next = "2.0.0"


### PR DESCRIPTION
Add tracing-subscriber initialization to both MCP and MCP internal
modules to enable structured logging with environment-based filters.
Log server start and client connection info at debug level to improve
observability and aid debugging during runtime.
