### PR TITLE
Improve hunk retain function

### DIFF
--- a/apps/desktop/src/lib/hunks/hunk.ts
+++ b/apps/desktop/src/lib/hunks/hunk.ts
@@ -117,9 +117,9 @@ export type HunkAssignment = {
 	 * This determines where the hunk can be assigned.
 	 */
 	readonly hunkLocks: HunkLock[] | null;
-	/** The line numbers that were added in this hunk. */
+	/** The line numbers that were added in this hunk. The "after" or "new" line numbers.*/
 	readonly lineNumsAdded: number[] | null;
-	/** The line numbers that were removed in this hunk. */
+	/** The line numbers that were removed in this hunk. The "before" or "old" line numbers.*/
 	readonly lineNumsRemoved: number[] | null;
 };
 

--- a/packages/ui/src/lib/utils/diffParsing.ts
+++ b/packages/ui/src/lib/utils/diffParsing.ts
@@ -713,7 +713,9 @@ function computeInlineWordDiff(
 }
 
 export interface LineId {
+	// The "before" or "removed" line number.
 	oldLine: number | undefined;
+	// The "after" or "added" line number.
 	newLine: number | undefined;
 }
 


### PR DESCRIPTION
This introduces a new updateLines function to handle the retaining of individually selected lines. It has the following behaviour:

- If every line is selected, they should remain all selected
- If some of the lines are selected, then filter out any old selected lines that no longer exist.
- If the selection ends up empty, return undefined which should signal that the entire selection should be dropped.

This could be made more intelligent in the future (IE updating the selection based on the similarity of old lines to new lines) but this seems to work well enough for now.

This also goes to the effort to introduce an everyLineSelected function which can be used in a follow up to update the checkLine logic to make it go from “Array that holds all the lines” to “Empty array"

---

Something worth touching on is that this makes use of Sets to try and avoid any O(n^2) logic. This is technically more complex, but I don’t think it impacts readability much.