### PR TITLE
Fix random newlines getting added

### DIFF
--- a/packages/ui/src/lib/RichTextEditor.svelte
+++ b/packages/ui/src/lib/RichTextEditor.svelte
@@ -2,6 +2,7 @@
 	import { WRAP_ALL_COMMAND } from '$lib/richText/commands';
 	import { standardConfig } from '$lib/richText/config/config';
 	import { standardTheme } from '$lib/richText/config/theme';
+	import { getCurrentText } from '$lib/richText/getText';
 	import EmojiPlugin from '$lib/richText/plugins/Emoji.svelte';
 	import PlainTextIndentPlugin from '$lib/richText/plugins/PlainTextIndentPlugin.svelte';
 	import MarkdownTransitionPlugin from '$lib/richText/plugins/markdownTransition';
@@ -71,12 +72,13 @@
 	}: Props = $props();
 
 	/** Standard configuration for our commit message editor. */
-	const initialConfig = standardConfig({
-		initialText,
-		namespace,
-		theme: standardTheme,
-		onError
-	});
+	const initialConfig = $derived(
+		standardConfig({
+			namespace,
+			theme: standardTheme,
+			onError
+		})
+	);
 
 	/**
 	 * Instance of the lexical composer, used for manipulating the contents of the editor
@@ -177,7 +179,7 @@
 			if (composer) {
 				const editor = composer.getEditor();
 				editor?.read(() => {
-					const text = getRoot().getTextContent();
+					const text = getCurrentText(markdown, wrapCountValue);
 					resolve(text);
 				});
 			}

--- a/packages/ui/src/lib/richText/getText.ts
+++ b/packages/ui/src/lib/richText/getText.ts
@@ -1,0 +1,13 @@
+import { getMarkdownString } from '$lib/richText/markdown';
+import { $getRoot as getRoot } from 'lexical';
+
+/**
+ * Should only be called inside of an editor scope.
+ *
+ * Gets the current text with the consideration of markdown formatting.
+ */
+export function getCurrentText(markdown: boolean, maxLength?: number) {
+	// If WYSIWYG is enabled, we need to transform the content to markdown strings
+	if (markdown) return getMarkdownString(maxLength);
+	return getRoot().getTextContent();
+}

--- a/packages/ui/src/lib/richText/plugins/onChange.svelte
+++ b/packages/ui/src/lib/richText/plugins/onChange.svelte
@@ -8,16 +8,14 @@
 
 <script lang="ts">
 	import { getEditor } from '$lib/richText/context';
-	import { getMarkdownString } from '$lib/richText/markdown';
+	import { getCurrentText } from '$lib/richText/getText';
 	import { getEditorTextAfterAnchor, getEditorTextUpToAnchor } from '$lib/richText/selection';
 	import {
 		BLUR_COMMAND,
 		COMMAND_PRIORITY_NORMAL,
-		$getRoot as getRoot,
 		$getSelection as getSelection,
 		$isRangeSelection as isRangeSelection
 	} from 'lexical';
-	import { untrack } from 'svelte';
 
 	type Props = {
 		markdown: boolean;
@@ -31,18 +29,12 @@
 
 	let text = $state<string>();
 
-	function getCurrentText() {
-		// If WYSIWYG is enabled, we need to transform the content to markdown strings
-		if (untrack(() => markdown)) return getMarkdownString(maxLength);
-		return getRoot().getTextContent();
-	}
-
 	$effect(() => {
 		return editor.registerCommand(
 			BLUR_COMMAND,
 			() => {
 				editor.read(() => {
-					const currentText = getCurrentText();
+					const currentText = getCurrentText(markdown, maxLength);
 					if (currentText === text) {
 						return;
 					}


### PR DESCRIPTION
This commit covers a few changes.

The main issue with the random newlines getting added seems to be to do with how the initialText parameter of the standardConfig function is handled.

We don’t strictly need to use this parameter as we have an effect that binds the initialText paramater further down.

The main fix was removing this.


This PR now adds in one function for getting the current text which always does the markdown parsing. I found it quite strange that we didn’t always do this. It also now creates the standardConfig in a derived block because it relies on reactive params. 