### PR TITLE
Resize similar lanes with shift + drag

### DIFF
--- a/apps/desktop/src/components/BranchLane.svelte
+++ b/apps/desktop/src/components/BranchLane.svelte
@@ -9,7 +9,7 @@
 	import { Project } from '$lib/project/project';
 	import { FileIdSelection } from '$lib/selection/fileIdSelection';
 	import { getContext, createContextStore } from '@gitbutler/shared/context';
-	import { persisted, persistWithExpiration } from '@gitbutler/shared/persisted';
+	import { persisted } from '@gitbutler/shared/persisted';
 	import { setContext } from 'svelte';
 	import { quintOut } from 'svelte/easing';
 	import { writable } from 'svelte/store';
@@ -45,7 +45,6 @@
 	let rsViewport: HTMLElement | undefined = $state();
 
 	const commitBoxOpen = persisted<boolean>(false, 'commitBoxExpanded_' + stack.id);
-	let width = persistWithExpiration(25, 'fileWidth_' + stack.id, 7 * 1440);
 
 	let isLaneCollapsed = $state(projectLaneCollapsed(project.id, stack.id));
 	$effect(() => {
@@ -63,7 +62,6 @@
 			class="file-preview"
 			bind:this={rsViewport}
 			in:slide={{ duration: 180, easing: quintOut, axis: 'x' }}
-			style:width={$width + 'rem'}
 		>
 			<FileCard
 				isUnapplied={false}
@@ -77,10 +75,11 @@
 			/>
 			<Resizer
 				viewport={rsViewport}
-				direction="right"
+				persistId={'fileWidth_' + stack.id}
+				defaultValue={25}
 				minWidth={20}
 				maxWidth={100}
-				onWidth={(value) => ($width = value)}
+				direction="right"
 				imitateBorder
 			/>
 		</div>

--- a/apps/desktop/src/components/BranchPreview.svelte
+++ b/apps/desktop/src/components/BranchPreview.svelte
@@ -9,7 +9,6 @@
 	import { DefaultForgeFactory } from '$lib/forge/forgeFactory.svelte';
 	import { FileIdSelection } from '$lib/selection/fileIdSelection';
 	import { getContext } from '@gitbutler/shared/context';
-	import { persistWithExpiration } from '@gitbutler/shared/persisted';
 	import Line from '@gitbutler/ui/commitLines/Line.svelte';
 	import { LineManagerFactory } from '@gitbutler/ui/commitLines/lineManager';
 	import Markdown from '@gitbutler/ui/markdown/Markdown.svelte';
@@ -34,7 +33,6 @@
 	const commitId = $derived($selectedFile?.commitId);
 	const selected = $derived($selectedFile?.file);
 
-	const width = persistWithExpiration<number>(30, 'branchPreviewLaneWidth', 7 * 1440);
 	const lineManagerFactory = getContext(LineManagerFactory);
 
 	const remoteCommitShas = $derived(
@@ -72,7 +70,7 @@
 
 {#if remoteBranch || localBranch}
 	<div class="base">
-		<div class="base__left" bind:this={rsViewport} style:width={$width + 'rem'}>
+		<div class="base__left" bind:this={rsViewport}>
 			<ScrollableContainer wide>
 				<div class="branch-preview">
 					<BranchPreviewHeader {projectId} {localBranch} {remoteBranch} {pr} />
@@ -143,9 +141,10 @@
 			</ScrollableContainer>
 			<Resizer
 				viewport={rsViewport}
+				defaultValue={30}
+				persistId="branchPreviewLaneWidth"
 				direction="right"
 				minWidth={20}
-				onWidth={(value) => ($width = value)}
 			/>
 		</div>
 		<div class="base__right">

--- a/apps/desktop/src/components/Navigation.svelte
+++ b/apps/desktop/src/components/Navigation.svelte
@@ -21,7 +21,6 @@
 
 	const minResizerWidth = 14;
 	const minResizerRatio = 7;
-	const width = persisted<number | undefined>(25, 'defaultTrayWidth_' + projectId);
 
 	let viewport = $state<HTMLDivElement>();
 	let isResizerHovered = $state(false);
@@ -52,11 +51,12 @@
 		{#if viewport}
 			<Resizer
 				{viewport}
+				persistId={'defaultTrayWidth_' + projectId}
+				passive={$isNavCollapsed}
 				direction="right"
 				minWidth={minResizerWidth}
 				zIndex="var(--z-floating)"
 				onDblClick={toggleNavCollapse}
-				onWidth={(value) => ($width = value)}
 				imitateBorder
 				onHover={(isHovering) => {
 					isResizerHovered = isHovering;
@@ -93,13 +93,7 @@
 		</button>
 	</div>
 
-	<div
-		class="navigation"
-		class:collapsed={$isNavCollapsed}
-		style:width={$width && !$isNavCollapsed ? $width + 'rem' : null}
-		bind:this={viewport}
-		role="menu"
-	>
+	<div class="navigation" class:collapsed={$isNavCollapsed} bind:this={viewport} role="menu">
 		<!-- condition prevents split second UI shift -->
 		{#if platformName || env.PUBLIC_TESTING}
 			<div class="navigation-top">

--- a/apps/desktop/src/components/Stack.svelte
+++ b/apps/desktop/src/components/Stack.svelte
@@ -16,7 +16,6 @@
 	import { FileIdSelection } from '$lib/selection/fileIdSelection';
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { getContextStore, inject } from '@gitbutler/shared/context';
-	import { persistWithExpiration } from '@gitbutler/shared/persisted';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import EmptyStatePlaceholder from '@gitbutler/ui/EmptyStatePlaceholder.svelte';
 	import Spacer from '@gitbutler/ui/Spacer.svelte';
@@ -39,7 +38,6 @@
 	const stackStore = getContextStore(BranchStack);
 	const stack = $derived($stackStore);
 
-	const width = persistWithExpiration<number>(24, 'stackWidth_' + projectId, 7 * 1440);
 	const branchHasFiles = $derived(stack.files !== undefined && stack.files.length > 0);
 	const branchHasNoCommits = $derived(stack.validSeries.flatMap((s) => s.patches).length === 0);
 	const dzFileHandler = $derived(
@@ -120,7 +118,7 @@
 					bottom: 12
 				}}
 			>
-				<div bind:this={rsViewport} style:width={`${$width}rem`} class="branch-card__contents">
+				<div bind:this={rsViewport} class="branch-card__contents">
 					<StackHeader
 						{projectId}
 						{stack}
@@ -207,9 +205,10 @@
 			{#if rsViewport}
 				<Resizer
 					viewport={rsViewport}
+					persistId={'stackWidth_' + projectId}
+					defaultValue={24}
 					direction="right"
 					minWidth={25}
-					onWidth={(value) => ($width = value)}
 					imitateBorder
 					imitateBorderColor={$fileIdSelection.length === 1 ? 'trnsparent' : 'var(--clr-border-2)'}
 				/>

--- a/apps/desktop/src/components/v3/StackView.svelte
+++ b/apps/desktop/src/components/v3/StackView.svelte
@@ -22,6 +22,7 @@
 	import { UiState } from '$lib/state/uiState.svelte';
 	import { TestId } from '$lib/testing/testIds';
 	import { inject } from '@gitbutler/shared/context';
+	import { persistWithExpiration } from '@gitbutler/shared/persisted';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import { intersectionObserver } from '@gitbutler/ui/utils/intersectionObserver';
 	import type { Stack } from '$lib/stacks/stack';
@@ -60,6 +61,12 @@
 	// If the user is making a commit to a different lane we dim this one.
 	const dimmed = $derived(
 		action?.type === 'commit' && action.stackId !== undefined && action.stackId !== stack.id
+	);
+
+	const persistedStackWidth = persistWithExpiration(
+		uiState.global.stackWidth.current,
+		`ui-stack-width-${stack.id}`,
+		1440
 	);
 
 	const branchesResult = $derived(stackService.branches(projectId, stack.id));
@@ -149,7 +156,7 @@
 	>
 		<div
 			class="stack-view"
-			style:width={uiState.global.stackWidth.current + 'rem'}
+			style:width={$persistedStackWidth + 'rem'}
 			bind:clientWidth
 			bind:clientHeight
 			bind:this={laneEl}
@@ -226,11 +233,12 @@
 							}}
 						/>
 						<Resizer
+							persistId="resizer-panel1-${stack.id}"
 							viewport={laneEl!}
 							direction="right"
 							minWidth={16}
 							maxWidth={64}
-							onWidth={(value) => uiState.global.stackWidth.set(value)}
+							syncName="panel1"
 						/>
 					</ConfigurableScrollableContainer>
 					<StackStickyButtons>
@@ -286,10 +294,11 @@
 				{/if}
 				<Resizer
 					viewport={detailsEl}
+					persistId="resizer-panel2-${stack.id}"
 					direction="right"
 					minWidth={16}
 					maxWidth={56}
-					onWidth={(value) => uiState.global.detailsWidth.set(value)}
+					syncName="panel2"
 				/>
 			</div>
 		{/if}
@@ -306,10 +315,11 @@
 				<SelectionView {projectId} selectionId={selectedKey} />
 				<Resizer
 					viewport={previewEl}
+					persistId="resizer-panel2-${stack.id}"
 					direction="right"
 					minWidth={20}
 					maxWidth={96}
-					onWidth={(value) => uiState.global.previewWidth.set(value)}
+					syncName="panel2"
 				/>
 			</div>
 		{/if}

--- a/apps/desktop/src/lib/utils/resizeSync.ts
+++ b/apps/desktop/src/lib/utils/resizeSync.ts
@@ -1,0 +1,33 @@
+type ResizeCallback = (value: number) => void;
+
+/**
+ * The `Resizer` component uses this class for shift + drag synchronizing
+ * widths across multiple instances.
+ */
+export class ResizeSync {
+	private map: Record<string, [symbol, ResizeCallback][]> = {};
+
+	subscribe(args: { key: string; resizerId: symbol; callback: ResizeCallback }) {
+		const { key, resizerId: id, callback } = args;
+		let callbacks = this.map[key];
+		if (callbacks === undefined) {
+			callbacks = [];
+			this.map[key] = callbacks;
+		}
+		const item = [id, callback] as [symbol, ResizeCallback];
+		callbacks.push(item);
+		return () => {
+			callbacks.splice(callbacks.indexOf(item));
+		};
+	}
+
+	emit(key: string, exclude: symbol, value: number) {
+		const callbacks = this.map[key];
+		if (!callbacks) return;
+		for (const [id, callback] of callbacks) {
+			if (id !== exclude) {
+				callback(value);
+			}
+		}
+	}
+}

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -62,6 +62,7 @@
 	import { UserService } from '$lib/user/userService';
 	import * as events from '$lib/utils/events';
 	import { createKeybind } from '$lib/utils/hotkeys';
+	import { ResizeSync } from '$lib/utils/resizeSync';
 	import { unsubscribe } from '$lib/utils/unsubscribe';
 	import { openExternalUrl } from '$lib/utils/url';
 	import { WorktreeService } from '$lib/worktree/worktreeService.svelte';
@@ -236,6 +237,7 @@
 	setContext(DependencyService, dependecyService);
 	setContext(IdSelection, idSelection);
 	setContext(DropzoneRegistry, new DropzoneRegistry());
+	setContext(ResizeSync, new ResizeSync());
 
 	setNameNormalizationServiceContext(new IpcNameNormalizationService(invoke));
 

--- a/apps/desktop/src/routes/[projectId]/base/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/base/+page.svelte
@@ -8,11 +8,7 @@
 	import { Project } from '$lib/project/project';
 	import { FileIdSelection } from '$lib/selection/fileIdSelection';
 	import { getContext } from '@gitbutler/shared/context';
-	import { persisted } from '@gitbutler/shared/persisted';
 	import { setContext } from 'svelte';
-
-	const laneWidthKey = 'baseLaneWidth';
-	const width = persisted<number>(20, laneWidthKey);
 
 	const project = getContext(Project);
 	const baseBranchService = getContext(BaseBranchService);
@@ -37,7 +33,7 @@
 	<FullviewLoading />
 {:else}
 	<div class="base">
-		<div class="base__left" bind:this={rsViewport} style:width={$width + 'rem'}>
+		<div class="base__left" bind:this={rsViewport}>
 			<ScrollableContainer>
 				<div class="card">
 					<BaseBranch base={baseBranch} />
@@ -45,9 +41,10 @@
 			</ScrollableContainer>
 			<Resizer
 				viewport={rsViewport}
+				persistId="baseLaneWidth"
 				direction="right"
 				minWidth={20}
-				onWidth={(value) => ($width = value)}
+				defaultValue={20}
 			/>
 		</div>
 		<div class="base__right">

--- a/apps/desktop/src/routes/[projectId]/history/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/history/+page.svelte
@@ -191,11 +191,7 @@
 
 <div class="history-view">
 	<div class="relative overflow-hidden radius-ml">
-		<div
-			bind:this={sidebarEl}
-			class="history-view__snapshots"
-			style:width="{sidebarWidth.current}rem"
-		>
+		<div bind:this={sidebarEl} class="history-view__snapshots">
 			<div class="history-view__snapshots-header">
 				<h3 class="history-view__snapshots-header-title text-15 text-bold">Operations history</h3>
 			</div>
@@ -207,7 +203,8 @@
 			direction="right"
 			minWidth={14}
 			borderRadius="ml"
-			onWidth={(value) => (sidebarWidth.current = value)}
+			persistId="resizer-historyWidth"
+			defaultValue={sidebarWidth.current}
 		/>
 	</div>
 


### PR DESCRIPTION
This commit makes each stack individually resizeable, but adds the
option to resize panels of the same type by holding shift during resize.

While at it I also simplify the resizer component so it now takes a
`persistId` for optional persistence of the last value, and the new
width is set directly from within the component. Not sure why it wasn't
that way from start.
