### PR TITLE
Downgrade some 'polluting' tauri calls to TRACE level. (#9018)

### DIFF
--- a/crates/gitbutler-tauri/src/commands.rs
+++ b/crates/gitbutler-tauri/src/commands.rs
@@ -94,7 +94,7 @@ pub fn git_remove_global_config(key: &str) -> Result<(), Error> {
 }
 
 #[tauri::command(async)]
-#[instrument(err(Debug))]
+#[instrument(err(Debug), level = "trace")]
 pub fn git_get_global_config(key: &str) -> Result<Option<String>, Error> {
     Ok(App::git_get_global_config(key)?)
 }

--- a/crates/gitbutler-tauri/src/secret.rs
+++ b/crates/gitbutler-tauri/src/secret.rs
@@ -6,7 +6,7 @@ use tracing::instrument;
 use crate::error::Error;
 
 #[tauri::command(async)]
-#[instrument(err(Debug))]
+#[instrument(err(Debug), level = "trace")]
 pub fn secret_get_global(handle: &str) -> Result<Option<String>, Error> {
     Ok(secret::retrieve(handle, secret::Namespace::Global)?.map(|s| s.0))
 }


### PR DESCRIPTION
That way they can be more effectively hidden by default.
