### PR TITLE
ai-understands-assignment

### DIFF
--- a/apps/desktop/src/components/v3/BranchHeaderContextMenu.svelte
+++ b/apps/desktop/src/components/v3/BranchHeaderContextMenu.svelte
@@ -88,6 +88,12 @@
 		if (!$aiGenEnabled || !aiConfigurationValid) return;
 
 		const commitMessages = commits?.map((commit) => commit.message) ?? [];
+		if (commitMessages.length === 0) {
+			throw new Error(
+				'There must be a commits in the branch before you can generate a branch name'
+			);
+		}
+
 		const prompt = promptService.selectedBranchPrompt(projectId);
 		const newBranchName = await aiService.summarizeBranch({
 			type: 'commitMessages',

--- a/apps/desktop/src/components/v3/CommitMessageEditor.svelte
+++ b/apps/desktop/src/components/v3/CommitMessageEditor.svelte
@@ -63,7 +63,7 @@
 	const diffInputArgs = $derived<DiffInputContextArgs>(
 		existingCommitId
 			? { type: 'commit', projectId, commitId: existingCommitId }
-			: { type: 'change-selection', projectId, uncommittedService }
+			: { type: 'change-selection', projectId, uncommittedService, stackId }
 	);
 	const diffInputContext = $derived(
 		new DiffInputContext(worktreeService, diffService, stackService, diffInputArgs)


### PR DESCRIPTION
Previously the message generation was only looking at the uncommitted changes, and did not correctly filter out unselected hunks.

This PR does a couple things to improve this:

1. Make `selectedChanges` behave like `worktreeChanges` in reguards to how it handles being given a `stackId`
2. Pass the relevant `stackId` through to `selectedChanges` when calling it from the `DiffInputContext` class.
3. After recieving diffs in the `DiffInputContext` class, filter the hunks so they don’t contain any irrelevant ones.

Other changes of note, `selectedChanges` was previously `async`. There was no need for this (given that we never `await` anything inside of it) which means we can also get rid of the `structuredClone` that it performs. The `structuredClone` which is done to ensure consistent state is not needed because syncronus JS code never gets interupted.

One thing I don’t like is that `worktreeChanges` and `selectedChanges` + `selectedLines` do very similar things, but  I felt that they were not quite similar enough, and unifiing them would require bastardizing a bunch of types or having an intermediary type that we then map, so I decided that keeping them seperate was the best choice for the time being.

I did test the reactivity and it seems to work as expected, so I’m reasonably happy that commit generation should be working now