### PR TITLE
Svelte Login migration PT I

### DIFF
--- a/packages/shared/src/lib/login/loginService.ts
+++ b/packages/shared/src/lib/login/loginService.ts
@@ -1,0 +1,146 @@
+import { InjectionToken } from '$lib/context';
+import { isStr } from '@gitbutler/ui/utils/string';
+import type { HttpClient } from '$lib/network/httpClient';
+
+interface BaseLoginResponse {
+	type: 'success' | 'error';
+}
+
+interface SuccessLoginResponse<T> extends BaseLoginResponse {
+	type: 'success';
+	data: T;
+}
+interface ErrorLoginResponse extends BaseLoginResponse {
+	type: 'error';
+
+	errorCode: string;
+	errorMessage: string;
+	raw?: unknown;
+}
+
+type LoginResponse<T = void> = SuccessLoginResponse<T> | ErrorLoginResponse;
+
+export const LOGIN_SERVICE = new InjectionToken<LoginService>('LoginService');
+export default class LoginService {
+	constructor(private readonly httpClient: HttpClient) {}
+
+	private async sendPostRequest<T>(
+		path: string,
+		body: Record<string, unknown>,
+		successHandler?: (data: any) => T | undefined
+	): Promise<LoginResponse<T>> {
+		try {
+			const response = await this.httpClient.postRaw(path, { body });
+
+			const data = await response.json();
+
+			if (response.ok) {
+				const result = successHandler ? successHandler(data) : data;
+				return {
+					type: 'success',
+					data: result as T
+				};
+			}
+
+			return {
+				type: 'error',
+				errorCode: data.error_code || 'unknown_error',
+				errorMessage: data.error || 'An unknown error occurred'
+			};
+		} catch (error) {
+			if (error instanceof Error) {
+				return {
+					type: 'error',
+					errorCode: 'network_error',
+					errorMessage: error.message,
+					raw: error
+				};
+			}
+			return {
+				type: 'error',
+				errorCode: 'unknown_error',
+				errorMessage: 'An unknown error occurred',
+				raw: error
+			};
+		}
+	}
+
+	async finalizeAccount(
+		token: string,
+		email: string,
+		username: string
+	): Promise<LoginResponse<{ message: string }>> {
+		return await this.sendPostRequest(
+			'sessions/finalize',
+			{
+				token,
+				email,
+				login: username
+			},
+			(data) => {
+				if (!isStr(data.message)) throw new Error('Invalid message format');
+				return { message: data.message };
+			}
+		);
+	}
+
+	async confirmPasswordReset(
+		token: string,
+		newPassword: string,
+		passwordConfirmation: string
+	): Promise<LoginResponse<{ message: string; token: string }>> {
+		return await this.sendPostRequest(
+			'sessions/confirm_new_password',
+			{
+				password_reset_token: token,
+				password: newPassword,
+				password_confirmation: passwordConfirmation
+			},
+			(data) => {
+				if (!isStr(data.message)) throw new Error('Invalid message format');
+				if (!isStr(data.token)) throw new Error('Invalid token format');
+				return { message: data.message, token: data.token };
+			}
+		);
+	}
+
+	async resetPassword(email: string): Promise<LoginResponse<{ message: string }>> {
+		return await this.sendPostRequest('sessions/forgot_password', { email }, (data) => {
+			if (!isStr(data.message)) throw new Error('Invalid message format');
+			return { message: data.message };
+		});
+	}
+
+	async loginWithEmail(email: string, password: string): Promise<LoginResponse<string>> {
+		return await this.sendPostRequest('sessions/login_with_email', { email, password }, (data) => {
+			if (!isStr(data.token)) throw new Error('Invalid token format');
+			return data.token;
+		});
+	}
+
+	async resendConfirmationEmail(email: string): Promise<LoginResponse<{ message: string }>> {
+		return await this.sendPostRequest('sessions/resend_confirmation', { email }, (data) => {
+			if (!isStr(data.message)) throw new Error('Invalid message format');
+			return { message: data.message };
+		});
+	}
+
+	async createAccountWithEmail(
+		email: string,
+		password: string,
+		passwordConfirmation: string
+	): Promise<LoginResponse<{ message: string }>> {
+		return await this.sendPostRequest(
+			'sessions/sign_up_email',
+			{
+				email,
+				password,
+				password_confirmation: passwordConfirmation
+			},
+			(data) => {
+				if (!isStr(data.message)) throw new Error('Invalid message format');
+				return { message: data.message };
+			}
+		);
+	}
+}

--- a/packages/shared/src/lib/routing/webRoutes.svelte.ts
+++ b/packages/shared/src/lib/routing/webRoutes.svelte.ts
@@ -57,11 +57,39 @@ export class WebRoutesService {
 		return this.toUrl(this.homePath());
 	}
 
+	loginPath() {
+		return `/login`;
+	}
+	loginUrl() {
+		return this.toUrl(this.loginPath());
+	}
+
+	resetPasswordPath() {
+		return `/login/reset-password`;
+	}
+	resetPasswordUrl() {
+		return this.toUrl(this.resetPasswordPath());
+	}
+
+	signupPath() {
+		return `/signup`;
+	}
+	signupUrl() {
+		return this.toUrl(this.signupPath());
+	}
+
 	projectsPath() {
 		return `/`;
 	}
 	projectsUrl() {
 		return this.toUrl(this.projectsPath());
+	}
+
+	finalizeAccountPath() {
+		return '/profile/finalize';
+	}
+	finalizeAccountUrl() {
+		return this.toUrl(this.finalizeAccountPath());
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-empty-object-type


### PR DESCRIPTION
- Adds a new LoginService class to the shared layer for handling email/password-based authentication, including methods for account finalization, login, logout, signup, password reset (initiate and confirm), resending confirmation emails, and typed API responses for success/error. The class centralizes all authentication network logic.
- Updates the webRoutes utility to include paths and URLs for login, signup, reset password, and finalize account flows, allowing Svelte and shared app components to easily reference route helpers for all user auth actions.