### PR TITLE
Temporarily disable uncommiting to assigned changes

### DIFF
--- a/apps/desktop/src/components/v3/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/v3/WorktreeChanges.svelte
@@ -106,7 +106,7 @@
 {/snippet}
 
 <Dropzone
-	handlers={[uncommitDzHandler, assignmentDZHandler].filter(isDefined)}
+	handlers={[stackId ? undefined : uncommitDzHandler, assignmentDZHandler].filter(isDefined)}
 	maxHeight
 	onActivated={onDropzoneActivated}
 >


### PR DESCRIPTION
A follow up PR will make this work as expected, but currently it behaves “strangely” so we are disabling it for now