### PR TITLE
Implement uncommiting and assigning

### DIFF
--- a/apps/desktop/src/components/v3/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/v3/WorktreeChanges.svelte
@@ -56,7 +56,9 @@
 		UncommittedService
 	);
 
-	const uncommitDzHandler = $derived(new UncommitDzHandler(projectId, stackService, uiState));
+	const uncommitDzHandler = $derived(
+		new UncommitDzHandler(projectId, stackService, uiState, stackId)
+	);
 
 	const projectState = $derived(uiState.project(projectId));
 	const exclusiveAction = $derived(projectState.exclusiveAction.current);
@@ -106,7 +108,7 @@
 {/snippet}
 
 <Dropzone
-	handlers={[stackId ? undefined : uncommitDzHandler, assignmentDZHandler].filter(isDefined)}
+	handlers={[uncommitDzHandler, assignmentDZHandler].filter(isDefined)}
 	maxHeight
 	onActivated={onDropzoneActivated}
 >

--- a/apps/desktop/src/lib/commits/dropHandler.ts
+++ b/apps/desktop/src/lib/commits/dropHandler.ts
@@ -128,7 +128,8 @@ export class UncommitDzHandler implements DropzoneHandler {
 	constructor(
 		private projectId: string,
 		private readonly stackService: StackService,
-		private readonly uiState: UiState
+		private readonly uiState: UiState,
+		private readonly assignTo?: string
 	) {}
 
 	accepts(data: unknown): boolean {
@@ -159,7 +160,8 @@ export class UncommitDzHandler implements DropzoneHandler {
 							projectId: this.projectId,
 							stackId,
 							commitId,
-							changes
+							changes,
+							assignTo: this.assignTo
 						});
 
 						// Update the project state to point to the new commit if needed.
@@ -200,7 +202,8 @@ export class UncommitDzHandler implements DropzoneHandler {
 							}
 						]
 					}
-				]
+				],
+				assignTo: this.assignTo
 			});
 
 			// Update the project state to point to the new commit if needed.

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -1126,15 +1126,17 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					changes: DiffSpec[];
 					commitId: string;
 					stackId: string;
+					assignTo?: string;
 				}
 			>({
-				query: ({ projectId, changes, commitId, stackId }) => ({
+				query: ({ projectId, changes, commitId, stackId, assignTo }) => ({
 					command: 'uncommit_changes',
 					params: {
 						projectId,
 						changes,
 						commitId,
-						stackId
+						stackId,
+						assignTo
 					},
 					actionName: 'Uncommit Changes'
 				}),


### PR DESCRIPTION
I thought a reasonable amount about whether or not we should make this a frontend concern, and I ended up deciding that it made more sense to live in the rust side so we can avoid trying to compose several potentially falliable operations. Having it all in the backend also means that we don’t have an intermediary loading step where the thing appears in the `Unassigned` pile.

I take the list of `before` assignments and the list of `after` assignments, and I find all the assignments in the `after` list that wern’t present in the `before` list. I do this based on whether the `stableId` was present in the `before` list or not.

It is concevable that the unapplied change gets merged into an existing hunk (and as such doesn’t get picked up), but this felt like a reasonable concession compared to potentially moving too much by relying on more fagile things like hunk headers.