### PR TITLE
Fix drawer not closign after asignment

### DIFF
--- a/apps/desktop/src/components/v3/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/v3/WorktreeChanges.svelte
@@ -11,6 +11,7 @@
 	import { focusable } from '$lib/focus/focusable.svelte';
 	import { DiffService } from '$lib/hunks/diffService.svelte';
 	import { AssignmentDropHandler } from '$lib/hunks/dropHandler';
+	import { IdSelection } from '$lib/selection/idSelection.svelte';
 	import { UncommittedService } from '$lib/selection/uncommittedService.svelte';
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { UiState } from '$lib/state/uiState.svelte';
@@ -49,11 +50,12 @@
 		onselect
 	}: Props = $props();
 
-	const [uiState, stackService, diffService, uncommittedService] = inject(
+	const [uiState, stackService, diffService, uncommittedService, idSelection] = inject(
 		UiState,
 		StackService,
 		DiffService,
-		UncommittedService
+		UncommittedService,
+		IdSelection
 	);
 
 	const uncommitDzHandler = $derived(
@@ -77,7 +79,13 @@
 	let scrollTopIsVisible = $state(true);
 
 	const assignmentDZHandler = $derived(
-		new AssignmentDropHandler(projectId, diffService, uncommittedService, stackId || null)
+		new AssignmentDropHandler(
+			projectId,
+			diffService,
+			uncommittedService,
+			stackId || null,
+			idSelection
+		)
 	);
 
 	function getDropzoneLabel(handler: DropzoneHandler | undefined): string {


### PR DESCRIPTION
#### Problem
When a file or hunk is reassigned (e.g. moved between lanes), its preview panel remains open — but shows an empty state due to the change no longer being present in the original location. This leads to a confusing UX and stale view.

#### Solution
This PR updates the `AssignmentDropHandler` to ensure the preview panel is closed if the assigned file or hunk is currently selected. Specifically:

- If an entire file is assigned, we always close its preview.
- If a hunk is moved, we check whether it’s the **last hunk** in that file. If so, we clear the selection and close the preview.
- This logic applies to both unassigned (worktree) and already-assigned changes because they  both still use the IdSelection mechanism

To achieve this, the `IdSelection` state is now a dependency of the drop handler, allowing it to clear the current selection when appropriate.