### PR TITLE
Result<Option>> for unified_diff()

### DIFF
--- a/crates/but-core/src/diff/worktree.rs
+++ b/crates/but-core/src/diff/worktree.rs
@@ -819,7 +819,7 @@ impl TreeChange {
         &self,
         repo: &gix::Repository,
         context_lines: u32,
-    ) -> anyhow::Result<UnifiedDiff> {
+    ) -> anyhow::Result<Option<UnifiedDiff>> {
         let mut diff_filter = crate::unified_diff::filter_from_state(
             repo,
             self.status.state(),
@@ -834,7 +834,7 @@ impl TreeChange {
         repo: &gix::Repository,
         context_lines: u32,
         diff_filter: &mut gix::diff::blob::Platform,
-    ) -> anyhow::Result<UnifiedDiff> {
+    ) -> anyhow::Result<Option<UnifiedDiff>> {
         match &self.status {
             TreeStatus::Deletion { previous_state } => UnifiedDiff::compute_with_filter(
                 repo,

--- a/crates/but-core/src/diff/worktree.rs
+++ b/crates/but-core/src/diff/worktree.rs
@@ -815,6 +815,7 @@ impl TreeChange {
     /// for obtaining a working tree to read files from disk.
     /// Note that the mount of lines of context around each hunk are currently hardcoded to `3` as it *might* be relevant for creating
     /// commits later.
+    /// Return `None` if this change cannot produce a diff, typically because a submodule is involved.
     pub fn unified_diff(
         &self,
         repo: &gix::Repository,

--- a/crates/but-core/src/ui.rs
+++ b/crates/but-core/src/ui.rs
@@ -84,23 +84,21 @@ fn changes_to_unidiff_string(
                 builder.push_str(&format!("rename to {}\n", &change.path.to_string()));
             }
         }
-        if let Ok(unidiff) = crate::TreeChange::from(change).unified_diff(repo, context_lines) {
-            match unidiff {
-                UnifiedDiff::Patch {
-                    hunks,
-                    is_result_of_binary_to_text_conversion,
-                    ..
-                } => {
-                    if is_result_of_binary_to_text_conversion {
-                        continue;
-                    }
-                    for hunk in hunks {
-                        builder.push_str(&hunk.diff.to_string());
-                        builder.push('\n');
-                    }
+        match crate::TreeChange::from(change).unified_diff(repo, context_lines)? {
+            Some(UnifiedDiff::Patch {
+                hunks,
+                is_result_of_binary_to_text_conversion,
+                ..
+            }) => {
+                if is_result_of_binary_to_text_conversion {
+                    continue;
                 }
-                _ => continue,
+                for hunk in hunks {
+                    builder.push_str(&hunk.diff.to_string());
+                    builder.push('\n');
+                }
             }
+            _ => continue,
         }
     }
     Ok(builder)

--- a/crates/but-core/src/unified_diff.rs
+++ b/crates/but-core/src/unified_diff.rs
@@ -76,7 +76,7 @@ impl UnifiedDiff {
         current_state: impl Into<Option<ChangeState>>,
         previous_state: impl Into<Option<ChangeState>>,
         context_lines: u32,
-    ) -> anyhow::Result<Self> {
+    ) -> anyhow::Result<Option<Self>> {
         let current_state = current_state.into();
         let mut cache = filter_from_state(repo, current_state, Self::CONVERSION_MODE)?;
         Self::compute_with_filter(
@@ -102,10 +102,10 @@ impl UnifiedDiff {
         previous_state: impl Into<Option<ChangeState>>,
         context_lines: u32,
         diff_filter: &mut gix::diff::blob::Platform,
-    ) -> anyhow::Result<Self> {
+    ) -> anyhow::Result<Option<Self>> {
         let current_state = current_state.into();
         let previous_state = previous_state.into();
-        diff_filter.set_resource(
+        match diff_filter.set_resource(
             current_state.map_or(repo.object_hash().null(), |state| state.id),
             current_state.map_or_else(
                 || {
@@ -118,8 +118,14 @@ impl UnifiedDiff {
             path.as_bstr(),
             ResourceKind::NewOrDestination,
             repo,
-        )?;
-        diff_filter.set_resource(
+        ) {
+            Ok(()) => {}
+            Err(gix::diff::blob::platform::set_resource::Error::InvalidMode { .. }) => {
+                return Ok(None);
+            }
+            Err(err) => return Err(err.into()),
+        };
+        match diff_filter.set_resource(
             previous_state.map_or(repo.object_hash().null(), |state| state.id),
             previous_state.map_or_else(
                 || {
@@ -132,10 +138,16 @@ impl UnifiedDiff {
             previous_path.unwrap_or(path.as_bstr()),
             ResourceKind::OldOrSource,
             repo,
-        )?;
+        ) {
+            Ok(()) => {}
+            Err(gix::diff::blob::platform::set_resource::Error::InvalidMode { .. }) => {
+                return Ok(None);
+            }
+            Err(err) => return Err(err.into()),
+        };
 
         let prep = diff_filter.prepare_diff()?;
-        Ok(match prep.operation {
+        Ok(Some(match prep.operation {
             Operation::InternalDiff { algorithm } => {
                 #[derive(Default)]
                 struct ProduceDiffHunk {
@@ -216,7 +228,7 @@ impl UnifiedDiff {
                     UnifiedDiff::Binary
                 }
             }
-        })
+        }))
     }
 }
 

--- a/crates/but-core/src/unified_diff.rs
+++ b/crates/but-core/src/unified_diff.rs
@@ -62,6 +62,7 @@ impl UnifiedDiff {
     /// `current_state` is either the state we know the resource currently has, or is `None`, if there is no current state.
     /// `previous_state`, if `None`, indicates the file is new so there is nothing to compare to.
     /// Otherwise, it's the state of the resource as previously known.
+    /// Return `None` if the given states cannot produce a diff, typically because a submodule is involved.
     ///
     /// ### Special Types
     ///

--- a/crates/but-core/tests/core/diff/ui.rs
+++ b/crates/but-core/tests/core/diff/ui.rs
@@ -583,7 +583,7 @@ fn worktree_changes_unified_diffs_json_example() -> anyhow::Result<()> {
         .map(|tree_change| tree_change.unified_diff(&repo, 3))
         .collect::<std::result::Result<Vec<_>, _>>()?
         .into_iter()
-        .filter_map(std::convert::identity)
+        .flatten()
         .collect();
     let actual = serde_json::to_string_pretty(&diffs)?;
     insta::assert_snapshot!(actual, @r#"

--- a/crates/but-core/tests/core/diff/ui.rs
+++ b/crates/but-core/tests/core/diff/ui.rs
@@ -1,4 +1,3 @@
-use but_core::UnifiedDiff;
 use but_testsupport::gix_testtools;
 
 #[test]
@@ -578,11 +577,14 @@ fn commit_to_commit() -> anyhow::Result<()> {
 #[test]
 fn worktree_changes_unified_diffs_json_example() -> anyhow::Result<()> {
     let repo = repo("many-in-worktree")?;
-    let diffs: Vec<UnifiedDiff> = but_core::diff::worktree_changes(&repo)?
+    let diffs: Vec<_> = but_core::diff::worktree_changes(&repo)?
         .changes
         .iter()
         .map(|tree_change| tree_change.unified_diff(&repo, 3))
-        .collect::<std::result::Result<_, _>>()?;
+        .collect::<std::result::Result<Vec<_>, _>>()?
+        .into_iter()
+        .filter_map(std::convert::identity)
+        .collect();
     let actual = serde_json::to_string_pretty(&diffs)?;
     insta::assert_snapshot!(actual, @r#"
     [

--- a/crates/but-core/tests/core/diff/worktree_changes.rs
+++ b/crates/but-core/tests/core/diff/worktree_changes.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use but_core::diff;
 use but_core::{UnifiedDiff, WorktreeChanges};
 use but_testsupport::gix_testtools;
@@ -1798,11 +1798,15 @@ fn unified_diffs(
     worktree: WorktreeChanges,
     repo: &gix::Repository,
 ) -> anyhow::Result<Vec<UnifiedDiff>> {
-    worktree
+    let mut out = Vec::new();
+    for diff in worktree
         .changes
         .into_iter()
         .map(|c| c.unified_diff(repo, 3))
-        .collect()
+    {
+        out.push(diff?.context("Can only diff blobs and links, not Commit")?);
+    }
+    Ok(out)
 }
 
 pub fn repo_in(fixture_name: &str, name: &str) -> anyhow::Result<gix::Repository> {

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -221,7 +221,10 @@ pub fn assign(
     let mut worktree_assignments = vec![];
     for change in &worktree_changes {
         let diff = change.unified_diff(repo, ctx.app_settings().context_lines);
-        worktree_assignments.extend(diff_to_assignments(diff.ok(), change.path.clone()));
+        worktree_assignments.extend(diff_to_assignments(
+            diff.ok().flatten(),
+            change.path.clone(),
+        ));
     }
 
     // Reconcile worktree with the persisted assignments
@@ -296,7 +299,10 @@ pub fn assignments_with_fallback(
     let mut worktree_assignments = vec![];
     for change in &worktree_changes {
         let diff = change.unified_diff(repo, ctx.app_settings().context_lines);
-        worktree_assignments.extend(diff_to_assignments(diff.ok(), change.path.clone()));
+        worktree_assignments.extend(diff_to_assignments(
+            diff.ok().flatten(),
+            change.path.clone(),
+        ));
     }
     let reconciled = reconcile_with_worktree_and_locks(
         ctx,

--- a/crates/but-hunk-dependency/src/lib.rs
+++ b/crates/but-hunk-dependency/src/lib.rs
@@ -184,21 +184,20 @@ pub fn tree_changes_to_input_files(
 ) -> anyhow::Result<Vec<InputFile>> {
     let mut files = Vec::new();
     for change in changes {
-        if let Ok(diff) = change.unified_diff(repo, 0) {
-            let UnifiedDiff::Patch { hunks, .. } = diff else {
-                trace::warn!(
-                    "Skipping change at '{}' as it doesn't have hunks to calculate dependencies for (binary/too large)",
-                    change.path
-                );
-                continue;
-            };
-            let change_type = change.status.kind();
-            files.push(InputFile {
-                path: change.path,
-                hunks: hunks.iter().map(InputDiffHunk::from_unified_diff).collect(),
-                change_type,
-            })
-        }
+        let diff = change.unified_diff(repo, 0)?;
+        let Some(UnifiedDiff::Patch { hunks, .. }) = diff else {
+            trace::warn!(
+                "Skipping change at '{}' as it doesn't have hunks to calculate dependencies for (binary/too large)",
+                change.path
+            );
+            continue;
+        };
+        let change_type = change.status.kind();
+        files.push(InputFile {
+            path: change.path,
+            hunks: hunks.iter().map(InputDiffHunk::from_unified_diff).collect(),
+            change_type,
+        })
     }
     Ok(files)
 }

--- a/crates/but-hunk-dependency/tests/hunk_dependency/main.rs
+++ b/crates/but-hunk-dependency/tests/hunk_dependency/main.rs
@@ -14,7 +14,7 @@ fn intersect_workspace_ranges(
     let mut missed_hunks = Vec::new();
     for change in worktree_changes {
         let unidiff = change.unified_diff(repo, 0)?;
-        let but_core::UnifiedDiff::Patch { hunks, .. } = unidiff else {
+        let Some(but_core::UnifiedDiff::Patch { hunks, .. }) = unidiff else {
             continue;
         };
         let mut intersections = Vec::new();

--- a/crates/but-testing/src/command/diff.rs
+++ b/crates/but-testing/src/command/diff.rs
@@ -121,7 +121,7 @@ fn unified_diff_for_changes(
         .map(|tree_change| {
             tree_change
                 .unified_diff(repo, context_lines)
-                .map(|diff| (tree_change, diff))
+                .map(|diff| (tree_change, diff.expect("no submodule")))
         })
         .collect::<Result<Vec<_>, _>>()
 }
@@ -135,7 +135,7 @@ fn intersect_workspace_ranges(
     let mut missed_hunks = Vec::new();
     for change in worktree_changes {
         let unidiff = change.unified_diff(repo, 0)?;
-        let but_core::UnifiedDiff::Patch { hunks, .. } = unidiff else {
+        let Some(but_core::UnifiedDiff::Patch { hunks, .. }) = unidiff else {
             continue;
         };
         let mut intersections = Vec::new();

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -519,7 +519,7 @@ fn indices_or_headers_to_hunk_headers(
                     change.path == *path
                         && change.previous_path() == previous_path.as_ref().map(|p| p.as_bstr())
                 }).with_context(|| format!("Couldn't find worktree change for file at '{path}' (previous-path: {previous_path:?}"))?;
-            let UnifiedDiff::Patch { hunks, .. } =
+            let Some(UnifiedDiff::Patch { hunks, .. }) =
                 worktree_changes.unified_diff(repo, UI_CONTEXT_LINES)?
             else {
                 bail!("No hunks available for given '{path}'")

--- a/crates/but-workspace/src/commit_engine/tree/mod.rs
+++ b/crates/but-workspace/src/commit_engine/tree/mod.rs
@@ -226,7 +226,7 @@ pub fn apply_worktree_changes<'repo>(
                 "BUG: if this changes, the uses of worktree filters need a review"
             );
             // TODO(perf): avoid computing the unified diff here, we only need hunks with, usually with zero context.
-            let UnifiedDiff::Patch { hunks, .. } =
+            let Some(UnifiedDiff::Patch { hunks, .. }) =
                 worktree_change.unified_diff_with_filter(repo, context_lines, &mut diff_filter)?
             else {
                 into_err_spec(possible_change, RejectionReason::FileToLargeOrBinary);
@@ -239,10 +239,10 @@ pub fn apply_worktree_changes<'repo>(
                 .any(|h| h.old_range().is_null() || h.new_range().is_null());
             let worktree_hunks: Vec<HunkHeader> = hunks.into_iter().map(Into::into).collect();
             let worktree_hunks_no_context = if has_hunk_selections {
-                let UnifiedDiff::Patch {
+                let Some(UnifiedDiff::Patch {
                     hunks: hunks_no_context,
                     ..
-                } = worktree_change.unified_diff_with_filter(repo, 0, &mut diff_filter)?
+                }) = worktree_change.unified_diff_with_filter(repo, 0, &mut diff_filter)?
                 else {
                     into_err_spec(possible_change, RejectionReason::FileToLargeOrBinary);
                     continue;

--- a/crates/but-workspace/src/tree_manipulation/discard_worktree_changes.rs
+++ b/crates/but-workspace/src/tree_manipulation/discard_worktree_changes.rs
@@ -599,10 +599,10 @@ mod hunk {
             Some(state_in_worktree),
             UnifiedDiff::CONVERSION_MODE,
         )?;
-        let UnifiedDiff::Patch {
+        let Some(UnifiedDiff::Patch {
             hunks: hunks_in_worktree,
             ..
-        } = wt_change.unified_diff_with_filter(repo, context_lines, &mut diff_filter)?
+        }) = wt_change.unified_diff_with_filter(repo, context_lines, &mut diff_filter)?
         else {
             bail!("Couldn't obtain diff for worktree changes.")
         };

--- a/crates/but-workspace/src/tree_manipulation/utils.rs
+++ b/crates/but-workspace/src/tree_manipulation/utils.rs
@@ -179,6 +179,9 @@ pub fn create_tree_without_diff(
                             kind: before_entry.mode().kind(),
                         },
                         context_lines,
+                    )?
+                    .context(
+                        "Cannot diff submodules - if this is encountered we should look into it",
                     )?;
 
                     let but_core::UnifiedDiff::Patch {

--- a/crates/but-workspace/tests/workspace/commit_engine/new_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/new_commit.rs
@@ -1142,7 +1142,7 @@ mod utils {
                 (
                     c.previous_path().map(ToOwned::to_owned),
                     c.path.clone(),
-                    c.unified_diff(repo, context_lines).unwrap(),
+                    c.unified_diff(repo, context_lines).unwrap().unwrap(),
                 )
             })
             .collect())

--- a/crates/but-workspace/tests/workspace/tree_manipulation/hunk.rs
+++ b/crates/but-workspace/tests/workspace/tree_manipulation/hunk.rs
@@ -124,7 +124,8 @@ fn from_end() -> anyhow::Result<()> {
         17
         18
         "));
-        let UnifiedDiff::Patch { mut hunks, .. } = change.unified_diff(&repo, CONTEXT_LINES)?
+        let Some(UnifiedDiff::Patch { mut hunks, .. }) =
+            change.unified_diff(&repo, CONTEXT_LINES)?
         else {
             unreachable!("We know there are hunks")
         };
@@ -197,7 +198,8 @@ fn from_beginning() -> anyhow::Result<()> {
         .into_iter()
         .find(|change| change.path == filename)
     {
-        let UnifiedDiff::Patch { mut hunks, .. } = change.unified_diff(&repo, CONTEXT_LINES)?
+        let Some(UnifiedDiff::Patch { mut hunks, .. }) =
+            change.unified_diff(&repo, CONTEXT_LINES)?
         else {
             unreachable!("We know there are hunks")
         };
@@ -852,7 +854,8 @@ mod util {
             .find(|change| change.path == filename)
             .expect("well-known fixture");
 
-        let UnifiedDiff::Patch { hunks, .. } = change.unified_diff(repo, context_lines)? else {
+        let Some(UnifiedDiff::Patch { hunks, .. }) = change.unified_diff(repo, context_lines)?
+        else {
             unreachable!("We know there are hunks")
         };
         Ok((change, hunks))

--- a/crates/but/src/mcp_internal/status.rs
+++ b/crates/but/src/mcp_internal/status.rs
@@ -133,7 +133,7 @@ fn unified_diff_for_changes(
         .map(|tree_change| {
             tree_change
                 .unified_diff(repo, context_lines)
-                .map(|diff| (tree_change, diff))
+                .map(|diff| (tree_change, diff.expect("no submodule")))
         })
         .collect::<Result<Vec<_>, _>>()
 }

--- a/crates/gitbutler-tauri/src/diff.rs
+++ b/crates/gitbutler-tauri/src/diff.rs
@@ -28,9 +28,9 @@ pub fn tree_change_diffs(
     let change: but_core::TreeChange = change.into();
     let project = projects.get(project_id)?;
     let repo = gix::open(project.path).map_err(anyhow::Error::from)?;
-    change
-        .unified_diff(&repo, settings.get()?.context_lines)
-        .map_err(Into::into)
+    Ok(change
+        .unified_diff(&repo, settings.get()?.context_lines)?
+        .context("TODO: Submodules must be handled specifically in the UI")?)
 }
 
 #[tauri::command(async)]


### PR DESCRIPTION
This way, no code can accidentally run into errors anymore for trying to diff undiffable things.

See https://discord.com/channels/1060193121130000425/1384601119338270872 for motivation.

### Tasks

* [x] ❌couldn't reproduce the issue when just obtaining worktree changes, but it's clearly there in the UI which doesn't treat submodules specifically yet.
* [x] fix