### PR TITLE
graph segmentation

### DIFF
--- a/crates/but-graph/Cargo.toml
+++ b/crates/but-graph/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [lib]
 doctest = false
-test = false
+test = true
 
 [dependencies]
 but-core.workspace = true

--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -177,6 +177,15 @@ impl Graph {
         self.inner.edge_count()
     }
 
+    /// Return the number of commits in all segments.
+    pub fn num_commits(&self) -> usize {
+        self.inner
+            .raw_nodes()
+            .iter()
+            .map(|n| n.weight.commits.len())
+            .sum::<usize>()
+    }
+
     /// Return an iterator over all indices of segments in the graph.
     pub fn segments(&self) -> impl Iterator<Item = SegmentIndex> {
         self.inner.node_indices()
@@ -257,7 +266,7 @@ impl Graph {
 
     /// Validate the graph for consistency and fail loudly when an issue was found, after printing the dot graph.
     /// Mostly useful for debugging to stop early when a connection wasn't created correctly.
-    #[cfg(target_os = "macos")]
+    #[cfg(unix)]
     pub fn validated_or_open_as_svg(self) -> anyhow::Result<Self> {
         for edge in self.inner.edge_references() {
             let res = check_edge(&self.inner, edge);
@@ -283,7 +292,8 @@ impl Graph {
     }
 
     /// Open an SVG dot visualization in the browser or panic if the `dot` or `open` tool can't be found.
-    #[cfg(target_os = "macos")]
+    #[cfg(unix)]
+    #[tracing::instrument(skip(self))]
     pub fn open_as_svg(&self) {
         use std::io::Write;
         use std::process::Stdio;

--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -232,11 +232,7 @@ impl Graph {
             .tip_segments()
             .map(|s| {
                 let s = &self[s];
-                (
-                    s.ref_name.as_ref().map(|rn| rn.clone()),
-                    s.id,
-                    s.flags_of_first_commit(),
-                )
+                (s.ref_name.clone(), s.id, s.flags_of_first_commit())
             })
             .collect();
         *segments_at_bottom = self.base_segments().count();

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -16,7 +16,7 @@ use utils::*;
 mod remotes;
 
 mod post;
-mod walk;
+pub(crate) mod walk;
 
 pub(super) type PetGraph = petgraph::Graph<Segment, Edge>;
 
@@ -273,7 +273,7 @@ impl Graph {
             let mut ws_segment = branch_segment_from_name_and_meta(Some(ws_ref), meta, None)?;
             // Drop the limit if we have a target ref
             let limit = if workspace_info.target_ref.is_some() {
-                Limit::unspecified()
+                limit.with_goal(tip.detach())
             } else {
                 limit
             };
@@ -306,7 +306,7 @@ impl Graph {
                         into: target_segment,
                     },
                     /* unlimited traversal for integrated commits */
-                    Limit::unspecified(),
+                    limit.with_goal(tip.detach()),
                 )) {
                     return Ok(graph.with_hard_limit());
                 }
@@ -438,7 +438,7 @@ impl Graph {
                 return Ok(graph.with_hard_limit());
             }
 
-            prune_integrated_tips(&mut graph.inner, &mut next, &desired_refs, max_limit);
+            prune_integrated_tips(&mut graph, &mut next, &desired_refs, max_limit);
         }
 
         graph.post_processed(

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -367,7 +367,7 @@ impl Graph {
 
             let refs_at_commit_before_removal = refs_by_id.remove(&id).unwrap_or_default();
             segment.commits.push(
-                info.into_local_commit(
+                info.into_commit(
                     repo,
                     segment
                         .commits

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -358,7 +358,8 @@ fn create_connected_multi_segment(
             })
     {
         let ref_name = &refs[ref_idx];
-        let new_segment = branch_segment_from_name_and_meta(Some(ref_name.clone()), meta, None)?;
+        let new_segment =
+            branch_segment_from_name_and_meta(Some((ref_name.clone(), None)), meta, None)?;
         let above_commit_idx = {
             let s = &graph[above_idx];
             let cidx = s.commit_index_of(commit.id);

--- a/crates/but-graph/src/init/walk.rs
+++ b/crates/but-graph/src/init/walk.rs
@@ -53,7 +53,7 @@ impl TopoWalk {
 /// Builder
 impl TopoWalk {
     /// Call to not return the tip as part of the iteration.
-    pub fn skip_tip(mut self) -> Self {
+    pub fn skip_tip_segment(mut self) -> Self {
         self.skip_tip = Some(());
         self
     }
@@ -107,7 +107,8 @@ impl TopoWalk {
                     {
                         continue;
                     }
-                    self.next.push_back((edge.source(), edge.weight().src));
+                    self.next
+                        .push_back((edge.source(), edge.weight().src.map(|cidx| cidx + 1)));
                 }
             }
         }

--- a/crates/but-graph/src/lib.rs
+++ b/crates/but-graph/src/lib.rs
@@ -18,6 +18,8 @@ pub struct Graph {
     /// The [`CommitIndex`] is empty if the entry point is an empty segment, one that is supposed to receive
     /// commits later.
     entrypoint: Option<(SegmentIndex, Option<CommitIndex>)>,
+    /// It's `true` only if we have stopped the traversal due to a hard limit.
+    hard_limit_hit: bool,
 }
 
 /// A resolved entry point into the graph for easy access to the segment, commit,

--- a/crates/but-graph/src/lib.rs
+++ b/crates/but-graph/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(missing_docs, rust_2018_idioms)]
 
 mod segment;
-pub use segment::{Commit, CommitFlags, Segment, SegmentMetadata};
+pub use segment::{Commit, CommitDetails, CommitFlags, Segment, SegmentMetadata};
 
 /// Edges to other segments are the index into the list of local commits of the parent segment.
 /// That way we can tell where a segment branches off, despite the graph only connecting segments, and not commits.
@@ -26,7 +26,7 @@ pub struct Graph {
 ///
 /// Note that the segment counts aren't mutually exclusive, so the sum of these fields can be more
 /// than the total of segments.
-#[derive(Default, Debug, Copy, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct Statistics {
     /// The number of segments in the graph.
     pub segments: usize,
@@ -56,6 +56,20 @@ pub struct Statistics {
     pub segments_behind_of_entrypoint: usize,
     /// Segments, excluding the entrypoint, that can be reached upwards through the entrypoint.
     pub segments_ahead_of_entrypoint: usize,
+    /// The entrypoint of the graph traversal.
+    pub entrypoint: (SegmentIndex, Option<CommitIndex>),
+    /// The number of incoming connections into the entrypoint segment.
+    pub segment_entrypoint_incoming: usize,
+    /// The number of outgoing connections into the entrypoint segment.
+    pub segment_entrypoint_outgoing: usize,
+    /// Segments without incoming connections.
+    pub top_segments: Vec<(
+        Option<gix::refs::FullName>,
+        SegmentIndex,
+        Option<CommitFlags>,
+    )>,
+    /// Segments without outgoing connections.
+    pub segments_at_bottom: usize,
     /// Connections between segments.
     pub connections: usize,
     /// All commits within segments.

--- a/crates/but-graph/src/lib.rs
+++ b/crates/but-graph/src/lib.rs
@@ -22,6 +22,50 @@ pub struct Graph {
     hard_limit_hit: bool,
 }
 
+/// All kinds of numbers generated from a graph, returned by [Graph::statistics()].
+///
+/// Note that the segment counts aren't mutually exclusive, so the sum of these fields can be more
+/// than the total of segments.
+#[derive(Default, Debug, Copy, Clone)]
+pub struct Statistics {
+    /// The number of segments in the graph.
+    pub segments: usize,
+    /// Segments where all commits are integrated.
+    pub segments_integrated: usize,
+    /// Segments where all commits are on a remote tracking branch.
+    pub segments_remote: usize,
+    /// Segments where the remote tracking branch is set
+    pub segments_with_remote_tracking_branch: usize,
+    /// Segments that are empty.
+    pub segments_empty: usize,
+    /// Segments that are anonymous.
+    pub segments_unnamed: usize,
+    /// Segments that are reachable by the workspace commit.
+    pub segments_in_workspace: usize,
+    /// Segments that are reachable by the workspace commit and are integrated.
+    pub segments_in_workspace_and_integrated: usize,
+    /// Segments that have metadata for workspaces.
+    pub segments_with_workspace_metadata: usize,
+    /// Segments that have metadata for branches.
+    pub segments_with_branch_metadata: usize,
+    /// `true` if the start of the traversal is in a workspace.
+    /// `None` if the information could not be determined, maybe because the entrypoint
+    /// is invalid (bug) or it's empty (unusual)
+    pub entrypoint_in_workspace: Option<bool>,
+    /// Segments, excluding the entrypoint, that can be reached downwards through the entrypoint.
+    pub segments_behind_of_entrypoint: usize,
+    /// Segments, excluding the entrypoint, that can be reached upwards through the entrypoint.
+    pub segments_ahead_of_entrypoint: usize,
+    /// Connections between segments.
+    pub connections: usize,
+    /// All commits within segments.
+    pub commits: usize,
+    /// All references stored with commits, i.e. not the ref-names absorbed by segments.
+    pub commit_references: usize,
+    /// The traversal was stopped at this many commits.
+    pub commits_at_cutoff: usize,
+}
+
 /// A resolved entry point into the graph for easy access to the segment, commit,
 /// and the respective indices for later traversal.
 #[derive(Debug, Copy, Clone)]

--- a/crates/but-graph/src/lib.rs
+++ b/crates/but-graph/src/lib.rs
@@ -3,9 +3,7 @@
 #![deny(missing_docs, rust_2018_idioms)]
 
 mod segment;
-pub use segment::{
-    Commit, CommitFlags, LocalCommit, LocalCommitRelation, RemoteCommit, Segment, SegmentMetadata,
-};
+pub use segment::{Commit, CommitFlags, Segment, SegmentMetadata};
 
 /// Edges to other segments are the index into the list of local commits of the parent segment.
 /// That way we can tell where a segment branches off, despite the graph only connecting segments, and not commits.
@@ -33,7 +31,7 @@ pub struct EntryPoint<'graph> {
     /// The segment that served starting point for the traversal into this graph.
     pub segment: &'graph Segment,
     /// If present, the commit that started the traversal in the `segment`.
-    pub commit: Option<&'graph LocalCommit>,
+    pub commit: Option<&'graph Commit>,
 }
 
 /// This structure is used as data associated with each edge and is mainly for collecting

--- a/crates/but-graph/src/segment.rs
+++ b/crates/but-graph/src/segment.rs
@@ -1,25 +1,33 @@
 use crate::{CommitIndex, SegmentIndex};
 use bitflags::bitflags;
+use bstr::ByteSlice;
 use gix::bstr::BString;
 
 /// A commit with must useful information extracted from the Git commit itself.
-///
-/// Note that additional information can be computed and placed in the [`LocalCommit`] and [`RemoteCommit`]
 #[derive(Clone, Eq, PartialEq)]
 pub struct Commit {
     /// The hash of the commit.
     pub id: gix::ObjectId,
     /// The IDs of the parent commits, but may be empty if this is the first commit.
     pub parent_ids: Vec<gix::ObjectId>,
+    /// Additional properties to help classify this commit.
+    pub flags: CommitFlags,
+    /// The references pointing to this commit, even after dereferencing tag objects.
+    /// These can be names of tags and branches.
+    pub refs: Vec<gix::refs::FullName>,
+    /// Additional, and possibly expensive information to obtain on demand for commits of interest only.
+    pub details: Option<CommitDetails>,
+}
+
+/// Lazily obtained detailed information.
+/// This should only be fetched when it's clear the commit is of interest,
+/// which a majority of commits in a traversal might not be.
+#[derive(Clone, Eq, PartialEq)]
+pub struct CommitDetails {
     /// The complete message, verbatim.
     pub message: BString,
     /// The signature at which the commit was authored.
     pub author: gix::actor::Signature,
-    /// The references pointing to this commit, even after dereferencing tag objects.
-    /// These can be names of tags and branches.
-    pub refs: Vec<gix::refs::FullName>,
-    /// Additional properties to help classify this commit.
-    pub flags: CommitFlags,
     /// Whether the commit is in a conflicted state, a GitButler concept.
     /// GitButler will perform rebasing/reordering etc. without interruptions and flag commits as conflicted if needed.
     /// Conflicts are resolved via the Edit Mode mechanism.
@@ -28,62 +36,30 @@ pub struct Commit {
     pub has_conflicts: bool,
 }
 
-impl Commit {
-    /// Read the object of the `commit_id` and extract relevant values, while setting `flags` as well.
-    pub fn new_from_id(
-        commit_id: gix::Id<'_>,
-        flags: CommitFlags,
-        has_conflicts: bool,
-    ) -> anyhow::Result<Self> {
-        let commit = commit_id.object()?.into_commit();
-        // Decode efficiently, no need to own this.
-        let commit = commit.decode()?;
-        Ok(Commit {
-            id: commit_id.detach(),
-            parent_ids: commit.parents().collect(),
-            message: commit.message.to_owned(),
-            author: commit.author.to_owned()?,
-            refs: Vec::new(),
-            flags,
-            has_conflicts,
-        })
-    }
-}
-
 impl std::fmt::Debug for Commit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "Commit({hash}, {msg:?}{flags})",
             hash = self.id.to_hex_with_len(7),
-            msg = self.message,
-            flags = if self.flags.is_empty() {
-                "".to_string()
-            } else {
-                format!(", {}", self.flags.debug_string())
-            }
+            msg = self
+                .details
+                .as_ref()
+                .map(|d| d.message.as_bstr())
+                .unwrap_or_default(),
+            flags = self.flags.debug_string()
         )
-    }
-}
-
-impl From<but_core::Commit<'_>> for Commit {
-    fn from(value: but_core::Commit<'_>) -> Self {
-        Commit {
-            id: value.id.into(),
-            parent_ids: value.parents.iter().cloned().collect(),
-            message: value.inner.message,
-            author: value.inner.author,
-            refs: Vec::new(),
-            flags: CommitFlags::empty(),
-            has_conflicts: false,
-        }
     }
 }
 
 bitflags! {
     /// Provide more information about a commit, as gathered during traversal.
+    ///
+    /// Note that unknown bits beyond this list are used to track individual goals that we want to discover.
+    /// This is useful for when they are ahead of the tip that looks for them.
+    /// If they are below, the goal will be propagated downward automatically.
     #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
-    pub struct CommitFlags: u8 {
+    pub struct CommitFlags: u32 {
         /// Identify commits that have never been owned *only* by a remote.
         /// It may be that a remote is directly pointing at them though.
         /// Note that this flag is negative as all flags are propagated through the graph,
@@ -107,15 +83,27 @@ impl CommitFlags {
         if self.is_empty() {
             "".into()
         } else {
-            let string = format!("{:?}", self);
+            let flags = *self & Self::all();
+            let extra = (self.bits() & !Self::all().bits()) >> Self::all().iter().count();
+            let string = format!("{:?}", flags);
             let out = &string["CommitFlags(".len()..];
-            out[..out.len() - 1]
+            let mut out = out[..out.len() - 1]
                 .to_string()
                 .replace("NotInRemote", "⌂")
                 .replace("InWorkspace", "🏘️")
                 .replace("Integrated", "✓")
-                .replace(" ", "")
+                .replace(" ", "");
+            if extra != 0 {
+                out.push_str(&format!("|{:b}", extra));
+            }
+            out
         }
+    }
+
+    /// Return `true` if this flag denotes a remote commit, i.e. a commit that isn't reachable from anything
+    /// but a remote tracking branch tip.
+    pub fn is_remote(&self) -> bool {
+        self.is_empty()
     }
 }
 

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -165,6 +165,30 @@ EOF
 
 )
 
+git init triple-merge
+(cd triple-merge
+  for c in $(seq 5); do
+    commit "$c"
+  done
+  git checkout -b A
+    git branch B
+    git branch C
+    for c in $(seq 3); do
+      commit "A$c"
+    done
+
+  git checkout B
+    for c in $(seq 3); do
+      commit "B$c"
+    done
+
+  git checkout C
+    for c in $(seq 3); do
+      commit "C$c"
+    done
+  git merge A B
+)
+
 mkdir ws
 (cd ws
   git init single-stack-ambiguous
@@ -355,6 +379,9 @@ EOF
     tick
     git checkout -b soon-origin-main main
       git merge --no-ff A
+      for c in $(seq 2); do
+        commit "remote-$c"
+      done
       setup_remote_tracking soon-origin-main main "move"
     git checkout gitbutler/workspace
   )

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -330,5 +330,47 @@ EOF
 
     git checkout gitbutler/workspace
   )
+
+  git init two-segments-one-integrated
+  (cd two-segments-one-integrated
+    for c in $(seq 3); do
+      commit "$c"
+    done
+    git checkout -b A
+      commit 4
+      git checkout -b A-feat
+        commit "A-feat-1"
+        commit "A-feat-2"
+      git checkout A
+      git merge --no-ff A-feat
+      for c in $(seq 5 8); do
+        commit "$c"
+      done
+    git checkout -b B
+      commit "B1"
+      commit "B2"
+
+    create_workspace_commit_once B
+
+    tick
+    git checkout -b soon-origin-main main
+      git merge --no-ff A
+      setup_remote_tracking soon-origin-main main "move"
+    git checkout gitbutler/workspace
+  )
+
+  git init on-top-of-target-with-history
+  (cd on-top-of-target-with-history
+    commit outdated-main
+    git checkout -b soon-origin-main
+    for c in $(seq 5); do
+      commit "$c"
+    done
+    for name in A B C D E F gitbutler/workspace; do
+      git branch "$name"
+    done
+    setup_remote_tracking soon-origin-main main "move"
+    git checkout gitbutler/workspace
+  )
 )
 

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -289,12 +289,20 @@ mkdir ws
   git init deduced-remote-ahead
   (cd deduced-remote-ahead
     commit init
+    git checkout -b A
     commit shared
     git checkout -b soon-remote;
+      git checkout -b tmp
+        commit feat-on-remote
+      git checkout soon-remote
+      git merge --no-ff -m "merge" tmp && git branch -d tmp
       commit only-remote-01;
       commit only-remote-02;
-    git checkout main && create_workspace_commit_once main
-    setup_remote_tracking soon-remote main "move"
+    git checkout A
+      commit A1
+      commit A2
+    create_workspace_commit_once A
+    setup_remote_tracking soon-remote A "move"
 
 cat <<EOF >>.git/config
 [remote "origin"]

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -407,5 +407,110 @@ EOF
     setup_remote_tracking soon-origin-main main "move"
     git checkout gitbutler/workspace
   )
+
+  # partition 1: main - start of traversal
+  # partition 2: workspace - connected to 1 via short route that isn't including the tip of partition 1
+  # partition 3: target - connected to 2 via short route and to 1 via longest rout (2 would find 1 first)
+  git init gitlab-case
+  (cd gitlab-case
+    # there is along tail of history under main which we should be able to traverse as well the entrypoint permits.
+    commit M1
+    commit M2
+    commit M3
+    commit M4
+    commit M5
+    commit M6
+    commit M7
+    commit M8
+    commit M9
+    commit M10
+    # short link to the workspace, connects to 'main'
+    git checkout -b main-to-workspace
+      commit Ws1
+
+    git checkout main
+    commit M2
+
+    # the long link to the workspace, through 'main'
+    git checkout -b long-main-to-workspace main
+      commit Wl1
+      commit Wl2
+      commit Wl3
+      commit Wl4
+
+    # workspace finds 'main' through short leg.
+    git checkout -b workspace main-to-workspace
+    git merge -m "W1-merge" --no-ff long-main-to-workspace
+    # NOTE: could have multiple lanes, to be done later for realism.
+    git checkout -b workspace-to-target
+      commit Ts1
+      commit Ts2
+      commit Ts3
+    git checkout -b long-workspace-to-target workspace
+      commit Tl1
+      commit Tl2
+      commit Tl3
+      commit Tl4
+      commit Tl5
+      commit Tl6
+      commit Tl7
+    git checkout -b soon-remote-main workspace-to-target
+      git merge -m "target" --no-ff long-workspace-to-target
+    git checkout workspace
+    # This creates a workspace commit outside of the workspace, it can't be reached by the target.
+    create_workspace_commit_once workspace
+
+    setup_remote_tracking soon-remote-main main "move"
+  )
+
+  # like above, but triggers a different case where 'main' can't be reached easily.
+  git init gitlab-case2
+  (cd gitlab-case2
+    commit M1
+    # short link to the workspace, connects to 'main'
+    git checkout -b main-to-workspace
+      commit Ws1
+    git checkout -b longer-workspace-to-target
+      commit Tll1
+      commit Tll2
+      commit Tll3
+      commit Tll4
+      commit Tll5
+      commit Tll6
+
+    git checkout main
+    commit M2
+
+    # the long link to the workspace, through 'main'
+    git checkout -b long-main-to-workspace main
+      commit Wl1
+      commit Wl2
+      commit Wl3
+      commit Wl4
+
+    # workspace finds 'main' through short leg.
+    git checkout -b workspace main-to-workspace
+    git merge -m "W1-merge" --no-ff long-main-to-workspace
+    # NOTE: could have multiple lanes, to be done later for realism.
+    git checkout -b long-workspace-to-target workspace
+      commit Tl1
+      git merge -m "Tl-merge" --no-ff longer-workspace-to-target
+      commit Tl2
+      commit Tl3
+      commit Tl4
+      commit Tl5
+      commit Tl6
+      commit Tl7
+      commit Tl8
+      commit Tl9
+      commit Tl10
+    # target is connected through a long leg that takes longer than everything else
+    git checkout -b soon-remote-main long-workspace-to-target
+    git checkout workspace
+    # This creates a workspace commit outside of the workspace, it can't be reached by the target.
+    create_workspace_commit_once workspace
+
+    setup_remote_tracking soon-remote-main main "move"
+  )
 )
 

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -206,7 +206,7 @@ fn four_diamond() -> anyhow::Result<()> {
     );
     assert_eq!(graph.num_commits(), 8, "one commit per node");
     assert_eq!(
-        graph.num_edges(),
+        graph.num_connections(),
         10,
         "however, we see only a portion of the edges as the tree can only show simple stacks"
     );
@@ -229,9 +229,9 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     let graph =
         Graph::from_head(&repo, &*meta, standard_options().with_limit_hint(1))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
-    ├── 👉►:0:B
+    ├── 👉►:0:B <> origin/B
     │   └── ·312f819 (⌂)❱"B"
-    │       └── ►:2:A
+    │       └── ►:2:A <> origin/A
     │           └── ·e255adc (⌂)❱"A"
     │               └── ►:4:main
     │                   └── ·fafd9d0 (⌂)❱"init"
@@ -259,9 +259,9 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     // Everything we encounter is checked for remotes.
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
-    ├── 👉►:0:B
+    ├── 👉►:0:B <> origin/B
     │   └── ·312f819 (⌂)❱"B"
-    │       └── ►:2:A
+    │       └── ►:2:A <> origin/A
     │           └── ·e255adc (⌂)❱"A"
     │               └── ►:4:main
     │                   └── ·fafd9d0 (⌂)❱"init"
@@ -276,7 +276,7 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     let (id, name) = id_at(&repo, "A");
     let graph = Graph::from_commit_traversal(id, name, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
-    ├── 👉►:0:A
+    ├── 👉►:0:A <> origin/A
     │   └── ·e255adc (⌂)❱"A"
     │       └── ►:2:main
     │           └── ·fafd9d0 (⌂)❱"init"
@@ -432,6 +432,30 @@ fn with_limits() -> anyhow::Result<()> {
                 ├── ·4f1f248 (⌂)❱"C2"
                 └── ✂️·487ffce (⌂)❱"C1"
     "#);
+
+    insta::assert_debug_snapshot!(graph.statistics(), @r"
+    Statistics {
+        segments: 5,
+        segments_integrated: 0,
+        segments_remote: 0,
+        segments_with_remote_tracking_branch: 0,
+        segments_empty: 0,
+        segments_unnamed: 1,
+        segments_in_workspace: 0,
+        segments_in_workspace_and_integrated: 0,
+        segments_with_workspace_metadata: 0,
+        segments_with_branch_metadata: 0,
+        entrypoint_in_workspace: Some(
+            false,
+        ),
+        segments_behind_of_entrypoint: 4,
+        segments_ahead_of_entrypoint: 0,
+        connections: 4,
+        commits: 12,
+        commit_references: 0,
+        commits_at_cutoff: 3,
+    }
+    ");
     Ok(())
 }
 

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -9,31 +9,30 @@ fn unborn() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?;
     insta::assert_snapshot!(graph_tree(&graph), @"└── 👉►:0:main");
     insta::assert_debug_snapshot!(graph, @r#"
-            Graph {
-                inner: Graph {
-                    Ty: "Directed",
-                    node_count: 1,
-                    edge_count: 0,
-                    node weights: {
-                        0: StackSegment {
-                            id: 0,
-                            ref_name: "refs/heads/main",
-                            remote_tracking_ref_name: "None",
-                            commits: [],
-                            commits_unique_in_remote_tracking_branch: [],
-                            metadata: "None",
-                        },
-                    },
-                    edge weights: {},
+    Graph {
+        inner: Graph {
+            Ty: "Directed",
+            node_count: 1,
+            edge_count: 0,
+            node weights: {
+                0: StackSegment {
+                    id: NodeIndex(0),
+                    ref_name: "refs/heads/main",
+                    remote_tracking_ref_name: "None",
+                    commits: [],
+                    metadata: "None",
                 },
-                entrypoint: Some(
-                    (
-                        NodeIndex(0),
-                        None,
-                    ),
-                ),
-            }
-            "#);
+            },
+            edge weights: {},
+        },
+        entrypoint: Some(
+            (
+                NodeIndex(0),
+                None,
+            ),
+        ),
+    }
+    "#);
     Ok(())
 }
 
@@ -61,23 +60,21 @@ fn detached() -> anyhow::Result<()> {
             edges: (0, 1),
             node weights: {
                 0: StackSegment {
-                    id: 0,
+                    id: NodeIndex(0),
                     ref_name: "refs/heads/main",
                     remote_tracking_ref_name: "None",
                     commits: [
-                        LocalCommit(541396b, "first\n", local, ►annotated, ►release/v1),
+                        Commit(541396b, "first\n", ⌂),
                     ],
-                    commits_unique_in_remote_tracking_branch: [],
                     metadata: "None",
                 },
                 1: StackSegment {
-                    id: 1,
+                    id: NodeIndex(1),
                     ref_name: "refs/heads/other",
                     remote_tracking_ref_name: "None",
                     commits: [
-                        LocalCommit(fafd9d0, "init\n", local),
+                        Commit(fafd9d0, "init\n", ⌂),
                     ],
-                    commits_unique_in_remote_tracking_branch: [],
                     metadata: "None",
                 },
             },

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -48,9 +48,9 @@ fn detached() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     └── 👉►:0:main
-        └── ·541396b (⌂)❱"first" ►tags/annotated, ►tags/release/v1
+        └── ·541396b (⌂|1)❱"first" ►tags/annotated, ►tags/release/v1
             └── ►:1:other
-                └── ·fafd9d0 (⌂)❱"init"
+                └── ·fafd9d0 (⌂|1)❱"init"
     "#);
     insta::assert_debug_snapshot!(graph, @r#"
     Graph {
@@ -65,7 +65,7 @@ fn detached() -> anyhow::Result<()> {
                     ref_name: "refs/heads/main",
                     remote_tracking_ref_name: "None",
                     commits: [
-                        Commit(541396b, "first\n", ⌂),
+                        Commit(541396b, "first\n"⌂|1),
                     ],
                     metadata: "None",
                 },
@@ -74,7 +74,7 @@ fn detached() -> anyhow::Result<()> {
                     ref_name: "refs/heads/other",
                     remote_tracking_ref_name: "None",
                     commits: [
-                        Commit(fafd9d0, "init\n", ⌂),
+                        Commit(fafd9d0, "init\n"⌂|1),
                     ],
                     metadata: "None",
                 },
@@ -129,19 +129,19 @@ fn multi_root() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     └── 👉►:0:main
-        └── ·c6c8c05 (⌂)❱"Merge branch \'C\'"
+        └── ·c6c8c05 (⌂|1)❱"Merge branch \'C\'"
             ├── ►:2:C
-            │   └── ·8631946 (⌂)❱"Merge branch \'D\' into C"
+            │   └── ·8631946 (⌂|1)❱"Merge branch \'D\' into C"
             │       ├── ►:6:D
-            │       │   └── ·f4955b6 (⌂)❱"D"
+            │       │   └── ·f4955b6 (⌂|1)❱"D"
             │       └── ►:5:anon:
-            │           └── ·00fab2a (⌂)❱"C"
+            │           └── ·00fab2a (⌂|1)❱"C"
             └── ►:1:anon:
-                └── ·76fc5c4 (⌂)❱"Merge branch \'B\'"
+                └── ·76fc5c4 (⌂|1)❱"Merge branch \'B\'"
                     ├── ►:4:B
-                    │   └── ·366d496 (⌂)❱"B"
+                    │   └── ·366d496 (⌂|1)❱"B"
                     └── ►:3:anon:
-                        └── ·e5d0542 (⌂)❱"A"
+                        └── ·e5d0542 (⌂|1)❱"A"
     "#);
     assert_eq!(
         graph.tip_segments().count(),
@@ -179,23 +179,23 @@ fn four_diamond() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     └── 👉►:0:merged
-        └── ·8a6c109 (⌂)❱"Merge branch \'C\' into merged"
+        └── ·8a6c109 (⌂|1)❱"Merge branch \'C\' into merged"
             ├── ►:2:C
-            │   └── ·7ed512a (⌂)❱"Merge branch \'D\' into C"
+            │   └── ·7ed512a (⌂|1)❱"Merge branch \'D\' into C"
             │       ├── ►:6:D
-            │       │   └── ·ecb1877 (⌂)❱"D"
+            │       │   └── ·ecb1877 (⌂|1)❱"D"
             │       │       └── ►:7:main
-            │       │           └── ·965998b (⌂)❱"base"
+            │       │           └── ·965998b (⌂|1)❱"base"
             │       └── ►:5:anon:
-            │           └── ·35ee481 (⌂)❱"C"
+            │           └── ·35ee481 (⌂|1)❱"C"
             │               └── →:7: (main)
             └── ►:1:A
-                └── ·62b409a (⌂)❱"Merge branch \'B\' into A"
+                └── ·62b409a (⌂|1)❱"Merge branch \'B\' into A"
                     ├── ►:4:B
-                    │   └── ·f16dddf (⌂)❱"B"
+                    │   └── ·f16dddf (⌂|1)❱"B"
                     │       └── →:7: (main)
                     └── ►:3:anon:
-                        └── ·592abec (⌂)❱"A"
+                        └── ·592abec (⌂|1)❱"A"
                             └── →:7: (main)
     "#);
 
@@ -230,11 +230,11 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
         Graph::from_head(&repo, &*meta, standard_options().with_limit_hint(1))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── 👉►:0:B <> origin/B
-    │   └── ·312f819 (⌂)❱"B"
+    │   └── ·312f819 (⌂|1)❱"B"
     │       └── ►:2:A <> origin/A
-    │           └── ·e255adc (⌂)❱"A"
+    │           └── ·e255adc (⌂|11)❱"A"
     │               └── ►:4:main
-    │                   └── ·fafd9d0 (⌂)❱"init"
+    │                   └── ·fafd9d0 (⌂|11)❱"init"
     └── ►:1:origin/B
         └── 🟣682be32❱"B"
             └── ►:3:origin/A
@@ -246,11 +246,11 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
         Graph::from_head(&repo, &*meta, standard_options().with_hard_limit(7))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── 👉►:0:B
-    │   └── ·312f819 (⌂)❱"B"
+    │   └── ·312f819 (⌂|1)❱"B"
     │       └── ►:2:A
-    │           └── ·e255adc (⌂)❱"A"
+    │           └── ·e255adc (⌂|11)❱"A"
     │               └── ►:4:main
-    │                   └── ·fafd9d0 (⌂)❱"init"
+    │                   └── ·fafd9d0 (⌂|11)❱"init"
     ├── ►:1:origin/B
     │   └── ❌🟣682be32❱"B"
     └── ►:3:origin/A
@@ -260,11 +260,11 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── 👉►:0:B <> origin/B
-    │   └── ·312f819 (⌂)❱"B"
+    │   └── ·312f819 (⌂|1)❱"B"
     │       └── ►:2:A <> origin/A
-    │           └── ·e255adc (⌂)❱"A"
+    │           └── ·e255adc (⌂|11)❱"A"
     │               └── ►:4:main
-    │                   └── ·fafd9d0 (⌂)❱"init"
+    │                   └── ·fafd9d0 (⌂|11)❱"init"
     └── ►:1:origin/B
         └── 🟣682be32❱"B"
             └── ►:3:origin/A
@@ -277,9 +277,9 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     let graph = Graph::from_commit_traversal(id, name, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── 👉►:0:A <> origin/A
-    │   └── ·e255adc (⌂)❱"A"
+    │   └── ·e255adc (⌂|1)❱"A"
     │       └── ►:2:main
-    │           └── ·fafd9d0 (⌂)❱"init"
+    │           └── ·fafd9d0 (⌂|1)❱"init"
     └── ►:1:origin/A
         └── 🟣e29c23d❱"A"
             └── →:2: (main)
@@ -315,26 +315,26 @@ fn with_limits() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     └── 👉►:0:C
-        └── ·2a95729 (⌂)❱"Merge branches \'A\' and \'B\' into C"
+        └── ·2a95729 (⌂|1)❱"Merge branches \'A\' and \'B\' into C"
             ├── ►:3:B
-            │   ├── ·9908c99 (⌂)❱"B3"
-            │   ├── ·60d9a56 (⌂)❱"B2"
-            │   └── ·9d171ff (⌂)❱"B1"
+            │   ├── ·9908c99 (⌂|1)❱"B3"
+            │   ├── ·60d9a56 (⌂|1)❱"B2"
+            │   └── ·9d171ff (⌂|1)❱"B1"
             │       └── ►:4:main
-            │           ├── ·edc4dee (⌂)❱"5"
-            │           ├── ·01d0e1e (⌂)❱"4"
-            │           ├── ·4b3e5a8 (⌂)❱"3"
-            │           ├── ·34d0715 (⌂)❱"2"
-            │           └── ·eb5f731 (⌂)❱"1"
+            │           ├── ·edc4dee (⌂|1)❱"5"
+            │           ├── ·01d0e1e (⌂|1)❱"4"
+            │           ├── ·4b3e5a8 (⌂|1)❱"3"
+            │           ├── ·34d0715 (⌂|1)❱"2"
+            │           └── ·eb5f731 (⌂|1)❱"1"
             ├── ►:2:A
-            │   ├── ·20a823c (⌂)❱"A3"
-            │   ├── ·442a12f (⌂)❱"A2"
-            │   └── ·686706b (⌂)❱"A1"
+            │   ├── ·20a823c (⌂|1)❱"A3"
+            │   ├── ·442a12f (⌂|1)❱"A2"
+            │   └── ·686706b (⌂|1)❱"A1"
             │       └── →:4: (main)
             └── ►:1:anon:
-                ├── ·6861158 (⌂)❱"C3"
-                ├── ·4f1f248 (⌂)❱"C2"
-                └── ·487ffce (⌂)❱"C1"
+                ├── ·6861158 (⌂|1)❱"C3"
+                ├── ·4f1f248 (⌂|1)❱"C2"
+                └── ·487ffce (⌂|1)❱"C1"
                     └── →:4: (main)
     "#);
 
@@ -344,7 +344,7 @@ fn with_limits() -> anyhow::Result<()> {
         Graph::from_head(&repo, &*meta, standard_options().with_limit_hint(0))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     └── 👉►:0:C
-        └── ✂️·2a95729 (⌂)❱"Merge branches \'A\' and \'B\' into C"
+        └── ✂️·2a95729 (⌂|1)❱"Merge branches \'A\' and \'B\' into C"
     "#);
 
     // A single commit, the merge commit.
@@ -352,13 +352,13 @@ fn with_limits() -> anyhow::Result<()> {
         Graph::from_head(&repo, &*meta, standard_options().with_limit_hint(1))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     └── 👉►:0:C
-        └── ·2a95729 (⌂)❱"Merge branches \'A\' and \'B\' into C"
+        └── ·2a95729 (⌂|1)❱"Merge branches \'A\' and \'B\' into C"
             ├── ►:3:B
-            │   └── ✂️·9908c99 (⌂)❱"B3"
+            │   └── ✂️·9908c99 (⌂|1)❱"B3"
             ├── ►:2:A
-            │   └── ✂️·20a823c (⌂)❱"A3"
+            │   └── ✂️·20a823c (⌂|1)❱"A3"
             └── ►:1:anon:
-                └── ✂️·6861158 (⌂)❱"C3"
+                └── ✂️·6861158 (⌂|1)❱"C3"
     "#);
 
     // The merge commit, then we witness lane-duplication of the limit so we get more than requested.
@@ -366,16 +366,16 @@ fn with_limits() -> anyhow::Result<()> {
         Graph::from_head(&repo, &*meta, standard_options().with_limit_hint(2))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     └── 👉►:0:C
-        └── ·2a95729 (⌂)❱"Merge branches \'A\' and \'B\' into C"
+        └── ·2a95729 (⌂|1)❱"Merge branches \'A\' and \'B\' into C"
             ├── ►:3:B
-            │   ├── ·9908c99 (⌂)❱"B3"
-            │   └── ✂️·60d9a56 (⌂)❱"B2"
+            │   ├── ·9908c99 (⌂|1)❱"B3"
+            │   └── ✂️·60d9a56 (⌂|1)❱"B2"
             ├── ►:2:A
-            │   ├── ·20a823c (⌂)❱"A3"
-            │   └── ✂️·442a12f (⌂)❱"A2"
+            │   ├── ·20a823c (⌂|1)❱"A3"
+            │   └── ✂️·442a12f (⌂|1)❱"A2"
             └── ►:1:anon:
-                ├── ·6861158 (⌂)❱"C3"
-                └── ✂️·4f1f248 (⌂)❱"C2"
+                ├── ·6861158 (⌂|1)❱"C3"
+                └── ✂️·4f1f248 (⌂|1)❱"C2"
     "#);
 
     // Allow to see more commits just in the middle lane, the limit is reset,
@@ -390,17 +390,17 @@ fn with_limits() -> anyhow::Result<()> {
     .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     └── 👉►:0:C
-        └── ·2a95729 (⌂)❱"Merge branches \'A\' and \'B\' into C"
+        └── ·2a95729 (⌂|1)❱"Merge branches \'A\' and \'B\' into C"
             ├── ►:3:B
-            │   ├── ·9908c99 (⌂)❱"B3"
-            │   └── ✂️·60d9a56 (⌂)❱"B2"
+            │   ├── ·9908c99 (⌂|1)❱"B3"
+            │   └── ✂️·60d9a56 (⌂|1)❱"B2"
             ├── ►:2:A
-            │   ├── ·20a823c (⌂)❱"A3"
-            │   ├── ·442a12f (⌂)❱"A2"
-            │   └── ✂️·686706b (⌂)❱"A1"
+            │   ├── ·20a823c (⌂|1)❱"A3"
+            │   ├── ·442a12f (⌂|1)❱"A2"
+            │   └── ✂️·686706b (⌂|1)❱"A1"
             └── ►:1:anon:
-                ├── ·6861158 (⌂)❱"C3"
-                └── ✂️·4f1f248 (⌂)❱"C2"
+                ├── ·6861158 (⌂|1)❱"C3"
+                └── ✂️·4f1f248 (⌂|1)❱"C2"
     "#);
 
     // Multiple extensions are fine as well.
@@ -415,25 +415,25 @@ fn with_limits() -> anyhow::Result<()> {
     .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     └── 👉►:0:C
-        └── ·2a95729 (⌂)❱"Merge branches \'A\' and \'B\' into C"
+        └── ·2a95729 (⌂|1)❱"Merge branches \'A\' and \'B\' into C"
             ├── ►:3:B
-            │   ├── ·9908c99 (⌂)❱"B3"
-            │   ├── ·60d9a56 (⌂)❱"B2"
-            │   └── ✂️·9d171ff (⌂)❱"B1"
+            │   ├── ·9908c99 (⌂|1)❱"B3"
+            │   ├── ·60d9a56 (⌂|1)❱"B2"
+            │   └── ✂️·9d171ff (⌂|1)❱"B1"
             ├── ►:2:A
-            │   ├── ·20a823c (⌂)❱"A3"
-            │   ├── ·442a12f (⌂)❱"A2"
-            │   └── ·686706b (⌂)❱"A1"
+            │   ├── ·20a823c (⌂|1)❱"A3"
+            │   ├── ·442a12f (⌂|1)❱"A2"
+            │   └── ·686706b (⌂|1)❱"A1"
             │       └── ►:4:main
-            │           ├── ·edc4dee (⌂)❱"5"
-            │           └── ✂️·01d0e1e (⌂)❱"4"
+            │           ├── ·edc4dee (⌂|1)❱"5"
+            │           └── ✂️·01d0e1e (⌂|1)❱"4"
             └── ►:1:anon:
-                ├── ·6861158 (⌂)❱"C3"
-                ├── ·4f1f248 (⌂)❱"C2"
-                └── ✂️·487ffce (⌂)❱"C1"
+                ├── ·6861158 (⌂|1)❱"C3"
+                ├── ·4f1f248 (⌂|1)❱"C2"
+                └── ✂️·487ffce (⌂|1)❱"C1"
     "#);
 
-    insta::assert_debug_snapshot!(graph.statistics(), @r"
+    insta::assert_debug_snapshot!(graph.statistics(), @r#"
     Statistics {
         segments: 5,
         segments_integrated: 0,
@@ -450,12 +450,36 @@ fn with_limits() -> anyhow::Result<()> {
         ),
         segments_behind_of_entrypoint: 4,
         segments_ahead_of_entrypoint: 0,
+        entrypoint: (
+            NodeIndex(0),
+            Some(
+                0,
+            ),
+        ),
+        segment_entrypoint_incoming: 0,
+        segment_entrypoint_outgoing: 3,
+        top_segments: [
+            (
+                Some(
+                    FullName(
+                        "refs/heads/C",
+                    ),
+                ),
+                NodeIndex(0),
+                Some(
+                    CommitFlags(
+                        NotInRemote | 0x8,
+                    ),
+                ),
+            ),
+        ],
+        segments_at_bottom: 3,
         connections: 4,
         commits: 12,
         commit_references: 0,
         commits_at_cutoff: 3,
     }
-    ");
+    "#);
     Ok(())
 }
 

--- a/crates/but-graph/tests/graph/init/utils.rs
+++ b/crates/but-graph/tests/graph/init/utils.rs
@@ -54,6 +54,11 @@ pub fn add_workspace(meta: &mut VirtualBranchesTomlMetadata) {
     );
 }
 
+pub fn add_workspace_without_target(meta: &mut VirtualBranchesTomlMetadata) {
+    add_workspace(meta);
+    meta.data_mut().default_target = None;
+}
+
 pub fn add_stack(
     meta: &mut VirtualBranchesTomlMetadata,
     stack_id: StackId,
@@ -127,5 +132,9 @@ pub fn id_by_rev<'repo>(repo: &'repo gix::Repository, rev: &str) -> gix::Id<'rep
 }
 
 pub fn standard_options() -> but_graph::init::Options {
-    but_graph::init::Options { collect_tags: true }
+    but_graph::init::Options {
+        collect_tags: true,
+        max_commits_outside_of_workspace: None,
+        max_commits_recharge_location: vec![],
+    }
 }

--- a/crates/but-graph/tests/graph/init/utils.rs
+++ b/crates/but-graph/tests/graph/init/utils.rs
@@ -134,7 +134,7 @@ pub fn id_by_rev<'repo>(repo: &'repo gix::Repository, rev: &str) -> gix::Id<'rep
 pub fn standard_options() -> but_graph::init::Options {
     but_graph::init::Options {
         collect_tags: true,
-        max_commits_outside_of_workspace: None,
-        max_commits_recharge_location: vec![],
+        commits_limit_hint: None,
+        commits_limit_recharge_location: vec![],
     }
 }

--- a/crates/but-graph/tests/graph/init/utils.rs
+++ b/crates/but-graph/tests/graph/init/utils.rs
@@ -136,5 +136,6 @@ pub fn standard_options() -> but_graph::init::Options {
         collect_tags: true,
         commits_limit_hint: None,
         commits_limit_recharge_location: vec![],
+        hard_limit: None,
     }
 }

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -24,14 +24,14 @@ fn single_stack_ambigous() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     └── 👉►►►:0:gitbutler/workspace
-        └── ·20de6ee (⌂|🏘️)❱"GitButler Workspace Commit"
+        └── ·20de6ee (⌂|🏘️|1)❱"GitButler Workspace Commit"
             └── ►:2:B
-                ├── ·70e9a36 (⌂|🏘️)❱"with-ref"
-                ├── ·320e105 (⌂|🏘️)❱"segment-B" ►tags/without-ref
-                ├── ·2a31450 (⌂|🏘️)❱"segment-B~1" ►B-empty, ►ambiguous-01
-                └── ·70bde6b (⌂|🏘️)❱"segment-A" ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
+                ├── ·70e9a36 (⌂|🏘️|1)❱"with-ref"
+                ├── ·320e105 (⌂|🏘️|1)❱"segment-B" ►tags/without-ref
+                ├── ·2a31450 (⌂|🏘️|1)❱"segment-B~1" ►B-empty, ►ambiguous-01
+                └── ·70bde6b (⌂|🏘️|1)❱"segment-A" ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
                     └── ►:1:origin/main
-                        └── ·fafd9d0 (⌂|🏘️|✓)❱"init" ►main, ►new-A, ►new-B
+                        └── ·fafd9d0 (⌂|🏘️|✓|1)❱"init" ►main, ►new-A, ►new-B
     "#);
 
     // There is always a segment for the entrypoint, and code working with the graph
@@ -45,11 +45,11 @@ fn single_stack_ambigous() -> anyhow::Result<()> {
             └── ►:3:B
                 └── ·70e9a36 (⌂|🏘️)❱"with-ref"
                     └── 👉►:0:tags/without-ref
-                        ├── ·320e105 (⌂|🏘️)❱"segment-B"
-                        ├── ·2a31450 (⌂|🏘️)❱"segment-B~1" ►B-empty, ►ambiguous-01
-                        └── ·70bde6b (⌂|🏘️)❱"segment-A" ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
+                        ├── ·320e105 (⌂|🏘️|1)❱"segment-B"
+                        ├── ·2a31450 (⌂|🏘️|1)❱"segment-B~1" ►B-empty, ►ambiguous-01
+                        └── ·70bde6b (⌂|🏘️|1)❱"segment-A" ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
                             └── ►:2:origin/main
-                                └── ·fafd9d0 (⌂|🏘️|✓)❱"init" ►main, ►new-A, ►new-B
+                                └── ·fafd9d0 (⌂|🏘️|✓|1)❱"init" ►main, ►new-A, ►new-B
     "#);
 
     // We don't have to give it a ref-name
@@ -61,11 +61,11 @@ fn single_stack_ambigous() -> anyhow::Result<()> {
             └── ►:3:B
                 └── ·70e9a36 (⌂|🏘️)❱"with-ref"
                     └── ►:0:anon:
-                        ├── 👉·320e105 (⌂|🏘️)❱"segment-B" ►tags/without-ref
-                        ├── ·2a31450 (⌂|🏘️)❱"segment-B~1" ►B-empty, ►ambiguous-01
-                        └── ·70bde6b (⌂|🏘️)❱"segment-A" ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
+                        ├── 👉·320e105 (⌂|🏘️|1)❱"segment-B" ►tags/without-ref
+                        ├── ·2a31450 (⌂|🏘️|1)❱"segment-B~1" ►B-empty, ►ambiguous-01
+                        └── ·70bde6b (⌂|🏘️|1)❱"segment-A" ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
                             └── ►:2:origin/main
-                                └── ·fafd9d0 (⌂|🏘️|✓)❱"init" ►main, ►new-A, ►new-B
+                                └── ·fafd9d0 (⌂|🏘️|✓|1)❱"init" ►main, ►new-A, ►new-B
     "#);
 
     // Putting the entrypoint onto a commit in an anonymous segment makes no difference.
@@ -79,10 +79,10 @@ fn single_stack_ambigous() -> anyhow::Result<()> {
                 ├── ·70e9a36 (⌂|🏘️)❱"with-ref"
                 └── ·320e105 (⌂|🏘️)❱"segment-B" ►tags/without-ref
                     └── ►:0:anon:
-                        ├── 👉·2a31450 (⌂|🏘️)❱"segment-B~1" ►B-empty, ►ambiguous-01
-                        └── ·70bde6b (⌂|🏘️)❱"segment-A" ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
+                        ├── 👉·2a31450 (⌂|🏘️|1)❱"segment-B~1" ►B-empty, ►ambiguous-01
+                        └── ·70bde6b (⌂|🏘️|1)❱"segment-A" ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
                             └── ►:2:origin/main
-                                └── ·fafd9d0 (⌂|🏘️|✓)❱"init" ►main, ►new-A, ►new-B
+                                └── ·fafd9d0 (⌂|🏘️|✓|1)❱"init" ►main, ►new-A, ►new-B
     "#);
 
     // If we pass an entrypoint ref name, it will be used as segment name (despite ambiguous without it)
@@ -95,10 +95,10 @@ fn single_stack_ambigous() -> anyhow::Result<()> {
                 ├── ·70e9a36 (⌂|🏘️)❱"with-ref"
                 └── ·320e105 (⌂|🏘️)❱"segment-B" ►tags/without-ref
                     └── 👉►:0:B-empty
-                        ├── ·2a31450 (⌂|🏘️)❱"segment-B~1" ►ambiguous-01
-                        └── ·70bde6b (⌂|🏘️)❱"segment-A" ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
+                        ├── ·2a31450 (⌂|🏘️|1)❱"segment-B~1" ►ambiguous-01
+                        └── ·70bde6b (⌂|🏘️|1)❱"segment-A" ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
                             └── ►:2:origin/main
-                                └── ·fafd9d0 (⌂|🏘️|✓)❱"init" ►main, ►new-A, ►new-B
+                                └── ·fafd9d0 (⌂|🏘️|✓|1)❱"init" ►main, ►new-A, ►new-B
     "#);
     Ok(())
 }
@@ -136,18 +136,18 @@ fn single_stack_ws_insertions() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     └── 👉►►►:0:gitbutler/workspace
-        └── ·20de6ee (⌂|🏘️)❱"GitButler Workspace Commit"
+        └── ·20de6ee (⌂|🏘️|1)❱"GitButler Workspace Commit"
             └── ►:2:B
-                ├── ·70e9a36 (⌂|🏘️)❱"with-ref"
-                └── ·320e105 (⌂|🏘️)❱"segment-B" ►tags/without-ref
+                ├── ·70e9a36 (⌂|🏘️|1)❱"with-ref"
+                └── ·320e105 (⌂|🏘️|1)❱"segment-B" ►tags/without-ref
                     └── ►:3:B-empty
-                        └── ·2a31450 (⌂|🏘️)❱"segment-B~1" ►ambiguous-01
+                        └── ·2a31450 (⌂|🏘️|1)❱"segment-B~1" ►ambiguous-01
                             └── ►:4:A-empty-03
                                 └── ►:5:A-empty-01
                                     └── ►:6:A
-                                        └── ·70bde6b (⌂|🏘️)❱"segment-A" ►A-empty-02
+                                        └── ·70bde6b (⌂|🏘️|1)❱"segment-A" ►A-empty-02
                                             └── ►:1:origin/main
-                                                └── ·fafd9d0 (⌂|🏘️|✓)❱"init" ►main, ►new-A, ►new-B
+                                                └── ·fafd9d0 (⌂|🏘️|✓|1)❱"init" ►main, ►new-A, ►new-B
     "#);
 
     // TODO: do more complex new-stack segmentation
@@ -227,15 +227,15 @@ fn single_stack() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     └── 👉►►►:0:gitbutler/workspace
-        └── ·2c12d75 (⌂|🏘️)❱"GitButler Workspace Commit"
+        └── ·2c12d75 (⌂|🏘️|1)❱"GitButler Workspace Commit"
             └── ►:2:B
-                └── ·320e105 (⌂|🏘️)❱"segment-B"
+                └── ·320e105 (⌂|🏘️|1)❱"segment-B"
                     └── ►:3:B-sub
-                        └── ·2a31450 (⌂|🏘️)❱"segment-B~1"
+                        └── ·2a31450 (⌂|🏘️|1)❱"segment-B~1"
                             └── ►:4:A
-                                └── ·70bde6b (⌂|🏘️)❱"segment-A"
+                                └── ·70bde6b (⌂|🏘️|1)❱"segment-A"
                                     └── ►:1:origin/main
-                                        └── ·fafd9d0 (⌂|🏘️|✓)❱"init" ►main, ►new-A
+                                        └── ·fafd9d0 (⌂|🏘️|✓|1)❱"init" ►main, ►new-A
     "#);
 
     meta.data_mut().branches.clear();
@@ -263,16 +263,16 @@ fn single_stack() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     └── 👉►►►:0:gitbutler/workspace
-        └── ·2c12d75 (⌂|🏘️)❱"GitButler Workspace Commit"
+        └── ·2c12d75 (⌂|🏘️|1)❱"GitButler Workspace Commit"
             └── ►:2:B
-                └── ·320e105 (⌂|🏘️)❱"segment-B"
+                └── ·320e105 (⌂|🏘️|1)❱"segment-B"
                     └── ►:3:B-sub
-                        └── ·2a31450 (⌂|🏘️)❱"segment-B~1"
+                        └── ·2a31450 (⌂|🏘️|1)❱"segment-B~1"
                             └── ►:4:A
-                                └── ·70bde6b (⌂|🏘️)❱"segment-A"
+                                └── ·70bde6b (⌂|🏘️|1)❱"segment-A"
                                     └── ►:1:origin/main
                                         └── ►:5:new-A
-                                            └── ·fafd9d0 (⌂|🏘️|✓)❱"init" ►main
+                                            └── ·fafd9d0 (⌂|🏘️|✓|1)❱"init" ►main
     "#);
 
     Ok(())
@@ -300,22 +300,22 @@ fn minimal_merge_no_refs() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     └── 👉►:0:gitbutler/workspace
-        └── ·47e1cf1 (⌂)❱"GitButler Workspace Commit"
+        └── ·47e1cf1 (⌂|1)❱"GitButler Workspace Commit"
             └── ►:1:anon:
-                └── ·f40fb16 (⌂)❱"Merge branch \'C\' into merge-2"
+                └── ·f40fb16 (⌂|1)❱"Merge branch \'C\' into merge-2"
                     ├── ►:3:anon:
-                    │   └── ·c6d714c (⌂)❱"C"
+                    │   └── ·c6d714c (⌂|1)❱"C"
                     │       └── ►:4:anon:
-                    │           └── ·0cc5a6f (⌂)❱"Merge branch \'A\' into merge"
+                    │           └── ·0cc5a6f (⌂|1)❱"Merge branch \'A\' into merge"
                     │               ├── ►:6:anon:
-                    │               │   └── ·e255adc (⌂)❱"A"
+                    │               │   └── ·e255adc (⌂|1)❱"A"
                     │               │       └── ►:7:anon:
-                    │               │           └── ·fafd9d0 (⌂)❱"init"
+                    │               │           └── ·fafd9d0 (⌂|1)❱"init"
                     │               └── ►:5:anon:
-                    │                   └── ·7fdb58d (⌂)❱"B"
+                    │                   └── ·7fdb58d (⌂|1)❱"B"
                     │                       └── →:7:
                     └── ►:2:anon:
-                        └── ·450c58a (⌂)❱"D"
+                        └── ·450c58a (⌂|1)❱"D"
                             └── →:4:
     "#);
     Ok(())
@@ -343,12 +343,12 @@ fn segment_on_each_incoming_connection() -> anyhow::Result<()> {
     let graph = Graph::from_commit_traversal(id, name, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── 👉►:0:entrypoint
-    │   ├── ·98c5aba (⌂)❱"C"
-    │   ├── ·807b6ce (⌂)❱"B"
-    │   └── ·6d05486 (⌂)❱"A"
+    │   ├── ·98c5aba (⌂|1)❱"C"
+    │   ├── ·807b6ce (⌂|1)❱"B"
+    │   └── ·6d05486 (⌂|1)❱"A"
     │       └── ►:3:anon:
-    │           ├── ·b688f2d (⌂|🏘️)❱"other-1"
-    │           └── ·fafd9d0 (⌂|🏘️)❱"init"
+    │           ├── ·b688f2d (⌂|🏘️|1)❱"other-1"
+    │           └── ·fafd9d0 (⌂|🏘️|1)❱"init"
     └── ►►►:1:gitbutler/workspace
         └── ·b6917c7 (⌂|🏘️)❱"GitButler Workspace Commit"
             └── ►:2:main
@@ -380,22 +380,22 @@ fn minimal_merge() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── 👉►:0:gitbutler/workspace
-    │   └── ·47e1cf1 (⌂)❱"GitButler Workspace Commit"
+    │   └── ·47e1cf1 (⌂|1)❱"GitButler Workspace Commit"
     │       └── ►:1:merge-2
-    │           └── ·f40fb16 (⌂)❱"Merge branch \'C\' into merge-2"
+    │           └── ·f40fb16 (⌂|1)❱"Merge branch \'C\' into merge-2"
     │               ├── ►:3:C
-    │               │   └── ·c6d714c (⌂)❱"C"
+    │               │   └── ·c6d714c (⌂|1)❱"C"
     │               │       └── ►:4:anon:
-    │               │           └── ·0cc5a6f (⌂)❱"Merge branch \'A\' into merge" ►empty-1-on-merge, ►empty-2-on-merge, ►merge
+    │               │           └── ·0cc5a6f (⌂|1)❱"Merge branch \'A\' into merge" ►empty-1-on-merge, ►empty-2-on-merge, ►merge
     │               │               ├── ►:6:A
-    │               │               │   └── ·e255adc (⌂)❱"A"
+    │               │               │   └── ·e255adc (⌂|1)❱"A"
     │               │               │       └── ►:7:main <> origin/main
-    │               │               │           └── ·fafd9d0 (⌂)❱"init"
+    │               │               │           └── ·fafd9d0 (⌂|11)❱"init"
     │               │               └── ►:5:B
-    │               │                   └── ·7fdb58d (⌂)❱"B"
+    │               │                   └── ·7fdb58d (⌂|1)❱"B"
     │               │                       └── →:7: (main)
     │               └── ►:2:D
-    │                   └── ·450c58a (⌂)❱"D"
+    │                   └── ·450c58a (⌂|1)❱"D"
     │                       └── →:4:
     └── ►:8:origin/main
         └── →:7: (main)
@@ -413,24 +413,24 @@ fn minimal_merge() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     └── 👉►►►:0:gitbutler/workspace
-        └── ·47e1cf1 (⌂|🏘️)❱"GitButler Workspace Commit"
+        └── ·47e1cf1 (⌂|🏘️|1)❱"GitButler Workspace Commit"
             └── ►:2:merge-2
-                └── ·f40fb16 (⌂|🏘️)❱"Merge branch \'C\' into merge-2"
+                └── ·f40fb16 (⌂|🏘️|1)❱"Merge branch \'C\' into merge-2"
                     ├── ►:4:C
-                    │   └── ·c6d714c (⌂|🏘️)❱"C"
+                    │   └── ·c6d714c (⌂|🏘️|1)❱"C"
                     │       └── ►:8:empty-2-on-merge
                     │           └── ►:9:empty-1-on-merge
                     │               └── ►:10:merge
-                    │                   └── ·0cc5a6f (⌂|🏘️)❱"Merge branch \'A\' into merge"
+                    │                   └── ·0cc5a6f (⌂|🏘️|1)❱"Merge branch \'A\' into merge"
                     │                       ├── ►:6:B
-                    │                       │   └── ·7fdb58d (⌂|🏘️)❱"B"
+                    │                       │   └── ·7fdb58d (⌂|🏘️|1)❱"B"
                     │                       │       └── ►:1:origin/main
-                    │                       │           └── ·fafd9d0 (⌂|🏘️|✓)❱"init" ►main
+                    │                       │           └── ·fafd9d0 (⌂|🏘️|✓|1)❱"init" ►main
                     │                       └── ►:7:A
-                    │                           └── ·e255adc (⌂|🏘️)❱"A"
+                    │                           └── ·e255adc (⌂|🏘️|1)❱"A"
                     │                               └── →:1: (origin/main)
                     └── ►:3:D
-                        └── ·450c58a (⌂|🏘️)❱"D"
+                        └── ·450c58a (⌂|🏘️|1)❱"D"
                             └── →:8: (empty-2-on-merge)
     "#);
     Ok(())
@@ -449,7 +449,7 @@ fn just_init_with_branches() -> anyhow::Result<()> {
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── 👉►:0:main <> origin/main
     │   └── ►:2:origin/main
-    │       └── ·fafd9d0 (⌂|🏘️|✓)❱"init" ►A, ►B, ►C, ►D, ►E, ►F, ►main
+    │       └── ·fafd9d0 (⌂|🏘️|✓|1)❱"init" ►A, ►B, ►C, ►D, ►E, ►F, ►main
     └── ►►►:1:gitbutler/workspace
         └── →:2: (origin/main)
     "#);
@@ -480,7 +480,7 @@ fn just_init_with_branches() -> anyhow::Result<()> {
     │       └── ►:3:C
     │           └── ►:4:B
     │               └── ►:5:A
-    │                   └── ·fafd9d0 (⌂|🏘️|✓)❱"init" ►D, ►E, ►F, ►main
+    │                   └── ·fafd9d0 (⌂|🏘️|✓|1)❱"init" ►D, ►E, ►F, ►main
     └── ►►►:1:gitbutler/workspace
         └── →:2: (origin/main)
     "#);
@@ -504,10 +504,10 @@ fn proper_remote_ahead() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── 👉►►►:0:gitbutler/workspace
-    │   └── ·9bcd3af (⌂|🏘️)❱"GitButler Workspace Commit"
+    │   └── ·9bcd3af (⌂|🏘️|1)❱"GitButler Workspace Commit"
     │       └── ►:2:main <> origin/main
-    │           ├── ·998eae6 (⌂|🏘️|✓)❱"shared"
-    │           └── ·fafd9d0 (⌂|🏘️|✓)❱"init"
+    │           ├── ·998eae6 (⌂|🏘️|✓|1)❱"shared"
+    │           └── ·fafd9d0 (⌂|🏘️|✓|1)❱"init"
     └── ►:1:origin/main
         ├── 🟣ca7baa7 (✓)❱"only-remote-02"
         └── 🟣7ea1468 (✓)❱"only-remote-01"
@@ -538,14 +538,14 @@ fn deduced_remote_ahead() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── 👉►►►:0:gitbutler/workspace
-    │   └── ·8b39ce4 (⌂|🏘️)❱"GitButler Workspace Commit"
+    │   └── ·8b39ce4 (⌂|🏘️|1)❱"GitButler Workspace Commit"
     │       └── ►:1:A <> origin/A
-    │           ├── ·9d34471 (⌂|🏘️)❱"A2"
-    │           └── ·5b89c71 (⌂|🏘️)❱"A1"
+    │           ├── ·9d34471 (⌂|🏘️|11)❱"A2"
+    │           └── ·5b89c71 (⌂|🏘️|11)❱"A1"
     │               └── ►:5:anon:
-    │                   └── ·998eae6 (⌂|🏘️)❱"shared"
+    │                   └── ·998eae6 (⌂|🏘️|11)❱"shared"
     │                       └── ►:3:main
-    │                           └── ·fafd9d0 (⌂|🏘️)❱"init"
+    │                           └── ·fafd9d0 (⌂|🏘️|11)❱"init"
     └── ►:2:origin/A
         ├── 🟣3ea1a8f❱"only-remote-02"
         └── 🟣9c50f71❱"only-remote-01"
@@ -563,12 +563,12 @@ fn deduced_remote_ahead() -> anyhow::Result<()> {
     ├── ►►►:1:gitbutler/workspace
     │   └── ·8b39ce4 (⌂|🏘️)❱"GitButler Workspace Commit"
     │       └── ►:2:A <> origin/A
-    │           ├── ·9d34471 (⌂|🏘️)❱"A2"
-    │           └── ·5b89c71 (⌂|🏘️)❱"A1"
+    │           ├── ·9d34471 (⌂|🏘️|10)❱"A2"
+    │           └── ·5b89c71 (⌂|🏘️|10)❱"A1"
     │               └── ►:5:anon:
-    │                   └── ·998eae6 (⌂|🏘️)❱"shared"
+    │                   └── ·998eae6 (⌂|🏘️|10)❱"shared"
     │                       └── 👉►:0:main
-    │                           └── ·fafd9d0 (⌂|🏘️)❱"init"
+    │                           └── ·fafd9d0 (⌂|🏘️|11)❱"init"
     └── ►:3:origin/A
         ├── 🟣3ea1a8f❱"only-remote-02"
         └── 🟣9c50f71❱"only-remote-01"
@@ -601,13 +601,13 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── 👉►►►:0:gitbutler/workspace
-    │   └── ·7786959 (⌂|🏘️)❱"GitButler Workspace Commit"
+    │   └── ·7786959 (⌂|🏘️|1)❱"GitButler Workspace Commit"
     │       └── ►:2:B <> origin/B
-    │           └── ·312f819 (⌂|🏘️)❱"B"
+    │           └── ·312f819 (⌂|🏘️|11)❱"B"
     │               └── ►:4:A <> origin/A
-    │                   └── ·e255adc (⌂|🏘️)❱"A"
+    │                   └── ·e255adc (⌂|🏘️|111)❱"A"
     │                       └── ►:1:origin/main
-    │                           └── ·fafd9d0 (⌂|🏘️|✓)❱"init" ►main
+    │                           └── ·fafd9d0 (⌂|🏘️|✓|111)❱"init" ►main
     └── ►:3:origin/B
         └── 🟣682be32❱"B"
             └── ►:5:origin/A
@@ -622,18 +622,18 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     ├── ►►►:1:gitbutler/workspace
     │   └── ·7786959 (⌂|🏘️)❱"GitButler Workspace Commit"
     │       └── ►:4:B <> origin/B
-    │           └── ·312f819 (⌂|🏘️)❱"B"
+    │           └── ·312f819 (⌂|🏘️|10)❱"B"
     │               └── 👉►:0:A <> origin/A
-    │                   └── ·e255adc (⌂|🏘️)❱"A"
+    │                   └── ·e255adc (⌂|🏘️|11)❱"A"
     │                       └── ►:2:origin/main
-    │                           └── ·fafd9d0 (⌂|🏘️|✓)❱"init" ►main
+    │                           └── ·fafd9d0 (⌂|🏘️|✓|11)❱"init" ►main
     └── ►:5:origin/B
         └── 🟣682be32❱"B"
             └── ►:3:origin/A
                 └── 🟣e29c23d❱"A"
                     └── →:2: (origin/main)
     "#);
-    insta::assert_debug_snapshot!(graph.statistics(), @r"
+    insta::assert_debug_snapshot!(graph.statistics(), @r#"
     Statistics {
         segments: 6,
         segments_integrated: 1,
@@ -650,12 +650,45 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
         ),
         segments_behind_of_entrypoint: 1,
         segments_ahead_of_entrypoint: 2,
+        entrypoint: (
+            NodeIndex(0),
+            Some(
+                0,
+            ),
+        ),
+        segment_entrypoint_incoming: 1,
+        segment_entrypoint_outgoing: 1,
+        top_segments: [
+            (
+                Some(
+                    FullName(
+                        "refs/heads/gitbutler/workspace",
+                    ),
+                ),
+                NodeIndex(1),
+                Some(
+                    CommitFlags(
+                        NotInRemote | InWorkspace,
+                    ),
+                ),
+            ),
+            (
+                Some(
+                    FullName(
+                        "refs/remotes/origin/B",
+                    ),
+                ),
+                NodeIndex(5),
+                None,
+            ),
+        ],
+        segments_at_bottom: 1,
         connections: 5,
         commits: 6,
         commit_references: 1,
         commits_at_cutoff: 0,
     }
-    ");
+    "#);
     Ok(())
 }
 
@@ -685,15 +718,15 @@ fn disambiguate_by_remote() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── 👉►►►:0:gitbutler/workspace
-    │   └── ·e30f90c (⌂|🏘️)❱"GitButler Workspace Commit"
+    │   └── ·e30f90c (⌂|🏘️|1)❱"GitButler Workspace Commit"
     │       └── ►:5:anon:
-    │           └── ·2173153 (⌂|🏘️)❱"C" ►C, ►ambiguous-C
+    │           └── ·2173153 (⌂|🏘️|11)❱"C" ►C, ►ambiguous-C
     │               └── ►:8:B <> origin/B
-    │                   └── ·312f819 (⌂|🏘️)❱"B" ►ambiguous-B
+    │                   └── ·312f819 (⌂|🏘️|111)❱"B" ►ambiguous-B
     │                       └── ►:7:A <> origin/A
-    │                           └── ·e255adc (⌂|🏘️)❱"A" ►ambiguous-A
+    │                           └── ·e255adc (⌂|🏘️|1111)❱"A" ►ambiguous-A
     │                               └── ►:1:origin/main
-    │                                   └── ·fafd9d0 (⌂|🏘️|✓)❱"init" ►main
+    │                                   └── ·fafd9d0 (⌂|🏘️|✓|1111)❱"init" ►main
     ├── ►:2:origin/C
     │   └── →:5:
     ├── ►:3:origin/ambiguous-C
@@ -748,12 +781,12 @@ fn integrated_tips_stop_early() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── 👉►►►:0:gitbutler/workspace
-    │   └── ·4077353 (⌂|🏘️)❱"GitButler Workspace Commit"
+    │   └── ·4077353 (⌂|🏘️|1)❱"GitButler Workspace Commit"
     │       └── ►:2:B
-    │           ├── ·6b1a13b (⌂|🏘️)❱"B2"
-    │           └── ·03ad472 (⌂|🏘️)❱"B1"
+    │           ├── ·6b1a13b (⌂|🏘️|1)❱"B2"
+    │           └── ·03ad472 (⌂|🏘️|1)❱"B1"
     │               └── ►:5:A
-    │                   └── ✂️·79bbb29 (⌂|🏘️|✓)❱"8"
+    │                   └── ✂️·79bbb29 (⌂|🏘️|✓|1)❱"8"
     └── ►:1:origin/main
         ├── 🟣d0df794 (✓)❱"remote-2"
         └── 🟣09c6e08 (✓)❱"remote-1"
@@ -779,17 +812,17 @@ fn integrated_tips_stop_early() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── 👉►►►:0:gitbutler/workspace
-    │   └── ·4077353 (⌂|🏘️)❱"GitButler Workspace Commit"
+    │   └── ·4077353 (⌂|🏘️|1)❱"GitButler Workspace Commit"
     │       └── ►:2:B
-    │           ├── ·6b1a13b (⌂|🏘️)❱"B2"
-    │           └── ·03ad472 (⌂|🏘️)❱"B1"
+    │           ├── ·6b1a13b (⌂|🏘️|1)❱"B2"
+    │           └── ·03ad472 (⌂|🏘️|1)❱"B1"
     │               └── ►:5:A
-    │                   ├── ·79bbb29 (⌂|🏘️|✓)❱"8"
-    │                   ├── ·fc98174 (⌂|🏘️|✓)❱"7"
-    │                   ├── ·a381df5 (⌂|🏘️|✓)❱"6"
-    │                   └── ·777b552 (⌂|🏘️|✓)❱"5"
+    │                   ├── ·79bbb29 (⌂|🏘️|✓|1)❱"8"
+    │                   ├── ·fc98174 (⌂|🏘️|✓|1)❱"7"
+    │                   ├── ·a381df5 (⌂|🏘️|✓|1)❱"6"
+    │                   └── ·777b552 (⌂|🏘️|✓|1)❱"5"
     │                       └── ►:6:anon:
-    │                           └── ✂️·ce4a760 (⌂|🏘️|✓)❱"Merge branch \'A-feat\' into A"
+    │                           └── ✂️·ce4a760 (⌂|🏘️|✓|1)❱"Merge branch \'A-feat\' into A"
     └── ►:1:origin/main
         ├── 🟣d0df794 (✓)❱"remote-2"
         └── 🟣09c6e08 (✓)❱"remote-1"
@@ -801,19 +834,20 @@ fn integrated_tips_stop_early() -> anyhow::Result<()> {
                         └── ✂️·34d0715 (⌂|✓)❱"2"
     "#);
 
-    // The limit is effective for integrated workspaces branches though to prevent runaways.
+    // The limit is effective for integrated workspaces branches, but the traversal proceeds until
+    // the integration branch finds its goal.
     let graph =
         Graph::from_head(&repo, &*meta, standard_options().with_limit_hint(1))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── 👉►►►:0:gitbutler/workspace
-    │   └── ·4077353 (⌂|🏘️)❱"GitButler Workspace Commit"
+    │   └── ·4077353 (⌂|🏘️|1)❱"GitButler Workspace Commit"
     │       └── ►:2:B
-    │           ├── ·6b1a13b (⌂|🏘️)❱"B2"
-    │           └── ·03ad472 (⌂|🏘️)❱"B1"
+    │           ├── ·6b1a13b (⌂|🏘️|1)❱"B2"
+    │           └── ·03ad472 (⌂|🏘️|1)❱"B1"
     │               └── ►:5:A
-    │                   ├── ·79bbb29 (⌂|🏘️|✓)❱"8"
-    │                   ├── ·fc98174 (⌂|🏘️|✓)❱"7"
-    │                   └── ✂️·a381df5 (⌂|🏘️|✓)❱"6"
+    │                   ├── ·79bbb29 (⌂|🏘️|✓|1)❱"8"
+    │                   ├── ·fc98174 (⌂|🏘️|✓|1)❱"7"
+    │                   └── ✂️·a381df5 (⌂|🏘️|✓|1)❱"6"
     └── ►:1:origin/main
         ├── 🟣d0df794 (✓)❱"remote-2"
         └── 🟣09c6e08 (✓)❱"remote-1"
@@ -839,10 +873,10 @@ fn integrated_tips_stop_early() -> anyhow::Result<()> {
     │           ├── ·6b1a13b (⌂|🏘️)❱"B2"
     │           └── ·03ad472 (⌂|🏘️)❱"B1"
     │               └── 👉►:0:A
-    │                   ├── ·79bbb29 (⌂|🏘️|✓)❱"8"
-    │                   ├── ·fc98174 (⌂|🏘️|✓)❱"7"
-    │                   ├── ·a381df5 (⌂|🏘️|✓)❱"6"
-    │                   └── ✂️·777b552 (⌂|🏘️|✓)❱"5"
+    │                   ├── ·79bbb29 (⌂|🏘️|✓|1)❱"8"
+    │                   ├── ·fc98174 (⌂|🏘️|✓|1)❱"7"
+    │                   ├── ·a381df5 (⌂|🏘️|✓|1)❱"6"
+    │                   └── ✂️·777b552 (⌂|🏘️|✓|1)❱"5"
     └── ►:2:origin/main
         ├── 🟣d0df794 (✓)❱"remote-2"
         └── 🟣09c6e08 (✓)❱"remote-1"
@@ -867,7 +901,7 @@ fn workspace_obeys_limit_when_target_branch_is_missing() -> anyhow::Result<()> {
         Graph::from_head(&repo, &*meta, standard_options().with_limit_hint(0))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     └── 👉►►►:0:gitbutler/workspace
-        └── ✂️·4077353 (⌂|🏘️)❱"GitButler Workspace Commit"
+        └── ✂️·4077353 (⌂|🏘️|1)❱"GitButler Workspace Commit"
     "#);
 
     meta.data_mut().branches.clear();
@@ -881,12 +915,12 @@ fn workspace_obeys_limit_when_target_branch_is_missing() -> anyhow::Result<()> {
         Graph::from_head(&repo, &*meta, standard_options().with_limit_hint(0))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── 👉►►►:0:gitbutler/workspace
-    │   └── ·4077353 (⌂|🏘️)❱"GitButler Workspace Commit"
+    │   └── ·4077353 (⌂|🏘️|1)❱"GitButler Workspace Commit"
     │       └── ►:2:B
-    │           ├── ·6b1a13b (⌂|🏘️)❱"B2"
-    │           └── ·03ad472 (⌂|🏘️)❱"B1"
+    │           ├── ·6b1a13b (⌂|🏘️|1)❱"B2"
+    │           └── ·03ad472 (⌂|🏘️|1)❱"B1"
     │               └── ►:5:A
-    │                   └── ✂️·79bbb29 (⌂|🏘️|✓)❱"8"
+    │                   └── ✂️·79bbb29 (⌂|🏘️|✓|1)❱"8"
     └── ►:1:origin/main
         ├── 🟣d0df794 (✓)❱"remote-2"
         └── 🟣09c6e08 (✓)❱"remote-1"
@@ -917,8 +951,8 @@ fn on_top_of_target_with_history() -> anyhow::Result<()> {
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     └── 👉►►►:0:gitbutler/workspace
         └── ►:1:origin/main
-            ├── ·2cde30a (⌂|🏘️|✓)❱"5" ►A, ►B, ►C, ►D, ►E, ►F
-            └── ✂️·1c938f4 (⌂|🏘️|✓)❱"4"
+            ├── ·2cde30a (⌂|🏘️|✓|1)❱"5" ►A, ►B, ►C, ►D, ►E, ►F
+            └── ✂️·1c938f4 (⌂|🏘️|✓|1)❱"4"
     "#);
 
     // TODO: fix this - it builds a wrong graph.

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -520,12 +520,17 @@ fn proper_remote_ahead() -> anyhow::Result<()> {
 fn deduced_remote_ahead() -> anyhow::Result<()> {
     let (repo, mut meta) = read_only_in_memory_scenario("ws/deduced-remote-ahead")?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * 9bcd3af (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    | * ca7baa7 (origin/main) only-remote-02
-    | * 7ea1468 only-remote-01
+    * 8b39ce4 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 9d34471 (A) A2
+    * 5b89c71 A1
+    | * 3ea1a8f (origin/A) only-remote-02
+    | * 9c50f71 only-remote-01
+    | * 2cfbb79 merge
+    |/| 
+    | * e898cd0 feat-on-remote
     |/  
-    * 998eae6 (main) shared
-    * fafd9d0 init
+    * 998eae6 shared
+    * fafd9d0 (main) init
     ");
 
     // Remote segments are picked up automatically and traversed - they never take ownership of already assigned commits.
@@ -533,29 +538,46 @@ fn deduced_remote_ahead() -> anyhow::Result<()> {
     let graph = Graph::from_head(&repo, &*meta, standard_options())?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── 👉►►►:0:gitbutler/workspace
-    │   └── ·9bcd3af (⌂|🏘️)❱"GitButler Workspace Commit"
-    │       └── ►:2:main
-    │           ├── ·998eae6 (⌂|🏘️|✓)❱"shared"
-    │           └── ·fafd9d0 (⌂|🏘️|✓)❱"init"
-    └── ►:1:origin/main
-        ├── 🟣ca7baa7 (✓)❱"only-remote-02"
-        └── 🟣7ea1468 (✓)❱"only-remote-01"
-            └── →:2: (main)
+    │   └── ·8b39ce4 (⌂|🏘️)❱"GitButler Workspace Commit"
+    │       └── ►:1:A
+    │           ├── ·9d34471 (⌂|🏘️)❱"A2"
+    │           └── ·5b89c71 (⌂|🏘️)❱"A1"
+    │               └── ►:5:anon:
+    │                   └── ·998eae6 (⌂|🏘️)❱"shared"
+    │                       └── ►:3:main
+    │                           └── ·fafd9d0 (⌂|🏘️)❱"init"
+    └── ►:2:origin/A
+        ├── 🟣3ea1a8f❱"only-remote-02"
+        └── 🟣9c50f71❱"only-remote-01"
+            └── ►:4:anon:
+                └── 🟣2cfbb79❱"merge"
+                    ├── ►:6:anon:
+                    │   └── 🟣e898cd0❱"feat-on-remote"
+                    │       └── →:5:
+                    └── →:5:
     "#);
 
     let id = id_by_rev(&repo, ":/init");
     let graph = Graph::from_commit_traversal(id, None, &*meta, standard_options())?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── ►►►:1:gitbutler/workspace
-    │   └── ·9bcd3af (⌂|🏘️)❱"GitButler Workspace Commit"
-    │       └── ►:3:main
-    │           └── ·998eae6 (⌂|🏘️|✓)❱"shared"
-    │               └── ►:0:anon:
-    │                   └── 👉·fafd9d0 (⌂|🏘️|✓)❱"init"
-    └── ►:2:origin/main
-        ├── 🟣ca7baa7 (✓)❱"only-remote-02"
-        └── 🟣7ea1468 (✓)❱"only-remote-01"
-            └── →:3: (main)
+    │   └── ·8b39ce4 (⌂|🏘️)❱"GitButler Workspace Commit"
+    │       └── ►:2:A
+    │           ├── ·9d34471 (⌂|🏘️)❱"A2"
+    │           └── ·5b89c71 (⌂|🏘️)❱"A1"
+    │               └── ►:5:anon:
+    │                   └── ·998eae6 (⌂|🏘️)❱"shared"
+    │                       └── 👉►:0:main
+    │                           └── ·fafd9d0 (⌂|🏘️)❱"init"
+    └── ►:3:origin/A
+        ├── 🟣3ea1a8f❱"only-remote-02"
+        └── 🟣9c50f71❱"only-remote-01"
+            └── ►:4:anon:
+                └── 🟣2cfbb79❱"merge"
+                    ├── ►:6:anon:
+                    │   └── 🟣e898cd0❱"feat-on-remote"
+                    │       └── →:5:
+                    └── →:5:
     "#);
     Ok(())
 }
@@ -727,11 +749,11 @@ fn integrated_tips_stop_early() -> anyhow::Result<()> {
         StackState::InWorkspace,
         &["A"],
     );
-    // As we start at a workspace, even a limit of 0 has no effect - we get to see the whole workspace.
-    let graph = Graph::from_head(&repo, &*meta, standard_options().with_limit(0))?.validated()?;
     // Now that `A` is part of the workspace, it's not cut off anymore.
     // Instead, we get to keep `A` in full, and it aborts only one later as the
     // segment definitely isn't in the workspace.
+    // As we start at a workspace, even a limit of 0 has no effect - we get to see the whole workspace.
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── 👉►►►:0:gitbutler/workspace
     │   └── ·4077353 (⌂|🏘️)❱"GitButler Workspace Commit"
@@ -745,6 +767,29 @@ fn integrated_tips_stop_early() -> anyhow::Result<()> {
     │                   └── ·777b552 (⌂|🏘️|✓)❱"5"
     │                       └── ►:6:anon:
     │                           └── ✂️·ce4a760 (⌂|🏘️|✓)❱"Merge branch \'A-feat\' into A"
+    └── ►:1:origin/main
+        ├── 🟣d0df794 (✓)❱"remote-2"
+        └── 🟣09c6e08 (✓)❱"remote-1"
+            └── ►:3:anon:
+                └── 🟣7b9f260 (✓)❱"Merge branch \'A\' into soon-origin-main"
+                    ├── →:5: (A)
+                    └── ►:4:main
+                        ├── ·4b3e5a8 (⌂|✓)❱"3"
+                        └── ✂️·34d0715 (⌂|✓)❱"2"
+    "#);
+
+    // The limit is effective for integrated workspaces branches though to prevent runaways.
+    let graph = Graph::from_head(&repo, &*meta, standard_options().with_limit(1))?.validated()?;
+    insta::assert_snapshot!(graph_tree(&graph), @r#"
+    ├── 👉►►►:0:gitbutler/workspace
+    │   └── ·4077353 (⌂|🏘️)❱"GitButler Workspace Commit"
+    │       └── ►:2:B
+    │           ├── ·6b1a13b (⌂|🏘️)❱"B2"
+    │           └── ·03ad472 (⌂|🏘️)❱"B1"
+    │               └── ►:5:A
+    │                   ├── ·79bbb29 (⌂|🏘️|✓)❱"8"
+    │                   ├── ·fc98174 (⌂|🏘️|✓)❱"7"
+    │                   └── ✂️·a381df5 (⌂|🏘️|✓)❱"6"
     └── ►:1:origin/main
         ├── 🟣d0df794 (✓)❱"remote-2"
         └── 🟣09c6e08 (✓)❱"remote-1"
@@ -795,7 +840,10 @@ fn workspace_obeys_limit_when_target_branch_is_missing() -> anyhow::Result<()> {
         "without target, limits affect workspaces too"
     );
     let graph = Graph::from_head(&repo, &*meta, standard_options().with_limit(0))?.validated()?;
-    insta::assert_snapshot!(graph_tree(&graph), @"└── 👉►►►:0:gitbutler/workspace");
+    insta::assert_snapshot!(graph_tree(&graph), @r#"
+    └── 👉►►►:0:gitbutler/workspace
+        └── ✂️·4077353 (⌂|🏘️)❱"GitButler Workspace Commit"
+    "#);
 
     meta.data_mut().branches.clear();
     add_workspace(&mut meta);

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -389,7 +389,7 @@ fn minimal_merge() -> anyhow::Result<()> {
     │               │           └── ·0cc5a6f (⌂)❱"Merge branch \'A\' into merge" ►empty-1-on-merge, ►empty-2-on-merge, ►merge
     │               │               ├── ►:6:A
     │               │               │   └── ·e255adc (⌂)❱"A"
-    │               │               │       └── ►:7:main
+    │               │               │       └── ►:7:main <> origin/main
     │               │               │           └── ·fafd9d0 (⌂)❱"init"
     │               │               └── ►:5:B
     │               │                   └── ·7fdb58d (⌂)❱"B"
@@ -447,7 +447,7 @@ fn just_init_with_branches() -> anyhow::Result<()> {
     add_workspace(&mut meta);
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
-    ├── 👉►:0:main
+    ├── 👉►:0:main <> origin/main
     │   └── ►:2:origin/main
     │       └── ·fafd9d0 (⌂|🏘️|✓)❱"init" ►A, ►B, ►C, ►D, ►E, ►F, ►main
     └── ►►►:1:gitbutler/workspace
@@ -475,7 +475,7 @@ fn just_init_with_branches() -> anyhow::Result<()> {
     //       also: order is wrong now due to target branch handling
     //       - needs insertion of multi-segment above 'fixed' references like the target branch.
     insta::assert_snapshot!(graph_tree(&graph), @r#"
-    ├── 👉►:0:main
+    ├── 👉►:0:main <> origin/main
     │   └── ►:2:origin/main
     │       └── ►:3:C
     │           └── ►:4:B
@@ -505,7 +505,7 @@ fn proper_remote_ahead() -> anyhow::Result<()> {
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── 👉►►►:0:gitbutler/workspace
     │   └── ·9bcd3af (⌂|🏘️)❱"GitButler Workspace Commit"
-    │       └── ►:2:main
+    │       └── ►:2:main <> origin/main
     │           ├── ·998eae6 (⌂|🏘️|✓)❱"shared"
     │           └── ·fafd9d0 (⌂|🏘️|✓)❱"init"
     └── ►:1:origin/main
@@ -539,7 +539,7 @@ fn deduced_remote_ahead() -> anyhow::Result<()> {
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── 👉►►►:0:gitbutler/workspace
     │   └── ·8b39ce4 (⌂|🏘️)❱"GitButler Workspace Commit"
-    │       └── ►:1:A
+    │       └── ►:1:A <> origin/A
     │           ├── ·9d34471 (⌂|🏘️)❱"A2"
     │           └── ·5b89c71 (⌂|🏘️)❱"A1"
     │               └── ►:5:anon:
@@ -562,7 +562,7 @@ fn deduced_remote_ahead() -> anyhow::Result<()> {
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── ►►►:1:gitbutler/workspace
     │   └── ·8b39ce4 (⌂|🏘️)❱"GitButler Workspace Commit"
-    │       └── ►:2:A
+    │       └── ►:2:A <> origin/A
     │           ├── ·9d34471 (⌂|🏘️)❱"A2"
     │           └── ·5b89c71 (⌂|🏘️)❱"A1"
     │               └── ►:5:anon:
@@ -602,9 +602,9 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── 👉►►►:0:gitbutler/workspace
     │   └── ·7786959 (⌂|🏘️)❱"GitButler Workspace Commit"
-    │       └── ►:2:B
+    │       └── ►:2:B <> origin/B
     │           └── ·312f819 (⌂|🏘️)❱"B"
-    │               └── ►:4:A
+    │               └── ►:4:A <> origin/A
     │                   └── ·e255adc (⌂|🏘️)❱"A"
     │                       └── ►:1:origin/main
     │                           └── ·fafd9d0 (⌂|🏘️|✓)❱"init" ►main
@@ -621,9 +621,9 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── ►►►:1:gitbutler/workspace
     │   └── ·7786959 (⌂|🏘️)❱"GitButler Workspace Commit"
-    │       └── ►:4:B
+    │       └── ►:4:B <> origin/B
     │           └── ·312f819 (⌂|🏘️)❱"B"
-    │               └── 👉►:0:A
+    │               └── 👉►:0:A <> origin/A
     │                   └── ·e255adc (⌂|🏘️)❱"A"
     │                       └── ►:2:origin/main
     │                           └── ·fafd9d0 (⌂|🏘️|✓)❱"init" ►main
@@ -633,7 +633,29 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
                 └── 🟣e29c23d❱"A"
                     └── →:2: (origin/main)
     "#);
-    assert_eq!(graph.num_remote_segments(), 2);
+    insta::assert_debug_snapshot!(graph.statistics(), @r"
+    Statistics {
+        segments: 6,
+        segments_integrated: 1,
+        segments_remote: 2,
+        segments_with_remote_tracking_branch: 2,
+        segments_empty: 0,
+        segments_unnamed: 0,
+        segments_in_workspace: 4,
+        segments_in_workspace_and_integrated: 1,
+        segments_with_workspace_metadata: 1,
+        segments_with_branch_metadata: 0,
+        entrypoint_in_workspace: Some(
+            true,
+        ),
+        segments_behind_of_entrypoint: 1,
+        segments_ahead_of_entrypoint: 2,
+        connections: 5,
+        commits: 6,
+        commit_references: 1,
+        commits_at_cutoff: 0,
+    }
+    ");
     Ok(())
 }
 
@@ -666,9 +688,9 @@ fn disambiguate_by_remote() -> anyhow::Result<()> {
     │   └── ·e30f90c (⌂|🏘️)❱"GitButler Workspace Commit"
     │       └── ►:5:anon:
     │           └── ·2173153 (⌂|🏘️)❱"C" ►C, ►ambiguous-C
-    │               └── ►:8:B
+    │               └── ►:8:B <> origin/B
     │                   └── ·312f819 (⌂|🏘️)❱"B" ►ambiguous-B
-    │                       └── ►:7:A
+    │                       └── ►:7:A <> origin/A
     │                           └── ·e255adc (⌂|🏘️)❱"A" ►ambiguous-A
     │                               └── ►:1:origin/main
     │                                   └── ·fafd9d0 (⌂|🏘️|✓)❱"init" ►main

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -633,6 +633,7 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
                 └── 🟣e29c23d❱"A"
                     └── →:2: (origin/main)
     "#);
+    assert_eq!(graph.num_remote_segments(), 2);
     Ok(())
 }
 
@@ -779,7 +780,8 @@ fn integrated_tips_stop_early() -> anyhow::Result<()> {
     "#);
 
     // The limit is effective for integrated workspaces branches though to prevent runaways.
-    let graph = Graph::from_head(&repo, &*meta, standard_options().with_limit(1))?.validated()?;
+    let graph =
+        Graph::from_head(&repo, &*meta, standard_options().with_limit_hint(1))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── 👉►►►:0:gitbutler/workspace
     │   └── ·4077353 (⌂|🏘️)❱"GitButler Workspace Commit"
@@ -839,7 +841,8 @@ fn workspace_obeys_limit_when_target_branch_is_missing() -> anyhow::Result<()> {
         meta.data_mut().default_target.is_none(),
         "without target, limits affect workspaces too"
     );
-    let graph = Graph::from_head(&repo, &*meta, standard_options().with_limit(0))?.validated()?;
+    let graph =
+        Graph::from_head(&repo, &*meta, standard_options().with_limit_hint(0))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     └── 👉►►►:0:gitbutler/workspace
         └── ✂️·4077353 (⌂|🏘️)❱"GitButler Workspace Commit"
@@ -852,7 +855,8 @@ fn workspace_obeys_limit_when_target_branch_is_missing() -> anyhow::Result<()> {
         "But with workspace and target, we see everything"
     );
     // It's notable that there is no way to bypass the early abort when everything is integrated.
-    let graph = Graph::from_head(&repo, &*meta, standard_options().with_limit(0))?.validated()?;
+    let graph =
+        Graph::from_head(&repo, &*meta, standard_options().with_limit_hint(0))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r#"
     ├── 👉►►►:0:gitbutler/workspace
     │   └── ·4077353 (⌂|🏘️)❱"GitButler Workspace Commit"

--- a/crates/but-graph/tests/graph/utils.rs
+++ b/crates/but-graph/tests/graph/utils.rs
@@ -11,6 +11,7 @@ pub fn graph_tree(graph: &but_graph::Graph) -> SegmentTree {
         has_conflicts: bool,
         is_entrypoint: bool,
         is_early_end: bool,
+        hard_limit_hit: bool,
     ) -> SegmentTree {
         Graph::commit_debug_string(
             commit,
@@ -18,6 +19,7 @@ pub fn graph_tree(graph: &but_graph::Graph) -> SegmentTree {
             is_entrypoint,
             true, /* show message */
             is_early_end,
+            hard_limit_hit,
         )
         .into()
     }
@@ -94,6 +96,7 @@ pub fn graph_tree(graph: &but_graph::Graph) -> SegmentTree {
                 commit.has_conflicts,
                 segment_is_entrypoint && Some(cidx) == ep.commit_index,
                 graph.is_early_end_of_traversal(sidx, cidx),
+                graph.hard_limit_hit(),
             );
             if let Some(segment_indices) = connected_segments.get(&Some(cidx)) {
                 for sidx in segment_indices {

--- a/crates/but-graph/tests/graph/utils.rs
+++ b/crates/but-graph/tests/graph/utils.rs
@@ -93,7 +93,11 @@ pub fn graph_tree(graph: &but_graph::Graph) -> SegmentTree {
         for (cidx, commit) in segment.commits.iter().enumerate() {
             let mut commit_tree = tree_for_commit(
                 commit,
-                commit.has_conflicts,
+                commit
+                    .details
+                    .as_ref()
+                    .map(|d| d.has_conflicts)
+                    .unwrap_or_default(),
                 segment_is_entrypoint && Some(cidx) == ep.commit_index,
                 graph.is_early_end_of_traversal(sidx, cidx),
                 graph.hard_limit_hit(),

--- a/crates/but-graph/tests/graph/utils.rs
+++ b/crates/but-graph/tests/graph/utils.rs
@@ -11,8 +11,17 @@ pub fn graph_tree(graph: &but_graph::Graph) -> SegmentTree {
         extra: impl Into<Option<&'a str>>,
         has_conflicts: bool,
         is_entrypoint: bool,
+        is_early_end: bool,
     ) -> SegmentTree {
-        Graph::commit_debug_string(commit, extra, has_conflicts, is_entrypoint, true).into()
+        Graph::commit_debug_string(
+            commit,
+            extra,
+            has_conflicts,
+            is_entrypoint,
+            true, /* show message */
+            is_early_end,
+        )
+        .into()
     }
     fn recurse_segment(
         graph: &but_graph::Graph,
@@ -91,6 +100,7 @@ pub fn graph_tree(graph: &but_graph::Graph) -> SegmentTree {
                 },
                 commit.has_conflicts,
                 segment_is_entrypoint && Some(cidx) == ep.commit_index,
+                graph.is_early_end_of_traversal(sidx, cidx),
             );
             if let Some(segment_indices) = connected_segments.get(&Some(cidx)) {
                 for sidx in segment_indices {
@@ -104,15 +114,6 @@ pub fn graph_tree(graph: &but_graph::Graph) -> SegmentTree {
             for sidx in segment_indices {
                 root.push(recurse_segment(graph, *sidx, seen));
             }
-        }
-
-        for commit in segment.commits_unique_in_remote_tracking_branch.iter() {
-            root.push(tree_for_commit(
-                &commit.inner,
-                None,
-                commit.has_conflicts,
-                false, /* is_entrypoint */
-            ));
         }
 
         root

--- a/crates/but-graph/tests/graph/utils.rs
+++ b/crates/but-graph/tests/graph/utils.rs
@@ -1,4 +1,4 @@
-use but_graph::{EntryPoint, Graph, LocalCommitRelation, SegmentIndex};
+use but_graph::{EntryPoint, Graph, SegmentIndex};
 use std::collections::{BTreeMap, BTreeSet};
 use termtree::Tree;
 
@@ -6,16 +6,14 @@ type SegmentTree = Tree<String>;
 
 /// Visualize `graph` as a tree.
 pub fn graph_tree(graph: &but_graph::Graph) -> SegmentTree {
-    fn tree_for_commit<'a>(
+    fn tree_for_commit(
         commit: &but_graph::Commit,
-        extra: impl Into<Option<&'a str>>,
         has_conflicts: bool,
         is_entrypoint: bool,
         is_early_end: bool,
     ) -> SegmentTree {
         Graph::commit_debug_string(
             commit,
-            extra,
             has_conflicts,
             is_entrypoint,
             true, /* show message */
@@ -61,7 +59,7 @@ pub fn graph_tree(graph: &but_graph::Graph) -> SegmentTree {
 
         let mut root = Tree::new(format!(
             "{entrypoint}{kind}:{id}:{ref_name}{remote}",
-            id = segment.id,
+            id = segment.id.index(),
             kind = if segment.workspace_metadata().is_some() {
                 "►►►"
             } else {
@@ -93,11 +91,6 @@ pub fn graph_tree(graph: &but_graph::Graph) -> SegmentTree {
         for (cidx, commit) in segment.commits.iter().enumerate() {
             let mut commit_tree = tree_for_commit(
                 commit,
-                if commit.relation == LocalCommitRelation::LocalOnly {
-                    None
-                } else {
-                    Some(commit.relation.display(commit.id))
-                },
                 commit.has_conflicts,
                 segment_is_entrypoint && Some(cidx) == ep.commit_index,
                 graph.is_early_end_of_traversal(sidx, cidx),

--- a/crates/but-graph/tests/graph/vis.rs
+++ b/crates/but-graph/tests/graph/vis.rs
@@ -2,7 +2,7 @@
 
 use crate::graph_tree;
 use but_core::ref_metadata;
-use but_graph::{CommitFlags, Graph, LocalCommit, Segment, SegmentMetadata};
+use but_graph::{Commit, CommitFlags, Graph, Segment, SegmentMetadata};
 
 /// Simulate a graph data structure after the first pass, i.e., right after the walk.
 /// There is no pruning of 'empty' branches, just a perfect representation of the graph as is,
@@ -14,7 +14,7 @@ fn post_graph_traversal() -> anyhow::Result<()> {
     // The local target branch sets right at the base and typically doesn't have commits,
     // these are in the segments above it.
     let local_target = Segment {
-        id: 0,
+        id: 0.into(),
         ref_name: Some("refs/heads/main".try_into()?),
         remote_tracking_ref_name: Some("refs/remotes/origin/main".try_into()?),
         metadata: Some(SegmentMetadata::Workspace(ref_metadata::Workspace {
@@ -32,7 +32,7 @@ fn post_graph_traversal() -> anyhow::Result<()> {
         None,
         // A newly created branch which appears at the workspace base.
         Segment {
-            id: 1,
+            id: 1.into(),
             ref_name: Some("refs/heads/new-stack".try_into()?),
             ..Default::default()
         },
@@ -41,55 +41,48 @@ fn post_graph_traversal() -> anyhow::Result<()> {
     );
 
     let remote_to_local_target = Segment {
-        id: 2,
+        id: 2.into(),
         ref_name: Some("refs/remotes/origin/main".try_into()?),
-        commits: vec![local_commit(commit(
+        commits: vec![commit(
             id("c"),
             "remote: on top of main",
             Some(init_commit_id),
             CommitFlags::empty(),
-        ))],
+        )],
         ..Default::default()
     };
     graph.connect_new_segment(local_target, None, remote_to_local_target, 0, None);
 
     let branch = Segment {
-        id: 3,
+        id: 3.into(),
         ref_name: Some("refs/heads/A".try_into()?),
         remote_tracking_ref_name: Some("refs/remotes/origin/A".try_into()?),
         commits: vec![
-            LocalCommit {
+            Commit {
                 has_conflicts: true,
-                ..local_commit(commit(
+                ..commit(
                     id("a"),
                     "2 in A",
                     Some(init_commit_id),
                     CommitFlags::InWorkspace,
-                ))
+                )
             },
-            local_commit(commit(
-                init_commit_id,
-                "1 in A",
-                None,
-                CommitFlags::InWorkspace,
-            )),
+            commit(init_commit_id, "1 in A", None, CommitFlags::InWorkspace),
         ],
-        // Empty as we didn't process commits yet, right after graph traversal
-        commits_unique_in_remote_tracking_branch: vec![],
         metadata: None,
     };
     let branch = graph.connect_new_segment(local_target, None, branch, 0, None);
 
     let remote_to_root_branch = Segment {
-        id: 4,
+        id: 4.into(),
         ref_name: Some("refs/remotes/origin/A".try_into()?),
         commits: vec![
-            local_commit(commit(
+            commit(
                 id("b"),
                 "remote: on top of 1A",
                 Some(init_commit_id),
                 CommitFlags::empty(),
-            )),
+            ),
             // Note that the initial commit was assigned to the base segment already,
             // and we are connected to it.
             // This also means that local branches absorb commits preferably and that commit-traversal
@@ -118,12 +111,7 @@ fn post_graph_traversal() -> anyhow::Result<()> {
 fn detached_head() {
     let mut graph = Graph::default();
     graph.insert_root(Segment {
-        commits: vec![local_commit(commit(
-            id("a"),
-            "init",
-            None,
-            CommitFlags::empty(),
-        ))],
+        commits: vec![commit(id("a"), "init", None, CommitFlags::empty())],
         ..Default::default()
     });
     insta::assert_snapshot!(graph_tree(&graph), @r#"
@@ -138,7 +126,7 @@ fn unborn_head() {
 }
 
 mod utils {
-    use but_graph::{Commit, CommitFlags, LocalCommit};
+    use but_graph::{Commit, CommitFlags};
     use gix::ObjectId;
     use std::str::FromStr;
 
@@ -155,13 +143,6 @@ mod utils {
             author: author(),
             refs: Vec::new(),
             flags,
-        }
-    }
-
-    pub fn local_commit(commit: Commit) -> LocalCommit {
-        LocalCommit {
-            inner: commit,
-            relation: Default::default(),
             has_conflicts: false,
         }
     }
@@ -188,4 +169,4 @@ mod utils {
         }
     }
 }
-use utils::{commit, id, local_commit};
+use utils::{commit, id};

--- a/crates/but-graph/tests/graph/vis.rs
+++ b/crates/but-graph/tests/graph/vis.rs
@@ -2,7 +2,7 @@
 
 use crate::graph_tree;
 use but_core::ref_metadata;
-use but_graph::{Commit, CommitFlags, Graph, Segment, SegmentMetadata};
+use but_graph::{Commit, CommitDetails, CommitFlags, Graph, Segment, SegmentMetadata};
 
 /// Simulate a graph data structure after the first pass, i.e., right after the walk.
 /// There is no pruning of 'empty' branches, just a perfect representation of the graph as is,
@@ -59,10 +59,14 @@ fn post_graph_traversal() -> anyhow::Result<()> {
         remote_tracking_ref_name: Some("refs/remotes/origin/A".try_into()?),
         commits: vec![
             Commit {
-                has_conflicts: true,
+                details: Some(CommitDetails {
+                    has_conflicts: true,
+                    author: author(),
+                    message: "2 in A".into(),
+                }),
                 ..commit(
                     id("a"),
-                    "2 in A",
+                    "overridden above",
                     Some(init_commit_id),
                     CommitFlags::InWorkspace,
                 )
@@ -126,7 +130,7 @@ fn unborn_head() {
 }
 
 mod utils {
-    use but_graph::{Commit, CommitFlags};
+    use but_graph::{Commit, CommitDetails, CommitFlags};
     use gix::ObjectId;
     use std::str::FromStr;
 
@@ -139,11 +143,13 @@ mod utils {
         Commit {
             id,
             parent_ids: parent_ids.into_iter().collect(),
-            message: message.into(),
-            author: author(),
             refs: Vec::new(),
             flags,
-            has_conflicts: false,
+            details: Some(CommitDetails {
+                message: message.into(),
+                author: author(),
+                has_conflicts: false,
+            }),
         }
     }
 
@@ -161,7 +167,7 @@ mod utils {
         .unwrap()
     }
 
-    fn author() -> gix::actor::Signature {
+    pub fn author() -> gix::actor::Signature {
         gix::actor::Signature {
             name: "Name".into(),
             email: "name@example.com".into(),
@@ -169,4 +175,4 @@ mod utils {
         }
     }
 }
-use utils::{commit, id};
+use utils::{author, commit, id};

--- a/crates/but-graph/tests/graph/vis.rs
+++ b/crates/but-graph/tests/graph/vis.rs
@@ -105,9 +105,9 @@ fn post_graph_traversal() -> anyhow::Result<()> {
         │   ├── 🟣💥aaaaaaa (🏘️)❱"2 in A"
         │   └── 🟣febafeb (🏘️)❱"1 in A"
         │       └── ►:4:origin/A
-        │           └── 🟣bbbbbbb❱"remote: on top of 1A"
+        │           └── ✂️🟣bbbbbbb❱"remote: on top of 1A"
         ├── ►:2:origin/main
-        │   └── 🟣ccccccc❱"remote: on top of main"
+        │   └── ✂️🟣ccccccc❱"remote: on top of main"
         └── ►:1:new-stack
     "#);
 

--- a/crates/but-testing/src/args.rs
+++ b/crates/but-testing/src/args.rs
@@ -150,6 +150,21 @@ pub enum Subcommands {
         /// The name of the ref to get workspace information for.
         ref_name: Option<String>,
     },
+    /// Returns a segmented graph starting from `HEAD`.
+    Graph {
+        /// The amount of commits to traverse in non-workspace regions.
+        /// Specifying no limit with `--limit` removes all limits.
+        #[clap(long, short = 'l', default_value = "300")]
+        limit: Option<Option<usize>>,
+        /// Refill the limit when running over these hashes, provided as short or long hash.
+        #[clap(long, short = 'e')]
+        limit_extension: Vec<String>,
+        /// Avoid opening the resulting dot-file and instead write it to standard output.
+        #[clap(long)]
+        no_open: bool,
+        /// The name of the ref to start the graph traversal at.
+        ref_name: Option<String>,
+    },
     /// Return all stack branches related to the given `id`.
     StackBranches {
         /// The ID of the stack to list branches from.

--- a/crates/but-testing/src/args.rs
+++ b/crates/but-testing/src/args.rs
@@ -152,7 +152,13 @@ pub enum Subcommands {
     },
     /// Returns a segmented graph starting from `HEAD`.
     Graph {
-        /// The amount of commits to traverse in non-workspace regions.
+        /// The maximum number of commits to traverse.
+        ///
+        /// Use only as safety net to prevent runaways.
+        #[clap(long)]
+        hard_limit: Option<usize>,
+        /// The hint of the number of commits to traverse.
+        ///
         /// Specifying no limit with `--limit` removes all limits.
         #[clap(long, short = 'l', default_value = "300")]
         limit: Option<Option<usize>>,

--- a/crates/but-testing/src/args.rs
+++ b/crates/but-testing/src/args.rs
@@ -152,6 +152,9 @@ pub enum Subcommands {
     },
     /// Returns a segmented graph starting from `HEAD`.
     Graph {
+        /// Debug-print the whole graph.
+        #[clap(long, short = 'd')]
+        debug: bool,
         /// The maximum number of commits to traverse.
         ///
         /// Use only as safety net to prevent runaways.

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -549,17 +549,7 @@ pub fn graph(
         }
     }?;
 
-    eprintln!(
-        "Graph with {num_segments} segments ({num_remote_segments} of which remote), {num_edges} edges and {num_commits} commits{hard_limit}",
-        num_segments = graph.num_segments(),
-        num_edges = graph.num_edges(),
-        num_commits = graph.num_commits(),
-        num_remote_segments = graph.num_remote_segments(),
-        hard_limit = graph
-            .hard_limit_hit()
-            .then_some(" (HARD LIMIT REACHED)")
-            .unwrap_or_default()
-    );
+    eprintln!("{:#?}", graph.statistics());
     if no_open {
         stdout().write_all(graph.dot_graph().as_bytes())?;
     } else {

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -504,6 +504,7 @@ pub fn graph(
     limit: Option<usize>,
     limit_extension: Vec<String>,
     hard_limit: Option<usize>,
+    debug: bool,
 ) -> anyhow::Result<()> {
     let (mut repo, project) = repo_and_maybe_project(args, RepositoryOpenMode::General)?;
     repo.objects.refresh = RefreshMode::Never;
@@ -549,12 +550,20 @@ pub fn graph(
         }
     }?;
 
+    let errors = graph.validation_errors();
+    if !errors.is_empty() {
+        eprintln!("VALIDATION FAILED: {errors:?}");
+    }
     eprintln!("{:#?}", graph.statistics());
     if no_open {
         stdout().write_all(graph.dot_graph().as_bytes())?;
     } else {
         #[cfg(unix)]
         graph.open_as_svg();
+    }
+
+    if debug {
+        eprintln!("{graph:#?}");
     }
     Ok(())
 }

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -5,6 +5,9 @@ use but_settings::AppSettings;
 use but_workspace::{DiffSpec, HunkHeader};
 use gitbutler_project::{Project, ProjectId};
 use gix::bstr::{BString, ByteSlice};
+use gix::odb::store::RefreshMode;
+use std::io::{Write, stdout};
+use std::mem::ManuallyDrop;
 use std::path::Path;
 use tokio::sync::mpsc::unbounded_channel;
 
@@ -492,6 +495,72 @@ pub fn ref_info(args: &super::Args, ref_name: Option<&str>, expensive: bool) -> 
         None => but_workspace::head_info(&repo, &meta, opts),
         Some(ref_name) => but_workspace::ref_info(repo.find_reference(ref_name)?, &meta, opts),
     }?)
+}
+
+pub fn graph(
+    args: &super::Args,
+    ref_name: Option<&str>,
+    no_open: bool,
+    limit: Option<usize>,
+    limit_extension: Vec<String>,
+) -> anyhow::Result<()> {
+    let (mut repo, project) = repo_and_maybe_project(args, RepositoryOpenMode::General)?;
+    repo.objects.refresh = RefreshMode::Never;
+    let opts = but_graph::init::Options {
+        collect_tags: true,
+        commits_limit_hint: limit,
+        commits_limit_recharge_location: limit_extension
+            .into_iter()
+            .map(|short_hash| {
+                repo.objects
+                    .lookup_prefix(
+                        gix::hash::Prefix::from_hex(&short_hash).expect("valid hex prefix"),
+                        None,
+                    )
+                    .unwrap()
+                    .expect("object for prefix exists")
+                    .expect("the prefix is unambiguous")
+            })
+            .collect(),
+    };
+
+    let meta_with_drop;
+    let meta_without_drop;
+    let meta = match project {
+        None => {
+            meta_without_drop = ManuallyDrop::new(VirtualBranchesTomlMetadata::from_path(
+                "should-never-be-written-back.toml",
+            )?);
+            &meta_without_drop
+        }
+        Some(project) => {
+            meta_with_drop = ref_metadata_toml(&project)?;
+            &meta_with_drop
+        }
+    };
+    let graph = match ref_name {
+        None => but_graph::Graph::from_head(&repo, meta, opts),
+        Some(ref_name) => {
+            let mut reference = repo.find_reference(ref_name)?;
+            let id = reference.peel_to_id_in_place()?;
+            but_graph::Graph::from_commit_traversal(id, reference.name().to_owned(), meta, opts)
+        }
+    }?;
+
+    eprintln!(
+        "Graph with {num_segments}, {num_edges} edges and {num_commits} commits",
+        num_segments = graph.num_segments(),
+        num_edges = graph.num_edges(),
+        num_commits = graph.num_commits()
+    );
+    if no_open {
+        stdout().write_all(graph.dot_graph().as_bytes())?;
+    } else if cfg!(unix) {
+        graph.open_as_svg();
+    } else {
+        bail!("Can't show SVG on non-unix")
+    }
+    Ok(())
 }
 
 fn indices_or_headers_to_hunk_headers(

--- a/crates/but-testing/src/main.rs
+++ b/crates/but-testing/src/main.rs
@@ -114,12 +114,14 @@ async fn main() -> Result<()> {
             no_open,
             limit,
             limit_extension,
+            hard_limit,
         } => command::graph(
             &args,
             ref_name.as_deref(),
             *no_open,
             limit.flatten(),
             limit_extension.clone(),
+            *hard_limit,
         ),
         args::Subcommands::HunkAssignments => {
             command::assignment::hunk_assignments(&args.current_dir, args.json)

--- a/crates/but-testing/src/main.rs
+++ b/crates/but-testing/src/main.rs
@@ -109,6 +109,18 @@ async fn main() -> Result<()> {
             ref_name,
             expensive,
         } => command::ref_info(&args, ref_name.as_deref(), *expensive),
+        args::Subcommands::Graph {
+            ref_name,
+            no_open,
+            limit,
+            limit_extension,
+        } => command::graph(
+            &args,
+            ref_name.as_deref(),
+            *no_open,
+            limit.flatten(),
+            limit_extension.clone(),
+        ),
         args::Subcommands::HunkAssignments => {
             command::assignment::hunk_assignments(&args.current_dir, args.json)
         }

--- a/crates/but-testing/src/main.rs
+++ b/crates/but-testing/src/main.rs
@@ -115,6 +115,7 @@ async fn main() -> Result<()> {
             limit,
             limit_extension,
             hard_limit,
+            debug,
         } => command::graph(
             &args,
             ref_name.as_deref(),
@@ -122,6 +123,7 @@ async fn main() -> Result<()> {
             limit.flatten(),
             limit_extension.clone(),
             *hard_limit,
+            *debug,
         ),
         args::Subcommands::HunkAssignments => {
             command::assignment::hunk_assignments(&args.current_dir, args.json)

--- a/crates/but-workspace/src/branch.rs
+++ b/crates/but-workspace/src/branch.rs
@@ -412,10 +412,9 @@
 //!                                      walk along.
 //! ```
 
-use crate::StashStatus;
+use crate::{StashStatus, ref_info};
 use anyhow::{Context, bail};
 use but_core::RefMetadata;
-use but_graph::Segment;
 use gix::prelude::ObjectIdExt;
 
 /// The result of [`add_branch_to_workspace`].
@@ -501,7 +500,7 @@ pub struct Stack {
     pub base: Option<gix::ObjectId>,
     /// The branch-name denoted segments of the stack from its tip to the point of reference, typically a merge-base.
     /// This array is never empty.
-    pub segments: Vec<Segment>,
+    pub segments: Vec<ref_info::ui::Segment>,
     /// Additional information about possibly still available stashes, sitting on top of this stack.
     ///
     /// This means the stash is still there to be applied, something that can happen if the user switches branches
@@ -535,6 +534,6 @@ impl Stack {
 }
 
 /// Return all stack segments within the given `stack`.
-pub fn stack_segments(stack: Stack) -> anyhow::Result<Vec<Segment>> {
+pub fn stack_segments(stack: Stack) -> anyhow::Result<Vec<ref_info::ui::Segment>> {
     todo!()
 }

--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -21,14 +21,246 @@ pub struct Options {
     pub expensive_commit_info: bool,
 }
 
+/// Types driven by the user interface, not general purpose.
+pub mod ui {
+    use but_graph::{Commit, CommitFlags, SegmentMetadata};
+    use std::ops::{Deref, DerefMut};
+
+    /// A commit that is reachable through the *local tracking branch*, with additional, computed information.
+    #[derive(Clone, Eq, PartialEq)]
+    pub struct LocalCommit {
+        /// The simple commit.
+        pub inner: Commit,
+        /// Provide additional information on how this commit relates to other points of reference, like its remote branch,
+        /// or the target branch to integrate with.
+        pub relation: LocalCommitRelation,
+    }
+
+    impl std::fmt::Debug for LocalCommit {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let refs = self
+                .refs
+                .iter()
+                .map(|rn| format!("►{}", rn.shorten()))
+                .collect::<Vec<_>>()
+                .join(", ");
+            write!(
+                f,
+                "LocalCommit({conflict}{hash}, {msg:?}, {relation}{refs})",
+                conflict = if self.has_conflicts { "💥" } else { "" },
+                hash = self.id.to_hex_with_len(7),
+                msg = self.message,
+                relation = self.relation.display(self.id),
+                refs = if refs.is_empty() {
+                    "".to_string()
+                } else {
+                    format!(", {refs}")
+                }
+            )
+        }
+    }
+
+    impl LocalCommit {
+        /// Create a new branch-commit, along with default values for the non-commit fields.
+        // TODO: remove this function once ref_info code doesn't need it anymore (i.e. mapping is implemented).
+        pub fn new_from_id(value: gix::Id<'_>, flags: CommitFlags) -> anyhow::Result<Self> {
+            Ok(LocalCommit {
+                inner: Commit::new_from_id(value, flags, false)?,
+                relation: LocalCommitRelation::LocalOnly,
+            })
+        }
+    }
+
+    /// The state of the [local commit](LocalCommit) in relation to its remote tracking branch or its integration branch.
+    #[derive(Default, Debug, Eq, PartialEq, Clone, Copy)]
+    pub enum LocalCommitRelation {
+        /// The commit is only local
+        #[default]
+        LocalOnly,
+        /// The commit is also present in the remote tracking branch.
+        ///
+        /// This is the case if:
+        ///  - The commit has been pushed to the remote
+        ///  - The commit has been copied from a remote commit (when applying a remote branch)
+        ///
+        /// This variant carries the remote commit id.
+        /// The `remote_commit_id` may be the same as the `id` or it may be different if the local commit has been rebased
+        /// or updated in another way.
+        LocalAndRemote(gix::ObjectId),
+        /// The commit is considered integrated.
+        /// This should happen when the commit or the contents of this commit is already part of the base.
+        Integrated,
+    }
+
+    impl LocalCommitRelation {
+        /// Convert this relation into something displaying, mainly for debugging.
+        pub fn display(&self, id: gix::ObjectId) -> &'static str {
+            match self {
+                LocalCommitRelation::LocalOnly => "local",
+                LocalCommitRelation::LocalAndRemote(remote_id) => {
+                    if *remote_id == id {
+                        "local/remote(identity)"
+                    } else {
+                        "local/remote(similarity)"
+                    }
+                }
+                LocalCommitRelation::Integrated => "integrated",
+            }
+        }
+    }
+
+    impl Deref for LocalCommit {
+        type Target = Commit;
+
+        fn deref(&self) -> &Self::Target {
+            &self.inner
+        }
+    }
+
+    impl DerefMut for LocalCommit {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.inner
+        }
+    }
+
+    /// A commit that is reachable only through the *remote tracking branch*, with additional, computed information.
+    ///
+    /// TODO: Remote commits can also be integrated, without the local branch being all caught up. Currently we can't represent that.
+    #[derive(Clone, Eq, PartialEq)]
+    pub struct RemoteCommit {
+        /// The simple commit.
+        pub inner: Commit,
+        /// Whether the commit is in a conflicted state, a GitButler concept.
+        /// GitButler will perform rebasing/reordering etc. without interruptions and flag commits as conflicted if needed.
+        /// Conflicts are resolved via the Edit Mode mechanism.
+        ///
+        /// Note that even though GitButler won't push branches with conflicts, the user can still push such branches at will.
+        /// For remote commits, this only happens if someone manually pushed them.
+        pub has_conflicts: bool,
+    }
+
+    impl std::fmt::Debug for RemoteCommit {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(
+                f,
+                "RemoteCommit({conflict}{hash}, {msg:?}",
+                conflict = if self.has_conflicts { "💥" } else { "" },
+                hash = self.id.to_hex_with_len(7),
+                msg = self.message,
+            )
+        }
+    }
+
+    impl Deref for RemoteCommit {
+        type Target = Commit;
+
+        fn deref(&self) -> &Self::Target {
+            &self.inner
+        }
+    }
+
+    impl DerefMut for RemoteCommit {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.inner
+        }
+    }
+
+    /// A segment of a commit graph, representing a set of commits exclusively.
+    #[derive(Default, Clone, Eq, PartialEq)]
+    pub struct Segment {
+        /// The unambiguous or disambiguated name of the branch at the tip of the segment, i.e. at the first commit.
+        ///
+        /// It is `None` if this branch is the top-most stack segment and the `ref_name` wasn't pointing to
+        /// a commit anymore that was reached by our rev-walk.
+        /// This can happen if the ref is deleted, or if it was advanced by other means.
+        /// Alternatively, the naming would have been ambiguous.
+        /// Finally, this is `None` of the original name can be found searching upwards, finding exactly one
+        /// named segment.
+        pub ref_name: Option<gix::refs::FullName>,
+        /// An ID which can uniquely identify this segment among all segments within the graph that owned it.
+        /// Note that it's not suitable to permanently identify the segment, so should not be persisted.
+        pub id: usize,
+        /// The name of the remote tracking branch of this segment, if present, i.e. `refs/remotes/origin/main`.
+        /// Its presence means that a remote is configured and that the stack content
+        pub remote_tracking_ref_name: Option<gix::refs::FullName>,
+        /// The portion of commits that can be reached from the tip of the *branch* downwards, so that they are unique
+        /// for that stack segment and not included in any other stack or stack segment.
+        ///
+        /// The list could be empty for when this is a dedicated empty segment as insertion position of commits.
+        pub commits: Vec<LocalCommit>,
+        /// Commits that are reachable from the remote-tracking branch associated with this branch,
+        /// but are not reachable from this branch or duplicated by a commit in it.
+        /// Note that commits that are also similar to commits in `commits` are pruned, and not present here.
+        ///
+        /// Note that remote commits along with their remote tracking branch should always retain a shared history
+        /// with the local tracking branch. If these diverge, we can represent this in data, but currently there is
+        /// no derived value to make this visible explicitly.
+        pub commits_unique_in_remote_tracking_branch: Vec<RemoteCommit>,
+        /// Read-only metadata with additional information, or `None` if nothing was present.
+        pub metadata: Option<SegmentMetadata>,
+    }
+
+    /// Direct Access (without graph)
+    impl Segment {
+        /// Return the top-most commit id of the segment.
+        pub fn tip(&self) -> Option<gix::ObjectId> {
+            self.commits.first().map(|commit| commit.id)
+        }
+    }
+
+    impl std::fmt::Debug for Segment {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let Segment {
+                ref_name,
+                id,
+                commits,
+                commits_unique_in_remote_tracking_branch,
+                remote_tracking_ref_name,
+                metadata,
+            } = self;
+            f.debug_struct("StackSegment")
+                .field("id", &id)
+                .field(
+                    "ref_name",
+                    &match ref_name.as_ref() {
+                        None => "None".to_string(),
+                        Some(name) => name.to_string(),
+                    },
+                )
+                .field(
+                    "remote_tracking_ref_name",
+                    &match remote_tracking_ref_name.as_ref() {
+                        None => "None".to_string(),
+                        Some(name) => name.to_string(),
+                    },
+                )
+                .field("commits", &commits)
+                .field(
+                    "commits_unique_in_remote_tracking_branch",
+                    &commits_unique_in_remote_tracking_branch,
+                )
+                .field(
+                    "metadata",
+                    match metadata {
+                        None => &"None",
+                        Some(SegmentMetadata::Branch(m)) => m,
+                        Some(SegmentMetadata::Workspace(m)) => m,
+                    },
+                )
+                .finish()
+        }
+    }
+}
+
 pub(crate) mod function {
+    use super::ui::{LocalCommit, LocalCommitRelation, RemoteCommit, Segment};
     use crate::branch::Stack;
     use crate::integrated::{IsCommitIntegrated, MergeBaseCommitGraph};
     use crate::{RefInfo, WorkspaceCommit};
     use anyhow::bail;
     use bstr::BString;
     use but_core::ref_metadata::{ValueInfo, Workspace, WorkspaceStack};
-    use but_graph::{CommitFlags, LocalCommit, LocalCommitRelation, RemoteCommit, Segment};
+    use but_graph::CommitFlags;
     use but_graph::{SegmentMetadata, is_workspace_ref_name};
     use gix::prelude::{ObjectIdExt, ReferenceExt};
     use gix::refs::{Category, FullName};

--- a/crates/but-workspace/src/stacks.rs
+++ b/crates/but-workspace/src/stacks.rs
@@ -1,5 +1,5 @@
 use crate::integrated::IsCommitIntegrated;
-use crate::ref_info::ui::Segment;
+use crate::ref_info::ui::{Commit, Segment};
 use crate::ref_info::ui::{LocalCommit, LocalCommitRelation, RemoteCommit};
 use crate::ui::{CommitState, PushStatus, StackDetails};
 use crate::{
@@ -8,7 +8,7 @@ use crate::{
 use anyhow::Context;
 use bstr::BString;
 use but_core::RefMetadata;
-use but_graph::{Commit, SegmentMetadata, VirtualBranchesTomlMetadata};
+use but_graph::{SegmentMetadata, VirtualBranchesTomlMetadata};
 use gitbutler_command_context::CommandContext;
 use gitbutler_commit::commit_ext::CommitExt;
 use gitbutler_oxidize::{ObjectIdExt, OidExt, git2_signature_to_gix_signature};

--- a/crates/but-workspace/src/stacks.rs
+++ b/crates/but-workspace/src/stacks.rs
@@ -1,4 +1,6 @@
 use crate::integrated::IsCommitIntegrated;
+use crate::ref_info::ui::Segment;
+use crate::ref_info::ui::{LocalCommit, LocalCommitRelation, RemoteCommit};
 use crate::ui::{CommitState, PushStatus, StackDetails};
 use crate::{
     RefInfo, StacksFilter, branch, head_info, id_from_name_v2_to_v3, ref_info, state_handle, ui,
@@ -6,10 +8,7 @@ use crate::{
 use anyhow::Context;
 use bstr::BString;
 use but_core::RefMetadata;
-use but_graph::{
-    Commit, LocalCommit, LocalCommitRelation, RemoteCommit, Segment, SegmentMetadata,
-    VirtualBranchesTomlMetadata,
-};
+use but_graph::{Commit, SegmentMetadata, VirtualBranchesTomlMetadata};
 use gitbutler_command_context::CommandContext;
 use gitbutler_commit::commit_ext::CommitExt;
 use gitbutler_oxidize::{ObjectIdExt, OidExt, git2_signature_to_gix_signature};
@@ -564,8 +563,9 @@ impl From<&RemoteCommit> for ui::UpstreamCommit {
                     refs: _,
                     // TODO: also pass flags for the frontend.
                     flags: _,
+                    // TODO: Represent this in the UI (maybe) and/or deal with divergence of the local and remote tracking branch.
+                    has_conflicts: _,
                 },
-            // TODO: Represent this in the UI (maybe) and/or deal with divergence of the local and remote tracking branch.
             has_conflicts: _,
         }: &RemoteCommit,
     ) -> Self {
@@ -593,9 +593,9 @@ impl From<&LocalCommit> for ui::Commit {
                     refs: _,
                     // TODO: also flags refs
                     flags: _,
+                    has_conflicts,
                 },
             relation,
-            has_conflicts,
         }: &LocalCommit,
     ) -> Self {
         ui::Commit {


### PR DESCRIPTION
Produce a datastructure that can represent any commit-graph as segments, which is the level of detail that we are interested in.
These segments can be traversed forward and backwards, and they know the commits that are uniquely assigned to it.
Segments can have inter-segment relations, to help with dealing with related remote tracking branches.


### Tasks

- [x] integrate the target branch
    - ~~make sure that integrated commits can be hidden (for instance, new (virtual) stacks shoudn't have a commit.~~ - this is more of a thing for the mapping later where more commit-cleanup is performed.
    - [x] early abort should work as well, check the queue to stop if there is only 'hidden' tips left.
    - [x] optional limit at abort after Y commits have been traversed
        - [x] assure we handle missing target refs (test) (limits apply to workspaces then)
- [x] CLI for opening graphs (with or without workspace, with ref support just like ref-info)
    - [x] make it work for webkit
    - [x] make it work for the linux kernel
    - [x] make `limit` work correctly in conjunction with remote tracking branches
    - [x] figure out what's going on in the GitLab workspace
        - worst case integrated branch tracking, and inability to go past workspace abort condition
    - [x] fix performance regression
        - [x] entrypoint must be goal
        - [x] linux: doesn't traverse remote branch
        - [x] gitlab: doesn't connect future to present
            - [x] source tracking along with goals
            - [x] ~~*possibly*: allow goals to not auto-clear their tips if one tip found the goal for longer searches, but assure it can always stop of the goal itself was found.~~ - no such clearing, everything must fully reconcile

### Mapping PR

- [ ] map graphs to stacks.
    - [ ] special handling for limit to handle bad overshoots in large repos.
- [ ] Integrate into `ref-info`
     - [ ] make sure all existing tests work and/or are adapted
- [ ] GitLab
    - [ ] Why does Lane 5 not get picked up as named segment, despite it being in the workspace? Problem is that target didn't fully catch up, and first commit in lane should be seen as integrated.

### For next PR (wrapup)

- [ ] add 'insert multi-segments above' capability for more natural reconciled graphs.
- [ ] split across stacks (those that are resting at the target ref (or maybe the merge base?))
    - We must be able to split out stacks of empty commits resting at the base, that is segments that will be mapped into stacks later. For that we connect them to the governing workspace.
- [ ] ⚠️ fix related TODOs and known issues
- [ ] ⚠️assure parent-order is correct during traversal (must match parents in merge commits)
- [ ] Show how typical segment-walks can now be facilitated with standard algorithms

### Not to forget

* ⚠️ current implementation supports multiple workspaces *in theory*, but it's not tested with them as the underlying ref-metadata is still VB-toml. So before supporting this, we probably already want to have migrated away from vb.toml, to then port the ref-metadata to something that can support more workspaces (also for testing).
* ⚠️ we probably don't correctly handle workspaces that include other workspaces.
* ⚠️ we probably don't handle [dot-repositories](https://git-scm.com/docs/git-config#Documentation/git-config.txt-branchltnamegtmerge) correctly, by merit of not really having them in mind. At least they shouldn't be in the way of handling normal remotes.

### Problems this should solve

This PR should allow us to see if this is the right way to go, as it should solve a couple of problems, all at once:

* [x] make complex commit-graphs graspable
    - Even though there are limits inherent to the tree-view, but it seems to do well enough for our idea of stacks.
* [x] make any commit-graph representable
  * [x] map any such graph to stacks
* [x] make complex workspace updates possible
    - [x] imagine updates to the rebase-engine to be able to transplant complex graphs as well
        - This would work by having well-known operations, supporting only one at a time for now, and then to return
           a pick-list for the rebase engine that can be reviewed before actually running it (i.e. dry-run built-in).

### Related

* #8905

### Previous

* #8919
* #8935
