### PR TITLE
fix: typo

### DIFF
--- a/apps/desktop/src/components/v3/MultiStackView.svelte
+++ b/apps/desktop/src/components/v3/MultiStackView.svelte
@@ -107,7 +107,7 @@
 					href={branchesPath(projectId)}>Branches view</a
 				>
 			{:else}
-				Drag chanes here to
+				Drag changes here to
 				<br />
 				branch off your changes
 			{/if}


### PR DESCRIPTION
## 🧢 Changes
Fix typo `chanes` to `changes`