### PR TITLE
fix-amend-hunk-assignments

### DIFF
--- a/apps/desktop/src/lib/commits/dropHandler.ts
+++ b/apps/desktop/src/lib/commits/dropHandler.ts
@@ -110,7 +110,8 @@ export class AmendCommitWithChangeDzHandler implements DropzoneHandler {
 				console.warn('Moving a branch into a commit is an invalid operation');
 				break;
 			case 'worktree': {
-				const diffSpec = changesToDiffSpec(await data.treeChanges());
+				const assignments = data.assignments();
+				const diffSpec = changesToDiffSpec(await data.treeChanges(), assignments);
 				return this.onresult(
 					await this.trigger({
 						projectId: this.projectId,

--- a/apps/desktop/src/lib/commits/utils.ts
+++ b/apps/desktop/src/lib/commits/utils.ts
@@ -1,6 +1,7 @@
+import { isDefined } from '@gitbutler/ui/utils/typeguards';
 import type { DetailedCommit } from '$lib/commits/commit';
 import type { TreeChange } from '$lib/hunks/change';
-import type { DiffSpec } from '$lib/hunks/hunk';
+import type { DiffSpec, HunkAssignment } from '$lib/hunks/hunk';
 
 type DivergenceResult =
 	| { type: 'localDiverged'; commit: DetailedCommit }
@@ -35,14 +36,20 @@ export function findLastDivergentCommit(
 	return { type: 'notDiverged' };
 }
 /** Helper function that turns tree changes into a diff spec */
-export function changesToDiffSpec(changes: TreeChange[]): DiffSpec[] {
+export function changesToDiffSpec(
+	changes: TreeChange[],
+	assignments?: Record<string, HunkAssignment[]>
+): DiffSpec[] {
 	return changes.map((change) => {
 		const previousPathBytes =
 			change.status.type === 'Rename' ? change.status.subject.previousPathBytes : null;
+		const assignment = assignments?.[change.path];
+		const hunkHeaders = assignment?.map((a) => a.hunkHeader).filter(isDefined) ?? [];
+
 		return {
 			previousPathBytes,
 			pathBytes: change.pathBytes,
-			hunkHeaders: []
+			hunkHeaders
 		};
 	});
 }

--- a/apps/desktop/src/lib/dragging/draggables.ts
+++ b/apps/desktop/src/lib/dragging/draggables.ts
@@ -4,7 +4,7 @@ import type { AnyCommit } from '$lib/commits/commit';
 import type { CommitDropData } from '$lib/commits/dropHandler';
 import type { AnyFile } from '$lib/files/file';
 import type { TreeChange } from '$lib/hunks/change';
-import type { Hunk, HunkHeader, HunkLock } from '$lib/hunks/hunk';
+import type { Hunk, HunkAssignment, HunkHeader, HunkLock } from '$lib/hunks/hunk';
 import type { IdSelection } from '$lib/selection/idSelection.svelte';
 
 export const NON_DRAGGABLE = {
@@ -70,6 +70,13 @@ export class ChangeDropData {
 			return await this.selection.treeChanges(this.projectId, this.selectionId);
 		}
 		return [this.change];
+	}
+
+	assignments(): Record<string, HunkAssignment[]> | undefined {
+		if (this.selection.has(this.change.path, this.selectionId)) {
+			return this.selection.hunkAssignments(this.selectionId) ?? undefined;
+		}
+		return undefined;
 	}
 
 	get isCommitted(): boolean {

--- a/apps/desktop/src/lib/selection/idSelection.svelte.ts
+++ b/apps/desktop/src/lib/selection/idSelection.svelte.ts
@@ -9,6 +9,7 @@ import {
 import { SvelteSet } from 'svelte/reactivity';
 import { get, writable, type Writable } from 'svelte/store';
 import type { TreeChange } from '$lib/hunks/change';
+import type { HunkAssignment } from '$lib/hunks/hunk';
 import type { UncommittedService } from '$lib/selection/uncommittedService.svelte';
 import type { StackService } from '$lib/stacks/stackService.svelte';
 
@@ -141,6 +142,27 @@ export class IdSelection {
 				return await this.stackService.commitChangesByPaths(projectId, params.commitId, paths);
 			case 'snapshot':
 				throw new Error('unsupported');
+		}
+	}
+
+	/**
+	 * Retrieve the hunk assignments for the current selection.
+	 *
+	 * Hunk assignments are only relevant when selecting worktree files.
+	 * For branches, commits, and snapshots, this will return null.
+	 */
+	hunkAssignments(params: SelectionId): Record<string, HunkAssignment[]> | null {
+		switch (params.type) {
+			case 'worktree': {
+				const paths = this.values(params).map((fileSelection) => {
+					return fileSelection.path;
+				});
+				return this.uncommittedService.getAssignmentsByPaths(params.stackId || null, paths);
+			}
+			case 'branch':
+			case 'commit':
+			case 'snapshot':
+				return null;
 		}
 	}
 

--- a/apps/desktop/src/lib/selection/uncommittedService.svelte.ts
+++ b/apps/desktop/src/lib/selection/uncommittedService.svelte.ts
@@ -275,7 +275,8 @@ export class UncommittedService {
 	}
 
 	getChangesByStackId(stackId: string | null): TreeChange[] {
-		return uncommittedSelectors.treeChanges.selectByStackId(this.state, stackId);
+		const stackIdChanges = uncommittedSelectors.treeChanges.selectByStackId(this.state, stackId);
+		return stackIdChanges;
 	}
 
 	changesByStackId(stackId: string | null): Reactive<TreeChange[]> {
@@ -288,6 +289,14 @@ export class UncommittedService {
 			this.state.hunkAssignments,
 			partialKey(stackId, path)
 		);
+	}
+
+	getAssignmentsByPaths(stackId: string | null, paths: string[]): Record<string, HunkAssignment[]> {
+		const assignments: Record<string, HunkAssignment[]> = {};
+		for (const path of paths) {
+			assignments[path] = this.getAssignmentsByPath(stackId, path);
+		}
+		return assignments;
 	}
 
 	getAssignmentsByStackId(stackId: string): HunkAssignment[] {


### PR DESCRIPTION
- Added logic to retrieve hunk assignments for current selections, limited to worktree files.
- Extended uncommittedService to support assignment retrieval by single and multiple paths.
- Updated amend functionality to read and apply hunk assignments when amending files into commits.
- Modified drop handler and utils to process hunk assignments, ensuring only selected hunks are amended.
- Integrated hunk assignment logic into draggable components for improved drag and drop operations.