### PR TITLE
Fix inability to drag changes between branches

### DIFF
--- a/apps/desktop/src/components/v3/BranchCard.svelte
+++ b/apps/desktop/src/components/v3/BranchCard.svelte
@@ -124,7 +124,7 @@
 		{#if !args.prNumber}
 			<PrNumberUpdater {projectId} stackId={args.stackId} {branchName} />
 		{/if}
-		<Dropzone handlers={[moveHandler]}>
+		<Dropzone handlers={args.first ? [moveHandler] : []}>
 			{#snippet overlay({ hovered, activated, handler })}
 				{@const label = handler instanceof MoveCommitDzHandler ? 'Move here' : 'Start commit'}
 				<CardOverlay {hovered} {activated} {label} />

--- a/apps/desktop/src/components/v3/BranchCommitList.svelte
+++ b/apps/desktop/src/components/v3/BranchCommitList.svelte
@@ -233,6 +233,8 @@
 			/>
 		{/if}
 
+		{@render commitReorderDz(stackingReorderDropzoneManager.top(branchName))}
+
 		{#if hasCommits}
 			<div class="commit-list hide-when-empty">
 				{#if hasRemoteCommits}
@@ -280,8 +282,6 @@
 						</CommitAction>
 					</CommitsAccordion>
 				{/if}
-
-				{@render commitReorderDz(stackingReorderDropzoneManager.top(branchName))}
 
 				{#each localAndRemoteCommits as commit, i (commit.id)}
 					{@const first = i === 0}


### PR DESCRIPTION
- The MoveCommitDzHandler looks like the obvious candidate, but it is "correctly" only responsible for moving commits between parallel branches
  - When dragging a commit from one stack to another stack with multiple branches, all the branches have the "move commit" dz. We should only show this on the top branch.
- What we "really" want is to make the reorder dropzone still show if your dragging between stacks
  -The "top-of-stack" reorder dropzone was accidentally hidden if you had no commits :not-like-this:


https://github.com/user-attachments/assets/ce456fb7-b16b-48ff-8bcb-7e95bf1e8efe

