### PR TITLE
Fix double click when writing messages

### DIFF
--- a/apps/desktop/src/components/v3/editor/MessageEditor.svelte
+++ b/apps/desktop/src/components/v3/editor/MessageEditor.svelte
@@ -184,6 +184,11 @@
 	export function setText(text: string) {
 		composer?.setText(text);
 	}
+
+	function stopPropagation(e: MouseEvent) {
+		e.stopPropagation();
+		e.preventDefault();
+	}
 </script>
 
 <Modal
@@ -223,6 +228,8 @@
 	{/snippet}
 </Modal>
 
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
 	class="editor-wrapper"
 	style:--extratoolbar-height={extendedTools ? '2.625rem' : '0'}
@@ -232,6 +239,8 @@
 	style:--code-block-font={$userSettings.diffFont}
 	style:--code-block-tab-size={$userSettings.tabSize}
 	style:--code-block-ligatures={$userSettings.diffLigatures ? 'common-ligatures' : 'normal'}
+	onclick={stopPropagation}
+	ondblclick={stopPropagation}
 >
 	<div role="presentation" class="message-textarea">
 		<div

--- a/apps/desktop/src/components/v3/editor/MessageEditorInput.svelte
+++ b/apps/desktop/src/components/v3/editor/MessageEditorInput.svelte
@@ -22,10 +22,17 @@
 	}: Props = $props();
 
 	let charsCount = $state(value.length);
+
+	function stopPropagation(e: MouseEvent) {
+		e.stopPropagation();
+		e.preventDefault();
+	}
 </script>
 
 <!-- svelte-ignore a11y_autofocus -->
-<div class="message-editor-input">
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="message-editor-input" onclick={stopPropagation} ondblclick={stopPropagation}>
 	<input
 		data-testid={testId}
 		bind:this={ref}


### PR DESCRIPTION
Requirements

- Prevent double or triple click behavior from affecting layout when selecting text in commit message or PR description fields.
- Clicking or selecting text in these input areas should not propagate events that trigger layout changes.

Thoughts

- This could either be a more global thing, or an isolated change to the specific components.
- Textbox already shares an "onclick" handler.
- I've ended up modifying the MessageEditor and the MessageEditorInput.
  - These two components are used for both commit and PR descriptions.
  - Editing these components keeps the change isolated to the relevant topic.

## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
