### PR TITLE
Fix dimming when committing to non-existant branch

### DIFF
--- a/apps/desktop/src/components/v3/StackView.svelte
+++ b/apps/desktop/src/components/v3/StackView.svelte
@@ -59,9 +59,7 @@
 	const isCommitting = $derived(action?.type === 'commit' && action.stackId === stack.id);
 
 	// If the user is making a commit to a different lane we dim this one.
-	const dimmed = $derived(
-		action?.type === 'commit' && action.stackId !== undefined && action.stackId !== stack.id
-	);
+	const dimmed = $derived(action?.type === 'commit' && action?.stackId !== stack.id);
 
 	const persistedStackWidth = persistWithExpiration(
 		uiState.global.stackWidth.current,


### PR DESCRIPTION
* Dim the other branches when commiting and creating a branch simultaneously.

* We already have greying out when committing regularly. We must be not hitting the same condition when committing *and* creating a branch.
* dimmed has the condition: `action?.type === 'commit' && action.stackId !== undefined && action.stackId !== stack.id` 

  * It seems like we can change it to `action?.type === 'commit'&& action?.stackId !== stack.id` and it should work as expected, because if `stackId` is undefined, we are committing to a stack doesn't exist yet; and if `undefined !== stack.id` we know we are not committing to this existant stack.

## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
