### PR TITLE
Add copy commit hash

### DIFF
--- a/apps/desktop/src/components/CommitContextMenu.svelte
+++ b/apps/desktop/src/components/CommitContextMenu.svelte
@@ -102,6 +102,13 @@
 			/>
 		{/if}
 		<ContextMenuItem
+			label="Copy commit hash"
+			onclick={() => {
+				writeClipboard(commit.id);
+				menu?.close();
+			}}
+		/>
+		<ContextMenuItem
 			label="Copy commit message"
 			onclick={() => {
 				writeClipboard(commit.description);

--- a/apps/desktop/src/components/v3/CommitContextMenu.svelte
+++ b/apps/desktop/src/components/v3/CommitContextMenu.svelte
@@ -123,6 +123,13 @@
 				/>
 			{/if}
 			<ContextMenuItem
+				label="Copy commit hash"
+				onclick={() => {
+					writeClipboard(commitId);
+					close();
+				}}
+			/>
+			<ContextMenuItem
 				label="Copy commit message"
 				onclick={() => {
 					writeClipboard(commitMessage);


### PR DESCRIPTION
## 🧢 Changes

This PR adds an option to `CommitContextMenu` that allows copying the hash to the clipboard.

## ☕️ Reasoning

At times, I need to copy the git hash. For instance, in V3, I have to click on the commit and copy it from the opened panel.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
