### PR TITLE
fix-commit-goes-here-duplication

### DIFF
--- a/apps/desktop/cypress/e2e/support/scenarios/stackWithTwoEmptyBranches.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/stackWithTwoEmptyBranches.ts
@@ -1,0 +1,35 @@
+import MockBackend from '../mock/backend';
+import { createMockBranchDetails, createMockStackDetails } from '../mock/stacks';
+import type { Stack } from '$lib/stacks/stack';
+
+const MOCK_STACK_A_ID = 'stack-a-id';
+const OTHER_HEADER_NAME = 'other-header-name';
+
+const MOCK_STACK_A: Stack = {
+	id: MOCK_STACK_A_ID,
+	heads: [
+		{ name: MOCK_STACK_A_ID, tip: '1234123' },
+		{ name: OTHER_HEADER_NAME, tip: '1234134' }
+	],
+	tip: '1234123'
+};
+
+const MOCK_STACK_A_DETAILS = createMockStackDetails({
+	derivedName: MOCK_STACK_A_ID,
+	branchDetails: [
+		createMockBranchDetails({ name: MOCK_STACK_A_ID, commits: [] }),
+		createMockBranchDetails({ name: OTHER_HEADER_NAME, commits: [] })
+	]
+});
+
+export default class StackWithTwoEmptyBranches extends MockBackend {
+	firstBranchName = MOCK_STACK_A_ID;
+	secondBranchName = OTHER_HEADER_NAME;
+
+	constructor() {
+		super();
+		this.stackId = MOCK_STACK_A_ID;
+		this.stacks = [MOCK_STACK_A];
+		this.stackDetails.set(MOCK_STACK_A_ID, MOCK_STACK_A_DETAILS);
+	}
+}

--- a/apps/desktop/src/components/v3/BranchCommitList.svelte
+++ b/apps/desktop/src/components/v3/BranchCommitList.svelte
@@ -64,6 +64,7 @@
 		stackId: string;
 		branchName: string;
 		selectedCommitId?: string;
+		firstBranch: boolean;
 		lastBranch: boolean;
 		branchDetails: BranchDetails;
 		stackingReorderDropzoneManager: ReorderCommitDzFactory;
@@ -86,6 +87,7 @@
 		branchName,
 		branchDetails,
 		selectedCommitId,
+		firstBranch,
 		lastBranch,
 		stackingReorderDropzoneManager,
 		handleUncommit,
@@ -214,8 +216,9 @@
 		{@const hasRemoteCommits = upstreamOnlyCommits.length > 0}
 		{@const hasCommits = localAndRemoteCommits.length > 0}
 		{@const ancestorMostConflicted = getAncestorMostConflicted(localAndRemoteCommits)}
+		{@const thisIsTheRightBranch = firstBranch && selectedCommitId === undefined}
 
-		{#if !hasCommits && isCommitting}
+		{#if !hasCommits && isCommitting && thisIsTheRightBranch}
 			<CommitGoesHere
 				last
 				draft

--- a/apps/desktop/src/components/v3/BranchList.svelte
+++ b/apps/desktop/src/components/v3/BranchList.svelte
@@ -139,6 +139,7 @@
 				)}
 			>
 				{#snippet children([localAndRemoteCommits, upstreamOnlyCommits, branchDetails, commit])}
+					{@const firstBranch = i === 0}
 					{@const lastBranch = i === branches.length - 1}
 					{@const iconName = getIconFromCommitState(commit?.id, commit?.state)}
 					{@const lineColor = commit
@@ -279,6 +280,7 @@
 
 						{#snippet branchContent()}
 							<BranchCommitList
+								{firstBranch}
 								{lastBranch}
 								active={focusedStackId === stackId}
 								{projectId}


### PR DESCRIPTION
- Propagate `firstBranch` prop to `BranchCommitList` to control rendering of 'Your commit goes here' text.
- Ensure 'Your commit goes here' text is only rendered in the top-most branch.
- Add Cypress test to verify the text appears only once when multiple empty branches exist.