### PR TITLE
fix-stackdraft-redundant-exclusiveaction

### DIFF
--- a/apps/desktop/cypress/e2e/commitActions.cy.ts
+++ b/apps/desktop/cypress/e2e/commitActions.cy.ts
@@ -822,7 +822,7 @@ describe('Commit Actions with no stacks', () => {
 	beforeEach(() => {
 		mockBackend = new MockBackend({ initalStacks: [] });
 		mockCommand('stacks', () => mockBackend.getStacks());
-		mockCommand('create_virtual_branch', () => mockBackend.createBranch());
+		mockCommand('create_virtual_branch', (params) => mockBackend.createBranch(params));
 		mockCommand('canned_branch_name', () => mockBackend.getCannedBranchName());
 		mockCommand('stack_details', (params) => mockBackend.getStackDetails(params));
 		mockCommand('update_commit_message', (params) => mockBackend.updateCommitMessage(params));
@@ -857,6 +857,7 @@ describe('Commit Actions with no stacks', () => {
 		// spies
 		cy.spy(mockBackend, 'getDiff').as('getDiffSpy');
 		cy.spy(mockBackend, 'createBranch').as('createBranchSpy');
+		cy.spy(mockBackend, 'createCommit').as('createCommitSpy');
 
 		// There should be uncommitted changes
 		cy.getByTestId('uncommitted-changes-file-list').should('be.visible');
@@ -909,6 +910,31 @@ describe('Commit Actions with no stacks', () => {
 		// Click on the commit button
 		cy.getByTestId('commit-drawer-action-button').should('be.visible').should('be.enabled').click();
 
+		cy.get('@createBranchSpy').should('be.calledWith', {
+			projectId: PROJECT_ID,
+			branch: {
+				name: 'my-cool-branch'
+			}
+		});
+
+		cy.get('@createCommitSpy').should('be.calledWith', {
+			projectId: '1',
+			parentId: undefined,
+			stackId: 'my-cool-branch',
+			message: 'New commit message\n\nNew commit message body',
+			stackBranchName: 'my-cool-branch',
+			worktreeChanges: [
+				{
+					pathBytes: [
+						47, 112, 97, 116, 104, 47, 116, 111, 47, 112, 114, 111, 106, 101, 99, 116, 65, 47, 102,
+						105, 108, 101, 65, 46, 116, 120, 116
+					],
+					previousPathBytes: null,
+					hunkHeaders: []
+				}
+			]
+		});
+
 		// Should display the commit rows
 		cy.getByTestId('commit-row').should('have.length', 1);
 
@@ -928,7 +954,7 @@ describe('Commit Actions with a stack of two empty branches', () => {
 	beforeEach(() => {
 		mockBackend = new StackWithTwoEmptyBranches();
 		mockCommand('stacks', () => mockBackend.getStacks());
-		mockCommand('create_virtual_branch', () => mockBackend.createBranch());
+		mockCommand('create_virtual_branch', (params) => mockBackend.createBranch(params));
 		mockCommand('canned_branch_name', () => mockBackend.getCannedBranchName());
 		mockCommand('stack_details', (params) => mockBackend.getStackDetails(params));
 		mockCommand('update_commit_message', (params) => mockBackend.updateCommitMessage(params));

--- a/apps/desktop/cypress/e2e/support/mock/backend.ts
+++ b/apps/desktop/cypress/e2e/support/mock/backend.ts
@@ -14,8 +14,11 @@ import { PROJECT_ID } from './projects';
 import { isAddRemoteParams } from './remote';
 import {
 	createMockBranchDetails,
+	createMockStack,
+	createMockStackDetails,
 	isCreateBranchParams,
 	isCreateCommitParams,
+	isCreateStackParams,
 	isCreateVirtualBranchFromBranchParams,
 	isDeleteLocalBranchParams,
 	isGetTargetCommitsParams,
@@ -29,7 +32,6 @@ import {
 	MOCK_BRAND_NEW_BRANCH_NAME,
 	MOCK_COMMIT,
 	MOCK_STACK_A_ID,
-	MOCK_STACK_BRAND_NEW,
 	MOCK_STACK_BRAND_NEW_ID,
 	MOCK_STACK_DETAILS,
 	MOCK_STACK_DETAILS_BRAND_NEW,
@@ -112,9 +114,31 @@ export default class MockBackend {
 		return this.cannedBranchName ?? 'super-cool-branch-name';
 	}
 
-	public createBranch(): Stack {
-		this.stacks.push(MOCK_STACK_BRAND_NEW);
-		return MOCK_STACK_BRAND_NEW;
+	public createBranch(args: InvokeArgs | undefined): Stack {
+		if (!args || !isCreateStackParams(args)) {
+			throw new Error('Invalid arguments for createBranch');
+		}
+		const { branch } = args;
+		const { name } = branch;
+		if (!name) throw new Error('Branch name is required');
+
+		const stack = createMockStack({
+			heads: [
+				{
+					name,
+					tip: 'werwer'
+				}
+			],
+			id: name
+		});
+		this.stacks.push(stack);
+		const stackDetails = createMockStackDetails({
+			branchDetails: [createMockBranchDetails({ name, commits: [] })],
+			derivedName: name,
+			pushStatus: 'completelyUnpushed'
+		});
+		this.stackDetails.set(name, stackDetails);
+		return stack;
 	}
 
 	public getStackDetails(args: InvokeArgs | undefined): StackDetails {

--- a/apps/desktop/cypress/e2e/support/mock/stacks.ts
+++ b/apps/desktop/cypress/e2e/support/mock/stacks.ts
@@ -30,6 +30,13 @@ export const MOCK_STACK_BRAND_NEW: Stack = {
 	tip: '1234123'
 };
 
+export function createMockStack(override: Partial<Stack>): Stack {
+	return {
+		...MOCK_STACK_A,
+		...override
+	};
+}
+
 export const MOCK_STACKS: Stack[] = [MOCK_STACK_A];
 
 export const MOCK_AUTHOR: Author = {
@@ -432,5 +439,48 @@ export function isCreateBranchParams(params: unknown): params is CreateBranchPar
 		((params.request as any).targetPatch === undefined ||
 			typeof (params.request as any).targetPatch === 'string') &&
 		typeof (params.request as any).name === 'string'
+	);
+}
+
+type BranchParams = {
+	name?: string;
+	ownership?: string;
+	order?: number;
+	allow_rebasing?: boolean;
+	notes?: string;
+	selected_for_changes?: boolean;
+};
+
+function isBranchParams(params: unknown): params is BranchParams {
+	return (
+		typeof params === 'object' &&
+		params !== null &&
+		((params as BranchParams).name === undefined ||
+			typeof (params as BranchParams).name === 'string') &&
+		((params as BranchParams).ownership === undefined ||
+			typeof (params as BranchParams).ownership === 'string') &&
+		((params as BranchParams).order === undefined ||
+			typeof (params as BranchParams).order === 'number') &&
+		((params as BranchParams).allow_rebasing === undefined ||
+			typeof (params as BranchParams).allow_rebasing === 'boolean') &&
+		((params as BranchParams).notes === undefined ||
+			typeof (params as BranchParams).notes === 'string') &&
+		((params as BranchParams).selected_for_changes === undefined ||
+			typeof (params as BranchParams).selected_for_changes === 'boolean')
+	);
+}
+export type CreateStackParams = {
+	projectId: string;
+	branch: BranchParams;
+};
+
+export function isCreateStackParams(params: unknown): params is CreateStackParams {
+	return (
+		typeof params === 'object' &&
+		params !== null &&
+		'projectId' in params &&
+		typeof (params as CreateStackParams).projectId === 'string' &&
+		'branch' in params &&
+		isBranchParams((params as CreateStackParams).branch)
 	);
 }

--- a/apps/desktop/src/components/v3/MultiStackCreateNew.svelte
+++ b/apps/desktop/src/components/v3/MultiStackCreateNew.svelte
@@ -4,7 +4,7 @@
 	import { UncommittedService } from '$lib/selection/uncommittedService.svelte';
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { UiState } from '$lib/state/uiState.svelte';
-	import { TestId } from '$lib/testing/testIds';
+	import { ElementId, TestId } from '$lib/testing/testIds';
 	import { sleep } from '$lib/utils/sleep';
 	import { inject } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
@@ -121,11 +121,11 @@
 	</div>
 </div>
 
-<Modal bind:this={createRefModal} width={500}>
+<Modal bind:this={createRefModal} width={500} testId={TestId.CreateNewBranchModal}>
 	<div class="content-wrap">
 		<Textbox
 			label="New branch"
-			id="newRemoteName"
+			id={ElementId.NewBranchNameInput}
 			bind:value={createRefName}
 			autofocus
 			helperText={generatedNameDiverges ? `Will be created as '${slugifiedRefName}'` : undefined}

--- a/apps/desktop/src/components/v3/StackDraft.svelte
+++ b/apps/desktop/src/components/v3/StackDraft.svelte
@@ -16,7 +16,6 @@
 
 	const [uiState, stackService] = inject(UiState, StackService);
 	const draftBranchName = $derived(uiState.global.draftBranchName);
-	const projectState = $derived(uiState.project(projectId));
 
 	// Automatic branch name suggested by back end.
 	let newName = $state('');
@@ -43,7 +42,7 @@
 	style:width={uiState.global.stackWidth.current + 'rem'}
 >
 	<div class="new-commit-view" data-testid={TestId.NewCommitView}>
-		<NewCommitView {projectId} onclose={() => projectState.exclusiveAction.set(undefined)} />
+		<NewCommitView {projectId} />
 	</div>
 	<BranchCard
 		type="draft-branch"

--- a/apps/desktop/src/lib/testing/testIds.ts
+++ b/apps/desktop/src/lib/testing/testIds.ts
@@ -93,7 +93,8 @@ export enum TestId {
 	PRBranchDrawer = 'pr-branch-view',
 	CreateStackButton = 'create-stack-button',
 	CommitToNewBranchButton = 'commit-to-new-branch-button',
-	ConfirmSubmit = 'confirm-submit'
+	ConfirmSubmit = 'confirm-submit',
+	CreateNewBranchModal = 'create-new-branch-modal'
 }
 
 export enum ElementId {


### PR DESCRIPTION
See https://discord.com/channels/1060193121130000425/1204524097241878629/1385255146686251088
 
- Removed redundant onclose callback that was resetting exclusiveAction to undefined, improving state management during draft stack creation.
- Added Cypress test to verify that canceling draft stack creation maintains reactivity.
- Updated mock backend and utilities to better support stack creation scenarios.
- Enhanced Svelte components with test IDs for improved testability.