### PR TITLE
fix(ui): ensure text wrap works in HunkDiff

### DIFF
--- a/apps/desktop/src/components/projectSettings/AppearanceSettings.svelte
+++ b/apps/desktop/src/components/projectSettings/AppearanceSettings.svelte
@@ -138,10 +138,10 @@
 
 	<SectionCard labelFor="wrapText" orientation="row" roundedTop={false} roundedBottom={false}>
 		{#snippet title()}
-			Text wrap
+			Soft wrap
 		{/snippet}
 		{#snippet caption()}
-			Wrap text in the diff view once it hits the end of the viewport.
+			Soft wrap long lines in the diff view to fit within the viewport.
 		{/snippet}
 
 		{#snippet actions()}

--- a/apps/desktop/src/components/projectSettings/AppearanceSettings.svelte
+++ b/apps/desktop/src/components/projectSettings/AppearanceSettings.svelte
@@ -21,7 +21,7 @@
 			on:branchSelected={async (e) => {
 -				selectedBranch = e.detail;
 -				if ($platformName === 'win32') {
-+				if ($platformName === 'win64') {
++				if ($platformName === 'win64' && $userSettings.enableAdvancedFeatures && project.hasRemoteOrigin) {
 					setTarget();
 				}
 			}}`;

--- a/packages/ui/src/lib/components/InfoButton.svelte
+++ b/packages/ui/src/lib/components/InfoButton.svelte
@@ -10,6 +10,7 @@
 		title?: string;
 		size?: 'small' | 'medium';
 		maxWidth?: string;
+		iconTopOffset?: string;
 		icon?: keyof typeof iconsJson;
 		inheritColor?: boolean;
 		children: Snippet;
@@ -19,6 +20,7 @@
 		title,
 		size = 'medium',
 		maxWidth = '16rem',
+		iconTopOffset = '10%',
 		icon,
 		children,
 		inheritColor
@@ -67,6 +69,8 @@
 	role="tooltip"
 	onmouseenter={handleMouseEnter}
 	onmouseleave={handleMouseLeave}
+	style:--icon-top-offset={iconTopOffset}
+	style:--size={size === 'small' ? '12px' : '14px'}
 >
 	{#if icon}
 		<div class="info-custom-icon" class:inherit-color={inheritColor}>
@@ -104,12 +108,9 @@
 
 <style lang="postcss">
 	.wrapper {
-		--default-size: 14px;
-		--small-size: 12px;
-
 		display: inline-flex;
 		position: relative;
-		transform: translateY(10%);
+		transform: translateY(var(--icon-top-offset));
 	}
 
 	.info-custom-icon {
@@ -124,8 +125,9 @@
 
 	.info-button {
 		position: relative;
-		width: 50px;
-		border-radius: var(--default-size);
+		width: var(--size);
+		height: var(--size);
+		border-radius: var(--size);
 		box-shadow: inset 0 0 0 1.5px var(--clr-text-2);
 		color: var(--clr-text-2);
 		transition: box-shadow var(--transition-fast);
@@ -152,38 +154,28 @@
 	}
 
 	.wrapper.medium {
-		& .info-button {
-			width: var(--default-size);
-			height: var(--default-size);
-
-			&::before {
-				top: 3px;
-				width: 2px;
-				height: 2px;
-			}
-			&::after {
-				top: 6px;
-				width: 2px;
-				height: 5px;
-			}
+		& .info-button::before {
+			top: 3px;
+			width: 2px;
+			height: 2px;
+		}
+		& .info-button::after {
+			top: 6px;
+			width: 2px;
+			height: 5px;
 		}
 	}
 
 	.wrapper.small {
-		& .info-button {
-			width: var(--small-size);
-			height: var(--small-size);
-
-			&::before {
-				top: 3px;
-				width: 2px;
-				height: 2px;
-			}
-			&::after {
-				top: 6px;
-				width: 2px;
-				height: 3px;
-			}
+		& .info-button::before {
+			top: 3px;
+			width: 2px;
+			height: 2px;
+		}
+		& .info-button::after {
+			top: 6px;
+			width: 2px;
+			height: 3px;
 		}
 	}
 

--- a/packages/ui/src/lib/components/hunkDiff/HunkDiffRow.svelte
+++ b/packages/ui/src/lib/components/hunkDiff/HunkDiffRow.svelte
@@ -206,7 +206,13 @@
 				class:locked
 				class:staged
 			>
-				<InfoButton inheritColor size="small" icon="locked-extra-small" maxWidth="15rem">
+				<InfoButton
+					inheritColor
+					size="small"
+					icon="locked-extra-small"
+					maxWidth="15rem"
+					iconTopOffset="0"
+				>
 					{@render lockWarning(row.locks ?? [])}
 				</InfoButton>
 			</td>
@@ -389,7 +395,9 @@
 		background-color: var(--clr-diff-count-bg);
 		color: var(--clr-diff-count-text);
 		font-size: 11px;
+		line-height: 1.5; /* Visually centered with 12px font size that diff lines have */
 		text-align: right;
+		vertical-align: top;
 		touch-action: none;
 		user-select: none;
 
@@ -449,6 +457,8 @@
 		border-right: 1px solid var(--clr-border-2);
 		background-color: var(--clr-diff-count-bg);
 		color: var(--clr-diff-count-text);
+		line-height: 1;
+		vertical-align: top;
 
 		&.diff-line-addition {
 			border-color: var(--clr-diff-addition-count-border);

--- a/packages/ui/src/lib/components/hunkDiff/HunkDiffRow.svelte
+++ b/packages/ui/src/lib/components/hunkDiff/HunkDiffRow.svelte
@@ -226,7 +226,9 @@
 
 	<td
 		class="table__textContent"
-		style="--tab-size: {tabSize}; --wrap: {wrapText ? 'wrap' : 'nowrap'}"
+		style="--tab-size: {tabSize}; --wrap: {wrapText ? 'wrap' : 'nowrap'}; --pre-wrap: {wrapText
+			? 'pre-wrap'
+			: 'pre'}"
 		class:readonly={true}
 		data-no-drag
 		class:diff-line-deletion={row.type === SectionType.RemovedLines}
@@ -309,7 +311,7 @@
 		font-size: 12px;
 		line-height: 1.25;
 		text-wrap: var(--wrap);
-		white-space: pre;
+		white-space: var(--pre-wrap);
 		cursor: text;
 		tab-size: var(--tab-size);
 		user-select: text;
@@ -319,7 +321,7 @@
 		position: relative;
 		min-height: 18px;
 		text-wrap: var(--wrap);
-		white-space: pre;
+		white-space: var(--pre-wrap);
 		cursor: text;
 	}
 

--- a/packages/ui/src/lib/components/hunkDiff/HunkDiffRow.svelte
+++ b/packages/ui/src/lib/components/hunkDiff/HunkDiffRow.svelte
@@ -226,9 +226,7 @@
 
 	<td
 		class="table__textContent"
-		style="--tab-size: {tabSize}; --wrap: {wrapText ? 'wrap' : 'nowrap'}; --pre-wrap: {wrapText
-			? 'pre-wrap'
-			: 'pre'}"
+		style="--tab-size: {tabSize}; --pre-wrap: {wrapText ? 'pre-wrap' : 'pre'}"
 		class:readonly={true}
 		data-no-drag
 		class:diff-line-deletion={row.type === SectionType.RemovedLines}
@@ -310,7 +308,6 @@
 		padding-left: 4px;
 		font-size: 12px;
 		line-height: 1.25;
-		text-wrap: var(--wrap);
 		white-space: var(--pre-wrap);
 		cursor: text;
 		tab-size: var(--tab-size);
@@ -320,7 +317,6 @@
 	.table__row-header {
 		position: relative;
 		min-height: 18px;
-		text-wrap: var(--wrap);
 		white-space: var(--pre-wrap);
 		cursor: text;
 	}


### PR DESCRIPTION
The Appearance -> Text wrap option in Global Settings doesn't seem to have any effect.
I found that the issue was caused by the `white-space: pre` style, which was preventing text from wrapping.

So I changed `white-space` to `pre-wrap` when `wrapText` is true. It should be working correctly now.

Ref: https://developer.mozilla.org/en-US/docs/Web/CSS/white-space