### PR TITLE
feat(commit-message-editor): improve floating commit box UX

### DIFF
--- a/apps/desktop/cypress/e2e/commitActions.cy.ts
+++ b/apps/desktop/cypress/e2e/commitActions.cy.ts
@@ -48,7 +48,7 @@ describe('Commit Actions', () => {
 		cy.getByTestId('commit-drawer-action-edit-message').should('contain', 'Edit message').click();
 
 		// Should open the commit rename drawer
-		cy.getByTestId('edit-commit-message-drawer').should('be.visible');
+		cy.getByTestId('edit-commit-message-box').should('be.visible');
 
 		// Should have the original commit message, and be focused
 		cy.getByTestId('commit-drawer-title-input')
@@ -73,7 +73,7 @@ describe('Commit Actions', () => {
 			.should('contain', 'Save')
 			.click();
 
-		cy.getByTestId('edit-commit-message-drawer').should('not.exist');
+		cy.getByTestId('edit-commit-message-box').should('not.exist');
 
 		cy.getByTestId('commit-drawer-title').should('contain', newCommitMessageTitle);
 		cy.getByTestId('commit-drawer-description').should('contain', newCommitMessageBody);
@@ -107,7 +107,7 @@ describe('Commit Actions', () => {
 		cy.getByTestId('commit-drawer-action-edit-message').should('contain', 'Edit message').click();
 
 		// Should open the commit rename drawer
-		cy.getByTestId('edit-commit-message-drawer').should('be.visible');
+		cy.getByTestId('edit-commit-message-box').should('be.visible');
 
 		// Should have the original commit message, and be focused
 		cy.getByTestId('commit-drawer-title-input')
@@ -130,7 +130,7 @@ describe('Commit Actions', () => {
 			.should('contain', 'Save')
 			.click();
 
-		cy.getByTestId('edit-commit-message-drawer').should('not.exist');
+		cy.getByTestId('edit-commit-message-box').should('not.exist');
 
 		cy.getByTestId('commit-drawer-title').should('contain', originalCommitMessage);
 		cy.getByTestId('commit-drawer-description').should('contain', newCommitDescription);
@@ -164,7 +164,7 @@ describe('Commit Actions', () => {
 		cy.getByTestId('commit-drawer-action-edit-message').should('contain', 'Edit message').click();
 
 		// Should open the commit rename drawer
-		cy.getByTestId('edit-commit-message-drawer').should('be.visible');
+		cy.getByTestId('edit-commit-message-box').should('be.visible');
 
 		// Should have the original commit message, and be focused
 		cy.getByTestId('commit-drawer-title-input')
@@ -185,7 +185,7 @@ describe('Commit Actions', () => {
 			.should('contain', 'Save')
 			.click();
 
-		cy.getByTestId('edit-commit-message-drawer').should('not.exist');
+		cy.getByTestId('edit-commit-message-box').should('not.exist');
 
 		cy.getByTestId('commit-drawer-title').should('contain', newCommitTitle);
 		cy.getByTestId('commit-drawer-description').should('not.exist');
@@ -217,7 +217,7 @@ describe('Commit Actions', () => {
 		cy.getByTestId('commit-drawer-action-edit-message').should('contain', 'Edit message').click();
 
 		// Should open the commit rename drawer
-		cy.getByTestId('edit-commit-message-drawer').should('be.visible');
+		cy.getByTestId('edit-commit-message-box').should('be.visible');
 
 		// Should have the original commit message, and be focused
 		cy.getByTestId('commit-drawer-title-input')
@@ -232,7 +232,7 @@ describe('Commit Actions', () => {
 			.should('contain', 'Save')
 			.click();
 
-		cy.getByTestId('edit-commit-message-drawer').should('not.exist');
+		cy.getByTestId('edit-commit-message-box').should('not.exist');
 
 		cy.getByTestId('commit-drawer-title').should('contain', originalCommitMessage);
 		cy.getByTestId('commit-drawer-description').should('not.exist');
@@ -271,7 +271,7 @@ describe('Commit Actions', () => {
 			});
 
 		// Should open the commit rename drawer
-		cy.getByTestId('edit-commit-message-drawer').should('be.visible');
+		cy.getByTestId('edit-commit-message-box').should('be.visible');
 
 		// Should have the original commit message, and be focused
 		cy.getByTestId('commit-drawer-title-input')
@@ -296,7 +296,7 @@ describe('Commit Actions', () => {
 			.should('contain', 'Save')
 			.click();
 
-		cy.getByTestId('edit-commit-message-drawer').should('not.exist');
+		cy.getByTestId('edit-commit-message-box').should('not.exist');
 
 		cy.getByTestId('commit-drawer-title').should('contain', newCommitMessageTitle);
 		cy.getByTestId('commit-drawer-description').should('contain', newCommitMessageBody);
@@ -330,7 +330,7 @@ describe('Commit Actions', () => {
 		cy.getByTestId('commit-drawer-action-edit-message').should('contain', 'Edit message').click();
 
 		// Should open the commit rename drawer
-		cy.getByTestId('edit-commit-message-drawer').should('be.visible');
+		cy.getByTestId('edit-commit-message-box').should('be.visible');
 
 		// Should have the original commit message, and be focused
 		cy.getByTestId('commit-drawer-title-input')
@@ -343,7 +343,7 @@ describe('Commit Actions', () => {
 		// Click on the cancel button
 		cy.getByTestId('commit-drawer-cancel-button').should('be.visible').should('be.enabled').click();
 
-		cy.getByTestId('edit-commit-message-drawer').should('not.exist');
+		cy.getByTestId('edit-commit-message-box').should('not.exist');
 
 		cy.getByTestId('commit-drawer-title').should('contain', originalCommitMessage);
 		cy.getByTestId('commit-drawer-description').should('not.exist');
@@ -356,7 +356,7 @@ describe('Commit Actions', () => {
 		cy.getByTestId('commit-drawer-action-edit-message').should('contain', 'Edit message').click();
 
 		// Should open the commit rename drawer
-		cy.getByTestId('edit-commit-message-drawer').should('be.visible');
+		cy.getByTestId('edit-commit-message-box').should('be.visible');
 
 		// Should have the original commit message, and be focused
 		cy.getByTestId('commit-drawer-title-input')
@@ -564,7 +564,7 @@ describe('Commit Actions with lots of uncommitted changes', () => {
 			cy.getByTestId('commit-drawer-action-edit-message').should('contain', 'Edit message').click();
 
 			// Should open the commit rename drawer
-			cy.getByTestId('edit-commit-message-drawer').should('be.visible');
+			cy.getByTestId('edit-commit-message-box').should('be.visible');
 
 			// Should have the original commit message
 			cy.getByTestId('commit-drawer-title-input')
@@ -589,7 +589,7 @@ describe('Commit Actions with lots of uncommitted changes', () => {
 				.should('contain', 'Save')
 				.click();
 
-			cy.getByTestId('edit-commit-message-drawer').should('not.exist');
+			cy.getByTestId('edit-commit-message-box').should('not.exist');
 
 			cy.getByTestId('commit-drawer-title').should('contain', newCommitTitle);
 			cy.getByTestId('commit-drawer-description').should('contain', newCommitDescription);
@@ -669,7 +669,7 @@ describe('Commit Actions with lots of uncommitted changes', () => {
 			cy.getByTestId('commit-drawer-action-edit-message').should('contain', 'Edit message').click();
 
 			// Should open the commit rename drawer
-			cy.getByTestId('edit-commit-message-drawer').should('be.visible');
+			cy.getByTestId('edit-commit-message-box').should('be.visible');
 
 			// Should have the original commit message, and be focused
 			cy.getByTestId('commit-drawer-title-input')
@@ -694,7 +694,7 @@ describe('Commit Actions with lots of uncommitted changes', () => {
 				.should('be.enabled')
 				.click();
 
-			cy.getByTestId('edit-commit-message-drawer').should('not.exist');
+			cy.getByTestId('edit-commit-message-box').should('not.exist');
 
 			cy.getByTestId('commit-drawer-title').should('contain', commitTitle);
 			cy.getByTestId('commit-drawer-description').should('contain', commitDescription);
@@ -784,7 +784,7 @@ describe('Commit Actions with lots of uncommitted changes', () => {
 			cy.getByTestId('commit-drawer-action-edit-message').should('contain', 'Edit message').click();
 
 			// Should open the commit rename drawer
-			cy.getByTestId('edit-commit-message-drawer').should('be.visible');
+			cy.getByTestId('edit-commit-message-box').should('be.visible');
 
 			// Should have the original commit message, and be focused
 			cy.getByTestId('commit-drawer-title-input')
@@ -808,7 +808,7 @@ describe('Commit Actions with lots of uncommitted changes', () => {
 				.should('be.enabled')
 				.click();
 
-			cy.getByTestId('edit-commit-message-drawer').should('not.exist');
+			cy.getByTestId('edit-commit-message-box').should('not.exist');
 
 			cy.getByTestId('commit-drawer-title').should('contain', newCommitTitle);
 			cy.getByTestId('commit-drawer-description').should('contain', newCommitDescription);

--- a/apps/desktop/cypress/e2e/errorHandling.cy.ts
+++ b/apps/desktop/cypress/e2e/errorHandling.cy.ts
@@ -56,7 +56,7 @@ describe('Error handling - commit actions', () => {
 		cy.getByTestId('commit-drawer-action-edit-message').should('contain', 'Edit message').click();
 
 		// Should open the commit rename drawer
-		cy.getByTestId('edit-commit-message-drawer').should('be.visible');
+		cy.getByTestId('edit-commit-message-box').should('be.visible');
 
 		// Should have the original commit message, and be focused
 		cy.getByTestId('commit-drawer-title-input')

--- a/apps/desktop/src/components/ReviewCreation.svelte
+++ b/apps/desktop/src/components/ReviewCreation.svelte
@@ -72,6 +72,7 @@
 	const aiService = getContext(AIService);
 	const remotesService = getContext(RemotesService);
 	const uiState = getContext(UiState);
+
 	const stackState = $derived(uiState.stack(stackId));
 
 	const user = userService.user;
@@ -451,6 +452,7 @@
 				}}
 			/>
 			<MessageEditor
+				isPrCreation
 				bind:this={messageEditor}
 				testId={TestId.ReviewDescriptionInput}
 				{projectId}
@@ -496,6 +498,7 @@
 
 	.pr-editor__content {
 		display: flex;
+		flex: 1;
 		flex-direction: column;
 	}
 </style>

--- a/apps/desktop/src/components/v3/BranchCard.svelte
+++ b/apps/desktop/src/components/v3/BranchCard.svelte
@@ -183,7 +183,7 @@
 				{/snippet}
 			</BranchHeader>
 		</Dropzone>
-		{#if stackState?.action.current === 'review' && selection?.branchName === branchName}
+		{#if stackState?.action.current === 'review'}
 			<div class="review-wrapper" class:no-padding={uiState.global.useFloatingPrBox.current}>
 				<ReviewView
 					{projectId}

--- a/apps/desktop/src/components/v3/BranchCard.svelte
+++ b/apps/desktop/src/components/v3/BranchCard.svelte
@@ -23,7 +23,6 @@
 		projectId: string;
 		branchName: string;
 		isCommitting?: boolean;
-		expand?: boolean;
 		lineColor: string;
 		readonly: boolean;
 		first?: boolean;
@@ -76,7 +75,7 @@
 
 	type Props = DraftBranchProps | NormalBranchProps | StackBranchProps | PrBranchProps;
 
-	let { projectId, branchName, expand, active, lineColor, readonly, ...args }: Props = $props();
+	let { projectId, branchName, active, lineColor, readonly, ...args }: Props = $props();
 
 	const [uiState, stackService] = inject(UiState, StackService);
 
@@ -115,7 +114,6 @@
 	class="branch-card"
 	class:selected
 	class:draft={args.type === 'draft-branch'}
-	class:expand
 	data-series-name={branchName}
 	data-testid={TestId.BranchCard}
 >
@@ -185,8 +183,8 @@
 				{/snippet}
 			</BranchHeader>
 		</Dropzone>
-		{#if stackState?.action.current === 'review'}
-			<div class="review-wrapper">
+		{#if stackState?.action.current === 'review' && selection?.branchName === branchName}
+			<div class="review-wrapper" class:no-padding={uiState.global.useFloatingPrBox.current}>
 				<ReviewView
 					{projectId}
 					{branchName}
@@ -285,9 +283,6 @@
 		border-radius: var(--radius-ml);
 		background: var(--clr-bg-1);
 	}
-	.expand {
-		height: 100%;
-	}
 
 	.branch-header__item {
 		color: var(--clr-text-2);
@@ -312,7 +307,10 @@
 	}
 
 	.review-wrapper {
-		padding: 12px;
 		border-top: 1px solid var(--clr-border-2);
+
+		&:not(.no-padding) {
+			padding: 12px;
+		}
 	}
 </style>

--- a/apps/desktop/src/components/v3/BranchList.svelte
+++ b/apps/desktop/src/components/v3/BranchList.svelte
@@ -237,8 +237,8 @@
 										shrinkable
 										icon="github-small"
 										onclick={(e) => {
+											e.stopPropagation();
 											stackState?.action.set('review');
-											e.stopPropagation(); // Do not select branch.
 										}}
 										testId={TestId.CreateReviewButton}
 									>
@@ -261,6 +261,7 @@
 								{/if}
 							{/if}
 						{/snippet}
+
 						{#snippet menu({ rightClickTrigger })}
 							{@const data = {
 								branch,

--- a/apps/desktop/src/components/v3/CommitMessageEditor.svelte
+++ b/apps/desktop/src/components/v3/CommitMessageEditor.svelte
@@ -54,7 +54,7 @@
 	const aiService = getContext(AIService);
 	const promptService = getContext(PromptService);
 
-	const useFloatingCommitBox = $derived(uiState.global.useFloatingCommitBox.current);
+	const useFloatingCommitBox = $derived(uiState.global.useFloatingCommitBox);
 
 	const worktreeService = getContext(WorktreeService);
 	const diffService = getContext(DiffService);
@@ -222,8 +222,16 @@
 	</EditorFooter>
 {/snippet}
 
-{#if useFloatingCommitBox}
-	<FloatingCommitBox branchName={stackSelection?.current?.branchName}>
+{#if useFloatingCommitBox.current}
+	<FloatingCommitBox
+		onExitFloatingModeClick={() => {
+			uiState.global.useFloatingCommitBox.set(false);
+		}}
+	>
+		{#snippet header()}
+			Create commit
+		{/snippet}
+
 		{@render editorContent()}
 	</FloatingCommitBox>
 {:else}
@@ -238,7 +246,6 @@
 		position: relative;
 		flex: 1;
 		flex-direction: column;
-		/* border-top: 1px solid var(--clr-border-2); */
 		background-color: var(--clr-bg-1);
 
 		&:not(.no-padding) {

--- a/apps/desktop/src/components/v3/CommitView.svelte
+++ b/apps/desktop/src/components/v3/CommitView.svelte
@@ -205,6 +205,7 @@
 				{#if projectState.editingCommitMessage.current}
 					<div
 						class="edit-commit-view"
+						data-testid={TestId.EditCommitMessageBox}
 						class:no-paddings={uiState.global.useFloatingCommitBox.current}
 					>
 						<CommitMessageEditor

--- a/apps/desktop/src/components/v3/CommitView.svelte
+++ b/apps/desktop/src/components/v3/CommitView.svelte
@@ -136,89 +136,92 @@
 <ReduxResult {stackId} {projectId} result={commitResult.current} {onerror}>
 	{#snippet children(commit, env)}
 		{@const isConflicted = isCommit(commit) && commit.hasConflicts}
-		{#if projectState.editingCommitMessage.current}
-			<Drawer testId={TestId.EditCommitMessageDrawer} title="Edit commit message" {onclose}>
-				<CommitMessageEditor
-					bind:this={editor}
-					noPadding
-					projectId={env.projectId}
-					stackId={env.stackId}
-					action={({ title, description }) => saveCommitMessage(title, description)}
-					actionLabel="Save changes"
-					onCancel={cancelEdit}
-					loading={messageUpdateResult.current.isLoading}
-					existingCommitId={commit.id}
-					title={parsedMessage?.title || ''}
-					description={parsedMessage?.description || ''}
-				/>
-			</Drawer>
-		{:else}
-			<Drawer testId={TestId.CommitDrawer} {onclose} headerNoPaddingLeft>
-				{#snippet header()}
-					<div class="commit-view__header text-13">
-						{#if isLocalAndRemoteCommit(commit)}
-							{@const commitState = commit.state}
-							<CommitLine
-								commitStatus={commitState.type}
-								diverged={commitState.type === 'LocalAndRemote' &&
-									commit.id !== commitState.subject}
-								width={24}
-							/>
-						{:else}
-							<CommitLine
-								commitStatus="Remote"
-								diverged={false}
-								tooltip={CommitStatus.Remote}
-								width={24}
-							/>
-						{/if}
 
-						<div class="commit-view__header-title text-13">
-							<Tooltip text="Copy commit SHA">
-								<button
-									type="button"
-									class="commit-view__header-sha"
-									onclick={() => {
-										writeClipboard(commit.id, {
-											message: 'Commit SHA copied'
-										});
-									}}
-								>
-									<span>
-										{commit.id.substring(0, 7)}
-									</span>
-									<Icon name="copy-small" /></button
-								>
-							</Tooltip>
-						</div>
-					</div>
-				{/snippet}
-
-				{#snippet kebabMenu(header)}
-					{@const data = isLocalAndRemoteCommit(commit)
-						? {
-								stackId,
-								commitId: commit.id,
-								commitMessage: commit.message,
-								commitStatus: commit.state.type,
-								commitUrl: forge.current.commitUrl(commit.id),
-								onUncommitClick: () => handleUncommit(),
-								onEditMessageClick: () => setMode('edit'),
-								onPatchEditClick: () => editPatch()
-							}
-						: undefined}
-					{#if data}
-						<KebabButton
-							contextElement={header}
-							onclick={(element) => (commitMenuContext = { data, position: { element } })}
-							oncontext={(coords) => (commitMenuContext = { data, position: { coords } })}
-							activated={!!commitMenuContext?.position.element}
+		<Drawer testId={TestId.CommitDrawer} {onclose} headerNoPaddingLeft>
+			{#snippet header()}
+				<div class="commit-view__header text-13">
+					{#if isLocalAndRemoteCommit(commit)}
+						{@const commitState = commit.state}
+						<CommitLine
+							commitStatus={commitState.type}
+							diverged={commitState.type === 'LocalAndRemote' && commit.id !== commitState.subject}
+							width={24}
+						/>
+					{:else}
+						<CommitLine
+							commitStatus="Remote"
+							diverged={false}
+							tooltip={CommitStatus.Remote}
+							width={24}
 						/>
 					{/if}
-				{/snippet}
 
-				<!-- <ConfigurableScrollableContainer> -->
-				<div class="commit-view">
+					<div class="commit-view__header-title text-13">
+						<Tooltip text="Copy commit SHA">
+							<button
+								type="button"
+								class="commit-view__header-sha"
+								onclick={() => {
+									writeClipboard(commit.id, {
+										message: 'Commit SHA copied'
+									});
+								}}
+							>
+								<span>
+									{commit.id.substring(0, 7)}
+								</span>
+								<Icon name="copy-small" /></button
+							>
+						</Tooltip>
+					</div>
+				</div>
+			{/snippet}
+
+			{#snippet kebabMenu(header)}
+				{@const data = isLocalAndRemoteCommit(commit)
+					? {
+							stackId,
+							commitId: commit.id,
+							commitMessage: commit.message,
+							commitStatus: commit.state.type,
+							commitUrl: forge.current.commitUrl(commit.id),
+							onUncommitClick: () => handleUncommit(),
+							onEditMessageClick: () => setMode('edit'),
+							onPatchEditClick: () => editPatch()
+						}
+					: undefined}
+				{#if data}
+					<KebabButton
+						contextElement={header}
+						onclick={(element) => (commitMenuContext = { data, position: { element } })}
+						oncontext={(coords) => (commitMenuContext = { data, position: { coords } })}
+						activated={!!commitMenuContext?.position.element}
+					/>
+				{/if}
+			{/snippet}
+
+			<!-- <ConfigurableScrollableContainer> -->
+			<div class="commit-view">
+				{#if projectState.editingCommitMessage.current}
+					<div
+						class="edit-commit-view"
+						class:no-paddings={uiState.global.useFloatingCommitBox.current}
+					>
+						<CommitMessageEditor
+							bind:this={editor}
+							noPadding
+							projectId={env.projectId}
+							stackId={env.stackId}
+							action={({ title, description }) => saveCommitMessage(title, description)}
+							actionLabel="Save changes"
+							onCancel={cancelEdit}
+							loading={messageUpdateResult.current.isLoading}
+							existingCommitId={commit.id}
+							title={parsedMessage?.title || ''}
+							description={parsedMessage?.description || ''}
+						/>
+					</div>
+				{:else}
 					<CommitHeader
 						commitMessage={commit.message}
 						className="text-14 text-semibold text-body"
@@ -260,29 +263,30 @@
 							<AsyncButton size="tag" kind="outline" action={editPatch}>Edit commit</AsyncButton>
 						{/if}
 					</CommitDetails>
-				</div>
+				{/if}
+			</div>
 
-				{#snippet filesSplitView()}
-					<ReduxResult {projectId} {stackId} result={changesResult.current}>
-						{#snippet children(changes, { projectId, stackId })}
-							<ChangedFiles
-								title="Changed files"
-								{projectId}
-								{stackId}
-								draggableFiles={true}
-								selectionId={{ type: 'commit', commitId: commit.id }}
-								changes={changes.changes.filter(
-									(change) => !(change.path in (changes.conflictEntries?.entries ?? {}))
-								)}
-								conflictEntries={changes.conflictEntries}
-								{active}
-							/>
-						{/snippet}
-					</ReduxResult>
-				{/snippet}
-				<!-- </ConfigurableScrollableContainer> -->
-			</Drawer>
-		{/if}
+			{#snippet filesSplitView()}
+				<ReduxResult {projectId} {stackId} result={changesResult.current}>
+					{#snippet children(changes, { projectId, stackId })}
+						<ChangedFiles
+							title="Changed files"
+							{projectId}
+							{stackId}
+							draggableFiles={true}
+							selectionId={{ type: 'commit', commitId: commit.id }}
+							changes={changes.changes.filter(
+								(change) => !(change.path in (changes.conflictEntries?.entries ?? {}))
+							)}
+							conflictEntries={changes.conflictEntries}
+							{active}
+						/>
+					{/snippet}
+				</ReduxResult>
+			{/snippet}
+			<!-- </ConfigurableScrollableContainer> -->
+		</Drawer>
+		<!-- {/if} -->
 
 		<ConflictResolutionConfirmModal
 			bind:this={conflictResolutionConfirmationModal}
@@ -327,6 +331,15 @@
 
 		&:hover {
 			color: var(--clr-text-1);
+		}
+	}
+
+	.edit-commit-view {
+		display: flex;
+		flex-direction: column;
+
+		&.no-paddings {
+			margin: -14px;
 		}
 	}
 </style>

--- a/apps/desktop/src/components/v3/Drawer.svelte
+++ b/apps/desktop/src/components/v3/Drawer.svelte
@@ -10,7 +10,6 @@
 		kebabMenu?: Snippet<[element: HTMLElement]>;
 		children: Snippet;
 		filesSplitView?: Snippet;
-
 		headerNoPaddingLeft?: boolean;
 		testId?: string;
 		onclose?: () => void;

--- a/apps/desktop/src/components/v3/FloatingCommitBox.svelte
+++ b/apps/desktop/src/components/v3/FloatingCommitBox.svelte
@@ -6,11 +6,12 @@
 	import { onMount, type Snippet } from 'svelte';
 
 	interface Props {
-		branchName?: string;
 		children: Snippet;
+		header: Snippet;
+		onExitFloatingModeClick: () => void;
 	}
 
-	const { branchName = 'Unknown branch', children }: Props = $props();
+	const { children, header, onExitFloatingModeClick }: Props = $props();
 
 	const uiState = getContext(UiState);
 
@@ -263,25 +264,6 @@
 		window.addEventListener('pointermove', onPointerMove);
 		window.addEventListener('pointerup', onPointerUp, { once: true });
 	}
-
-	function findBranchCardEl() {
-		//  select by "data-series-name" attribute
-		const branchCardEl = document.querySelector(
-			`.branch-card[data-series-name="${branchName}"]`
-		) as HTMLElement;
-
-		if (branchCardEl) {
-			// Scroll to the branch card element
-			branchCardEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
-			// add wiggle effect
-			branchCardEl.classList.add('highlight-animation');
-			setTimeout(() => {
-				branchCardEl.classList.remove('highlight-animation');
-			}, 1000); // Remove wiggle after 1 second
-		} else {
-			console.warn(`Branch card for "${branchName}" not found.`);
-		}
-	}
 </script>
 
 <div
@@ -297,9 +279,7 @@
 			<Icon name="draggable" />
 		</div>
 		<h4 class="text-14 text-semibold">
-			Commit to <span role="presentation" class="branch-name" onclick={findBranchCardEl}
-				>{branchName}</span
-			>
+			{@render header()}
 		</h4>
 
 		<div class="resize-handle" onpointerdown={onResizePointerDown}>
@@ -311,14 +291,8 @@
 	</div>
 </div>
 
-<button
-	class="exit-floating-mode"
-	type="button"
-	onclick={() => {
-		uiState.global.useFloatingCommitBox.set(false);
-	}}
->
-	<span class="text-12 text-semibold underline-dotted">Exit floating commit</span>
+<button class="exit-floating-mode" type="button" onclick={onExitFloatingModeClick}>
+	<span class="text-12 text-semibold underline-dotted">Exit floating mode</span>
 </button>
 
 <style>

--- a/apps/desktop/src/components/v3/ReviewView.svelte
+++ b/apps/desktop/src/components/v3/ReviewView.svelte
@@ -2,8 +2,8 @@
 	import ReviewCreation from '$components/ReviewCreation.svelte';
 	import ReviewCreationControls from '$components/ReviewCreationControls.svelte';
 	import AsyncRender from '$components/v3/AsyncRender.svelte';
+	import FloatingCommitBox from '$components/v3/FloatingCommitBox.svelte';
 	import { DefaultForgeFactory } from '$lib/forge/forgeFactory.svelte';
-
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { UiState } from '$lib/state/uiState.svelte';
 	import { TestId } from '$lib/testing/testIds';
@@ -19,6 +19,7 @@
 	const { projectId, stackId, branchName, oncancel }: Props = $props();
 
 	const uiState = getContext(UiState);
+	const useFloatingPrBox = $derived(uiState.global.useFloatingPrBox);
 
 	let reviewCreation = $state<ReturnType<typeof ReviewCreation>>();
 
@@ -68,12 +69,26 @@
 	</AsyncRender>
 {/snippet}
 
-{@render editor()}
+{#if useFloatingPrBox.current}
+	<FloatingCommitBox
+		onExitFloatingModeClick={() => {
+			uiState.global.useFloatingPrBox.set(false);
+		}}
+	>
+		{#snippet header()}
+			Create Review
+		{/snippet}
+		{@render editor()}
+	</FloatingCommitBox>
+{:else}
+	{@render editor()}
+{/if}
 
 <style lang="postcss">
 	.review-view {
 		display: flex;
 		flex-direction: column;
+		height: 100%;
 		gap: 10px;
 	}
 </style>

--- a/apps/desktop/src/components/v3/StackDraft.svelte
+++ b/apps/desktop/src/components/v3/StackDraft.svelte
@@ -95,7 +95,7 @@
 		}
 		.new-commit-view {
 			margin-bottom: 12px;
-			padding: 12px;
+			overflow: hidden;
 			border: 1px solid var(--clr-border-2);
 			border-radius: var(--radius-ml);
 			background-color: var(--clr-bg-1);

--- a/apps/desktop/src/components/v3/editor/MessageEditor.svelte
+++ b/apps/desktop/src/components/v3/editor/MessageEditor.svelte
@@ -29,6 +29,7 @@
 	const ACCEPTED_FILE_TYPES = ['image/*', 'application/*', 'text/*', 'audio/*', 'video/*'];
 
 	interface Props {
+		isPrCreation?: boolean;
 		projectId: string;
 		disabled?: boolean;
 		initialValue?: string;
@@ -46,6 +47,7 @@
 	}
 
 	let {
+		isPrCreation,
 		initialValue,
 		placeholder,
 		disabled,
@@ -65,10 +67,13 @@
 	const MAX_RULER_VALUE = 200;
 
 	const uiState = getContext(UiState);
+
 	const uploadsService = getContext(UploadsService);
 	const userSettings = getContextStoreBySymbol<Settings>(SETTINGS);
 
-	const useFloatingBox = uiState.global.useFloatingCommitBox;
+	const useFloatingBox = $derived(
+		isPrCreation ? uiState.global.useFloatingPrBox : uiState.global.useFloatingCommitBox
+	);
 
 	const useRuler = uiState.global.useRuler;
 	const rulerCountValue = uiState.global.rulerCountValue;

--- a/apps/desktop/src/lib/state/uiState.svelte.ts
+++ b/apps/desktop/src/lib/state/uiState.svelte.ts
@@ -81,6 +81,7 @@ export type GlobalUiState = {
 	historySidebarWidth: number;
 	branchesViewSidebarWidth: number;
 	useFloatingCommitBox: boolean;
+	useFloatingPrBox: boolean;
 	floatingCommitWidth: number;
 	floatingCommitHeight: number;
 	floatingCommitPosition: FloatingCommitPosition;
@@ -125,6 +126,7 @@ export class UiState {
 		historySidebarWidth: 30,
 		branchesViewSidebarWidth: 30,
 		useFloatingCommitBox: false,
+		useFloatingPrBox: false,
 		floatingCommitPosition: 'bottom-center',
 		floatingCommitWidth: 640,
 		floatingCommitHeight: 330,

--- a/apps/desktop/src/lib/testing/mockUiState.ts
+++ b/apps/desktop/src/lib/testing/mockUiState.ts
@@ -34,6 +34,7 @@ const MOCK_GLOBAL_UI_STATE: GlobalUiState = {
 	channel: undefined,
 	draftBranchName: undefined,
 	useFloatingCommitBox: false,
+	useFloatingPrBox: false,
 	floatingCommitPosition: 'bottom-center',
 	floatingCommitWidth: 640,
 	floatingCommitHeight: 330,

--- a/apps/desktop/src/lib/testing/testIds.ts
+++ b/apps/desktop/src/lib/testing/testIds.ts
@@ -21,7 +21,7 @@ export enum TestId {
 	BranchHeaderAddDependanttBranchModal = 'branch-header-add-dependent-branch-modal',
 	BranchHeaderAddDependanttBranchModal_ActionButton = 'branch-header-add-dependent-branch-modal-action-button',
 	BranchHeaderContextMenu_SquashAllCommits = 'branch-header-context-menu-squash-all-commits',
-	EditCommitMessageDrawer = 'edit-commit-message-drawer',
+	EditCommitMessageBox = 'edit-commit-message-box',
 	CommitDrawer = 'commit-drawer',
 	CommitDrawerActionUncommit = 'commit-drawer-action-uncommit',
 	CommitDrawerActionEditMessage = 'commit-drawer-action-edit-message',


### PR DESCRIPTION
Refactor CommitMessageEditor to use reactive store for floating commit
box visibility and add explicit exit button to close it. Remove unused
branch name prop and related scroll-to-branch logic from FloatingCommitBox.

Add support for floating PR box state in MessageEditor and ReviewCreation
components to enable consistent UI behavior for PR creation.

Fix layout and styling issues in StackDraft and ReviewCreation for better
content overflow handling and flexible sizing.

These changes improve user control over floating commit/PR boxes and
simplify component logic for better maintainability.