### PR TITLE
fix(viewport): update right drawer resizer width and persist ID

### DIFF
--- a/apps/desktop/src/components/v3/MainViewport.svelte
+++ b/apps/desktop/src/components/v3/MainViewport.svelte
@@ -185,9 +185,10 @@ the window, then enlarge it and retain the original widths of the layout.
 				<Resizer
 					viewport={drawerRightDiv}
 					direction="left"
-					minWidth={24}
+					minWidth={pxToRem(24, zoom)}
+					defaultValue={pxToRem(24, zoom)}
 					borderRadius="ml"
-					persistId="viewport-${name}-middle"
+					persistId="viewport-${name}-right-drawer"
 					onWidth={(width) => (rightDrawerPreferredWidth = width)}
 				/>
 				{@render drawerRight()}


### PR DESCRIPTION
Adjust the right drawer Resizer component to use zoom-aware width values
by converting fixed pixel widths to rem units. Update minWidth and
defaultValue to use pxToRem with the current zoom level for consistent
scaling. Change persistId to a more descriptive and unique value to avoid
conflicts and improve state persistence.