### PR TITLE
Remove undo/redo menu items from MacOS menu (#9124)

### DIFF
--- a/crates/gitbutler-tauri/src/menu.rs
+++ b/crates/gitbutler-tauri/src/menu.rs
@@ -116,11 +116,7 @@ pub fn build<R: Runtime>(
 
     #[cfg(target_os = "macos")]
     {
-        edit_menu.append_items(&[
-            &PredefinedMenuItem::undo(handle, None)?,
-            &PredefinedMenuItem::redo(handle, None)?,
-            &PredefinedMenuItem::separator(handle)?,
-        ])?;
+        edit_menu.append_items(&[&PredefinedMenuItem::separator(handle)?])?;
     }
     #[cfg(not(target_os = "linux"))]
     {


### PR DESCRIPTION
They don't seem to do anything yet.
Besides that, they only seem to be present in MacOS.
