### PR TITLE
feat(feed): improve action source display and fallback content

### DIFF
--- a/apps/desktop/src/components/v3/FeedItem.svelte
+++ b/apps/desktop/src/components/v3/FeedItem.svelte
@@ -78,16 +78,26 @@
 		{/if}
 		<div class="action-item__content">
 			<div class="action-item__content__header">
-				<div>
-					<p class="text-13 text-bold">Recorded changes</p>
-					<p class="text-13 text-bold text-grey">(MCP call)</p>
-					<span class="text-13 text-greyer"
-						><TimeAgo date={new Date(action.createdAt)} addSuffix /></span
-					>
-				</div>
+				{#if isStr(action.source) || !action.source.Mcp}
+					<div>
+						<p class="text-13 text-bold">Action</p>
+						<p class="text-13 text-bold text-grey">{action.source}</p>
+						<span class="text-13 text-greyer"
+							><TimeAgo date={new Date(action.createdAt)} addSuffix /></span
+						>
+					</div>
+				{:else}
+					<div>
+						<p class="text-13 text-bold">Recorded changes</p>
+						<p class="text-13 text-bold text-grey">(MCP call)</p>
+						<span class="text-13 text-greyer"
+							><TimeAgo date={new Date(action.createdAt)} addSuffix /></span
+						>
+					</div>
+				{/if}
 			</div>
 			<span class="text-14 text-darkgrey">
-				<Markdown content={action.externalPrompt} />
+				<Markdown content={action.externalPrompt ?? action.externalSummary} />
 			</span>
 			{#if action.response && action.response.updatedBranches.length > 0}
 				<div class="action-item__content__metadata">


### PR DESCRIPTION
Update FeedItem component to conditionally render the action source label.  
If the action source is a string or lacks an MCP flag, display it as "Action"  
with the source text; otherwise, show "Recorded changes (MCP call)". Also,  
add a fallback to use externalSummary when externalPrompt is not available.  
These changes enhance clarity and ensure content is always shown correctly.