### PR TITLE
more robust app startup in the light of database failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3277,6 +3277,7 @@ dependencies = [
  "backtrace",
  "but-action",
  "but-core",
+ "but-db",
  "but-graph",
  "but-hunk-assignment",
  "but-hunk-dependency",

--- a/apps/desktop/src/lib/project/projectsService.ts
+++ b/apps/desktop/src/lib/project/projectsService.ts
@@ -10,6 +10,11 @@ import { plainToInstance } from 'class-transformer';
 import { derived, get, writable, type Readable } from 'svelte/store';
 import type { HttpClient } from '@gitbutler/shared/network/httpClient';
 
+type ProjectInfo = {
+	is_exclusive: boolean;
+	db_error?: string;
+};
+
 export class ProjectsService {
 	private persistedId = persisted<string | undefined>(undefined, 'lastProject');
 	readonly projects = writable<Project[] | undefined>(undefined, (set) => {
@@ -40,10 +45,10 @@ export class ProjectsService {
 		this.projects.set(await this.loadAll());
 	}
 
-	async setActiveProject(projectId: string): Promise<boolean> {
-		const is_exclusive = await invoke<boolean>('set_project_active', { id: projectId });
+	async setActiveProject(projectId: string): Promise<ProjectInfo> {
+		const info = await invoke<ProjectInfo>('set_project_active', { id: projectId });
 		await this.reload();
-		return is_exclusive;
+		return info;
 	}
 
 	async getProject(projectId: string, noValidation?: boolean) {

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -262,12 +262,15 @@
 	async function setActiveProjectOrRedirect() {
 		// Optimistically assume the project is viewable
 		try {
-			const is_first_window_on_project = await projectsService.setActiveProject(projectId);
-			if (!is_first_window_on_project) {
+			const info = await projectsService.setActiveProject(projectId);
+			if (!info.is_exclusive) {
 				showInfo(
 					'Just FYI, this project is already open in another window',
 					'There might be some unexpected behavior if you open it in multiple windows'
 				);
+			}
+			if (info.db_error) {
+				showError('The database was corrupted', info.db_error);
 			}
 		} catch (error: unknown) {
 			showError('Failed to set the project active', error);

--- a/crates/but-db/src/lib.rs
+++ b/crates/but-db/src/lib.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use diesel::connection::SimpleConnection;
@@ -39,7 +39,7 @@ impl DbHandle {
         if db_dir.is_relative() {
             db_dir = cwd.join(db_dir);
         }
-        let db_file_path = db_dir.join(FILE_NAME);
+        let db_file_path = Self::db_file_path(&db_dir);
         if let Some(parent_dir_to_create) = db_file_path.parent().filter(|dir| !dir.exists()) {
             std::fs::create_dir_all(parent_dir_to_create)?;
         }
@@ -56,6 +56,11 @@ impl DbHandle {
         improve_concurrency(&mut conn)?;
         run_migrations(&mut conn)?;
         Ok(DbHandle { conn, url })
+    }
+
+    /// Return the path to the standard database file.
+    pub fn db_file_path(db_dir: impl AsRef<Path>) -> PathBuf {
+        db_dir.as_ref().join(FILE_NAME)
     }
 }
 

--- a/crates/gitbutler-tauri/Cargo.toml
+++ b/crates/gitbutler-tauri/Cargo.toml
@@ -74,6 +74,7 @@ gitbutler-operating-modes.workspace = true
 gitbutler-edit-mode.workspace = true
 gitbutler-sync.workspace = true
 gitbutler-forge.workspace = true
+but-db.workspace = true
 but-settings.workspace = true
 but-workspace.workspace = true
 but-core.workspace = true


### PR DESCRIPTION
Helps to make #9128 more obvious by allowing `set_project_active` to check for possible errors.

### Tasks

* [x] implementation
* [x] test UI and see if this can be a popup.
* [ ] @estib-vega the is_exclusive check doesn't seem to kick in in my testing and I don't know why. Maybe it's the application caching this value somehow?