### PR TITLE
always-show-locking-information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,6 +3400,7 @@ dependencies = [
  "anyhow",
  "but-core",
  "but-hunk-assignment",
+ "but-hunk-dependency",
  "but-settings",
  "gitbutler-branch-actions",
  "gitbutler-command-context",

--- a/apps/desktop/cypress/e2e/errorHandling.cy.ts
+++ b/apps/desktop/cypress/e2e/errorHandling.cy.ts
@@ -24,9 +24,6 @@ describe('Error handling - commit actions', () => {
 		mockCommand('undo_commit', () => {
 			throw new Error(COMMIT_UNDO_ERROR_MESSAGE);
 		});
-		mockCommand('hunk_dependencies_for_workspace_changes', (params) =>
-			mockBackend.getHunkDependencies(params)
-		);
 		mockCommand('hunk_assignments', (params) => mockBackend.getHunkAssignments(params));
 
 		cy.visit('/');

--- a/apps/desktop/cypress/e2e/review.cy.ts
+++ b/apps/desktop/cypress/e2e/review.cy.ts
@@ -13,9 +13,6 @@ describe('Review', () => {
 		mockCommand('changes_in_branch', (args) => mockBackend.getBranchChanges(args));
 		mockCommand('changes_in_worktree', (params) => mockBackend.getWorktreeChanges(params));
 		mockCommand('tree_change_diffs', (params) => mockBackend.getDiff(params));
-		mockCommand('hunk_dependencies_for_workspace_changes', (params) =>
-			mockBackend.getHunkDependencies(params)
-		);
 		mockCommand('get_base_branch_data', () => mockBackend.getBaseBranchData());
 		mockCommand('get_available_review_templates', () => mockBackend.getAvailableReviewTemplates());
 		mockCommand('push_stack', (params) => mockBackend.pushStack(params));

--- a/apps/desktop/cypress/e2e/support/mock/backend.ts
+++ b/apps/desktop/cypress/e2e/support/mock/backend.ts
@@ -40,7 +40,6 @@ import {
 import { MOCK_BRANCH_STATUSES_RESPONSE, MOCK_INTEGRATION_OUTCOME } from './upstreamIntegration';
 import type { BranchListing } from '$lib/branches/branchListing';
 import type { Commit } from '$lib/branches/v3';
-import type { HunkDependencies } from '$lib/dependencies/dependencies';
 import type { TreeChange, TreeChanges, WorktreeChanges } from '$lib/hunks/change';
 import type { UnifiedDiff } from '$lib/hunks/diff';
 import type { HunkAssignment } from '$lib/hunks/hunk';
@@ -69,7 +68,6 @@ export default class MockBackend {
 	protected branchChanges: Map<StackId, BranchChanges>;
 	protected worktreeChanges: WorktreeChanges;
 	protected unifiedDiffs: Map<string, UnifiedDiff>;
-	protected hunkDependencies: HunkDependencies;
 	protected branchListings: BranchListing[];
 	protected baseBranchCommits: Commit[];
 
@@ -88,13 +86,14 @@ export default class MockBackend {
 			changes: [MOCK_TREE_CHANGE_A],
 			ignoredChanges: [],
 			assignments: [],
-			assignmentsError: null
+			assignmentsError: null,
+			dependencies: {
+				diffs: [],
+				errors: []
+			},
+			dependenciesError: null
 		};
 		this.unifiedDiffs = new Map<string, UnifiedDiff>();
-		this.hunkDependencies = {
-			diffs: [],
-			errors: []
-		};
 
 		this.branchListings = MOCK_BRANCH_LISTINGS;
 		this.branchListing = MOCK_BRANCH_LISTINGS[0]!;
@@ -486,13 +485,6 @@ export default class MockBackend {
 	): string[] {
 		const changes = this.getBranchChanges({ projectId, stackId, branchName });
 		return changes.changes.map((change) => change.path).map((path) => path.split('/').pop()!);
-	}
-
-	public getHunkDependencies(args: InvokeArgs | undefined): HunkDependencies {
-		if (!args) {
-			throw new Error('Invalid arguments for getHunkDependencies');
-		}
-		return this.hunkDependencies;
 	}
 
 	public listBranches(args: InvokeArgs | undefined): BranchListing[] {

--- a/apps/desktop/cypress/e2e/support/mock/stacks.ts
+++ b/apps/desktop/cypress/e2e/support/mock/stacks.ts
@@ -5,6 +5,7 @@ import type { BranchDetails, Stack, StackDetails } from '$lib/stacks/stack';
 export const MOCK_STACK_A_ID = '1234-123';
 
 export const MOCK_STACK_A: Stack = {
+	order: 0,
 	id: MOCK_STACK_A_ID,
 	heads: [
 		{
@@ -20,6 +21,7 @@ export const MOCK_BRAND_NEW_BRANCH_NAME = 'super-cool-branch-name';
 export const MOCK_STACK_BRAND_NEW_ID = 'empty-stack';
 
 export const MOCK_STACK_BRAND_NEW: Stack = {
+	order: 1,
 	id: MOCK_STACK_BRAND_NEW_ID,
 	heads: [
 		{

--- a/apps/desktop/cypress/e2e/support/mock/worktree.ts
+++ b/apps/desktop/cypress/e2e/support/mock/worktree.ts
@@ -4,5 +4,10 @@ export const MOCK_WORKTREE_CHANGES: WorktreeChanges = {
 	changes: [],
 	ignoredChanges: [],
 	assignments: [],
-	assignmentsError: null
+	assignmentsError: null,
+	dependencies: {
+		diffs: [],
+		errors: []
+	},
+	dependenciesError: null
 };

--- a/apps/desktop/cypress/e2e/support/scenarios/branchesWithChanges.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/branchesWithChanges.ts
@@ -17,6 +17,7 @@ const MOCK_STACK_B_ID = 'stack-b-id';
 const MOCK_STACK_C_ID = 'stack-c-id';
 
 const MOCK_STACK_A: Stack = {
+	order: 0,
 	id: MOCK_STACK_A_ID,
 	heads: [{ name: MOCK_STACK_A_ID, tip: '1234123' }],
 	tip: '1234123'
@@ -43,6 +44,7 @@ const MOCK_STACK_DETAILS_A = createMockStackDetails({
 });
 
 const MOCK_STACK_B: Stack = {
+	order: 1,
 	id: MOCK_STACK_B_ID,
 	heads: [{ name: MOCK_STACK_B_ID, tip: '1234123' }],
 	tip: '1234123'
@@ -81,6 +83,7 @@ const MOCK_STACK_DETAILS_B = createMockStackDetails({
 });
 
 const MOCK_STACK_C: Stack = {
+	order: 2,
 	id: MOCK_STACK_C_ID,
 	heads: [{ name: MOCK_STACK_C_ID, tip: '1234123' }],
 	tip: '1234123'
@@ -265,7 +268,12 @@ export default class BranchesWithChanges extends MockBackend {
 			changes: MOCK_UNCOMMITTED_CHANGES,
 			ignoredChanges: [],
 			assignments: [],
-			assignmentsError: null
+			assignmentsError: null,
+			dependencies: {
+				diffs: MOCK_DIFF_DEPENDENCY,
+				errors: []
+			},
+			dependenciesError: null
 		};
 
 		this.stacks = [MOCK_STACK_A, MOCK_STACK_B, MOCK_STACK_C];
@@ -288,10 +296,6 @@ export default class BranchesWithChanges extends MockBackend {
 
 		this.unifiedDiffs.set(MOCK_FILE_D, MOCK_FILE_D_MODIFICATION);
 		this.unifiedDiffs.set(MOCK_FILE_J, MOCK_FILE_J_MODIFICATION);
-		this.hunkDependencies = {
-			diffs: MOCK_DIFF_DEPENDENCY,
-			errors: []
-		};
 	}
 
 	getCommitTitle(stackId: string): string {

--- a/apps/desktop/cypress/e2e/support/scenarios/branchesWithRemoteChanges.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/branchesWithRemoteChanges.ts
@@ -24,6 +24,7 @@ const MOCK_STACK_B_ID = 'stack-b-id';
 const MOCK_STACK_C_ID = 'stack-c-id';
 
 const MOCK_STACK_A: Stack = {
+	order: 0,
 	id: MOCK_STACK_A_ID,
 	heads: [{ name: MOCK_STACK_A_ID, tip: '1234123' }],
 	tip: '1234123'
@@ -60,6 +61,7 @@ const MOCK_STACK_DETAILS_A = createMockStackDetails({
 });
 
 const MOCK_STACK_B: Stack = {
+	order: 1,
 	id: MOCK_STACK_B_ID,
 	heads: [{ name: MOCK_STACK_B_ID, tip: '1234123' }],
 	tip: '1234123'
@@ -84,6 +86,7 @@ const MOCK_STACK_DETAILS_B = createMockStackDetails({
 });
 
 const MOCK_STACK_C: Stack = {
+	order: 2,
 	id: MOCK_STACK_C_ID,
 	heads: [{ name: MOCK_STACK_C_ID, tip: '1234123' }],
 	tip: '1234123'
@@ -176,7 +179,12 @@ export default class BranchesWithRemoteChanges extends MockBackend {
 			changes: MOCK_UNCOMMITTED_CHANGES,
 			ignoredChanges: [],
 			assignments: [],
-			assignmentsError: null
+			assignmentsError: null,
+			dependencies: {
+				diffs: MOCK_DIFF_DEPENDENCY,
+				errors: []
+			},
+			dependenciesError: null
 		};
 
 		this.stacks = [MOCK_STACK_A, MOCK_STACK_B, MOCK_STACK_C];
@@ -198,10 +206,6 @@ export default class BranchesWithRemoteChanges extends MockBackend {
 		this.branchChanges.set(MOCK_STACK_C_ID, stackCChanges);
 
 		this.unifiedDiffs.set(MOCK_FILE_D, MOCK_FILE_D_MODIFICATION);
-		this.hunkDependencies = {
-			diffs: MOCK_DIFF_DEPENDENCY,
-			errors: []
-		};
 	}
 
 	public integrateUpstreamCommits(args: InvokeArgs | undefined) {

--- a/apps/desktop/cypress/e2e/support/scenarios/complexHunks.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/complexHunks.ts
@@ -645,7 +645,12 @@ export default class ComplexHunks extends MockBackend {
 			changes: MOCK_UNCOMMITTED_CHANGES,
 			ignoredChanges: [],
 			assignments: [],
-			assignmentsError: null
+			assignmentsError: null,
+			dependencies: {
+				diffs: [],
+				errors: []
+			},
+			dependenciesError: null
 		};
 
 		this.stacks = [MOCK_STACK_A, MOCK_STACK_B];
@@ -663,11 +668,6 @@ export default class ComplexHunks extends MockBackend {
 
 		this.unifiedDiffs.set(MOCK_FILE_D, MOCK_FILE_D_MODIFICATION);
 		this.unifiedDiffs.set(MOCK_FILE_J, MOCK_FILE_J_MODIFICATION);
-
-		this.hunkDependencies = {
-			diffs: [],
-			errors: []
-		};
 	}
 
 	getCommitTitle(stackId: string): string {

--- a/apps/desktop/cypress/e2e/support/scenarios/lotsOfFileChanges.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/lotsOfFileChanges.ts
@@ -93,7 +93,12 @@ export default class LotsOfFileChanges extends MockBackend {
 			changes: MOCK_FILE_TREE_CHANGES,
 			ignoredChanges: [],
 			assignments: [],
-			assignmentsError: null
+			assignmentsError: null,
+			dependencies: {
+				diffs: [],
+				errors: []
+			},
+			dependenciesError: null
 		};
 	}
 }

--- a/apps/desktop/cypress/e2e/support/scenarios/partialllyIntegratedBranches.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/partialllyIntegratedBranches.ts
@@ -13,12 +13,14 @@ const MOCK_STACK_B_ID = 'stack-b-id';
 const MOCK_STACK_C_ID = 'stack-c-id';
 
 const MOCK_STACK_A: Stack = {
+	order: 0,
 	id: MOCK_STACK_A_ID,
 	heads: [{ name: MOCK_STACK_A_ID, tip: '1234123' }],
 	tip: '1234123'
 };
 
 const MOCK_STACK_B: Stack = {
+	order: 1,
 	id: MOCK_STACK_B_ID,
 	heads: [
 		{ name: MOCK_STACK_B_ID, tip: '1234123' },
@@ -28,6 +30,7 @@ const MOCK_STACK_B: Stack = {
 };
 
 const MOCK_STACK_C: Stack = {
+	order: 2,
 	id: MOCK_STACK_C_ID,
 	heads: [
 		{ name: MOCK_STACK_C_ID, tip: '1234123' },

--- a/apps/desktop/cypress/e2e/support/scenarios/someDeeplyNestedChanges.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/someDeeplyNestedChanges.ts
@@ -37,7 +37,12 @@ export default class SomeDeeplyNestedChanges extends MockBackend {
 			changes: MOCK_FILE_TREE_CHANGES,
 			ignoredChanges: [],
 			assignments: [],
-			assignmentsError: null
+			assignmentsError: null,
+			dependencies: {
+				diffs: [],
+				errors: []
+			},
+			dependenciesError: null
 		};
 	}
 }

--- a/apps/desktop/cypress/e2e/support/scenarios/stackWithTwoEmptyBranches.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/stackWithTwoEmptyBranches.ts
@@ -6,6 +6,7 @@ const MOCK_STACK_A_ID = 'stack-a-id';
 const OTHER_HEADER_NAME = 'other-header-name';
 
 const MOCK_STACK_A: Stack = {
+	order: 0,
 	id: MOCK_STACK_A_ID,
 	heads: [
 		{ name: MOCK_STACK_A_ID, tip: '1234123' },

--- a/apps/desktop/cypress/e2e/unifiedDiffView.cy.ts
+++ b/apps/desktop/cypress/e2e/unifiedDiffView.cy.ts
@@ -11,9 +11,6 @@ describe('Unified Diff View', () => {
 		mockCommand('stacks', () => mockBackend.getStacks());
 		mockCommand('stack_details', (params) => mockBackend.getStackDetails(params));
 		mockCommand('changes_in_branch', (args) => mockBackend.getBranchChanges(args));
-		mockCommand('hunk_dependencies_for_workspace_changes', (params) =>
-			mockBackend.getHunkDependencies(params)
-		);
 		mockCommand('changes_in_worktree', (params) => mockBackend.getWorktreeChanges(params));
 		mockCommand('tree_change_diffs', (params) => mockBackend.getDiff(params));
 		mockCommand('hunk_assignments', (params) => mockBackend.getHunkAssignments(params));
@@ -265,9 +262,6 @@ describe('Unified Diff View with complex hunks', () => {
 		mockCommand('changes_in_branch', (args) => mockBackend.getBranchChanges(args));
 		mockCommand('changes_in_worktree', (params) => mockBackend.getWorktreeChanges(params));
 		mockCommand('tree_change_diffs', (params) => mockBackend.getDiff(params));
-		mockCommand('hunk_dependencies_for_workspace_changes', (params) =>
-			mockBackend.getHunkDependencies(params)
-		);
 		mockCommand('create_commit_from_worktree_changes', (params) =>
 			mockBackend.createCommit(params)
 		);

--- a/apps/desktop/src/components/v3/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/v3/UnifiedDiffView.svelte
@@ -61,9 +61,6 @@
 
 	const projectState = $derived(uiState.project(projectId));
 	const exclusiveAction = $derived(projectState.exclusiveAction.current);
-	const targetStackId = $derived(
-		exclusiveAction?.type === 'commit' ? exclusiveAction.stackId : undefined
-	);
 
 	const isCommiting = $derived(
 		exclusiveAction?.type === 'commit' && selectionId.type === 'worktree'
@@ -129,11 +126,7 @@
 							change.path,
 							hunk
 						)}
-						{@const [fullyLocked, lineLocks] = getLineLocks(
-							targetStackId,
-							hunk,
-							fileDependencies.dependencies ?? []
-						)}
+						{@const [_, lineLocks] = getLineLocks(hunk, fileDependencies.dependencies ?? [])}
 						<div
 							class="hunk-content"
 							use:draggableChips={{
@@ -166,7 +159,6 @@
 								diffContrast={$userSettings.diffContrast}
 								inlineUnifiedDiffs={$userSettings.inlineUnifiedDiffs}
 								onLineClick={(p) => {
-									if (fullyLocked) return;
 									if (!canBePartiallySelected(diff.subject)) {
 										uncommittedService.checkHunk(stackId || null, change.path, hunk);
 									}
@@ -203,7 +195,7 @@
 									}
 								}}
 								onChangeStage={(selected) => {
-									if (fullyLocked || !selectable) return;
+									if (!selectable) return;
 									if (selected) {
 										uncommittedService.checkHunk(stackId || null, change.path, hunk);
 									} else {

--- a/apps/desktop/src/lib/hunks/change.ts
+++ b/apps/desktop/src/lib/hunks/change.ts
@@ -1,4 +1,5 @@
 import type { TauriCommandError } from '$lib/backend/ipc';
+import type { HunkDependencies } from '$lib/dependencies/dependencies';
 import type { HunkAssignment } from '$lib/hunks/hunk';
 
 /** Contains the changes that are in the worktree */
@@ -12,6 +13,8 @@ export type WorktreeChanges = {
 	readonly ignoredChanges: IgnoredChange[];
 	readonly assignments: HunkAssignment[];
 	readonly assignmentsError: TauriCommandError | null;
+	readonly dependencies: HunkDependencies | null;
+	readonly dependenciesError: TauriCommandError | null;
 };
 
 /**

--- a/apps/desktop/src/lib/hunks/hunk.test.ts
+++ b/apps/desktop/src/lib/hunks/hunk.test.ts
@@ -308,7 +308,7 @@ describe('getLineLocks', () => {
 		}
 	];
 	test('returns line locks for lines covered by locks', () => {
-		const [fullyLocked, lineLocks] = getLineLocks('stack2', hunk, locks);
+		const [fullyLocked, lineLocks] = getLineLocks(hunk, locks);
 		expect(fullyLocked).toBe(true);
 		expect(lineLocks).toEqual([
 			{ oldLine: 2, newLine: undefined, locks: [{ stackId: 'stack1', commitId: 'commit1' }] },
@@ -322,7 +322,7 @@ describe('getLineLocks', () => {
 				locks: [{ stackId: 'stack2', commitId: 'commit2' }]
 			}
 		];
-		const [fullyLocked, lineLocks] = getLineLocks('stack1', hunk, noLocks);
+		const [fullyLocked, lineLocks] = getLineLocks(hunk, noLocks);
 		expect(fullyLocked).toBe(false);
 		expect(lineLocks).toEqual([]);
 	});
@@ -338,7 +338,7 @@ describe('getLineLocks', () => {
 			}
 		];
 		// Only line 3 is locked, lines 2 and 4 are not
-		const [fullyLocked, lineLocks] = getLineLocks('stack2', partialHunk, partialLocks);
+		const [fullyLocked, lineLocks] = getLineLocks(partialHunk, partialLocks);
 		expect(fullyLocked).toBe(false);
 		expect(lineLocks).toEqual([
 			{ oldLine: 3, newLine: undefined, locks: [{ stackId: 'stack1', commitId: 'commit1' }] },

--- a/apps/desktop/src/lib/hunks/hunk.ts
+++ b/apps/desktop/src/lib/hunks/hunk.ts
@@ -423,14 +423,9 @@ export function hunkContainsLine(hunk: DiffHunk, line: LineId): boolean {
  * Get the line locks for a hunk.
  */
 export function getLineLocks(
-	excludeStackId: string | undefined,
 	hunk: DiffHunk,
 	locks: HunkLocks[]
 ): [boolean, LineLock[] | undefined] {
-	if (excludeStackId === undefined) {
-		return [false, undefined];
-	}
-
 	const lineLocks: LineLock[] = [];
 	const parsedHunk = memoizedParseHunk(hunk.diff);
 
@@ -449,17 +444,6 @@ export function getLineLocks(
 
 			const hunkLocks = locksContained.filter((lock) => hunkContainsLine(lock.hunk, lineId));
 			if (hunkLocks.length === 0) {
-				hunkIsFullyLocked = false;
-				continue;
-			}
-
-			// Filter out locks to the current stack ID
-			const locks = hunkLocks
-				.map((lock) => lock.locks)
-				.flat()
-				.filter((lock) => lock.stackId !== excludeStackId);
-
-			if (locks.length === 0) {
 				hunkIsFullyLocked = false;
 				continue;
 			}

--- a/apps/desktop/src/lib/worktree/worktreeService.svelte.ts
+++ b/apps/desktop/src/lib/worktree/worktreeService.svelte.ts
@@ -69,6 +69,14 @@ export class WorktreeService {
 			{ transform: (res) => worktreeSelectors.selectById(res.changes, path)! }
 		);
 	}
+
+	/**
+	 * Exposes the worktreeChanges endpoint. This is currently intended to be
+	 * consumed by just the `DependencyService`.
+	 */
+	get worktreeChanges() {
+		return this.api.endpoints.worktreeChanges;
+	}
 }
 
 function injectEndpoints(api: ClientState['backendApi']) {

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -153,7 +153,7 @@
 	const organizationService = new OrganizationService(data.cloud, appState.appDispatch);
 	const cloudUserService = new CloudUserService(data.cloud, appState.appDispatch);
 	const cloudProjectService = new CloudProjectService(data.cloud, appState.appDispatch);
-	const dependecyService = new DependencyService(clientState.backendApi);
+	const dependecyService = new DependencyService(worktreeService);
 	const diffService = new DiffService(clientState);
 
 	const uncommittedService = new UncommittedService(clientState, worktreeService, diffService);

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -29,6 +29,7 @@
 		"src/**/*.js",
 		"src/**/*.ts",
 		"src/**/*.svelte",
-		"cypress.config.ts"
+		"cypress.config.ts",
+		"cypress/**/*.ts"
 	]
 }

--- a/crates/but-action/src/simple.rs
+++ b/crates/but-action/src/simple.rs
@@ -104,6 +104,7 @@ fn handle_changes_simple_inner(
         ctx,
         true,
         None::<Vec<but_core::TreeChange>>,
+        None,
     )
     .map_err(|err| serde_error::Error::new(&*err))?;
     if assignments.is_empty() {

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -139,6 +139,7 @@ pub mod assignment {
             ctx,
             false,
             None::<Vec<but_core::TreeChange>>,
+            None,
         )?;
         if use_json {
             let json = serde_json::to_string_pretty(&assignments)?;
@@ -156,7 +157,7 @@ pub mod assignment {
     ) -> anyhow::Result<()> {
         let project = project_from_path(current_dir)?;
         let ctx = &mut CommandContext::open(&project, AppSettings::default())?;
-        let rejections = but_hunk_assignment::assign(ctx, vec![assignment])?;
+        let rejections = but_hunk_assignment::assign(ctx, vec![assignment], None)?;
         if use_json {
             let json = serde_json::to_string_pretty(&rejections)?;
             println!("{json}");

--- a/crates/but/src/mcp_internal/status.rs
+++ b/crates/but/src/mcp_internal/status.rs
@@ -147,6 +147,7 @@ pub fn hunk_assignments(
         ctx,
         false,
         None::<Vec<but_core::TreeChange>>,
+        None,
     )?;
 
     Ok(assignments)

--- a/crates/but/src/rub/amend.rs
+++ b/crates/but/src/rub/amend.rs
@@ -70,7 +70,7 @@ fn wt_assignments(ctx: &mut CommandContext) -> anyhow::Result<Vec<HunkAssignment
     let changes =
         but_core::diff::ui::worktree_changes_by_worktree_dir(ctx.project().path.clone())?.changes;
     let (assignments, _assignments_error) =
-        but_hunk_assignment::assignments_with_fallback(ctx, false, Some(changes.clone()))?;
+        but_hunk_assignment::assignments_with_fallback(ctx, false, Some(changes.clone()), None)?;
     Ok(assignments)
 }
 

--- a/crates/but/src/rub/assign.rs
+++ b/crates/but/src/rub/assign.rs
@@ -39,7 +39,7 @@ pub(crate) fn assign_all(
     let changes =
         but_core::diff::ui::worktree_changes_by_worktree_dir(ctx.project().path.clone())?.changes;
     let (assignments, _assignments_error) =
-        but_hunk_assignment::assignments_with_fallback(ctx, false, Some(changes.clone()))?;
+        but_hunk_assignment::assignments_with_fallback(ctx, false, Some(changes.clone()), None)?;
 
     let mut reqs = Vec::new();
     for assignment in assignments {
@@ -77,7 +77,7 @@ fn do_assignments(
     ctx: &mut CommandContext,
     reqs: Vec<HunkAssignmentRequest>,
 ) -> anyhow::Result<()> {
-    let rejections = but_hunk_assignment::assign(ctx, reqs)?;
+    let rejections = but_hunk_assignment::assign(ctx, reqs, None)?;
     if !rejections.is_empty() {
         command::print(&rejections, false)?;
     }
@@ -109,7 +109,7 @@ fn to_assignment_request(
     let changes =
         but_core::diff::ui::worktree_changes_by_worktree_dir(ctx.project().path.clone())?.changes;
     let (assignments, _assignments_error) =
-        but_hunk_assignment::assignments_with_fallback(ctx, false, Some(changes.clone()))?;
+        but_hunk_assignment::assignments_with_fallback(ctx, false, Some(changes.clone()), None)?;
     let mut reqs = Vec::new();
     for assignment in assignments {
         if assignment.path == path {

--- a/crates/but/src/status/mod.rs
+++ b/crates/but/src/status/mod.rs
@@ -28,7 +28,7 @@ pub(crate) fn worktree(repo_path: &Path, _json: bool) -> anyhow::Result<()> {
 
     let changes = but_core::diff::ui::worktree_changes_by_worktree_dir(project.path)?.changes;
     let (assignments, _assignments_error) =
-        but_hunk_assignment::assignments_with_fallback(ctx, false, Some(changes.clone()))?;
+        but_hunk_assignment::assignments_with_fallback(ctx, false, Some(changes.clone()), None)?;
 
     let mut by_file: BTreeMap<BString, Vec<HunkAssignment>> = BTreeMap::new();
     for assignment in &assignments {
@@ -125,7 +125,7 @@ pub(crate) fn all_files(ctx: &mut CommandContext) -> anyhow::Result<Vec<CliId>> 
     let changes =
         but_core::diff::ui::worktree_changes_by_worktree_dir(ctx.project().path.clone())?.changes;
     let (assignments, _assignments_error) =
-        but_hunk_assignment::assignments_with_fallback(ctx, false, Some(changes.clone()))?;
+        but_hunk_assignment::assignments_with_fallback(ctx, false, Some(changes.clone()), None)?;
     let out = assignments
         .iter()
         .map(CliId::file_from_assignment)

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -273,6 +273,7 @@ pub mod commands {
             ctx,
             false,
             Some(but_core::diff::ui::worktree_changes_by_worktree_dir(project.path)?.changes),
+            None,
         )?;
         let assigned_diffspec = but_workspace::flatten_diff_specs(
             assignments

--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -362,6 +362,7 @@ pub fn uncommit_changes(
             &mut ctx,
             false,
             None::<Vec<but_core::TreeChange>>,
+            None,
         )?;
         Some(changes.0)
     } else {
@@ -384,6 +385,7 @@ pub fn uncommit_changes(
             &mut ctx,
             false,
             None::<Vec<but_core::TreeChange>>,
+            None,
         )?;
 
         let before_assignments = before_assignments
@@ -401,7 +403,7 @@ pub fn uncommit_changes(
             })
             .collect::<Vec<_>>();
 
-        but_hunk_assignment::assign(&mut ctx, to_assign)?;
+        but_hunk_assignment::assign(&mut ctx, to_assign, None)?;
     }
 
     let app_settings = ctx.app_settings();

--- a/crates/gitbutler-watcher/Cargo.toml
+++ b/crates/gitbutler-watcher/Cargo.toml
@@ -27,6 +27,7 @@ gitbutler-project.workspace = true
 but-core.workspace = true
 but-settings.workspace = true
 but-hunk-assignment.workspace = true
+but-hunk-dependency.workspace = true
 serde-error = "0.1.3"
 
 [lints.clippy]

--- a/packages/ui/src/lib/hunkDiff/HunkDiffRow.svelte
+++ b/packages/ui/src/lib/hunkDiff/HunkDiffRow.svelte
@@ -110,7 +110,7 @@
 	});
 
 	const locked = $derived(row.locks !== undefined && row.locks.length > 0);
-	const clickable = $derived(isClickable && !locked);
+	const clickable = $derived(isClickable);
 </script>
 
 {#snippet countColumn(side: CountColumnSide)}
@@ -130,9 +130,9 @@
 		class:locked
 		style="--staging-column-width: {stagingColumnWidth}px; --number-col-width: {minWidth}rem;"
 		class:stagable={staged !== undefined && !hideCheckboxes}
-		onmousedown={(ev) => !locked && lineSelection.onStart(ev, row, idx)}
-		onmouseenter={(ev) => !locked && lineSelection.onMoveOver(ev, row, idx)}
-		onmouseup={() => !locked && lineSelection.onEnd()}
+		onmousedown={(ev) => lineSelection.onStart(ev, row, idx)}
+		onmouseenter={(ev) => lineSelection.onMoveOver(ev, row, idx)}
+		onmouseup={() => lineSelection.onEnd()}
 		oncontextmenu={(ev) => {
 			ev.preventDefault();
 			ev.stopPropagation();
@@ -170,9 +170,9 @@
 			class:is-last={row.isLast}
 			class:staged={staged && deltaLine}
 			class:locked
-			onmousedown={(ev) => !locked && lineSelection.onStart(ev, row, idx)}
-			onmouseenter={(ev) => !locked && lineSelection.onMoveOver(ev, row, idx)}
-			onmouseup={() => !locked && lineSelection.onEnd()}
+			onmousedown={(ev) => lineSelection.onStart(ev, row, idx)}
+			onmouseenter={(ev) => lineSelection.onMoveOver(ev, row, idx)}
+			onmouseup={() => lineSelection.onEnd()}
 			oncontextmenu={(ev) => {
 				ev.preventDefault();
 				ev.stopPropagation();
@@ -430,6 +430,11 @@
 			border-color: var(--clr-diff-locked-count-border);
 			background-color: var(--clr-diff-locked-count-bg);
 			color: var(--clr-diff-locked-count-text);
+			&.staged {
+				border-color: var(--clr-diff-locked-count-border);
+				background-color: var(--clr-scale-warn-60);
+				color: var(--clr-scale-warn-30);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Goal

-   Show a lock icon next to a file or diff to indicate that it is locked to a
    specific branch.

## Investigation

-   We now have lock information from the HunkAssignments.
    -   We can also get file dependencies through it's own endpoint.
    -   The issue is that the HunkAssignment information is fallible. This means
        that we probably shouldn't rely on it at the minute?
-   We're going to compute the locking information separately and then pass it
    into the hunk assignments seperatly.
    -   We could either pass in just the `diffs` property of
        the `HunkDependencies` struct, or we could just pass the entire thing.
    -   I think passing the entire think makes more sense. The other property is the
        `errors` struct which could be helpful in the future.
-   We already have the `DependencyService` which is currently responsible for
    returning locking information. It feels like there are a handful of options that
    we could take to adapt the existing logic:
    1.  Inject the `WorktreeService` into the `DependencyService` and then use
        the `worktreeData` endpoint to get the dependencies.
    2.  Remove the `DependencyService` in favor of having it's existing methods
        sit in `WorktreeService`
    -   For now I am inclined to consume the `WorktreeService` from inside the
        `DependencyService`. This is because the `DependencyService` is using an
        entity adapter, and it feels like there is _enough_ logic going on there
        that it warrents it's own home.
-   `getLineLocks` is currently used to extract individual lines that are locked
    from the the information.
    -   Currently, this takes a `excludeStackId` as a filter, which hides a
        particular stack from the output, and if filter is `undefined`, it will
        filter out everything.
        -   In `Unassigned changes` we presumibly will always want to show the
            changes.
        -   In `Assigned changes` we may still want to show them, or might want
            to show them differently.
            -   Talking to pavel, it seems like we are going to want to show
                them differently. So I'm going to remove the input `stackId`
