### PR TITLE
Tools, structured output and auto-commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,7 +749,9 @@ dependencies = [
  "but-db",
  "but-graph",
  "but-hunk-assignment",
+ "but-hunk-dependency",
  "but-settings",
+ "but-tools",
  "but-workspace",
  "chrono",
  "gitbutler-branch",
@@ -965,6 +967,27 @@ dependencies = [
  "gix",
  "gix-testtools",
  "termtree",
+]
+
+[[package]]
+name = "but-tools"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "async-openai",
+ "but-core",
+ "but-graph",
+ "but-workspace",
+ "futures",
+ "gitbutler-branch",
+ "gitbutler-branch-actions",
+ "gitbutler-command-context",
+ "gitbutler-oplog",
+ "gix",
+ "schemars 0.9.0",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ but-db = { path = "crates/but-db" }
 but-graph = { path = "crates/but-graph" }
 but-action = { path = "crates/but-action" }
 but-status = { path = "crates/but-status" }
+but-tools = { path = "crates/but-tools" }
 git2-hooks = { version = "0.5.0" }
 itertools = "0.14.0"
 

--- a/apps/desktop/src/components/v3/Feed.svelte
+++ b/apps/desktop/src/components/v3/Feed.svelte
@@ -65,6 +65,7 @@
 		top: 0;
 		width: 100%;
 		padding: 16px;
+		gap: 8px;
 		border-bottom: 1px solid var(--clr-border-2);
 	}
 

--- a/apps/desktop/src/lib/actions/actionService.svelte.ts
+++ b/apps/desktop/src/lib/actions/actionService.svelte.ts
@@ -1,0 +1,34 @@
+import { invalidatesList, ReduxTag } from '$lib/state/tags';
+import type { TreeChange } from '$lib/hunks/change';
+import type { BackendApi, ClientState } from '$lib/state/clientState.svelte';
+
+export class ActionService {
+	private api: ReturnType<typeof injectEndpoints>;
+
+	constructor(backendApi: BackendApi) {
+		this.api = injectEndpoints(backendApi);
+	}
+
+	get autoCommit() {
+		return this.api.endpoints.autoCommit.useMutation();
+	}
+}
+
+function injectEndpoints(api: ClientState['backendApi']) {
+	return api.injectEndpoints({
+		endpoints: (build) => ({
+			autoCommit: build.mutation<void, { projectId: string; changes: TreeChange[] }>({
+				query: ({ projectId, changes }) => ({
+					command: 'auto_commit',
+					params: { projectId, changes },
+					actionName: 'Figure out where to commit the given changes'
+				}),
+				invalidatesTags: [
+					invalidatesList(ReduxTag.Stacks),
+					invalidatesList(ReduxTag.StackDetails),
+					invalidatesList(ReduxTag.WorktreeChanges)
+				]
+			})
+		})
+	});
+}

--- a/apps/desktop/src/lib/ai/service.ts
+++ b/apps/desktop/src/lib/ai/service.ts
@@ -258,6 +258,13 @@ export class AIService {
 		);
 	}
 
+	async validateGitButlerAPIConfiguration(): Promise<boolean> {
+		if (!(await this.usingGitButlerAPI())) {
+			return false;
+		}
+		return !!get(this.tokenMemoryService.token);
+	}
+
 	// This optionally returns a summarizer. There are a few conditions for how this may occur
 	// Firstly, if the user has opted to use the GB API and isn't logged in, it will return undefined
 	// Secondly, if the user has opted to bring their own key but hasn't provided one, it will return undefined

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -16,6 +16,7 @@
 	import SwitchThemeMenuAction from '$components/SwitchThemeMenuAction.svelte';
 	import ToastController from '$components/ToastController.svelte';
 	import ZoomInOutMenuAction from '$components/ZoomInOutMenuAction.svelte';
+	import { ActionService } from '$lib/actions/actionService.svelte';
 	import { PromptService as AIPromptService } from '$lib/ai/promptService';
 	import { AIService } from '$lib/ai/service';
 	import { PostHogWrapper } from '$lib/analytics/posthog';
@@ -146,6 +147,7 @@
 	setContext(UiState, uiState);
 
 	const stackService = new StackService(clientState['backendApi'], forgeFactory, uiState);
+	const actionService = new ActionService(clientState['backendApi']);
 	const oplogService = new OplogService(clientState['backendApi']);
 	const baseBranchService = new BaseBranchService(clientState.backendApi);
 	const worktreeService = new WorktreeService(clientState);
@@ -227,6 +229,7 @@
 	setContext(StackingLineManagerFactory, data.stackingLineManagerFactory);
 	setContext(AppSettings, data.appSettings);
 	setContext(StackService, stackService);
+	setContext(ActionService, actionService);
 	setContext(OplogService, oplogService);
 	setContext(BaseBranchService, baseBranchService);
 	setContext(UpstreamIntegrationService, upstreamIntegrationService);

--- a/crates/but-action/Cargo.toml
+++ b/crates/but-action/Cargo.toml
@@ -43,3 +43,5 @@ but-core.workspace = true
 but-graph.workspace = true
 but-workspace.workspace = true
 but-hunk-assignment.workspace = true
+but-hunk-dependency.workspace = true
+but-tools.workspace = true

--- a/crates/but-action/src/auto_commit.rs
+++ b/crates/but-action/src/auto_commit.rs
@@ -1,0 +1,46 @@
+use but_tools::workspace::{
+    CommitParameters, CreateBranchParameters, create_branch, create_commit,
+};
+use gitbutler_command_context::CommandContext;
+
+use crate::OpenAiProvider;
+
+pub fn auto_commit(
+    ctx: &mut CommandContext,
+    openai: &OpenAiProvider,
+    changes: Vec<but_core::TreeChange>,
+) -> anyhow::Result<()> {
+    let repo = ctx.gix_repo()?;
+
+    let project_status = crate::get_project_status(ctx, &repo, Some(changes))?;
+
+    let grouping = crate::grouping::group(openai, &project_status)?;
+    for branch in &grouping.branches_to_create {
+        let name = branch.branch_name.clone();
+        let description = branch.description.clone();
+        create_branch(
+            ctx,
+            CreateBranchParameters {
+                branch_name: name,
+                description,
+            },
+        )?;
+    }
+
+    for group in &grouping.groups {
+        let commit_message = group.commit_message.clone();
+        let files = group.files.clone();
+        let branch_name = group.suggested_branch.name();
+
+        create_commit(
+            ctx,
+            CommitParameters {
+                message: commit_message,
+                branch_name,
+                files,
+            },
+        )?;
+    }
+
+    Ok(())
+}

--- a/crates/but-action/src/grouping.rs
+++ b/crates/but-action/src/grouping.rs
@@ -1,0 +1,106 @@
+use std::{fmt::Debug, str};
+
+use async_openai::types::{ChatCompletionRequestSystemMessage, ChatCompletionRequestUserMessage};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{OpenAiProvider, ProjectStatus, openai};
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub enum BranchSuggestion {
+    #[serde(rename = "new")]
+    New(String),
+    #[serde(rename = "existing")]
+    Existing(String),
+}
+
+impl BranchSuggestion {
+    pub fn name(&self) -> String {
+        match self {
+            BranchSuggestion::New(name) => name.clone(),
+            BranchSuggestion::Existing(name) => name.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct Group {
+    #[schemars(
+        description = "A list of the files in this group. They should be file paths relative to the project root."
+    )]
+    pub files: Vec<String>,
+    #[schemars(
+        description = "The commit message for this group, including a detailed explanation of the changes in this group.
+        It should not include the intention, only an overview of the actual changes made and why they are related."
+    )]
+    pub commit_message: String,
+    #[schemars(description = "The suggested branch to apply these changes to.
+        This can be either an existing branch or a new one.")]
+    pub suggested_branch: BranchSuggestion,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct BranchCreation {
+    #[schemars(description = "The name of the branch to create.")]
+    pub branch_name: String,
+    #[schemars(
+        description = "A detailed description of the changes in this branch, including the files changed and the commit messages."
+    )]
+    pub description: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct Grouping {
+    #[schemars(description = "The information of the branches to create.
+    If any of the groups requires a new branch to be created, this field will contain the details of that branch.")]
+    pub branches_to_create: Vec<BranchCreation>,
+    #[schemars(description = "A list of file change groups.
+        The files are grouped by related changes that should be committed together.")]
+    pub groups: Vec<Group>,
+}
+
+pub fn group(openai: &OpenAiProvider, project_status: &ProjectStatus) -> anyhow::Result<Grouping> {
+    let system_message ="
+        You are an expert in grouping file changes into logical units for version control.
+        When given the status of a project, you should be able to identify related changes and suggest how they should be grouped into commits.
+        It's also important to suggest a branch for each group of changes.
+        The branch can be either an existing branch or a new one.
+        In order to determine the branch, you should consider diffs, the assignments and the dependency locks, if any.
+        ";
+
+    let serialized_project_status = serde_json::to_string_pretty(project_status)
+        .map_err(|e| anyhow::anyhow!("Failed to serialize project status: {}", e))?;
+    let user_message = format!(
+        "
+        Please group the file changes into logical units for version control.
+        Each group should include:
+        - A list of files in the group (relative paths to the project root).
+        - A detailed summary of the changes in the group (not the intention, but an overview
+        of the actual changes made and why they are related).
+        - A suggested branch for the group of changes (either an existing branch or a new one
+        with a descriptive name).
+
+        Multiple groups can (and usually should) belong to the same branch.
+        Name the branches descriptively, in kebab-case (e.g., `fix-user-login-bug`). Don't use slashes (/).
+
+        Here is the status of the project:
+        <project_status>
+        {}
+        </project_status>
+            ",
+        serialized_project_status
+    );
+
+    let messages = vec![
+        ChatCompletionRequestSystemMessage::from(system_message).into(),
+        ChatCompletionRequestUserMessage::from(user_message).into(),
+    ];
+
+    let grouping = openai::structured_output_blocking::<Grouping>(openai, messages)?
+        .ok_or_else(|| anyhow::anyhow!("Failed to get grouping from OpenAI"))?;
+
+    Ok(grouping)
+}

--- a/crates/but-action/src/lib.rs
+++ b/crates/but-action/src/lib.rs
@@ -5,6 +5,7 @@ use std::{
     str::FromStr,
 };
 
+use but_core::{TreeChange, UnifiedDiff};
 use but_workspace::ui::StackEntry;
 use gitbutler_branch::BranchCreateRequest;
 use gitbutler_command_context::CommandContext;
@@ -15,8 +16,10 @@ pub use openai::{CredentialsKind, OpenAiProvider};
 use serde::{Deserialize, Serialize};
 
 mod action;
+mod auto_commit;
 mod gb_client;
 mod generate;
+mod grouping;
 mod openai;
 pub mod reword;
 mod serialize;
@@ -30,6 +33,16 @@ use strum::EnumString;
 use uuid::Uuid;
 pub use workflow::WorkflowList;
 pub use workflow::list_workflows;
+
+pub(crate) const DIFF_CONTEXT_LINES: u32 = 3;
+
+pub fn auto_commit(
+    ctx: &mut CommandContext,
+    openai: &OpenAiProvider,
+    changes: Vec<TreeChange>,
+) -> anyhow::Result<()> {
+    auto_commit::auto_commit(ctx, openai, changes)
+}
 
 pub fn handle_changes(
     ctx: &mut CommandContext,
@@ -81,6 +94,13 @@ fn default_target_setting_if_none(
     Ok(target)
 }
 
+fn stacks(ctx: &CommandContext, repo: &gix::Repository) -> anyhow::Result<Vec<StackEntry>> {
+    let meta = VirtualBranchesTomlMetadata::from_path(
+        ctx.project().gb_dir().join("virtual_branches.toml"),
+    )?;
+    but_workspace::stacks_v3(repo, &meta, but_workspace::StacksFilter::InWorkspace)
+}
+
 /// Returns the currently applied stacks, creating one if none exists.
 fn stacks_creating_if_none(
     ctx: &CommandContext,
@@ -88,10 +108,7 @@ fn stacks_creating_if_none(
     repo: &gix::Repository,
     perm: &mut WorktreeWritePermission,
 ) -> anyhow::Result<Vec<StackEntry>> {
-    let meta = VirtualBranchesTomlMetadata::from_path(
-        ctx.project().gb_dir().join("virtual_branches.toml"),
-    )?;
-    let stacks = but_workspace::stacks_v3(repo, &meta, but_workspace::StacksFilter::InWorkspace)?;
+    let stacks = stacks(ctx, repo)?;
     if stacks.is_empty() {
         let template = gitbutler_stack::canned_branch_name(ctx.repo())?;
         let branch_name = gitbutler_stack::Stack::next_available_name(
@@ -137,4 +154,146 @@ pub struct Outcome {
 pub struct UpdatedBranch {
     pub branch_name: String,
     pub new_commits: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RichHunk {
+    /// The diff string.
+    pub diff: String,
+    /// The stack ID this hunk is assigned to, if any.
+    pub assigned_to_stack: Option<but_workspace::StackId>,
+    /// The locks this hunk has, if any.
+    pub dependency_locks: Vec<but_hunk_dependency::ui::HunkLock>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileChange {
+    /// The path of the file that has changed.
+    pub path: String,
+    /// The file change status
+    pub status: String,
+    /// The hunk changes in the file.
+    pub hunks: Vec<RichHunk>,
+}
+
+/// Represents the status of a project, including applied stacks and file changes.
+///
+/// The shape of this struct is designed to be serializable and as simple as possible for use in LLM context.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectStatus {
+    /// List of stacks applied to the project's workspace
+    stacks: Vec<but_workspace::ui::StackEntry>,
+    /// Unified diff changes that could be committed.
+    file_changes: Vec<FileChange>,
+}
+
+pub fn get_project_status(
+    ctx: &mut CommandContext,
+    repo: &gix::Repository,
+    filter_changes: Option<Vec<but_core::TreeChange>>,
+) -> anyhow::Result<ProjectStatus> {
+    let stacks = crate::stacks(ctx, repo)?;
+
+    let worktree = but_core::diff::worktree_changes(repo)?;
+    let changes = if let Some(filter) = filter_changes {
+        worktree
+            .changes
+            .into_iter()
+            .filter(|change| filter.iter().any(|f| f.path == change.path))
+            .collect::<Vec<_>>()
+    } else {
+        worktree.changes.clone()
+    };
+    let diff = unified_diff_for_changes(repo, changes, crate::DIFF_CONTEXT_LINES)?;
+    // Get any assignments that may have been made, which also includes any hunk locks. Assignments should be updated according to locks where applicable.
+    let (assignments, _) = but_hunk_assignment::assignments_with_fallback(
+        ctx,
+        true,
+        None::<Vec<but_core::TreeChange>>,
+        None,
+    )
+    .map_err(|err| serde_error::Error::new(&*err))?;
+
+    let file_changes = get_file_changes(&diff, assignments.clone());
+
+    Ok(ProjectStatus {
+        stacks,
+        file_changes,
+    })
+}
+
+fn get_file_changes(
+    changes: &[(TreeChange, UnifiedDiff)],
+    assingments: Vec<but_hunk_assignment::HunkAssignment>,
+) -> Vec<FileChange> {
+    let mut file_changes = vec![];
+    for (change, unified_diff) in changes.iter() {
+        match unified_diff {
+            but_core::UnifiedDiff::Patch { hunks, .. } => {
+                let path = change.path.to_string();
+                let status = match &change.status {
+                    but_core::TreeStatus::Addition { .. } => "added".to_string(),
+                    but_core::TreeStatus::Deletion { .. } => "deleted".to_string(),
+                    but_core::TreeStatus::Modification { .. } => "modified".to_string(),
+                    but_core::TreeStatus::Rename { previous_path, .. } => {
+                        format!("renamed from {}", previous_path)
+                    }
+                };
+
+                let hunks = hunks
+                    .iter()
+                    .map(|hunk| {
+                        let diff = hunk.diff.to_string();
+                        let assignment = assingments
+                            .iter()
+                            .find(|a| {
+                                a.path_bytes == change.path && a.hunk_header == Some(hunk.into())
+                            })
+                            .map(|a| (a.stack_id, a.hunk_locks.clone()));
+
+                        let (assigned_to_stack, dependency_locks) =
+                            if let Some((stack_id, locks)) = assignment {
+                                let locks = locks.unwrap_or_default();
+                                (stack_id, locks)
+                            } else {
+                                (None, vec![])
+                            };
+
+                        RichHunk {
+                            diff,
+                            assigned_to_stack,
+                            dependency_locks,
+                        }
+                    })
+                    .collect::<Vec<_>>();
+
+                file_changes.push(FileChange {
+                    path,
+                    status,
+                    hunks,
+                });
+            }
+            _ => continue,
+        }
+    }
+
+    file_changes
+}
+
+fn unified_diff_for_changes(
+    repo: &gix::Repository,
+    changes: Vec<but_core::TreeChange>,
+    context_lines: u32,
+) -> anyhow::Result<Vec<(but_core::TreeChange, but_core::UnifiedDiff)>> {
+    changes
+        .into_iter()
+        .map(|tree_change| {
+            tree_change
+                .unified_diff(repo, context_lines)
+                .map(|diff| (tree_change, diff.expect("no submodule")))
+        })
+        .collect::<Result<Vec<_>, _>>()
 }

--- a/crates/but-tools/Cargo.toml
+++ b/crates/but-tools/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "but-tools"
+version = "0.0.0"
+edition = "2024"
+authors = ["GitButler <gitbutler@gitbutler.com>"]
+publish = false
+
+[lib]
+doctest = false
+test = false
+
+[dependencies]
+async-openai = "0.28.2"
+tokio = { workspace = true, features = ["rt-multi-thread", "io-std"] }
+serde_json = "1.0.138"
+futures = "0.3.31"
+anyhow = "1.0.98"
+schemars = "0.9.0"
+serde = { workspace = true, features = ["std"] }
+gix.workspace = true
+but-core.workspace = true
+but-workspace.workspace = true
+gitbutler-command-context.workspace = true
+gitbutler-oplog.workspace = true
+but-graph.workspace = true
+gitbutler-branch-actions.workspace = true
+gitbutler-branch.workspace = true

--- a/crates/but-tools/src/lib.rs
+++ b/crates/but-tools/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod openai;
+pub mod tool;
+pub mod workspace;

--- a/crates/but-tools/src/openai.rs
+++ b/crates/but-tools/src/openai.rs
@@ -1,0 +1,20 @@
+use async_openai::types::{ChatCompletionTool, ChatCompletionToolType, FunctionObject};
+
+use crate::tool::Tool;
+
+impl TryFrom<&dyn Tool> for ChatCompletionTool {
+    type Error = anyhow::Error;
+    fn try_from(tool: &dyn Tool) -> Result<ChatCompletionTool, Self::Error> {
+        let tool = ChatCompletionTool {
+            r#type: ChatCompletionToolType::Function,
+            function: FunctionObject {
+                name: tool.name(),
+                description: Some(tool.description()),
+                parameters: Some(tool.parameters()),
+                strict: Some(false),
+            },
+        };
+
+        Ok(tool)
+    }
+}

--- a/crates/but-tools/src/tool.rs
+++ b/crates/but-tools/src/tool.rs
@@ -1,0 +1,49 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use gitbutler_command_context::CommandContext;
+
+pub struct Toolset<'a> {
+    ctx: &'a mut CommandContext,
+    tools: BTreeMap<String, Arc<dyn Tool>>,
+}
+
+impl<'a> Toolset<'a> {
+    pub fn new(ctx: &'a mut CommandContext) -> Self {
+        Toolset {
+            ctx,
+            tools: BTreeMap::new(),
+        }
+    }
+
+    pub fn register_tool<T: Tool>(&mut self, tool: T) {
+        self.tools.insert(tool.name(), Arc::new(tool));
+    }
+
+    pub fn get(&self, name: &str) -> Option<Arc<dyn Tool>> {
+        self.tools.get(name).cloned()
+    }
+
+    pub fn list(&self) -> Vec<Arc<dyn Tool>> {
+        self.tools.values().cloned().collect()
+    }
+
+    pub fn call_tool(&mut self, name: &str, parameters: &str) -> anyhow::Result<serde_json::Value> {
+        let tool = self
+            .get(name)
+            .ok_or_else(|| anyhow::anyhow!("Tool '{}' not found", name))?;
+        let params: serde_json::Value = serde_json::from_str(parameters)
+            .map_err(|e| anyhow::anyhow!("Failed to parse parameters: {}", e))?;
+        tool.call(params, self.ctx)
+    }
+}
+
+pub trait Tool: 'static + Send + Sync {
+    fn name(&self) -> String;
+    fn description(&self) -> String;
+    fn parameters(&self) -> serde_json::Value;
+    fn call(
+        self: Arc<Self>,
+        parameters: serde_json::Value,
+        ctx: &mut CommandContext,
+    ) -> anyhow::Result<serde_json::Value>;
+}

--- a/crates/but-tools/src/workspace.rs
+++ b/crates/but-tools/src/workspace.rs
@@ -1,0 +1,183 @@
+use std::sync::Arc;
+
+use but_graph::VirtualBranchesTomlMetadata;
+use gitbutler_command_context::CommandContext;
+use gitbutler_oplog::{OplogExt, SnapshotExt};
+use schemars::{JsonSchema, schema_for};
+
+use crate::tool::{Tool, Toolset};
+
+/// Creates a toolset for workspace-related operations.
+pub fn commit_toolset(ctx: &mut CommandContext) -> anyhow::Result<Toolset> {
+    let mut toolset = Toolset::new(ctx);
+
+    toolset.register_tool(Commit);
+    toolset.register_tool(CreateBranch);
+
+    Ok(toolset)
+}
+
+pub struct Commit;
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitParameters {
+    /// The commit message to use.
+    #[schemars(description = "The commit message to use")]
+    pub message: String,
+    /// The branch name to commit to.
+    #[schemars(description = "The branch name to commit to")]
+    pub branch_name: String,
+    /// The list of files to commit.
+    #[schemars(
+        description = "The list of files to commit. This should be the paths of the files relative to the project root."
+    )]
+    pub files: Vec<String>,
+}
+
+/// Commit tool.
+///
+/// Takes in a commit message, target branch name, and a list of file paths to commit.
+impl Tool for Commit {
+    fn name(&self) -> String {
+        "commit".to_string()
+    }
+
+    fn description(&self) -> String {
+        "Commit the file changes into a branch".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        let schema = schema_for!(CommitParameters);
+        serde_json::to_value(&schema).unwrap_or_default()
+    }
+
+    fn call(
+        self: Arc<Self>,
+        parameters: serde_json::Value,
+        ctx: &mut CommandContext,
+    ) -> anyhow::Result<serde_json::Value> {
+        let params: CommitParameters = serde_json::from_value(parameters)
+            .map_err(|e| anyhow::anyhow!("Failed to parse input parameters: {}", e))?;
+
+        create_commit(ctx, params)
+    }
+}
+
+pub fn create_commit(
+    ctx: &mut CommandContext,
+    params: CommitParameters,
+) -> Result<serde_json::Value, anyhow::Error> {
+    let repo = ctx.gix_repo()?;
+    let mut guard = ctx.project().exclusive_worktree_access();
+
+    let worktree = but_core::diff::worktree_changes(&repo)?;
+    let file_changes: Vec<but_workspace::DiffSpec> = worktree
+        .changes
+        .iter()
+        .filter(|change| params.files.contains(&change.path.to_string()))
+        .map(Into::into)
+        .collect::<Vec<_>>();
+
+    let stacks = stacks(ctx, &repo)?;
+
+    let stack_id = stacks
+        .iter()
+        .find(|s| s.heads.iter().any(|h| h.name == params.branch_name))
+        .map(|s| s.id)
+        .ok_or_else(|| anyhow::anyhow!("Branch '{}' not found", params.branch_name))?;
+
+    let snapshot_tree = ctx.prepare_snapshot(guard.read_permission());
+
+    let outcome = but_workspace::commit_engine::create_commit_simple(
+        ctx,
+        stack_id,
+        None,
+        file_changes,
+        params.message.clone(),
+        params.branch_name,
+        guard.write_permission(),
+    );
+
+    let _ = snapshot_tree.and_then(|snapshot_tree| {
+        ctx.snapshot_commit_creation(
+            snapshot_tree,
+            outcome.as_ref().err(),
+            params.message,
+            None,
+            guard.write_permission(),
+        )
+    });
+
+    let outcome: but_workspace::commit_engine::ui::CreateCommitOutcome = outcome?.into();
+    Ok(serde_json::to_value(outcome)?)
+}
+
+fn stacks(
+    ctx: &CommandContext,
+    repo: &gix::Repository,
+) -> anyhow::Result<Vec<but_workspace::ui::StackEntry>> {
+    let meta = VirtualBranchesTomlMetadata::from_path(
+        ctx.project().gb_dir().join("virtual_branches.toml"),
+    )?;
+    but_workspace::stacks_v3(repo, &meta, but_workspace::StacksFilter::InWorkspace)
+}
+
+pub struct CreateBranch;
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateBranchParameters {
+    /// The name of the new branch to create.
+    #[schemars(description = "The name of the new branch to create")]
+    pub branch_name: String,
+    /// The description of the new branch.
+    #[schemars(
+        description = "The description of the new branch. This should be a short summary of the branch's purpose."
+    )]
+    pub description: String,
+}
+
+impl Tool for CreateBranch {
+    fn name(&self) -> String {
+        "createBranch".to_string()
+    }
+
+    fn description(&self) -> String {
+        "Create a new branch in the workspace".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        let schema = schema_for!(CreateBranchParameters);
+        serde_json::to_value(&schema).unwrap_or_default()
+    }
+
+    fn call(
+        self: Arc<Self>,
+        parameters: serde_json::Value,
+        ctx: &mut CommandContext,
+    ) -> anyhow::Result<serde_json::Value> {
+        let params: CreateBranchParameters = serde_json::from_value(parameters)
+            .map_err(|e| anyhow::anyhow!("Failed to parse input parameters: {}", e))?;
+
+        create_branch(ctx, params)
+    }
+}
+
+pub fn create_branch(
+    ctx: &mut CommandContext,
+    params: CreateBranchParameters,
+) -> Result<serde_json::Value, anyhow::Error> {
+    let mut guard = ctx.project().exclusive_worktree_access();
+    let perm = guard.write_permission();
+
+    let branch = gitbutler_branch::BranchCreateRequest {
+        name: Some(params.branch_name),
+        ..Default::default()
+    };
+
+    let stack = gitbutler_branch_actions::create_virtual_branch(ctx, &branch, perm)?;
+
+    let outcome = serde_json::to_value(stack)?;
+    Ok(outcome)
+}

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -28,7 +28,7 @@ use anyhow::{Context, Result};
 use bstr::BString;
 use serde::{Deserialize, Serialize};
 
-use but_core::RefMetadata;
+use but_core::{RefMetadata, TreeChange};
 use gitbutler_command_context::CommandContext;
 use gitbutler_oxidize::OidExt;
 use gitbutler_stack::VirtualBranchesHandle;
@@ -107,6 +107,16 @@ pub struct DiffSpec {
     /// If empty, the whole file is taken as is if this seems to be an addition.
     /// Otherwise, the whole file is being deleted.
     pub hunk_headers: Vec<HunkHeader>,
+}
+
+impl From<&TreeChange> for DiffSpec {
+    fn from(change: &but_core::TreeChange) -> Self {
+        Self {
+            previous_path: change.previous_path().map(ToOwned::to_owned),
+            path: change.path.to_owned(),
+            hunk_headers: vec![],
+        }
+    }
 }
 
 /// The header of a hunk that represents a change to a file.

--- a/crates/gitbutler-tauri/src/action.rs
+++ b/crates/gitbutler-tauri/src/action.rs
@@ -1,5 +1,6 @@
 use crate::error::Error;
 use but_action::OpenAiProvider;
+use but_core::ui::TreeChange;
 use gitbutler_command_context::CommandContext;
 use gitbutler_project::ProjectId;
 use tracing::instrument;
@@ -54,4 +55,27 @@ pub fn list_workflows(
     let project = projects.get(project_id)?;
     let ctx = &mut CommandContext::open(&project, settings.get()?.clone())?;
     but_action::list_workflows(ctx, offset, limit).map_err(|e| Error::from(anyhow::anyhow!(e)))
+}
+
+#[tauri::command(async)]
+#[instrument(skip(projects, settings), err(Debug))]
+pub fn auto_commit(
+    projects: tauri::State<'_, gitbutler_project::Controller>,
+    settings: tauri::State<'_, but_settings::AppSettingsWithDiskSync>,
+    project_id: ProjectId,
+    changes: Vec<TreeChange>,
+) -> anyhow::Result<(), Error> {
+    let project = projects.get(project_id)?;
+    let changes: Vec<but_core::TreeChange> =
+        changes.into_iter().map(|change| change.into()).collect();
+    let ctx = &mut CommandContext::open(&project, settings.get()?.clone())?;
+    let openai = OpenAiProvider::with(Some(but_action::CredentialsKind::GitButlerProxied));
+    match openai {
+        Some(openai) => but_action::auto_commit(ctx, &openai, changes).map_err(|e| Error::from(anyhow::anyhow!(e))),
+        None => {
+            Err(Error::from(anyhow::anyhow!(
+                "No valid credentials found for AI provider. Please configure your GitButler account credentials."
+            )))
+        }
+    }
 }

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -288,6 +288,7 @@ fn main() {
                     action::list_actions,
                     action::handle_changes,
                     action::list_workflows,
+                    action::auto_commit,
                     cli::install_cli,
                     cli::cli_path,
                     workspace::stacks,


### PR DESCRIPTION
Added the primitives for:
- tools
- tool calling
- structured output

In addition to the first *AI workflow* based on these primitives: **Auto commit**.
This basically, just determines what to commit where.

### Description

- Added new `but-tools` crate with core tool abstractions and OpenAI integration for tool representation and invocation. Inspired by @krlvi ’s [tool-stuff changes](https://github.com/gitbutlerapp/gitbutler/tree/tool-stuff)
- Implemented tooling for commit and branch creation.
- Introduced auto-commit functionality with intelligent grouping and branch suggestion using OpenAI in `but-action`.
- Exposed `auto_commit` command in Tauri backend to trigger auto-commit from frontend.
- Integrated auto-commit feature and AI configuration validation into desktop frontend UI with new context menu item and service bindings.