### PR TITLE
Fix getting stuck committting

### DIFF
--- a/apps/desktop/src/components/v3/StackView.svelte
+++ b/apps/desktop/src/components/v3/StackView.svelte
@@ -231,7 +231,8 @@
 			<ReduxResult {projectId} result={branchesResult.current}>
 				{#snippet children(branches)}
 					<ConfigurableScrollableContainer>
-						{#if startCommitVisible.current}
+						<!-- If we are currently committing, we should keep this open so users can actually stop committing again :wink: -->
+						{#if startCommitVisible.current || isCommitting}
 							<div
 								class="assignments-wrap"
 								class:assignments__empty={changes.current.length === 0 && !isCommitting}


### PR DESCRIPTION
If you started off with just one change, and then you discard that change either in GB or in your editor, the commit message editor would close and you would be stuck committing. This keeps the commit editor open so you can cancel the commit operation