### PR TITLE
style(profile): remove custom checkmark styling from checked state

### DIFF
--- a/apps/web/src/routes/(app)/profile/+page.svelte
+++ b/apps/web/src/routes/(app)/profile/+page.svelte
@@ -804,18 +804,6 @@
 			&:checked {
 				border-color: var(--clr-scale-pop-70);
 				background-color: var(--clr-scale-pop-70);
-
-				&::after {
-					position: absolute;
-					top: 2px;
-					left: 5px;
-					width: 4px;
-					height: 8px;
-					transform: rotate(45deg);
-					border: solid white;
-					border-width: 0 2px 2px 0;
-					content: '';
-				}
 			}
 
 			&:disabled {


### PR DESCRIPTION
Eliminate the ::after pseudo-element that rendered a custom checkmark
in the checked state of the input.

This was mistakenly adding an extra element at the top of the section (soooo weird)