### PR TITLE
Introduce smart scrolling

### DIFF
--- a/apps/desktop/src/components/v3/BranchList.svelte
+++ b/apps/desktop/src/components/v3/BranchList.svelte
@@ -15,6 +15,7 @@
 	import { getColorFromCommitState, getIconFromCommitState } from '$components/v3/lib';
 	import { StackingReorderDropzoneManagerFactory } from '$lib/dragging/stackingReorderDropzoneManager';
 	import { DefaultForgeFactory } from '$lib/forge/forgeFactory.svelte';
+	import { IntelligentScrollingService } from '$lib/intelligentScrolling/service';
 	import { ModeService } from '$lib/mode/modeService';
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { combineResults } from '$lib/state/helpers';
@@ -39,11 +40,12 @@
 	};
 
 	const { projectId, branches, stackId, focusedStackId, onselect }: Props = $props();
-	const [stackService, uiState, modeService, forge] = inject(
+	const [stackService, uiState, modeService, forge, intelligentScrollingService] = inject(
 		StackService,
 		UiState,
 		ModeService,
-		DefaultForgeFactory
+		DefaultForgeFactory,
+		IntelligentScrollingService
 	);
 
 	const [insertBlankCommitInBranch, commitInsertion] = stackService.insertBlankCommit;
@@ -182,6 +184,7 @@
 								uiState.stack(stackId).selection.set(undefined);
 							} else {
 								uiState.stack(stackId).selection.set({ branchName });
+								intelligentScrollingService.show(projectId, stackId, 'details');
 							}
 							onselect?.();
 						}}

--- a/apps/desktop/src/components/v3/ChangedFiles.svelte
+++ b/apps/desktop/src/components/v3/ChangedFiles.svelte
@@ -2,6 +2,8 @@
 	import FileList from '$components/v3/FileList.svelte';
 	import FileListMode from '$components/v3/FileListMode.svelte';
 	import emptyFolderSvg from '$lib/assets/empty-state/empty-folder.svg?raw';
+	import { IntelligentScrollingService } from '$lib/intelligentScrolling/service';
+	import { inject } from '@gitbutler/shared/context';
 	import Badge from '@gitbutler/ui/Badge.svelte';
 	import EmptyStatePlaceholder from '@gitbutler/ui/EmptyStatePlaceholder.svelte';
 	import type { ConflictEntriesObj } from '$lib/files/conflicts';
@@ -30,6 +32,8 @@
 		draggableFiles
 	}: Props = $props();
 
+	const [intelligentScrollingService] = inject(IntelligentScrollingService);
+
 	let listMode: 'list' | 'tree' = $state('tree');
 </script>
 
@@ -50,6 +54,11 @@
 		{active}
 		{conflictEntries}
 		{draggableFiles}
+		onselect={() => {
+			if (stackId) {
+				intelligentScrollingService.show(projectId, stackId, 'diff');
+			}
+		}}
 	/>
 {:else}
 	<EmptyStatePlaceholder image={emptyFolderSvg} width={180} gap={4}>

--- a/apps/desktop/src/components/v3/SelectionView.svelte
+++ b/apps/desktop/src/components/v3/SelectionView.svelte
@@ -10,9 +10,10 @@
 		projectId: string;
 		selectionId?: SelectionId;
 		draggableFiles?: boolean;
+		onclose?: () => void;
 	};
 
-	let { projectId, selectionId, draggableFiles }: Props = $props();
+	let { projectId, selectionId, draggableFiles, onclose }: Props = $props();
 
 	const [idSelection] = inject(IdSelection);
 
@@ -38,6 +39,7 @@
 					if (selectionId) {
 						idSelection.remove(selectedFile.path, selectedFile);
 					}
+					onclose?.();
 				}}
 			/>
 		</ScrollableContainer>

--- a/apps/desktop/src/components/v3/UnassignedView.svelte
+++ b/apps/desktop/src/components/v3/UnassignedView.svelte
@@ -3,13 +3,13 @@
 	import WorktreeTipsFooter from '$components/v3/WorktreeTipsFooter.svelte';
 	import noChanges from '$lib/assets/illustrations/no-changes.svg?raw';
 	import { DefinedFocusable } from '$lib/focus/focusManager.svelte';
+	import { IntelligentScrollingService } from '$lib/intelligentScrolling/service';
 	import { UncommittedService } from '$lib/selection/uncommittedService.svelte';
 	import { UiState } from '$lib/state/uiState.svelte';
 	import { TestId } from '$lib/testing/testIds';
 	import { inject } from '@gitbutler/shared/context';
 	import Button from '@gitbutler/ui/Button.svelte';
 	import type { SelectionId } from '$lib/selection/key';
-
 	interface Props {
 		projectId: string;
 		focus: DefinedFocusable;
@@ -19,7 +19,11 @@
 
 	const selectionId = { type: 'worktree', stackId: undefined } as SelectionId;
 
-	const [uiState, uncommittedService] = inject(UiState, UncommittedService);
+	const [uiState, uncommittedService, intelligentScrollingService] = inject(
+		UiState,
+		UncommittedService,
+		IntelligentScrollingService
+	);
 	const projectState = $derived(uiState.project(projectId));
 	const exclusiveAction = $derived(projectState.exclusiveAction.current);
 	const isCommitting = $derived(exclusiveAction?.type === 'commit');
@@ -41,6 +45,9 @@
 			isScrollable = exists;
 		}}
 		overflow
+		onselect={() => {
+			intelligentScrollingService.unassignedFileClicked(projectId);
+		}}
 	>
 		{#snippet emptyPlaceholder()}
 			<div class="unassigned-changes__empty">

--- a/apps/desktop/src/lib/intelligentScrolling/service.ts
+++ b/apps/desktop/src/lib/intelligentScrolling/service.ts
@@ -1,0 +1,76 @@
+import { sleep } from '$lib/utils/sleep';
+import type { UiState } from '$lib/state/uiState.svelte';
+
+type Target = 'stack' | 'new-stack' | 'details' | 'diff';
+
+export class IntelligentScrollingService {
+	private targets: {
+		element: Element;
+		target: Target;
+		projectId: string;
+		stackId: string;
+	}[] = [];
+
+	constructor(private readonly uiState: UiState) {}
+
+	register(target: { element: Element; target: Target; projectId: string; stackId: string }) {
+		this.targets.push(target);
+
+		return () => {
+			this.targets = this.targets.filter((t) => t !== target);
+		};
+	}
+
+	async unassignedFileClicked(projectId: string) {
+		await sleep(15);
+
+		const projectState = this.uiState.project(projectId);
+
+		const committingState = projectState.exclusiveAction?.current;
+		if (committingState?.type !== 'commit') return;
+
+		const targetId = committingState.stackId;
+		const target = this.targets.find(
+			(t) => t.projectId === projectId && t.target === 'stack' && t.stackId === targetId
+		);
+
+		if (!target) return;
+
+		this.scroll(target.element);
+	}
+
+	/** Handles clicking on either a commit or branch header */
+	async show(projectId: string, stackId: string, type: Target) {
+		await sleep(15);
+
+		const target = this.targets.find(
+			(t) => t.projectId === projectId && t.target === type && t.stackId === stackId
+		);
+
+		if (!target) return;
+
+		this.scroll(target.element);
+	}
+
+	private scroll(element: Element) {
+		element.scrollIntoView({ behavior: 'smooth' });
+	}
+}
+
+export function scrollingAttachment(
+	intelligentScrollingService: IntelligentScrollingService,
+	projectId: string,
+	stackId: string,
+	target: Target
+) {
+	return (el: Element) => {
+		const registration = intelligentScrollingService.register({
+			element: el,
+			target,
+			projectId,
+			stackId
+		});
+
+		return () => registration();
+	};
+}

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -42,6 +42,7 @@
 	import { OplogService } from '$lib/history/oplogService.svelte';
 	import { HooksService } from '$lib/hooks/hooksService';
 	import { DiffService } from '$lib/hunks/diffService.svelte';
+	import { IntelligentScrollingService } from '$lib/intelligentScrolling/service';
 	import { IrcClient } from '$lib/irc/ircClient.svelte';
 	import { IrcService } from '$lib/irc/ircService.svelte';
 	import { platformName } from '$lib/platform/platform';
@@ -86,7 +87,6 @@
 	import { Toaster } from 'svelte-french-toast';
 	import type { LayoutData } from './$types';
 	import { env } from '$env/dynamic/public';
-
 	const { data, children }: { data: LayoutData; children: Snippet } = $props();
 
 	const userSettings = loadUserSettings();
@@ -144,6 +144,8 @@
 		clientState.dispatch
 	);
 	setContext(UiState, uiState);
+	const intelligentScrollingService = new IntelligentScrollingService(uiState);
+	setContext(IntelligentScrollingService, intelligentScrollingService);
 
 	const stackService = new StackService(clientState['backendApi'], forgeFactory, uiState);
 	const oplogService = new OplogService(clientState['backendApi']);


### PR DESCRIPTION
# Goal

- When clicking on items that shift content, make sure the most relevant content is scrolled to be on screen.

# Exploration

- There are some different situations that whatever this new system, it should cover:
  - When committing, if you view an uncommited file:
    - Scroll to stack
  - Clicking on a commit
    - Scroll to commit details
  - Clicking on an assigned file:
    - Scroll to hunk view

- It would be nice if we could just send off messages like "clicked on uncommitted file", "clicked on commit in stack X" ect... and then have the system handle whether or not it _should_ scroll.
- I don't want to have lots of logic for _when_ to scroll inside individual components as that will make it hard to change in the future.
- I don't think this should be tied into any existing services either because it's not really related to our current notions of "focus" or "selection". It's more of an extra behaviour that can be triggered on a click.

- It feels like there should be one service that components can register themselves into, and then the call-sites can call a funciton on the service to trigger the scroll.

- We have three target types:
  - New stack and branch
  - Stack
  - Details
    - Branch
    - Commit
  - Diff
    - Branch
    - Commit

- All of these can thingys can be identified by a stackId because there can only be one of each per stack.
- We could either make a component OR make a use:thingy or a new svelte attachment.
  - We should _probably_ make an attachment because it's the new thingy?

- One concern I have is in the timing on opening things. If I click on a file item, do I need to wait before trying to scroll to it?
  - I've had to add a 15ms delay before we start to scroll in order to give the thing time to get registered.
  - Having an arbitrary timeout sucks. One thing I could have a thingy that retries the find for a certain amount of time.
    - Perhaps this is too complicated for now

# Implementation

- Added new service `IntelligentScrollingService` that
  - Lets components register them as things that can be scrolled to.
    - There is an "attachment" that makes the registration more ergonomic. This is a relatively new thing that replaces the `use:` directives.
  - Lets components trigger a scroll. Some of these triggers have additional logic with the aim of making the various call-sites simpler.