### PR TITLE
Fix resizing bug

### DIFF
--- a/apps/desktop/src/components/v3/StackView.svelte
+++ b/apps/desktop/src/components/v3/StackView.svelte
@@ -414,11 +414,11 @@
 				/>
 				<Resizer
 					viewport={previewEl}
-					persistId="resizer-panel2-${stack.id}"
+					persistId="resizer-panel3-${stack.id}"
 					direction="right"
 					minWidth={20}
 					maxWidth={96}
-					syncName="panel2"
+					syncName="panel3"
 					dblclickSize
 				/>
 			</div>


### PR DESCRIPTION
The details view and diff view accidentally shared both persistedId and syncName.