### PR TITLE
Tool events and Auto-commit changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,6 +775,7 @@ dependencies = [
  "serde-error",
  "serde_json",
  "strum",
+ "tauri",
  "tokio",
  "tracing",
  "uuid",
@@ -983,10 +984,12 @@ dependencies = [
  "gitbutler-branch-actions",
  "gitbutler-command-context",
  "gitbutler-oplog",
+ "gitbutler-project",
  "gix",
  "schemars 0.9.0",
  "serde",
  "serde_json",
+ "tauri",
  "tokio",
 ]
 

--- a/apps/desktop/src/components/v3/FileList.svelte
+++ b/apps/desktop/src/components/v3/FileList.svelte
@@ -79,7 +79,7 @@
 
 		showToast({
 			style: 'neutral',
-			title: 'Creating a branch and commit...',
+			title: 'Figuring out where to commit the changes',
 			message: 'This may take a few seconds.'
 		});
 
@@ -94,7 +94,7 @@
 
 		showToast({
 			style: 'success',
-			title: 'Branch and commit created successfully.',
+			title: 'And... done!',
 			message: `Now, you're free to continue`
 		});
 	}

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -324,6 +324,11 @@
 			});
 		}
 	});
+
+	// Listen for stack details updates from the backend.
+	$effect(() => {
+		stackService.stackDetailsUpdateListener(projectId);
+	});
 </script>
 
 <!-- forces components to be recreated when projectId changes -->

--- a/crates/but-action/Cargo.toml
+++ b/crates/but-action/Cargo.toml
@@ -25,6 +25,7 @@ strum = { version = "0.27", features = ["derive"] }
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 gix.workspace = true
 rmcp = "0.1.5"
+tauri = { version = "^2.4.1", features = ["unstable"] }
 gitbutler-command-context.workspace = true
 gitbutler-stack.workspace = true
 gitbutler-operating-modes.workspace = true

--- a/crates/but-action/src/grouping.rs
+++ b/crates/but-action/src/grouping.rs
@@ -15,6 +15,7 @@ pub enum BranchSuggestion {
 }
 
 impl BranchSuggestion {
+    #[allow(dead_code)]
     pub fn name(&self) -> String {
         match self {
             BranchSuggestion::New(name) => name.clone(),
@@ -62,6 +63,7 @@ pub struct Grouping {
     pub groups: Vec<Group>,
 }
 
+#[allow(dead_code)]
 pub fn group(openai: &OpenAiProvider, project_status: &ProjectStatus) -> anyhow::Result<Grouping> {
     let system_message ="
         You are an expert in grouping file changes into logical units for version control.

--- a/crates/but-action/src/lib.rs
+++ b/crates/but-action/src/lib.rs
@@ -36,11 +36,12 @@ pub use workflow::list_workflows;
 pub(crate) const DIFF_CONTEXT_LINES: u32 = 3;
 
 pub fn auto_commit(
+    app_handle: &tauri::AppHandle,
     ctx: &mut CommandContext,
     openai: &OpenAiProvider,
     changes: Vec<TreeChange>,
 ) -> anyhow::Result<()> {
-    auto_commit::auto_commit(ctx, openai, changes)
+    auto_commit::auto_commit(app_handle, ctx, openai, changes)
 }
 
 pub fn handle_changes(

--- a/crates/but-tools/Cargo.toml
+++ b/crates/but-tools/Cargo.toml
@@ -17,6 +17,7 @@ futures = "0.3.31"
 anyhow = "1.0.98"
 schemars = "0.9.0"
 serde = { workspace = true, features = ["std"] }
+tauri = { version = "^2.4.1", features = ["unstable"] }
 gix.workspace = true
 but-core.workspace = true
 but-workspace.workspace = true
@@ -25,3 +26,4 @@ gitbutler-oplog.workspace = true
 but-graph.workspace = true
 gitbutler-branch-actions.workspace = true
 gitbutler-branch.workspace = true
+gitbutler-project.workspace = true

--- a/crates/but-tools/src/emit.rs
+++ b/crates/but-tools/src/emit.rs
@@ -1,0 +1,24 @@
+use but_workspace::StackId;
+use gitbutler_project::ProjectId;
+use tauri::Emitter;
+
+pub trait EmitStackUpdate {
+    /// Emits a stack update event with the given stack ID.
+    ///
+    /// This method should be implemented to emit an event that updates the stack details in the UI.
+    ///
+    /// # Arguments
+    ///
+    /// * `project_id` - The ID of the project to which the stack belongs.
+    /// * `stack_id` - The ID of the stack to update.
+    fn emit_stack_update(&self, project_id: ProjectId, stack_id: StackId);
+}
+
+impl EmitStackUpdate for tauri::AppHandle {
+    fn emit_stack_update(&self, project_id: ProjectId, stack_id: StackId) {
+        let name = format!("project://{}/stack_details_update", project_id);
+        let payload = serde_json::json!({ "stackId": stack_id });
+        self.emit(&name, payload)
+            .expect("Failed to emit stack details update");
+    }
+}

--- a/crates/but-tools/src/lib.rs
+++ b/crates/but-tools/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod emit;
 pub mod openai;
 pub mod tool;
 pub mod workspace;

--- a/crates/but-tools/src/tool.rs
+++ b/crates/but-tools/src/tool.rs
@@ -4,13 +4,15 @@ use gitbutler_command_context::CommandContext;
 
 pub struct Toolset<'a> {
     ctx: &'a mut CommandContext,
+    app_handle: Option<&'a tauri::AppHandle>,
     tools: BTreeMap<String, Arc<dyn Tool>>,
 }
 
 impl<'a> Toolset<'a> {
-    pub fn new(ctx: &'a mut CommandContext) -> Self {
+    pub fn new(ctx: &'a mut CommandContext, app_handle: Option<&'a tauri::AppHandle>) -> Self {
         Toolset {
             ctx,
+            app_handle,
             tools: BTreeMap::new(),
         }
     }
@@ -33,7 +35,7 @@ impl<'a> Toolset<'a> {
             .ok_or_else(|| anyhow::anyhow!("Tool '{}' not found", name))?;
         let params: serde_json::Value = serde_json::from_str(parameters)
             .map_err(|e| anyhow::anyhow!("Failed to parse parameters: {}", e))?;
-        tool.call(params, self.ctx)
+        tool.call(params, self.ctx, self.app_handle)
     }
 }
 
@@ -45,5 +47,6 @@ pub trait Tool: 'static + Send + Sync {
         self: Arc<Self>,
         parameters: serde_json::Value,
         ctx: &mut CommandContext,
+        app_handle: Option<&tauri::AppHandle>,
     ) -> anyhow::Result<serde_json::Value>;
 }

--- a/crates/gitbutler-tauri/src/action.rs
+++ b/crates/gitbutler-tauri/src/action.rs
@@ -58,8 +58,9 @@ pub fn list_workflows(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(projects, settings), err(Debug))]
+#[instrument(skip(app_handle, projects, settings), err(Debug))]
 pub fn auto_commit(
+    app_handle: tauri::AppHandle,
     projects: tauri::State<'_, gitbutler_project::Controller>,
     settings: tauri::State<'_, but_settings::AppSettingsWithDiskSync>,
     project_id: ProjectId,
@@ -71,7 +72,7 @@ pub fn auto_commit(
     let ctx = &mut CommandContext::open(&project, settings.get()?.clone())?;
     let openai = OpenAiProvider::with(Some(but_action::CredentialsKind::GitButlerProxied));
     match openai {
-        Some(openai) => but_action::auto_commit(ctx, &openai, changes).map_err(|e| Error::from(anyhow::anyhow!(e))),
+        Some(openai) => but_action::auto_commit(&app_handle, ctx, &openai, changes).map_err(|e| Error::from(anyhow::anyhow!(e))),
         None => {
             Err(Error::from(anyhow::anyhow!(
                 "No valid credentials found for AI provider. Please configure your GitButler account credentials."


### PR DESCRIPTION
The tools now can emit events to the Front End so that the changes are displayed as they are executed.
Also, the auto-commit workflow is again a tool calling loop

### Description

- Emit Tauri events from tools to update the Front End UI in real-time during workflow execution.
- Refactor auto-commit workflow to use tool-calling and integrate Tauri app handle for event emission.
- Add real-time stack details update subscription via Tauri events for automatic cache invalidation and UI refresh.
- Ensure consistent toast messaging when triggering auto-commit from the UI.
- Allow dead code in the grouping file for flexibility.