### PR TITLE
Show helpful message on bundling error

### DIFF
--- a/apps/desktop/src/hooks.client.ts
+++ b/apps/desktop/src/hooks.client.ts
@@ -1,4 +1,4 @@
-import { isParsedError } from '$lib/error/parser';
+import { isBundlingError, isParsedError } from '$lib/error/parser';
 import { showError } from '$lib/notifications/toasts';
 import { captureException } from '@sentry/sveltekit';
 import { error as logErrorToFile } from '@tauri-apps/plugin-log';
@@ -41,6 +41,14 @@ function logError(error: unknown) {
 		}
 
 		if (isParsedError(error) && error.name) {
+			if (isBundlingError(error)) {
+				console.warn(
+					'You are likely experiencing a dev mode bundling error, ' +
+						'try disabling the chache from the network tab and ' +
+						'reload the page.'
+				);
+				return;
+			}
 			showError(error.name, error.message);
 		} else {
 			showError('Unhandled exception', error);

--- a/apps/desktop/src/lib/error/parser.ts
+++ b/apps/desktop/src/lib/error/parser.ts
@@ -25,6 +25,19 @@ export function isParsedError(something: unknown): something is ParsedError {
 	);
 }
 
+/**
+ * It appears that Vite sporadically experiences some bundling error where
+ * a resource that no longer exists is requested. The fastest way to resolve
+ * such an error is to disable the cache from the network tab and reload the
+ * page once. It would be great if we could root cause and fix this problem.
+ */
+export function isBundlingError(error: ParsedError): boolean {
+	return (
+		error.name === 'TypeError' &&
+		error.message.startsWith("undefined is not an object (evaluating 'first_child_getter.call')")
+	);
+}
+
 export function parseError(error: unknown): ParsedError {
 	if (isStr(error)) {
 		return { message: error };

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -44,14 +44,6 @@ export default defineConfig({
 		strictPort: true,
 		fs: {
 			strict: false
-		},
-		// Disabling browser cache prevents sporadic error where the cache
-		// busting URLs somehow fail, and the webview ends up requesting
-		// files that no longer exist. The resulting error references
-		// something about a `first_child_getter`.
-		headers: {
-			'Cache-Control': 'no-store',
-			Pragma: 'no-cache'
 		}
 	},
 	// to make use of `TAURI_ENV_DEBUG` and other env variables


### PR DESCRIPTION
We have sporadically been hit by a vite bundling bug that results in an 
error that mentions something about `first_child_getter.call`. While we 
don't know what causes this, the error appears because resources that no
longer exist are being requested from the Vite dev server.

This commit adds a console.warn letting the user know that it can be 
resolved by disabling the browser cache from the network tab.