### PR TITLE
Switch everyone to v3

### DIFF
--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -8,10 +8,10 @@
 	import Navigation from '$components/Navigation.svelte';
 	import NoBaseBranch from '$components/NoBaseBranch.svelte';
 	import NotOnGitButlerBranch from '$components/NotOnGitButlerBranch.svelte';
+	import NowV3Modal from '$components/NowV3Modal.svelte';
 	import ProblemLoadingRepo from '$components/ProblemLoadingRepo.svelte';
 	import ProjectSettingsMenuAction from '$components/ProjectSettingsMenuAction.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
-	import TryV3Modal from '$components/TryV3Modal.svelte';
 	import IrcPopups from '$components/v3/IrcPopups.svelte';
 	import NotOnGitButlerBranchV3 from '$components/v3/NotOnGitButlerBranch.svelte';
 	import { BaseBranch } from '$lib/baseBranch/baseBranch';
@@ -350,12 +350,12 @@
 				{:else if baseBranch}
 					{#if $mode?.type === 'OpenWorkspace' || $mode?.type === 'Edit'}
 						<div class="view-wrap" role="group" ondragover={(e) => e.preventDefault()}>
+							<NowV3Modal />
 							{#if $settingsStore?.featureFlags.v3}
 								<Chrome {projectId} sidebarDisabled={$mode?.type === 'Edit'}>
 									{@render pageChildren()}
 								</Chrome>
 							{:else}
-								<TryV3Modal />
 								<Navigation {projectId} />
 								{@render pageChildren()}
 							{/if}


### PR DESCRIPTION
# Default v3 enabled

- We should default all users to v3.
- We should inform users that have just been moved that they can switch back for now.
- Need to do a hard reload after the switch.

We probably want the frontend to take responsibility for the switch. That way we can switch at a good time (after onboarding) and correctly reload the frontend.

We can:
- Use a persisted value "switched_to_v3" that defaults to false
- When the frontend is loaded on the v2 version and "switched_to_v3" is false
  - We switch to v3 & hard reload
  - Show the user the modal with the option to switch back to v2.
  - Set "switched_to_v3" to true

- If "switched_to_v3" is true, we won't prompt the user again.

I have an `onMount` in the component that does the switch over to v3.
- We perform a hard reload in the switching logic which means we need to be a little clever about how to actually get the modal to show.
- By performing a hard reload we have no way to refer to the _new_ modal component that is rendered after the reload.
- As such, we need to persist the fact that we should show the modal.