### PR TITLE
Fix double push errors

### DIFF
--- a/apps/desktop/src/hooks.client.ts
+++ b/apps/desktop/src/hooks.client.ts
@@ -1,3 +1,4 @@
+import { SilentError } from '$lib/error/error';
 import { isBundlingError, isParsedError } from '$lib/error/parser';
 import { showError } from '$lib/notifications/toasts';
 import { captureException } from '@sentry/sveltekit';
@@ -40,18 +41,20 @@ function logError(error: unknown) {
 			error = error.reason;
 		}
 
-		if (isParsedError(error) && error.name) {
-			if (isBundlingError(error)) {
-				console.warn(
-					'You are likely experiencing a dev mode bundling error, ' +
-						'try disabling the chache from the network tab and ' +
-						'reload the page.'
-				);
-				return;
+		if (!(error instanceof SilentError)) {
+			if (isParsedError(error) && error.name) {
+				if (isBundlingError(error)) {
+					console.warn(
+						'You are likely experiencing a dev mode bundling error, ' +
+							'try disabling the chache from the network tab and ' +
+							'reload the page.'
+					);
+					return;
+				}
+				showError(error.name, error.message);
+			} else {
+				showError('Unhandled exception', error);
 			}
-			showError(error.name, error.message);
-		} else {
-			showError('Unhandled exception', error);
 		}
 
 		console.error(error);

--- a/apps/desktop/src/lib/error/error.ts
+++ b/apps/desktop/src/lib/error/error.ts
@@ -23,3 +23,22 @@ export interface UnhandledPromiseError {
 	reason: Error;
 	message: string;
 }
+
+/**
+ * A subclass of `Error` that won't have a toast shown for it.
+ *
+ * This is useful for errors that are get handled elsewhere but should still
+ * throw to stop execution.
+ */
+export class SilentError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'SilentError';
+	}
+
+	static from(error: Error): SilentError {
+		const e = new SilentError(error.message);
+		e.stack = error.stack;
+		return e;
+	}
+}

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -391,7 +391,8 @@ export class StackService {
 			onError: (commandError: TauriCommandError) => {
 				const { code, message } = commandError;
 				surfaceStackError('push', code ?? '', message);
-			}
+			},
+			throwSlientError: true
 		});
 	}
 


### PR DESCRIPTION
This introduces an `Error` sublcass which doesn’t create a toast when caught by our global error handler.

I considered both this approach as well as the approach of adding an extra `_slientErrorThingy` to any objects, but that felt kind of icky.