### PR TITLE
fix: restrict Auto commit option to uncommitted files

### DIFF
--- a/apps/desktop/src/components/v3/FileContextMenu.svelte
+++ b/apps/desktop/src/components/v3/FileContextMenu.svelte
@@ -194,7 +194,7 @@
 							}}
 						/>
 					{/if}
-					{#if canUseGBAI}
+					{#if canUseGBAI && isUncommitted}
 						<ContextMenuItem
 							label="Auto commit"
 							onclick={async () => {


### PR DESCRIPTION
Update FileContextMenu to show the Auto commit context menu item
only when the file is uncommitted and GBAI is available. This prevents
offering the auto commit action for files that are already committed,
improving the user experience and avoiding unnecessary operations.