### PR TITLE
fix(support): add handler for start_watching_db event

### DIFF
--- a/apps/desktop/cypress/e2e/support/index.ts
+++ b/apps/desktop/cypress/e2e/support/index.ts
@@ -151,7 +151,8 @@ Cypress.on('window:before:load', (win) => {
 				return listProjects();
 			case 'update_telemetry_distinct_id':
 				return await Promise.resolve();
-
+			case 'start_watching_db':
+				return await Promise.resolve();
 			case 'plugin:updater|check':
 				return null;
 			case 'get_user':


### PR DESCRIPTION
Add a new case for 'start_watching_db' in the support index to handle
the event gracefully by returning a resolved promise. This prevents
unhandled cases and potential errors during test execution.