### PR TITLE
Commit flow fixes and tests: Your commit goes here position and commit selection after creation

### DIFF
--- a/apps/desktop/cypress/e2e/selection.cy.ts
+++ b/apps/desktop/cypress/e2e/selection.cy.ts
@@ -74,9 +74,9 @@ describe('Selection', () => {
 			.within(() => {
 				cy.getByTestId('commit-drawer-title').should('contain', 'Initial commit');
 				cy.getByTestId('commit-drawer-description').should('contain', 'This is a test commit');
-				cy.getByTestId('file-list-item', 'fileB.txt').should('be.visible');
-				cy.getByTestId('file-list-item', 'fileC.txt').should('be.visible');
-				cy.getByTestId('file-list-item', 'fileA.ts').should('be.visible').click();
+				cy.getByTestId('file-list-item', 'fileF.txt').should('be.visible');
+				cy.getByTestId('file-list-item', 'fileE.txt').should('be.visible');
+				cy.getByTestId('file-list-item', 'fileD.txt').should('be.visible').click();
 			});
 
 		cy.getByTestId('stack-selection-view').should('be.visible');

--- a/apps/desktop/cypress/e2e/support/index.ts
+++ b/apps/desktop/cypress/e2e/support/index.ts
@@ -271,7 +271,7 @@ beforeEach(() => {
 	cy.intercept({ hostname: 'api.github.com' }, (req) => {
 		console.warn('Intercepted request to GitHub API:', req.method, req.url);
 		req.destroy();
-	});
+	}).as('githubApi');
 
 	cy.viewport('macbook-11');
 });

--- a/apps/desktop/cypress/e2e/support/scenarios/branchesWithChanges.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/branchesWithChanges.ts
@@ -603,6 +603,8 @@ const MOCK_UNIFIED_DIFF_FILE_A = createMockUnifiedDiffPatch(
 export default class BranchesWithChanges extends MockBackend {
 	dependsOnStack = MOCK_STACK_B_ID;
 	bigFileName = MOCK_FILE_J;
+	stackWithTwoCommits = MOCK_STACK_B_ID;
+	firstCommitInSecondStack = MOCK_COMMIT_IN_BRANCH_B_2;
 
 	constructor() {
 		super();
@@ -644,6 +646,8 @@ export default class BranchesWithChanges extends MockBackend {
 		this.unifiedDiffs.set(MOCK_FILE_J, MOCK_FILE_J_MODIFICATION);
 
 		this.commitChanges.set(MOCK_COMMIT_IN_BRANCH_A.id, MOCK_BRANCH_A_CHANGES);
+		this.commitChanges.set(MOCK_COMMIT_IN_BRANCH_B.id, MOCK_BRANCH_B_CHANGES);
+		this.commitChanges.set(MOCK_COMMIT_IN_BRANCH_B_2.id, MOCK_BRANCH_B_CHANGES);
 	}
 
 	getCommitTitle(stackId: string): string {

--- a/apps/desktop/src/components/v3/BranchCommitList.svelte
+++ b/apps/desktop/src/components/v3/BranchCommitList.svelte
@@ -63,7 +63,6 @@
 		projectId: string;
 		stackId: string;
 		branchName: string;
-		selectedCommitId?: string;
 		firstBranch: boolean;
 		lastBranch: boolean;
 		branchDetails: BranchDetails;
@@ -86,7 +85,6 @@
 		stackId,
 		branchName,
 		branchDetails,
-		selectedCommitId,
 		firstBranch,
 		lastBranch,
 		stackingReorderDropzoneManager,
@@ -114,6 +112,7 @@
 	const stackState = $derived(uiState.stack(stackId));
 	const selection = $derived(stackState.selection.get());
 	const selectedBranchName = $derived(selection.current?.branchName);
+	const selectedCommitId = $derived(selection.current?.commitId);
 
 	const localAndRemoteCommits = $derived(stackService.commits(projectId, stackId, branchName));
 	const upstreamOnlyCommits = $derived(
@@ -157,6 +156,7 @@
 		} else {
 			stackState.selection.set({ branchName, commitId, upstream });
 		}
+		projectState.stackId.set(stackId);
 		onselect?.();
 	}
 </script>
@@ -220,6 +220,7 @@
 
 		{#if !hasCommits && isCommitting && thisIsTheRightBranch}
 			<CommitGoesHere
+				commitId={baseSha}
 				last
 				draft
 				selected={branchName === commitAction?.branchName ||
@@ -294,6 +295,7 @@
 					{#if isCommitting}
 						<!-- Only commits to the base can be `last`, see next `CommitGoesHere`. -->
 						<CommitGoesHere
+							{commitId}
 							selected={(commitAction?.parentCommitId === commitId ||
 								(first && commitAction?.parentCommitId === undefined)) &&
 								commitAction?.branchName === branchName}
@@ -310,11 +312,11 @@
 						/>
 					{/if}
 					{@const dzCommit: DzCommitData = {
-					id: commit.id,
-					isRemote: isUpstreamCommit(commit),
-					isIntegrated: isLocalAndRemoteCommit(commit) && commit.state.type === 'Integrated',
-					hasConflicts: isLocalAndRemoteCommit(commit) && commit.hasConflicts,
-				}}
+						id: commit.id,
+						isRemote: isUpstreamCommit(commit),
+						isIntegrated: isLocalAndRemoteCommit(commit) && commit.state.type === 'Integrated',
+						hasConflicts: isLocalAndRemoteCommit(commit) && commit.hasConflicts,
+					}}
 					{@const amendHandler = new AmendCommitWithChangeDzHandler(
 						projectId,
 						stackService,
@@ -438,6 +440,7 @@
 					)}
 					{#if isCommitting && last}
 						<CommitGoesHere
+							commitId={baseSha}
 							{first}
 							{last}
 							selected={exclusiveAction?.parentCommitId === baseSha}

--- a/apps/desktop/src/components/v3/BranchList.svelte
+++ b/apps/desktop/src/components/v3/BranchList.svelte
@@ -290,7 +290,6 @@
 								{projectId}
 								{stackId}
 								{branchName}
-								{selectedCommitId}
 								{branchDetails}
 								{stackingReorderDropzoneManager}
 								{handleUncommit}

--- a/apps/desktop/src/components/v3/CommitGoesHere.svelte
+++ b/apps/desktop/src/components/v3/CommitGoesHere.svelte
@@ -3,6 +3,7 @@
 	import Badge from '@gitbutler/ui/Badge.svelte';
 
 	type Props = {
+		commitId: string | undefined;
 		first?: boolean;
 		last?: boolean;
 		draft?: boolean;
@@ -10,12 +11,13 @@
 		onclick?: () => void;
 	};
 
-	const { first, last, draft, selected, onclick }: Props = $props();
+	const { commitId, first, last, draft, selected, onclick }: Props = $props();
 </script>
 
 {#snippet indicator(args?: { last?: boolean; first?: boolean; draft?: boolean })}
 	<div
 		data-testid={TestId.YourCommitGoesHere}
+		data-testid-commit-id={commitId}
 		class="indicator"
 		class:first={args?.first}
 		class:last={args?.last}

--- a/apps/desktop/src/components/v3/CommitRow.svelte
+++ b/apps/desktop/src/components/v3/CommitRow.svelte
@@ -78,6 +78,7 @@
 </script>
 
 <div
+	data-testid={TestId.CommitRow}
 	bind:this={container}
 	role="button"
 	tabindex="0"
@@ -116,7 +117,7 @@
 		{lastBranch}
 	/>
 
-	<div data-testid={TestId.CommitRow} class="commit-content" class:shift-to-left={hasConflicts}>
+	<div class="commit-content" class:shift-to-left={hasConflicts}>
 		{#if hasConflicts}
 			<div class="commit-conflict-indicator">
 				<Icon name="warning" size={12} />

--- a/apps/desktop/src/components/v3/NewCommitView.svelte
+++ b/apps/desktop/src/components/v3/NewCommitView.svelte
@@ -78,7 +78,6 @@
 
 	const stackState = $derived(stackId ? uiState.stack(stackId) : undefined);
 	const selection = $derived(stackState?.selection.current);
-	const selectedCommitId = $derived(selection?.commitId);
 
 	const exclusiveAction = $derived(projectState.exclusiveAction.current);
 	const commitAction = $derived(exclusiveAction?.type === 'commit' ? exclusiveAction : undefined);
@@ -99,6 +98,7 @@
 	async function createCommit(message: string) {
 		let finalStackId = stackId;
 		let finalBranchName = commitAction?.branchName || topBranchName;
+		const parentId = commitAction?.parentCommitId;
 
 		if (!finalStackId) {
 			const stack = await createNewStack({
@@ -126,7 +126,7 @@
 
 		const response = await createCommitInStack({
 			projectId,
-			parentId: selectedCommitId,
+			parentId,
 			stackId: finalStackId,
 			message: message,
 			stackBranchName: finalBranchName,

--- a/apps/desktop/src/components/v3/StackDraft.svelte
+++ b/apps/desktop/src/components/v3/StackDraft.svelte
@@ -64,7 +64,7 @@
 					lineColor="var(--clr-commit-local)"
 				>
 					{#snippet branchContent()}
-						<CommitGoesHere selected last />
+						<CommitGoesHere commitId={undefined} selected last />
 					{/snippet}
 				</BranchCard>
 				<Resizer

--- a/apps/desktop/src/components/v3/StackView.svelte
+++ b/apps/desktop/src/components/v3/StackView.svelte
@@ -113,7 +113,8 @@
 		projectState.exclusiveAction.set({
 			type: 'commit',
 			branchName: defaultBranchName,
-			stackId: stack.id
+			stackId: stack.id,
+			parentCommitId: stackState.selection.current?.commitId
 		});
 		const stackAssignments = uncommittedService.getAssignmentsByStackId(stack.id);
 		if (stackAssignments.length > 0) {


### PR DESCRIPTION
### Description

- ~~Select the new commit automatically after successful creation~~.
- Pass the selected commit ID as the parent when creating a new commit.
- Improve commit flow tests to verify commit parent correctness and UI behavior.
- Set commit row test IDs to their parent commits for better test accuracy.
- Ensure "Your commit goes here" position is correctly asserted in tests.
- Select stack ID when clicking on one of its commits.
- Add an alias for the GitHub API umbrella interceptor for cleaner code.