### PR TITLE
Fix bug in focus tracking

### DIFF
--- a/apps/desktop/src/components/v3/StackView.svelte
+++ b/apps/desktop/src/components/v3/StackView.svelte
@@ -406,10 +406,6 @@
 				style:width={uiState.global.previewWidth.current + 'rem'}
 				class="preview"
 				data-remove-from-draggable
-				use:focusable={{
-					id: DefinedFocusable.Preview + ':' + stack.id,
-					parentId: DefinedFocusable.ViewportRight
-				}}
 				{@attach scrollingAttachment(intelligentScrollingService, projectId, stack.id, 'diff')}
 			>
 				<SelectionView

--- a/apps/desktop/src/lib/focus/focusable.svelte.ts
+++ b/apps/desktop/src/lib/focus/focusable.svelte.ts
@@ -12,16 +12,21 @@ interface FocusableOptions {
  */
 // eslint-disable-next-line func-style
 export const focusable: Action<HTMLElement, FocusableOptions> = (element, options) => {
-	const { id, parentId = null } = options;
 	const focus = getContext(FocusManager);
 
+	let { id, parentId = null } = options;
 	focus.register(id, parentId, element);
+
 	return {
 		destroy() {
 			focus.unregister(id);
 		},
 		update(options) {
-			focus.unregister(options.id);
+			if (id !== options.id) {
+				focus.unregister(id);
+			}
+			id = options.id;
+			parentId = options.parentId || null;
 			focus.register(id, parentId, element);
 		}
 	};


### PR DESCRIPTION
The svelte action for focusables should not unfocus the item on 
parameter updates, unless the focusable id has changed.