### PR TITLE
fix auto-commit and improve it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,6 +990,7 @@ dependencies = [
  "gitbutler-command-context",
  "gitbutler-oplog",
  "gitbutler-project",
+ "gitbutler-stack",
  "gix",
  "schemars 0.9.0",
  "serde",

--- a/crates/but-tools/Cargo.toml
+++ b/crates/but-tools/Cargo.toml
@@ -27,3 +27,4 @@ but-graph.workspace = true
 gitbutler-branch-actions.workspace = true
 gitbutler-branch.workspace = true
 gitbutler-project.workspace = true
+gitbutler-stack.workspace = true


### PR DESCRIPTION
Fix the auto-commit workflow and add some improvements on top.

- fix: Use the v2 stacks call to get the data about the applied stacks, this used to be broken because it would be able to find empty branches
- Improvement: Commit tool creates a branch is none is found.
    This speeds up the workflow by reducing a two-tool call operation to one
- Improvement: Tool failures won't stop a workflow, we just encode the tool error into the response