### PR TITLE
Separate the commit selection from the commit parent id selection

### DIFF
--- a/apps/desktop/cypress/e2e/commitActions.cy.ts
+++ b/apps/desktop/cypress/e2e/commitActions.cy.ts
@@ -490,7 +490,6 @@ describe('Commit Actions with branches containing changes', () => {
 	});
 
 	it('should be able to commit in the middle', () => {
-		const firstCommitTitle = mockBackend.firstCommitInSecondStack.message.split('\n')[0];
 		const firsCommitId = mockBackend.firstCommitInSecondStack.id;
 
 		cy.spy(mockBackend, 'createCommit').as('createCommitSpy');
@@ -498,12 +497,15 @@ describe('Commit Actions with branches containing changes', () => {
 		cy.get(`[data-testid-stackid="${mockBackend.stackWithTwoCommits}"]`)
 			.should('be.visible')
 			.within(() => {
-				// Click on the first commit from the bottom
-				cy.getByTestId('commit-row', firstCommitTitle).first().should('be.visible').click();
-				cy.getByTestId('commit-row', firstCommitTitle).should('have.class', 'selected');
-
 				// Start committing
 				cy.getByTestId('start-commit-button').should('be.visible').should('be.enabled').click();
+
+				// Click where we want to commit
+				cy.getByTestId('commit-here-button')
+					.should('have.attr', 'data-testid-commit-id', firsCommitId)
+					.first()
+					.trigger('mouseenter')
+					.click();
 
 				// 'Your commit goes here' should be visible at the right position
 				cy.getByTestId('your-commit-goes-here')
@@ -592,7 +594,7 @@ describe('Commit Actions with lots of uncommitted changes', () => {
 		clearCommandMocks();
 	});
 
-	it.only('should be able to commit a bunch of times in a row and edit their message', () => {
+	it('should be able to commit a bunch of times in a row and edit their message', () => {
 		const TIMES = 3;
 		for (let i = 0; i < TIMES; i++) {
 			// Click commit button

--- a/apps/desktop/src/components/v3/CommitGoesHere.svelte
+++ b/apps/desktop/src/components/v3/CommitGoesHere.svelte
@@ -34,7 +34,14 @@
 {/snippet}
 {#snippet commitHere(args: { last?: boolean })}
 	{@const last = args?.last}
-	<button class="commit-here" class:commit-here_last={last} type="button" {onclick}>
+	<button
+		data-testid={TestId.CommitHereButton}
+		data-testid-commit-id={commitId}
+		class="commit-here"
+		class:commit-here_last={last}
+		type="button"
+		{onclick}
+	>
 		<div class="commit-here__line"></div>
 		<div class="commit-here__circle"></div>
 

--- a/apps/desktop/src/components/v3/StackView.svelte
+++ b/apps/desktop/src/components/v3/StackView.svelte
@@ -112,8 +112,7 @@
 		projectState.exclusiveAction.set({
 			type: 'commit',
 			branchName: defaultBranchName,
-			stackId: stack.id,
-			parentCommitId: stackState.selection.current?.commitId
+			stackId: stack.id
 		});
 		const stackAssignments = uncommittedService.getAssignmentsByStackId(stack.id);
 		if (stackAssignments.length > 0) {

--- a/apps/desktop/src/lib/testing/testIds.ts
+++ b/apps/desktop/src/lib/testing/testIds.ts
@@ -42,6 +42,7 @@ export enum TestId {
 	NewCommitView = 'new-commit-view',
 	StackDraft = 'draft-stack',
 	YourCommitGoesHere = 'your-commit-goes-here',
+	CommitHereButton = 'commit-here-button',
 	KebabMenuButton = 'kebab-menu-btn',
 	IntegrateUpstreamCommitsButton = 'integrate-upstream-commits-button',
 	IntegrateUpstreamCommitsModal = 'integrate-upstream-commits-modal',


### PR DESCRIPTION
- Default to committing to the top of the stack
- Separate commit selection from the commit parent ID selection
- Add tests to ensure committing to the middle of the stack works correctly