### PR TITLE
Rewrote stack reordering to use simpler (and not broken) logic

### DIFF
--- a/apps/desktop/src/components/v3/StackView.svelte
+++ b/apps/desktop/src/components/v3/StackView.svelte
@@ -185,6 +185,8 @@
 	}}
 	<div
 		bind:this={viewWrapperEl}
+		bind:clientWidth
+		bind:clientHeight
 		class="stack-view-wrapper"
 		role="presentation"
 		class:dimmed
@@ -211,8 +213,6 @@
 		<div
 			class="stack-view"
 			style:width={$persistedStackWidth + 'rem'}
-			bind:clientWidth
-			bind:clientHeight
 			bind:this={stackViewEl}
 			{@attach scrollingAttachment(intelligentScrollingService, projectId, stack.id, 'stack')}
 		>


### PR DESCRIPTION
This moves the “ondragover” handler to the lanes themselves rather than the whole workspace view.

This means we can avoid writing any logic with reguards to calculating widths and can just focus on simply when to or when not to swap the elements