### PR TITLE
feat(desktop): update StartCommit button style based on changes

### DIFF
--- a/apps/desktop/src/components/v3/StackView.svelte
+++ b/apps/desktop/src/components/v3/StackView.svelte
@@ -278,6 +278,8 @@
 									<div class="start-commit">
 										<Button
 											testId={TestId.StartCommitButton}
+											kind={changes.current.length > 0 ? 'solid' : 'outline'}
+											style={changes.current.length > 0 ? 'pop' : 'neutral'}
 											type="button"
 											wide
 											disabled={defaultBranchResult?.current.isLoading}


### PR DESCRIPTION
Change the StartCommit button to use 'solid' kind and 'pop' style
when there are current changes, otherwise use 'outline' and
'neutral'. This improves visual feedback to indicate when commits
are available to start.