### PR TITLE
fix(dragging): hide overflow on reorder clone element

### DIFF
--- a/apps/desktop/src/lib/dragging/reordering.ts
+++ b/apps/desktop/src/lib/dragging/reordering.ts
@@ -68,6 +68,7 @@ export function onReorderStart(
 	clone.style.backgroundColor = 'var(--clr-bg-2)';
 	clone.style.border = '1px solid var(--clr-border-2)';
 	clone.style.borderRadius = 'var(--radius-ml)';
+	clone.style.overflow = 'hidden';
 }
 
 export function onReorderEnd() {


### PR DESCRIPTION
Add overflow: hidden style to the clone element during dragging to
prevent content from spilling outside its boundaries. This improves
visual consistency and avoids layout issues when reordering items.