### PR TITLE
Make it easier to add context to posthog events

### DIFF
--- a/apps/desktop/src/components/AppUpdater.test.ts
+++ b/apps/desktop/src/components/AppUpdater.test.ts
@@ -1,4 +1,5 @@
 import AppUpdater from '$components/AppUpdater.svelte';
+import { AnalyticsContext } from '$lib/analytics/analyticsContext';
 import { PostHogWrapper } from '$lib/analytics/posthog';
 import { Tauri } from '$lib/backend/tauri';
 import { getSettingsdServiceMock } from '$lib/testing/mockSettingsdService';
@@ -13,7 +14,8 @@ describe('AppUpdater', () => {
 	let context: Map<any, any>;
 	const MockSettingsService = getSettingsdServiceMock();
 	const settingsService = new MockSettingsService();
-	const posthog = new PostHogWrapper(settingsService);
+	const analyticsContext = new AnalyticsContext();
+	const posthog = new PostHogWrapper(settingsService, analyticsContext);
 
 	beforeEach(() => {
 		vi.useFakeTimers();

--- a/apps/desktop/src/components/MetricsReporter.test.ts
+++ b/apps/desktop/src/components/MetricsReporter.test.ts
@@ -3,12 +3,12 @@ import MetricsReporter, {
 	DELAY_MS,
 	INTERVAL_MS
 } from '$components/MetricsReporter.svelte';
+import { AnalyticsContext } from '$lib/analytics/analyticsContext';
 import { PostHogWrapper } from '$lib/analytics/posthog';
 import { ProjectMetrics } from '$lib/metrics/projectMetrics';
 import { ProjectService } from '$lib/project/projectService';
 import { getSettingsdServiceMock } from '$lib/testing/mockSettingsdService';
 import { render } from '@testing-library/svelte';
-import { writable } from 'svelte/store';
 import { assert, test, describe, vi, beforeEach, afterEach } from 'vitest';
 
 const PROJECT_ID = 'test-project';
@@ -18,19 +18,18 @@ describe('MetricsReporter', () => {
 	let projectMetrics: ProjectMetrics;
 	let context: Map<any, any>;
 	let posthog: PostHogWrapper;
-	let projectService: ProjectService;
 
 	beforeEach(() => {
 		vi.useFakeTimers();
 		projectMetrics = new ProjectMetrics();
 		const MockSettingsService = getSettingsdServiceMock();
 		const settingsService = new MockSettingsService();
-		posthog = new PostHogWrapper(settingsService);
+		const analyticsContext = new AnalyticsContext();
+		posthog = new PostHogWrapper(settingsService, analyticsContext);
 
-		projectService = { project: writable(undefined), projectId: PROJECT_ID };
 		context = new Map([
 			[PostHogWrapper as object, posthog as any],
-			[ProjectService as object, projectService as any]
+			[ProjectService as object, vi.fn() as any]
 		]);
 	});
 

--- a/apps/desktop/src/components/v3/AnalyticsMonitor.svelte
+++ b/apps/desktop/src/components/v3/AnalyticsMonitor.svelte
@@ -1,0 +1,77 @@
+<!--
+@component
+This component keeps the analytics context up-to-date, i.e. the metadata
+attached to posthog events.
+-->
+<script lang="ts">
+	import { AnalyticsContext } from '$lib/analytics/analyticsContext';
+	import { SettingsService } from '$lib/config/appSettingsV2';
+	import { confettiEnabled } from '$lib/config/uiFeatureFlags';
+	import { ProjectService } from '$lib/project/projectService';
+	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
+	import { UiState } from '$lib/state/uiState.svelte';
+	import { getContextStoreBySymbol, inject } from '@gitbutler/shared/context';
+	import type { Writable } from 'svelte/store';
+
+	const { projectId }: { projectId: string } = $props();
+
+	const [uiState, analyticsContext, projectService, settingsService] = inject(
+		UiState,
+		AnalyticsContext,
+		ProjectService,
+		SettingsService
+	);
+
+	const globalState = uiState.global;
+	const projectState = $derived(uiState.project(projectId));
+
+	const settings = getContextStoreBySymbol<Settings, Writable<Settings>>(SETTINGS);
+
+	$effect(() => {
+		analyticsContext.update({
+			showActions: projectState.showActions.current,
+			exclusiveAction: projectState.exclusiveAction.current?.type
+		});
+	});
+
+	$effect(() => {
+		analyticsContext.update({
+			rulerCount: globalState.rulerCountValue.current,
+			useRuler: globalState.useRuler.current,
+			wrapTextByRuler: globalState.wrapTextByRuler.current
+		});
+	});
+
+	$effect(() => {
+		analyticsContext.update({
+			zoom: $settings.zoom,
+			theme: $settings.theme,
+			tabSize: $settings.tabSize,
+			defaultCodeEditor: $settings.defaultCodeEditor.schemeIdentifer,
+			aiSummariesEnabled: $settings.aiSummariesEnabled,
+			diffLigatures: $settings.diffLigatures
+		});
+	});
+
+	$effect(() => {
+		analyticsContext.update({
+			forcePushAllowed: $projectService?.ok_with_force_push,
+			gitAuthType: $projectService?.gitAuthType()
+		});
+	});
+
+	$effect(() => {
+		analyticsContext.update({
+			v3: $settingsService?.featureFlags.v3,
+			butlerActions: $settingsService?.featureFlags.actions,
+			ws3: $settingsService?.featureFlags.ws3
+		});
+	});
+
+	$effect(() => {
+		analyticsContext.update({ confetti: $confettiEnabled });
+	});
+</script>
+
+<style lang="postcss">
+</style>

--- a/apps/desktop/src/lib/analytics/analyticsContext.ts
+++ b/apps/desktop/src/lib/analytics/analyticsContext.ts
@@ -1,0 +1,28 @@
+type StateValue = string | number | boolean | undefined;
+
+interface StateData {
+	[key: string]: StateValue;
+}
+
+/**
+ * Stuff that gets added to posthog events.
+ */
+export class AnalyticsContext {
+	private state: StateData = {};
+
+	set(key: string, value: StateValue): void {
+		this.state[key] = value;
+	}
+
+	get(key: string): StateValue | undefined {
+		return this.state[key];
+	}
+
+	update(updates: StateData): void {
+		Object.assign(this.state, updates);
+	}
+
+	getAll(): StateData {
+		return { ...this.state };
+	}
+}

--- a/apps/desktop/src/lib/analytics/posthog.ts
+++ b/apps/desktop/src/lib/analytics/posthog.ts
@@ -1,4 +1,5 @@
 import { PostHog, posthog } from 'posthog-js';
+import type { AnalyticsContext } from '$lib/analytics/analyticsContext';
 import type { SettingsService } from '$lib/config/appSettingsV2';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import { PUBLIC_POSTHOG_API_KEY } from '$env/static/public';
@@ -6,10 +7,15 @@ import { PUBLIC_POSTHOG_API_KEY } from '$env/static/public';
 export class PostHogWrapper {
 	private _instance: PostHog | void = undefined;
 
-	constructor(private settingsService: SettingsService) {}
+	constructor(
+		private settingsService: SettingsService,
+		private analyticsContext: AnalyticsContext
+	) {}
 
 	capture(...args: Parameters<typeof posthog.capture>) {
-		this._instance?.capture(...args);
+		const context = this.analyticsContext.getAll();
+		const properties = { ...context, ...(args[1] || {}) };
+		this._instance?.capture(args[0], properties, args[2]);
 	}
 
 	async init(appName: string, appVersion: string) {

--- a/apps/desktop/src/lib/forge/forgeFactory.test.ts
+++ b/apps/desktop/src/lib/forge/forgeFactory.test.ts
@@ -1,3 +1,4 @@
+import { AnalyticsContext } from '$lib/analytics/analyticsContext';
 import { PostHogWrapper } from '$lib/analytics/posthog';
 import { DefaultForgeFactory } from '$lib/forge/forgeFactory.svelte';
 import { GitHub } from '$lib/forge/github/github';
@@ -13,7 +14,8 @@ import type { ThunkDispatch, UnknownAction } from '@reduxjs/toolkit';
 describe.concurrent('DefaultforgeFactory', () => {
 	const MockSettingsService = getSettingsdServiceMock();
 	const settingsService = new MockSettingsService();
-	const posthog = new PostHogWrapper(settingsService);
+	const analyticsContext = new AnalyticsContext();
+	const posthog = new PostHogWrapper(settingsService, analyticsContext);
 	const projectMetrics = new ProjectMetrics();
 	const gitHubApi: GitHubApi = {
 		endpoints: {},

--- a/apps/desktop/src/lib/forge/github/githubListingService.svelte.test.ts
+++ b/apps/desktop/src/lib/forge/github/githubListingService.svelte.test.ts
@@ -1,3 +1,4 @@
+import { AnalyticsContext } from '$lib/analytics/analyticsContext';
 import { PostHogWrapper } from '$lib/analytics/posthog';
 import { GitHub } from '$lib/forge/github/github';
 import { ProjectMetrics } from '$lib/metrics/projectMetrics';
@@ -18,7 +19,8 @@ describe('GitHubListingService', () => {
 	let projectMetrics: ProjectMetrics;
 	const MockSettingsService = getSettingsdServiceMock();
 	const settingsService = new MockSettingsService();
-	const posthog = new PostHogWrapper(settingsService);
+	const analyticsContext = new AnalyticsContext();
+	const posthog = new PostHogWrapper(settingsService, analyticsContext);
 
 	vi.useFakeTimers();
 

--- a/apps/desktop/src/lib/project/projectService.ts
+++ b/apps/desktop/src/lib/project/projectService.ts
@@ -10,11 +10,13 @@ import type { Readable } from 'svelte/store';
 
 export class ProjectService {
 	project: Readable<Project | undefined>;
+	subscribe: typeof this.project.subscribe;
 
 	constructor(
 		projectsService: ProjectsService,
 		readonly projectId: string
 	) {
 		this.project = projectsService.getProjectStore(projectId);
+		this.subscribe = this.project.subscribe;
 	}
 }

--- a/apps/desktop/src/lib/state/backendQuery.ts
+++ b/apps/desktop/src/lib/state/backendQuery.ts
@@ -1,13 +1,8 @@
 import { PostHogWrapper } from '$lib/analytics/posthog';
 import { isTauriCommandError, type TauriCommandError } from '$lib/backend/ipc';
 import { Tauri } from '$lib/backend/tauri';
-import { SettingsService } from '$lib/config/appSettingsV2';
-import { confettiEnabled } from '$lib/config/uiFeatureFlags';
 import { isErrorlike } from '@gitbutler/ui/utils/typeguards';
 import { type BaseQueryApi, type QueryReturnValue } from '@reduxjs/toolkit/query';
-import { get, type Readable } from 'svelte/store';
-import type { Project } from '$lib/project/project';
-import type { Settings } from '$lib/settings/userSettings';
 
 export type TauriBaseQueryFn = typeof tauriBaseQuery;
 
@@ -20,49 +15,19 @@ export async function tauriBaseQuery(
 			error: { name: 'Failed to execute Tauri query', message: 'Redux dependency Tauri not found!' }
 		};
 	}
-
 	const posthog = hasPosthogExtra(api.extra) ? api.extra.posthog : undefined;
-	const settingsService = hasSettingsExtra(api.extra) ? api.extra.settingsService : undefined;
-	const userSettings = hasUserSettingsExtra(api.extra) ? get(api.extra.userSettings) : undefined;
-	const appSettings = settingsService?.appSettings;
-	const project = hasProjectExtra(api.extra) ? get(api.extra.project) : undefined;
-
-	const v3 = appSettings ? get(appSettings)?.featureFlags.v3 : false;
-	const butlerActions = appSettings ? get(appSettings)?.featureFlags.actions : false;
-	const confetti = get(confettiEnabled);
-
-	const someUserSettings = userSettings
-		? {
-				zoom: userSettings.zoom,
-				theme: userSettings.theme,
-				tabSize: userSettings?.tabSize,
-				defaultCodeEditor: userSettings.defaultCodeEditor.schemeIdentifer,
-				aiSummariesEnabled: userSettings.aiSummariesEnabled,
-				diffLigatures: userSettings.diffLigatures,
-				forcePushAllowed: project?.ok_with_force_push,
-				gitAuthType: project?.gitAuthType()
-			}
-		: {};
-	const settingsSnapshot = {
-		...someUserSettings,
-		v3,
-		confetti,
-		butlerActions
-	};
 
 	const startTime = Date.now();
 	try {
 		const result = { data: await api.extra.tauri.invoke(args.command, args.params) };
 		const durationMs = Date.now() - startTime;
 		posthog?.capture('tauri_command', {
-			...settingsSnapshot,
 			command: args.command,
 			durationMs,
 			failure: false
 		});
 		if (posthog && args.actionName) {
 			posthog.capture(`${args.actionName} Successful`, {
-				...settingsSnapshot,
 				durationMs
 			});
 		}
@@ -70,13 +35,12 @@ export async function tauriBaseQuery(
 	} catch (error: unknown) {
 		const durationMs = Date.now() - startTime;
 		posthog?.capture('tauri_command', {
-			...settingsSnapshot,
 			command: args.command,
 			durationMs,
 			failure: true
 		});
 		if (posthog && args.actionName) {
-			posthog.capture(`${args.actionName} Failed`, { error, ...settingsSnapshot });
+			posthog.capture(`${args.actionName} Failed`, { error });
 		}
 
 		const name = `API error: ${args.actionName} (${args.command})`;
@@ -125,28 +89,4 @@ export function hasPosthogExtra(extra: unknown): extra is {
 		'posthog' in extra &&
 		extra.posthog instanceof PostHogWrapper
 	);
-}
-
-export function hasSettingsExtra(extra: unknown): extra is {
-	settingsService: SettingsService;
-} {
-	return (
-		!!extra &&
-		typeof extra === 'object' &&
-		extra !== null &&
-		'settingsService' in extra &&
-		extra.settingsService instanceof SettingsService
-	);
-}
-
-export function hasUserSettingsExtra(extra: unknown): extra is {
-	userSettings: Readable<Settings>;
-} {
-	return !!extra && typeof extra === 'object' && extra !== null && 'userSettings' in extra;
-}
-
-export function hasProjectExtra(extra: unknown): extra is {
-	project: Readable<Project>;
-} {
-	return !!extra && typeof extra === 'object' && extra !== null && 'project' in extra;
 }

--- a/apps/desktop/src/lib/state/clientState.svelte.ts
+++ b/apps/desktop/src/lib/state/clientState.svelte.ts
@@ -10,12 +10,9 @@ import persistStore from 'redux-persist/lib/persistStore';
 import storage from 'redux-persist/lib/storage';
 import type { PostHogWrapper } from '$lib/analytics/posthog';
 import type { Tauri } from '$lib/backend/tauri';
-import type { SettingsService } from '$lib/config/appSettingsV2';
 import type { GitHubClient } from '$lib/forge/github/githubClient';
 import type { GitLabClient } from '$lib/forge/gitlab/gitlabClient.svelte';
 import type { IrcClient } from '$lib/irc/ircClient.svelte';
-import type { Settings } from '$lib/settings/userSettings';
-import type { Readable } from 'svelte/store';
 
 /**
  * GitHub API object that enables the declaration and usage of endpoints
@@ -67,9 +64,7 @@ export class ClientState {
 		gitHubClient: GitHubClient,
 		gitLabClient: GitLabClient,
 		ircClient: IrcClient,
-		posthog: PostHogWrapper,
-		settingsService: SettingsService,
-		userSettings: Readable<Settings>
+		posthog: PostHogWrapper
 	) {
 		const butlerMod = butlerModule({
 			// Reactive loop without nested function.
@@ -89,9 +84,7 @@ export class ClientState {
 			backendApi: this.backendApi,
 			githubApi: this.githubApi,
 			gitlabApi: this.gitlabApi,
-			posthog,
-			settingsService,
-			userSettings
+			posthog
 		});
 
 		this.store = store;
@@ -132,8 +125,6 @@ function createStore(params: {
 	githubApi: GitHubApi;
 	gitlabApi: GitLabApi;
 	posthog: PostHogWrapper;
-	settingsService: SettingsService;
-	userSettings: Readable<Settings>;
 }) {
 	const {
 		tauri,
@@ -143,9 +134,7 @@ function createStore(params: {
 		backendApi,
 		githubApi,
 		gitlabApi,
-		posthog,
-		settingsService,
-		userSettings
+		posthog
 	} = params;
 
 	// We can't use the `persistStore` function because it doesn't work
@@ -177,9 +166,7 @@ function createStore(params: {
 						gitHubClient,
 						gitLabClient,
 						ircClient,
-						posthog,
-						settingsService,
-						userSettings
+						posthog
 					}
 				},
 				serializableCheck: {

--- a/apps/desktop/src/lib/updater/updater.test.ts
+++ b/apps/desktop/src/lib/updater/updater.test.ts
@@ -1,3 +1,4 @@
+import { AnalyticsContext } from '$lib/analytics/analyticsContext';
 import { PostHogWrapper } from '$lib/analytics/posthog';
 import { Tauri } from '$lib/backend/tauri';
 import { getSettingsdServiceMock } from '$lib/testing/mockSettingsdService';
@@ -15,7 +16,8 @@ describe('Updater', () => {
 	let updater: UpdaterService;
 	const MockSettingsService = getSettingsdServiceMock();
 	const settingsService = new MockSettingsService();
-	const posthog = new PostHogWrapper(settingsService);
+	const analyticsContext = new AnalyticsContext();
+	const posthog = new PostHogWrapper(settingsService, analyticsContext);
 
 	beforeEach(() => {
 		vi.useFakeTimers();

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -19,6 +19,7 @@
 	import { ActionService } from '$lib/actions/actionService.svelte';
 	import { PromptService as AIPromptService } from '$lib/ai/promptService';
 	import { AIService } from '$lib/ai/service';
+	import { AnalyticsContext } from '$lib/analytics/analyticsContext';
 	import { PostHogWrapper } from '$lib/analytics/posthog';
 	import { CommandService, invoke } from '$lib/backend/ipc';
 	import BaseBranchService from '$lib/baseBranch/baseBranchService.svelte';
@@ -113,9 +114,7 @@
 		gitHubClient,
 		gitLabClient,
 		ircClient,
-		data.posthog,
-		data.settingsService,
-		userSettings
+		data.posthog
 	);
 
 	const ircService = new IrcService(clientState, clientState.dispatch, ircClient);
@@ -240,6 +239,7 @@
 	setContext(LineManagerFactory, data.lineManagerFactory);
 	setContext(StackingLineManagerFactory, data.stackingLineManagerFactory);
 	setContext(AppSettings, data.appSettings);
+	setContext(AnalyticsContext, data.analyticsContext);
 	setContext(StackService, stackService);
 	setContext(ActionService, actionService);
 	setContext(OplogService, oplogService);
@@ -253,7 +253,6 @@
 	setContext(IdSelection, idSelection);
 	setContext(DropzoneRegistry, new DropzoneRegistry());
 	setContext(ResizeSync, new ResizeSync());
-
 	setNameNormalizationServiceContext(new IpcNameNormalizationService(invoke));
 
 	const settingsService = data.settingsService;

--- a/apps/desktop/src/routes/+layout.ts
+++ b/apps/desktop/src/routes/+layout.ts
@@ -1,6 +1,7 @@
 import { PromptService as AIPromptService } from '$lib/ai/promptService';
 import { AIService } from '$lib/ai/service';
 import { initAnalyticsIfEnabled } from '$lib/analytics/analytics';
+import { AnalyticsContext } from '$lib/analytics/analyticsContext';
 import { PostHogWrapper } from '$lib/analytics/posthog';
 import { CommandService } from '$lib/backend/ipc';
 import { Tauri } from '$lib/backend/tauri';
@@ -49,9 +50,10 @@ export const load: LayoutLoad = async () => {
 	const projectsService = new ProjectsService(defaultPath, httpClient);
 	const settingsService = new SettingsService(tauri, projectsService);
 
+	const analyticsContext = new AnalyticsContext();
 	// Awaited and will block initial render, but it is necessary in order to respect the user
 	// settings on telemetry.
-	const posthog = new PostHogWrapper(settingsService);
+	const posthog = new PostHogWrapper(settingsService, analyticsContext);
 	const appSettings = await loadAppSettings();
 	initAnalyticsIfEnabled(appSettings, posthog);
 
@@ -94,6 +96,7 @@ export const load: LayoutLoad = async () => {
 		hooksService,
 		settingsService,
 		projectMetrics,
-		uploadsService
+		uploadsService,
+		analyticsContext
 	};
 };

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -12,6 +12,7 @@
 	import ProblemLoadingRepo from '$components/ProblemLoadingRepo.svelte';
 	import ProjectSettingsMenuAction from '$components/ProjectSettingsMenuAction.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
+	import AnalyticsMonitor from '$components/v3/AnalyticsMonitor.svelte';
 	import IrcPopups from '$components/v3/IrcPopups.svelte';
 	import NotOnGitButlerBranchV3 from '$components/v3/NotOnGitButlerBranch.svelte';
 	import { BaseBranch } from '$lib/baseBranch/baseBranch';
@@ -388,6 +389,7 @@
 
 <!-- Mounting metrics reporter in the board ensures dependent services are subscribed to. -->
 <MetricsReporter {projectId} {projectMetrics} />
+<AnalyticsMonitor {projectId} />
 
 <style>
 	.view-wrap {


### PR DESCRIPTION
Replaces the dependencies that were pushed into the backend query with
a new model where an `AnalyticsMonitor` keeps an `AnalyticsContext` 
up-to-date, and attached to each `posthog.capture` call.