### PR TITLE
Fix viewport resizing calculations

### DIFF
--- a/apps/desktop/src/components/Resizer.svelte
+++ b/apps/desktop/src/components/Resizer.svelte
@@ -60,7 +60,8 @@
 		onResizing,
 		onOverflow,
 		onHover,
-		onDblClick
+		onDblClick,
+		onWidth
 	}: Props = $props();
 
 	const orientation = $derived(['left', 'right'].includes(direction) ? 'horizontal' : 'vertical');
@@ -119,6 +120,7 @@
 		}
 		if (newValue) {
 			updateDom(newValue);
+			onWidth?.(newValue);
 		}
 		if (overflow) {
 			onOverflow?.(overflow);
@@ -158,10 +160,7 @@
 			return resizeSync.subscribe({
 				key: syncName,
 				resizerId,
-				callback: (newValue) => {
-					value.set(newValue);
-					updateDom(newValue);
-				}
+				callback: (newValue) => value.set(newValue)
 			});
 		}
 	});
@@ -169,6 +168,7 @@
 	$effect(() => {
 		if ($value && viewport) {
 			updateDom($value);
+			onWidth?.($value);
 		}
 	});
 

--- a/apps/desktop/src/components/v3/WorkspaceView.svelte
+++ b/apps/desktop/src/components/v3/WorkspaceView.svelte
@@ -123,25 +123,26 @@
 	}
 </script>
 
-{#snippet drawerRight()}
+{#snippet right()}
 	<Feed {projectId} onCloseClick={() => uiState.project(projectId).showActions.set(false)} />
 {/snippet}
 
-{#snippet leftSideview()}
+{#snippet leftPreview()}
 	<SelectionView {projectId} {selectionId} draggableFiles />
 {/snippet}
 
 <MainViewport
 	name="workspace"
-	leftSectionWidth={{ default: 280, min: 240 }}
-	leftSideviewWidth={{ default: 380, min: 240 }}
-	rightSideview={showingActions ? drawerRight : undefined}
-	leftSideview={previewOpen ? leftSideview : undefined}
+	leftWidth={{ default: 280, min: 220 }}
+	preview={previewOpen ? leftPreview : undefined}
+	previewWidth={{ default: 480, min: 220 }}
+	right={showingActions ? right : undefined}
+	rightWidth={{ default: 320, min: 220 }}
 >
-	{#snippet leftSection()}
+	{#snippet left()}
 		<UnassignedView {projectId} focus={focusGroup.current as DefinedFocusable} />
 	{/snippet}
-	{#snippet mainSection()}
+	{#snippet middle()}
 		<ReduxResult {projectId} result={stacksResult?.current}>
 			{#snippet loading()}
 				<div class="stacks-view-skeleton"></div>


### PR DESCRIPTION
With the introduction of a fourth panel we need to account for that in 
calculating available width for the three or four viewports in the 
workspace view.

To keep things as simple as possible we constrain the max width of the 
left container by the minimum widths of the others. In turn we then 
constrain the max width of the preview panel by the current size of the 
left container, and the min sizes of the others. Lastly, the right 
container is constrained by the actual sizes of the left and preview 
containers, leaving the middle container to take up the remainding 
space.