### PR TITLE
Fix reactivity issue in branches view

### DIFF
--- a/apps/desktop/src/components/v3/SelectionView.svelte
+++ b/apps/desktop/src/components/v3/SelectionView.svelte
@@ -18,13 +18,13 @@
 
 	const [idSelection] = inject(IdSelection);
 
-	const selection = $derived(selectionId ? idSelection.values(selectionId) : []);
+	const selection = $derived(selectionId ? idSelection.valuesReactive(selectionId) : undefined);
 	const lastAdded = $derived(selectionId ? idSelection.getById(selectionId).lastAdded : undefined);
 
 	const selectedFile = $derived.by(() => {
-		if (!selectionId) return;
-		if (selection.length === 0) return;
-		if (selection.length === 1 || !$lastAdded) return selection[0];
+		if (!selectionId || !selection) return;
+		if (selection.current.length === 0) return;
+		if (selection.current.length === 1 || !$lastAdded) return selection.current[0];
 		return readKey($lastAdded.key);
 	});
 </script>

--- a/apps/desktop/src/lib/selection/idSelection.svelte.ts
+++ b/apps/desktop/src/lib/selection/idSelection.svelte.ts
@@ -6,6 +6,7 @@ import {
 	type SelectionId,
 	type SelectedFile
 } from '$lib/selection/key';
+import { reactive } from '@gitbutler/shared/reactiveUtils.svelte';
 import { SvelteSet } from 'svelte/reactivity';
 import { get, writable, type Writable } from 'svelte/store';
 import type { TreeChange } from '$lib/hunks/change';
@@ -113,6 +114,12 @@ export class IdSelection {
 
 	values(params: SelectionId) {
 		return this.keys(params).map((key) => readKey(key));
+	}
+
+	valuesReactive(params: SelectionId) {
+		const selection = this.getById(params);
+		const keys = $derived(Array.from(selection.entries).map(readKey));
+		return reactive(() => keys);
 	}
 
 	/**


### PR DESCRIPTION
I have no idea why this makes a difference, but it does. I can only presume there is some form of sveltey reactivity bug that stops the regular `values` function from working right.