### PR TITLE
Update to the latest version of `gix` for unidiff fix.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1362,7 +1362,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3482,7 +3482,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.72.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "gix-actor 0.35.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-attributes 0.26.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3553,7 +3553,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.35.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "gix-date 0.10.2 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3584,7 +3584,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.26.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "gix-glob 0.20.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3610,7 +3610,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.14"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "thiserror 2.0.12",
 ]
@@ -3627,7 +3627,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "thiserror 2.0.12",
 ]
@@ -3635,7 +3635,7 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.6.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "gix-path 0.10.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3660,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "gix-chunk 0.4.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3673,7 +3673,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.45.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -3693,7 +3693,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -3705,7 +3705,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3736,7 +3736,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.10.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "itoa",
@@ -3749,7 +3749,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.52.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "gix-attributes 0.26.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3772,7 +3772,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.14.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "gix-discover 0.40.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3807,7 +3807,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.40.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "dunce",
@@ -3829,14 +3829,14 @@ dependencies = [
  "gix-trace 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "gix-utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
- "prodash",
+ "prodash 29.0.2",
  "walkdir",
 ]
 
 [[package]]
 name = "gix-features"
 version = "0.42.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -3848,7 +3848,7 @@ dependencies = [
  "libc",
  "once_cell",
  "parking_lot",
- "prodash",
+ "prodash 30.0.1",
  "thiserror 2.0.12",
  "walkdir",
 ]
@@ -3856,7 +3856,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.19.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -3890,7 +3890,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "fastrand",
@@ -3915,7 +3915,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.20.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -3939,7 +3939,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.18.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "faster-hex",
  "gix-features 0.42.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.8.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "gix-hash 0.18.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "hashbrown 0.15.4",
@@ -3985,7 +3985,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "gix-glob 0.20.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4026,7 +4026,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.40.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -4065,7 +4065,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "17.1.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "gix-tempfile 17.1.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4075,7 +4075,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.27.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "gix-actor 0.35.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4087,7 +4087,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.5.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4111,7 +4111,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.20.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bitflags 2.9.1",
  "gix-commitgraph 0.28.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4147,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.49.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "gix-actor 0.35.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4168,7 +4168,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.69.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "arc-swap",
  "gix-date 0.10.2 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4189,7 +4189,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.59.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "clru",
  "gix-chunk 0.4.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4210,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4221,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4246,7 +4246,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.18"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "gix-trace 0.1.12 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4259,7 +4259,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -4273,7 +4273,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4285,7 +4285,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.50.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -4322,7 +4322,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4353,7 +4353,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.52.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "gix-actor 0.35.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-features 0.42.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4374,7 +4374,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.30.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "gix-hash 0.18.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4387,7 +4387,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.34.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -4420,7 +4420,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.20.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "gix-commitgraph 0.28.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-date 0.10.2 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4446,7 +4446,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.11.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bitflags 2.9.1",
  "gix-path 0.10.18 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4458,7 +4458,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.4.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "gix-hash 0.18.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4470,7 +4470,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "filetime",
@@ -4492,7 +4492,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "gix-config",
@@ -4521,7 +4521,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "17.1.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "dashmap",
  "gix-fs 0.15.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4564,7 +4564,7 @@ checksum = "7c396a2036920c69695f760a65e7f2677267ccf483f25046977d87e4cb2665f7"
 [[package]]
 name = "gix-trace"
 version = "0.1.12"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "tracing-core",
 ]
@@ -4572,7 +4572,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.47.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -4608,7 +4608,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.46.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bitflags 2.9.1",
  "gix-commitgraph 0.28.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4624,7 +4624,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "gix-features 0.42.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4648,7 +4648,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4668,7 +4668,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "thiserror 2.0.12",
@@ -4696,7 +4696,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.41.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "gix-attributes 0.26.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4715,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8007f1d0bad357688acd1235d079bf164290cda6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f87967d4983f96133d184eff9d689a333c819958"
 dependencies = [
  "bstr",
  "gix-features 0.42.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -5564,9 +5564,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -5579,9 +5579,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5774,9 +5774,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libdbus-sys"
@@ -7291,6 +7291,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "prodash"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6efc566849d3d9d737c5cb06cc50e48950ebe3d3f9d70631490fff3a07b139"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8603,9 +8612,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
@@ -9843,9 +9852,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -10511,7 +10520,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
I took a moment to refactor the code and make the necessary comments
to finally understand it after it got copied from `imara-diff`, and
hope that this is now all the missing tests to make it work correctly,
even on top of the file.

### Task

* [x] update `gix`
* [x] local testing by wildly clicking previously incorrect diffs and other commit diffs
