### PR TITLE
Add mechanism for injecting event properties through `useMutation()`

### DIFF
--- a/apps/desktop/src/components/AppUpdater.test.ts
+++ b/apps/desktop/src/components/AppUpdater.test.ts
@@ -1,5 +1,5 @@
 import AppUpdater from '$components/AppUpdater.svelte';
-import { AnalyticsContext } from '$lib/analytics/analyticsContext';
+import { EventContext } from '$lib/analytics/eventContext';
 import { PostHogWrapper } from '$lib/analytics/posthog';
 import { Tauri } from '$lib/backend/tauri';
 import { getSettingsdServiceMock } from '$lib/testing/mockSettingsdService';
@@ -14,8 +14,8 @@ describe('AppUpdater', () => {
 	let context: Map<any, any>;
 	const MockSettingsService = getSettingsdServiceMock();
 	const settingsService = new MockSettingsService();
-	const analyticsContext = new AnalyticsContext();
-	const posthog = new PostHogWrapper(settingsService, analyticsContext);
+	const eventContext = new EventContext();
+	const posthog = new PostHogWrapper(settingsService, eventContext);
 
 	beforeEach(() => {
 		vi.useFakeTimers();

--- a/apps/desktop/src/components/MetricsReporter.test.ts
+++ b/apps/desktop/src/components/MetricsReporter.test.ts
@@ -3,7 +3,7 @@ import MetricsReporter, {
 	DELAY_MS,
 	INTERVAL_MS
 } from '$components/MetricsReporter.svelte';
-import { AnalyticsContext } from '$lib/analytics/analyticsContext';
+import { EventContext } from '$lib/analytics/eventContext';
 import { PostHogWrapper } from '$lib/analytics/posthog';
 import { ProjectMetrics } from '$lib/metrics/projectMetrics';
 import { ProjectService } from '$lib/project/projectService';
@@ -24,8 +24,8 @@ describe('MetricsReporter', () => {
 		projectMetrics = new ProjectMetrics();
 		const MockSettingsService = getSettingsdServiceMock();
 		const settingsService = new MockSettingsService();
-		const analyticsContext = new AnalyticsContext();
-		posthog = new PostHogWrapper(settingsService, analyticsContext);
+		const eventContext = new EventContext();
+		posthog = new PostHogWrapper(settingsService, eventContext);
 
 		context = new Map([
 			[PostHogWrapper as object, posthog as any],

--- a/apps/desktop/src/components/v3/AnalyticsMonitor.svelte
+++ b/apps/desktop/src/components/v3/AnalyticsMonitor.svelte
@@ -4,7 +4,7 @@ This component keeps the analytics context up-to-date, i.e. the metadata
 attached to posthog events.
 -->
 <script lang="ts">
-	import { AnalyticsContext } from '$lib/analytics/analyticsContext';
+	import { EventContext } from '$lib/analytics/eventContext';
 	import { SettingsService } from '$lib/config/appSettingsV2';
 	import { confettiEnabled } from '$lib/config/uiFeatureFlags';
 	import { ProjectService } from '$lib/project/projectService';
@@ -15,9 +15,9 @@ attached to posthog events.
 
 	const { projectId }: { projectId: string } = $props();
 
-	const [uiState, analyticsContext, projectService, settingsService] = inject(
+	const [uiState, eventContext, projectService, settingsService] = inject(
 		UiState,
-		AnalyticsContext,
+		EventContext,
 		ProjectService,
 		SettingsService
 	);
@@ -28,14 +28,14 @@ attached to posthog events.
 	const settings = getContextStoreBySymbol<Settings, Writable<Settings>>(SETTINGS);
 
 	$effect(() => {
-		analyticsContext.update({
+		eventContext.update({
 			showActions: projectState.showActions.current,
 			exclusiveAction: projectState.exclusiveAction.current?.type
 		});
 	});
 
 	$effect(() => {
-		analyticsContext.update({
+		eventContext.update({
 			rulerCount: globalState.rulerCountValue.current,
 			useRuler: globalState.useRuler.current,
 			wrapTextByRuler: globalState.wrapTextByRuler.current
@@ -43,7 +43,7 @@ attached to posthog events.
 	});
 
 	$effect(() => {
-		analyticsContext.update({
+		eventContext.update({
 			zoom: $settings.zoom,
 			theme: $settings.theme,
 			tabSize: $settings.tabSize,
@@ -54,14 +54,14 @@ attached to posthog events.
 	});
 
 	$effect(() => {
-		analyticsContext.update({
+		eventContext.update({
 			forcePushAllowed: $projectService?.ok_with_force_push,
 			gitAuthType: $projectService?.gitAuthType()
 		});
 	});
 
 	$effect(() => {
-		analyticsContext.update({
+		eventContext.update({
 			v3: $settingsService?.featureFlags.v3,
 			butlerActions: $settingsService?.featureFlags.actions,
 			ws3: $settingsService?.featureFlags.ws3
@@ -69,7 +69,7 @@ attached to posthog events.
 	});
 
 	$effect(() => {
-		analyticsContext.update({ confetti: $confettiEnabled });
+		eventContext.update({ confetti: $confettiEnabled });
 	});
 </script>
 

--- a/apps/desktop/src/components/v3/NewCommitView.svelte
+++ b/apps/desktop/src/components/v3/NewCommitView.svelte
@@ -28,7 +28,13 @@
 
 	const projectState = $derived(uiState.project(projectId));
 
-	const [createCommitInStack, commitCreation] = stackService.createCommit;
+	const useFloatingCommitBox = $derived(uiState.global.useFloatingCommitBox);
+
+	const [createCommitInStack, commitCreation] = stackService.createCommit({
+		propertiesFn: () => ({
+			floatingCommitBox: useFloatingCommitBox.current
+		})
+	});
 
 	const runCommitHooks = $derived(projectRunCommitHooks(projectId));
 
@@ -124,14 +130,17 @@
 		const preHookFailed = await runPreHook(worktreeChanges);
 		if (preHookFailed) return;
 
-		const response = await createCommitInStack({
-			projectId,
-			parentId,
-			stackId: finalStackId,
-			message: message,
-			stackBranchName: finalBranchName,
-			worktreeChanges
-		});
+		const response = await createCommitInStack(
+			{
+				projectId,
+				parentId,
+				stackId: finalStackId,
+				message: message,
+				stackBranchName: finalBranchName,
+				worktreeChanges
+			},
+			{ properties: { messageLength: message.length } }
+		);
 
 		const postHookFailed = await runPostHook();
 		if (postHookFailed) return;

--- a/apps/desktop/src/lib/analytics/eventContext.ts
+++ b/apps/desktop/src/lib/analytics/eventContext.ts
@@ -7,7 +7,7 @@ interface StateData {
 /**
  * Stuff that gets added to posthog events.
  */
-export class AnalyticsContext {
+export class EventContext {
 	private state: StateData = {};
 
 	set(key: string, value: StateValue): void {

--- a/apps/desktop/src/lib/analytics/posthog.ts
+++ b/apps/desktop/src/lib/analytics/posthog.ts
@@ -1,5 +1,5 @@
-import { PostHog, posthog } from 'posthog-js';
-import type { AnalyticsContext } from '$lib/analytics/analyticsContext';
+import { PostHog, posthog, type Properties } from 'posthog-js';
+import type { EventContext } from '$lib/analytics/eventContext';
 import type { SettingsService } from '$lib/config/appSettingsV2';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import { PUBLIC_POSTHOG_API_KEY } from '$env/static/public';
@@ -9,13 +9,13 @@ export class PostHogWrapper {
 
 	constructor(
 		private settingsService: SettingsService,
-		private analyticsContext: AnalyticsContext
+		private eventContext: EventContext
 	) {}
 
-	capture(...args: Parameters<typeof posthog.capture>) {
-		const context = this.analyticsContext.getAll();
-		const properties = { ...context, ...(args[1] || {}) };
-		this._instance?.capture(args[0], properties, args[2]);
+	capture(eventName: string, properties?: Properties) {
+		const context = this.eventContext.getAll();
+		const newProperties = { ...context, ...properties };
+		this._instance?.capture(eventName, newProperties);
 	}
 
 	async init(appName: string, appVersion: string) {

--- a/apps/desktop/src/lib/forge/forgeFactory.test.ts
+++ b/apps/desktop/src/lib/forge/forgeFactory.test.ts
@@ -1,4 +1,4 @@
-import { AnalyticsContext } from '$lib/analytics/analyticsContext';
+import { EventContext } from '$lib/analytics/eventContext';
 import { PostHogWrapper } from '$lib/analytics/posthog';
 import { DefaultForgeFactory } from '$lib/forge/forgeFactory.svelte';
 import { GitHub } from '$lib/forge/github/github';
@@ -14,8 +14,8 @@ import type { ThunkDispatch, UnknownAction } from '@reduxjs/toolkit';
 describe.concurrent('DefaultforgeFactory', () => {
 	const MockSettingsService = getSettingsdServiceMock();
 	const settingsService = new MockSettingsService();
-	const analyticsContext = new AnalyticsContext();
-	const posthog = new PostHogWrapper(settingsService, analyticsContext);
+	const eventContext = new EventContext();
+	const posthog = new PostHogWrapper(settingsService, eventContext);
 	const projectMetrics = new ProjectMetrics();
 	const gitHubApi: GitHubApi = {
 		endpoints: {},

--- a/apps/desktop/src/lib/forge/github/githubListingService.svelte.test.ts
+++ b/apps/desktop/src/lib/forge/github/githubListingService.svelte.test.ts
@@ -1,4 +1,4 @@
-import { AnalyticsContext } from '$lib/analytics/analyticsContext';
+import { EventContext } from '$lib/analytics/eventContext';
 import { PostHogWrapper } from '$lib/analytics/posthog';
 import { GitHub } from '$lib/forge/github/github';
 import { ProjectMetrics } from '$lib/metrics/projectMetrics';
@@ -19,8 +19,8 @@ describe('GitHubListingService', () => {
 	let projectMetrics: ProjectMetrics;
 	const MockSettingsService = getSettingsdServiceMock();
 	const settingsService = new MockSettingsService();
-	const analyticsContext = new AnalyticsContext();
-	const posthog = new PostHogWrapper(settingsService, analyticsContext);
+	const eventContext = new EventContext();
+	const posthog = new PostHogWrapper(settingsService, eventContext);
 
 	vi.useFakeTimers();
 

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -26,6 +26,7 @@ import type { DefaultForgeFactory } from '$lib/forge/forgeFactory.svelte';
 import type { TreeChange, TreeChanges } from '$lib/hunks/change';
 import type { DiffSpec, Hunk } from '$lib/hunks/hunk';
 import type { BranchDetails, Stack, StackDetails } from '$lib/stacks/stack';
+import type { PropertiesFn } from '$lib/state/customHooks.svelte';
 import type { UiState } from '$lib/state/uiState.svelte';
 import type { User } from '$lib/user/user';
 
@@ -415,8 +416,9 @@ export class StackService {
 		});
 	}
 
-	get createCommit() {
-		return this.api.endpoints.createCommit.useMutation();
+	createCommit(args: { propertiesFn?: PropertiesFn }) {
+		const propertiesFn = args.propertiesFn;
+		return this.api.endpoints.createCommit.useMutation({ propertiesFn });
 	}
 
 	get createCommitMutation() {
@@ -968,7 +970,8 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					invalidatesList(ReduxTag.WorktreeChanges),
 					invalidatesList(ReduxTag.UpstreamIntegrationStatus),
 					invalidatesItem(ReduxTag.StackDetails, args.stackId)
-				]
+				],
+				extraOptions: { actionName: 'Commit' }
 			}),
 			createCommitLegacy: build.mutation<
 				undefined,

--- a/apps/desktop/src/lib/state/backendQuery.ts
+++ b/apps/desktop/src/lib/state/backendQuery.ts
@@ -4,12 +4,16 @@ import { Tauri } from '$lib/backend/tauri';
 import { isErrorlike } from '@gitbutler/ui/utils/typeguards';
 import { type BaseQueryApi, type QueryReturnValue } from '@reduxjs/toolkit/query';
 
-export type TauriBaseQueryFn = typeof tauriBaseQuery;
+import type { BaseQueryFn } from '@reduxjs/toolkit/query';
 
-export async function tauriBaseQuery(
+export type ExtraOptions = { [key: string]: string };
+export type TauriBaseQueryFn = BaseQueryFn<ApiArgs, unknown, unknown, ExtraOptions | undefined>;
+
+// eslint-disable-next-line func-style
+export const tauriBaseQuery: TauriBaseQueryFn = async (
 	args: ApiArgs,
 	api: BaseQueryApi
-): Promise<QueryReturnValue<unknown, TauriCommandError, undefined>> {
+): Promise<QueryReturnValue<unknown, TauriCommandError, undefined>> => {
 	if (!hasTauriExtra(api.extra)) {
 		return {
 			error: { name: 'Failed to execute Tauri query', message: 'Redux dependency Tauri not found!' }
@@ -56,7 +60,7 @@ export async function tauriBaseQuery(
 
 		return { error: { name, message: String(error) } };
 	}
-}
+};
 
 type ApiArgs = {
 	command: string;

--- a/apps/desktop/src/lib/state/clientState.svelte.ts
+++ b/apps/desktop/src/lib/state/clientState.svelte.ts
@@ -70,7 +70,8 @@ export class ClientState {
 			// Reactive loop without nested function.
 			// TODO: Can it be done without nesting?
 			getState: () => () => this.rootState as any as RootState<any, any, any>,
-			getDispatch: () => this.dispatch
+			getDispatch: () => this.dispatch,
+			posthog
 		});
 		this.githubApi = createGitHubApi(butlerMod);
 		this.gitlabApi = createGitLabApi(butlerMod);

--- a/apps/desktop/src/lib/state/context.ts
+++ b/apps/desktop/src/lib/state/context.ts
@@ -1,3 +1,4 @@
+import type { PostHogWrapper } from '$lib/analytics/posthog';
 import type { EntityState, ThunkDispatch, UnknownAction } from '@reduxjs/toolkit';
 import type { CombinedState } from '@reduxjs/toolkit/query';
 
@@ -12,4 +13,5 @@ export type HookContext = {
 	/** Without the nested function we get looping reactivity.  */
 	getState: () => () => { [k: string]: CombinedState<any, any, any> | EntityState<any, any> };
 	getDispatch: () => ThunkDispatch<any, any, UnknownAction>;
+	posthog?: PostHogWrapper;
 };

--- a/apps/desktop/src/lib/updater/updater.test.ts
+++ b/apps/desktop/src/lib/updater/updater.test.ts
@@ -1,4 +1,4 @@
-import { AnalyticsContext } from '$lib/analytics/analyticsContext';
+import { EventContext } from '$lib/analytics/eventContext';
 import { PostHogWrapper } from '$lib/analytics/posthog';
 import { Tauri } from '$lib/backend/tauri';
 import { getSettingsdServiceMock } from '$lib/testing/mockSettingsdService';
@@ -16,8 +16,8 @@ describe('Updater', () => {
 	let updater: UpdaterService;
 	const MockSettingsService = getSettingsdServiceMock();
 	const settingsService = new MockSettingsService();
-	const analyticsContext = new AnalyticsContext();
-	const posthog = new PostHogWrapper(settingsService, analyticsContext);
+	const eventContext = new EventContext();
+	const posthog = new PostHogWrapper(settingsService, eventContext);
 
 	beforeEach(() => {
 		vi.useFakeTimers();

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -19,7 +19,7 @@
 	import { ActionService } from '$lib/actions/actionService.svelte';
 	import { PromptService as AIPromptService } from '$lib/ai/promptService';
 	import { AIService } from '$lib/ai/service';
-	import { AnalyticsContext } from '$lib/analytics/analyticsContext';
+	import { EventContext } from '$lib/analytics/eventContext';
 	import { PostHogWrapper } from '$lib/analytics/posthog';
 	import { CommandService, invoke } from '$lib/backend/ipc';
 	import BaseBranchService from '$lib/baseBranch/baseBranchService.svelte';
@@ -239,7 +239,7 @@
 	setContext(LineManagerFactory, data.lineManagerFactory);
 	setContext(StackingLineManagerFactory, data.stackingLineManagerFactory);
 	setContext(AppSettings, data.appSettings);
-	setContext(AnalyticsContext, data.analyticsContext);
+	setContext(EventContext, data.eventContext);
 	setContext(StackService, stackService);
 	setContext(ActionService, actionService);
 	setContext(OplogService, oplogService);

--- a/apps/desktop/src/routes/+layout.ts
+++ b/apps/desktop/src/routes/+layout.ts
@@ -1,7 +1,7 @@
 import { PromptService as AIPromptService } from '$lib/ai/promptService';
 import { AIService } from '$lib/ai/service';
 import { initAnalyticsIfEnabled } from '$lib/analytics/analytics';
-import { AnalyticsContext } from '$lib/analytics/analyticsContext';
+import { EventContext } from '$lib/analytics/eventContext';
 import { PostHogWrapper } from '$lib/analytics/posthog';
 import { CommandService } from '$lib/backend/ipc';
 import { Tauri } from '$lib/backend/tauri';
@@ -50,10 +50,10 @@ export const load: LayoutLoad = async () => {
 	const projectsService = new ProjectsService(defaultPath, httpClient);
 	const settingsService = new SettingsService(tauri, projectsService);
 
-	const analyticsContext = new AnalyticsContext();
+	const eventContext = new EventContext();
 	// Awaited and will block initial render, but it is necessary in order to respect the user
 	// settings on telemetry.
-	const posthog = new PostHogWrapper(settingsService, analyticsContext);
+	const posthog = new PostHogWrapper(settingsService, eventContext);
 	const appSettings = await loadAppSettings();
 	initAnalyticsIfEnabled(appSettings, posthog);
 
@@ -97,6 +97,6 @@ export const load: LayoutLoad = async () => {
 		settingsService,
 		projectMetrics,
 		uploadsService,
-		analyticsContext
+		eventContext
 	};
 };


### PR DESCRIPTION
We already have app level information in our event properties, but lacked an ability to inject additional attributes at the time an action is taken.

As an example usage of this new mechanism this commit also adds a floatingCommitBox boolean, as well as a messageLength number to the commit posthog event metadata.