### PR TITLE
ui-fixes-99

### DIFF
--- a/apps/desktop/src/components/v3/BranchCard.svelte
+++ b/apps/desktop/src/components/v3/BranchCard.svelte
@@ -140,7 +140,6 @@
 				{branchName}
 				isEmpty={args.isNewBranch}
 				selected={args.selected}
-				selectIndicator
 				draft={false}
 				{lineColor}
 				isCommitting={args.isCommitting}
@@ -206,7 +205,6 @@
 			{branchName}
 			isEmpty={args.isNewBranch}
 			selected={args.selected}
-			selectIndicator
 			draft={false}
 			{lineColor}
 			iconName={args.iconName}
@@ -234,7 +232,6 @@
 			{branchName}
 			isEmpty
 			selected={args.selected}
-			selectIndicator
 			draft={false}
 			{lineColor}
 			iconName="branch-remote"
@@ -257,7 +254,6 @@
 			{branchName}
 			isEmpty
 			selected
-			selectIndicator={false}
 			draft
 			{lineColor}
 			iconName="branch-local"

--- a/apps/desktop/src/components/v3/BranchHeader.svelte
+++ b/apps/desktop/src/components/v3/BranchHeader.svelte
@@ -12,7 +12,6 @@
 		branchName: string;
 		isEmpty: boolean | undefined;
 		selected: boolean;
-		selectIndicator: boolean;
 		active: boolean | undefined;
 		readonly: boolean;
 		draft: boolean;
@@ -33,7 +32,6 @@
 		branchName,
 		isEmpty = false,
 		selected,
-		selectIndicator,
 		draft,
 		active,
 		isCommitting,
@@ -69,7 +67,7 @@
 	tabindex="0"
 	class:active
 >
-	{#if selected && selectIndicator}
+	{#if selected && !draft}
 		<div
 			class="branch-header__select-indicator"
 			in:slide={{ axis: 'x', duration: 150 }}
@@ -131,7 +129,6 @@
 		padding-right: 10px;
 		padding-left: 15px;
 		overflow: hidden;
-		/* border-bottom: 1px solid var(--clr-border-2); */
 		background-color: var(--branch-selected-bg);
 
 		/* Selected but NOT in focus */

--- a/apps/desktop/src/components/v3/MultiStackPagination.svelte
+++ b/apps/desktop/src/components/v3/MultiStackPagination.svelte
@@ -32,11 +32,11 @@
 
 	function getPaginationTooltip(index: number) {
 		if (visibleIndexes.includes(index)) {
-			return `Branch ${index + 1}`;
+			return 'In view';
 		} else if (index === selectedBranchIndex) {
-			return 'Selected branch';
+			return 'Selected';
 		} else {
-			return `Switch to branch ${index + 1}`;
+			return 'Scroll to lane';
 		}
 	}
 </script>

--- a/apps/desktop/src/components/v3/MultiStackView.svelte
+++ b/apps/desktop/src/components/v3/MultiStackView.svelte
@@ -24,13 +24,12 @@
 
 	type Props = {
 		projectId: string;
-		selectedId?: string;
 		stacks: Stack[];
 		selectionId: SelectionId;
 		focusedStackId?: string;
 	};
 
-	let { projectId, selectedId, stacks, focusedStackId }: Props = $props();
+	let { projectId, stacks, focusedStackId }: Props = $props();
 
 	const [uiState, stackService, intelligentScrollingService] = inject(
 		UiState,
@@ -105,7 +104,7 @@
 			{visibleIndexes}
 			{isCreateNewVisible}
 			selectedBranchIndex={stacks.findIndex((s) => {
-				return s.id === selectedId;
+				return s.id === focusedStackId;
 			})}
 			onPageClick={(index) => scrollToLane(lanesScrollableEl, index)}
 			onCreateNewClick={() => {

--- a/apps/desktop/src/components/v3/WorkspaceView.svelte
+++ b/apps/desktop/src/components/v3/WorkspaceView.svelte
@@ -23,10 +23,9 @@
 
 	interface Props {
 		projectId: string;
-		stackId?: string;
 	}
 
-	const { stackId, projectId }: Props = $props();
+	const { projectId }: Props = $props();
 
 	const [stackService, focusManager, idSelection, uiState, settingsService] = inject(
 		StackService,
@@ -148,7 +147,7 @@
 				<div class="stacks-view-skeleton"></div>
 			{/snippet}
 			{#snippet children(stacks, { projectId })}
-				<MultiStackView {projectId} {stacks} {selectionId} selectedId={stackId} {focusedStackId} />
+				<MultiStackView {projectId} {stacks} {selectionId} {focusedStackId} />
 			{/snippet}
 		</ReduxResult>
 	{/snippet}

--- a/apps/desktop/src/components/v3/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/v3/WorktreeChanges.svelte
@@ -144,14 +144,14 @@
 			parentId: stackId ? DefinedFocusable.ViewportRight : DefinedFocusable.ViewportLeft
 		}}
 	>
-		{#if mode === 'unassigned'}
+		{#if mode === 'unassigned' || changes.current.length > 0}
 			<div
 				role="presentation"
 				data-testid={TestId.UncommittedChanges_Header}
 				class="worktree-header"
 				class:sticked-top={!scrollTopIsVisible}
 			>
-				{#if !isCommitting}
+				{#if !isCommitting && mode === 'unassigned' && !unassignedSidebaFolded.current}
 					<div class="worktree-header__fold">
 						<UnassignedFoldButton active={false} onclick={foldUnnassignedView} />
 					</div>

--- a/apps/desktop/src/routes/[projectId]/workspace/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/workspace/+page.svelte
@@ -58,4 +58,4 @@
 	});
 </script>
 
-<WorkspaceView {projectId} {stackId} />
+<WorkspaceView {projectId} />


### PR DESCRIPTION
- Fixed header display for unassigned or current changes in the worktree.
- Removed extra property from branchHeader component.
- Removed unused stackId property and related logic from workspace.
- Updated pagination tooltip text for better clarity.