### PR TITLE
fix symlink committing

### DIFF
--- a/crates/but-db/Cargo.toml
+++ b/crates/but-db/Cargo.toml
@@ -23,7 +23,7 @@ anyhow = "1.0.98"
 diesel_migrations = { version = "2.0.0", features = ["sqlite"] }
 chrono = { version = "0.4.41", features = ["serde"] }
 # other things
-tokio = { workspace = true, features = ["rt-multi-thread", "parking_lot"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "parking_lot", "time", "sync"] }
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/but-workspace/src/commit_engine/tree/mod.rs
+++ b/crates/but-workspace/src/commit_engine/tree/mod.rs
@@ -299,6 +299,7 @@ pub fn apply_worktree_changes<'repo>(
 
             worktree_file_to_git_in_buf(
                 &mut current_worktree,
+                &md,
                 base_rela_path,
                 &path,
                 &mut pipeline,
@@ -324,28 +325,37 @@ pub fn apply_worktree_changes<'repo>(
     Ok((altered_base_tree_id, actual_base_tree))
 }
 
+/// `md` is used to know how to read the entry, and we assume that it was pre-filtered
+/// so we only hit items we can handle.
 pub(crate) fn worktree_file_to_git_in_buf(
     buf: &mut Vec<u8>,
+    md: &gix::index::fs::Metadata,
     rela_path: &BStr,
     path: &Path,
     pipeline: &mut gix::filter::Pipeline<'_>,
     index: &gix::index::State,
 ) -> anyhow::Result<()> {
     buf.clear();
-    let to_git = pipeline.convert_to_git(
-        std::fs::File::open(path)?,
-        &gix::path::from_bstr(rela_path),
-        index,
-    )?;
-    match to_git {
-        ToGitOutcome::Unchanged(mut file) => {
-            file.read_to_end(buf)?;
-        }
-        ToGitOutcome::Process(mut stream) => {
-            stream.read_to_end(buf)?;
-        }
-        ToGitOutcome::Buffer(buf2) => buf.extend_from_slice(buf2),
-    };
+    if md.is_symlink() {
+        buf.extend_from_slice(&gix::path::os_string_into_bstring(
+            std::fs::read_link(path)?.into(),
+        )?);
+    } else {
+        let to_git = pipeline.convert_to_git(
+            std::fs::File::open(path)?,
+            &gix::path::from_bstr(rela_path),
+            index,
+        )?;
+        match to_git {
+            ToGitOutcome::Unchanged(mut file) => {
+                file.read_to_end(buf)?;
+            }
+            ToGitOutcome::Process(mut stream) => {
+                stream.read_to_end(buf)?;
+            }
+            ToGitOutcome::Buffer(buf2) => buf.extend_from_slice(buf2),
+        };
+    }
     Ok(())
 }
 

--- a/crates/but-workspace/src/tree_manipulation/discard_worktree_changes.rs
+++ b/crates/but-workspace/src/tree_manipulation/discard_worktree_changes.rs
@@ -655,8 +655,13 @@ mod hunk {
         let mut new = repo.empty_reusable_buffer();
         let rela_path = wt_change.path.as_bstr();
         let worktree_path = path_check.verified_path_allow_nonexisting(rela_path)?;
-        // TODO: assure we don't mess with symlinks wrongly.
         let md = gix::index::fs::Metadata::from_path_no_follow(&worktree_path)?;
+        if !md.is_file() {
+            bail!(
+                "Cannot discard lines in '{}' - invalid type",
+                worktree_path.display()
+            );
+        }
         worktree_file_to_git_in_buf(&mut new, &md, rela_path, &worktree_path, pipeline, index)?;
 
         let base_with_patches = apply_hunks(old.as_bstr(), new.as_bstr(), &hunks_to_keep)?;

--- a/crates/but-workspace/src/tree_manipulation/discard_worktree_changes.rs
+++ b/crates/but-workspace/src/tree_manipulation/discard_worktree_changes.rs
@@ -152,7 +152,7 @@ pub fn discard_workspace_changes(
                 } => {
                     if flags.is_some_and(|f| f.is_typechange()) {
                         bail!(
-                            "Type-changed items can't be discard by hunks - use the whole-file mode isntead"
+                            "Type-changed items can't be discard by hunks - use the whole-file mode instead"
                         )
                     }
                     hunk::restore_state_to_worktree(
@@ -655,7 +655,9 @@ mod hunk {
         let mut new = repo.empty_reusable_buffer();
         let rela_path = wt_change.path.as_bstr();
         let worktree_path = path_check.verified_path_allow_nonexisting(rela_path)?;
-        worktree_file_to_git_in_buf(&mut new, rela_path, &worktree_path, pipeline, index)?;
+        // TODO: assure we don't mess with symlinks wrongly.
+        let md = gix::index::fs::Metadata::from_path_no_follow(&worktree_path)?;
+        worktree_file_to_git_in_buf(&mut new, &md, rela_path, &worktree_path, pipeline, index)?;
 
         let base_with_patches = apply_hunks(old.as_bstr(), new.as_bstr(), &hunks_to_keep)?;
 

--- a/crates/but-workspace/tests/fixtures/generated-archives/.gitignore
+++ b/crates/but-workspace/tests/fixtures/generated-archives/.gitignore
@@ -3,6 +3,7 @@
 /delete-all-file-types.tar
 /two-commits-with-line-offset.tar
 /all-file-types-changed.tar
+/all-file-types-modified.tar
 /merge-with-two-branches-line-offset-two-files.tar
 /merge-with-two-branches-line-offset.tar
 /unborn-with-submodules.tar

--- a/crates/but-workspace/tests/fixtures/scenario/all-file-types-modified.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/all-file-types-modified.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+### Description
+# A commit with an executable, a normal file, a symlink and an untracked fifo.
+# All of them get changed in the worktree.
+set -eu -o pipefail
+
+git init
+seq 5 8 >file
+seq 1 3 >executable && chmod +x executable
+ln -s nonexisting-target link
+mkfifo fifo-should-be-ignored
+
+git add . && git commit -m "init"
+
+seq 5 10 >file
+seq 1 5 >executable
+
+rm link
+ln -s other-nonexisting-target link
+


### PR DESCRIPTION
It seems symlinks are added as symlinks, but their content being the content of the file they
link to, instead of their original value as read by `readlink()`.

This is a huge oversight and I can't believe that I didn't test this precisely enough.
It also means that all symlinks currently created by the app are broken.

### Task

* [x] reproduce in Nightly
* [x] reproduce in test or check existing tests accuracy
    - it's not obviously broken on a low level
    - workspace changes are shown correctly
    - it's probably related to the UI passing in hunk information, so the new link is a single-line change `path: "ho", hunk_headers: [HunkHeader("-1,0", "+1,1")]`
* [x] fix - allow it, but do it correctly
     - This works as ultimately the operation on a single-line buffer is valid, and we work with Git directly without having to deal with the worktree.
* [x] what about discarding? Added protection, barking loudly, so this can be handled better in future if needed.
    - The UI will allow passing hunks when discarding individual lines in a symlnk, but it doesn't do anything.