### PR TITLE
fix(workspace): update snapshot operation to AmendCommit

### DIFF
--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -255,7 +255,7 @@ pub fn move_changes_between_commits(
     let mut guard = project.exclusive_worktree_access();
 
     let _ = ctx.create_snapshot(
-        SnapshotDetails::new(OperationKind::DiscardChanges),
+        SnapshotDetails::new(OperationKind::AmendCommit),
         guard.write_permission(),
     );
     let result = but_workspace::move_changes_between_commits(


### PR DESCRIPTION
Move changes between commits is technically an amend operation. Not discarding