### PR TITLE
Experimental: butbot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,6 +992,7 @@ dependencies = [
  "gitbutler-branch-actions",
  "gitbutler-command-context",
  "gitbutler-oplog",
+ "gitbutler-oxidize",
  "gitbutler-project",
  "gitbutler-serde",
  "gitbutler-stack",

--- a/apps/desktop/cypress/e2e/support/mock/settings.ts
+++ b/apps/desktop/cypress/e2e/support/mock/settings.ts
@@ -10,7 +10,8 @@ export const MOCK_TELEMETRY_SETINGS: TelemetrySettings = {
 export const MOCK_FEATURE_FLAGS: FeatureFlags = {
 	v3: true,
 	ws3: false,
-	actions: false
+	actions: false,
+	butbot: false
 };
 
 export const MOCK_APP_SETTINGS: AppSettings = {

--- a/apps/desktop/src/components/v3/Feed.svelte
+++ b/apps/desktop/src/components/v3/Feed.svelte
@@ -47,12 +47,12 @@
 		const content = await editor?.getPlaintext();
 		if (!content || content?.trim() === '') return;
 		editor?.clear();
-		feed.addUserMessage(content);
+		const messages = await feed.addUserMessage(content);
 		const response = await freestyle({
 			projectId,
-			prompt: content
+			chatMessages: messages
 		});
-		feed.addAssistantMessage(response);
+		await feed.addAssistantMessage(response);
 	}
 
 	function handleKeyDown(event: KeyboardEvent | null): boolean {

--- a/apps/desktop/src/components/v3/FeedItem.svelte
+++ b/apps/desktop/src/components/v3/FeedItem.svelte
@@ -4,6 +4,7 @@
 	import FeedItemKind from '$components/v3/FeedItemKind.svelte';
 	import { ButlerAction, getDisplayNameForWorkflowKind, Workflow } from '$lib/actions/types';
 	import butbotSvg from '$lib/assets/butbot-actions.svg?raw';
+	import { isFeedMessage, type FeedEntry } from '$lib/feed/feed';
 	import SnapshotDiffService from '$lib/history/snapshotDiffService.svelte';
 	import { Snapshot } from '$lib/history/types';
 	import { User } from '$lib/user/user';
@@ -20,7 +21,7 @@
 
 	type Props = {
 		projectId: string;
-		action: ButlerAction | Snapshot | Workflow;
+		action: FeedEntry;
 	};
 
 	const { action, projectId }: Props = $props();
@@ -174,6 +175,31 @@
 			</span>
 
 			<FeedItemKind {projectId} kind={action.kind} />
+		</div>
+	{:else if isFeedMessage(action)}
+		{#if action.type === 'assistant'}
+			<div>
+				<AgentAvatar />
+			</div>
+		{:else}
+			<div class="action-item__picture">
+				{#if $user?.picture && !failedToLoadImage}
+					<img
+						class="user-icon__image"
+						src={$user.picture}
+						alt=""
+						referrerpolicy="no-referrer"
+						onerror={() => (failedToLoadImage = true)}
+					/>
+				{:else}
+					<Icon name="profile" />
+				{/if}
+			</div>
+		{/if}
+		<div class="action-item__content">
+			<span class="text-14 text-darkgrey">
+				<Markdown content={action.content} />
+			</span>
 		</div>
 	{/if}
 </div>

--- a/apps/desktop/src/components/v3/profileSettings/ExperimentalSettings.svelte
+++ b/apps/desktop/src/components/v3/profileSettings/ExperimentalSettings.svelte
@@ -91,8 +91,31 @@
 
 	{#if $user?.role === 'admin'}
 		<Spacer margin={20} />
+		{#if $settingsStore?.featureFlags.actions}
+			<SectionCard labelFor="butbot" roundedTop roundedBottom={false} orientation="row">
+				{#snippet title()}
+					butbot
+				{/snippet}
+				{#snippet caption()}
+					Enable the butbot chat.
+				{/snippet}
+				{#snippet actions()}
+					<Toggle
+						id="butbot"
+						checked={$settingsStore?.featureFlags.butbot}
+						onclick={() =>
+							settingsService.updateFeatureFlags({ butbot: !$settingsStore?.featureFlags.butbot })}
+					/>
+				{/snippet}
+			</SectionCard>
+		{/if}
 
-		<SectionCard labelFor="irc" roundedTop={false} roundedBottom={!$ircEnabled} orientation="row">
+		<SectionCard
+			labelFor="irc"
+			roundedTop={!$settingsStore?.featureFlags.actions}
+			roundedBottom={!$ircEnabled}
+			orientation="row"
+		>
 			{#snippet title()}
 				IRC
 			{/snippet}

--- a/apps/desktop/src/lib/actions/actionService.svelte.ts
+++ b/apps/desktop/src/lib/actions/actionService.svelte.ts
@@ -20,6 +20,10 @@ export class ActionService {
 	get absorb() {
 		return this.api.endpoints.absorb.useMutation();
 	}
+
+	get freestyle() {
+		return this.api.endpoints.freestyle.useMutation();
+	}
 }
 
 function injectEndpoints(api: ClientState['backendApi']) {
@@ -54,6 +58,18 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'absorb',
 					params: { projectId, changes },
 					actionName: 'Absorb changes into the best matching branch and commit'
+				}),
+				invalidatesTags: [
+					invalidatesList(ReduxTag.Stacks),
+					invalidatesList(ReduxTag.StackDetails),
+					invalidatesList(ReduxTag.WorktreeChanges)
+				]
+			}),
+			freestyle: build.mutation<string, { projectId: string; prompt: string }>({
+				query: ({ projectId, prompt }) => ({
+					command: 'freestyle',
+					params: { projectId, prompt },
+					actionName: 'Perform a freestyle action based on the given prompt'
 				}),
 				invalidatesTags: [
 					invalidatesList(ReduxTag.Stacks),

--- a/apps/desktop/src/lib/actions/actionService.svelte.ts
+++ b/apps/desktop/src/lib/actions/actionService.svelte.ts
@@ -70,10 +70,13 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					invalidatesList(ReduxTag.WorktreeChanges)
 				]
 			}),
-			freestyle: build.mutation<string, { projectId: string; chatMessages: ChatMessage[] }>({
-				query: ({ projectId, chatMessages }) => ({
+			freestyle: build.mutation<
+				string,
+				{ projectId: string; chatMessages: ChatMessage[]; model: string | null }
+			>({
+				query: ({ projectId, chatMessages, model }) => ({
 					command: 'freestyle',
-					params: { projectId, chatMessages },
+					params: { projectId, chatMessages, model },
 					actionName: 'Perform a freestyle action based on the given prompt'
 				}),
 				invalidatesTags: [

--- a/apps/desktop/src/lib/actions/actionService.svelte.ts
+++ b/apps/desktop/src/lib/actions/actionService.svelte.ts
@@ -2,6 +2,11 @@ import { invalidatesList, ReduxTag } from '$lib/state/tags';
 import type { TreeChange } from '$lib/hunks/change';
 import type { BackendApi, ClientState } from '$lib/state/clientState.svelte';
 
+type ChatMessage = {
+	type: 'user' | 'assistant';
+	content: string;
+};
+
 export class ActionService {
 	private api: ReturnType<typeof injectEndpoints>;
 
@@ -65,10 +70,10 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					invalidatesList(ReduxTag.WorktreeChanges)
 				]
 			}),
-			freestyle: build.mutation<string, { projectId: string; prompt: string }>({
-				query: ({ projectId, prompt }) => ({
+			freestyle: build.mutation<string, { projectId: string; chatMessages: ChatMessage[] }>({
+				query: ({ projectId, chatMessages }) => ({
 					command: 'freestyle',
-					params: { projectId, prompt },
+					params: { projectId, chatMessages },
 					actionName: 'Perform a freestyle action based on the given prompt'
 				}),
 				invalidatesTags: [

--- a/apps/desktop/src/lib/config/appSettingsV2.ts
+++ b/apps/desktop/src/lib/config/appSettingsV2.ts
@@ -91,6 +91,8 @@ export type FeatureFlags = {
 	ws3: boolean;
 	/** Enable the usage of GitButler Acitions. */
 	actions: boolean;
+	/** Enable the usage of butbot chat */
+	butbot: boolean;
 };
 
 export type Fetch = {

--- a/apps/desktop/src/lib/config/config.ts
+++ b/apps/desktop/src/lib/config/config.ts
@@ -61,3 +61,11 @@ export function persistedCommitMessage(projectId: string, branchId: string): Per
 }
 
 export const showHistoryView = persisted(false, 'showHistoryView');
+
+export function persistedChatModelName<T extends string>(
+	projectId: string,
+	defaultValue: T
+): Persisted<T> {
+	const key = 'projectChatModelName_';
+	return persisted(defaultValue, key + projectId);
+}

--- a/apps/desktop/src/lib/feed/feed.ts
+++ b/apps/desktop/src/lib/feed/feed.ts
@@ -28,6 +28,36 @@ class Mutex {
 	}
 }
 
+export type UserMessage = {
+	id: `user-${string}`;
+	type: 'user';
+	content: string;
+};
+
+export type AssistantMessage = {
+	id: `assistant-${string}`;
+	type: 'assistant';
+	content: string;
+};
+
+export type FeedMessage = UserMessage | AssistantMessage;
+
+export type FeedEntry = ButlerAction | Workflow | Snapshot | FeedMessage;
+
+export function isFeedMessage(entry: FeedEntry): entry is FeedMessage {
+	return (entry as FeedMessage).type !== undefined;
+}
+
+export function isUserMessage(entry: FeedEntry): entry is UserMessage {
+	if (!isFeedMessage(entry)) return false;
+	return (entry as UserMessage).id.startsWith('user-');
+}
+
+export function isAssistantMessage(entry: FeedEntry): entry is AssistantMessage {
+	if (!isFeedMessage(entry)) return false;
+	return (entry as AssistantMessage).id.startsWith('assistant-');
+}
+
 export class Feed {
 	private actionsBuffer: ButlerAction[] = [];
 	private workflowsBuffer: Workflow[] = [];
@@ -39,7 +69,7 @@ export class Feed {
 	readonly lastAddedId = writable<string | null>(null);
 	readonly stackToUpdate = writable<string | null>(null);
 
-	readonly combined = writable<(Snapshot | ButlerAction | Workflow)[]>([], () => {
+	readonly combined = writable<FeedEntry[]>([], () => {
 		this.fetch();
 	});
 
@@ -67,13 +97,49 @@ export class Feed {
 		}
 	}
 
-	private async handleLastAdded(entry: Snapshot | ButlerAction | Workflow) {
+	private async handleLastAdded(entry: FeedEntry) {
 		this.lastAddedId.set(entry.id);
 
 		if (entry instanceof Workflow) {
 			const stackId = entry.kind.subject?.stackId;
 			if (stackId) this.stackToUpdate.set(stackId);
 		}
+	}
+
+	async addUserMessage(content: string) {
+		const message: UserMessage = {
+			id: `user-${crypto.randomUUID()}`,
+			type: 'user',
+			content
+		};
+		await this.mutex.lock(async () => {
+			this.combined.update((entries) => {
+				const existing = entries.find((entry) => entry.id === message.id);
+				if (!existing) {
+					this.handleLastAdded(message);
+					return [message, ...entries];
+				}
+				return entries;
+			});
+		});
+	}
+
+	async addAssistantMessage(content: string) {
+		const message: AssistantMessage = {
+			id: `assistant-${crypto.randomUUID()}`,
+			type: 'assistant',
+			content
+		};
+		await this.mutex.lock(async () => {
+			this.combined.update((entries) => {
+				const existing = entries.find((entry) => entry.id === message.id);
+				if (!existing) {
+					this.handleLastAdded(message);
+					return [message, ...entries];
+				}
+				return entries;
+			});
+		});
 	}
 
 	async updateCombinedFeed() {

--- a/apps/desktop/src/lib/feed/feed.ts
+++ b/apps/desktop/src/lib/feed/feed.ts
@@ -106,6 +106,10 @@ export class Feed {
 		}
 	}
 
+	private getFeedMessages(): FeedMessage[] {
+		return get(this.combined).filter((entry) => isFeedMessage(entry)) as FeedMessage[];
+	}
+
 	async addUserMessage(content: string) {
 		const message: UserMessage = {
 			id: `user-${crypto.randomUUID()}`,
@@ -122,6 +126,8 @@ export class Feed {
 				return entries;
 			});
 		});
+
+		return this.getFeedMessages();
 	}
 
 	async addAssistantMessage(content: string) {

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -1542,7 +1542,8 @@ function injectEndpoints(api: ClientState['backendApi']) {
 							lifecycleApi.dispatch(
 								api.util.invalidateTags([
 									invalidatesItem(ReduxTag.StackDetails, event.payload.stackId),
-									invalidatesList(ReduxTag.Stacks)
+									invalidatesList(ReduxTag.Stacks),
+									invalidatesList(ReduxTag.WorktreeChanges)
 								])
 							);
 						}

--- a/crates/but-action/src/absorb.rs
+++ b/crates/but-action/src/absorb.rs
@@ -98,7 +98,13 @@ pub fn absorb(
     ", path_strings,  serialized_status);
 
     // Now we trigger the tool calling loop to absorb the remaining changes.
-    crate::openai::tool_calling_loop(openai, system_message, &prompt, &mut toolset)?;
+    crate::openai::tool_calling_loop(
+        openai,
+        system_message,
+        vec![prompt.into()],
+        &mut toolset,
+        None,
+    )?;
 
     Ok(())
 }

--- a/crates/but-action/src/auto_commit.rs
+++ b/crates/but-action/src/auto_commit.rs
@@ -54,7 +54,13 @@ pub fn auto_commit(
         </project_status>
     ", serialized_status);
 
-    crate::openai::tool_calling_loop(openai, system_message, &prompt, &mut toolset)?;
+    crate::openai::tool_calling_loop(
+        openai,
+        system_message,
+        vec![prompt.into()],
+        &mut toolset,
+        None,
+    )?;
 
     Ok(())
 }

--- a/crates/but-action/src/branch_changes.rs
+++ b/crates/but-action/src/branch_changes.rs
@@ -50,7 +50,13 @@ pub fn branch_changes(
         </project_status>
     ", serialized_status);
 
-    crate::openai::tool_calling_loop(openai, system_message, &prompt, &mut toolset)?;
+    crate::openai::tool_calling_loop(
+        openai,
+        system_message,
+        vec![prompt.into()],
+        &mut toolset,
+        None,
+    )?;
 
     Ok(())
 }

--- a/crates/but-action/src/lib.rs
+++ b/crates/but-action/src/lib.rs
@@ -41,6 +41,7 @@ pub fn freestyle(
     ctx: &mut CommandContext,
     openai: &OpenAiProvider,
     chat_messages: Vec<openai::ChatMessage>,
+    model: Option<String>,
 ) -> anyhow::Result<String> {
     let repo = ctx.gix_repo()?;
 
@@ -117,7 +118,7 @@ pub fn freestyle(
         system_message,
         chat_messages,
         &mut toolset,
-        Some("gpt-4.1".to_string()),
+        model,
     )?;
 
     let response_message = response

--- a/crates/but-action/src/lib.rs
+++ b/crates/but-action/src/lib.rs
@@ -30,10 +30,95 @@ pub use action::ActionListing;
 pub use action::Source;
 pub use action::list_actions;
 use but_graph::VirtualBranchesTomlMetadata;
+pub use openai::ChatMessage;
 use strum::EnumString;
 use uuid::Uuid;
 pub use workflow::WorkflowList;
 pub use workflow::list_workflows;
+
+pub fn freestyle(
+    app_handle: &tauri::AppHandle,
+    ctx: &mut CommandContext,
+    openai: &OpenAiProvider,
+    chat_messages: Vec<openai::ChatMessage>,
+) -> anyhow::Result<String> {
+    let repo = ctx.gix_repo()?;
+
+    let project_status = but_tools::workspace::get_project_status(ctx, &repo, None)?;
+    let serialized_status = serde_json::to_string_pretty(&project_status)
+        .map_err(|e| anyhow::anyhow!("Failed to serialize project status: {}", e))?;
+
+    let mut toolset = but_tools::workspace::workspace_toolset(ctx, Some(app_handle))?;
+
+    let system_message ="
+    You are a GitButler agent that can perform various actions on a Git project.
+    Your name is ButBot. Your main goal is to help the user with handling file changes in the project.
+    Use the tools provided to you to perform the actions and respond with a summary of the action you've taken.\
+    Don't be too verbose, but provide enough information to understand what you did.
+    
+    Please, take a look at the provided prompt and the project status below, and perform the actions you think are necessary.
+    In order to do that, please follow these steps:
+        1. Take a look at the prompt and reflect on what the intention of the user is.
+        2. Take a look at the project status and see what changes are present in the project. It's important to understand what stacks and branche are present, and what the file changes are.
+        3. Try to correlate the prompt with the project status and determine what actions you can take to help the user.
+        4. Use the tools provided to you to perform the actions.
+    ";
+
+    let mut internal_chat_messages = vec![];
+    let mut updated_last_user_message = false;
+    for message in chat_messages.iter().rev() {
+        match message {
+            openai::ChatMessage::User(content) => {
+                if !updated_last_user_message {
+                    // Update the last user message with the prompt.
+                    let prompt = format!(
+                        "
+                            <prompt>
+                            {}
+                            </prompt>
+
+                            Here is the project status:
+                            <project_status>
+                            {}
+                            </project_status>
+                        ",
+                        content, serialized_status
+                    );
+
+                    internal_chat_messages.push(openai::ChatMessage::User(prompt));
+                    updated_last_user_message = true;
+                } else {
+                    // Add the user message as is.
+                    internal_chat_messages.push(openai::ChatMessage::User(content.clone()));
+                }
+            }
+            openai::ChatMessage::Assistant(content) => {
+                // Add the assistant message as is.
+                internal_chat_messages.push(openai::ChatMessage::Assistant(content.clone()));
+            }
+        }
+    }
+
+    // Reverse the messages to maintain the original order.
+    internal_chat_messages.reverse();
+
+    // Now we trigger the tool calling loop to absorb the remaining changes.
+    let response = crate::openai::tool_calling_loop(
+        openai,
+        system_message,
+        chat_messages,
+        &mut toolset,
+        Some("gpt-4.1".to_string()),
+    )?;
+
+    let response_message = response
+        .choices
+        .first()
+        .and_then(|choice| choice.message.content.clone())
+        .unwrap_or_else(|| "No response from OpenAI".to_string());
+
+    Ok(response_message)
+}
 
 pub fn absorb(
     app_handle: &tauri::AppHandle,

--- a/crates/but-action/src/lib.rs
+++ b/crates/but-action/src/lib.rs
@@ -53,15 +53,24 @@ pub fn freestyle(
     let system_message ="
     You are a GitButler agent that can perform various actions on a Git project.
     Your name is ButBot. Your main goal is to help the user with handling file changes in the project.
-    Use the tools provided to you to perform the actions and respond with a summary of the action you've taken.\
-    Don't be too verbose, but provide enough information to understand what you did.
+    Use the tools provided to you to perform the actions and respond with a summary of the action you've taken.
+    Don't be too verbose, but be thorough and outline everything you did.
     
+    ### Main task
     Please, take a look at the provided prompt and the project status below, and perform the actions you think are necessary.
     In order to do that, please follow these steps:
         1. Take a look at the prompt and reflect on what the intention of the user is.
         2. Take a look at the project status and see what changes are present in the project. It's important to understand what stacks and branche are present, and what the file changes are.
         3. Try to correlate the prompt with the project status and determine what actions you can take to help the user.
         4. Use the tools provided to you to perform the actions.
+    
+    ### Capabilities
+    You can generally perform the normal Git operations, such as creating branches and committing to them.
+    You can also perform more advanced operations, such as:
+    - `absorb`: Take a set of file changes and amend them into the existing commits in the project.
+      This requires you to figure out where the changes should go based on the locks, assingments and any other user provided information.
+    - `split`: Take an existing commit and split it into multiple commits based on the the user directive.
+        This is a multi-step operation where you will need to create one or more black commits, and the move the file changes from the original commit to the new commits.
     ";
 
     let mut internal_chat_messages = vec![];

--- a/crates/but-settings/assets/defaults.jsonc
+++ b/crates/but-settings/assets/defaults.jsonc
@@ -23,7 +23,9 @@
 		/// Enable the usage of V3 workspace APIs.
 		"ws3": false,
 		/// Enable the usage of GitButler Acitions.
-		"actions": false
+		"actions": false,
+		/// Enable the usage of the butbot chat.
+		"butbot": false
 	},
 	// Allows for additional "connect-src" hosts to be included. Requires app restart.
 	"extraCsp": {

--- a/crates/but-settings/src/api.rs
+++ b/crates/but-settings/src/api.rs
@@ -18,6 +18,7 @@ pub struct FeatureFlagsUpdate {
     pub v3: Option<bool>,
     pub ws3: Option<bool>,
     pub actions: Option<bool>,
+    pub butbot: Option<bool>,
 }
 
 /// Mutation, immediately followed by writing everything to disk.
@@ -50,7 +51,12 @@ impl AppSettingsWithDiskSync {
 
     pub fn update_feature_flags(
         &self,
-        FeatureFlagsUpdate { v3, ws3, actions }: FeatureFlagsUpdate,
+        FeatureFlagsUpdate {
+            v3,
+            ws3,
+            actions,
+            butbot,
+        }: FeatureFlagsUpdate,
     ) -> Result<()> {
         let mut settings = self.get_mut_enforce_save()?;
         if let Some(v3) = v3 {
@@ -61,6 +67,9 @@ impl AppSettingsWithDiskSync {
         }
         if let Some(actions) = actions {
             settings.feature_flags.actions = actions;
+        }
+        if let Some(butbot) = butbot {
+            settings.feature_flags.butbot = butbot;
         }
         settings.save()
     }

--- a/crates/but-settings/src/app_settings.rs
+++ b/crates/but-settings/src/app_settings.rs
@@ -29,6 +29,8 @@ pub struct FeatureFlags {
     pub ws3: bool,
     /// Enable the usage of GitButler Acitions.
     pub actions: bool,
+    /// Enable the usage of the butbot chat.
+    pub butbot: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -362,6 +362,7 @@ pub mod stacks {
                 // Keep this off until it caught up at least.
                 ws3: false,
                 actions: false,
+                butbot: false,
             },
             ..AppSettings::default()
         };

--- a/crates/but-tools/Cargo.toml
+++ b/crates/but-tools/Cargo.toml
@@ -31,5 +31,6 @@ gitbutler-branch.workspace = true
 gitbutler-project.workspace = true
 gitbutler-stack.workspace = true
 gitbutler-serde.workspace = true
+gitbutler-oxidize.workspace = true
 but-hunk-dependency.workspace = true
 but-hunk-assignment.workspace = true

--- a/crates/but-tools/src/tool.rs
+++ b/crates/but-tools/src/tool.rs
@@ -53,6 +53,12 @@ pub trait Tool: 'static + Send + Sync {
     ) -> anyhow::Result<serde_json::Value>;
 }
 
+pub fn error_to_json(error: &anyhow::Error, action_identifier: &str) -> serde_json::Value {
+    serde_json::json!({
+        "error": format!("Failed to {}: {}", action_identifier, error.to_string())
+    })
+}
+
 pub fn result_to_json<T: serde::Serialize>(
     result: &Result<T, anyhow::Error>,
     action_identifier: &str,
@@ -62,7 +68,7 @@ pub fn result_to_json<T: serde::Serialize>(
         Ok(entry) => serde_json::to_value(entry).unwrap_or_else(
             |e| json!({ "error": format!("Failed to serialize {}: {}", data_identifier, e.to_string())}),
         ),
-        Err(e) => serde_json::json!({ "error": format!("Failed to {}: {}", action_identifier, e.to_string())}),
+        Err(e) => error_to_json(e, action_identifier)
     }
 }
 

--- a/crates/but-tools/src/workspace.rs
+++ b/crates/but-tools/src/workspace.rs
@@ -15,6 +15,21 @@ use schemars::{JsonSchema, schema_for};
 use crate::emit::EmitStackUpdate;
 use crate::tool::{Tool, ToolResult, Toolset, result_to_json};
 
+/// Creates a toolset for any kind of workspace operations.
+pub fn workspace_toolset<'a>(
+    ctx: &'a mut CommandContext,
+    app_handle: Option<&'a tauri::AppHandle>,
+) -> anyhow::Result<Toolset<'a>> {
+    let mut toolset = Toolset::new(ctx, app_handle);
+
+    toolset.register_tool(Commit);
+    toolset.register_tool(CreateBranch);
+    toolset.register_tool(Amend);
+    toolset.register_tool(GetProjectStatus);
+
+    Ok(toolset)
+}
+
 /// Creates a toolset for workspace-related operations.
 pub fn commit_toolset<'a>(
     ctx: &'a mut CommandContext,
@@ -36,6 +51,7 @@ pub fn amend_toolset<'a>(
     let mut toolset = Toolset::new(ctx, app_handle);
 
     toolset.register_tool(Amend);
+    toolset.register_tool(GetProjectStatus);
 
     Ok(toolset)
 }

--- a/crates/but/src/mcp_internal/stack.rs
+++ b/crates/but/src/mcp_internal/stack.rs
@@ -33,6 +33,7 @@ pub fn create_stack_with_branch(
             // Keep this off until it caught up at least.
             ws3: false,
             actions: false,
+            butbot: false,
         },
         ..AppSettings::load_from_default_path_creating()?
     };

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -391,7 +391,8 @@ pub fn insert_blank_commit(
     stack_id: StackId,
     commit_oid: git2::Oid,
     offset: i32,
-) -> Result<()> {
+    message: Option<&str>,
+) -> Result<Vec<(gix::ObjectId, gix::ObjectId)>> {
     let mut guard = ctx.project().exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
     assure_open_workspace_mode(ctx)
@@ -400,7 +401,7 @@ pub fn insert_blank_commit(
         SnapshotDetails::new(OperationKind::InsertBlankCommit),
         guard.write_permission(),
     );
-    vbranch::insert_blank_commit(ctx, stack_id, commit_oid, offset)
+    vbranch::insert_blank_commit(ctx, stack_id, commit_oid, offset, message)
 }
 
 pub fn reorder_stack(

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/insert_blank_commit.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/insert_blank_commit.rs
@@ -38,7 +38,8 @@ fn insert_blank_commit_down() -> anyhow::Result<()> {
     let _commit3_id =
         gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit three", None).unwrap();
 
-    gitbutler_branch_actions::insert_blank_commit(ctx, stack_entry.id, commit2_id, 1).unwrap();
+    gitbutler_branch_actions::insert_blank_commit(ctx, stack_entry.id, commit2_id, 1, None)
+        .unwrap();
 
     let branch = gitbutler_branch_actions::list_virtual_branches(ctx)
         .unwrap()
@@ -111,7 +112,8 @@ fn insert_blank_commit_up() -> anyhow::Result<()> {
     let _commit3_id =
         gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit three", None).unwrap();
 
-    gitbutler_branch_actions::insert_blank_commit(ctx, stack_entry.id, commit2_id, -1).unwrap();
+    gitbutler_branch_actions::insert_blank_commit(ctx, stack_entry.id, commit2_id, -1, None)
+        .unwrap();
 
     let branch = gitbutler_branch_actions::list_virtual_branches(ctx)
         .unwrap()

--- a/crates/gitbutler-tauri/src/action.rs
+++ b/crates/gitbutler-tauri/src/action.rs
@@ -128,3 +128,25 @@ pub fn absorb(
         }
     }
 }
+
+#[tauri::command(async)]
+#[instrument(skip(app_handle, projects, settings), err(Debug))]
+pub fn freestyle(
+    app_handle: tauri::AppHandle,
+    projects: tauri::State<'_, gitbutler_project::Controller>,
+    settings: tauri::State<'_, but_settings::AppSettingsWithDiskSync>,
+    project_id: ProjectId,
+    chat_messages: Vec<but_action::ChatMessage>,
+) -> anyhow::Result<String, Error> {
+    let project = projects.get(project_id)?;
+    let ctx = &mut CommandContext::open(&project, settings.get()?.clone())?;
+    let openai = OpenAiProvider::with(Some(but_action::CredentialsKind::GitButlerProxied));
+    match openai {
+        Some(openai) => but_action::freestyle(&app_handle, ctx, &openai, chat_messages).map_err(|e| Error::from(anyhow::anyhow!(e))),
+        None => {
+            Err(Error::from(anyhow::anyhow!(
+                "No valid credentials found for AI provider. Please configure your GitButler account credentials."
+            )))
+        }
+    }
+}

--- a/crates/gitbutler-tauri/src/action.rs
+++ b/crates/gitbutler-tauri/src/action.rs
@@ -137,12 +137,13 @@ pub fn freestyle(
     settings: tauri::State<'_, but_settings::AppSettingsWithDiskSync>,
     project_id: ProjectId,
     chat_messages: Vec<but_action::ChatMessage>,
+    model: Option<String>,
 ) -> anyhow::Result<String, Error> {
     let project = projects.get(project_id)?;
     let ctx = &mut CommandContext::open(&project, settings.get()?.clone())?;
     let openai = OpenAiProvider::with(Some(but_action::CredentialsKind::GitButlerProxied));
     match openai {
-        Some(openai) => but_action::freestyle(&app_handle, ctx, &openai, chat_messages).map_err(|e| Error::from(anyhow::anyhow!(e))),
+        Some(openai) => but_action::freestyle(&app_handle, ctx, &openai, chat_messages, model).map_err(|e| Error::from(anyhow::anyhow!(e))),
         None => {
             Err(Error::from(anyhow::anyhow!(
                 "No valid credentials found for AI provider. Please configure your GitButler account credentials."

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -291,6 +291,7 @@ fn main() {
                     action::auto_commit,
                     action::auto_branch_changes,
                     action::absorb,
+                    action::freestyle,
                     cli::install_cli,
                     cli::cli_path,
                     workspace::stacks,

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -471,7 +471,7 @@ pub mod commands {
                 stack.head_oid(&gix_repo)?.to_git2()
             }
         };
-        gitbutler_branch_actions::insert_blank_commit(&ctx, stack_id, commit_oid, offset)?;
+        gitbutler_branch_actions::insert_blank_commit(&ctx, stack_id, commit_oid, offset, None)?;
         emit_vbranches(&windows, project_id, ctx.app_settings());
         Ok(())
     }


### PR DESCRIPTION
Add the ability to execute some commands through chat.
This is an admin experimental feature for now.


- Implemented full chat support for ButBot in the backend, including refactored message handling and new `ChatMessage` enum.
- Updated frontend with a new chat input, message display for users and ButBot, and integrated RichTextEditor.
- Frontend now sends the entire chat history to the backend for richer context in assistant responses.
- Improved stack invalidation logic to keep worktree status accurate after stack actions.
- Added tools for inserting blank commits and moving commit changes between files.
- Enabled selection of custom chat models, defaulting to gpt-4.1-mini with admin-only access to gpt-4.1.