### PR TITLE
Cancel a commit also unselects assigned changes

### DIFF
--- a/apps/desktop/src/components/v3/NewCommitView.svelte
+++ b/apps/desktop/src/components/v3/NewCommitView.svelte
@@ -212,6 +212,9 @@
 		projectState.commitDescription.set(args.description);
 		projectState.exclusiveAction.set(undefined);
 		uncommittedService.uncheckAll(null);
+		if (stackId) {
+			uncommittedService.uncheckAll(stackId);
+		}
 		onclose?.();
 	}
 </script>


### PR DESCRIPTION
Modified NewCommitView.svelte to conditionally call uncommittedService.uncheckAll with stackId if provided. That way, we unselect the assinged changes as well, whenever we cancel