### PR TITLE
improve git-lfs handling

### DIFF
--- a/apps/desktop/src/lib/project/projectsService.ts
+++ b/apps/desktop/src/lib/project/projectsService.ts
@@ -13,6 +13,7 @@ import type { HttpClient } from '@gitbutler/shared/network/httpClient';
 export type ProjectInfo = {
 	is_exclusive: boolean;
 	db_error?: string;
+	headsup?: string;
 };
 
 export class ProjectsService {

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -275,6 +275,9 @@
 			if (info.db_error) {
 				showError('The database was corrupted', info.db_error);
 			}
+			if (info.headsup) {
+				showError('Important PSA', info.headsup);
+			}
 		} catch (error: unknown) {
 			showError('Failed to set the project active', error);
 		}


### PR DESCRIPTION
Specifically, detect if there are any tracked files with an `lfs` filter and inform how to mitigate the issues stemming from taht.

Related to #2595.

Now there will be this warning:

<img width="992" alt="Screenshot 2025-07-04 at 15 18 38" src="https://github.com/user-attachments/assets/5b090189-e9a8-468a-bb04-9a9b8762d87d" />
