### PR TITLE
add custom -v/--version flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,7 +705,7 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "but"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "bstr",

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "but"
-version = "0.0.0"
+version = "0.0.1"
 edition = "2024"
 repository = "https://github.com/gitbutlerapp/gitbutler"
 license-file = "../../LICENSE.md"
@@ -53,3 +53,6 @@ tracing-subscriber = { version = "0.3", features = [
     "fmt",
 ] }
 dirs-next = "2.0.0"
+
+[build-dependencies]
+chrono = "0.4"

--- a/crates/but/build.rs
+++ b/crates/but/build.rs
@@ -9,4 +9,18 @@ fn main() {
         "com.gitbutler.app"
     };
     println!("cargo:rustc-env=IDENTIFIER={}", identifier);
+
+    // Read version from Cargo.toml
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let cargo_toml = std::fs::read_to_string(format!("{}/Cargo.toml", manifest_dir)).unwrap();
+    let version = cargo_toml
+        .lines()
+        .find(|line| line.trim_start().starts_with("version = "))
+        .and_then(|line| line.split('=').nth(1))
+        .map(|v| v.trim().trim_matches('"'))
+        .unwrap_or("0.0.0");
+    // Set build date as version string
+    let build_date = chrono::Utc::now().format("%Y%m%d").to_string();
+    let full_version = format!("v{}-{}", version, build_date);
+    println!("cargo:rustc-env=GIX_VERSION={}", full_version);
 }

--- a/crates/but/src/args.rs
+++ b/crates/but/src/args.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 #[derive(Debug, clap::Parser)]
-#[clap(name = "but", about = "A GitButler CLI tool", version = option_env!("GIX_VERSION"))]
+#[clap(name = "but", about = "A GitButler CLI tool", version = option_env!("GIX_VERSION"), disable_version_flag = true)]
 pub struct Args {
     /// Run as if gitbutler-cli was started in PATH instead of the current working directory.
     #[clap(short = 'C', long, default_value = ".", value_name = "PATH")]
@@ -9,9 +9,12 @@ pub struct Args {
     /// Whether to use JSON output format.
     #[clap(long, short = 'j')]
     pub json: bool,
+    /// Show the version and exit (custom -v/--version flag).
+    #[clap(long = "version", short = 'v', action)]
+    pub custom_version: bool,
     /// Subcommand to run.
     #[clap(subcommand)]
-    pub cmd: Subcommands,
+    pub cmd: Option<Subcommands>,
 }
 
 #[derive(Debug, clap::Subcommand)]

--- a/crates/but/src/main.rs
+++ b/crates/but/src/main.rs
@@ -15,55 +15,72 @@ mod status;
 #[tokio::main]
 async fn main() -> Result<()> {
     let args: Args = clap::Parser::parse();
+
+    // Handle custom -v/--version flag
+    if args.custom_version {
+        let version = option_env!("GIX_VERSION").unwrap_or("unknown");
+        println!("but version {}", version);
+        return Ok(());
+    }
+
     let app_settings = AppSettings::load_from_default_path_creating()?;
 
     let namespace = option_env!("IDENTIFIER").unwrap_or("com.gitbutler.app");
     gitbutler_secret::secret::set_application_namespace(namespace);
 
     match &args.cmd {
-        Subcommands::Mcp { internal } => {
-            if *internal {
-                mcp_internal::start().await
-            } else {
-                mcp::start(app_settings).await
+        Some(cmd) => match cmd {
+            Subcommands::Mcp { internal } => {
+                if *internal {
+                    mcp_internal::start().await
+                } else {
+                    mcp::start(app_settings).await
+                }
             }
-        }
-        Subcommands::Actions(actions::Platform { cmd }) => match cmd {
-            Some(actions::Subcommands::HandleChanges {
-                description,
-                handler,
-            }) => {
-                let handler = *handler;
-                command::handle_changes(&args.current_dir, args.json, handler, description)
+            Subcommands::Actions(actions::Platform { cmd }) => match cmd {
+                Some(actions::Subcommands::HandleChanges {
+                    description,
+                    handler,
+                }) => {
+                    let handler = *handler;
+                    command::handle_changes(&args.current_dir, args.json, handler, description)
+                }
+                None => command::list_actions(&args.current_dir, args.json, 0, 10),
+            },
+            Subcommands::Claude(claude::Platform { cmd }) => match cmd {
+                claude::Subcommands::PreTool => {
+                    let out = command::claude::handle_pre_tool_call()?;
+                    println!("{}", serde_json::to_string(&out)?);
+                    Ok(())
+                }
+                claude::Subcommands::PostTool => {
+                    let out = command::claude::handle_post_tool_call()?;
+                    println!("{}", serde_json::to_string(&out)?);
+                    Ok(())
+                }
+                claude::Subcommands::Stop => {
+                    let out = command::claude::handle_stop().await?;
+                    println!("{}", serde_json::to_string(&out)?);
+                    Ok(())
+                }
+            },
+            Subcommands::Log => log::commit_graph(&args.current_dir, args.json),
+            Subcommands::Status => status::worktree(&args.current_dir, args.json),
+            Subcommands::Rub { source, target } => {
+                let result = rub::handle(&args.current_dir, args.json, source, target)
+                    .context("Rubbed the wrong way.");
+                if let Err(e) = &result {
+                    eprintln!("{} {}", e, e.root_cause());
+                }
+                Ok(())
             }
-            None => command::list_actions(&args.current_dir, args.json, 0, 10),
         },
-        Subcommands::Claude(claude::Platform { cmd }) => match cmd {
-            claude::Subcommands::PreTool => {
-                let out = command::claude::handle_pre_tool_call()?;
-                println!("{}", serde_json::to_string(&out)?);
-                Ok(())
-            }
-            claude::Subcommands::PostTool => {
-                let out = command::claude::handle_post_tool_call()?;
-                println!("{}", serde_json::to_string(&out)?);
-                Ok(())
-            }
-            claude::Subcommands::Stop => {
-                let out = command::claude::handle_stop().await?;
-                println!("{}", serde_json::to_string(&out)?);
-                Ok(())
-            }
-        },
-        Subcommands::Log => log::commit_graph(&args.current_dir, args.json),
-        Subcommands::Status => status::worktree(&args.current_dir, args.json),
-        Subcommands::Rub { source, target } => {
-            let result = rub::handle(&args.current_dir, args.json, source, target)
-                .context("Rubbed the wrong way.");
-            if let Err(e) = &result {
-                eprintln!("{} {}", e, e.root_cause());
-            }
-            Ok(())
+        None => {
+            eprintln!("error: 'but' requires a subcommand but one was not provided");
+            eprintln!("  [subcommands: log, status, rub, mcp, actions, claude, help]");
+            eprintln!("\nUsage: but [OPTIONS] <COMMAND>\n");
+            eprintln!("For more information, try '--help'.");
+            std::process::exit(1);
         }
     }
 }


### PR DESCRIPTION
I would like to see what version of `but` I’m running, so this will set 
the GIX_VERSION thing to whatever the Cargo.toml file version string is,
plus  a date string (in YYYYMMDD format), so we don’t have to always 
bump it. So something like:  

``` 
❯ ./target/debug/but -v 
but version v0.0.1-20250706
```

I also had to make subcommands optional so it it wouldn’t bail there.
<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#5KDR1cZae`](https://gitbutler.com/schacon/gitbutler/reviews/5KDR1cZae)

**add custom -v/--version flag**


I would like to see what version of `but` I’m running, so this will set 
the GIX_VERSION thing to whatever the Cargo.toml file version string is,
plus  a date string (in YYYYMMDD format), so we don’t have to always 
bump it. So something like:  

``` 
❯ ./target/debug/but -v 
but version v0.0.1-20250706
```

I also had to make subcommands optional so it it wouldn’t bail there.

1 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [add custom -v/--version flag](https://gitbutler.com/schacon/gitbutler/reviews/5KDR1cZae/commit/fc97e65d-f538-4479-a06d-76828bb8c677) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/schacon/gitbutler/reviews/5KDR1cZae)_
<!-- GitButler Review Footer Boundary Bottom -->
