### PR TITLE
PR template fix: Auto-apply the last selected template

### DIFF
--- a/apps/desktop/cypress/e2e/support/mock/backend.ts
+++ b/apps/desktop/cypress/e2e/support/mock/backend.ts
@@ -12,6 +12,7 @@ import {
 } from './changes';
 import { PROJECT_ID } from './projects';
 import { isAddRemoteParams } from './remote';
+import { getMockTemplateContent, isGetReviewTemplateParams } from './review';
 import {
 	createMockBranchDetails,
 	createMockStack,
@@ -710,5 +711,13 @@ export default class MockBackend {
 		const { name } = args;
 
 		return `refs/remotes/${name}`;
+	}
+
+	public getTemplateContent(args: InvokeArgs | undefined): string {
+		if (!args || !isGetReviewTemplateParams(args)) {
+			throw new Error('Invalid arguments for getTemplateContent');
+		}
+
+		return getMockTemplateContent();
 	}
 }

--- a/apps/desktop/cypress/e2e/support/mock/review.ts
+++ b/apps/desktop/cypress/e2e/support/mock/review.ts
@@ -1,0 +1,27 @@
+import type { InvokeArgs } from '@tauri-apps/api/core';
+
+export type GetReviewTemplateParams = {
+	relativePath: string;
+	projectId: string;
+	forge: { name: string };
+};
+
+export function isGetReviewTemplateParams(
+	args: InvokeArgs | undefined
+): args is GetReviewTemplateParams {
+	return (
+		!!args &&
+		typeof args === 'object' &&
+		args !== null &&
+		'relativePath' in args &&
+		'projectId' in args &&
+		'forge' in args &&
+		typeof args.forge === 'object' &&
+		args.forge !== null &&
+		'name' in args.forge
+	);
+}
+
+export function getMockTemplateContent(): string {
+	return `# This is a mock template\n\n## Template Content\n\nOMG this is suuuuuuch a great template. Sweet baby cheesus.`;
+}

--- a/apps/desktop/cypress/e2e/support/scenarios/branchesWithChanges.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/branchesWithChanges.ts
@@ -5,6 +5,7 @@ import {
 	createMockModificationTreeChange,
 	createMockUnifiedDiffPatch
 } from '../mock/changes';
+import { getMockTemplateContent } from '../mock/review';
 import { createMockBranchDetails, createMockCommit, createMockStackDetails } from '../mock/stacks';
 import type { DiffDependency } from '$lib/dependencies/dependencies';
 import type { TreeChange } from '$lib/hunks/change';
@@ -605,6 +606,7 @@ export default class BranchesWithChanges extends MockBackend {
 	bigFileName = MOCK_FILE_J;
 	stackWithTwoCommits = MOCK_STACK_B_ID;
 	firstCommitInSecondStack = MOCK_COMMIT_IN_BRANCH_B_2;
+	prTemplateContent = getMockTemplateContent();
 
 	constructor() {
 		super();
@@ -690,5 +692,9 @@ export default class BranchesWithChanges extends MockBackend {
 				['workspaceMergeConflict', MOCK_FILE_6]
 			]
 		};
+	}
+
+	public getAvailableReviewTemplates(): string[] {
+		return ['.github/PULL_REQUEST_TEMPLATE.md'];
 	}
 }

--- a/apps/desktop/src/lib/testing/testIds.ts
+++ b/apps/desktop/src/lib/testing/testIds.ts
@@ -81,6 +81,7 @@ export enum TestId {
 	ReviewDescriptionInput = 'review-view-description-input',
 	ReviewCreateButton = 'review-view-create-button',
 	ReviewCancelButton = 'review-view-cancel-button',
+	ReviewTemplateToggle = 'review-view-template-toggle',
 	StackedPullRequestCard = 'stacked-pull-request-card',
 	BranchView = 'branch-view',
 	HunkContextMenu = 'hunk-context-menu',

--- a/packages/ui/src/lib/Toggle.svelte
+++ b/packages/ui/src/lib/Toggle.svelte
@@ -5,14 +5,25 @@
 		checked?: boolean;
 		value?: string;
 		id?: string;
+		testId?: string;
 		onclick?: (e: MouseEvent) => void;
 		onchange?: (checked: boolean) => void;
 	}
 
-	let { small, disabled, checked = $bindable(), value, id, onclick, onchange }: Props = $props();
+	let {
+		testId,
+		small,
+		disabled,
+		checked = $bindable(),
+		value,
+		id,
+		onclick,
+		onchange
+	}: Props = $props();
 </script>
 
 <input
+	data-testid={testId}
 	bind:checked
 	onclick={(e) => {
 		e.stopPropagation();


### PR DESCRIPTION
The last selected template for the PR is automatically applied on the next time a PR is created

### Description

- Refactored PR template content application to use new PrTemplateStore logic.
- Updated PrTemplateSection, ReviewCreation, and prContents to integrate with the new store.
- Implemented async template content fetching for proper default values.
- Wired template toggle to the new store for seamless template resolution and selection.
- Enhanced Cypress tests and mocks to cover template enablement, toggling, content persistence, and multi-stack scenarios.
- Added test IDs for template toggle and improved test environment configuration.
