### PR TITLE
Fix persisteds having isolated reactivity

### DIFF
--- a/apps/desktop/src/components/CollapsedLane.svelte
+++ b/apps/desktop/src/components/CollapsedLane.svelte
@@ -5,11 +5,11 @@
 	import Button from '@gitbutler/ui/Button.svelte';
 	import Icon from '@gitbutler/ui/Icon.svelte';
 	import SeriesLabelsRow from '@gitbutler/ui/SeriesLabelsRow.svelte';
-	import type { Persisted } from '@gitbutler/shared/persisted';
+	import type { Writable } from 'svelte/store';
 
 	interface Props {
 		uncommittedChanges?: number;
-		isLaneCollapsed: Persisted<boolean>;
+		isLaneCollapsed: Writable<boolean>;
 	}
 
 	const { uncommittedChanges = 0, isLaneCollapsed }: Props = $props();

--- a/apps/desktop/src/lib/config/config.ts
+++ b/apps/desktop/src/lib/config/config.ts
@@ -38,17 +38,9 @@ export function projectAiGenEnabled(projectId: string): Persisted<boolean> {
 	return persisted(false, key + projectId);
 }
 
-// Using a WeakRef means that if all the users of the persisted go away, the
-// objects can get correctly GCed.
-const projectRunCommitHookPersisteds = new Map<string, WeakRef<Persisted<boolean>>>();
 export function projectRunCommitHooks(projectId: string): Persisted<boolean> {
-	const key = `projectRunCommitHooks_${projectId}`;
-	let out = projectRunCommitHookPersisteds.get(key)?.deref();
-	if (!out) {
-		out = persisted(false, key + projectId);
-		projectRunCommitHookPersisteds.set(key, new WeakRef(out));
-	}
-	return out;
+	const key = 'projectRunCommitHooks_';
+	return persisted(false, key + projectId);
 }
 
 export function projectLaneCollapsed(projectId: string, laneId: string): Persisted<boolean> {

--- a/packages/shared/src/lib/persisted.test.ts
+++ b/packages/shared/src/lib/persisted.test.ts
@@ -10,24 +10,24 @@ describe('persisted store', () => {
 	});
 
 	test('initial value', async () => {
-		const store = persisted(TEST_VALUE, TEST_KEY);
+		const store = persisted(TEST_VALUE, TEST_KEY + '1');
 		assert.equal(get(store), TEST_VALUE);
 	});
 
 	test('updated value', async () => {
-		const store = persisted<string | undefined>(undefined, TEST_KEY);
+		const store = persisted<string | undefined>(undefined, TEST_KEY + '2');
 		assert.equal(get(store), undefined);
 
 		store.set(TEST_VALUE);
 		assert.equal(get(store), TEST_VALUE);
 
-		const anotherStore = persisted<string | undefined>(undefined, TEST_KEY);
+		const anotherStore = persisted<string | undefined>(undefined, TEST_KEY + '2');
 		assert.equal(get(anotherStore), TEST_VALUE);
 	});
 
 	test('stored value', async () => {
-		setStorageItem(TEST_KEY, TEST_VALUE);
-		const store = persisted<string | undefined>(undefined, TEST_KEY);
+		setStorageItem(TEST_KEY + '3', TEST_VALUE);
+		const store = persisted<string | undefined>(undefined, TEST_KEY + '3');
 		assert.equal(get(store), TEST_VALUE);
 	});
 });

--- a/packages/shared/src/lib/persisted.ts
+++ b/packages/shared/src/lib/persisted.ts
@@ -3,7 +3,12 @@
  */
 import lscache from 'lscache';
 import { writable, type Writable } from 'svelte/store';
-export type Persisted<T> = Writable<T>;
+export type Persisted<T> = Writable<T> & { synchronize: () => void };
+
+// Using a WeakRef means that if all the users of the persisted go away, the
+// objects can get correctly GCed.
+const persistedInstances = new Map<string, WeakRef<Persisted<unknown>>>();
+const persistedInstancesWithExpiration = new Map<string, WeakRef<Persisted<unknown>>>();
 
 export function getStorageItem(key: string): unknown {
 	const item = window.localStorage.getItem(key);
@@ -19,6 +24,13 @@ export function setStorageItem(key: string, value: unknown): void {
 }
 
 export function persisted<T>(initial: T, key: string): Persisted<T> {
+	// Check if we already have an instance for this key
+	const instance = persistedInstances.get(key)?.deref();
+	if (instance) {
+		instance.synchronize();
+		return instance as Persisted<T>;
+	}
+
 	function setAndPersist(value: T, set: (value: T) => void) {
 		setStorageItem(key, value);
 		set(value);
@@ -47,11 +59,17 @@ export function persisted<T>(initial: T, key: string): Persisted<T> {
 
 	const subscribe = thisStore.subscribe;
 
-	return {
+	const persistedStore = {
 		subscribe,
 		set,
-		update
+		update,
+		synchronize: () => synchronize(thisStore.set)
 	};
+
+	// Store the instance with a WeakRef
+	persistedInstances.set(key, new WeakRef(persistedStore));
+
+	return persistedStore;
 }
 
 export function setEphemeralStorageItem(
@@ -85,6 +103,13 @@ export function persistWithExpiration<T>(
 	key: string,
 	expirationInMinutes: number
 ): Persisted<T> {
+	// Check if we already have an instance for this key
+	const instance = persistedInstancesWithExpiration.get(key)?.deref();
+	if (instance) {
+		instance.synchronize();
+		return instance as Persisted<T>;
+	}
+
 	function setAndPersist(value: T, set: (value: T) => void) {
 		setEphemeralStorageItem(key, value, expirationInMinutes);
 		set(value);
@@ -113,9 +138,14 @@ export function persistWithExpiration<T>(
 
 	const subscribe = thisStore.subscribe;
 
-	return {
+	const persistedStore = {
 		subscribe,
 		set,
-		update
+		update,
+		synchronize: () => synchronize(thisStore.set)
 	};
+
+	persistedInstancesWithExpiration.set(key, new WeakRef(persistedStore));
+
+	return persistedStore;
 }


### PR DESCRIPTION
This change makes persisteds behave like a singleton instance based on the key passed in.

This makes use of the JS `WeakMap` to make sure that they can still be GCed correctly
