### PR TITLE
test: add Cypress test for compact workspace mode

### DIFF
--- a/apps/desktop/cypress/e2e/selection.cy.ts
+++ b/apps/desktop/cypress/e2e/selection.cy.ts
@@ -76,12 +76,141 @@ describe('Selection', () => {
 			.within(() => {
 				cy.getByTestId('commit-drawer-title').should('contain', 'Initial commit');
 				cy.getByTestId('commit-drawer-description').should('contain', 'This is a test commit');
-				cy.getByTestId('file-list-item', 'fileF.txt').should('be.visible');
-				cy.getByTestId('file-list-item', 'fileE.txt').should('be.visible');
-				cy.getByTestId('file-list-item', 'fileD.txt').should('be.visible').click();
+				cy.getByTestId('file-list-item', 'fileA.ts').should('be.visible').click();
+				cy.getByTestId('file-list-item', 'fileB.txt').should('be.visible').click();
+				cy.getByTestId('file-list-item', 'fileC.txt').should('be.visible').click();
 			});
 
 		cy.getByTestId('stack-selection-view').should('be.visible');
+	});
+
+	it('should be update the commit drawer when changing the commit selection', () => {
+		// Stack with branch should  be opened by default
+		cy.getByTestId('branch-header').should('contain', mockBackend.stackWithTwoCommits);
+
+		const stacks = mockBackend.getStacks();
+		// There shuold be three stacks
+		cy.getByTestId('stack').should('have.length', stacks.length);
+
+		cy.getByTestIdByValue('stack', mockBackend.stackWithTwoCommits)
+			.should('be.visible')
+			.within(() => {
+				// Select the first commit
+				cy.getByTestId('commit-row').should('have.length', 2).first().click();
+				cy.getByTestId('commit-drawer-title').should('contain', 'Second commit');
+				cy.getByTestId('commit-drawer-description').should(
+					'contain',
+					'This is another test commit'
+				);
+				cy.getByTestId('file-list-item', 'fileD.txt').should('be.visible');
+
+				// Select the second commit
+				cy.getByTestId('commit-row').should('have.length', 2).last().click();
+				cy.getByTestId('commit-drawer-title').should('contain', 'Also second commit');
+				cy.getByTestId('commit-drawer-description').should(
+					'contain',
+					'This is another test commit, but with a different title'
+				);
+				cy.getByTestId('file-list-item', 'fileE.txt').should('be.visible');
+				cy.getByTestId('file-list-item', 'fileF.txt').should('be.visible');
+
+				// Select the first commit again
+				cy.getByTestId('commit-row').should('have.length', 2).first().click();
+				cy.getByTestId('commit-drawer-title').should('contain', 'Second commit');
+				cy.getByTestId('commit-drawer-description').should(
+					'contain',
+					'This is another test commit'
+				);
+				cy.getByTestId('file-list-item', 'fileD.txt').should('be.visible');
+				cy.getByTestId('file-list-item', 'fileE.txt').should('not.exist');
+				cy.getByTestId('file-list-item', 'fileF.txt').should('not.exist');
+
+				// Select the branch header
+				cy.getByTestId('branch-header').click();
+				cy.getByTestId('commit-drawer').should('not.exist');
+				cy.getByTestId('file-list-item', 'fileD.txt').should('be.visible');
+				cy.getByTestId('file-list-item', 'fileE.txt').should('be.visible');
+				cy.getByTestId('file-list-item', 'fileF.txt').should('be.visible');
+
+				// Select the second commit again
+				cy.getByTestId('commit-row').should('have.length', 2).last().click();
+				cy.getByTestId('commit-drawer-title').should('contain', 'Also second commit');
+				cy.getByTestId('commit-drawer-description').should(
+					'contain',
+					'This is another test commit, but with a different title'
+				);
+				cy.getByTestId('file-list-item', 'fileE.txt').should('be.visible');
+				cy.getByTestId('file-list-item', 'fileF.txt').should('be.visible');
+				cy.getByTestId('file-list-item', 'fileD.txt').should('not.exist');
+			});
+	});
+
+	it('should be update the commit drawer when changing the commit selection - compact', () => {
+		// Set the compact workspace feature flag
+		cy.window().then((win) => {
+			win.localStorage.setItem('lscache-compact-workspace', JSON.stringify(true));
+		});
+
+		// Stack with branch should  be opened by default
+		cy.getByTestId('branch-header').should('contain', mockBackend.stackWithTwoCommits);
+
+		const stacks = mockBackend.getStacks();
+		// There shuold be three stacks
+		cy.getByTestId('stack').should('have.length', stacks.length);
+
+		cy.getByTestIdByValue('stack', mockBackend.stackWithTwoCommits)
+			.should('be.visible')
+			.within(() => {
+				// Select the first commit
+				cy.getByTestId('commit-row').should('have.length', 2).first().click();
+				cy.getByTestId('commit-drawer-title').should('contain', 'Second commit');
+				cy.getByTestId('commit-drawer-description').should(
+					'contain',
+					'This is another test commit'
+				);
+				cy.getByTestId('file-list-item', 'fileD.txt').should('be.visible');
+
+				// Select the second commit
+				cy.getByTestId('commit-row').should('have.length', 2).last().click();
+				cy.getByTestId('commit-drawer-title').should('contain', 'Also second commit');
+				cy.getByTestId('commit-drawer-description').should(
+					'contain',
+					'This is another test commit, but with a different title'
+				);
+				cy.getByTestId('file-list-item', 'fileE.txt').should('be.visible');
+				cy.getByTestId('file-list-item', 'fileF.txt').should('be.visible');
+
+				// Select the first commit again
+				cy.getByTestId('commit-row').should('have.length', 2).first().click();
+				cy.getByTestId('commit-drawer-title').should('contain', 'Second commit');
+				cy.getByTestId('commit-drawer-description').should(
+					'contain',
+					'This is another test commit'
+				);
+				cy.getByTestId('file-list-item', 'fileD.txt').should('be.visible');
+				cy.getByTestId('file-list-item', 'fileE.txt').should('not.exist');
+				cy.getByTestId('file-list-item', 'fileF.txt').should('not.exist');
+
+				// Select the branch header
+				cy.getByTestId('branch-header').click();
+				cy.getByTestId('commit-drawer').should('not.exist');
+				cy.getByTestId('file-list-item', 'fileD.txt').should('be.visible');
+				cy.getByTestId('file-list-item', 'fileE.txt').should('be.visible');
+				cy.getByTestId('file-list-item', 'fileF.txt').should('be.visible');
+
+				// Select the second commit again
+				cy.getByTestId('commit-row').should('have.length', 2).last().click();
+				cy.getByTestId('commit-drawer-title').should('contain', 'Also second commit');
+				cy.getByTestId('commit-drawer-description').should(
+					'contain',
+					'This is another test commit, but with a different title'
+				);
+				cy.getByTestId('file-list-item', 'fileF.txt').should('be.visible');
+				cy.getByTestId('file-list-item', 'fileD.txt').should('not.exist');
+
+				// Open a file
+				cy.getByTestId('file-list-item', 'fileE.txt').should('be.visible').click();
+			});
 	});
 });
 

--- a/apps/desktop/cypress/e2e/support/scenarios/branchesWithChanges.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/branchesWithChanges.ts
@@ -35,6 +35,7 @@ const MOCK_COMMIT_TITLE_A = 'Initial commit';
 const MOCK_COMMIT_MESSAGE_A = 'This is a test commit';
 
 const MOCK_COMMIT_IN_BRANCH_A = createMockCommit({
+	id: '444444',
 	message: `${MOCK_COMMIT_TITLE_A}\n\n${MOCK_COMMIT_MESSAGE_A}`
 });
 
@@ -55,11 +56,14 @@ const MOCK_STACK_B: Stack = {
 const MOCK_FILE_D = 'fileD.txt';
 const MOCK_FILE_J = 'fileJ.txt';
 
-const MOCK_BRANCH_B_CHANGES: TreeChange[] = [
-	createMockAdditionTreeChange({ path: MOCK_FILE_D }),
+const MOCK_COMMIT_B_CHANGES: TreeChange[] = [createMockAdditionTreeChange({ path: MOCK_FILE_D })];
+
+const MOCK_COMMIT_B_CHANGES_2: TreeChange[] = [
 	createMockModificationTreeChange({ path: 'fileE.txt' }),
 	createMockDeletionTreeChange({ path: 'fileF.txt' })
 ];
+
+const MOCK_BRANCH_B_CHANGES: TreeChange[] = [...MOCK_COMMIT_B_CHANGES, ...MOCK_COMMIT_B_CHANGES_2];
 
 const MOCK_COMMIT_TITLE_B = 'Second commit';
 const MOCK_COMMIT_MESSAGE_B = 'This is another test commit';
@@ -648,8 +652,8 @@ export default class BranchesWithChanges extends MockBackend {
 		this.unifiedDiffs.set(MOCK_FILE_J, MOCK_FILE_J_MODIFICATION);
 
 		this.commitChanges.set(MOCK_COMMIT_IN_BRANCH_A.id, MOCK_BRANCH_A_CHANGES);
-		this.commitChanges.set(MOCK_COMMIT_IN_BRANCH_B.id, MOCK_BRANCH_B_CHANGES);
-		this.commitChanges.set(MOCK_COMMIT_IN_BRANCH_B_2.id, MOCK_BRANCH_B_CHANGES);
+		this.commitChanges.set(MOCK_COMMIT_IN_BRANCH_B.id, MOCK_COMMIT_B_CHANGES);
+		this.commitChanges.set(MOCK_COMMIT_IN_BRANCH_B_2.id, MOCK_COMMIT_B_CHANGES_2);
 	}
 
 	getCommitTitle(stackId: string): string {


### PR DESCRIPTION
Adds an end-to-end Cypress test to cover the compact workspace mode in the selection view. Updates the test scenarios with more granular commit change mocking to allow correct diffing per commit. No changes outside the test code. Also adjusts scenario helper logic for test accuracy.