### PR TITLE
Fix feed message order in feed.ts

### DIFF
--- a/apps/desktop/src/lib/feed/feed.ts
+++ b/apps/desktop/src/lib/feed/feed.ts
@@ -107,7 +107,8 @@ export class Feed {
 	}
 
 	private getFeedMessages(): FeedMessage[] {
-		return get(this.combined).filter((entry) => isFeedMessage(entry)) as FeedMessage[];
+		const messages = get(this.combined).filter((entry) => isFeedMessage(entry)) as FeedMessage[];
+		return messages.reverse();
 	}
 
 	async addUserMessage(content: string) {


### PR DESCRIPTION
Modified getFeedMessages method in feed.ts to reverse the order of feed messages so that messages appear in the correct chronological order in the desktop app feed module.