### PR TITLE
graph -> stacks: conformity

### DIFF
--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -180,6 +180,7 @@ impl Graph {
     ///   as will happen at merge commits).
     /// * The traversal is always as long as it needs to be to fully reconcile possibly disjoint branches, despite
     ///   this sometimes costing some time when the remote is far ahead in a huge repository.
+    // TODO: review the docs!
     #[instrument(skip(meta, ref_name), err(Debug))]
     pub fn from_commit_traversal(
         tip: gix::Id<'_>,
@@ -366,6 +367,7 @@ impl Graph {
             }
         }
 
+        prioritize_initial_tips(&graph.inner, &mut next);
         max_commits_recharge_location.sort();
         while let Some((id, mut propagated_flags, instruction, mut limit)) = next.pop_front() {
             if max_commits_recharge_location.binary_search(&id).is_ok() {

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -255,10 +255,10 @@ impl Graph {
         };
 
         let mut next = Queue::new_with_limit(hard_limit);
-        if !workspaces
+        let tip_is_not_workspace_commit = !workspaces
             .iter()
-            .any(|(_, wsrn, _)| Some(wsrn) == ref_name.as_ref())
-        {
+            .any(|(_, wsrn, _)| Some(wsrn) == ref_name.as_ref());
+        if tip_is_not_workspace_commit {
             let current = graph.insert_root(branch_segment_from_name_and_meta(
                 ref_name.clone().map(|rn| (rn, None)),
                 meta,
@@ -389,6 +389,7 @@ impl Graph {
                 // have to adjust the existing queue item.
                 existing_segment
             } else {
+                // TODO: test in graph
                 let extra_target_sidx = graph.insert_root(branch_segment_from_name_and_meta(
                     None,
                     meta,
@@ -549,6 +550,7 @@ impl Graph {
             &target_symbolic_remote_names,
             &configured_remote_tracking_branches,
             inserted_proxy_segments,
+            &refs_by_id,
         )
     }
 

--- a/crates/but-graph/src/lib.rs
+++ b/crates/but-graph/src/lib.rs
@@ -227,6 +227,8 @@ pub struct Graph {
     /// The [`CommitIndex`] is empty if the entry point is an empty segment, one that is supposed to receive
     /// commits later.
     entrypoint: Option<(SegmentIndex, Option<CommitIndex>)>,
+    /// The segment index of the extra target as provided for traversal.
+    extra_target: Option<SegmentIndex>,
     /// It's `true` only if we have stopped the traversal due to a hard limit.
     hard_limit_hit: bool,
 }

--- a/crates/but-graph/src/projection/mod.rs
+++ b/crates/but-graph/src/projection/mod.rs
@@ -9,7 +9,25 @@
 ///
 /// Note that these are always a simplification, degenerating information, while maintaining a link back to the graph.
 mod stack;
+
 pub use stack::{Stack, StackCommit, StackCommitDebugFlags, StackCommitFlags, StackSegment};
 
 mod workspace;
-pub use workspace::{HeadLocation, Target, Workspace};
+pub use workspace::{Target, Workspace, WorkspaceKind};
+
+/// utilities for workspace-related commits.
+pub mod commit {
+    use bstr::{BStr, ByteSlice};
+
+    const GITBUTLER_INTEGRATION_COMMIT_TITLE: &str = "GitButler Integration Commit";
+    const GITBUTLER_WORKSPACE_COMMIT_TITLE: &str = "GitButler Workspace Commit";
+
+    /// Return `true` if this `commit_message` indicates a workspace commit managed by GitButler.
+    /// If `false`, this is the tip of the stack itself which will be put underneath a *managed* workspace commit
+    /// once another branch is added to the workspace.
+    pub fn is_managed_workspace_by_message(commit_message: &BStr) -> bool {
+        let message = gix::objs::commit::MessageRef::from_bytes(commit_message);
+        let title = message.title.trim().as_bstr();
+        title == GITBUTLER_INTEGRATION_COMMIT_TITLE || title == GITBUTLER_WORKSPACE_COMMIT_TITLE
+    }
+}

--- a/crates/but-graph/src/projection/workspace.rs
+++ b/crates/but-graph/src/projection/workspace.rs
@@ -192,9 +192,13 @@ impl Graph {
         };
 
         // The entrypoint is integrated and has a workspace above it.
-        // Right now we would be using it, but will discard it the entrypoint is *at* or *below* the merge-base.
+        // Right now we would be using it, but will discard it the entrypoint is *at* or *below* the merge-base,
+        // but only if it doesn't obviously belong to the workspace, by having metadata..
         if let Some(((_lowest_base, lowest_base_sidx), ep_sidx)) = merge_info
-            .filter(|_| entrypoint_first_commit_flags.contains(CommitFlags::Integrated))
+            .filter(|(_, ep_sidx)| {
+                entrypoint_first_commit_flags.contains(CommitFlags::Integrated)
+                    && self[*ep_sidx].metadata.is_none()
+            })
             .zip(entrypoint_sidx)
         {
             if ep_sidx == lowest_base_sidx

--- a/crates/but-graph/src/projection/workspace.rs
+++ b/crates/but-graph/src/projection/workspace.rs
@@ -198,7 +198,7 @@ impl Graph {
         };
 
         // The entrypoint is integrated and has a workspace above it.
-        // Right now we would be using it, but will discard it the entrypoint is at or below the merge-base.
+        // Right now we would be using it, but will discard it the entrypoint is *at* or *below* the merge-base.
         if let Some(((_lowest_base, lowest_base_sidx), ep_sidx)) = merge_info
             .filter(|_| entrypoint_first_commit_flags.contains(CommitFlags::Integrated))
             .zip(entrypoint_sidx)
@@ -221,7 +221,7 @@ impl Graph {
                     metadata,
                 } = &mut ws;
                 *id = ep_sidx;
-                // TODO: deduplicate head location
+                // TODO: deduplicate head location and 'id' - feels like `HeadLocation` could be a without data.
                 *head = HeadLocation::Segment {
                     segment_index: ep_sidx,
                 };

--- a/crates/but-graph/src/projection/workspace.rs
+++ b/crates/but-graph/src/projection/workspace.rs
@@ -15,12 +15,11 @@ use tracing::instrument;
 #[derive(Clone)]
 pub struct Workspace<'graph> {
     /// The underlying graph for providing simplified access to data.
-    // TODO: remove this if this struct wants to be more than intermediate.
     pub graph: &'graph Graph,
     /// An ID which uniquely identifies the [graph segment](Segment) that represents the tip of the workspace.
     pub id: SegmentIndex,
-    /// Where `HEAD` is currently pointing to.
-    pub head: HeadLocation,
+    /// Specify what kind of workspace this is.
+    pub kind: WorkspaceKind,
     /// One or more stacks that live in the workspace.
     pub stacks: Vec<Stack>,
     /// The target to integrate workspace stacks into.
@@ -29,26 +28,35 @@ pub struct Workspace<'graph> {
     /// This happens when there is a local branch checked out without a remote tracking branch.
     pub target: Option<Target>,
     /// Read-only workspace metadata with additional information, or `None` if nothing was present.
+    /// If this is `Some()` the `kind` is always [`WorkspaceKind::Managed`]
     pub metadata: Option<ref_metadata::Workspace>,
 }
 
-/// Learn where the current `HEAD` is pointing to.
+/// A classifier for the workspace.
 #[derive(Debug, Clone)]
-pub enum HeadLocation {
-    /// The `HEAD` is pointing to the workspace reference, like `refs/heads/gitbutler/workspace`.
-    Workspace {
+pub enum WorkspaceKind {
+    /// The `HEAD` is pointing to a dedicated workspace reference, like `refs/heads/gitbutler/workspace`.
+    Managed {
         /// The name of the reference pointing to the workspace commit. Useful for deriving the workspace name.
         ref_name: gix::refs::FullName,
     },
     /// A segment is checked out directly.
     ///
-    /// It can be inside or outside of a workspace.
-    /// If the respective segment is not named, this means the `HEAD` id detached.
+    /// It can be inside or outside a workspace.
+    /// If the respective segment is [not named](Workspace::ref_name), this means the `HEAD` id detached.
     /// The commit that the working tree is at is always implied to be the first commit of the [`StackSegment`].
-    Segment {
-        /// The id of the segment to be found in any stack of the [workspace stacks](Workspace::stacks).
-        segment_index: SegmentIndex,
-    },
+    AdHoc,
+}
+
+impl WorkspaceKind {
+    fn managed(ref_name: &Option<gix::refs::FullName>) -> anyhow::Result<Self> {
+        Ok(WorkspaceKind::Managed {
+            ref_name: ref_name
+                .as_ref()
+                .cloned()
+                .context("BUG: managed workspaces must always be on a named segment")?,
+        })
+    }
 }
 
 /// Information about the target reference.
@@ -95,20 +103,14 @@ impl Graph {
     /// only do so on the ones that the user can interact with.
     #[instrument(skip(self), err(Debug))]
     pub fn to_workspace(&self) -> anyhow::Result<Workspace<'_>> {
-        let (head, metadata, mut ws_tip_segment, entrypoint_sidx, entrypoint_first_commit_flags) = {
+        let (kind, metadata, mut ws_tip_segment, entrypoint_sidx, entrypoint_first_commit_flags) = {
             let ep = self.lookup_entrypoint()?;
             match ep.segment.workspace_metadata() {
                 None => {
                     // Skip over empty segments.
-                    if let Some((maybe_integrated_flags, sidx_of_flags)) = ep
-                        .segment
-                        .non_empty_flags_of_first_commit()
-                        .map(|f| (f, ep.segment_index))
-                        .or_else(|| {
-                            self.find_map_downwards_along_first_parent(ep.segment_index, |s| {
-                                s.commits.first().map(|c| (c.flags, s.id))
-                            })
-                        })
+                    if let Some((maybe_integrated_flags, sidx_of_flags)) = self
+                        .first_commit_or_find_along_first_parent(ep.segment_index)
+                        .map(|(c, sidx)| (c.flags, sidx))
                         .filter(|(f, _sidx)| f.contains(CommitFlags::InWorkspace))
                     {
                         // search the (for now just one) workspace upstream and use it instead,
@@ -126,16 +128,7 @@ impl Graph {
                             })?;
 
                         (
-                            HeadLocation::Workspace {
-                                ref_name: ws_segment
-                                    .ref_name
-                                    .as_ref()
-                                    .context(
-                                        "BUG: cannot have workspace metadata but \
-                                no ref name in segment",
-                                    )?
-                                    .clone(),
-                            },
+                            WorkspaceKind::managed(&ws_segment.ref_name)?,
                             ws_segment.workspace_metadata().cloned(),
                             ws_segment,
                             Some(ep.segment_index),
@@ -143,9 +136,7 @@ impl Graph {
                         )
                     } else {
                         (
-                            HeadLocation::Segment {
-                                segment_index: ep.segment_index,
-                            },
+                            WorkspaceKind::AdHoc,
                             None,
                             ep.segment,
                             None,
@@ -154,16 +145,7 @@ impl Graph {
                     }
                 }
                 Some(meta) => (
-                    HeadLocation::Workspace {
-                        ref_name: ep
-                            .segment
-                            .ref_name
-                            .as_ref()
-                            .context(
-                                "BUG: cannot have workspace metadata but no ref name in segment",
-                            )?
-                            .clone(),
-                    },
+                    WorkspaceKind::managed(&ep.segment.ref_name)?,
                     Some(meta.clone()),
                     ep.segment,
                     None,
@@ -175,7 +157,7 @@ impl Graph {
         let mut ws = Workspace {
             graph: self,
             id: ws_tip_segment.id,
-            head,
+            kind,
             stacks: vec![],
             target: metadata
                 .as_ref()
@@ -187,11 +169,19 @@ impl Graph {
             self.compute_lowest_base(ws.id, ws.target.as_ref())
                 .or_else(|| {
                     // target not available? Try the base of the workspace itself
-                    // TODO: test
-                    self.inner
+                    if self
+                        .inner
                         .neighbors_directed(ws_tip_segment.id, Direction::Outgoing)
-                        .reduce(|a, b| self.first_merge_base(a, b).unwrap_or(a))
-                        .and_then(|base| self[base].commits.first().map(|c| (c.id, base)))
+                        .count()
+                        == 1
+                    {
+                        None
+                    } else {
+                        self.inner
+                            .neighbors_directed(ws_tip_segment.id, Direction::Outgoing)
+                            .reduce(|a, b| self.first_merge_base(a, b).unwrap_or(a))
+                            .and_then(|base| self[base].commits.first().map(|c| (c.id, base)))
+                    }
                 })
         } else {
             None
@@ -215,16 +205,13 @@ impl Graph {
                 let Workspace {
                     graph: _,
                     id,
-                    head,
+                    kind: head,
                     stacks: _,
                     target,
                     metadata,
                 } = &mut ws;
                 *id = ep_sidx;
-                // TODO: deduplicate head location and 'id' - feels like `HeadLocation` could be a without data.
-                *head = HeadLocation::Segment {
-                    segment_index: ep_sidx,
-                };
+                *head = WorkspaceKind::AdHoc;
                 *target = None;
                 *metadata = None;
                 ws_tip_segment = &self[ep_sidx];
@@ -284,7 +271,9 @@ impl Graph {
                                 .is_some_and(|c| c.flags.contains(StackCommitFlags::Integrated))
                         },
                     )?
-                    .map(|segments| Stack::from_base_and_segments(lowest_base, segments)),
+                    .map(|segments| {
+                        Stack::from_base_and_segments(lowest_base, lowest_base_sidx, segments)
+                    }),
                 );
             }
         } else {
@@ -310,7 +299,7 @@ impl Graph {
                     // Never discard stacks
                     |_s| false,
                 )?
-                .map(|segments| Stack::from_base_and_segments(None, segments)),
+                .map(|segments| Stack::from_base_and_segments(None, None, segments)),
             );
         }
 
@@ -346,15 +335,8 @@ impl Graph {
         if base == stack_tip {
             None
         } else {
-            self[base]
-                .commits
-                .first()
-                .map(|c| (c.id, base))
-                .or_else(|| {
-                    self.find_map_downwards_along_first_parent(base, |s| {
-                        s.commits.first().map(|c| (c.id, s.id))
-                    })
-                })
+            self.first_commit_or_find_along_first_parent(base)
+                .map(|(c, sidx)| (c.id, sidx))
         }
     }
 
@@ -477,6 +459,18 @@ impl Graph {
             }
         });
         out
+    }
+
+    /// Return `(commit, start)` if `start` has a commit, or find the first commit downstream along the first parent.
+    pub(crate) fn first_commit_or_find_along_first_parent(
+        &self,
+        start: SegmentIndex,
+    ) -> Option<(&crate::Commit, SegmentIndex)> {
+        self[start].commits.first().map(|c| (c, start)).or_else(|| {
+            self.find_map_downwards_along_first_parent(start, |s| s.commits.first().map(|_c| s.id))
+                // workaround borrowchk
+                .map(|sidx| (self[sidx].commits.first().expect("present"), sidx))
+        })
     }
 
     /// Return `OK(None)` if the post-process discarded this segment after collecting it in full as it was not
@@ -737,7 +731,14 @@ impl Workspace<'_> {
     /// Return `true` if this workspace is managed, meaning we control certain aspects of it.
     /// If `false`, we are more conservative and may not support all features.
     pub fn is_managed(&self) -> bool {
-        self.metadata.is_some()
+        matches!(self.kind, WorkspaceKind::Managed { .. })
+    }
+
+    /// Return the name of the workspace reference by looking our segment up in `graph`.
+    /// Note that for managed workspaces, this can be retrieved via [`WorkspaceKind::Managed`].
+    /// Note that it can be expected to be set on any workspace, but the data would allow it to not be set.
+    pub fn ref_name<'a>(&self, graph: &'a Graph) -> Option<&'a gix::refs::FullNameRef> {
+        graph[self.id].ref_name.as_ref().map(|rn| rn.as_ref())
     }
 }
 
@@ -746,10 +747,10 @@ impl Workspace<'_> {
     /// Produce a distinct and compressed debug string to show at a glance what the workspace is about.
     pub fn debug_string(&self) -> String {
         let graph = self.graph;
-        let (name, sign) = match &self.head {
-            HeadLocation::Workspace { ref_name } => (Graph::ref_debug_string(ref_name), "🏘️"),
-            HeadLocation::Segment { segment_index } => (
-                graph[*segment_index]
+        let (name, sign) = match &self.kind {
+            WorkspaceKind::Managed { ref_name } => (Graph::ref_debug_string(ref_name), "🏘️"),
+            WorkspaceKind::AdHoc => (
+                graph[self.id]
                     .ref_name
                     .as_ref()
                     .map_or("DETACHED".into(), Graph::ref_debug_string),

--- a/crates/but-graph/src/segment.rs
+++ b/crates/but-graph/src/segment.rs
@@ -17,9 +17,15 @@ pub struct Commit {
 
 impl std::fmt::Debug for Commit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let refs = self
+            .refs
+            .iter()
+            .map(|rn| format!("►{}", rn.shorten()))
+            .collect::<Vec<_>>()
+            .join(", ");
         write!(
             f,
-            "Commit({hash}, {flags})",
+            "Commit({hash}, {flags}{refs})",
             hash = self.id.to_hex_with_len(7),
             flags = self.flags.debug_string()
         )

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -675,5 +675,66 @@ EOF
     create_workspace_commit_once A
   )
 
+  git init no-target-without-ws-commit
+  (cd no-target-without-ws-commit
+    commit init
+    git checkout -b A
+      commit A1
+      commit A2
+    git branch gitbutler/workspace
+    git checkout -b soon-A-remote
+      commit A-remote
+      setup_remote_tracking soon-A-remote A "move"
+    git checkout gitbutler/workspace
+  )
+
+  git init no-target-without-ws-commit-ambiguous
+  (cd no-target-without-ws-commit-ambiguous
+    commit init
+    git checkout -b A
+      commit A1
+      commit A2
+    git branch gitbutler/workspace
+    git branch B
+    git checkout -b soon-A-remote
+      commit A-remote
+      setup_remote_tracking soon-A-remote A "move"
+    git checkout gitbutler/workspace
+  )
+
+  git init no-target-with-ws-commit
+  (cd no-target-with-ws-commit
+    commit init
+    git checkout -b A
+      commit A1
+      commit A2
+    git checkout -b soon-A-remote
+      commit A-remote
+      setup_remote_tracking soon-A-remote A "move"
+
+    git checkout A
+    create_workspace_commit_once A
+  )
+
+  git init ws-commit-pushed-to-target
+  (cd ws-commit-pushed-to-target
+    commit init
+    git checkout -b A
+      commit A1
+    create_workspace_commit_once A
+    git checkout -b soon-main-remote
+      setup_remote_tracking soon-main-remote main "move"
+
+    git checkout gitbutler/workspace
+  )
+
+  git init no-ws-no-target-commit-with-managed-ref
+  (cd no-ws-no-target-commit-with-managed-ref
+    commit init
+    git checkout -b A
+      commit A1
+    git checkout -b gitbutler/workspace
+      commit unmanaged
+  )
 )
 

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -208,9 +208,11 @@ mkdir ws
          git branch "$name"
        done
      git checkout -b B
+       git branch soon-origin-B
        commit segment-B~1 && git branch B-empty && git branch ambiguous-01
        commit segment-B && git tag without-ref
        commit with-ref
+       setup_remote_tracking soon-origin-B B "move"
      create_workspace_commit_once B
   )
 

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -736,5 +736,22 @@ EOF
     git checkout -b gitbutler/workspace
       commit unmanaged
   )
+
+  git init one-stacks-many-refs
+  (cd one-stacks-many-refs
+    commit init && setup_target_to_match_main
+    for name in A B C;  do
+      git branch "$name"
+    done
+    git checkout -b S1
+      commit 1
+        git branch D
+        git branch E
+      commit 2
+        git branch F
+        git branch G
+
+    create_workspace_commit_once S1
+  )
 )
 

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -34,6 +34,7 @@ fn unborn() -> anyhow::Result<()> {
                 None,
             ),
         ),
+        extra_target: None,
         hard_limit_hit: false,
     }
     "#);
@@ -127,6 +128,7 @@ fn detached() -> anyhow::Result<()> {
                 ),
             ),
         ),
+        extra_target: None,
         hard_limit_hit: false,
     }
     "#);

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -85,7 +85,7 @@ fn detached() -> anyhow::Result<()> {
                     remote_tracking_ref_name: "None",
                     sibling_segment_id: "None",
                     commits: [
-                        Commit(541396b, ⌂|1),
+                        Commit(541396b, ⌂|1►annotated, ►release/v1, ►main),
                     ],
                     metadata: "None",
                 },

--- a/crates/but-graph/tests/graph/init/utils.rs
+++ b/crates/but-graph/tests/graph/init/utils.rs
@@ -139,5 +139,22 @@ pub fn standard_options() -> but_graph::init::Options {
         commits_limit_hint: None,
         commits_limit_recharge_location: vec![],
         hard_limit: None,
+        extra_target_commit_id: None,
+    }
+}
+
+pub fn standard_options_with_extra_target(
+    repo: &gix::Repository,
+    name: &str,
+) -> but_graph::init::Options {
+    but_graph::init::Options {
+        extra_target_commit_id: Some(
+            repo.find_reference(name)
+                .expect("present")
+                .peel_to_id_in_place()
+                .unwrap()
+                .detach(),
+        ),
+        ..standard_options()
     }
 }

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -14,7 +14,7 @@ fn single_stack_ambigous() -> anyhow::Result<()> {
     * 70e9a36 (B) with-ref
     * 320e105 (tag: without-ref) segment-B
     * 2a31450 (ambiguous-01, B-empty) segment-B~1
-    * 70bde6b (A-empty-03, A-empty-02, A-empty-01, A) segment-A
+    * 70bde6b (origin/B, A-empty-03, A-empty-02, A-empty-01, A) segment-A
     * fafd9d0 (origin/main, new-B, new-A, main) init
     ");
 
@@ -25,26 +25,27 @@ fn single_stack_ambigous() -> anyhow::Result<()> {
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 👉📕►►►:0:gitbutler/workspace
     │   └── ·20de6ee (⌂|🏘️|1)
-    │       └── ►:3:B
-    │           ├── ·70e9a36 (⌂|🏘️|1)
-    │           ├── ·320e105 (⌂|🏘️|1) ►tags/without-ref
-    │           ├── ·2a31450 (⌂|🏘️|1) ►B-empty, ►ambiguous-01
-    │           └── ·70bde6b (⌂|🏘️|1) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
-    │               └── ►:1:origin/main →:2:
-    │                   └── ·fafd9d0 (⌂|🏘️|✓|11) ►main, ►new-A, ►new-B
-    └── ►:2:main <> origin/main →:1:
-        └── →:1: (origin/main →:2:)
+    │       └── ►:3:B <> origin/B →:4:
+    │           ├── ·70e9a36 (⌂|🏘️|101)
+    │           ├── ·320e105 (⌂|🏘️|101) ►tags/without-ref
+    │           └── ·2a31450 (⌂|🏘️|101) ►B-empty, ►ambiguous-01
+    │               └── ►:4:origin/B →:3:
+    │                   └── ·70bde6b (⌂|🏘️|101) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
+    │                       └── ►:2:main <> origin/main →:1:
+    │                           └── ·fafd9d0 (⌂|🏘️|✓|111) ►new-A, ►new-B
+    └── ►:1:origin/main →:2:
+        └── →:2: (main →:1:)
     ");
 
     // All non-integrated segments are visible.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
-    └── ≡:3:B on fafd9d0
-        └── :3:B
+    └── ≡:3:B <> origin/B →:4:⇡3 on fafd9d0
+        └── :3:B <> origin/B →:4:⇡3
             ├── ·70e9a36 (🏘️)
             ├── ·320e105 (🏘️) ►tags/without-ref
             ├── ·2a31450 (🏘️) ►B-empty, ►ambiguous-01
-            └── ·70bde6b (🏘️) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
+            └── ❄️70bde6b (🏘️) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
     ");
 
     // There is always a segment for the entrypoint, and code working with the graph
@@ -55,28 +56,29 @@ fn single_stack_ambigous() -> anyhow::Result<()> {
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 📕►►►:1:gitbutler/workspace
     │   └── ·20de6ee (⌂|🏘️)
-    │       └── ►:4:B
-    │           └── ·70e9a36 (⌂|🏘️)
+    │       └── ►:4:B <> origin/B →:5:
+    │           └── ·70e9a36 (⌂|🏘️|100)
     │               └── 👉►:0:tags/without-ref
-    │                   ├── ·320e105 (⌂|🏘️|1)
-    │                   ├── ·2a31450 (⌂|🏘️|1) ►B-empty, ►ambiguous-01
-    │                   └── ·70bde6b (⌂|🏘️|1) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
-    │                       └── ►:2:origin/main →:3:
-    │                           └── ·fafd9d0 (⌂|🏘️|✓|11) ►main, ►new-A, ►new-B
-    └── ►:3:main <> origin/main →:2:
-        └── →:2: (origin/main →:3:)
+    │                   ├── ·320e105 (⌂|🏘️|101)
+    │                   └── ·2a31450 (⌂|🏘️|101) ►B-empty, ►ambiguous-01
+    │                       └── ►:5:origin/B →:4:
+    │                           └── ·70bde6b (⌂|🏘️|101) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
+    │                               └── ►:3:main <> origin/main →:2:
+    │                                   └── ·fafd9d0 (⌂|🏘️|✓|111) ►new-A, ►new-B
+    └── ►:2:origin/main →:3:
+        └── →:3: (main →:2:)
     ");
     // Now `HEAD` is outside a workspace, which goes to single-branch mode. But it knows it's in a workspace
     // and shows the surrounding parts, while marking the segment as entrypoint.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main
-    └── ≡:4:B on fafd9d0
-        ├── :4:B
+    └── ≡:4:B <> origin/B →:5:⇡1 on fafd9d0
+        ├── :4:B <> origin/B →:5:⇡1
         │   └── ·70e9a36 (🏘️)
         └── 👉:0:tags/without-ref
             ├── ·320e105 (🏘️)
             ├── ·2a31450 (🏘️) ►B-empty, ►ambiguous-01
-            └── ·70bde6b (🏘️) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
+            └── ❄70bde6b (🏘️) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
     ");
 
     // We don't have to give it a ref-name
@@ -85,28 +87,31 @@ fn single_stack_ambigous() -> anyhow::Result<()> {
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 📕►►►:1:gitbutler/workspace
     │   └── ·20de6ee (⌂|🏘️)
-    │       └── ►:4:B
-    │           └── ·70e9a36 (⌂|🏘️)
+    │       └── ►:4:B <> origin/B →:5:
+    │           └── ·70e9a36 (⌂|🏘️|100)
     │               └── ►:0:anon:
-    │                   ├── 👉·320e105 (⌂|🏘️|1) ►tags/without-ref
-    │                   ├── ·2a31450 (⌂|🏘️|1) ►B-empty, ►ambiguous-01
-    │                   └── ·70bde6b (⌂|🏘️|1) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
-    │                       └── ►:2:origin/main →:3:
-    │                           └── ·fafd9d0 (⌂|🏘️|✓|11) ►main, ►new-A, ►new-B
-    └── ►:3:main <> origin/main →:2:
-        └── →:2: (origin/main →:3:)
+    │                   ├── 👉·320e105 (⌂|🏘️|101) ►tags/without-ref
+    │                   └── ·2a31450 (⌂|🏘️|101) ►B-empty, ►ambiguous-01
+    │                       └── ►:6:anon:
+    │                           └── ·70bde6b (⌂|🏘️|101) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
+    │                               └── ►:3:main <> origin/main →:2:
+    │                                   └── ·fafd9d0 (⌂|🏘️|✓|111) ►new-A, ►new-B
+    ├── ►:2:origin/main →:3:
+    │   └── →:3: (main →:2:)
+    └── ►:5:origin/B →:4:
+        └── →:6:
     ");
 
     // Entrypoint is now unnamed (as no ref-name was provided for traversal)
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main
-    └── ≡:4:B on fafd9d0
-        ├── :4:B
+    └── ≡:4:B <> origin/B →:5:⇡1 on fafd9d0
+        ├── :4:B <> origin/B →:5:⇡1
         │   └── ·70e9a36 (🏘️)
         └── 👉:0:anon:
             ├── ·320e105 (🏘️) ►tags/without-ref
             ├── ·2a31450 (🏘️) ►B-empty, ►ambiguous-01
-            └── ·70bde6b (🏘️) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
+            └── ❄70bde6b (🏘️) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
     ");
 
     // Putting the entrypoint onto a commit in an anonymous segment with ambiguous refs makes no difference.
@@ -116,28 +121,31 @@ fn single_stack_ambigous() -> anyhow::Result<()> {
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 📕►►►:1:gitbutler/workspace
     │   └── ·20de6ee (⌂|🏘️)
-    │       └── ►:4:B
-    │           ├── ·70e9a36 (⌂|🏘️)
-    │           └── ·320e105 (⌂|🏘️) ►tags/without-ref
+    │       └── ►:4:B <> origin/B →:5:
+    │           ├── ·70e9a36 (⌂|🏘️|100)
+    │           └── ·320e105 (⌂|🏘️|100) ►tags/without-ref
     │               └── ►:0:anon:
-    │                   ├── 👉·2a31450 (⌂|🏘️|1) ►B-empty, ►ambiguous-01
-    │                   └── ·70bde6b (⌂|🏘️|1) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
-    │                       └── ►:2:origin/main →:3:
-    │                           └── ·fafd9d0 (⌂|🏘️|✓|11) ►main, ►new-A, ►new-B
-    └── ►:3:main <> origin/main →:2:
-        └── →:2: (origin/main →:3:)
+    │                   └── 👉·2a31450 (⌂|🏘️|101) ►B-empty, ►ambiguous-01
+    │                       └── ►:6:anon:
+    │                           └── ·70bde6b (⌂|🏘️|101) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
+    │                               └── ►:3:main <> origin/main →:2:
+    │                                   └── ·fafd9d0 (⌂|🏘️|✓|111) ►new-A, ►new-B
+    ├── ►:2:origin/main →:3:
+    │   └── →:3: (main →:2:)
+    └── ►:5:origin/B →:4:
+        └── →:6:
     ");
 
     // Doing this is very much like edit mode, and there is always a segment starting at the entrypoint.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main
-    └── ≡:4:B on fafd9d0
-        ├── :4:B
+    └── ≡:4:B <> origin/B →:5:⇡2 on fafd9d0
+        ├── :4:B <> origin/B →:5:⇡2
         │   ├── ·70e9a36 (🏘️)
         │   └── ·320e105 (🏘️) ►tags/without-ref
         └── 👉:0:anon:
             ├── ·2a31450 (🏘️) ►B-empty, ►ambiguous-01
-            └── ·70bde6b (🏘️) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
+            └── ❄70bde6b (🏘️) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
     ");
 
     // If we pass an entrypoint ref name, it will be used as segment name (despite being ambiguous without it)
@@ -146,27 +154,30 @@ fn single_stack_ambigous() -> anyhow::Result<()> {
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 📕►►►:1:gitbutler/workspace
     │   └── ·20de6ee (⌂|🏘️)
-    │       └── ►:4:B
-    │           ├── ·70e9a36 (⌂|🏘️)
-    │           └── ·320e105 (⌂|🏘️) ►tags/without-ref
+    │       └── ►:4:B <> origin/B →:5:
+    │           ├── ·70e9a36 (⌂|🏘️|100)
+    │           └── ·320e105 (⌂|🏘️|100) ►tags/without-ref
     │               └── 👉►:0:B-empty
-    │                   ├── ·2a31450 (⌂|🏘️|1) ►ambiguous-01
-    │                   └── ·70bde6b (⌂|🏘️|1) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
-    │                       └── ►:2:origin/main →:3:
-    │                           └── ·fafd9d0 (⌂|🏘️|✓|11) ►main, ►new-A, ►new-B
-    └── ►:3:main <> origin/main →:2:
-        └── →:2: (origin/main →:3:)
+    │                   └── ·2a31450 (⌂|🏘️|101) ►ambiguous-01
+    │                       └── ►:6:anon:
+    │                           └── ·70bde6b (⌂|🏘️|101) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
+    │                               └── ►:3:main <> origin/main →:2:
+    │                                   └── ·fafd9d0 (⌂|🏘️|✓|111) ►new-A, ►new-B
+    ├── ►:2:origin/main →:3:
+    │   └── →:3: (main →:2:)
+    └── ►:5:origin/B →:4:
+        └── →:6:
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main
-    └── ≡:4:B on fafd9d0
-        ├── :4:B
+    └── ≡:4:B <> origin/B →:5:⇡2 on fafd9d0
+        ├── :4:B <> origin/B →:5:⇡2
         │   ├── ·70e9a36 (🏘️)
         │   └── ·320e105 (🏘️) ►tags/without-ref
         └── 👉:0:B-empty
             ├── ·2a31450 (🏘️) ►ambiguous-01
-            └── ·70bde6b (🏘️) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
+            └── ❄70bde6b (🏘️) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
     ");
     Ok(())
 }
@@ -179,13 +190,12 @@ fn single_stack_ws_insertions() -> anyhow::Result<()> {
     * 70e9a36 (B) with-ref
     * 320e105 (tag: without-ref) segment-B
     * 2a31450 (ambiguous-01, B-empty) segment-B~1
-    * 70bde6b (A-empty-03, A-empty-02, A-empty-01, A) segment-A
+    * 70bde6b (origin/B, A-empty-03, A-empty-02, A-empty-01, A) segment-A
     * fafd9d0 (origin/main, new-B, new-A, main) init
     ");
     // Fully defined workspace with multiple empty segments on top of each other.
     // Notably the order doesn't match, 'B-empty' is after 'B', but we use it anyway for segment definition.
     // On single commits, the desired order fully defines where stacks go.
-    meta.data_mut().branches.clear();
     // Note that this does match the single-stack (one big segment) configuration we actually have.
     add_stack_with_segments(
         &mut meta,
@@ -205,93 +215,122 @@ fn single_stack_ws_insertions() -> anyhow::Result<()> {
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 👉📕►►►:0:gitbutler/workspace
     │   └── ·20de6ee (⌂|🏘️|1)
-    │       └── 📙►:3:B
-    │           ├── ·70e9a36 (⌂|🏘️|1)
-    │           └── ·320e105 (⌂|🏘️|1) ►tags/without-ref
-    │               └── 📙►:4:B-empty
-    │                   └── ·2a31450 (⌂|🏘️|1) ►ambiguous-01
-    │                       └── 📙►:5:A-empty-03
-    │                           └── 📙►:6:A-empty-01
-    │                               └── 📙►:7:A
-    │                                   └── ·70bde6b (⌂|🏘️|1) ►A-empty-02
-    │                                       └── ►:1:origin/main →:2:
-    │                                           └── ·fafd9d0 (⌂|🏘️|✓|11) ►main, ►new-A, ►new-B
-    └── ►:2:main <> origin/main →:1:
-        └── →:1: (origin/main →:2:)
+    │       └── 📙►:3:B <> origin/B →:4:
+    │           ├── ·70e9a36 (⌂|🏘️|101)
+    │           └── ·320e105 (⌂|🏘️|101) ►tags/without-ref
+    │               └── 📙►:5:B-empty
+    │                   └── ·2a31450 (⌂|🏘️|101) ►ambiguous-01
+    │                       └── ►:4:origin/B →:3:
+    │                           └── 📙►:6:A-empty-03
+    │                               └── 📙►:7:A-empty-01
+    │                                   └── 📙►:8:A
+    │                                       └── ·70bde6b (⌂|🏘️|101) ►A-empty-02
+    │                                           └── ►:2:main <> origin/main →:1:
+    │                                               └── ·fafd9d0 (⌂|🏘️|✓|111) ►new-A, ►new-B
+    └── ►:1:origin/main →:2:
+        └── →:2: (main →:1:)
     ");
 
     // We pickup empty segments.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
-    └── ≡📙:3:B on fafd9d0
-        ├── 📙:3:B
+    └── ≡📙:3:B <> origin/B →:4:⇡2 on fafd9d0
+        ├── 📙:3:B <> origin/B →:4:⇡2
         │   ├── ·70e9a36 (🏘️)
         │   └── ·320e105 (🏘️) ►tags/without-ref
-        ├── 📙:4:B-empty
+        ├── 📙:5:B-empty
         │   └── ·2a31450 (🏘️) ►ambiguous-01
-        ├── 📙:5:A-empty-03
-        ├── 📙:6:A-empty-01
-        └── 📙:7:A
-            └── ·70bde6b (🏘️) ►A-empty-02
+        ├── 📙:6:A-empty-03
+        ├── 📙:7:A-empty-01
+        └── 📙:8:A
+            └── ❄70bde6b (🏘️) ►A-empty-02
     ");
 
-    // TODO: do more complex new-stack segmentation
-    // // Note that this doesn't match the single-stack (one big segment) configuration we actually have.
-    // // Only stack B should be used here.
-    // meta.data_mut().branches.clear();
-    // add_stack_with_segments(
-    //     &mut meta,
-    //     StackId::from_number_for_testing(0),
-    //     "B-empty",
-    //     StackState::InWorkspace,
-    //     &["B"],
-    // );
-    // add_stack_with_segments(
-    //     &mut meta,
-    //     StackId::from_number_for_testing(1),
-    //     "A-empty-03",
-    //     StackState::InWorkspace,
-    //     &["A-empty-02", "A-empty-01", "A"],
-    // );
+    // Now something similar but with two stacks.
+    // As the actual topology is different, we can't really comply with that's desired.
+    // Instead, we re-use as many of the named segments as possible, even if they are from multiple branches.
+    meta.data_mut().branches.clear();
+    add_stack_with_segments(&mut meta, 0, "B-empty", StackState::InWorkspace, &["B"]);
+    add_stack_with_segments(
+        &mut meta,
+        1,
+        "A-empty-03",
+        StackState::InWorkspace,
+        &["A-empty-02", "A-empty-01", "A"],
+    );
 
-    // let graph = Graph::from_head(&repo, &*meta, standard_options())?;
-    // insta::assert_snapshot!(graph_tree(&graph), @r#"
-    // └── 👉►►►refs/heads/gitbutler/workspace
-    //     ├── 🔵2c12d75 (InWorkspace)❱"GitButler Workspace Commit"
-    //     ├── 🔵320e105 (InWorkspace)❱"segment-B" ►B, ►ambiguous-02
-    //     ├── 🔵2a31450 (InWorkspace)❱"segment-B~1" ►B-empty, ►ambiguous-01
-    //     ├── 🔵70bde6b (InWorkspace)❱"segment-A" ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
-    //     └── 🔵fafd9d0 (InWorkspace)❱"init" ►main, ►new-A, ►new-B
-    // "#);
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?;
+    insta::assert_snapshot!(graph_tree(&graph), @r"
+    ├── 👉📕►►►:0:gitbutler/workspace
+    │   └── ·20de6ee (⌂|🏘️|1)
+    │       └── 📙►:3:B <> origin/B →:4:
+    │           ├── ·70e9a36 (⌂|🏘️|101)
+    │           └── ·320e105 (⌂|🏘️|101) ►tags/without-ref
+    │               └── 📙►:5:B-empty
+    │                   └── ·2a31450 (⌂|🏘️|101) ►ambiguous-01
+    │                       └── ►:4:origin/B →:3:
+    │                           └── 📙►:6:A-empty-03
+    │                               └── 📙►:7:A-empty-02
+    │                                   └── 📙►:8:A-empty-01
+    │                                       └── 📙►:9:A
+    │                                           └── ·70bde6b (⌂|🏘️|101)
+    │                                               └── ►:2:main <> origin/main →:1:
+    │                                                   └── ·fafd9d0 (⌂|🏘️|✓|111) ►new-A, ►new-B
+    └── ►:1:origin/main →:2:
+        └── →:2: (main →:1:)
+    ");
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    └── ≡📙:3:B <> origin/B →:4:⇡2 on fafd9d0
+        ├── 📙:3:B <> origin/B →:4:⇡2
+        │   ├── ·70e9a36 (🏘️)
+        │   └── ·320e105 (🏘️) ►tags/without-ref
+        ├── 📙:5:B-empty
+        │   └── ·2a31450 (🏘️) ►ambiguous-01
+        ├── 📙:6:A-empty-03
+        ├── 📙:7:A-empty-02
+        ├── 📙:8:A-empty-01
+        └── 📙:9:A
+            └── ❄70bde6b (🏘️)
+    ");
 
-    // // Define only some of the branches, it should figure that out.
-    // meta.data_mut().branches.clear();
-    // add_stack_with_segments(
-    //     &mut meta,
-    //     StackId::from_number_for_testing(0),
-    //     "A",
-    //     StackState::InWorkspace,
-    //     &["A-empty-01"],
-    // );
-    // add_stack_with_segments(
-    //     &mut meta,
-    //     StackId::from_number_for_testing(1),
-    //     "B-empty",
-    //     StackState::InWorkspace,
-    //     &["B"],
-    // );
-    //
-    // // TODO: show how the entrypoint affects the segmentation, by design.
-    // let graph = Graph::from_head(&repo, &*meta, standard_options())?;
-    // insta::assert_snapshot!(graph_tree(&graph), @r#"
-    // └── 👉►►►refs/heads/gitbutler/workspace
-    //     ├── 🔵2c12d75 (InWorkspace)❱"GitButler Workspace Commit"
-    //     ├── 🔵320e105 (InWorkspace)❱"segment-B" ►B, ►ambiguous-02
-    //     ├── 🔵2a31450 (InWorkspace)❱"segment-B~1" ►B-empty, ►ambiguous-01
-    //     └── 🔵70bde6b (InWorkspace)❱"segment-A" ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
-    //         └── ►refs/heads/main
-    //             └── 🔵fafd9d0 (InWorkspace)❱"init"
-    // "#);
+    // Define only some of the branches, it should figure that out.
+    meta.data_mut().branches.clear();
+    add_stack_with_segments(&mut meta, 0, "A", StackState::InWorkspace, &["A-empty-01"]);
+    add_stack_with_segments(&mut meta, 1, "B-empty", StackState::InWorkspace, &["B"]);
+
+    let (id, ref_name) = id_at(&repo, "A-empty-01");
+    let graph = Graph::from_commit_traversal(id, ref_name, &*meta, standard_options())?;
+    insta::assert_snapshot!(graph_tree(&graph), @r"
+    ├── 📕►►►:1:gitbutler/workspace
+    │   └── ·20de6ee (⌂|🏘️)
+    │       └── 📙►:4:B <> origin/B →:5:
+    │           ├── ·70e9a36 (⌂|🏘️|100)
+    │           └── ·320e105 (⌂|🏘️|100) ►tags/without-ref
+    │               └── 📙►:6:B-empty
+    │                   └── ·2a31450 (⌂|🏘️|100) ►ambiguous-01
+    │                       └── 👉📙►:0:A-empty-01
+    │                           └── 📙►:7:A
+    │                               └── ·70bde6b (⌂|🏘️|101) ►A-empty-02, ►A-empty-03
+    │                                   └── ►:3:main <> origin/main →:2:
+    │                                       └── ·fafd9d0 (⌂|🏘️|✓|111) ►new-A, ►new-B
+    ├── ►:2:origin/main →:3:
+    │   └── →:3: (main →:2:)
+    └── ►:5:origin/B →:4:
+        └── →:0: (A-empty-01)
+    ");
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main
+    └── ≡📙:4:B <> origin/B →:5:⇡2 on fafd9d0
+        ├── 📙:4:B <> origin/B →:5:⇡2
+        │   ├── ·70e9a36 (🏘️)
+        │   └── ·320e105 (🏘️) ►tags/without-ref
+        ├── 📙:6:B-empty
+        │   └── ·2a31450 (🏘️) ►ambiguous-01
+        ├── 👉📙:0:A-empty-01
+        └── 📙:7:A
+            └── ❄70bde6b (🏘️) ►A-empty-02, ►A-empty-03
+    ");
     Ok(())
 }
 
@@ -319,10 +358,10 @@ fn single_stack() -> anyhow::Result<()> {
     │                   └── ·2a31450 (⌂|🏘️|1)
     │                       └── ►:5:A
     │                           └── ·70bde6b (⌂|🏘️|1)
-    │                               └── ►:1:origin/main →:2:
-    │                                   └── ·fafd9d0 (⌂|🏘️|✓|11) ►main, ►new-A
-    └── ►:2:main <> origin/main →:1:
-        └── →:1: (origin/main →:2:)
+    │                               └── ►:2:main <> origin/main →:1:
+    │                                   └── ·fafd9d0 (⌂|🏘️|✓|11) ►new-A
+    └── ►:1:origin/main →:2:
+        └── →:2: (main →:1:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
@@ -345,6 +384,7 @@ fn single_stack() -> anyhow::Result<()> {
     //       but even then it would be hard to know where to reasonably put it in
     //       as remote tracking branches should keep pointing to their original targets,
     //       maybe?
+    // TODO: new-A shouldn't be below, workspace upgrade must respect the boundary.
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 👉📕►►►:0:gitbutler/workspace
@@ -355,11 +395,10 @@ fn single_stack() -> anyhow::Result<()> {
     │                   └── ·2a31450 (⌂|🏘️|1)
     │                       └── 📙►:5:A
     │                           └── ·70bde6b (⌂|🏘️|1)
-    │                               └── ►:1:origin/main →:2:
-    │                                   └── 📙►:6:new-A
-    │                                       └── ·fafd9d0 (⌂|🏘️|✓|11) ►main
-    └── ►:2:main <> origin/main →:1:
-        └── →:1: (origin/main →:2:)
+    │                               └── ►:2:main <> origin/main →:1:
+    │                                   └── ·fafd9d0 (⌂|🏘️|✓|11) ►new-A
+    └── ►:1:origin/main →:2:
+        └── →:2: (main →:1:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
@@ -563,16 +602,16 @@ fn minimal_merge() -> anyhow::Result<()> {
     │               │                   └── ·0cc5a6f (⌂|🏘️|1)
     │               │                       ├── ►:7:B
     │               │                       │   └── ·7fdb58d (⌂|🏘️|1)
-    │               │                       │       └── ►:1:origin/main →:2:
-    │               │                       │           └── ·fafd9d0 (⌂|🏘️|✓|11) ►main
+    │               │                       │       └── ►:2:main <> origin/main →:1:
+    │               │                       │           └── ·fafd9d0 (⌂|🏘️|✓|11)
     │               │                       └── ►:8:A
     │               │                           └── ·e255adc (⌂|🏘️|1)
-    │               │                               └── →:1: (origin/main →:2:)
+    │               │                               └── →:2: (main →:1:)
     │               └── ►:5:C
     │                   └── ·c6d714c (⌂|🏘️|1)
     │                       └── →:9: (empty-2-on-merge)
-    └── ►:2:main <> origin/main →:1:
-        └── →:1: (origin/main →:2:)
+    └── ►:1:origin/main →:2:
+        └── →:2: (main →:1:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
@@ -600,47 +639,74 @@ fn just_init_with_branches() -> anyhow::Result<()> {
 
     // Without hints - `main` is picked up as it's the entrypoint.
     add_workspace(&mut meta);
-    // TODO: graph traversal can't decide this, either is handled when 'collisions' occur
-    //       or we change the order in which tips are queued to let 'main' naturally find its commits first,
-    //      (needs multi-goal).
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉►:0:main <> origin/main →:2:
-    │   └── ►:2:origin/main →:0:
-    │       └── ·fafd9d0 (⌂|🏘️|✓|1) ►A, ►B, ►C, ►D, ►E, ►F, ►main
-    └── 📕►►►:1:gitbutler/workspace
-        └── →:2: (origin/main →:0:)
+    ├── 📕►►►:1:gitbutler/workspace
+    │   └── 👉►:0:main <> origin/main →:2:
+    │       └── ·fafd9d0 (⌂|🏘️|✓|1) ►A, ►B, ►C, ►D, ►E, ►F
+    └── ►:2:origin/main →:0:
+        └── →:0: (main →:2:)
     ");
 
-    // TODO: review after graph is correctly ordered - should not have origin.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main");
+    // There is no workspace as `main` is the base of the workspace, so it's shown directly,
+    // outside the workspace.
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    ⌂:0:main <> ✓!
+    └── ≡:0:main <> origin/main →:2:
+        └── :0:main <> origin/main →:2:
+            └── ❄️fafd9d0 (🏘️|✓) ►A, ►B, ►C, ►D, ►E, ►F
+    ");
+
+    let (id, ref_name) = id_at(&repo, "gitbutler/workspace");
+    let graph = Graph::from_commit_traversal(id, ref_name.clone(), &*meta, standard_options())?
+        .validated()?;
+    insta::assert_snapshot!(graph_tree(&graph), @r"
+    ├── 👉📕►►►:0:gitbutler/workspace
+    │   └── ►:2:main <> origin/main →:1:
+    │       └── ·fafd9d0 (⌂|🏘️|✓|1) ►A, ►B, ►C, ►D, ►E, ►F
+    └── ►:1:origin/main →:2:
+        └── →:2: (main →:1:)
+    ");
+
+    // However, when the workspace is checked out, it's at least empty.
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main");
 
     // The simplest possible setup where we can define how the workspace should look like,
     // in terms of dependent and independent virtual segments.
     add_stack_with_segments(&mut meta, 0, "C", StackState::InWorkspace, &["B", "A"]);
     add_stack_with_segments(&mut meta, 1, "D", StackState::InWorkspace, &["E", "F"]);
+
     let graph = Graph::from_head(&repo, &*meta, standard_options())?;
-    // TODO: where is the segmentation of D E F in a separate stack?
-    //       also: order is wrong now due to target branch handling
-    //       - needs insertion of multi-segment above 'fixed' references like the target branch.
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    ├── 👉►:0:main <> origin/main →:2:
-    │   └── ►:2:origin/main →:0:
-    │       └── 📙►:3:C
-    │           └── 📙►:4:B
-    │               └── 📙►:5:A
-    │                   └── ·fafd9d0 (⌂|🏘️|✓|1) ►D, ►E, ►F, ►main
-    └── 📕►►►:1:gitbutler/workspace
-        └── →:2: (origin/main →:0:)
+    ├── 📕►►►:1:gitbutler/workspace
+    │   └── 👉►:0:main <> origin/main →:2:
+    │       └── ·fafd9d0 (⌂|🏘️|✓|1) ►A, ►B, ►C, ►D, ►E, ►F
+    └── ►:2:origin/main →:0:
+        └── →:0: (main →:2:)
     ");
 
-    // We don't accidentally list any workspace, nor non-local branches.
+    // There is no segmentation outside the workspace.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main
-    └── ≡📙:3:C on fafd9d0
-        ├── 📙:3:C
-        └── 📙:4:B
+    ⌂:0:main <> ✓!
+    └── ≡:0:main <> origin/main →:2:
+        └── :0:main <> origin/main →:2:
+            └── ❄️fafd9d0 (🏘️|✓) ►A, ►B, ►C, ►D, ►E, ►F
     ");
+
+    // TODO: where is the segmentation of D E F in a separate stack, and C B A?
+    let graph =
+        Graph::from_commit_traversal(id, ref_name, &*meta, standard_options())?.validated()?;
+    // Now the dependent segments are applied, and so is the separate stack.
+    insta::assert_snapshot!(graph_tree(&graph), @r"
+    ├── 👉📕►►►:0:gitbutler/workspace
+    │   └── ►:2:main <> origin/main →:1:
+    │       └── ·fafd9d0 (⌂|🏘️|✓|1) ►A, ►B, ►C, ►D, ►E, ►F
+    └── ►:1:origin/main →:2:
+        └── →:2: (main →:1:)
+    ");
+
+    // TODO: we should see C B A (but it's a new stack and we don't support that yet
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main");
     Ok(())
 }
 
@@ -826,15 +892,15 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     │           └── ·312f819 (⌂|🏘️|101)
     │               └── ►:5:A <> origin/A →:6:
     │                   └── ·e255adc (⌂|🏘️|1101)
-    │                       └── ►:1:origin/main →:2:
-    │                           └── ·fafd9d0 (⌂|🏘️|✓|1111) ►main
-    ├── ►:2:main <> origin/main →:1:
-    │   └── →:1: (origin/main →:2:)
+    │                       └── ►:2:main <> origin/main →:1:
+    │                           └── ·fafd9d0 (⌂|🏘️|✓|1111)
+    ├── ►:1:origin/main →:2:
+    │   └── →:2: (main →:1:)
     └── ►:4:origin/B →:3:
         └── 🟣682be32
             └── ►:6:origin/A →:5:
                 └── 🟣e29c23d
-                    └── →:1: (origin/main →:2:)
+                    └── →:2: (main →:1:)
     ");
     // It's worth noting that we avoid double-listing remote commits that are also
     // directly owned by another remote segment.
@@ -860,15 +926,15 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     │           └── ·312f819 (⌂|🏘️|100)
     │               └── 👉►:0:A <> origin/A →:4:
     │                   └── ·e255adc (⌂|🏘️|101)
-    │                       └── ►:2:origin/main →:3:
-    │                           └── ·fafd9d0 (⌂|🏘️|✓|111) ►main
-    ├── ►:3:main <> origin/main →:2:
-    │   └── →:2: (origin/main →:3:)
+    │                       └── ►:3:main <> origin/main →:2:
+    │                           └── ·fafd9d0 (⌂|🏘️|✓|111)
+    ├── ►:2:origin/main →:3:
+    │   └── →:3: (main →:2:)
     └── ►:6:origin/B →:5:
         └── 🟣682be32
             └── ►:4:origin/A →:0:
                 └── 🟣e29c23d
-                    └── →:2: (origin/main →:3:)
+                    └── →:3: (main →:2:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main
@@ -922,10 +988,10 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
             (
                 Some(
                     FullName(
-                        "refs/heads/main",
+                        "refs/remotes/origin/main",
                     ),
                 ),
-                NodeIndex(3),
+                NodeIndex(2),
                 None,
             ),
             (
@@ -941,7 +1007,7 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
         segments_at_bottom: 1,
         connections: 6,
         commits: 6,
-        commit_references: 1,
+        commit_references: 0,
         commits_at_cutoff: 0,
     }
     "#);
@@ -981,10 +1047,10 @@ fn disambiguate_by_remote() -> anyhow::Result<()> {
     │                   └── ·312f819 (⌂|🏘️|1101) ►ambiguous-B
     │                       └── ►:8:A <> origin/A →:7:
     │                           └── ·e255adc (⌂|🏘️|11101) ►ambiguous-A
-    │                               └── ►:1:origin/main →:2:
-    │                                   └── ·fafd9d0 (⌂|🏘️|✓|11111) ►main
-    ├── ►:2:main <> origin/main →:1:
-    │   └── →:1: (origin/main →:2:)
+    │                               └── ►:2:main <> origin/main →:1:
+    │                                   └── ·fafd9d0 (⌂|🏘️|✓|11111)
+    ├── ►:1:origin/main →:2:
+    │   └── →:2: (main →:1:)
     ├── ►:3:origin/C
     │   └── →:6:
     ├── ►:4:origin/ambiguous-C
@@ -1026,10 +1092,10 @@ fn disambiguate_by_remote() -> anyhow::Result<()> {
     │                   └── ·312f819 (⌂|🏘️|1101) ►ambiguous-B
     │                       └── ►:8:A <> origin/A →:7:
     │                           └── ·e255adc (⌂|🏘️|11101) ►ambiguous-A
-    │                               └── ►:1:origin/main →:2:
-    │                                   └── ·fafd9d0 (⌂|🏘️|✓|11111) ►main
-    ├── ►:2:main <> origin/main →:1:
-    │   └── →:1: (origin/main →:2:)
+    │                               └── ►:2:main <> origin/main →:1:
+    │                                   └── ·fafd9d0 (⌂|🏘️|✓|11111)
+    ├── ►:1:origin/main →:2:
+    │   └── →:2: (main →:1:)
     ├── ►:4:origin/C →:3:
     │   └── →:3: (C →:4:)
     ├── ►:5:origin/ambiguous-C
@@ -1097,19 +1163,20 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     │       └── ►:2:B
     │           ├── ·6b1a13b (⌂|🏘️|1)
     │           └── ·03ad472 (⌂|🏘️|1)
-    │               └── ►:5:A
+    │               └── ►:4:A
     │                   ├── ·79bbb29 (⌂|🏘️|✓|1)
-    │                   └── ✂️·fc98174 (⌂|🏘️|✓|1)
+    │                   ├── ·fc98174 (⌂|🏘️|✓|1)
+    │                   └── ✂️·a381df5 (⌂|🏘️|✓|1)
     └── ►:1:origin/main
         ├── 🟣d0df794 (✓)
         └── 🟣09c6e08 (✓)
             └── ►:3:anon:
                 └── 🟣7b9f260 (✓)
-                    ├── ►:4:main
+                    ├── ►:5:main
                     │   ├── 🟣4b3e5a8 (✓)
                     │   ├── 🟣34d0715 (✓)
                     │   └── 🟣eb5f731 (✓)
-                    └── →:5: (A)
+                    └── →:4: (A)
     ");
     // It's true that `A` is fully integrated so it isn't displayed. so from a workspace-perspective
     // it's the right answer.
@@ -1132,19 +1199,20 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     │       └── 📙►:2:B
     │           ├── ·6b1a13b (⌂|🏘️|1)
     │           └── ·03ad472 (⌂|🏘️|1)
-    │               └── 📙►:5:A
+    │               └── 📙►:4:A
     │                   ├── ·79bbb29 (⌂|🏘️|✓|1)
-    │                   └── ✂️·fc98174 (⌂|🏘️|✓|1)
+    │                   ├── ·fc98174 (⌂|🏘️|✓|1)
+    │                   └── ✂️·a381df5 (⌂|🏘️|✓|1)
     └── ►:1:origin/main
         ├── 🟣d0df794 (✓)
         └── 🟣09c6e08 (✓)
             └── ►:3:anon:
                 └── 🟣7b9f260 (✓)
-                    ├── ►:4:main
+                    ├── ►:5:main
                     │   ├── 🟣4b3e5a8 (✓)
                     │   ├── 🟣34d0715 (✓)
                     │   └── 🟣eb5f731 (✓)
-                    └── →:5: (A)
+                    └── →:4: (A)
     ");
     // `A` is integrated, hence it's not shown.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
@@ -1165,19 +1233,20 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     │       └── 📙►:2:B
     │           ├── ·6b1a13b (⌂|🏘️|1)
     │           └── ·03ad472 (⌂|🏘️|1)
-    │               └── 📙►:5:A
+    │               └── 📙►:4:A
     │                   ├── ·79bbb29 (⌂|🏘️|✓|1)
-    │                   └── ✂️·fc98174 (⌂|🏘️|✓|1)
+    │                   ├── ·fc98174 (⌂|🏘️|✓|1)
+    │                   └── ✂️·a381df5 (⌂|🏘️|✓|1)
     └── ►:1:origin/main
         ├── 🟣d0df794 (✓)
         └── 🟣09c6e08 (✓)
             └── ►:3:anon:
                 └── 🟣7b9f260 (✓)
-                    ├── ►:4:main
+                    ├── ►:5:main
                     │   ├── 🟣4b3e5a8 (✓)
                     │   ├── 🟣34d0715 (✓)
                     │   └── 🟣eb5f731 (✓)
-                    └── →:5: (A)
+                    └── →:4: (A)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣6
@@ -1270,7 +1339,8 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     │                               │           └── ·eb5f731 (⌂|🏘️|✓|1)
     │                               └── ►:8:A-feat
     │                                   ├── ·fea59b5 (⌂|🏘️|✓|1)
-    │                                   └── ✂️·4deea74 (⌂|🏘️|✓|1)
+    │                                   └── ·4deea74 (⌂|🏘️|✓|1)
+    │                                       └── →:7:
     └── ►:2:origin/main
         ├── 🟣d0df794 (✓)
         └── 🟣09c6e08 (✓)
@@ -1416,7 +1486,6 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
     ");
 
     // When converting to a workspace, we are still aware of the workspace membership.
-    // TODO: make this work, need to detect workspace above.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main⇣3
     └── ≡:4:B on 4b3e5a8
@@ -1487,9 +1556,8 @@ fn workspace_obeys_limit_when_target_branch_is_missing() -> anyhow::Result<()> {
         "But with workspace and target, we see everything"
     );
     // It's notable that there is no way to bypass the early abort when everything is integrated.
-    // TODO: should workspace search for the target branch, which is now set?
-    //       it should always manage to be complete, as this is partial and wrong.
-    //       It's complete enough though, so maybe not really wrong?
+    // and there is no deductible remote relationship between origin/main and main (no remote not configured).
+    // Then the traversal ends on integrated branches as `main` isn't a target.
     let graph =
         Graph::from_head(&repo, &*meta, standard_options().with_limit_hint(0))?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
@@ -1498,19 +1566,20 @@ fn workspace_obeys_limit_when_target_branch_is_missing() -> anyhow::Result<()> {
     │       └── ►:2:B
     │           ├── ·6b1a13b (⌂|🏘️|1)
     │           └── ·03ad472 (⌂|🏘️|1)
-    │               └── ►:5:A
+    │               └── ►:4:A
     │                   ├── ·79bbb29 (⌂|🏘️|✓|1)
-    │                   └── ✂️·fc98174 (⌂|🏘️|✓|1)
+    │                   ├── ·fc98174 (⌂|🏘️|✓|1)
+    │                   └── ✂️·a381df5 (⌂|🏘️|✓|1)
     └── ►:1:origin/main
         ├── 🟣d0df794 (✓)
         └── 🟣09c6e08 (✓)
             └── ►:3:anon:
                 └── 🟣7b9f260 (✓)
-                    ├── ►:4:main
+                    ├── ►:5:main
                     │   ├── 🟣4b3e5a8 (✓)
                     │   ├── 🟣34d0715 (✓)
                     │   └── 🟣eb5f731 (✓)
-                    └── →:5: (A)
+                    └── →:4: (A)
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
@@ -1543,10 +1612,10 @@ fn three_branches_one_advanced_ws_commit_advanced_fully_pushed_empty_dependant()
     │   └── ·f8f33a7 (⌂|🏘️|1)
     │       └── ►:4:advanced-lane <> origin/advanced-lane →:3:
     │           └── ·cbc6713 (⌂|🏘️|101) ►dependant, ►on-top-of-dependant
-    │               └── ►:1:origin/main →:2:
-    │                   └── ·fafd9d0 (⌂|🏘️|✓|111) ►lane, ►main
-    ├── ►:2:main <> origin/main →:1:
-    │   └── →:1: (origin/main →:2:)
+    │               └── ►:2:main <> origin/main →:1:
+    │                   └── ·fafd9d0 (⌂|🏘️|✓|111) ►lane
+    ├── ►:1:origin/main →:2:
+    │   └── →:2: (main →:1:)
     └── ►:3:origin/advanced-lane
         └── →:4: (advanced-lane →:3:)
     ");
@@ -1575,10 +1644,10 @@ fn three_branches_one_advanced_ws_commit_advanced_fully_pushed_empty_dependant()
     │       └── 📙►:5:dependant
     │           └── 📙►:6:advanced-lane <> origin/advanced-lane →:3:
     │               └── ·cbc6713 (⌂|🏘️|101) ►on-top-of-dependant
-    │                   └── ►:1:origin/main →:2:
-    │                       └── ·fafd9d0 (⌂|🏘️|✓|111) ►lane, ►main
-    ├── ►:2:main <> origin/main →:1:
-    │   └── →:1: (origin/main →:2:)
+    │                   └── ►:2:main <> origin/main →:1:
+    │                       └── ·fafd9d0 (⌂|🏘️|✓|111) ►lane
+    ├── ►:1:origin/main →:2:
+    │   └── →:2: (main →:1:)
     └── ►:3:origin/advanced-lane →:6:
         └── →:5: (dependant)
     ");
@@ -1610,8 +1679,8 @@ fn on_top_of_target_with_history() -> anyhow::Result<()> {
     // It sees the entire history as it had to find `main`.
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉📕►►►:0:gitbutler/workspace
-        └── ►:1:origin/main →:2:
+    └── ►:1:origin/main →:2:
+        └── 👉📕►►►:0:gitbutler/workspace
             ├── ·2cde30a (⌂|🏘️|✓|1) ►A, ►B, ►C, ►D, ►E, ►F
             ├── ·1c938f4 (⌂|🏘️|✓|1)
             ├── ·b82769f (⌂|🏘️|✓|1)
@@ -1628,33 +1697,19 @@ fn on_top_of_target_with_history() -> anyhow::Result<()> {
     add_stack_with_segments(&mut meta, 1, "D", StackState::InWorkspace, &["E", "F"]);
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
-    └── 👉📕►►►:0:gitbutler/workspace
-        └── ►:1:origin/main →:2:
-            └── 📙►:3:C
-                └── 📙►:4:B
-                    └── 📙►:5:A
-                        ├── ·2cde30a (⌂|🏘️|✓|1) ►D, ►E, ►F
-                        ├── ·1c938f4 (⌂|🏘️|✓|1)
-                        ├── ·b82769f (⌂|🏘️|✓|1)
-                        ├── ·988032f (⌂|🏘️|✓|1)
-                        └── ·cd5b655 (⌂|🏘️|✓|1)
-                            └── ►:2:main <> origin/main →:1:
-                                └── ·2be54cd (⌂|🏘️|✓|11)
+    └── ►:1:origin/main →:2:
+        └── 👉📕►►►:0:gitbutler/workspace
+            ├── ·2cde30a (⌂|🏘️|✓|1) ►A, ►B, ►C, ►D, ►E, ►F
+            ├── ·1c938f4 (⌂|🏘️|✓|1)
+            ├── ·b82769f (⌂|🏘️|✓|1)
+            ├── ·988032f (⌂|🏘️|✓|1)
+            └── ·cd5b655 (⌂|🏘️|✓|1)
+                └── ►:2:main <> origin/main →:1:
+                    └── ·2be54cd (⌂|🏘️|✓|11)
     ");
     // Empty stack segments on top of integrated portions will show.
     // `A` is there despite being integrated because it's above the merge-base.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
-    └── ≡📙:3:C on 2be54cd
-        ├── 📙:3:C
-        ├── 📙:4:B
-        └── 📙:5:A
-            ├── ·2cde30a (🏘️|✓) ►D, ►E, ►F
-            ├── ·1c938f4 (🏘️|✓)
-            ├── ·b82769f (🏘️|✓)
-            ├── ·988032f (🏘️|✓)
-            └── ·cd5b655 (🏘️|✓)
-    ");
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main");
     Ok(())
 }
 
@@ -1709,7 +1764,7 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 📕►►►:1:gitbutler/workspace
     │   └── ·41ed0e4 (⌂|🏘️)
-    │       └── ►:5:workspace
+    │       └── ►:3:workspace
     │           └── ·9730cbf (⌂|🏘️|✓)
     │               ├── ►:6:main-to-workspace
     │               │   └── ·dc7ab57 (⌂|🏘️|✓)
@@ -1734,12 +1789,12 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     │                               └── →:8:
     └── ►:2:origin/main
         └── 🟣232ed06 (✓)
-            ├── ►:3:workspace-to-target
+            ├── ►:4:workspace-to-target
             │   ├── 🟣abcfd9a (✓)
             │   ├── 🟣bc86eba (✓)
             │   └── 🟣c7ae303 (✓)
-            │       └── →:5: (workspace)
-            └── ►:4:long-workspace-to-target
+            │       └── →:3: (workspace)
+            └── ►:5:long-workspace-to-target
                 ├── 🟣9e2a79e (✓)
                 ├── 🟣fdeaa43 (✓)
                 ├── 🟣30565ee (✓)
@@ -1747,7 +1802,7 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
                 ├── 🟣56d152c (✓)
                 ├── 🟣e6e1360 (✓)
                 └── 🟣1a22a39 (✓)
-                    └── →:5: (workspace)
+                    └── →:3: (workspace)
     ");
     // Entrypoint is outside of workspace.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
@@ -1776,7 +1831,7 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 📕►►►:1:gitbutler/workspace
     │   └── ·41ed0e4 (⌂|🏘️)
-    │       └── ►:5:workspace
+    │       └── ►:3:workspace
     │           └── ·9730cbf (⌂|🏘️|✓)
     │               ├── ►:6:main-to-workspace
     │               │   └── ·dc7ab57 (⌂|🏘️|✓)
@@ -1789,7 +1844,8 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     │               │           ├── ·c32dd03 (⌂|🏘️|✓|1)
     │               │           ├── ·b625665 (⌂|🏘️|✓|1)
     │               │           ├── ·a821094 (⌂|🏘️|✓|1)
-    │               │           └── ✂️·bce0c5e (⌂|🏘️|✓|1)
+    │               │           ├── ·bce0c5e (⌂|🏘️|✓|1)
+    │               │           └── ·3183e43 (⌂|🏘️|✓|1)
     │               └── ►:7:long-main-to-workspace
     │                   ├── ·77f31a0 (⌂|🏘️|✓)
     │                   ├── ·eb17e31 (⌂|🏘️|✓)
@@ -1800,12 +1856,12 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     │                               └── →:8:
     └── ►:2:origin/main
         └── 🟣232ed06 (✓)
-            ├── ►:3:workspace-to-target
+            ├── ►:4:workspace-to-target
             │   ├── 🟣abcfd9a (✓)
             │   ├── 🟣bc86eba (✓)
             │   └── 🟣c7ae303 (✓)
-            │       └── →:5: (workspace)
-            └── ►:4:long-workspace-to-target
+            │       └── →:3: (workspace)
+            └── ►:5:long-workspace-to-target
                 ├── 🟣9e2a79e (✓)
                 ├── 🟣fdeaa43 (✓)
                 ├── 🟣30565ee (✓)
@@ -1813,7 +1869,7 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
                 ├── 🟣56d152c (✓)
                 ├── 🟣e6e1360 (✓)
                 └── 🟣1a22a39 (✓)
-                    └── →:5: (workspace)
+                    └── →:3: (workspace)
     ");
     // The limit is visible as well.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
@@ -1829,7 +1885,8 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
             ├── ·c32dd03 (🏘️|✓)
             ├── ·b625665 (🏘️|✓)
             ├── ·a821094 (🏘️|✓)
-            └── ✂️·bce0c5e (🏘️|✓)
+            ├── ·bce0c5e (🏘️|✓)
+            └── ·3183e43 (🏘️|✓)
     ");
 
     // From the workspace, even without limit, we don't traverse all of 'main' as it's uninteresting.
@@ -1838,7 +1895,7 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 👉📕►►►:0:gitbutler/workspace
     │   └── ·41ed0e4 (⌂|🏘️|1)
-    │       └── ►:4:workspace
+    │       └── ►:2:workspace
     │           └── ·9730cbf (⌂|🏘️|✓|1)
     │               ├── ►:5:main-to-workspace
     │               │   └── ·dc7ab57 (⌂|🏘️|✓|1)
@@ -1848,7 +1905,8 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     │               │           ├── ·7b7ebb2 (⌂|🏘️|✓|1)
     │               │           ├── ·dca4960 (⌂|🏘️|✓|1)
     │               │           ├── ·11c29b8 (⌂|🏘️|✓|1)
-    │               │           └── ✂️·c32dd03 (⌂|🏘️|✓|1)
+    │               │           ├── ·c32dd03 (⌂|🏘️|✓|1)
+    │               │           └── ✂️·b625665 (⌂|🏘️|✓|1)
     │               └── ►:6:long-main-to-workspace
     │                   ├── ·77f31a0 (⌂|🏘️|✓|1)
     │                   ├── ·eb17e31 (⌂|🏘️|✓|1)
@@ -1859,12 +1917,12 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     │                               └── →:8:
     └── ►:1:origin/main
         └── 🟣232ed06 (✓)
-            ├── ►:2:workspace-to-target
+            ├── ►:3:workspace-to-target
             │   ├── 🟣abcfd9a (✓)
             │   ├── 🟣bc86eba (✓)
             │   └── 🟣c7ae303 (✓)
-            │       └── →:4: (workspace)
-            └── ►:3:long-workspace-to-target
+            │       └── →:2: (workspace)
+            └── ►:4:long-workspace-to-target
                 ├── 🟣9e2a79e (✓)
                 ├── 🟣fdeaa43 (✓)
                 ├── 🟣30565ee (✓)
@@ -1872,7 +1930,7 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
                 ├── 🟣56d152c (✓)
                 ├── 🟣e6e1360 (✓)
                 └── 🟣1a22a39 (✓)
-                    └── →:4: (workspace)
+                    └── →:2: (workspace)
     ");
 
     // Everything is integrated, nothing to see here.
@@ -2056,29 +2114,29 @@ fn multi_lane_with_shared_segment_one_integrated() -> anyhow::Result<()> {
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 👉📕►►►:0:gitbutler/workspace
     │   └── ·2b30d94 (⌂|🏘️|1)
-    │       ├── ►:4:D
+    │       ├── ►:3:D
     │       │   └── ·9895054 (⌂|🏘️|1)
-    │       │       └── ►:7:C
+    │       │       └── ►:6:C
     │       │           ├── ·de625cc (⌂|🏘️|1)
     │       │           ├── ·23419f8 (⌂|🏘️|1)
     │       │           └── ·5dc4389 (⌂|🏘️|1)
-    │       │               └── ►:6:shared
+    │       │               └── ►:7:shared
     │       │                   ├── ·d4f537e (⌂|🏘️|✓|1)
     │       │                   ├── ·b448757 (⌂|🏘️|✓|1)
     │       │                   └── ·e9a378d (⌂|🏘️|✓|1)
     │       │                       └── ►:2:main <> origin/main →:1:
     │       │                           └── ·3183e43 (⌂|🏘️|✓|11)
-    │       ├── ►:3:A
+    │       ├── ►:4:A
     │       │   └── ·0bad3af (⌂|🏘️|✓|1)
-    │       │       └── →:6: (shared)
+    │       │       └── →:7: (shared)
     │       └── ►:5:B
     │           ├── ·acdc49a (⌂|🏘️|1)
     │           └── ·f0117e0 (⌂|🏘️|1)
-    │               └── →:6: (shared)
+    │               └── →:7: (shared)
     └── ►:1:origin/main →:2:
         └── 🟣c08dc6b (✓)
             ├── →:2: (main →:1:)
-            └── →:3: (A)
+            └── →:4: (A)
     ");
 
     // A is still shown despite it being fully integrated, as it's still enclosed by the
@@ -2089,18 +2147,18 @@ fn multi_lane_with_shared_segment_one_integrated() -> anyhow::Result<()> {
     │   ├── :5:B
     │   │   ├── ·acdc49a (🏘️)
     │   │   └── ·f0117e0 (🏘️)
-    │   └── :6:shared
+    │   └── :7:shared
     │       ├── ·d4f537e (🏘️|✓)
     │       ├── ·b448757 (🏘️|✓)
     │       └── ·e9a378d (🏘️|✓)
-    └── ≡:4:D on 3183e43
-        ├── :4:D
+    └── ≡:3:D on 3183e43
+        ├── :3:D
         │   └── ·9895054 (🏘️)
-        ├── :7:C
+        ├── :6:C
         │   ├── ·de625cc (🏘️)
         │   ├── ·23419f8 (🏘️)
         │   └── ·5dc4389 (🏘️)
-        └── :6:shared
+        └── :7:shared
             ├── ·d4f537e (🏘️|✓)
             ├── ·b448757 (🏘️|✓)
             └── ·e9a378d (🏘️|✓)
@@ -2137,7 +2195,7 @@ fn multi_lane_with_shared_segment() -> anyhow::Result<()> {
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 👉📕►►►:0:gitbutler/workspace
     │   └── ·2b30d94 (⌂|🏘️|1)
-    │       ├── ►:3:D
+    │       ├── ►:2:D
     │       │   └── ·9895054 (⌂|🏘️|1)
     │       │       └── ►:6:C
     │       │           ├── ·de625cc (⌂|🏘️|1)
@@ -2147,40 +2205,40 @@ fn multi_lane_with_shared_segment() -> anyhow::Result<()> {
     │       │                   ├── ·d4f537e (⌂|🏘️|1)
     │       │                   ├── ·b448757 (⌂|🏘️|1)
     │       │                   └── ·e9a378d (⌂|🏘️|1)
-    │       │                       └── ►:2:main
+    │       │                       └── ►:5:main
     │       │                           └── ·3183e43 (⌂|🏘️|✓|1)
-    │       ├── ►:4:A
+    │       ├── ►:3:A
     │       │   └── ·0bad3af (⌂|🏘️|1)
     │       │       └── →:7: (shared)
-    │       └── ►:5:B
+    │       └── ►:4:B
     │           ├── ·acdc49a (⌂|🏘️|1)
     │           └── ·f0117e0 (⌂|🏘️|1)
     │               └── →:7: (shared)
     └── ►:1:origin/main
         └── 🟣bce0c5e (✓)
-            └── →:2: (main)
+            └── →:5: (main)
     ");
 
     // Segments can definitely repeat
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1
-    ├── ≡:5:B on 3183e43
-    │   ├── :5:B
+    ├── ≡:4:B on 3183e43
+    │   ├── :4:B
     │   │   ├── ·acdc49a (🏘️)
     │   │   └── ·f0117e0 (🏘️)
     │   └── :7:shared
     │       ├── ·d4f537e (🏘️)
     │       ├── ·b448757 (🏘️)
     │       └── ·e9a378d (🏘️)
-    ├── ≡:4:A on 3183e43
-    │   ├── :4:A
+    ├── ≡:3:A on 3183e43
+    │   ├── :3:A
     │   │   └── ·0bad3af (🏘️)
     │   └── :7:shared
     │       ├── ·d4f537e (🏘️)
     │       ├── ·b448757 (🏘️)
     │       └── ·e9a378d (🏘️)
-    └── ≡:3:D on 3183e43
-        ├── :3:D
+    └── ≡:2:D on 3183e43
+        ├── :2:D
         │   └── ·9895054 (🏘️)
         ├── :6:C
         │   ├── ·de625cc (🏘️)
@@ -2202,14 +2260,14 @@ fn multi_lane_with_shared_segment() -> anyhow::Result<()> {
     │   ├── :5:B
     │   │   ├── ·acdc49a (🏘️)
     │   │   └── ·f0117e0 (🏘️)
-    │   └── :6:shared
+    │   └── :3:shared
     │       ├── ·d4f537e (🏘️)
     │       ├── ·b448757 (🏘️)
     │       └── ·e9a378d (🏘️)
     ├── ≡👉:0:A on 3183e43
     │   ├── 👉:0:A
     │   │   └── ·0bad3af (🏘️)
-    │   └── :6:shared
+    │   └── :3:shared
     │       ├── ·d4f537e (🏘️)
     │       ├── ·b448757 (🏘️)
     │       └── ·e9a378d (🏘️)
@@ -2220,7 +2278,7 @@ fn multi_lane_with_shared_segment() -> anyhow::Result<()> {
         │   ├── ·de625cc (🏘️)
         │   ├── ·23419f8 (🏘️)
         │   └── ·5dc4389 (🏘️)
-        └── :6:shared
+        └── :3:shared
             ├── ·d4f537e (🏘️)
             ├── ·b448757 (🏘️)
             └── ·e9a378d (🏘️)
@@ -2253,14 +2311,14 @@ fn dependent_branch_insertion() -> anyhow::Result<()> {
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 👉📕►►►:0:gitbutler/workspace
     │   └── ·335d6f2 (⌂|🏘️|1)
-    │       ├── ►:1:origin/main →:2:
-    │       │   └── ·fafd9d0 (⌂|🏘️|✓|111) ►lane, ►main
+    │       ├── ►:2:main <> origin/main →:1:
+    │       │   └── ·fafd9d0 (⌂|🏘️|✓|111) ►lane
     │       └── 📙►:5:dependant
     │           └── 📙►:6:advanced-lane <> origin/advanced-lane →:4:
     │               └── ·cbc6713 (⌂|🏘️|101)
-    │                   └── →:1: (origin/main →:2:)
-    ├── ►:2:main <> origin/main →:1:
-    │   └── →:1: (origin/main →:2:)
+    │                   └── →:2: (main →:1:)
+    ├── ►:1:origin/main →:2:
+    │   └── →:2: (main →:1:)
     └── ►:4:origin/advanced-lane →:6:
         └── →:5: (dependant)
     ");
@@ -2287,14 +2345,14 @@ fn dependent_branch_insertion() -> anyhow::Result<()> {
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 👉📕►►►:0:gitbutler/workspace
     │   └── ·335d6f2 (⌂|🏘️|1)
-    │       ├── ►:1:origin/main →:2:
-    │       │   └── ·fafd9d0 (⌂|🏘️|✓|111) ►lane, ►main
+    │       ├── ►:2:main <> origin/main →:1:
+    │       │   └── ·fafd9d0 (⌂|🏘️|✓|111) ►lane
     │       └── 📙►:5:advanced-lane <> origin/advanced-lane →:4:
     │           └── 📙►:6:dependant
     │               └── ·cbc6713 (⌂|🏘️|101)
-    │                   └── →:1: (origin/main →:2:)
-    ├── ►:2:main <> origin/main →:1:
-    │   └── →:1: (origin/main →:2:)
+    │                   └── →:2: (main →:1:)
+    ├── ►:1:origin/main →:2:
+    │   └── →:2: (main →:1:)
     └── ►:4:origin/advanced-lane →:5:
         └── →:5: (advanced-lane →:4:)
     ");
@@ -2350,13 +2408,13 @@ fn multiple_stacks_with_shared_parent_and_remote() -> anyhow::Result<()> {
     │       │   └── ·4f1bb32 (⌂|🏘️|1)
     │       │       └── ►:5:A <> origin/A →:6:
     │       │           └── ·e255adc (⌂|🏘️|101)
-    │       │               └── ►:1:origin/main →:2:
-    │       │                   └── ·fafd9d0 (⌂|🏘️|✓|111) ►main
+    │       │               └── ►:2:main <> origin/main →:1:
+    │       │                   └── ·fafd9d0 (⌂|🏘️|✓|111)
     │       └── ►:4:B-on-A
     │           └── ·aff8449 (⌂|🏘️|1)
     │               └── →:5: (A →:6:)
-    ├── ►:2:main <> origin/main →:1:
-    │   └── →:1: (origin/main →:2:)
+    ├── ►:1:origin/main →:2:
+    │   └── →:2: (main →:1:)
     └── ►:6:origin/A →:5:
         └── 🟣b627ca7
             └── →:5: (A →:6:)
@@ -2475,29 +2533,29 @@ fn two_dependent_branches_with_embedded_remote() -> anyhow::Result<()> {
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 👉📕►►►:0:gitbutler/workspace
     │   └── ·a221221 (⌂|🏘️|1)
-    │       └── 📙►:4:A <> origin/A →:5:
+    │       └── 📙►:3:A <> origin/A →:4:
     │           └── ·aadad9d (⌂|🏘️|101)
     │               └── ►:1:origin/main →:2:
     │                   └── ·96a2408 (⌂|🏘️|✓|101)
-    │                       └── ►:3:integrated
+    │                       └── ►:5:integrated
     │                           ├── ·f15ca75 (⌂|🏘️|✓|101)
     │                           └── ·9456d79 (⌂|🏘️|✓|101)
     │                               └── ►:2:main <> origin/main →:1:
     │                                   └── ·fafd9d0 (⌂|🏘️|✓|111)
-    └── ►:5:origin/A →:4:
+    └── ►:4:origin/A →:3:
         └── 🟣2b1808c
-            └── →:3: (integrated)
+            └── →:5: (integrated)
     ");
 
     // Remote tracking branches we just want to aggregate, just like anonymous segments.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
-    └── ≡📙:4:A <> origin/A →:5:⇡1⇣1 on fafd9d0
-        ├── 📙:4:A <> origin/A →:5:⇡1⇣1
+    └── ≡📙:3:A <> origin/A →:4:⇡1⇣1 on fafd9d0
+        ├── 📙:3:A <> origin/A →:4:⇡1⇣1
         │   ├── 🟣2b1808c
         │   ├── ·aadad9d (🏘️)
         │   └── ·96a2408 (🏘️|✓)
-        └── :3:integrated
+        └── :5:integrated
             ├── ❄f15ca75 (🏘️|✓)
             └── ❄9456d79 (🏘️|✓)
     ");

--- a/crates/but-testing/src/args.rs
+++ b/crates/but-testing/src/args.rs
@@ -156,6 +156,9 @@ pub enum Subcommands {
         /// Debug-print the whole graph.
         #[clap(long, short = 'd')]
         debug: bool,
+        /// The rev-spec of the extra target to provide for traversal.
+        #[clap(long)]
+        extra_target: Option<String>,
         /// Do not debug-print the workspace.
         ///
         /// If too large, it takes a long time or runs out of memory.

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -524,6 +524,7 @@ pub fn graph(
     no_open: bool,
     limit: Option<usize>,
     limit_extension: Vec<String>,
+    extra_target_spec: Option<&str>,
     hard_limit: Option<usize>,
     debug_graph: bool,
     no_debug_workspace: bool,
@@ -531,7 +532,12 @@ pub fn graph(
 ) -> anyhow::Result<()> {
     let (mut repo, project) = repo_and_maybe_project(args, RepositoryOpenMode::General)?;
     repo.objects.refresh = RefreshMode::Never;
+    let extra_target = extra_target_spec
+        .map(|rev_spec| repo.rev_parse_single(rev_spec))
+        .transpose()?
+        .map(|id| id.detach());
     let opts = but_graph::init::Options {
+        extra_target_commit_id: extra_target,
         collect_tags: true,
         hard_limit,
         commits_limit_hint: limit,

--- a/crates/but-testing/src/main.rs
+++ b/crates/but-testing/src/main.rs
@@ -117,6 +117,7 @@ async fn main() -> Result<()> {
             limit_extension,
             hard_limit,
             debug,
+            extra_target,
             no_debug_workspace,
             no_dot,
         } => command::graph(
@@ -125,6 +126,7 @@ async fn main() -> Result<()> {
             *no_open,
             limit.flatten(),
             limit_extension.clone(),
+            extra_target.as_deref(),
             *hard_limit,
             *debug,
             *no_debug_workspace,

--- a/crates/but-workspace/src/commit.rs
+++ b/crates/but-workspace/src/commit.rs
@@ -3,7 +3,6 @@ use bstr::ByteSlice;
 
 /// Construction
 impl<'repo> WorkspaceCommit<'repo> {
-    const GITBUTLER_INTEGRATION_COMMIT_TITLE: &'static str = "GitButler Integration Commit";
     const GITBUTLER_WORKSPACE_COMMIT_TITLE: &'static str = "GitButler Workspace Commit";
 
     /// Decode the object at `commit_id` and keep its data for later query.
@@ -93,10 +92,7 @@ impl WorkspaceCommit<'_> {
     /// If `false`, this is the tip of the stack itself which will be put underneath a *managed* workspace commit
     /// once another branch is added to the workspace.
     pub fn is_managed(&self) -> bool {
-        let message = gix::objs::commit::MessageRef::from_bytes(&self.message);
-        let title = message.title.trim().as_bstr();
-        title == Self::GITBUTLER_INTEGRATION_COMMIT_TITLE
-            || title == Self::GITBUTLER_WORKSPACE_COMMIT_TITLE
+        but_graph::projection::commit::is_managed_workspace_by_message(self.message.as_bstr())
     }
 }
 

--- a/crates/but-workspace/src/stacks.rs
+++ b/crates/but-workspace/src/stacks.rs
@@ -174,6 +174,7 @@ pub fn stacks_v3(
         Ok(out)
     }
 
+    let extra_target = meta.data().default_target.as_ref().map(|t| t.sha.to_gix());
     let info = head_info2(
         repo,
         meta,
@@ -186,6 +187,7 @@ pub fn stacks_v3(
                 commits_limit_hint: Some(300),
                 commits_limit_recharge_location: vec![],
                 hard_limit: None,
+                extra_target_commit_id: extra_target,
             },
         },
     )?;
@@ -401,6 +403,7 @@ pub fn stack_details_v3(
             commits_limit_hint: Some(300),
             commits_limit_recharge_location: vec![],
             hard_limit: None,
+            extra_target_commit_id: meta.data().default_target.as_ref().map(|t| t.sha.to_gix()),
         },
     };
     let stack = meta.data().branches.get(&stack_id).with_context(|| {

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -1702,6 +1702,8 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
     let opts = standard_options();
     let info = head_info2(&repo, &*meta, opts.clone())?;
     // It's fine to have no managed commit, but we have to deal with it - see flag is_managed.
+    // TODO: shouldn't have 'main' as stack segment, but it's a strange workspace segment to start with.
+    //       Can't really say it's invalid though, just have to deal with it.
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
         workspace_ref_name: Some(
@@ -1709,30 +1711,7 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
                 "refs/heads/gitbutler/workspace",
             ),
         ),
-        stacks: [
-            Stack {
-                base: Some(
-                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
-                ),
-                segments: [
-                    ref_info::ui::Segment {
-                        id: 3,
-                        ref_name: "refs/heads/advanced-lane",
-                        remote_tracking_ref_name: "None",
-                        commits: [
-                            LocalCommit(cbc6713, "change\n", local),
-                        ],
-                        commits_unique_in_remote_tracking_branch: [],
-                        metadata: Branch {
-                            ref_info: RefInfo { created_at: None, updated_at: "1970-01-01 00:00:00 +0000" },
-                            description: None,
-                            review: Review { pull_request: None, review_id: None },
-                        },
-                    },
-                ],
-                stash_status: None,
-            },
-        ],
+        stacks: [],
         target_ref: Some(
             FullName(
                 "refs/remotes/origin/main",
@@ -2308,7 +2287,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                         },
                     },
                     ref_info::ui::Segment {
-                        id: 5,
+                        id: 4,
                         ref_name: "refs/heads/A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
@@ -2328,7 +2307,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                 ),
                 segments: [
                     ref_info::ui::Segment {
-                        id: 4,
+                        id: 6,
                         ref_name: "refs/heads/B-on-A",
                         remote_tracking_ref_name: "None",
                         commits: [
@@ -2338,7 +2317,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                         metadata: "None",
                     },
                     ref_info::ui::Segment {
-                        id: 5,
+                        id: 4,
                         ref_name: "refs/heads/A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
@@ -2381,7 +2360,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                 ),
                 segments: [
                     ref_info::ui::Segment {
-                        id: 4,
+                        id: 6,
                         ref_name: "refs/heads/C-on-A",
                         remote_tracking_ref_name: "None",
                         commits: [
@@ -2395,7 +2374,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                         },
                     },
                     ref_info::ui::Segment {
-                        id: 5,
+                        id: 4,
                         ref_name: "refs/heads/A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
@@ -2425,7 +2404,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                         metadata: "None",
                     },
                     ref_info::ui::Segment {
-                        id: 5,
+                        id: 4,
                         ref_name: "refs/heads/A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -1,7 +1,32 @@
 use bstr::ByteSlice;
 use but_testsupport::{visualize_commit_graph, visualize_commit_graph_all};
-use but_workspace::{head_info, head_info2, ref_info, ref_info2};
+use but_workspace::{RefInfo, head_info, ref_info};
+use gitbutler_oxidize::OidExt;
 use gitbutler_stack::StackId;
+
+pub fn head_info2(
+    repo: &gix::Repository,
+    meta: &but_graph::VirtualBranchesTomlMetadata,
+    mut opts: but_workspace::ref_info::Options,
+) -> anyhow::Result<RefInfo> {
+    if opts.traversal.extra_target_commit_id.is_none() {
+        opts.traversal.extra_target_commit_id =
+            meta.data().default_target.as_ref().map(|t| t.sha.to_gix());
+    }
+    but_workspace::head_info2(repo, meta, opts)
+}
+
+pub fn ref_info2(
+    existing_ref: gix::Reference<'_>,
+    meta: &but_graph::VirtualBranchesTomlMetadata,
+    mut opts: but_workspace::ref_info::Options,
+) -> anyhow::Result<RefInfo> {
+    if opts.traversal.extra_target_commit_id.is_none() {
+        opts.traversal.extra_target_commit_id =
+            meta.data().default_target.as_ref().map(|t| t.sha.to_gix());
+    }
+    but_workspace::ref_info2(existing_ref, meta, opts)
+}
 
 #[test]
 fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
@@ -23,7 +48,7 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
     );
     // We can look at a workspace ref directly (via HEAD)
     let opts = standard_options();
-    let info = head_info2(&repo, &*meta, opts.clone())?;
+    let info = head_info2(&repo, &meta, opts.clone())?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
         workspace_ref_name: Some(
@@ -69,7 +94,7 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
     "#);
 
     let at = repo.find_reference("refs/heads/A")?;
-    let info = ref_info2(at, &*meta, opts.clone())?;
+    let info = ref_info2(at, &meta, opts.clone())?;
     // Information doesn't change just because the starting point is different.
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
@@ -121,7 +146,7 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
         .remove_section("branch", info.stacks[0].name().unwrap().shorten().as_bstr());
 
     let at = repo.find_reference("refs/heads/A")?;
-    let info = ref_info2(at, &*meta, opts)?;
+    let info = ref_info2(at, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
         workspace_ref_name: Some(
@@ -191,7 +216,7 @@ fn two_dependent_branches_rebased_with_remotes() -> anyhow::Result<()> {
     );
 
     let opts = standard_options();
-    let info = head_info2(&repo, &*meta, opts)?;
+    let info = head_info2(&repo, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
         workspace_ref_name: Some(
@@ -277,7 +302,7 @@ fn two_dependent_branches_rebased_explicit_remote_in_extra_segment() -> anyhow::
     );
 
     let opts = standard_options();
-    let info = head_info2(&repo, &*meta, opts)?;
+    let info = head_info2(&repo, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
         workspace_ref_name: Some(
@@ -548,7 +573,7 @@ fn two_dependent_branches_first_rebased_and_merged_into_target() -> anyhow::Resu
     add_workspace(&mut meta);
 
     let opts = standard_options();
-    let info = head_info2(&repo, &*meta, opts)?;
+    let info = head_info2(&repo, &meta, opts)?;
     // TODO: need to detect that A is integrated.
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
@@ -628,7 +653,7 @@ fn target_ahead_remote_rewritten() -> anyhow::Result<()> {
         StackState::InWorkspace,
     );
     let opts = standard_options();
-    let info = ref_info2(repo.find_reference("A")?, &*meta, opts)?;
+    let info = ref_info2(repo.find_reference("A")?, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
         workspace_ref_name: Some(
@@ -1169,7 +1194,7 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit() -> anyhow::Result<(
     // For complexity, we also don't set up any branch metadata, only 'something' to get the target ref.
     add_workspace(&mut meta);
     let opts = standard_options();
-    let info = head_info2(&repo, &*meta, opts)?;
+    let info = head_info2(&repo, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
         workspace_ref_name: Some(
@@ -1232,7 +1257,7 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit_empty_dependant() -> 
     );
 
     let opts = standard_options();
-    let info = head_info2(&repo, &*meta, opts.clone())?;
+    let info = head_info2(&repo, &meta, opts.clone())?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
         workspace_ref_name: Some(
@@ -1298,7 +1323,7 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit_empty_dependant() -> 
 
     // Even though we *could* special-case this to keep the commit in the branch that has a remote,
     // we just keep it below at all times. The frontend currently only creates them on top, for good reason.
-    let info = head_info2(&repo, &*meta, opts)?;
+    let info = head_info2(&repo, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
         workspace_ref_name: Some(
@@ -1375,7 +1400,7 @@ fn single_commit_pushed_ws_commit_empty_dependant() -> anyhow::Result<()> {
     );
 
     let opts = standard_options();
-    let info = head_info2(&repo, &*meta, opts.clone())?;
+    let info = head_info2(&repo, &meta, opts.clone())?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
         workspace_ref_name: Some(
@@ -1451,7 +1476,7 @@ fn single_commit_pushed_ws_commit_empty_dependant() -> anyhow::Result<()> {
         &["on-top-of-dependant", "advanced-lane"],
     );
 
-    let info = head_info2(&repo, &*meta, opts.clone())?;
+    let info = head_info2(&repo, &meta, opts.clone())?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
         workspace_ref_name: Some(
@@ -1540,7 +1565,7 @@ fn two_branches_stacked_with_remotes() -> anyhow::Result<()> {
     );
 
     let opts = standard_options();
-    let info = head_info2(&repo, &*meta, opts)?;
+    let info = head_info2(&repo, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
         workspace_ref_name: Some(
@@ -1623,7 +1648,7 @@ fn two_branches_stacked_with_interesting_remote_setup() -> anyhow::Result<()> {
     );
 
     let opts = standard_options();
-    let info = ref_info2(repo.find_reference("A")?, &*meta, opts).unwrap();
+    let info = ref_info2(repo.find_reference("A")?, &meta, opts).unwrap();
 
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
@@ -1700,7 +1725,7 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
     }
 
     let opts = standard_options();
-    let info = head_info2(&repo, &*meta, opts.clone())?;
+    let info = head_info2(&repo, &meta, opts.clone())?;
     // It's fine to have no managed commit, but we have to deal with it - see flag is_managed.
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
@@ -1760,7 +1785,7 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
     }
     "#);
 
-    let info = ref_info2(repo.find_reference("advanced-lane")?, &*meta, opts).unwrap();
+    let info = ref_info2(repo.find_reference("advanced-lane")?, &meta, opts).unwrap();
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
         workspace_ref_name: Some(
@@ -1851,7 +1876,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
     }
 
     let opts = standard_options();
-    let info = head_info2(&repo, &*meta, opts.clone())?;
+    let info = head_info2(&repo, &meta, opts.clone())?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
         workspace_ref_name: Some(
@@ -1866,12 +1891,10 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 ),
                 segments: [
                     ref_info::ui::Segment {
-                        id: 3,
+                        id: 4,
                         ref_name: "refs/heads/lane",
                         remote_tracking_ref_name: "None",
-                        commits: [
-                            LocalCommit(fafd9d0, "init\n", local, ►main),
-                        ],
+                        commits: [],
                         commits_unique_in_remote_tracking_branch: [],
                         metadata: Branch {
                             ref_info: RefInfo { created_at: None, updated_at: "1970-01-01 00:00:00 +0000" },
@@ -1888,7 +1911,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 ),
                 segments: [
                     ref_info::ui::Segment {
-                        id: 2,
+                        id: 3,
                         ref_name: "refs/heads/advanced-lane",
                         remote_tracking_ref_name: "None",
                         commits: [
@@ -1917,7 +1940,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
     "#);
 
     // Everything is show so the workspace stays clear, the entrypoint says what to focus on.
-    let info = ref_info2(repo.find_reference("advanced-lane")?, &*meta, opts.clone())?;
+    let info = ref_info2(repo.find_reference("advanced-lane")?, &meta, opts.clone())?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
         workspace_ref_name: Some(
@@ -1932,12 +1955,10 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 ),
                 segments: [
                     ref_info::ui::Segment {
-                        id: 3,
+                        id: 4,
                         ref_name: "refs/heads/lane",
                         remote_tracking_ref_name: "None",
-                        commits: [
-                            LocalCommit(fafd9d0, "init\n", local, ►main),
-                        ],
+                        commits: [],
                         commits_unique_in_remote_tracking_branch: [],
                         metadata: Branch {
                             ref_info: RefInfo { created_at: None, updated_at: "1970-01-01 00:00:00 +0000" },
@@ -1982,7 +2003,8 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
     }
     "#);
 
-    let info = ref_info2(repo.find_reference("lane")?, &*meta, opts.clone())?;
+    let info = ref_info2(repo.find_reference("lane")?, &meta, opts.clone())?;
+    // TODO: test for entrypoint movement to newly proxied segments
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
         workspace_ref_name: Some(
@@ -1996,13 +2018,11 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
                 segments: [
-                    👉ref_info::ui::Segment {
-                        id: 0,
+                    ref_info::ui::Segment {
+                        id: 4,
                         ref_name: "refs/heads/lane",
                         remote_tracking_ref_name: "None",
-                        commits: [
-                            LocalCommit(fafd9d0, "init\n", local, ►main),
-                        ],
+                        commits: [],
                         commits_unique_in_remote_tracking_branch: [],
                         metadata: Branch {
                             ref_info: RefInfo { created_at: None, updated_at: "1970-01-01 00:00:00 +0000" },
@@ -2031,6 +2051,24 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                             description: None,
                             review: Review { pull_request: None, review_id: None },
                         },
+                    },
+                ],
+                stash_status: None,
+            },
+            Stack {
+                base: Some(
+                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                ),
+                segments: [
+                    👉ref_info::ui::Segment {
+                        id: 0,
+                        ref_name: "None",
+                        remote_tracking_ref_name: "None",
+                        commits: [
+                            LocalCommit(fafd9d0, "init\n", local, ►main),
+                        ],
+                        commits_unique_in_remote_tracking_branch: [],
+                        metadata: "None",
                     },
                 ],
                 stash_status: None,
@@ -2058,7 +2096,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
         );
     }
 
-    let info = head_info2(&repo, &*meta, opts)?;
+    let info = head_info2(&repo, &meta, opts)?;
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
         workspace_ref_name: Some(
@@ -2073,7 +2111,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 ),
                 segments: [
                     ref_info::ui::Segment {
-                        id: 2,
+                        id: 3,
                         ref_name: "refs/heads/advanced-lane",
                         remote_tracking_ref_name: "None",
                         commits: [
@@ -2095,12 +2133,10 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 ),
                 segments: [
                     ref_info::ui::Segment {
-                        id: 3,
+                        id: 4,
                         ref_name: "refs/heads/lane",
                         remote_tracking_ref_name: "None",
-                        commits: [
-                            LocalCommit(fafd9d0, "init\n", local, ►main),
-                        ],
+                        commits: [],
                         commits_unique_in_remote_tracking_branch: [],
                         metadata: Branch {
                             ref_info: RefInfo { created_at: None, updated_at: "1970-01-01 00:00:00 +0000" },
@@ -2141,7 +2177,7 @@ fn disjoint() -> anyhow::Result<()> {
     );
 
     let opts = standard_options();
-    let info = head_info2(&repo, &*meta, opts)?;
+    let info = head_info2(&repo, &meta, opts)?;
 
     // We see the commit in the branch as there is no base to hide it.
     insta::assert_debug_snapshot!(info, @r#"
@@ -2205,7 +2241,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
     );
 
     let opts = standard_options();
-    let info = head_info2(&repo, &*meta, opts.clone())?;
+    let info = head_info2(&repo, &meta, opts.clone())?;
 
     // The shared "A" segment is used in both stacks, as it's reachable from both.
     insta::assert_debug_snapshot!(info, @r#"
@@ -2292,7 +2328,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
     }
     "#);
 
-    let info = ref_info2(repo.find_reference("C-on-A")?, &*meta, opts.clone())?;
+    let info = ref_info2(repo.find_reference("C-on-A")?, &meta, opts.clone())?;
 
     // A partial workspace is provided, but the entire workspace is known.
     insta::assert_debug_snapshot!(info, @r#"
@@ -2379,7 +2415,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
     }
     "#);
 
-    let b_info = ref_info2(repo.find_reference("B-on-A")?, &*meta, opts.clone())?;
+    let b_info = ref_info2(repo.find_reference("B-on-A")?, &meta, opts.clone())?;
 
     // It's like the stack is part of the workspace, the result is the same, with entrypoints changed.
     insta::assert_debug_snapshot!(b_info, @r#"
@@ -2466,7 +2502,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
     }
     "#);
 
-    let a_info = ref_info2(repo.find_reference("A")?, &*meta, opts)?;
+    let a_info = ref_info2(repo.find_reference("A")?, &meta, opts)?;
 
     // We can also show segments that are part of the stack (like homing in on them), as long as they are in a workspace.
     // It's notable how there are two entrypoints, so the UI has to assure both are visible.
@@ -2624,7 +2660,7 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
         StackState::Inactive,
     );
 
-    let info = head_info2(&repo, &*meta, opts.clone())?;
+    let info = head_info2(&repo, &meta, opts.clone())?;
     // Now there should be no stack, it's an empty workspace.
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
@@ -2696,6 +2732,7 @@ mod legacy;
 mod utils {
     use crate::ref_info::utils::named_read_only_in_memory_scenario;
     use but_graph::VirtualBranchesTomlMetadata;
+    use gitbutler_oxidize::ObjectIdExt;
     use gitbutler_stack::StackId;
 
     pub fn read_only_in_memory_scenario(
@@ -2712,7 +2749,10 @@ mod utils {
             branch: gitbutler_reference::RemoteRefname::new("origin", "main"),
             // Not required
             remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
-            sha: git2::Oid::zero(),
+            sha: repo
+                .find_reference("main")?
+                .peel_to_id_in_place()?
+                .to_git2(),
             push_remote_name: None,
         });
         Ok((repo, meta))

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -2004,7 +2004,6 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
     "#);
 
     let info = ref_info2(repo.find_reference("lane")?, &meta, opts.clone())?;
-    // TODO: test for entrypoint movement to newly proxied segments
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
         workspace_ref_name: Some(
@@ -2018,7 +2017,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
                 segments: [
-                    ref_info::ui::Segment {
+                    👉ref_info::ui::Segment {
                         id: 4,
                         ref_name: "refs/heads/lane",
                         remote_tracking_ref_name: "None",
@@ -2060,7 +2059,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
                 segments: [
-                    👉ref_info::ui::Segment {
+                    ref_info::ui::Segment {
                         id: 0,
                         ref_name: "None",
                         remote_tracking_ref_name: "None",

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -1702,29 +1702,6 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
     let opts = standard_options();
     let info = head_info2(&repo, &*meta, opts.clone())?;
     // It's fine to have no managed commit, but we have to deal with it - see flag is_managed.
-    // TODO: shouldn't have 'main' as stack segment, but it's a strange workspace segment to start with.
-    //       Can't really say it's invalid though, just have to deal with it.
-    insta::assert_debug_snapshot!(info, @r#"
-    RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
-        ),
-        stacks: [],
-        target_ref: Some(
-            FullName(
-                "refs/remotes/origin/main",
-            ),
-        ),
-        is_managed_ref: true,
-        is_managed_commit: false,
-        is_entrypoint: true,
-    }
-    "#);
-
-    // TODO(ref_info2): virtual lane should still be present even if entrypoint is changed. After all, it's still in the workspace.
-    let info = ref_info(repo.find_reference("advanced-lane")?, &*meta, opts).unwrap();
     insta::assert_debug_snapshot!(info, @r#"
     RefInfo {
         workspace_ref_name: Some(
@@ -1739,6 +1716,65 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
                 ),
                 segments: [
                     ref_info::ui::Segment {
+                        id: 3,
+                        ref_name: "refs/heads/advanced-lane",
+                        remote_tracking_ref_name: "None",
+                        commits: [
+                            LocalCommit(cbc6713, "change\n", local),
+                        ],
+                        commits_unique_in_remote_tracking_branch: [],
+                        metadata: "None",
+                    },
+                ],
+                stash_status: None,
+            },
+            Stack {
+                base: Some(
+                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                ),
+                segments: [
+                    ref_info::ui::Segment {
+                        id: 4,
+                        ref_name: "refs/heads/lane",
+                        remote_tracking_ref_name: "None",
+                        commits: [],
+                        commits_unique_in_remote_tracking_branch: [],
+                        metadata: Branch {
+                            ref_info: RefInfo { created_at: None, updated_at: "1970-01-01 00:00:00 +0000" },
+                            description: None,
+                            review: Review { pull_request: None, review_id: None },
+                        },
+                    },
+                ],
+                stash_status: None,
+            },
+        ],
+        target_ref: Some(
+            FullName(
+                "refs/remotes/origin/main",
+            ),
+        ),
+        is_managed_ref: true,
+        is_managed_commit: false,
+        is_entrypoint: true,
+    }
+    "#);
+
+    let info = ref_info2(repo.find_reference("advanced-lane")?, &*meta, opts).unwrap();
+    insta::assert_debug_snapshot!(info, @r#"
+    RefInfo {
+        workspace_ref_name: Some(
+            FullName(
+                "refs/heads/gitbutler/workspace",
+            ),
+        ),
+        stacks: [
+            Stack {
+                base: Some(
+                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                ),
+                segments: [
+                    👉ref_info::ui::Segment {
                         id: 0,
                         ref_name: "refs/heads/advanced-lane",
                         remote_tracking_ref_name: "None",
@@ -1761,7 +1797,7 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
                 ),
                 segments: [
                     ref_info::ui::Segment {
-                        id: 0,
+                        id: 4,
                         ref_name: "refs/heads/lane",
                         remote_tracking_ref_name: "None",
                         commits: [],


### PR DESCRIPTION
Bring the new Graph based backend for workspaces to conformity with the existing implementation - it shouldn't be worse, but ideally can be the daily driver for `ws3` users.


### Tasks

- [x] improve 'everything is on one commit' situation (`just_init_with_branches`) as basis for more graph manipulation
- [x] rethink workspace upgrades as part of traversal - can it be done with a first version of the workspace as guidance?
    - That way it would only have to consider segments in the workspace and can process them in order.
- [x] split across stacks (those that are resting at the target ref (or maybe the merge base?)) - see `single_stack` 
    - We must be able to split out stacks of empty commits resting at the base, that is segments that will be mapped into stacks later. For that we connect them to the governing workspace.
        - Turns out this base is most reliably the merge-base between all branches in the workspace
        -  Effectively implemented as creating a stack on top of a commit, without stealing it.
             - have a test that creates multiple empty stacks from the same spot.
- [x] merge-base improvements
    - [x] integrate extra targets into Graph and auto-use them in `to_workspace()`
    - [x] review ref-info merge-base computation and integrate 'sha' from virtual-branches toml for backwards compatibility (only) - in future it's always computed and dynamic.
    - [x] fix entrypoint segment after workspace upgrades (needs test in graph)
    - [x] last fixes
- [ ] dynamic search for bases to put stacks on top of?
- [ ] check remaining tests and TODOs
    - [ ] switch over rest of ref-info tests
    - [ ] remove unused ref-info code
- [ ] ~~'archived' out-of-workspace refs are forcefully added (and marked) accordingly~~ - archived segments can still be used for reconcilation if they are reachable, it's really about the frontend having this data even after a workspace update
- [ ] in-workspace segments with all-integrated-by-similarity (remote rebased + merged) stay visible (`two_dependent_branches_first_rebased_and_merged_into_target`)
- [x] Validate that using the local tracking branch of target to compute the merge-base is the right choice
     - It is not the right thing, but allowing additional targets is the way to go here also to support the 'sha' field while it exists.
- [ ] REVIEW if local tracking branches of targets should be traversed.
- [ ] ⚠️ fix related TODOs and known issues
- [x] ⚠️assure parent-order is correct during traversal (must match parents in merge commits)
- [ ] delete now unused code

### Not to forget

* There might be an issue with the way it uses searches - a tip with a search might be blocked at an existing commit, discovered by a tip with a different search, and even though the thing it searches is reachable through that, it stops looking.
* ‼️if branches in the workspace are advanced outside of the workspace, it currently doesn't see these commits and the branch looses its name in the workspace. The traversal really should try to add the known tips explicitly for traversal and expose that information.
* ‼️Have tests and assure that the workspace commit (managed) doesn't ever get owned by an unmanaged workspace segment.
* ⚠️ the amount of commits of remotes ahead of their local branch doesn't seem to always match git (particularly when it's a lot of them)
* ⚠️handle the `archived` flag
* ⚠️ current implementation supports multiple workspaces *in theory*, but it's not tested with them as the underlying ref-metadata is still VB-toml. So before supporting this, we probably already want to have migrated away from vb.toml, to then port the ref-metadata to something that can support more workspaces (also for testing).
* ⚠️ we probably don't correctly handle workspaces that include other workspaces.
* ⚠️ we probably don't handle [dot-repositories](https://git-scm.com/docs/git-config#Documentation/git-config.txt-branchltnamegtmerge) correctly, by merit of not really having them in mind. At least they shouldn't be in the way of handling normal remotes.

### Related

* #8905

### Previous

* #8919
* #8935
* #9096
* #9122
* #9209

