### PR TITLE
Give default width to panel 1 in stack view

### DIFF
--- a/apps/desktop/src/components/v3/StackView.svelte
+++ b/apps/desktop/src/components/v3/StackView.svelte
@@ -437,6 +437,7 @@
 				direction="right"
 				minWidth={16}
 				maxWidth={64}
+				defaultValue={23}
 				syncName="panel1"
 				imitateBorder
 			/>


### PR DESCRIPTION
Prevents changing width as visible diff line lengths vary.