### PR TITLE
Extract Mutex class to utils/mutex.ts and update feed.ts

### DIFF
--- a/apps/desktop/src/lib/utils/mutex.ts
+++ b/apps/desktop/src/lib/utils/mutex.ts
@@ -1,0 +1,16 @@
+export default class Mutex {
+	private mutex = Promise.resolve();
+
+	async lock<T>(fn: () => Promise<T>): Promise<T> {
+		let release: () => void;
+		const wait = new Promise<void>((res) => (release = res));
+		const prev = this.mutex;
+		this.mutex = prev.then(async () => await wait);
+		await prev;
+		try {
+			return await fn();
+		} finally {
+			release!();
+		}
+	}
+}


### PR DESCRIPTION
- Extracted the Mutex class from feed.ts and created a new module at utils/mutex.ts for improved code modularity and reuse.
- Updated feed.ts to import the Mutex class from the new location instead of defining it inline.