### PR TITLE
Simplify rtkq back end queries

### DIFF
--- a/apps/desktop/cypress/e2e/commitActions.cy.ts
+++ b/apps/desktop/cypress/e2e/commitActions.cy.ts
@@ -83,7 +83,7 @@ describe('Commit Actions', () => {
 		cy.get('@updateCommitMessageSpy').should('be.calledWith', {
 			projectId: PROJECT_ID,
 			stackId: mockBackend.stackId,
-			commitOid: mockBackend.commitOid,
+			commitId: mockBackend.commitId,
 			message: `${newCommitMessageTitle}\n\n${newCommitMessageBody}`
 		});
 
@@ -140,7 +140,7 @@ describe('Commit Actions', () => {
 		cy.get('@updateCommitMessageSpy').should('be.calledWith', {
 			projectId: PROJECT_ID,
 			stackId: mockBackend.stackId,
-			commitOid: mockBackend.commitOid,
+			commitId: mockBackend.commitId,
 			message: `${originalCommitMessage}\n\n${newCommitDescription}`
 		});
 
@@ -195,7 +195,7 @@ describe('Commit Actions', () => {
 		cy.get('@updateCommitMessageSpy').should('be.calledWith', {
 			projectId: PROJECT_ID,
 			stackId: mockBackend.stackId,
-			commitOid: mockBackend.commitOid,
+			commitId: mockBackend.commitId,
 			message: newCommitTitle
 		});
 
@@ -242,7 +242,7 @@ describe('Commit Actions', () => {
 		cy.get('@updateCommitMessageSpy').should('be.calledWith', {
 			projectId: PROJECT_ID,
 			stackId: mockBackend.stackId,
-			commitOid: mockBackend.commitOid,
+			commitId: mockBackend.commitId,
 			message: originalCommitMessage
 		});
 
@@ -306,7 +306,7 @@ describe('Commit Actions', () => {
 		cy.get('@updateCommitMessageSpy').should('be.calledWith', {
 			projectId: PROJECT_ID,
 			stackId: mockBackend.stackId,
-			commitOid: mockBackend.commitOid,
+			commitId: mockBackend.commitId,
 			message: `${newCommitMessageTitle}\n\n${newCommitMessageBody}`
 		});
 

--- a/apps/desktop/cypress/e2e/support/mock/backend.ts
+++ b/apps/desktop/cypress/e2e/support/mock/backend.ts
@@ -74,7 +74,7 @@ export default class MockBackend {
 
 	stackId: string = MOCK_STACK_A_ID;
 	renamedCommitId: string = '424242424242';
-	commitOid: string = MOCK_COMMIT.id;
+	commitId: string = MOCK_COMMIT.id;
 	cannedBranchName = MOCK_BRAND_NEW_BRANCH_NAME;
 	branchListing: BranchListing;
 
@@ -157,7 +157,7 @@ export default class MockBackend {
 		if (!args || !isUpdateCommitMessageParams(args)) {
 			throw new Error('Invalid arguments for renameCommit');
 		}
-		const { stackId, commitOid, message } = args;
+		const { stackId, commitId, message } = args;
 
 		const stackDetails = this.stackDetails.get(stackId);
 		if (!stackDetails) {
@@ -167,7 +167,7 @@ export default class MockBackend {
 		const editableDetails = structuredClone(stackDetails);
 
 		for (const branch of editableDetails.branchDetails) {
-			const commitIndex = branch.commits.findIndex((commit) => commit.id === commitOid);
+			const commitIndex = branch.commits.findIndex((commit) => commit.id === commitId);
 			if (commitIndex === -1) continue;
 			const commit = branch.commits[commitIndex]!;
 			const newId = this.renamedCommitId + message;
@@ -181,7 +181,7 @@ export default class MockBackend {
 			return newId;
 		}
 
-		throw new Error(`Commit with ID ${commitOid} not found`);
+		throw new Error(`Commit with ID ${commitId} not found`);
 	}
 
 	public getWorktreeChanges(args: InvokeArgs | undefined): WorktreeChanges {
@@ -383,7 +383,7 @@ export default class MockBackend {
 			throw new Error('Invalid arguments for getCommitChanges');
 		}
 
-		const { stackId, commitOid } = args;
+		const { stackId, commitId } = args;
 
 		const stackDetails = this.stackDetails.get(stackId);
 		if (!stackDetails) {
@@ -393,16 +393,16 @@ export default class MockBackend {
 		const editableDetails = structuredClone(stackDetails);
 
 		for (const branch of editableDetails.branchDetails) {
-			const commitToUndo = branch.commits.find((commit) => commit.id === commitOid);
+			const commitToUndo = branch.commits.find((commit) => commit.id === commitId);
 			if (!commitToUndo) continue;
 
-			branch.commits = branch.commits.filter((commit) => commit.id !== commitOid);
+			branch.commits = branch.commits.filter((commit) => commit.id !== commitId);
 			this.stackDetails.set(stackId, editableDetails);
 			// TODO: update the worktree changes
 			return;
 		}
 
-		throw new Error(`Commit with ID ${commitOid} not found`);
+		throw new Error(`Commit with ID ${commitId} not found`);
 	}
 
 	public getBaseBranchData() {

--- a/apps/desktop/cypress/e2e/support/mock/changes.ts
+++ b/apps/desktop/cypress/e2e/support/mock/changes.ts
@@ -168,7 +168,7 @@ export function isGetBranchChangesParams(args: unknown): args is GetBranchChange
 export type UndoCommitParams = {
 	projectId: string;
 	stackId: string;
-	commitOid: string;
+	commitId: string;
 };
 
 export function isUndoCommitParams(args: unknown): args is UndoCommitParams {
@@ -177,8 +177,8 @@ export function isUndoCommitParams(args: unknown): args is UndoCommitParams {
 		args !== null &&
 		'projectId' in args &&
 		typeof args['projectId'] === 'string' &&
-		'commitOid' in args &&
-		typeof args['commitOid'] === 'string' &&
+		'commitId' in args &&
+		typeof args['commitId'] === 'string' &&
 		'stackId' in args &&
 		typeof args['stackId'] === 'string'
 	);

--- a/apps/desktop/cypress/e2e/support/mock/stacks.ts
+++ b/apps/desktop/cypress/e2e/support/mock/stacks.ts
@@ -150,7 +150,7 @@ export function createMockStackDetails(overrides: Partial<StackDetails> = {}): S
 export type UpdateCommitMessageParams = {
 	projectId: string;
 	stackId: string;
-	commitOid: string;
+	commitId: string;
 	message: string;
 };
 
@@ -162,8 +162,8 @@ export function isUpdateCommitMessageParams(params: unknown): params is UpdateCo
 		typeof params.projectId === 'string' &&
 		'stackId' in params &&
 		typeof params.stackId === 'string' &&
-		'commitOid' in params &&
-		typeof params.commitOid === 'string' &&
+		'commitId' in params &&
+		typeof params.commitId === 'string' &&
 		'message' in params &&
 		typeof params.message === 'string'
 	);

--- a/apps/desktop/src/components/CommitCard.svelte
+++ b/apps/desktop/src/components/CommitCard.svelte
@@ -151,7 +151,7 @@
 		await updateCommitMessage({
 			projectId: project.id,
 			stackId: stack.id,
-			commitId: commit.id,
+			commitOid: commit.id,
 			message: description
 		});
 

--- a/apps/desktop/src/components/CommitCard.svelte
+++ b/apps/desktop/src/components/CommitCard.svelte
@@ -151,7 +151,7 @@
 		await updateCommitMessage({
 			projectId: project.id,
 			stackId: stack.id,
-			commitOid: commit.id,
+			commitId: commit.id,
 			message: description
 		});
 

--- a/apps/desktop/src/components/CommitContextMenu.svelte
+++ b/apps/desktop/src/components/CommitContextMenu.svelte
@@ -53,7 +53,7 @@
 		await insertBlankCommitMutation({
 			projectId: project.id,
 			stackId: branch.id,
-			commitOid: commitId,
+			commitId: commitId,
 			offset: location === 'above' ? -1 : 1
 		});
 	}

--- a/apps/desktop/src/components/EditMode.svelte
+++ b/apps/desktop/src/components/EditMode.svelte
@@ -54,7 +54,7 @@
 	let commit = $state<Commit>();
 
 	async function getCommitData() {
-		commit = await remoteCommitService.find(project.id, editModeMetadata.commitOid);
+		commit = await remoteCommitService.find(project.id, editModeMetadata.commitId);
 	}
 
 	$effect(() => {
@@ -238,7 +238,7 @@
 	<div class="editmode__container">
 		<h2 class="editmode__title text-18 text-body text-bold">
 			You are editing commit <span class="code-string">
-				{editModeMetadata.commitOid.slice(0, 7)}
+				{editModeMetadata.commitId.slice(0, 7)}
 			</span>
 			<InfoButton title="Edit Mode">
 				Edit Mode lets you modify an existing commit in isolation or resolve conflicts. Any changes
@@ -258,7 +258,7 @@
 							<Avatar srcUrl={authorImgUrl} tooltip={commit.author.email} />
 							<span class="commit-card__divider">•</span>
 						{/if}
-						<span class="">{editModeMetadata.commitOid.slice(0, 7)}</span>
+						<span class="">{editModeMetadata.commitId.slice(0, 7)}</span>
 						<span class="commit-card__divider">•</span>
 						<span class="">{commit.author.name}</span>
 					</div>

--- a/apps/desktop/src/components/SeriesHeaderContextMenuContents.svelte
+++ b/apps/desktop/src/components/SeriesHeaderContextMenuContents.svelte
@@ -112,7 +112,7 @@
 			await insertBlankCommitInBranch({
 				projectId,
 				stackId,
-				commitOid: undefined,
+				commitId: undefined,
 				offset: -1
 			});
 			contextMenuEl?.close();

--- a/apps/desktop/src/components/v3/BranchHeaderContextMenu.svelte
+++ b/apps/desktop/src/components/v3/BranchHeaderContextMenu.svelte
@@ -183,7 +183,7 @@
 						await insertBlankCommitInBranch({
 							projectId,
 							stackId,
-							commitOid: undefined,
+							commitId: undefined,
 							offset: -1
 						});
 						close();

--- a/apps/desktop/src/components/v3/BranchList.svelte
+++ b/apps/desktop/src/components/v3/BranchList.svelte
@@ -199,7 +199,7 @@
 									await insertBlankCommitInBranch({
 										projectId,
 										stackId,
-										commitOid: undefined,
+										commitId: undefined,
 										offset: -1
 									});
 								}}

--- a/apps/desktop/src/components/v3/CommitContextMenu.svelte
+++ b/apps/desktop/src/components/v3/CommitContextMenu.svelte
@@ -60,7 +60,7 @@
 		await insertBlankCommitInBranch({
 			projectId,
 			stackId: context?.data.stackId,
-			commitOid: commitId,
+			commitId: commitId,
 			offset: location === 'above' ? -1 : 1
 		});
 	}

--- a/apps/desktop/src/components/v3/CommitView.svelte
+++ b/apps/desktop/src/components/v3/CommitView.svelte
@@ -117,7 +117,7 @@
 		const newCommitId = await updateCommitMessage({
 			projectId,
 			stackId,
-			commitId: commitKey.commitId,
+			commitOid: commitKey.commitId,
 			message: commitMessage
 		});
 

--- a/apps/desktop/src/components/v3/CommitView.svelte
+++ b/apps/desktop/src/components/v3/CommitView.svelte
@@ -117,7 +117,7 @@
 		const newCommitId = await updateCommitMessage({
 			projectId,
 			stackId,
-			commitOid: commitKey.commitId,
+			commitId: commitKey.commitId,
 			message: commitMessage
 		});
 

--- a/apps/desktop/src/lib/actions/actionService.svelte.ts
+++ b/apps/desktop/src/lib/actions/actionService.svelte.ts
@@ -39,9 +39,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'auto_commit',
 					actionName: 'Figure out where to commit the given changes'
 				},
-				query: ({ projectId, changes }) => ({
-					params: { projectId, changes }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: [
 					invalidatesList(ReduxTag.Stacks),
 					invalidatesList(ReduxTag.StackDetails),
@@ -53,9 +51,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'auto_branch_changes',
 					actionName: 'Create a branch for the given changes'
 				},
-				query: ({ projectId, changes }) => ({
-					params: { projectId, changes }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: [
 					invalidatesList(ReduxTag.Stacks),
 					invalidatesList(ReduxTag.StackDetails),
@@ -67,9 +63,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'absorb',
 					actionName: 'Absorb changes into the best matching branch and commit'
 				},
-				query: ({ projectId, changes }) => ({
-					params: { projectId, changes }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: [
 					invalidatesList(ReduxTag.Stacks),
 					invalidatesList(ReduxTag.StackDetails),
@@ -84,9 +78,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'freestyle',
 					actionName: 'Perform a freestyle action based on the given prompt'
 				},
-				query: ({ projectId, chatMessages, model }) => ({
-					params: { projectId, chatMessages, model }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: [
 					invalidatesList(ReduxTag.Stacks),
 					invalidatesList(ReduxTag.StackDetails),

--- a/apps/desktop/src/lib/actions/actionService.svelte.ts
+++ b/apps/desktop/src/lib/actions/actionService.svelte.ts
@@ -39,7 +39,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'auto_commit',
 					actionName: 'Figure out where to commit the given changes'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: [
 					invalidatesList(ReduxTag.Stacks),
 					invalidatesList(ReduxTag.StackDetails),
@@ -51,7 +51,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'auto_branch_changes',
 					actionName: 'Create a branch for the given changes'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: [
 					invalidatesList(ReduxTag.Stacks),
 					invalidatesList(ReduxTag.StackDetails),
@@ -63,7 +63,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'absorb',
 					actionName: 'Absorb changes into the best matching branch and commit'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: [
 					invalidatesList(ReduxTag.Stacks),
 					invalidatesList(ReduxTag.StackDetails),
@@ -78,7 +78,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'freestyle',
 					actionName: 'Perform a freestyle action based on the given prompt'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: [
 					invalidatesList(ReduxTag.Stacks),
 					invalidatesList(ReduxTag.StackDetails),

--- a/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
+++ b/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
@@ -117,15 +117,13 @@ function injectEndpoints(api: BackendApi) {
 	return api.injectEndpoints({
 		endpoints: (build) => ({
 			baseBranch: build.query<unknown, { projectId: string }>({
-				query: ({ projectId }) => ({
-					command: 'get_base_branch_data',
-					params: { projectId }
-				}),
+				extraOptions: { command: 'get_base_branch_data' },
+				query: (args) => ({ params: args }),
 				providesTags: [providesType(ReduxTag.BaseBranchData)]
 			}),
 			fetchFromRemotes: build.mutation<void, { projectId: string; action?: string }>({
+				extraOptions: { command: 'fetch_from_remotes' },
 				query: ({ projectId, action }) => ({
-					command: 'fetch_from_remotes',
 					params: { projectId, action: action ?? 'auto' }
 				}),
 				invalidatesTags: [
@@ -139,9 +137,7 @@ function injectEndpoints(api: BackendApi) {
 				BaseBranch,
 				{ projectId: string; branch: string; pushRemote?: string; stashUncommitted?: boolean }
 			>({
-				extraOptions: {
-					command: 'set_base_branch'
-				},
+				extraOptions: { command: 'set_base_branch' },
 				query: (args) => ({ params: args }),
 				invalidatesTags: [
 					invalidatesType(ReduxTag.BaseBranchData),
@@ -150,17 +146,15 @@ function injectEndpoints(api: BackendApi) {
 				]
 			}),
 			push: build.mutation<void, { projectId: string; withForce?: boolean }>({
-				extraOptions: {
-					command: 'push_base_branch'
-				},
+				extraOptions: { command: 'push_base_branch' },
 				query: (args) => ({ params: args }),
 				invalidatesTags: [invalidatesType(ReduxTag.BaseBranchData)]
 			}),
 			remoteBranches: build.query<RemoteBranchInfo[], { projectId: string }>({
-				query: ({ projectId }) => ({
-					command: 'git_remote_branches',
-					params: { projectId }
-				}),
+				extraOptions: {
+					command: 'git_remote_branches'
+				},
+				query: (args) => ({ params: args }),
 				transformResponse: (data: string[]) => {
 					return data
 						.map((name) => name.substring(13))

--- a/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
+++ b/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
@@ -142,9 +142,7 @@ function injectEndpoints(api: BackendApi) {
 				extraOptions: {
 					command: 'set_base_branch'
 				},
-				query: ({ projectId, branch, pushRemote, stashUncommitted }) => ({
-					params: { projectId, branch, pushRemote, stashUncommitted }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: [
 					invalidatesType(ReduxTag.BaseBranchData),
 					invalidatesList(ReduxTag.Stacks),
@@ -155,9 +153,7 @@ function injectEndpoints(api: BackendApi) {
 				extraOptions: {
 					command: 'push_base_branch'
 				},
-				query: ({ projectId, withForce }) => ({
-					params: { projectId, withForce }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: [invalidatesType(ReduxTag.BaseBranchData)]
 			}),
 			remoteBranches: build.query<RemoteBranchInfo[], { projectId: string }>({

--- a/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
+++ b/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
@@ -118,13 +118,14 @@ function injectEndpoints(api: BackendApi) {
 		endpoints: (build) => ({
 			baseBranch: build.query<unknown, { projectId: string }>({
 				extraOptions: { command: 'get_base_branch_data' },
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				providesTags: [providesType(ReduxTag.BaseBranchData)]
 			}),
 			fetchFromRemotes: build.mutation<void, { projectId: string; action?: string }>({
 				extraOptions: { command: 'fetch_from_remotes' },
 				query: ({ projectId, action }) => ({
-					params: { projectId, action: action ?? 'auto' }
+					projectId,
+					action: action ?? 'auto'
 				}),
 				invalidatesTags: [
 					invalidatesType(ReduxTag.BaseBranchData),
@@ -138,7 +139,7 @@ function injectEndpoints(api: BackendApi) {
 				{ projectId: string; branch: string; pushRemote?: string; stashUncommitted?: boolean }
 			>({
 				extraOptions: { command: 'set_base_branch' },
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: [
 					invalidatesType(ReduxTag.BaseBranchData),
 					invalidatesList(ReduxTag.Stacks),
@@ -147,14 +148,12 @@ function injectEndpoints(api: BackendApi) {
 			}),
 			push: build.mutation<void, { projectId: string; withForce?: boolean }>({
 				extraOptions: { command: 'push_base_branch' },
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: [invalidatesType(ReduxTag.BaseBranchData)]
 			}),
 			remoteBranches: build.query<RemoteBranchInfo[], { projectId: string }>({
-				extraOptions: {
-					command: 'git_remote_branches'
-				},
-				query: (args) => ({ params: args }),
+				extraOptions: { command: 'git_remote_branches' },
+				query: (args) => args,
 				transformResponse: (data: string[]) => {
 					return data
 						.map((name) => name.substring(13))

--- a/apps/desktop/src/lib/branches/branchService.svelte.ts
+++ b/apps/desktop/src/lib/branches/branchService.svelte.ts
@@ -27,19 +27,13 @@ function injectEndpoints(api: ClientState['backendApi']) {
 	return api.injectEndpoints({
 		endpoints: (build) => ({
 			listBranches: build.query<BranchListing[], { projectId: string }>({
-				extraOptions: {
-					command: 'list_branches'
-				},
-				query: (args) => ({ params: args }),
+				extraOptions: { command: 'list_branches' },
+				query: (args) => args,
 				providesTags: [providesList(ReduxTag.BranchListing)]
 			}),
 			branchDetails: build.query<BranchListingDetails, { projectId: string; branchName: string }>({
-				extraOptions: {
-					command: 'get_branch_listing_details'
-				},
-				query: ({ projectId, branchName }) => ({
-					params: { projectId, branchNames: [branchName] }
-				}),
+				extraOptions: { command: 'get_branch_listing_details' },
+				query: ({ projectId, branchName }) => ({ projectId, branchNames: [branchName] }),
 				transformResponse: (response: BranchListingDetails[]) => response.at(0)!,
 				providesTags: [providesList(ReduxTag.BranchListing)]
 			})

--- a/apps/desktop/src/lib/branches/branchService.svelte.ts
+++ b/apps/desktop/src/lib/branches/branchService.svelte.ts
@@ -27,15 +27,17 @@ function injectEndpoints(api: ClientState['backendApi']) {
 	return api.injectEndpoints({
 		endpoints: (build) => ({
 			listBranches: build.query<BranchListing[], { projectId: string }>({
-				query: ({ projectId }) => ({
-					command: 'list_branches',
-					params: { projectId }
-				}),
+				extraOptions: {
+					command: 'list_branches'
+				},
+				query: (args) => ({ params: args }),
 				providesTags: [providesList(ReduxTag.BranchListing)]
 			}),
 			branchDetails: build.query<BranchListingDetails, { projectId: string; branchName: string }>({
+				extraOptions: {
+					command: 'get_branch_listing_details'
+				},
 				query: ({ projectId, branchName }) => ({
-					command: 'get_branch_listing_details',
 					params: { projectId, branchNames: [branchName] }
 				}),
 				transformResponse: (response: BranchListingDetails[]) => response.at(0)!,

--- a/apps/desktop/src/lib/commits/commitService.svelte.ts
+++ b/apps/desktop/src/lib/commits/commitService.svelte.ts
@@ -3,7 +3,7 @@ import { Commit } from '$lib/commits/commit';
 import { plainToInstance } from 'class-transformer';
 
 export class CommitService {
-	async find(projectId: string, commitOid: string) {
-		return plainToInstance(Commit, await invoke<Commit>('find_commit', { projectId, commitOid }));
+	async find(projectId: string, commitId: string) {
+		return plainToInstance(Commit, await invoke<Commit>('find_commit', { projectId, commitId }));
 	}
 }

--- a/apps/desktop/src/lib/commits/dropHandler.ts
+++ b/apps/desktop/src/lib/commits/dropHandler.ts
@@ -47,7 +47,7 @@ export class MoveCommitDzHandler implements DropzoneHandler {
 		this.stackService.moveCommit({
 			projectId: this.projectId,
 			targetStackId: this.stackId,
-			commitOid: data.commit.id,
+			commitId: data.commit.id,
 			sourceStackId: data.stackId
 		});
 	}

--- a/apps/desktop/src/lib/files/fileService.ts
+++ b/apps/desktop/src/lib/files/fileService.ts
@@ -29,10 +29,10 @@ export class FileService {
 		};
 	}
 
-	async listCommitFiles(projectId: string, commitOid: string) {
+	async listCommitFiles(projectId: string, commitId: string) {
 		return plainToInstance(
 			RemoteFile,
-			await this.tauri.invoke<any[]>('list_commit_files', { projectId, commitOid })
+			await this.tauri.invoke<any[]>('list_commit_files', { projectId, commitId })
 		).sort((a, b) => a.path?.localeCompare(b.path));
 	}
 }

--- a/apps/desktop/src/lib/history/oplogService.svelte.ts
+++ b/apps/desktop/src/lib/history/oplogService.svelte.ts
@@ -43,7 +43,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				{ projectId: string; before: string; after: string }
 			>({
 				extraOptions: { command: 'oplog_diff_worktrees' },
-				query: (args) => ({ params: args })
+				query: (args) => args
 			})
 		})
 	});

--- a/apps/desktop/src/lib/history/oplogService.svelte.ts
+++ b/apps/desktop/src/lib/history/oplogService.svelte.ts
@@ -42,10 +42,8 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				TreeChanges,
 				{ projectId: string; before: string; after: string }
 			>({
-				query: ({ projectId, before, after }) => ({
-					command: 'oplog_diff_worktrees',
-					params: { projectId, before, after }
-				})
+				extraOptions: { command: 'oplog_diff_worktrees' },
+				query: (args) => ({ params: args })
 			})
 		})
 	});

--- a/apps/desktop/src/lib/history/snapshotDiffService.svelte.ts
+++ b/apps/desktop/src/lib/history/snapshotDiffService.svelte.ts
@@ -45,7 +45,10 @@ function injectEndpoints(api: ClientState['backendApi']) {
 	return api.injectEndpoints({
 		endpoints: (build) => ({
 			diff: build.query<{ [key: string]: unknown }, { projectId: string; sha: string }>({
-				query: ({ projectId, sha }) => ({ command: 'snapshot_diff', params: { projectId, sha } }),
+				extraOptions: {
+					command: 'snapshot_diff'
+				},
+				query: (args) => ({ params: args }),
 				providesTags: (_result, _error, args) => providesItem(ReduxTag.SnapshotDiff, args.sha)
 			})
 		})

--- a/apps/desktop/src/lib/history/snapshotDiffService.svelte.ts
+++ b/apps/desktop/src/lib/history/snapshotDiffService.svelte.ts
@@ -48,7 +48,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				extraOptions: {
 					command: 'snapshot_diff'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				providesTags: (_result, _error, args) => providesItem(ReduxTag.SnapshotDiff, args.sha)
 			})
 		})

--- a/apps/desktop/src/lib/hunks/diffService.svelte.ts
+++ b/apps/desktop/src/lib/hunks/diffService.svelte.ts
@@ -56,10 +56,10 @@ function injectEndpoints(api: ClientState['backendApi']) {
 	return api.injectEndpoints({
 		endpoints: (build) => ({
 			getDiff: build.query<UnifiedDiff, { projectId: string; change: TreeChange }>({
-				query: ({ projectId, change }) => ({
-					command: 'tree_change_diffs',
-					params: { projectId, change }
-				}),
+				extraOptions: {
+					command: 'tree_change_diffs'
+				},
+				query: (args) => ({ params: args }),
 				providesTags: [providesList(ReduxTag.Diff)]
 			}),
 			assignHunk: build.mutation<

--- a/apps/desktop/src/lib/hunks/diffService.svelte.ts
+++ b/apps/desktop/src/lib/hunks/diffService.svelte.ts
@@ -56,10 +56,8 @@ function injectEndpoints(api: ClientState['backendApi']) {
 	return api.injectEndpoints({
 		endpoints: (build) => ({
 			getDiff: build.query<UnifiedDiff, { projectId: string; change: TreeChange }>({
-				extraOptions: {
-					command: 'tree_change_diffs'
-				},
-				query: (args) => ({ params: args }),
+				extraOptions: { command: 'tree_change_diffs' },
+				query: (args) => args,
 				providesTags: [providesList(ReduxTag.Diff)]
 			}),
 			assignHunk: build.mutation<
@@ -69,7 +67,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				extraOptions: {
 					command: 'assign_hunk'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: [invalidatesList(ReduxTag.WorktreeChanges)]
 			})
 		})

--- a/apps/desktop/src/lib/hunks/diffService.svelte.ts
+++ b/apps/desktop/src/lib/hunks/diffService.svelte.ts
@@ -69,9 +69,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				extraOptions: {
 					command: 'assign_hunk'
 				},
-				query: ({ projectId, assignments }) => ({
-					params: { projectId, assignments }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: [invalidatesList(ReduxTag.WorktreeChanges)]
 			})
 		})

--- a/apps/desktop/src/lib/mode/modeService.ts
+++ b/apps/desktop/src/lib/mode/modeService.ts
@@ -6,7 +6,7 @@ import type { ConflictEntryPresence } from '$lib/conflictEntryPresence';
 import type { StackService } from '$lib/stacks/stackService.svelte';
 
 export interface EditModeMetadata {
-	commitOid: string;
+	commitId: string;
 	branchReference: string;
 }
 
@@ -58,10 +58,10 @@ export class ModeService {
 		this.headAndMode.set({ head, operatingMode });
 	}
 
-	async enterEditMode(commitOid: string, stackId: string) {
+	async enterEditMode(commitId: string, stackId: string) {
 		this.stackService.enterEditMode({
 			projectId: this.projectId,
-			commitOid,
+			commitId,
 			stackId
 		});
 		await this.awaitMode('Edit');

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -814,7 +814,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 		endpoints: (build) => ({
 			stacks: build.query<EntityState<Stack, string>, { projectId: string }>({
 				extraOptions: { command: 'stacks' },
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				providesTags: [providesList(ReduxTag.Stacks)],
 				transformResponse(response: Stack[]) {
 					return stackAdapter.addMany(stackAdapter.getInitialState(), response);
@@ -822,7 +822,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 			}),
 			allStacks: build.query<EntityState<Stack, string>, { projectId: string }>({
 				extraOptions: { command: 'stacks' },
-				query: ({ projectId }) => ({ params: { projectId, filter: 'All' } }),
+				query: ({ projectId }) => ({ projectId, filter: 'All' }),
 				providesTags: [providesList(ReduxTag.Stacks)],
 				transformResponse(response: Stack[]) {
 					return stackAdapter.addMany(stackAdapter.getInitialState(), response);
@@ -833,7 +833,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'create_virtual_branch',
 					actionName: 'Create Stack'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: (result, _error) => [
 					invalidatesItem(ReduxTag.StackDetails, result?.id),
 					invalidatesList(ReduxTag.Stacks),
@@ -849,7 +849,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'update_virtual_branch',
 					actionName: 'Update Stack'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: (result, _error) => [
 					invalidatesItem(ReduxTag.StackDetails, result?.id),
 					invalidatesList(ReduxTag.Stacks),
@@ -865,7 +865,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'update_stack_order',
 					actionName: 'Update Stack Order'
 				},
-				query: (args) => ({ params: args })
+				query: (args) => args
 				// This invalidation causes the order to jump back and forth
 				// on save, and it's a bit unclear why. It's not important to
 				// reload, however, so leaving it like this for now.
@@ -881,7 +881,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				{ projectId: string; stackId: string }
 			>({
 				extraOptions: { command: 'stack_details' },
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				providesTags: (_result, _error, { stackId }) => [
 					...providesItem(ReduxTag.StackDetails, stackId)
 				],
@@ -928,7 +928,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				{ projectId: string; branchName: string; remote?: string }
 			>({
 				extraOptions: { command: 'branch_details' },
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				transformResponse(branchDetails: BranchDetails) {
 					// This is a list of all the commits accross all branches in the stack.
 					// If you want to acces the commits of a specific branch, use the
@@ -970,7 +970,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'push_stack',
 					actionName: 'Push'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesList(ReduxTag.Checks),
 					invalidatesItem(ReduxTag.PullRequests, args.stackId),
@@ -986,7 +986,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'create_commit_from_worktree_changes',
 					actionName: 'Commit'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesList(ReduxTag.WorktreeChanges),
 					invalidatesList(ReduxTag.UpstreamIntegrationStatus),
@@ -1006,7 +1006,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'commit_virtual_branch',
 					actionName: 'Commit'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesList(ReduxTag.UpstreamIntegrationStatus),
 					invalidatesItem(ReduxTag.StackDetails, args.stackId)
@@ -1021,7 +1021,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				{ projectId: string; commitId: string }
 			>({
 				extraOptions: { command: 'commit_details' },
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				providesTags: (_result, _error, { commitId }) => [
 					...providesItem(ReduxTag.CommitChanges, commitId)
 				],
@@ -1045,7 +1045,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				{ projectId: string; stackId?: string; branchName: string; remote?: string }
 			>({
 				extraOptions: { command: 'changes_in_branch' },
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				providesTags: (_result, _error, { stackId }) =>
 					stackId ? providesItem(ReduxTag.BranchChanges, stackId) : [],
 				transformResponse(rsp: TreeChanges) {
@@ -1054,13 +1054,13 @@ function injectEndpoints(api: ClientState['backendApi']) {
 			}),
 			updateCommitMessage: build.mutation<
 				string,
-				{ projectId: string; stackId: string; commitId: string; message: string }
+				{ projectId: string; stackId: string; commitOid: string; message: string }
 			>({
 				extraOptions: {
 					command: 'update_commit_message',
 					actionName: 'Update Commit Message'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesItem(ReduxTag.StackDetails, args.stackId)
 				]
@@ -1073,7 +1073,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'create_branch',
 					actionName: 'Create Branch'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesItem(ReduxTag.StackDetails, args.stackId),
 					invalidatesList(ReduxTag.BranchListing)
@@ -1084,9 +1084,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'undo_commit',
 					actionName: 'Uncommit'
 				},
-				query: ({ projectId, stackId, commitId: commitOid }) => ({
-					params: { projectId, stackId, commitOid }
-				}),
+				query: (args) => args,
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesList(ReduxTag.WorktreeChanges),
 					invalidatesItem(ReduxTag.StackDetails, args.stackId)
@@ -1105,7 +1103,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'amend_virtual_branch',
 					actionName: 'Amend Commit'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesList(ReduxTag.WorktreeChanges),
 					invalidatesItem(ReduxTag.BranchChanges, args.stackId),
@@ -1120,9 +1118,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'insert_blank_commit',
 					actionName: 'Insert Blank Commit'
 				},
-				query: ({ projectId, stackId, commitOid, offset }) => ({
-					params: { projectId, stackId, commitOid, offset }
-				}),
+				query: (args) => args,
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesItem(ReduxTag.StackDetails, args.stackId)
 				]
@@ -1135,7 +1131,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'discard_worktree_changes',
 					actionName: 'Discard Changes'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: [invalidatesList(ReduxTag.WorktreeChanges)]
 			}),
 			moveChangesBetweenCommits: build.mutation<
@@ -1153,7 +1149,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'move_changes_between_commits',
 					actionName: 'Move Changes Between Commits'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags(result, _error, arg) {
 					const commitChangesTags = [arg.sourceCommitId, arg.destinationCommitId]
 						.map((id) => result?.replacedCommits.find(([oldId]) => oldId === id)?.[1])
@@ -1181,7 +1177,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'uncommit_changes',
 					actionName: 'Uncommit Changes'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags(_result, _error, arg) {
 					return [
 						invalidatesItem(ReduxTag.BranchChanges, arg.stackId),
@@ -1198,9 +1194,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'stash_into_branch',
 					actionName: 'Stash Changes'
 				},
-				query: ({ projectId, branchName, worktreeChanges }) => ({
-					params: { projectId, branchName, worktreeChanges }
-				}),
+				query: (args) => args,
 				invalidatesTags: [
 					invalidatesList(ReduxTag.WorktreeChanges),
 					invalidatesList(ReduxTag.BranchListing)
@@ -1211,7 +1205,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'unapply_stack',
 					actionName: 'Unapply Stack'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: () => [
 					invalidatesList(ReduxTag.WorktreeChanges),
 					invalidatesList(ReduxTag.Stacks),
@@ -1226,7 +1220,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'push_stack_to_review',
 					actionName: 'Publish Stack'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesItem(ReduxTag.StackDetails, args.stackId)
 				]
@@ -1245,7 +1239,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'update_branch_pr_number',
 					actionName: 'Update Branch PR Number'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesItem(ReduxTag.StackDetails, args.stackId),
 					invalidatesList(ReduxTag.BranchListing)
@@ -1264,7 +1258,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'update_branch_name',
 					actionName: 'Update Branch Name'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: (_r, _e, args) => [
 					invalidatesList(ReduxTag.Stacks),
 					invalidatesItem(ReduxTag.StackDetails, args.stackId),
@@ -1283,7 +1277,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'remove_branch',
 					actionName: 'Remove Branch'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesItem(ReduxTag.StackDetails, args.stackId),
 					invalidatesList(ReduxTag.BranchListing)
@@ -1297,7 +1291,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'update_branch_description',
 					actionName: 'Update Branch Description'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesItem(ReduxTag.StackDetails, args.stackId),
 					invalidatesList(ReduxTag.BranchListing)
@@ -1311,9 +1305,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'reorder_stack',
 					actionName: 'Reorder Stack'
 				},
-				query: ({ projectId, stackId, stackOrder }) => ({
-					params: { projectId, stackId, stackOrder }
-				}),
+				query: (args) => args,
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesItem(ReduxTag.StackDetails, args.stackId)
 				]
@@ -1326,7 +1318,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'move_commit',
 					actionName: 'Move Commit'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesList(ReduxTag.WorktreeChanges), // Moving commits can cause conflicts
 					invalidatesItem(ReduxTag.StackDetails, args.sourceStackId),
@@ -1346,7 +1338,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'integrate_upstream_commits',
 					actionName: 'Integrate Upstream Commits'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesList(ReduxTag.WorktreeChanges),
 					invalidatesItem(ReduxTag.StackDetails, args.stackId)
@@ -1361,11 +1353,9 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					actionName: 'Legacy Unapply Lines'
 				},
 				query: ({ projectId, hunk, linesToUnapply }) => ({
-					params: {
-						projectId,
-						ownership: `${hunk.filePath}:${hunk.id}-${hunk.hash}`,
-						lines: { [hunk.id]: linesToUnapply }
-					}
+					projectId,
+					ownership: `${hunk.filePath}:${hunk.id}-${hunk.hash}`,
+					lines: { [hunk.id]: linesToUnapply }
 				})
 			}),
 			legacyUnapplyHunk: build.mutation<void, { projectId: string; hunk: Hunk }>({
@@ -1374,7 +1364,8 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					actionName: 'Legacy Unapply Hunk'
 				},
 				query: ({ projectId, hunk }) => ({
-					params: { projectId, ownership: `${hunk.filePath}:${hunk.id}-${hunk.hash}` }
+					projectId,
+					ownership: `${hunk.filePath}:${hunk.id}-${hunk.hash}`
 				})
 			}),
 			legacyUnapplyFiles: build.mutation<
@@ -1386,7 +1377,9 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					actionName: 'Legacy Unapply Files'
 				},
 				query: ({ projectId, stackId, files }) => ({
-					params: { projectId, stackId, files: files?.flatMap((f) => f.path) ?? [] }
+					projectId,
+					stackId,
+					files: files?.flatMap((f) => f.path) ?? []
 				})
 			}),
 			legacyUpdateBranchOwnership: build.mutation<
@@ -1398,7 +1391,8 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					actionName: 'Legacy Update Branch Ownership'
 				},
 				query: ({ projectId, stackId, ownership }) => ({
-					params: { projectId, branch: { id: stackId, ownership } }
+					projectId,
+					branch: { id: stackId, ownership }
 				})
 			}),
 			createVirtualBranchFromBranch: build.mutation<
@@ -1409,7 +1403,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'create_virtual_branch_from_branch',
 					actionName: 'Create Virtual Branch From Branch'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: [invalidatesList(ReduxTag.Stacks), invalidatesList(ReduxTag.BranchListing)]
 			}),
 			deleteLocalBranch: build.mutation<
@@ -1420,7 +1414,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'delete_local_branch',
 					actionName: 'Delete Local Branch'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: (_result, _error, { givenName: branchName }) => [
 					invalidatesItem(ReduxTag.BranchDetails, branchName)
 				]
@@ -1433,7 +1427,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'squash_commits',
 					actionName: 'Squash Commits'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesList(ReduxTag.WorktreeChanges), // Could cause conflicts
 					invalidatesItem(ReduxTag.StackDetails, args.stackId)
@@ -1453,7 +1447,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'move_commit_file',
 					actionName: 'Move Commit File'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesList(ReduxTag.WorktreeChanges), // Could cause conflicts
 					invalidatesItem(ReduxTag.StackDetails, args.stackId),
@@ -1467,7 +1461,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				}
 			>({
 				extraOptions: { command: 'canned_branch_name' },
-				query: (args) => ({ params: args })
+				query: (args) => args
 			}),
 			normalizeBranchName: build.query<
 				string,
@@ -1476,7 +1470,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				}
 			>({
 				extraOptions: { command: 'normalize_branch_name' },
-				query: (args) => ({ params: args })
+				query: (args) => args
 			}),
 			targetCommits: build.query<
 				EntityState<Commit, string>,
@@ -1487,7 +1481,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				}
 			>({
 				extraOptions: { command: 'target_commits' },
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				transformResponse: (commits: Commit[]) =>
 					commitAdapter.addMany(commitAdapter.getInitialState(), commits)
 			}),
@@ -1496,15 +1490,15 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				{ projectId: string; commitOid: string; stackId: string }
 			>({
 				extraOptions: { command: 'enter_edit_mode' },
-				query: (args) => ({ params: args })
+				query: (args) => args
 			}),
 			abortEditAndReturnToWorkspace: build.mutation<void, { projectId: string }>({
 				extraOptions: { command: 'abort_edit_and_return_to_workspace' },
-				query: (args) => ({ params: args })
+				query: (args) => args
 			}),
 			saveEditAndReturnToWorkspace: build.mutation<void, { projectId: string }>({
 				extraOptions: { command: 'save_edit_and_return_to_workspace' },
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: [
 					invalidatesList(ReduxTag.WorktreeChanges),
 					invalidatesList(ReduxTag.StackDetails)

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -1054,7 +1054,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 			}),
 			updateCommitMessage: build.mutation<
 				string,
-				{ projectId: string; stackId: string; commitOid: string; message: string }
+				{ projectId: string; stackId: string; commitId: string; message: string }
 			>({
 				extraOptions: {
 					command: 'update_commit_message',
@@ -1112,7 +1112,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 			}),
 			insertBlankCommit: build.mutation<
 				void,
-				{ projectId: string; stackId: string; commitOid: string | undefined; offset: number }
+				{ projectId: string; stackId: string; commitId: string | undefined; offset: number }
 			>({
 				extraOptions: {
 					command: 'insert_blank_commit',
@@ -1312,7 +1312,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 			}),
 			moveCommit: build.mutation<
 				void,
-				{ projectId: string; sourceStackId: string; commitOid: string; targetStackId: string }
+				{ projectId: string; sourceStackId: string; commitId: string; targetStackId: string }
 			>({
 				extraOptions: {
 					command: 'move_commit',
@@ -1485,13 +1485,12 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				transformResponse: (commits: Commit[]) =>
 					commitAdapter.addMany(commitAdapter.getInitialState(), commits)
 			}),
-			enterEditMode: build.mutation<
-				void,
-				{ projectId: string; commitOid: string; stackId: string }
-			>({
-				extraOptions: { command: 'enter_edit_mode' },
-				query: (args) => args
-			}),
+			enterEditMode: build.mutation<void, { projectId: string; commitId: string; stackId: string }>(
+				{
+					extraOptions: { command: 'enter_edit_mode' },
+					query: (args) => args
+				}
+			),
 			abortEditAndReturnToWorkspace: build.mutation<void, { projectId: string }>({
 				extraOptions: { command: 'abort_edit_and_return_to_workspace' },
 				query: (args) => args

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -831,9 +831,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'create_virtual_branch',
 					actionName: 'Create Stack'
 				},
-				query: ({ projectId, branch }) => ({
-					params: { projectId, branch }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: (result, _error) => [
 					invalidatesItem(ReduxTag.StackDetails, result?.id),
 					invalidatesList(ReduxTag.Stacks),
@@ -849,9 +847,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'update_virtual_branch',
 					actionName: 'Update Stack'
 				},
-				query: ({ projectId, branch }) => ({
-					params: { projectId, branch }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: (result, _error) => [
 					invalidatesItem(ReduxTag.StackDetails, result?.id),
 					invalidatesList(ReduxTag.Stacks),
@@ -867,9 +863,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'update_stack_order',
 					actionName: 'Update Stack Order'
 				},
-				query: ({ projectId, stacks }) => ({
-					params: { projectId, stacks }
-				})
+				query: (args) => ({ params: args })
 				// This invalidation causes the order to jump back and forth
 				// on save, and it's a bit unclear why. It's not important to
 				// reload, however, so leaving it like this for now.
@@ -937,9 +931,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'branch_details',
 					actionName: 'Unstacked Branch Details'
 				},
-				query: ({ projectId, branchName, remote }) => ({
-					params: { projectId, branchName, remote }
-				}),
+				query: (args) => ({ params: args }),
 				transformResponse(branchDetails: BranchDetails) {
 					// This is a list of all the commits accross all branches in the stack.
 					// If you want to acces the commits of a specific branch, use the
@@ -981,9 +973,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'push_stack',
 					actionName: 'Push'
 				},
-				query: ({ projectId, stackId, withForce, branch }) => ({
-					params: { projectId, stackId, withForce, branch }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesList(ReduxTag.Checks),
 					invalidatesItem(ReduxTag.PullRequests, args.stackId),
@@ -999,9 +989,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'create_commit_from_worktree_changes',
 					actionName: 'Commit'
 				},
-				query: ({ projectId, ...commitData }) => ({
-					params: { projectId, ...commitData }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesList(ReduxTag.WorktreeChanges),
 					invalidatesList(ReduxTag.UpstreamIntegrationStatus),
@@ -1021,9 +1009,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'commit_virtual_branch',
 					actionName: 'Commit'
 				},
-				query: ({ projectId, stackId, message, ownership }) => ({
-					params: { projectId, stackId, message, ownership }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesList(ReduxTag.UpstreamIntegrationStatus),
 					invalidatesItem(ReduxTag.StackDetails, args.stackId)
@@ -1096,9 +1082,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'create_branch',
 					actionName: 'Create Branch'
 				},
-				query: ({ projectId, stackId, request: { targetPatch, name } }) => ({
-					params: { projectId, stackId, request: { targetPatch, name } }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesItem(ReduxTag.StackDetails, args.stackId),
 					invalidatesList(ReduxTag.BranchListing)
@@ -1130,9 +1114,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'amend_virtual_branch',
 					actionName: 'Amend Commit'
 				},
-				query: ({ projectId, stackId, commitId, worktreeChanges }) => ({
-					params: { projectId, stackId, commitId, worktreeChanges }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesList(ReduxTag.WorktreeChanges),
 					invalidatesItem(ReduxTag.BranchChanges, args.stackId),
@@ -1162,9 +1144,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'discard_worktree_changes',
 					actionName: 'Discard Changes'
 				},
-				query: ({ projectId, worktreeChanges }) => ({
-					params: { projectId, worktreeChanges }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: [invalidatesList(ReduxTag.WorktreeChanges)]
 			}),
 			moveChangesBetweenCommits: build.mutation<
@@ -1182,23 +1162,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'move_changes_between_commits',
 					actionName: 'Move Changes Between Commits'
 				},
-				query: ({
-					projectId,
-					changes,
-					sourceCommitId,
-					sourceStackId,
-					destinationCommitId,
-					destinationStackId
-				}) => ({
-					params: {
-						projectId,
-						changes,
-						sourceCommitId,
-						sourceStackId,
-						destinationCommitId,
-						destinationStackId
-					}
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags(result, _error, arg) {
 					const commitChangesTags = [arg.sourceCommitId, arg.destinationCommitId]
 						.map((id) => result?.replacedCommits.find(([oldId]) => oldId === id)?.[1])
@@ -1226,9 +1190,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'uncommit_changes',
 					actionName: 'Uncommit Changes'
 				},
-				query: ({ projectId, changes, commitId, stackId, assignTo }) => ({
-					params: { projectId, changes, commitId, stackId, assignTo }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags(_result, _error, arg) {
 					return [
 						invalidatesItem(ReduxTag.BranchChanges, arg.stackId),
@@ -1258,9 +1220,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'unapply_stack',
 					actionName: 'Unapply Stack'
 				},
-				query: ({ projectId, stackId }) => ({
-					params: { projectId, stackId }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: () => [
 					invalidatesList(ReduxTag.WorktreeChanges),
 					invalidatesList(ReduxTag.Stacks),
@@ -1275,9 +1235,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'push_stack_to_review',
 					actionName: 'Publish Stack'
 				},
-				query: ({ projectId, stackId, user, topBranch }) => ({
-					params: { projectId, stackId, user, topBranch }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesItem(ReduxTag.StackDetails, args.stackId)
 				]
@@ -1296,14 +1254,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'update_branch_pr_number',
 					actionName: 'Update Branch PR Number'
 				},
-				query: ({ projectId, stackId, branchName, prNumber }) => ({
-					params: {
-						projectId,
-						stackId,
-						branchName,
-						prNumber
-					}
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesItem(ReduxTag.StackDetails, args.stackId),
 					invalidatesList(ReduxTag.BranchListing)
@@ -1322,14 +1273,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'update_branch_name',
 					actionName: 'Update Branch Name'
 				},
-				query: ({ projectId, stackId, branchName, newName }) => ({
-					params: {
-						projectId,
-						stackId,
-						branchName,
-						newName
-					}
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: (_r, _e, args) => [
 					invalidatesList(ReduxTag.Stacks),
 					invalidatesItem(ReduxTag.StackDetails, args.stackId),
@@ -1348,13 +1292,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'remove_branch',
 					actionName: 'Remove Branch'
 				},
-				query: ({ projectId, stackId, branchName }) => ({
-					params: {
-						projectId,
-						stackId,
-						branchName
-					}
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesItem(ReduxTag.StackDetails, args.stackId),
 					invalidatesList(ReduxTag.BranchListing)
@@ -1368,9 +1306,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'update_branch_description',
 					actionName: 'Update Branch Description'
 				},
-				query: ({ projectId, stackId, branchName, description }) => ({
-					params: { projectId, stackId, branchName, description }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesItem(ReduxTag.StackDetails, args.stackId),
 					invalidatesList(ReduxTag.BranchListing)
@@ -1399,9 +1335,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'move_commit',
 					actionName: 'Move Commit'
 				},
-				query: ({ projectId, sourceStackId, commitOid, targetStackId }) => ({
-					params: { projectId, sourceStackId, commitOid, targetStackId }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesList(ReduxTag.WorktreeChanges), // Moving commits can cause conflicts
 					invalidatesItem(ReduxTag.StackDetails, args.sourceStackId),
@@ -1421,9 +1355,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'integrate_upstream_commits',
 					actionName: 'Integrate Upstream Commits'
 				},
-				query: ({ projectId, stackId, seriesName, strategy }) => ({
-					params: { projectId, stackId, seriesName, strategy }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesList(ReduxTag.WorktreeChanges),
 					invalidatesItem(ReduxTag.StackDetails, args.stackId)
@@ -1486,9 +1418,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'create_virtual_branch_from_branch',
 					actionName: 'Create Virtual Branch From Branch'
 				},
-				query: ({ projectId, branch, remote, prNumber }) => ({
-					params: { projectId, branch, remote, prNumber }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: [invalidatesList(ReduxTag.Stacks), invalidatesList(ReduxTag.BranchListing)]
 			}),
 			deleteLocalBranch: build.mutation<
@@ -1499,9 +1429,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'delete_local_branch',
 					actionName: 'Delete Local Branch'
 				},
-				query: ({ projectId, refname, givenName }) => ({
-					params: { projectId, refname, givenName }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: (_result, _error, { givenName: branchName }) => [
 					invalidatesItem(ReduxTag.BranchDetails, branchName)
 				]
@@ -1514,9 +1442,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'squash_commits',
 					actionName: 'Squash Commits'
 				},
-				query: ({ projectId, stackId, sourceCommitOids, targetCommitOid }) => ({
-					params: { projectId, stackId, sourceCommitOids, targetCommitOid }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesList(ReduxTag.WorktreeChanges), // Could cause conflicts
 					invalidatesItem(ReduxTag.StackDetails, args.stackId)

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -813,14 +813,16 @@ function injectEndpoints(api: ClientState['backendApi']) {
 	return api.injectEndpoints({
 		endpoints: (build) => ({
 			stacks: build.query<EntityState<Stack, string>, { projectId: string }>({
-				query: ({ projectId }) => ({ command: 'stacks', params: { projectId } }),
+				extraOptions: { command: 'stacks' },
+				query: (args) => ({ params: args }),
 				providesTags: [providesList(ReduxTag.Stacks)],
 				transformResponse(response: Stack[]) {
 					return stackAdapter.addMany(stackAdapter.getInitialState(), response);
 				}
 			}),
 			allStacks: build.query<EntityState<Stack, string>, { projectId: string }>({
-				query: ({ projectId }) => ({ command: 'stacks', params: { projectId, filter: 'All' } }),
+				extraOptions: { command: 'stacks' },
+				query: ({ projectId }) => ({ params: { projectId, filter: 'All' } }),
 				providesTags: [providesList(ReduxTag.Stacks)],
 				transformResponse(response: Stack[]) {
 					return stackAdapter.addMany(stackAdapter.getInitialState(), response);
@@ -878,10 +880,8 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				},
 				{ projectId: string; stackId: string }
 			>({
-				query: ({ projectId, stackId }) => ({
-					command: 'stack_details',
-					params: { projectId, stackId }
-				}),
+				extraOptions: { command: 'stack_details' },
+				query: (args) => ({ params: args }),
 				providesTags: (_result, _error, { stackId }) => [
 					...providesItem(ReduxTag.StackDetails, stackId)
 				],
@@ -927,10 +927,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				},
 				{ projectId: string; branchName: string; remote?: string }
 			>({
-				extraOptions: {
-					command: 'branch_details',
-					actionName: 'Unstacked Branch Details'
-				},
+				extraOptions: { command: 'branch_details' },
 				query: (args) => ({ params: args }),
 				transformResponse(branchDetails: BranchDetails) {
 					// This is a list of all the commits accross all branches in the stack.
@@ -1023,10 +1020,8 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				},
 				{ projectId: string; commitId: string }
 			>({
-				query: ({ projectId, commitId }) => ({
-					command: 'commit_details',
-					params: { projectId, commitId }
-				}),
+				extraOptions: { command: 'commit_details' },
+				query: (args) => ({ params: args }),
 				providesTags: (_result, _error, { commitId }) => [
 					...providesItem(ReduxTag.CommitChanges, commitId)
 				],
@@ -1049,10 +1044,8 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				EntityState<TreeChange, string>,
 				{ projectId: string; stackId?: string; branchName: string; remote?: string }
 			>({
-				query: ({ projectId, stackId, branchName, remote }) => ({
-					command: 'changes_in_branch',
-					params: { projectId, stackId, branchName, remote }
-				}),
+				extraOptions: { command: 'changes_in_branch' },
+				query: (args) => ({ params: args }),
 				providesTags: (_result, _error, { stackId }) =>
 					stackId ? providesItem(ReduxTag.BranchChanges, stackId) : [],
 				transformResponse(rsp: TreeChanges) {
@@ -1067,9 +1060,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'update_commit_message',
 					actionName: 'Update Commit Message'
 				},
-				query: ({ projectId, stackId, commitId, message }) => ({
-					params: { projectId, stackId, commitOid: commitId, message }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesItem(ReduxTag.StackDetails, args.stackId)
 				]
@@ -1458,10 +1449,11 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					ownership: string;
 				}
 			>({
-				query: ({ projectId, stackId, fromCommitOid, toCommitOid, ownership }) => ({
+				extraOptions: {
 					command: 'move_commit_file',
-					params: { projectId, stackId, fromCommitOid, toCommitOid, ownership }
-				}),
+					actionName: 'Move Commit File'
+				},
+				query: (args) => ({ params: args }),
 				invalidatesTags: (_result, _error, args) => [
 					invalidatesList(ReduxTag.WorktreeChanges), // Could cause conflicts
 					invalidatesItem(ReduxTag.StackDetails, args.stackId),
@@ -1474,10 +1466,8 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					projectId: string;
 				}
 			>({
-				query: ({ projectId }) => ({
-					command: 'canned_branch_name',
-					params: { projectId }
-				})
+				extraOptions: { command: 'canned_branch_name' },
+				query: (args) => ({ params: args })
 			}),
 			normalizeBranchName: build.query<
 				string,
@@ -1485,10 +1475,8 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					name: string;
 				}
 			>({
-				query: ({ name }) => ({
-					command: 'normalize_branch_name',
-					params: { name }
-				})
+				extraOptions: { command: 'normalize_branch_name' },
+				query: (args) => ({ params: args })
 			}),
 			targetCommits: build.query<
 				EntityState<Commit, string>,
@@ -1498,10 +1486,8 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					pageSize: number;
 				}
 			>({
-				query: (params) => ({
-					command: 'target_commits',
-					params
-				}),
+				extraOptions: { command: 'target_commits' },
+				query: (args) => ({ params: args }),
 				transformResponse: (commits: Commit[]) =>
 					commitAdapter.addMany(commitAdapter.getInitialState(), commits)
 			}),
@@ -1509,22 +1495,16 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				void,
 				{ projectId: string; commitOid: string; stackId: string }
 			>({
-				query: (params) => ({
-					command: 'enter_edit_mode',
-					params
-				})
+				extraOptions: { command: 'enter_edit_mode' },
+				query: (args) => ({ params: args })
 			}),
 			abortEditAndReturnToWorkspace: build.mutation<void, { projectId: string }>({
-				query: (params) => ({
-					command: 'abort_edit_and_return_to_workspace',
-					params
-				})
+				extraOptions: { command: 'abort_edit_and_return_to_workspace' },
+				query: (args) => ({ params: args })
 			}),
 			saveEditAndReturnToWorkspace: build.mutation<void, { projectId: string }>({
-				query: (params) => ({
-					command: 'save_edit_and_return_to_workspace',
-					params
-				}),
+				extraOptions: { command: 'save_edit_and_return_to_workspace' },
+				query: (args) => ({ params: args }),
 				invalidatesTags: [
 					invalidatesList(ReduxTag.WorktreeChanges),
 					invalidatesList(ReduxTag.StackDetails)

--- a/apps/desktop/src/lib/state/backendQuery.ts
+++ b/apps/desktop/src/lib/state/backendQuery.ts
@@ -15,7 +15,7 @@ export const tauriBaseQuery: TauriBaseQueryFn = async (
 	api: BaseQueryApi,
 	extra: TauriExtraOptions
 ): Promise<QueryReturnValue<unknown, TauriCommandError, undefined>> => {
-	const command = extra.command || args.command;
+	const command = extra.command;
 	if (!command) {
 		return newError('Expected a command!');
 	}
@@ -25,13 +25,13 @@ export const tauriBaseQuery: TauriBaseQueryFn = async (
 	}
 
 	try {
-		const result = { data: await api.extra.tauri.invoke(command, args.params) };
+		const result = { data: await api.extra.tauri.invoke(command, args) };
 		return result;
 	} catch (error: unknown) {
 		const name = `API error: (${command})`;
 		if (isTauriCommandError(error)) {
 			const newMessage =
-				`command: ${command}\nparams: ${JSON.stringify(args.params)})\n\n` + error.message;
+				`command: ${command}\nparams: ${JSON.stringify(args)})\n\n` + error.message;
 			return { error: { name, message: newMessage, code: error.code } };
 		}
 
@@ -49,10 +49,7 @@ function newError(message: string) {
 	};
 }
 
-type ApiArgs = {
-	command?: string;
-	params: Record<string, unknown>;
-};
+type ApiArgs = Record<string, unknown>;
 
 /**
  * Typeguard for accessing injected Tauri dependency safely.

--- a/apps/desktop/src/lib/state/backendQuery.ts
+++ b/apps/desktop/src/lib/state/backendQuery.ts
@@ -13,9 +13,9 @@ export type TauriBaseQueryFn = BaseQueryFn<ApiArgs, unknown, unknown, TauriExtra
 export const tauriBaseQuery: TauriBaseQueryFn = async (
 	args: ApiArgs,
 	api: BaseQueryApi,
-	extra?: TauriExtraOptions
+	extra: TauriExtraOptions
 ): Promise<QueryReturnValue<unknown, TauriCommandError, undefined>> => {
-	const command = extra?.command || args.command;
+	const command = extra.command || args.command;
 	if (!command) {
 		return newError('Expected a command!');
 	}

--- a/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
+++ b/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
@@ -115,10 +115,8 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				BranchStatusesResponse | undefined,
 				{ projectId: string; targetCommitOid?: string }
 			>({
-				query: ({ projectId, targetCommitOid }) => ({
-					command: 'upstream_integration_statuses',
-					params: { projectId, targetCommitOid }
-				}),
+				extraOptions: { command: 'upstream_integration_statuses' },
+				query: (args) => ({ params: args }),
 				providesTags: [providesList(ReduxTag.UpstreamIntegrationStatus)]
 			}),
 			integrateUpstream: build.mutation<

--- a/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
+++ b/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
@@ -116,7 +116,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				{ projectId: string; targetCommitOid?: string }
 			>({
 				extraOptions: { command: 'upstream_integration_statuses' },
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				providesTags: [providesList(ReduxTag.UpstreamIntegrationStatus)]
 			}),
 			integrateUpstream: build.mutation<
@@ -131,7 +131,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'integrate_upstream',
 					actionName: 'Integrate Upstream'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: [
 					invalidatesList(ReduxTag.UpstreamIntegrationStatus),
 					invalidatesList(ReduxTag.Stacks),
@@ -146,7 +146,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: `resolve_upstream_integration`,
 					actionName: 'Resolve Integrate Upstream'
 				},
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				invalidatesTags: [invalidatesList(ReduxTag.UpstreamIntegrationStatus)]
 			})
 		})

--- a/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
+++ b/apps/desktop/src/lib/upstream/upstreamIntegrationService.svelte.ts
@@ -133,9 +133,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: 'integrate_upstream',
 					actionName: 'Integrate Upstream'
 				},
-				query: ({ projectId, resolutions, baseBranchResolution }) => ({
-					params: { projectId, resolutions, baseBranchResolution }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: [
 					invalidatesList(ReduxTag.UpstreamIntegrationStatus),
 					invalidatesList(ReduxTag.Stacks),
@@ -150,9 +148,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					command: `resolve_upstream_integration`,
 					actionName: 'Resolve Integrate Upstream'
 				},
-				query: ({ projectId, resolutionApproach }) => ({
-					params: { projectId, resolutionApproach }
-				}),
+				query: (args) => ({ params: args }),
 				invalidatesTags: [invalidatesList(ReduxTag.UpstreamIntegrationStatus)]
 			})
 		})

--- a/apps/desktop/src/lib/worktree/worktreeService.svelte.ts
+++ b/apps/desktop/src/lib/worktree/worktreeService.svelte.ts
@@ -100,7 +100,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				{ projectId: string }
 			>({
 				extraOptions: { command: 'changes_in_worktree' },
-				query: (args) => ({ params: args }),
+				query: (args) => args,
 				/** Invalidating tags causes data to be refreshed. */
 				providesTags: [providesList(ReduxTag.WorktreeChanges)],
 				/**

--- a/apps/desktop/src/lib/worktree/worktreeService.svelte.ts
+++ b/apps/desktop/src/lib/worktree/worktreeService.svelte.ts
@@ -99,7 +99,8 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				},
 				{ projectId: string }
 			>({
-				query: ({ projectId }) => ({ command: 'changes_in_worktree', params: { projectId } }),
+				extraOptions: { command: 'changes_in_worktree' },
+				query: (args) => ({ params: args }),
 				/** Invalidating tags causes data to be refreshed. */
 				providesTags: [providesList(ReduxTag.WorktreeChanges)],
 				/**

--- a/crates/gitbutler-tauri/src/modes.rs
+++ b/crates/gitbutler-tauri/src/modes.rs
@@ -34,7 +34,7 @@ pub fn enter_edit_mode(
     projects: State<'_, Controller>,
     settings: State<'_, AppSettingsWithDiskSync>,
     project_id: ProjectId,
-    commit_oid: String,
+    commit_id: String,
     stack_id: StackId,
 ) -> Result<EditModeMetadata, Error> {
     let project = projects.get(project_id)?;
@@ -42,7 +42,7 @@ pub fn enter_edit_mode(
     let handle = VirtualBranchesHandle::new(project.gb_dir());
     let stack = handle.get_stack(stack_id)?;
 
-    let commit = git2::Oid::from_str(&commit_oid).context("Failed to parse commit oid")?;
+    let commit = git2::Oid::from_str(&commit_id).context("Failed to parse commit oid")?;
 
     gitbutler_edit_mode::commands::enter_edit_mode(
         &ctx,

--- a/crates/gitbutler-tauri/src/repo.rs
+++ b/crates/gitbutler-tauri/src/repo.rs
@@ -86,8 +86,8 @@ pub mod commands {
         commit_id: String,
     ) -> Result<FileInfo, Error> {
         let project = projects.get(project_id)?;
-        let commit_oid = git2::Oid::from_str(commit_id.as_ref()).map_err(anyhow::Error::from)?;
-        Ok(project.read_file_from_commit(commit_oid, relative_path)?)
+        let commit_id = git2::Oid::from_str(commit_id.as_ref()).map_err(anyhow::Error::from)?;
+        Ok(project.read_file_from_commit(commit_id, relative_path)?)
     }
 
     #[tauri::command(async)]


### PR DESCRIPTION
From now we only specify the `command` in the query defintion, rather 
than passing it as an argument to the `TauriBaseQueryFn`.