### PR TITLE
fix(format): correct newline format in prompt string

### DIFF
--- a/crates/but-action/src/simple.rs
+++ b/crates/but-action/src/simple.rs
@@ -154,7 +154,7 @@ fn handle_changes_simple_inner(
             &diff,
         )?
     } else if let Some(prompt) = external_prompt {
-        format!("{}/n/n{}", prompt, change_summary)
+        format!("{}\n\n{}", prompt, change_summary)
     } else {
         change_summary.to_string()
     };


### PR DESCRIPTION
Corrected the format string in crates/but-action/src/simple.rs to properly format the prompt and change summary by replacing incorrect '/n/n' with '\n\n'. This ensures the newline characters render as intended in the output.