### PR TITLE
feat: add metrics instrumentation to internal MCP server

### DIFF
--- a/crates/but/src/main.rs
+++ b/crates/but/src/main.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
     match &args.cmd {
         Subcommands::Mcp { internal } => {
             if *internal {
-                mcp_internal::start().await
+                mcp_internal::start(app_settings).await
             } else {
                 mcp::start(app_settings).await
             }

--- a/crates/but/src/metrics/mod.rs
+++ b/crates/but/src/metrics/mod.rs
@@ -12,6 +12,7 @@ pub struct Metrics {
 #[serde(rename_all = "camelCase")]
 pub enum EventKind {
     Mcp,
+    McpInternal,
 }
 #[derive(Debug, Clone)]
 pub struct Event {


### PR DESCRIPTION
- Instrument the internal MCP server with metrics:
  - Capture duration, endpoint name, and client details (name and version) for important endpoints: project_status, commit, amend, branch_details, create_branch.
  - Integrate the Metrics handling struct and event capturing in MCP server logic.
  - Pass AppSettings and client_info as needed through server instantiation.
- Add a new `McpInternal` variant to EventKind for more granular event typing.
- Update relevant method signatures and invocations.

This change provides foundational metrics collection suitable for internal observability purposes in the MCP server.