### PR TITLE
Handle errors in listVirtualBranches and default to empty

### DIFF
--- a/apps/desktop/src/lib/branches/virtualBranchService.ts
+++ b/apps/desktop/src/lib/branches/virtualBranchService.ts
@@ -109,7 +109,13 @@ export class VirtualBranchService {
 	}
 
 	private async listVirtualBranches(): Promise<BranchStack[]> {
-		const response = await invoke<any>('list_virtual_branches', { projectId: this.projectId });
+		const response = await invoke<any>('list_virtual_branches', {
+			projectId: this.projectId
+		}).catch((e) => {
+			// Swallow this error since this is only a transitional error from v2 -> v3.
+			console.error('Failed to list virtual branches (v2):', e);
+			return { branches: [], dependencyErrors: [], skippedFiles: [] };
+		});
 		const virtualBranches = plainToInstance(VirtualBranches, response);
 
 		if (virtualBranches.dependencyErrors.length > 0) {


### PR DESCRIPTION
Update the listVirtualBranches method to catch any errors thrown by invoke('list_virtual_branches'), log a console error, and return empty data for branches, dependencyErrors, and skippedFiles. This change ensures smoother migration and prevents transitional errors from creating unhandled exceptions during virtual branch listing.