### PR TITLE
graphs -> stacks: remove abandoned impl

### DIFF
--- a/apps/desktop/src/lib/config/appSettingsV2.ts
+++ b/apps/desktop/src/lib/config/appSettingsV2.ts
@@ -45,10 +45,6 @@ export class SettingsService {
 	}
 
 	async updateFeatureFlags(update: Partial<FeatureFlags>) {
-		// Doing a call to list_virtual_branches first to ensure the stack.tree properties are updated
-		await this.tauri.invoke<any>('list_virtual_branches', {
-			projectId: this.projectsService.getLastOpenedProject()
-		});
 		await this.tauri.invoke('update_feature_flags', { update });
 	}
 

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -2,10 +2,8 @@
 	import '@gitbutler/ui/main.css';
 	import '../styles/styles.css';
 
-	import { browser } from '$app/environment';
-	import { dev } from '$app/environment';
-	import { beforeNavigate, afterNavigate } from '$app/navigation';
-	import { goto } from '$app/navigation';
+	import { browser, dev } from '$app/environment';
+	import { afterNavigate, beforeNavigate, goto } from '$app/navigation';
 	import AppUpdater from '$components/AppUpdater.svelte';
 	import GlobalModal from '$components/GlobalModal.svelte';
 	import GlobalSettingsMenuAction from '$components/GlobalSettingsMenuAction.svelte';
@@ -56,7 +54,7 @@
 	import { setSecretsService } from '$lib/secrets/secretsService';
 	import { IdSelection } from '$lib/selection/idSelection.svelte';
 	import { UncommittedService } from '$lib/selection/uncommittedService.svelte';
-	import { SETTINGS, loadUserSettings } from '$lib/settings/userSettings';
+	import { loadUserSettings, SETTINGS } from '$lib/settings/userSettings';
 	import { ShortcutService } from '$lib/shortcuts/shortcutService.svelte';
 	import { CommitAnalytics } from '$lib/soup/commitAnalytics';
 	import { StackService } from '$lib/stacks/stackService.svelte';
@@ -85,8 +83,10 @@
 	import { WebRoutesService } from '@gitbutler/shared/routing/webRoutes.svelte';
 	import { UploadsService } from '@gitbutler/shared/uploads/uploadsService';
 	import { UserService as CloudUserService } from '@gitbutler/shared/users/userService';
-	import { LineManagerFactory as StackingLineManagerFactory } from '@gitbutler/ui/commitLines/lineManager';
-	import { LineManagerFactory } from '@gitbutler/ui/commitLines/lineManager';
+	import {
+		LineManagerFactory as StackingLineManagerFactory,
+		LineManagerFactory
+	} from '@gitbutler/ui/commitLines/lineManager';
 	import { setExternalLinkService } from '@gitbutler/ui/link/externalLinkService';
 	import { onMount, setContext, type Snippet } from 'svelte';
 	import { Toaster } from 'svelte-french-toast';
@@ -303,6 +303,12 @@
 		// Toggle v3 workspace APIs on/off
 		'w s 3': () => {
 			settingsService.updateFeatureFlags({ ws3: !$settingsStore?.featureFlags.ws3 });
+		},
+		// This is a debug tool to see how the commit-graph looks like, the basis for all workspace computation.
+		// For good measure, it also shows the workspace.
+		'd o t': async () => {
+			const projectId = new URL(window.location.href).pathname.split('/')[1];
+			await invoke('show_graph_svg', { projectId });
 		},
 		// This is a debug tool to learn about environment variables actually present - only available if the backend is in debug mode.
 		'e n v': async () => {

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -15,7 +15,7 @@ use tracing::instrument;
 impl Graph {
     /// Now that the graph is complete, perform additional structural improvements with
     /// the requirement of them to be computationally cheap.
-    #[instrument(skip(self, meta, repo), err(Debug))]
+    #[instrument(skip(self, meta, repo, refs_by_id), err(Debug))]
     #[allow(clippy::too_many_arguments)]
     pub(super) fn post_processed(
         mut self,
@@ -196,7 +196,7 @@ impl Graph {
         let mut out: Vec<_> = ws_stacks
             .iter()
             .filter_map(|s| {
-                s.base_segment_id.and_then(|sidx| {
+                s.base_segment_id().and_then(|sidx| {
                     let base_is_directly_connected_to_workspace = self
                         .inner
                         .neighbors_directed(sidx, Direction::Incoming)
@@ -207,7 +207,7 @@ impl Graph {
                     let base_segment = &self[sidx];
                     // These are naturally in the workspace.
                     base_segment
-                        .commit_index_of(s.base.expect("must be set if sidx is set"))
+                        .commit_index_of(s.base().expect("must be set if sidx is set"))
                         .map(|cidx| (sidx, &base_segment.commits[cidx]))
                 })
             })

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -39,7 +39,7 @@ fn single_stack_ambigous() -> anyhow::Result<()> {
 
     // All non-integrated segments are visible.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:3:B <> origin/B →:4:⇡3 on fafd9d0
         └── :3:B <> origin/B →:4:⇡3
             ├── ·70e9a36 (🏘️)
@@ -71,7 +71,7 @@ fn single_stack_ambigous() -> anyhow::Result<()> {
     // Now `HEAD` is outside a workspace, which goes to single-branch mode. But it knows it's in a workspace
     // and shows the surrounding parts, while marking the segment as entrypoint.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:4:B <> origin/B →:5:⇡1 on fafd9d0
         ├── :4:B <> origin/B →:5:⇡1
         │   └── ·70e9a36 (🏘️)
@@ -104,7 +104,7 @@ fn single_stack_ambigous() -> anyhow::Result<()> {
 
     // Entrypoint is now unnamed (as no ref-name was provided for traversal)
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:4:B <> origin/B →:5:⇡1 on fafd9d0
         ├── :4:B <> origin/B →:5:⇡1
         │   └── ·70e9a36 (🏘️)
@@ -138,7 +138,7 @@ fn single_stack_ambigous() -> anyhow::Result<()> {
 
     // Doing this is very much like edit mode, and there is always a segment starting at the entrypoint.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:4:B <> origin/B →:5:⇡2 on fafd9d0
         ├── :4:B <> origin/B →:5:⇡2
         │   ├── ·70e9a36 (🏘️)
@@ -170,7 +170,7 @@ fn single_stack_ambigous() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:4:B <> origin/B →:5:⇡2 on fafd9d0
         ├── :4:B <> origin/B →:5:⇡2
         │   ├── ·70e9a36 (🏘️)
@@ -233,7 +233,7 @@ fn single_stack_ws_insertions() -> anyhow::Result<()> {
 
     // We pickup empty segments.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:3:B <> origin/B →:4:⇡2 on fafd9d0
         ├── 📙:3:B <> origin/B →:4:⇡2
         │   ├── ·70e9a36 (🏘️)
@@ -280,7 +280,7 @@ fn single_stack_ws_insertions() -> anyhow::Result<()> {
         └── →:2: (main →:1:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:3:B <> origin/B →:4:⇡2 on fafd9d0
         ├── 📙:3:B <> origin/B →:4:⇡2
         │   ├── ·70e9a36 (🏘️)
@@ -320,7 +320,7 @@ fn single_stack_ws_insertions() -> anyhow::Result<()> {
         └── →:0: (A-empty-01)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:4:B <> origin/B →:5:⇡2 on fafd9d0
         ├── 📙:4:B <> origin/B →:5:⇡2
         │   ├── ·70e9a36 (🏘️)
@@ -364,7 +364,7 @@ fn single_stack() -> anyhow::Result<()> {
         └── →:2: (main →:1:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:3:B on fafd9d0
         ├── :3:B
         │   └── ·320e105 (🏘️)
@@ -403,7 +403,7 @@ fn single_stack() -> anyhow::Result<()> {
         └── →:2: (main →:1:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     ├── ≡📙:6:new-A on fafd9d0
     │   └── 📙:6:new-A
     └── ≡📙:3:B on fafd9d0
@@ -618,7 +618,7 @@ fn minimal_merge() -> anyhow::Result<()> {
         └── →:2: (main →:1:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:3:merge-2 on fafd9d0
         ├── :3:merge-2
         │   └── ·f40fb16 (🏘️)
@@ -673,7 +673,7 @@ fn just_init_with_branches() -> anyhow::Result<()> {
     ");
 
     // However, when the workspace is checked out, it's at least empty.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main");
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0");
 
     // The simplest possible setup where we can define how the workspace should look like,
     // in terms of dependent and independent virtual segments.
@@ -717,7 +717,7 @@ fn just_init_with_branches() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     ├── ≡📙:6:D on fafd9d0
     │   ├── 📙:6:D
     │   ├── 📙:7:E
@@ -757,7 +757,7 @@ fn two_stacks_many_refs() -> anyhow::Result<()> {
 
     // With no workspace at all as the workspace segment isn't split.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:3:anon: on fafd9d0
         └── :3:anon:
             ├── ·16f132b (🏘️) ►F, ►G, ►S1
@@ -780,7 +780,7 @@ fn two_stacks_many_refs() -> anyhow::Result<()> {
         └── →:3: (main →:2:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡👉:0:S1 on fafd9d0
         └── 👉:0:S1
             ├── ·16f132b (🏘️) ►F, ►G
@@ -817,7 +817,7 @@ fn two_stacks_many_refs() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     ├── ≡📙:7:S1 on fafd9d0
     │   ├── 📙:7:S1
     │   ├── 📙:8:G
@@ -857,7 +857,7 @@ fn two_stacks_many_refs() -> anyhow::Result<()> {
         └── →:3: (main →:2:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     ├── ≡👉📙:0:S1 on fafd9d0
     │   ├── 👉📙:0:S1
     │   ├── 📙:7:G
@@ -907,7 +907,7 @@ fn just_init_with_branches_complex() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     ├── ≡📙:8:F on fafd9d0
     │   └── 📙:8:F
     ├── ≡📙:6:D on fafd9d0
@@ -945,7 +945,7 @@ fn just_init_with_branches_complex() -> anyhow::Result<()> {
 
     // We should see the same stacks as we did before, just with a different entrypoint.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     ├── ≡📙:8:F on fafd9d0
     │   └── 📙:8:F
     ├── ≡📙:6:D on fafd9d0
@@ -988,7 +988,7 @@ fn proper_remote_ahead() -> anyhow::Result<()> {
     ");
 
     // Everything in the workspace is integrated, thus it's empty.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣2");
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣2 on 998eae6");
 
     let (id, ref_name) = id_at(&repo, "main");
     // The integration branch can be in the workspace and be checked out.
@@ -1156,7 +1156,7 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     // directly owned by another remote segment.
     // they have to be considered as something relevant to the branch history.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:3:B <> origin/B →:4:⇡1⇣1 on fafd9d0
         ├── :3:B <> origin/B →:4:⇡1⇣1
         │   ├── 🟣682be32
@@ -1187,7 +1187,7 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
                     └── →:3: (main →:2:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:5:B <> origin/B →:6:⇡1⇣1 on fafd9d0
         ├── :5:B <> origin/B →:6:⇡1⇣1
         │   ├── 🟣682be32
@@ -1313,7 +1313,7 @@ fn disambiguate_by_remote() -> anyhow::Result<()> {
     ");
     // An anonymous segment to start with is alright, and can always happen for other situations as well.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:6:anon: on fafd9d0
         ├── :6:anon:
         │   └── ·2173153 (🏘️) ►C, ►ambiguous-C
@@ -1358,7 +1358,7 @@ fn disambiguate_by_remote() -> anyhow::Result<()> {
     ");
     // And because `C` is in the workspace data, its data is denoted.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:3:C <> origin/C →:4: on fafd9d0
         ├── 📙:3:C <> origin/C →:4:
         │   └── ❄️2173153 (🏘️) ►ambiguous-C
@@ -1431,7 +1431,7 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     // It's true that `A` is fully integrated so it isn't displayed. so from a workspace-perspective
     // it's the right answer.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣6
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣6 on 79bbb29
     └── ≡:2:B on 79bbb29
         └── :2:B
             ├── ·6b1a13b (🏘️)
@@ -1466,7 +1466,7 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     ");
     // `A` is integrated, hence it's not shown.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣6
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣6 on 79bbb29
     └── ≡📙:2:B on 79bbb29
         └── 📙:2:B
             ├── ·6b1a13b (🏘️)
@@ -1499,7 +1499,7 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
                     └── →:4: (A)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣6
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣6 on 79bbb29
     └── ≡📙:2:B on 79bbb29
         └── 📙:2:B
             ├── ·6b1a13b (🏘️)
@@ -1615,6 +1615,83 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
             ├── ·34d0715 (🏘️|✓)
             └── ·eb5f731 (🏘️|✓)
     ");
+
+    // See what happens with an out-of-workspace HEAD and an arbitrary extra target.
+    let (id, _ref_name) = id_at(&repo, "origin/main");
+    let graph = Graph::from_commit_traversal(
+        id,
+        None,
+        &*meta,
+        standard_options_with_extra_target(&repo, "gitbutler/workspace"),
+    )?
+    .validated()?;
+    // It keeps the tip-settings of the workspace it setup by itself, and doesn't override this
+    // with the extra-target settings.
+    insta::assert_snapshot!(graph_tree(&graph), @r"
+    ├── 📕►►►:1:gitbutler/workspace
+    │   └── ·4077353 (⌂|🏘️)
+    │       └── ►:3:B
+    │           ├── ·6b1a13b (⌂|🏘️)
+    │           └── ·03ad472 (⌂|🏘️)
+    │               └── ►:6:A
+    │                   ├── ·79bbb29 (⌂|🏘️|✓|1)
+    │                   ├── ·fc98174 (⌂|🏘️|✓|1)
+    │                   ├── ·a381df5 (⌂|🏘️|✓|1)
+    │                   └── ·777b552 (⌂|🏘️|✓|1)
+    │                       └── ►:7:anon:
+    │                           └── ·ce4a760 (⌂|🏘️|✓|1)
+    │                               ├── ►:8:anon:
+    │                               │   └── ·01d0e1e (⌂|🏘️|✓|1)
+    │                               │       └── ►:5:main
+    │                               │           ├── ·4b3e5a8 (⌂|🏘️|✓|1)
+    │                               │           ├── ·34d0715 (⌂|🏘️|✓|1)
+    │                               │           └── ·eb5f731 (⌂|🏘️|✓|1)
+    │                               └── ►:9:A-feat
+    │                                   ├── ·fea59b5 (⌂|🏘️|✓|1)
+    │                                   └── ·4deea74 (⌂|🏘️|✓|1)
+    │                                       └── →:8:
+    └── ►:2:origin/main
+        └── ►:0:anon:
+            ├── 👉·d0df794 (⌂|✓|1)
+            └── ·09c6e08 (⌂|✓|1)
+                └── ►:4:anon:
+                    └── ·7b9f260 (⌂|✓|1)
+                        ├── →:5: (main)
+                        └── →:6: (A)
+    ");
+
+    // However, when choosing an initially unknown branch, it will get the extra target tip settings.
+    let graph = Graph::from_commit_traversal(
+        id,
+        None,
+        &*meta,
+        standard_options_with_extra_target(&repo, "B"),
+    )?
+    .validated()?;
+    // For now we don't do anything to limit the each in single-branch mode using extra-targets.
+    // TODO(extra-target): make it work so they limit single branches even.
+    insta::assert_snapshot!(graph_tree(&graph), @r"
+    ├── 📕►►►:1:gitbutler/workspace
+    │   └── ·4077353 (⌂|🏘️)
+    │       └── ►:3:B
+    │           ├── ·6b1a13b (⌂|🏘️|✓)
+    │           └── ·03ad472 (⌂|🏘️|✓)
+    │               └── ►:5:A
+    │                   ├── ·79bbb29 (⌂|🏘️|✓|1)
+    │                   └── ✂️·fc98174 (⌂|🏘️|✓|1)
+    └── ►:2:origin/main
+        └── ►:0:anon:
+            ├── 👉·d0df794 (⌂|✓|1)
+            └── ·09c6e08 (⌂|✓|1)
+                └── ►:4:anon:
+                    └── ·7b9f260 (⌂|✓|1)
+                        ├── ►:6:main
+                        │   ├── ·4b3e5a8 (⌂|✓|1)
+                        │   ├── ·34d0715 (⌂|✓|1)
+                        │   └── ·eb5f731 (⌂|✓|1)
+                        └── →:5: (A)
+    ");
+
     Ok(())
 }
 
@@ -1683,7 +1760,7 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
 
     // This search discovers the whole workspace, without the integrated one.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣3
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣3 on 79bbb29
     └── ≡:3:B on 79bbb29
         └── :3:B
             ├── ·6b1a13b (🏘️)
@@ -1698,7 +1775,7 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
     )?
     .validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣3
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣3 on 4b3e5a8
     └── ≡:3:B on 4b3e5a8
         ├── :3:B
         │   ├── ·6b1a13b (🏘️)
@@ -1779,7 +1856,7 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
     )?
     .validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main⇣3
+    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main⇣3 on 4b3e5a8
     └── ≡:4:B on 4b3e5a8
         ├── :4:B
         │   ├── ·6b1a13b (🏘️)
@@ -1826,6 +1903,30 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
 fn workspace_obeys_limit_when_target_branch_is_missing() -> anyhow::Result<()> {
     let (repo, mut meta) =
         read_only_in_memory_scenario("ws/two-segments-one-integrated-without-remote")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * d0df794 (origin/main) remote-2
+    * 09c6e08 remote-1
+    *   7b9f260 Merge branch 'A' into soon-origin-main
+    |\  
+    | | * 4077353 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | | * 6b1a13b (B) B2
+    | | * 03ad472 B1
+    | |/  
+    | * 79bbb29 (A) 8
+    | * fc98174 7
+    | * a381df5 6
+    | * 777b552 5
+    | *   ce4a760 Merge branch 'A-feat' into A
+    | |\  
+    | | * fea59b5 (A-feat) A-feat-2
+    | | * 4deea74 A-feat-1
+    | |/  
+    | * 01d0e1e 4
+    |/  
+    * 4b3e5a8 (main) 3
+    * 34d0715 2
+    * eb5f731 1
+    ");
     add_workspace_without_target(&mut meta);
     assert!(
         meta.data_mut().default_target.is_none(),
@@ -1875,7 +1976,7 @@ fn workspace_obeys_limit_when_target_branch_is_missing() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣6
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣6 on 79bbb29
     └── ≡:2:B on 79bbb29
         └── :2:B
             ├── ·6b1a13b (🏘️)
@@ -1914,7 +2015,7 @@ fn three_branches_one_advanced_ws_commit_advanced_fully_pushed_empty_dependant()
 
     // By default, the advanced lane is simply frozen as its remote contains the commit.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡:4:advanced-lane <> origin/advanced-lane →:3: on fafd9d0
         └── :4:advanced-lane <> origin/advanced-lane →:3:
             └── ❄️cbc6713 (🏘️) ►dependant, ►on-top-of-dependant
@@ -1946,7 +2047,7 @@ fn three_branches_one_advanced_ws_commit_advanced_fully_pushed_empty_dependant()
 
     // When putting the dependent branch on top as empty segment, the frozen state is retained.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:5:dependant on fafd9d0
         ├── 📙:5:dependant
         └── 📙:6:advanced-lane <> origin/advanced-lane →:3:
@@ -1982,7 +2083,7 @@ fn on_top_of_target_with_history() -> anyhow::Result<()> {
                     └── ·2be54cd (⌂|🏘️|✓|11)
     ");
     // Workspace is empty as everything is integrated.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main");
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 2cde30a");
 
     add_stack_with_segments(&mut meta, 0, "C", StackState::InWorkspace, &["B", "A"]);
     add_stack_with_segments(&mut meta, 1, "D", StackState::InWorkspace, &["E", "F"]);
@@ -2009,7 +2110,7 @@ fn on_top_of_target_with_history() -> anyhow::Result<()> {
 
     // Empty stack segments on top of integrated portions will show, and nothing integrated shows.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 2cde30a
     ├── ≡📙:6:D on 2cde30a
     │   ├── 📙:6:D
     │   ├── 📙:7:E
@@ -2030,7 +2131,7 @@ fn on_top_of_target_with_history() -> anyhow::Result<()> {
     )?
     .validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 2be54cd
     ├── ≡📙:6:D on 2be54cd
     │   ├── 📙:6:D
     │   ├── 📙:7:E
@@ -2274,7 +2375,7 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     ");
 
     // Everything is integrated, nothing to see here.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣11");
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣11 on 9730cbf");
     Ok(())
 }
 
@@ -2416,7 +2517,7 @@ fn partitions_with_long_and_short_connections_to_each_other_part_2() -> anyhow::
                             └── →:3: (main-to-workspace)
     ");
     // Everything is integrated.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣17");
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣17 on c9120f1");
     Ok(())
 }
 
@@ -2487,11 +2588,18 @@ fn multi_lane_with_shared_segment_one_integrated() -> anyhow::Result<()> {
     // A is still shown despite it being fully integrated, as it's still enclosed by the
     // workspace tip and the fork-point, at least when we provide the previous known location of the target.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on 3183e43
     ├── ≡:5:B on 3183e43
     │   ├── :5:B
     │   │   ├── ·acdc49a (🏘️)
     │   │   └── ·f0117e0 (🏘️)
+    │   └── :7:shared
+    │       ├── ·d4f537e (🏘️|✓)
+    │       ├── ·b448757 (🏘️|✓)
+    │       └── ·e9a378d (🏘️|✓)
+    ├── ≡:4:A on 3183e43
+    │   ├── :4:A
+    │   │   └── ·0bad3af (🏘️|✓)
     │   └── :7:shared
     │       ├── ·d4f537e (🏘️|✓)
     │       ├── ·b448757 (🏘️|✓)
@@ -2512,11 +2620,14 @@ fn multi_lane_with_shared_segment_one_integrated() -> anyhow::Result<()> {
     // If we do not, integrated portions are removed.
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on d4f537e
     ├── ≡:5:B on d4f537e
     │   └── :5:B
     │       ├── ·acdc49a (🏘️)
     │       └── ·f0117e0 (🏘️)
+    ├── ≡:4:A on d4f537e
+    │   └── :4:A
+    │       └── ·0bad3af (🏘️|✓)
     └── ≡:3:D on d4f537e
         ├── :3:D
         │   └── ·9895054 (🏘️)
@@ -2583,7 +2694,7 @@ fn multi_lane_with_shared_segment() -> anyhow::Result<()> {
 
     // Segments can definitely repeat
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on 3183e43
     ├── ≡:4:B on 3183e43
     │   ├── :4:B
     │   │   ├── ·acdc49a (🏘️)
@@ -2617,7 +2728,7 @@ fn multi_lane_with_shared_segment() -> anyhow::Result<()> {
         .validated()?;
     // Checking out anything inside the workspace yields the same result.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1
+    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on 3183e43
     ├── ≡:5:B on 3183e43
     │   ├── :5:B
     │   │   ├── ·acdc49a (🏘️)
@@ -2687,7 +2798,7 @@ fn dependent_branch_insertion() -> anyhow::Result<()> {
 
     // The dependant branch is empty and on top of the one with the remote
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:5:dependant on fafd9d0
         ├── 📙:5:dependant
         └── 📙:6:advanced-lane <> origin/advanced-lane →:4:
@@ -2724,7 +2835,7 @@ fn dependent_branch_insertion() -> anyhow::Result<()> {
     // It's probably OK to leave it like this for now, and instead allow users to reorder
     // these more easily.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:5:advanced-lane <> origin/advanced-lane →:4: on fafd9d0
         ├── 📙:5:advanced-lane <> origin/advanced-lane →:4:
         └── 📙:6:dependant
@@ -2735,7 +2846,7 @@ fn dependent_branch_insertion() -> anyhow::Result<()> {
     let graph =
         Graph::from_commit_traversal(id, ref_name, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡👉📙:0:advanced-lane <> origin/advanced-lane →:4: on fafd9d0
         ├── 👉📙:0:advanced-lane <> origin/advanced-lane →:4:
         └── 📙:5:dependant
@@ -2746,7 +2857,7 @@ fn dependent_branch_insertion() -> anyhow::Result<()> {
     let graph =
         Graph::from_commit_traversal(id, ref_name, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡👉📙:0:dependant on fafd9d0
         ├── 👉📙:0:dependant
         └── 📙:5:advanced-lane <> origin/advanced-lane →:4:
@@ -2794,7 +2905,7 @@ fn multiple_stacks_with_shared_parent_and_remote() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     ├── ≡:4:B-on-A on fafd9d0
     │   ├── :4:B-on-A
     │   │   └── ·aff8449 (🏘️)
@@ -2847,8 +2958,8 @@ fn a_stack_segment_can_be_a_segment_elsewhere_and_stack_order() -> anyhow::Resul
     // However, as nothing is integrated, it really is another name for `main` now,
     // `main` is nothing special.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1
-    ├── ≡📙:3:lane on fafd9d0
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on fafd9d0
+    ├── ≡📙:3:lane
     │   └── 📙:3:lane
     │       └── ·fafd9d0 (🏘️) ►main
     └── ≡📙:2:advanced-lane on fafd9d0
@@ -2874,11 +2985,11 @@ fn a_stack_segment_can_be_a_segment_elsewhere_and_stack_order() -> anyhow::Resul
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main⇣1 on fafd9d0
     ├── ≡📙:2:advanced-lane on fafd9d0
     │   └── 📙:2:advanced-lane
     │       └── ·cbc6713 (🏘️)
-    └── ≡📙:3:lane on fafd9d0
+    └── ≡📙:3:lane
         └── 📙:3:lane
             └── ·fafd9d0 (🏘️) ►main
     ");
@@ -2930,7 +3041,7 @@ fn two_dependent_branches_with_embedded_remote() -> anyhow::Result<()> {
     // Remote tracking branches we just want to aggregate, just like anonymous segments,
     // but only when another target is provided (the old position, `main`).
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     └── ≡📙:3:A <> origin/A →:4:⇡1⇣1 on fafd9d0
         ├── 📙:3:A <> origin/A →:4:⇡1⇣1
         │   ├── 🟣2b1808c
@@ -2945,7 +3056,7 @@ fn two_dependent_branches_with_embedded_remote() -> anyhow::Result<()> {
     // but it's skipped because it's actually part of an integrated otherwise ignored segment.
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main
+    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 96a2408
     └── ≡📙:3:A <> origin/A →:4:⇡1⇣1 on 96a2408
         └── 📙:3:A <> origin/A →:4:⇡1⇣1
             ├── 🟣2b1808c
@@ -3174,7 +3285,7 @@ fn workspace_commit_pushed_to_target() -> anyhow::Result<()> {
                             └── ·fafd9d0 (⌂|🏘️|✓|1)
     ");
     // Everything is integrated, so nothing is shown.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main");
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 120a217");
     Ok(())
 }
 

--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -438,6 +438,9 @@ pub(crate) mod function {
             stacks,
             target,
             metadata,
+            // TODO: use base
+            lower_bound: _,
+            lower_bound_segment_id: _,
         } = graph.to_workspace()?;
 
         let cache = repo.commit_graph_if_enabled()?;
@@ -484,14 +487,12 @@ pub(crate) mod function {
 
     impl branch::Stack {
         fn try_from_graph_stack<'repo>(
-            but_graph::projection::Stack {
-                base,
-                base_segment_id: _,
-                segments,
-            }: but_graph::projection::Stack,
+            stack: but_graph::projection::Stack,
             repo: &'repo gix::Repository,
             mut ctx: SimilarityContext<'_, '_, 'repo, '_>,
         ) -> anyhow::Result<Self> {
+            let base = stack.base();
+            let but_graph::projection::Stack { segments } = stack;
             Ok(branch::Stack {
                 base,
                 segments: segments

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -2054,24 +2054,6 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 ],
                 stash_status: None,
             },
-            Stack {
-                base: Some(
-                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
-                ),
-                segments: [
-                    ref_info::ui::Segment {
-                        id: 0,
-                        ref_name: "None",
-                        remote_tracking_ref_name: "None",
-                        commits: [
-                            LocalCommit(fafd9d0, "init\n", local, ►main),
-                        ],
-                        commits_unique_in_remote_tracking_branch: [],
-                        metadata: "None",
-                    },
-                ],
-                stash_status: None,
-            },
         ],
         target_ref: Some(
             FullName(

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -299,9 +299,11 @@ fn main() {
                     diff::changes_in_branch,
                     diff::tree_change_diffs,
                     diff::assign_hunk,
-                    // `env_vars` is only supposed to be avaialble in debug mode, not in production.
+                    // Debug-only - not for production!
                     #[cfg(debug_assertions)]
                     env::env_vars,
+                    #[cfg(all(debug_assertions, unix))]
+                    workspace::show_graph_svg,
                 ])
                 .menu(menu::build)
                 .on_window_event(|window, event| match event {


### PR DESCRIPTION
Bring the new Graph based backend for workspaces to conformity with the existing implementation - it shouldn't be worse, but ideally can be the daily driver for `ws3` users.


### Tasks

- [x] assure stacks that are fully integrated don't disappear (they are still within the bounds of the workspace)
- [x] add `dot` support for UI as debugging tool
- [ ] check remaining tests and TODOs
    - [ ] switch over rest of ref-info tests
    - [ ] remove unused ref-info code
- [ ] ~~dynamic search for bases to put stacks on top of?~~ - later when needed, can probably use  a refactor of dependent and independent branch handling.
- [ ] ~~'archived' out-of-workspace refs are forcefully added (and marked) accordingly~~ - archived segments can still be used for reconcilation if they are reachable, it's really about the frontend having this data even after a workspace update
- [ ] in-workspace segments with all-integrated-by-similarity (remote rebased + merged) stay visible (`two_dependent_branches_first_rebased_and_merged_into_target`)
- [x] Validate that using the local tracking branch of target to compute the merge-base is the right choice
     - It is not the right thing, but allowing additional targets is the way to go here also to support the 'sha' field while it exists.
- [ ] REVIEW if local tracking branches of targets should be traversed.
- [ ] ⚠️ fix related TODOs and known issues
- [x] ⚠️assure parent-order is correct during traversal (must match parents in merge commits)
- [ ] delete now unused code

### Not to forget

* There might be an issue with the way it uses searches - a tip with a search might be blocked at an existing commit, discovered by a tip with a different search, and even though the thing it searches is reachable through that, it stops looking.
* ‼️if branches in the workspace are advanced outside of the workspace, it currently doesn't see these commits and the branch looses its name in the workspace. The traversal really should try to add the known tips explicitly for traversal and expose that information.
* ‼️Have tests and assure that the workspace commit (managed) doesn't ever get owned by an unmanaged workspace segment.
* ⚠️ the amount of commits of remotes ahead of their local branch doesn't seem to always match git (particularly when it's a lot of them)
* ⚠️handle the `archived` flag
* ⚠️ current implementation supports multiple workspaces *in theory*, but it's not tested with them as the underlying ref-metadata is still VB-toml. So before supporting this, we probably already want to have migrated away from vb.toml, to then port the ref-metadata to something that can support more workspaces (also for testing).
* ⚠️ we probably don't correctly handle workspaces that include other workspaces.
* ⚠️ we probably don't handle [dot-repositories](https://git-scm.com/docs/git-config#Documentation/git-config.txt-branchltnamegtmerge) correctly, by merit of not really having them in mind. At least they shouldn't be in the way of handling normal remotes.

### Related

* #8905

### Previous

* #8919
* #8935
* #9096
* #9122
* #9209
* #9313

