### PR TITLE
Improve wrapping in commit message editor

### DIFF
--- a/apps/desktop/src/components/v3/editor/MessageEditor.svelte
+++ b/apps/desktop/src/components/v3/editor/MessageEditor.svelte
@@ -572,11 +572,6 @@
 		align-items: center;
 		padding: 0 4px;
 		gap: 5px;
-
-		&.disabled {
-			opacity: 0.5;
-			pointer-events: none;
-		}
 	}
 
 	.message-textarea__ruler-input {

--- a/packages/ui/src/lib/RichTextEditor.svelte
+++ b/packages/ui/src/lib/RichTextEditor.svelte
@@ -172,6 +172,9 @@
 			const currentText = await getPlaintext();
 			if (currentText?.trim() === '') {
 				setText(initialText);
+				if (wrapCountValue !== undefined) {
+					wrapAll();
+				}
 			}
 		}
 	}

--- a/packages/ui/src/lib/richText/css/component.css
+++ b/packages/ui/src/lib/richText/css/component.css
@@ -29,6 +29,8 @@
 		height: 100%;
 		min-height: unset;
 		overflow: hidden;
+		/* Use of !important for white-space since it cannot be overridden. */
+		white-space: nowrap !important;
 	}
 }
 


### PR DESCRIPTION
The main thing here is that we force the content editable root to use 
white-space: nowrap. This prevents the accidental mix of soft and hard 
wraps.