### PR TITLE
ui-fixes-109

### DIFF
--- a/apps/desktop/src/components/v3/BranchView.svelte
+++ b/apps/desktop/src/components/v3/BranchView.svelte
@@ -77,7 +77,6 @@
 			{scrollToType}
 			{resizer}
 			{onclose}
-			bottomBorder={!!resizer || !collapsible}
 			{ontoggle}
 			{grow}
 		>

--- a/apps/desktop/src/components/v3/CommitView.svelte
+++ b/apps/desktop/src/components/v3/CommitView.svelte
@@ -151,7 +151,6 @@
 		<Drawer
 			{collapsible}
 			testId={TestId.CommitDrawer}
-			bottomBorder={!!resizer || !collapsible}
 			{scrollToId}
 			{scrollToType}
 			{ontoggle}

--- a/apps/desktop/src/components/v3/Drawer.svelte
+++ b/apps/desktop/src/components/v3/Drawer.svelte
@@ -76,14 +76,14 @@
 	class="drawer"
 	bind:this={containerDiv}
 	class:collapsed={$collapsed}
-	class:bottom-border={bottomBorder || collapsed}
+	class:bottom-border={bottomBorder}
 	class:transparent
 	class:grow
 	style:max-height={maxHeight}
 	class:no-shrink={!shrink && resizer && $collapsed !== undefined}
 	{@attach scrollingAttachment(intelligentScrollingService, scrollToId, scrollToType)}
 >
-	<div bind:this={headerDiv} class="drawer-header">
+	<div bind:this={headerDiv} class="drawer-header" class:bottom-border={!$collapsed}>
 		{#if $collapsed !== undefined}
 			{@const name = $collapsed ? 'chevron-right' : ('chevron-down' as const)}
 			<button
@@ -185,8 +185,12 @@
 		height: 42px;
 		padding: 0 12px 0 14px;
 		gap: 8px;
-		border-bottom: 1px solid var(--clr-border-2);
+		border-bottom: 1px solid transparent;
 		background-color: var(--clr-bg-2);
+
+		&.bottom-border {
+			border-bottom-color: var(--clr-border-2);
+		}
 	}
 
 	.drawer-header__title {

--- a/apps/desktop/src/components/v3/MultiStackView.svelte
+++ b/apps/desktop/src/components/v3/MultiStackView.svelte
@@ -69,6 +69,7 @@
 
 	// Enable panning when a stack is being dragged.
 	let draggingStack = $state(false);
+	let endStackDrag: (() => void) | undefined = $state();
 
 	// This is a bit of anti-pattern, and reordering should be better
 	// encapsulated such that we don't need this somewhat messy code.
@@ -154,6 +155,7 @@
 				ondragstart={(e) => {
 					onReorderStart(e, stack.id, () => {
 						draggingStack = true;
+						endStackDrag = dragStateService.startDragging();
 						selection.set(undefined);
 						intelligentScrollingService.show(projectId, stack.id, 'stack');
 					});
@@ -163,6 +165,8 @@
 				}}
 				ondragend={() => {
 					draggingStack = false;
+					endStackDrag?.();
+					endStackDrag = undefined;
 					onReorderEnd();
 				}}
 			>

--- a/apps/desktop/src/components/v3/StackView.svelte
+++ b/apps/desktop/src/components/v3/StackView.svelte
@@ -594,6 +594,7 @@
 				class="combined-view"
 				bind:this={compactDiv}
 				bind:clientHeight={verticalHeight}
+				data-remove-from-draggable
 				data-details={stack.id}
 			>
 				{#if branchName && commitId}

--- a/apps/desktop/src/components/v3/StackView.svelte
+++ b/apps/desktop/src/components/v3/StackView.svelte
@@ -305,13 +305,14 @@
 				<Resizer
 					bind:clientHeight={actualDetailsHeight}
 					viewport={element}
-					passive={collapsed}
 					direction="down"
 					persistId="resizer-panel2-details-${stack.id}"
 					defaultValue={undefined}
 					minHeight={minDetailsHeight}
 					maxHeight={maxDetailsHeight}
 					order={0}
+					imitateBorder
+					hidden={collapsed}
 					{resizeGroup}
 				/>
 			{/if}
@@ -343,8 +344,9 @@
 					bind:clientHeight={actualDetailsHeight}
 					defaultValue={undefined}
 					viewport={element}
-					passive={collapsed}
+					hidden={collapsed}
 					direction="down"
+					imitateBorder
 					persistId="resizer-panel2-details-${stack.id}"
 					minHeight={minDetailsHeight}
 					maxHeight={maxDetailsHeight}
@@ -385,11 +387,12 @@
 							unsetMaxHeight={previewKey ? unsetMaxHeight : undefined}
 							order={1}
 							viewport={element}
+							imitateBorder
+							hidden={collapsed}
 							maxHeight={maxChangedFilesHeight}
 							minHeight={minChangedFilesHeight}
 							defaultValue={undefined}
 							persistId="resizer-panel2-changed-files-${stack.id}"
-							passive={collapsed}
 							direction="down"
 						/>
 					{/if}
@@ -431,7 +434,8 @@
 							minHeight={minChangedFilesHeight}
 							defaultValue={undefined}
 							persistId="resizer-panel2-changed-files-${stack.id}"
-							passive={collapsed}
+							imitateBorder
+							hidden={collapsed}
 							direction="down"
 						/>
 					{/if}
@@ -591,7 +595,7 @@
 						{#snippet children(previewChange)}
 							{@const diffResult = diffService.getDiff(projectId, previewChange)}
 							{@const diffData = diffResult.current.data}
-							<Drawer collapsible>
+							<Drawer collapsible bottomBorder>
 								{#snippet header()}
 									<FileViewHeader
 										compact

--- a/apps/desktop/src/components/v3/WorkspaceView.svelte
+++ b/apps/desktop/src/components/v3/WorkspaceView.svelte
@@ -6,6 +6,7 @@
 	import SelectionView from '$components/v3/SelectionView.svelte';
 	import UnassignedView from '$components/v3/UnassignedView.svelte';
 	import { SettingsService } from '$lib/config/appSettingsV2';
+	import { DragStateService } from '$lib/dragging/dragStateService.svelte';
 	import {
 		DefinedFocusable,
 		FocusManager,
@@ -27,13 +28,8 @@
 
 	const { projectId }: Props = $props();
 
-	const [stackService, focusManager, idSelection, uiState, settingsService] = inject(
-		StackService,
-		FocusManager,
-		IdSelection,
-		UiState,
-		SettingsService
-	);
+	const [stackService, focusManager, idSelection, uiState, settingsService, dragStateService] =
+		inject(StackService, FocusManager, IdSelection, UiState, SettingsService, DragStateService);
 	const worktreeSelection = $derived(idSelection.getById({ type: 'worktree' }));
 	const stacksResult = $derived(stackService.stacks(projectId));
 	const projectState = $derived(uiState.project(projectId));
@@ -77,6 +73,17 @@
 
 	const lastAdded = $derived(worktreeSelection.lastAdded);
 	const previewOpen = $derived(!!$lastAdded?.key);
+
+	// Close preview when dragging starts (without clearing file selections)
+	$effect(() => {
+		const unsubscribe = dragStateService.isDragging.subscribe((isDragging) => {
+			if (isDragging) {
+				// Only clear the lastAdded to close preview, keep file selections intact
+				worktreeSelection.lastAdded.set(undefined);
+			}
+		});
+		return unsubscribe;
+	});
 
 	// Ensures that the exclusive action is still valid.
 	$effect(() => {


### PR DESCRIPTION
- Fixed resizer borders in compactWorkspace by removing double bottom borders and disabling interaction on collapsed resizers.
- Closed unassigned and assigned file previews on drag start.
- Added `data-remove-from-draggable` attribute to StackView component.
- Added drag end handler to close file preview on drag start.