### PR TITLE
Tool: Squash commits

### DIFF
--- a/apps/desktop/src/components/v3/FeedItemKind.svelte
+++ b/apps/desktop/src/components/v3/FeedItemKind.svelte
@@ -166,6 +166,8 @@
 								{parsedCall.parameters?.commitId.substring(0, 7)}
 							</span>
 						</p>
+					{:else if parsedCall.name === 'squash_commits'}
+						<p class="operation__title">Squashed commits</p>
 					{/if}
 				</div>
 

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -389,7 +389,7 @@ pub fn squash_commits(
     stack_id: StackId,
     source_ids: Vec<git2::Oid>,
     destination_id: git2::Oid,
-) -> Result<()> {
+) -> Result<git2::Oid> {
     let mut guard = ctx.project().exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
     assure_open_workspace_mode(ctx).context("Squashing a commit requires open workspace mode")?;

--- a/crates/gitbutler-branch-actions/src/squash.rs
+++ b/crates/gitbutler-branch-actions/src/squash.rs
@@ -29,7 +29,7 @@ pub(crate) fn squash_commits(
     source_ids: Vec<git2::Oid>,
     desitnation_id: git2::Oid,
     perm: &mut WorktreeWritePermission,
-) -> Result<()> {
+) -> Result<git2::Oid> {
     // create a snapshot
     let snap = ctx.create_snapshot(SnapshotDetails::new(OperationKind::SquashCommit), perm)?;
     let result = do_squash_commits(ctx, stack_id, source_ids, desitnation_id, perm);
@@ -46,7 +46,7 @@ fn do_squash_commits(
     mut source_ids: Vec<git2::Oid>,
     desitnation_id: git2::Oid,
     perm: &mut WorktreeWritePermission,
-) -> Result<()> {
+) -> Result<git2::Oid> {
     let old_workspace = WorkspaceState::create(ctx, perm.read_permission())?;
     let vb_state = ctx.project().virtual_branches();
     let stack = vb_state.get_stack_in_workspace(stack_id)?;
@@ -205,7 +205,7 @@ fn do_squash_commits(
     crate::integration::update_workspace_commit(&vb_state, ctx)
         .context("failed to update gitbutler workspace")?;
     stack.set_heads_from_rebase_output(ctx, output.references)?;
-    Ok(())
+    Ok(new_commit_oid)
 }
 
 fn validate(


### PR DESCRIPTION
### Description

- Implemented the `squash_commits` tool with support for multiple commit IDs and destination commit.
- Updated `squash_commits` function to return the new commit ID after squashing.
- Registered `SquashCommits` tool in the workspace toolset and improved API and documentation.
- Added UI support in the desktop app, including display of squashed commits and integration with tool calls.