### PR TITLE
ui-fixes-110

### DIFF
--- a/apps/desktop/src/components/v3/BranchesView.svelte
+++ b/apps/desktop/src/components/v3/BranchesView.svelte
@@ -400,10 +400,7 @@
 					{/if}
 
 					{#if !isNonLocalPr}
-						<!-- <div class="preview-column" bind:this={previewColumn}> -->
 						<SelectionView testId={TestId.BranchesSelectionView} {projectId} {selectionId} />
-
-						<!-- </div> -->
 					{/if}
 				</div>
 				<Scrollbar viewport={rightWrapper} horz />

--- a/apps/desktop/src/components/v3/ChangedFiles.svelte
+++ b/apps/desktop/src/components/v3/ChangedFiles.svelte
@@ -87,7 +87,6 @@
 	.filelist-wrapper {
 		display: flex;
 		flex-direction: column;
-		border-bottom: 1px solid var(--clr-border-2);
 		background-color: var(--clr-bg-1);
 	}
 </style>

--- a/apps/desktop/src/components/v3/CommitView.svelte
+++ b/apps/desktop/src/components/v3/CommitView.svelte
@@ -234,7 +234,6 @@
 						/>
 					</div>
 				{:else}
-					<!-- <CommitTitle commitMessage={commit.message} className="text-14 text-semibold text-body" /> -->
 					<CommitDetails {commit} />
 				{/if}
 			</div>

--- a/apps/desktop/src/components/v3/SelectionView.svelte
+++ b/apps/desktop/src/components/v3/SelectionView.svelte
@@ -118,6 +118,7 @@
 		overflow: hidden;
 	}
 	.selected-change-item {
+		border-bottom: 1px solid var(--clr-border-2);
 		background-color: var(--clr-bg-1);
 	}
 </style>

--- a/apps/desktop/src/components/v3/SelectionView.svelte
+++ b/apps/desktop/src/components/v3/SelectionView.svelte
@@ -18,9 +18,9 @@
 		selectionId?: SelectionId;
 		draggableFiles?: boolean;
 		diffOnly?: boolean;
-		topPadding?: boolean;
 		onclose?: () => void;
 		testId?: string;
+		bottomBorder?: boolean;
 	};
 
 	let {
@@ -28,9 +28,9 @@
 		selectionId,
 		draggableFiles: draggable,
 		diffOnly,
-		topPadding,
 		onclose,
-		testId
+		testId,
+		bottomBorder
 	}: Props = $props();
 
 	const [idSelection, diffService, intelligentScrollingService] = inject(
@@ -68,7 +68,11 @@
 					<ReduxResult {projectId} result={diffResult.current}>
 						{#snippet children(diff, env)}
 							{@const isExecutable = true}
-							<div class="selected-change-item" data-remove-from-panning>
+							<div
+								class="selected-change-item"
+								class:bottom-border={bottomBorder}
+								data-remove-from-panning
+							>
 								{#if !diffOnly}
 									<FileListItemWrapper
 										selectionId={selectedFile}
@@ -96,7 +100,7 @@
 									{diff}
 									selectable
 									selectionId={selectedFile}
-									{topPadding}
+									topPadding={diffOnly}
 								/>
 							</div>
 						{/snippet}
@@ -118,7 +122,10 @@
 		overflow: hidden;
 	}
 	.selected-change-item {
-		border-bottom: 1px solid var(--clr-border-2);
 		background-color: var(--clr-bg-1);
+
+		&.bottom-border {
+			border-bottom: 1px solid var(--clr-border-2);
+		}
 	}
 </style>

--- a/apps/desktop/src/components/v3/StackView.svelte
+++ b/apps/desktop/src/components/v3/StackView.svelte
@@ -271,10 +271,9 @@
 
 {#snippet assignedChangePreview(stackId?: string)}
 	<SelectionView
+		bottomBorder
 		testId={TestId.WorktreeSelectionView}
 		{projectId}
-		diffOnly={true}
-		topPadding={true}
 		selectionId={{ ...assignedKey, type: 'worktree', stackId }}
 		onclose={() => {
 			intelligentScrollingService.show(projectId, stack.id, 'stack');
@@ -289,7 +288,6 @@
 		{projectId}
 		{selectionId}
 		diffOnly={true}
-		topPadding={true}
 		onclose={() => {
 			intelligentScrollingService.show(projectId, stack.id, 'details');
 		}}
@@ -595,30 +593,32 @@
 						{#snippet children(previewChange)}
 							{@const diffResult = diffService.getDiff(projectId, previewChange)}
 							{@const diffData = diffResult.current.data}
-							<Drawer>
-								{#snippet header()}
-									<FileViewHeader
-										noPaddings
-										transparent
-										filePath={previewChange.path}
-										fileStatus={computeChangeStatus(previewChange)}
-										linesAdded={diffData?.type === 'Patch'
-											? diffData.subject.linesAdded
-											: undefined}
-										linesRemoved={diffData?.type === 'Patch'
-											? diffData.subject.linesRemoved
-											: undefined}
-									/>
-								{/snippet}
-								{#if assignedKey?.type === 'worktree' && assignedKey.stackId}
-									{@render assignedChangePreview(assignedKey.stackId)}
-								{:else if selectedKey}
+
+							{#if assignedKey?.type === 'worktree' && assignedKey.stackId}
+								{@render assignedChangePreview(assignedKey.stackId)}
+							{:else if selectedKey}
+								<Drawer bottomBorder>
+									{#snippet header()}
+										<FileViewHeader
+											noPaddings
+											transparent
+											filePath={previewChange.path}
+											fileStatus={computeChangeStatus(previewChange)}
+											linesAdded={diffData?.type === 'Patch'
+												? diffData.subject.linesAdded
+												: undefined}
+											linesRemoved={diffData?.type === 'Patch'
+												? diffData.subject.linesRemoved
+												: undefined}
+										/>
+									{/snippet}
 									{@render otherChangePreview(selectedKey)}
-								{/if}
-							</Drawer>
+								</Drawer>
+							{/if}
 						{/snippet}
 					</ReduxResult>
 				{/if}
+
 				<!-- The id of this resizer is intentionally the same as in default view. -->
 				<Resizer
 					viewport={compactDiv}

--- a/apps/desktop/src/components/v3/StackView.svelte
+++ b/apps/desktop/src/components/v3/StackView.svelte
@@ -354,7 +354,7 @@
 				direction="down"
 				imitateBorder
 				persistId="resizer-panel2-details-${stack.id}"
-				minHeight={minDetailsHeight}
+				minHeight={undefined}
 				maxHeight={maxDetailsHeight}
 				order={0}
 				{resizeGroup}

--- a/apps/desktop/src/components/v3/StackView.svelte
+++ b/apps/desktop/src/components/v3/StackView.svelte
@@ -595,7 +595,7 @@
 						{#snippet children(previewChange)}
 							{@const diffResult = diffService.getDiff(projectId, previewChange)}
 							{@const diffData = diffResult.current.data}
-							<Drawer bottomBorder>
+							<Drawer>
 								{#snippet header()}
 									<FileViewHeader
 										noPaddings

--- a/apps/desktop/src/components/v3/WorkspaceView.svelte
+++ b/apps/desktop/src/components/v3/WorkspaceView.svelte
@@ -134,7 +134,7 @@
 {/snippet}
 
 {#snippet leftPreview()}
-	<SelectionView {projectId} {selectionId} draggableFiles />
+	<SelectionView bottomBorder {projectId} {selectionId} draggableFiles />
 {/snippet}
 
 <MainViewport


### PR DESCRIPTION
### Description

- Added bottom-border to file preview areas for better visual separation.
- Removed commented out CommitTitle component in CommitView to clean up the code.
- Removed minHeight constraint on the commit resizer in StackView to accommodate single-line commits.
- Made assigned previews non-collapsible to improve usability.