### PR TITLE
Split branch feature and tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,6 +996,7 @@ dependencies = [
  "gitbutler-oplog",
  "gitbutler-oxidize",
  "gitbutler-project",
+ "gitbutler-reference",
  "gitbutler-serde",
  "gitbutler-stack",
  "gix",

--- a/apps/desktop/src/components/SnapshotCard.svelte
+++ b/apps/desktop/src/components/SnapshotCard.svelte
@@ -154,6 +154,8 @@
 				return { text: 'Enter Edit Mode', icon: 'edit-text' };
 			case 'RestoreFromSnapshot':
 				return { text: 'Revert snapshot' };
+			case 'SplitBranch':
+				return { text: 'Split branch', icon: 'branch-local' };
 			default:
 				return { text: snapshotDetails.operation, icon: 'commit' };
 		}

--- a/apps/desktop/src/components/v3/FeedItemKind.svelte
+++ b/apps/desktop/src/components/v3/FeedItemKind.svelte
@@ -168,6 +168,24 @@
 						</p>
 					{:else if parsedCall.name === 'squash_commits'}
 						<p class="operation__title">Squashed commits</p>
+					{:else if parsedCall.name === 'split_branch'}
+						<p class="operation__title">
+							Split branch
+							<span>
+								{parsedCall.parameters?.sourceBranchName}
+							</span>
+							<span>→</span>
+							<span>
+								{parsedCall.parameters?.newBranchName}
+							</span>
+						</p>
+					{:else if parsedCall.name === 'get_branch_changes'}
+						<p class="operation__title">
+							Reading branch changes for
+							<span>
+								{parsedCall.parameters?.branchName}
+							</span>
+						</p>
 					{/if}
 				</div>
 

--- a/apps/desktop/src/lib/history/types.ts
+++ b/apps/desktop/src/lib/history/types.ts
@@ -39,7 +39,8 @@ export type Operation =
 	| 'UpdateDependentBranchDescription'
 	| 'UpdateDependentBranchPrNumber'
 	| 'AutoHandleChangesBefore'
-	| 'AutoHandleChangesAfter';
+	| 'AutoHandleChangesAfter'
+	| 'SplitBranch';
 
 export class Trailer {
 	key!: string;

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -793,6 +793,10 @@ export class StackService {
 		return this.api.endpoints.saveEditAndReturnToWorkspace.mutate;
 	}
 
+	get splitBranch() {
+		return this.api.endpoints.splitBranch.useMutation();
+	}
+
 	stackDetailsUpdateListener(projectId: string) {
 		return this.api.endpoints.stackDetailsUpdate.useQuery({
 			projectId
@@ -1502,6 +1506,26 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				invalidatesTags: [
 					invalidatesList(ReduxTag.WorktreeChanges),
 					invalidatesList(ReduxTag.StackDetails)
+				]
+			}),
+			splitBranch: build.mutation<
+				{ replacedCommits: [string, string][] },
+				{
+					projectId: string;
+					sourceStackId: string;
+					sourceBranchName: string;
+					newBranchName: string;
+					fileChangesToSplitOff: string[];
+				}
+			>({
+				extraOptions: {
+					command: 'split_branch'
+				},
+				query: (args) => args,
+				invalidatesTags: (_result, _error, args) => [
+					invalidatesItem(ReduxTag.StackDetails, args.sourceStackId),
+					invalidatesItem(ReduxTag.BranchChanges, args.sourceStackId),
+					invalidatesList(ReduxTag.Stacks)
 				]
 			}),
 			stackDetailsUpdate: build.query<void, { projectId: string }>({

--- a/crates/but-action/src/lib.rs
+++ b/crates/but-action/src/lib.rs
@@ -80,8 +80,11 @@ pub fn freestyle(
     You can also perform more advanced operations, such as:
     - `absorb`: Take a set of file changes and amend them into the existing commits in the project.
       This requires you to figure out where the changes should go based on the locks, assingments and any other user provided information.
-    - `split`: Take an existing commit and split it into multiple commits based on the the user directive.
+    - `split a commit`: Take an existing commit and split it into multiple commits based on the the user directive.
         This is a multi-step operation where you will need to create one or more black commits, and the move the file changes from the original commit to the new commits.
+    - `split a branch`: Take an existing branch and split it into two branches, one with the specified file changes and one without.
+        This is useful when you want to separate the changes into a new branch for further work.
+        In order to do this, you will need to get the branch changes for the intended source branch (call the `get_branch_changes` tool), and then call the split branch tool with the changes you want to split off.
     
     ### Important notes
     - Only perform the action on the file changes specified in the prompt.

--- a/crates/but-tools/Cargo.toml
+++ b/crates/but-tools/Cargo.toml
@@ -32,5 +32,6 @@ gitbutler-project.workspace = true
 gitbutler-stack.workspace = true
 gitbutler-serde.workspace = true
 gitbutler-oxidize.workspace = true
+gitbutler-reference.workspace = true
 but-hunk-dependency.workspace = true
 but-hunk-assignment.workspace = true

--- a/crates/but-tools/src/tool.rs
+++ b/crates/but-tools/src/tool.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, sync::Arc};
 
-use but_workspace::ui::StackEntry;
+use but_workspace::{StackId, ui::StackEntry};
 use gitbutler_command_context::CommandContext;
 use serde_json::json;
 
@@ -123,5 +123,11 @@ impl ToolResult for Result<StackEntry, anyhow::Error> {
 impl ToolResult for Result<but_workspace::commit_engine::ui::CreateCommitOutcome, anyhow::Error> {
     fn to_json(&self, action_identifier: &str) -> serde_json::Value {
         result_to_json(self, action_identifier, "CreateCommitOutcome")
+    }
+}
+
+impl ToolResult for Result<StackId, anyhow::Error> {
+    fn to_json(&self, action_identifier: &str) -> serde_json::Value {
+        result_to_json(self, action_identifier, "StackId")
     }
 }

--- a/crates/but-tools/src/workspace.rs
+++ b/crates/but-tools/src/workspace.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 use std::sync::Arc;
 
+use anyhow::Context;
 use bstr::BString;
 use but_core::{TreeChange, UnifiedDiff};
 use but_graph::VirtualBranchesTomlMetadata;
@@ -10,7 +11,7 @@ use gitbutler_branch_actions::{BranchManagerExt, update_workspace_commit};
 use gitbutler_command_context::CommandContext;
 use gitbutler_oplog::entry::{OperationKind, SnapshotDetails};
 use gitbutler_oplog::{OplogExt, SnapshotExt};
-use gitbutler_oxidize::{ObjectIdExt, git2_to_gix_object_id};
+use gitbutler_oxidize::{ObjectIdExt, OidExt, git2_to_gix_object_id};
 use gitbutler_project::Project;
 use gitbutler_reference::{LocalRefname, Refname};
 use gitbutler_stack::{PatchReferenceUpdate, VirtualBranchesHandle};
@@ -35,6 +36,7 @@ pub fn workspace_toolset<'a>(
     toolset.register_tool(CreateBlankCommit);
     toolset.register_tool(MoveFileChanges);
     toolset.register_tool(GetCommitDetails);
+    toolset.register_tool(GetBranchChanges);
     toolset.register_tool(SplitBranch);
 
     Ok(toolset)
@@ -990,6 +992,89 @@ pub fn commit_details(
     Ok(file_changes)
 }
 
+pub struct GetBranchChanges;
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct GetBranchChangesParameters {
+    /// The branch name to get changes for.
+    #[schemars(description = "
+    <description>
+        The name of the branch to get changes for.
+    </description>
+
+    <important_notes>
+        The branch name should be a valid Git branch name present in the workspace.
+    </important_notes>
+    ")]
+    pub branch_name: String,
+}
+
+impl Tool for GetBranchChanges {
+    fn name(&self) -> String {
+        "get_branch_changes".to_string()
+    }
+
+    fn description(&self) -> String {
+        "
+        <description>
+            Get the list of file changes for a specific branch in the workspace.
+        </description>
+
+        <important_notes>
+            This tool allows you to retrieve a list of file paths that have been changed on a specific branch.
+            Call this tool before splitting a branch.
+            Use this to inspect what files have been changed on a branch.
+        </important_notes>
+        ".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        let schema = schema_for!(GetBranchChangesParameters);
+        serde_json::to_value(&schema).unwrap_or_default()
+    }
+
+    fn call(
+        self: Arc<Self>,
+        parameters: serde_json::Value,
+        ctx: &mut CommandContext,
+        _app_handle: Option<&tauri::AppHandle>,
+    ) -> anyhow::Result<serde_json::Value> {
+        let params: GetBranchChangesParameters = serde_json::from_value(parameters)
+            .map_err(|e| anyhow::anyhow!("Failed to parse input parameters: {}", e))?;
+
+        let file_changes = branch_changes(ctx, params).to_json("get_branch_changes");
+
+        Ok(file_changes)
+    }
+}
+
+pub fn branch_changes(
+    ctx: &mut CommandContext,
+    params: GetBranchChangesParameters,
+) -> anyhow::Result<Vec<FileChangeSimple>> {
+    let repo = ctx.gix_repo()?;
+    let stacks = stacks(ctx, &repo)?;
+    let stack_id = stacks
+        .iter()
+        .find_map(|s| {
+            let found = s.heads.iter().any(|h| h.name == params.branch_name);
+            if found { Some(s.id) } else { None }
+        })
+        .ok_or_else(|| {
+            anyhow::anyhow!("Branch '{}' not found in the workspace", params.branch_name)
+        })?;
+
+    let changes = changes_in_branch_inner(ctx, params.branch_name, Some(stack_id))?;
+    let file_changes = changes
+        .changes
+        .into_iter()
+        .map(|change| change.into())
+        .collect();
+
+    Ok(file_changes)
+}
+
 pub struct SquashCommits;
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize, JsonSchema)]
@@ -1343,6 +1428,36 @@ pub struct SimpleStack {
     /// The branches in the stack.
     pub branches: Vec<SimpleBranch>,
 }
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileChangeSimple {
+    /// The path of the file that has changed.
+    pub path: String,
+    /// The file change status
+    pub status: String,
+}
+
+impl From<but_core::ui::TreeChange> for FileChangeSimple {
+    fn from(change: but_core::ui::TreeChange) -> Self {
+        FileChangeSimple {
+            path: change.path.to_string(),
+            status: match change.status {
+                but_core::ui::TreeStatus::Addition { .. } => "added".to_string(),
+                but_core::ui::TreeStatus::Deletion { .. } => "deleted".to_string(),
+                but_core::ui::TreeStatus::Modification { .. } => "modified".to_string(),
+                but_core::ui::TreeStatus::Rename { .. } => "renamed".to_string(),
+            },
+        }
+    }
+}
+
+impl ToolResult for Result<Vec<FileChangeSimple>, anyhow::Error> {
+    fn to_json(&self, action_identifier: &str) -> serde_json::Value {
+        result_to_json(self, action_identifier, "Vec<FileChangeSimple>")
+    }
+}
+
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FileChange {
@@ -1535,6 +1650,69 @@ fn unified_diff_for_changes(
                 .map(|diff| (tree_change, diff.expect("no submodule")))
         })
         .collect::<Result<Vec<_>, _>>()
+}
+
+fn changes_in_branch_inner(
+    ctx: &CommandContext,
+    branch_name: String,
+    stack_id: Option<StackId>,
+) -> anyhow::Result<but_core::ui::TreeChanges> {
+    let state = VirtualBranchesHandle::new(ctx.project().gb_dir());
+    let repo = ctx.gix_repo()?;
+    let (start_commit_id, base_commit_id) = if let Some(stack_id) = stack_id {
+        commit_and_base_from_stack(ctx, &state, stack_id, branch_name.clone())
+    } else {
+        let start_commit_id = repo.find_reference(&branch_name)?.peel_to_commit()?.id;
+        let target = state.get_default_target()?;
+        let merge_base = ctx
+            .repo()
+            .merge_base(start_commit_id.to_git2(), target.sha)?;
+        Ok((start_commit_id, merge_base.to_gix()))
+    }?;
+
+    but_core::diff::ui::changes_in_range(
+        ctx.project().path.clone(),
+        start_commit_id,
+        base_commit_id,
+    )
+}
+
+fn commit_and_base_from_stack(
+    ctx: &CommandContext,
+    state: &VirtualBranchesHandle,
+    stack_id: StackId,
+    branch_name: String,
+) -> anyhow::Result<(gix::ObjectId, gix::ObjectId)> {
+    let stack = state.get_stack(stack_id)?;
+
+    // Find the branch head and the one before it
+    let heads = stack.heads(false);
+    let (start, end) = heads
+        .iter()
+        .rev()
+        .fold((None, None), |(start, end), branch| {
+            if start.is_some() && end.is_none() {
+                (start, Some(branch))
+            } else if branch == &branch_name {
+                (Some(branch), None)
+            } else {
+                (start, end)
+            }
+        });
+    let repo = ctx.gix_repo()?;
+
+    // Find the head that matches the branch name - the commit contained is our commit_id
+    let start_commit_id = repo
+        .find_reference(start.with_context(|| format!("Branch {} not found", branch_name))?)?
+        .peel_to_commit()?
+        .id;
+
+    // Now, find the preceding head in the stack. If it is not present, use the stack merge base
+    let base_commit_id = match end {
+        Some(end) => repo.find_reference(end)?.peel_to_commit()?.id,
+        None => stack.merge_base(ctx)?,
+    };
+    Ok((start_commit_id, base_commit_id))
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, JsonSchema)]

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -45,6 +45,7 @@ pub use tree_manipulation::MoveChangesResult;
 pub use tree_manipulation::discard_worktree_changes::discard_workspace_changes;
 pub use tree_manipulation::move_between_commits::move_changes_between_commits;
 pub use tree_manipulation::remove_changes_from_commit_in_stack::remove_changes_from_commit_in_stack;
+pub use tree_manipulation::split_branch::split_branch;
 pub mod head;
 pub use head::{head, merge_worktree_with_workspace};
 mod relapath;

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -120,6 +120,16 @@ impl From<&TreeChange> for DiffSpec {
     }
 }
 
+impl From<TreeChange> for DiffSpec {
+    fn from(change: but_core::TreeChange) -> Self {
+        Self {
+            previous_path: change.previous_path().map(ToOwned::to_owned),
+            path: change.path.to_owned(),
+            hunk_headers: vec![],
+        }
+    }
+}
+
 /// The header of a hunk that represents a change to a file.
 #[derive(Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/but-workspace/src/tree_manipulation/mod.rs
+++ b/crates/but-workspace/src/tree_manipulation/mod.rs
@@ -9,9 +9,32 @@ pub struct MoveChangesResult {
     pub replaced_commits: Vec<(gix::ObjectId, gix::ObjectId)>,
 }
 
+impl MoveChangesResult {
+    /// Merges the changes from another `MoveChangesResult` into this one.
+    pub fn merge(&mut self, other: MoveChangesResult) {
+        let mut new_replaced_commits = self.replaced_commits.clone();
+
+        for (before, after) in other.replaced_commits {
+            let matching_commit_mapping =
+                new_replaced_commits.iter_mut().find(|(_, a)| *a == before);
+            if let Some(found_matching_mapping) = matching_commit_mapping {
+                // If we found a matching commit mapping, we update the "after" id
+                // to the new "after" id.
+                found_matching_mapping.1 = after;
+            } else {
+                // Otherwise, we add the new mapping.
+                new_replaced_commits.push((before, after));
+            }
+        }
+
+        self.replaced_commits = new_replaced_commits;
+    }
+}
+
 pub(super) mod discard_worktree_changes;
 pub(super) mod move_between_commits;
 pub(super) mod remove_changes_from_commit_in_stack;
+pub(super) mod split_branch;
 
 pub(crate) mod hunk;
 mod utils;

--- a/crates/but-workspace/src/tree_manipulation/split_branch.rs
+++ b/crates/but-workspace/src/tree_manipulation/split_branch.rs
@@ -1,0 +1,190 @@
+use anyhow::Result;
+use but_core::Reference;
+use but_core::TreeChange;
+use but_rebase::Rebase;
+use but_rebase::RebaseStep;
+use but_rebase::ReferenceSpec;
+use gitbutler_command_context::CommandContext;
+use gitbutler_oxidize::ObjectIdExt;
+use gitbutler_oxidize::OidExt;
+use gitbutler_repo::logging::{LogUntil, RepositoryExt as _};
+use gitbutler_stack::{StackId, VirtualBranchesHandle};
+use gix::ObjectId;
+
+use crate::DiffSpec;
+use crate::MoveChangesResult;
+use crate::remove_changes_from_commit_in_stack;
+use crate::tree_manipulation::remove_changes_from_commit_in_stack::remove_changes_from_commit;
+
+/// Splits a branch by creating a new branch with the specified changes.
+///
+/// This function creates a new branch from the specified source branch
+/// and applies the specified changes to it. The new branch will contain only
+/// the changes specified in `file_changes_to_split_off`, effectively removing
+/// those changes from the source branch.
+///
+///
+/// In steps:
+/// 1. Create a new branch from the source branch's head.
+/// 2. Remove all the specified changes from the source branch.
+/// 3. Remove all but the specified changes from the new branch.
+/// 4. Create a stack from out of the new branch.
+pub fn split_branch(
+    ctx: &CommandContext,
+    stack_id: StackId,
+    source_branch_name: String,
+    new_branch_name: String,
+    file_changes_to_split_off: &[String],
+    context_lines: u32,
+) -> Result<(ReferenceSpec, Option<MoveChangesResult>)> {
+    let repository = ctx.gix_repo()?;
+    let vb_state = VirtualBranchesHandle::new(ctx.project().gb_dir());
+
+    let default_target = vb_state.get_default_target()?;
+    let stack = vb_state.get_stack_in_workspace(stack_id)?;
+    let merge_base = ctx
+        .repo()
+        .merge_base(stack.head_oid(&repository)?.to_git2(), default_target.sha)?;
+
+    let push_details = stack.push_details(ctx, source_branch_name.clone())?;
+    let branch_head = push_details.head;
+
+    // Create a new branch from the source branch's head
+    let new_branch_ref_name = format!("refs/heads/{}", new_branch_name);
+    let new_branch_log_message = format!(
+        "Split off changes from branch '{}' into new branch '{}'",
+        source_branch_name, new_branch_name
+    );
+
+    let mut new_ref = repository.reference(
+        new_branch_ref_name.clone(),
+        branch_head.to_gix(),
+        gix::refs::transaction::PreviousValue::Any,
+        new_branch_log_message.clone(),
+    )?;
+
+    // Remove all the specified changes from the source branch
+    let source_branch_commits = ctx
+        .repo()
+        .l(branch_head, LogUntil::Commit(merge_base), false)?;
+
+    let mut move_changes_result: Option<MoveChangesResult> = None;
+
+    for commit in source_branch_commits {
+        let commit_id = commit.to_gix();
+
+        let result = remove_file_changes_from_commit(
+            ctx,
+            stack_id,
+            commit_id,
+            file_changes_to_split_off,
+            context_lines,
+        )?;
+
+        if let Some(ref mut res) = move_changes_result {
+            res.merge(result);
+        } else {
+            move_changes_result = Some(result);
+        }
+    }
+
+    // Remove all but the specified changes from the new branch
+    let new_branch_commits = ctx
+        .repo()
+        .l(branch_head, LogUntil::Commit(merge_base), false)?;
+
+    // Branch as rebase steps
+    let mut steps: Vec<RebaseStep> = Vec::new();
+
+    let reference_step = RebaseStep::Reference(but_core::Reference::Git(new_ref.name().to_owned()));
+    steps.push(reference_step);
+
+    for commit in new_branch_commits {
+        let commit_id = commit.to_gix();
+        let new_commit_id = keep_only_file_changes_in_commit(
+            ctx,
+            commit_id,
+            file_changes_to_split_off,
+            context_lines,
+        )?;
+        let pick_step = RebaseStep::Pick {
+            commit_id: new_commit_id,
+            new_message: None,
+        };
+        steps.push(pick_step);
+    }
+    steps.reverse();
+
+    let mut rebase = Rebase::new(&repository, merge_base.to_gix(), None)?;
+    rebase.steps(steps)?;
+    rebase.rebase_noops(false);
+    let result = rebase.rebase()?;
+
+    let new_branch_full_name: gix::refs::FullName = new_branch_ref_name.try_into()?;
+
+    let new_branch_ref = result
+        .references
+        .into_iter()
+        .find(|r| match r.reference.clone() {
+            Reference::Git(full_name) => full_name == new_branch_full_name,
+            Reference::Virtual(name) => name == new_branch_name,
+        })
+        .ok_or_else(|| anyhow::anyhow!("New branch reference not found in rebase output"))?;
+
+    new_ref.set_target_id(new_branch_ref.commit_id, new_branch_log_message)?;
+
+    Ok((new_branch_ref, move_changes_result))
+}
+
+fn remove_file_changes_from_commit(
+    ctx: &CommandContext,
+    source_stack_id: StackId,
+    source_commit_id: gix::ObjectId,
+    file_changes_to_split_off: &[String],
+    context_lines: u32,
+) -> Result<MoveChangesResult> {
+    let repository = ctx.gix_repo()?;
+    let commit_changes =
+        but_core::diff::ui::commit_changes_by_worktree_dir(&repository, source_commit_id)?;
+    let changes_to_remove: Vec<TreeChange> = commit_changes
+        .changes
+        .into_iter()
+        .filter(|change| file_changes_to_split_off.contains(&change.path.to_string()))
+        .map(|change| change.into())
+        .collect();
+    let diff_specs: Vec<DiffSpec> = changes_to_remove
+        .into_iter()
+        .map(|change| change.into())
+        .collect();
+
+    remove_changes_from_commit_in_stack(
+        ctx,
+        source_stack_id,
+        source_commit_id,
+        diff_specs,
+        context_lines,
+    )
+}
+
+fn keep_only_file_changes_in_commit(
+    ctx: &CommandContext,
+    source_commit_id: gix::ObjectId,
+    file_changes_to_keep: &[String],
+    context_lines: u32,
+) -> Result<ObjectId> {
+    let repository = ctx.gix_repo()?;
+    let commit_changes =
+        but_core::diff::ui::commit_changes_by_worktree_dir(&repository, source_commit_id)?;
+    let changes_to_remove: Vec<TreeChange> = commit_changes
+        .changes
+        .into_iter()
+        .filter(|change| !file_changes_to_keep.contains(&change.path.to_string()))
+        .map(|change| change.into())
+        .collect();
+    let diff_specs: Vec<DiffSpec> = changes_to_remove
+        .into_iter()
+        .map(|change| change.into())
+        .collect();
+
+    remove_changes_from_commit(ctx, source_commit_id, diff_specs, context_lines)
+}

--- a/crates/gitbutler-oplog/src/entry.rs
+++ b/crates/gitbutler-oplog/src/entry.rs
@@ -167,6 +167,7 @@ pub enum OperationKind {
     UpdateDependentBranchPrNumber,
     AutoHandleChangesBefore,
     AutoHandleChangesAfter,
+    SplitBranch,
     #[default]
     Unknown,
 }

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -294,6 +294,7 @@ fn main() {
                     workspace::target_commits,
                     workspace::move_changes_between_commits,
                     workspace::uncommit_changes,
+                    workspace::split_branch,
                     diff::changes_in_worktree,
                     diff::commit_details,
                     diff::changes_in_branch,


### PR DESCRIPTION
### Description

This PR introduces comprehensive support for splitting branches based on selected file changes, including backend logic, frontend integration, and automation tools.

- Add `split_branch.rs` module to implement branch splitting functionality by moving specified changes to a new branch.
- Introduce utilities for commit change removal and merging `MoveChangesResult` mappings to support splitting operations.
- Expose `split_branch` as a Tauri command and integrate it into the backend operation system.
- Implement frontend wiring to call the split branch command, including UI options in file context menus for splitting off changes.
- Add `SplitBranch` and `GetBranchChanges` tools for agent/automation use, enabling programmatic branch splitting and querying branch file changes.
- Enhance frontend feed UI to display split branch and branch changes operations.
- Update documentation to describe the new branch splitting features and related tools.