### PR TITLE
Fix FeedStreamMessage to correctly display stream with tool calls

### DIFF
--- a/apps/desktop/src/components/FeedStreamMessage.svelte
+++ b/apps/desktop/src/components/FeedStreamMessage.svelte
@@ -49,23 +49,27 @@
 	});
 </script>
 
-{#if messageContent === '' && toolCalls.length === 0}
-	<p class="thinking">Thinking...</p>
-{:else if toolCalls.length > 0}
-	<p class="vibing">Vibing</p>
-	{#each toolCalls as toolCall, index (index)}
-		<FeedItemKind type="tool-call" {projectId} {toolCall} />
-	{/each}
-{:else}
-	{#each messageContentLines as line, index (index)}
-		{#if line === ''}
-			<br />
-		{:else}
-			<Markdown content={line} />
+<div>
+	{#if messageContent === '' && toolCalls.length === 0}
+		<p class="thinking">Thinking...</p>
+	{:else}
+		{#if toolCalls.length > 0}
+			<p class="vibing">Vibing</p>
+			{#each toolCalls as toolCall, index (index)}
+				<FeedItemKind type="tool-call" {projectId} {toolCall} />
+			{/each}
 		{/if}
-	{/each}
-{/if}
-<div bind:this={bottom} style="margin-top: 8px;height: 1px; width: 100%;"></div>
+
+		{#each messageContentLines as line, index (index)}
+			{#if line === ''}
+				<br />
+			{:else}
+				<Markdown content={line} />
+			{/if}
+		{/each}
+	{/if}
+	<div bind:this={bottom} style="margin-top: 8px; height: 1px; width: 100%;"></div>
+</div>
 
 <style>
 	.thinking,


### PR DESCRIPTION
This commit updates FeedStreamMessage.svelte to address a bug where the message stream would not be displayed if there were any tool calls. The logic now allows both the tool call information and the message content lines to display together as intended.