### PR TITLE
feat: improved commit remapping and tracking in Rust

### DIFF
--- a/crates/but-action/src/absorb.rs
+++ b/crates/but-action/src/absorb.rs
@@ -259,6 +259,7 @@ fn absorb_file_changes_into_commit(
             message_body: commit.message_body.clone(),
             files: files.iter().map(|f| f.to_owned().path).collect(),
         },
+        None,
     )?;
 
     Ok(outcome)

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -336,7 +336,7 @@ pub fn insert_blank_commit(
     commit_oid: git2::Oid,
     offset: i32,
     message: Option<&str>,
-) -> Result<Vec<(gix::ObjectId, gix::ObjectId)>> {
+) -> Result<(gix::ObjectId, Vec<(gix::ObjectId, gix::ObjectId)>)> {
     let mut guard = ctx.project().exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
     assure_open_workspace_mode(ctx)


### PR DESCRIPTION
This commit updates the commit remapping logic in the Rust crates. It adds a commit mapping structure, threads it throughout the core APIs for amending, blank commit insertion, move, and split operations; and ensures correct handling and propagation of commit IDs. The changes refine result handling, update relevant signatures, and clarify requirements for tracking new/old commit relationships. Also includes minor consistency tweaks and error handling improvements throughout the implementation.