### PR TITLE
fix: use correct parameter names for squash command

### DIFF
--- a/apps/desktop/src/lib/commits/dropHandler.ts
+++ b/apps/desktop/src/lib/commits/dropHandler.ts
@@ -460,8 +460,8 @@ export class SquashCommitDzHandler implements DropzoneHandler {
 			await stackService.squashCommits({
 				projectId,
 				stackId,
-				sourceCommitOids: [data.commit.id],
-				targetCommitOid: commit.id
+				sourceCommitIds: [data.commit.id],
+				targetCommitId: commit.id
 			});
 		}
 	}

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -731,8 +731,8 @@ export class StackService {
 		await this.squashCommits({
 			projectId,
 			stackId,
-			sourceCommitOids: squashCommits.map((commit) => commit.id),
-			targetCommitOid: targetCommit.id
+			sourceCommitIds: squashCommits.map((commit) => commit.id),
+			targetCommitId: targetCommit.id
 		});
 	}
 
@@ -1426,7 +1426,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 			}),
 			squashCommits: build.mutation<
 				void,
-				{ projectId: string; stackId: string; sourceCommitOids: string[]; targetCommitOid: string }
+				{ projectId: string; stackId: string; sourceCommitIds: string[]; targetCommitId: string }
 			>({
 				extraOptions: {
 					command: 'squash_commits',


### PR DESCRIPTION
This commit updates the squash command implementation in TypeScript source files to use the correct parameter names:
- Changes 'sourceCommitOids' to 'sourceCommitIds'
- Changes 'targetCommitOid' to 'targetCommitId'

Files affected:
- apps/desktop/src/lib/commits/dropHandler.ts
- apps/desktop/src/lib/stacks/stackService.svelte.ts

These changes ensure the squash command uses the right parameters for API calls and mutations.