### PR TITLE
review-stacked-branch-branch-param-required

### DIFF
--- a/apps/desktop/cypress/e2e/support/index.ts
+++ b/apps/desktop/cypress/e2e/support/index.ts
@@ -203,6 +203,12 @@ declare global {
 			 */
 			getByTestIdByValue(testId: TestIdValues, withValue: string): Chainable<JQuery<HTMLElement>>;
 			/**
+			 *  Get an element by its data-* attribute value.
+			 * @param dataName - The data-* attribute name to search for.
+			 * @param value - The value of the data-* attribute to search for.
+			 */
+			getByDataValue(dataName: string, value: string): Chainable<JQuery<HTMLElement>>;
+			/**
 			 * Clear all mocks.
 			 */
 			clearMocks(): void;
@@ -241,6 +247,10 @@ Cypress.Commands.add('getByTestId', (testId: TestIdValues, containingText?: stri
 
 Cypress.Commands.add('getByTestIdByValue', (testId: TestIdValues, withValue: string) => {
 	return cy.get(`[data-testid-${testId}="${withValue}"]`, { timeout: 15000 }).first();
+});
+
+Cypress.Commands.add('getByDataValue', (dataName: string, value: string) => {
+	return cy.get(`[data-${dataName}="${value}"]`, { timeout: 15000 }).first();
 });
 
 Cypress.Commands.add('selectText', (element: Cypress.Chainable<JQuery<HTMLElement>>) => {

--- a/apps/desktop/cypress/e2e/support/mock/backend.ts
+++ b/apps/desktop/cypress/e2e/support/mock/backend.ts
@@ -659,7 +659,7 @@ export default class MockBackend {
 		this.stackDetails.set(args.stackId, editableDetails);
 
 		return {
-			refname: `refs/remotes/origin/${args.stackId}`,
+			refname: `refs/remotes/origin/${args.branch}`,
 			remote: 'origin'
 		};
 	}

--- a/apps/desktop/cypress/e2e/support/mock/stacks.ts
+++ b/apps/desktop/cypress/e2e/support/mock/stacks.ts
@@ -341,6 +341,7 @@ export type PushStackParams = {
 	projectId: string;
 	stackId: string;
 	withForce: boolean;
+	branch: string;
 };
 
 export function isPushStackParams(params: unknown): params is PushStackParams {
@@ -352,7 +353,9 @@ export function isPushStackParams(params: unknown): params is PushStackParams {
 		'stackId' in params &&
 		typeof params.stackId === 'string' &&
 		'withForce' in params &&
-		typeof params.withForce === 'boolean'
+		typeof params.withForce === 'boolean' &&
+		'branch' in params &&
+		typeof params.branch === 'string'
 	);
 }
 

--- a/apps/desktop/cypress/e2e/support/scenarios/stackBrancheshWithCommits.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/stackBrancheshWithCommits.ts
@@ -1,0 +1,84 @@
+import MockBackend from '../mock/backend';
+import {
+	createMockBranchDetails,
+	createMockCommit,
+	createMockStack,
+	createMockStackDetails
+} from '../mock/stacks';
+
+const MOCK_STACK_A_ID = 'stack-a-id';
+const MOCK_SECOND_BRANCH_NAME = 'second-branch';
+
+const MOCK_COMMIT_TITLE_A = 'Initial commit';
+const MOCK_COMMIT_MESSAGE_A = 'This is a test commit';
+
+const MOCK_COMMIT_IN_BRANCH_A = createMockCommit({
+	id: '444444',
+	message: `${MOCK_COMMIT_TITLE_A}\n\n${MOCK_COMMIT_MESSAGE_A}`
+});
+
+const MOCK_COMMIT_IN_SECOND_BRANCH = createMockCommit({
+	id: '555555',
+	message: 'This is a commit in the second branch'
+});
+
+const MOCK_STACK_DETAILS_A = createMockStackDetails({
+	derivedName: MOCK_STACK_A_ID,
+	branchDetails: [
+		createMockBranchDetails({ name: MOCK_STACK_A_ID, commits: [MOCK_COMMIT_IN_BRANCH_A] }),
+		createMockBranchDetails({
+			name: MOCK_SECOND_BRANCH_NAME,
+			commits: [MOCK_COMMIT_IN_SECOND_BRANCH]
+		})
+	]
+});
+
+const MOCK_STACK_A = createMockStack({
+	id: MOCK_STACK_A_ID,
+	heads: [
+		{ name: MOCK_STACK_A_ID, tip: MOCK_COMMIT_IN_BRANCH_A.id },
+		{ name: MOCK_SECOND_BRANCH_NAME, tip: MOCK_COMMIT_IN_SECOND_BRANCH.id }
+	],
+	tip: MOCK_COMMIT_IN_BRANCH_A.id
+});
+
+export default class StackBranchesWithCommits extends MockBackend {
+	topBranchName = MOCK_STACK_A_ID;
+	bottomBranchName = MOCK_SECOND_BRANCH_NAME;
+	constructor() {
+		super();
+		this.stacks = [MOCK_STACK_A];
+		this.stackId = MOCK_STACK_A_ID;
+		this.stackDetails.set(MOCK_STACK_A_ID, MOCK_STACK_DETAILS_A);
+
+		this.branchChanges.set(
+			MOCK_STACK_A_ID,
+			new Map([
+				[MOCK_STACK_A_ID, []],
+				[MOCK_SECOND_BRANCH_NAME, []]
+			])
+		);
+	}
+
+	getCommitTitle(branchName: string): string {
+		switch (branchName) {
+			case MOCK_STACK_A_ID:
+				return MOCK_COMMIT_TITLE_A;
+			case MOCK_SECOND_BRANCH_NAME:
+				return MOCK_COMMIT_IN_SECOND_BRANCH.message;
+			default:
+				throw new Error(`Unknown branch name: ${branchName}`);
+		}
+	}
+
+	getCommitMessage(branchName: string): string {
+		switch (branchName) {
+			case MOCK_STACK_A_ID:
+				return MOCK_COMMIT_MESSAGE_A;
+			case MOCK_SECOND_BRANCH_NAME:
+				return '';
+			default:
+				throw new Error(`Unknown branch name: ${branchName}`);
+		}
+	}
+}

--- a/apps/desktop/src/components/ReviewCreation.svelte
+++ b/apps/desktop/src/components/ReviewCreation.svelte
@@ -184,14 +184,15 @@
 		prTitle.setDefault(commits);
 	});
 
-	async function pushIfNeeded(): Promise<string | undefined> {
+	async function pushIfNeeded(branchName: string): Promise<string | undefined> {
 		let upstreamBranchName: string | undefined = branchName;
 		if (pushBeforeCreate) {
 			const firstPush = branchDetails?.pushStatus === 'completelyUnpushed';
 			const pushResult = await pushStack({
 				projectId,
 				stackId,
-				withForce: branchDetails?.pushStatus === 'unpushedCommitsRequiringForce'
+				withForce: branchDetails?.pushStatus === 'unpushedCommitsRequiringForce',
+				branch: branchName
 			});
 
 			if (pushResult) {
@@ -235,7 +236,7 @@
 			isCreatingReview = true;
 			await tick();
 
-			const upstreamBranchName = await pushIfNeeded();
+			const upstreamBranchName = await pushIfNeeded(closureBranchName);
 
 			let newReviewId: string | undefined;
 			let newPrNumber: number | undefined;

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -966,8 +966,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					projectId: string;
 					stackId: string;
 					withForce: boolean;
-					/** if set, it will push up to this branch (inclusive) */
-					branch?: string | undefined;
+					branch: string;
 				}
 			>({
 				extraOptions: {

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -165,7 +165,7 @@ pub fn push_stack(
     ctx: &CommandContext,
     stack_id: StackId,
     with_force: bool,
-    branch_limit: Option<String>,
+    branch_limit: String,
 ) -> Result<()> {
     ctx.verify(ctx.project().exclusive_worktree_access().write_permission())?;
     assure_open_workspace_mode(ctx).context("Requires an open workspace mode")?;
@@ -211,11 +211,9 @@ pub fn push_stack(
             None,
             Some(Some(stack.id)),
         )?;
-        if let Some(limit) = &branch_limit {
-            // Push only up to the specified branch limit (inclusive)
-            if branch.name().eq(limit) {
-                break;
-            }
+
+        if branch.name().eq(&branch_limit) {
+            break;
         }
     }
     Ok(())

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/amend.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/amend.rs
@@ -51,7 +51,13 @@ fn forcepush_allowed() -> anyhow::Result<()> {
     let commit_id =
         gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit one", None).unwrap();
 
-    gitbutler_branch_actions::stack::push_stack(ctx, stack_entry.id, false, None).unwrap();
+    gitbutler_branch_actions::stack::push_stack(
+        ctx,
+        stack_entry.id,
+        false,
+        stack_entry.name().map(|s| s.to_string()).unwrap(),
+    )
+    .unwrap();
 
     {
         // amend another hunk

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
@@ -29,7 +29,13 @@ fn integration() {
 
         std::fs::write(repo.path().join("file.txt"), "first\n").unwrap();
         gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "first", None).unwrap();
-        gitbutler_branch_actions::stack::push_stack(ctx, stack_entry.id, false, None).unwrap();
+        gitbutler_branch_actions::stack::push_stack(
+            ctx,
+            stack_entry.id,
+            false,
+            stack_entry.name().map(|n| n.to_string()).unwrap(),
+        )
+        .unwrap();
 
         let (_, b) = stack_details(ctx)
             .into_iter()
@@ -68,7 +74,13 @@ fn integration() {
 
     {
         // merge branch into master
-        gitbutler_branch_actions::stack::push_stack(ctx, branch_id, false, None).unwrap();
+        gitbutler_branch_actions::stack::push_stack(
+            ctx,
+            branch_id,
+            false,
+            branch_name.simple_name(),
+        )
+        .unwrap();
 
         let (_, b) = stack_details(ctx)
             .into_iter()

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/update_commit_message.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/update_commit_message.rs
@@ -171,7 +171,13 @@ fn forcepush_allowed() {
         gitbutler_branch_actions::create_commit(ctx, stack_entry.id, "commit one", None).unwrap()
     };
 
-    gitbutler_branch_actions::stack::push_stack(ctx, stack_entry.id, false, None).unwrap();
+    gitbutler_branch_actions::stack::push_stack(
+        ctx,
+        stack_entry.id,
+        false,
+        stack_entry.name().map(|n| n.to_string()).unwrap(),
+    )
+    .unwrap();
 
     gitbutler_branch_actions::update_commit_message(
         ctx,

--- a/crates/gitbutler-tauri/src/stack.rs
+++ b/crates/gitbutler-tauri/src/stack.rs
@@ -106,7 +106,7 @@ pub fn push_stack(
     project_id: ProjectId,
     stack_id: StackId,
     with_force: bool,
-    branch: Option<String>,
+    branch: String,
 ) -> Result<(), Error> {
     let project = projects.get(project_id)?;
     let ctx = CommandContext::open(&project, settings.get()?.clone())?;


### PR DESCRIPTION
fix the way that we'd create PRs  for stacked branches.
Push only the correct stacked branch when opening a review.

Before, this was broken in that the whole stack would be unintentionally pushed and attached to the PR. This was obviously wrong.

Add a test that ensures this will behave the same again