### PR TITLE
ux: do not close previews when dragging unassigned

### DIFF
--- a/apps/desktop/src/components/MultiStackView.svelte
+++ b/apps/desktop/src/components/MultiStackView.svelte
@@ -69,7 +69,6 @@
 
 	// Enable panning when a stack is being dragged.
 	let draggingStack = $state(false);
-	let endStackDrag: (() => void) | undefined = $state();
 
 	// This is a bit of anti-pattern, and reordering should be better
 	// encapsulated such that we don't need this somewhat messy code.
@@ -155,7 +154,6 @@
 				ondragstart={(e) => {
 					onReorderStart(e, stack.id, () => {
 						draggingStack = true;
-						endStackDrag = dragStateService.startDragging();
 						selection.set(undefined);
 						intelligentScrollingService.show(projectId, stack.id, 'stack');
 					});
@@ -165,8 +163,6 @@
 				}}
 				ondragend={() => {
 					draggingStack = false;
-					endStackDrag?.();
-					endStackDrag = undefined;
 					onReorderEnd();
 				}}
 			>

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -11,7 +11,6 @@
 	import Resizer from '$components/Resizer.svelte';
 	import SelectionView from '$components/SelectionView.svelte';
 	import WorktreeChanges from '$components/WorktreeChanges.svelte';
-	import { DragStateService } from '$lib/dragging/dragStateService.svelte';
 	import { isParsedError } from '$lib/error/parser';
 	import { DefinedFocusable } from '$lib/focus/focusManager.svelte';
 	import { focusable } from '$lib/focus/focusable.svelte';
@@ -66,16 +65,14 @@
 		idSelection,
 		stackService,
 		intelligentScrollingService,
-		diffService,
-		dragStateService
+		diffService
 	] = inject(
 		UiState,
 		UncommittedService,
 		IdSelection,
 		StackService,
 		IntelligentScrollingService,
-		DiffService,
-		DragStateService
+		DiffService
 	);
 	const projectState = $derived(uiState.project(projectId));
 
@@ -110,17 +107,6 @@
 	const assignedKey = $derived(
 		$lastAddedAssigned?.key ? readKey($lastAddedAssigned.key) : undefined
 	);
-
-	// Close assigned preview when dragging starts (without clearing file selections)
-	$effect(() => {
-		const unsubscribe = dragStateService.isDragging.subscribe((isDragging) => {
-			if (isDragging) {
-				// Only clear the lastAdded to close preview, keep file selections intact
-				assignedSelection.lastAdded.set(undefined);
-			}
-		});
-		return unsubscribe;
-	});
 
 	const commitId = $derived(selection.current?.commitId);
 	const branchName = $derived(selection.current?.branchName);


### PR DESCRIPTION
There could be many previews open. Right now, we close all of them, which looks weird.