### PR TITLE
Move pre-commit hooks setting to project details form

### DIFF
--- a/apps/desktop/src/components/DetailsForm.svelte
+++ b/apps/desktop/src/components/DetailsForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { projectRunCommitHooks } from '$lib/config/config';
 	import { Project } from '$lib/project/project';
 	import { ProjectsService } from '$lib/project/projectsService';
 	import { getContext } from '@gitbutler/shared/context';
@@ -6,9 +7,12 @@
 	import Spacer from '@gitbutler/ui/Spacer.svelte';
 	import Textarea from '@gitbutler/ui/Textarea.svelte';
 	import Textbox from '@gitbutler/ui/Textbox.svelte';
+	import Toggle from '@gitbutler/ui/Toggle.svelte';
 
 	const project = getContext(Project);
 	const projectsService = getContext(ProjectsService);
+
+	const runCommitHooks = $derived(projectRunCommitHooks(project.id));
 
 	let title = $state(project?.title);
 	let description = $state(project?.description);
@@ -45,6 +49,20 @@
 			</section>
 		</fieldset>
 	</form>
+</SectionCard>
+
+<Spacer />
+
+<SectionCard labelFor="runHooks" orientation="row">
+	{#snippet title()}
+		Run commit hooks
+	{/snippet}
+	{#snippet caption()}
+		Enabling this will run any git pre and post commit hooks you have configured in your repository.
+	{/snippet}
+	{#snippet actions()}
+		<Toggle id="runHooks" bind:checked={$runCommitHooks} />
+	{/snippet}
 </SectionCard>
 
 <Spacer />

--- a/apps/desktop/src/components/PreferencesForm.svelte
+++ b/apps/desktop/src/components/PreferencesForm.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import Section from '$components/Section.svelte';
-	import { projectRunCommitHooks } from '$lib/config/config';
 	import { Project } from '$lib/project/project';
 	import { ProjectsService } from '$lib/project/projectsService';
 	import { getContext } from '@gitbutler/shared/context';
@@ -13,8 +12,6 @@
 
 	let snaphotLinesThreshold = project?.snapshot_lines_threshold || 20; // when undefined, the default is 20
 	let omitCertificateCheck = project?.omit_certificate_check;
-
-	const runCommitHooks = projectRunCommitHooks(project.id);
 
 	async function setOmitCertificateCheck(value: boolean | undefined) {
 		project.omit_certificate_check = !!value;
@@ -45,19 +42,6 @@
 				checked={omitCertificateCheck}
 				onclick={handleOmitCertificateCheckClick}
 			/>
-		{/snippet}
-	</SectionCard>
-
-	<SectionCard labelFor="runHooks" orientation="row">
-		{#snippet title()}
-			Run commit hooks
-		{/snippet}
-		{#snippet caption()}
-			Enabling this will run any git pre and post commit hooks you have configured in your
-			repository.
-		{/snippet}
-		{#snippet actions()}
-			<Toggle id="runHooks" bind:checked={$runCommitHooks} />
 		{/snippet}
 	</SectionCard>
 


### PR DESCRIPTION
This change relocates the UI that toggles pre-commit hooks:
- Adds the toggle to the DetailsForm within the general project settings, clarifying its purpose with proper labeling and captioning.
- Removes the toggle and related logic from the Experimental page.
This aligns the setting's location with its project-wide scope for better organization and discoverability.