### PR TITLE
Split commit tool

### DIFF
--- a/apps/desktop/src/components/FeedItemKind.svelte
+++ b/apps/desktop/src/components/FeedItemKind.svelte
@@ -186,6 +186,13 @@
 								{parsedCall.parameters?.branchName}
 							</span>
 						</p>
+					{:else if parsedCall.name === 'split_commit'}
+						<p class="operation__title">
+							Split commit
+							<span>
+								{parsedCall.parameters?.sourceCommitId.substring(0, 7)}
+							</span>
+						</p>
 					{/if}
 				</div>
 

--- a/crates/but-action/src/lib.rs
+++ b/crates/but-action/src/lib.rs
@@ -90,7 +90,7 @@ pub fn freestyle(
     - `absorb`: Take a set of file changes and amend them into the existing commits in the project.
       This requires you to figure out where the changes should go based on the locks, assingments and any other user provided information.
     - `split a commit`: Take an existing commit and split it into multiple commits based on the the user directive.
-        This is a multi-step operation where you will need to create one or more black commits, and the move the file changes from the original commit to the new commits.
+        This can be achieved by using the `split_commit` tool.
     - `split a branch`: Take an existing branch and split it into two branches. This basically takes a set of committed file changes and moves them to a new branch, removing them from the original branch.
         This is useful when you want to separate the changes into a new branch for further work.
         In order to do this, you will need to get the branch changes for the intended source branch (call the `get_branch_changes` tool), and then call the split branch tool with the changes you want to split off.

--- a/crates/but-tools/src/tool.rs
+++ b/crates/but-tools/src/tool.rs
@@ -144,3 +144,8 @@ impl ToolResult for Result<gix::ObjectId, anyhow::Error> {
         result_to_json(self, action_identifier, "gix::ObjectId")
     }
 }
+impl ToolResult for Result<Vec<gix::ObjectId>, anyhow::Error> {
+    fn to_json(&self, action_identifier: &str) -> serde_json::Value {
+        result_to_json(self, action_identifier, "Vec<gix::ObjectId>")
+    }
+}

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -46,6 +46,7 @@ pub use tree_manipulation::discard_worktree_changes::discard_workspace_changes;
 pub use tree_manipulation::move_between_commits::move_changes_between_commits;
 pub use tree_manipulation::remove_changes_from_commit_in_stack::remove_changes_from_commit_in_stack;
 pub use tree_manipulation::split_branch::split_branch;
+pub use tree_manipulation::split_commit::{CommitFiles, CommmitSplitOutcome, split_commit};
 pub mod head;
 pub use head::{head, merge_worktree_with_workspace};
 mod relapath;

--- a/crates/but-workspace/src/tree_manipulation/mod.rs
+++ b/crates/but-workspace/src/tree_manipulation/mod.rs
@@ -35,6 +35,7 @@ pub(super) mod discard_worktree_changes;
 pub(super) mod move_between_commits;
 pub(super) mod remove_changes_from_commit_in_stack;
 pub(super) mod split_branch;
+pub(super) mod split_commit;
 
 pub(crate) mod hunk;
 mod utils;

--- a/crates/but-workspace/src/tree_manipulation/split_branch.rs
+++ b/crates/but-workspace/src/tree_manipulation/split_branch.rs
@@ -9,12 +9,11 @@ use gitbutler_oxidize::ObjectIdExt;
 use gitbutler_oxidize::OidExt;
 use gitbutler_repo::logging::{LogUntil, RepositoryExt as _};
 use gitbutler_stack::{StackId, VirtualBranchesHandle};
-use gix::ObjectId;
 
 use crate::DiffSpec;
 use crate::MoveChangesResult;
 use crate::remove_changes_from_commit_in_stack;
-use crate::tree_manipulation::remove_changes_from_commit_in_stack::remove_changes_from_commit;
+use crate::tree_manipulation::remove_changes_from_commit_in_stack::keep_only_file_changes_in_commit;
 
 /// Splits a branch by creating a new branch with the specified changes.
 ///
@@ -164,27 +163,4 @@ fn remove_file_changes_from_commit(
         diff_specs,
         context_lines,
     )
-}
-
-fn keep_only_file_changes_in_commit(
-    ctx: &CommandContext,
-    source_commit_id: gix::ObjectId,
-    file_changes_to_keep: &[String],
-    context_lines: u32,
-) -> Result<ObjectId> {
-    let repository = ctx.gix_repo()?;
-    let commit_changes =
-        but_core::diff::ui::commit_changes_by_worktree_dir(&repository, source_commit_id)?;
-    let changes_to_remove: Vec<TreeChange> = commit_changes
-        .changes
-        .into_iter()
-        .filter(|change| !file_changes_to_keep.contains(&change.path.to_string()))
-        .map(|change| change.into())
-        .collect();
-    let diff_specs: Vec<DiffSpec> = changes_to_remove
-        .into_iter()
-        .map(|change| change.into())
-        .collect();
-
-    remove_changes_from_commit(ctx, source_commit_id, diff_specs, context_lines)
 }

--- a/crates/but-workspace/src/tree_manipulation/split_commit.rs
+++ b/crates/but-workspace/src/tree_manipulation/split_commit.rs
@@ -1,0 +1,101 @@
+use anyhow::Result;
+use but_rebase::Rebase;
+use gitbutler_command_context::CommandContext;
+use gitbutler_stack::{StackId, VirtualBranchesHandle};
+
+use crate::{
+    MoveChangesResult,
+    stack_ext::StackExt,
+    tree_manipulation::{
+        remove_changes_from_commit_in_stack::keep_only_file_changes_in_commit,
+        utils::replace_pick_with_multiple_commits,
+    },
+};
+
+/// Splits a commit into multiple commits based on the specified file changes.
+///
+/// This function creates new commits for each specified piece of the original commit.
+/// The new commits will contain only the specified files, effectively splitting the original commit.
+/// In steps:
+/// 1. Create new commits for each specified piece of the original commit.
+/// 2. Replace the original commit in the stack with the new commits.
+/// 3. Update the stack to reflect the new commits.
+pub fn split_commit(
+    ctx: &mut CommandContext,
+    stack_id: StackId,
+    source_commit_id: gix::ObjectId,
+    pieces: &[CommitFiles],
+    context_lines: u32,
+) -> Result<CommmitSplitOutcome> {
+    let repository = ctx.gix_repo()?;
+    let vb_state = VirtualBranchesHandle::new(ctx.project().gb_dir());
+
+    let source_stack = vb_state.get_stack_in_workspace(stack_id)?;
+
+    let mut steps = source_stack.as_rebase_steps(ctx, &repository)?;
+    let commit_pieces = new_commits(ctx, source_commit_id, pieces, context_lines)?;
+    replace_pick_with_multiple_commits(&mut steps, source_commit_id, &commit_pieces)?;
+    let base = source_stack.merge_base(ctx)?;
+    let mut rebase = Rebase::new(&repository, base, None)?;
+    rebase.steps(steps)?;
+    rebase.rebase_noops(false);
+    let result = rebase.rebase()?;
+
+    let commit_mapping = result
+        .commit_mapping
+        .iter()
+        .filter_map(
+            |(_, old, new)| {
+                if old == new { None } else { Some((*old, *new)) }
+            },
+        )
+        .collect();
+
+    let mut source_stack = source_stack;
+    source_stack.set_heads_from_rebase_output(ctx, result.references)?;
+
+    let new_commits = commit_pieces.iter().map(|(id, _)| *id).collect::<Vec<_>>();
+
+    Ok(CommmitSplitOutcome {
+        new_commits,
+        move_changes_result: MoveChangesResult {
+            replaced_commits: commit_mapping,
+        },
+    })
+}
+
+fn new_commits(
+    ctx: &CommandContext,
+    source_commit_id: gix::ObjectId,
+    pieces: &[CommitFiles],
+    context_lines: u32,
+) -> Result<Vec<(gix::ObjectId, Option<String>)>> {
+    let mut new_commits = Vec::new();
+    for piece in pieces {
+        let rewritten_commit =
+            keep_only_file_changes_in_commit(ctx, source_commit_id, &piece.files, context_lines)?;
+        new_commits.push((rewritten_commit, Some(piece.message.clone())));
+    }
+    Ok(new_commits)
+}
+
+/// Represents the files to be included in a new commit when splitting an existing commit.
+pub struct CommitFiles {
+    /// The message for the new commit.
+    pub message: String,
+    /// A subset of the files in the commit that should be included in the new commit.
+    pub files: Vec<String>,
+}
+
+/// Represents the outcome of splitting a commit, including the newly created commits
+/// and the result of moving changes between them.
+///
+/// # Fields
+/// - `new_commits`: A vector containing the object IDs of the new commits that were created as a result of the split.
+/// - `move_changes_result`: The result of the operation that moved changes between commits during the split process.
+pub struct CommmitSplitOutcome {
+    /// The new commits created
+    pub new_commits: Vec<gix::ObjectId>,
+    /// The moved changes outcome
+    pub move_changes_result: MoveChangesResult,
+}


### PR DESCRIPTION
- Implement core logic and entry points in but-workspace for commit splitting, including outcome types, export/configuration, and file tree manipulations.
- Add split_commit tool entry point, types, serde support, and command logic; integrate with Rust workspace core API.
- Update workspace module exports, error types, and results to handle split_commit outcomes.
- Extend UI and TypeScript support for split_commit, including tool parsing, feed integration, type definitions, and rendering split_commit operations in the app feed.