### PR TITLE
Remove AI commit message support from but-action and call sites

### DIFF
--- a/crates/but-action/src/generate.rs
+++ b/crates/but-action/src/generate.rs
@@ -10,6 +10,7 @@ use schemars::{JsonSchema, schema_for};
 
 use crate::OpenAiProvider;
 
+#[allow(dead_code)]
 pub fn commit_message_blocking(
     openai: &OpenAiProvider,
     external_summary: &str,

--- a/crates/but-action/src/lib.rs
+++ b/crates/but-action/src/lib.rs
@@ -162,7 +162,6 @@ pub fn auto_commit(
 
 pub fn handle_changes(
     ctx: &mut CommandContext,
-    openai: &Option<OpenAiProvider>,
     change_summary: &str,
     external_prompt: Option<String>,
     handler: ActionHandler,
@@ -170,7 +169,7 @@ pub fn handle_changes(
 ) -> anyhow::Result<(Uuid, Outcome)> {
     match handler {
         ActionHandler::HandleChangesSimple => {
-            simple::handle_changes(ctx, openai, change_summary, external_prompt, source)
+            simple::handle_changes(ctx, change_summary, external_prompt, source)
         }
     }
 }

--- a/crates/but/src/command/claude.rs
+++ b/crates/but/src/command/claude.rs
@@ -103,7 +103,6 @@ pub(crate) async fn handle_stop() -> anyhow::Result<ClaudeHookOutput> {
 
     let (id, outcome) = but_action::handle_changes(
         defer.ctx,
-        &None,
         &summary,
         Some(prompt.clone()),
         ActionHandler::HandleChangesSimple,

--- a/crates/but/src/command/mod.rs
+++ b/crates/but/src/command/mod.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use but_action::{OpenAiProvider, Source};
+use but_action::Source;
 use but_settings::AppSettings;
 use gitbutler_command_context::CommandContext;
 use gitbutler_project::Project;
@@ -17,10 +17,8 @@ pub(crate) fn handle_changes(
 ) -> anyhow::Result<()> {
     let project = Project::from_path(repo_path).expect("Failed to create project from path");
     let ctx = &mut CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
-    let openai = OpenAiProvider::with(None);
     let response = but_action::handle_changes(
         ctx,
-        &openai,
         change_description,
         None,
         handler.into(),

--- a/crates/but/src/mcp/mod.rs
+++ b/crates/but/src/mcp/mod.rs
@@ -137,7 +137,6 @@ impl Mcp {
 
         let (id, outcome) = but_action::handle_changes(
             ctx,
-            &None,
             &request.changes_summary,
             Some(request.full_prompt.clone()),
             ActionHandler::HandleChangesSimple,

--- a/crates/gitbutler-tauri/src/action.rs
+++ b/crates/gitbutler-tauri/src/action.rs
@@ -30,10 +30,8 @@ pub fn handle_changes(
 ) -> anyhow::Result<but_action::Outcome, Error> {
     let project = projects.get(project_id)?;
     let ctx = &mut CommandContext::open(&project, settings.get()?.clone())?;
-    let openai = OpenAiProvider::with(None);
     but_action::handle_changes(
         ctx,
-        &openai,
         &change_summary,
         None,
         handler,


### PR DESCRIPTION
Refactor to eliminate AI commit message generation plumbing and OpenAiProvider dependency in but-action::handle_changes and all call sites: 
- Remove OpenAiProvider argument and related logic from handle_changes and handle_changes_simple.
- Adjust commit message assignment logic to choose prompt/summary instead of calling out to OpenAI.
- Update all call sites in but, but/src/command/mod.rs, but/src/command/claude.rs, but/src/mcp/mod.rs, and gitbutler-tauri to match signature change and drop AI setup.
- This simplifies message path and makes commit step deterministic and prompt-driven only.