### PR TITLE
rename-branch-workflow

### DIFF
--- a/apps/desktop/src/components/FeedItem.svelte
+++ b/apps/desktop/src/components/FeedItem.svelte
@@ -3,7 +3,15 @@
 	import FeedStreamMessage from '$components/FeedStreamMessage.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
 	import SnapshotAttachment from '$components/SnapshotAttachment.svelte';
-	import { ButlerAction, getDisplayNameForWorkflowKind, Workflow } from '$lib/actions/types';
+	import {
+		ButlerAction,
+		getDisplayNameForWorkflowKind,
+		isClaudeCodeActionSource,
+		isDefinedMCPActionSource,
+		isStringActionSource,
+		isUndefinedMCPActionSource,
+		Workflow
+	} from '$lib/actions/types';
 	import butbotSvg from '$lib/assets/butbot-actions.svg?raw';
 	import { isFeedMessage, isInProgressAssistantMessage, type FeedEntry } from '$lib/feed/feed';
 	import SnapshotDiffService from '$lib/history/snapshotDiffService.svelte';
@@ -57,15 +65,22 @@
 
 <div class="action-item" id="action-{action.id}">
 	{#if action instanceof ButlerAction}
-		{#if isStr(action.source) || !action.source.Mcp}
+		{#if isStringActionSource(action.source) || isUndefinedMCPActionSource(action.source)}
 			<div>
 				<div class="action-item__robot">
 					<Icon name="robot" />
 				</div>
 			</div>
-		{:else}
+		{:else if isDefinedMCPActionSource(action.source)}
 			<div class="action-item__editor-logo">
-				<EditorLogo name={action.source.Mcp?.name} />
+				<EditorLogo name={action.source.Mcp.name} />
+				<div class="action-item__editor-source">
+					{@html butbotSvg}
+				</div>
+			</div>
+		{:else if isClaudeCodeActionSource(action.source)}
+			<div class="action-item__editor-logo">
+				<EditorLogo name="claude" />
 				<div class="action-item__editor-source">
 					{@html butbotSvg}
 				</div>

--- a/apps/desktop/src/components/FeedItemKind.svelte
+++ b/apps/desktop/src/components/FeedItemKind.svelte
@@ -37,6 +37,15 @@
 		});
 		projectState.stackId.set(stackId);
 	}
+
+	function selectBranch(stackId: string, branchName: string) {
+		const projectState = uiState.project(projectId);
+		const stackState = uiState.stack(stackId);
+		stackState.selection.set({
+			branchName
+		});
+		projectState.stackId.set(stackId);
+	}
 </script>
 
 {#snippet code(value: unknown)}
@@ -83,6 +92,35 @@
 			{:else}
 				<span class="text-13 text-greyer">Reword action without subject</span>
 			{/if}
+		</div>
+	{:else if kind.type === 'renameBranch'}
+		<div class="text-13">
+			<div class="operations">
+				<div class="operation-row text-13">
+					<div class="operation-icon">
+						<Icon name="branch-local" />
+					</div>
+
+					<div class="operation-content">
+						<p class="operation__title">
+							Renamed branch from
+							<span>{kind.subject.oldBranchName}</span>
+
+							<span>→</span>
+
+							<button
+								class="operation__commit-branch"
+								type="button"
+								onclick={() => selectBranch(kind.subject.stackId, kind.subject.newBranchName)}
+							>
+								<span>
+									{kind.subject.newBranchName}
+								</span>
+							</button>
+						</p>
+					</div>
+				</div>
+			</div>
 		</div>
 	{/if}
 {:else if rest.type === 'tool-call'}
@@ -255,6 +293,7 @@
 		text-wrap: nowrap;
 	}
 
+	.operation__commit-branch,
 	.operation__commit-sha {
 		display: inline-flex;
 		align-items: center;

--- a/crates/but-action/src/lib.rs
+++ b/crates/but-action/src/lib.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use but_core::TreeChange;
-use but_workspace::ui::StackEntry;
+use but_workspace::{StackId, ui::StackEntry};
 use gitbutler_branch::BranchCreateRequest;
 use gitbutler_command_context::CommandContext;
 use gitbutler_oxidize::ObjectIdExt;
@@ -24,6 +24,7 @@ mod emit;
 mod generate;
 mod grouping;
 mod openai;
+pub mod rename_branch;
 pub mod reword;
 mod serialize;
 mod simple;
@@ -279,6 +280,7 @@ pub struct Outcome {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdatedBranch {
+    pub stack_id: StackId,
     pub branch_name: String,
     pub new_commits: Vec<String>,
 }

--- a/crates/but-action/src/rename_branch.rs
+++ b/crates/but-action/src/rename_branch.rs
@@ -1,0 +1,50 @@
+use async_openai::{Client, config::OpenAIConfig};
+use but_workspace::StackId;
+use gitbutler_command_context::CommandContext;
+use gix::bstr::BString;
+
+use crate::workflow::{self, Workflow};
+
+pub async fn rename_branch(
+    ctx: &mut CommandContext,
+    client: &Client<OpenAIConfig>,
+    commit_id: gix::ObjectId,
+    commit_message: BString,
+    stack_id: StackId,
+    current_branch_name: String,
+    trigger_id: uuid::Uuid,
+) -> anyhow::Result<()> {
+    let commit_messages = vec![commit_message.to_string()];
+    let branch_name = crate::generate::branch_name(client, &commit_messages).await?;
+    let normalized_branch_name = gitbutler_reference::normalize_branch_name(&branch_name)?;
+
+    let update = gitbutler_branch_actions::stack::update_branch_name(
+        ctx,
+        stack_id,
+        current_branch_name.clone(),
+        normalized_branch_name.clone(),
+    )
+    .map_err(|e| anyhow::anyhow!("Failed to rename branch: {}", e));
+
+    let status = match &update {
+        Ok(_) => workflow::Status::Completed,
+        Err(e) => workflow::Status::Failed(e.to_string()),
+    };
+
+    Workflow::new(
+        workflow::Kind::RenameBranch(workflow::RenameBranchOutcome {
+            stack_id,
+            old_branch_name: current_branch_name,
+            new_branch_name: normalized_branch_name,
+        }),
+        workflow::Trigger::Snapshot(trigger_id),
+        status,
+        vec![commit_id],
+        vec![commit_id],
+        None,
+    )
+    .persist(ctx)
+    .ok();
+
+    Ok(())
+}

--- a/crates/but-action/src/simple.rs
+++ b/crates/but-action/src/simple.rs
@@ -164,6 +164,7 @@ fn handle_changes_simple_inner(
 
         if let Some(new_commit) = outcome.new_commit {
             updated_branches.push(crate::UpdatedBranch {
+                stack_id,
                 branch_name: stack_branch_name,
                 new_commits: vec![new_commit.to_string()],
             });

--- a/crates/but-action/src/workflow.rs
+++ b/crates/but-action/src/workflow.rs
@@ -17,10 +17,19 @@ pub struct RewordOutcome {
     pub new_message: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RenameBranchOutcome {
+    pub stack_id: StackId,
+    pub old_branch_name: String,
+    pub new_branch_name: String,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type", content = "subject", rename_all = "camelCase")]
 pub enum Kind {
     Reword(Option<RewordOutcome>),
+    RenameBranch(RenameBranchOutcome),
 }
 
 #[derive(Deserialize)]

--- a/packages/ui/src/lib/EditorLogo.svelte
+++ b/packages/ui/src/lib/EditorLogo.svelte
@@ -5,7 +5,7 @@
 	import vsCodeLogoSvg from '$lib/assets/vscode.svg?raw';
 
 	type Props = {
-		name: string;
+		name: 'vscode' | 'cursor' | 'claude' | (string & {});
 	};
 
 	const { name }: Props = $props();


### PR DESCRIPTION
Rename the branch after creating the first commit to it through claude code.

Also, add a dedicated Claude Code entry to the feed

 
 - Implement rename branch workflow with async GPT-based naming and outcome persistence.
- Add generator logic and UI/CLI integrations for rename branch workflow support.
- Update UpdatedBranch struct for stack-aware info and integrate auto rename eligibility logic.
- Enhance UI to display rename branch actions and support interactive branch selection.
- Expand action source types and add type helpers for correct component rendering.
- Improve EditorLogo component with autosuggested editor names for better type safety.