### PR TITLE
single-rebase-split-branch

### DIFF
--- a/crates/but-tools/src/workspace.rs
+++ b/crates/but-tools/src/workspace.rs
@@ -1391,11 +1391,9 @@ pub fn split_branch(
         app_handle.emit_stack_update(project_id, stack_id);
     }
 
-    if let Some(move_result) = move_result {
-        // Update the commit mapping with the new commit ids.
-        for (old_commit_id, new_commit_id) in move_result.replaced_commits.iter() {
-            commit_mapping.insert(*old_commit_id, *new_commit_id);
-        }
+    // Update the commit mapping with the new commit ids.
+    for (old_commit_id, new_commit_id) in move_result.replaced_commits.iter() {
+        commit_mapping.insert(*old_commit_id, *new_commit_id);
     }
 
     Ok(stack_id)

--- a/crates/but-workspace/src/tree_manipulation/split_commit.rs
+++ b/crates/but-workspace/src/tree_manipulation/split_commit.rs
@@ -72,9 +72,15 @@ fn new_commits(
 ) -> Result<Vec<(gix::ObjectId, Option<String>)>> {
     let mut new_commits = Vec::new();
     for piece in pieces {
-        let rewritten_commit =
-            keep_only_file_changes_in_commit(ctx, source_commit_id, &piece.files, context_lines)?;
-        new_commits.push((rewritten_commit, Some(piece.message.clone())));
+        if let Some(rewritten_commit) = keep_only_file_changes_in_commit(
+            ctx,
+            source_commit_id,
+            &piece.files,
+            context_lines,
+            false,
+        )? {
+            new_commits.push((rewritten_commit, Some(piece.message.clone())));
+        }
     }
     Ok(new_commits)
 }

--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -332,7 +332,7 @@ pub fn split_branch(
     source_branch_name: String,
     new_branch_name: String,
     file_changes_to_split_off: Vec<String>,
-) -> Result<Option<UIMoveChangesResult>, Error> {
+) -> Result<UIMoveChangesResult, Error> {
     let project = projects.get(project_id)?;
     let ctx = CommandContext::open(&project, settings.get()?.clone())?;
     let mut guard = project.exclusive_worktree_access();
@@ -363,7 +363,7 @@ pub fn split_branch(
         guard.write_permission(),
     )?;
 
-    Ok(move_changes_result.map(Into::into))
+    Ok(move_changes_result.into())
 }
 
 /// Uncommits the changes specified in the `diffspec`.


### PR DESCRIPTION
Speed up the branch split operation and drop empty commits