### PR TITLE
enhance-branch-name-generation

### DIFF
--- a/crates/but-action/src/rename_branch.rs
+++ b/crates/but-action/src/rename_branch.rs
@@ -5,17 +5,30 @@ use gix::bstr::BString;
 
 use crate::workflow::{self, Workflow};
 
+pub struct RenameBranchParams {
+    pub commit_id: gix::ObjectId,
+    pub commit_message: BString,
+    pub stack_id: StackId,
+    pub current_branch_name: String,
+    pub existing_branch_names: Vec<String>,
+}
+
 pub async fn rename_branch(
     ctx: &mut CommandContext,
     client: &Client<OpenAIConfig>,
-    commit_id: gix::ObjectId,
-    commit_message: BString,
-    stack_id: StackId,
-    current_branch_name: String,
+    parameters: RenameBranchParams,
     trigger_id: uuid::Uuid,
 ) -> anyhow::Result<()> {
+    let RenameBranchParams {
+        commit_id,
+        commit_message,
+        stack_id,
+        current_branch_name,
+        existing_branch_names,
+    } = parameters;
     let commit_messages = vec![commit_message.to_string()];
-    let branch_name = crate::generate::branch_name(client, &commit_messages).await?;
+    let branch_name =
+        crate::generate::branch_name(client, &commit_messages, &existing_branch_names).await?;
     let normalized_branch_name = gitbutler_reference::normalize_branch_name(&branch_name)?;
 
     let update = gitbutler_branch_actions::stack::update_branch_name(

--- a/crates/but-tools/src/workspace.rs
+++ b/crates/but-tools/src/workspace.rs
@@ -1177,6 +1177,8 @@ impl Tool for SquashCommits {
         <important_notes>
             This tool allows you to squash a sequence of commits in a stack into a single commit with a new message.
             Use this tool to clean up commit history before merging or sharing.
+            Always squash the commits down, meanding newer commits into their parents.
+            Remember that the commits listed in the project status are in reverse order, so the first commit in the list is the newest one.
         </important_notes>
         ".to_string()
     }


### PR DESCRIPTION
Branch name generation will try to create better branch names

To do this:
- Be explicit about not using backticks
- Expect structured output
- Provide the existing branch names, and direct to generate a noticeably different name