### PR TITLE
Increase changed files min-height for a roomier feel

### DIFF
--- a/apps/desktop/src/components/Resizer.svelte
+++ b/apps/desktop/src/components/Resizer.svelte
@@ -113,19 +113,31 @@
 		let overflow: number;
 		switch (direction) {
 			case 'down':
-				newValue = Math.min(Math.max(value, minHeight), maxHeight);
+				newValue =
+					minHeight > maxHeight
+						? Math.max(value, minHeight)
+						: Math.min(Math.max(value, minHeight), maxHeight);
 				overflow = minHeight - value;
 				break;
 			case 'up':
-				newValue = Math.min(Math.max(value, minHeight), maxHeight);
+				newValue =
+					minHeight > maxHeight
+						? Math.max(value, minHeight)
+						: Math.min(Math.max(value, minHeight), maxHeight);
 				overflow = minHeight - value;
 				break;
 			case 'right':
-				newValue = Math.min(Math.max(value, minWidth), maxWidth);
+				newValue =
+					minWidth > maxWidth
+						? Math.max(value, minWidth)
+						: Math.min(Math.max(value, minWidth), maxWidth);
 				overflow = minWidth - value;
 				break;
 			case 'left':
-				newValue = Math.min(Math.max(value, minWidth), maxWidth);
+				newValue =
+					minWidth > maxWidth
+						? Math.max(value, minWidth)
+						: Math.min(Math.max(value, minWidth), maxWidth);
 				overflow = minWidth - value;
 				break;
 		}

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -141,7 +141,7 @@
 	let actualDetailsHeight = $state<number>(0);
 	let actualDetailsHeightRem = $derived(pxToRem(actualDetailsHeight, zoom));
 
-	let minChangedFilesHeight = $state(5);
+	let minChangedFilesHeight = $state(8);
 	let minPreviewHeight = $derived(previewChangeResult ? 7 : 0);
 
 	let maxChangedFilesHeight = $derived(


### PR DESCRIPTION
Increase the minimum height of the changed files section from 5 to 8
to improve visibility and accommodate more content without scrolling.
This change enhances the user experience by reducing the need for
frequent resizing or scrolling in the stack view component.