### PR TITLE
Add rewrap toggle for commit message formatting

### DIFF
--- a/apps/desktop/src/components/CommitContextMenu.svelte
+++ b/apps/desktop/src/components/CommitContextMenu.svelte
@@ -30,6 +30,7 @@
 <script lang="ts">
 	import ContextMenu from '$components/ContextMenu.svelte';
 	import { writeClipboard } from '$lib/backend/clipboard';
+	import { rewrapCommitMessage } from '$lib/config/uiFeatureFlags';
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { TestId } from '$lib/testing/testIds';
 	import { openExternalUrl } from '$lib/utils/url';
@@ -157,5 +158,16 @@
 				/>
 			</ContextMenuSection>
 		{/if}
+		<ContextMenuSection>
+			<ContextMenuItem
+				icon="text-wrap"
+				label={$rewrapCommitMessage ? 'Original' : 'Re-wrap'}
+				disabled={commitInsertion.current.isLoading}
+				onclick={() => {
+					rewrapCommitMessage.set(!$rewrapCommitMessage);
+					close();
+				}}
+			/>
+		</ContextMenuSection>
 	</ContextMenu>
 {/if}

--- a/apps/desktop/src/components/CommitDetails.svelte
+++ b/apps/desktop/src/components/CommitDetails.svelte
@@ -6,7 +6,7 @@
 	import { TestId } from '$lib/testing/testIds';
 	import { UserService } from '$lib/user/userService';
 	import { splitMessage } from '$lib/utils/commitMessage';
-	import { truncate } from '$lib/utils/string';
+	import { rejoinParagraphs, truncate } from '$lib/utils/string';
 	import { getContextStoreBySymbol, inject } from '@gitbutler/shared/context';
 	import Icon from '@gitbutler/ui/Icon.svelte';
 	import Tooltip from '@gitbutler/ui/Tooltip.svelte';
@@ -17,9 +17,10 @@
 
 	type Props = {
 		commit: UpstreamCommit | Commit;
+		rewrap?: boolean;
 	};
 
-	const { commit }: Props = $props();
+	const { commit, rewrap }: Props = $props();
 
 	const [userService] = inject(UserService, UiState);
 	const userSettings = getContextStoreBySymbol<Settings, Writable<Settings>>(SETTINGS);
@@ -36,7 +37,8 @@
 	const maxLength = $derived((messageWidthRem - 2) * 2 - 1 * (Math.pow(zoom, 2) - 1));
 
 	const message = $derived(commit.message);
-	const description = $derived(splitMessage(message).description);
+	const raw = $derived(splitMessage(message).description);
+	const description = $derived(rewrap ? rejoinParagraphs(raw) : raw);
 	const abbreviated = $derived(truncate(description, maxLength, 3));
 	const isAbbrev = $derived(abbreviated !== description);
 

--- a/apps/desktop/src/components/CommitView.svelte
+++ b/apps/desktop/src/components/CommitView.svelte
@@ -10,6 +10,7 @@
 	import { isLocalAndRemoteCommit } from '$components/lib';
 	import { isCommit } from '$lib/branches/v3';
 	import { type CommitKey } from '$lib/commits/commit';
+	import { rewrapCommitMessage } from '$lib/config/uiFeatureFlags';
 	import { DefaultForgeFactory } from '$lib/forge/forgeFactory.svelte';
 	import { ModeService } from '$lib/mode/modeService';
 	import { showToast } from '$lib/notifications/toasts';
@@ -238,7 +239,7 @@
 						/>
 					</div>
 				{:else}
-					<CommitDetails {commit} />
+					<CommitDetails {commit} rewrap={$rewrapCommitMessage} />
 				{/if}
 			</div>
 		</Drawer>

--- a/apps/desktop/src/lib/config/uiFeatureFlags.ts
+++ b/apps/desktop/src/lib/config/uiFeatureFlags.ts
@@ -13,3 +13,4 @@ export const workspaceSwapPanels = persisted<
 
 export const ircEnabled = persistWithExpiration(false, 'feature-irc', 1440 * 30);
 export const ircServer = persistWithExpiration('', 'feature-irc-server', 1440 * 30);
+export const rewrapCommitMessage = persistWithExpiration(true, 'rewrap-commit-msg', 1440 * 30);

--- a/apps/desktop/src/lib/utils/string.ts
+++ b/apps/desktop/src/lib/utils/string.ts
@@ -28,3 +28,53 @@ export function truncate(text: string, maxChars: number, maxLines: number): stri
 		return text.substring(0, maxChars) + '…';
 	}
 }
+
+export function rejoinParagraphs(text: string): string {
+	const lines = text.split('\n');
+	const result: string[] = [];
+	let currentParagraph = '';
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i]!;
+		const trimmedLine = line.trim();
+
+		// Check if this line should start a new block (headers, lists, code blocks, etc.)
+		const isBlockElement = /^(#{1,6}\s|```|~~~|\*\s|-\s|\d+\.\s|>\s|\|\s|$)/.test(trimmedLine);
+
+		// Check if previous line was a block element
+		const prevLine = i > 0 ? lines[i - 1]!.trim() : '';
+		const prevWasBlock = /^(#{1,6}\s|```|~~~|\*\s|-\s|\d+\.\s|>\s|\|\s)/.test(prevLine);
+
+		// Empty line - signals paragraph break
+		if (trimmedLine === '') {
+			if (currentParagraph.trim()) {
+				result.push(currentParagraph.trim());
+				currentParagraph = '';
+			}
+			continue;
+		}
+
+		// Start new paragraph for block elements or after block elements
+		if (isBlockElement || prevWasBlock) {
+			if (currentParagraph.trim()) {
+				result.push(currentParagraph.trim());
+				currentParagraph = '';
+			}
+			result.push(line);
+		} else {
+			// Continue current paragraph
+			if (currentParagraph) {
+				currentParagraph += ' ' + trimmedLine;
+			} else {
+				currentParagraph = trimmedLine;
+			}
+		}
+	}
+
+	// Add any remaining paragraph
+	if (currentParagraph.trim()) {
+		result.push(currentParagraph.trim());
+	}
+
+	return result.join('\n\n');
+}


### PR DESCRIPTION
Introduce a "rewrap" option when viewing commit messages, making it 
easier to read if you often resize branches/stacks.