### PR TITLE
Make drawer resizing a bit nore intuitive

### DIFF
--- a/apps/desktop/src/components/Drawer.svelte
+++ b/apps/desktop/src/components/Drawer.svelte
@@ -73,6 +73,19 @@
 	let headerHeight = $state(0);
 	let contentHeight = $state(0);
 	const totalHeightRem = $derived(pxToRem(headerHeight + contentHeight, zoom));
+
+	let resizerInstance = $state<Resizer>();
+	$effect(() => {
+		// Reset resizer if we happen on a value that equals the scroll
+		// height, enabling the user to more easily undo manual sizing. It
+		// is assumed that an unset value makes the element display in
+		// full, otherwise there would be sudden content shift.
+		if (clientHeight === headerHeight + contentHeight) {
+			requestAnimationFrame(() => {
+				resizerInstance?.setValue(undefined);
+			});
+		}
+	});
 </script>
 
 <div
@@ -155,6 +168,7 @@
 	{/if}
 	{#if resizer}
 		<Resizer
+			bind:this={resizerInstance}
 			defaultValue={undefined}
 			viewport={containerDiv}
 			hidden={$collapsed}

--- a/apps/desktop/src/components/Resizer.svelte
+++ b/apps/desktop/src/components/Resizer.svelte
@@ -243,7 +243,7 @@
 		return pxToRem(viewport.clientHeight, zoom);
 	}
 
-	function setValue(newSize?: number) {
+	export function setValue(newSize?: number) {
 		value.set(newSize);
 		updateDom(newSize);
 		if (newSize !== undefined) {


### PR DESCRIPTION
Interpret height = scroll height as a reset, it feels more intuitive this way.