### PR TITLE
Enable persistence in user-chosen keyring for keyring-rs on linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ tokio = { version = "1.45.1", default-features = false }
 keyring = { version = "3.6.1", features = [
     "apple-native",
     "windows-native",
-    "linux-native",
+    "linux-native-sync-persistent",
     "crypto-rust",
 ] }
 anyhow = "1.0.98"


### PR DESCRIPTION
## 🧢 Changes

Workspace Cargo.toml updated to use linux-native-sync-persistent feature flag on keyring-rs instead of linux-native, to allow for proper persistence in user-provided keyring across system power cycles. 

## ☕️ Reasoning

Before this commit, keyring-rs for linux was configured to only use keyutils' session store (through the linux-native flag), meaning that credentials were only stored on the machine until the next power cycle. This commit replaces the linux-native feature flag with linux-native-sync-persistent flag, which incorporates linux-native but will preferentially use a user's persistent keyring (e.g. gnome-keyring or kwallet) via org.freedesktop.secrets over dbus.

## 🎫 Affected issues

Fixes: #5493
