### PR TITLE
fix: Animation on rename

### DIFF
--- a/apps/desktop/src/components/MultiStackView.svelte
+++ b/apps/desktop/src/components/MultiStackView.svelte
@@ -146,9 +146,11 @@
 		{#each mutableStacks as stack, i (stack.id)}
 			{@const stackState = uiState.stack(stack.id)}
 			{@const selection = stackState.selection}
+			{@const laneWraperMinWidth = laneWidths[i] ?? 0}
 			<div
 				class="reorderable-stack"
 				role="presentation"
+				style:min-width="{laneWraperMinWidth}px"
 				animate:flip={{ duration: 150 }}
 				onmousedown={onReorderMouseDown}
 				ondragstart={(e) => {


### PR DESCRIPTION
Don’t bounce on the rename of a branch.

Basically, the Svelte flip animatin runs always. Independently from this example: https://svelte.dev/tutorial/svelte/animations

This seems to be by design. The flip animations aims to bridge the different states a component can be in, so that there’s no jumpiness about it. It determines the start state of a component’s rect, and it’s end state. And basically interpolates them. Read more here: https://aerotwist.com/blog/flip-your-animations/

The bounciness in our case seems to come from the fact that the div’s width is initially considered to be 0, and then the actual width of the stack. The bounciness can be completely removed by passing the `laneWidth` to it as min-width. This makes the start and end state of the rect match.