### PR TITLE
integration-checks (testing)

### DIFF
--- a/crates/but-workspace/tests/fixtures/scenario/journey02.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/journey02.sh
@@ -16,13 +16,23 @@ We change the name of the first commit and also need the similarity to be detect
   git checkout -b A
     git branch soon-A-remote
     echo A-new >file && git add file && git commit -m A1
-    commit A2
+    echo A-new >other && git add other && git commit -m A2
   git checkout soon-A-remote
     echo A-new >file && git add file && git commit -m "A1 (same but different)"
     setup_remote_tracking soon-A-remote A "move"
 
   git checkout A
   create_workspace_commit_once A
+)
+
+cp -R 01-one-rewritten-one-local-after-push 01.5-one-rewritten-one-local-after-push-merge
+(cd 01.5-one-rewritten-one-local-after-push-merge
+  echo "On the remote, a rewritten/rebased commit we have locally is merged back into target." >.git/description
+  git checkout -b soon-main-remote origin/main
+    git merge --no-ff origin/A -m "merge origin/A"
+    setup_remote_tracking soon-main-remote main "move"
+
+  git checkout gitbutler/workspace
 )
 
 git init 02-diverged-remote
@@ -43,6 +53,18 @@ The tip of the local branch isn't in the ancestry of the remote anymore." >.git/
   create_workspace_commit_once A
 )
 
+cp -R 02-diverged-remote 02.5-diverged-remote-merge
+(cd 02.5-diverged-remote-merge
+  echo "A remote sharing a commit with a stack and its own commit gets merged.
+
+We'd not want to see the remote unique commit anymore as it's also considered integrated." >.git/description
+  git checkout main
+    git merge --no-ff origin/A
+    git rev-parse @ >.git/refs/remotes/origin/main
+
+  git checkout gitbutler/workspace
+)
+
 git init 03-remote-one-behind
 (cd 03-remote-one-behind
   echo "A can be pushed as it has local, unpushed commits" >.git/description
@@ -53,6 +75,16 @@ git init 03-remote-one-behind
     commit A2
 
   create_workspace_commit_once A
+)
+
+cp -R 03-remote-one-behind 03.5-remote-one-behind-merge-no-ff
+(cd 03.5-remote-one-behind-merge-no-ff
+  echo "Remote origin/A is merged back (with forceful merge commit) while there are still local commits." >.git/description
+  git checkout main
+    git merge --no-ff origin/A
+    git rev-parse @ >.git/refs/remotes/origin/main
+
+  git checkout gitbutler/workspace
 )
 
 git init 04-remote-one-ahead-ff
@@ -67,4 +99,14 @@ git init 04-remote-one-ahead-ff
 
   git checkout A
   create_workspace_commit_once A
+)
+
+cp -R 04-remote-one-ahead-ff 04.5-remote-one-ahead-ff-merge
+(cd 04.5-remote-one-ahead-ff-merge
+  echo "Remote origin/A is merged back (fast-forward), bringing all into the target branch" >.git/description
+  git checkout main
+    git merge origin/A
+    git rev-parse @ >.git/refs/remotes/origin/main
+
+  git checkout gitbutler/workspace
 )

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
@@ -806,6 +806,8 @@ A new multi-segment stack is created without remote and squash merged locally.
     * fafd9d0 init
     ");
 
+    // TODO: if the user now puts another dependent branch, it's breaking down in many ways.
+    //       We should be smarter about that and flesh out additional steps on top.
     add_stack_with_segments(&mut meta, 0, "S1", StackState::InWorkspace, &[]);
     let info = but_workspace::head_info(&repo, &*meta, standard_options());
     insta::assert_debug_snapshot!(info, @r#"

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_merges.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_merges.rs
@@ -1,5 +1,6 @@
 //! A loose collection of states that users typically encounter.
 use crate::ref_info::utils::standard_options;
+use crate::ref_info::with_workspace_commit::journey::utils::standard_options_with_extra_target;
 use crate::ref_info::with_workspace_commit::utils::named_read_only_in_memory_scenario_with_description;
 use but_graph::VirtualBranchesTomlMetadata;
 use but_testsupport::visualize_commit_graph_all;
@@ -13,8 +14,8 @@ fn two_commits_require_force_push() -> anyhow::Result<()> {
     We change the name of the first commit and also need the similarity to be detected by changeset
     ");
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * 0d9835f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    * a1b4326 (A) A2
+    * 946cdb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * f9c2b14 (A) A2
     * e1f216e A1
     | * 3fcd07a (origin/A) A1 (same but different)
     |/  
@@ -41,7 +42,7 @@ fn two_commits_require_force_push() -> anyhow::Result<()> {
                             ref_name: "refs/heads/A",
                             remote_tracking_ref_name: "refs/remotes/origin/A",
                             commits: [
-                                LocalCommit(a1b4326, "A2\n", local),
+                                LocalCommit(f9c2b14, "A2\n", local),
                                 LocalCommit(e1f216e, "A1\n", local/remote(similarity)),
                             ],
                             commits_unique_in_remote_tracking_branch: [],
@@ -59,6 +60,74 @@ fn two_commits_require_force_push() -> anyhow::Result<()> {
                     ),
                     segment_index: NodeIndex(1),
                     commits_ahead: 0,
+                },
+            ),
+            extra_target: None,
+            lower_bound: Some(
+                NodeIndex(2),
+            ),
+            is_managed_ref: true,
+            is_managed_commit: true,
+            is_entrypoint: true,
+        },
+    )
+    "#);
+    Ok(())
+}
+
+#[test]
+fn two_commits_require_force_push_merged() -> anyhow::Result<()> {
+    let (repo, meta, description) = scenario("01.5-one-rewritten-one-local-after-push-merge")?;
+    insta::assert_snapshot!(description, @"On the remote, a rewritten/rebased commit we have locally is merged back into target.");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 946cdb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * f9c2b14 (A) A2
+    * e1f216e A1
+    | * c635f08 (origin/main) merge origin/A
+    |/| 
+    | * 3fcd07a (origin/A) A1 (same but different)
+    |/  
+    * fafd9d0 (main) init
+    ");
+
+    let info = but_workspace::head_info(&repo, &*meta, standard_options());
+    insta::assert_debug_snapshot!(info, @r#"
+    Ok(
+        RefInfo {
+            workspace_ref_name: Some(
+                FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+            ),
+            stacks: [
+                Stack {
+                    base: Some(
+                        Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                    ),
+                    segments: [
+                        ref_info::ui::Segment {
+                            id: NodeIndex(3),
+                            ref_name: "refs/heads/A",
+                            remote_tracking_ref_name: "refs/remotes/origin/A",
+                            commits: [
+                                LocalCommit(f9c2b14, "A2\n", local),
+                                LocalCommit(e1f216e, "A1\n", integrated(c635f08)),
+                            ],
+                            commits_unique_in_remote_tracking_branch: [],
+                            metadata: "None",
+                            push_status: UnpushedCommitsRequiringForce,
+                            base: "fafd9d0",
+                        },
+                    ],
+                },
+            ],
+            target: Some(
+                Target {
+                    ref_name: FullName(
+                        "refs/remotes/origin/main",
+                    ),
+                    segment_index: NodeIndex(1),
+                    commits_ahead: 2,
                 },
             ),
             extra_target: None,
@@ -147,6 +216,86 @@ fn remote_diverged() -> anyhow::Result<()> {
 }
 
 #[test]
+fn remote_diverged_merge() -> anyhow::Result<()> {
+    let (repo, meta, description) = scenario("02.5-diverged-remote-merge")?;
+    insta::assert_snapshot!(description, @r"
+    A remote sharing a commit with a stack and its own commit gets merged.
+
+    We'd not want to see the remote unique commit anymore as it's also considered integrated.
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 3ea2742 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * a62b0de (A) A2
+    | *   085089c (origin/main, main) Merge remote-tracking branch 'origin/A'
+    | |\  
+    | | * 0c06863 (origin/A) A3
+    | |/  
+    |/|   
+    * | 120a217 A1
+    |/  
+    * fafd9d0 init
+    ");
+
+    let info = but_workspace::head_info(
+        &repo,
+        &*meta,
+        standard_options_with_extra_target(&repo, "fafd9d0"),
+    );
+    insta::assert_debug_snapshot!(info, @r#"
+    Ok(
+        RefInfo {
+            workspace_ref_name: Some(
+                FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+            ),
+            stacks: [
+                Stack {
+                    base: Some(
+                        Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                    ),
+                    segments: [
+                        ref_info::ui::Segment {
+                            id: NodeIndex(5),
+                            ref_name: "refs/heads/A",
+                            remote_tracking_ref_name: "refs/remotes/origin/A",
+                            commits: [
+                                LocalCommit(a62b0de, "A2\n", local),
+                                LocalCommit(120a217, "A1\n", integrated(120a217)),
+                            ],
+                            commits_unique_in_remote_tracking_branch: [],
+                            metadata: "None",
+                            push_status: UnpushedCommitsRequiringForce,
+                            base: "fafd9d0",
+                        },
+                    ],
+                },
+            ],
+            target: Some(
+                Target {
+                    ref_name: FullName(
+                        "refs/remotes/origin/main",
+                    ),
+                    segment_index: NodeIndex(1),
+                    commits_ahead: 0,
+                },
+            ),
+            extra_target: Some(
+                NodeIndex(3),
+            ),
+            lower_bound: Some(
+                NodeIndex(3),
+            ),
+            is_managed_ref: true,
+            is_managed_commit: true,
+            is_entrypoint: true,
+        },
+    )
+    "#);
+    Ok(())
+}
+
+#[test]
 fn remote_behind() -> anyhow::Result<()> {
     let (repo, meta, description) = scenario("03-remote-one-behind")?;
     insta::assert_snapshot!(description, @"A can be pushed as it has local, unpushed commits");
@@ -200,6 +349,81 @@ fn remote_behind() -> anyhow::Result<()> {
             extra_target: None,
             lower_bound: Some(
                 NodeIndex(2),
+            ),
+            is_managed_ref: true,
+            is_managed_commit: true,
+            is_entrypoint: true,
+        },
+    )
+    "#);
+    Ok(())
+}
+
+#[test]
+fn remote_behind_merge_no_ff() -> anyhow::Result<()> {
+    let (repo, meta, description) = scenario("03.5-remote-one-behind-merge-no-ff")?;
+    insta::assert_snapshot!(description, @"Remote origin/A is merged back (with forceful merge commit) while there are still local commits.");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 3ea2742 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * a62b0de (A) A2
+    | *   a670cd5 (origin/main, main) Merge remote-tracking branch 'origin/A'
+    | |\  
+    | |/  
+    |/|   
+    * | 120a217 (origin/A) A1
+    |/  
+    * fafd9d0 init
+    ");
+
+    let info = but_workspace::head_info(
+        &repo,
+        &*meta,
+        standard_options_with_extra_target(&repo, "fafd9d0"),
+    );
+    insta::assert_debug_snapshot!(info, @r#"
+    Ok(
+        RefInfo {
+            workspace_ref_name: Some(
+                FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+            ),
+            stacks: [
+                Stack {
+                    base: Some(
+                        Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                    ),
+                    segments: [
+                        ref_info::ui::Segment {
+                            id: NodeIndex(5),
+                            ref_name: "refs/heads/A",
+                            remote_tracking_ref_name: "refs/remotes/origin/A",
+                            commits: [
+                                LocalCommit(a62b0de, "A2\n", local),
+                                LocalCommit(120a217, "A1\n", integrated(120a217)),
+                            ],
+                            commits_unique_in_remote_tracking_branch: [],
+                            metadata: "None",
+                            push_status: UnpushedCommitsRequiringForce,
+                            base: "fafd9d0",
+                        },
+                    ],
+                },
+            ],
+            target: Some(
+                Target {
+                    ref_name: FullName(
+                        "refs/remotes/origin/main",
+                    ),
+                    segment_index: NodeIndex(1),
+                    commits_ahead: 0,
+                },
+            ),
+            extra_target: Some(
+                NodeIndex(3),
+            ),
+            lower_bound: Some(
+                NodeIndex(3),
             ),
             is_managed_ref: true,
             is_managed_commit: true,
@@ -266,6 +490,76 @@ fn remote_ahead() -> anyhow::Result<()> {
             extra_target: None,
             lower_bound: Some(
                 NodeIndex(2),
+            ),
+            is_managed_ref: true,
+            is_managed_commit: true,
+            is_entrypoint: true,
+        },
+    )
+    "#);
+    Ok(())
+}
+
+#[test]
+fn remote_ahead_merge_ff() -> anyhow::Result<()> {
+    let (repo, meta, description) = scenario("04.5-remote-one-ahead-ff-merge")?;
+    insta::assert_snapshot!(description, @"Remote origin/A is merged back (fast-forward), bringing all into the target branch");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 8ee08de (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    | * a62b0de (origin/main, origin/A, main) A2
+    |/  
+    * 120a217 (A) A1
+    * fafd9d0 init
+    ");
+
+    let info = but_workspace::head_info(
+        &repo,
+        &*meta,
+        standard_options_with_extra_target(&repo, "fafd9d0"),
+    );
+    insta::assert_debug_snapshot!(info, @r#"
+    Ok(
+        RefInfo {
+            workspace_ref_name: Some(
+                FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+            ),
+            stacks: [
+                Stack {
+                    base: Some(
+                        Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                    ),
+                    segments: [
+                        ref_info::ui::Segment {
+                            id: NodeIndex(4),
+                            ref_name: "refs/heads/A",
+                            remote_tracking_ref_name: "refs/remotes/origin/A",
+                            commits: [
+                                LocalCommit(120a217, "A1\n", integrated(120a217)),
+                            ],
+                            commits_unique_in_remote_tracking_branch: [],
+                            metadata: "None",
+                            push_status: Integrated,
+                            base: "fafd9d0",
+                        },
+                    ],
+                },
+            ],
+            target: Some(
+                Target {
+                    ref_name: FullName(
+                        "refs/remotes/origin/main",
+                    ),
+                    segment_index: NodeIndex(1),
+                    commits_ahead: 0,
+                },
+            ),
+            extra_target: Some(
+                NodeIndex(3),
+            ),
+            lower_bound: Some(
+                NodeIndex(3),
             ),
             is_managed_ref: true,
             is_managed_commit: true,

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/mod.rs
@@ -5,17 +5,11 @@ mod utils {
     use crate::ref_info::utils::standard_options;
     pub fn standard_options_with_extra_target(
         repo: &gix::Repository,
-        short_name: &str,
+        revspec: &str,
     ) -> but_workspace::ref_info::Options {
         but_workspace::ref_info::Options {
             traversal: but_graph::init::Options {
-                extra_target_commit_id: repo
-                    .find_reference(short_name)
-                    .expect("target reference is valid")
-                    .peel_to_id_in_place()
-                    .unwrap()
-                    .detach()
-                    .into(),
+                extra_target_commit_id: repo.rev_parse_single(revspec).unwrap().detach().into(),
                 ..Default::default()
             },
             ..standard_options()

--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -58,7 +58,7 @@ pub fn show_graph_svg(
         &repo,
         &meta,
         but_graph::init::Options {
-            collect_tags: false,
+            collect_tags: true,
             commits_limit_hint: Some(300),
             commits_limit_recharge_location: vec![],
             hard_limit: None,


### PR DESCRIPTION
Re-implement integration checks with all the tests we'd expect to assure detection works at least in principle.

Remove abandoned `ref_info` implementation and review/migrate all tests.

### Tasks

- [x] changeset integration check if a base segment is already integrated - can't really be tested, the workflow with squash-merges breaks down anyway.
- [x] test for remote-only merge
- [ ] test for remote-only rebase
- [ ] figure out what to do with GitLab
    - would need caching, and multi-threading, to compute the diffs much faster. Maybe cache isn't big enough? (check 60m instrumentation)
- [ ] handle the `archived` flag  and have a test for that.

### Next related tasks

* ~~branch listing powered by The Graph~~ - not needed just now
* ‼️if branches in the workspace are advanced outside of the workspace, it currently doesn't see these commits and the branch looses its name in the workspace. The traversal really should try to add the known tips explicitly for traversal and expose that information.
* ⚠️ fix related TODOs and known issues

### Not to forget

* There might be an issue with the way it uses searches - a tip with a search might be blocked at an existing commit, discovered by a tip with a different search, and even though the thing it searches is reachable through that, it stops looking.
* the amount of commits of remotes ahead of their local branch doesn't seem to always match git (particularly when it's a lot of them)
* ⚠️ current implementation supports multiple workspaces *in theory*, but it's not tested with them as the underlying ref-metadata is still VB-toml. So before supporting this, we probably already want to have migrated away from vb.toml, to then port the ref-metadata to something that can support more workspaces (also for testing).
* ⚠️ we probably don't correctly handle workspaces that include other workspaces.
* ⚠️ we probably don't handle [dot-repositories](https://git-scm.com/docs/git-config#Documentation/git-config.txt-branchltnamegtmerge) correctly, by merit of not really having them in mind. At least they shouldn't be in the way of handling normal remotes.

### Related issues

* #8457
* #9408
