### PR TITLE
Split branch into dependent branch

### DIFF
--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -808,6 +808,10 @@ export class StackService {
 		return this.api.endpoints.splitBranch.useMutation();
 	}
 
+	get splitBrancIntoDependentBranch() {
+		return this.api.endpoints.splitBranchIntoDependentBranch.useMutation();
+	}
+
 	stackDetailsUpdateListener(projectId: string) {
 		return this.api.endpoints.stackDetailsUpdate.useQuery({
 			projectId
@@ -1530,6 +1534,26 @@ function injectEndpoints(api: ClientState['backendApi']) {
 			>({
 				extraOptions: {
 					command: 'split_branch'
+				},
+				query: (args) => args,
+				invalidatesTags: (_result, _error, args) => [
+					invalidatesItem(ReduxTag.StackDetails, args.sourceStackId),
+					invalidatesItem(ReduxTag.BranchChanges, args.sourceStackId),
+					invalidatesList(ReduxTag.Stacks)
+				]
+			}),
+			splitBranchIntoDependentBranch: build.mutation<
+				{ replacedCommits: [string, string][] },
+				{
+					projectId: string;
+					sourceStackId: string;
+					sourceBranchName: string;
+					newBranchName: string;
+					fileChangesToSplitOff: string[];
+				}
+			>({
+				extraOptions: {
+					command: 'split_branch_into_dependent_branch'
 				},
 				query: (args) => args,
 				invalidatesTags: (_result, _error, args) => [

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -45,7 +45,7 @@ pub use tree_manipulation::{
     discard_worktree_changes::discard_workspace_changes,
     move_between_commits::move_changes_between_commits,
     remove_changes_from_commit_in_stack::remove_changes_from_commit_in_stack,
-    split_branch::split_branch,
+    split_branch::{split_branch, split_into_dependent_branch},
     split_commit::{CommitFiles, CommmitSplitOutcome, split_commit},
 };
 pub mod head;

--- a/crates/but-workspace/src/tree_manipulation/split_branch.rs
+++ b/crates/but-workspace/src/tree_manipulation/split_branch.rs
@@ -3,10 +3,13 @@ use but_core::Reference;
 use but_rebase::Rebase;
 use but_rebase::RebaseStep;
 use but_rebase::ReferenceSpec;
+use gitbutler_cherry_pick::GixRepositoryExt;
 use gitbutler_command_context::CommandContext;
 use gitbutler_oxidize::ObjectIdExt;
 use gitbutler_oxidize::OidExt;
 use gitbutler_repo::logging::{LogUntil, RepositoryExt as _};
+use gitbutler_stack::CommitOrChangeId;
+use gitbutler_stack::StackBranch;
 use gitbutler_stack::{StackId, VirtualBranchesHandle};
 
 use crate::MoveChangesResult;
@@ -128,6 +131,142 @@ pub fn split_branch(
     Ok((new_branch_ref, move_changes_result))
 }
 
+/// Splits a branch into a dependent branch.
+///
+/// This function splits a branch into two dependent branches,
+/// moving the specified changes to the new branch (dependent branch).
+///
+/// In steps:
+///
+/// 1. Create a new branch from the source branch's head.
+/// 2. Remove all the specified changes from the source branch.
+/// 3. Remove all but the specified changes from the new branch.
+/// 4. Insert the new branch as a dependent branch in the stack.
+/// 5. Update the stack
+pub fn split_into_dependent_branch(
+    ctx: &CommandContext,
+    stack_id: StackId,
+    source_branch_name: String,
+    new_branch_name: String,
+    file_changes_to_split_off: &[String],
+    context_lines: u32,
+) -> Result<MoveChangesResult> {
+    let repository = ctx.gix_repo()?;
+    let vb_state = VirtualBranchesHandle::new(ctx.project().gb_dir());
+
+    let source_stack = vb_state.get_stack_in_workspace(stack_id)?;
+    let merge_base = source_stack.merge_base(ctx)?;
+
+    // Create a new branch from the source branch's head
+    let push_details = source_stack.push_details(ctx, source_branch_name.clone())?;
+    let branch_head = push_details.head;
+
+    // Create a new branch reference
+    let new_branch_ref_name = format!("refs/heads/{}", new_branch_name);
+    let new_branch_log_message = format!(
+        "Split off changes from branch '{}' into new dependent branch '{}'",
+        source_branch_name, new_branch_name
+    );
+
+    let new_ref = repository.reference(
+        new_branch_ref_name.clone(),
+        branch_head.to_gix(),
+        gix::refs::transaction::PreviousValue::Any,
+        new_branch_log_message.clone(),
+    )?;
+
+    // Remove all but the specified changes from the new branch
+    let new_branch_commits =
+        ctx.repo()
+            .l(branch_head, LogUntil::Commit(merge_base.to_git2()), false)?;
+
+    // Branch as rebase steps
+    let mut dependent_branch_steps: Vec<RebaseStep> = Vec::new();
+
+    let reference_step = RebaseStep::Reference(but_core::Reference::Git(new_ref.name().to_owned()));
+    dependent_branch_steps.push(reference_step);
+
+    for commit in new_branch_commits {
+        let commit_id = commit.to_gix();
+        if let Some(new_commit_id) = keep_only_file_changes_in_commit(
+            ctx,
+            commit_id,
+            file_changes_to_split_off,
+            context_lines,
+            true,
+        )? {
+            let pick_step = RebaseStep::Pick {
+                commit_id: new_commit_id,
+                new_message: None,
+            };
+            dependent_branch_steps.push(pick_step);
+        }
+    }
+
+    println!(
+        "Dependent branch steps before filtering: {:?}",
+        dependent_branch_steps
+    );
+
+    let steps = construct_source_steps(
+        ctx,
+        &repository,
+        file_changes_to_split_off,
+        &source_stack,
+        source_branch_name.clone(),
+        context_lines,
+        Some(&dependent_branch_steps),
+    )?;
+
+    println!(
+        "Rebasing source branch '{}' with steps: {:?}",
+        source_branch_name, steps
+    );
+
+    let mut source_rebase = Rebase::new(&repository, merge_base, None)?;
+    source_rebase.steps(steps)?;
+    source_rebase.rebase_noops(false);
+    let source_result = source_rebase.rebase()?;
+    // let new_head = repo_git2.find_commit(source_result.top_commit.to_git2())?;
+    let new_head = repository.find_commit(source_result.top_commit)?;
+
+    let mut source_stack = source_stack;
+
+    source_stack.add_series(
+        ctx,
+        StackBranch::new(
+            CommitOrChangeId::CommitId(branch_head.to_string()),
+            new_branch_name,
+            None,
+            &repository,
+        )?,
+        Some(source_branch_name),
+    )?;
+
+    source_stack.set_stack_head(
+        &vb_state,
+        &repository,
+        new_head.id().to_git2(),
+        Some(
+            repository
+                .find_real_tree(&new_head.id(), Default::default())?
+                .to_git2(),
+        ),
+    )?;
+    source_stack.set_heads_from_rebase_output(ctx, source_result.clone().references)?;
+
+    let move_changes_result = MoveChangesResult {
+        replaced_commits: source_result
+            .commit_mapping
+            .iter()
+            .filter(|(_, old, new)| old != new)
+            .map(|(_, old, new)| (*old, *new))
+            .collect(),
+    };
+
+    Ok(move_changes_result)
+}
+
 /// Filters out the specified file changes from the branch.
 ///
 /// All commits that end up empty after removing the specified file changes will be dropped.
@@ -140,6 +279,37 @@ fn filter_file_changes_in_branch(
     merge_base: gix::ObjectId,
     context_lines: u32,
 ) -> Result<but_rebase::RebaseOutput, anyhow::Error> {
+    let source_steps = construct_source_steps(
+        ctx,
+        repository,
+        file_changes_to_split_off,
+        &source_stack,
+        source_branch_name,
+        context_lines,
+        None,
+    )?;
+
+    let mut source_rebase = Rebase::new(repository, merge_base, None)?;
+    source_rebase.steps(source_steps)?;
+    source_rebase.rebase_noops(false);
+    let source_result = source_rebase.rebase()?;
+
+    let mut source_stack = source_stack;
+
+    source_stack.set_heads_from_rebase_output(ctx, source_result.clone().references)?;
+
+    Ok(source_result)
+}
+
+fn construct_source_steps(
+    ctx: &CommandContext,
+    repository: &gix::Repository,
+    file_changes_to_split_off: &[String],
+    source_stack: &gitbutler_stack::Stack,
+    source_branch_name: String,
+    context_lines: u32,
+    steps_to_insert: Option<&[RebaseStep]>,
+) -> Result<Vec<RebaseStep>, anyhow::Error> {
     let source_steps = source_stack.as_rebase_steps_rev(ctx, repository)?;
     let mut new_source_steps = Vec::new();
     let mut inside_branch = false;
@@ -153,6 +323,7 @@ fn filter_file_changes_in_branch(
         })?;
     let branch_ref_name = branch_ref.name().to_owned();
 
+    let mut inserted_steps = false;
     for step in source_steps {
         if let RebaseStep::Reference(but_core::Reference::Git(name)) = &step {
             if *name == branch_ref_name {
@@ -174,6 +345,14 @@ fn filter_file_changes_in_branch(
             // Not inside the source branch, keep the step as is
             new_source_steps.push(step);
             continue;
+        }
+
+        // Insert steps just above the branch reference step
+        if !inserted_steps {
+            if let Some(steps_to_insert) = steps_to_insert {
+                inserted_steps = true;
+                new_source_steps.extend(steps_to_insert.iter().cloned());
+            }
         }
 
         if let RebaseStep::Pick { commit_id, .. } = &step {
@@ -206,16 +385,6 @@ fn filter_file_changes_in_branch(
             new_source_steps.push(step);
         }
     }
-
     new_source_steps.reverse();
-
-    let mut source_rebase = Rebase::new(repository, merge_base, None)?;
-    source_rebase.steps(new_source_steps)?;
-    source_rebase.rebase_noops(false);
-    let source_result = source_rebase.rebase()?;
-
-    let mut source_stack = source_stack;
-    source_stack.set_heads_from_rebase_output(ctx, source_result.clone().references)?;
-
-    Ok(source_result)
+    Ok(new_source_steps)
 }

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -299,6 +299,7 @@ fn main() {
                     workspace::move_changes_between_commits,
                     workspace::uncommit_changes,
                     workspace::split_branch,
+                    workspace::split_branch_into_dependent_branch,
                     diff::changes_in_worktree,
                     diff::commit_details,
                     diff::changes_in_branch,


### PR DESCRIPTION
### Description

- Added Rust backend implementation for splitting branches into dependent branches, including the new `split_into_dependent_branch` function with rebase and update logic.
- Exported the new API in `lib.rs` and integrated Tauri command handlers in `workspace.rs` and `main.rs`.
- Updated the desktop UI with menu items for "Split into dependent branch" and added support in `stackService` for the new feature.