### PR TITLE
Add numTestsKeptInMemory to Cypress config

### DIFF
--- a/apps/desktop/cypress.config.ts
+++ b/apps/desktop/cypress.config.ts
@@ -11,5 +11,6 @@ export default defineConfig({
 		baseUrl: 'http://localhost:1420',
 		supportFile: 'cypress/e2e/support/index.ts'
 	},
-	experimentalWebKitSupport: true
+	experimentalWebKitSupport: true,
+	numTestsKeptInMemory: 10
 });


### PR DESCRIPTION
This commit modifies the Cypress configuration file to include the numTestsKeptInMemory option set to 10.
- This setting helps improve test runner performance and memory usage by limiting how many test results are kept in memory during test execution.
- No other functional changes or features were added.