### PR TITLE
integration-checks (testing)

### DIFF
--- a/crates/but-graph/src/projection/workspace.rs
+++ b/crates/but-graph/src/projection/workspace.rs
@@ -473,12 +473,12 @@ impl Graph {
         (out, stopped_at)
     }
 
-    /// Visit the ancestry of `start` along the first parents, itself included, until `stop` returns `true`.
+    /// Visit the ancestry of `start` along the first parents, itself excluded, until `stop` returns `true`.
     /// Also return the segment that we stopped at.
     /// **Important**: `stop` is not called with `start`, this is a feature.
     ///
     /// Note that the traversal assumes as well-segmented graph without cycles.
-    fn visit_segments_along_first_parent_until(
+    fn visit_segments_downward_along_first_parent_until(
         &self,
         start: SegmentIndex,
         mut stop: impl FnMut(&Segment) -> bool,
@@ -507,7 +507,7 @@ impl Graph {
         mut find: impl FnMut(&Segment) -> Option<T>,
     ) -> Option<T> {
         let mut out = None;
-        self.visit_segments_along_first_parent_until(start, |s| {
+        self.visit_segments_downward_along_first_parent_until(start, |s| {
             if let Some(res) = find(s) {
                 out = Some(res);
                 true

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -466,7 +466,7 @@ pub fn operating_mode(args: &super::Args) -> anyhow::Result<()> {
 }
 
 pub fn ref_info(args: &super::Args, ref_name: Option<&str>, expensive: bool) -> anyhow::Result<()> {
-    let (repo, project) = repo_and_maybe_project(args, RepositoryOpenMode::General)?;
+    let (repo, project) = repo_and_maybe_project(args, RepositoryOpenMode::Merge)?;
     let opts = but_workspace::ref_info::Options {
         stack_commit_limit: 0,
         expensive_commit_info: expensive,

--- a/crates/but-workspace/src/changeset.rs
+++ b/crates/but-workspace/src/changeset.rs
@@ -101,7 +101,17 @@ impl RefInfo {
                     // top-to-bottom
                     .commits
                     .iter_mut()
-                    .take_while(|c| c.relation == LocalCommitRelation::LocalOnly)
+                    .take_while(|c| {
+                        matches!(
+                            c.relation,
+                            // This happens when the identity match with the remote didn't work.
+                            LocalCommitRelation::LocalOnly |
+                            // This would be expected to be a remote-match by identity (we don't check for this),
+                            // something that is determined during graph traversal time. But we want ot see
+                            // if any of these is also integrated.
+                            LocalCommitRelation::LocalAndRemote(_)
+                        )
+                    })
                 {
                     let expensive = changeset_identifier(repo, expensive.then_some(local))?;
                     if let Some(upstream_commit_id) =

--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -160,13 +160,14 @@ pub mod ui {
         /// Convert this relation into something displaying, mainly for debugging.
         pub fn display(&self, id: gix::ObjectId) -> Cow<'static, str> {
             match self {
-                LocalCommitRelation::LocalOnly => "local".into(),
-                LocalCommitRelation::LocalAndRemote(remote_id) => if *remote_id == id {
-                    "local/remote(identity)"
-                } else {
-                    "local/remote(similarity)"
+                LocalCommitRelation::LocalOnly => Cow::Borrowed("local"),
+                LocalCommitRelation::LocalAndRemote(remote_id) => {
+                    if *remote_id == id {
+                        "local/remote(identity)".into()
+                    } else {
+                        format!("local/remote({})", remote_id.to_hex_with_len(7)).into()
+                    }
                 }
-                .into(),
                 LocalCommitRelation::Integrated(id) => {
                     format!("integrated({})", id.to_hex_with_len(7)).into()
                 }

--- a/crates/but-workspace/tests/fixtures/scenario/journey02.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/journey02.sh
@@ -2,7 +2,7 @@
 
 ### General Description
 
-# Various stages through a typical user journey. Ideally complete enough to test everything that matters to us.
+# Disjoint scenarios related to remote branches that are merged in.
 set -eu -o pipefail
 
 source "${BASH_SOURCE[0]%/*}/shared.sh"

--- a/crates/but-workspace/tests/fixtures/scenario/journey03.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/journey03.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+### General Description
+
+# Disjoint scenarios related to remote branches that have been rebased and merged.
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git init 01-one-rewritten-one-local-after-push
+(cd 01-one-rewritten-one-local-after-push
+  echo "two local commits pushed to a remote, then rebased onto target.
+
+The branch should then be considered integrated" >.git/description
+  commit init && setup_target_to_match_main
+  git checkout -b A
+    echo A-new >file && git add file && git commit -m A1
+    echo A-new >other && git add other && git commit -m A2
+    git rev-parse @ >.git/refs/remotes/origin/A
+
+  git checkout main
+    commit M1
+    git cherry-pick :/A1
+    git cherry-pick :/A2
+    echo M-change >>file && git commit -am M2
+    echo M-change >>other && git commit -am M3
+    git rev-parse @ >.git/refs/remotes/origin/main
+
+  git checkout A
+  create_workspace_commit_once A
+)
+
+git init 01-one-rewritten-one-local-after-push-author-date-change
+(cd 01-one-rewritten-one-local-after-push-author-date-change
+  echo "two local commits pushed to a remote, then rebased onto target, but with the author date adjusted.
+
+This prevents quick-checks to work." >.git/description
+  commit init && setup_target_to_match_main
+  git checkout -b A
+    echo A-new >file && git add file && git commit -m A1
+    echo A-new >other && git add other && git commit -m A2
+    git rev-parse @ >.git/refs/remotes/origin/A
+
+  git checkout main
+    commit M1
+    tick
+    git cherry-pick :/A1
+    tick
+    git cherry-pick :/A2
+    echo M-change >>file && git commit -am M2
+    echo M-change >>other && git commit -am M3
+    git rev-parse @ >.git/refs/remotes/origin/main
+
+  git checkout A
+  create_workspace_commit_once A
+)

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
@@ -561,54 +561,54 @@ fn j09_rewritten_remote_and_local_commit() -> anyhow::Result<()> {
     add_stack_with_segments(&mut meta, 0, "S1", StackState::InWorkspace, &[]);
     let info = but_workspace::head_info(&repo, &*meta, standard_options());
     insta::assert_debug_snapshot!(info, @r#"
-Ok(
-    RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
+    Ok(
+        RefInfo {
+            workspace_ref_name: Some(
+                FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
             ),
-        ),
-        stacks: [
-            Stack {
-                base: Some(
-                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
-                ),
-                segments: [
-                    ref_info::ui::Segment {
-                        id: NodeIndex(3),
-                        ref_name: "refs/heads/S1",
-                        remote_tracking_ref_name: "refs/remotes/origin/S1",
-                        commits: [
-                            LocalCommit(314cacb, "two\n", local/remote(similarity)),
-                            LocalCommit(3234835, "one\n", local/remote(identity)),
-                        ],
-                        commits_unique_in_remote_tracking_branch: [],
-                        metadata: Branch,
-                        push_status: UnpushedCommitsRequiringForce,
-                        base: "fafd9d0",
-                    },
-                ],
-            },
-        ],
-        target: Some(
-            Target {
-                ref_name: FullName(
-                    "refs/remotes/origin/main",
-                ),
-                segment_index: NodeIndex(1),
-                commits_ahead: 0,
-            },
-        ),
-        extra_target: None,
-        lower_bound: Some(
-            NodeIndex(2),
-        ),
-        is_managed_ref: true,
-        is_managed_commit: true,
-        is_entrypoint: true,
-    },
-)
-"#);
+            stacks: [
+                Stack {
+                    base: Some(
+                        Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                    ),
+                    segments: [
+                        ref_info::ui::Segment {
+                            id: NodeIndex(3),
+                            ref_name: "refs/heads/S1",
+                            remote_tracking_ref_name: "refs/remotes/origin/S1",
+                            commits: [
+                                LocalCommit(314cacb, "two\n", local/remote(9a2fcdf)),
+                                LocalCommit(3234835, "one\n", local/remote(identity)),
+                            ],
+                            commits_unique_in_remote_tracking_branch: [],
+                            metadata: Branch,
+                            push_status: UnpushedCommitsRequiringForce,
+                            base: "fafd9d0",
+                        },
+                    ],
+                },
+            ],
+            target: Some(
+                Target {
+                    ref_name: FullName(
+                        "refs/remotes/origin/main",
+                    ),
+                    segment_index: NodeIndex(1),
+                    commits_ahead: 0,
+                },
+            ),
+            extra_target: None,
+            lower_bound: Some(
+                NodeIndex(2),
+            ),
+            is_managed_ref: true,
+            is_managed_commit: true,
+            is_entrypoint: true,
+        },
+    )
+    "#);
     Ok(())
 }
 

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_merges.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_merges.rs
@@ -43,7 +43,7 @@ fn two_commits_require_force_push() -> anyhow::Result<()> {
                             remote_tracking_ref_name: "refs/remotes/origin/A",
                             commits: [
                                 LocalCommit(f9c2b14, "A2\n", local),
-                                LocalCommit(e1f216e, "A1\n", local/remote(similarity)),
+                                LocalCommit(e1f216e, "A1\n", local/remote(3fcd07a)),
                             ],
                             commits_unique_in_remote_tracking_branch: [],
                             metadata: "None",

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_rebase.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_rebase.rs
@@ -1,0 +1,164 @@
+//! A loose collection of states that users typically encounter.
+use crate::ref_info::utils::standard_options;
+use crate::ref_info::with_workspace_commit::utils::named_read_only_in_memory_scenario_with_description;
+use but_graph::VirtualBranchesTomlMetadata;
+use but_testsupport::visualize_commit_graph_all;
+
+#[test]
+fn two_commits_rebased_onto_target() -> anyhow::Result<()> {
+    let (repo, meta, description) = scenario("01-one-rewritten-one-local-after-push")?;
+    insta::assert_snapshot!(description, @r"
+    two local commits pushed to a remote, then rebased onto target.
+
+    The branch should then be considered integrated
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 946cdb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * f9c2b14 (origin/A, A) A2
+    * e1f216e A1
+    | * eabf298 (origin/main, main) M3
+    | * 1ff86ae M2
+    | * 36c87e5 A2
+    | * 818dbb2 A1
+    | * ce09734 M1
+    |/  
+    * fafd9d0 init
+    ");
+
+    let info = but_workspace::head_info(&repo, &*meta, standard_options());
+    insta::assert_debug_snapshot!(info, @r#"
+    Ok(
+        RefInfo {
+            workspace_ref_name: Some(
+                FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+            ),
+            stacks: [
+                Stack {
+                    base: Some(
+                        Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                    ),
+                    segments: [
+                        ref_info::ui::Segment {
+                            id: NodeIndex(3),
+                            ref_name: "refs/heads/A",
+                            remote_tracking_ref_name: "refs/remotes/origin/A",
+                            commits: [
+                                LocalCommit(f9c2b14, "A2\n", integrated(36c87e5)),
+                                LocalCommit(e1f216e, "A1\n", integrated(818dbb2)),
+                            ],
+                            commits_unique_in_remote_tracking_branch: [],
+                            metadata: "None",
+                            push_status: Integrated,
+                            base: "fafd9d0",
+                        },
+                    ],
+                },
+            ],
+            target: Some(
+                Target {
+                    ref_name: FullName(
+                        "refs/remotes/origin/main",
+                    ),
+                    segment_index: NodeIndex(1),
+                    commits_ahead: 0,
+                },
+            ),
+            extra_target: None,
+            lower_bound: Some(
+                NodeIndex(5),
+            ),
+            is_managed_ref: true,
+            is_managed_commit: true,
+            is_entrypoint: true,
+        },
+    )
+    "#);
+    Ok(())
+}
+
+#[test]
+fn two_commits_rebased_onto_target_with_changeset_check() -> anyhow::Result<()> {
+    let (repo, meta, description) =
+        scenario("01-one-rewritten-one-local-after-push-author-date-change")?;
+    insta::assert_snapshot!(description, @r"
+    two local commits pushed to a remote, then rebased onto target, but with the author date adjusted.
+
+    This prevents quick-checks to work.
+    ");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * f1caa51 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * f9c2b14 (origin/A, A) A2
+    * e1f216e A1
+    | * 7a2d071 (origin/main, main) M3
+    | * 34dac9d M2
+    | * 85063c1 A2
+    | * 444639d A1
+    | * ce09734 M1
+    |/  
+    * fafd9d0 init
+    ");
+
+    let info = but_workspace::head_info(&repo, &*meta, standard_options());
+    insta::assert_debug_snapshot!(info, @r#"
+    Ok(
+        RefInfo {
+            workspace_ref_name: Some(
+                FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
+            ),
+            stacks: [
+                Stack {
+                    base: Some(
+                        Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                    ),
+                    segments: [
+                        ref_info::ui::Segment {
+                            id: NodeIndex(3),
+                            ref_name: "refs/heads/A",
+                            remote_tracking_ref_name: "refs/remotes/origin/A",
+                            commits: [
+                                LocalCommit(f9c2b14, "A2\n", integrated(85063c1)),
+                                LocalCommit(e1f216e, "A1\n", integrated(444639d)),
+                            ],
+                            commits_unique_in_remote_tracking_branch: [],
+                            metadata: "None",
+                            push_status: Integrated,
+                            base: "fafd9d0",
+                        },
+                    ],
+                },
+            ],
+            target: Some(
+                Target {
+                    ref_name: FullName(
+                        "refs/remotes/origin/main",
+                    ),
+                    segment_index: NodeIndex(1),
+                    commits_ahead: 0,
+                },
+            ),
+            extra_target: None,
+            lower_bound: Some(
+                NodeIndex(5),
+            ),
+            is_managed_ref: true,
+            is_managed_commit: true,
+            is_entrypoint: true,
+        },
+    )
+    "#);
+    Ok(())
+}
+
+pub fn scenario(
+    name: &str,
+) -> anyhow::Result<(
+    gix::Repository,
+    std::mem::ManuallyDrop<VirtualBranchesTomlMetadata>,
+    String,
+)> {
+    named_read_only_in_memory_scenario_with_description("journey03", name)
+}

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/mod.rs
@@ -1,5 +1,6 @@
 mod exhaustive_with_squash_merges;
 mod integrate_with_merges;
+mod integrate_with_rebase;
 
 mod utils {
     use crate::ref_info::utils::standard_options;

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -244,7 +244,7 @@ fn two_dependent_branches_rebased_with_remotes() -> anyhow::Result<()> {
                         ref_name: "refs/heads/B-on-A",
                         remote_tracking_ref_name: "refs/remotes/origin/B-on-A",
                         commits: [
-                            LocalCommit(31b3f92, "change in B\n", local/remote(similarity)),
+                            LocalCommit(31b3f92, "change in B\n", local/remote(ec39463)),
                         ],
                         commits_unique_in_remote_tracking_branch: [],
                         metadata: Branch,
@@ -329,7 +329,7 @@ fn two_dependent_branches_rebased_explicit_remote_in_extra_segment() -> anyhow::
                         ref_name: "refs/heads/B-on-A",
                         remote_tracking_ref_name: "refs/remotes/origin/B-on-A",
                         commits: [
-                            LocalCommit(31b3f92, "change in B\n", local/remote(similarity)),
+                            LocalCommit(31b3f92, "change in B\n", local/remote(ec39463)),
                         ],
                         commits_unique_in_remote_tracking_branch: [],
                         metadata: Branch,
@@ -805,7 +805,7 @@ fn target_ahead_remote_rewritten() -> anyhow::Result<()> {
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
                             LocalCommit(d5d3a92, "unique local tip\n", local),
-                            LocalCommit(6ffd040, "shared by name\n", local/remote(similarity)),
+                            LocalCommit(6ffd040, "shared by name\n", local/remote(a9954f1)),
                             LocalCommit(4cd56ab, "unique local\n", local),
                             LocalCommit(872c22f, "shared local/remote\n", local/remote(identity)),
                         ],
@@ -1776,7 +1776,7 @@ fn two_branches_stacked_with_interesting_remote_setup() -> anyhow::Result<()> {
                         ref_name: "refs/heads/A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
-                            LocalCommit(aadad9d, "shared by name\n", local/remote(similarity)),
+                            LocalCommit(aadad9d, "shared by name\n", local/remote(2b1808c)),
                             LocalCommit(96a2408, "another unrelated\n", integrated(96a2408)),
                         ],
                         commits_unique_in_remote_tracking_branch: [],


### PR DESCRIPTION
More tests to validate integration checks and push-status.

### Tasks

- [x] test for remote-only rebase
- [ ] commits_ahead in `target` can't take must deal with the workspace base to cutoff, remote commits aren't relevant for the workspace.
- [ ] figure out what to do with GitLab
    - would need caching, and multi-threading, to compute the diffs much faster. Maybe cache isn't big enough? (check 60m instrumentation)
    - right now it sees 90k commits, many more than the 14k listed currently.
- [ ] handle the `archived` flag  and have a test for that.

### Next related tasks

* stack-ids in workspace metadata
    - for single-branch derive stack-id from ref-name
* ~~branch listing powered by The Graph~~ - not needed just now
* ‼️if branches in the workspace are advanced outside of the workspace, it currently doesn't see these commits and the branch looses its name in the workspace. The traversal really should try to add the known tips explicitly for traversal and expose that information.
* ⚠️ fix related TODOs and known issues

### Not to forget

* There might be an issue with the way it uses searches - a tip with a search might be blocked at an existing commit, discovered by a tip with a different search, and even though the thing it searches is reachable through that, it stops looking.
* the amount of commits of remotes ahead of their local branch doesn't seem to always match git (particularly when it's a lot of them)
* ⚠️ current implementation supports multiple workspaces *in theory*, but it's not tested with them as the underlying ref-metadata is still VB-toml. So before supporting this, we probably already want to have migrated away from vb.toml, to then port the ref-metadata to something that can support more workspaces (also for testing).
* ⚠️ we probably don't correctly handle workspaces that include other workspaces.
* ⚠️ we probably don't handle [dot-repositories](https://git-scm.com/docs/git-config#Documentation/git-config.txt-branchltnamegtmerge) correctly, by merit of not really having them in mind. At least they shouldn't be in the way of handling normal remotes.

### Related issues

* #8457
* #9408
