### PR TITLE
Fix textarea focus delay in Textarea.svelte

### DIFF
--- a/packages/ui/src/lib/Textarea.svelte
+++ b/packages/ui/src/lib/Textarea.svelte
@@ -75,7 +75,7 @@
 			// set time out to ensure the element is rendered
 			setTimeout(() => {
 				textBoxEl?.focus();
-			}, 0);
+			}, 100);
 		}
 	});
 


### PR DESCRIPTION
 Increased the delay in the focus timeout from 0 to 100 milliseconds to ensure the textarea element is rendered before trying to focus it. 

## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
