### PR TITLE
refactor: remove existing_branch_names from rename_branch

### DIFF
--- a/crates/but-action/src/rename_branch.rs
+++ b/crates/but-action/src/rename_branch.rs
@@ -11,7 +11,6 @@ pub struct RenameBranchParams {
     pub commit_message: String,
     pub stack_id: StackId,
     pub current_branch_name: String,
-    pub existing_branch_names: Vec<String>,
 }
 
 pub async fn rename_branch(
@@ -25,10 +24,14 @@ pub async fn rename_branch(
         commit_message,
         stack_id,
         current_branch_name,
-        existing_branch_names,
     } = parameters;
 
     let repo = &ctx.gix_repo_for_merging_non_persisting()?;
+    let stacks = crate::stacks(ctx, repo)?;
+    let existing_branch_names = stacks
+        .iter()
+        .flat_map(|s| s.heads.iter().map(|h| h.name.clone().to_string()))
+        .collect::<Vec<_>>();
     let changes = but_core::diff::ui::commit_changes_by_worktree_dir(repo, commit_id)?;
     let diff = changes.try_as_unidiff_string(repo, ctx.app_settings().context_lines)?;
     let diffs = vec![diff];

--- a/crates/but/src/command/claude.rs
+++ b/crates/but/src/command/claude.rs
@@ -112,10 +112,6 @@ pub(crate) async fn handle_stop() -> anyhow::Result<ClaudeHookOutput> {
     )?;
 
     let stacks = crate::log::stacks(defer.ctx)?;
-    let existing_branch_names = stacks
-        .iter()
-        .flat_map(|s| s.heads.iter().map(|h| h.name.clone().to_string()))
-        .collect::<Vec<_>>();
 
     // Trigger commit message generation for newly created commits
     // TODO: Maybe this can be done in the main app process i.e. the GitButler GUI, if avaialbe
@@ -162,7 +158,6 @@ pub(crate) async fn handle_stop() -> anyhow::Result<ClaudeHookOutput> {
                             commit_message,
                             stack_id: branch.stack_id,
                             current_branch_name: branch.branch_name.clone(),
-                            existing_branch_names: existing_branch_names.clone(),
                         };
                         but_action::rename_branch::rename_branch(
                             defer.ctx,


### PR DESCRIPTION
Get the branch names right before the generation of the branch names starts. That way, you can be assured that the existing branch names list can be up to date

## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
