### PR TITLE
don't bail on merge-conflict with unrelated file

### DIFF
--- a/packages/mcp/src/shared/entities/stacks.ts
+++ b/packages/mcp/src/shared/entities/stacks.ts
@@ -92,6 +92,7 @@ export const RejectedChangesSchema = z.tuple([
 		'NoEffectiveChanges',
 		'CherryPickMergeConflict',
 		'WorkspaceMergeConflict',
+		'WorkspaceMergeConflictOfUnrelatedFile',
 		'WorktreeFileMissingForObjectConversion',
 		'FileToLargeOrBinary',
 		'PathNotFoundInBaseTree',


### PR DESCRIPTION
Merges might fail in files that weren't touched, now we turn them into a diffspec.

That way these paths can also be handled, even though I thought they don't exist.

Related to https://discord.com/channels/1060193121130000425/1206670506271707156/1395775296728465459