### PR TITLE
Rule fileters use AND logic

### DIFF
--- a/apps/desktop/src/lib/rules/rule.ts
+++ b/apps/desktop/src/lib/rules/rule.ts
@@ -5,6 +5,8 @@ export type WorkspaceRuleId = BrandedId<'WorkspaceRule'>;
  * A workspace rule.
  * @remarks
  * A rule is evaluated in the app and determines what happens to files or changes based on triggers, filters, and actions.
+ *
+ * Multiple rules can defined and will be evaluated in the order they are defined using an OR logic.
  */
 export interface WorkspaceRule {
 	/** A UUID unique identifier for the rule. */
@@ -15,7 +17,11 @@ export interface WorkspaceRule {
 	enabled: boolean;
 	/** The trigger of the rule is what causes it to be evaluated in the app. */
 	trigger: Trigger;
-	/** These filters determine what files or changes the rule applies to. Multiple filters are combined with OR logic. */
+	/** These filters determine what files or changes the rule applies to
+	 *  Multiple filters are combined with AND logic (i.e. all conditions must be met).
+	 *  This allows for the expressions of rules like "If a file is modified, its path matches
+	 *  the regex 'src/.*', and its content matches the regex 'TODO', then do something.
+	 *  */
 	filters: Filter[];
 	/** The action determines what happens to the files or changes that matched the filters. */
 	action: Action;
@@ -33,8 +39,8 @@ export type Trigger =
  * Multiple conditions in a filter are combined with AND logic.
  */
 export type Filter =
-	| { type: 'pathMatchesRegex'; subject: string[] } // regex patterns as strings
-	| { type: 'contentMatchesRegex'; subject: string[] } // regex patterns as strings
+	| { type: 'pathMatchesRegex'; subject: string } // regex patterns as strings
+	| { type: 'contentMatchesRegex'; subject: string } // regex patterns as strings
 	| { type: 'fileChangeType'; subject: TreeStatus }
 	| { type: 'semanticType'; subject: SemanticType };
 

--- a/crates/but-rules/src/lib.rs
+++ b/crates/but-rules/src/lib.rs
@@ -15,7 +15,9 @@ pub struct WorkspaceRule {
     /// The trigger of the rule is what causes it to be evaluated in the app.
     trigger: Trigger,
     /// These filtes determine what files or changes the rule applies to.
-    /// Within a rule, multiple filters are combined with OR logic (i.e. it's sufficient to match any of the filters)
+    /// Within a rule, multiple filters are combined with AND logic (i.e. all conditions must be met).
+    /// This allows for the expressions of rules like "If a file is modified, its path matches
+    /// the regex 'src/.*', and its content matches the regex 'TODO', then do something."
     filters: Vec<Filter>,
     /// The action determines what happens to the files or changes that matched the filters.
     action: Action,
@@ -34,12 +36,12 @@ pub enum Trigger {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", tag = "type", content = "subject")]
 pub enum Filter {
-    /// Matches the file path (relative to the repository root) against all provided regex patterns.
+    /// Matches the file path (relative to the repository root).
     #[serde(with = "serde_regex")]
-    PathMatchesRegex(Vec<regex::Regex>),
-    /// Match the file content against all provided regex patterns.
+    PathMatchesRegex(regex::Regex),
+    /// Match the file content.
     #[serde(with = "serde_regex")]
-    ContentMatchesRegex(Vec<regex::Regex>),
+    ContentMatchesRegex(regex::Regex),
     /// Matches the file change operation type (e.g. addition, deletion, modification, rename)
     FileChangeType(TreeStatus),
     /// Matches the semantic type of the change.


### PR DESCRIPTION
The filters in a rule are combined using the AND logic.

Update the types and documentation accordingly


This allows us to express rules like:

All deleted files under the *src* dir that have the extension .rs should be assigned to a branch