### PR TITLE
fix(web/ui): improve clickOutside handling and fix spacing in chat

### DIFF
--- a/apps/web/src/lib/components/chat/MessageText.svelte
+++ b/apps/web/src/lib/components/chat/MessageText.svelte
@@ -12,6 +12,7 @@
 
 	const userMap = $derived(new Map(mentions.map((user) => [user.id, user])));
 	const words = $derived(getChatMessageWords(text, userMap));
+	const SPACE = ' ';
 </script>
 
 <span>
@@ -21,6 +22,6 @@
 		{:else}
 			<Mention mention={word.mention} />
 		{/if}
-		&nbsp;
+		{SPACE}
 	{/each}
 </span>

--- a/packages/ui/src/lib/hunkDiff/HunkDiffBody.svelte
+++ b/packages/ui/src/lib/hunkDiff/HunkDiffBody.svelte
@@ -36,7 +36,7 @@
 		stagedLines?: LineId[];
 		hideCheckboxes?: boolean;
 		handleLineContextMenu?: (params: ContextMenuParams) => void;
-		clickOutsideExcludeElement?: HTMLElement;
+		clickOutsideExcludeElements?: HTMLElement[];
 		comment?: string;
 		lockWarning?: Snippet<[DependencyLock[]]>;
 	}
@@ -60,7 +60,7 @@
 		stagedLines,
 		hideCheckboxes,
 		handleLineContextMenu,
-		clickOutsideExcludeElement,
+		clickOutsideExcludeElements,
 		lockWarning
 	}: Props = $props();
 
@@ -240,7 +240,7 @@
 		bind:clientHeight={chunkHeight[chunkIdx]}
 		use:clickOutside={{
 			handler: handleClearSelection,
-			excludeElement: clickOutsideExcludeElement
+			excludeElement: clickOutsideExcludeElements
 		}}
 		use:intersectionObserver={{
 			callback: (entries) => {

--- a/packages/ui/src/lib/utils/clickOutside.ts
+++ b/packages/ui/src/lib/utils/clickOutside.ts
@@ -1,11 +1,25 @@
-export type ClickOpts = { excludeElement?: Element; handler: (event: MouseEvent) => void };
+export type ClickOpts = {
+	excludeElement?: Element | Element[];
+	handler: (event: MouseEvent) => void;
+};
+
+function elementShouldBeExcluded(
+	element: Element | Element[] | undefined,
+	target: HTMLElement
+): boolean {
+	if (!element) return false;
+	if (Array.isArray(element)) {
+		return element.some((el) => el.contains(target));
+	}
+	return element.contains(target);
+}
 
 export function clickOutside(node: HTMLElement, params: ClickOpts) {
 	function onClick(event: MouseEvent) {
 		if (
 			node &&
 			!node.contains(event.target as HTMLElement) &&
-			!params.excludeElement?.contains(event.target as HTMLElement)
+			!elementShouldBeExcluded(params.excludeElement, event.target as HTMLElement)
 		) {
 			params.handler(event);
 		}


### PR DESCRIPTION
Refactor clickOutside utility to support multiple excluded elements,
enabling better control over click event handling in complex UI parts.
Update HunkDiff to wait for table wrapper mount before setting excluded
elements for clickOutside, ensuring correct behavior. Fix prop names
accordingly in HunkDiffBody. Also replace non-breaking space with normal
space in MessageText for consistent spacing.