### PR TITLE
Fix bug in draft stack branch name

### DIFF
--- a/apps/desktop/src/components/MultiStackCreateNew.svelte
+++ b/apps/desktop/src/components/MultiStackCreateNew.svelte
@@ -108,7 +108,7 @@
 
 	async function showAndPrefillName() {
 		createRefModal?.show();
-		createRefName = await stackService.newBranchName(projectId);
+		createRefName = await stackService.fetchNewBranchName(projectId);
 		// Reset selected stack to default
 		selectedStackId = undefined;
 	}

--- a/apps/desktop/src/components/StackDraft.svelte
+++ b/apps/desktop/src/components/StackDraft.svelte
@@ -3,6 +3,7 @@
 	import CommitGoesHere from '$components/CommitGoesHere.svelte';
 	import ConfigurableScrollableContainer from '$components/ConfigurableScrollableContainer.svelte';
 	import NewCommitView from '$components/NewCommitView.svelte';
+	import ReduxResult from '$components/ReduxResult.svelte';
 	import Resizer from '$components/Resizer.svelte';
 	import { StackService } from '$lib/stacks/stackService.svelte';
 	import { UiState } from '$lib/state/uiState.svelte';
@@ -43,20 +44,22 @@
 				<div class="new-commit-view" data-testid={TestId.NewCommitView}>
 					<NewCommitView {projectId} />
 				</div>
-				{#await newNameResult then newName}
-					{@const branchName = draftBranchName.current || newName}
-					<BranchCard
-						type="draft-branch"
-						{projectId}
-						{branchName}
-						readonly={false}
-						lineColor="var(--clr-commit-local)"
-					>
-						{#snippet branchContent()}
-							<CommitGoesHere commitId={undefined} selected last />
-						{/snippet}
-					</BranchCard>
-				{/await}
+				<ReduxResult {projectId} result={newNameResult.current}>
+					{#snippet children(newName)}
+						{@const branchName = draftBranchName.current || newName}
+						<BranchCard
+							type="draft-branch"
+							{projectId}
+							{branchName}
+							readonly={false}
+							lineColor="var(--clr-commit-local)"
+						>
+							{#snippet branchContent()}
+								<CommitGoesHere commitId={undefined} selected last />
+							{/snippet}
+						</BranchCard>
+					{/snippet}
+				</ReduxResult>
 				<Resizer
 					persistId="resizer-darft-panel"
 					viewport={draftPanelEl}

--- a/apps/desktop/src/components/v3/FileContextMenu.svelte
+++ b/apps/desktop/src/components/v3/FileContextMenu.svelte
@@ -231,7 +231,7 @@
 		const branchName = selectionId.branchName;
 
 		const fileNames = changes.map((change) => change.path);
-		const newBranchName = await stackService.newBranchName(projectId);
+		const newBranchName = await stackService.fetchNewBranchName(projectId);
 
 		if (!newBranchName) {
 			toasts.error('Failed to generate a new branch name.');
@@ -261,7 +261,7 @@
 		const branchName = selectionId.branchName;
 
 		const fileNames = changes.map((change) => change.path);
-		const newBranchName = await stackService.newBranchName(projectId);
+		const newBranchName = await stackService.fetchNewBranchName(projectId);
 
 		if (!newBranchName) {
 			toasts.error('Failed to generate a new branch name.');
@@ -298,7 +298,7 @@
 						<ContextMenuItem
 							label="Stash into branch"
 							onclick={() => {
-								stackService.newBranchName(projectId).then((name) => {
+								stackService.fetchNewBranchName(projectId).then((name) => {
 									stashBranchName = name || '';
 								});
 								stashConfirmationModal?.show(item);

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -736,7 +736,14 @@ export class StackService {
 		});
 	}
 
-	async newBranchName(projectId: string) {
+	newBranchName(projectId: string) {
+		const result = $derived(
+			this.api.endpoints.newBranchName.useQuery({ projectId }, { forceRefetch: true })
+		);
+		return result;
+	}
+
+	async fetchNewBranchName(projectId: string) {
 		return await this.api.endpoints.newBranchName.fetch({ projectId }, { forceRefetch: true });
 	}
 


### PR DESCRIPTION
This came about with a change to the `UiState` draft branch name, where 
we don't set it unless the user changes the default branch name.