### PR TITLE
Persistent Stack-IDs

### DIFF
--- a/crates/but-core/src/id.rs
+++ b/crates/but-core/src/id.rs
@@ -1,0 +1,68 @@
+use std::{fmt, hash::Hash, str};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use uuid::Uuid;
+
+/// A generic UUID, to be specialised for each kind of UUID.
+///
+/// `Default` is implemented to generate a new UUID
+/// via [`Uuid::new_v4`].
+#[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Id<const KIND: char>(Uuid);
+
+impl<const KIND: char> Id<KIND> {
+    /// Generate a new ID.
+    #[must_use]
+    pub fn generate() -> Self {
+        Id(Uuid::new_v4())
+    }
+
+    /// Create a new ID that is stable. Only useful for testing.
+    pub fn from_number_for_testing(stable_id: u128) -> Self {
+        Id(Uuid::from_u128(stable_id))
+    }
+}
+
+impl<const KIND: char> From<Uuid> for Id<KIND> {
+    fn from(value: Uuid) -> Self {
+        Self(value)
+    }
+}
+
+impl<'de, const KIND: char> Deserialize<'de> for Id<KIND> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Uuid::deserialize(deserializer).map(Into::into)
+    }
+}
+
+impl<const KIND: char> Serialize for Id<KIND> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<const KIND: char> fmt::Display for Id<KIND> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<const KIND: char> fmt::Debug for Id<KIND> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<const KIND: char> str::FromStr for Id<KIND> {
+    type Err = uuid::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Uuid::parse_str(s).map(Into::into)
+    }
+}

--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -58,6 +58,9 @@ pub mod commit;
 /// Types for use in the user interface.
 pub mod ui;
 
+mod id;
+pub use id::Id;
+
 /// utility types
 pub mod unified_diff;
 

--- a/crates/but-core/src/ref_metadata.rs
+++ b/crates/but-core/src/ref_metadata.rs
@@ -1,3 +1,5 @@
+use crate::Id;
+
 /// Metadata about workspaces, associated with references that are designated to a workspace,
 /// i.e. `refs/heads/gitbutler/workspaces/<name>`.
 /// Such a ref either points to a *Workspace Commit* which we rewrite at will, or a commit
@@ -140,9 +142,14 @@ impl RefInfo {
     }
 }
 
+/// The ID of a stack for somewhat stable identification of ever-changing stacks.
+pub type StackId = Id<'S'>;
+
 /// A stack that was applied to the workspace, i.e. a parent of the *workspace commit*.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkspaceStack {
+    /// A unique and stable identifier for the stack itself.
+    pub id: StackId,
     /// All branches that were reachable from the tip of the stack that at the time it was merged into
     /// the *workspace commit*.
     /// `[0]` is the first reachable branch, usually the tip of the stack, and `[N]` is the last

--- a/crates/but-graph/Cargo.toml
+++ b/crates/but-graph/Cargo.toml
@@ -26,7 +26,6 @@ itertools.workspace = true
 gitbutler-stack.workspace = true
 toml.workspace = true
 
-
 [dev-dependencies]
 gix-testtools.workspace = true
 insta = "1.43.1"

--- a/crates/but-graph/src/projection/stack.rs
+++ b/crates/but-graph/src/projection/stack.rs
@@ -3,12 +3,16 @@ use crate::{CommitFlags, Graph, SegmentIndex, SegmentMetadata};
 use anyhow::{Context, bail};
 use bitflags::bitflags;
 use but_core::ref_metadata;
+use but_core::ref_metadata::StackId;
 use petgraph::Direction;
 use std::fmt::Formatter;
 
 /// A list of segments that together represent a list of dependent branches, stacked on top of each other.
 #[derive(Clone)]
 pub struct Stack {
+    /// If the stack belongs to a managed workspace, the `id` will be set and persist.
+    /// Otherwise, it is `None`.
+    pub id: Option<StackId>,
     /// The branch-name denoted segments of the stack from its tip to the point of reference, typically a merge-base.
     /// This array is never empty.
     pub segments: Vec<StackSegment>,
@@ -31,6 +35,7 @@ impl Stack {
     pub(crate) fn from_base_and_segments(
         graph: &PetGraph,
         mut segments: Vec<StackSegment>,
+        id: Option<StackId>,
     ) -> Self {
         let mut iter = segments.iter_mut();
         let mut cur = iter.next();
@@ -62,7 +67,7 @@ impl Stack {
                 first_parent_sidx.filter(|_| last_segment.base.is_some());
         }
 
-        Stack { segments }
+        Stack { id, segments }
     }
 }
 

--- a/crates/but-hunk-dependency/tests/hunk_dependency/ui.rs
+++ b/crates/but-hunk-dependency/tests/hunk_dependency/ui.rs
@@ -20,7 +20,7 @@ fn hunk_dependencies_json_sample() -> anyhow::Result<()> {
           [
             {
               "stackId": "stack_1",
-              "commitId": "4bc98513b032b5992b85be8dd551e841bf959a3f"
+              "commitId": "375e35becbf67fe2b246b120bc76bf070e3e41d8"
             }
           ]
         ],
@@ -36,15 +36,15 @@ fn hunk_dependencies_json_sample() -> anyhow::Result<()> {
           [
             {
               "stackId": "stack_1",
-              "commitId": "dea907e862f2101c2ac493554e86abb1225b278e"
+              "commitId": "e954269ca7be71d09da50ec389b13f268a779c27"
             },
             {
               "stackId": "stack_1",
-              "commitId": "7558793046d64ea2070bf0856d5b2500371f0da6"
+              "commitId": "fba21e9ecacde86f327537add23f96775064a486"
             },
             {
               "stackId": "stack_1",
-              "commitId": "3bdeccbfca50778abfe67960f0732b0e4e065ab9"
+              "commitId": "250b92ba3b6451781f6632cd34be70db814ec4ac"
             }
           ]
         ],
@@ -60,7 +60,7 @@ fn hunk_dependencies_json_sample() -> anyhow::Result<()> {
           [
             {
               "stackId": "stack_1",
-              "commitId": "7558793046d64ea2070bf0856d5b2500371f0da6"
+              "commitId": "fba21e9ecacde86f327537add23f96775064a486"
             }
           ]
         ]
@@ -92,11 +92,11 @@ fn complex_file_manipulation_with_uncommitted_changes() -> anyhow::Result<()> {
                 [
                     HunkLock {
                         stack_id: stack_1,
-                        commit_id: Sha1(60a2022fc47aec1959cdf3e9b4a2c3cf441c918c),
+                        commit_id: Sha1(b2510a88eab2cf2f7dde23202c7a8e536905f4f7),
                     },
                     HunkLock {
                         stack_id: stack_1,
-                        commit_id: Sha1(0bfc8418d23102d123a376394f3364db66e0ef16),
+                        commit_id: Sha1(3113ca08b2b23d7646cdb9c9b88ffde8d1c7784a),
                     },
                 ],
             ),
@@ -109,7 +109,7 @@ fn complex_file_manipulation_with_uncommitted_changes() -> anyhow::Result<()> {
                 [
                     HunkLock {
                         stack_id: stack_1,
-                        commit_id: Sha1(be6a4b2f1372586f4f1f434abea8087634b54148),
+                        commit_id: Sha1(98231f63bb3539acf42356c886c07b140d42b68c),
                     },
                 ],
             ),
@@ -137,7 +137,7 @@ fn complex_file_manipulation_multiple_hunks_with_uncommitted_changes() -> anyhow
                 [
                     HunkLock {
                         stack_id: stack_1,
-                        commit_id: Sha1(4bc98513b032b5992b85be8dd551e841bf959a3f),
+                        commit_id: Sha1(375e35becbf67fe2b246b120bc76bf070e3e41d8),
                     },
                 ],
             ),
@@ -151,15 +151,15 @@ fn complex_file_manipulation_multiple_hunks_with_uncommitted_changes() -> anyhow
                 [
                     HunkLock {
                         stack_id: stack_1,
-                        commit_id: Sha1(dea907e862f2101c2ac493554e86abb1225b278e),
+                        commit_id: Sha1(e954269ca7be71d09da50ec389b13f268a779c27),
                     },
                     HunkLock {
                         stack_id: stack_1,
-                        commit_id: Sha1(7558793046d64ea2070bf0856d5b2500371f0da6),
+                        commit_id: Sha1(fba21e9ecacde86f327537add23f96775064a486),
                     },
                     HunkLock {
                         stack_id: stack_1,
-                        commit_id: Sha1(3bdeccbfca50778abfe67960f0732b0e4e065ab9),
+                        commit_id: Sha1(250b92ba3b6451781f6632cd34be70db814ec4ac),
                     },
                 ],
             ),
@@ -173,7 +173,7 @@ fn complex_file_manipulation_multiple_hunks_with_uncommitted_changes() -> anyhow
                 [
                     HunkLock {
                         stack_id: stack_1,
-                        commit_id: Sha1(7558793046d64ea2070bf0856d5b2500371f0da6),
+                        commit_id: Sha1(fba21e9ecacde86f327537add23f96775064a486),
                     },
                 ],
             ),
@@ -199,7 +199,7 @@ fn dependencies_ignore_merge_commits() -> anyhow::Result<()> {
                 [
                     HunkLock {
                         stack_id: stack_1,
-                        commit_id: Sha1(7184f6b6ff8d248c65507c863118b25888bdc013),
+                        commit_id: Sha1(1179d94bda967d9fb70b518b9b7225524c185218),
                     },
                 ],
             ),

--- a/crates/but-hunk-dependency/tests/hunk_dependency/workspace_dependencies.rs
+++ b/crates/but-hunk-dependency/tests/hunk_dependency/workspace_dependencies.rs
@@ -11,7 +11,7 @@ fn every_commit_is_independent() -> anyhow::Result<()> {
                     [
                         StableHunkRange {
                             change_type: Addition,
-                            commit_id: Sha1(51ec59cb5b96509c755b0ec0b656dcb66d4c38b5),
+                            commit_id: Sha1(c7bae2e8c4ed7aba203c752cd6736f70f04fd544),
                             start: 1,
                             lines: 1,
                             line_shift: 1,
@@ -23,7 +23,7 @@ fn every_commit_is_independent() -> anyhow::Result<()> {
                     [
                         StableHunkRange {
                             change_type: Addition,
-                            commit_id: Sha1(5233c17e9ae7ae9902a377cf18f526c87ea10090),
+                            commit_id: Sha1(f3235c8c52ba77ee341c02cc9fa3b8bd9969f048),
                             start: 1,
                             lines: 1,
                             line_shift: 1,
@@ -35,7 +35,7 @@ fn every_commit_is_independent() -> anyhow::Result<()> {
                     [
                         StableHunkRange {
                             change_type: Addition,
-                            commit_id: Sha1(847c738a74b7e8dc9a041abb324cc30bb1ec7601),
+                            commit_id: Sha1(6a97e922f1021217da59dcb91e7b5e1088ad0ac8),
                             start: 1,
                             lines: 1,
                             line_shift: 1,
@@ -47,7 +47,7 @@ fn every_commit_is_independent() -> anyhow::Result<()> {
                     [
                         StableHunkRange {
                             change_type: Addition,
-                            commit_id: Sha1(91d1bdabf8ea1f82ccc4650c944e30e37b3fb7d0),
+                            commit_id: Sha1(9b0dc3c781e575aba25d7dca67df9bace74d72d3),
                             start: 1,
                             lines: 1,
                             line_shift: 1,
@@ -59,7 +59,7 @@ fn every_commit_is_independent() -> anyhow::Result<()> {
                     [
                         StableHunkRange {
                             change_type: Addition,
-                            commit_id: Sha1(69a5d567e227e7925501ce12543ee8d078bed387),
+                            commit_id: Sha1(0b15614231606e65246f7ad52685612b495d63ff),
                             start: 1,
                             lines: 1,
                             line_shift: 1,
@@ -71,7 +71,7 @@ fn every_commit_is_independent() -> anyhow::Result<()> {
                     [
                         StableHunkRange {
                             change_type: Addition,
-                            commit_id: Sha1(b801632fbe7050fa95b68914c392cc7472e53f1c),
+                            commit_id: Sha1(0c8146ee1326d65c2e2b895a636a5dc26d55e6e4),
                             start: 1,
                             lines: 1,
                             line_shift: 1,
@@ -100,7 +100,7 @@ fn multiple_stacks_with_multiple_branches_each() -> anyhow::Result<()> {
                     [
                         StableHunkRange {
                             change_type: Addition,
-                            commit_id: Sha1(51ec59cb5b96509c755b0ec0b656dcb66d4c38b5),
+                            commit_id: Sha1(c7bae2e8c4ed7aba203c752cd6736f70f04fd544),
                             start: 1,
                             lines: 1,
                             line_shift: 1,
@@ -112,7 +112,7 @@ fn multiple_stacks_with_multiple_branches_each() -> anyhow::Result<()> {
                     [
                         StableHunkRange {
                             change_type: Addition,
-                            commit_id: Sha1(5233c17e9ae7ae9902a377cf18f526c87ea10090),
+                            commit_id: Sha1(f3235c8c52ba77ee341c02cc9fa3b8bd9969f048),
                             start: 1,
                             lines: 1,
                             line_shift: 1,
@@ -124,7 +124,7 @@ fn multiple_stacks_with_multiple_branches_each() -> anyhow::Result<()> {
                     [
                         StableHunkRange {
                             change_type: Addition,
-                            commit_id: Sha1(847c738a74b7e8dc9a041abb324cc30bb1ec7601),
+                            commit_id: Sha1(6a97e922f1021217da59dcb91e7b5e1088ad0ac8),
                             start: 1,
                             lines: 1,
                             line_shift: 1,
@@ -136,7 +136,7 @@ fn multiple_stacks_with_multiple_branches_each() -> anyhow::Result<()> {
                     [
                         StableHunkRange {
                             change_type: Addition,
-                            commit_id: Sha1(91d1bdabf8ea1f82ccc4650c944e30e37b3fb7d0),
+                            commit_id: Sha1(9b0dc3c781e575aba25d7dca67df9bace74d72d3),
                             start: 1,
                             lines: 1,
                             line_shift: 1,
@@ -148,7 +148,7 @@ fn multiple_stacks_with_multiple_branches_each() -> anyhow::Result<()> {
                     [
                         StableHunkRange {
                             change_type: Addition,
-                            commit_id: Sha1(69a5d567e227e7925501ce12543ee8d078bed387),
+                            commit_id: Sha1(0b15614231606e65246f7ad52685612b495d63ff),
                             start: 1,
                             lines: 1,
                             line_shift: 1,
@@ -160,7 +160,7 @@ fn multiple_stacks_with_multiple_branches_each() -> anyhow::Result<()> {
                     [
                         StableHunkRange {
                             change_type: Addition,
-                            commit_id: Sha1(b801632fbe7050fa95b68914c392cc7472e53f1c),
+                            commit_id: Sha1(0c8146ee1326d65c2e2b895a636a5dc26d55e6e4),
                             start: 1,
                             lines: 1,
                             line_shift: 1,
@@ -172,7 +172,7 @@ fn multiple_stacks_with_multiple_branches_each() -> anyhow::Result<()> {
                     [
                         StableHunkRange {
                             change_type: Addition,
-                            commit_id: Sha1(e134730e7c1b2e3ddc8d94ae2a1344866d002e1d),
+                            commit_id: Sha1(2ecdbf9d2deb34a2a11caa9d6ceddf567033d8b9),
                             start: 1,
                             lines: 1,
                             line_shift: 1,
@@ -184,7 +184,7 @@ fn multiple_stacks_with_multiple_branches_each() -> anyhow::Result<()> {
                     [
                         StableHunkRange {
                             change_type: Addition,
-                            commit_id: Sha1(a655019fd0b2df1cb380dd14c80a3290786408cb),
+                            commit_id: Sha1(5469306a5386f7ce63eb914c638198b8e8549e75),
                             start: 1,
                             lines: 1,
                             line_shift: 1,
@@ -196,7 +196,7 @@ fn multiple_stacks_with_multiple_branches_each() -> anyhow::Result<()> {
                     [
                         StableHunkRange {
                             change_type: Addition,
-                            commit_id: Sha1(a74fc2d6bc6027a28c68b8bac5fdf48fb85fadfa),
+                            commit_id: Sha1(0d5184fdb9b4735f2717dc040e0995f5cc5f5af1),
                             start: 1,
                             lines: 1,
                             line_shift: 1,
@@ -208,7 +208,7 @@ fn multiple_stacks_with_multiple_branches_each() -> anyhow::Result<()> {
                     [
                         StableHunkRange {
                             change_type: Addition,
-                            commit_id: Sha1(4a82a7a0f6910e52f96d062606fbf1040c300a13),
+                            commit_id: Sha1(e2af430b8fe8fa7c208c1c9548fffa70fb7c5923),
                             start: 1,
                             lines: 1,
                             line_shift: 1,
@@ -220,7 +220,7 @@ fn multiple_stacks_with_multiple_branches_each() -> anyhow::Result<()> {
                     [
                         StableHunkRange {
                             change_type: Addition,
-                            commit_id: Sha1(862d101dbbcdec1f1d263670f1833b7e68569628),
+                            commit_id: Sha1(855154a10af961174b5a0a1544d36641c1a9e85e),
                             start: 1,
                             lines: 1,
                             line_shift: 1,
@@ -232,7 +232,7 @@ fn multiple_stacks_with_multiple_branches_each() -> anyhow::Result<()> {
                     [
                         StableHunkRange {
                             change_type: Addition,
-                            commit_id: Sha1(6690284f0d4ffb291fa619db4dd3f46a0023f9ff),
+                            commit_id: Sha1(874b74abfca585b57deb72f98ffcded86016221b),
                             start: 1,
                             lines: 1,
                             line_shift: 1,
@@ -260,7 +260,7 @@ fn every_commit_is_sequentially_dependent() -> anyhow::Result<()> {
                     [
                         StableHunkRange {
                             change_type: Modification,
-                            commit_id: Sha1(a1e0611ace0aeaf59f58550c1801575d240e292a),
+                            commit_id: Sha1(90bdc8c6752c9045fc667f7aea605d526ad8e574),
                             start: 1,
                             lines: 1,
                             line_shift: 0,
@@ -289,7 +289,7 @@ fn every_commit_is_sequentially_dependent_multi_stack() -> anyhow::Result<()> {
                     [
                         StableHunkRange {
                             change_type: Modification,
-                            commit_id: Sha1(a1e0611ace0aeaf59f58550c1801575d240e292a),
+                            commit_id: Sha1(90bdc8c6752c9045fc667f7aea605d526ad8e574),
                             start: 1,
                             lines: 1,
                             line_shift: 0,
@@ -301,7 +301,7 @@ fn every_commit_is_sequentially_dependent_multi_stack() -> anyhow::Result<()> {
                     [
                         StableHunkRange {
                             change_type: Modification,
-                            commit_id: Sha1(ec45a328b989fc64aa072f625731caa00d03a89d),
+                            commit_id: Sha1(517d4baf97701f602df4b3672618b4199d4b1a71),
                             start: 1,
                             lines: 1,
                             line_shift: 0,
@@ -329,7 +329,7 @@ fn delete_and_recreate_file_multi_stack() -> anyhow::Result<()> {
                 [
                     StableHunkRange {
                         change_type: Addition,
-                        commit_id: Sha1(32ffdb24b5272de977351fa9c2e71a7ec1fe40e1),
+                        commit_id: Sha1(925d483a4608e3588d24d8c28c3b626c6d946a93),
                         start: 1,
                         lines: 1,
                         line_shift: 1,
@@ -341,7 +341,7 @@ fn delete_and_recreate_file_multi_stack() -> anyhow::Result<()> {
                 [
                     StableHunkRange {
                         change_type: Deletion,
-                        commit_id: Sha1(c59d9958755e135db22be8d9e81723f8b7bfa8e4),
+                        commit_id: Sha1(36e261b96c0a7ef265c66909c1efc1c354038874),
                         start: 1,
                         lines: 0,
                         line_shift: 0,
@@ -368,35 +368,35 @@ fn complex_file_manipulation() -> anyhow::Result<()> {
                 [
                     StableHunkRange {
                         change_type: Addition,
-                        commit_id: Sha1(0bfc8418d23102d123a376394f3364db66e0ef16),
+                        commit_id: Sha1(3113ca08b2b23d7646cdb9c9b88ffde8d1c7784a),
                         start: 1,
                         lines: 0,
                         line_shift: 7,
                     },
                     StableHunkRange {
                         change_type: Modification,
-                        commit_id: Sha1(60a2022fc47aec1959cdf3e9b4a2c3cf441c918c),
+                        commit_id: Sha1(b2510a88eab2cf2f7dde23202c7a8e536905f4f7),
                         start: 1,
                         lines: 2,
                         line_shift: 2,
                     },
                     StableHunkRange {
                         change_type: Addition,
-                        commit_id: Sha1(0bfc8418d23102d123a376394f3364db66e0ef16),
+                        commit_id: Sha1(3113ca08b2b23d7646cdb9c9b88ffde8d1c7784a),
                         start: 3,
                         lines: 6,
                         line_shift: 7,
                     },
                     StableHunkRange {
                         change_type: Modification,
-                        commit_id: Sha1(96f1e1fe9da3a1e977a0cf5177eb0f6a3da17980),
+                        commit_id: Sha1(4f6e1f7479f83a4c669f45e2381d69c02b2c5e1f),
                         start: 9,
                         lines: 3,
                         line_shift: 2,
                     },
                     StableHunkRange {
                         change_type: Addition,
-                        commit_id: Sha1(0bfc8418d23102d123a376394f3364db66e0ef16),
+                        commit_id: Sha1(3113ca08b2b23d7646cdb9c9b88ffde8d1c7784a),
                         start: 12,
                         lines: 0,
                         line_shift: 7,
@@ -408,28 +408,28 @@ fn complex_file_manipulation() -> anyhow::Result<()> {
                 [
                     StableHunkRange {
                         change_type: Modification,
-                        commit_id: Sha1(60a2022fc47aec1959cdf3e9b4a2c3cf441c918c),
+                        commit_id: Sha1(b2510a88eab2cf2f7dde23202c7a8e536905f4f7),
                         start: 1,
                         lines: 1,
                         line_shift: 0,
                     },
                     StableHunkRange {
                         change_type: Addition,
-                        commit_id: Sha1(be6a4b2f1372586f4f1f434abea8087634b54148),
+                        commit_id: Sha1(98231f63bb3539acf42356c886c07b140d42b68c),
                         start: 2,
                         lines: 5,
                         line_shift: 0,
                     },
                     StableHunkRange {
                         change_type: Modification,
-                        commit_id: Sha1(d183b4d1138e672911177f3338c9f2e11f973a68),
+                        commit_id: Sha1(dfb757b02a06e28a9d6822376b2f8829f90d46bd),
                         start: 7,
                         lines: 0,
                         line_shift: -3,
                     },
                     StableHunkRange {
                         change_type: Addition,
-                        commit_id: Sha1(be6a4b2f1372586f4f1f434abea8087634b54148),
+                        commit_id: Sha1(98231f63bb3539acf42356c886c07b140d42b68c),
                         start: 7,
                         lines: 1,
                         line_shift: 10,
@@ -457,35 +457,35 @@ fn complex_file_manipulation_with_uncommitted_changes() -> anyhow::Result<()> {
                 [
                     StableHunkRange {
                         change_type: Addition,
-                        commit_id: Sha1(0bfc8418d23102d123a376394f3364db66e0ef16),
+                        commit_id: Sha1(3113ca08b2b23d7646cdb9c9b88ffde8d1c7784a),
                         start: 1,
                         lines: 0,
                         line_shift: 7,
                     },
                     StableHunkRange {
                         change_type: Modification,
-                        commit_id: Sha1(60a2022fc47aec1959cdf3e9b4a2c3cf441c918c),
+                        commit_id: Sha1(b2510a88eab2cf2f7dde23202c7a8e536905f4f7),
                         start: 1,
                         lines: 2,
                         line_shift: 2,
                     },
                     StableHunkRange {
                         change_type: Addition,
-                        commit_id: Sha1(0bfc8418d23102d123a376394f3364db66e0ef16),
+                        commit_id: Sha1(3113ca08b2b23d7646cdb9c9b88ffde8d1c7784a),
                         start: 3,
                         lines: 6,
                         line_shift: 7,
                     },
                     StableHunkRange {
                         change_type: Modification,
-                        commit_id: Sha1(96f1e1fe9da3a1e977a0cf5177eb0f6a3da17980),
+                        commit_id: Sha1(4f6e1f7479f83a4c669f45e2381d69c02b2c5e1f),
                         start: 9,
                         lines: 3,
                         line_shift: 2,
                     },
                     StableHunkRange {
                         change_type: Addition,
-                        commit_id: Sha1(0bfc8418d23102d123a376394f3364db66e0ef16),
+                        commit_id: Sha1(3113ca08b2b23d7646cdb9c9b88ffde8d1c7784a),
                         start: 12,
                         lines: 0,
                         line_shift: 7,
@@ -497,28 +497,28 @@ fn complex_file_manipulation_with_uncommitted_changes() -> anyhow::Result<()> {
                 [
                     StableHunkRange {
                         change_type: Modification,
-                        commit_id: Sha1(60a2022fc47aec1959cdf3e9b4a2c3cf441c918c),
+                        commit_id: Sha1(b2510a88eab2cf2f7dde23202c7a8e536905f4f7),
                         start: 1,
                         lines: 1,
                         line_shift: 0,
                     },
                     StableHunkRange {
                         change_type: Addition,
-                        commit_id: Sha1(be6a4b2f1372586f4f1f434abea8087634b54148),
+                        commit_id: Sha1(98231f63bb3539acf42356c886c07b140d42b68c),
                         start: 2,
                         lines: 5,
                         line_shift: 0,
                     },
                     StableHunkRange {
                         change_type: Modification,
-                        commit_id: Sha1(d183b4d1138e672911177f3338c9f2e11f973a68),
+                        commit_id: Sha1(dfb757b02a06e28a9d6822376b2f8829f90d46bd),
                         start: 7,
                         lines: 0,
                         line_shift: -3,
                     },
                     StableHunkRange {
                         change_type: Addition,
-                        commit_id: Sha1(be6a4b2f1372586f4f1f434abea8087634b54148),
+                        commit_id: Sha1(98231f63bb3539acf42356c886c07b140d42b68c),
                         start: 7,
                         lines: 1,
                         line_shift: 10,
@@ -543,14 +543,14 @@ fn complex_file_manipulation_with_uncommitted_changes() -> anyhow::Result<()> {
                         commit_intersections: [
                             StableHunkRange {
                                 change_type: Modification,
-                                commit_id: Sha1(60a2022fc47aec1959cdf3e9b4a2c3cf441c918c),
+                                commit_id: Sha1(b2510a88eab2cf2f7dde23202c7a8e536905f4f7),
                                 start: 1,
                                 lines: 2,
                                 line_shift: 2,
                             },
                             StableHunkRange {
                                 change_type: Addition,
-                                commit_id: Sha1(0bfc8418d23102d123a376394f3364db66e0ef16),
+                                commit_id: Sha1(3113ca08b2b23d7646cdb9c9b88ffde8d1c7784a),
                                 start: 3,
                                 lines: 6,
                                 line_shift: 7,
@@ -570,7 +570,7 @@ fn complex_file_manipulation_with_uncommitted_changes() -> anyhow::Result<()> {
                         commit_intersections: [
                             StableHunkRange {
                                 change_type: Addition,
-                                commit_id: Sha1(be6a4b2f1372586f4f1f434abea8087634b54148),
+                                commit_id: Sha1(98231f63bb3539acf42356c886c07b140d42b68c),
                                 start: 2,
                                 lines: 5,
                                 line_shift: 0,
@@ -598,77 +598,77 @@ fn complex_file_manipulation_multiple_hunks() -> anyhow::Result<()> {
                 [
                     StableHunkRange {
                         change_type: Modification,
-                        commit_id: Sha1(4bc98513b032b5992b85be8dd551e841bf959a3f),
+                        commit_id: Sha1(375e35becbf67fe2b246b120bc76bf070e3e41d8),
                         start: 1,
                         lines: 0,
                         line_shift: 9,
                     },
                     StableHunkRange {
                         change_type: Modification,
-                        commit_id: Sha1(7558793046d64ea2070bf0856d5b2500371f0da6),
+                        commit_id: Sha1(fba21e9ecacde86f327537add23f96775064a486),
                         start: 1,
                         lines: 1,
                         line_shift: 1,
                     },
                     StableHunkRange {
                         change_type: Modification,
-                        commit_id: Sha1(4bc98513b032b5992b85be8dd551e841bf959a3f),
+                        commit_id: Sha1(375e35becbf67fe2b246b120bc76bf070e3e41d8),
                         start: 2,
                         lines: 2,
                         line_shift: 9,
                     },
                     StableHunkRange {
                         change_type: Modification,
-                        commit_id: Sha1(7558793046d64ea2070bf0856d5b2500371f0da6),
+                        commit_id: Sha1(fba21e9ecacde86f327537add23f96775064a486),
                         start: 4,
                         lines: 0,
                         line_shift: -2,
                     },
                     StableHunkRange {
                         change_type: Modification,
-                        commit_id: Sha1(dea907e862f2101c2ac493554e86abb1225b278e),
+                        commit_id: Sha1(e954269ca7be71d09da50ec389b13f268a779c27),
                         start: 5,
                         lines: 1,
                         line_shift: 0,
                     },
                     StableHunkRange {
                         change_type: Modification,
-                        commit_id: Sha1(4bc98513b032b5992b85be8dd551e841bf959a3f),
+                        commit_id: Sha1(375e35becbf67fe2b246b120bc76bf070e3e41d8),
                         start: 6,
                         lines: 1,
                         line_shift: 9,
                     },
                     StableHunkRange {
                         change_type: Modification,
-                        commit_id: Sha1(dea907e862f2101c2ac493554e86abb1225b278e),
+                        commit_id: Sha1(e954269ca7be71d09da50ec389b13f268a779c27),
                         start: 7,
                         lines: 0,
                         line_shift: -1,
                     },
                     StableHunkRange {
                         change_type: Modification,
-                        commit_id: Sha1(7558793046d64ea2070bf0856d5b2500371f0da6),
+                        commit_id: Sha1(fba21e9ecacde86f327537add23f96775064a486),
                         start: 7,
                         lines: 1,
                         line_shift: 0,
                     },
                     StableHunkRange {
                         change_type: Modification,
-                        commit_id: Sha1(3bdeccbfca50778abfe67960f0732b0e4e065ab9),
+                        commit_id: Sha1(250b92ba3b6451781f6632cd34be70db814ec4ac),
                         start: 8,
                         lines: 1,
                         line_shift: 0,
                     },
                     StableHunkRange {
                         change_type: Modification,
-                        commit_id: Sha1(4bc98513b032b5992b85be8dd551e841bf959a3f),
+                        commit_id: Sha1(375e35becbf67fe2b246b120bc76bf070e3e41d8),
                         start: 9,
                         lines: 1,
                         line_shift: 9,
                     },
                     StableHunkRange {
                         change_type: Modification,
-                        commit_id: Sha1(7558793046d64ea2070bf0856d5b2500371f0da6),
+                        commit_id: Sha1(fba21e9ecacde86f327537add23f96775064a486),
                         start: 10,
                         lines: 1,
                         line_shift: 1,
@@ -704,7 +704,7 @@ fn complex_file_manipulation_multiple_hunks_with_uncommitted_changes() -> anyhow
                         commit_intersections: [
                             StableHunkRange {
                                 change_type: Modification,
-                                commit_id: Sha1(4bc98513b032b5992b85be8dd551e841bf959a3f),
+                                commit_id: Sha1(375e35becbf67fe2b246b120bc76bf070e3e41d8),
                                 start: 2,
                                 lines: 2,
                                 line_shift: 9,
@@ -720,21 +720,21 @@ fn complex_file_manipulation_multiple_hunks_with_uncommitted_changes() -> anyhow
                         commit_intersections: [
                             StableHunkRange {
                                 change_type: Modification,
-                                commit_id: Sha1(dea907e862f2101c2ac493554e86abb1225b278e),
+                                commit_id: Sha1(e954269ca7be71d09da50ec389b13f268a779c27),
                                 start: 7,
                                 lines: 0,
                                 line_shift: -1,
                             },
                             StableHunkRange {
                                 change_type: Modification,
-                                commit_id: Sha1(7558793046d64ea2070bf0856d5b2500371f0da6),
+                                commit_id: Sha1(fba21e9ecacde86f327537add23f96775064a486),
                                 start: 7,
                                 lines: 1,
                                 line_shift: 0,
                             },
                             StableHunkRange {
                                 change_type: Modification,
-                                commit_id: Sha1(3bdeccbfca50778abfe67960f0732b0e4e065ab9),
+                                commit_id: Sha1(250b92ba3b6451781f6632cd34be70db814ec4ac),
                                 start: 8,
                                 lines: 1,
                                 line_shift: 0,
@@ -750,7 +750,7 @@ fn complex_file_manipulation_multiple_hunks_with_uncommitted_changes() -> anyhow
                         commit_intersections: [
                             StableHunkRange {
                                 change_type: Modification,
-                                commit_id: Sha1(7558793046d64ea2070bf0856d5b2500371f0da6),
+                                commit_id: Sha1(fba21e9ecacde86f327537add23f96775064a486),
                                 start: 10,
                                 lines: 1,
                                 line_shift: 1,
@@ -784,7 +784,7 @@ fn dependencies_ignore_merge_commits() -> anyhow::Result<()> {
                         commit_intersections: [
                             StableHunkRange {
                                 change_type: Modification,
-                                commit_id: Sha1(7184f6b6ff8d248c65507c863118b25888bdc013),
+                                commit_id: Sha1(1179d94bda967d9fb70b518b9b7225524c185218),
                                 start: 8,
                                 lines: 1,
                                 line_shift: -1,

--- a/crates/but-rebase/tests/rebase/main.rs
+++ b/crates/but-rebase/tests/rebase/main.rs
@@ -36,20 +36,20 @@ fn single_stack_journey() -> Result<()> {
     // The base remains unchanged, and two commits remain: a squash commit and a merge with
     // the original `c` commit.
     insta::assert_snapshot!(visualize_commit_graph(&repo, out.top_commit)?, @r"
-    * a466bf8 second step: squash b into a
+    * b036cfe second step: squash b into a
     * 35b8235 base
     ");
 
     // The reference points to the commit and correctly refers to the one that was fixed up.
     insta::assert_debug_snapshot!(out, @r#"
     RebaseOutput {
-        top_commit: Sha1(a466bf82eed2e6aa725eb61a85cc73281fc02960),
+        top_commit: Sha1(b036cfe2b7250396114e433883a48271a90ebe4d),
         references: [
             ReferenceSpec {
                 reference: Virtual(
                     "anchor",
                 ),
-                commit_id: Sha1(a466bf82eed2e6aa725eb61a85cc73281fc02960),
+                commit_id: Sha1(b036cfe2b7250396114e433883a48271a90ebe4d),
                 previous_commit_id: Sha1(a96434e2505c2ea0896cf4f58fec0778e074d3da),
             },
         ],
@@ -59,21 +59,21 @@ fn single_stack_journey() -> Result<()> {
                     Sha1(35b8235197020a417e9405ab5d4db6f204e8d84b),
                 ),
                 Sha1(d591dfed1777b8f00f5b7b6f427537eeb5878178),
-                Sha1(5c028a33efc5184dc46db016d9567ab79bc3e348),
+                Sha1(1975d0213524434c3c7470404e3165a3d13bce06),
             ),
             (
                 Some(
                     Sha1(35b8235197020a417e9405ab5d4db6f204e8d84b),
                 ),
                 Sha1(a96434e2505c2ea0896cf4f58fec0778e074d3da),
-                Sha1(a466bf82eed2e6aa725eb61a85cc73281fc02960),
+                Sha1(b036cfe2b7250396114e433883a48271a90ebe4d),
             ),
             (
                 Some(
                     Sha1(35b8235197020a417e9405ab5d4db6f204e8d84b),
                 ),
                 Sha1(a96434e2505c2ea0896cf4f58fec0778e074d3da),
-                Sha1(a466bf82eed2e6aa725eb61a85cc73281fc02960),
+                Sha1(b036cfe2b7250396114e433883a48271a90ebe4d),
             ),
         ],
     }
@@ -123,9 +123,9 @@ fn amended_commit() -> Result<()> {
         .rebase()?;
     // Note how the `C` isn't visible anymore as we don't rewrite reference here.
     insta::assert_snapshot!(visualize_commit_graph(&repo, out.top_commit)?, @r"
-    *-.   7997ae5 Merge branches 'A', 'B' and 'C' - rewritten
+    *-.   cc1d6d5 Merge branches 'A', 'B' and 'C' - rewritten
     |\ \  
-    | | * 39bb1d3 C: add another 10 lines to new file - amended
+    | | * b24c308 C: add another 10 lines to new file - amended
     | | * 68a2fc3 C: add 10 lines to new file
     | | * 984fd1c C: new file with 10 lines
     | * | a748762 (B) B: another 10 lines at the bottom
@@ -138,7 +138,7 @@ fn amended_commit() -> Result<()> {
     // This time without anchor.
     insta::assert_debug_snapshot!(out, @r"
     RebaseOutput {
-        top_commit: Sha1(7997ae52819cc4ceb88e2e675453bbfb4dd8cd46),
+        top_commit: Sha1(cc1d6d57b45f1967b8ee333941a6d6d6d512da13),
         references: [],
         commit_mapping: [
             (
@@ -146,14 +146,14 @@ fn amended_commit() -> Result<()> {
                     Sha1(68a2fc349e13a186e6d65871a31bad244d25e6f4),
                 ),
                 Sha1(930563a048351f05b14cc7b9c0a48640e5a306b0),
-                Sha1(39bb1d32a72c9aead133a0d867879e88ca724fcb),
+                Sha1(b24c30842ff50512edff72f5d89cafdea5be99d8),
             ),
             (
                 Some(
                     Sha1(68a2fc349e13a186e6d65871a31bad244d25e6f4),
                 ),
                 Sha1(134887021e06909021776c023a608f8ef179e859),
-                Sha1(7997ae52819cc4ceb88e2e675453bbfb4dd8cd46),
+                Sha1(cc1d6d57b45f1967b8ee333941a6d6d6d512da13),
             ),
         ],
     }
@@ -200,9 +200,9 @@ fn reorder_merge_in_reverse() -> Result<()> {
         .expect("the first parent of a merge is replaced unconditionally");
     // Note that we don't rewrite references here.
     insta::assert_snapshot!(visualize_commit_graph(&repo, out.top_commit)?, @r"
-    * dd53133 was dd59d2 below merge
-    * 9052688 was e8ee978 on top
-    *   fc4d1b4 was merge 2fc288c one below top
+    * 5949b5b was dd59d2 below merge
+    * 24494dc was e8ee978 on top
+    *   5b2cbb3 was merge 2fc288c one below top
     |\  
     | * 984fd1c (B) C: new file with 10 lines
     |/  
@@ -210,7 +210,7 @@ fn reorder_merge_in_reverse() -> Result<()> {
     ");
     insta::assert_debug_snapshot!(out, @r"
     RebaseOutput {
-        top_commit: Sha1(dd53133693ef1e4e6c327eb2559054dc03eb688d),
+        top_commit: Sha1(5949b5b6f3de27a6f8db16c3ae2bdda155220e6a),
         references: [],
         commit_mapping: [
             (
@@ -218,21 +218,21 @@ fn reorder_merge_in_reverse() -> Result<()> {
                     Sha1(8f0d33828e5c859c95fb9e9fc063374fdd482536),
                 ),
                 Sha1(2fc288c36c8bb710c78203f78ea9883724ce142b),
-                Sha1(fc4d1b46b54457385c79347d45cd3a5dae96c651),
+                Sha1(5b2cbb31707d3362c461eeb117393c6d5420372f),
             ),
             (
                 Some(
                     Sha1(8f0d33828e5c859c95fb9e9fc063374fdd482536),
                 ),
                 Sha1(e8ee978dac10e6a85006543ef08be07c5824b4f7),
-                Sha1(9052688af4d3fea6e8ed77a9b4aa471cb02828d5),
+                Sha1(24494dcbc1aeea776c5ac427f7ca720bd6cc640a),
             ),
             (
                 Some(
                     Sha1(8f0d33828e5c859c95fb9e9fc063374fdd482536),
                 ),
                 Sha1(add59d26b2ffd7468fcb44c2db48111dd8f481e5),
-                Sha1(dd53133693ef1e4e6c327eb2559054dc03eb688d),
+                Sha1(5949b5b6f3de27a6f8db16c3ae2bdda155220e6a),
             ),
         ],
     }
@@ -284,7 +284,7 @@ fn reorder_with_conflict_and_remerge_and_pick_from_conflicts() -> Result<()> {
         .rebase()?;
     insta::assert_debug_snapshot!(out, @r"
     RebaseOutput {
-        top_commit: Sha1(49915cc7bbd6cf82a009f34b66272766441bc392),
+        top_commit: Sha1(555c076b0434c148991fc6be55cafbcdde37f8eb),
         references: [],
         commit_mapping: [
             (
@@ -292,38 +292,38 @@ fn reorder_with_conflict_and_remerge_and_pick_from_conflicts() -> Result<()> {
                     Sha1(8f0d33828e5c859c95fb9e9fc063374fdd482536),
                 ),
                 Sha1(984fd1c6d3975901147b1f02aae6ef0a16e5904e),
-                Sha1(da071f9661f4894bd5ea699590940764365fa0f4),
+                Sha1(f1add68a71f4dbc2d142e2a7b12afccef9159f9d),
             ),
             (
                 Some(
                     Sha1(8f0d33828e5c859c95fb9e9fc063374fdd482536),
                 ),
                 Sha1(930563a048351f05b14cc7b9c0a48640e5a306b0),
-                Sha1(9b5f097bef4a78ed114ca1e0a095e552ef3c2ac2),
+                Sha1(93e675006a90be2c95f722ef9dd40f426331f4b9),
             ),
             (
                 Some(
                     Sha1(8f0d33828e5c859c95fb9e9fc063374fdd482536),
                 ),
                 Sha1(68a2fc349e13a186e6d65871a31bad244d25e6f4),
-                Sha1(a9bf1a73aab4f4a54f748c487a277f84e341aaf2),
+                Sha1(189f8c4dd7a5b2029c902257ae1cdbacc3cdd688),
             ),
             (
                 Some(
                     Sha1(8f0d33828e5c859c95fb9e9fc063374fdd482536),
                 ),
                 Sha1(134887021e06909021776c023a608f8ef179e859),
-                Sha1(49915cc7bbd6cf82a009f34b66272766441bc392),
+                Sha1(555c076b0434c148991fc6be55cafbcdde37f8eb),
             ),
         ],
     }
     ");
     insta::assert_snapshot!(visualize_commit_graph(&repo, out.top_commit)?, @r"
-    *-.   49915cc Re-merge branches 'A', 'B' and 'C'
+    *-.   555c076 Re-merge branches 'A', 'B' and 'C'
     |\ \  
-    | | * a9bf1a7 C~1
-    | | * 9b5f097 C
-    | | * da071f9 C~2
+    | | * 189f8c4 C~1
+    | | * 93e6750 C
+    | | * f1add68 C~2
     | * | a748762 (B) B: another 10 lines at the bottom
     | * | 62e05ba B: 10 lines at the bottom
     | |/  
@@ -366,11 +366,11 @@ fn reorder_with_conflict_and_remerge_and_pick_from_conflicts() -> Result<()> {
     // gitbutler headers were added here to indicate conflict (change-id is frozen for testing)
     insta::assert_snapshot!(conflict_commit_id.object()?.data.as_bstr(), @r"
     tree db4a5b82b209e5165cdf8d04ff4328ec1fc2526d
-    parent 9b5f097bef4a78ed114ca1e0a095e552ef3c2ac2
+    parent 93e675006a90be2c95f722ef9dd40f426331f4b9
     author author <author@example.com> 946684800 +0000
     committer Committer (Memory Override) <committer@example.com> 946684800 +0000
     gitbutler-headers-version 2
-    gitbutler-change-id change-id
+    gitbutler-change-id 00000000-0000-0000-0000-000000000001
     gitbutler-conflicted 1
 
     C~1
@@ -381,11 +381,11 @@ fn reorder_with_conflict_and_remerge_and_pick_from_conflicts() -> Result<()> {
     tree 6abc3da6f1642bfd5543ef97f98b924f4f232a96
     parent add59d26b2ffd7468fcb44c2db48111dd8f481e5
     parent a7487625f079bedf4d20e48f052312c010117b38
-    parent a9bf1a73aab4f4a54f748c487a277f84e341aaf2
+    parent 189f8c4dd7a5b2029c902257ae1cdbacc3cdd688
     author author <author@example.com> 946684800 +0000
     committer Committer (Memory Override) <committer@example.com> 946684800 +0000
     gitbutler-headers-version 2
-    gitbutler-change-id change-id
+    gitbutler-change-id 00000000-0000-0000-0000-000000000001
 
     Re-merge branches 'A', 'B' and 'C'
     ");
@@ -398,7 +398,7 @@ fn reorder_with_conflict_and_remerge_and_pick_from_conflicts() -> Result<()> {
     author author <author@example.com> 946684800 +0000
     committer Committer (Memory Override) <committer@example.com> 946684800 +0000
     gitbutler-headers-version 2
-    gitbutler-change-id change-id
+    gitbutler-change-id 00000000-0000-0000-0000-000000000001
 
     C~2
     ");
@@ -530,11 +530,11 @@ fn reversible_conflicts() -> anyhow::Result<()> {
 
     let conflict_tip = repo.rev_parse_single(format!("{}^3", out.top_commit).as_str())?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, out.top_commit)?, @r"
-    *-.   49915cc Re-merge branches 'A', 'B' and 'C'
+    *-.   555c076 Re-merge branches 'A', 'B' and 'C'
     |\ \  
-    | | * a9bf1a7 C~1
-    | | * 9b5f097 C
-    | | * da071f9 C~2
+    | | * 189f8c4 C~1
+    | | * 93e6750 C
+    | | * f1add68 C~2
     | * | a748762 (B) B: another 10 lines at the bottom
     | * | 62e05ba B: 10 lines at the bottom
     | |/  
@@ -600,10 +600,10 @@ fn pick_the_first_commit_with_no_parents_for_squashing() -> Result<()> {
             },
         ])?
         .rebase()?;
-    insta::assert_snapshot!(visualize_commit_graph(&repo, out.top_commit)?, @"* 9078131 reworded base after squash");
+    insta::assert_snapshot!(visualize_commit_graph(&repo, out.top_commit)?, @"* 9c68471 reworded base after squash");
     insta::assert_debug_snapshot!(out, @r"
     RebaseOutput {
-        top_commit: Sha1(9078131ba71afab019afd55f9dbce97c80858a42),
+        top_commit: Sha1(9c68471968e68ffe5df832a4cb850e8c3e7b7cd0),
         references: [],
         commit_mapping: [
             (
@@ -614,7 +614,7 @@ fn pick_the_first_commit_with_no_parents_for_squashing() -> Result<()> {
             (
                 None,
                 Sha1(d591dfed1777b8f00f5b7b6f427537eeb5878178),
-                Sha1(9078131ba71afab019afd55f9dbce97c80858a42),
+                Sha1(9c68471968e68ffe5df832a4cb850e8c3e7b7cd0),
             ),
         ],
     }

--- a/crates/but-testsupport/src/lib.rs
+++ b/crates/but-testsupport/src/lib.rs
@@ -63,9 +63,9 @@ pub fn open_repo(path: &Path) -> anyhow::Result<gix::Repository> {
 /// This changes the process environment, be aware.
 pub fn assure_stable_env() {
     let env = gix_testtools::Env::new()
-        // TODO(gix): once everything is ported, the only variable needed here
-        //            is CHANGE_ID, and even that could be a global. Call `but_testsupport::open_repo()`
-        //            for basic settings.
+        // TODO(gix): once everything is ported, all these can be configured on `gix::Repository`.
+        //            CHANGE_ID now works with a single value.
+        //            Call `but_testsupport::open_repo()` for basic settings.
         .set("GIT_AUTHOR_DATE", "2000-01-01 00:00:00 +0000")
         .set("GIT_AUTHOR_EMAIL", "author@example.com")
         .set("GIT_AUTHOR_NAME", "author (From Env)")

--- a/crates/but-workspace/src/branch.rs
+++ b/crates/but-workspace/src/branch.rs
@@ -415,6 +415,7 @@
 use crate::ref_info;
 use anyhow::{Context, bail};
 use but_core::RefMetadata;
+use but_core::ref_metadata::StackId;
 use gix::prelude::ObjectIdExt;
 
 /// The result of [`add_branch_to_workspace`].
@@ -494,6 +495,9 @@ pub fn remove_branch_from_workspace(
 // TODO: this is going to be the UI version, ideally consumed directly.
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct Stack {
+    /// If the stack belongs to a managed workspace, the `id` will be set and persist.
+    /// Otherwise, it is `None`.
+    pub id: Option<StackId>,
     /// If there is an integration branch, we know a base commit shared with the integration branch from
     /// which we branched off.
     /// Otherwise, it's the merge-base of all stacks in the current workspace.

--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -64,8 +64,7 @@ pub mod ui {
         pub has_conflicts: bool,
         /// The GitButler assigned change-id that we hold on to for convenience to avoid duplicate decoding of commits
         /// when trying to associate remote commits with local ones.
-        /// TODO: Skip once this type is serialized to the UI directly.
-        pub change_id: Option<String>,
+        pub change_id: Option<but_core::commit::ChangeId>,
     }
 
     impl std::fmt::Debug for Commit {

--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -410,8 +410,9 @@ pub(crate) mod function {
             repo: &gix::Repository,
         ) -> anyhow::Result<Self> {
             let base = stack.base();
-            let but_graph::projection::Stack { segments } = stack;
+            let but_graph::projection::Stack { segments, id } = stack;
             Ok(branch::Stack {
+                id,
                 base,
                 segments: segments
                     .into_iter()

--- a/crates/but-workspace/src/stacks.rs
+++ b/crates/but-workspace/src/stacks.rs
@@ -23,12 +23,19 @@ fn id_from_name_v2_to_v3(
     meta: &VirtualBranchesTomlMetadata,
 ) -> anyhow::Result<StackId> {
     let ref_meta = meta.branch(name)?;
-    ref_meta.stack_id().with_context(|| {
-        format!(
-            "{name:?} didn't have a stack-id even though \
+    ref_meta
+        .stack_id()
+        .with_context(|| {
+            format!(
+                "{name:?} didn't have a stack-id even though \
         it was supposed to be in virtualbranches.toml"
-        )
-    })
+            )
+        })
+        .map(|id| {
+            id.to_string()
+                .parse()
+                .expect("new stack ids are just UUIDs, like the old ones")
+        })
 }
 
 /// Returns the list of branch information for the branches in a stack.

--- a/crates/but-workspace/tests/fixtures/scenario/shared.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/shared.sh
@@ -30,6 +30,16 @@ function tick () {
   export GIT_COMMITTER_DATE GIT_AUTHOR_DATE
 }
 
+function tick_committer () {
+  if test -z "${tick+set}"; then
+    tick=1675176957
+  else
+    tick=$(($tick + 60))
+  fi
+  GIT_COMMITTER_DATE="$tick +0100"
+  export GIT_COMMITTER_DATE
+}
+
 function setup_target_to_match_main() {
   remote_tracking_caught_up main
 

--- a/crates/but-workspace/tests/fixtures/scenario/with-remotes-and-workspace.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/with-remotes-and-workspace.sh
@@ -233,7 +233,7 @@ git init two-dependent-branches-rebased-with-remotes
   # this emulates someone adding another commit in the lower level
   # of a stack after push.
   # The tick makes it more realistic, indicating that the rebased commits are newer.
-  git checkout A && tick
+  git checkout A && tick_committer
   git commit -m "change after push" --allow-empty
 
   git checkout -b B-on-A

--- a/crates/but-workspace/tests/workspace/commit_engine/new_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/new_commit.rs
@@ -28,7 +28,7 @@ fn from_unborn_head() -> anyhow::Result<()> {
     CreateCommitOutcome {
         rejected_specs: [],
         new_commit: Some(
-            Sha1(4b817cae4681bbb09fe059db1d469ad9f2c95724),
+            Sha1(b7cb7efa62f48dfc60e4db44837121d3b3eab4e0),
         ),
         changed_tree_pre_cherry_pick: Some(
             Sha1(861d6e23ee6a2d7276618bb78700354a3506bd71),
@@ -72,7 +72,7 @@ fn from_unborn_head() -> anyhow::Result<()> {
     CreateCommitOutcome {
         rejected_specs: [],
         new_commit: Some(
-            Sha1(62d1565d1b9644eb9204fd2addd53db078ca20ef),
+            Sha1(b7cd2309cbac81a85596b3e39756230943cfd8e5),
         ),
         changed_tree_pre_cherry_pick: Some(
             Sha1(a0044697412bfa8432298d6bd6a2ad0dbd655c9f),
@@ -900,7 +900,7 @@ fn commit_to_one_below_tip_with_three_context_lines() -> anyhow::Result<()> {
 
         assert_eq!(
             outcome.new_commit.map(|id| id.to_string()),
-            Some("f7fcd2012b2eaa23bd5bb93d45b394d2db47d4e6".to_string())
+            Some("215719d87875599c931d04a6e9b87dd2b6ef9885".to_string())
         );
         let tree = visualize_tree(&repo, &outcome)?;
         assert_eq!(
@@ -1127,7 +1127,7 @@ fn unborn_untracked_worktree_filters_are_applied_to_whole_files() -> anyhow::Res
     CreateCommitOutcome {
         rejected_specs: [],
         new_commit: Some(
-            Sha1(5417579095aeb4867c15ba4cee2d7968d499e15a),
+            Sha1(81dee909affdf17107ffdee354d682fb36c82f78),
         ),
         changed_tree_pre_cherry_pick: Some(
             Sha1(d5949f12727c8e89e1351b89e8e510dfa1e2adc9),
@@ -1166,7 +1166,7 @@ fn unborn_untracked_worktree_filters_are_applied_to_whole_files() -> anyhow::Res
     CreateCommitOutcome {
         rejected_specs: [],
         new_commit: Some(
-            Sha1(c8c768a877e4a2832edbf54bbe3cf3aa1a98e3ea),
+            Sha1(d736d5adfcad413d89d99c0f30f03a0dde606ab1),
         ),
         changed_tree_pre_cherry_pick: Some(
             Sha1(cef74127e0e9f4c46b5ff360d6208ee0cc839eba),

--- a/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
@@ -46,7 +46,7 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
     );
 
     // The head was updated, along with the ref that it points to.
-    insta::assert_snapshot!(visualize_commit_graph(&repo, new_commit_id)?, @"* 0939187 (HEAD -> main) initial commit");
+    insta::assert_snapshot!(visualize_commit_graph(&repo, new_commit_id)?, @"* 3dd3955 (HEAD -> main) initial commit");
     insta::assert_snapshot!(visualize_tree(&repo, &outcome)?, @r#"
     861d6e2
     └── not-yet-tracked:100644:d95f3ad "content\n"
@@ -72,8 +72,8 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
     )?;
     // The HEAD reference was updated.
     insta::assert_snapshot!(graph_commit_outcome(&repo, &outcome)?, @r"
-    * f1b87da (HEAD -> main) second commit
-    * 0939187 initial commit
+    * 64c4463 (HEAD -> main) second commit
+    * 3dd3955 initial commit
     ");
 
     // Create another tip at the same location as head to see if it gets updated as well.
@@ -112,9 +112,9 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
     // The HEAD reference was updated, along with all other tag-references that pointed to it.
     let new_commit = outcome.new_commit.expect("a new commit was created");
     insta::assert_snapshot!(visualize_commit_graph(&repo, new_commit)?, @r"
-    * 1c4bb33 (HEAD -> main) third commit
-    * f1b87da (tag: tag-that-should-not-move, another-tip) second commit
-    * 0939187 initial commit
+    * b780e49 (HEAD -> main) third commit
+    * 64c4463 (tag: tag-that-should-not-move, another-tip) second commit
+    * 3dd3955 initial commit
     ");
 
     write_worktree_file(&repo, "new-file", "yet another change")?;
@@ -137,9 +137,9 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
     assure_no_worktree_changes(&repo)?;
     // The top commit has a different hash now thanks to amending.
     insta::assert_snapshot!(graph_commit_outcome(&repo, &outcome)?, @r"
-    * 2abfa5c (HEAD -> main) third commit
-    * f1b87da (tag: tag-that-should-not-move, another-tip) second commit
-    * 0939187 initial commit
+    * 6073a81 (HEAD -> main) third commit
+    * 64c4463 (tag: tag-that-should-not-move, another-tip) second commit
+    * 3dd3955 initial commit
     ");
 
     assert_eq!(vb, VirtualBranchesState::default(), "Nothing changed yet");
@@ -193,7 +193,7 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
     CreateCommitOutcome {
         rejected_specs: [],
         new_commit: Some(
-            Sha1(189ac82eb44ddb97677d7d7b1859cf6f2e33a473),
+            Sha1(28868dd070be350f335ad8869c728343fa2929f8),
         ),
         changed_tree_pre_cherry_pick: Some(
             Sha1(273aeca7ca98af0f7972af6e7859a3ae7fde497a),
@@ -205,22 +205,22 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
                         "refs/heads/main",
                     ),
                 ),
-                old_commit_id: Sha1(2abfa5cc3c7c48b8b9eabbd10c21b88347801f15),
-                new_commit_id: Sha1(189ac82eb44ddb97677d7d7b1859cf6f2e33a473),
+                old_commit_id: Sha1(6073a81d14db7169b56ac39bcf59f906df532302),
+                new_commit_id: Sha1(28868dd070be350f335ad8869c728343fa2929f8),
             },
             UpdatedReference {
                 reference: Virtual(
                     "s1-b/second",
                 ),
-                old_commit_id: Sha1(2abfa5cc3c7c48b8b9eabbd10c21b88347801f15),
-                new_commit_id: Sha1(189ac82eb44ddb97677d7d7b1859cf6f2e33a473),
+                old_commit_id: Sha1(6073a81d14db7169b56ac39bcf59f906df532302),
+                new_commit_id: Sha1(28868dd070be350f335ad8869c728343fa2929f8),
             },
             UpdatedReference {
                 reference: Virtual(
                     "s2-b/second",
                 ),
-                old_commit_id: Sha1(2abfa5cc3c7c48b8b9eabbd10c21b88347801f15),
-                new_commit_id: Sha1(189ac82eb44ddb97677d7d7b1859cf6f2e33a473),
+                old_commit_id: Sha1(6073a81d14db7169b56ac39bcf59f906df532302),
+                new_commit_id: Sha1(28868dd070be350f335ad8869c728343fa2929f8),
             },
         ],
         rebase_output: None,
@@ -230,10 +230,10 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
     write_vrbranches_to_refs(&vb, &repo)?;
     // It updates stack heads and stack branch heads.
     insta::assert_snapshot!(graph_commit_outcome(&repo, &outcome)?, @r"
-    * 189ac82 (HEAD -> main, s2-b/second, s1-b/second) fourth commit
-    * 2abfa5c third commit
-    * f1b87da (tag: tag-that-should-not-move, s2-b/first, s1-b/first, another-tip) second commit
-    * 0939187 (s2-b/init, s1-b/init) initial commit
+    * 28868dd (HEAD -> main, s2-b/second, s1-b/second) fourth commit
+    * 6073a81 third commit
+    * 64c4463 (tag: tag-that-should-not-move, s2-b/first, s1-b/first, another-tip) second commit
+    * 3dd3955 (s2-b/init, s1-b/init) initial commit
     ");
     insta::assert_snapshot!(visualize_tree(&repo, &outcome)?, @r#"
     273aeca
@@ -305,9 +305,9 @@ fn new_stack_receives_commit_and_adds_it_to_workspace_commit() -> anyhow::Result
     write_vrbranches_to_refs(&vb, &repo)?;
     // head was updated to point to the new workspace commit.
     insta::assert_snapshot!(visualize_commit_graph(&repo, repo.head_id()?)?, @r"
-    *   8ce8b3d (HEAD -> main) GitButler Workspace Commit
+    *   3a78d15 (HEAD -> main) GitButler Workspace Commit
     |\  
-    | * 00fbfba (s2/top) new file with 15 lines
+    | * 2ed9fca (s2/top) new file with 15 lines
     * | b451685 (s1/top, feat1) insert 5 lines to the top
     |/  
     * d15b5ae (tag: first-commit) init
@@ -409,7 +409,7 @@ fn first_partial_commit_to_tip_from_unborn_head() -> anyhow::Result<()> {
     "#);
 
     let head_commit = outcome.new_commit.unwrap();
-    insta::assert_snapshot!(visualize_commit_graph(&repo, head_commit)?, @"* 697a30e (HEAD -> main) initial commit with two lines");
+    insta::assert_snapshot!(visualize_commit_graph(&repo, head_commit)?, @"* 5284afd (HEAD -> main) initial commit with two lines");
 
     let outcome = but_workspace::commit_engine::create_commit_and_update_refs(
         &repo,
@@ -464,8 +464,8 @@ fn first_partial_commit_to_tip_from_unborn_head() -> anyhow::Result<()> {
 
     let head_commit = outcome.new_commit.unwrap();
     insta::assert_snapshot!(visualize_commit_graph(&repo, head_commit)?, @r"
-    * e6088b7 (HEAD -> main) Add yet another line
-    * 697a30e initial commit with two lines
+    * b43af70 (HEAD -> main) Add yet another line
+    * 5284afd initial commit with two lines
     ");
 
     write_sequence(&repo, "other-untracked-non-racy", [(4, None)])?;
@@ -516,9 +516,9 @@ fn first_partial_commit_to_tip_from_unborn_head() -> anyhow::Result<()> {
 
     let head_commit = outcome.new_commit.unwrap();
     insta::assert_snapshot!(visualize_commit_graph(&repo, head_commit)?, @r"
-    * eba2b4c (HEAD -> main) add a part of an untracked file, again
-    * e6088b7 Add yet another line
-    * 697a30e initial commit with two lines
+    * fde2fa5 (HEAD -> main) add a part of an untracked file, again
+    * b43af70 Add yet another line
+    * 5284afd initial commit with two lines
     ");
 
     insta::assert_snapshot!(visualize_tree(&repo, &outcome)?, @r#"
@@ -606,8 +606,8 @@ fn insert_commit_into_single_stack_with_signatures() -> anyhow::Result<()> {
     write_vrbranches_to_refs(&vb, &repo)?;
     let rewritten_head_id = repo.head_id()?.detach();
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
-    * 3d1262e (HEAD -> main) insert 10 lines to the top
-    * 3aec753 (s1-b/init) between initial and former first
+    * a8fbed8 (HEAD -> main) insert 10 lines to the top
+    * 170d5fe (s1-b/init) between initial and former first
     * ecd6722 (tag: first-commit, first-commit) init
     ");
     insta::assert_snapshot!(but_testsupport::visualize_tree(rewritten_head_id.attach(&repo)), @r#"
@@ -622,7 +622,7 @@ fn insert_commit_into_single_stack_with_signatures() -> anyhow::Result<()> {
     CreateCommitOutcome {
         rejected_specs: [],
         new_commit: Some(
-            Sha1(3aec75308383b83d85a78a90308a618755a7b0f8),
+            Sha1(170d5fe258ee28dd6de85bfd6d566231c446d8ec),
         ),
         changed_tree_pre_cherry_pick: Some(
             Sha1(5fdd31363b3f0987135feaa00a734ca31e1652d6),
@@ -633,7 +633,7 @@ fn insert_commit_into_single_stack_with_signatures() -> anyhow::Result<()> {
                     "",
                 ),
                 old_commit_id: Sha1(ecd67221705b069c4f46365a46c8f2cd8a97ec19),
-                new_commit_id: Sha1(3aec75308383b83d85a78a90308a618755a7b0f8),
+                new_commit_id: Sha1(170d5fe258ee28dd6de85bfd6d566231c446d8ec),
             },
             UpdatedReference {
                 reference: Git(
@@ -642,27 +642,27 @@ fn insert_commit_into_single_stack_with_signatures() -> anyhow::Result<()> {
                     ),
                 ),
                 old_commit_id: Sha1(8b9db8455554fe317ea3ab86b9a042805326b493),
-                new_commit_id: Sha1(3d1262e63b945d97e1eaeb736b48cf4dcdb3e9cf),
+                new_commit_id: Sha1(a8fbed8ea304d850e168033468be9d9f128e17c3),
             },
             UpdatedReference {
                 reference: Virtual(
                     "s1-b/init",
                 ),
                 old_commit_id: Sha1(ecd67221705b069c4f46365a46c8f2cd8a97ec19),
-                new_commit_id: Sha1(3aec75308383b83d85a78a90308a618755a7b0f8),
+                new_commit_id: Sha1(170d5fe258ee28dd6de85bfd6d566231c446d8ec),
             },
         ],
         rebase_output: Some(
             RebaseOutput {
-                top_commit: Sha1(3d1262e63b945d97e1eaeb736b48cf4dcdb3e9cf),
+                top_commit: Sha1(a8fbed8ea304d850e168033468be9d9f128e17c3),
                 references: [],
                 commit_mapping: [
                     (
                         Some(
-                            Sha1(3aec75308383b83d85a78a90308a618755a7b0f8),
+                            Sha1(170d5fe258ee28dd6de85bfd6d566231c446d8ec),
                         ),
                         Sha1(8b9db8455554fe317ea3ab86b9a042805326b493),
-                        Sha1(3d1262e63b945d97e1eaeb736b48cf4dcdb3e9cf),
+                        Sha1(a8fbed8ea304d850e168033468be9d9f128e17c3),
                     ),
                 ],
             },
@@ -699,8 +699,8 @@ fn insert_commit_into_single_stack_with_signatures() -> anyhow::Result<()> {
     )?;
     let rewritten_head_id = repo.head_id()?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
-    * 4b649eb (HEAD -> main) insert 10 lines to the top
-    * d26d789 (s1-b/init) between initial and former first
+    * 07a0229 (HEAD -> main) insert 10 lines to the top
+    * d9d87b9 (s1-b/init) between initial and former first
     * ecd6722 (tag: first-commit, first-commit) init
     ");
     insta::assert_snapshot!(but_testsupport::visualize_tree(rewritten_head_id), @r#"
@@ -760,8 +760,8 @@ fn branch_tip_below_non_merge_workspace_commit() -> anyhow::Result<()> {
 
     write_vrbranches_to_refs(&vb, &repo)?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, repo.head_id()?)?, @r"
-    * ec84c94 (HEAD -> main) insert 20 lines to the top
-    * 82bb267 (s1-b/init) extend lines to 110
+    * 5f32f5c (HEAD -> main) insert 20 lines to the top
+    * e798e62 (s1-b/init) extend lines to 110
     * 4342edf (tag: first-commit) init
     ");
 
@@ -866,10 +866,10 @@ fn insert_commits_into_workspace() -> anyhow::Result<()> {
 
     let rewritten_head_id = repo.head_id()?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
-    *   a97960f (HEAD -> merge) Merge branch 'A' into merge
+    *   7f680d5 (HEAD -> merge) Merge branch 'A' into merge
     |\  
     | * 3538622 (A) add 10 to the beginning
-    * | 46991ae (s1-b/init) add 10 more lines at end
+    * | 9762353 (s1-b/init) add 10 more lines at end
     * | e81b470 (B) add 10 to the end
     |/  
     * 9cf2979 (main) init
@@ -1141,9 +1141,9 @@ fn merge_commit_remains_unsigned_in_remerge() -> anyhow::Result<()> {
 
     let rewritten_head_id = repo.head_id()?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
-    *   595a255 (HEAD -> merge) Merge branch 'A' into merge
+    *   7044c9b (HEAD -> merge) Merge branch 'A' into merge
     |\  
-    | * 057f154 (s1-b/top) remove 5 lines from beginning
+    | * 12d8f47 (s1-b/top) remove 5 lines from beginning
     | * eede47d (A) add 10 to the beginning
     * | 16fe86e (B) add 10 to the end
     |/  
@@ -1227,7 +1227,7 @@ fn two_commits_three_buckets_disambiguate_insertion_position_to_one_below_top() 
 
     write_vrbranches_to_refs(&vb, &repo)?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, outcome.new_commit.unwrap())?, @r"
-    * 8e21dd3 (HEAD -> main, C, B) replace 'file' with 5 lines
+    * 2185d68 (HEAD -> main, C, B) replace 'file' with 5 lines
     * e399378 2
     * 2db94ad (A) 1
     ");
@@ -1285,7 +1285,7 @@ fn two_commits_three_buckets_disambiguate_insertion_position_to_top() -> anyhow:
 
     write_vrbranches_to_refs(&vb, &repo)?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, outcome.new_commit.unwrap())?, @r"
-    * 8e21dd3 (HEAD -> main, C) replace 'file' with 5 lines
+    * 2185d68 (HEAD -> main, C) replace 'file' with 5 lines
     * e399378 (B) 2
     * 2db94ad (A) 1
     ");
@@ -1362,9 +1362,9 @@ fn commit_on_top_of_branch_in_workspace() -> anyhow::Result<()> {
 
     let rewritten_head_id = repo.head_id()?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
-    *   09ac476 (HEAD -> merge) Merge branch 'A' into merge
+    *   f00525a (HEAD -> merge) Merge branch 'A' into merge
     |\  
-    | * 99f3a1c (s1-b/top) remove 5 lines from beginning
+    | * 608f07b (s1-b/top) remove 5 lines from beginning
     | * 7f389ed (s1-b/below-top, A) add 10 to the beginning
     * | 91ef6f6 (s2-b/top, s2-b/below-top, B) add 10 to the end
     |/  
@@ -1450,11 +1450,11 @@ fn commit_on_top_of_branch_in_workspace() -> anyhow::Result<()> {
     let rewritten_head_id = repo.head_id()?;
     // The B-segment refs moved
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
-    *   098effd (HEAD -> merge) Merge branch 'A' into merge
+    *   376bcdb (HEAD -> merge) Merge branch 'A' into merge
     |\  
-    | * 99f3a1c (s1-b/top) remove 5 lines from beginning
+    | * 608f07b (s1-b/top) remove 5 lines from beginning
     | * 7f389ed (s1-b/below-top, A) add 10 to the beginning
-    * | 03e9b6f (s2-b/top) remove 5 lines from the end
+    * | b5ec010 (s2-b/top) remove 5 lines from the end
     * | 91ef6f6 (s2-b/below-top, B) add 10 to the end
     |/  
     * ff045ef (main) init
@@ -1520,12 +1520,12 @@ fn commit_on_top_of_branch_in_workspace() -> anyhow::Result<()> {
     let rewritten_head_id = repo.head_id()?;
     // The empty commit was inserted.
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
-    *   b2df034 (HEAD -> merge) Merge branch 'A' into merge
+    *   4e7e322 (HEAD -> merge) Merge branch 'A' into merge
     |\  
-    | * 99f3a1c (s1-b/top) remove 5 lines from beginning
+    | * 608f07b (s1-b/top) remove 5 lines from beginning
     | * 7f389ed (s1-b/below-top, A) add 10 to the beginning
-    * | deef8f7 (s2-b/top) empty commmit
-    * | 03e9b6f remove 5 lines from the end
+    * | 262b17d (s2-b/top) empty commmit
+    * | b5ec010 remove 5 lines from the end
     * | 91ef6f6 (s2-b/below-top, B) add 10 to the end
     |/  
     * ff045ef (main) init
@@ -1578,7 +1578,7 @@ fn amend_on_top_of_branch_in_workspace() -> anyhow::Result<()> {
 
     let rewritten_head_id = repo.head_id()?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
-    *   20d9863 (HEAD -> merge) Merge branch 'A' into merge
+    *   0bb4efb (HEAD -> merge) Merge branch 'A' into merge
     |\  
     | * 3edfe68 (s1-b/top, A) add 10 to the beginning
     * | 91ef6f6 (B) add 10 to the end
@@ -1655,7 +1655,7 @@ fn amend_edit_message_only() -> anyhow::Result<()> {
     let rewritten_head_id = repo.head_id()?;
     // TODO: make some change observable.
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
-    *   244ac76 (HEAD -> merge) Merge branch 'A' into merge
+    *   42690f2 (HEAD -> merge) Merge branch 'A' into merge
     |\  
     | * bc22104 (s1-b/top, A) add 10 to the beginning (amended)
     * | 91ef6f6 (B) add 10 to the end

--- a/crates/but-workspace/tests/workspace/ref_info/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/mod.rs
@@ -19,6 +19,7 @@ fn unborn_untracked() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: None,
                 base: None,
                 segments: [
                     ref_info::ui::Segment {
@@ -56,6 +57,7 @@ fn detached() -> anyhow::Result<()> {
         workspace_ref_name: None,
         stacks: [
             Stack {
+                id: None,
                 base: None,
                 segments: [
                     ref_info::ui::Segment {
@@ -98,6 +100,7 @@ fn conflicted_in_local_branch() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: None,
                 base: None,
                 segments: [
                     ref_info::ui::Segment {
@@ -146,6 +149,7 @@ fn single_branch() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: None,
                 base: None,
                 segments: [
                     ref_info::ui::Segment {
@@ -197,6 +201,7 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: None,
                 base: None,
                 segments: [
                     ref_info::ui::Segment {

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
@@ -16,39 +16,40 @@ fn j01_unborn() -> anyhow::Result<()> {
 
     let info = but_workspace::head_info(&repo, &*meta, standard_options());
     insta::assert_debug_snapshot!(info, @r#"
-Ok(
-    RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/main",
+    Ok(
+        RefInfo {
+            workspace_ref_name: Some(
+                FullName(
+                    "refs/heads/main",
+                ),
             ),
-        ),
-        stacks: [
-            Stack {
-                base: None,
-                segments: [
-                    ref_info::ui::Segment {
-                        id: NodeIndex(0),
-                        ref_name: "refs/heads/main",
-                        remote_tracking_ref_name: "None",
-                        commits: [],
-                        commits_unique_in_remote_tracking_branch: [],
-                        metadata: "None",
-                        push_status: CompletelyUnpushed,
-                        base: "None",
-                    },
-                ],
-            },
-        ],
-        target: None,
-        extra_target: None,
-        lower_bound: None,
-        is_managed_ref: false,
-        is_managed_commit: false,
-        is_entrypoint: true,
-    },
-)
-"#);
+            stacks: [
+                Stack {
+                    id: None,
+                    base: None,
+                    segments: [
+                        ref_info::ui::Segment {
+                            id: NodeIndex(0),
+                            ref_name: "refs/heads/main",
+                            remote_tracking_ref_name: "None",
+                            commits: [],
+                            commits_unique_in_remote_tracking_branch: [],
+                            metadata: "None",
+                            push_status: CompletelyUnpushed,
+                            base: "None",
+                        },
+                    ],
+                },
+            ],
+            target: None,
+            extra_target: None,
+            lower_bound: None,
+            is_managed_ref: false,
+            is_managed_commit: false,
+            is_entrypoint: true,
+        },
+    )
+    "#);
     Ok(())
 }
 
@@ -60,41 +61,42 @@ fn j02_first_commit() -> anyhow::Result<()> {
 
     let info = but_workspace::head_info(&repo, &*meta, standard_options());
     insta::assert_debug_snapshot!(info, @r#"
-Ok(
-    RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/main",
+    Ok(
+        RefInfo {
+            workspace_ref_name: Some(
+                FullName(
+                    "refs/heads/main",
+                ),
             ),
-        ),
-        stacks: [
-            Stack {
-                base: None,
-                segments: [
-                    ref_info::ui::Segment {
-                        id: NodeIndex(0),
-                        ref_name: "refs/heads/main",
-                        remote_tracking_ref_name: "None",
-                        commits: [
-                            LocalCommit(fafd9d0, "init\n", local),
-                        ],
-                        commits_unique_in_remote_tracking_branch: [],
-                        metadata: "None",
-                        push_status: CompletelyUnpushed,
-                        base: "None",
-                    },
-                ],
-            },
-        ],
-        target: None,
-        extra_target: None,
-        lower_bound: None,
-        is_managed_ref: false,
-        is_managed_commit: false,
-        is_entrypoint: true,
-    },
-)
-"#);
+            stacks: [
+                Stack {
+                    id: None,
+                    base: None,
+                    segments: [
+                        ref_info::ui::Segment {
+                            id: NodeIndex(0),
+                            ref_name: "refs/heads/main",
+                            remote_tracking_ref_name: "None",
+                            commits: [
+                                LocalCommit(fafd9d0, "init\n", local),
+                            ],
+                            commits_unique_in_remote_tracking_branch: [],
+                            metadata: "None",
+                            push_status: CompletelyUnpushed,
+                            base: "None",
+                        },
+                    ],
+                },
+            ],
+            target: None,
+            extra_target: None,
+            lower_bound: None,
+            is_managed_ref: false,
+            is_managed_commit: false,
+            is_entrypoint: true,
+        },
+    )
+    "#);
     Ok(())
 }
 
@@ -110,41 +112,42 @@ However, without an official workspace it still won't be acting as a target.
 
     let info = but_workspace::head_info(&repo, &*meta, standard_options());
     insta::assert_debug_snapshot!(info, @r#"
-Ok(
-    RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/main",
+    Ok(
+        RefInfo {
+            workspace_ref_name: Some(
+                FullName(
+                    "refs/heads/main",
+                ),
             ),
-        ),
-        stacks: [
-            Stack {
-                base: None,
-                segments: [
-                    ref_info::ui::Segment {
-                        id: NodeIndex(0),
-                        ref_name: "refs/heads/main",
-                        remote_tracking_ref_name: "None",
-                        commits: [
-                            LocalCommit(fafd9d0, "init\n", local),
-                        ],
-                        commits_unique_in_remote_tracking_branch: [],
-                        metadata: "None",
-                        push_status: CompletelyUnpushed,
-                        base: "None",
-                    },
-                ],
-            },
-        ],
-        target: None,
-        extra_target: None,
-        lower_bound: None,
-        is_managed_ref: false,
-        is_managed_commit: false,
-        is_entrypoint: true,
-    },
-)
-"#);
+            stacks: [
+                Stack {
+                    id: None,
+                    base: None,
+                    segments: [
+                        ref_info::ui::Segment {
+                            id: NodeIndex(0),
+                            ref_name: "refs/heads/main",
+                            remote_tracking_ref_name: "None",
+                            commits: [
+                                LocalCommit(fafd9d0, "init\n", local),
+                            ],
+                            commits_unique_in_remote_tracking_branch: [],
+                            metadata: "None",
+                            push_status: CompletelyUnpushed,
+                            base: "None",
+                        },
+                    ],
+                },
+            ],
+            target: None,
+            extra_target: None,
+            lower_bound: None,
+            is_managed_ref: false,
+            is_managed_commit: false,
+            is_entrypoint: true,
+        },
+    )
+    "#);
 
     let info = but_workspace::head_info(
         &repo,
@@ -154,43 +157,44 @@ Ok(
     // With an extra target, even in this situation we have a notion of upstream commits.
     // Thus it's possible to compute the integation status.
     insta::assert_debug_snapshot!(info, @r#"
-Ok(
-    RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/main",
+    Ok(
+        RefInfo {
+            workspace_ref_name: Some(
+                FullName(
+                    "refs/heads/main",
+                ),
             ),
-        ),
-        stacks: [
-            Stack {
-                base: None,
-                segments: [
-                    ref_info::ui::Segment {
-                        id: NodeIndex(0),
-                        ref_name: "refs/heads/main",
-                        remote_tracking_ref_name: "None",
-                        commits: [
-                            LocalCommit(fafd9d0, "init\n", integrated(fafd9d0)),
-                        ],
-                        commits_unique_in_remote_tracking_branch: [],
-                        metadata: "None",
-                        push_status: CompletelyUnpushed,
-                        base: "None",
-                    },
-                ],
-            },
-        ],
-        target: None,
-        extra_target: Some(
-            NodeIndex(0),
-        ),
-        lower_bound: None,
-        is_managed_ref: false,
-        is_managed_commit: false,
-        is_entrypoint: true,
-    },
-)
-"#);
+            stacks: [
+                Stack {
+                    id: None,
+                    base: None,
+                    segments: [
+                        ref_info::ui::Segment {
+                            id: NodeIndex(0),
+                            ref_name: "refs/heads/main",
+                            remote_tracking_ref_name: "None",
+                            commits: [
+                                LocalCommit(fafd9d0, "init\n", integrated(fafd9d0)),
+                            ],
+                            commits_unique_in_remote_tracking_branch: [],
+                            metadata: "None",
+                            push_status: CompletelyUnpushed,
+                            base: "None",
+                        },
+                    ],
+                },
+            ],
+            target: None,
+            extra_target: Some(
+                NodeIndex(0),
+            ),
+            lower_bound: None,
+            is_managed_ref: false,
+            is_managed_commit: false,
+            is_entrypoint: true,
+        },
+    )
+    "#);
     Ok(())
 }
 
@@ -251,51 +255,54 @@ fn j05_empty_stack() -> anyhow::Result<()> {
     add_stack_with_segments(&mut meta, 0, "S1", StackState::InWorkspace, &[]);
     let info = but_workspace::head_info(&repo, &*meta, standard_options());
     insta::assert_debug_snapshot!(info, @r#"
-Ok(
-    RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
+    Ok(
+        RefInfo {
+            workspace_ref_name: Some(
+                FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
             ),
-        ),
-        stacks: [
-            Stack {
-                base: Some(
-                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
-                ),
-                segments: [
-                    ref_info::ui::Segment {
-                        id: NodeIndex(3),
-                        ref_name: "refs/heads/S1",
-                        remote_tracking_ref_name: "None",
-                        commits: [],
-                        commits_unique_in_remote_tracking_branch: [],
-                        metadata: Branch,
-                        push_status: CompletelyUnpushed,
-                        base: "fafd9d0",
-                    },
-                ],
-            },
-        ],
-        target: Some(
-            Target {
-                ref_name: FullName(
-                    "refs/remotes/origin/main",
-                ),
-                segment_index: NodeIndex(1),
-                commits_ahead: 0,
-            },
-        ),
-        extra_target: None,
-        lower_bound: Some(
-            NodeIndex(2),
-        ),
-        is_managed_ref: true,
-        is_managed_commit: true,
-        is_entrypoint: true,
-    },
-)
-"#);
+            stacks: [
+                Stack {
+                    id: Some(
+                        00000000-0000-0000-0000-000000000000,
+                    ),
+                    base: Some(
+                        Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                    ),
+                    segments: [
+                        ref_info::ui::Segment {
+                            id: NodeIndex(3),
+                            ref_name: "refs/heads/S1",
+                            remote_tracking_ref_name: "None",
+                            commits: [],
+                            commits_unique_in_remote_tracking_branch: [],
+                            metadata: Branch,
+                            push_status: CompletelyUnpushed,
+                            base: "fafd9d0",
+                        },
+                    ],
+                },
+            ],
+            target: Some(
+                Target {
+                    ref_name: FullName(
+                        "refs/remotes/origin/main",
+                    ),
+                    segment_index: NodeIndex(1),
+                    commits_ahead: 0,
+                },
+            ),
+            extra_target: None,
+            lower_bound: Some(
+                NodeIndex(2),
+            ),
+            is_managed_ref: true,
+            is_managed_commit: true,
+            is_entrypoint: true,
+        },
+    )
+    "#);
     Ok(())
 }
 
@@ -312,104 +319,108 @@ fn j06_create_commit_in_stack() -> anyhow::Result<()> {
     // Now that there is a commit, the stack is picked up automatically, but without additional data.
     let info = but_workspace::head_info(&repo, &*meta, standard_options());
     insta::assert_debug_snapshot!(info, @r#"
-Ok(
-    RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
+    Ok(
+        RefInfo {
+            workspace_ref_name: Some(
+                FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
             ),
-        ),
-        stacks: [
-            Stack {
-                base: Some(
-                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
-                ),
-                segments: [
-                    ref_info::ui::Segment {
-                        id: NodeIndex(3),
-                        ref_name: "refs/heads/S1",
-                        remote_tracking_ref_name: "None",
-                        commits: [
-                            LocalCommit(ba16348, "one\n", local),
-                        ],
-                        commits_unique_in_remote_tracking_branch: [],
-                        metadata: "None",
-                        push_status: CompletelyUnpushed,
-                        base: "fafd9d0",
-                    },
-                ],
-            },
-        ],
-        target: Some(
-            Target {
-                ref_name: FullName(
-                    "refs/remotes/origin/main",
-                ),
-                segment_index: NodeIndex(1),
-                commits_ahead: 0,
-            },
-        ),
-        extra_target: None,
-        lower_bound: Some(
-            NodeIndex(2),
-        ),
-        is_managed_ref: true,
-        is_managed_commit: true,
-        is_entrypoint: true,
-    },
-)
-"#);
+            stacks: [
+                Stack {
+                    id: None,
+                    base: Some(
+                        Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                    ),
+                    segments: [
+                        ref_info::ui::Segment {
+                            id: NodeIndex(3),
+                            ref_name: "refs/heads/S1",
+                            remote_tracking_ref_name: "None",
+                            commits: [
+                                LocalCommit(ba16348, "one\n", local),
+                            ],
+                            commits_unique_in_remote_tracking_branch: [],
+                            metadata: "None",
+                            push_status: CompletelyUnpushed,
+                            base: "fafd9d0",
+                        },
+                    ],
+                },
+            ],
+            target: Some(
+                Target {
+                    ref_name: FullName(
+                        "refs/remotes/origin/main",
+                    ),
+                    segment_index: NodeIndex(1),
+                    commits_ahead: 0,
+                },
+            ),
+            extra_target: None,
+            lower_bound: Some(
+                NodeIndex(2),
+            ),
+            is_managed_ref: true,
+            is_managed_commit: true,
+            is_entrypoint: true,
+        },
+    )
+    "#);
 
     add_stack_with_segments(&mut meta, 0, "S1", StackState::InWorkspace, &[]);
     let info = but_workspace::head_info(&repo, &*meta, standard_options());
     insta::assert_debug_snapshot!(info, @r#"
-Ok(
-    RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
+    Ok(
+        RefInfo {
+            workspace_ref_name: Some(
+                FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
             ),
-        ),
-        stacks: [
-            Stack {
-                base: Some(
-                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
-                ),
-                segments: [
-                    ref_info::ui::Segment {
-                        id: NodeIndex(3),
-                        ref_name: "refs/heads/S1",
-                        remote_tracking_ref_name: "None",
-                        commits: [
-                            LocalCommit(ba16348, "one\n", local),
-                        ],
-                        commits_unique_in_remote_tracking_branch: [],
-                        metadata: Branch,
-                        push_status: CompletelyUnpushed,
-                        base: "fafd9d0",
-                    },
-                ],
-            },
-        ],
-        target: Some(
-            Target {
-                ref_name: FullName(
-                    "refs/remotes/origin/main",
-                ),
-                segment_index: NodeIndex(1),
-                commits_ahead: 0,
-            },
-        ),
-        extra_target: None,
-        lower_bound: Some(
-            NodeIndex(2),
-        ),
-        is_managed_ref: true,
-        is_managed_commit: true,
-        is_entrypoint: true,
-    },
-)
-"#);
+            stacks: [
+                Stack {
+                    id: Some(
+                        00000000-0000-0000-0000-000000000000,
+                    ),
+                    base: Some(
+                        Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                    ),
+                    segments: [
+                        ref_info::ui::Segment {
+                            id: NodeIndex(3),
+                            ref_name: "refs/heads/S1",
+                            remote_tracking_ref_name: "None",
+                            commits: [
+                                LocalCommit(ba16348, "one\n", local),
+                            ],
+                            commits_unique_in_remote_tracking_branch: [],
+                            metadata: Branch,
+                            push_status: CompletelyUnpushed,
+                            base: "fafd9d0",
+                        },
+                    ],
+                },
+            ],
+            target: Some(
+                Target {
+                    ref_name: FullName(
+                        "refs/remotes/origin/main",
+                    ),
+                    segment_index: NodeIndex(1),
+                    commits_ahead: 0,
+                },
+            ),
+            extra_target: None,
+            lower_bound: Some(
+                NodeIndex(2),
+            ),
+            is_managed_ref: true,
+            is_managed_commit: true,
+            is_entrypoint: true,
+        },
+    )
+    "#);
     Ok(())
 }
 
@@ -426,53 +437,56 @@ fn j07_push_commit() -> anyhow::Result<()> {
     add_stack_with_segments(&mut meta, 0, "S1", StackState::InWorkspace, &[]);
     let info = but_workspace::head_info(&repo, &*meta, standard_options());
     insta::assert_debug_snapshot!(info, @r#"
-Ok(
-    RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
+    Ok(
+        RefInfo {
+            workspace_ref_name: Some(
+                FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
             ),
-        ),
-        stacks: [
-            Stack {
-                base: Some(
-                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
-                ),
-                segments: [
-                    ref_info::ui::Segment {
-                        id: NodeIndex(3),
-                        ref_name: "refs/heads/S1",
-                        remote_tracking_ref_name: "refs/remotes/origin/S1",
-                        commits: [
-                            LocalCommit(ba16348, "one\n", local/remote(identity)),
-                        ],
-                        commits_unique_in_remote_tracking_branch: [],
-                        metadata: Branch,
-                        push_status: NothingToPush,
-                        base: "fafd9d0",
-                    },
-                ],
-            },
-        ],
-        target: Some(
-            Target {
-                ref_name: FullName(
-                    "refs/remotes/origin/main",
-                ),
-                segment_index: NodeIndex(1),
-                commits_ahead: 0,
-            },
-        ),
-        extra_target: None,
-        lower_bound: Some(
-            NodeIndex(2),
-        ),
-        is_managed_ref: true,
-        is_managed_commit: true,
-        is_entrypoint: true,
-    },
-)
-"#);
+            stacks: [
+                Stack {
+                    id: Some(
+                        00000000-0000-0000-0000-000000000000,
+                    ),
+                    base: Some(
+                        Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                    ),
+                    segments: [
+                        ref_info::ui::Segment {
+                            id: NodeIndex(3),
+                            ref_name: "refs/heads/S1",
+                            remote_tracking_ref_name: "refs/remotes/origin/S1",
+                            commits: [
+                                LocalCommit(ba16348, "one\n", local/remote(identity)),
+                            ],
+                            commits_unique_in_remote_tracking_branch: [],
+                            metadata: Branch,
+                            push_status: NothingToPush,
+                            base: "fafd9d0",
+                        },
+                    ],
+                },
+            ],
+            target: Some(
+                Target {
+                    ref_name: FullName(
+                        "refs/remotes/origin/main",
+                    ),
+                    segment_index: NodeIndex(1),
+                    commits_ahead: 0,
+                },
+            ),
+            extra_target: None,
+            lower_bound: Some(
+                NodeIndex(2),
+            ),
+            is_managed_ref: true,
+            is_managed_commit: true,
+            is_entrypoint: true,
+        },
+    )
+    "#);
     Ok(())
 }
 
@@ -494,54 +508,57 @@ Create a new local commit right after the previous pushed one
     add_stack_with_segments(&mut meta, 0, "S1", StackState::InWorkspace, &[]);
     let info = but_workspace::head_info(&repo, &*meta, standard_options());
     insta::assert_debug_snapshot!(info, @r#"
-Ok(
-    RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
+    Ok(
+        RefInfo {
+            workspace_ref_name: Some(
+                FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
             ),
-        ),
-        stacks: [
-            Stack {
-                base: Some(
-                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
-                ),
-                segments: [
-                    ref_info::ui::Segment {
-                        id: NodeIndex(3),
-                        ref_name: "refs/heads/S1",
-                        remote_tracking_ref_name: "refs/remotes/origin/S1",
-                        commits: [
-                            LocalCommit(9f4d478, "two\n", local),
-                            LocalCommit(ba16348, "one\n", local/remote(identity)),
-                        ],
-                        commits_unique_in_remote_tracking_branch: [],
-                        metadata: Branch,
-                        push_status: UnpushedCommits,
-                        base: "fafd9d0",
-                    },
-                ],
-            },
-        ],
-        target: Some(
-            Target {
-                ref_name: FullName(
-                    "refs/remotes/origin/main",
-                ),
-                segment_index: NodeIndex(1),
-                commits_ahead: 0,
-            },
-        ),
-        extra_target: None,
-        lower_bound: Some(
-            NodeIndex(2),
-        ),
-        is_managed_ref: true,
-        is_managed_commit: true,
-        is_entrypoint: true,
-    },
-)
-"#);
+            stacks: [
+                Stack {
+                    id: Some(
+                        00000000-0000-0000-0000-000000000000,
+                    ),
+                    base: Some(
+                        Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                    ),
+                    segments: [
+                        ref_info::ui::Segment {
+                            id: NodeIndex(3),
+                            ref_name: "refs/heads/S1",
+                            remote_tracking_ref_name: "refs/remotes/origin/S1",
+                            commits: [
+                                LocalCommit(9f4d478, "two\n", local),
+                                LocalCommit(ba16348, "one\n", local/remote(identity)),
+                            ],
+                            commits_unique_in_remote_tracking_branch: [],
+                            metadata: Branch,
+                            push_status: UnpushedCommits,
+                            base: "fafd9d0",
+                        },
+                    ],
+                },
+            ],
+            target: Some(
+                Target {
+                    ref_name: FullName(
+                        "refs/remotes/origin/main",
+                    ),
+                    segment_index: NodeIndex(1),
+                    commits_ahead: 0,
+                },
+            ),
+            extra_target: None,
+            lower_bound: Some(
+                NodeIndex(2),
+            ),
+            is_managed_ref: true,
+            is_managed_commit: true,
+            is_entrypoint: true,
+        },
+    )
+    "#);
     Ok(())
 }
 
@@ -570,6 +587,9 @@ fn j09_rewritten_remote_and_local_commit() -> anyhow::Result<()> {
             ),
             stacks: [
                 Stack {
+                    id: Some(
+                        00000000-0000-0000-0000-000000000000,
+                    ),
                     base: Some(
                         Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                     ),
@@ -635,54 +655,57 @@ The remote squash-merges S1 *and* changes the 'file' so it looks entirely differ
     add_stack_with_segments(&mut meta, 0, "S1", StackState::InWorkspace, &[]);
     let info = but_workspace::head_info(&repo, &*meta, standard_options());
     insta::assert_debug_snapshot!(info, @r#"
-Ok(
-    RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
+    Ok(
+        RefInfo {
+            workspace_ref_name: Some(
+                FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
             ),
-        ),
-        stacks: [
-            Stack {
-                base: Some(
-                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
-                ),
-                segments: [
-                    ref_info::ui::Segment {
-                        id: NodeIndex(3),
-                        ref_name: "refs/heads/S1",
-                        remote_tracking_ref_name: "refs/remotes/origin/S1",
-                        commits: [
-                            LocalCommit(314cacb, "two\n", integrated(d110262)),
-                            LocalCommit(3234835, "one\n", integrated(d110262)),
-                        ],
-                        commits_unique_in_remote_tracking_branch: [],
-                        metadata: Branch,
-                        push_status: Integrated,
-                        base: "fafd9d0",
-                    },
-                ],
-            },
-        ],
-        target: Some(
-            Target {
-                ref_name: FullName(
-                    "refs/remotes/origin/main",
-                ),
-                segment_index: NodeIndex(1),
-                commits_ahead: 2,
-            },
-        ),
-        extra_target: None,
-        lower_bound: Some(
-            NodeIndex(2),
-        ),
-        is_managed_ref: true,
-        is_managed_commit: true,
-        is_entrypoint: true,
-    },
-)
-"#);
+            stacks: [
+                Stack {
+                    id: Some(
+                        00000000-0000-0000-0000-000000000000,
+                    ),
+                    base: Some(
+                        Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                    ),
+                    segments: [
+                        ref_info::ui::Segment {
+                            id: NodeIndex(3),
+                            ref_name: "refs/heads/S1",
+                            remote_tracking_ref_name: "refs/remotes/origin/S1",
+                            commits: [
+                                LocalCommit(314cacb, "two\n", integrated(d110262)),
+                                LocalCommit(3234835, "one\n", integrated(d110262)),
+                            ],
+                            commits_unique_in_remote_tracking_branch: [],
+                            metadata: Branch,
+                            push_status: Integrated,
+                            base: "fafd9d0",
+                        },
+                    ],
+                },
+            ],
+            target: Some(
+                Target {
+                    ref_name: FullName(
+                        "refs/remotes/origin/main",
+                    ),
+                    segment_index: NodeIndex(1),
+                    commits_ahead: 2,
+                },
+            ),
+            extra_target: None,
+            lower_bound: Some(
+                NodeIndex(2),
+            ),
+            is_managed_ref: true,
+            is_managed_commit: true,
+            is_entrypoint: true,
+        },
+    )
+    "#);
     Ok(())
 }
 
@@ -719,57 +742,60 @@ The remote was re-used and merged once more with more changes.
     // TODO: remote-only squashes aren't currently detected (so remote commits are visible),
     //       but could be if it was common.
     insta::assert_debug_snapshot!(info, @r#"
-Ok(
-    RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
+    Ok(
+        RefInfo {
+            workspace_ref_name: Some(
+                FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
             ),
-        ),
-        stacks: [
-            Stack {
-                base: Some(
-                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
-                ),
-                segments: [
-                    ref_info::ui::Segment {
-                        id: NodeIndex(3),
-                        ref_name: "refs/heads/S1",
-                        remote_tracking_ref_name: "refs/remotes/origin/S1",
-                        commits: [
-                            LocalCommit(314cacb, "two\n", integrated(d110262)),
-                            LocalCommit(3234835, "one\n", integrated(d110262)),
-                        ],
-                        commits_unique_in_remote_tracking_branch: [
-                            Commit(16d0628, "add other remote file\n"),
-                            Commit(66fe1d7, "add remote file\n"),
-                        ],
-                        metadata: Branch,
-                        push_status: Integrated,
-                        base: "fafd9d0",
-                    },
-                ],
-            },
-        ],
-        target: Some(
-            Target {
-                ref_name: FullName(
-                    "refs/remotes/origin/main",
-                ),
-                segment_index: NodeIndex(1),
-                commits_ahead: 5,
-            },
-        ),
-        extra_target: None,
-        lower_bound: Some(
-            NodeIndex(5),
-        ),
-        is_managed_ref: true,
-        is_managed_commit: true,
-        is_entrypoint: true,
-    },
-)
-"#);
+            stacks: [
+                Stack {
+                    id: Some(
+                        00000000-0000-0000-0000-000000000000,
+                    ),
+                    base: Some(
+                        Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                    ),
+                    segments: [
+                        ref_info::ui::Segment {
+                            id: NodeIndex(3),
+                            ref_name: "refs/heads/S1",
+                            remote_tracking_ref_name: "refs/remotes/origin/S1",
+                            commits: [
+                                LocalCommit(314cacb, "two\n", integrated(d110262)),
+                                LocalCommit(3234835, "one\n", integrated(d110262)),
+                            ],
+                            commits_unique_in_remote_tracking_branch: [
+                                Commit(16d0628, "add other remote file\n"),
+                                Commit(66fe1d7, "add remote file\n"),
+                            ],
+                            metadata: Branch,
+                            push_status: Integrated,
+                            base: "fafd9d0",
+                        },
+                    ],
+                },
+            ],
+            target: Some(
+                Target {
+                    ref_name: FullName(
+                        "refs/remotes/origin/main",
+                    ),
+                    segment_index: NodeIndex(1),
+                    commits_ahead: 5,
+                },
+            ),
+            extra_target: None,
+            lower_bound: Some(
+                NodeIndex(5),
+            ),
+            is_managed_ref: true,
+            is_managed_commit: true,
+            is_entrypoint: true,
+        },
+    )
+    "#);
     Ok(())
 }
 
@@ -811,88 +837,94 @@ A new multi-segment stack is created without remote and squash merged locally.
     add_stack_with_segments(&mut meta, 0, "S1", StackState::InWorkspace, &[]);
     let info = but_workspace::head_info(&repo, &*meta, standard_options());
     insta::assert_debug_snapshot!(info, @r#"
-Ok(
-    RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
+    Ok(
+        RefInfo {
+            workspace_ref_name: Some(
+                FullName(
+                    "refs/heads/gitbutler/workspace",
+                ),
             ),
-        ),
-        stacks: [
-            Stack {
-                base: Some(
-                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
-                ),
-                segments: [
-                    ref_info::ui::Segment {
-                        id: NodeIndex(3),
-                        ref_name: "refs/heads/S1",
-                        remote_tracking_ref_name: "refs/remotes/origin/S1",
-                        commits: [
-                            LocalCommit(314cacb, "two\n", integrated(d110262)),
-                            LocalCommit(3234835, "one\n", integrated(d110262)),
-                        ],
-                        commits_unique_in_remote_tracking_branch: [
-                            Commit(16d0628, "add other remote file\n"),
-                            Commit(66fe1d7, "add remote file\n"),
-                        ],
-                        metadata: Branch,
-                        push_status: Integrated,
-                        base: "fafd9d0",
-                    },
-                ],
-            },
-            Stack {
-                base: Some(
-                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
-                ),
-                segments: [
-                    ref_info::ui::Segment {
-                        id: NodeIndex(5),
-                        ref_name: "refs/heads/local",
-                        remote_tracking_ref_name: "None",
-                        commits: [
-                            LocalCommit(1af5d57, "new local file\n", integrated(ca783a4)),
-                        ],
-                        commits_unique_in_remote_tracking_branch: [],
-                        metadata: "None",
-                        push_status: CompletelyUnpushed,
-                        base: "de02b20",
-                    },
-                    ref_info::ui::Segment {
-                        id: NodeIndex(6),
-                        ref_name: "refs/heads/local-bottom",
-                        remote_tracking_ref_name: "None",
-                        commits: [
-                            LocalCommit(de02b20, "new local-bottom file\n", integrated(ca783a4)),
-                        ],
-                        commits_unique_in_remote_tracking_branch: [],
-                        metadata: "None",
-                        push_status: CompletelyUnpushed,
-                        base: "fafd9d0",
-                    },
-                ],
-            },
-        ],
-        target: Some(
-            Target {
-                ref_name: FullName(
-                    "refs/remotes/origin/main",
-                ),
-                segment_index: NodeIndex(1),
-                commits_ahead: 7,
-            },
-        ),
-        extra_target: None,
-        lower_bound: Some(
-            NodeIndex(7),
-        ),
-        is_managed_ref: true,
-        is_managed_commit: true,
-        is_entrypoint: true,
-    },
-)
-"#);
+            stacks: [
+                Stack {
+                    id: Some(
+                        00000000-0000-0000-0000-000000000000,
+                    ),
+                    base: Some(
+                        Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                    ),
+                    segments: [
+                        ref_info::ui::Segment {
+                            id: NodeIndex(3),
+                            ref_name: "refs/heads/S1",
+                            remote_tracking_ref_name: "refs/remotes/origin/S1",
+                            commits: [
+                                LocalCommit(314cacb, "two\n", integrated(d110262)),
+                                LocalCommit(3234835, "one\n", integrated(d110262)),
+                            ],
+                            commits_unique_in_remote_tracking_branch: [
+                                Commit(16d0628, "add other remote file\n"),
+                                Commit(66fe1d7, "add remote file\n"),
+                            ],
+                            metadata: Branch,
+                            push_status: Integrated,
+                            base: "fafd9d0",
+                        },
+                    ],
+                },
+                Stack {
+                    id: Some(
+                        00000000-0000-0000-0000-000000000000,
+                    ),
+                    base: Some(
+                        Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                    ),
+                    segments: [
+                        ref_info::ui::Segment {
+                            id: NodeIndex(5),
+                            ref_name: "refs/heads/local",
+                            remote_tracking_ref_name: "None",
+                            commits: [
+                                LocalCommit(1af5d57, "new local file\n", integrated(ca783a4)),
+                            ],
+                            commits_unique_in_remote_tracking_branch: [],
+                            metadata: "None",
+                            push_status: CompletelyUnpushed,
+                            base: "de02b20",
+                        },
+                        ref_info::ui::Segment {
+                            id: NodeIndex(6),
+                            ref_name: "refs/heads/local-bottom",
+                            remote_tracking_ref_name: "None",
+                            commits: [
+                                LocalCommit(de02b20, "new local-bottom file\n", integrated(ca783a4)),
+                            ],
+                            commits_unique_in_remote_tracking_branch: [],
+                            metadata: "None",
+                            push_status: CompletelyUnpushed,
+                            base: "fafd9d0",
+                        },
+                    ],
+                },
+            ],
+            target: Some(
+                Target {
+                    ref_name: FullName(
+                        "refs/remotes/origin/main",
+                    ),
+                    segment_index: NodeIndex(1),
+                    commits_ahead: 7,
+                },
+            ),
+            extra_target: None,
+            lower_bound: Some(
+                NodeIndex(7),
+            ),
+            is_managed_ref: true,
+            is_managed_commit: true,
+            is_entrypoint: true,
+        },
+    )
+    "#);
     Ok(())
 }
 

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_merges.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_merges.rs
@@ -33,6 +33,7 @@ fn two_commits_require_force_push() -> anyhow::Result<()> {
             ),
             stacks: [
                 Stack {
+                    id: None,
                     base: Some(
                         Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                     ),
@@ -101,6 +102,7 @@ fn two_commits_require_force_push_merged() -> anyhow::Result<()> {
             ),
             stacks: [
                 Stack {
+                    id: None,
                     base: Some(
                         Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                     ),
@@ -171,6 +173,7 @@ fn remote_diverged() -> anyhow::Result<()> {
             ),
             stacks: [
                 Stack {
+                    id: None,
                     base: Some(
                         Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                     ),
@@ -251,6 +254,7 @@ fn remote_diverged_merge() -> anyhow::Result<()> {
             ),
             stacks: [
                 Stack {
+                    id: None,
                     base: Some(
                         Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                     ),
@@ -317,6 +321,7 @@ fn remote_behind() -> anyhow::Result<()> {
             ),
             stacks: [
                 Stack {
+                    id: None,
                     base: Some(
                         Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                     ),
@@ -390,6 +395,7 @@ fn remote_behind_merge_no_ff() -> anyhow::Result<()> {
             ),
             stacks: [
                 Stack {
+                    id: None,
                     base: Some(
                         Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                     ),
@@ -457,6 +463,7 @@ fn remote_ahead() -> anyhow::Result<()> {
             ),
             stacks: [
                 Stack {
+                    id: None,
                     base: Some(
                         Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                     ),
@@ -527,6 +534,7 @@ fn remote_ahead_merge_ff() -> anyhow::Result<()> {
             ),
             stacks: [
                 Stack {
+                    id: None,
                     base: Some(
                         Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                     ),

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_rebase.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_rebase.rs
@@ -36,6 +36,7 @@ fn two_commits_rebased_onto_target() -> anyhow::Result<()> {
             ),
             stacks: [
                 Stack {
+                    id: None,
                     base: Some(
                         Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                     ),
@@ -111,6 +112,7 @@ fn two_commits_rebased_onto_target_with_changeset_check() -> anyhow::Result<()> 
             ),
             stacks: [
                 Stack {
+                    id: None,
                     base: Some(
                         Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                     ),

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -52,6 +52,9 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
                 ),
@@ -106,6 +109,9 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
                 ),
@@ -164,6 +170,9 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
                 ),
@@ -235,6 +244,9 @@ fn two_dependent_branches_rebased_with_remotes() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000000,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -320,6 +332,9 @@ fn two_dependent_branches_rebased_explicit_remote_in_extra_segment() -> anyhow::
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000000,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -415,6 +430,9 @@ fn two_dependent_branches_first_merged_no_ff() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000000,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -507,6 +525,9 @@ fn two_dependent_branches_first_merged_no_ff_second_merged_on_remote_into_base_b
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000000,
+                ),
                 base: Some(
                     Sha1(0ee3a9e12c17b59a8507bbfe2ae98ab362feb21a),
                 ),
@@ -563,6 +584,9 @@ fn two_dependent_branches_first_merged_no_ff_second_merged_on_remote_into_base_b
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000000,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -645,6 +669,7 @@ fn two_dependent_branches_first_rebased_and_merged_into_target() -> anyhow::Resu
         ),
         stacks: [
             Stack {
+                id: None,
                 base: Some(
                     Sha1(281456a55524d78e1e0ecab946032423aec1abe8),
                 ),
@@ -711,6 +736,7 @@ fn two_dependent_branches_first_rebased_and_merged_into_target() -> anyhow::Resu
         ),
         stacks: [
             Stack {
+                id: None,
                 base: Some(
                     Sha1(281456a55524d78e1e0ecab946032423aec1abe8),
                 ),
@@ -795,6 +821,9 @@ fn target_ahead_remote_rewritten() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
                 ),
@@ -873,6 +902,9 @@ fn single_commit_but_two_branches_one_in_ws_commit() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -890,6 +922,9 @@ fn single_commit_but_two_branches_one_in_ws_commit() -> anyhow::Result<()> {
                 ],
             },
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000000,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -909,6 +944,9 @@ fn single_commit_but_two_branches_one_in_ws_commit() -> anyhow::Result<()> {
                 ],
             },
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000000,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -989,6 +1027,9 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -1008,6 +1049,9 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
                 ],
             },
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000000,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -1094,6 +1138,9 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -1131,6 +1178,9 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
                 ],
             },
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000000,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -1200,6 +1250,9 @@ fn single_commit_but_two_branches_both_in_ws_commit() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -1219,6 +1272,9 @@ fn single_commit_but_two_branches_both_in_ws_commit() -> anyhow::Result<()> {
                 ],
             },
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000000,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -1285,6 +1341,7 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit() -> anyhow::Result<(
         ),
         stacks: [
             Stack {
+                id: None,
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -1359,6 +1416,9 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit_empty_dependant() -> 
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000000,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -1430,6 +1490,9 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit_empty_dependant() -> 
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000000,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -1512,6 +1575,9 @@ fn single_commit_pushed_ws_commit_empty_dependant() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000000,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -1591,6 +1657,9 @@ fn single_commit_pushed_ws_commit_empty_dependant() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000000,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -1683,6 +1752,9 @@ fn two_branches_stacked_with_remotes() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000000,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -1767,6 +1839,9 @@ fn two_branches_stacked_with_interesting_remote_setup() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -1848,6 +1923,9 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -1867,6 +1945,9 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
                 ],
             },
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000000,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -1915,6 +1996,9 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -1934,6 +2018,9 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
                 ],
             },
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000000,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -2005,6 +2092,9 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -2022,6 +2112,9 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 ],
             },
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000000,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -2073,6 +2166,9 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -2090,6 +2186,9 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 ],
             },
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000000,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -2140,6 +2239,9 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -2157,6 +2259,9 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 ],
             },
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000000,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -2213,6 +2318,9 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -2232,6 +2340,9 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
                 ],
             },
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000000,
+                ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
                 ),
@@ -2295,6 +2406,7 @@ fn disjoint() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: None,
                 base: None,
                 segments: [
                     ref_info::ui::Segment {
@@ -2355,6 +2467,9 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
                 ),
@@ -2388,6 +2503,9 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                 ],
             },
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
                 ),
@@ -2454,6 +2572,9 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
                 ),
@@ -2487,6 +2608,9 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                 ],
             },
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
                 ),
@@ -2553,6 +2677,9 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
                 ),
@@ -2586,6 +2713,9 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                 ],
             },
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
                 ),
@@ -2653,6 +2783,9 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
                 ),
@@ -2686,6 +2819,9 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
                 ],
             },
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
                 ),
@@ -2765,6 +2901,9 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
                 ),
@@ -2814,6 +2953,9 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 base: Some(
                     Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
                 ),
@@ -2898,6 +3040,7 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
         ),
         stacks: [
             Stack {
+                id: None,
                 base: None,
                 segments: [
                     ref_info::ui::Segment {

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -213,9 +213,9 @@ fn two_dependent_branches_rebased_with_remotes() -> anyhow::Result<()> {
     let (repo, mut meta) =
         read_only_in_memory_scenario("two-dependent-branches-rebased-with-remotes")?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * e26f4fd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    * 31b3f92 (B-on-A) change in B
-    * 51db0ec (A) change after push
+    * d909178 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 3ba6995 (B-on-A) change in B
+    * f504e38 (A) change after push
     | * ec39463 (origin/B-on-A) change in B
     |/  
     * 807f596 (origin/A) change in A
@@ -244,19 +244,19 @@ fn two_dependent_branches_rebased_with_remotes() -> anyhow::Result<()> {
                         ref_name: "refs/heads/B-on-A",
                         remote_tracking_ref_name: "refs/remotes/origin/B-on-A",
                         commits: [
-                            LocalCommit(31b3f92, "change in B\n", local/remote(ec39463)),
+                            LocalCommit(3ba6995, "change in B\n", local/remote(ec39463)),
                         ],
                         commits_unique_in_remote_tracking_branch: [],
                         metadata: Branch,
                         push_status: UnpushedCommitsRequiringForce,
-                        base: "51db0ec",
+                        base: "f504e38",
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(5),
                         ref_name: "refs/heads/A",
                         remote_tracking_ref_name: "refs/remotes/origin/A",
                         commits: [
-                            LocalCommit(51db0ec, "change after push\n", local),
+                            LocalCommit(f504e38, "change after push\n", local),
                             LocalCommit(807f596, "change in A\n", local/remote(identity)),
                         ],
                         commits_unique_in_remote_tracking_branch: [],
@@ -296,9 +296,9 @@ fn two_dependent_branches_rebased_explicit_remote_in_extra_segment() -> anyhow::
         "two-dependent-branches-rebased-explicit-remote-in-extra-segment",
     )?;
     insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
-    * e26f4fd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-    * 31b3f92 (B-on-A) change in B
-    * 51db0ec (A) change after push
+    * d909178 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+    * 3ba6995 (B-on-A) change in B
+    * f504e38 (A) change after push
     | * ec39463 (origin/B-on-A) change in B
     |/  
     * 807f596 (origin/A, base-of-A) change in A
@@ -329,19 +329,19 @@ fn two_dependent_branches_rebased_explicit_remote_in_extra_segment() -> anyhow::
                         ref_name: "refs/heads/B-on-A",
                         remote_tracking_ref_name: "refs/remotes/origin/B-on-A",
                         commits: [
-                            LocalCommit(31b3f92, "change in B\n", local/remote(ec39463)),
+                            LocalCommit(3ba6995, "change in B\n", local/remote(ec39463)),
                         ],
                         commits_unique_in_remote_tracking_branch: [],
                         metadata: Branch,
                         push_status: UnpushedCommitsRequiringForce,
-                        base: "51db0ec",
+                        base: "f504e38",
                     },
                     ref_info::ui::Segment {
                         id: NodeIndex(5),
                         ref_name: "refs/heads/A",
                         remote_tracking_ref_name: "None",
                         commits: [
-                            LocalCommit(51db0ec, "change after push\n", local),
+                            LocalCommit(f504e38, "change after push\n", local),
                         ],
                         commits_unique_in_remote_tracking_branch: [],
                         metadata: Branch,


### PR DESCRIPTION
Better support the Frontend by re-introducing stack-ids to workspace stacks.

### Tasks

- [x] cleanup ID-related types and bring in `StackId` without relation to `gitbutler-id`
- [x] add stack-id to workspace metadata and make it transfer correctly.
- [x] add `stack_id` to workspace metadata.
- [x] add `StackId` field to projection and related types.
- [ ] What about scenarios where there is no stack ID?

### Next related tasks

* ‼️if branches in the workspace are advanced outside of the workspace, it currently doesn't see these commits and the branch looses its name in the workspace. The traversal really should try to add the known tips explicitly for traversal and expose that information.
* 🏎️ Use per-commit metadata to avoid recomputing changeset IDs for each commit, enabling processing more and more commits with the 1s compute budget.
* 🏎️ graph-based merge-base computation would be much faster if a bitmap was used. Could be intrinsic or separate, with intrinsic certainly being better.
* ⚠️ fix related TODOs and known issues

### Not to forget

* There might be an issue with the way it uses searches - a tip with a search might be blocked at an existing commit, discovered by a tip with a different search, and even though the thing it searches is reachable through that, it stops looking.
* the amount of commits of remotes ahead of their local branch doesn't seem to always match git (particularly when it's a lot of them)
* ⚠️ current implementation supports multiple workspaces *in theory*, but it's not tested with them as the underlying ref-metadata is still VB-toml. So before supporting this, we probably already want to have migrated away from vb.toml, to then port the ref-metadata to something that can support more workspaces (also for testing).
* ⚠️ we probably don't correctly handle workspaces that include other workspaces.
* ⚠️ we probably don't handle [dot-repositories](https://git-scm.com/docs/git-config#Documentation/git-config.txt-branchltnamegtmerge) correctly, by merit of not really having them in mind. At least they shouldn't be in the way of handling normal remotes.

### Related issues

* #8457
* #9408

