### PR TITLE
Fix draggable noDrag check for missing dragHandle

### DIFF
--- a/apps/desktop/src/lib/dragging/draggable.ts
+++ b/apps/desktop/src/lib/dragging/draggable.ts
@@ -65,7 +65,7 @@ function setupDragHandlers(
 		if (!opts || opts.disabled) return;
 		e.stopPropagation();
 
-		if (dragHandle && dragHandle.dataset.noDrag !== undefined) {
+		if (!dragHandle || dragHandle.dataset.noDrag !== undefined) {
 			e.preventDefault();
 			return false;
 		}


### PR DESCRIPTION
If there is no drag handle, it’s because it’s been filtered out, and hence should not be draggable.

This fixes the bug in which the scrollbar in the hunk diffs triggered the hunk to be dragged