### PR TITLE
Remove unnecessary derived

### DIFF
--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -737,10 +737,7 @@ export class StackService {
 	}
 
 	newBranchName(projectId: string) {
-		const result = $derived(
-			this.api.endpoints.newBranchName.useQuery({ projectId }, { forceRefetch: true })
-		);
-		return result;
+		return this.api.endpoints.newBranchName.useQuery({ projectId }, { forceRefetch: true });
 	}
 
 	async fetchNewBranchName(projectId: string) {


### PR DESCRIPTION
Fetching the name of the branch doesn’t need to be double-wrapped in a derived