### PR TITLE
Branch selection fix

### DIFF
--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -12,7 +12,11 @@ import {
 	providesList,
 	ReduxTag
 } from '$lib/state/tags';
-import { replaceBranchInExclusiveAction, type UiState } from '$lib/state/uiState.svelte';
+import {
+	replaceBranchInExclusiveAction,
+	replaceBranchInStackSelection,
+	type UiState
+} from '$lib/state/uiState.svelte';
 import { isDefined } from '@gitbutler/ui/utils/typeguards';
 import {
 	createEntityAdapter,
@@ -615,12 +619,16 @@ export class StackService {
 				const stackState = this.uiState.stack(args.stackId);
 				const projectState = this.uiState.project(args.projectId);
 				const exclusiveAction = projectState.exclusiveAction.current;
-				const previousSelection = stackState.selection.current ?? {};
+				const previousSelection = stackState.selection.current;
 
-				stackState.selection.set({
-					...previousSelection,
-					branchName: args.newName
-				});
+				if (previousSelection) {
+					const updatedSelection = replaceBranchInStackSelection(
+						previousSelection,
+						args.branchName,
+						args.newName
+					);
+					stackState.selection.set(updatedSelection);
+				}
 
 				if (exclusiveAction) {
 					const updatedExclusiveAction = replaceBranchInExclusiveAction(

--- a/apps/desktop/src/lib/state/uiState.svelte.ts
+++ b/apps/desktop/src/lib/state/uiState.svelte.ts
@@ -267,3 +267,14 @@ export function replaceBranchInExclusiveAction(
 			return action;
 	}
 }
+
+export function replaceBranchInStackSelection(
+	selection: StackSelection,
+	oldBranchName: string,
+	branchName: string
+): StackSelection {
+	if (selection.branchName === oldBranchName) {
+		return { ...selection, branchName };
+	}
+	return selection;
+}


### PR DESCRIPTION
When generating the branch name, we'd still see as squish animation. 

Only replace the branch name if the branch was selected.
