### PR TITLE
refactor: introduce FeedFactory for per-project feeds

### DIFF
--- a/apps/desktop/src/components/Feed.svelte
+++ b/apps/desktop/src/components/Feed.svelte
@@ -8,7 +8,7 @@
 	import { invoke } from '$lib/backend/ipc';
 	import { SettingsService } from '$lib/config/appSettingsV2';
 	import { persistedChatModelName, projectAiGenEnabled } from '$lib/config/config';
-	import { Feed } from '$lib/feed/feed';
+	import FeedFactory from '$lib/feed/feed';
 	import { newProjectSettingsPath } from '$lib/routes/routes.svelte';
 	import { User } from '$lib/user/user';
 	import { getContext, getContextStore } from '@gitbutler/shared/context';
@@ -29,15 +29,16 @@
 
 	const { projectId, onCloseClick }: Props = $props();
 
-	const feed = getContext(Feed);
+	const feedFactory = getContext(FeedFactory);
+	const feed = $derived(feedFactory.getFeed(projectId));
 	const actionService = getContext(ActionService);
 	const user = getContextStore(User);
 	const settingsService = getContext(SettingsService);
 	const settingsStore = $derived(settingsService.appSettings);
 
 	const isAdmin = $derived($user.role === 'admin');
-	const combinedEntries = feed.combined;
-	const lastAddedId = feed.lastAddedId;
+	const combinedEntries = $derived(feed.combined);
+	const lastAddedId = $derived(feed.lastAddedId);
 
 	const MODELS = ['gpt-4.1', 'gpt-4.1-mini'] as const;
 

--- a/apps/desktop/src/components/FeedStreamMessage.svelte
+++ b/apps/desktop/src/components/FeedStreamMessage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import FeedItemKind from '$components/FeedItemKind.svelte';
-	import { Feed, type InProgressAssistantMessage } from '$lib/feed/feed';
+	import FeedFactory, { type InProgressAssistantMessage } from '$lib/feed/feed';
 	import { getContext } from '@gitbutler/shared/context';
 	import Markdown from '@gitbutler/ui/markdown/Markdown.svelte';
 	import type { ToolCall } from '$lib/ai/tool';
@@ -12,7 +12,8 @@
 
 	const { projectId, message }: Props = $props();
 
-	const feed = getContext(Feed);
+	const feedFactory = getContext(FeedFactory);
+	const feed = $derived(feedFactory.getFeed(projectId));
 	let toolCalls = $state<ToolCall[]>(message.toolCalls);
 	let messageContent = $state(message.content);
 	const messageContentLines = $derived(messageContent.split('\n'));

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -31,6 +31,7 @@
 	import DependencyService from '$lib/dependencies/dependencyService.svelte';
 	import { DragStateService } from '$lib/dragging/dragStateService.svelte';
 	import { DropzoneRegistry } from '$lib/dragging/registry';
+	import FeedFactory from '$lib/feed/feed';
 	import { FileService } from '$lib/files/fileService';
 	import { UncommitedFilesWatcher } from '$lib/files/watcher';
 	import { DefaultForgeFactory } from '$lib/forge/forgeFactory.svelte';
@@ -148,6 +149,7 @@
 		forgeFactory,
 		uiState
 	);
+	const feedFactory = new FeedFactory(data.tauri, stackService);
 	const rulesService = new RulesService(clientState['backendApi']);
 	const actionService = new ActionService(clientState['backendApi']);
 	const oplogService = new OplogService(clientState['backendApi']);
@@ -226,6 +228,7 @@
 	setContext(AppSettings, data.appSettings);
 	setContext(EventContext, data.eventContext);
 	setContext(StackService, stackService);
+	setContext(FeedFactory, feedFactory);
 	setContext(RulesService, rulesService);
 	setContext(ActionService, actionService);
 	setContext(OplogService, oplogService);

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -18,7 +18,7 @@
 	import { SettingsService } from '$lib/config/appSettingsV2';
 	import { showHistoryView } from '$lib/config/config';
 	import { StackingReorderDropzoneManagerFactory } from '$lib/dragging/stackingReorderDropzoneManager';
-	import { Feed } from '$lib/feed/feed';
+	import FeedFactory from '$lib/feed/feed';
 	import { FocusManager } from '$lib/focus/focusManager.svelte';
 	import { DefaultForgeFactory } from '$lib/forge/forgeFactory.svelte';
 	import { GitHubClient } from '$lib/forge/github/githubClient';
@@ -43,7 +43,7 @@
 
 	const { data, children: pageChildren }: { data: LayoutData; children: Snippet } = $props();
 
-	const { projectId, userService, posthog, projectMetrics, tauri } = $derived(data);
+	const { projectId, userService, posthog, projectMetrics } = $derived(data);
 
 	const baseBranchService = getContext(BaseBranchService);
 	const repoInfoResponse = $derived(baseBranchService.repo(projectId));
@@ -56,7 +56,7 @@
 	const branchService = getContext(BranchService);
 
 	const stackService = getContext(StackService);
-	const feed = $derived(new Feed(tauri, projectId, stackService));
+	const feedFactory = getContext(FeedFactory);
 	const modeService = $derived(new ModeService(projectId, stackService));
 	$effect.pre(() => {
 		setContext(ModeService, modeService);
@@ -95,9 +95,6 @@
 	$effect.pre(() => {
 		setContext(HistoryService, data.historyService);
 		setContext(BaseBranch, baseBranch);
-
-		// Cloud related services
-		setContext(Feed, feed);
 	});
 
 	const focusManager = new FocusManager();
@@ -279,6 +276,11 @@
 	// Listen for stack details updates from the backend.
 	$effect(() => {
 		stackService.stackDetailsUpdateListener(projectId);
+	});
+
+	// Listen for the feed updates from the backend.
+	$effect(() => {
+		feedFactory.getFeed(projectId);
 	});
 </script>
 


### PR DESCRIPTION
Refactor the feed architecture. The feed is now constructed through a FeedFactory rooted at routes/layout. When a project is visited, a new project-specific feed instance is created using the factory. Updates all consumers and context usage, including Feed.svelte, FeedStreamMessage.svelte, project root layout, and per-project layouts. All logic for feed instantiation/multiplexing is now contained in FeedFactory for improved encapsulation and reusability.