### PR TITLE
workspace robustness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6419,7 +6419,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -10582,7 +10582,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/but-core/src/commit.rs
+++ b/crates/but-core/src/commit.rs
@@ -67,9 +67,8 @@ impl HeadersV2 {
         }
     }
 
-    /// Write the values from this instance to the given `commit`,  fully replacing any header
-    /// that might have been there before.
-    pub fn set_in_commit(&self, commit: &mut gix::objs::Commit) {
+    /// Remove all header fields from `commit`.
+    pub fn remove_in_commit(commit: &mut gix::objs::Commit) {
         for field in [
             HEADERS_VERSION_FIELD,
             HEADERS_CHANGE_ID_FIELD,
@@ -79,7 +78,12 @@ impl HeadersV2 {
                 commit.extra_headers.remove(pos);
             }
         }
+    }
 
+    /// Write the values from this instance to the given `commit`,  fully replacing any header
+    /// that might have been there before.
+    pub fn set_in_commit(&self, commit: &mut gix::objs::Commit) {
+        Self::remove_in_commit(commit);
         commit
             .extra_headers
             .extend(Vec::<(BString, BString)>::from(self));

--- a/crates/but-graph/src/projection/workspace.rs
+++ b/crates/but-graph/src/projection/workspace.rs
@@ -492,19 +492,18 @@ fn find_matching_stack_id(
         .stacks
         .iter()
         .map(|s| {
-            (
-                s.id,
-                s.branches
-                    .iter()
-                    .filter(|b| {
-                        segments
-                            .iter()
-                            .any(|s| s.ref_name.as_ref().is_some_and(|rn| rn == &b.ref_name))
-                    })
-                    .count(),
-            )
+            let num_matching_refs = s
+                .branches
+                .iter()
+                .filter(|b| {
+                    segments
+                        .iter()
+                        .any(|s| s.ref_name.as_ref().is_some_and(|rn| rn == &b.ref_name))
+                })
+                .count();
+            (s.id, num_matching_refs)
         })
-        .sorted_by_key(|(_, num_matches)| *num_matches)
+        .sorted_by(|(_, lhs), (_, rhs)| lhs.cmp(rhs).reverse())
         .next()
         .map(|(stack_id, _)| stack_id)
 }

--- a/crates/but-graph/src/projection/workspace.rs
+++ b/crates/but-graph/src/projection/workspace.rs
@@ -328,9 +328,6 @@ impl Graph {
                         entrypoint_sidx,
                         |s| {
                             let stop = true;
-                            if segment_name_is_special(s) {
-                                return !stop;
-                            }
                             // The lowest base is a segment that all stacks will run into.
                             // If we meet it, we are done. Note how we ignored the integration state
                             // as pruning of fully integrated stacks happens later.
@@ -341,6 +338,9 @@ impl Graph {
                             // Assure entrypoints get their own segments
                             if s.id != stack_top_sidx && Some(s.id) == entrypoint_sidx {
                                 return stop;
+                            }
+                            if segment_name_is_special(s) {
+                                return !stop;
                             }
                             match (
                                 &stack_segment.ref_name,

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -806,5 +806,19 @@ EOF
     commit top
     create_workspace_commit_once main
   )
+
+  git init special-branches-edgecase
+  (cd special-branches-edgecase
+    commit init
+    commit M1
+    git branch gitbutler/target
+    commit M2
+    setup_target_to_match_main
+    git checkout -b A
+    commit middle
+      git branch gitbutler/edit
+    commit top
+    create_workspace_commit_once A
+  )
 )
 

--- a/crates/but-graph/tests/graph/init/utils.rs
+++ b/crates/but-graph/tests/graph/init/utils.rs
@@ -148,13 +148,7 @@ pub fn standard_options_with_extra_target(
     name: &str,
 ) -> but_graph::init::Options {
     but_graph::init::Options {
-        extra_target_commit_id: Some(
-            repo.find_reference(name)
-                .expect("present")
-                .peel_to_id_in_place()
-                .unwrap()
-                .detach(),
-        ),
+        extra_target_commit_id: Some(repo.rev_parse_single(name).expect("present").detach()),
         ..standard_options()
     }
 }

--- a/crates/but-rebase/src/cherry_pick.rs
+++ b/crates/but-rebase/src/cherry_pick.rs
@@ -24,7 +24,7 @@ pub enum EmptyCommit {
 
 pub(crate) mod function {
     use crate::cherry_pick::{EmptyCommit, PickMode};
-    use crate::commit::CommitterMode;
+    use crate::commit::DateMode;
     use anyhow::{Context, bail};
     use bstr::BString;
     use but_core::commit::{HEADERS_CONFLICTED_FIELD, HeadersV2, TreeKind};
@@ -184,7 +184,10 @@ pub(crate) mod function {
                 .extend(Vec::<(BString, BString)>::from(&HeadersV2::default()));
         }
         set_parent(&mut new_commit, head.id.detach())?;
-        Ok(crate::commit::create(repo, new_commit, CommitterMode::Update)?.attach(repo))
+        Ok(
+            crate::commit::create(repo, new_commit, DateMode::CommitterUpdateAuthorKeep)?
+                .attach(repo),
+        )
     }
 
     fn commit_from_conflicted_tree<'repo>(
@@ -241,7 +244,10 @@ pub(crate) mod function {
         set_parent(&mut to_rebase, head.id.detach())?;
 
         to_rebase.set_headers(&headers);
-        Ok(crate::commit::create(repo, to_rebase.inner, CommitterMode::Update)?.attach(repo))
+        Ok(
+            crate::commit::create(repo, to_rebase.inner, DateMode::CommitterUpdateAuthorKeep)?
+                .attach(repo),
+        )
     }
 
     fn extract_conflicted_files(

--- a/crates/but-rebase/src/lib.rs
+++ b/crates/but-rebase/src/lib.rs
@@ -3,7 +3,7 @@
 //! It will only affect the commit-graph, and never the alter the worktree in any way.
 #![deny(rust_2018_idioms, missing_docs)]
 
-use crate::commit::CommitterMode;
+use crate::commit::DateMode;
 use anyhow::{Context, Ok, Result, anyhow, bail};
 use bstr::BString;
 use gix::objs::Exists;
@@ -281,7 +281,11 @@ fn rebase(
                             if let Some(new_message) = new_message {
                                 new_commit.message = new_message;
                             }
-                            cursor = Some(commit::create(repo, new_commit, CommitterMode::Update)?);
+                            cursor = Some(commit::create(
+                                repo,
+                                new_commit,
+                                DateMode::CommitterUpdateAuthorKeep,
+                            )?);
                         }
                         None => {
                             // TODO: should this be supported? This would be as easy as forgetting its parents.
@@ -315,7 +319,7 @@ fn rebase(
                 if let Some(new_message) = new_message {
                     new_commit.message = new_message;
                 }
-                *cursor = commit::create(repo, new_commit, CommitterMode::Update)?;
+                *cursor = commit::create(repo, new_commit, DateMode::CommitterUpdateAuthorKeep)?;
             }
             RebaseStep::Reference(reference) => {
                 references.push(ReferenceSpec {
@@ -355,7 +359,11 @@ fn reword_commit(
 ) -> Result<gix::ObjectId> {
     let mut new_commit = repo.find_commit(oid)?.decode()?.to_owned();
     new_commit.message = new_message;
-    Ok(commit::create(repo, new_commit, CommitterMode::Update)?)
+    Ok(commit::create(
+        repo,
+        new_commit,
+        DateMode::CommitterUpdateAuthorKeep,
+    )?)
 }
 
 /// Replaces the tree of a commit for use in the rebase engine.
@@ -366,7 +374,11 @@ pub fn replace_commit_tree(
 ) -> Result<gix::ObjectId> {
     let mut new_commit = repo.find_commit(oid)?.decode()?.to_owned();
     new_commit.tree = new_tree;
-    Ok(commit::create(repo, new_commit, CommitterMode::Update)?)
+    Ok(commit::create(
+        repo,
+        new_commit,
+        DateMode::CommitterUpdateAuthorKeep,
+    )?)
 }
 
 /// A reference that is an output of a rebase operation.

--- a/crates/but-rebase/src/merge.rs
+++ b/crates/but-rebase/src/merge.rs
@@ -1,4 +1,4 @@
-use crate::commit::CommitterMode;
+use crate::commit::DateMode;
 use anyhow::{Result, anyhow, bail};
 use bstr::{BString, ByteSlice};
 use but_core::commit::TreeKind;
@@ -101,7 +101,11 @@ pub fn octopus(
         .pgp_signature()
         .is_some()
     {
-        crate::commit::create(repo, target_merge_commit, CommitterMode::Update)
+        crate::commit::create(
+            repo,
+            target_merge_commit,
+            DateMode::CommitterUpdateAuthorKeep,
+        )
     } else {
         crate::commit::update_committer(repo, &mut target_merge_commit)?;
         Ok(repo.write_object(target_merge_commit)?.detach())

--- a/crates/but-workspace/tests/fixtures/scenario/all-file-types-renamed-and-modified.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/all-file-types-renamed-and-modified.sh
@@ -3,6 +3,25 @@
 ### Description
 # A commit with an executable, a normal file, a symlink and an untracked fifo.
 # Then each item gets renamed in the worktree.
+
+function add_change_id_and_reset_head() {
+   local change_id="00000000-0000-0000-0000-000000003333"
+
+   # Insert the Change-ID header lines after the committer line.
+   git cat-file -p "${1:?first argument is the commit to add a changeid to}" \
+   | awk -v cid="$change_id" '
+     BEGIN { injected = 0 }
+     /^$/ && !injected {
+       print "gitbutler-headers-version 2"
+       print "gitbutler-change-id " cid
+       print ""
+       injected = 1
+       next
+     }
+     { print }
+     ' \
+   | git hash-object -wt commit --stdin >.git/refs/heads/main
+}
 set -eu -o pipefail
 
 git init
@@ -12,6 +31,7 @@ ln -s nonexisting-target link
 mkfifo fifo-should-be-ignored
 
 git add . && git commit -m "init"
+add_change_id_and_reset_head "$(git rev-parse HEAD)"
 
 seq 5 10 >file
 seq 1 5 >executable

--- a/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
@@ -137,7 +137,7 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
     assure_no_worktree_changes(&repo)?;
     // The top commit has a different hash now thanks to amending.
     insta::assert_snapshot!(graph_commit_outcome(&repo, &outcome)?, @r"
-    * 6073a81 (HEAD -> main) third commit
+    * 4d1daf3 (HEAD -> main) third commit
     * 64c4463 (tag: tag-that-should-not-move, another-tip) second commit
     * 3dd3955 initial commit
     ");
@@ -193,7 +193,7 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
     CreateCommitOutcome {
         rejected_specs: [],
         new_commit: Some(
-            Sha1(28868dd070be350f335ad8869c728343fa2929f8),
+            Sha1(a1722ae3783c7a463c1d73d6d5498c8f37a5e066),
         ),
         changed_tree_pre_cherry_pick: Some(
             Sha1(273aeca7ca98af0f7972af6e7859a3ae7fde497a),
@@ -205,22 +205,22 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
                         "refs/heads/main",
                     ),
                 ),
-                old_commit_id: Sha1(6073a81d14db7169b56ac39bcf59f906df532302),
-                new_commit_id: Sha1(28868dd070be350f335ad8869c728343fa2929f8),
+                old_commit_id: Sha1(4d1daf36b8ab77aff228e580486f2ae7017e442b),
+                new_commit_id: Sha1(a1722ae3783c7a463c1d73d6d5498c8f37a5e066),
             },
             UpdatedReference {
                 reference: Virtual(
                     "s1-b/second",
                 ),
-                old_commit_id: Sha1(6073a81d14db7169b56ac39bcf59f906df532302),
-                new_commit_id: Sha1(28868dd070be350f335ad8869c728343fa2929f8),
+                old_commit_id: Sha1(4d1daf36b8ab77aff228e580486f2ae7017e442b),
+                new_commit_id: Sha1(a1722ae3783c7a463c1d73d6d5498c8f37a5e066),
             },
             UpdatedReference {
                 reference: Virtual(
                     "s2-b/second",
                 ),
-                old_commit_id: Sha1(6073a81d14db7169b56ac39bcf59f906df532302),
-                new_commit_id: Sha1(28868dd070be350f335ad8869c728343fa2929f8),
+                old_commit_id: Sha1(4d1daf36b8ab77aff228e580486f2ae7017e442b),
+                new_commit_id: Sha1(a1722ae3783c7a463c1d73d6d5498c8f37a5e066),
             },
         ],
         rebase_output: None,
@@ -230,8 +230,8 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
     write_vrbranches_to_refs(&vb, &repo)?;
     // It updates stack heads and stack branch heads.
     insta::assert_snapshot!(graph_commit_outcome(&repo, &outcome)?, @r"
-    * 28868dd (HEAD -> main, s2-b/second, s1-b/second) fourth commit
-    * 6073a81 third commit
+    * a1722ae (HEAD -> main, s2-b/second, s1-b/second) fourth commit
+    * 4d1daf3 third commit
     * 64c4463 (tag: tag-that-should-not-move, s2-b/first, s1-b/first, another-tip) second commit
     * 3dd3955 (s2-b/init, s1-b/init) initial commit
     ");
@@ -699,8 +699,8 @@ fn insert_commit_into_single_stack_with_signatures() -> anyhow::Result<()> {
     )?;
     let rewritten_head_id = repo.head_id()?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
-    * 07a0229 (HEAD -> main) insert 10 lines to the top
-    * d9d87b9 (s1-b/init) between initial and former first
+    * 0dea79a (HEAD -> main) insert 10 lines to the top
+    * 701a621 (s1-b/init) between initial and former first
     * ecd6722 (tag: first-commit, first-commit) init
     ");
     insta::assert_snapshot!(but_testsupport::visualize_tree(rewritten_head_id), @r#"

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -903,7 +903,7 @@ fn single_commit_but_two_branches_one_in_ws_commit() -> anyhow::Result<()> {
         stacks: [
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000001,
+                    00000000-0000-0000-0000-000000000000,
                 ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
@@ -923,7 +923,7 @@ fn single_commit_but_two_branches_one_in_ws_commit() -> anyhow::Result<()> {
             },
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000000,
+                    00000000-0000-0000-0000-000000000001,
                 ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
@@ -945,7 +945,7 @@ fn single_commit_but_two_branches_one_in_ws_commit() -> anyhow::Result<()> {
             },
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000000,
+                    00000000-0000-0000-0000-000000000002,
                 ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
@@ -1028,7 +1028,7 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
         stacks: [
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000001,
+                    00000000-0000-0000-0000-000000000000,
                 ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
@@ -1050,7 +1050,7 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
             },
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000000,
+                    00000000-0000-0000-0000-000000000001,
                 ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
@@ -1139,7 +1139,7 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
         stacks: [
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000001,
+                    00000000-0000-0000-0000-000000000000,
                 ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
@@ -1179,7 +1179,7 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
             },
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000000,
+                    00000000-0000-0000-0000-000000000001,
                 ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
@@ -1251,7 +1251,7 @@ fn single_commit_but_two_branches_both_in_ws_commit() -> anyhow::Result<()> {
         stacks: [
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000001,
+                    00000000-0000-0000-0000-000000000000,
                 ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
@@ -1273,7 +1273,7 @@ fn single_commit_but_two_branches_both_in_ws_commit() -> anyhow::Result<()> {
             },
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000000,
+                    00000000-0000-0000-0000-000000000001,
                 ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
@@ -1924,7 +1924,7 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
         stacks: [
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000001,
+                    00000000-0000-0000-0000-000000000000,
                 ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
@@ -1946,7 +1946,7 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
             },
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000000,
+                    00000000-0000-0000-0000-000000000001,
                 ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
@@ -1997,7 +1997,7 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
         stacks: [
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000001,
+                    00000000-0000-0000-0000-000000000000,
                 ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
@@ -2019,7 +2019,7 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
             },
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000000,
+                    00000000-0000-0000-0000-000000000001,
                 ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
@@ -2093,7 +2093,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
         stacks: [
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000001,
+                    00000000-0000-0000-0000-000000000000,
                 ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
@@ -2113,7 +2113,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
             },
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000000,
+                    00000000-0000-0000-0000-000000000001,
                 ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
@@ -2167,7 +2167,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
         stacks: [
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000001,
+                    00000000-0000-0000-0000-000000000000,
                 ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
@@ -2187,7 +2187,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
             },
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000000,
+                    00000000-0000-0000-0000-000000000001,
                 ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
@@ -2240,7 +2240,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
         stacks: [
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000001,
+                    00000000-0000-0000-0000-000000000000,
                 ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
@@ -2260,7 +2260,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
             },
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000000,
+                    00000000-0000-0000-0000-000000000001,
                 ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
@@ -2319,7 +2319,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
         stacks: [
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000001,
+                    00000000-0000-0000-0000-000000000000,
                 ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
@@ -2341,7 +2341,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
             },
             Stack {
                 id: Some(
-                    00000000-0000-0000-0000-000000000000,
+                    00000000-0000-0000-0000-000000000001,
                 ),
                 base: Some(
                     Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),

--- a/crates/but-workspace/tests/workspace/utils.rs
+++ b/crates/but-workspace/tests/workspace/utils.rs
@@ -329,14 +329,16 @@ pub fn visualize_commit(
     repo: &gix::Repository,
     outcome: &but_workspace::commit_engine::CreateCommitOutcome,
 ) -> anyhow::Result<String> {
-    Ok(outcome
-        .new_commit
-        .expect("the amended commit was created")
-        .attach(repo)
-        .object()?
-        .data
-        .as_bstr()
-        .to_string())
+    cat_commit(
+        outcome
+            .new_commit
+            .expect("a new commit was created")
+            .attach(repo),
+    )
+}
+
+pub fn cat_commit(commit: gix::Id<'_>) -> anyhow::Result<String> {
+    Ok(commit.object()?.data.as_bstr().to_string())
 }
 
 // In-memory config changes aren't enough as we still only have snapshots, without the ability to keep


### PR DESCRIPTION
‼️ if branches in the workspace are advanced outside of the workspace, it currently doesn't see these commits and the branch looses its name in the workspace.
The traversal really should try to add the known tips explicitly for traversal and expose that information.

### Tasks

- [x] What about scenarios where there is no stack ID?
    - we already have a bunch of cases where there is no stack-id, and for now we don't set it as the UI as to be able to deal with it being optional. Depending on the usecase, there can probably be adjustments once we know what we need.
- [x] fixes around amending and integration checks
- [x] take a look at misclassification below
- [ ] expose segments that were moved out of the workspace

### Next related tasks

* 🏎️ Use per-commit metadata to avoid recomputing changeset IDs for each commit, enabling processing more and more commits with the 1s compute budget.
* 🏎️ graph-based merge-base computation would be much faster if a bitmap was used. Could be intrinsic or separate, with intrinsic certainly being better.
* ⚠️ fix related TODOs and known issues

### Not to forget

* There might be an issue with the way it uses searches - a tip with a search might be blocked at an existing commit, discovered by a tip with a different search, and even though the thing it searches is reachable through that, it stops looking.
* the amount of commits of remotes ahead of their local branch doesn't seem to always match git (particularly when it's a lot of them)
* ⚠️ current implementation supports multiple workspaces *in theory*, but it's not tested with them as the underlying ref-metadata is still VB-toml. So before supporting this, we probably already want to have migrated away from vb.toml, to then port the ref-metadata to something that can support more workspaces (also for testing).
* ⚠️ we probably don't correctly handle workspaces that include other workspaces.
* ⚠️ we probably don't handle [dot-repositories](https://git-scm.com/docs/git-config#Documentation/git-config.txt-branchltnamegtmerge) correctly, by merit of not really having them in mind. At least they shouldn't be in the way of handling normal remotes.

### Related issues

* #8457
* #9408

