### PR TITLE
Improve GitLab Errors

### DIFF
--- a/apps/desktop/src/components/PullRequestCard.svelte
+++ b/apps/desktop/src/components/PullRequestCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import PrStatusBadge from '$components/PrStatusBadge.svelte';
 	import PullRequestPolling from '$components/PullRequestPolling.svelte';
+	import ReduxResult from '$components/ReduxResult.svelte';
 	import { writeClipboard } from '$lib/backend/clipboard';
 	import { DefaultForgeFactory } from '$lib/forge/forgeFactory.svelte';
 	import { TestId } from '$lib/testing/testIds';
@@ -101,125 +102,127 @@
 	});
 </script>
 
-{#if pr}
-	{#if poll}
-		<PullRequestPolling number={pr.number} />
-	{/if}
+<ReduxResult result={prResult?.current} projectId="dummy">
+	{#snippet children(pr)}
+		{#if poll}
+			<PullRequestPolling number={pr.number} />
+		{/if}
 
-	<ContextMenu bind:this={contextMenuEl} rightClickTrigger={container}>
-		<ContextMenuSection>
-			<ContextMenuItem
-				label="Open in browser"
-				onclick={() => {
-					openExternalUrl(pr.htmlUrl);
-					contextMenuEl?.close();
-				}}
-			/>
-			<ContextMenuItem
-				label="Copy link"
-				onclick={() => {
-					writeClipboard(pr.htmlUrl);
-					contextMenuEl?.close();
-				}}
-			/>
-			<ContextMenuItem
-				label="Refetch status"
-				onclick={() => {
-					prService?.fetch(pr.number, { forceRefetch: true });
-					contextMenuEl?.close();
-					if (hasChecks) {
-						checksService?.fetch(pr.sourceBranch, { forceRefetch: true });
-					}
-				}}
-			/>
-		</ContextMenuSection>
-		{#if hasChecks}
+		<ContextMenu bind:this={contextMenuEl} rightClickTrigger={container}>
 			<ContextMenuSection>
 				<ContextMenuItem
-					label="Open checks"
+					label="Open in browser"
 					onclick={() => {
-						openExternalUrl(`${pr.htmlUrl}/checks`);
+						openExternalUrl(pr.htmlUrl);
 						contextMenuEl?.close();
 					}}
 				/>
 				<ContextMenuItem
-					label="Copy checks"
+					label="Copy link"
 					onclick={() => {
-						writeClipboard(`${pr.htmlUrl}/checks`);
+						writeClipboard(pr.htmlUrl);
 						contextMenuEl?.close();
+					}}
+				/>
+				<ContextMenuItem
+					label="Refetch status"
+					onclick={() => {
+						prService?.fetch(pr.number, { forceRefetch: true });
+						contextMenuEl?.close();
+						if (hasChecks) {
+							checksService?.fetch(pr.sourceBranch, { forceRefetch: true });
+						}
 					}}
 				/>
 			</ContextMenuSection>
-		{/if}
-	</ContextMenu>
+			{#if hasChecks}
+				<ContextMenuSection>
+					<ContextMenuItem
+						label="Open checks"
+						onclick={() => {
+							openExternalUrl(`${pr.htmlUrl}/checks`);
+							contextMenuEl?.close();
+						}}
+					/>
+					<ContextMenuItem
+						label="Copy checks"
+						onclick={() => {
+							writeClipboard(`${pr.htmlUrl}/checks`);
+							contextMenuEl?.close();
+						}}
+					/>
+				</ContextMenuSection>
+			{/if}
+		</ContextMenu>
 
-	<div
-		data-testid={testId}
-		bind:this={container}
-		role="article"
-		class="review-card pr-card"
-		oncontextmenu={(e: MouseEvent) => {
-			e.preventDefault();
-			e.stopPropagation();
-			contextMenuEl?.open(e);
-		}}
-	>
-		<div class="pr-actions">
-			<Button
-				kind="outline"
-				size="tag"
-				icon="copy-small"
-				tooltip="Copy {abbr} link"
-				onclick={() => {
-					writeClipboard(pr.htmlUrl);
-				}}
-			/>
-			<Button
-				kind="outline"
-				size="tag"
-				icon="open-link"
-				tooltip="Open {abbr} in browser"
-				onclick={() => {
-					openExternalUrl(pr.htmlUrl);
-				}}
-			/>
-		</div>
-
-		<div class="text-13 text-semibold pr-row">
-			<Icon name="github" />
-			<h4 class="text-14 text-semibold">
-				{`${abbr} ${symbol}${pr.number}`}
-			</h4>
-
-			<PrStatusBadge testId={TestId.PRStatusBadge} {pr} />
-		</div>
-		<div class="text-12 pr-row">
-			<div class="factoid">
-				{#if pr.reviewers.length > 0}
-					<span class="label">Reviewers:</span>
-					<div class="avatar-group-container">
-						<AvatarGroup avatars={pr.reviewers} />
-					</div>
-				{:else}
-					<span class="label italic">No reviewers</span>
-				{/if}
+		<div
+			data-testid={testId}
+			bind:this={container}
+			role="article"
+			class="review-card pr-card"
+			oncontextmenu={(e: MouseEvent) => {
+				e.preventDefault();
+				e.stopPropagation();
+				contextMenuEl?.open(e);
+			}}
+		>
+			<div class="pr-actions">
+				<Button
+					kind="outline"
+					size="tag"
+					icon="copy-small"
+					tooltip="Copy {abbr} link"
+					onclick={() => {
+						writeClipboard(pr.htmlUrl);
+					}}
+				/>
+				<Button
+					kind="outline"
+					size="tag"
+					icon="open-link"
+					tooltip="Open {abbr} in browser"
+					onclick={() => {
+						openExternalUrl(pr.htmlUrl);
+					}}
+				/>
 			</div>
-			<span class="seperator">•</span>
-			<div class="factoid">
-				<span class="label">
-					<Icon name="chat-small" />
-				</span>
-				<span>{pr.commentsCount}</span>
-			</div>
-		</div>
 
-		{#if button}
-			<div class="pr-row">
-				{@render button({ pr, mergeStatus, reopenStatus })}
+			<div class="text-13 text-semibold pr-row">
+				<Icon name="github" />
+				<h4 class="text-14 text-semibold">
+					{`${abbr} ${symbol}${pr.number}`}
+				</h4>
+
+				<PrStatusBadge testId={TestId.PRStatusBadge} {pr} />
 			</div>
-		{/if}
-	</div>
-{/if}
+			<div class="text-12 pr-row">
+				<div class="factoid">
+					{#if pr.reviewers.length > 0}
+						<span class="label">Reviewers:</span>
+						<div class="avatar-group-container">
+							<AvatarGroup avatars={pr.reviewers} />
+						</div>
+					{:else}
+						<span class="label italic">No reviewers</span>
+					{/if}
+				</div>
+				<span class="seperator">•</span>
+				<div class="factoid">
+					<span class="label">
+						<Icon name="chat-small" />
+					</span>
+					<span>{pr.commentsCount}</span>
+				</div>
+			</div>
+
+			{#if button}
+				<div class="pr-row">
+					{@render button({ pr, mergeStatus, reopenStatus })}
+				</div>
+			{/if}
+		</div>
+	{/snippet}
+</ReduxResult>
 
 <style lang="postcss">
 	.pr-row {

--- a/apps/desktop/src/components/StackedPullRequestCard.svelte
+++ b/apps/desktop/src/components/StackedPullRequestCard.svelte
@@ -88,39 +88,37 @@
 	}
 </script>
 
-{#if pr}
-	<PullRequestCard
-		testId={TestId.StackedPullRequestCard}
-		{branchName}
-		{prNumber}
-		{isPushed}
-		{hasParent}
-		{parentIsPushed}
-		{baseIsTargetBranch}
-		poll
-	>
-		{#snippet button({ pr, mergeStatus, reopenStatus })}
-			{#if pr.state === 'open'}
-				<MergeButton
-					wide
-					{projectId}
-					disabled={mergeStatus.disabled}
-					tooltip={mergeStatus.tooltip}
-					onclick={handleMerge}
-				/>
-			{:else if !pr.merged}
-				<AsyncButton
-					kind="outline"
-					disabled={reopenStatus.disabled}
-					tooltip={reopenStatus.tooltip}
-					action={handleReopen}
-				>
-					{`Reopen ${prUnit}`}
-				</AsyncButton>
-			{/if}
-		{/snippet}
-	</PullRequestCard>
-{/if}
+<PullRequestCard
+	testId={TestId.StackedPullRequestCard}
+	{branchName}
+	{prNumber}
+	{isPushed}
+	{hasParent}
+	{parentIsPushed}
+	{baseIsTargetBranch}
+	poll
+>
+	{#snippet button({ pr, mergeStatus, reopenStatus })}
+		{#if pr.state === 'open'}
+			<MergeButton
+				wide
+				{projectId}
+				disabled={mergeStatus.disabled}
+				tooltip={mergeStatus.tooltip}
+				onclick={handleMerge}
+			/>
+		{:else if !pr.merged}
+			<AsyncButton
+				kind="outline"
+				disabled={reopenStatus.disabled}
+				tooltip={reopenStatus.tooltip}
+				action={handleReopen}
+			>
+				{`Reopen ${prUnit}`}
+			</AsyncButton>
+		{/if}
+	{/snippet}
+</PullRequestCard>
 
 <style lang="postcss">
 </style>

--- a/apps/desktop/src/lib/forge/gitlab/gitlab.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlab.ts
@@ -53,6 +53,7 @@ export class GitLab implements Forge {
 	}
 
 	get listService() {
+		if (!this.authenticated) return;
 		const { api: gitLabApi, projectMetrics } = this.params;
 		return new GitLabListingService(gitLabApi, projectMetrics);
 	}
@@ -62,6 +63,7 @@ export class GitLab implements Forge {
 	}
 
 	get prService() {
+		if (!this.authenticated) return;
 		const { api: gitLabApi, posthog } = this.params;
 		return new GitLabPrService(gitLabApi, posthog);
 	}

--- a/apps/desktop/src/lib/forge/gitlab/gitlabListingService.svelte.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlabListingService.svelte.ts
@@ -2,6 +2,7 @@ import { gitlab } from '$lib/forge/gitlab/gitlabClient.svelte';
 import { mrToInstance } from '$lib/forge/gitlab/types';
 import { createSelectByIds } from '$lib/state/customSelectors';
 import { providesList, ReduxTag } from '$lib/state/tags';
+import { toSerializable } from '@gitbutler/shared/network/types';
 import { reactive } from '@gitbutler/shared/reactiveUtils.svelte';
 import { isDefined } from '@gitbutler/ui/utils/typeguards';
 import { createEntityAdapter, type EntityState } from '@reduxjs/toolkit';
@@ -67,54 +68,62 @@ function injectEndpoints(api: GitLabApi) {
 		endpoints: (build) => ({
 			listPrs: build.query<EntityState<PullRequest, string>, string>({
 				queryFn: async (_, query) => {
-					const { api, upstreamProjectId, forkProjectId } = gitlab(query.extra);
-					const upstreamMrs = await api.MergeRequests.all({
-						projectId: upstreamProjectId,
-						state: 'opened'
-					});
-					const forkMrs = await api.MergeRequests.all({
-						projectId: forkProjectId,
-						state: 'opened'
-					});
+					try {
+						const { api, upstreamProjectId, forkProjectId } = gitlab(query.extra);
+						const upstreamMrs = await api.MergeRequests.all({
+							projectId: upstreamProjectId,
+							state: 'opened'
+						});
+						const forkMrs = await api.MergeRequests.all({
+							projectId: forkProjectId,
+							state: 'opened'
+						});
 
-					return {
-						data: prAdapter.addMany(
-							prAdapter.getInitialState(),
-							[...upstreamMrs, ...forkMrs].map((mr) => mrToInstance(mr))
-						)
-					};
+						return {
+							data: prAdapter.addMany(
+								prAdapter.getInitialState(),
+								[...upstreamMrs, ...forkMrs].map((mr) => mrToInstance(mr))
+							)
+						};
+					} catch (e: unknown) {
+						return { error: toSerializable(e) };
+					}
 				},
 				providesTags: [providesList(ReduxTag.PullRequests)]
 			}),
 			listPrsByBranch: build.query<PullRequest | null, { projectId: string; branchName: string }>({
 				queryFn: async ({ branchName }, query) => {
-					const { api, upstreamProjectId, forkProjectId } = gitlab(query.extra);
-					const upstreamMrs = await api.MergeRequests.all({
-						projectId: upstreamProjectId,
-						sourceBranch: branchName,
-						state: 'opened'
-					});
-					const forkMrs = await api.MergeRequests.all({
-						projectId: forkProjectId,
-						sourceBranch: branchName,
-						state: 'opened'
-					});
+					try {
+						const { api, upstreamProjectId, forkProjectId } = gitlab(query.extra);
+						const upstreamMrs = await api.MergeRequests.all({
+							projectId: upstreamProjectId,
+							sourceBranch: branchName,
+							state: 'opened'
+						});
+						const forkMrs = await api.MergeRequests.all({
+							projectId: forkProjectId,
+							sourceBranch: branchName,
+							state: 'opened'
+						});
 
-					const allMrs = [...upstreamMrs, ...forkMrs];
-					if (allMrs.length === 0) {
-						return { data: null };
+						const allMrs = [...upstreamMrs, ...forkMrs];
+						if (allMrs.length === 0) {
+							return { data: null };
+						}
+
+						if (allMrs.length > 1) {
+							return { error: new Error(`Multiple merge requests found for branch ${branchName}`) };
+						}
+
+						const mrData = allMrs[0]!;
+						const mr = mrToInstance(mrData);
+
+						return {
+							data: mr
+						};
+					} catch (e: unknown) {
+						return { error: toSerializable(e) };
 					}
-
-					if (allMrs.length > 1) {
-						return { error: new Error(`Multiple merge requests found for branch ${branchName}`) };
-					}
-
-					const mrData = allMrs[0]!;
-					const mr = mrToInstance(mrData);
-
-					return {
-						data: mr
-					};
 				}
 			})
 		})

--- a/apps/desktop/src/lib/forge/gitlab/gitlabState.svelte.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlabState.svelte.ts
@@ -69,9 +69,9 @@ export class GitLabState {
 		this.instanceUrl = instanceUrl;
 
 		this.configured = derived(
-			[this.token, this.forkProjectId, this.instanceUrl],
-			([token, forkProjectId, instanceUrl]) => {
-				return !!token && !!forkProjectId && !!instanceUrl;
+			[this.token, this.upstreamProjectId, this.forkProjectId, this.instanceUrl],
+			([token, upstreamProjectId, forkProjectId, instanceUrl]) => {
+				return !!token && !!upstreamProjectId && !!forkProjectId && !!instanceUrl;
 			}
 		);
 	}


### PR DESCRIPTION
- Prevent "noise" errors (`Failed to find GitLab client`). Note that it only ever been surfaced in the console. (The user in the chat also mentions that it was only in the console logs).
- Surface PR related errors correctly. Previously we were throwing in redux when we should have been returning an error variant.