### PR TITLE
Redirect to root on project deletion

### DIFF
--- a/apps/desktop/src/lib/project/projectsService.ts
+++ b/apps/desktop/src/lib/project/projectsService.ts
@@ -40,8 +40,8 @@ export class ProjectsService {
 		return await this.api.endpoints.project.fetch({ projectId, noValidation });
 	}
 
-	async setActiveProject(projectId: string): Promise<ProjectInfo> {
-		const info = await invoke<ProjectInfo>('set_project_active', { id: projectId });
+	async setActiveProject(projectId: string): Promise<ProjectInfo | null> {
+		const info = await invoke<ProjectInfo | null>('set_project_active', { id: projectId });
 		return info;
 	}
 


### PR DESCRIPTION
- Set project active returns an optional in order to gracefully handle the case in which a project is deleted
- Redirect to the root if the project was not found
- Don't error out if the it fails to update the branches