### PR TITLE
Provide a special hint on how to deal with a missing keychain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3270,6 +3270,7 @@ name = "gitbutler-secret"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "gitbutler-error",
  "gix",
  "keyring",
  "serde",

--- a/apps/desktop/src/lib/backend/ipc.ts
+++ b/apps/desktop/src/lib/backend/ipc.ts
@@ -8,7 +8,8 @@ export enum Code {
 	ProjectsGitAuth = 'errors.projects.git.auth',
 	DefaultTargetNotFound = 'errors.projects.default_target.not_found',
 	CommitSigningFailed = 'errors.commit.signing_failed',
-	ProjectMissing = 'errors.projects.missing'
+	ProjectMissing = 'errors.projects.missing',
+	SecretKeychainNotFound = 'errors.secret.keychain_notfound'
 }
 
 export type TauriCommandError = { name: string; message: string; code?: string };

--- a/apps/desktop/src/lib/error/knownErrors.ts
+++ b/apps/desktop/src/lib/error/knownErrors.ts
@@ -1,7 +1,14 @@
-export const KNOWN_ERRORS: Record<string, string> = {
-	'errors.commit.signing_failed': `
-			Commit signing failed and has now been disabled. You can configure commit signing in the project settings.
+import { Code } from '$lib/backend/ipc';
 
-			Please check our [documentation](https://docs.gitbutler.com/features/virtual-branches/verifying-commits) on setting up commit signing and verification.
-		`
+export const KNOWN_ERRORS: Record<string, string> = {
+	[Code.CommitSigningFailed]: `
+Commit signing failed and has now been disabled. You can configure commit signing in the project settings.
+
+Please check our [documentation](https://docs.gitbutler.com/features/virtual-branches/verifying-commits) on setting up commit signing and verification.
+		`,
+	[Code.SecretKeychainNotFound]: `
+Please install a keychain service to store and retrieve secrets with.
+
+This can be done using \`sudo apt install gnome-keyring\` for instance.
+	`
 };

--- a/crates/gitbutler-error/src/error.rs
+++ b/crates/gitbutler-error/src/error.rs
@@ -135,6 +135,7 @@ pub enum Code {
     ProjectMissing,
     AuthorMissing,
     BranchNotFound,
+    SecretKeychainNotFound,
 }
 
 impl std::fmt::Display for Code {
@@ -149,6 +150,7 @@ impl std::fmt::Display for Code {
             Code::AuthorMissing => "errors.git.author_missing",
             Code::ProjectMissing => "errors.projects.missing",
             Code::BranchNotFound => "errors.branch.notfound",
+            Code::SecretKeychainNotFound => "errors.secret.keychain_notfound",
         };
         f.write_str(code)
     }

--- a/crates/gitbutler-secret/Cargo.toml
+++ b/crates/gitbutler-secret/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.98"
 tracing.workspace = true
 serde = { workspace = true, features = ["std"]}
 gix = { workspace = true, features = ["dirwalk", "credentials", "parallel"] }
+gitbutler-error.workspace = true
 keyring.workspace = true
 
 [[test]]


### PR DESCRIPTION
On linux it's possible to not have any keychain to allow persistence of secrets beyond reboot.
Then even attempts to read passwords will result in an error like:

```
The name org.freedesktop.secrets was not provided by any .service files
```

The solution is to install a keychain, which we will now propose.

Related #9507
