### PR TITLE
fix-commit-squashing

### DIFF
--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -733,8 +733,6 @@ export class StackService {
 
 		const targetCommit = localCommits.at(-1)!;
 		const squashCommits = localCommits.slice(0, -1);
-		// API squashes them in the order they are given, so we must reverse the list.
-		squashCommits.reverse();
 
 		await this.squashCommits({
 			projectId,

--- a/crates/but-tools/src/workspace.rs
+++ b/crates/but-tools/src/workspace.rs
@@ -1177,8 +1177,8 @@ impl Tool for SquashCommits {
         <important_notes>
             This tool allows you to squash a sequence of commits in a stack into a single commit with a new message.
             Use this tool to clean up commit history before merging or sharing.
-            Always squash the commits down, meanding newer commits into their parents.
-            Remember that the commits listed in the project status are in reverse order, so the first commit in the list is the newest one.
+            Always squash the commits down, meaning newer commits into their parents.
+            Remember that the commits listed in the project status are in reverse order, so the first commit in the array is the newest one.
         </important_notes>
         ".to_string()
     }
@@ -1198,9 +1198,10 @@ impl Tool for SquashCommits {
         let params: SquashCommitsParameters = serde_json::from_value(parameters)
             .map_err(|e| anyhow::anyhow!("Failed to parse input parameters: {}", e))?;
 
-        squash_commits(ctx, app_handle, params, commit_mapping)?;
+        let value =
+            squash_commits(ctx, app_handle, params, commit_mapping).to_json("squash_commits");
 
-        Ok("Success".into())
+        Ok(value)
     }
 }
 


### PR DESCRIPTION
Fixes squashing multiple (e.g. the squash all commits function)

This simplifies the logic and the performance as well.

Also: Expose the commit ID if the squash commit tool was successful