### PR TITLE
optional stack-id for single-branch support

### DIFF
--- a/apps/desktop/src/lib/stacks/stack.ts
+++ b/apps/desktop/src/lib/stacks/stack.ts
@@ -36,6 +36,37 @@ export type Stack = {
 };
 
 /**
+ * Return (future) type of Tauri `stacks` command.
+ * It's currently used to assure the frontend doesn't accidentally see
+ * an optional stack-id yet, and to show what it would have to be.
+ *
+ * This is only useful if one wants to go from `Stack` -> `StackOpt` -> `RefInfo`.
+ * Ultimately, this is just a step on the way to deal with the entire workspace at once.
+ */
+export type StackOpt = {
+	/**
+	 * The id of the stack, or null if there is no permanent id.
+	 * This can happen if no workspace is known, or even (rare) the workspace
+	 * would be out-of-sync with the workspace data that only we can attach.
+	 * Ideally there is no catastrophic failure if this is null for one
+	 * stack but set for the others.
+	 */
+	id?: string;
+	/**
+	 * Information about the branches contained in the stack.
+	 */
+	heads: StackHeadInfo[];
+	/**
+	 * The commit hash of the tip of the stack.
+	 */
+	tip: string;
+	/**
+	 * Zero-based index for sorting the stacks.
+	 */
+	order: number;
+};
+
+/**
  * Returns the name of the stack.
  *
  * This is the name of the top-most branch in the stack.

--- a/crates/but-action/src/lib.rs
+++ b/crates/but-action/src/lib.rs
@@ -257,7 +257,7 @@ fn stacks_creating_if_none(
             selected_for_changes: None,
         };
         let stack = gitbutler_branch_actions::create_virtual_branch(ctx, &create_req, perm)?;
-        Ok(vec![stack])
+        Ok(vec![stack.into()])
     } else {
         Ok(stacks)
     }

--- a/crates/but-action/src/reword.rs
+++ b/crates/but-action/src/reword.rs
@@ -39,7 +39,7 @@ pub async fn commit(
     let stack_id = stacks
         .iter()
         .find(|s| s.heads.iter().any(|h| h.name == event.branch_name))
-        .map(|s| s.id)
+        .and_then(|s| s.id)
         .ok_or_else(|| anyhow::anyhow!("Stack with name '{}' not found", event.branch_name))?;
     let result = gitbutler_branch_actions::update_commit_message(
         ctx,

--- a/crates/but-action/src/simple.rs
+++ b/crates/but-action/src/simple.rs
@@ -117,11 +117,13 @@ fn handle_changes_simple_inner(
     let stacks = crate::stacks_creating_if_none(ctx, vb_state, &repo, perm)?;
 
     // Put the assignments into buckets by stack ID.
-    let mut stack_assignments: HashMap<StackId, Vec<DiffSpec>> =
-        stacks.iter().map(|s| (s.id, vec![])).collect();
+    let mut stack_assignments: HashMap<StackId, Vec<DiffSpec>> = stacks
+        .iter()
+        .filter_map(|s| Some((s.id?, vec![])))
+        .collect();
     let default_stack_id = stacks
         .first()
-        .map(|s| s.id)
+        .and_then(|s| s.id)
         .ok_or_else(|| anyhow::anyhow!("No stacks found in the workspace"))?;
     for assignment in assignments {
         if let Some(stack_id) = assignment.stack_id {
@@ -161,7 +163,7 @@ fn handle_changes_simple_inner(
 
         let stack_branch_name = stacks
             .iter()
-            .find(|s| s.id == stack_id)
+            .find(|s| s.id == Some(stack_id))
             .and_then(|s| s.heads.first().map(|h| h.name.to_string()))
             .ok_or(anyhow!("Could not find associated reference name"))?;
 

--- a/crates/but-hunk-dependency/src/lib.rs
+++ b/crates/but-hunk-dependency/src/lib.rs
@@ -128,6 +128,7 @@
 //! so in that case it should be fine to fallback to using the first parent.
 mod input;
 
+use anyhow::Context;
 use but_core::{TreeChange, UnifiedDiff};
 use gitbutler_oxidize::ObjectIdExt;
 use gix::prelude::ObjectIdExt as _;
@@ -170,7 +171,9 @@ pub fn workspace_stacks_to_input_stacks(
             commits_from_base_to_tip.push(InputCommit { commit_id, files });
         }
         out.push(InputStack {
-            stack_id: stack.id,
+            stack_id: stack.id.context(
+                "BUG(opt-stack-id): stack-entry without stack-id can't become an input stack",
+            )?,
             commits_from_base_to_tip,
         });
     }

--- a/crates/but-rules/src/handler.rs
+++ b/crates/but-rules/src/handler.rs
@@ -43,7 +43,10 @@ pub fn on_filesystem_change(
         match rule.action {
             super::Action::Explicit(super::Operation::Assign { stack_id }) => {
                 if let Ok(stack_id) = StackId::from_str(&stack_id) {
-                    if !stacks_in_ws.iter().any(|e| e.id == stack_id) {
+                    if !stacks_in_ws
+                        .iter()
+                        .any(|e| e.id.is_some_and(|id| id == stack_id))
+                    {
                         continue;
                     }
                     let assignments = matching(worktree_changes.clone(), rule.filters.clone())

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -225,7 +225,7 @@ pub mod stacks {
         let details = if v3 {
             let meta = ref_metadata_toml(ctx.project())?;
             let repo = ctx.gix_repo_for_merging_non_persisting()?;
-            but_workspace::stack_details_v3(id, &repo, &meta)
+            but_workspace::stack_details_v3(id.into(), &repo, &meta)
         } else {
             but_workspace::stack_details(&project.gb_dir(), id, &ctx)
         }?;

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -280,7 +280,7 @@ pub mod stacks {
         ctx: &CommandContext,
         name: &str,
         description: Option<&str>,
-    ) -> anyhow::Result<ui::StackEntry> {
+    ) -> anyhow::Result<ui::StackEntryNoOpt> {
         let creation_request = gitbutler_branch::BranchCreateRequest {
             name: Some(name.to_string()),
             ..Default::default()
@@ -325,13 +325,13 @@ pub mod stacks {
 
         let stack_entry = stack_entries
             .into_iter()
-            .find(|entry| entry.id == stack_id)
+            .find(|entry| entry.id == Some(stack_id))
             .ok_or_else(|| anyhow::anyhow!("Failed to find stack with ID: {stack_id}"))?;
 
         if description.is_some() {
             gitbutler_branch_actions::stack::update_branch_description(
                 ctx,
-                stack_entry.id,
+                stack_entry.id.context("BUG(opt-stack-id)")?,
                 name.to_string(),
                 description.map(ToOwned::to_owned),
             )?;
@@ -370,7 +370,7 @@ pub mod stacks {
 
         let stack_entry = match id {
             Some(id) => add_branch_to_stack(&ctx, id, name, description, project.clone(), &repo)?,
-            None => create_stack_with_branch(&ctx, name, description)?,
+            None => create_stack_with_branch(&ctx, name, description)?.into(),
         };
 
         if use_json {

--- a/crates/but-tools/src/tool.rs
+++ b/crates/but-tools/src/tool.rs
@@ -3,12 +3,12 @@ use std::{
     sync::Arc,
 };
 
+use crate::emit::EmitToolCall;
+use but_workspace::ui::StackEntryNoOpt;
 use but_workspace::{StackId, ui::StackEntry};
 use gitbutler_command_context::CommandContext;
 use gix::ObjectId;
 use serde_json::json;
-
-use crate::emit::EmitToolCall;
 
 pub struct Toolset<'a> {
     ctx: &'a mut CommandContext,
@@ -142,6 +142,12 @@ pub trait ToolResult: 'static + Send + Sync {
 }
 
 impl ToolResult for Result<StackEntry, anyhow::Error> {
+    fn to_json(&self, action_identifier: &str) -> serde_json::Value {
+        result_to_json(self, action_identifier, "StackEntry")
+    }
+}
+
+impl ToolResult for Result<StackEntryNoOpt, anyhow::Error> {
     fn to_json(&self, action_identifier: &str) -> serde_json::Value {
         result_to_json(self, action_identifier, "StackEntry")
     }

--- a/crates/but-workspace/src/commit.rs
+++ b/crates/but-workspace/src/commit.rs
@@ -20,8 +20,8 @@ impl<'repo> WorkspaceCommit<'repo> {
     /// It still needs its tree set to something non-empty.
     ///
     /// `object_hash` is needed to create an empty tree hash.
-    pub fn create_commit_from_vb_state(
-        stacks: &[crate::ui::StackEntry],
+    pub(crate) fn create_commit_from_vb_state(
+        stacks: &[crate::ui::StackEntryNoOpt],
         object_hash: gix::hash::Kind,
     ) -> gix::objs::Commit {
         // message that says how to get back to where they were

--- a/crates/but-workspace/src/commit_engine/mod.rs
+++ b/crates/but-workspace/src/commit_engine/mod.rs
@@ -495,7 +495,7 @@ pub fn create_commit_and_update_refs(
                             .branches
                             .values()
                             .filter(|stack| stack.in_workspace)
-                            .map(|stack| crate::ui::StackEntry::try_new(repo, stack))
+                            .map(|stack| crate::ui::StackEntryNoOpt::try_new(repo, stack))
                             .collect::<Result<_, _>>()?;
                         stacks.sort_by(|a, b| a.name().cmp(&b.name()));
                         let new_wc = WorkspaceCommit::create_commit_from_vb_state(

--- a/crates/but-workspace/src/stacks.rs
+++ b/crates/but-workspace/src/stacks.rs
@@ -3,7 +3,7 @@ use crate::ref_info::ui::{Commit, Segment};
 use crate::ref_info::ui::{LocalCommit, LocalCommitRelation};
 use crate::ui::{CommitState, PushStatus, StackDetails};
 use crate::{RefInfo, StacksFilter, branch, head_info, ref_info, state_handle, ui};
-use anyhow::Context;
+use anyhow::{Context, bail};
 use bstr::BString;
 use but_core::RefMetadata;
 use but_graph::VirtualBranchesTomlMetadata;
@@ -394,12 +394,13 @@ pub fn stack_details(
     })
 }
 
-/// Get additional information for the stack identified by `stack_id`.
+/// Get additional information for the stack identified by `stack_id`. If `None`, it's the first available stack
+/// and we expect it to have no ID.
 // TODO: StackId shouldn't be used, instead use the ref-name or stack index as universal tip identifier.
 //       It's notable that there isn't always a ref-name available right now in case the ref advanced, but maybe this is something
 //       we can pull out of the metadata information.
 pub fn stack_details_v3(
-    stack_id: StackId,
+    stack_id: Option<StackId>,
     repo: &gix::Repository,
     meta: &VirtualBranchesTomlMetadata,
 ) -> anyhow::Result<ui::StackDetails> {
@@ -432,16 +433,32 @@ pub fn stack_details_v3(
             extra_target_commit_id: meta.data().default_target.as_ref().map(|t| t.sha.to_gix()),
         },
     };
-    let stack = meta.data().branches.get(&stack_id).with_context(|| {
-        format!("Couldn't find {stack_id} even when looking at virtual_branches.toml directly")
-    })?;
-    let full_name = gix::refs::FullName::try_from(format!(
-        "refs/heads/{shortname}",
-        shortname = stack.derived_name()?
-    ))?;
-    let existing_ref = repo.find_reference(&full_name)?;
-    let stack = stack_by_id(ref_info(existing_ref, meta, ref_info_options)?, stack_id, meta)?
-        .with_context(|| format!("Really couldn't find {stack_id} in current HEAD or when searching virtual_branches.toml plainly"))?;
+    let stack = match stack_id {
+        None => {
+            let mut info = head_info(repo, meta, ref_info_options)?;
+            if info.stacks.len() != 1 {
+                bail!(
+                    "BUG(opt-stack-id): should have gotten exactly one stack, got {}",
+                    info.stacks.len()
+                );
+            }
+            info.stacks.pop().unwrap()
+        }
+        Some(stack_id) => {
+            let stack = meta.data().branches.get(&stack_id).with_context(|| {
+                format!(
+                    "Couldn't find {stack_id} even when looking at virtual_branches.toml directly"
+                )
+            })?;
+            let full_name = gix::refs::FullName::try_from(format!(
+                "refs/heads/{shortname}",
+                shortname = stack.derived_name()?
+            ))?;
+            let existing_ref = repo.find_reference(&full_name)?;
+            stack_by_id(ref_info(existing_ref, meta, ref_info_options)?, stack_id, meta)?
+                .with_context(|| format!("Really couldn't find {stack_id} in current HEAD or when searching virtual_branches.toml plainly"))?
+        }
+    };
 
     let branch_details = stack
         .segments

--- a/crates/but-workspace/src/ui.rs
+++ b/crates/but-workspace/src/ui.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use bstr::{BStr, BString, ByteSlice};
 use serde::Serialize;
 
@@ -78,6 +79,24 @@ pub struct StackHeadInfo {
 #[serde(rename_all = "camelCase")]
 pub struct StackEntry {
     /// The ID of the stack.
+    pub id: Option<StackId>,
+    /// The list of the branch information that are part of the stack.
+    /// The list is never empty.
+    /// The first entry in the list is always the most recent branch on top the stack.
+    pub heads: Vec<StackHeadInfo>,
+    /// The tip of the top-most branch, i.e., the most recent commit that would become the parent of new commits of the topmost stack branch.
+    #[serde(with = "gitbutler_serde::object_id")]
+    pub tip: gix::ObjectId,
+    /// The zero-based index for sorting stacks.
+    pub order: Option<usize>,
+}
+
+/// Temporary type to help transitioning to the optional version of stack-entry and ultimately, to [`crate::RefInfo`].
+/// WARNING: for use by parts in the code that can rely on having a `stack_id`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StackEntryNoOpt {
+    /// The ID of the stack.
     pub id: StackId,
     /// The list of the branch information that are part of the stack.
     /// The list is never empty.
@@ -93,15 +112,70 @@ pub struct StackEntry {
 impl StackEntry {
     /// The name of the stack, which is the name of the top-most branch.
     pub fn name(&self) -> Option<&BStr> {
-        self.heads
-            .first()
-            .map(|head| AsRef::<BStr>::as_ref(&head.name))
+        self.heads.first().map(|head| head.name.as_ref())
+    }
+}
+
+impl StackEntryNoOpt {
+    /// The name of the stack, which is the name of the top-most branch.
+    pub fn name(&self) -> Option<&BStr> {
+        self.heads.first().map(|head| head.name.as_ref())
+    }
+}
+
+impl TryFrom<StackEntry> for StackEntryNoOpt {
+    type Error = anyhow::Error;
+
+    fn try_from(
+        StackEntry {
+            id,
+            heads,
+            tip,
+            order,
+        }: StackEntry,
+    ) -> Result<Self, Self::Error> {
+        let id = id.context("BUG(opt-stack-id)")?;
+        Ok(StackEntryNoOpt {
+            id,
+            heads,
+            tip,
+            order,
+        })
+    }
+}
+
+impl From<StackEntryNoOpt> for StackEntry {
+    fn from(
+        StackEntryNoOpt {
+            id,
+            heads,
+            tip,
+            order,
+        }: StackEntryNoOpt,
+    ) -> Self {
+        StackEntry {
+            id: Some(id),
+            heads,
+            tip,
+            order,
+        }
     }
 }
 
 impl StackEntry {
     pub(crate) fn try_new(repo: &gix::Repository, stack: &Stack) -> anyhow::Result<Self> {
         Ok(StackEntry {
+            id: Some(stack.id),
+            heads: crate::stack_heads_info(stack, repo)?,
+            tip: stack.head_oid(repo)?,
+            order: Some(stack.order),
+        })
+    }
+}
+
+impl StackEntryNoOpt {
+    pub(crate) fn try_new(repo: &gix::Repository, stack: &Stack) -> anyhow::Result<Self> {
+        Ok(StackEntryNoOpt {
             id: stack.id,
             heads: crate::stack_heads_info(stack, repo)?,
             tip: stack.head_oid(repo)?,

--- a/crates/but-workspace/src/ui.rs
+++ b/crates/but-workspace/src/ui.rs
@@ -91,8 +91,8 @@ pub struct StackEntry {
     pub order: Option<usize>,
 }
 
-/// Temporary type to help transitioning to the optional version of stack-entry and ultimately, to [`crate::RefInfo`].
-/// WARNING: for use by parts in the code that can rely on having a `stack_id`.
+/// **Temporary type to help transitioning to the optional version of stack-entry** and ultimately, to [`crate::RefInfo`].
+/// WARNING: for use by parts in the code that can rely on having a non-optional `stack_id`. The goal is to have none of these.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StackEntryNoOpt {

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/legacy.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/legacy.rs
@@ -39,7 +39,9 @@ mod stacks {
         insta::assert_debug_snapshot!(actual, @r#"
         [
             StackEntry {
-                id: 00000000-0000-0000-0000-000000000002,
+                id: Some(
+                    00000000-0000-0000-0000-000000000002,
+                ),
                 heads: [
                     StackHeadInfo {
                         name: "C-on-A",
@@ -54,7 +56,9 @@ mod stacks {
                 order: None,
             },
             StackEntry {
-                id: 00000000-0000-0000-0000-000000000001,
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 heads: [
                     StackHeadInfo {
                         name: "B-on-A",
@@ -76,7 +80,9 @@ mod stacks {
         insta::assert_debug_snapshot!(actual, @r#"
         [
             StackEntry {
-                id: 00000000-0000-0000-0000-000000000002,
+                id: Some(
+                    00000000-0000-0000-0000-000000000002,
+                ),
                 heads: [
                     StackHeadInfo {
                         name: "C-on-A",
@@ -91,7 +97,9 @@ mod stacks {
                 order: None,
             },
             StackEntry {
-                id: 00000000-0000-0000-0000-000000000001,
+                id: Some(
+                    00000000-0000-0000-0000-000000000001,
+                ),
                 heads: [
                     StackHeadInfo {
                         name: "B-on-A",
@@ -119,7 +127,9 @@ mod stacks {
         insta::assert_debug_snapshot!(actual, @r#"
         [
             StackEntry {
-                id: 00000000-0000-0000-0000-000000000005,
+                id: Some(
+                    00000000-0000-0000-0000-000000000005,
+                ),
                 heads: [
                     StackHeadInfo {
                         name: "main",
@@ -160,7 +170,7 @@ mod stack_details {
             StackState::InWorkspace,
             &["advanced-lane"],
         );
-        let actual = but_workspace::stack_details_v3(stack_id, &repo, &meta)?;
+        let actual = but_workspace::stack_details_v3(stack_id.into(), &repo, &meta)?;
         insta::assert_debug_snapshot!(actual, @r#"
         StackDetails {
             derived_name: "dependant",
@@ -233,7 +243,7 @@ mod stack_details {
 
         let b_stack_id = add_stack(&mut meta, 1, "B-on-A", StackState::InWorkspace);
         let c_stack_id = add_stack(&mut meta, 2, "C-on-A", StackState::InWorkspace);
-        let actual = but_workspace::stack_details_v3(b_stack_id, &repo, &meta)?;
+        let actual = but_workspace::stack_details_v3(Some(b_stack_id), &repo, &meta)?;
         insta::assert_debug_snapshot!(actual, @r#"
         StackDetails {
             derived_name: "B-on-A",
@@ -290,7 +300,7 @@ mod stack_details {
         }
         "#);
 
-        let actual = but_workspace::stack_details_v3(c_stack_id, &repo, &meta)?;
+        let actual = but_workspace::stack_details_v3(Some(c_stack_id), &repo, &meta)?;
         insta::assert_debug_snapshot!(actual, @r#"
         StackDetails {
             derived_name: "C-on-A",

--- a/crates/but/src/log/mod.rs
+++ b/crates/but/src/log/mod.rs
@@ -16,7 +16,7 @@ pub(crate) fn commit_graph(repo_path: &Path, _json: bool) -> anyhow::Result<()> 
     let ctx = &mut CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
     let stacks = stacks(ctx)?
         .iter()
-        .map(|s| stack_details(ctx, s.id))
+        .filter_map(|s| s.id.map(|id| stack_details(ctx, id)))
         .filter_map(Result::ok)
         .collect::<Vec<_>>();
 
@@ -149,7 +149,7 @@ pub(crate) fn commit_graph(repo_path: &Path, _json: bool) -> anyhow::Result<()> 
 pub(crate) fn all_commits(ctx: &CommandContext) -> anyhow::Result<Vec<CliId>> {
     let stacks = stacks(ctx)?
         .iter()
-        .map(|s| stack_details(ctx, s.id))
+        .filter_map(|s| s.id.map(|id| stack_details(ctx, id)))
         .filter_map(Result::ok)
         .collect::<Vec<_>>();
     let mut matches = Vec::new();

--- a/crates/but/src/log/mod.rs
+++ b/crates/but/src/log/mod.rs
@@ -187,7 +187,7 @@ pub(crate) fn stack_details(
         let meta = VirtualBranchesTomlMetadata::from_path(
             ctx.project().gb_dir().join("virtual_branches.toml"),
         )?;
-        but_workspace::stack_details_v3(stack_id, &repo, &meta)
+        but_workspace::stack_details_v3(Some(stack_id), &repo, &meta)
     } else {
         but_workspace::stack_details(&ctx.project().gb_dir(), stack_id, ctx)
     }

--- a/crates/but/src/mcp_internal/stack.rs
+++ b/crates/but/src/mcp_internal/stack.rs
@@ -24,7 +24,7 @@ pub fn create_stack_with_branch(
     name: &str,
     description: &str,
     current_dir: &Path,
-) -> anyhow::Result<but_workspace::ui::StackEntry> {
+) -> anyhow::Result<but_workspace::ui::StackEntryNoOpt> {
     let project = super::project::project_from_path(current_dir)?;
     // Enable v3 feature flags for the command context
     let app_settings = AppSettings {

--- a/crates/but/src/rub/assign.rs
+++ b/crates/but/src/rub/assign.rs
@@ -92,7 +92,7 @@ pub(crate) fn branch_name_to_stack_id(
         crate::log::stacks(ctx)?
             .iter()
             .find(|s| s.heads.iter().any(|h| h.name == branch_name))
-            .map(|s| s.id)
+            .and_then(|s| s.id)
     } else {
         None
     };

--- a/crates/but/src/rub/undo.rs
+++ b/crates/but/src/rub/undo.rs
@@ -16,7 +16,9 @@ pub(crate) fn stack_id_by_commit_id(
 ) -> anyhow::Result<StackId> {
     let stacks = crate::log::stacks(ctx)?
         .iter()
-        .map(|s| crate::log::stack_details(ctx, s.id).map(|d| (s.id, d)))
+        .filter_map(|s| {
+            s.id.map(|id| crate::log::stack_details(ctx, id).map(|d| (id, d)))
+        })
         .filter_map(Result::ok)
         .collect::<Vec<_>>();
     if let Some((id, _)) = stacks.iter().find(|(_, stack)| {

--- a/crates/but/src/status/mod.rs
+++ b/crates/but/src/status/mod.rs
@@ -19,9 +19,10 @@ pub(crate) fn worktree(repo_path: &Path, _json: bool) -> anyhow::Result<()> {
     let stack_id_to_branch = crate::log::stacks(ctx)?
         .iter()
         .filter_map(|s| {
-            s.heads.first().map(|head| {
+            s.heads.first().and_then(|head| {
+                let id = s.id?;
                 let x = head.name.to_string();
-                (s.id, x)
+                Some((id, x))
             })
         })
         .collect::<BTreeMap<but_workspace::StackId, String>>();

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -70,13 +70,13 @@ pub fn create_virtual_branch(
     ctx: &CommandContext,
     create: &BranchCreateRequest,
     perm: &mut WorktreeWritePermission,
-) -> Result<ui::StackEntry> {
+) -> Result<ui::StackEntryNoOpt> {
     ctx.verify(perm)?;
     ensure_open_workspace_mode(ctx).context("Creating a branch requires open workspace mode")?;
     let branch_manager = ctx.branch_manager();
     let stack = branch_manager.create_virtual_branch(create, perm)?;
     let repo = ctx.gix_repo()?;
-    Ok(ui::StackEntry {
+    Ok(ui::StackEntryNoOpt {
         id: stack.id,
         heads: stack_heads_info(&stack, &repo)?,
         tip: stack.head_oid(&repo)?,

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -55,9 +55,10 @@ pub fn get_base_branch_data(ctx: &CommandContext) -> Result<BaseBranch> {
 
 fn go_back_to_integration(ctx: &CommandContext, default_target: &Target) -> Result<BaseBranch> {
     let gix_repo = ctx.gix_repo_for_merging()?;
-    let mut outcome = but_workspace::merge_worktree_with_workspace(ctx, &gix_repo)?;
+    let (mut outcome, conflict_kind) =
+        but_workspace::merge_worktree_with_workspace(ctx, &gix_repo)?;
 
-    if !outcome.conflicts.is_empty() {
+    if outcome.has_unresolved_conflicts(conflict_kind) {
         return Err(anyhow!("Conflicts while going back to gitbutler/workspace"))
             .context(Marker::ProjectConflict);
     }

--- a/crates/gitbutler-cli/src/command/vbranch.rs
+++ b/crates/gitbutler-cli/src/command/vbranch.rs
@@ -78,15 +78,18 @@ pub(crate) fn stacks(ctx: &CommandContext) -> Result<Vec<(StackId, StackDetails)
     }?;
     let mut details = vec![];
     for stack in stacks {
+        let stack_id = stack
+            .id
+            .context("BUG(opt-stack-id): CLI code shouldn't trigger this")?;
         details.push((
-            stack.id,
+            stack_id,
             if ctx.app_settings().feature_flags.ws3 {
                 let meta = VirtualBranchesTomlMetadata::from_path(
                     ctx.project().gb_dir().join("virtual_branches.toml"),
                 )?;
-                but_workspace::stack_details_v3(stack.id, &repo, &meta)
+                but_workspace::stack_details_v3(stack_id, &repo, &meta)
             } else {
-                but_workspace::stack_details(&ctx.project().gb_dir(), stack.id, ctx)
+                but_workspace::stack_details(&ctx.project().gb_dir(), stack_id, ctx)
             }?,
         ));
     }

--- a/crates/gitbutler-cli/src/command/vbranch.rs
+++ b/crates/gitbutler-cli/src/command/vbranch.rs
@@ -87,7 +87,7 @@ pub(crate) fn stacks(ctx: &CommandContext) -> Result<Vec<(StackId, StackDetails)
                 let meta = VirtualBranchesTomlMetadata::from_path(
                     ctx.project().gb_dir().join("virtual_branches.toml"),
                 )?;
-                but_workspace::stack_details_v3(stack_id, &repo, &meta)
+                but_workspace::stack_details_v3(stack_id.into(), &repo, &meta)
             } else {
                 but_workspace::stack_details(&ctx.project().gb_dir(), stack_id, ctx)
             }?,

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -1,7 +1,7 @@
 pub mod commands {
     use anyhow::{anyhow, Context};
     use but_settings::AppSettingsWithDiskSync;
-    use but_workspace::ui::StackEntry;
+    use but_workspace::ui::StackEntryNoOpt;
     use but_workspace::DiffSpec;
     use gitbutler_branch::{BranchCreateRequest, BranchUpdateRequest};
     use gitbutler_branch_actions::branch_upstream_integration::IntegrationStrategy;
@@ -37,7 +37,7 @@ pub mod commands {
         settings: State<'_, AppSettingsWithDiskSync>,
         project_id: ProjectId,
         branch: BranchCreateRequest,
-    ) -> Result<StackEntry, Error> {
+    ) -> Result<StackEntryNoOpt, Error> {
         let project = projects.get(project_id)?;
         let ctx = CommandContext::open(&project, settings.get()?.clone())?;
         let stack_entry = gitbutler_branch_actions::create_virtual_branch(

--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -96,7 +96,7 @@ pub fn stack_details(
     projects: State<'_, projects::Controller>,
     settings: State<'_, AppSettingsWithDiskSync>,
     project_id: ProjectId,
-    stack_id: StackId,
+    stack_id: Option<StackId>,
 ) -> Result<but_workspace::ui::StackDetails, Error> {
     let project = projects.get(project_id)?;
     let ctx = CommandContext::open(&project, settings.get()?.clone())?;
@@ -105,7 +105,11 @@ pub fn stack_details(
         let meta = ref_metadata_toml(ctx.project())?;
         but_workspace::stack_details_v3(stack_id, &repo, &meta)
     } else {
-        but_workspace::stack_details(&project.gb_dir(), stack_id, &ctx)
+        but_workspace::stack_details(
+            &project.gb_dir(),
+            stack_id.context("BUG(opt-stack-id)")?,
+            &ctx,
+        )
     }
     .map_err(Into::into)
 }

--- a/crates/gitbutler-testsupport/src/lib.rs
+++ b/crates/gitbutler-testsupport/src/lib.rs
@@ -179,16 +179,19 @@ pub fn stack_details(ctx: &CommandContext) -> Vec<(StackId, StackDetails)> {
     .unwrap();
     let mut details = vec![];
     for stack in stacks {
+        let stack_id = stack
+            .id
+            .expect("BUG(opt-stack-id): test code shouldn't trigger this");
         details.push((
-            stack.id,
+            stack_id,
             if ctx.app_settings().feature_flags.ws3 {
                 let meta = VirtualBranchesTomlMetadata::from_path(
                     ctx.project().gb_dir().join("virtual_branches.toml"),
                 )
                 .unwrap();
-                but_workspace::stack_details_v3(stack.id, &repo, &meta)
+                but_workspace::stack_details_v3(stack_id, &repo, &meta)
             } else {
-                but_workspace::stack_details(&ctx.project().gb_dir(), stack.id, ctx)
+                but_workspace::stack_details(&ctx.project().gb_dir(), stack_id, ctx)
             }
             .unwrap(),
         ));

--- a/crates/gitbutler-testsupport/src/lib.rs
+++ b/crates/gitbutler-testsupport/src/lib.rs
@@ -189,7 +189,7 @@ pub fn stack_details(ctx: &CommandContext) -> Vec<(StackId, StackDetails)> {
                     ctx.project().gb_dir().join("virtual_branches.toml"),
                 )
                 .unwrap();
-                but_workspace::stack_details_v3(stack_id, &repo, &meta)
+                but_workspace::stack_details_v3(stack_id.into(), &repo, &meta)
             } else {
                 but_workspace::stack_details(&ctx.project().gb_dir(), stack_id, ctx)
             }


### PR DESCRIPTION
That way it's possible to start consuming the underlying workspace data, instead of relying on `stack_details`.

Doing so would also enable GB to follow the user to any checked-out branch.

Related to #9516, which would be needed to recover from commits that put a stack-segment's ref outside of the workspace.

### Tasks

* [ ] ~~backend endpoint and RefInfo serialisation~~
    - not for now, prefer a small step.
* [x] stacks returns stackentry with optional stack-id
* [x] stack_details with optional stack-id
* [x] test for `stacks` and `stack_details()` outside workspace
* [x] adapt frontend to optional stack-id
* [ ] ~~(optional) let `ws3` not respond with a 'need workspace' screen, but instead let it refresh the view~~
    - Even though I could change the backend, I would have no idea how to make this do anything useful in the frontend.
       Thus the frontend still wouldn't encounter a non-workspace branch in the wild.
* [x] validate UI still works

### Notes for the reviewer

* I validated that the UI still works normally with limited UI testing.
* the old `stacks` and `stack_details` APIs are retrofitted to use optional `stack_id`, indicating that there is no workspace and just a single stack.
* detached heads can't be represented with the old API as branches must have names, it needs the new `head_info()` data.
* The frontend is adjusted to stop missing stack-ids at runtime, to allow adjusting it in a controlled fashion.
* The backend code that consumes the old APIs, `stacks` and `stack_details`, was adjusted to basically filter-out and ignore such stacks, and I suppose it would go to `head_info` directly.
