### PR TITLE
update all docs urls

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_documentation.yml
+++ b/.github/ISSUE_TEMPLATE/2_documentation.yml
@@ -17,6 +17,6 @@ body:
   - type: input
     attributes:
       label: Does the docs page already exist? If so, please link to it.
-      description: https://docs.gitbutler.com/features/virtual-branches
+      description: https://docs.gitbutler.com/features/virtual-branches/virtual-branches
     validations:
       required: false

--- a/apps/desktop/src/components/CommitSigningForm.svelte
+++ b/apps/desktop/src/components/CommitSigningForm.svelte
@@ -184,7 +184,7 @@
 			<SectionCardDisclaimer>
 				Signing commits can allow other people to verify your commits if you publish the public
 				version of your signing key.
-				<Link href="https://docs.gitbutler.com/features/virtual-branches/verifying-commits"
+				<Link href="https://docs.gitbutler.com/features/virtual-branches/signing-commits"
 					>Read more</Link
 				> about commit signing and verification.
 			</SectionCardDisclaimer>

--- a/apps/desktop/src/components/Feed.svelte
+++ b/apps/desktop/src/components/Feed.svelte
@@ -188,7 +188,7 @@
 									controlled.
 								</p>
 								<Link
-									href="https://docs.gitbutler.com/agentic-workflows"
+									href="https://docs.gitbutler.com/features/ai-integration/ai-overview"
 									target="_blank"
 									class="clr-text-2">Learn more</Link
 								>
@@ -251,7 +251,8 @@
 									<li>
 										Cursor / VSCode setup. <Link
 											class="clr-text-2"
-											href="https://docs.gitbutler.com/agentic-workflows/cursor">Learn more</Link
+											href="https://docs.gitbutler.com/features/ai-integration/mcp-server"
+											>Learn more</Link
 										>
 									</li>
 								</ul>

--- a/apps/desktop/src/components/ForgeForm.svelte
+++ b/apps/desktop/src/components/ForgeForm.svelte
@@ -113,7 +113,7 @@
 
 			{#snippet caption()}
 				Learn how find your GitLab Personal Token and Project ID in our <Link
-					href="https://docs.gitbutler.com/features/gitlab-integration">docs</Link
+					href="https://docs.gitbutler.com/features/forge-integration/gitlab-integration">docs</Link
 				>
 				<br />
 				The Fork Project ID is where your branches will be pushed, and the Upstream Project ID is where

--- a/apps/desktop/src/components/NewBranchModal.svelte
+++ b/apps/desktop/src/components/NewBranchModal.svelte
@@ -14,7 +14,8 @@
 		stackId: string;
 	}
 
-	const BRANCH_STACKING_DOCS = 'https://docs.gitbutler.com/features/stacked-branches';
+	const BRANCH_STACKING_DOCS =
+		'https://docs.gitbutler.com/features/virtual-branches/stacked-branches';
 	function clickOnDocsLink() {
 		openExternalUrl(BRANCH_STACKING_DOCS);
 	}

--- a/apps/desktop/src/components/profileSettings/GitSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/GitSettings.svelte
@@ -30,7 +30,7 @@
 		<Link
 			target="_blank"
 			rel="noreferrer"
-			href="https://docs.gitbutler.com/features/virtual-branches/committer-mark"
+			href="https://github.com/gitbutlerapp/gitbutler-docs/blob/d81a23779302c55f8b20c75bf7842082815b4702/content/docs/features/virtual-branches/committer-mark.mdx"
 		>
 			Learn more
 		</Link>

--- a/apps/desktop/src/lib/error/knownErrors.ts
+++ b/apps/desktop/src/lib/error/knownErrors.ts
@@ -4,7 +4,7 @@ export const KNOWN_ERRORS: Record<string, string> = {
 	[Code.CommitSigningFailed]: `
 Commit signing failed and has now been disabled. You can configure commit signing in the project settings.
 
-Please check our [documentation](https://docs.gitbutler.com/features/virtual-branches/verifying-commits) on setting up commit signing and verification.
+Please check our [documentation](https://docs.gitbutler.com/features/virtual-branches/signing-commits) on setting up commit signing and verification.
 		`,
 	[Code.SecretKeychainNotFound]: `
 Please install a keychain service to store and retrieve secrets with.

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -76,7 +76,7 @@
 					<Button style="pop" icon="open-link">Learn How to Create Reviews</Button>
 				</a>
 				<a
-					href="https://docs.gitbutler.com/features/virtual-branches"
+					href="https://docs.gitbutler.com/features/virtual-branches/virtual-branches"
 					target="_blank"
 					rel="noopener noreferrer"
 				>

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -14,7 +14,7 @@
 //!   - GitButler implements the concept of a branch stack. This is essentially a collection of "heads"
 //!     (pseudo branches) that contain each other.
 //!   - Always contains at least one branch.
-//!   - High level documentation here: <https://docs.gitbutler.com/features/stacked-branches>
+//!   - High level documentation here: <https://docs.gitbutler.com/features/virtual-branches/stacked-branches>
 //! * **Target Branch**
 //!   - The branch every stack in the workspace wants to get merged into.
 //!   - It's usually a local tracking branch, but doesn't have to if no Git *remote* is associated with it.


### PR DESCRIPTION
Some of these docs urls have been changed. I have added redirects for 
all the existing ones, but it’s probably better to also update the urls 
for new builds.