### PR TITLE
fix: mode service listens to the right endpoint

### DIFF
--- a/apps/desktop/src/lib/mode/modeService.ts
+++ b/apps/desktop/src/lib/mode/modeService.ts
@@ -143,7 +143,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					}
 					await lifecycleApi.cacheDataLoaded;
 					const unsubscribe = lifecycleApi.extra.tauri.listen<HeadAndMode>(
-						`project://${arg.projectId}/head`,
+						`project://${arg.projectId}/git/head`,
 						(event) => {
 							lifecycleApi.updateCachedData(() => event.payload.operatingMode);
 							lifecycleApi.dispatch(


### PR DESCRIPTION
The mode service listens to the correct channel endpoint in order to determine which mode the appliction is in