### PR TITLE
fix integration check for amended pushed commits

### DIFF
--- a/crates/but-workspace/src/commit_engine/mod.rs
+++ b/crates/but-workspace/src/commit_engine/mod.rs
@@ -4,7 +4,6 @@ use crate::{DiffSpec, commit_engine::reference_frame::InferenceMode};
 use anyhow::{Context, bail};
 use bstr::BString;
 use but_core::RepositoryExt;
-use but_core::commit::HeadersV2;
 use but_rebase::RebaseOutput;
 use but_rebase::commit::DateMode;
 use but_rebase::merge::ConflictErrorContext;
@@ -258,9 +257,6 @@ pub fn create_commit(
                 commit.tree = new_tree;
                 if let Some(message) = new_message {
                     commit.message = message.into();
-                }
-                if commit.headers().is_some() {
-                    HeadersV2::remove_in_commit(&mut commit);
                 }
                 Some(but_rebase::commit::create(
                     repo,

--- a/crates/but-workspace/tests/workspace/commit_engine/amend_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/amend_commit.rs
@@ -51,7 +51,7 @@ fn all_changes_and_renames_to_topmost_commit_no_parent() -> anyhow::Result<()> {
     CreateCommitOutcome {
         rejected_specs: [],
         new_commit: Some(
-            Sha1(b8af2cbc086bd0eb212ff21fd3f7c472663238eb),
+            Sha1(1e8275bd6e656965ed0729797362abc2e1fb633d),
         ),
         changed_tree_pre_cherry_pick: Some(
             Sha1(e56fc9bacdd11ebe576b5d96d21127c423698126),
@@ -70,13 +70,14 @@ fn all_changes_and_renames_to_topmost_commit_no_parent() -> anyhow::Result<()> {
     "#);
 
     // It adjusts both the author and the committer date.
-    // It also *removes* the change-id as it to assure we won't use it to determine
-    // commit similarity anymore - after all, the commit is likely to have been changed,
-    // and we have to use the changeset ID (computed) to figure it out now.
+    // It does, however, leave the change-id as it's considered the ID of the commit itself,
+    // which thus should never be removed.
     insta::assert_snapshot!(visualize_commit(&repo, &outcome)?, @r"
     tree e56fc9bacdd11ebe576b5d96d21127c423698126
     author author <author@example.com> 946684866 +0633
     committer committer (From Env) <committer@example.com> 946771266 +0633
+    gitbutler-headers-version 2
+    gitbutler-change-id 00000000-0000-0000-0000-000000003333
 
     init: amended
     ");

--- a/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
@@ -137,7 +137,7 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
     assure_no_worktree_changes(&repo)?;
     // The top commit has a different hash now thanks to amending.
     insta::assert_snapshot!(graph_commit_outcome(&repo, &outcome)?, @r"
-    * 4d1daf3 (HEAD -> main) third commit
+    * 6073a81 (HEAD -> main) third commit
     * 64c4463 (tag: tag-that-should-not-move, another-tip) second commit
     * 3dd3955 initial commit
     ");
@@ -193,7 +193,7 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
     CreateCommitOutcome {
         rejected_specs: [],
         new_commit: Some(
-            Sha1(a1722ae3783c7a463c1d73d6d5498c8f37a5e066),
+            Sha1(28868dd070be350f335ad8869c728343fa2929f8),
         ),
         changed_tree_pre_cherry_pick: Some(
             Sha1(273aeca7ca98af0f7972af6e7859a3ae7fde497a),
@@ -205,22 +205,22 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
                         "refs/heads/main",
                     ),
                 ),
-                old_commit_id: Sha1(4d1daf36b8ab77aff228e580486f2ae7017e442b),
-                new_commit_id: Sha1(a1722ae3783c7a463c1d73d6d5498c8f37a5e066),
+                old_commit_id: Sha1(6073a81d14db7169b56ac39bcf59f906df532302),
+                new_commit_id: Sha1(28868dd070be350f335ad8869c728343fa2929f8),
             },
             UpdatedReference {
                 reference: Virtual(
                     "s1-b/second",
                 ),
-                old_commit_id: Sha1(4d1daf36b8ab77aff228e580486f2ae7017e442b),
-                new_commit_id: Sha1(a1722ae3783c7a463c1d73d6d5498c8f37a5e066),
+                old_commit_id: Sha1(6073a81d14db7169b56ac39bcf59f906df532302),
+                new_commit_id: Sha1(28868dd070be350f335ad8869c728343fa2929f8),
             },
             UpdatedReference {
                 reference: Virtual(
                     "s2-b/second",
                 ),
-                old_commit_id: Sha1(4d1daf36b8ab77aff228e580486f2ae7017e442b),
-                new_commit_id: Sha1(a1722ae3783c7a463c1d73d6d5498c8f37a5e066),
+                old_commit_id: Sha1(6073a81d14db7169b56ac39bcf59f906df532302),
+                new_commit_id: Sha1(28868dd070be350f335ad8869c728343fa2929f8),
             },
         ],
         rebase_output: None,
@@ -230,8 +230,8 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
     write_vrbranches_to_refs(&vb, &repo)?;
     // It updates stack heads and stack branch heads.
     insta::assert_snapshot!(graph_commit_outcome(&repo, &outcome)?, @r"
-    * a1722ae (HEAD -> main, s2-b/second, s1-b/second) fourth commit
-    * 4d1daf3 third commit
+    * 28868dd (HEAD -> main, s2-b/second, s1-b/second) fourth commit
+    * 6073a81 third commit
     * 64c4463 (tag: tag-that-should-not-move, s2-b/first, s1-b/first, another-tip) second commit
     * 3dd3955 (s2-b/init, s1-b/init) initial commit
     ");
@@ -699,8 +699,8 @@ fn insert_commit_into_single_stack_with_signatures() -> anyhow::Result<()> {
     )?;
     let rewritten_head_id = repo.head_id()?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
-    * 0dea79a (HEAD -> main) insert 10 lines to the top
-    * 701a621 (s1-b/init) between initial and former first
+    * 07a0229 (HEAD -> main) insert 10 lines to the top
+    * d9d87b9 (s1-b/init) between initial and former first
     * ecd6722 (tag: first-commit, first-commit) init
     ");
     insta::assert_snapshot!(but_testsupport::visualize_tree(rewritten_head_id), @r#"


### PR DESCRIPTION
Removing it might help the integration check to do the right thing, but it's always wrong considering that the change-id tracks the 'container'.

Thus, in order to prevent integrated commits to seem unchanged after amend, the integration check has to avoid using the changeid for them instead.

Meanwhile, the changeid should be used still when dealing with amends to pushed commits, or else these will show up as completely separate.

### Tasks

* [x] undo the previous fix to keep change-ids after amends
    - This can be merged at any time to fix the issue, should the need arise
* [ ] add tests for change-id related integration checks for both pushed commits
      and integrated ones.
    - [ ] integrated commits shouldn't seem integrated after an amend
    - [ ] remote commits should still match their remote-commit after amend

https://github.com/user-attachments/assets/feb9047f-94c5-4c3b-8ad2-6d6814c2b79c

