### PR TITLE
fix integration check for amended pushed commits

### DIFF
--- a/crates/but-workspace/tests/fixtures/scenario/all-file-types-renamed-and-modified.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/all-file-types-renamed-and-modified.sh
@@ -4,24 +4,8 @@
 # A commit with an executable, a normal file, a symlink and an untracked fifo.
 # Then each item gets renamed in the worktree.
 
-function add_change_id_and_reset_head() {
-   local change_id="00000000-0000-0000-0000-000000003333"
+source "${BASH_SOURCE[0]%/*}/shared.sh"
 
-   # Insert the Change-ID header lines after the committer line.
-   git cat-file -p "${1:?first argument is the commit to add a changeid to}" \
-   | awk -v cid="$change_id" '
-     BEGIN { injected = 0 }
-     /^$/ && !injected {
-       print "gitbutler-headers-version 2"
-       print "gitbutler-change-id " cid
-       print ""
-       injected = 1
-       next
-     }
-     { print }
-     ' \
-   | git hash-object -wt commit --stdin >.git/refs/heads/main
-}
 set -eu -o pipefail
 
 git init
@@ -31,7 +15,7 @@ ln -s nonexisting-target link
 mkfifo fifo-should-be-ignored
 
 git add . && git commit -m "init"
-add_change_id_and_reset_head "$(git rev-parse HEAD)"
+add_change_id_to_given_commit 3333 "$(git rev-parse HEAD)" >.git/refs/heads/main
 
 seq 5 10 >file
 seq 1 5 >executable

--- a/crates/but-workspace/tests/fixtures/scenario/journey03.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/journey03.sh
@@ -30,6 +30,62 @@ The branch should then be considered integrated" >.git/description
   create_workspace_commit_once A
 )
 
+git init 01-with-local-amended-after-integration
+(cd 01-with-local-amended-after-integration
+  echo "two local commits pushed to a remote, then rebased onto target, and local amended
+
+The branch should then *not* be considered integrated anymore as A2 has changed" >.git/description
+  commit init && setup_target_to_match_main
+  git checkout -b A
+    echo A-new >file && git add file && git commit -m A1
+    echo A-new >other-squashed && git add other-squashed && git commit -m A2
+    add_change_id_to_given_commit 2 @ | write_ref_safely .git/refs/heads/A
+    git rev-parse @ >.git/refs/remotes/origin/A
+
+  git checkout main
+    # assure the time and message based check won't match.
+    tick
+    commit M1
+    git cherry-pick :/A1
+    # instead of cherry-picking, we create the 'original' version of the commit
+    # and assign it the right change-id.
+    echo A-new >other && git add other && git commit -m A2
+    add_change_id_to_given_commit 2 @ | write_ref_safely .git/refs/heads/main
+
+    echo M-change >>file && git commit -am M2
+    echo M-change >>other && git commit -am M3
+    git rev-parse @ >.git/refs/remotes/origin/main
+
+  git checkout A
+  create_workspace_commit_once A
+)
+
+git init 01-rewritten-local-commit-is-paired-with-remote
+(cd 01-rewritten-local-commit-is-paired-with-remote
+  echo "two local commits pushed to a remote, then changed locally.
+
+One is changed locally and matched by message, the other one is matched by change-id
+as the content is too different." >.git/description
+  commit init && setup_target_to_match_main
+  git checkout -b A
+    git branch soon-A-remote
+    echo A-new >file-different && git add file-different && git commit -m A1
+    echo A-new >other-different && git add other-different && git commit -m A2
+    add_change_id_to_given_commit 2 @ | write_ref_safely .git/refs/heads/A
+
+  git checkout soon-A-remote
+    # Here we want to the time and author check to match.
+    echo A-new >file && git add file && git commit -m A1
+    # assure the time and message based check won't match, so we get the change-id
+    tick
+    echo A-new >other && git add other && git commit -m A2
+    add_change_id_to_given_commit 2 @ | write_ref_safely .git/refs/heads/soon-A-remote
+    setup_remote_tracking soon-A-remote A "move"
+
+  git checkout A
+  create_workspace_commit_once A
+)
+
 git init 01-one-rewritten-one-local-after-push-author-date-change
 (cd 01-one-rewritten-one-local-after-push-author-date-change
   echo "two local commits pushed to a remote, then rebased onto target, but with the author date adjusted.

--- a/crates/but-workspace/tests/fixtures/scenario/shared.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/shared.sh
@@ -108,3 +108,29 @@ function commit() {
   local message=${1:?first argument is the commit message}
   git commit -m "$message" --allow-empty
 }
+
+function add_change_id_to_given_commit() {
+  local a="00000000-0000-0000-0000-000000000000"
+  local b="${1:?first argument is the single-digit number of the change-id}"
+  local change_id="${a:0:${#a}-${#b}}${b}"
+
+   # Insert the Change-ID header lines after the committer line.
+   git cat-file -p "${2:?second argument is the commit to add a changeid to}" \
+   | awk -v cid="$change_id" '
+     BEGIN { injected = 0 }
+     /^$/ && !injected {
+       print "gitbutler-headers-version 2"
+       print "gitbutler-change-id " cid
+       print ""
+       injected = 1
+       next
+     }
+     { print }
+     ' \
+   | git hash-object -wt commit --stdin
+}
+
+function write_ref_safely() {
+  cat >.git/tmp
+  mv .git/tmp "${1:?first argument is the full path to the ref to write}"
+}


### PR DESCRIPTION
Removing it might help the integration check to do the right thing, but it's always wrong considering that the change-id tracks the 'container'.

Thus, in order to prevent integrated commits to seem unchanged after amend, the integration check has to avoid using the changeid for them instead.

Meanwhile, the changeid should be used still when dealing with amends to pushed commits, or else these will show up as completely separate.

### Tasks

* [x] add tests for change-id related integration checks for both pushed commits
      and integrated ones.
    - [x] integrated commits shouldn't seem integrated after an amend
    - [x] remote commits should still match their remote-commit after amend

https://github.com/user-attachments/assets/feb9047f-94c5-4c3b-8ad2-6d6814c2b79c


