### PR TITLE
Set backend retention to 0 from detault (60)

### DIFF
--- a/apps/desktop/src/lib/state/clientState.svelte.ts
+++ b/apps/desktop/src/lib/state/clientState.svelte.ts
@@ -186,6 +186,7 @@ function createBackendApi(butlerMod: ReturnType<typeof butlerModule>) {
 		reducerPath: 'backend',
 		tagTypes: Object.values(ReduxTag),
 		invalidationBehavior: 'immediately',
+		keepUnusedDataFor: 0,
 		baseQuery: tauriBaseQuery,
 		endpoints: (_) => {
 			return {};


### PR DESCRIPTION
This way `listen()` commands will actually terminate as expected when a 
query is unsubscribed.