### PR TITLE
Fix: commit title stale value on click after generate

### DIFF
--- a/apps/desktop/cypress/e2e/unifiedDiffView.cy.ts
+++ b/apps/desktop/cypress/e2e/unifiedDiffView.cy.ts
@@ -223,7 +223,7 @@ describe('Unified Diff View', () => {
 			});
 	});
 
-	it('should display the correct option in the hunk context menu for the uncommitted changes with selected lines', () => {
+	it.only('should display the correct option in the hunk context menu for the uncommitted changes with selected lines', () => {
 		// There should be uncommitted changes
 		cy.getByTestId('uncommitted-changes-file-list').should('be.visible');
 
@@ -241,11 +241,13 @@ describe('Unified Diff View', () => {
 			cy.getByTestId('file-list-item').first().click();
 		});
 
-		cy.getByTestId('unified-diff-view').within(() => {
-			// Select the first line in the hunk
-			// and then right click on it.
-			cy.get('[data-is-delta-line=true]').first().click().rightclick();
-		});
+		cy.getByTestId('unified-diff-view')
+			.first()
+			.within(() => {
+				// Select the first line in the hunk
+				// and then right click on it.
+				cy.get('[data-is-delta-line=true]').first().click().rightclick();
+			});
 
 		// The hunk context menu should be opened
 		cy.getByTestId('hunk-context-menu')

--- a/apps/desktop/src/components/CommitMessageEditor.svelte
+++ b/apps/desktop/src/components/CommitMessageEditor.svelte
@@ -46,7 +46,7 @@
 		noPadding,
 		disabledAction,
 		loading,
-		title = $bindable(),
+		title,
 		description,
 		floatingBoxHeader = 'Create commit',
 		existingCommitId
@@ -95,7 +95,6 @@
 		if (generatedText) {
 			const newMessage = splitMessage(generatedText);
 			title = newMessage.title;
-
 			composer?.setText(newMessage.description);
 		}
 	});
@@ -130,6 +129,8 @@
 
 			if (output) {
 				generatedText = output;
+				const newMessage = splitMessage(generatedText);
+				onChange?.({ title: newMessage.title, description: newMessage.description });
 			}
 		} finally {
 			aiIsLoading = false;

--- a/apps/desktop/src/components/NewCommitView.svelte
+++ b/apps/desktop/src/components/NewCommitView.svelte
@@ -8,7 +8,7 @@
 	import { UNCOMMITTED_SERVICE } from '$lib/selection/uncommittedService.svelte';
 	import { COMMIT_ANALYTICS } from '$lib/soup/commitAnalytics';
 	import { STACK_SERVICE, type RejectionReason } from '$lib/stacks/stackService.svelte';
-	import { UI_STATE } from '$lib/state/uiState.svelte';
+	import { UI_STATE, type NewCommitMessage } from '$lib/state/uiState.svelte';
 	import { TestId } from '$lib/testing/testIds';
 	import { inject } from '@gitbutler/shared/context';
 	import toasts from '@gitbutler/ui/toasts';
@@ -217,11 +217,23 @@
 	}
 
 	function handleMessageUpdate(title?: string, description?: string) {
+		let newCommitMessageUpdate: Partial<NewCommitMessage> | undefined = undefined;
 		if (typeof title === 'string') {
-			stackState.newCommitMessage.current = { ...stackState.newCommitMessage.current, title };
+			newCommitMessageUpdate = { title };
 		}
+
 		if (typeof description === 'string') {
-			stackState.newCommitMessage.current = { ...stackState.newCommitMessage.current, description };
+			newCommitMessageUpdate = {
+				...newCommitMessageUpdate,
+				description
+			};
+		}
+
+		if (newCommitMessageUpdate) {
+			stackState.newCommitMessage.set({
+				...stackState.newCommitMessage.current,
+				...newCommitMessageUpdate
+			});
 		}
 	}
 


### PR DESCRIPTION
Fixes an issue where clicking on the commit title immediately after generating it would apply a stale value due to improper state updates. Updates CommitMessageEditor to correctly synchronize title/description with parent state on AI generation. Refactors NewCommitView to robustly update new commit message state using partial updates, preventing loss of information when updating title or description separately.