### PR TITLE
Improve project cloning UX, error messages and navigation

### DIFF
--- a/apps/desktop/src/lib/project/projectsService.ts
+++ b/apps/desktop/src/lib/project/projectsService.ts
@@ -149,7 +149,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				query: (args) => args,
 				providesTags: (_result, _error, args) => providesItem(ReduxTag.Project, args.projectId)
 			}),
-			addProject: build.mutation<Project[], { path: string }>({
+			addProject: build.mutation<Project, { path: string }>({
 				extraOptions: { command: 'add_project' },
 				query: (args) => args,
 				invalidatesTags: () => [invalidatesList(ReduxTag.Project)]


### PR DESCRIPTION
- Display user-friendly actionable error messages when project cloning fails in the CloneForm UI.
- After successful clone, automatically navigate to the project.
- Correct the return type from the add_project endpoint to return a single Project (not an array), updating usage accordingly.

This commit improves both the user experience and service correctness for project cloning.