### PR TITLE
Fix Windows project add - restore setTarget on branch select

### DIFF
--- a/apps/desktop/src/components/ProjectSetup.svelte
+++ b/apps/desktop/src/components/ProjectSetup.svelte
@@ -66,6 +66,7 @@
 					{remoteBranches}
 					onBranchSelected={async (branch) => {
 						selectedBranch = branch;
+						setTarget();
 					}}
 				/>
 			{/snippet}


### PR DESCRIPTION
Fixes a condition where Windows users were not able to add a project to GitButler due to the mistaken removal of the setTarget call. 

This reinstates the correct setting of the project target for Windows users when selecting a branch.

fixes https://github.com/gitbutlerapp/gitbutler/issues/9532

