### PR TITLE
Open in finder

### DIFF
--- a/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
+++ b/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
@@ -37,6 +37,16 @@
 		);
 	});
 
+	shortcutService.on('show-in-finder', async () => {
+		const project = await projectsService.fetchProject(projectId);
+		if (!project) {
+			throw new Error(`Project not found: ${projectId}`);
+		}
+		// Show the project directory in the default file manager (cross-platform)
+		const { invoke } = await import('@tauri-apps/api/core');
+		await invoke('show_in_finder', { path: project.path });
+	});
+
 	shortcutService.on('history', () => {
 		$showHistoryView = !$showHistoryView;
 	});

--- a/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
+++ b/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
@@ -8,7 +8,7 @@
 	import { SHORTCUT_SERVICE } from '$lib/shortcuts/shortcutService.svelte';
 	import * as events from '$lib/utils/events';
 	import { unsubscribe } from '$lib/utils/unsubscribe';
-	import { getEditorUri, openExternalUrl } from '$lib/utils/url';
+	import { getEditorUri, openExternalUrl, showFileInFolder } from '$lib/utils/url';
 	import { inject } from '@gitbutler/shared/context';
 	import { onMount } from 'svelte';
 
@@ -43,8 +43,7 @@
 			throw new Error(`Project not found: ${projectId}`);
 		}
 		// Show the project directory in the default file manager (cross-platform)
-		const { invoke } = await import('@tauri-apps/api/core');
-		await invoke('show_in_finder', { path: project.path });
+		await showFileInFolder(project.path);
 	});
 
 	shortcutService.on('history', () => {

--- a/apps/desktop/src/components/v3/FileContextMenu.svelte
+++ b/apps/desktop/src/components/v3/FileContextMenu.svelte
@@ -390,18 +390,13 @@
 						<ContextMenuItem
 							label={showInFolderLabel}
 							onclick={async () => {
-								try {
-									const project = await projectService.fetchProject(projectId);
-									const projectPath = project?.path;
-									if (projectPath) {
-										const absPath = await join(projectPath, changes[0]!.path);
-										await showFileInFolder(absPath);
-									}
-									contextMenu.close();
-								} catch (error) {
-									console.error('Failed to show in file manager:', error);
-									toasts.error('Failed to show in file manager');
+								const project = await projectService.fetchProject(projectId);
+								const projectPath = project?.path;
+								if (projectPath) {
+									const absPath = await join(projectPath, changes[0]!.path);
+									await showFileInFolder(absPath);
 								}
+								contextMenu.close();
 							}}
 						/>
 					{/if}

--- a/apps/desktop/src/lib/utils/url.ts
+++ b/apps/desktop/src/lib/utils/url.ts
@@ -22,12 +22,7 @@ export async function openExternalUrl(href: string) {
 }
 
 export async function showFileInFolder(filePath: string) {
-	try {
-		await invoke<void>('show_in_finder', { path: filePath });
-	} catch (error) {
-		console.error('Failed to show in file manager:', error);
-		throw error;
-	}
+	await invoke<void>('show_in_finder', { path: filePath });
 }
 
 export interface EditorUriParams {

--- a/apps/desktop/src/lib/utils/url.ts
+++ b/apps/desktop/src/lib/utils/url.ts
@@ -21,6 +21,15 @@ export async function openExternalUrl(href: string) {
 	}
 }
 
+export async function showFileInFolder(filePath: string) {
+	try {
+		await invoke<void>('show_in_finder', { path: filePath });
+	} catch (error) {
+		console.error('Failed to show in file manager:', error);
+		throw error;
+	}
+}
+
 export interface EditorUriParams {
 	schemeId: string;
 	path: string[];

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -267,6 +267,7 @@ fn main() {
                     modes::edit_initial_index_state,
                     modes::edit_changes_from_initial,
                     open::open_url,
+                    open::show_in_finder,
                     forge::commands::pr_templates,
                     forge::commands::pr_template,
                     settings::get_app_settings,

--- a/crates/gitbutler-tauri/src/menu.rs
+++ b/crates/gitbutler-tauri/src/menu.rs
@@ -160,13 +160,34 @@ pub fn build<R: Runtime>(handle: &AppHandle<R>) -> tauri::Result<tauri::menu::Me
             .build(handle)?,
     ])?;
 
-    let project_menu = &SubmenuBuilder::new(handle, "Project")
+    let mut project_menu_builder = SubmenuBuilder::new(handle, "Project")
         .item(
             &MenuItemBuilder::with_id("project/history", "Project History")
                 .accelerator("CmdOrCtrl+Shift+H")
                 .build(handle)?,
         )
-        .text("project/open-in-vscode", "Open in Editor")
+        .separator()
+        .text("project/open-in-vscode", "Open in Editor");
+
+    #[cfg(target_os = "macos")]
+    {
+        project_menu_builder =
+            project_menu_builder.text("project/show-in-finder", "Show in Finder");
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        project_menu_builder =
+            project_menu_builder.text("project/show-in-finder", "Show in Explorer");
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        project_menu_builder =
+            project_menu_builder.text("project/show-in-finder", "Show in File Manager");
+    }
+
+    let project_menu = &project_menu_builder
         .separator()
         .text("project/settings", "Project Settings")
         .build()?;
@@ -294,6 +315,11 @@ pub fn handle_event(webview: &WebviewWindow, event: &MenuEvent) {
 
     if event.id() == "project/open-in-vscode" {
         emit(webview, SHORTCUT_EVENT, "open-in-vscode");
+        return;
+    }
+
+    if event.id() == "project/show-in-finder" {
+        emit(webview, SHORTCUT_EVENT, "show-in-finder");
         return;
     }
 


### PR DESCRIPTION
## 🧢 Changes

There are two `FileContextMenu.svelte` files. I only updated the one for V3. We should probably refactor and remove the old one later, but I’ll do that in a separate PR.

Added "Open In Finder" in two places.

<img width="566" height="268" alt="image" src="https://github.com/user-attachments/assets/7e6415b9-92cf-4a9e-98ff-e1dcb0e552fd" />
<img width="280" height="181" alt="image" src="https://github.com/user-attachments/assets/87693e42-daa7-497a-9323-12f7fe215042" />


## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
