### PR TITLE
Fix project modeService head event listener

### DIFF
--- a/apps/desktop/src/lib/mode/modeService.ts
+++ b/apps/desktop/src/lib/mode/modeService.ts
@@ -164,7 +164,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					}
 					await lifecycleApi.cacheDataLoaded;
 					const unsubscribe = lifecycleApi.extra.tauri.listen<HeadAndMode>(
-						`project://${arg.projectId}/head`,
+						`project://${arg.projectId}/git/head`,
 						(event) => {
 							lifecycleApi.updateCachedData(() => event.payload.head);
 						}


### PR DESCRIPTION
Update event listener for project head in modeService.ts. Now listens on `project://${projectId}/git/head` (added '/git' for correct routing) instead of the previous `project://${projectId}/head`.