### PR TITLE
Remove unnecessary review creation eligibility check

### DIFF
--- a/apps/desktop/src/components/BranchReview.svelte
+++ b/apps/desktop/src/components/BranchReview.svelte
@@ -35,8 +35,6 @@
 	let modal = $state<Modal>();
 	let confirmCreatePrModal = $state<ReturnType<typeof Modal>>();
 	let reviewCreation = $state<ReturnType<typeof ReviewCreation>>();
-
-	const submitDisabled = $derived(reviewCreation ? !reviewCreation.imports.creationEnabled : false);
 </script>
 
 <CanPublishReviewPlugin
@@ -82,7 +80,6 @@
 		{#snippet controls(close)}
 			<ReviewCreationControls
 				isSubmitting={!!reviewCreation?.imports.isLoading}
-				{submitDisabled}
 				{canPublishPR}
 				{reviewUnit}
 				onCancel={close}

--- a/apps/desktop/src/components/CreateReviewBox.svelte
+++ b/apps/desktop/src/components/CreateReviewBox.svelte
@@ -40,8 +40,6 @@
 	const pr = $derived(prResult?.current.data);
 
 	const canPublishPR = $derived(!!(forge.current.authenticated && !pr));
-
-	const submitDisabled = $derived(reviewCreation ? !reviewCreation.imports.creationEnabled : false);
 </script>
 
 {#snippet editor()}
@@ -56,7 +54,6 @@
 			/>
 			<ReviewCreationControls
 				isSubmitting={!!reviewCreation?.imports.isLoading}
-				{submitDisabled}
 				{canPublishPR}
 				{reviewUnit}
 				onCancel={() => {

--- a/apps/desktop/src/components/ReviewCreation.svelte
+++ b/apps/desktop/src/components/ReviewCreation.svelte
@@ -45,12 +45,11 @@
 		projectId: string;
 		stackId: string;
 		branchName: string;
-		prNumber?: number;
 		reviewId?: string;
 		onClose: () => void;
 	};
 
-	const { projectId, stackId, branchName, prNumber, onClose }: Props = $props();
+	const { projectId, stackId, branchName, onClose }: Props = $props();
 
 	const baseBranch = inject(BASE_BRANCH);
 	const forge = inject(DEFAULT_FORGE_FACTORY);
@@ -80,14 +79,10 @@
 	const commitsResult = $derived(stackService.commits(projectId, stackId, branchName));
 	const commits = $derived(commitsResult.current.data || []);
 
-	const prResult = $derived(prNumber ? prService?.get(prNumber) : undefined);
-	const pr = $derived(prResult?.current.data);
-
 	const forgeBranch = $derived(branchName ? forge.current.branch(branchName) : undefined);
 	const baseBranchName = $derived(baseBranch.shortName);
 
 	const createDraft = persisted<boolean>(false, 'createDraftPr');
-	const createPullRequest = persisted<boolean>(true, 'createPullRequest');
 
 	const pushBeforeCreate = $derived(
 		!forgeBranch || (branchDetails ? requiresPush(branchDetails.pushStatus) : true)
@@ -110,8 +105,6 @@
 
 	let isCreatingReview = $state<boolean>(false);
 	const isExecuting = $derived(stackPush.current.isLoading || aiIsLoading || isCreatingReview);
-
-	const canPublishPR = $derived(!!(forge.current.authenticated && !pr));
 
 	async function getDefaultTitle(commits: Commit[]): Promise<string> {
 		if (commits.length === 1) {
@@ -305,13 +298,6 @@
 		}
 	}
 
-	const isCreateButtonEnabled = $derived.by(() => {
-		if (canPublishPR && $createPullRequest) {
-			return true;
-		}
-		return false;
-	});
-
 	async function onAiButtonClick() {
 		if (!aiGenEnabled || aiIsLoading) return;
 
@@ -347,9 +333,6 @@
 	}
 
 	export const imports = {
-		get creationEnabled() {
-			return isCreateButtonEnabled;
-		},
 		get isLoading() {
 			return isExecuting;
 		}

--- a/apps/desktop/src/components/ReviewCreationControls.svelte
+++ b/apps/desktop/src/components/ReviewCreationControls.svelte
@@ -10,7 +10,7 @@
 	interface Props {
 		isSubmitting: boolean;
 		canPublishPR: boolean;
-		submitDisabled: boolean;
+		submitDisabled?: boolean;
 		reviewUnit: string | undefined;
 		onCancel: () => void;
 		onSubmit: () => void;


### PR DESCRIPTION
This commit removes an unnecessary check that previously determined whether a review could be created or not. Simplifies logic in BranchReview.svelte, CreateReviewBox.svelte, ReviewCreation.svelte, and ReviewCreationControls.svelte by eliminating isCreateButtonEnabled, submitDisabled logic, and related properties. 