### PR TITLE
Move UI state update to stack service

### DIFF
--- a/apps/desktop/src/components/BranchList.svelte
+++ b/apps/desktop/src/components/BranchList.svelte
@@ -72,7 +72,12 @@
 
 	function startEditingCommitMessage(branchName: string, commitId: string) {
 		stackState.selection.set({ branchName, commitId });
-		projectState.exclusiveAction.set({ type: 'edit-commit-message', commitId });
+		projectState.exclusiveAction.set({
+			type: 'edit-commit-message',
+			stackId,
+			branchName,
+			commitId
+		});
 	}
 
 	async function handleEditPatch(args: {

--- a/apps/desktop/src/components/CommitView.svelte
+++ b/apps/desktop/src/components/CommitView.svelte
@@ -79,6 +79,8 @@
 			case 'edit':
 				projectState.exclusiveAction.set({
 					type: 'edit-commit-message',
+					stackId,
+					branchName: commitKey.branchName,
 					commitId: commitKey.commitId
 				});
 				break;

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -182,48 +182,6 @@
 		intelligentScrollingService.show(projectId, stack.id, 'stack');
 	}
 
-	// Clear selection if branch cannot be found.
-	// TODO: How can we express this better?
-	$effect(() => {
-		if (selection.current && branchesResult.current.data) {
-			setTimeout(() => {
-				if (selection.current && branchesResult.current.data) {
-					const { branchName } = selection.current;
-					if (!branchesResult.current.data.some((b) => b.name === branchName)) {
-						selection.set(undefined);
-					}
-				}
-			}, 500);
-		}
-	});
-
-	// Clear selection if commit cannot be found.
-	// TODO: How can we express this better?
-	$effect(() => {
-		if (selection.current) {
-			setTimeout(() => {
-				if (selection.current) {
-					const { branchName, commitId, upstream } = selection.current;
-					if (branchName && commitId) {
-						if (upstream) {
-							stackService.fetchUpstreamCommitById(projectId, stack.id, commitId).then((result) => {
-								if (!result) {
-									selection.set(undefined);
-								}
-							});
-						} else {
-							stackService.fetchCommitById(projectId, stack.id, commitId).then((result) => {
-								if (!result) {
-									selection.set(undefined);
-								}
-							});
-						}
-					}
-				}
-			}, 500);
-		}
-	});
-
 	const startCommitVisible = $derived(uncommittedService.startCommitVisible(stack.id));
 
 	function onerror(err: unknown) {

--- a/apps/desktop/src/components/UnassignedView.svelte
+++ b/apps/desktop/src/components/UnassignedView.svelte
@@ -96,7 +96,11 @@
 					wide
 					disabled={!!projectState.exclusiveAction.current}
 					onclick={() => {
-						projectState.exclusiveAction.set({ type: 'commit' });
+						projectState.exclusiveAction.set({
+							type: 'commit',
+							stackId: undefined,
+							branchName: undefined
+						});
 						uncommittedService.checkAll(null);
 					}}
 					icon={isCommitting ? undefined : 'plus-small'}


### PR DESCRIPTION
Move UI state update logic into the stack service. This ensures the UI consistently clears selections of stacks, branches, or commits that no longer exist. The changes implement utilities to unselect stale stacks and branch selections according to up-to-date stack and branch state, fixing cases where the UI would otherwise display selections for deleted entities.