### PR TITLE
fix: add selectable derived store for worktree selection

### DIFF
--- a/apps/desktop/src/components/SelectionView.svelte
+++ b/apps/desktop/src/components/SelectionView.svelte
@@ -49,6 +49,8 @@
 	const stackId = $derived(
 		selectionId && `stackId` in selectionId ? selectionId.stackId : undefined
 	);
+
+	const selectable = $derived(selectionId?.type === 'worktree');
 </script>
 
 <div
@@ -89,7 +91,7 @@
 								{draggable}
 								{change}
 								{diff}
-								selectable
+								{selectable}
 								selectionId={selectedFile}
 								topPadding={diffOnly}
 							/>


### PR DESCRIPTION
Introduce a new derived store `selectable` that evaluates to true
when the current selection type is 'worktree'. This enables conditional
rendering or behavior based on whether the selection is a worktree,
improving component flexibility and clarity.