### PR TITLE
Make UiState read-write consistent

### DIFF
--- a/apps/desktop/src/components/BranchCommitList.svelte
+++ b/apps/desktop/src/components/BranchCommitList.svelte
@@ -108,7 +108,8 @@
 		exclusiveAction?.type === 'commit' && exclusiveAction.stackId === stackId
 	);
 	const stackState = $derived(uiState.stack(stackId));
-	const selection = $derived(stackState.selection.get());
+	const selection = $derived(stackState.selection);
+
 	const selectedBranchName = $derived(selection.current?.branchName);
 	const selectedCommitId = $derived(selection.current?.commitId);
 

--- a/apps/desktop/src/components/BranchesViewBranch.svelte
+++ b/apps/desktop/src/components/BranchesViewBranch.svelte
@@ -62,11 +62,11 @@
 			branchesState.current.stackId === env.stackId &&
 			!branchesState.current.commitId}
 		onclick={() => {
-			branchesState.current = {
+			branchesState.set({
 				branchName,
 				stackId: env.stackId,
 				remote
-			};
+			});
 		}}
 	>
 		{#snippet branchContent()}

--- a/apps/desktop/src/components/CommitView.svelte
+++ b/apps/desktop/src/components/CommitView.svelte
@@ -61,7 +61,7 @@
 	const modeService = injectOptional(MODE_SERVICE, undefined);
 	const stackState = $derived(uiState.stack(stackId));
 	const projectState = $derived(uiState.project(projectId));
-	const selected = $derived(stackState.selection.get());
+	const selected = $derived(stackState.selection);
 	const branchName = $derived(selected.current?.branchName);
 
 	const commitResult = $derived(

--- a/apps/desktop/src/components/FloatingCommitBox.svelte
+++ b/apps/desktop/src/components/FloatingCommitBox.svelte
@@ -34,7 +34,7 @@
 		uiState.global.floatingBoxSize.set({ width: newWidth, height: newHeight });
 	}}
 	onUpdateSnapPosition={(snapPosition: SnapPositionName) => {
-		uiState.global.floatingBoxPosition.current = snapPosition;
+		uiState.global.floatingBoxPosition.set(snapPosition);
 	}}
 	dragHandleElement={headerElRef}
 >

--- a/apps/desktop/src/components/NewCommitView.svelte
+++ b/apps/desktop/src/components/NewCommitView.svelte
@@ -180,7 +180,7 @@
 
 			if (newId) {
 				// Clear saved state for commit message editor.
-				stackState.newCommitMessage.current = { title: '', description: '' };
+				stackState.newCommitMessage.set({ title: '', description: '' });
 
 				// Close the drawer.
 				projectState.exclusiveAction.set(undefined);
@@ -215,7 +215,7 @@
 	const [createNewStack, newStackResult] = stackService.newStack;
 
 	async function handleCommitCreation(title: string, description: string) {
-		stackState.newCommitMessage.current = { title, description };
+		stackState.newCommitMessage.set({ title, description });
 
 		const message = description ? title + '\n\n' + description : title;
 		if (!message) {
@@ -252,7 +252,7 @@
 	}
 
 	function cancel(args: { title: string; description: string }) {
-		stackState.newCommitMessage.current = args;
+		stackState.newCommitMessage.set(args);
 		projectState.exclusiveAction.set(undefined);
 		uncommittedService.uncheckAll(null);
 		if (stackId) {

--- a/apps/desktop/src/components/editor/MessageEditor.svelte
+++ b/apps/desktop/src/components/editor/MessageEditor.svelte
@@ -361,7 +361,7 @@
 					icon={useFloatingBox.current ? 'exit-floating-box' : 'enter-floating-box'}
 					tooltip={useFloatingBox.current ? 'Exit floating mode' : 'Use floating mode'}
 					onclick={() => {
-						useFloatingBox.current = !useFloatingBox.current;
+						useFloatingBox.set(!useFloatingBox.current);
 					}}
 				/>
 				<div class="message-textarea__toolbar__divider"></div>
@@ -382,7 +382,7 @@
 						activated={useRuler.current}
 						tooltip="Wrap text automatically"
 						onclick={async () => {
-							useRuler.current = !useRuler.current;
+							useRuler.set(!useRuler.current);
 							await tick(); // Wait for reactive update.
 							if (useRuler.current) {
 								composer?.wrapAll();
@@ -400,14 +400,14 @@
 								onblur={() => {
 									if (rulerCountValue.current < MIN_RULER_VALUE) {
 										console.warn('Ruler value must be greater than 10');
-										rulerCountValue.current = MIN_RULER_VALUE;
+										rulerCountValue.set(MIN_RULER_VALUE);
 									} else if (rulerCountValue.current > MAX_RULER_VALUE) {
-										rulerCountValue.current = MAX_RULER_VALUE;
+										rulerCountValue.set(MAX_RULER_VALUE);
 									}
 								}}
 								oninput={(e) => {
 									const input = e.currentTarget as HTMLInputElement;
-									rulerCountValue.current = parseInt(input.value);
+									rulerCountValue.set(parseInt(input.value));
 								}}
 								onkeydown={(e) => {
 									if (e.key === 'Enter') {

--- a/apps/desktop/src/lib/state/uiState.svelte.ts
+++ b/apps/desktop/src/lib/state/uiState.svelte.ts
@@ -1,7 +1,7 @@
 import { type SnapPositionName } from '$lib/floating/types';
 import { InjectionToken } from '@gitbutler/shared/context';
 import { reactive } from '@gitbutler/shared/reactiveUtils.svelte';
-import { type Reactive, type WritableReactive } from '@gitbutler/shared/storeUtils';
+import { type Reactive } from '@gitbutler/shared/storeUtils';
 import {
 	createEntityAdapter,
 	createSlice,
@@ -108,14 +108,19 @@ export const UI_STATE = new InjectionToken<UiState>('UiState');
 export class UiState {
 	private state = $state.raw<EntityState<UiStateVariable, string>>(uiStateSlice.getInitialState());
 
+	private scopesCache = {
+		stacks: {} as Record<string, GlobalStore<any>>,
+		projects: {} as Record<string, GlobalStore<any>>
+	};
+
 	/** Properties scoped to a specific stack. */
-	readonly stack = this.buildScopedProps<StackState>({
+	readonly stack = this.buildScopedProps<StackState>(this.scopesCache.stacks, {
 		selection: undefined,
 		newCommitMessage: { title: '', description: '' }
 	});
 
 	/** Properties scoped to a specific project. */
-	readonly project = this.buildScopedProps<ProjectUiState>({
+	readonly project = this.buildScopedProps<ProjectUiState>(this.scopesCache.projects, {
 		exclusiveAction: undefined,
 		branchesSelection: {},
 		stackId: undefined,
@@ -170,16 +175,15 @@ export class UiState {
 	private buildGlobalProps<T extends DefaultConfig>(param: T): GlobalStore<T> {
 		const props: GlobalStore<DefaultConfig> = {};
 		for (const [key, defaultValue] of Object.entries(param)) {
-			const current = this.getById(key, defaultValue);
-			const boundUpdate = this.update.bind(this);
+			const result = this.getById(key, defaultValue);
+			let mutableResult = $derived(result.current);
 			props[key] = {
-				get: () => current,
-				set: (val: UiStateValue) => this.update(key, val),
-				get current() {
-					return current.current;
+				set: (value: UiStateValue) => {
+					mutableResult = value;
+					this.update(key, value);
 				},
-				set current(value: UiStateValue) {
-					boundUpdate(key, value);
+				get current() {
+					return mutableResult;
 				}
 			};
 		}
@@ -191,24 +195,33 @@ export class UiState {
 	 * parameter for the key. This allows us to define values that are scoped
 	 * to e.g. a projectId.
 	 */
-	private buildScopedProps<T extends DefaultConfig>(param: T): (id: string) => GlobalStore<T> {
+	private buildScopedProps<T extends DefaultConfig>(
+		scopeCache: Record<string, GlobalStore<T>>,
+		defaultConfig: T
+	): (id: string) => GlobalStore<T> {
 		return (id: string) => {
+			if (id in scopeCache) {
+				return scopeCache[id] as GlobalStore<T>;
+			}
 			const props: GlobalStore<DefaultConfig> = {};
-			for (const [key, defaultValue] of Object.entries(param)) {
-				const current = this.getById(`${id}:${key}`, defaultValue);
-				const boundUpdate = this.update.bind(this);
+			for (const [key, defaultValue] of Object.entries(defaultConfig)) {
+				const result = this.getById(`${id}:${key}`, defaultValue);
+
+				// We need a mutable value here for read/write consistency.
+				let mutableResult = $derived(result.current);
+
 				props[key] = {
-					get: () => current,
-					set: (val: UiStateValue) => this.update(`${id}:${key}`, val),
-					get current() {
-						return current.current;
+					set: (value: UiStateValue) => {
+						mutableResult = value;
+						this.update(`${id}:${key}`, value);
 					},
-					set current(value: UiStateValue) {
-						boundUpdate(`${id}:${key}`, value);
+					get current() {
+						return mutableResult;
 					}
 				};
 			}
-			return props as GlobalStore<T>;
+			scopeCache[id] = props as GlobalStore<T>;
+			return scopeCache[id];
 		};
 	}
 }
@@ -244,9 +257,8 @@ type DefaultConfig = Record<string, UiStateValue>;
 
 /** Node type for global properties. */
 export type GlobalProperty<T> = {
-	get(): Reactive<T>;
 	set(value: T): void;
-} & WritableReactive<T>;
+} & Reactive<T>;
 
 /** Type returned by the build function for global properties. */
 type GlobalStore<T extends DefaultConfig> = {


### PR DESCRIPTION
After a write you can now immediately read the written value. It should 
perhaps always have been this way, but we recently had a bug related to 
this.