### PR TITLE
Fix Claude command stop hanging and improve error output

### DIFF
--- a/crates/but/src/main.rs
+++ b/crates/but/src/main.rs
@@ -4,6 +4,8 @@ mod args;
 use args::{Args, CommandName, Subcommands, actions, claude};
 use but_settings::AppSettings;
 use metrics::{Event, Metrics, Props, metrics_if_configured};
+
+use crate::command::claude::OutputAsJson;
 mod command;
 mod id;
 mod log;
@@ -55,22 +57,32 @@ async fn main() -> Result<()> {
             claude::Subcommands::PreTool => {
                 let result = command::claude::handle_pre_tool_call();
                 let p = props(start, &result);
-                println!("{}", serde_json::to_string(&result?)?);
+                result.out_json();
                 metrics_if_configured(app_settings, CommandName::ClaudePreTool, p).ok();
+                if result.is_err() {
+                    std::process::exit(2);
+                }
                 Ok(())
             }
             claude::Subcommands::PostTool => {
                 let result = command::claude::handle_post_tool_call();
                 let p = props(start, &result);
-                println!("{}", serde_json::to_string(&result?)?);
+                result.out_json();
                 metrics_if_configured(app_settings, CommandName::ClaudePostTool, p).ok();
+
+                if result.is_err() {
+                    std::process::exit(2);
+                }
                 Ok(())
             }
             claude::Subcommands::Stop => {
                 let result = command::claude::handle_stop().await;
                 let p = props(start, &result);
-                println!("{}", serde_json::to_string(&result?)?);
+                result.out_json();
                 metrics_if_configured(app_settings, CommandName::ClaudeStop, p).ok();
+                if result.is_err() {
+                    std::process::exit(2);
+                }
                 Ok(())
             }
         },


### PR DESCRIPTION
Fixes a condition where the stop hook could be left unresolved due to the write guard not being dropped before awaiting the other guard. This kept the stop handler process running indefinitely. Now, guards are dropped in the correct order.

Also updates error handling for Claude-command so that errors print to stderr via a new OutputAsJson trait implementation, and exit with code 2 if there is an error.

https://docs.anthropic.com/en/docs/claude-code/hooks#hook-output
