### PR TITLE
Navigate to setup page after project add

### DIFF
--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -129,7 +129,11 @@
 					onClick={async () => {
 						newProjectLoading = true;
 						try {
-							await projectsService.addProject();
+							const project = await projectsService.addProject();
+							if (!project) {
+								throw new Error('Failed to add project.');
+							}
+							goto(projectPath(project.id));
 						} finally {
 							newProjectLoading = false;
 						}

--- a/apps/desktop/src/components/FileMenuAction.svelte
+++ b/apps/desktop/src/components/FileMenuAction.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
-	import { clonePath } from '$lib/routes/routes.svelte';
+	import { clonePath, projectPath } from '$lib/routes/routes.svelte';
 	import { SHORTCUT_SERVICE } from '$lib/shortcuts/shortcutService';
 	import { inject } from '@gitbutler/shared/context';
 	import { mergeUnlisten } from '@gitbutler/ui/utils/mergeUnlisten';
@@ -12,7 +12,11 @@
 	$effect(() =>
 		mergeUnlisten(
 			shortcutService.on('add-local-repo', async () => {
-				await projectsService.addProject();
+				const project = await projectsService.addProject();
+				if (!project) {
+					throw new Error('Failed to add project.');
+				}
+				goto(projectPath(project.id));
 			}),
 			shortcutService.on('clone-repo', async () => {
 				goto(clonePath());

--- a/apps/desktop/src/components/ProjectSwitcher.svelte
+++ b/apps/desktop/src/components/ProjectSwitcher.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
+	import { projectPath } from '$lib/routes/routes.svelte';
 	import { inject } from '@gitbutler/shared/context';
 	import { Button, OptionsGroup, Select, SelectItem } from '@gitbutler/ui';
 
@@ -46,7 +47,11 @@
 				onClick={async () => {
 					newProjectLoading = true;
 					try {
-						await projectsService.addProject();
+						const project = await projectsService.addProject();
+						if (!project) {
+							throw new Error('Failed to add project.');
+						}
+						goto(projectPath(project.id));
 					} finally {
 						newProjectLoading = false;
 					}


### PR DESCRIPTION
This commit adjusts the behavior when adding a project so that the application navigates to the new project's setup page after successful creation. It updates relevant logic in ChromeHeader.svelte, ProjectSwitcher.svelte, and FileMenuAction.svelte to use returned project info from the addProject call, check for absence, and navigate accordingly.