### PR TITLE
workspace robustness: ws ref advanced

### DIFF
--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -875,5 +875,47 @@ EOF
       commit D2-outside
     git checkout gitbutler/workspace
   )
+
+  git init advanced-workspace-ref
+  (cd advanced-workspace-ref
+    commit M1
+    commit M2
+    setup_target_to_match_main
+    git checkout -b A
+      git branch B
+      commit A1
+    git checkout B
+      commit B1
+
+    create_workspace_commit_once B A
+    commit on-top1
+    git checkout -b branch-on-top
+      commit on-top-sibling
+    git checkout gitbutler/workspace
+    git merge --no-ff branch-on-top -m "on-top2-merge"
+    commit on-top3
+    git branch intermediate-ref
+    commit on-top4
+  )
+
+  git init advanced-workspace-ref-and-single-stack
+  (cd advanced-workspace-ref-and-single-stack
+    commit M1
+    commit M2
+    setup_target_to_match_main
+    git checkout -b A
+      commit A1
+    create_workspace_commit_once A
+    commit on-top1
+    git checkout -b branch-on-top
+      commit on-top-sibling
+    git checkout gitbutler/workspace
+    git merge --no-ff branch-on-top -m "on-top2-merge"
+    commit on-top3
+    git branch intermediate-ref
+    commit on-top4
+
+    git checkout gitbutler/workspace
+  )
 )
 

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -675,7 +675,7 @@ fn just_init_with_branches() -> anyhow::Result<()> {
     ");
 
     // However, when the workspace is checked out, it's at least empty.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0");
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0");
 
     // The simplest possible setup where we can define how the workspace should look like,
     // in terms of dependent and independent virtual segments.
@@ -725,7 +725,7 @@ fn just_init_with_branches() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     ├── ≡📙:6:D on fafd9d0
     │   ├── 📙:6:D
     │   ├── 📙:7:E
@@ -914,7 +914,7 @@ fn just_init_with_branches_complex() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     ├── ≡📙:8:F on fafd9d0
     │   └── 📙:8:F
     ├── ≡📙:6:D on fafd9d0
@@ -951,7 +951,7 @@ fn just_init_with_branches_complex() -> anyhow::Result<()> {
 
     // We should see the same stacks as we did before, just with a different entrypoint.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️⚠️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     ├── ≡📙:8:F on fafd9d0
     │   └── 📙:8:F
     ├── ≡📙:6:D on fafd9d0
@@ -2116,7 +2116,7 @@ fn on_top_of_target_with_history() -> anyhow::Result<()> {
                     └── ·2be54cd (⌂|🏘️|✓|11)
     ");
     // Workspace is empty as everything is integrated.
-    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 2cde30a");
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @"📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 2cde30a");
 
     add_stack_with_segments(&mut meta, 0, "C", StackState::InWorkspace, &["B", "A"]);
     add_stack_with_segments(&mut meta, 1, "D", StackState::InWorkspace, &["E", "F"]);
@@ -2142,7 +2142,7 @@ fn on_top_of_target_with_history() -> anyhow::Result<()> {
 
     // Empty stack segments on top of integrated portions will show, and nothing integrated shows.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 2cde30a
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 2cde30a
     ├── ≡📙:6:D on 2cde30a
     │   ├── 📙:6:D
     │   ├── 📙:7:E
@@ -2163,7 +2163,7 @@ fn on_top_of_target_with_history() -> anyhow::Result<()> {
     )?
     .validated()?;
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 2be54cd
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 2be54cd
     ├── ≡📙:6:D on 2be54cd
     │   ├── 📙:6:D
     │   ├── 📙:7:E
@@ -3118,7 +3118,7 @@ fn without_target_ref_or_managed_commit() -> anyhow::Result<()> {
                     └── ·fafd9d0 (⌂|🏘️|1)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓!
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓!
     └── ≡:1:A
         ├── :1:A
         │   ├── ·a62b0de (🏘️)
@@ -3141,7 +3141,7 @@ fn without_target_ref_or_managed_commit() -> anyhow::Result<()> {
 
     // Main can be a normal segment if there is no target ref.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓!
+    📕🏘️⚠️:1:gitbutler/workspace <> ✓!
     └── ≡👉:0:A
         ├── 👉:0:A
         │   ├── ·a62b0de (🏘️)
@@ -3175,7 +3175,7 @@ fn without_target_ref_or_managed_commit_ambiguous() -> anyhow::Result<()> {
                     └── ·fafd9d0 (⌂|🏘️|1)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓!
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓!
     └── ≡:1:anon:
         ├── :1:anon:
         │   ├── ·a62b0de (🏘️) ►A, ►B
@@ -3201,7 +3201,7 @@ fn without_target_ref_or_managed_commit_ambiguous() -> anyhow::Result<()> {
 
     // Main can be a normal segment if there is no target ref.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:1:gitbutler/workspace <> ✓!
+    📕🏘️⚠️:1:gitbutler/workspace <> ✓!
     └── ≡👉:0:A
         ├── 👉:0:A
         ├── 📙:3:B
@@ -3223,7 +3223,7 @@ fn without_target_ref_or_managed_commit_ambiguous() -> anyhow::Result<()> {
     ");
 
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓!
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓!
     └── ≡📙:1:B
         ├── 📙:1:B
         │   ├── ·a62b0de (🏘️) ►A
@@ -3346,7 +3346,7 @@ fn no_workspace_no_target_commit_under_managed_ref() -> anyhow::Result<()> {
     // It's notable how hard the workspace ref tries to not own the commit
     // it's under unless it's a managed commit.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓!
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓!
     └── ≡:1:anon:
         ├── :1:anon:
         │   └── ·dca94a4 (🏘️)
@@ -3401,7 +3401,7 @@ fn no_workspace_commit() -> anyhow::Result<()> {
         └── →:2: (main →:1:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     ├── ≡📙:4:lane-2 on fafd9d0
     │   ├── 📙:4:lane-2
     │   ├── 📙:5:lane-2-segment-01
@@ -3444,7 +3444,7 @@ fn no_workspace_commit() -> anyhow::Result<()> {
         └── →:2: (main →:1:)
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
-    📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
     ├── ≡📙:3:lane on fafd9d0
     │   └── 📙:3:lane
     │       └── ·cbc6713 (🏘️)
@@ -3896,6 +3896,185 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_ttb() -> anyhow::Resu
     └── ≡📙:2:lane
         └── 📙:2:lane
             └── ·fafd9d0 (🏘️) ►main
+    ");
+    Ok(())
+}
+
+#[test]
+fn advanced_workspace_ref() -> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario("ws/advanced-workspace-ref")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * a7131b1 (HEAD -> gitbutler/workspace) on-top4
+    * 4d3831e (intermediate-ref) on-top3
+    *   468357f on-top2-merge
+    |\  
+    | * d3166f7 (branch-on-top) on-top-sibling
+    |/  
+    * 118ddbb on-top1
+    *   619d548 GitButler Workspace Commit
+    |\  
+    | * 6fdab32 (A) A1
+    * | 8a352d5 (B) B1
+    |/  
+    * bce0c5e (origin/main, main) M2
+    * 3183e43 M1
+    ");
+
+    add_stack_with_segments(&mut meta, 0, "A", StackState::InWorkspace, &[]);
+    add_stack_with_segments(&mut meta, 1, "B", StackState::InWorkspace, &[]);
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    insta::assert_snapshot!(graph_tree(&graph), @r"
+    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    │   └── ►:5[1]:anon:
+    │       └── ·a7131b1 (⌂|🏘️|1)
+    │           └── ►:6[2]:intermediate-ref
+    │               └── ·4d3831e (⌂|🏘️|1)
+    │                   └── ►:7[3]:anon:
+    │                       └── ·468357f (⌂|🏘️|1)
+    │                           ├── ►:8[5]:anon:
+    │                           │   └── ·118ddbb (⌂|🏘️|1)
+    │                           │       └── ►:10[6]:anon:
+    │                           │           └── ·619d548 (⌂|🏘️|1)
+    │                           │               ├── 📙►:4[7]:B
+    │                           │               │   └── ·8a352d5 (⌂|🏘️|1)
+    │                           │               │       └── ►:2[8]:main <> origin/main →:1:
+    │                           │               │           ├── ·bce0c5e (⌂|🏘️|✓|11)
+    │                           │               │           └── ·3183e43 (⌂|🏘️|✓|11)
+    │                           │               └── 📙►:3[7]:A
+    │                           │                   └── ·6fdab32 (⌂|🏘️|1)
+    │                           │                       └── →:2: (main →:1:)
+    │                           └── ►:9[4]:branch-on-top
+    │                               └── ·d3166f7 (⌂|🏘️|1)
+    │                                   └── →:8:
+    └── ►:1[0]:origin/main →:2:
+        └── →:2: (main →:1:)
+    ");
+
+    // TODO: fix this - should probably show original workspace, or nothing
+    //       with a hint on the two commits that need to be integrated.
+    //       And in that case, what to do with the ref? But it's not our current problem.
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e
+    └── ≡:5:anon: on bce0c5e
+        ├── :5:anon:
+        │   └── ·a7131b1 (🏘️)
+        ├── :6:intermediate-ref
+        │   ├── ·4d3831e (🏘️)
+        │   ├── ·468357f (🏘️)
+        │   ├── ·118ddbb (🏘️)
+        │   └── ·619d548 (🏘️)
+        └── 📙:4:B
+            └── ·8a352d5 (🏘️)
+    ");
+
+    let graph = Graph::from_head(
+        &repo,
+        &*meta,
+        standard_options_with_extra_target(&repo, "main"),
+    )?
+    .validated()?;
+    // The extra-target as would happen in the typical case would change nothing though.
+    insta::assert_snapshot!(graph_tree(&graph), @r"
+    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    │   └── ►:5[1]:anon:
+    │       └── ·a7131b1 (⌂|🏘️|1)
+    │           └── ►:6[2]:intermediate-ref
+    │               └── ·4d3831e (⌂|🏘️|1)
+    │                   └── ►:7[3]:anon:
+    │                       └── ·468357f (⌂|🏘️|1)
+    │                           ├── ►:8[5]:anon:
+    │                           │   └── ·118ddbb (⌂|🏘️|1)
+    │                           │       └── ►:10[6]:anon:
+    │                           │           └── ·619d548 (⌂|🏘️|1)
+    │                           │               ├── 📙►:4[7]:B
+    │                           │               │   └── ·8a352d5 (⌂|🏘️|1)
+    │                           │               │       └── ►:2[8]:main <> origin/main →:1:
+    │                           │               │           ├── ·bce0c5e (⌂|🏘️|✓|11)
+    │                           │               │           └── ·3183e43 (⌂|🏘️|✓|11)
+    │                           │               └── 📙►:3[7]:A
+    │                           │                   └── ·6fdab32 (⌂|🏘️|1)
+    │                           │                       └── →:2: (main →:1:)
+    │                           └── ►:9[4]:branch-on-top
+    │                               └── ·d3166f7 (⌂|🏘️|1)
+    │                                   └── →:8:
+    └── ►:1[0]:origin/main →:2:
+        └── →:2: (main →:1:)
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e
+    └── ≡:5:anon: on bce0c5e
+        ├── :5:anon:
+        │   └── ·a7131b1 (🏘️)
+        ├── :6:intermediate-ref
+        │   ├── ·4d3831e (🏘️)
+        │   ├── ·468357f (🏘️)
+        │   ├── ·118ddbb (🏘️)
+        │   └── ·619d548 (🏘️)
+        └── 📙:4:B
+            └── ·8a352d5 (🏘️)
+    ");
+    Ok(())
+}
+
+#[test]
+fn advanced_workspace_ref_single_stack() -> anyhow::Result<()> {
+    let (repo, mut meta) =
+        read_only_in_memory_scenario("ws/advanced-workspace-ref-and-single-stack")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * da912a8 (HEAD -> gitbutler/workspace) on-top4
+    * 198eaf8 (intermediate-ref) on-top3
+    *   3147997 on-top2-merge
+    |\  
+    | * dd7bb9a (branch-on-top) on-top-sibling
+    |/  
+    * 9785229 on-top1
+    * c58f157 GitButler Workspace Commit
+    * 6fdab32 (A) A1
+    * bce0c5e (origin/main, main) M2
+    * 3183e43 M1
+    ");
+
+    add_stack_with_segments(&mut meta, 0, "A", StackState::InWorkspace, &[]);
+
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
+    insta::assert_snapshot!(graph_tree(&graph), @r"
+    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    │   └── ►:4[1]:anon:
+    │       └── ·da912a8 (⌂|🏘️|1)
+    │           └── ►:5[2]:intermediate-ref
+    │               └── ·198eaf8 (⌂|🏘️|1)
+    │                   └── ►:6[3]:anon:
+    │                       └── ·3147997 (⌂|🏘️|1)
+    │                           ├── ►:7[5]:anon:
+    │                           │   ├── ·9785229 (⌂|🏘️|1)
+    │                           │   └── ·c58f157 (⌂|🏘️|1)
+    │                           │       └── 📙►:3[6]:A
+    │                           │           └── ·6fdab32 (⌂|🏘️|1)
+    │                           │               └── ►:2[7]:main <> origin/main →:1:
+    │                           │                   ├── ·bce0c5e (⌂|🏘️|✓|11)
+    │                           │                   └── ·3183e43 (⌂|🏘️|✓|11)
+    │                           └── ►:8[4]:branch-on-top
+    │                               └── ·dd7bb9a (⌂|🏘️|1)
+    │                                   └── →:7:
+    └── ►:1[0]:origin/main →:2:
+        └── →:2: (main →:1:)
+    ");
+
+    // TODO: fix this
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on bce0c5e
+    └── ≡:4:anon: on bce0c5e
+        ├── :4:anon:
+        │   └── ·da912a8 (🏘️)
+        ├── :5:intermediate-ref
+        │   ├── ·198eaf8 (🏘️)
+        │   ├── ·3147997 (🏘️)
+        │   ├── ·9785229 (🏘️)
+        │   └── ·c58f157 (🏘️)
+        └── 📙:3:A
+            └── ·6fdab32 (🏘️)
     ");
     Ok(())
 }

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -199,9 +199,30 @@ pub struct RefInfo {
     pub is_managed_ref: bool,
     /// The `workspace_ref_name` points to a commit that was specifically created by us.
     /// If the user advanced the workspace head by hand, this would be `false`.
+    /// See if `ancestor_workspace_commit` is `Some()` to understand if anything could be fixed here.
+    /// If there is no managed commits, we have to be extra careful as to what we allow, but setting
+    /// up stacks and dependent branches is usually fine, and limited commit creation. Play it safe though,
+    /// this is mainly for graceful handling of special cases.
     pub is_managed_commit: bool,
+    /// The workspace commit as it exists in the past of `workspace_ref_name`.
+    ///
+    /// **Warning**: If `Some()`, only fixing this issue should be allowed.
+    pub ancestor_workspace_commit: Option<AncestorWorkspaceCommit>,
     /// The workspace represents what `HEAD` is pointing to.
     pub is_entrypoint: bool,
+}
+
+/// Describes a workspace commit that is in the ancestry of a managed workspace reference,
+/// probably because it was advanced by user commits.
+#[derive(Debug, Clone)]
+pub struct AncestorWorkspaceCommit {
+    /// The commits along the first parent that are between the managed workspace reference and the managed workspace commit.
+    /// The vec is never empty.
+    pub commits_outside: Vec<ref_info::ui::Commit>,
+    /// The index of the segment that actually holds the managed workspace commit.
+    pub segment_with_managed_commit: SegmentIndex,
+    /// The index of the workspace commit within the `commits` array in its parent segment.
+    pub commit_index_of_managed_commit: but_graph::CommitIndex,
 }
 
 /// A representation of the commit that is the tip of the workspace i.e., usually what `HEAD` points to,

--- a/crates/but-workspace/tests/fixtures/scenario/with-remotes-and-workspace.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/with-remotes-and-workspace.sh
@@ -336,3 +336,45 @@ git init "two-dependent-branches-first-rebased-and-merged"
   add_main_remote_setup
   cp .git/refs/remotes/origin/main .git/refs/remotes/origin/A
 )
+
+git init advanced-workspace-ref
+(cd advanced-workspace-ref
+  commit M1
+  commit M2
+  setup_target_to_match_main
+  git checkout -b A
+    git branch B
+    commit A1
+  git checkout B
+    commit B1
+
+  create_workspace_commit_once B A
+  commit on-top1
+  git checkout -b branch-on-top
+    commit on-top-sibling
+  git checkout gitbutler/workspace
+  git merge --no-ff branch-on-top -m "on-top2-merge"
+  commit on-top3
+  git branch intermediate-ref
+  commit on-top4
+)
+
+git init advanced-workspace-ref-and-single-stack
+(cd advanced-workspace-ref-and-single-stack
+  commit M1
+  commit M2
+  setup_target_to_match_main
+  git checkout -b A
+    commit A1
+  create_workspace_commit_once A
+  commit on-top1
+  git checkout -b branch-on-top
+    commit on-top-sibling
+  git checkout gitbutler/workspace
+  git merge --no-ff branch-on-top -m "on-top2-merge"
+  commit on-top3
+  git branch intermediate-ref
+  commit on-top4
+
+  git checkout gitbutler/workspace
+)

--- a/crates/but-workspace/tests/workspace/ref_info/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/mod.rs
@@ -41,6 +41,7 @@ fn unborn_untracked() -> anyhow::Result<()> {
         lower_bound: None,
         is_managed_ref: false,
         is_managed_commit: false,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -129,6 +130,7 @@ fn detached() -> anyhow::Result<()> {
         lower_bound: None,
         is_managed_ref: false,
         is_managed_commit: false,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -184,6 +186,7 @@ fn conflicted_in_local_branch() -> anyhow::Result<()> {
         lower_bound: None,
         is_managed_ref: false,
         is_managed_commit: false,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -293,6 +296,7 @@ fn single_branch() -> anyhow::Result<()> {
         lower_bound: None,
         is_managed_ref: false,
         is_managed_commit: false,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -451,6 +455,7 @@ fn single_branch_multiple_segments() -> anyhow::Result<()> {
         lower_bound: None,
         is_managed_ref: false,
         is_managed_commit: false,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
@@ -47,6 +47,7 @@ fn j01_unborn() -> anyhow::Result<()> {
             lower_bound: None,
             is_managed_ref: false,
             is_managed_commit: false,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )
@@ -95,6 +96,7 @@ fn j02_first_commit() -> anyhow::Result<()> {
             lower_bound: None,
             is_managed_ref: false,
             is_managed_commit: false,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )
@@ -147,6 +149,7 @@ However, without an official workspace it still won't be acting as a target.
             lower_bound: None,
             is_managed_ref: false,
             is_managed_commit: false,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )
@@ -195,6 +198,7 @@ However, without an official workspace it still won't be acting as a target.
             lower_bound: None,
             is_managed_ref: false,
             is_managed_commit: false,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )
@@ -215,33 +219,34 @@ fn j04_create_workspace() -> anyhow::Result<()> {
     // (despite the target being set by the test-suite).
     let info = but_workspace::head_info(&repo, &*meta, standard_options());
     insta::assert_debug_snapshot!(info, @r#"
-Ok(
-    RefInfo {
-        workspace_ref_name: Some(
-            FullName(
-                "refs/heads/gitbutler/workspace",
-            ),
-        ),
-        stacks: [],
-        target: Some(
-            Target {
-                ref_name: FullName(
-                    "refs/remotes/origin/main",
+    Ok(
+        RefInfo {
+            workspace_ref_name: Some(
+                FullName(
+                    "refs/heads/gitbutler/workspace",
                 ),
-                segment_index: NodeIndex(1),
-                commits_ahead: 0,
-            },
-        ),
-        extra_target: None,
-        lower_bound: Some(
-            NodeIndex(2),
-        ),
-        is_managed_ref: true,
-        is_managed_commit: true,
-        is_entrypoint: true,
-    },
-)
-"#);
+            ),
+            stacks: [],
+            target: Some(
+                Target {
+                    ref_name: FullName(
+                        "refs/remotes/origin/main",
+                    ),
+                    segment_index: NodeIndex(1),
+                    commits_ahead: 0,
+                },
+            ),
+            extra_target: None,
+            lower_bound: Some(
+                NodeIndex(2),
+            ),
+            is_managed_ref: true,
+            is_managed_commit: true,
+            ancestor_workspace_commit: None,
+            is_entrypoint: true,
+        },
+    )
+    "#);
     Ok(())
 }
 
@@ -304,6 +309,7 @@ fn j05_empty_stack() -> anyhow::Result<()> {
             ),
             is_managed_ref: true,
             is_managed_commit: true,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )
@@ -369,6 +375,7 @@ fn j06_create_commit_in_stack() -> anyhow::Result<()> {
             ),
             is_managed_ref: true,
             is_managed_commit: true,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )
@@ -424,6 +431,7 @@ fn j06_create_commit_in_stack() -> anyhow::Result<()> {
             ),
             is_managed_ref: true,
             is_managed_commit: true,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )
@@ -491,6 +499,7 @@ fn j07_push_commit() -> anyhow::Result<()> {
             ),
             is_managed_ref: true,
             is_managed_commit: true,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )
@@ -564,6 +573,7 @@ Create a new local commit right after the previous pushed one
             ),
             is_managed_ref: true,
             is_managed_commit: true,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )
@@ -635,6 +645,7 @@ fn j09_rewritten_remote_and_local_commit() -> anyhow::Result<()> {
             ),
             is_managed_ref: true,
             is_managed_commit: true,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )
@@ -713,6 +724,7 @@ The remote squash-merges S1 *and* changes the 'file' so it looks entirely differ
             ),
             is_managed_ref: true,
             is_managed_commit: true,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )
@@ -804,6 +816,7 @@ The remote was re-used and merged once more with more changes.
             ),
             is_managed_ref: true,
             is_managed_commit: true,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )
@@ -936,6 +949,7 @@ A new multi-segment stack is created without remote and squash merged locally.
             ),
             is_managed_ref: true,
             is_managed_commit: true,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_merges.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_merges.rs
@@ -70,6 +70,7 @@ fn two_commits_require_force_push() -> anyhow::Result<()> {
             ),
             is_managed_ref: true,
             is_managed_commit: true,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )
@@ -140,6 +141,7 @@ fn two_commits_require_force_push_merged() -> anyhow::Result<()> {
             ),
             is_managed_ref: true,
             is_managed_commit: true,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )
@@ -214,6 +216,7 @@ fn remote_diverged() -> anyhow::Result<()> {
             ),
             is_managed_ref: true,
             is_managed_commit: true,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )
@@ -296,6 +299,7 @@ fn remote_diverged_merge() -> anyhow::Result<()> {
             ),
             is_managed_ref: true,
             is_managed_commit: true,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )
@@ -362,6 +366,7 @@ fn remote_behind() -> anyhow::Result<()> {
             ),
             is_managed_ref: true,
             is_managed_commit: true,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )
@@ -439,6 +444,7 @@ fn remote_behind_merge_no_ff() -> anyhow::Result<()> {
             ),
             is_managed_ref: true,
             is_managed_commit: true,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )
@@ -507,6 +513,7 @@ fn remote_ahead() -> anyhow::Result<()> {
             ),
             is_managed_ref: true,
             is_managed_commit: true,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )
@@ -579,6 +586,7 @@ fn remote_ahead_merge_ff() -> anyhow::Result<()> {
             ),
             is_managed_ref: true,
             is_managed_commit: true,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_rebase.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/integrate_with_rebase.rs
@@ -73,6 +73,7 @@ fn two_commits_rebased_onto_target() -> anyhow::Result<()> {
             ),
             is_managed_ref: true,
             is_managed_commit: true,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )
@@ -150,6 +151,7 @@ fn two_commits_rebased_onto_target_one_amended_afterwards() -> anyhow::Result<()
             ),
             is_managed_ref: true,
             is_managed_commit: true,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )
@@ -224,6 +226,7 @@ fn two_rewritten_commits_track_as_local_and_remote() -> anyhow::Result<()> {
             ),
             is_managed_ref: true,
             is_managed_commit: true,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )
@@ -301,6 +304,7 @@ fn two_commits_rebased_onto_target_with_changeset_check() -> anyhow::Result<()> 
             ),
             is_managed_ref: true,
             is_managed_commit: true,
+            ancestor_workspace_commit: None,
             is_entrypoint: true,
         },
     )

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -94,6 +94,7 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -152,6 +153,7 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: false,
     }
     "#);
@@ -214,6 +216,7 @@ fn remote_ahead_fast_forwardable() -> anyhow::Result<()> {
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: false,
     }
     "#);
@@ -301,6 +304,7 @@ fn two_dependent_branches_rebased_with_remotes() -> anyhow::Result<()> {
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -403,6 +407,7 @@ fn two_dependent_branches_rebased_explicit_remote_in_extra_segment() -> anyhow::
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -491,6 +496,7 @@ fn two_dependent_branches_first_merged_no_ff() -> anyhow::Result<()> {
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -575,6 +581,7 @@ fn two_dependent_branches_first_merged_no_ff_second_merged_on_remote_into_base_b
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -650,6 +657,7 @@ fn two_dependent_branches_first_merged_no_ff_second_merged_on_remote_into_base_b
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -733,6 +741,7 @@ fn two_dependent_branches_first_rebased_and_merged_into_target() -> anyhow::Resu
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -802,6 +811,7 @@ fn two_dependent_branches_first_rebased_and_merged_into_target() -> anyhow::Resu
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -883,6 +893,7 @@ fn target_ahead_remote_rewritten() -> anyhow::Result<()> {
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: false,
     }
     "#);
@@ -1004,6 +1015,7 @@ fn single_commit_but_two_branches_one_in_ws_commit() -> anyhow::Result<()> {
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -1131,6 +1143,7 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
         ),
         is_managed_ref: true,
         is_managed_commit: false,
+        ancestor_workspace_commit: None,
         is_entrypoint: false,
     }
     "#);
@@ -1246,6 +1259,7 @@ fn single_commit_but_two_branches_one_in_ws_commit_with_virtual_segments() -> an
         ),
         is_managed_ref: true,
         is_managed_commit: false,
+        ancestor_workspace_commit: None,
         is_entrypoint: false,
     }
     "#);
@@ -1340,6 +1354,7 @@ fn single_commit_but_two_branches_both_in_ws_commit() -> anyhow::Result<()> {
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -1410,6 +1425,7 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit() -> anyhow::Result<(
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -1499,6 +1515,7 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit_empty_dependant() -> 
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -1575,6 +1592,7 @@ fn single_commit_pushed_but_two_branches_both_in_ws_commit_empty_dependant() -> 
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -1673,6 +1691,7 @@ fn single_commit_pushed_ws_commit_empty_dependant() -> anyhow::Result<()> {
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -1758,6 +1777,7 @@ fn single_commit_pushed_ws_commit_empty_dependant() -> anyhow::Result<()> {
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -1847,6 +1867,7 @@ fn two_branches_stacked_with_remotes() -> anyhow::Result<()> {
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -1938,6 +1959,7 @@ fn two_branches_stacked_with_interesting_remote_setup() -> anyhow::Result<()> {
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: false,
     }
     "#);
@@ -2030,6 +2052,7 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
         ),
         is_managed_ref: true,
         is_managed_commit: false,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -2105,6 +2128,7 @@ fn single_commit_but_two_branches_stack_on_top_of_ws_commit() -> anyhow::Result<
         ),
         is_managed_ref: true,
         is_managed_commit: false,
+        ancestor_workspace_commit: None,
         is_entrypoint: false,
     }
     "#);
@@ -2203,6 +2227,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -2279,6 +2304,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: false,
     }
     "#);
@@ -2354,6 +2380,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: false,
     }
     "#);
@@ -2435,6 +2462,7 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_remote_tracking_branc
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -2490,6 +2518,7 @@ fn disjoint() -> anyhow::Result<()> {
         lower_bound: None,
         is_managed_ref: false,
         is_managed_commit: false,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -2619,6 +2648,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -2728,6 +2758,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: false,
     }
     "#);
@@ -2837,6 +2868,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: false,
     }
     "#);
@@ -2947,6 +2979,7 @@ fn multiple_branches_with_shared_segment() -> anyhow::Result<()> {
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: false,
     }
     "#);
@@ -3014,6 +3047,7 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -3067,6 +3101,7 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: false,
     }
     "#);
@@ -3101,6 +3136,7 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
         ),
         is_managed_ref: true,
         is_managed_commit: true,
+        ancestor_workspace_commit: None,
         is_entrypoint: true,
     }
     "#);
@@ -3143,6 +3179,143 @@ fn empty_workspace_with_branch_below() -> anyhow::Result<()> {
         lower_bound: None,
         is_managed_ref: false,
         is_managed_commit: false,
+        ancestor_workspace_commit: None,
+        is_entrypoint: true,
+    }
+    "#);
+    Ok(())
+}
+
+#[test]
+fn advanced_workspace_multi_stack() -> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario("advanced-workspace-ref")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * a7131b1 (HEAD -> gitbutler/workspace) on-top4
+    * 4d3831e (intermediate-ref) on-top3
+    *   468357f on-top2-merge
+    |\  
+    | * d3166f7 (branch-on-top) on-top-sibling
+    |/  
+    * 118ddbb on-top1
+    *   619d548 GitButler Workspace Commit
+    |\  
+    | * 6fdab32 (A) A1
+    * | 8a352d5 (B) B1
+    |/  
+    * bce0c5e (origin/main, main) M2
+    * 3183e43 M1
+    ");
+
+    add_stack_with_segments(&mut meta, 0, "A", StackState::InWorkspace, &[]);
+    add_stack_with_segments(&mut meta, 1, "B", StackState::InWorkspace, &[]);
+
+    let opts = standard_options();
+    let info = head_info(&repo, &meta, opts)?;
+    // It can find the exact location of the workspace commit in the ancestry.
+    insta::assert_debug_snapshot!(info, @r#"
+    RefInfo {
+        workspace_ref_name: Some(
+            FullName(
+                "refs/heads/gitbutler/workspace",
+            ),
+        ),
+        stacks: [],
+        target: Some(
+            Target {
+                ref_name: FullName(
+                    "refs/remotes/origin/main",
+                ),
+                segment_index: NodeIndex(1),
+                commits_ahead: 0,
+            },
+        ),
+        extra_target: Some(
+            NodeIndex(1),
+        ),
+        lower_bound: Some(
+            NodeIndex(2),
+        ),
+        is_managed_ref: true,
+        is_managed_commit: false,
+        ancestor_workspace_commit: Some(
+            AncestorWorkspaceCommit {
+                commits_outside: [
+                    Commit(a7131b1, "on-top4\n"🏘️),
+                    Commit(4d3831e, "on-top3\n"🏘️),
+                    Commit(468357f, "on-top2-merge\n"🏘️),
+                    Commit(d3166f7, "on-top-sibling\n"🏘️),
+                    Commit(118ddbb, "on-top1\n"🏘️),
+                ],
+                segment_with_managed_commit: NodeIndex(10),
+                commit_index_of_managed_commit: 0,
+            },
+        ),
+        is_entrypoint: true,
+    }
+    "#);
+    Ok(())
+}
+
+#[test]
+fn advanced_workspace_single_stack() -> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario("advanced-workspace-ref-and-single-stack")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * da912a8 (HEAD -> gitbutler/workspace) on-top4
+    * 198eaf8 (intermediate-ref) on-top3
+    *   3147997 on-top2-merge
+    |\  
+    | * dd7bb9a (branch-on-top) on-top-sibling
+    |/  
+    * 9785229 on-top1
+    * c58f157 GitButler Workspace Commit
+    * 6fdab32 (A) A1
+    * bce0c5e (origin/main, main) M2
+    * 3183e43 M1
+    ");
+
+    add_stack_with_segments(&mut meta, 0, "A", StackState::InWorkspace, &[]);
+
+    let opts = standard_options();
+    let info = head_info(&repo, &meta, opts)?;
+    // It can find the exact location of the workspace commit in the ancestry.
+    insta::assert_debug_snapshot!(info, @r#"
+    RefInfo {
+        workspace_ref_name: Some(
+            FullName(
+                "refs/heads/gitbutler/workspace",
+            ),
+        ),
+        stacks: [],
+        target: Some(
+            Target {
+                ref_name: FullName(
+                    "refs/remotes/origin/main",
+                ),
+                segment_index: NodeIndex(1),
+                commits_ahead: 0,
+            },
+        ),
+        extra_target: Some(
+            NodeIndex(1),
+        ),
+        lower_bound: Some(
+            NodeIndex(2),
+        ),
+        is_managed_ref: true,
+        is_managed_commit: false,
+        ancestor_workspace_commit: Some(
+            AncestorWorkspaceCommit {
+                commits_outside: [
+                    Commit(da912a8, "on-top4\n"🏘️),
+                    Commit(198eaf8, "on-top3\n"🏘️),
+                    Commit(3147997, "on-top2-merge\n"🏘️),
+                    Commit(dd7bb9a, "on-top-sibling\n"🏘️),
+                    Commit(9785229, "on-top1\n"🏘️),
+                ],
+                segment_with_managed_commit: NodeIndex(7),
+                commit_index_of_managed_commit: 1,
+            },
+        ),
         is_entrypoint: true,
     }
     "#);


### PR DESCRIPTION
Test what happens when workspace refs are advanced so commits land on top of the workspace commit.
Provide enough information to let the UI visualise what's going on, and ideally allow the system to continue working, while enabling implementing a recovery.

### Tasks

- [x] what happens if the workspace branch is committed into? - needs work
- [x] improve the system to be able to handle that, simply in the workspace view
- [x] test in `but-workspace` to show the code actually runs

### Next related tasks

* 🏎️ Use per-commit metadata to avoid recomputing changeset IDs for each commit, enabling processing more and more commits with the 1s compute budget.
* 🏎️ graph-based merge-base computation would be much faster if a bitmap was used. Could be intrinsic or separate, with intrinsic certainly being better.

### Not to forget

* ⚠️Right now there is no occasion where branch-metadata would be deleted, so it's likely to go stale. Ideally we will be able to delete it as soon as it leaves our 'sphere of influence', but at the latest once the local branch doesn't exist anymore. Probably best to have a GC/cleanup step of sorts.
* ⚠️single-branch mode currently doesn't limit itself to only show what's not reachable by extra-target
* There might be an issue with the way it uses searches - a tip with a search might be blocked at an existing commit, discovered by a tip with a different search, and even though the thing it searches is reachable through that, it stops looking.
* the amount of commits of remotes ahead of their local branch doesn't seem to always match git (particularly when it's a lot of them)
* ⚠️ current implementation supports multiple workspaces *in theory*, but it's not tested with them as the underlying ref-metadata is still VB-toml. So before supporting this, we probably already want to have migrated away from vb.toml, to then port the ref-metadata to something that can support more workspaces (also for testing).
* ⚠️ we probably don't correctly handle workspaces that include other workspaces.
* ⚠️ we probably don't handle [dot-repositories](https://git-scm.com/docs/git-config#Documentation/git-config.txt-branchltnamegtmerge) correctly, by merit of not really having them in mind. At least they shouldn't be in the way of handling normal remotes.



