### PR TITLE
ui-fixes-116

### DIFF
--- a/apps/desktop/src/components/BranchBadge.svelte
+++ b/apps/desktop/src/components/BranchBadge.svelte
@@ -15,8 +15,11 @@
 	});
 </script>
 
-<span class={[!unstyled && 'text-10 text-bold branch-badge truncate']} style:--b-bg-color={bgColor}>
-	<span class:truncate={!unstyled}>{label}</span>
+<span
+	class={[!unstyled && 'text-10 text-bold branch-badge', 'truncate']}
+	style:--b-bg-color={bgColor}
+>
+	{label}
 </span>
 
 <style class="postcss">

--- a/apps/desktop/src/components/BranchCard.svelte
+++ b/apps/desktop/src/components/BranchCard.svelte
@@ -15,11 +15,12 @@
 	import { UI_STATE } from '$lib/state/uiState.svelte';
 	import { TestId } from '$lib/testing/testIds';
 	import { inject } from '@gitbutler/shared/context';
-	import { ReviewBadge } from '@gitbutler/ui';
+	import { ReviewBadge, Icon, Tooltip } from '@gitbutler/ui';
 	import { getTimeAgo } from '@gitbutler/ui/utils/timeAgo';
 	import type { DropzoneHandler } from '$lib/dragging/handler';
 	import type { PushStatus } from '$lib/stacks/stack';
 	import type iconsJson from '@gitbutler/ui/data/icons.json';
+
 	import type { Snippet } from 'svelte';
 
 	interface BranchCardProps {
@@ -173,16 +174,17 @@
 					<br />
 					Create or drag & drop commits here.
 				{/snippet}
+
 				{#snippet content()}
-					<span class="branch-header__item">
-						<BranchBadge pushStatus={args.pushStatus} unstyled />
-					</span>
-					<span class="branch-header__divider">•</span>
+					<BranchBadge pushStatus={args.pushStatus} unstyled />
 
 					{#if args.isConflicted}
-						<span class="branch-header__item branch-header__item--conflict"> Conflicts </span>
-						<span class="branch-header__divider">•</span>
+						<Tooltip text="This branch has conflicts">
+							<Icon name="warning-small" color="error" />
+						</Tooltip>
 					{/if}
+
+					<span class="branch-header__divider">•</span>
 
 					{#if args.lastUpdatedAt}
 						<span class="branch-header__item">

--- a/apps/desktop/src/components/BranchHeader.svelte
+++ b/apps/desktop/src/components/BranchHeader.svelte
@@ -150,8 +150,8 @@
 
 	.branch-header__details {
 		display: flex;
-		flex-wrap: wrap;
 		align-items: center;
+		overflow: hidden;
 		gap: 6px;
 		color: var(--clr-text-2);
 

--- a/apps/desktop/src/components/BranchLabel.svelte
+++ b/apps/desktop/src/components/BranchLabel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { autoSelectBranchNameFeature } from '$lib/config/uiFeatureFlags';
 	import { TestId } from '$lib/testing/testIds';
+	import { clickOutside } from '@gitbutler/ui/utils/clickOutside';
 	import { resizeObserver } from '@gitbutler/ui/utils/resizeObserver';
 
 	interface Props {
@@ -124,6 +125,10 @@
 	autocomplete="off"
 	autocorrect="off"
 	spellcheck="false"
+	data-remove-from-panning
+	use:clickOutside={{
+		handler: () => inputEl?.blur()
+	}}
 	style:width={inputWidth}
 />
 

--- a/apps/desktop/src/components/BranchLabel.svelte
+++ b/apps/desktop/src/components/BranchLabel.svelte
@@ -24,78 +24,107 @@
 	}: Props = $props();
 
 	let inputEl: HTMLInputElement | undefined = $state();
-	let editableName = $derived(name);
-	let nameWidth = $state(0);
-	let editableNameWidth = $state(0);
-	const nameWidthPx = $derived(`${Math.max(nameWidth, editableNameWidth)}px`);
+	let measureWidth = $state(0);
+
+	// Use the actual name or current input value for measurement
+	let currentValue = $state.raw(name);
+
+	// Sync currentValue with name prop changes
+	$effect(() => {
+		currentValue = name;
+	});
+
+	const inputWidth = $derived(`${Math.max(measureWidth, 44)}px`);
+
+	function handleInputChange(e: Event) {
+		const target = e.currentTarget as HTMLInputElement;
+		const value = target.value.trim();
+
+		if (value === name) return;
+
+		if (value === '' && !allowClear) {
+			currentValue = name;
+			target.value = name;
+			return;
+		}
+
+		onChange?.(value);
+	}
+
+	function handleClick(e: MouseEvent) {
+		if (readonly) return;
+		e.stopPropagation();
+		inputEl?.focus();
+
+		if ($autoSelectBranchNameFeature) {
+			inputEl?.select();
+		}
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter' || e.key === 'Escape' || e.key === 'Tab') {
+			inputEl?.blur();
+		}
+	}
+
+	function handleDoubleClick(e: MouseEvent) {
+		e.stopPropagation();
+		onDblClick?.();
+	}
+
+	function handleContextMenu(e: MouseEvent) {
+		e.stopPropagation();
+	}
+
+	function handleKeypress(e: KeyboardEvent) {
+		if (readonly) return;
+		e.stopPropagation();
+	}
+
+	function handleFocus() {
+		currentValue = name;
+		if (inputEl) {
+			inputEl.value = name;
+		}
+	}
+
+	function handleInput(e: Event) {
+		const target = e.currentTarget as HTMLInputElement;
+		currentValue = target.value;
+	}
 </script>
 
+<!-- Hidden element for measuring text width -->
 <span
 	data-testid={TestId.BranchNameLabel}
 	use:resizeObserver={(e) => {
-		nameWidth = Math.round(e.frame.width);
+		measureWidth = Math.round(e.frame.width);
 	}}
 	class="branch-name-measure-el text-{fontSize} text-bold"
 >
-	{name}
+	{currentValue}
 </span>
 
-<span
-	use:resizeObserver={(e) => {
-		editableNameWidth = Math.round(e.frame.width);
-	}}
-	class="branch-name-measure-el text-{fontSize} text-bold"
->
-	{editableName}
-</span>
 <input
 	type="text"
 	{disabled}
 	{readonly}
 	bind:this={inputEl}
-	bind:value={editableName}
-	onchange={(e) => {
-		const value = e.currentTarget.value.trim();
-		if (value === name) return;
-		if (value === '' && !allowClear) {
-			editableName = name;
-			return;
-		}
-		onChange?.(value);
-	}}
-	title={editableName}
+	bind:value={currentValue}
+	onchange={handleInputChange}
+	oninput={handleInput}
+	title={currentValue}
 	class="branch-name-input text-{fontSize} text-bold"
-	ondblclick={(e) => {
-		e.stopPropagation();
-		onDblClick?.();
-	}}
-	oncontextmenu={(e) => {
-		e.stopPropagation();
-	}}
-	onclick={(e) => {
-		if (readonly) return;
-		e.stopPropagation();
-		inputEl?.focus();
-		if ($autoSelectBranchNameFeature) {
-			inputEl?.select();
-		}
-	}}
-	onkeypress={(e) => {
-		if (readonly) return;
-		e.stopPropagation();
-	}}
-	onfocus={() => {
-		editableName = name;
-	}}
-	onkeydown={(e) => {
-		if (e.key === 'Enter' || e.key === 'Escape' || e.key === 'Tab') {
-			inputEl?.blur();
-		}
-	}}
+	ondblclick={handleDoubleClick}
+	oncontextmenu={handleContextMenu}
+	onclick={handleClick}
+	onkeypress={handleKeypress}
+	onfocus={handleFocus}
+	onkeydown={handleKeydown}
 	autocomplete="off"
 	autocorrect="off"
 	spellcheck="false"
-	style:width={nameWidthPx}
+	style:width={inputWidth}
 />
 
 <style lang="postcss">
@@ -106,9 +135,9 @@
 		padding: 2px 3px;
 		border: 1px solid transparent;
 	}
+
 	.branch-name-measure-el {
 		display: inline-block;
-		visibility: hidden;
 		visibility: hidden;
 		position: fixed;
 		width: fit-content;
@@ -117,9 +146,9 @@
 		white-space: pre;
 		pointer-events: none;
 	}
+
 	.branch-name-input {
 		width: 100%;
-
 		max-width: 100%;
 		overflow: hidden;
 		border-radius: var(--radius-s);
@@ -134,15 +163,16 @@
 
 		/* not readonly */
 		&:not([readonly]):not([disabled]):not(:focus):hover {
-			border: 1px solid var(--clr-border-2);
+			border: 1px solid color-mix(in srgb, var(--clr-scale-ntrl-40), transparent 70%);
 		}
 
 		&:not([readonly]):not([disabled]):focus {
-			border: 1px solid var(--clr-border-2);
+			border: 1px solid color-mix(in srgb, var(--clr-scale-ntrl-40), transparent 60%);
 			outline: none;
 			background-color: var(--clr-bg-1-muted);
 		}
 	}
+
 	.branch-name-input[readonly] {
 		cursor: default;
 	}

--- a/apps/desktop/src/components/BranchesView.svelte
+++ b/apps/desktop/src/components/BranchesView.svelte
@@ -398,7 +398,12 @@
 					{#if !isNonLocalPr}
 						<div class="preview-selection">
 							<ConfigurableScrollableContainer zIndex="var(--z-lifted)">
-								<SelectionView testId={TestId.BranchesSelectionView} {projectId} {selectionId} />
+								<SelectionView
+									testId={TestId.BranchesSelectionView}
+									{projectId}
+									{selectionId}
+									bottomBorder
+								/>
 							</ConfigurableScrollableContainer>
 						</div>
 					{/if}

--- a/apps/desktop/src/components/BranchesView.svelte
+++ b/apps/desktop/src/components/BranchesView.svelte
@@ -19,6 +19,7 @@
 	import CurrentOriginCard from '$components/branchesPage/CurrentOriginCard.svelte';
 	import PRListCard from '$components/branchesPage/PRListCard.svelte';
 	import { BASE_BRANCH_SERVICE } from '$lib/baseBranch/baseBranchService.svelte';
+	import { HorizontalPanner } from '$lib/dragging/horizontalPanner';
 	import { isParsedError } from '$lib/error/parser';
 	import { workspacePath } from '$lib/routes/routes.svelte';
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
@@ -129,6 +130,15 @@
 			console.warn('Branches selection cleared');
 		}
 	}
+
+	const horizontalPanner = $derived(rightWrapper ? new HorizontalPanner(rightWrapper) : undefined);
+
+	$effect(() => {
+		if (horizontalPanner) {
+			const unsub = horizontalPanner.registerListeners();
+			return () => unsub?.();
+		}
+	});
 </script>
 
 <Modal

--- a/apps/desktop/src/components/BranchesView.svelte
+++ b/apps/desktop/src/components/BranchesView.svelte
@@ -438,6 +438,7 @@
 		display: flex;
 		position: relative;
 		height: 100%;
+		margin-right: -1px;
 		margin-left: -1px;
 		overflow: hidden;
 		overflow-x: auto;
@@ -449,7 +450,7 @@
 		flex-grow: 0;
 		flex-shrink: 0;
 		flex-direction: column;
-		max-height: calc(100% + 1px);
+		max-height: 100%;
 		border-right: 1px solid var(--clr-border-2);
 		border-left: 1px solid var(--clr-border-2);
 	}
@@ -460,7 +461,7 @@
 		flex-grow: 0;
 		flex-shrink: 0;
 		flex-direction: column;
-		max-height: calc(100% + 1px);
+		max-height: 100%;
 		overflow: hidden;
 		border-right: 1px solid var(--clr-border-2);
 
@@ -499,5 +500,6 @@
 		min-width: 460px;
 		min-height: 100%;
 		overflow: hidden;
+		border-right: 1px solid var(--clr-border-2);
 	}
 </style>

--- a/apps/desktop/src/components/BranchesView.svelte
+++ b/apps/desktop/src/components/BranchesView.svelte
@@ -43,7 +43,6 @@
 
 	const projectState = $derived(uiState.project(projectId));
 	const branchesState = $derived(projectState.branchesSelection);
-	const sidebarWidth = $derived(uiState.global.historySidebarWidth);
 
 	const baseBranchResult = $derived(baseBranchService.baseBranch(projectId));
 	const branchesSelection = $derived(projectState.branchesSelection);
@@ -257,8 +256,8 @@
 					direction="right"
 					minWidth={14}
 					borderRadius="ml"
-					persistId="resizer-historyWidth"
-					defaultValue={sidebarWidth.current}
+					persistId="resizer-branchesWidth"
+					defaultValue={24}
 				/>
 			</div>
 

--- a/apps/desktop/src/components/BranchesView.svelte
+++ b/apps/desktop/src/components/BranchesView.svelte
@@ -496,6 +496,7 @@
 		position: relative;
 		flex: 1;
 		flex-direction: column;
+		min-width: 460px;
 		min-height: 100%;
 		overflow: hidden;
 	}

--- a/apps/desktop/src/components/ChangedFiles.svelte
+++ b/apps/desktop/src/components/ChangedFiles.svelte
@@ -25,6 +25,7 @@
 		draggableFiles?: boolean;
 		grow?: boolean;
 		noshrink?: boolean;
+		bottomBorder?: boolean;
 		resizer?: Partial<ComponentProps<typeof Resizer>>;
 		autoselect?: boolean;
 		ontoggle?: (collapsed: boolean) => void;
@@ -41,6 +42,7 @@
 		draggableFiles,
 		grow,
 		noshrink,
+		bottomBorder,
 		resizer,
 		autoselect,
 		ontoggle
@@ -76,7 +78,7 @@
 		<FileListMode bind:mode={listMode} persist="committed" />
 	{/snippet}
 
-	<div class="filelist-wrapper">
+	<div class="filelist-wrapper" class:bottom-border={bottomBorder}>
 		{#if changes.length > 0}
 			<FileList
 				{selectionId}
@@ -108,5 +110,9 @@
 		display: flex;
 		flex-direction: column;
 		background-color: var(--clr-bg-1);
+
+		&.bottom-border {
+			border-bottom: 1px solid var(--clr-border-2);
+		}
 	}
 </style>

--- a/apps/desktop/src/components/ChromeSidebar.svelte
+++ b/apps/desktop/src/components/ChromeSidebar.svelte
@@ -135,6 +135,7 @@
 				width={34}
 				class={['btn-square', isHistoryPath() && 'btn-active']}
 				tooltip="Operations history"
+				tooltipHotkey="⇧⌘H"
 				{disabled}
 			>
 				{#snippet custom()}

--- a/apps/desktop/src/components/Drawer.svelte
+++ b/apps/desktop/src/components/Drawer.svelte
@@ -20,8 +20,7 @@
 		header?: Snippet<[HTMLDivElement]>;
 		extraActions?: Snippet;
 		kebabMenu?: Snippet<[element: HTMLElement]>;
-		children?: Snippet;
-		filesSplitView?: Snippet;
+		children: Snippet;
 		testId?: string;
 		persistId?: string;
 		bottomBorder?: boolean;
@@ -42,7 +41,6 @@
 		extraActions,
 		kebabMenu,
 		children,
-		filesSplitView,
 		testId,
 		persistId,
 		bottomBorder,
@@ -140,17 +138,9 @@
 
 	{#if !$collapsed}
 		<ConfigurableScrollableContainer>
-			{#if children}
-				<div class="drawer__content" bind:clientHeight={contentHeight}>
-					{@render children()}
-				</div>
-
-				{#if filesSplitView}
-					<div class="drawer__files-split-view">
-						{@render filesSplitView()}
-					</div>
-				{/if}
-			{/if}
+			<div class="drawer__content" bind:clientHeight={contentHeight}>
+				{@render children()}
+			</div>
 		</ConfigurableScrollableContainer>
 	{/if}
 	{#if resizer}

--- a/apps/desktop/src/components/FileList.svelte
+++ b/apps/desktop/src/components/FileList.svelte
@@ -184,7 +184,6 @@
 		draggable={draggableFiles}
 		executable={!!isExecutable}
 		showCheckbox={showCheckboxes}
-		isLast={idx === visibleFiles.length - 1}
 		selected={idSelection.has(change.path, selectionId)}
 		onclick={(e) => {
 			e.stopPropagation();

--- a/apps/desktop/src/components/FileListItemWrapper.svelte
+++ b/apps/desktop/src/components/FileListItemWrapper.svelte
@@ -29,7 +29,6 @@
 		selected?: boolean;
 		isHeader?: boolean;
 		active?: boolean;
-		isLast?: boolean;
 		listMode: 'list' | 'tree';
 		linesAdded?: number;
 		linesRemoved?: number;
@@ -53,7 +52,6 @@
 		selected,
 		isHeader,
 		active,
-		isLast,
 		listMode,
 		depth,
 		executable,
@@ -184,7 +182,6 @@
 			checked={checkStatus.current === 'checked' || checkStatus.current === 'indeterminate'}
 			{active}
 			indeterminate={checkStatus.current === 'indeterminate'}
-			{isLast}
 			{depth}
 			{executable}
 			draggable={!draggableDisabled}

--- a/apps/desktop/src/components/MultiStackView.svelte
+++ b/apps/desktop/src/components/MultiStackView.svelte
@@ -92,6 +92,7 @@
 	const horizontalPanner = $derived(
 		lanesScrollableEl ? new HorizontalPanner(lanesScrollableEl) : undefined
 	);
+
 	$effect(() => {
 		if (horizontalPanner) {
 			const unsub = horizontalPanner.registerListeners();

--- a/apps/desktop/src/components/UnappliedBranchView.svelte
+++ b/apps/desktop/src/components/UnappliedBranchView.svelte
@@ -111,17 +111,16 @@
 
 		<ReduxResult {projectId} result={changesResult.current}>
 			{#snippet children(changes, env)}
-				<div class="changed-files">
-					<ChangedFiles
-						title="All changed files"
-						projectId={env.projectId}
-						stackId={env.stackId}
-						active
-						autoselect
-						{selectionId}
-						{changes}
-					/>
-				</div>
+				<ChangedFiles
+					title="All changed files"
+					projectId={env.projectId}
+					stackId={env.stackId}
+					active
+					autoselect
+					grow
+					{selectionId}
+					{changes}
+				/>
 			{/snippet}
 		</ReduxResult>
 	{/snippet}
@@ -146,13 +145,6 @@
 		width: 100%;
 		overflow: hidden;
 		gap: 8px;
-	}
-
-	.changed-files {
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
-		border-bottom: 1px solid var(--clr-border-2);
 	}
 
 	.remote-tracking-branch-icon {

--- a/apps/desktop/src/components/UnappliedBranchView.svelte
+++ b/apps/desktop/src/components/UnappliedBranchView.svelte
@@ -57,7 +57,7 @@
 		{@const hasCommits = branch.commits.length > 0}
 		{@const remoteTrackingBranch = branch.remoteTrackingBranch}
 		{@const preferredPrNumber = branch.prNumber || prNumber}
-		<Drawer testId={TestId.UnappliedBranchDrawer} {onclose}>
+		<Drawer testId={TestId.UnappliedBranchDrawer} {onclose} bottomBorder>
 			{#snippet header()}
 				<div class="branch__header">
 					{#if hasCommits}
@@ -107,23 +107,23 @@
 					</BranchDetails>
 				</div>
 			</div>
-
-			{#snippet filesSplitView()}
-				<ReduxResult {projectId} result={changesResult.current}>
-					{#snippet children(changes, env)}
-						<ChangedFiles
-							title="All changed files"
-							projectId={env.projectId}
-							stackId={env.stackId}
-							active
-							autoselect
-							{selectionId}
-							{changes}
-						/>
-					{/snippet}
-				</ReduxResult>
-			{/snippet}
 		</Drawer>
+
+		<ReduxResult {projectId} result={changesResult.current}>
+			{#snippet children(changes, env)}
+				<div class="changed-files">
+					<ChangedFiles
+						title="All changed files"
+						projectId={env.projectId}
+						stackId={env.stackId}
+						active
+						autoselect
+						{selectionId}
+						{changes}
+					/>
+				</div>
+			{/snippet}
+		</ReduxResult>
 	{/snippet}
 </ReduxResult>
 
@@ -148,7 +148,13 @@
 		gap: 8px;
 	}
 
-	/*  */
+	.changed-files {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		border-bottom: 1px solid var(--clr-border-2);
+	}
+
 	.remote-tracking-branch-icon {
 		display: flex;
 		gap: 6px;

--- a/apps/desktop/src/components/UnappliedCommitView.svelte
+++ b/apps/desktop/src/components/UnappliedCommitView.svelte
@@ -42,6 +42,7 @@
 					title="Changed files"
 					active
 					autoselect
+					grow
 					{projectId}
 					selectionId={{ type: 'commit', commitId }}
 					changes={changes.changes}

--- a/apps/desktop/src/lib/state/uiState.svelte.ts
+++ b/apps/desktop/src/lib/state/uiState.svelte.ts
@@ -86,8 +86,6 @@ export type GlobalUiState = {
 	stackWidth: number;
 	detailsWidth: number;
 	previewWidth: number;
-	historySidebarWidth: number;
-	branchesViewSidebarWidth: number;
 	useFloatingBox: boolean;
 	floatingBoxSize: {
 		width: number;
@@ -136,8 +134,6 @@ export class UiState {
 		stackWidth: 22.5,
 		detailsWidth: 32,
 		previewWidth: 48,
-		historySidebarWidth: 30,
-		branchesViewSidebarWidth: 30,
 		useFloatingBox: false,
 		floatingBoxSize: {
 			width: 640,

--- a/apps/desktop/src/lib/testing/mockUiState.ts
+++ b/apps/desktop/src/lib/testing/mockUiState.ts
@@ -26,7 +26,6 @@ const MOCK_PROJECT_UI_STATE: ProjectUiState = {
 
 const MOCK_GLOBAL_UI_STATE: GlobalUiState = {
 	drawerHeight: 20,
-	historySidebarWidth: 30,
 	aiSuggestionsOnType: true,
 	channel: undefined,
 	draftBranchName: undefined,
@@ -39,8 +38,7 @@ const MOCK_GLOBAL_UI_STATE: GlobalUiState = {
 	modal: undefined,
 	stackWidth: 22.5,
 	detailsWidth: 25,
-	previewWidth: 30,
-	branchesViewSidebarWidth: 40
+	previewWidth: 30
 };
 
 export function getUiStateMock() {

--- a/apps/desktop/src/routes/[projectId]/history/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/history/+page.svelte
@@ -12,7 +12,6 @@
 	import { RemoteFile } from '$lib/files/file';
 	import { HISTORY_SERVICE, createdOnDay } from '$lib/history/history';
 	import { SETTINGS } from '$lib/settings/userSettings';
-	import { UI_STATE } from '$lib/state/uiState.svelte';
 	import { inject } from '@gitbutler/shared/context';
 	import { EmptyStatePlaceholder, HunkDiff, Icon, FileViewHeader } from '@gitbutler/ui';
 	import { stickyHeader } from '@gitbutler/ui/utils/stickyHeader';
@@ -25,8 +24,6 @@
 	const MIN_SNAPSHOTS_TO_LOAD = 30;
 	const userSettings = inject(SETTINGS);
 
-	const uiState = inject(UI_STATE);
-	const sidebarWidth = $derived(uiState.global.historySidebarWidth);
 	let sidebarEl = $state<HTMLElement>();
 
 	const historyService = inject(HISTORY_SERVICE);
@@ -202,7 +199,7 @@
 			minWidth={14}
 			borderRadius="ml"
 			persistId="resizer-historyWidth"
-			defaultValue={sidebarWidth.current}
+			defaultValue={30}
 		/>
 	</div>
 

--- a/packages/ui/src/lib/components/Button.svelte
+++ b/packages/ui/src/lib/components/Button.svelte
@@ -29,6 +29,7 @@
 		icon?: keyof typeof iconsJson | undefined;
 		hotkey?: string;
 		tooltip?: string;
+		tooltipHotkey?: string;
 		tooltipPosition?: TooltipPosition;
 		tooltipAlign?: TooltipAlign;
 		tooltipDelay?: number;
@@ -79,6 +80,7 @@
 		testId,
 		icon,
 		tooltip,
+		tooltipHotkey,
 		tooltipPosition,
 		tooltipAlign,
 		tooltipDelay,
@@ -100,7 +102,13 @@
 	}
 </script>
 
-<Tooltip text={tooltip} align={tooltipAlign} position={tooltipPosition} delay={tooltipDelay}>
+<Tooltip
+	text={tooltip}
+	align={tooltipAlign}
+	position={tooltipPosition}
+	delay={tooltipDelay}
+	hotkey={tooltipHotkey}
+>
 	<button
 		bind:this={el}
 		class={[

--- a/packages/ui/src/lib/components/Icon.svelte
+++ b/packages/ui/src/lib/components/Icon.svelte
@@ -68,7 +68,6 @@
 		--spinner-stroke-width: 1.5;
 		display: inline-block;
 		flex-shrink: 0;
-		pointer-events: none;
 	}
 
 	.success {

--- a/packages/ui/src/lib/components/ReviewBadge.svelte
+++ b/packages/ui/src/lib/components/ReviewBadge.svelte
@@ -54,11 +54,13 @@
 
 <Tooltip text={getBadgeDetails().text}>
 	<div class="review-badge" class:pr-type={status}>
-		{#if type === 'MR'}
-			{@html glLogo}
-		{:else if type === 'PR'}
-			{@html ghLogo}
-		{/if}
+		<div class="review-badge__icon">
+			{#if type === 'MR'}
+				{@html glLogo}
+			{:else if type === 'PR'}
+				{@html ghLogo}
+			{/if}
+		</div>
 
 		<span class="text-10 text-semibold review-badge-text">
 			{#if status === 'draft'}
@@ -89,6 +91,15 @@
 		background-color: var(--clr-bg-1-muted);
 		color: var(--clr-text-1);
 		line-height: 1;
+	}
+
+	.review-badge__icon {
+		display: flex;
+		flex-shrink: 0;
+	}
+
+	.review-badge-text {
+		white-space: nowrap;
 	}
 
 	.pr-status {

--- a/packages/ui/src/lib/components/ReviewBadge.svelte
+++ b/packages/ui/src/lib/components/ReviewBadge.svelte
@@ -64,7 +64,7 @@
 			{#if status === 'draft'}
 				Draft
 			{:else}
-				{reviewUnit}
+				{reviewUnit} #{number}
 			{/if}
 		</span>
 

--- a/packages/ui/src/lib/components/Tooltip.svelte
+++ b/packages/ui/src/lib/components/Tooltip.svelte
@@ -18,6 +18,7 @@
 		position?: TooltipPosition;
 		overrideYScroll?: number;
 		maxWidth?: number;
+		hotkey?: string;
 		children: Snippet;
 	}
 
@@ -29,6 +30,7 @@
 		position: requestedPosition = 'bottom',
 		overrideYScroll,
 		maxWidth = 240,
+		hotkey,
 		children
 	}: Props = $props();
 
@@ -106,6 +108,10 @@
 				}}
 			>
 				<span>{text}</span>
+
+				{#if hotkey}
+					<span class="tooltip-hotkey">{hotkey}</span>
+				{/if}
 			</div>
 		{/if}
 	</span>
@@ -135,5 +141,10 @@
 		white-space: pre-line;
 		word-break: break-word;
 		pointer-events: none;
+	}
+
+	.tooltip-hotkey {
+		margin-left: 3px;
+		opacity: 0.6;
 	}
 </style>

--- a/packages/ui/src/lib/components/scroll/ScrollableContainer.svelte
+++ b/packages/ui/src/lib/components/scroll/ScrollableContainer.svelte
@@ -19,6 +19,7 @@
 		viewport?: HTMLDivElement;
 		viewportHeight?: number;
 		childrenWrapHeight?: string;
+		childrenWrapDisplay?: 'block' | 'content'; // 'content' is used for virtual lists to avoid unnecessary height calculations
 		/** used only with virtual list. */
 		top?: number;
 		bottom?: number;
@@ -51,7 +52,8 @@
 		bottom,
 		viewport = $bindable(),
 		viewportHeight = $bindable(),
-		childrenWrapHeight
+		childrenWrapHeight,
+		childrenWrapDisplay = 'block'
 	}: ScrollableProps = $props();
 
 	let scrollTopVisible = $state<boolean>(true);
@@ -112,7 +114,11 @@
 		class="viewport hide-native-scrollbar"
 		style="padding-top: {top}px; padding-bottom: {bottom}px;"
 	>
-		<div class="children-wrap hide-native-scrollbar" style:height={childrenWrapHeight}>
+		<div
+			class="hide-native-scrollbar"
+			style:height={childrenWrapHeight}
+			style:display={childrenWrapDisplay}
+		>
 			{@render children()}
 		</div>
 		<Scrollbar
@@ -144,11 +150,5 @@
 		width: 100%;
 		height: 100%;
 		overflow-y: auto;
-	}
-
-	.children-wrap {
-		/* Having this be `display: content` seems to trigger excessive layout
-		   computations that makes resizing the viewport really slow. */
-		display: block;
 	}
 </style>

--- a/packages/ui/src/stories/components/Tooltip.stories.svelte
+++ b/packages/ui/src/stories/components/Tooltip.stories.svelte
@@ -10,6 +10,7 @@
 			align: 'center',
 			position: 'top',
 			disabled: false,
+			hotkey: '⇧⌘K',
 			children
 		},
 		argTypes: {
@@ -53,6 +54,7 @@
 					position={args.position}
 					disabled={args.disabled}
 					children={args.children}
+					hotkey={args.hotkey}
 				></Tooltip> for you.
 			</p>
 		</div>


### PR DESCRIPTION
- Added clickOutside directive to blur input on outside click  
- Display review number alongside review unit in badge  
- Truncate BranchBadge status instead of wrapping  
- Added tooltip hotkey option and applied it to Operations history button in sidebar  
- Simplified resizer on branches and history page  
- Simplified children rendering and added bottom border to drawer in branch view  
- Updated filelist view for branches page  
- Set min-width to 460px for BranchesView layout stability  
- Show visual borders for the first and last panels on branches page  
- Added horizontal panning support to branch and stack views for improved navigation