### PR TITLE
fix: use correct symbol for referencing branches on forges

### DIFF
--- a/apps/desktop/src/lib/forge/shared/prFooter.ts
+++ b/apps/desktop/src/lib/forge/shared/prFooter.ts
@@ -20,7 +20,7 @@ export async function updatePrDescriptionTables(prService: ForgePrService, prNum
 		const prs = await Promise.all(prNumbers.map(async (id) => await prService.fetch(id)));
 		const updates = prs.filter(isDefined).map((pr) => ({
 			prNumber: pr.number,
-			description: updateBody(pr.body, pr.number, prNumbers)
+			description: updateBody(pr.body, pr.number, prNumbers, prService.unit.symbol)
 		}));
 		await Promise.all(
 			updates.map(async ({ prNumber, description }) => {
@@ -33,10 +33,15 @@ export async function updatePrDescriptionTables(prService: ForgePrService, prNum
 /**
  * Replaces or inserts a new footer into an existing body of text.
  */
-function updateBody(body: string | undefined, prNumber: number, allPrNumbers: number[]) {
+function updateBody(
+	body: string | undefined,
+	prNumber: number,
+	allPrNumbers: number[],
+	symbol: string
+) {
 	const head = (body?.split(STACKING_FOOTER_BOUNDARY_TOP).at(0) || '').trim();
 	const tail = (body?.split(STACKING_FOOTER_BOUNDARY_BOTTOM).at(1) || '').trim();
-	const footer = generateFooter(prNumber, allPrNumbers);
+	const footer = generateFooter(prNumber, allPrNumbers, symbol);
 	const description = head + '\n\n' + footer + '\n\n' + tail;
 	return description;
 }
@@ -44,7 +49,7 @@ function updateBody(body: string | undefined, prNumber: number, allPrNumbers: nu
 /**
  * Generates a footer for use in pull request descriptions when part of a stack.
  */
-function generateFooter(forPrNumber: number, allPrNumbers: number[]) {
+function generateFooter(forPrNumber: number, allPrNumbers: number[], symbol: string) {
 	const stackLength = allPrNumbers.length;
 	const stackIndex = allPrNumbers.findIndex((number) => number === forPrNumber);
 	const nth = stackLength - stackIndex;
@@ -54,7 +59,7 @@ function generateFooter(forPrNumber: number, allPrNumbers: number[]) {
 	footer += `This is **part ${nth} of ${stackLength} in a stack** made with GitButler:\n`;
 	allPrNumbers.forEach((prNumber, i) => {
 		const current = i === stackIndex;
-		footer += `- <kbd>&nbsp;${stackLength - i}&nbsp;</kbd> #${prNumber} ${current ? '👈 ' : ''}\n`;
+		footer += `- <kbd>&nbsp;${stackLength - i}&nbsp;</kbd> ${symbol}${prNumber} ${current ? '👈 ' : ''}\n`;
 	});
 	footer += STACKING_FOOTER_BOUNDARY_BOTTOM;
 	return footer;


### PR DESCRIPTION


## 🧢 Changes

Use the correct symbol for referencing branches on different forges. 

## ☕️ Reasoning

The issue arose when using stacked branches on GitLab in a merge request. We used `#` instead of `!` which worked fine for GitHub but did not work  for GitLab. 

Now, we utilize the already present information in the `ForgePrService`  such that we always use the correct symbol when referencing branches.
