### PR TITLE
Alert user about expired GH credentials

### DIFF
--- a/apps/desktop/src/components/Chrome.svelte
+++ b/apps/desktop/src/components/Chrome.svelte
@@ -3,7 +3,8 @@
 	import ChromeSidebar from '$components/ChromeSidebar.svelte';
 	import ProjectNotFound from '$components/ProjectNotFound.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
-	import { Code, isTauriCommandError } from '$lib/backend/ipc';
+	import { isTauriCommandError } from '$lib/backend/ipc';
+	import { Code } from '$lib/error/knownErrors';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
 	import { inject } from '@gitbutler/shared/context';
 	import type { Snippet } from 'svelte';

--- a/apps/desktop/src/hooks.client.ts
+++ b/apps/desktop/src/hooks.client.ts
@@ -1,5 +1,4 @@
 import { SilentError } from '$lib/error/error';
-import { isBundlingError, isParsedError } from '$lib/error/parser';
 import { showError } from '$lib/notifications/toasts';
 import { captureException } from '@sentry/sveltekit';
 import { error as logErrorToFile } from '@tauri-apps/plugin-log';
@@ -42,19 +41,7 @@ function logError(error: unknown) {
 		}
 
 		if (!(error instanceof SilentError)) {
-			if (isParsedError(error) && error.name) {
-				if (isBundlingError(error)) {
-					console.warn(
-						'You are likely experiencing a dev mode bundling error, ' +
-							'try disabling the chache from the network tab and ' +
-							'reload the page.'
-					);
-					return;
-				}
-				showError(error.name, error.message);
-			} else {
-				showError('Unhandled exception', error);
-			}
+			showError('Unhandled exception', error);
 		}
 
 		console.error(error);

--- a/apps/desktop/src/lib/backend/ipc.ts
+++ b/apps/desktop/src/lib/backend/ipc.ts
@@ -1,17 +1,7 @@
+import { Code } from '$lib/error/knownErrors';
 import { invoke as invokeTauri } from '@tauri-apps/api/core';
 import { listen as listenTauri } from '@tauri-apps/api/event';
 import type { EventCallback, EventName } from '@tauri-apps/api/event';
-
-export enum Code {
-	Unknown = 'errors.unknown',
-	Validation = 'errors.validation',
-	ProjectsGitAuth = 'errors.projects.git.auth',
-	DefaultTargetNotFound = 'errors.projects.default_target.not_found',
-	CommitSigningFailed = 'errors.commit.signing_failed',
-	ProjectMissing = 'errors.projects.missing',
-	SecretKeychainNotFound = 'errors.secret.keychain_notfound',
-	MissingLoginKeychain = 'errors.secret.missing_login_keychain'
-}
 
 export type TauriCommandError = { name: string; message: string; code?: string };
 

--- a/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
+++ b/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
@@ -1,5 +1,6 @@
-import { Code, isTauriCommandError } from '$lib/backend/ipc';
+import { isTauriCommandError } from '$lib/backend/ipc';
 import { BaseBranch, type RemoteBranchInfo } from '$lib/baseBranch/baseBranch';
+import { Code } from '$lib/error/knownErrors';
 import { showError } from '$lib/notifications/toasts';
 import { invalidatesList, invalidatesType, providesType, ReduxTag } from '$lib/state/tags';
 import { parseRemoteUrl } from '$lib/url/gitUrl';

--- a/apps/desktop/src/lib/error/knownErrors.ts
+++ b/apps/desktop/src/lib/error/knownErrors.ts
@@ -1,4 +1,14 @@
-import { Code } from '$lib/backend/ipc';
+export enum Code {
+	Unknown = 'errors.unknown',
+	Validation = 'errors.validation',
+	ProjectsGitAuth = 'errors.projects.git.auth',
+	DefaultTargetNotFound = 'errors.projects.default_target.not_found',
+	CommitSigningFailed = 'errors.commit.signing_failed',
+	ProjectMissing = 'errors.projects.missing',
+	SecretKeychainNotFound = 'errors.secret.keychain_notfound',
+	MissingLoginKeychain = 'errors.secret.missing_login_keychain',
+	GitHubTokenExpired = 'errors.github.expired_token'
+}
 
 export const KNOWN_ERRORS: Record<string, string> = {
 	[Code.CommitSigningFailed]: `
@@ -15,5 +25,8 @@ This can be done using \`sudo apt install gnome-keyring\` for instance.
 Missing default keychain.
 
 With \`seahorse\` or equivalent, create a \`Login\` password store, right click it and choose \`Set Default\`.
+	`,
+	[Code.GitHubTokenExpired]: `
+Your GitHub token appears expired, please check your settings!
 	`
 };

--- a/apps/desktop/src/lib/error/parser.ts
+++ b/apps/desktop/src/lib/error/parser.ts
@@ -31,11 +31,8 @@ export function isParsedError(something: unknown): something is ParsedError {
  * such an error is to disable the cache from the network tab and reload the
  * page once. It would be great if we could root cause and fix this problem.
  */
-export function isBundlingError(error: ParsedError): boolean {
-	return (
-		error.name === 'TypeError' &&
-		error.message.startsWith("undefined is not an object (evaluating 'first_child_getter.call')")
-	);
+export function isBundlingError(message: string): boolean {
+	return message.startsWith("undefined is not an object (evaluating 'first_child_getter.call')");
 }
 
 export function parseError(error: unknown): ParsedError {
@@ -44,7 +41,8 @@ export function parseError(error: unknown): ParsedError {
 	}
 
 	if (error instanceof PromiseRejectionEvent && isTauriCommandError(error.reason)) {
-		return { message: error.reason.message };
+		const { name, message, code } = error.reason;
+		return { name, message, code };
 	}
 
 	if (isPromiseRejection(error)) {
@@ -55,10 +53,9 @@ export function parseError(error: unknown): ParsedError {
 	}
 
 	if (isTauriCommandError(error)) {
-		if (error.code && error.code in KNOWN_ERRORS)
-			return { description: KNOWN_ERRORS[error.code], message: error.message };
-
-		return { message: error.message, code: error.code };
+		const { name, message, code } = error;
+		const description = code ? KNOWN_ERRORS[code] : undefined;
+		return { name, message, code, description };
 	}
 
 	if (isReduxActionError(error)) {

--- a/apps/desktop/src/lib/forge/github/ghQuery.ts
+++ b/apps/desktop/src/lib/forge/github/ghQuery.ts
@@ -1,3 +1,4 @@
+import { Code } from '$lib/error/knownErrors';
 import { GitHubClient } from '$lib/forge/github/githubClient';
 import { DEFAULT_HEADERS } from '$lib/forge/github/headers';
 import { isErrorlike } from '@gitbutler/ui/utils/typeguards';
@@ -62,11 +63,10 @@ export async function ghQuery<
 			? `GitHub API error: ${argInfo.domain}/${argInfo.action}`
 			: 'GitHub API error';
 
-		if (isErrorlike(err)) {
-			return { error: { name: title, message: err.message } };
-		}
+		const message = isErrorlike(err) ? err.message : String(err);
+		const code = message.startsWith('Not Found -') ? Code.GitHubTokenExpired : undefined;
 
-		return { error: { name: title, message: String(err) } };
+		return { error: { name: title, message, code } };
 	}
 }
 
@@ -88,7 +88,7 @@ type GhArgs<
 
 export type GhResponse<T> =
 	| { data: T; error?: never }
-	| { error: { name: string; message: string }; data?: never };
+	| { error: { name: string; message: string; code?: string }; data?: never };
 /**
  * Response type for `ghQuery` inferred from octokit.js.
  */

--- a/apps/desktop/src/lib/notifications/toasts.ts
+++ b/apps/desktop/src/lib/notifications/toasts.ts
@@ -1,4 +1,4 @@
-import { parseError } from '$lib/error/parser';
+import { isBundlingError, parseError } from '$lib/error/parser';
 import posthog from 'posthog-js';
 import { writable, type Writable } from 'svelte/store';
 import type { MessageStyle } from '$components/InfoMessage.svelte';
@@ -37,10 +37,18 @@ export function showToast(toast: Toast) {
 }
 
 export function showError(title: string, error: unknown, extraAction?: ExtraAction) {
-	const { message, description, ignored } = parseError(error);
+	const { name, message, description, ignored } = parseError(error);
+	if (isBundlingError(message)) {
+		console.warn(
+			'You are likely experiencing a dev mode bundling error, ' +
+				'try disabling the chache from the network tab and ' +
+				'reload the page.'
+		);
+		return;
+	}
 	if (!ignored) {
 		showToast({
-			title,
+			title: name || title,
 			message: description,
 			error: message,
 			style: 'error',

--- a/apps/desktop/src/routes/+error.svelte
+++ b/apps/desktop/src/routes/+error.svelte
@@ -2,7 +2,7 @@
 	import { page } from '$app/state';
 	import ProjectNotFound from '$components/ProjectNotFound.svelte';
 	import SomethingWentWrong from '$components/SomethingWentWrong.svelte';
-	import { Code } from '$lib/backend/ipc';
+	import { Code } from '$lib/error/knownErrors';
 
 	const code = $derived(page.error?.errorCode);
 	const status = $derived(page.status);


### PR DESCRIPTION
Moving the known error codes from a backend specific location to the 
error package so it can be used for both Tauri and forges.

The other changes just make error handling behave more as intended.

<img width="486" height="182" alt="image" src="https://github.com/user-attachments/assets/09206ccb-224a-4b72-a87f-05bc3b316ec2" />
