### PR TITLE
Remove console warning in history page component

### DIFF
--- a/apps/desktop/src/routes/[projectId]/history/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/history/+page.svelte
@@ -209,7 +209,6 @@
 							filePath={selectedFile.path}
 							draggable={false}
 							oncloseclick={() => {
-								console.warn('oncloseclick');
 								selectedFile = undefined;
 							}}
 						/>


### PR DESCRIPTION
Removed an unnecessary console.warn statement in the oncloseclick handler in the +page.svelte file for the history route. This cleanup reduces noise in the console output without changing any functionality.