### PR TITLE
fix-fe-be-inconsistency-stack-pushinfo

### DIFF
--- a/apps/desktop/cypress/e2e/support/mock/backend.ts
+++ b/apps/desktop/cypress/e2e/support/mock/backend.ts
@@ -664,7 +664,7 @@ export default class MockBackend {
 		this.stackDetails.set(args.stackId, editableDetails);
 
 		return {
-			refname: `refs/remotes/origin/${args.branch}`,
+			branchToRemote: [[args.branch, `refs/remotes/origin/${args.branch}`]],
 			remote: 'origin'
 		};
 	}

--- a/apps/desktop/src/components/PushButton.svelte
+++ b/apps/desktop/src/components/PushButton.svelte
@@ -11,6 +11,7 @@
 	import { inject } from '@gitbutler/shared/context';
 	import { persisted } from '@gitbutler/shared/persisted';
 	import { Button, Checkbox, Modal } from '@gitbutler/ui';
+	import { isDefined } from '@gitbutler/ui/utils/typeguards';
 
 	type Props = {
 		projectId: string;
@@ -58,9 +59,11 @@
 			branch: branchName
 		});
 
-		const upstreamBranchName = getBranchNameFromRef(pushResult.refname, pushResult.remote);
-		if (upstreamBranchName === undefined) return;
-		uiState.project(projectId).branchesToPoll.add(upstreamBranchName);
+		const upstreamBranchNames = pushResult.branchToRemote
+			.map(([_, refname]) => getBranchNameFromRef(refname, pushResult.remote))
+			.filter(isDefined);
+		if (upstreamBranchNames.length === 0) return;
+		uiState.project(projectId).branchesToPoll.add(...upstreamBranchNames);
 	}
 
 	const loading = $derived(pushResult.current.isLoading || stackInfoResult.current.isLoading);

--- a/apps/desktop/src/lib/state/uiState.svelte.ts
+++ b/apps/desktop/src/lib/state/uiState.svelte.ts
@@ -225,8 +225,8 @@ export class UiState {
 				// If the value is an array of strings, we add methods to add/remove
 				if (Array.isArray(mutableResult) && mutableResult.every(isStr)) {
 					const result = mutableResult;
-					(props[key] as GlobalProperty<string[]>).add = (value: string) => {
-						mutableResult = result.includes(value) ? result : [...result, value];
+					(props[key] as GlobalProperty<string[]>).add = (...value: string[]) => {
+						mutableResult = [...result, ...value.filter((v) => !result.includes(v))];
 						this.update(`${id}:${key}`, mutableResult);
 					};
 					(props[key] as GlobalProperty<string[]>).remove = (value: string) => {
@@ -279,7 +279,7 @@ type DefaultConfig = Record<string, UiStateValue>;
 type ArrayPropertyMethods<T> = T extends string[]
 	? {
 			/** Will not add the value if it already exists in the array. */
-			add(value: string): void;
+			add(...value: string[]): void;
 			/** Removes the value from the array. */
 			remove(value: string): void;
 		}

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -31,8 +31,10 @@ use std::{collections::HashMap, path::PathBuf, vec};
 #[derive(Debug, PartialEq, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PushResult {
+    /// The name of the remote to which the branches were pushed.
     pub remote: String,
-    pub refname: Refname,
+    /// The list of pushed branches and their corresponding remote refnames.
+    pub branch_to_remote: Vec<(String, Refname)>,
 }
 
 fn find_base_tree<'a>(

--- a/crates/gitbutler-tauri/src/stack.rs
+++ b/crates/gitbutler-tauri/src/stack.rs
@@ -1,4 +1,5 @@
 use but_settings::AppSettingsWithDiskSync;
+use gitbutler_branch_actions::internal::PushResult;
 use gitbutler_branch_actions::stack::CreateSeriesRequest;
 use gitbutler_command_context::CommandContext;
 use gitbutler_project as projects;
@@ -107,11 +108,11 @@ pub fn push_stack(
     stack_id: StackId,
     with_force: bool,
     branch: String,
-) -> Result<(), Error> {
+) -> Result<PushResult, Error> {
     let project = projects.get(project_id)?;
     let ctx = CommandContext::open(&project, settings.get()?.clone())?;
-    gitbutler_branch_actions::stack::push_stack(&ctx, stack_id, with_force, branch)?;
-    Ok(())
+    gitbutler_branch_actions::stack::push_stack(&ctx, stack_id, with_force, branch)
+        .map_err(|e| e.into())
 }
 
 #[tauri::command(async)]


### PR DESCRIPTION
In short, the backend stopped propagating a result that the FE expected


### Description

- Overhaul backend push contract to return detailed PushResult with full stack info, including remote and branch-to-remote mapping.
- Update frontend UI state to track multiple branches per stack push, matching new backend output.
- Adjust Svelte components (PushButton, ReviewCreation) to handle multiple pushed branches and remotes.
- Align stackService interface and logic with updated PushResult contract.
- Update Cypress tests to mock new push info shape for end-to-end verification.