### PR TITLE
Choose a better merge-base in `changes_in_branch` so it matches what the UI shows.

### DIFF
--- a/crates/but-workspace/tests/workspace/ui.rs
+++ b/crates/but-workspace/tests/workspace/ui.rs
@@ -66,7 +66,6 @@ mod changes_in_branch {
             },
         }
         "#);
-        // The same as what's in A, but it can find it.
         insta::assert_debug_snapshot!(ui::diff::changes_in_branch(&repo, &ws, r("refs/heads/gitbutler/workspace"))?, @r#"
         TreeChanges {
             changes: [
@@ -91,6 +90,43 @@ mod changes_in_branch {
             },
         }
         "#);
+
+        insta::assert_debug_snapshot!(ui::diff::changes_in_branch(&repo, &ws, r("refs/remotes/origin/A"))?, @r#"
+        TreeChanges {
+            changes: [
+                TreeChange {
+                    path: BStringForFrontend(
+                        "file-in-A",
+                    ),
+                    path_bytes: "file-in-A",
+                    status: Addition {
+                        state: ChangeState {
+                            id: Sha1(0835e4f9714005ed591f68d306eea0d6d2ae8fd7),
+                            kind: Blob,
+                        },
+                        is_untracked: false,
+                    },
+                },
+            ],
+            stats: TreeStats {
+                lines_added: 1,
+                lines_removed: 0,
+                files_changed: 1,
+            },
+        }
+        "#);
+
+        // Nothing here, it's the target.
+        insta::assert_debug_snapshot!(ui::diff::changes_in_branch(&repo, &ws, r("refs/remotes/origin/main"))?, @r"
+        TreeChanges {
+            changes: [],
+            stats: TreeStats {
+                lines_added: 0,
+                lines_removed: 0,
+                files_changed: 0,
+            },
+        }
+        ");
 
         let err =
             ui::diff::changes_in_branch(&repo, &ws, r("refs/heads/does-not-exist")).unwrap_err();


### PR DESCRIPTION
Before

<img width="653" height="261" alt="Screenshot_2025-07-29_at_13 58 34" src="https://github.com/user-attachments/assets/58af55ad-9299-4e2d-bbc3-4076b0c777e2" />

After

<img width="666" height="434" alt="Screenshot 2025-07-29 at 14 40 56" src="https://github.com/user-attachments/assets/288c9189-69fe-4422-97ed-681994b18db7" />
