### PR TITLE
fix(desktop): make PushButton read branch details for its state

### DIFF
--- a/apps/desktop/src/lib/stacks/stack.ts
+++ b/apps/desktop/src/lib/stacks/stack.ts
@@ -209,12 +209,24 @@ export function stackRequiresForcePush(stack: StackDetails): boolean {
 	return stack.pushStatus === 'unpushedCommitsRequiringForce';
 }
 
+export function branchRequiresForcePush(branch: BranchDetails): boolean {
+	return branch.pushStatus === 'unpushedCommitsRequiringForce';
+}
+
 export function stackHasConflicts(stack: StackDetails): boolean {
 	return stack.isConflicted;
 }
 
+export function branchHasConflicts(branch: BranchDetails): boolean {
+	return branch.isConflicted;
+}
+
 export function stackHasUnpushedCommits(stack: StackDetails): boolean {
 	return requiresPush(stack.pushStatus);
+}
+
+export function branchHasUnpushedCommits(branch: BranchDetails): boolean {
+	return requiresPush(branch.pushStatus);
 }
 
 export function requiresPush(status: PushStatus): boolean {


### PR DESCRIPTION
- Fix PushButton to read its state from branch details instead of the whole branch
- Remove reliance on stackInfo for branch state detection
- Improve accuracy of push button state determination to reflect current branch status

This change fixes incorrect push button state caused by reading from a broader context than the branch details, ensuring correct UI behavior.