### PR TITLE
Upgrade to the latest version of `gix` to support negative Push specs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,7 +1390,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3542,7 +3542,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.73.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "gix-actor 0.35.2 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-attributes 0.27.0",
@@ -3613,7 +3613,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.35.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "gix-date 0.10.3 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3644,7 +3644,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.27.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "gix-glob 0.21.0",
@@ -3670,7 +3670,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.14"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "thiserror 2.0.12",
 ]
@@ -3687,7 +3687,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "thiserror 2.0.12",
 ]
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.6.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "gix-path 0.10.19 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3720,7 +3720,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "gix-chunk 0.4.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3733,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.46.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -3753,7 +3753,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.15.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -3765,7 +3765,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3796,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.10.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "itoa",
@@ -3809,7 +3809,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.53.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "gix-attributes 0.27.0",
@@ -3832,7 +3832,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "gix-discover 0.41.0",
@@ -3867,7 +3867,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.41.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "dunce",
@@ -3896,7 +3896,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.43.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -3916,7 +3916,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -3950,7 +3950,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "fastrand",
@@ -3975,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -3999,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "faster-hex",
  "gix-features 0.43.0",
@@ -4022,7 +4022,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.9.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "gix-hash 0.19.0",
  "hashbrown 0.15.4",
@@ -4045,7 +4045,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "gix-glob 0.21.0",
@@ -4086,7 +4086,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.41.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -4125,7 +4125,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "18.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "gix-tempfile 18.0.0",
  "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4135,7 +4135,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.27.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "gix-actor 0.35.2 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4147,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4171,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bitflags 2.9.1",
  "gix-commitgraph 0.29.0",
@@ -4207,7 +4207,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.50.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "gix-actor 0.35.2 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4228,7 +4228,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.70.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "arc-swap",
  "gix-date 0.10.3 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4249,7 +4249,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.60.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "clru",
  "gix-chunk 0.4.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4270,7 +4270,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4281,7 +4281,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4306,7 +4306,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.19"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "gix-trace 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4319,7 +4319,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -4333,7 +4333,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.11.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.51.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -4382,7 +4382,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4413,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.53.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "gix-actor 0.35.2 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
  "gix-features 0.43.0",
@@ -4434,7 +4434,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "gix-hash 0.19.0",
@@ -4447,7 +4447,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -4480,7 +4480,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "gix-commitgraph 0.29.0",
  "gix-date 0.10.3 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4506,7 +4506,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bitflags 2.9.1",
  "gix-path 0.10.19 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4518,7 +4518,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.5.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "gix-hash 0.19.0",
@@ -4530,7 +4530,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "filetime",
@@ -4552,7 +4552,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "gix-config",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "18.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "dashmap",
  "gix-fs 0.16.0",
@@ -4624,7 +4624,7 @@ checksum = "e2ccaf54b0b1743a695b482ca0ab9d7603744d8d10b2e5d1a332fef337bee658"
 [[package]]
 name = "gix-trace"
 version = "0.1.13"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "tracing-core",
 ]
@@ -4632,7 +4632,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.48.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -4668,7 +4668,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.47.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bitflags 2.9.1",
  "gix-commitgraph 0.29.0",
@@ -4684,7 +4684,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "gix-features 0.43.0",
@@ -4708,7 +4708,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4728,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "thiserror 2.0.12",
@@ -4756,7 +4756,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.42.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "gix-attributes 0.27.0",
@@ -4775,7 +4775,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8d4d18d0b7a3ddc98bb4b40be45b3b66a2b1299a"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#8892cb18ccf4606df97181e9bc43461d1c71a28a"
 dependencies = [
  "bstr",
  "gix-features 0.43.0",
@@ -10633,7 +10633,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Related to https://discord.com/channels/1060193121130000425/1206670506271707156/1399796984444883079 .

### Tasks
* [x] https://github.com/GitoxideLabs/gitoxide/pull/2088
* [x] upgrade `main`