### PR TITLE
Improve typings and function handling for GH query

### DIFF
--- a/apps/desktop/src/lib/forge/github/ghQuery.ts
+++ b/apps/desktop/src/lib/forge/github/ghQuery.ts
@@ -2,13 +2,36 @@ import { Code } from '$lib/error/knownErrors';
 import { GitHubClient } from '$lib/forge/github/githubClient';
 import { DEFAULT_HEADERS } from '$lib/forge/github/headers';
 import { isErrorlike } from '@gitbutler/ui/utils/typeguards';
-import type { Octokit, RestEndpointMethodTypes } from '@octokit/rest';
+import type { Prettify } from '@gitbutler/shared/utils/typeUtils';
+import type { Octokit } from '@octokit/rest';
 
 type OwnerAndRepo = { owner: string; repo: string };
 
+type DomainKey = keyof Octokit;
+
+type StringFunctionKeys<T> = {
+	[K in keyof T]: T[K] extends (...args: any[]) => any ? (K extends string ? K : never) : never;
+}[keyof T];
+
+type DomainAction<K extends DomainKey> = StringFunctionKeys<Octokit[K]>;
+
+type ActionType<KB extends DomainKey, A extends DomainAction<KB>> = Octokit[KB][A];
+
+type DomainActionParameters<D extends DomainKey, A extends DomainAction<D>> =
+	ActionType<D, A> extends (...args: any[]) => any
+		? Prettify<Parameters<ActionType<D, A>>[0]>
+		: never;
+
+type DomainActionResponse<D extends DomainKey, A extends DomainAction<D>> =
+	ActionType<D, A> extends (...args: any[]) => Promise<infer R>
+		? R extends { data: infer Data }
+			? Data
+			: never
+		: never;
+
 type GhQueryArgs<
-	T extends keyof RestEndpointMethodTypes,
-	S extends keyof RestEndpointMethodTypes[T],
+	T extends DomainKey,
+	S extends DomainAction<T>,
 	RequiresOwnerAndRepo extends 'required' | 'optional'
 > =
 	| GhArgs<T, S>
@@ -20,12 +43,10 @@ type GhQueryArgs<
 /**
  * Effectively the `BaseQueryFn` we want, but located in this service file
  * until we figure out a way of making the generic parameters work.
- *
- * TODO: Figure out a way of doing this without @ts-expect-error?
  */
 export async function ghQuery<
-	T extends keyof RestEndpointMethodTypes,
-	S extends keyof RestEndpointMethodTypes[T],
+	T extends DomainKey,
+	S extends DomainAction<T>,
 	RequiresOwnerAndRepo extends 'required' | 'optional'
 >(
 	args: GhQueryArgs<T, S, RequiresOwnerAndRepo>,
@@ -37,18 +58,19 @@ export async function ghQuery<
 	if (!hasGitHub(extra)) throw new Error('No GitHub client!');
 	const gh = extra.gitHubClient;
 	try {
-		let result;
 		if (typeof args === 'function') {
 			if ((!gh.owner || !gh.repo) && requiresOwnerAndRepo === 'required') {
 				throw { name: 'GitHub API error', message: 'No GitHub owner or repo!' };
 			}
-			result = await args(gh.octokit, {
+			return await args(gh.octokit, {
 				owner: gh.owner,
 				repo: gh.repo
 			} as RequiresOwnerAndRepo extends 'required' ? OwnerAndRepo : Partial<OwnerAndRepo>);
-		} else {
-			// @ts-expect-error because of dynamic keys.
-			result = await gh.octokit[args.domain][args.action]({
+		}
+
+		const action = gh.octokit[args.domain][args.action];
+		if (typeof action === 'function') {
+			return await action({
 				...args.parameters,
 				headers: DEFAULT_HEADERS,
 				owner: gh.owner,
@@ -56,7 +78,7 @@ export async function ghQuery<
 			});
 		}
 
-		return result;
+		throw new Error(`Invalid action: ${args.domain}/${args.action}`);
 	} catch (err: unknown) {
 		const argInfo = extractDomainAndAction<T, S, RequiresOwnerAndRepo>(args);
 		const title = argInfo
@@ -73,16 +95,10 @@ export async function ghQuery<
 /**
  * Argument to `ghQuery` where parameters are inferred from octokit.js.
  */
-type GhArgs<
-	T extends keyof RestEndpointMethodTypes,
-	S extends keyof RestEndpointMethodTypes[T],
-	O extends keyof RestEndpointMethodTypes[T][S] = keyof RestEndpointMethodTypes[T][S] &
-		'parameters',
-	P extends RestEndpointMethodTypes[T][S][O] = RestEndpointMethodTypes[T][S][O]
-> = {
+type GhArgs<T extends DomainKey, S extends DomainAction<T>> = {
 	domain: T;
 	action: S;
-	parameters?: Omit<P, 'owner' | 'string'>;
+	parameters?: Omit<DomainActionParameters<T, S>, 'owner' | 'string'>;
 	extra: unknown;
 };
 
@@ -92,18 +108,13 @@ export type GhResponse<T> =
 /**
  * Response type for `ghQuery` inferred from octokit.js.
  */
-type InferGhResponse<
-	T extends keyof RestEndpointMethodTypes,
-	S extends keyof RestEndpointMethodTypes[T],
-	O extends keyof RestEndpointMethodTypes[T][S] = keyof RestEndpointMethodTypes[T][S] & 'response',
-	Q extends keyof RestEndpointMethodTypes[T][S][O] = keyof RestEndpointMethodTypes[T][S][O] &
-		'data',
-	P extends RestEndpointMethodTypes[T][S][O][Q] = RestEndpointMethodTypes[T][S][O][Q]
-> = GhResponse<P>;
+type InferGhResponse<T extends DomainKey, S extends DomainAction<T>> = GhResponse<
+	DomainActionResponse<T, S>
+>;
 
 function extractExtraParameters<
-	T extends keyof RestEndpointMethodTypes,
-	S extends keyof RestEndpointMethodTypes[T],
+	T extends DomainKey,
+	S extends DomainAction<T>,
 	RequiresOwnerAndRepo extends 'required' | 'optional'
 >(args: GhQueryArgs<T, S, RequiresOwnerAndRepo>, passedExtra: unknown) {
 	let extra;
@@ -116,8 +127,8 @@ function extractExtraParameters<
 }
 
 function extractDomainAndAction<
-	T extends keyof RestEndpointMethodTypes,
-	S extends keyof RestEndpointMethodTypes[T],
+	T extends DomainKey,
+	S extends DomainAction<T>,
 	RequiresOwnerAndRepo extends 'required' | 'optional'
 >(args: GhQueryArgs<T, S, RequiresOwnerAndRepo>): { domain: string; action: string } | undefined {
 	if (typeof args !== 'function') {


### PR DESCRIPTION
Make nice types and remove the need for the expect ts-error

Refactor ghQuery.ts to improve typing safety and clarity:
- Define DomainKey and DomainAction types for GitHub API domains and actions.
- Introduce utility types to extract parameters and response types for actions.
- Simplify ghQuery function to use typed args and handle functions and dynamic keys more robustly.
- Remove unused variables and tighten error handling on invalid actions.
- Update type aliases for argument and response types to leverage new utility types.
These changes enhance type safety and maintainability for interacting with GitHub's API via Octokit in this module.