### PR TITLE
Enable project settings access outside workspace

### DIFF
--- a/apps/desktop/src/components/ChromeSidebar.svelte
+++ b/apps/desktop/src/components/ChromeSidebar.svelte
@@ -198,13 +198,18 @@
 				{/if}
 				<Button
 					kind="outline"
-					onclick={() => goto(newProjectSettingsPath(projectId))}
+					onclick={() => {
+						if (isNewProjectSettingsPath()) {
+							goto(workspacePath(projectId));
+						} else {
+							goto(newProjectSettingsPath(projectId));
+						}
+					}}
 					width={34}
 					class={['btn-square', isNewProjectSettingsPath() && 'btn-active']}
 					tooltipPosition="top"
 					tooltipAlign="start"
 					tooltip="Project settings"
-					{disabled}
 				>
 					{#snippet custom()}
 						<svg
@@ -283,7 +288,6 @@
 				onclick={() => {
 					shareIssueModal?.show();
 				}}
-				disabled={false}
 			/>
 		</div>
 	</div>

--- a/apps/desktop/src/components/NotOnGitButlerBranch.svelte
+++ b/apps/desktop/src/components/NotOnGitButlerBranch.svelte
@@ -5,19 +5,22 @@
 	import directionDoubtSvg from '$lib/assets/illustrations/direction-doubt.svg?raw';
 	import { BASE_BRANCH_SERVICE } from '$lib/baseBranch/baseBranchService.svelte';
 	import { MODE_SERVICE } from '$lib/mode/modeService';
+	import { isNewProjectSettingsPath } from '$lib/routes/routes.svelte';
 	import { WORKTREE_SERVICE } from '$lib/worktree/worktreeService.svelte';
 	import { inject } from '@gitbutler/shared/context';
 	import { AsyncButton, RadioButton, FileListItem, Link } from '@gitbutler/ui';
 	import type { BaseBranch } from '$lib/baseBranch/baseBranch';
+	import type { Snippet } from 'svelte';
 
 	type OptionsType = 'stash' | 'bring-to-workspace';
 
 	interface Props {
 		projectId: string;
 		baseBranch: BaseBranch;
+		children?: Snippet;
 	}
 
-	const { projectId, baseBranch }: Props = $props();
+	const { projectId, baseBranch, children }: Props = $props();
 
 	const baseBranchService = inject(BASE_BRANCH_SERVICE);
 	const [setBaseBranchTarget, targetBranchSwitch] = baseBranchService.setTarget;
@@ -68,102 +71,107 @@
 </script>
 
 <Chrome {projectId} sidebarDisabled>
-	<DecorativeSplitView img={directionDoubtSvg} hideDetails>
-		{@const uncommittedChanges = changes.current.data || []}
+	{#if children && isNewProjectSettingsPath()}
+		<!-- Allow the display of the project settings -->
+		{@render children()}
+	{:else}
+		<DecorativeSplitView img={directionDoubtSvg} hideDetails>
+			{@const uncommittedChanges = changes.current.data || []}
 
-		<div class="switchrepo__content">
-			<p class="switchrepo__title text-18 text-body text-bold">
-				You've switched away from <span class="code-string"> gitbutler/workspace </span>
-			</p>
+			<div class="switchrepo__content">
+				<p class="switchrepo__title text-18 text-body text-bold">
+					You've switched away from <span class="code-string"> gitbutler/workspace </span>
+				</p>
 
-			<p class="switchrepo__message text-13 text-body">
-				Due to GitButler managing multiple virtual branches, you cannot switch back and forth
-				between git branches and virtual branches easily.
-				<Link href="https://docs.gitbutler.com/features/virtual-branches/integration-branch">
-					Learn more
-				</Link>
-			</p>
+				<p class="switchrepo__message text-13 text-body">
+					Due to GitButler managing multiple virtual branches, you cannot switch back and forth
+					between git branches and virtual branches easily.
+					<Link href="https://docs.gitbutler.com/features/virtual-branches/integration-branch">
+						Learn more
+					</Link>
+				</p>
 
-			{#if uncommittedChanges.length > 0}
-				<div class="switchrepo__uncommited-changes">
-					<div class="switchrepo__uncommited-changes__section">
-						<p class="switchrepo__label text-13 text-body text-bold">
-							You have uncommitted changes:
-						</p>
-						<div class="switchrepo__file-list">
-							{#each uncommittedChanges as change}
-								<FileListItem
-									filePath={change.path}
-									clickable={false}
-									hideBorder={change === uncommittedChanges[uncommittedChanges.length - 1]}
-								/>
-							{/each}
-						</div>
-						{#if conflicts}
-							<p class="switchrepo__label text-13 text-body clr-text-2">
-								Some files can’t be applied due to conflicts:
+				{#if uncommittedChanges.length > 0}
+					<div class="switchrepo__uncommited-changes">
+						<div class="switchrepo__uncommited-changes__section">
+							<p class="switchrepo__label text-13 text-body text-bold">
+								You have uncommitted changes:
 							</p>
 							<div class="switchrepo__file-list">
-								<ReduxResult result={mode.current} {projectId}>
-									{#snippet children(mode, _env)}
-										{#if mode.type === 'OutsideWorkspace'}
-											{#each mode.subject.worktreeConflicts || [] as path}
-												<FileListItem
-													filePath={path}
-													clickable={false}
-													conflicted
-													conflictHint="Resolve to apply"
-													hideBorder={path ===
-														mode.subject.worktreeConflicts[
-															mode.subject.worktreeConflicts.length - 1
-														]}
-												/>
-											{/each}
-										{/if}
-									{/snippet}
-								</ReduxResult>
+								{#each uncommittedChanges as change}
+									<FileListItem
+										filePath={change.path}
+										clickable={false}
+										hideBorder={change === uncommittedChanges[uncommittedChanges.length - 1]}
+									/>
+								{/each}
 							</div>
-						{/if}
+							{#if conflicts}
+								<p class="switchrepo__label text-13 text-body clr-text-2">
+									Some files can’t be applied due to conflicts:
+								</p>
+								<div class="switchrepo__file-list">
+									<ReduxResult result={mode.current} {projectId}>
+										{#snippet children(mode, _env)}
+											{#if mode.type === 'OutsideWorkspace'}
+												{#each mode.subject.worktreeConflicts || [] as path}
+													<FileListItem
+														filePath={path}
+														clickable={false}
+														conflicted
+														conflictHint="Resolve to apply"
+														hideBorder={path ===
+															mode.subject.worktreeConflicts[
+																mode.subject.worktreeConflicts.length - 1
+															]}
+													/>
+												{/each}
+											{/if}
+										{/snippet}
+									</ReduxResult>
+								</div>
+							{/if}
+						</div>
+
+						<hr class="switchrepo__divider" />
+
+						<p class="switchrepo__label text-13 text-body text-bold">
+							What should we do with your uncommitted changes?
+						</p>
+
+						<div class="switchrepo__handling-options">
+							{#each handlingOptions as item (item.value)}
+								<label for={item.value} class="switchrepo__handling-options__item">
+									<RadioButton
+										id={item.value}
+										value={item.value}
+										onchange={() => {
+											selectedHandlingOfUncommitted = item.value as OptionsType;
+											doStash = selectedHandlingOfUncommitted === 'stash';
+										}}
+										checked={selectedHandlingOfUncommitted === item.value}
+									/>
+									<p class="text-13 text-body">{item.label}</p>
+								</label>
+							{/each}
+						</div>
 					</div>
+				{/if}
 
-					<hr class="switchrepo__divider" />
-
-					<p class="switchrepo__label text-13 text-body text-bold">
-						What should we do with your uncommitted changes?
-					</p>
-
-					<div class="switchrepo__handling-options">
-						{#each handlingOptions as item (item.value)}
-							<label for={item.value} class="switchrepo__handling-options__item">
-								<RadioButton
-									id={item.value}
-									value={item.value}
-									onchange={() => {
-										selectedHandlingOfUncommitted = item.value as OptionsType;
-										doStash = selectedHandlingOfUncommitted === 'stash';
-									}}
-									checked={selectedHandlingOfUncommitted === item.value}
-								/>
-								<p class="text-13 text-body">{item.label}</p>
-							</label>
-						{/each}
-					</div>
+				<div class="switchrepo__actions">
+					<AsyncButton
+						style="pop"
+						icon="undo-small"
+						reversedDirection
+						loading={targetBranchSwitch.current.isLoading}
+						action={initSwithToWorkspace}
+					>
+						Switch back
+					</AsyncButton>
 				</div>
-			{/if}
-
-			<div class="switchrepo__actions">
-				<AsyncButton
-					style="pop"
-					icon="undo-small"
-					reversedDirection
-					loading={targetBranchSwitch.current.isLoading}
-					action={initSwithToWorkspace}
-				>
-					Switch back
-				</AsyncButton>
 			</div>
-		</div>
-	</DecorativeSplitView>
+		</DecorativeSplitView>
+	{/if}
 </Chrome>
 
 <style lang="postcss">

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -295,7 +295,9 @@
 					</Chrome>
 				</div>
 			{:else if mode.type === 'OutsideWorkspace'}
-				<NotOnGitButlerBranch {projectId} {baseBranch} />
+				<NotOnGitButlerBranch {projectId} {baseBranch}>
+					{@render pageChildren()}
+				</NotOnGitButlerBranch>
 			{/if}
 		{/if}
 	{/snippet}

--- a/apps/desktop/src/routes/[projectId]/new-settings/[[selectedId]]/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/new-settings/[[selectedId]]/+page.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import CloudForm from '$components/CloudForm.svelte';
 	import GitForm from '$components/GitForm.svelte';
 	import PreferencesForm from '$components/PreferencesForm.svelte';
 	import SettingsPages, { type Page } from '$components/SettingsPages.svelte';
 	import GeneralSettings from '$components/projectSettings/GeneralSettings.svelte';
-	import { newProjectSettingsPath } from '$lib/routes/routes.svelte';
+	import { newProjectSettingsPath, workspacePath } from '$lib/routes/routes.svelte';
 
 	const pages: Page[] = [
 		{
@@ -48,5 +49,8 @@
 	{selectedId}
 	{pages}
 	pageUrl={(pageId) => newProjectSettingsPath(projectId, pageId)}
+	onclose={() => {
+		goto(workspacePath(projectId));
+	}}
 	hidePageHeader
 />


### PR DESCRIPTION
- Allow access to project settings from state outside the gitbutler workspace branch by rendering the settings via NotOnGitButlerBranch
- Add the ability to go back to the workspace from project settings (using goto and page events)
- Update ChromeSidebar and layout handling to support navigation differences depending on workspace/settings context
- Update settings page to close back to workspace on exit
