### PR TITLE
Stack Service: return null if stack not found in selector

### DIFF
--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -180,7 +180,7 @@ export class StackService {
 		return this.api.endpoints.stacks.useQuery(
 			{ projectId },
 			{
-				transform: (stacks) => stackSelectors.selectById(stacks, id)
+				transform: (stacks) => stackSelectors.selectById(stacks, id) ?? null
 			}
 		);
 	}


### PR DESCRIPTION
Update transform function in stackService to return null when
stackSelectors.selectById returns undefined. This prevents
unexpected undefined values and ensures consistent handling of
missing stack entries in the query result.