### PR TITLE
feat(utils): add typedKeys utility function

### DIFF
--- a/apps/desktop/src/lib/utils/object.ts
+++ b/apps/desktop/src/lib/utils/object.ts
@@ -1,0 +1,3 @@
+export function typedKeys<T extends Record<string, unknown>>(obj: T): (keyof T)[] {
+	return Object.keys(obj) as (keyof T)[];
+}


### PR DESCRIPTION
- Added a new utility function typedKeys in object.ts.
- This function returns typed keys of an object, improving type safety when accessing keys.
- It casts keys from Object.keys to (keyof T)[], ensuring stronger typing in utility usage.
- No functional or UI impact, purely a utility enhancement for type safety.