### PR TITLE
Allow empty rule filters in RulesList.svelte

### DIFF
--- a/apps/desktop/src/components/Rule.svelte
+++ b/apps/desktop/src/components/Rule.svelte
@@ -97,6 +97,10 @@
 	<div class="rule">
 		{#each filters as filter (filter.type)}
 			{@render filterPill(filter)}
+		{:else}
+			<div class="rule__pill">
+				<span class="text-12 trucate">All files matched</span>
+			</div>
 		{/each}
 		{@render assignChip()}
 		{@render stackTarget(stackId)}

--- a/apps/desktop/src/components/RulesList.svelte
+++ b/apps/desktop/src/components/RulesList.svelte
@@ -126,9 +126,11 @@
 
 	async function saveRule() {
 		// Logic to save the rule
-		const ruleFilters = ruleFiltersEditor?.getRuleFilters();
+		// This needs to be writtent like this.
+		// If there's no rule filters editor, it means that the match is all files
+		const ruleFilters = ruleFiltersEditor ? ruleFiltersEditor.getRuleFilters() : [];
 
-		if (!ruleFilters) {
+		if (ruleFilters === undefined) {
 			chipToasts.error('Invalid rule filters');
 			return;
 		}

--- a/apps/desktop/src/lib/rules/rule.ts
+++ b/apps/desktop/src/lib/rules/rule.ts
@@ -167,7 +167,7 @@ export type ImplicitOperation =
 export interface CreateRuleRequest {
 	/** The trigger that causes the rule to be evaluated. */
 	trigger: Trigger;
-	/** The filters that determine what files or changes the rule applies to. Cannot be empty. */
+	/** The filters that determine what files or changes the rule applies to. If empty, all files are matched. */
 	filters: RuleFilter[];
 	/** The action that determines what happens to the files or changes that matched the filters. */
 	action: RuleAction;

--- a/crates/but-rules/src/lib.rs
+++ b/crates/but-rules/src/lib.rs
@@ -123,7 +123,7 @@ pub enum ImplicitOperation {
 pub struct CreateRuleRequest {
     /// The trigger that causes the rule to be evaluated.
     pub trigger: Trigger,
-    /// The filters that determine what files or changes the rule applies to. Can not be empty.
+    /// The filters that determine what files or changes the rule applies to. If left empty, all files will be matched
     pub filters: Vec<Filter>,
     /// The action that determines what happens to the files or changes that matched the filters.
     pub action: Action,
@@ -134,9 +134,6 @@ pub fn create_rule(
     ctx: &mut CommandContext,
     req: CreateRuleRequest,
 ) -> anyhow::Result<WorkspaceRule> {
-    if req.filters.is_empty() {
-        return Err(anyhow::anyhow!("At least one filter is required"));
-    }
     let rule = WorkspaceRule {
         id: uuid::Uuid::new_v4().to_string(),
         created_at: chrono::Local::now().naive_local(),


### PR DESCRIPTION
Fixes the rule saving logic to correctly handle empty filter scenarios. Now, if there is no ruleFiltersEditor present, it sets ruleFilters to an empty array, allowing for rules with no filters.

Also, refactors the undefined check for ruleFilters to permit empty arrays (valid), but reject when truly undefined, keeping validation clear.