### PR TITLE
Remove exit calls from main.rs error handling

### DIFF
--- a/crates/but/src/main.rs
+++ b/crates/but/src/main.rs
@@ -59,9 +59,6 @@ async fn main() -> Result<()> {
                 let p = props(start, &result);
                 result.out_json();
                 metrics_if_configured(app_settings, CommandName::ClaudePreTool, p).ok();
-                if result.is_err() {
-                    std::process::exit(2);
-                }
                 Ok(())
             }
             claude::Subcommands::PostTool => {
@@ -69,10 +66,6 @@ async fn main() -> Result<()> {
                 let p = props(start, &result);
                 result.out_json();
                 metrics_if_configured(app_settings, CommandName::ClaudePostTool, p).ok();
-
-                if result.is_err() {
-                    std::process::exit(2);
-                }
                 Ok(())
             }
             claude::Subcommands::Stop => {
@@ -80,9 +73,6 @@ async fn main() -> Result<()> {
                 let p = props(start, &result);
                 result.out_json();
                 metrics_if_configured(app_settings, CommandName::ClaudeStop, p).ok();
-                if result.is_err() {
-                    std::process::exit(2);
-                }
                 Ok(())
             }
         },


### PR DESCRIPTION
This commit removes explicit exit calls (std::process::exit(2)) from the main.rs file in the but crate. The removed exit calls were present in the error handling sections of the ClaudePreTool, ClaudePostTool, and ClaudeStop subcommands. The change avoids abrupt termination of the process on error, which triggers a loop on the CC agent run