### PR TITLE
Rename IpcContext to App

### DIFF
--- a/crates/but-api/src/commands/askpass.rs
+++ b/crates/but-api/src/commands/askpass.rs
@@ -3,7 +3,7 @@ use gitbutler_id::id::Id;
 use gitbutler_repo_actions::askpass::{self, AskpassRequest};
 use serde::Deserialize;
 
-use crate::{IpcContext, error::Error};
+use crate::{App, error::Error};
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -13,7 +13,7 @@ pub struct SubmitPromptResponseParams {
 }
 
 pub async fn submit_prompt_response(
-    _ipc_ctx: &IpcContext,
+    _app: &App,
     params: SubmitPromptResponseParams,
 ) -> Result<(), Error> {
     askpass::get_broker()

--- a/crates/but-api/src/commands/cli.rs
+++ b/crates/but-api/src/commands/cli.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use anyhow::{Context, anyhow, bail};
 
-use crate::{IpcContext, NoParams, error::Error};
+use crate::{App, NoParams, error::Error};
 
 fn get_cli_path() -> anyhow::Result<std::path::PathBuf> {
     let cli_path = std::env::current_exe()?;
@@ -84,11 +84,11 @@ fn do_install_cli() -> anyhow::Result<()> {
     }
 }
 
-pub fn install_cli(_ipc_ctx: &IpcContext, _params: NoParams) -> Result<(), Error> {
+pub fn install_cli(_app: &App, _params: NoParams) -> Result<(), Error> {
     do_install_cli().map_err(Error::from)
 }
 
-pub fn cli_path(_ipc_ctx: &IpcContext, _params: NoParams) -> Result<String, Error> {
+pub fn cli_path(_app: &App, _params: NoParams) -> Result<String, Error> {
     let cli_path = get_cli_path()?;
     if !cli_path.exists() {
         return Err(anyhow::anyhow!(

--- a/crates/but-api/src/commands/config.rs
+++ b/crates/but-api/src/commands/config.rs
@@ -2,7 +2,7 @@ use but_core::{RepositoryExt, settings::git::ui::GitConfigSettings};
 use gitbutler_project::ProjectId;
 use serde::Deserialize;
 
-use crate::{IpcContext, error::Error};
+use crate::{App, error::Error};
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -10,10 +10,7 @@ pub struct GetGbConfigParams {
     pub project_id: ProjectId,
 }
 
-pub fn get_gb_config(
-    _ipc_ctx: &IpcContext,
-    params: GetGbConfigParams,
-) -> Result<GitConfigSettings, Error> {
+pub fn get_gb_config(_app: &App, params: GetGbConfigParams) -> Result<GitConfigSettings, Error> {
     but_core::open_repo(gitbutler_project::get(params.project_id)?.path)?
         .git_settings()
         .map(Into::into)
@@ -27,7 +24,7 @@ pub struct SetGbConfigParams {
     pub config: GitConfigSettings,
 }
 
-pub fn set_gb_config(_ipc_ctx: &IpcContext, params: SetGbConfigParams) -> Result<(), Error> {
+pub fn set_gb_config(_app: &App, params: SetGbConfigParams) -> Result<(), Error> {
     but_core::open_repo(gitbutler_project::get(params.project_id)?.path)?
         .set_git_settings(&params.config.into())
         .map_err(Into::into)

--- a/crates/but-api/src/commands/forge.rs
+++ b/crates/but-api/src/commands/forge.rs
@@ -10,7 +10,7 @@ use gitbutler_project::ProjectId;
 use gitbutler_repo::RepoCommands;
 use serde::Deserialize;
 
-use crate::{IpcContext, error::Error};
+use crate::{App, error::Error};
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -19,10 +19,7 @@ pub struct PrTemplatesParams {
     pub forge: ForgeName,
 }
 
-pub fn pr_templates(
-    _ipc_ctx: &IpcContext,
-    params: PrTemplatesParams,
-) -> Result<Vec<String>, Error> {
+pub fn pr_templates(_app: &App, params: PrTemplatesParams) -> Result<Vec<String>, Error> {
     let project = gitbutler_project::get_validated(params.project_id)?;
     Ok(available_review_templates(&project.path, &params.forge))
 }
@@ -35,7 +32,7 @@ pub struct PrTemplateParams {
     pub forge: ForgeName,
 }
 
-pub fn pr_template(_ipc_ctx: &IpcContext, params: PrTemplateParams) -> Result<String, Error> {
+pub fn pr_template(_app: &App, params: PrTemplateParams) -> Result<String, Error> {
     let project = gitbutler_project::get_validated(params.project_id)?;
 
     let ReviewTemplateFunctions {

--- a/crates/but-api/src/commands/git.rs
+++ b/crates/but-api/src/commands/git.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 
 use crate::NoParams;
 use crate::error::ToError as _;
-use crate::{IpcContext, error::Error};
+use crate::{App, error::Error};
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -19,11 +19,11 @@ pub struct GitRemoteBranchesParams {
 }
 
 pub fn git_remote_branches(
-    ipc_ctx: &IpcContext,
+    app: &App,
     params: GitRemoteBranchesParams,
 ) -> Result<Vec<RemoteRefname>, Error> {
     let project = gitbutler_project::get(params.project_id)?;
-    let ctx = CommandContext::open(&project, ipc_ctx.app_settings.get()?.clone())?;
+    let ctx = CommandContext::open(&project, app.app_settings.get()?.clone())?;
     Ok(ctx.repo().remote_branches()?)
 }
 
@@ -35,9 +35,9 @@ pub struct GitTestPushParams {
     pub branch_name: String,
 }
 
-pub fn git_test_push(ipc_ctx: &IpcContext, params: GitTestPushParams) -> Result<(), Error> {
+pub fn git_test_push(app: &App, params: GitTestPushParams) -> Result<(), Error> {
     let project = gitbutler_project::get(params.project_id)?;
-    let ctx = CommandContext::open(&project, ipc_ctx.app_settings.get()?.clone())?;
+    let ctx = CommandContext::open(&project, app.app_settings.get()?.clone())?;
     ctx.git_test_push(&params.remote_name, &params.branch_name, Some(None))?;
     Ok(())
 }
@@ -50,9 +50,9 @@ pub struct GitTestFetchParams {
     pub action: Option<String>,
 }
 
-pub fn git_test_fetch(ipc_ctx: &IpcContext, params: GitTestFetchParams) -> Result<(), Error> {
+pub fn git_test_fetch(app: &App, params: GitTestFetchParams) -> Result<(), Error> {
     let project = gitbutler_project::get(params.project_id)?;
-    let ctx = CommandContext::open(&project, ipc_ctx.app_settings.get()?.clone())?;
+    let ctx = CommandContext::open(&project, app.app_settings.get()?.clone())?;
     ctx.fetch(
         &params.remote_name,
         Some(params.action.unwrap_or_else(|| "test".to_string())),
@@ -66,9 +66,9 @@ pub struct GitIndexSizeParams {
     pub project_id: ProjectId,
 }
 
-pub fn git_index_size(ipc_ctx: &IpcContext, params: GitIndexSizeParams) -> Result<usize, Error> {
+pub fn git_index_size(app: &App, params: GitIndexSizeParams) -> Result<usize, Error> {
     let project = gitbutler_project::get(params.project_id)?;
-    let ctx = CommandContext::open(&project, ipc_ctx.app_settings.get()?.clone())?;
+    let ctx = CommandContext::open(&project, app.app_settings.get()?.clone())?;
     let size = ctx
         .repo()
         .index()
@@ -83,14 +83,14 @@ pub struct GitHeadParams {
     pub project_id: ProjectId,
 }
 
-pub fn git_head(ipc_ctx: &IpcContext, params: GitHeadParams) -> Result<String, Error> {
+pub fn git_head(app: &App, params: GitHeadParams) -> Result<String, Error> {
     let project = gitbutler_project::get(params.project_id)?;
-    let ctx = CommandContext::open(&project, ipc_ctx.app_settings.get()?.clone())?;
+    let ctx = CommandContext::open(&project, app.app_settings.get()?.clone())?;
     let head = ctx.repo().head().context("failed to get repository head")?;
     Ok(head.name().unwrap().to_string())
 }
 
-pub fn delete_all_data(_ipc_ctx: &IpcContext, _params: NoParams) -> Result<(), Error> {
+pub fn delete_all_data(_app: &App, _params: NoParams) -> Result<(), Error> {
     for project in gitbutler_project::list().context("failed to list projects")? {
         gitbutler_project::delete(project.id)
             .map_err(|err| err.context("failed to delete project"))?;
@@ -106,7 +106,7 @@ pub struct GitSetGlobalConfigParams {
 }
 
 pub fn git_set_global_config(
-    _ipc_ctx: &IpcContext,
+    _app: &App,
     params: GitSetGlobalConfigParams,
 ) -> Result<String, Error> {
     let mut config = git2::Config::open_default().to_error()?;
@@ -121,7 +121,7 @@ pub struct GitRemoveGlobalConfigParams {
 }
 
 pub fn git_remove_global_config(
-    _ipc_ctx: &IpcContext,
+    _app: &App,
     params: GitRemoveGlobalConfigParams,
 ) -> Result<(), Error> {
     let mut config = git2::Config::open_default().to_error()?;
@@ -136,7 +136,7 @@ pub struct GitGetGlobalConfigParams {
 }
 
 pub fn git_get_global_config(
-    _ipc_ctx: &IpcContext,
+    _app: &App,
     params: GitGetGlobalConfigParams,
 ) -> Result<Option<String>, Error> {
     let config = git2::Config::open_default().to_error()?;

--- a/crates/but-api/src/commands/github.rs
+++ b/crates/but-api/src/commands/github.rs
@@ -3,7 +3,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::{IpcContext, NoParams, error::Error};
+use crate::{App, NoParams, error::Error};
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct Verification {
@@ -11,12 +11,9 @@ pub struct Verification {
     pub device_code: String,
 }
 
-pub async fn init_device_oauth(
-    ipc_ctx: &IpcContext,
-    _params: NoParams,
-) -> Result<Verification, Error> {
+pub async fn init_device_oauth(app: &App, _params: NoParams) -> Result<Verification, Error> {
     let mut req_body = HashMap::new();
-    let client_id = ipc_ctx
+    let client_id = app
         .app_settings
         .get()?
         .github_oauth_app
@@ -53,17 +50,14 @@ pub struct CheckAuthStatusParams {
     pub device_code: String,
 }
 
-pub async fn check_auth_status(
-    ipc_ctx: &IpcContext,
-    params: CheckAuthStatusParams,
-) -> Result<String, Error> {
+pub async fn check_auth_status(app: &App, params: CheckAuthStatusParams) -> Result<String, Error> {
     #[derive(Debug, Deserialize, Serialize, Clone, Default)]
     struct AccessTokenContainer {
         access_token: String,
     }
 
     let mut req_body = HashMap::new();
-    let client_id = ipc_ctx
+    let client_id = app
         .app_settings
         .get()?
         .github_oauth_app

--- a/crates/but-api/src/commands/modes.rs
+++ b/crates/but-api/src/commands/modes.rs
@@ -9,7 +9,7 @@ use gitbutler_project::ProjectId;
 use gitbutler_stack::VirtualBranchesHandle;
 use serde::Deserialize;
 
-use crate::{IpcContext, error::Error};
+use crate::{App, error::Error};
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -17,12 +17,9 @@ pub struct OperatingModeParams {
     pub project_id: ProjectId,
 }
 
-pub fn operating_mode(
-    ipc_ctx: &IpcContext,
-    params: OperatingModeParams,
-) -> Result<OperatingMode, Error> {
+pub fn operating_mode(app: &App, params: OperatingModeParams) -> Result<OperatingMode, Error> {
     let project = gitbutler_project::get(params.project_id)?;
-    let ctx = CommandContext::open(&project, ipc_ctx.app_settings.get()?.clone())?;
+    let ctx = CommandContext::open(&project, app.app_settings.get()?.clone())?;
     Ok(gitbutler_operating_modes::operating_mode(&ctx))
 }
 
@@ -34,12 +31,9 @@ pub struct EnterEditModeParams {
     pub stack_id: StackId,
 }
 
-pub fn enter_edit_mode(
-    ipc_ctx: &IpcContext,
-    params: EnterEditModeParams,
-) -> Result<EditModeMetadata, Error> {
+pub fn enter_edit_mode(app: &App, params: EnterEditModeParams) -> Result<EditModeMetadata, Error> {
     let project = gitbutler_project::get(params.project_id)?;
-    let ctx = CommandContext::open(&project, ipc_ctx.app_settings.get()?.clone())?;
+    let ctx = CommandContext::open(&project, app.app_settings.get()?.clone())?;
     let handle = VirtualBranchesHandle::new(project.gb_dir());
     let stack = handle.get_stack(params.stack_id)?;
 
@@ -60,11 +54,11 @@ pub struct AbortEditAndReturnToWorkspaceParams {
 }
 
 pub fn abort_edit_and_return_to_workspace(
-    ipc_ctx: &IpcContext,
+    app: &App,
     params: AbortEditAndReturnToWorkspaceParams,
 ) -> Result<(), Error> {
     let project = gitbutler_project::get(params.project_id)?;
-    let ctx = CommandContext::open(&project, ipc_ctx.app_settings.get()?.clone())?;
+    let ctx = CommandContext::open(&project, app.app_settings.get()?.clone())?;
 
     gitbutler_edit_mode::commands::abort_and_return_to_workspace(&ctx)?;
 
@@ -78,11 +72,11 @@ pub struct SaveEditAndReturnToWorkspaceParams {
 }
 
 pub fn save_edit_and_return_to_workspace(
-    ipc_ctx: &IpcContext,
+    app: &App,
     params: SaveEditAndReturnToWorkspaceParams,
 ) -> Result<(), Error> {
     let project = gitbutler_project::get(params.project_id)?;
-    let ctx = CommandContext::open(&project, ipc_ctx.app_settings.get()?.clone())?;
+    let ctx = CommandContext::open(&project, app.app_settings.get()?.clone())?;
 
     gitbutler_edit_mode::commands::save_and_return_to_workspace(&ctx)?;
 
@@ -96,11 +90,11 @@ pub struct EditInitialIndexStateParams {
 }
 
 pub fn edit_initial_index_state(
-    ipc_ctx: &IpcContext,
+    app: &App,
     params: EditInitialIndexStateParams,
 ) -> Result<Vec<(TreeChange, Option<ConflictEntryPresence>)>, Error> {
     let project = gitbutler_project::get(params.project_id)?;
-    let ctx = CommandContext::open(&project, ipc_ctx.app_settings.get()?.clone())?;
+    let ctx = CommandContext::open(&project, app.app_settings.get()?.clone())?;
 
     gitbutler_edit_mode::commands::starting_index_state(&ctx).map_err(Into::into)
 }
@@ -112,11 +106,11 @@ pub struct EditChangesFromInitialParams {
 }
 
 pub fn edit_changes_from_initial(
-    ipc_ctx: &IpcContext,
+    app: &App,
     params: EditChangesFromInitialParams,
 ) -> Result<Vec<TreeChange>, Error> {
     let project = gitbutler_project::get(params.project_id)?;
-    let ctx = CommandContext::open(&project, ipc_ctx.app_settings.get()?.clone())?;
+    let ctx = CommandContext::open(&project, app.app_settings.get()?.clone())?;
 
     gitbutler_edit_mode::commands::changes_from_initial(&ctx).map_err(Into::into)
 }

--- a/crates/but-api/src/commands/open.rs
+++ b/crates/but-api/src/commands/open.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 use std::env;
 use url::Url;
 
-use crate::{IpcContext, error::Error};
+use crate::{App, error::Error};
 
 pub(crate) fn open_that(path: &str) -> anyhow::Result<()> {
     let target_url = Url::parse(path).with_context(|| format!("Invalid path format: '{path}'"))?;
@@ -88,7 +88,7 @@ pub struct OpenUrlParams {
     pub url: String,
 }
 
-pub fn open_url(_ipc_ctx: &IpcContext, params: OpenUrlParams) -> Result<(), Error> {
+pub fn open_url(_app: &App, params: OpenUrlParams) -> Result<(), Error> {
     Ok(open_that(&params.url)?)
 }
 
@@ -98,7 +98,7 @@ pub struct ShowInFinderParams {
     pub path: String,
 }
 
-pub fn show_in_finder(_ipc_ctx: &IpcContext, params: ShowInFinderParams) -> Result<(), Error> {
+pub fn show_in_finder(_app: &App, params: ShowInFinderParams) -> Result<(), Error> {
     // Cross-platform implementation to open file/directory in the default file manager
     // macOS: Opens in Finder (with -R flag to reveal the item)
     // Windows: Opens in File Explorer

--- a/crates/but-api/src/commands/projects.rs
+++ b/crates/but-api/src/commands/projects.rs
@@ -1,4 +1,4 @@
-use crate::{IpcContext, error::Error};
+use crate::{App, error::Error};
 use gitbutler_project::{self as projects, ProjectId};
 use serde::Deserialize;
 use std::path::PathBuf;
@@ -9,10 +9,7 @@ pub struct UpdateProjectParams {
     pub project: projects::UpdateRequest,
 }
 
-pub fn update_project(
-    _ipc_ctx: &IpcContext,
-    params: UpdateProjectParams,
-) -> Result<projects::Project, Error> {
+pub fn update_project(_app: &App, params: UpdateProjectParams) -> Result<projects::Project, Error> {
     Ok(gitbutler_project::update(&params.project)?)
 }
 
@@ -22,11 +19,8 @@ pub struct AddProjectParams {
     pub path: PathBuf,
 }
 
-pub fn add_project(
-    ipc_ctx: &IpcContext,
-    params: AddProjectParams,
-) -> Result<projects::Project, Error> {
-    let user = ipc_ctx.user_controller.get_user()?;
+pub fn add_project(app: &App, params: AddProjectParams) -> Result<projects::Project, Error> {
+    let user = app.user_controller.get_user()?;
     let name = user.as_ref().and_then(|u| u.name.clone());
     let email = user.as_ref().and_then(|u| u.email.clone());
     Ok(gitbutler_project::add(&params.path, name, email)?)
@@ -39,10 +33,7 @@ pub struct GetProjectParams {
     pub no_validation: Option<bool>,
 }
 
-pub fn get_project(
-    _ipc_ctx: &IpcContext,
-    params: GetProjectParams,
-) -> Result<projects::Project, Error> {
+pub fn get_project(_app: &App, params: GetProjectParams) -> Result<projects::Project, Error> {
     if params.no_validation.unwrap_or(false) {
         Ok(gitbutler_project::get_raw(params.project_id)?)
     } else {
@@ -56,6 +47,6 @@ pub struct DeleteProjectParams {
     pub project_id: ProjectId,
 }
 
-pub fn delete_project(_ipc_ctx: &IpcContext, params: DeleteProjectParams) -> Result<(), Error> {
+pub fn delete_project(_app: &App, params: DeleteProjectParams) -> Result<(), Error> {
     gitbutler_project::delete(params.project_id).map_err(Into::into)
 }

--- a/crates/but-api/src/commands/remotes.rs
+++ b/crates/but-api/src/commands/remotes.rs
@@ -3,7 +3,7 @@ use gitbutler_project::ProjectId;
 use gitbutler_repo::{GitRemote, RepoCommands};
 use serde::Deserialize;
 
-use crate::{IpcContext, error::Error};
+use crate::{App, error::Error};
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -11,10 +11,7 @@ pub struct ListRemotesParams {
     pub project_id: ProjectId,
 }
 
-pub fn list_remotes(
-    _ipc_ctx: &IpcContext,
-    params: ListRemotesParams,
-) -> Result<Vec<GitRemote>, Error> {
+pub fn list_remotes(_app: &App, params: ListRemotesParams) -> Result<Vec<GitRemote>, Error> {
     let project = gitbutler_project::get(params.project_id)?;
     Ok(project.remotes()?)
 }
@@ -27,7 +24,7 @@ pub struct AddRemoteParams {
     pub url: String,
 }
 
-pub fn add_remote(_ipc_ctx: &IpcContext, params: AddRemoteParams) -> Result<(), Error> {
+pub fn add_remote(_app: &App, params: AddRemoteParams) -> Result<(), Error> {
     let project = gitbutler_project::get(params.project_id)?;
     Ok(project.add_remote(&params.name, &params.url)?)
 }

--- a/crates/but-api/src/commands/rules.rs
+++ b/crates/but-api/src/commands/rules.rs
@@ -7,7 +7,7 @@ use gitbutler_command_context::CommandContext;
 use gitbutler_project::ProjectId;
 use serde::Deserialize;
 
-use crate::{IpcContext, error::Error};
+use crate::{App, error::Error};
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -17,12 +17,12 @@ pub struct CreateWorkspaceRuleParams {
 }
 
 pub fn create_workspace_rule(
-    ipc_ctx: &IpcContext,
+    app: &App,
     params: CreateWorkspaceRuleParams,
 ) -> Result<WorkspaceRule, Error> {
     let ctx = &mut CommandContext::open(
         &gitbutler_project::get(params.project_id)?,
-        ipc_ctx.app_settings.get()?.clone(),
+        app.app_settings.get()?.clone(),
     )?;
     create_rule(ctx, params.request).map_err(Into::into)
 }
@@ -34,13 +34,10 @@ pub struct DeleteWorkspaceRuleParams {
     pub id: String,
 }
 
-pub fn delete_workspace_rule(
-    ipc_ctx: &IpcContext,
-    params: DeleteWorkspaceRuleParams,
-) -> Result<(), Error> {
+pub fn delete_workspace_rule(app: &App, params: DeleteWorkspaceRuleParams) -> Result<(), Error> {
     let ctx = &mut CommandContext::open(
         &gitbutler_project::get(params.project_id)?,
-        ipc_ctx.app_settings.get()?.clone(),
+        app.app_settings.get()?.clone(),
     )?;
     delete_rule(ctx, &params.id).map_err(Into::into)
 }
@@ -53,12 +50,12 @@ pub struct UpdateWorkspaceRuleParams {
 }
 
 pub fn update_workspace_rule(
-    ipc_ctx: &IpcContext,
+    app: &App,
     params: UpdateWorkspaceRuleParams,
 ) -> Result<WorkspaceRule, Error> {
     let ctx = &mut CommandContext::open(
         &gitbutler_project::get(params.project_id)?,
-        ipc_ctx.app_settings.get()?.clone(),
+        app.app_settings.get()?.clone(),
     )?;
     update_rule(ctx, params.request).map_err(Into::into)
 }
@@ -70,12 +67,12 @@ pub struct ListWorkspaceRulesParams {
 }
 
 pub fn list_workspace_rules(
-    ipc_ctx: &IpcContext,
+    app: &App,
     params: ListWorkspaceRulesParams,
 ) -> Result<Vec<WorkspaceRule>, Error> {
     let ctx = &mut CommandContext::open(
         &gitbutler_project::get(params.project_id)?,
-        ipc_ctx.app_settings.get()?.clone(),
+        app.app_settings.get()?.clone(),
     )?;
     list_rules(ctx).map_err(Into::into)
 }

--- a/crates/but-api/src/commands/secret.rs
+++ b/crates/but-api/src/commands/secret.rs
@@ -2,7 +2,7 @@ use gitbutler_secret::{Sensitive, secret};
 use serde::Deserialize;
 use std::sync::Mutex;
 
-use crate::{IpcContext, error::Error};
+use crate::{App, error::Error};
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -11,7 +11,7 @@ pub struct SecretGetGlobalParams {
 }
 
 pub fn secret_get_global(
-    _ipc_ctx: &IpcContext,
+    _app: &App,
     params: SecretGetGlobalParams,
 ) -> Result<Option<String>, Error> {
     Ok(secret::retrieve(&params.handle, secret::Namespace::Global)?.map(|s| s.0))
@@ -24,10 +24,7 @@ pub struct SecretSetGlobalParams {
     pub secret: String,
 }
 
-pub fn secret_set_global(
-    _ipc_ctx: &IpcContext,
-    params: SecretSetGlobalParams,
-) -> Result<(), Error> {
+pub fn secret_set_global(_app: &App, params: SecretSetGlobalParams) -> Result<(), Error> {
     static FAIR_QUEUE: Mutex<()> = Mutex::new(());
     let _one_at_a_time_to_prevent_races = FAIR_QUEUE.lock().unwrap();
     Ok(secret::persist(

--- a/crates/but-api/src/commands/settings.rs
+++ b/crates/but-api/src/commands/settings.rs
@@ -4,10 +4,10 @@ use but_settings::api::{FeatureFlagsUpdate, TelemetryUpdate};
 use serde::Deserialize;
 
 use crate::NoParams;
-use crate::{IpcContext, error::Error};
+use crate::{App, error::Error};
 
-pub fn get_app_settings(ipc_ctx: &IpcContext, _params: NoParams) -> Result<AppSettings, Error> {
-    Ok(ipc_ctx.app_settings.get()?.clone())
+pub fn get_app_settings(app: &App, _params: NoParams) -> Result<AppSettings, Error> {
+    Ok(app.app_settings.get()?.clone())
 }
 
 #[derive(Deserialize)]
@@ -17,11 +17,10 @@ pub struct UpdateOnboardingCompleteParams {
 }
 
 pub fn update_onboarding_complete(
-    ipc_ctx: &IpcContext,
+    app: &App,
     params: UpdateOnboardingCompleteParams,
 ) -> Result<(), Error> {
-    ipc_ctx
-        .app_settings
+    app.app_settings
         .update_onboarding_complete(params.update)
         .map_err(|e| e.into())
 }
@@ -32,9 +31,8 @@ pub struct UpdateTelemetryParams {
     pub update: TelemetryUpdate,
 }
 
-pub fn update_telemetry(ipc_ctx: &IpcContext, params: UpdateTelemetryParams) -> Result<(), Error> {
-    ipc_ctx
-        .app_settings
+pub fn update_telemetry(app: &App, params: UpdateTelemetryParams) -> Result<(), Error> {
+    app.app_settings
         .update_telemetry(params.update)
         .map_err(|e| e.into())
 }
@@ -46,11 +44,10 @@ pub struct UpdateTelemetryDistinctIdParams {
 }
 
 pub fn update_telemetry_distinct_id(
-    ipc_ctx: &IpcContext,
+    app: &App,
     params: UpdateTelemetryDistinctIdParams,
 ) -> Result<(), Error> {
-    ipc_ctx
-        .app_settings
+    app.app_settings
         .update_telemetry_distinct_id(params.app_distinct_id)
         .map_err(|e| e.into())
 }
@@ -61,12 +58,8 @@ pub struct UpdateFeatureFlagsParams {
     pub update: FeatureFlagsUpdate,
 }
 
-pub fn update_feature_flags(
-    ipc_ctx: &IpcContext,
-    params: UpdateFeatureFlagsParams,
-) -> Result<(), Error> {
-    ipc_ctx
-        .app_settings
+pub fn update_feature_flags(app: &App, params: UpdateFeatureFlagsParams) -> Result<(), Error> {
+    app.app_settings
         .update_feature_flags(params.update)
         .map_err(|e| e.into())
 }

--- a/crates/but-api/src/commands/stack.rs
+++ b/crates/but-api/src/commands/stack.rs
@@ -6,7 +6,7 @@ use gitbutler_stack::StackId;
 use gitbutler_user::User;
 use serde::Deserialize;
 
-use crate::{IpcContext, error::Error};
+use crate::{App, error::Error};
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -16,9 +16,9 @@ pub struct CreateBranchParams {
     pub request: CreateSeriesRequest,
 }
 
-pub fn create_branch(ipc_ctx: &IpcContext, params: CreateBranchParams) -> Result<(), Error> {
+pub fn create_branch(app: &App, params: CreateBranchParams) -> Result<(), Error> {
     let project = gitbutler_project::get(params.project_id)?;
-    let ctx = CommandContext::open(&project, ipc_ctx.app_settings.get()?.clone())?;
+    let ctx = CommandContext::open(&project, app.app_settings.get()?.clone())?;
     gitbutler_branch_actions::stack::create_branch(&ctx, params.stack_id, params.request)?;
     Ok(())
 }
@@ -31,9 +31,9 @@ pub struct RemoveBranchParams {
     pub branch_name: String,
 }
 
-pub fn remove_branch(ipc_ctx: &IpcContext, params: RemoveBranchParams) -> Result<(), Error> {
+pub fn remove_branch(app: &App, params: RemoveBranchParams) -> Result<(), Error> {
     let project = gitbutler_project::get(params.project_id)?;
-    let ctx = CommandContext::open(&project, ipc_ctx.app_settings.get()?.clone())?;
+    let ctx = CommandContext::open(&project, app.app_settings.get()?.clone())?;
     gitbutler_branch_actions::stack::remove_branch(&ctx, params.stack_id, params.branch_name)?;
     Ok(())
 }
@@ -47,12 +47,9 @@ pub struct UpdateBranchNameParams {
     pub new_name: String,
 }
 
-pub fn update_branch_name(
-    ipc_ctx: &IpcContext,
-    params: UpdateBranchNameParams,
-) -> Result<(), Error> {
+pub fn update_branch_name(app: &App, params: UpdateBranchNameParams) -> Result<(), Error> {
     let project = gitbutler_project::get(params.project_id)?;
-    let ctx = CommandContext::open(&project, ipc_ctx.app_settings.get()?.clone())?;
+    let ctx = CommandContext::open(&project, app.app_settings.get()?.clone())?;
     gitbutler_branch_actions::stack::update_branch_name(
         &ctx,
         params.stack_id,
@@ -72,11 +69,11 @@ pub struct UpdateBranchDescriptionParams {
 }
 
 pub fn update_branch_description(
-    ipc_ctx: &IpcContext,
+    app: &App,
     params: UpdateBranchDescriptionParams,
 ) -> Result<(), Error> {
     let project = gitbutler_project::get(params.project_id)?;
-    let ctx = CommandContext::open(&project, ipc_ctx.app_settings.get()?.clone())?;
+    let ctx = CommandContext::open(&project, app.app_settings.get()?.clone())?;
     gitbutler_branch_actions::stack::update_branch_description(
         &ctx,
         params.stack_id,
@@ -95,12 +92,9 @@ pub struct UpdateBranchPrNumberParams {
     pub pr_number: Option<usize>,
 }
 
-pub fn update_branch_pr_number(
-    ipc_ctx: &IpcContext,
-    params: UpdateBranchPrNumberParams,
-) -> Result<(), Error> {
+pub fn update_branch_pr_number(app: &App, params: UpdateBranchPrNumberParams) -> Result<(), Error> {
     let project = gitbutler_project::get(params.project_id)?;
-    let ctx = CommandContext::open(&project, ipc_ctx.app_settings.get()?.clone())?;
+    let ctx = CommandContext::open(&project, app.app_settings.get()?.clone())?;
     gitbutler_branch_actions::stack::update_branch_pr_number(
         &ctx,
         params.stack_id,
@@ -119,9 +113,9 @@ pub struct PushStackParams {
     pub branch: String,
 }
 
-pub fn push_stack(ipc_ctx: &IpcContext, params: PushStackParams) -> Result<PushResult, Error> {
+pub fn push_stack(app: &App, params: PushStackParams) -> Result<PushResult, Error> {
     let project = gitbutler_project::get(params.project_id)?;
-    let ctx = CommandContext::open(&project, ipc_ctx.app_settings.get()?.clone())?;
+    let ctx = CommandContext::open(&project, app.app_settings.get()?.clone())?;
     gitbutler_branch_actions::stack::push_stack(
         &ctx,
         params.stack_id,
@@ -140,12 +134,9 @@ pub struct PushStackToReviewParams {
     pub user: User,
 }
 
-pub fn push_stack_to_review(
-    ipc_ctx: &IpcContext,
-    params: PushStackToReviewParams,
-) -> Result<String, Error> {
+pub fn push_stack_to_review(app: &App, params: PushStackToReviewParams) -> Result<String, Error> {
     let project = gitbutler_project::get(params.project_id)?;
-    let ctx = CommandContext::open(&project, ipc_ctx.app_settings.get()?.clone())?;
+    let ctx = CommandContext::open(&project, app.app_settings.get()?.clone())?;
     let review_id = gitbutler_sync::stack_upload::push_stack_to_review(
         &ctx,
         &params.user,

--- a/crates/but-api/src/commands/undo.rs
+++ b/crates/but-api/src/commands/undo.rs
@@ -5,7 +5,7 @@ use gitbutler_oplog::{OplogExt, entry::Snapshot};
 use gitbutler_project::ProjectId;
 use serde::Deserialize;
 
-use crate::{IpcContext, error::Error};
+use crate::{App, error::Error};
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -16,12 +16,9 @@ pub struct ListSnapshotsParams {
     pub exclude_kind: Option<Vec<OperationKind>>,
 }
 
-pub fn list_snapshots(
-    ipc_ctx: &IpcContext,
-    params: ListSnapshotsParams,
-) -> Result<Vec<Snapshot>, Error> {
+pub fn list_snapshots(app: &App, params: ListSnapshotsParams) -> Result<Vec<Snapshot>, Error> {
     let project = gitbutler_project::get(params.project_id).context("failed to get project")?;
-    let ctx = CommandContext::open(&project, ipc_ctx.app_settings.get()?.clone())?;
+    let ctx = CommandContext::open(&project, app.app_settings.get()?.clone())?;
     let snapshots = ctx.list_snapshots(
         params.limit,
         params
@@ -40,9 +37,9 @@ pub struct RestoreSnapshotParams {
     pub sha: String,
 }
 
-pub fn restore_snapshot(ipc_ctx: &IpcContext, params: RestoreSnapshotParams) -> Result<(), Error> {
+pub fn restore_snapshot(app: &App, params: RestoreSnapshotParams) -> Result<(), Error> {
     let project = gitbutler_project::get(params.project_id).context("failed to get project")?;
-    let ctx = CommandContext::open(&project, ipc_ctx.app_settings.get()?.clone())?;
+    let ctx = CommandContext::open(&project, app.app_settings.get()?.clone())?;
     let mut guard = project.exclusive_worktree_access();
     ctx.restore_snapshot(
         params.sha.parse().map_err(anyhow::Error::from)?,
@@ -59,11 +56,11 @@ pub struct SnapshotDiffParams {
 }
 
 pub fn snapshot_diff(
-    ipc_ctx: &IpcContext,
+    app: &App,
     params: SnapshotDiffParams,
 ) -> Result<Vec<but_core::ui::TreeChange>, Error> {
     let project = gitbutler_project::get(params.project_id).context("failed to get project")?;
-    let ctx = CommandContext::open(&project, ipc_ctx.app_settings.get()?.clone())?;
+    let ctx = CommandContext::open(&project, app.app_settings.get()?.clone())?;
     let diff = ctx.snapshot_diff(params.sha.parse().map_err(anyhow::Error::from)?)?;
     let diff: Vec<but_core::ui::TreeChange> = diff.into_iter().map(Into::into).collect();
     Ok(diff)

--- a/crates/but-api/src/commands/users.rs
+++ b/crates/but-api/src/commands/users.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use gitbutler_user::User;
 use serde::{Deserialize, Serialize};
 
-use crate::{IpcContext, NoParams, error::Error};
+use crate::{App, NoParams, error::Error};
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -62,11 +62,11 @@ impl TryFrom<User> for UserWithSecrets {
     }
 }
 
-pub fn get_user(ipc_ctx: &IpcContext, _params: NoParams) -> Result<Option<UserWithSecrets>, Error> {
-    match ipc_ctx.user_controller.get_user()? {
+pub fn get_user(app: &App, _params: NoParams) -> Result<Option<UserWithSecrets>, Error> {
+    match app.user_controller.get_user()? {
         Some(user) => {
             if let Err(err) = user.access_token() {
-                ipc_ctx.user_controller.delete_user()?;
+                app.user_controller.delete_user()?;
                 return Err(err.context("Please login to GitButler again").into());
             }
             Ok(Some(user.try_into()?))
@@ -75,12 +75,12 @@ pub fn get_user(ipc_ctx: &IpcContext, _params: NoParams) -> Result<Option<UserWi
     }
 }
 
-pub fn set_user(ipc_ctx: &IpcContext, params: SetUserParams) -> Result<User, Error> {
-    ipc_ctx.user_controller.set_user(&params.user)?;
+pub fn set_user(app: &App, params: SetUserParams) -> Result<User, Error> {
+    app.user_controller.set_user(&params.user)?;
     Ok(params.user)
 }
 
-pub fn delete_user(ipc_ctx: &IpcContext, _params: NoParams) -> Result<(), Error> {
-    ipc_ctx.user_controller.delete_user()?;
+pub fn delete_user(app: &App, _params: NoParams) -> Result<(), Error> {
+    app.user_controller.delete_user()?;
     Ok(())
 }

--- a/crates/but-api/src/commands/zip.rs
+++ b/crates/but-api/src/commands/zip.rs
@@ -1,4 +1,4 @@
-use crate::{IpcContext, error::Error};
+use crate::{App, error::Error};
 use anyhow::Context;
 use gitbutler_error::{error, error::Code};
 use serde::Deserialize;
@@ -11,7 +11,7 @@ pub struct GetProjectArchivePathParams {
 }
 
 pub fn get_project_archive_path(
-    ipc_ctx: &IpcContext,
+    app: &App,
     params: GetProjectArchivePathParams,
 ) -> Result<PathBuf, Error> {
     let project_id = params
@@ -21,7 +21,7 @@ pub fn get_project_archive_path(
             Code::Validation,
             "Malformed project id",
         ))?;
-    ipc_ctx.archival.archive(project_id).map_err(Into::into)
+    app.archival.archive(project_id).map_err(Into::into)
 }
 
 #[derive(Deserialize)]
@@ -29,8 +29,8 @@ pub fn get_project_archive_path(
 pub struct GetLogsArchivePathParams {}
 
 pub fn get_logs_archive_path(
-    ipc_ctx: &IpcContext,
+    app: &App,
     _params: GetLogsArchivePathParams,
 ) -> Result<PathBuf, Error> {
-    ipc_ctx.archival.logs_archive().map_err(Into::into)
+    app.archival.logs_archive().map_err(Into::into)
 }

--- a/crates/but-api/src/lib.rs
+++ b/crates/but-api/src/lib.rs
@@ -12,7 +12,7 @@ pub mod error;
 pub mod hex_hash;
 
 #[derive(Clone)]
-pub struct IpcContext {
+pub struct App {
     pub app_settings: Arc<AppSettingsWithDiskSync>,
     pub user_controller: Arc<gitbutler_user::Controller>,
     pub broadcaster: Arc<Mutex<Broadcaster>>,

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -10,7 +10,7 @@ use axum::{
     routing::{any, get},
 };
 use but_api::{
-    IpcContext, NoParams,
+    App, NoParams,
     broadcaster::Broadcaster,
     commands::{
         askpass, cli, config, diff, forge, git, github, modes, open, projects as iprojects,
@@ -63,7 +63,7 @@ pub async fn run() {
         active_projects: Arc::new(Mutex::new(ActiveProjects::new())),
     };
 
-    let ipc_ctx = IpcContext {
+    let app = App {
         app_settings: Arc::new(
             AppSettingsWithDiskSync::new(config_dir.clone())
                 .expect("failed to create app settings"),
@@ -81,9 +81,9 @@ pub async fn run() {
         .route(
             "/",
             get(|| async { "Hello, World!" }).post({
-                let ipc_ctx = ipc_ctx.clone();
+                let app = app.clone();
                 let extra = extra.clone();
-                move |req| handle_command(req, ipc_ctx, extra)
+                move |req| handle_command(req, app, extra)
             }),
         )
         .route(
@@ -142,305 +142,265 @@ async fn handle_websocket(socket: WebSocket, broadcaster: Arc<Mutex<Broadcaster>
 fn run_cmd<
     D: DeserializeOwned,
     S: Serialize,
-    Fun: Fn(&IpcContext, D) -> Result<S, but_api::error::Error>,
+    Fun: Fn(&App, D) -> Result<S, but_api::error::Error>,
 >(
-    ipc_ctx: &IpcContext,
+    app: &App,
     params: serde_json::Value,
     fun: Fun,
 ) -> Result<serde_json::Value, but_api::error::Error> {
-    let result = fun(ipc_ctx, serde_json::from_value(params).to_error()?)?;
+    let result = fun(app, serde_json::from_value(params).to_error()?)?;
     Ok(json!(result))
 }
 
 async fn handle_command(
     Json(request): Json<Request>,
-    ipc_ctx: IpcContext,
+    app: App,
     extra: Extra,
 ) -> Json<serde_json::Value> {
     let command: &str = &request.command;
     let result = match command {
         // General commands
-        "git_remote_branches" => run_cmd(&ipc_ctx, request.params, git::git_remote_branches),
-        "git_test_push" => run_cmd(&ipc_ctx, request.params, git::git_test_push),
-        "git_test_fetch" => run_cmd(&ipc_ctx, request.params, git::git_test_fetch),
-        "git_index_size" => run_cmd(&ipc_ctx, request.params, git::git_index_size),
-        "git_head" => run_cmd(&ipc_ctx, request.params, git::git_head),
-        "delete_all_data" => run_cmd(&ipc_ctx, request.params, git::delete_all_data),
-        "git_set_global_config" => run_cmd(&ipc_ctx, request.params, git::git_set_global_config),
-        "git_remove_global_config" => {
-            run_cmd(&ipc_ctx, request.params, git::git_remove_global_config)
-        }
-        "git_get_global_config" => run_cmd(&ipc_ctx, request.params, git::git_get_global_config),
+        "git_remote_branches" => run_cmd(&app, request.params, git::git_remote_branches),
+        "git_test_push" => run_cmd(&app, request.params, git::git_test_push),
+        "git_test_fetch" => run_cmd(&app, request.params, git::git_test_fetch),
+        "git_index_size" => run_cmd(&app, request.params, git::git_index_size),
+        "git_head" => run_cmd(&app, request.params, git::git_head),
+        "delete_all_data" => run_cmd(&app, request.params, git::delete_all_data),
+        "git_set_global_config" => run_cmd(&app, request.params, git::git_set_global_config),
+        "git_remove_global_config" => run_cmd(&app, request.params, git::git_remove_global_config),
+        "git_get_global_config" => run_cmd(&app, request.params, git::git_get_global_config),
         // Diff commands
-        "tree_change_diffs" => run_cmd(&ipc_ctx, request.params, diff::tree_change_diffs),
-        "commit_details" => run_cmd(&ipc_ctx, request.params, diff::commit_details),
-        "changes_in_branch" => run_cmd(&ipc_ctx, request.params, diff::changes_in_branch),
-        "changes_in_worktree" => run_cmd(&ipc_ctx, request.params, diff::changes_in_worktree),
-        "assign_hunk" => run_cmd(&ipc_ctx, request.params, diff::assign_hunk),
+        "tree_change_diffs" => run_cmd(&app, request.params, diff::tree_change_diffs),
+        "commit_details" => run_cmd(&app, request.params, diff::commit_details),
+        "changes_in_branch" => run_cmd(&app, request.params, diff::changes_in_branch),
+        "changes_in_worktree" => run_cmd(&app, request.params, diff::changes_in_worktree),
+        "assign_hunk" => run_cmd(&app, request.params, diff::assign_hunk),
         // Workspace commands
-        "stacks" => run_cmd(&ipc_ctx, request.params, workspace::stacks),
+        "stacks" => run_cmd(&app, request.params, workspace::stacks),
         #[cfg(unix)]
-        "show_graph_svg" => run_cmd(&ipc_ctx, request.params, workspace::show_graph_svg),
-        "stack_details" => run_cmd(&ipc_ctx, request.params, workspace::stack_details),
-        "branch_details" => run_cmd(&ipc_ctx, request.params, workspace::branch_details),
+        "show_graph_svg" => run_cmd(&app, request.params, workspace::show_graph_svg),
+        "stack_details" => run_cmd(&app, request.params, workspace::stack_details),
+        "branch_details" => run_cmd(&app, request.params, workspace::branch_details),
         "create_commit_from_worktree_changes" => run_cmd(
-            &ipc_ctx,
+            &app,
             request.params,
             workspace::create_commit_from_worktree_changes,
         ),
         "amend_commit_from_worktree_changes" => run_cmd(
-            &ipc_ctx,
+            &app,
             request.params,
             workspace::amend_commit_from_worktree_changes,
         ),
-        "discard_worktree_changes" => run_cmd(
-            &ipc_ctx,
-            request.params,
-            workspace::discard_worktree_changes,
-        ),
+        "discard_worktree_changes" => {
+            run_cmd(&app, request.params, workspace::discard_worktree_changes)
+        }
         "move_changes_between_commits" => run_cmd(
-            &ipc_ctx,
+            &app,
             request.params,
             workspace::move_changes_between_commits,
         ),
-        "split_branch" => run_cmd(&ipc_ctx, request.params, workspace::split_branch),
+        "split_branch" => run_cmd(&app, request.params, workspace::split_branch),
         "split_branch_into_dependent_branch" => run_cmd(
-            &ipc_ctx,
+            &app,
             request.params,
             workspace::split_branch_into_dependent_branch,
         ),
-        "uncommit_changes" => run_cmd(&ipc_ctx, request.params, workspace::uncommit_changes),
-        "stash_into_branch" => run_cmd(&ipc_ctx, request.params, workspace::stash_into_branch),
-        "canned_branch_name" => run_cmd(&ipc_ctx, request.params, workspace::canned_branch_name),
-        "target_commits" => run_cmd(&ipc_ctx, request.params, workspace::target_commits),
+        "uncommit_changes" => run_cmd(&app, request.params, workspace::uncommit_changes),
+        "stash_into_branch" => run_cmd(&app, request.params, workspace::stash_into_branch),
+        "canned_branch_name" => run_cmd(&app, request.params, workspace::canned_branch_name),
+        "target_commits" => run_cmd(&app, request.params, workspace::target_commits),
         // App settings
-        "get_app_settings" => run_cmd(&ipc_ctx, request.params, settings::get_app_settings),
-        "update_onboarding_complete" => run_cmd(
-            &ipc_ctx,
-            request.params,
-            settings::update_onboarding_complete,
-        ),
-        "update_telemetry" => run_cmd(&ipc_ctx, request.params, settings::update_telemetry),
-        "update_telemetry_distinct_id" => run_cmd(
-            &ipc_ctx,
-            request.params,
-            settings::update_telemetry_distinct_id,
-        ),
-        "update_feature_flags" => run_cmd(&ipc_ctx, request.params, settings::update_feature_flags),
-        // Secret management
-        "secret_get_global" => run_cmd(&ipc_ctx, request.params, secret::secret_get_global),
-        "secret_set_global" => run_cmd(&ipc_ctx, request.params, secret::secret_set_global),
-        // User management
-        "get_user" => run_cmd(&ipc_ctx, request.params, users::get_user),
-        "set_user" => run_cmd(&ipc_ctx, request.params, users::set_user),
-        "delete_user" => run_cmd(&ipc_ctx, request.params, users::delete_user),
-        // Project management
-        "update_project" => run_cmd(&ipc_ctx, request.params, iprojects::update_project),
-        "add_project" => run_cmd(&ipc_ctx, request.params, iprojects::add_project),
-        "get_project" => run_cmd(&ipc_ctx, request.params, iprojects::get_project),
-        "delete_project" => run_cmd(&ipc_ctx, request.params, iprojects::delete_project),
-        "list_projects" => projects::list_projects(&extra).await,
-        "set_project_active" => {
-            projects::set_project_active(&ipc_ctx, &extra, request.params).await
+        "get_app_settings" => run_cmd(&app, request.params, settings::get_app_settings),
+        "update_onboarding_complete" => {
+            run_cmd(&app, request.params, settings::update_onboarding_complete)
         }
+        "update_telemetry" => run_cmd(&app, request.params, settings::update_telemetry),
+        "update_telemetry_distinct_id" => {
+            run_cmd(&app, request.params, settings::update_telemetry_distinct_id)
+        }
+        "update_feature_flags" => run_cmd(&app, request.params, settings::update_feature_flags),
+        // Secret management
+        "secret_get_global" => run_cmd(&app, request.params, secret::secret_get_global),
+        "secret_set_global" => run_cmd(&app, request.params, secret::secret_set_global),
+        // User management
+        "get_user" => run_cmd(&app, request.params, users::get_user),
+        "set_user" => run_cmd(&app, request.params, users::set_user),
+        "delete_user" => run_cmd(&app, request.params, users::delete_user),
+        // Project management
+        "update_project" => run_cmd(&app, request.params, iprojects::update_project),
+        "add_project" => run_cmd(&app, request.params, iprojects::add_project),
+        "get_project" => run_cmd(&app, request.params, iprojects::get_project),
+        "delete_project" => run_cmd(&app, request.params, iprojects::delete_project),
+        "list_projects" => projects::list_projects(&extra).await,
+        "set_project_active" => projects::set_project_active(&app, &extra, request.params).await,
         // Virtual branches commands
         "normalize_branch_name" => run_cmd(
-            &ipc_ctx,
+            &app,
             request.params,
             virtual_branches::normalize_branch_name,
         ),
         "create_virtual_branch" => run_cmd(
-            &ipc_ctx,
+            &app,
             request.params,
             virtual_branches::create_virtual_branch,
         ),
-        "delete_local_branch" => run_cmd(
-            &ipc_ctx,
-            request.params,
-            virtual_branches::delete_local_branch,
-        ),
+        "delete_local_branch" => {
+            run_cmd(&app, request.params, virtual_branches::delete_local_branch)
+        }
         "create_virtual_branch_from_branch" => run_cmd(
-            &ipc_ctx,
+            &app,
             request.params,
             virtual_branches::create_virtual_branch_from_branch,
         ),
         "integrate_upstream_commits" => run_cmd(
-            &ipc_ctx,
+            &app,
             request.params,
             virtual_branches::integrate_upstream_commits,
         ),
-        "get_base_branch_data" => run_cmd(
-            &ipc_ctx,
-            request.params,
-            virtual_branches::get_base_branch_data,
-        ),
-        "set_base_branch" => run_cmd(&ipc_ctx, request.params, virtual_branches::set_base_branch),
-        "push_base_branch" => run_cmd(&ipc_ctx, request.params, virtual_branches::push_base_branch),
-        "update_stack_order" => run_cmd(
-            &ipc_ctx,
-            request.params,
-            virtual_branches::update_stack_order,
-        ),
-        "unapply_stack" => run_cmd(&ipc_ctx, request.params, virtual_branches::unapply_stack),
+        "get_base_branch_data" => {
+            run_cmd(&app, request.params, virtual_branches::get_base_branch_data)
+        }
+        "set_base_branch" => run_cmd(&app, request.params, virtual_branches::set_base_branch),
+        "push_base_branch" => run_cmd(&app, request.params, virtual_branches::push_base_branch),
+        "update_stack_order" => run_cmd(&app, request.params, virtual_branches::update_stack_order),
+        "unapply_stack" => run_cmd(&app, request.params, virtual_branches::unapply_stack),
         "can_apply_remote_branch" => run_cmd(
-            &ipc_ctx,
+            &app,
             request.params,
             virtual_branches::can_apply_remote_branch,
         ),
-        "list_commit_files" => run_cmd(
-            &ipc_ctx,
-            request.params,
-            virtual_branches::list_commit_files,
-        ),
-        "amend_virtual_branch" => run_cmd(
-            &ipc_ctx,
-            request.params,
-            virtual_branches::amend_virtual_branch,
-        ),
-        "move_commit_file" => run_cmd(&ipc_ctx, request.params, virtual_branches::move_commit_file),
-        "undo_commit" => run_cmd(&ipc_ctx, request.params, virtual_branches::undo_commit),
-        "insert_blank_commit" => run_cmd(
-            &ipc_ctx,
-            request.params,
-            virtual_branches::insert_blank_commit,
-        ),
-        "reorder_stack" => run_cmd(&ipc_ctx, request.params, virtual_branches::reorder_stack),
-        "find_git_branches" => run_cmd(
-            &ipc_ctx,
-            request.params,
-            virtual_branches::find_git_branches,
-        ),
-        "list_branches" => run_cmd(&ipc_ctx, request.params, virtual_branches::list_branches),
+        "list_commit_files" => run_cmd(&app, request.params, virtual_branches::list_commit_files),
+        "amend_virtual_branch" => {
+            run_cmd(&app, request.params, virtual_branches::amend_virtual_branch)
+        }
+        "move_commit_file" => run_cmd(&app, request.params, virtual_branches::move_commit_file),
+        "undo_commit" => run_cmd(&app, request.params, virtual_branches::undo_commit),
+        "insert_blank_commit" => {
+            run_cmd(&app, request.params, virtual_branches::insert_blank_commit)
+        }
+        "reorder_stack" => run_cmd(&app, request.params, virtual_branches::reorder_stack),
+        "find_git_branches" => run_cmd(&app, request.params, virtual_branches::find_git_branches),
+        "list_branches" => run_cmd(&app, request.params, virtual_branches::list_branches),
         "get_branch_listing_details" => run_cmd(
-            &ipc_ctx,
+            &app,
             request.params,
             virtual_branches::get_branch_listing_details,
         ),
-        "squash_commits" => run_cmd(&ipc_ctx, request.params, virtual_branches::squash_commits),
-        "fetch_from_remotes" => run_cmd(
-            &ipc_ctx,
-            request.params,
-            virtual_branches::fetch_from_remotes,
-        ),
-        "move_commit" => run_cmd(&ipc_ctx, request.params, virtual_branches::move_commit),
+        "squash_commits" => run_cmd(&app, request.params, virtual_branches::squash_commits),
+        "fetch_from_remotes" => run_cmd(&app, request.params, virtual_branches::fetch_from_remotes),
+        "move_commit" => run_cmd(&app, request.params, virtual_branches::move_commit),
         "update_commit_message" => run_cmd(
-            &ipc_ctx,
+            &app,
             request.params,
             virtual_branches::update_commit_message,
         ),
-        "find_commit" => run_cmd(&ipc_ctx, request.params, virtual_branches::find_commit),
+        "find_commit" => run_cmd(&app, request.params, virtual_branches::find_commit),
         "upstream_integration_statuses" => run_cmd(
-            &ipc_ctx,
+            &app,
             request.params,
             virtual_branches::upstream_integration_statuses,
         ),
-        "integrate_upstream" => run_cmd(
-            &ipc_ctx,
-            request.params,
-            virtual_branches::integrate_upstream,
-        ),
+        "integrate_upstream" => run_cmd(&app, request.params, virtual_branches::integrate_upstream),
         "resolve_upstream_integration" => run_cmd(
-            &ipc_ctx,
+            &app,
             request.params,
             virtual_branches::resolve_upstream_integration,
         ),
         // Operating modes commands
-        "operating_mode" => run_cmd(&ipc_ctx, request.params, modes::operating_mode),
-        "enter_edit_mode" => run_cmd(&ipc_ctx, request.params, modes::enter_edit_mode),
+        "operating_mode" => run_cmd(&app, request.params, modes::operating_mode),
+        "enter_edit_mode" => run_cmd(&app, request.params, modes::enter_edit_mode),
         "abort_edit_and_return_to_workspace" => run_cmd(
-            &ipc_ctx,
+            &app,
             request.params,
             modes::abort_edit_and_return_to_workspace,
         ),
         "save_edit_and_return_to_workspace" => run_cmd(
-            &ipc_ctx,
+            &app,
             request.params,
             modes::save_edit_and_return_to_workspace,
         ),
         "edit_initial_index_state" => {
-            run_cmd(&ipc_ctx, request.params, modes::edit_initial_index_state)
+            run_cmd(&app, request.params, modes::edit_initial_index_state)
         }
         "edit_changes_from_initial" => {
-            run_cmd(&ipc_ctx, request.params, modes::edit_changes_from_initial)
+            run_cmd(&app, request.params, modes::edit_changes_from_initial)
         }
         // Repository commands
-        "git_get_local_config" => run_cmd(&ipc_ctx, request.params, repo::git_get_local_config),
-        "git_set_local_config" => run_cmd(&ipc_ctx, request.params, repo::git_set_local_config),
-        "check_signing_settings" => run_cmd(&ipc_ctx, request.params, repo::check_signing_settings),
-        "git_clone_repository" => run_cmd(&ipc_ctx, request.params, repo::git_clone_repository),
-        "get_uncommited_files" => run_cmd(&ipc_ctx, request.params, repo::get_uncommitted_files),
-        "get_commit_file" => run_cmd(&ipc_ctx, request.params, repo::get_commit_file),
-        "get_workspace_file" => run_cmd(&ipc_ctx, request.params, repo::get_workspace_file),
-        "pre_commit_hook" => run_cmd(&ipc_ctx, request.params, repo::pre_commit_hook),
+        "git_get_local_config" => run_cmd(&app, request.params, repo::git_get_local_config),
+        "git_set_local_config" => run_cmd(&app, request.params, repo::git_set_local_config),
+        "check_signing_settings" => run_cmd(&app, request.params, repo::check_signing_settings),
+        "git_clone_repository" => run_cmd(&app, request.params, repo::git_clone_repository),
+        "get_uncommited_files" => run_cmd(&app, request.params, repo::get_uncommitted_files),
+        "get_commit_file" => run_cmd(&app, request.params, repo::get_commit_file),
+        "get_workspace_file" => run_cmd(&app, request.params, repo::get_workspace_file),
+        "pre_commit_hook" => run_cmd(&app, request.params, repo::pre_commit_hook),
         "pre_commit_hook_diffspecs" => {
-            run_cmd(&ipc_ctx, request.params, repo::pre_commit_hook_diffspecs)
+            run_cmd(&app, request.params, repo::pre_commit_hook_diffspecs)
         }
-        "post_commit_hook" => run_cmd(&ipc_ctx, request.params, repo::post_commit_hook),
-        "message_hook" => run_cmd(&ipc_ctx, request.params, repo::message_hook),
+        "post_commit_hook" => run_cmd(&app, request.params, repo::post_commit_hook),
+        "message_hook" => run_cmd(&app, request.params, repo::message_hook),
         // Stack management commands
-        "create_branch" => run_cmd(&ipc_ctx, request.params, stack::create_branch),
-        "remove_branch" => run_cmd(&ipc_ctx, request.params, stack::remove_branch),
-        "update_branch_name" => run_cmd(&ipc_ctx, request.params, stack::update_branch_name),
+        "create_branch" => run_cmd(&app, request.params, stack::create_branch),
+        "remove_branch" => run_cmd(&app, request.params, stack::remove_branch),
+        "update_branch_name" => run_cmd(&app, request.params, stack::update_branch_name),
         "update_branch_description" => {
-            run_cmd(&ipc_ctx, request.params, stack::update_branch_description)
+            run_cmd(&app, request.params, stack::update_branch_description)
         }
-        "update_branch_pr_number" => {
-            run_cmd(&ipc_ctx, request.params, stack::update_branch_pr_number)
-        }
-        "push_stack" => run_cmd(&ipc_ctx, request.params, stack::push_stack),
-        "push_stack_to_review" => run_cmd(&ipc_ctx, request.params, stack::push_stack_to_review),
+        "update_branch_pr_number" => run_cmd(&app, request.params, stack::update_branch_pr_number),
+        "push_stack" => run_cmd(&app, request.params, stack::push_stack),
+        "push_stack_to_review" => run_cmd(&app, request.params, stack::push_stack_to_review),
         // Undo/Snapshot commands
-        "list_snapshots" => run_cmd(&ipc_ctx, request.params, undo::list_snapshots),
-        "restore_snapshot" => run_cmd(&ipc_ctx, request.params, undo::restore_snapshot),
-        "snapshot_diff" => run_cmd(&ipc_ctx, request.params, undo::snapshot_diff),
+        "list_snapshots" => run_cmd(&app, request.params, undo::list_snapshots),
+        "restore_snapshot" => run_cmd(&app, request.params, undo::restore_snapshot),
+        "snapshot_diff" => run_cmd(&app, request.params, undo::snapshot_diff),
         // "oplog_diff_worktrees" => undo::oplog_diff_worktrees(&ctx, request.params),
         // Config management commands
-        "get_gb_config" => run_cmd(&ipc_ctx, request.params, config::get_gb_config),
-        "set_gb_config" => run_cmd(&ipc_ctx, request.params, config::set_gb_config),
+        "get_gb_config" => run_cmd(&app, request.params, config::get_gb_config),
+        "set_gb_config" => run_cmd(&app, request.params, config::set_gb_config),
         // Remotes management commands
-        "list_remotes" => run_cmd(&ipc_ctx, request.params, remotes::list_remotes),
-        "add_remote" => run_cmd(&ipc_ctx, request.params, remotes::add_remote),
+        "list_remotes" => run_cmd(&app, request.params, remotes::list_remotes),
+        "add_remote" => run_cmd(&app, request.params, remotes::add_remote),
         // Rules/Workspace rules commands
-        "create_workspace_rule" => run_cmd(&ipc_ctx, request.params, rules::create_workspace_rule),
-        "delete_workspace_rule" => run_cmd(&ipc_ctx, request.params, rules::delete_workspace_rule),
-        "update_workspace_rule" => run_cmd(&ipc_ctx, request.params, rules::update_workspace_rule),
-        "list_workspace_rules" => run_cmd(&ipc_ctx, request.params, rules::list_workspace_rules),
+        "create_workspace_rule" => run_cmd(&app, request.params, rules::create_workspace_rule),
+        "delete_workspace_rule" => run_cmd(&app, request.params, rules::delete_workspace_rule),
+        "update_workspace_rule" => run_cmd(&app, request.params, rules::update_workspace_rule),
+        "list_workspace_rules" => run_cmd(&app, request.params, rules::list_workspace_rules),
         "init_device_oauth" => {
-            let result = github::init_device_oauth(&ipc_ctx, NoParams {}).await;
+            let result = github::init_device_oauth(&app, NoParams {}).await;
             result.map(|r| json!(r))
         }
         "check_auth_status" => {
             let params = serde_json::from_value(request.params).to_error();
             match params {
                 Ok(params) => {
-                    let result = github::check_auth_status(&ipc_ctx, params).await;
+                    let result = github::check_auth_status(&app, params).await;
                     result.map(|r| json!(r))
                 }
                 Err(e) => Err(e),
             }
         }
         // Forge commands
-        "pr_templates" => run_cmd(&ipc_ctx, request.params, forge::pr_templates),
-        "pr_template" => run_cmd(&ipc_ctx, request.params, forge::pr_template),
+        "pr_templates" => run_cmd(&app, request.params, forge::pr_templates),
+        "pr_template" => run_cmd(&app, request.params, forge::pr_template),
         // // Menu commands (limited - no menu_item_set_enabled as it's Tauri-specific)
         // "get_editor_link_scheme" => menu::get_editor_link_scheme(&ctx, request.params),
         // CLI commands
-        "install_cli" => run_cmd(&ipc_ctx, request.params, cli::install_cli),
-        "cli_path" => run_cmd(&ipc_ctx, request.params, cli::cli_path),
+        "install_cli" => run_cmd(&app, request.params, cli::install_cli),
+        "cli_path" => run_cmd(&app, request.params, cli::cli_path),
         // Askpass commands (async)
         "submit_prompt_response" => {
             let params = serde_json::from_value(request.params).to_error();
             match params {
                 Ok(params) => {
-                    let result = askpass::submit_prompt_response(&ipc_ctx, params).await;
+                    let result = askpass::submit_prompt_response(&app, params).await;
                     result.map(|r| json!(r))
                 }
                 Err(e) => Err(e),
             }
         }
         // Open/System commands (limited - no open_project_in_window as it's Tauri-specific)
-        "open_url" => run_cmd(&ipc_ctx, request.params, open::open_url),
-        "show_in_finder" => run_cmd(&ipc_ctx, request.params, open::show_in_finder),
+        "open_url" => run_cmd(&app, request.params, open::open_url),
+        "show_in_finder" => run_cmd(&app, request.params, open::show_in_finder),
 
         // TODO: Tauri-specific commands that cannot be ported to HTTP API:
         //
@@ -455,10 +415,8 @@ async fn handle_command(
         // - "open_project_in_window" => projects::open_project_in_window() // Requires Tauri window creation
         //
         // Zip/Archive commands
-        "get_project_archive_path" => {
-            run_cmd(&ipc_ctx, request.params, zip::get_project_archive_path)
-        }
-        "get_logs_archive_path" => run_cmd(&ipc_ctx, request.params, zip::get_logs_archive_path),
+        "get_project_archive_path" => run_cmd(&app, request.params, zip::get_project_archive_path),
+        "get_logs_archive_path" => run_cmd(&app, request.params, zip::get_logs_archive_path),
         _ => Err(anyhow::anyhow!("Command {} not found!", command).into()),
     };
 

--- a/crates/but-server/src/projects.rs
+++ b/crates/but-server/src/projects.rs
@@ -1,6 +1,6 @@
 use crate::Extra;
 use anyhow::{Context as _, Result};
-use but_api::{IpcContext, broadcaster::FrontendEvent, error::ToError};
+use but_api::{App, broadcaster::FrontendEvent, error::ToError};
 use gitbutler_project::{Project, ProjectId};
 use gitbutler_watcher::{Change, WatcherHandle};
 use serde::Deserialize;
@@ -24,7 +24,7 @@ impl ActiveProjects {
         }
     }
 
-    pub fn set_active(&mut self, project: &Project, ctx: &IpcContext) -> Result<()> {
+    pub fn set_active(&mut self, project: &Project, ctx: &App) -> Result<()> {
         if self.projects.contains_key(&project.id) {
             return Ok(());
         }
@@ -105,7 +105,7 @@ pub async fn list_projects(extra: &Extra) -> Result<serde_json::Value, but_api::
 }
 
 pub async fn set_project_active(
-    ctx: &IpcContext,
+    ctx: &App,
     extra: &Extra,
     params: serde_json::Value,
 ) -> Result<serde_json::Value, but_api::error::Error> {

--- a/crates/gitbutler-tauri/src/askpass.rs
+++ b/crates/gitbutler-tauri/src/askpass.rs
@@ -1,4 +1,4 @@
-use but_api::{commands::askpass, IpcContext};
+use but_api::{commands::askpass, App};
 use gitbutler_id::id::Id;
 use gitbutler_repo_actions::askpass::AskpassRequest;
 use tauri::State;
@@ -7,15 +7,12 @@ use tracing::instrument;
 use but_api::error::Error;
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx, response))]
+#[instrument(skip(app, response))]
 pub async fn submit_prompt_response(
-    ipc_ctx: State<'_, IpcContext>,
+    app: State<'_, App>,
     id: Id<AskpassRequest>,
     response: Option<String>,
 ) -> Result<(), Error> {
-    askpass::submit_prompt_response(
-        &ipc_ctx,
-        askpass::SubmitPromptResponseParams { id, response },
-    )
-    .await
+    askpass::submit_prompt_response(&app, askpass::SubmitPromptResponseParams { id, response })
+        .await
 }

--- a/crates/gitbutler-tauri/src/cli.rs
+++ b/crates/gitbutler-tauri/src/cli.rs
@@ -1,17 +1,17 @@
-use but_api::{commands::cli, IpcContext, NoParams};
+use but_api::{commands::cli, App, NoParams};
 use tauri::State;
 use tracing::instrument;
 
 use but_api::error::Error;
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn install_cli(ipc_ctx: State<'_, IpcContext>) -> Result<(), Error> {
-    cli::install_cli(&ipc_ctx, NoParams {})
+#[instrument(skip(app), err(Debug))]
+pub fn install_cli(app: State<'_, App>) -> Result<(), Error> {
+    cli::install_cli(&app, NoParams {})
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn cli_path(ipc_ctx: State<'_, IpcContext>) -> Result<String, Error> {
-    cli::cli_path(&ipc_ctx, NoParams {})
+#[instrument(skip(app), err(Debug))]
+pub fn cli_path(app: State<'_, App>) -> Result<String, Error> {
+    cli::cli_path(&app, NoParams {})
 }

--- a/crates/gitbutler-tauri/src/commands.rs
+++ b/crates/gitbutler-tauri/src/commands.rs
@@ -1,4 +1,4 @@
-use but_api::{commands::git, IpcContext, NoParams};
+use but_api::{commands::git, App, NoParams};
 use gitbutler_project::ProjectId;
 use gitbutler_reference::RemoteRefname;
 use tauri::State;
@@ -7,24 +7,24 @@ use tracing::instrument;
 use but_api::error::Error;
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn git_remote_branches(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
 ) -> Result<Vec<RemoteRefname>, Error> {
-    git::git_remote_branches(&ipc_ctx, git::GitRemoteBranchesParams { project_id })
+    git::git_remote_branches(&app, git::GitRemoteBranchesParams { project_id })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn git_test_push(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     remote_name: String,
     branch_name: String,
 ) -> Result<(), Error> {
     git::git_test_push(
-        &ipc_ctx,
+        &app,
         git::GitTestPushParams {
             project_id,
             remote_name,
@@ -34,15 +34,15 @@ pub fn git_test_push(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn git_test_fetch(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     remote_name: String,
     action: Option<String>,
 ) -> Result<(), Error> {
     git::git_test_fetch(
-        &ipc_ctx,
+        &app,
         git::GitTestFetchParams {
             project_id,
             remote_name,
@@ -52,44 +52,37 @@ pub fn git_test_fetch(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn git_index_size(ipc_ctx: State<IpcContext>, project_id: ProjectId) -> Result<usize, Error> {
-    git::git_index_size(&ipc_ctx, git::GitIndexSizeParams { project_id })
+#[instrument(skip(app), err(Debug))]
+pub fn git_index_size(app: State<App>, project_id: ProjectId) -> Result<usize, Error> {
+    git::git_index_size(&app, git::GitIndexSizeParams { project_id })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn git_head(ipc_ctx: State<IpcContext>, project_id: ProjectId) -> Result<String, Error> {
-    git::git_head(&ipc_ctx, git::GitHeadParams { project_id })
+#[instrument(skip(app), err(Debug))]
+pub fn git_head(app: State<App>, project_id: ProjectId) -> Result<String, Error> {
+    git::git_head(&app, git::GitHeadParams { project_id })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn delete_all_data(ipc_ctx: State<IpcContext>) -> Result<(), Error> {
-    git::delete_all_data(&ipc_ctx, NoParams {})
+#[instrument(skip(app), err(Debug))]
+pub fn delete_all_data(app: State<App>) -> Result<(), Error> {
+    git::delete_all_data(&app, NoParams {})
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn git_set_global_config(
-    ipc_ctx: State<IpcContext>,
-    key: String,
-    value: String,
-) -> Result<String, Error> {
-    git::git_set_global_config(&ipc_ctx, git::GitSetGlobalConfigParams { key, value })
+#[instrument(skip(app), err(Debug))]
+pub fn git_set_global_config(app: State<App>, key: String, value: String) -> Result<String, Error> {
+    git::git_set_global_config(&app, git::GitSetGlobalConfigParams { key, value })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn git_remove_global_config(ipc_ctx: State<IpcContext>, key: String) -> Result<(), Error> {
-    git::git_remove_global_config(&ipc_ctx, git::GitRemoveGlobalConfigParams { key })
+#[instrument(skip(app), err(Debug))]
+pub fn git_remove_global_config(app: State<App>, key: String) -> Result<(), Error> {
+    git::git_remove_global_config(&app, git::GitRemoveGlobalConfigParams { key })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug), level = "trace")]
-pub fn git_get_global_config(
-    ipc_ctx: State<IpcContext>,
-    key: String,
-) -> Result<Option<String>, Error> {
-    git::git_get_global_config(&ipc_ctx, git::GitGetGlobalConfigParams { key })
+#[instrument(skip(app), err(Debug), level = "trace")]
+pub fn git_get_global_config(app: State<App>, key: String) -> Result<Option<String>, Error> {
+    git::git_get_global_config(&app, git::GitGetGlobalConfigParams { key })
 }

--- a/crates/gitbutler-tauri/src/config.rs
+++ b/crates/gitbutler-tauri/src/config.rs
@@ -1,4 +1,4 @@
-use but_api::{commands::config, IpcContext};
+use but_api::{commands::config, App};
 use but_core::settings::git::ui::GitConfigSettings;
 use gitbutler_project::ProjectId;
 use tauri::State;
@@ -7,20 +7,17 @@ use tracing::instrument;
 use but_api::error::Error;
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn get_gb_config(
-    ipc_ctx: State<IpcContext>,
-    project_id: ProjectId,
-) -> Result<GitConfigSettings, Error> {
-    config::get_gb_config(&ipc_ctx, config::GetGbConfigParams { project_id })
+#[instrument(skip(app), err(Debug))]
+pub fn get_gb_config(app: State<App>, project_id: ProjectId) -> Result<GitConfigSettings, Error> {
+    config::get_gb_config(&app, config::GetGbConfigParams { project_id })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn set_gb_config(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     config: GitConfigSettings,
 ) -> Result<(), Error> {
-    config::set_gb_config(&ipc_ctx, config::SetGbConfigParams { project_id, config })
+    config::set_gb_config(&app, config::SetGbConfigParams { project_id, config })
 }

--- a/crates/gitbutler-tauri/src/diff.rs
+++ b/crates/gitbutler-tauri/src/diff.rs
@@ -14,24 +14,24 @@ use tracing::instrument;
 /// Provide a unified diff for `change`, but fail if `change` is a [type-change](but_core::ModeFlags::TypeChange)
 /// or if it involves a change to a [submodule](gix::object::Kind::Commit).
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn tree_change_diffs(
-    ipc_ctx: State<'_, but_api::IpcContext>,
+    app: State<'_, but_api::App>,
     project_id: ProjectId,
     change: TreeChange,
 ) -> anyhow::Result<but_core::UnifiedDiff, Error> {
-    diff::tree_change_diffs(&ipc_ctx, TreeChangeDiffsParams { project_id, change })
+    diff::tree_change_diffs(&app, TreeChangeDiffsParams { project_id, change })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn commit_details(
-    ipc_ctx: State<'_, but_api::IpcContext>,
+    app: State<'_, but_api::App>,
     project_id: ProjectId,
     commit_id: HexHash,
 ) -> anyhow::Result<CommitDetails, Error> {
     diff::commit_details(
-        &ipc_ctx,
+        &app,
         CommitDetailsParams {
             project_id,
             commit_id,
@@ -46,9 +46,9 @@ pub fn commit_details(
 /// Note that `stack_id` is deprecated in favor of `branch_name`
 /// *(which should be a full ref-name as well and make `remote` unnecessary)*
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn changes_in_branch(
-    ipc_ctx: State<'_, but_api::IpcContext>,
+    app: State<'_, but_api::App>,
     project_id: ProjectId,
     // TODO: remove this, go by name. Ideally, the UI would pass us two commits.
     _stack_id: Option<StackId>,
@@ -56,7 +56,7 @@ pub fn changes_in_branch(
     remote: Option<String>,
 ) -> anyhow::Result<TreeChanges, Error> {
     diff::changes_in_branch(
-        &ipc_ctx,
+        &app,
         ChangesInBranchParams {
             project_id,
             _stack_id,
@@ -76,23 +76,23 @@ pub fn changes_in_branch(
 ///
 /// All ignored status changes are also provided so they can be displayed separately.
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn changes_in_worktree(
-    ipc_ctx: State<'_, but_api::IpcContext>,
+    app: State<'_, but_api::App>,
     project_id: ProjectId,
 ) -> anyhow::Result<WorktreeChanges, Error> {
-    diff::changes_in_worktree(&ipc_ctx, ChangesInWorktreeParams { project_id })
+    diff::changes_in_worktree(&app, ChangesInWorktreeParams { project_id })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn assign_hunk(
-    ipc_ctx: State<'_, but_api::IpcContext>,
+    app: State<'_, but_api::App>,
     project_id: ProjectId,
     assignments: Vec<HunkAssignmentRequest>,
 ) -> anyhow::Result<Vec<AssignmentRejection>, Error> {
     diff::assign_hunk(
-        &ipc_ctx,
+        &app,
         AssignHunkParams {
             project_id,
             assignments,

--- a/crates/gitbutler-tauri/src/forge.rs
+++ b/crates/gitbutler-tauri/src/forge.rs
@@ -1,4 +1,4 @@
-use but_api::{commands::forge, IpcContext};
+use but_api::{commands::forge, App};
 use gitbutler_forge::forge::ForgeName;
 use gitbutler_project::ProjectId;
 use std::path::PathBuf;
@@ -8,25 +8,25 @@ use tracing::instrument;
 use but_api::error::Error;
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn pr_templates(
-    ipc_ctx: State<'_, IpcContext>,
+    app: State<'_, App>,
     project_id: ProjectId,
     forge: ForgeName,
 ) -> Result<Vec<String>, Error> {
-    forge::pr_templates(&ipc_ctx, forge::PrTemplatesParams { project_id, forge })
+    forge::pr_templates(&app, forge::PrTemplatesParams { project_id, forge })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx))]
+#[instrument(skip(app))]
 pub fn pr_template(
-    ipc_ctx: State<'_, IpcContext>,
+    app: State<'_, App>,
     project_id: ProjectId,
     relative_path: PathBuf,
     forge: ForgeName,
 ) -> Result<String, Error> {
     forge::pr_template(
-        &ipc_ctx,
+        &app,
         forge::PrTemplateParams {
             project_id,
             relative_path,

--- a/crates/gitbutler-tauri/src/github.rs
+++ b/crates/gitbutler-tauri/src/github.rs
@@ -1,6 +1,6 @@
 use but_api::{
     commands::github::{self, Verification},
-    IpcContext, NoParams,
+    App, NoParams,
 };
 use tauri::State;
 use tracing::instrument;
@@ -8,16 +8,13 @@ use tracing::instrument;
 use but_api::error::Error;
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub async fn init_device_oauth(ipc_ctx: State<'_, IpcContext>) -> Result<Verification, Error> {
-    github::init_device_oauth(&ipc_ctx, NoParams {}).await
+#[instrument(skip(app), err(Debug))]
+pub async fn init_device_oauth(app: State<'_, App>) -> Result<Verification, Error> {
+    github::init_device_oauth(&app, NoParams {}).await
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub async fn check_auth_status(
-    ipc_ctx: State<'_, IpcContext>,
-    device_code: String,
-) -> Result<String, Error> {
-    github::check_auth_status(&ipc_ctx, github::CheckAuthStatusParams { device_code }).await
+#[instrument(skip(app), err(Debug))]
+pub async fn check_auth_status(app: State<'_, App>, device_code: String) -> Result<String, Error> {
+    github::check_auth_status(&app, github::CheckAuthStatusParams { device_code }).await
 }

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -14,7 +14,7 @@
 use std::sync::Arc;
 
 use but_api::broadcaster::Broadcaster;
-use but_api::IpcContext;
+use but_api::App;
 use but_settings::AppSettingsWithDiskSync;
 use gitbutler_tauri::csp::csp_with_extras;
 use gitbutler_tauri::{
@@ -137,7 +137,7 @@ fn main() {
                         cache_dir: app_cache_dir.clone(),
                         logs_dir: app_log_dir.clone(),
                     });
-                    let ipc_ctx = IpcContext {
+                    let app = App {
                         app_settings: Arc::new(
                             AppSettingsWithDiskSync::new(config_dir.clone())
                                 .expect("failed to create app settings"),
@@ -149,7 +149,7 @@ fn main() {
                         archival: archival.clone(),
                     };
 
-                    app_handle.manage(ipc_ctx);
+                    app_handle.manage(app);
 
                     tauri_app.on_menu_event(move |_handle, event| {
                         menu::handle_event(&window.clone(), &event)

--- a/crates/gitbutler-tauri/src/modes.rs
+++ b/crates/gitbutler-tauri/src/modes.rs
@@ -1,4 +1,4 @@
-use but_api::{commands::modes, IpcContext};
+use but_api::{commands::modes, App};
 use but_core::ui::TreeChange;
 use but_workspace::StackId;
 use gitbutler_edit_mode::ConflictEntryPresence;
@@ -10,24 +10,21 @@ use tracing::instrument;
 use but_api::error::Error;
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn operating_mode(
-    ipc_ctx: State<IpcContext>,
-    project_id: ProjectId,
-) -> Result<OperatingMode, Error> {
-    modes::operating_mode(&ipc_ctx, modes::OperatingModeParams { project_id })
+#[instrument(skip(app), err(Debug))]
+pub fn operating_mode(app: State<App>, project_id: ProjectId) -> Result<OperatingMode, Error> {
+    modes::operating_mode(&app, modes::OperatingModeParams { project_id })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn enter_edit_mode(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     commit_id: String,
     stack_id: StackId,
 ) -> Result<EditModeMetadata, Error> {
     modes::enter_edit_mode(
-        &ipc_ctx,
+        &app,
         modes::EnterEditModeParams {
             project_id,
             commit_id,
@@ -37,43 +34,43 @@ pub fn enter_edit_mode(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn abort_edit_and_return_to_workspace(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
 ) -> Result<(), Error> {
     modes::abort_edit_and_return_to_workspace(
-        &ipc_ctx,
+        &app,
         modes::AbortEditAndReturnToWorkspaceParams { project_id },
     )
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn save_edit_and_return_to_workspace(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
 ) -> Result<(), Error> {
     modes::save_edit_and_return_to_workspace(
-        &ipc_ctx,
+        &app,
         modes::SaveEditAndReturnToWorkspaceParams { project_id },
     )
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn edit_initial_index_state(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
 ) -> Result<Vec<(TreeChange, Option<ConflictEntryPresence>)>, Error> {
-    modes::edit_initial_index_state(&ipc_ctx, modes::EditInitialIndexStateParams { project_id })
+    modes::edit_initial_index_state(&app, modes::EditInitialIndexStateParams { project_id })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn edit_changes_from_initial(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
 ) -> Result<Vec<TreeChange>, Error> {
-    modes::edit_changes_from_initial(&ipc_ctx, modes::EditChangesFromInitialParams { project_id })
+    modes::edit_changes_from_initial(&app, modes::EditChangesFromInitialParams { project_id })
 }

--- a/crates/gitbutler-tauri/src/open.rs
+++ b/crates/gitbutler-tauri/src/open.rs
@@ -1,17 +1,17 @@
-use but_api::{commands::open, IpcContext};
+use but_api::{commands::open, App};
 use tauri::State;
 use tracing::instrument;
 
 use but_api::error::Error;
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn open_url(ipc_ctx: State<'_, IpcContext>, url: String) -> Result<(), Error> {
-    open::open_url(&ipc_ctx, open::OpenUrlParams { url })
+#[instrument(skip(app), err(Debug))]
+pub fn open_url(app: State<'_, App>, url: String) -> Result<(), Error> {
+    open::open_url(&app, open::OpenUrlParams { url })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn show_in_finder(ipc_ctx: State<'_, IpcContext>, path: String) -> Result<(), Error> {
-    open::show_in_finder(&ipc_ctx, open::ShowInFinderParams { path })
+#[instrument(skip(app), err(Debug))]
+pub fn show_in_finder(app: State<'_, App>, path: String) -> Result<(), Error> {
+    open::show_in_finder(&app, open::ShowInFinderParams { path })
 }

--- a/crates/gitbutler-tauri/src/projects.rs
+++ b/crates/gitbutler-tauri/src/projects.rs
@@ -17,22 +17,22 @@ use crate::window::state::ProjectAccessMode;
 use crate::{window, WindowState};
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn update_project(
-    ipc_ctx: State<'_, but_api::IpcContext>,
+    app: State<'_, but_api::App>,
     project: gitbutler_project::UpdateRequest,
 ) -> Result<gitbutler_project::Project, Error> {
-    projects::update_project(&ipc_ctx, UpdateProjectParams { project })
+    projects::update_project(&app, UpdateProjectParams { project })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn add_project(
-    ipc_ctx: State<'_, but_api::IpcContext>,
+    app: State<'_, but_api::App>,
     path: &path::Path,
 ) -> Result<gitbutler_project::Project, Error> {
     projects::add_project(
-        &ipc_ctx,
+        &app,
         AddProjectParams {
             path: path.to_path_buf(),
         },
@@ -40,14 +40,14 @@ pub fn add_project(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn get_project(
-    ipc_ctx: State<'_, but_api::IpcContext>,
+    app: State<'_, but_api::App>,
     project_id: ProjectId,
     no_validation: Option<bool>,
 ) -> Result<gitbutler_project::Project, Error> {
     projects::get_project(
-        &ipc_ctx,
+        &app,
         GetProjectParams {
             project_id,
             no_validation,
@@ -146,12 +146,9 @@ pub fn open_project_in_window(handle: tauri::AppHandle, id: ProjectId) -> Result
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn delete_project(
-    ipc_ctx: State<'_, but_api::IpcContext>,
-    project_id: ProjectId,
-) -> Result<(), Error> {
-    projects::delete_project(&ipc_ctx, DeleteProjectParams { project_id })
+#[instrument(skip(app), err(Debug))]
+pub fn delete_project(app: State<'_, but_api::App>, project_id: ProjectId) -> Result<(), Error> {
+    projects::delete_project(&app, DeleteProjectParams { project_id })
 }
 
 #[derive(serde::Deserialize, serde::Serialize)]

--- a/crates/gitbutler-tauri/src/remotes.rs
+++ b/crates/gitbutler-tauri/src/remotes.rs
@@ -1,4 +1,4 @@
-use but_api::{commands::remotes, IpcContext};
+use but_api::{commands::remotes, App};
 use gitbutler_project::ProjectId;
 use gitbutler_repo::GitRemote;
 use tauri::State;
@@ -7,24 +7,21 @@ use tracing::instrument;
 use but_api::error::Error;
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn list_remotes(
-    ipc_ctx: State<IpcContext>,
-    project_id: ProjectId,
-) -> Result<Vec<GitRemote>, Error> {
-    remotes::list_remotes(&ipc_ctx, remotes::ListRemotesParams { project_id })
+#[instrument(skip(app), err(Debug))]
+pub fn list_remotes(app: State<App>, project_id: ProjectId) -> Result<Vec<GitRemote>, Error> {
+    remotes::list_remotes(&app, remotes::ListRemotesParams { project_id })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn add_remote(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     name: String,
     url: String,
 ) -> Result<(), Error> {
     remotes::add_remote(
-        &ipc_ctx,
+        &app,
         remotes::AddRemoteParams {
             project_id,
             name,

--- a/crates/gitbutler-tauri/src/repo.rs
+++ b/crates/gitbutler-tauri/src/repo.rs
@@ -1,4 +1,4 @@
-use but_api::{commands::repo, IpcContext};
+use but_api::{commands::repo, App};
 use but_graph::virtual_branches_legacy_types::BranchOwnershipClaims;
 use but_workspace::DiffSpec;
 use gitbutler_branch_actions::RemoteBranchFile;
@@ -12,25 +12,25 @@ use tracing::instrument;
 use but_api::error::Error;
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn git_get_local_config(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     key: String,
 ) -> Result<Option<String>, Error> {
-    repo::git_get_local_config(&ipc_ctx, repo::GitGetLocalConfigParams { project_id, key })
+    repo::git_get_local_config(&app, repo::GitGetLocalConfigParams { project_id, key })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn git_set_local_config(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     key: String,
     value: String,
 ) -> Result<(), Error> {
     repo::git_set_local_config(
-        &ipc_ctx,
+        &app,
         repo::GitSetLocalConfigParams {
             project_id,
             key,
@@ -40,23 +40,20 @@ pub fn git_set_local_config(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn check_signing_settings(
-    ipc_ctx: State<IpcContext>,
-    project_id: ProjectId,
-) -> Result<bool, Error> {
-    repo::check_signing_settings(&ipc_ctx, repo::CheckSigningSettingsParams { project_id })
+#[instrument(skip(app), err(Debug))]
+pub fn check_signing_settings(app: State<App>, project_id: ProjectId) -> Result<bool, Error> {
+    repo::check_signing_settings(&app, repo::CheckSigningSettingsParams { project_id })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn git_clone_repository(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     repository_url: String,
     target_dir: &Path,
 ) -> Result<(), Error> {
     repo::git_clone_repository(
-        &ipc_ctx,
+        &app,
         repo::GitCloneRepositoryParams {
             repository_url,
             target_dir: target_dir.to_path_buf(),
@@ -65,24 +62,24 @@ pub fn git_clone_repository(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn get_uncommited_files(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
 ) -> Result<Vec<RemoteBranchFile>, Error> {
-    repo::get_uncommitted_files(&ipc_ctx, repo::GetUncommittedFilesParams { project_id })
+    repo::get_uncommitted_files(&app, repo::GetUncommittedFilesParams { project_id })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn get_commit_file(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     relative_path: &Path,
     commit_id: String,
 ) -> Result<FileInfo, Error> {
     repo::get_commit_file(
-        &ipc_ctx,
+        &app,
         repo::GetCommitFileParams {
             project_id,
             relative_path: relative_path.to_path_buf(),
@@ -92,14 +89,14 @@ pub fn get_commit_file(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn get_workspace_file(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     relative_path: &Path,
 ) -> Result<FileInfo, Error> {
     repo::get_workspace_file(
-        &ipc_ctx,
+        &app,
         repo::GetWorkspaceFileParams {
             project_id,
             relative_path: relative_path.to_path_buf(),
@@ -108,14 +105,14 @@ pub fn get_workspace_file(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn pre_commit_hook(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     ownership: BranchOwnershipClaims,
 ) -> Result<HookResult, Error> {
     repo::pre_commit_hook(
-        &ipc_ctx,
+        &app,
         repo::PreCommitHookParams {
             project_id,
             ownership,
@@ -124,14 +121,14 @@ pub fn pre_commit_hook(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn pre_commit_hook_diffspecs(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     changes: Vec<DiffSpec>,
 ) -> Result<HookResult, Error> {
     repo::pre_commit_hook_diffspecs(
-        &ipc_ctx,
+        &app,
         repo::PreCommitHookDiffspecsParams {
             project_id,
             changes,
@@ -140,23 +137,20 @@ pub fn pre_commit_hook_diffspecs(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn post_commit_hook(
-    ipc_ctx: State<IpcContext>,
-    project_id: ProjectId,
-) -> Result<HookResult, Error> {
-    repo::post_commit_hook(&ipc_ctx, repo::PostCommitHookParams { project_id })
+#[instrument(skip(app), err(Debug))]
+pub fn post_commit_hook(app: State<App>, project_id: ProjectId) -> Result<HookResult, Error> {
+    repo::post_commit_hook(&app, repo::PostCommitHookParams { project_id })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn message_hook(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     message: String,
 ) -> Result<MessageHookResult, Error> {
     repo::message_hook(
-        &ipc_ctx,
+        &app,
         repo::MessageHookParams {
             project_id,
             message,

--- a/crates/gitbutler-tauri/src/rules.rs
+++ b/crates/gitbutler-tauri/src/rules.rs
@@ -1,4 +1,4 @@
-use but_api::{commands::rules, IpcContext};
+use but_api::{commands::rules, App};
 use but_rules::{CreateRuleRequest, UpdateRuleRequest, WorkspaceRule};
 use gitbutler_project::ProjectId;
 use tauri::State;
@@ -7,14 +7,14 @@ use tracing::instrument;
 use but_api::error::Error;
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn create_workspace_rule(
-    ipc_ctx: State<'_, IpcContext>,
+    app: State<'_, App>,
     project_id: ProjectId,
     request: CreateRuleRequest,
 ) -> Result<WorkspaceRule, Error> {
     rules::create_workspace_rule(
-        &ipc_ctx,
+        &app,
         rules::CreateWorkspaceRuleParams {
             project_id,
             request,
@@ -23,27 +23,24 @@ pub fn create_workspace_rule(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn delete_workspace_rule(
-    ipc_ctx: State<'_, IpcContext>,
+    app: State<'_, App>,
     project_id: ProjectId,
     id: String,
 ) -> Result<(), Error> {
-    rules::delete_workspace_rule(
-        &ipc_ctx,
-        rules::DeleteWorkspaceRuleParams { project_id, id },
-    )
+    rules::delete_workspace_rule(&app, rules::DeleteWorkspaceRuleParams { project_id, id })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn update_workspace_rule(
-    ipc_ctx: State<'_, IpcContext>,
+    app: State<'_, App>,
     project_id: ProjectId,
     request: UpdateRuleRequest,
 ) -> Result<WorkspaceRule, Error> {
     rules::update_workspace_rule(
-        &ipc_ctx,
+        &app,
         rules::UpdateWorkspaceRuleParams {
             project_id,
             request,
@@ -52,10 +49,10 @@ pub fn update_workspace_rule(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn list_workspace_rules(
-    ipc_ctx: State<'_, IpcContext>,
+    app: State<'_, App>,
     project_id: ProjectId,
 ) -> Result<Vec<WorkspaceRule>, Error> {
-    rules::list_workspace_rules(&ipc_ctx, rules::ListWorkspaceRulesParams { project_id })
+    rules::list_workspace_rules(&app, rules::ListWorkspaceRulesParams { project_id })
 }

--- a/crates/gitbutler-tauri/src/secret.rs
+++ b/crates/gitbutler-tauri/src/secret.rs
@@ -1,24 +1,17 @@
-use but_api::{commands::secret, IpcContext};
+use but_api::{commands::secret, App};
 use tauri::State;
 use tracing::instrument;
 
 use but_api::error::Error;
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn secret_get_global(
-    ipc_ctx: State<IpcContext>,
-    handle: String,
-) -> Result<Option<String>, Error> {
-    secret::secret_get_global(&ipc_ctx, secret::SecretGetGlobalParams { handle })
+#[instrument(skip(app), err(Debug))]
+pub fn secret_get_global(app: State<App>, handle: String) -> Result<Option<String>, Error> {
+    secret::secret_get_global(&app, secret::SecretGetGlobalParams { handle })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx, secret), err(Debug), fields(secret = "<redacted>"))]
-pub fn secret_set_global(
-    ipc_ctx: State<IpcContext>,
-    handle: String,
-    secret: String,
-) -> Result<(), Error> {
-    secret::secret_set_global(&ipc_ctx, secret::SecretSetGlobalParams { handle, secret })
+#[instrument(skip(app, secret), err(Debug), fields(secret = "<redacted>"))]
+pub fn secret_set_global(app: State<App>, handle: String, secret: String) -> Result<(), Error> {
+    secret::secret_set_global(&app, secret::SecretSetGlobalParams { handle, secret })
 }

--- a/crates/gitbutler-tauri/src/settings.rs
+++ b/crates/gitbutler-tauri/src/settings.rs
@@ -1,6 +1,6 @@
 #![allow(deprecated)]
 use but_api::NoParams;
-use but_api::{commands::settings, IpcContext};
+use but_api::{commands::settings, App};
 use but_settings::api::{FeatureFlagsUpdate, TelemetryUpdate};
 use but_settings::AppSettings;
 use tauri::State;
@@ -9,49 +9,37 @@ use tracing::instrument;
 use but_api::error::Error;
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn get_app_settings(ipc_ctx: State<'_, IpcContext>) -> Result<AppSettings, Error> {
-    settings::get_app_settings(&ipc_ctx, NoParams {})
+#[instrument(skip(app), err(Debug))]
+pub fn get_app_settings(app: State<'_, App>) -> Result<AppSettings, Error> {
+    settings::get_app_settings(&app, NoParams {})
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn update_onboarding_complete(
-    ipc_ctx: State<'_, IpcContext>,
-    update: bool,
-) -> Result<(), Error> {
-    settings::update_onboarding_complete(
-        &ipc_ctx,
-        settings::UpdateOnboardingCompleteParams { update },
-    )
+#[instrument(skip(app), err(Debug))]
+pub fn update_onboarding_complete(app: State<'_, App>, update: bool) -> Result<(), Error> {
+    settings::update_onboarding_complete(&app, settings::UpdateOnboardingCompleteParams { update })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn update_telemetry(
-    ipc_ctx: State<'_, IpcContext>,
-    update: TelemetryUpdate,
-) -> Result<(), Error> {
-    settings::update_telemetry(&ipc_ctx, settings::UpdateTelemetryParams { update })
+#[instrument(skip(app), err(Debug))]
+pub fn update_telemetry(app: State<'_, App>, update: TelemetryUpdate) -> Result<(), Error> {
+    settings::update_telemetry(&app, settings::UpdateTelemetryParams { update })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn update_telemetry_distinct_id(
-    ipc_ctx: State<'_, IpcContext>,
+    app: State<'_, App>,
     app_distinct_id: Option<String>,
 ) -> Result<(), Error> {
     settings::update_telemetry_distinct_id(
-        &ipc_ctx,
+        &app,
         settings::UpdateTelemetryDistinctIdParams { app_distinct_id },
     )
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn update_feature_flags(
-    ipc_ctx: State<'_, IpcContext>,
-    update: FeatureFlagsUpdate,
-) -> Result<(), Error> {
-    settings::update_feature_flags(&ipc_ctx, settings::UpdateFeatureFlagsParams { update })
+#[instrument(skip(app), err(Debug))]
+pub fn update_feature_flags(app: State<'_, App>, update: FeatureFlagsUpdate) -> Result<(), Error> {
+    settings::update_feature_flags(&app, settings::UpdateFeatureFlagsParams { update })
 }

--- a/crates/gitbutler-tauri/src/stack.rs
+++ b/crates/gitbutler-tauri/src/stack.rs
@@ -1,4 +1,4 @@
-use but_api::{commands::stack, IpcContext};
+use but_api::{commands::stack, App};
 use gitbutler_branch_actions::internal::PushResult;
 use gitbutler_branch_actions::stack::CreateSeriesRequest;
 use gitbutler_project::ProjectId;
@@ -10,15 +10,15 @@ use tracing::instrument;
 use but_api::error::Error;
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn create_branch(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     stack_id: StackId,
     request: CreateSeriesRequest,
 ) -> Result<(), Error> {
     stack::create_branch(
-        &ipc_ctx,
+        &app,
         stack::CreateBranchParams {
             project_id,
             stack_id,
@@ -28,15 +28,15 @@ pub fn create_branch(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn remove_branch(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     stack_id: StackId,
     branch_name: String,
 ) -> Result<(), Error> {
     stack::remove_branch(
-        &ipc_ctx,
+        &app,
         stack::RemoveBranchParams {
             project_id,
             stack_id,
@@ -46,16 +46,16 @@ pub fn remove_branch(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn update_branch_name(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     stack_id: StackId,
     branch_name: String,
     new_name: String,
 ) -> Result<(), Error> {
     stack::update_branch_name(
-        &ipc_ctx,
+        &app,
         stack::UpdateBranchNameParams {
             project_id,
             stack_id,
@@ -66,16 +66,16 @@ pub fn update_branch_name(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn update_branch_description(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     stack_id: StackId,
     branch_name: String,
     description: Option<String>,
 ) -> Result<(), Error> {
     stack::update_branch_description(
-        &ipc_ctx,
+        &app,
         stack::UpdateBranchDescriptionParams {
             project_id,
             stack_id,
@@ -86,16 +86,16 @@ pub fn update_branch_description(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn update_branch_pr_number(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     stack_id: StackId,
     branch_name: String,
     pr_number: Option<usize>,
 ) -> Result<(), Error> {
     stack::update_branch_pr_number(
-        &ipc_ctx,
+        &app,
         stack::UpdateBranchPrNumberParams {
             project_id,
             stack_id,
@@ -106,16 +106,16 @@ pub fn update_branch_pr_number(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn push_stack(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     stack_id: StackId,
     with_force: bool,
     branch: String,
 ) -> Result<PushResult, Error> {
     stack::push_stack(
-        &ipc_ctx,
+        &app,
         stack::PushStackParams {
             project_id,
             stack_id,
@@ -126,16 +126,16 @@ pub fn push_stack(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn push_stack_to_review(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     stack_id: StackId,
     top_branch: String,
     user: User,
 ) -> Result<String, Error> {
     stack::push_stack_to_review(
-        &ipc_ctx,
+        &app,
         stack::PushStackToReviewParams {
             project_id,
             stack_id,

--- a/crates/gitbutler-tauri/src/undo.rs
+++ b/crates/gitbutler-tauri/src/undo.rs
@@ -1,4 +1,4 @@
-use but_api::{commands::undo, IpcContext};
+use but_api::{commands::undo, App};
 use gitbutler_oplog::entry::OperationKind;
 use gitbutler_oplog::entry::Snapshot;
 use gitbutler_project::ProjectId;
@@ -8,16 +8,16 @@ use tracing::instrument;
 use but_api::error::Error;
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn list_snapshots(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     limit: usize,
     sha: Option<String>,
     exclude_kind: Option<Vec<OperationKind>>,
 ) -> Result<Vec<Snapshot>, Error> {
     undo::list_snapshots(
-        &ipc_ctx,
+        &app,
         undo::ListSnapshotsParams {
             project_id,
             limit,
@@ -28,21 +28,17 @@ pub fn list_snapshots(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn restore_snapshot(
-    ipc_ctx: State<IpcContext>,
-    project_id: ProjectId,
-    sha: String,
-) -> Result<(), Error> {
-    undo::restore_snapshot(&ipc_ctx, undo::RestoreSnapshotParams { project_id, sha })
+#[instrument(skip(app), err(Debug))]
+pub fn restore_snapshot(app: State<App>, project_id: ProjectId, sha: String) -> Result<(), Error> {
+    undo::restore_snapshot(&app, undo::RestoreSnapshotParams { project_id, sha })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn snapshot_diff(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     sha: String,
 ) -> Result<Vec<but_core::ui::TreeChange>, Error> {
-    undo::snapshot_diff(&ipc_ctx, undo::SnapshotDiffParams { project_id, sha })
+    undo::snapshot_diff(&app, undo::SnapshotDiffParams { project_id, sha })
 }

--- a/crates/gitbutler-tauri/src/users.rs
+++ b/crates/gitbutler-tauri/src/users.rs
@@ -1,4 +1,4 @@
-use but_api::{commands::users, IpcContext, NoParams};
+use but_api::{commands::users, App, NoParams};
 use gitbutler_user::User;
 use tauri::State;
 use tracing::instrument;
@@ -6,19 +6,19 @@ use tracing::instrument;
 use but_api::error::Error;
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn get_user(ipc_ctx: State<IpcContext>) -> Result<Option<users::UserWithSecrets>, Error> {
-    users::get_user(&ipc_ctx, NoParams {})
+#[instrument(skip(app), err(Debug))]
+pub fn get_user(app: State<App>) -> Result<Option<users::UserWithSecrets>, Error> {
+    users::get_user(&app, NoParams {})
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn set_user(ipc_ctx: State<IpcContext>, user: User) -> Result<User, Error> {
-    users::set_user(&ipc_ctx, users::SetUserParams { user })
+#[instrument(skip(app), err(Debug))]
+pub fn set_user(app: State<App>, user: User) -> Result<User, Error> {
+    users::set_user(&app, users::SetUserParams { user })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn delete_user(ipc_ctx: State<IpcContext>) -> Result<(), Error> {
-    users::delete_user(&ipc_ctx, NoParams {})
+#[instrument(skip(app), err(Debug))]
+pub fn delete_user(app: State<App>) -> Result<(), Error> {
+    users::delete_user(&app, NoParams {})
 }

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -1,4 +1,4 @@
-use but_api::{commands::virtual_branches, IpcContext};
+use but_api::{commands::virtual_branches, App};
 use but_graph::virtual_branches_legacy_types::BranchOwnershipClaims;
 use but_workspace::ui::StackEntryNoOpt;
 use but_workspace::DiffSpec;
@@ -21,34 +21,34 @@ use tracing::instrument;
 use but_api::error::Error;
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn normalize_branch_name(ipc_ctx: State<IpcContext>, name: String) -> Result<String, Error> {
-    virtual_branches::normalize_branch_name(&ipc_ctx, name)
+#[instrument(skip(app), err(Debug))]
+pub fn normalize_branch_name(app: State<App>, name: String) -> Result<String, Error> {
+    virtual_branches::normalize_branch_name(&app, name)
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn create_virtual_branch(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     branch: BranchCreateRequest,
 ) -> Result<StackEntryNoOpt, Error> {
     virtual_branches::create_virtual_branch(
-        &ipc_ctx,
+        &app,
         virtual_branches::CreateVirtualBranchParams { project_id, branch },
     )
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn delete_local_branch(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     refname: Refname,
     given_name: String,
 ) -> Result<(), Error> {
     virtual_branches::delete_local_branch(
-        &ipc_ctx,
+        &app,
         virtual_branches::DeleteLocalBranchParams {
             project_id,
             refname,
@@ -58,16 +58,16 @@ pub fn delete_local_branch(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn create_virtual_branch_from_branch(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     branch: Refname,
     remote: Option<RemoteRefname>,
     pr_number: Option<usize>,
 ) -> Result<StackId, Error> {
     virtual_branches::create_virtual_branch_from_branch(
-        &ipc_ctx,
+        &app,
         virtual_branches::CreateVirtualBranchFromBranchParams {
             project_id,
             branch,
@@ -78,16 +78,16 @@ pub fn create_virtual_branch_from_branch(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn integrate_upstream_commits(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     stack_id: StackId,
     series_name: String,
     integration_strategy: Option<IntegrationStrategy>,
 ) -> Result<(), Error> {
     virtual_branches::integrate_upstream_commits(
-        &ipc_ctx,
+        &app,
         virtual_branches::IntegrateUpstreamCommitsParams {
             project_id,
             stack_id,
@@ -98,28 +98,28 @@ pub fn integrate_upstream_commits(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn get_base_branch_data(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
 ) -> Result<Option<BaseBranch>, Error> {
     virtual_branches::get_base_branch_data(
-        &ipc_ctx,
+        &app,
         virtual_branches::GetBaseBranchDataParams { project_id },
     )
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn set_base_branch(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     branch: String,
     push_remote: Option<String>,
     stash_uncommitted: Option<bool>,
 ) -> Result<BaseBranch, Error> {
     virtual_branches::set_base_branch(
-        &ipc_ctx,
+        &app,
         virtual_branches::SetBaseBranchParams {
             project_id,
             branch,
@@ -130,14 +130,14 @@ pub fn set_base_branch(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn push_base_branch(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     with_force: bool,
 ) -> Result<(), Error> {
     virtual_branches::push_base_branch(
-        &ipc_ctx,
+        &app,
         virtual_branches::PushBaseBranchParams {
             project_id,
             with_force,
@@ -146,27 +146,27 @@ pub fn push_base_branch(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn update_stack_order(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     stacks: Vec<BranchUpdateRequest>,
 ) -> Result<(), Error> {
     virtual_branches::update_stack_order(
-        &ipc_ctx,
+        &app,
         virtual_branches::UpdateStackOrderParams { project_id, stacks },
     )
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn unapply_stack(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     stack_id: StackId,
 ) -> Result<(), Error> {
     virtual_branches::unapply_stack(
-        &ipc_ctx,
+        &app,
         virtual_branches::UnapplyStackParams {
             project_id,
             stack_id,
@@ -175,27 +175,27 @@ pub fn unapply_stack(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn can_apply_remote_branch(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     branch: RemoteRefname,
 ) -> Result<bool, Error> {
     virtual_branches::can_apply_remote_branch(
-        &ipc_ctx,
+        &app,
         virtual_branches::CanApplyRemoteBranchParams { project_id, branch },
     )
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn list_commit_files(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     commit_id: String,
 ) -> Result<Vec<RemoteBranchFile>, Error> {
     virtual_branches::list_commit_files(
-        &ipc_ctx,
+        &app,
         virtual_branches::ListCommitFilesParams {
             project_id,
             commit_id,
@@ -204,16 +204,16 @@ pub fn list_commit_files(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn amend_virtual_branch(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     stack_id: StackId,
     commit_id: String,
     worktree_changes: Vec<DiffSpec>,
 ) -> Result<String, Error> {
     virtual_branches::amend_virtual_branch(
-        &ipc_ctx,
+        &app,
         virtual_branches::AmendVirtualBranchParams {
             project_id,
             stack_id,
@@ -224,9 +224,9 @@ pub fn amend_virtual_branch(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn move_commit_file(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     stack_id: StackId,
     from_commit_id: String,
@@ -234,7 +234,7 @@ pub fn move_commit_file(
     ownership: BranchOwnershipClaims,
 ) -> Result<String, Error> {
     virtual_branches::move_commit_file(
-        &ipc_ctx,
+        &app,
         virtual_branches::MoveCommitFileParams {
             project_id,
             stack_id,
@@ -246,15 +246,15 @@ pub fn move_commit_file(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn undo_commit(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     stack_id: StackId,
     commit_id: String,
 ) -> Result<(), Error> {
     virtual_branches::undo_commit(
-        &ipc_ctx,
+        &app,
         virtual_branches::UndoCommitParams {
             project_id,
             stack_id,
@@ -264,16 +264,16 @@ pub fn undo_commit(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn insert_blank_commit(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     stack_id: StackId,
     commit_id: Option<String>,
     offset: i32,
 ) -> Result<(), Error> {
     virtual_branches::insert_blank_commit(
-        &ipc_ctx,
+        &app,
         virtual_branches::InsertBlankCommitParams {
             project_id,
             stack_id,
@@ -284,15 +284,15 @@ pub fn insert_blank_commit(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn reorder_stack(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     stack_id: StackId,
     stack_order: StackOrder,
 ) -> Result<(), Error> {
     virtual_branches::reorder_stack(
-        &ipc_ctx,
+        &app,
         virtual_branches::ReorderStackParams {
             project_id,
             stack_id,
@@ -302,14 +302,14 @@ pub fn reorder_stack(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn find_git_branches(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     branch_name: String,
 ) -> Result<Vec<RemoteBranchData>, Error> {
     virtual_branches::find_git_branches(
-        &ipc_ctx,
+        &app,
         virtual_branches::FindGitBranchesParams {
             project_id,
             branch_name,
@@ -318,27 +318,27 @@ pub fn find_git_branches(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn list_branches(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     filter: Option<BranchListingFilter>,
 ) -> Result<Vec<BranchListing>, Error> {
     virtual_branches::list_branches(
-        &ipc_ctx,
+        &app,
         virtual_branches::ListBranchesParams { project_id, filter },
     )
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn get_branch_listing_details(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     branch_names: Vec<String>,
 ) -> Result<Vec<BranchListingDetails>, Error> {
     virtual_branches::get_branch_listing_details(
-        &ipc_ctx,
+        &app,
         virtual_branches::GetBranchListingDetailsParams {
             project_id,
             branch_names,
@@ -347,16 +347,16 @@ pub fn get_branch_listing_details(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn squash_commits(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     stack_id: StackId,
     source_commit_ids: Vec<String>,
     target_commit_id: String,
 ) -> Result<(), Error> {
     virtual_branches::squash_commits(
-        &ipc_ctx,
+        &app,
         virtual_branches::SquashCommitsParams {
             project_id,
             stack_id,
@@ -367,29 +367,29 @@ pub fn squash_commits(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn fetch_from_remotes(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     action: Option<String>,
 ) -> Result<BaseBranch, Error> {
     virtual_branches::fetch_from_remotes(
-        &ipc_ctx,
+        &app,
         virtual_branches::FetchFromRemotesParams { project_id, action },
     )
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn move_commit(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     commit_id: String,
     target_stack_id: StackId,
     source_stack_id: StackId,
 ) -> Result<(), Error> {
     virtual_branches::move_commit(
-        &ipc_ctx,
+        &app,
         virtual_branches::MoveCommitParams {
             project_id,
             commit_id,
@@ -400,16 +400,16 @@ pub fn move_commit(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn update_commit_message(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     stack_id: StackId,
     commit_id: String,
     message: String,
 ) -> Result<String, Error> {
     virtual_branches::update_commit_message(
-        &ipc_ctx,
+        &app,
         virtual_branches::UpdateCommitMessageParams {
             project_id,
             stack_id,
@@ -420,14 +420,14 @@ pub fn update_commit_message(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn find_commit(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     commit_id: String,
 ) -> Result<Option<RemoteCommit>, Error> {
     virtual_branches::find_commit(
-        &ipc_ctx,
+        &app,
         virtual_branches::FindCommitParams {
             project_id,
             commit_id,
@@ -436,14 +436,14 @@ pub fn find_commit(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn upstream_integration_statuses(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     target_commit_id: Option<String>,
 ) -> Result<StackStatuses, Error> {
     virtual_branches::upstream_integration_statuses(
-        &ipc_ctx,
+        &app,
         virtual_branches::UpstreamIntegrationStatusesParams {
             project_id,
             target_commit_id,
@@ -452,15 +452,15 @@ pub fn upstream_integration_statuses(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn integrate_upstream(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     resolutions: Vec<Resolution>,
     base_branch_resolution: Option<BaseBranchResolution>,
 ) -> Result<IntegrationOutcome, Error> {
     virtual_branches::integrate_upstream(
-        &ipc_ctx,
+        &app,
         virtual_branches::IntegrateUpstreamParams {
             project_id,
             resolutions,
@@ -470,14 +470,14 @@ pub fn integrate_upstream(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn resolve_upstream_integration(
-    ipc_ctx: State<IpcContext>,
+    app: State<App>,
     project_id: ProjectId,
     resolution_approach: BaseBranchResolutionApproach,
 ) -> Result<String, Error> {
     virtual_branches::resolve_upstream_integration(
-        &ipc_ctx,
+        &app,
         virtual_branches::ResolveUpstreamIntegrationParams {
             project_id,
             resolution_approach,

--- a/crates/gitbutler-tauri/src/window.rs
+++ b/crates/gitbutler-tauri/src/window.rs
@@ -2,7 +2,7 @@ pub(crate) mod state {
     use std::{collections::BTreeMap, sync::Arc};
 
     use anyhow::Result;
-    use but_api::IpcContext;
+    use but_api::App;
     use but_settings::AppSettingsWithDiskSync;
     use gitbutler_command_context::CommandContext;
     use gitbutler_project as projects;
@@ -158,13 +158,13 @@ pub(crate) mod state {
         state: Arc<parking_lot::Mutex<BTreeMap<WindowLabel, State>>>,
     }
 
-    fn handler_from_app(app: &AppHandle) -> Result<gitbutler_watcher::Handler> {
-        let ipc_ctx = app.state::<IpcContext>().inner().clone();
+    fn handler_from_app(app_handle: &AppHandle) -> Result<gitbutler_watcher::Handler> {
+        let app = app_handle.state::<App>().inner().clone();
 
         Ok(gitbutler_watcher::Handler::new(
-            (*ipc_ctx.user_controller).clone(),
+            (*app.user_controller).clone(),
             {
-                let app = app.clone();
+                let app = app_handle.clone();
                 move |change| ChangeForFrontend::from(change).send(&app)
             },
         ))

--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -15,34 +15,31 @@ use tauri::State;
 use tracing::instrument;
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn stacks(
-    ipc_ctx: State<'_, but_api::IpcContext>,
+    app: State<'_, but_api::App>,
     project_id: ProjectId,
     filter: Option<StacksFilter>,
 ) -> Result<Vec<StackEntry>, Error> {
-    workspace::stacks(&ipc_ctx, StacksParams { project_id, filter })
+    workspace::stacks(&app, StacksParams { project_id, filter })
 }
 
 #[cfg(unix)]
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
-pub fn show_graph_svg(
-    ipc_ctx: State<'_, but_api::IpcContext>,
-    project_id: ProjectId,
-) -> Result<(), Error> {
-    workspace::show_graph_svg(&ipc_ctx, ShowGraphSvgParams { project_id })
+#[instrument(skip(app), err(Debug))]
+pub fn show_graph_svg(app: State<'_, but_api::App>, project_id: ProjectId) -> Result<(), Error> {
+    workspace::show_graph_svg(&app, ShowGraphSvgParams { project_id })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn stack_details(
-    ipc_ctx: State<'_, but_api::IpcContext>,
+    app: State<'_, but_api::App>,
     project_id: ProjectId,
     stack_id: Option<StackId>,
 ) -> Result<but_workspace::ui::StackDetails, Error> {
     workspace::stack_details(
-        &ipc_ctx,
+        &app,
         StackDetailsParams {
             project_id,
             stack_id,
@@ -51,15 +48,15 @@ pub fn stack_details(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn branch_details(
-    ipc_ctx: State<'_, but_api::IpcContext>,
+    app: State<'_, but_api::App>,
     project_id: ProjectId,
     branch_name: String,
     remote: Option<String>,
 ) -> Result<but_workspace::ui::BranchDetails, Error> {
     workspace::branch_details(
-        &ipc_ctx,
+        &app,
         BranchDetailsParams {
             project_id,
             branch_name,
@@ -69,10 +66,10 @@ pub fn branch_details(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 #[allow(clippy::too_many_arguments)]
 pub fn create_commit_from_worktree_changes(
-    ipc_ctx: State<'_, but_api::IpcContext>,
+    app: State<'_, but_api::App>,
     project_id: ProjectId,
     stack_id: StackId,
     parent_id: Option<HexHash>,
@@ -81,7 +78,7 @@ pub fn create_commit_from_worktree_changes(
     stack_branch_name: String,
 ) -> Result<commit_engine::ui::CreateCommitOutcome, Error> {
     workspace::create_commit_from_worktree_changes(
-        &ipc_ctx,
+        &app,
         CreateCommitFromWorktreeChangesParams {
             project_id,
             stack_id,
@@ -94,16 +91,16 @@ pub fn create_commit_from_worktree_changes(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn amend_commit_from_worktree_changes(
-    ipc_ctx: State<'_, but_api::IpcContext>,
+    app: State<'_, but_api::App>,
     project_id: ProjectId,
     stack_id: StackId,
     commit_id: HexHash,
     worktree_changes: Vec<but_workspace::DiffSpec>,
 ) -> Result<commit_engine::ui::CreateCommitOutcome, Error> {
     workspace::amend_commit_from_worktree_changes(
-        &ipc_ctx,
+        &app,
         AmendCommitFromWorktreeChangesParams {
             project_id,
             stack_id,
@@ -114,14 +111,14 @@ pub fn amend_commit_from_worktree_changes(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn discard_worktree_changes(
-    ipc_ctx: State<'_, but_api::IpcContext>,
+    app: State<'_, but_api::App>,
     project_id: ProjectId,
     worktree_changes: Vec<but_workspace::DiffSpec>,
 ) -> Result<Vec<but_workspace::DiffSpec>, Error> {
     workspace::discard_worktree_changes(
-        &ipc_ctx,
+        &app,
         DiscardWorktreeChangesParams {
             project_id,
             worktree_changes,
@@ -130,10 +127,10 @@ pub fn discard_worktree_changes(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 #[allow(clippy::too_many_arguments)]
 pub fn move_changes_between_commits(
-    ipc_ctx: State<'_, but_api::IpcContext>,
+    app: State<'_, but_api::App>,
     project_id: ProjectId,
     source_stack_id: StackId,
     source_commit_id: HexHash,
@@ -142,7 +139,7 @@ pub fn move_changes_between_commits(
     changes: Vec<but_workspace::DiffSpec>,
 ) -> Result<UIMoveChangesResult, Error> {
     workspace::move_changes_between_commits(
-        &ipc_ctx,
+        &app,
         MoveChangesBetweenCommitsParams {
             project_id,
             source_stack_id,
@@ -155,10 +152,10 @@ pub fn move_changes_between_commits(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 #[allow(clippy::too_many_arguments)]
 pub fn split_branch(
-    ipc_ctx: State<'_, but_api::IpcContext>,
+    app: State<'_, but_api::App>,
     project_id: ProjectId,
     source_stack_id: StackId,
     source_branch_name: String,
@@ -166,7 +163,7 @@ pub fn split_branch(
     file_changes_to_split_off: Vec<String>,
 ) -> Result<UIMoveChangesResult, Error> {
     workspace::split_branch(
-        &ipc_ctx,
+        &app,
         SplitBranchParams {
             project_id,
             source_stack_id,
@@ -178,10 +175,10 @@ pub fn split_branch(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 #[allow(clippy::too_many_arguments)]
 pub fn split_branch_into_dependent_branch(
-    ipc_ctx: State<'_, but_api::IpcContext>,
+    app: State<'_, but_api::App>,
     project_id: ProjectId,
     source_stack_id: StackId,
     source_branch_name: String,
@@ -189,7 +186,7 @@ pub fn split_branch_into_dependent_branch(
     file_changes_to_split_off: Vec<String>,
 ) -> Result<UIMoveChangesResult, Error> {
     workspace::split_branch_into_dependent_branch(
-        &ipc_ctx,
+        &app,
         SplitBranchIntoDependentBranchParams {
             project_id,
             source_stack_id,
@@ -201,10 +198,10 @@ pub fn split_branch_into_dependent_branch(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 #[allow(clippy::too_many_arguments)]
 pub fn uncommit_changes(
-    ipc_ctx: State<'_, but_api::IpcContext>,
+    app: State<'_, but_api::App>,
     project_id: ProjectId,
     stack_id: StackId,
     commit_id: HexHash,
@@ -212,7 +209,7 @@ pub fn uncommit_changes(
     assign_to: Option<StackId>,
 ) -> Result<UIMoveChangesResult, Error> {
     workspace::uncommit_changes(
-        &ipc_ctx,
+        &app,
         UncommitChangesParams {
             project_id,
             stack_id,
@@ -224,15 +221,15 @@ pub fn uncommit_changes(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn stash_into_branch(
-    ipc_ctx: State<'_, but_api::IpcContext>,
+    app: State<'_, but_api::App>,
     project_id: ProjectId,
     branch_name: String,
     worktree_changes: Vec<but_workspace::DiffSpec>,
 ) -> Result<commit_engine::ui::CreateCommitOutcome, Error> {
     workspace::stash_into_branch(
-        &ipc_ctx,
+        &app,
         StashIntoBranchParams {
             project_id,
             branch_name,
@@ -242,24 +239,24 @@ pub fn stash_into_branch(
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn canned_branch_name(
-    ipc_ctx: State<'_, but_api::IpcContext>,
+    app: State<'_, but_api::App>,
     project_id: ProjectId,
 ) -> Result<String, Error> {
-    workspace::canned_branch_name(&ipc_ctx, CannedBranchNameParams { project_id })
+    workspace::canned_branch_name(&app, CannedBranchNameParams { project_id })
 }
 
 #[tauri::command(async)]
-#[instrument(skip(ipc_ctx), err(Debug))]
+#[instrument(skip(app), err(Debug))]
 pub fn target_commits(
-    ipc_ctx: State<'_, but_api::IpcContext>,
+    app: State<'_, but_api::App>,
     project_id: ProjectId,
     last_commit_id: Option<HexHash>,
     page_size: Option<usize>,
 ) -> Result<Vec<but_workspace::ui::Commit>, Error> {
     workspace::target_commits(
-        &ipc_ctx,
+        &app,
         TargetCommitsParams {
             project_id,
             last_commit_id,

--- a/crates/gitbutler-tauri/src/zip.rs
+++ b/crates/gitbutler-tauri/src/zip.rs
@@ -7,13 +7,13 @@ pub mod commands {
     use tracing::instrument;
 
     #[tauri::command(async)]
-    #[instrument(skip(ipc_ctx), err(Debug))]
+    #[instrument(skip(app), err(Debug))]
     pub fn get_project_archive_path(
-        ipc_ctx: State<'_, but_api::IpcContext>,
+        app: State<'_, but_api::App>,
         project_id: &str,
     ) -> Result<PathBuf, Error> {
         zip::get_project_archive_path(
-            &ipc_ctx,
+            &app,
             GetProjectArchivePathParams {
                 project_id: project_id.to_string(),
             },
@@ -21,10 +21,8 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(ipc_ctx), err(Debug))]
-    pub fn get_logs_archive_path(
-        ipc_ctx: State<'_, but_api::IpcContext>,
-    ) -> Result<PathBuf, Error> {
-        zip::get_logs_archive_path(&ipc_ctx, GetLogsArchivePathParams {})
+    #[instrument(skip(app), err(Debug))]
+    pub fn get_logs_archive_path(app: State<'_, but_api::App>) -> Result<PathBuf, Error> {
+        zip::get_logs_archive_path(&app, GetLogsArchivePathParams {})
     }
 }


### PR DESCRIPTION
This state lives for the duration of the app, not for the duration of an IPC, therefore the original name was confusing