### PR TITLE
Remove base branch from global context and update usage

### DIFF
--- a/apps/desktop/src/components/KeysForm.svelte
+++ b/apps/desktop/src/components/KeysForm.svelte
@@ -3,12 +3,12 @@
 	import ProjectNameLabel from '$components/ProjectNameLabel.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
 	import Section from '$components/Section.svelte';
-	import { BASE_BRANCH } from '$lib/baseBranch/baseBranch';
+	import { BASE_BRANCH_SERVICE } from '$lib/baseBranch/baseBranchService.svelte';
 	import { showError } from '$lib/notifications/toasts';
 	import { type AuthKey, type KeyType } from '$lib/project/project';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
 	import { TestId } from '$lib/testing/testIds';
-	import { inject, injectOptional } from '@gitbutler/shared/context';
+	import { inject } from '@gitbutler/shared/context';
 	import { Link, RadioButton, SectionCard, Textbox } from '@gitbutler/ui';
 
 	import { onMount } from 'svelte';
@@ -30,7 +30,9 @@
 		disabled = false
 	}: Props = $props();
 
-	const baseBranch = injectOptional(BASE_BRANCH, undefined);
+	const baseBranchService = inject(BASE_BRANCH_SERVICE);
+	const baseBranchResponse = $derived(baseBranchService.baseBranch(projectId));
+	const baseBranch = $derived(baseBranchResponse.current.data);
 	const projectsService = inject(PROJECTS_SERVICE);
 	const projectResult = $derived(projectsService.getProject(projectId));
 	const project = $derived(projectResult.current.data);

--- a/apps/desktop/src/lib/baseBranch/baseBranch.ts
+++ b/apps/desktop/src/lib/baseBranch/baseBranch.ts
@@ -1,12 +1,9 @@
 import { Commit } from '$lib/commits/commit';
-import { InjectionToken } from '@gitbutler/shared/context';
 import { Type } from 'class-transformer';
 
 export interface RemoteBranchInfo {
 	name: string;
 }
-
-export const BASE_BRANCH = new InjectionToken<BaseBranch>('BaseBranch');
 
 export class BaseBranch {
 	branchName!: string;

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -10,7 +10,6 @@
 	import ProblemLoadingRepo from '$components/ProblemLoadingRepo.svelte';
 	import ProjectSettingsMenuAction from '$components/ProjectSettingsMenuAction.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
-	import { BASE_BRANCH } from '$lib/baseBranch/baseBranch';
 	import { BASE_BRANCH_SERVICE } from '$lib/baseBranch/baseBranchService.svelte';
 	import { BRANCH_SERVICE } from '$lib/branches/branchService.svelte';
 	import { SETTINGS_SERVICE } from '$lib/config/appSettingsV2';
@@ -49,9 +48,9 @@
 	const repoInfo = $derived(repoInfoResponse.current.data);
 	const baseBranchResponse = $derived(baseBranchService.baseBranch(projectId));
 	const baseBranch = $derived(baseBranchResponse.current.data);
+	const baseBranchName = $derived(baseBranch?.shortName);
 	const pushRepoResponse = $derived(baseBranchService.pushRepo(projectId));
 	const forkInfo = $derived(pushRepoResponse.current.data);
-	const baseBranchName = $derived(baseBranch?.shortName);
 	const branchService = inject(BRANCH_SERVICE);
 
 	const stackService = inject(STACK_SERVICE);
@@ -85,10 +84,6 @@
 		);
 
 		provide(STACKING_REORDER_DROPZONE_MANAGER_FACTORY, stackingReorderDropzoneManagerFactory);
-	});
-
-	$effect.pre(() => {
-		provide(BASE_BRANCH, baseBranch);
 	});
 
 	const focusManager = new FocusManager();


### PR DESCRIPTION
This fixes a reactivity issue in which updating the base branch would not display the right values

This change removes the global context for the base branch, enforcing that it is fetched dynamically where needed. All references to the previous global `BASE_BRANCH` context token are removed. Component and service logic are updated to use the new approach via BASE_BRANCH_SERVICE and fresh fetches, ensuring updates work correctly and prevent stale data.

Files updated include:
- BaseBranchSwitch.svelte: remove global context injection, switch to derived service response
- KeysForm.svelte: fetch base branch from service instead of context
- ReviewCreation.svelte: update logic for base branch name and push remote name, add error condition for missing data
- baseBranch.ts: remove unused global InjectionToken definition
- +layout.svelte: remove context provider effect and handle base branch via service
