### PR TITLE
editmode-service-mutation

### DIFF
--- a/apps/desktop/src/components/EditMode.svelte
+++ b/apps/desktop/src/components/EditMode.svelte
@@ -46,11 +46,11 @@
 	const userService = inject(USER_SERVICE);
 	const user = userService.user;
 
-	let modeServiceAborting = $state<'inert' | 'loading' | 'completed'>('inert');
-	let modeServiceSaving = $state<'inert' | 'loading' | 'completed'>('inert');
-
 	const initialFiles = $derived(modeService.initialEditModeState({ projectId }));
 	const uncommittedFiles = $derived(modeService.changesSinceInitialEditState({ projectId }));
+
+	const [saveEdit, savingEdit] = modeService.saveEditAndReturnToWorkspaceMutation;
+	const [abortEdit, abortingEdit] = modeService.abortEditAndReturnToWorkspaceMutation;
 
 	function readFromWorkspace(
 		filePath: string,
@@ -186,25 +186,11 @@
 	}
 
 	async function abort() {
-		modeServiceAborting = 'loading';
-
-		try {
-			await modeService.abortEditAndReturnToWorkspace({ projectId });
-			modeServiceAborting = 'completed';
-		} finally {
-			modeServiceAborting = 'inert';
-		}
+		await abortEdit({ projectId });
 	}
 
 	async function save() {
-		modeServiceSaving = 'loading';
-
-		try {
-			await modeService.saveEditAndReturnToWorkspace({ projectId });
-			modeServiceSaving = 'completed';
-		} finally {
-			modeServiceAborting = 'inert';
-		}
+		await saveEdit({ projectId });
 	}
 
 	async function handleSave() {
@@ -228,7 +214,7 @@
 
 	let isCommitListScrolled = $state(false);
 
-	const loading = $derived(modeServiceSaving === 'loading' || modeServiceAborting === 'loading');
+	const loading = $derived(savingEdit.current.isLoading || abortingEdit.current.isLoading);
 </script>
 
 <div class="editmode-wrapper">

--- a/apps/desktop/src/lib/mode/modeService.ts
+++ b/apps/desktop/src/lib/mode/modeService.ts
@@ -49,8 +49,16 @@ export class ModeService {
 		return this.api.endpoints.abortEditAndReturnToWorkspace.mutate;
 	}
 
+	get abortEditAndReturnToWorkspaceMutation() {
+		return this.api.endpoints.abortEditAndReturnToWorkspace.useMutation();
+	}
+
 	get saveEditAndReturnToWorkspace() {
 		return this.api.endpoints.saveEditAndReturnToWorkspace.mutate;
+	}
+
+	get saveEditAndReturnToWorkspaceMutation() {
+		return this.api.endpoints.saveEditAndReturnToWorkspace.useMutation();
 	}
 
 	get initialEditModeState() {


### PR DESCRIPTION
- Added mutation hooks abortEditAndReturnToWorkspaceMutation and saveEditAndReturnToWorkspaceMutation in modeService.ts using useMutation.
- Refactored EditMode.svelte to use these mutation hooks instead of manual state tracking.
- Updated abort and save functions in EditMode to call the new mutations.
- Modified loading state in EditMode to derive from mutation loading states for improved reactivity and simpler state management.