### PR TITLE
feat: add `--force-if-includes` flag to force push

### DIFF
--- a/crates/gitbutler-git/src/repository.rs
+++ b/crates/gitbutler-git/src/repository.rs
@@ -362,7 +362,7 @@ where
     args.push(&refspec);
 
     if force {
-        args.push("--force-with-lease");
+        args.push("--force-with-lease --force-if-includes");
     }
 
     let (status, stdout, stderr) =


### PR DESCRIPTION
## 🧢 Changes
- feat: add `--force-if-includes` flag to force push

## ☕️ Reasoning

- I am aware that the hole branch code and integrate upstream (yellow and cyan button) is being refactored at the moment, which is great and highly needed. In my opinion, we should almost never need a force push for a lot of actions - see this issue https://github.com/gitbutlerapp/gitbutler/issues/8031 & https://github.com/gitbutlerapp/gitbutler/issues/2847#issuecomment-3148533731 for more details but if we do need to force push for example after a rebase from main, it should be done as securely as possible so that no commits can be lost.
- The `--force-if-includes` protects commits even more than just `--force-with-lease` as it ensures that any remote changes have been integrated locally (not just fetched). For more details see https://stackoverflow.com/a/78298145

## Note

- I am unsure if this is the only change needed to use both flags all the time when force pushing.