### PR TITLE
feed: Don't snapshot diff, diff the commits instead

### DIFF
--- a/apps/desktop/src/lib/actions/types.ts
+++ b/apps/desktop/src/lib/actions/types.ts
@@ -11,6 +11,10 @@ export type Outcome = {
 	updatedBranches: UpdatedBranch[];
 };
 
+export function allCommitsUpdated(outcome: Outcome): string[] {
+	return outcome.updatedBranches.flatMap((branch) => branch.newCommits);
+}
+
 export type ActionHandler = 'handleChangesSimple';
 
 type MCPSourceDefinition = {

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -457,6 +457,18 @@ export class StackService {
 		return this.api.endpoints.createCommit.mutate;
 	}
 
+	filePathsChangedInCommits(projectId: string, commitIds: string[]) {
+		const params = commitIds.map((commitId) => ({
+			projectId,
+			commitId
+		}));
+		return this.api.endpoints.commitDetails.useQueries(params, {
+			transform: (results) => {
+				return results.changes.ids;
+			}
+		});
+	}
+
 	commitChanges(projectId: string, commitId: string) {
 		return this.api.endpoints.commitDetails.useQuery(
 			{ projectId, commitId },

--- a/packages/shared/src/lib/utils/array.ts
+++ b/packages/shared/src/lib/utils/array.ts
@@ -31,3 +31,7 @@ export function filterWithRest<T>(array: T[], predicate: (item: T) => boolean): 
 
 	return [filtered, rest];
 }
+
+export function flattenAndDeduplicate<T>(array: T[][]): T[] {
+	return deduplicate(array.flat());
+}


### PR DESCRIPTION
The feed snapshots were broken in a migration.
Hooking them up yielded that wrong results as well. Instead attempting to get the file changes from the snapshot differ, we'll now get the diff from the new commits added in the action.


### changes
Add allCommitsUpdated helper to extract commit IDs from updated
branches. Use stackService.filePathsChangedInCommits to fetch changed
files for all commits related to an action. Combine and deduplicate
file paths before rendering them in SnapshotAttachment.

Introduce flattenAndDeduplicate utility to simplify array handling.