### PR TITLE
fix: Tools - Don't set the assignments when reading them

### DIFF
--- a/crates/but-tools/src/workspace.rs
+++ b/crates/but-tools/src/workspace.rs
@@ -1769,7 +1769,7 @@ pub fn get_filtered_changes(
     let diff = unified_diff_for_changes(repo, changes, ctx.app_settings().context_lines)?;
     let (assignments, _) = but_hunk_assignment::assignments_with_fallback(
         ctx,
-        true,
+        false,
         None::<Vec<but_core::TreeChange>>,
         None,
     )


### PR DESCRIPTION
Don’t assign the uncommitted files when reading the assignments