### PR TITLE
fix: ensure stacks have a name

### DIFF
--- a/crates/but-graph/src/virtual_branches_legacy_types.rs
+++ b/crates/but-graph/src/virtual_branches_legacy_types.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// The state of virtual branches data, as persisted in a TOML file.
-#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct VirtualBranches {
     /// This is the target/base that is set when a repo is added to gb
     pub default_target: Option<Target>,

--- a/crates/but-graph/tests/graph/ref_metadata_legacy.rs
+++ b/crates/but-graph/tests/graph/ref_metadata_legacy.rs
@@ -498,7 +498,7 @@ fn create_workspace_and_stacks_with_branches_from_scratch() -> anyhow::Result<()
 
     [branches.1]
     id = "1"
-    name = ""
+    name = "feat-on-top"
     notes = ""
     created_timestamp_ms = 12345
     updated_timestamp_ms = 12345


### PR DESCRIPTION
The new create_reference() implementation can create stacks that have no name,
leading to errors lateron.
The stack.name() field is redundant, but most of the code needs it.
