### PR TITLE
fix(rule): remove unnecessary paragraph tag from delete prompt

### DIFF
--- a/apps/desktop/src/components/Rule.svelte
+++ b/apps/desktop/src/components/Rule.svelte
@@ -127,7 +127,7 @@
 		close();
 	}}
 >
-	<p class="text-12">Are you sure you want to delete this rule? This action cannot be undone.</p>
+	Are you sure you want to delete this rule? This action cannot be undone.
 
 	{#snippet controls(close)}
 		<Button kind="outline" onclick={close}>Cancel</Button>


### PR DESCRIPTION
### Description

- Removed an unnecessary paragraph tag from the delete prompt to improve markup cleanliness and potentially fix styling or layout issues.