### PR TITLE
Use `fakeBaseQuery` with GitHub and GitLab rtkq api's

### DIFF
--- a/apps/desktop/src/components/Chrome.svelte
+++ b/apps/desktop/src/components/Chrome.svelte
@@ -3,9 +3,9 @@
 	import ChromeSidebar from '$components/ChromeSidebar.svelte';
 	import ProjectNotFound from '$components/ProjectNotFound.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
-	import { isTauriCommandError } from '$lib/backend/ipc';
 	import { Code } from '$lib/error/knownErrors';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
+	import { isReduxError } from '$lib/state/reduxError';
 	import { inject } from '@gitbutler/shared/context';
 	import type { Snippet } from 'svelte';
 
@@ -36,7 +36,7 @@
 		</div>
 	{/snippet}
 	{#snippet error(e)}
-		{#if isTauriCommandError(e)}
+		{#if isReduxError(e)}
 			{#if e.code === Code.ProjectMissing}
 				<ProjectNotFound {projectId} />
 			{/if}

--- a/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
+++ b/apps/desktop/src/lib/baseBranch/baseBranchService.svelte.ts
@@ -1,7 +1,7 @@
-import { isTauriCommandError } from '$lib/backend/ipc';
 import { BaseBranch, type RemoteBranchInfo } from '$lib/baseBranch/baseBranch';
 import { Code } from '$lib/error/knownErrors';
 import { showError } from '$lib/notifications/toasts';
+import { isReduxError } from '$lib/state/reduxError';
 import { invalidatesList, invalidatesType, providesType, ReduxTag } from '$lib/state/tags';
 import { parseRemoteUrl } from '$lib/url/gitUrl';
 import { InjectionToken } from '@gitbutler/shared/context';
@@ -74,7 +74,7 @@ export default class BaseBranchService {
 		return await this.api.endpoints.fetchFromRemotes
 			.mutate({ projectId, action })
 			.catch((error: unknown) => {
-				if (!isTauriCommandError(error)) {
+				if (!isReduxError(error)) {
 					if (action === 'auto') return;
 					showError('Failed to fetch', String(error));
 					return;

--- a/apps/desktop/src/lib/error/parser.ts
+++ b/apps/desktop/src/lib/error/parser.ts
@@ -1,10 +1,10 @@
-import { isTauriCommandError } from '$lib/backend/ipc';
 import { KNOWN_ERRORS } from '$lib/error/knownErrors';
 import {
 	isHttpError,
 	isPromiseRejection,
 	isReduxActionError as isReduxActionError
 } from '$lib/error/typeguards';
+import { isReduxError } from '$lib/state/reduxError';
 import { isStr } from '@gitbutler/ui/utils/string';
 import { isErrorlike } from '@gitbutler/ui/utils/typeguards';
 
@@ -40,7 +40,7 @@ export function parseError(error: unknown): ParsedError {
 		return { message: error };
 	}
 
-	if (error instanceof PromiseRejectionEvent && isTauriCommandError(error.reason)) {
+	if (error instanceof PromiseRejectionEvent && isReduxError(error.reason)) {
 		const { name, message, code } = error.reason;
 		return { name, message, code };
 	}
@@ -52,7 +52,7 @@ export function parseError(error: unknown): ParsedError {
 		};
 	}
 
-	if (isTauriCommandError(error)) {
+	if (isReduxError(error)) {
 		const { name, message, code } = error;
 		const description = code ? KNOWN_ERRORS[code] : undefined;
 		return { name, message, code, description };

--- a/apps/desktop/src/lib/hunks/change.ts
+++ b/apps/desktop/src/lib/hunks/change.ts
@@ -1,6 +1,6 @@
-import type { TauriCommandError } from '$lib/backend/ipc';
 import type { HunkDependencies } from '$lib/dependencies/dependencies';
 import type { HunkAssignment } from '$lib/hunks/hunk';
+import type { ReduxError } from '$lib/state/reduxError';
 
 /** Contains the changes that are in the worktree */
 export type WorktreeChanges = {
@@ -12,9 +12,9 @@ export type WorktreeChanges = {
 	 */
 	readonly ignoredChanges: IgnoredChange[];
 	readonly assignments: HunkAssignment[];
-	readonly assignmentsError: TauriCommandError | null;
+	readonly assignmentsError: ReduxError | null;
 	readonly dependencies: HunkDependencies | null;
-	readonly dependenciesError: TauriCommandError | null;
+	readonly dependenciesError: ReduxError | null;
 };
 
 /**

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -27,7 +27,6 @@ import {
 	type ThunkDispatch,
 	type UnknownAction
 } from '@reduxjs/toolkit';
-import type { TauriCommandError } from '$lib/backend/ipc';
 import type { StackOrder } from '$lib/branches/branch';
 import type { Commit, CommitDetails, UpstreamCommit } from '$lib/branches/v3';
 import type { CommitKey } from '$lib/commits/commit';
@@ -36,6 +35,7 @@ import type { TreeChange, TreeChanges, TreeStats } from '$lib/hunks/change';
 import type { DiffSpec } from '$lib/hunks/hunk';
 import type { BranchDetails, Stack, StackOpt, StackDetails } from '$lib/stacks/stack';
 import type { PropertiesFn } from '$lib/state/customHooks.svelte';
+import type { ReduxError } from '$lib/state/reduxError';
 
 type BranchParams = {
 	name?: string;
@@ -440,7 +440,7 @@ export class StackService {
 					]);
 				}, 2000);
 			},
-			onError: (commandError: TauriCommandError) => {
+			onError: (commandError: ReduxError) => {
 				const { code, message } = commandError;
 				surfaceStackError('push', code ?? '', message);
 			},

--- a/apps/desktop/src/lib/state/backendQuery.ts
+++ b/apps/desktop/src/lib/state/backendQuery.ts
@@ -1,5 +1,5 @@
-import { isTauriCommandError, type TauriCommandError } from '$lib/backend/ipc';
 import { Tauri } from '$lib/backend/tauri';
+import { isReduxError, type ReduxError } from '$lib/state/reduxError';
 import { isErrorlike } from '@gitbutler/ui/utils/typeguards';
 import { type BaseQueryApi, type QueryReturnValue } from '@reduxjs/toolkit/query';
 import type { ExtraOptions } from '$lib/state/butlerModule';
@@ -14,7 +14,7 @@ export const tauriBaseQuery: TauriBaseQueryFn = async (
 	args: ApiArgs,
 	api: BaseQueryApi,
 	extra: TauriExtraOptions
-): Promise<QueryReturnValue<unknown, TauriCommandError, undefined>> => {
+): Promise<QueryReturnValue<unknown, ReduxError, undefined>> => {
 	const command = extra.command;
 	if (!command) {
 		return newError('Expected a command!');
@@ -29,7 +29,7 @@ export const tauriBaseQuery: TauriBaseQueryFn = async (
 		return result;
 	} catch (error: unknown) {
 		const name = `API error: (${command})`;
-		if (isTauriCommandError(error)) {
+		if (isReduxError(error)) {
 			const newMessage =
 				`command: ${command}\nparams: ${JSON.stringify(args)})\n\n` + error.message;
 			return { error: { name, message: newMessage, code: error.code } };

--- a/apps/desktop/src/lib/state/customHooks.svelte.ts
+++ b/apps/desktop/src/lib/state/customHooks.svelte.ts
@@ -1,5 +1,5 @@
-import { isTauriCommandError, type TauriCommandError } from '$lib/backend/ipc';
 import { SilentError } from '$lib/error/error';
+import { isReduxError, type ReduxError } from '$lib/state/reduxError';
 import { reactive } from '@gitbutler/shared/reactiveUtils.svelte';
 import { type Reactive } from '@gitbutler/shared/storeUtils';
 import { isErrorlike } from '@gitbutler/ui/utils/typeguards';
@@ -196,7 +196,7 @@ export type UseMutationHookParams<Definition extends MutationDefinition<any, any
 	 *
 	 * This does not stop the error from being thrown, but allows you to add a side effect depending on the error.
 	 */
-	onError?: (error: TauriCommandError, queryArgs: QueryArgFrom<Definition>) => void;
+	onError?: (error: ReduxError, queryArgs: QueryArgFrom<Definition>) => void;
 	/**
 	 * If true, wraps the error in a `SilentError`. This is useful if you are
 	 * providing error messages through `onError` and don't want the global
@@ -343,7 +343,7 @@ export function buildMutationHook<
 			return result;
 		} catch (error: unknown) {
 			track({ failure: true, properties, startTime, error });
-			if (onError && isTauriCommandError(error)) {
+			if (onError && isReduxError(error)) {
 				onError(error, queryArg);
 			}
 			throwError(error, throwSlientError ?? false);
@@ -381,7 +381,7 @@ export function buildMutationHook<
 				return result;
 			} catch (error: unknown) {
 				track({ failure: true, properties, startTime, error });
-				if (onError && isTauriCommandError(error)) {
+				if (onError && isReduxError(error)) {
 					onError(error, queryArg);
 				}
 				throwError(error, throwSlientError ?? false);

--- a/apps/desktop/src/lib/state/reduxError.ts
+++ b/apps/desktop/src/lib/state/reduxError.ts
@@ -1,0 +1,12 @@
+export type ReduxError = { name: string; message: string; code?: string };
+
+export function isReduxError(something: unknown): something is ReduxError {
+	return (
+		!!something &&
+		typeof something === 'object' &&
+		something !== null &&
+		'message' in something &&
+		typeof (something as ReduxError).message === 'string' &&
+		('code' in something ? typeof (something as ReduxError).code === 'string' : true)
+	);
+}

--- a/apps/desktop/src/lib/worktree/worktreeService.svelte.ts
+++ b/apps/desktop/src/lib/worktree/worktreeService.svelte.ts
@@ -3,11 +3,11 @@ import { createSelectByIds } from '$lib/state/customSelectors';
 import { invalidatesList, providesList, ReduxTag } from '$lib/state/tags';
 import { InjectionToken } from '@gitbutler/shared/context';
 import { createEntityAdapter, type EntityState } from '@reduxjs/toolkit';
-import type { TauriCommandError } from '$lib/backend/ipc';
 import type { HunkDependencies } from '$lib/dependencies/dependencies';
 import type { IgnoredChange, TreeChange, WorktreeChanges } from '$lib/hunks/change';
 import type { HunkAssignment } from '$lib/hunks/hunk';
 import type { ClientState } from '$lib/state/clientState.svelte';
+import type { ReduxError } from '$lib/state/reduxError';
 
 export const WORKTREE_SERVICE = new InjectionToken<WorktreeService>('WorktreeService');
 
@@ -98,7 +98,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 					ignoredChanges: IgnoredChange[];
 					hunkAssignments: HunkAssignment[];
 					dependencies: HunkDependencies | undefined;
-					dependenciesError: TauriCommandError | undefined;
+					dependenciesError: ReduxError | undefined;
 				},
 				{ projectId: string }
 			>({


### PR DESCRIPTION
At the same time, we rename `TauriCommandError` to `ReduxError` since 
the type is shared by all RTKQ api's.

This change has no real effect, but is correct and less confusing to 
developers.