### PR TITLE
Add setAnonymousPostHogUser and call on non-authenticated user

### DIFF
--- a/apps/desktop/src/lib/analytics/posthog.ts
+++ b/apps/desktop/src/lib/analytics/posthog.ts
@@ -49,6 +49,13 @@ export class PostHogWrapper {
 		this.settingsService.updateTelemetryDistinctId(distinctId);
 	}
 
+	setAnonymousPostHogUser() {
+		if (this._instance) {
+			const distinctId = this._instance.get_distinct_id();
+			this.settingsService.updateTelemetryDistinctId(distinctId);
+		}
+	}
+
 	async resetPostHog() {
 		this._instance?.capture('logout');
 		this._instance?.reset();

--- a/apps/desktop/src/lib/user/userService.ts
+++ b/apps/desktop/src/lib/user/userService.ts
@@ -51,6 +51,8 @@ export class UserService {
 			setSentryUser(user);
 			return user;
 		}
+
+		this.posthog.setAnonymousPostHogUser();
 		this.user.set(undefined);
 	}
 	readonly accessToken$ = derived(this.user, (user) => {


### PR DESCRIPTION
Added a new method setAnonymousPostHogUser to the PostHog analytics service. This method retrieves the current distinct ID from PostHog instance and updates the telemetry distinct ID in the settings service. 