### PR TITLE
Make combineResult return undef if no arguments

### DIFF
--- a/apps/desktop/src/components/FeedActionDiff.svelte
+++ b/apps/desktop/src/components/FeedActionDiff.svelte
@@ -6,7 +6,6 @@
 	import { inject } from '@gitbutler/shared/context';
 	import { flattenAndDeduplicate } from '@gitbutler/shared/utils/array';
 	import { FileListItem } from '@gitbutler/ui';
-	import { isDefined } from '@gitbutler/ui/utils/typeguards';
 
 	type Props = {
 		projectId: string;
@@ -18,38 +17,31 @@
 	const changedFilesInCommits = $derived(
 		stackService.filePathsChangedInCommits(projectId, newCommits)
 	);
-
-	const filteredChange = $derived(changedFilesInCommits.current.filter(isDefined));
 </script>
 
-{#if filteredChange.length > 0}
-	<ReduxResult
-		{projectId}
-		result={combineResults(...changedFilesInCommits.current.filter(isDefined))}
-	>
-		{#snippet children(filesPaths)}
-			{@const dedupedFilePaths = flattenAndDeduplicate(filesPaths)}
-			{#if dedupedFilePaths.length === 0}
-				<p class="text-13 text-grey">No changes detected</p>
-			{:else}
-				<SnapshotAttachment
-					foldable={dedupedFilePaths.length > 2}
-					foldedAmount={dedupedFilePaths.length}
-				>
-					<div class="snapshot-files">
-						{#each dedupedFilePaths as path, idx (path)}
-							<FileListItem
-								listMode="list"
-								filePath={path}
-								hideBorder={idx === dedupedFilePaths.length - 1}
-							/>
-						{/each}
-					</div>
-				</SnapshotAttachment>
-			{/if}
-		{/snippet}
-	</ReduxResult>
-{/if}
+<ReduxResult {projectId} result={combineResults(...changedFilesInCommits.current)}>
+	{#snippet children(filesPaths)}
+		{@const dedupedFilePaths = flattenAndDeduplicate(filesPaths)}
+		{#if dedupedFilePaths.length === 0}
+			<p class="text-13 text-grey">No changes detected</p>
+		{:else}
+			<SnapshotAttachment
+				foldable={dedupedFilePaths.length > 2}
+				foldedAmount={dedupedFilePaths.length}
+			>
+				<div class="snapshot-files">
+					{#each dedupedFilePaths as path, idx (path)}
+						<FileListItem
+							listMode="list"
+							filePath={path}
+							hideBorder={idx === dedupedFilePaths.length - 1}
+						/>
+					{/each}
+				</div>
+			</SnapshotAttachment>
+		{/if}
+	{/snippet}
+</ReduxResult>
 
 <style lang="postcss">
 	.snapshot-files {

--- a/apps/desktop/src/lib/state/helpers.test.ts
+++ b/apps/desktop/src/lib/state/helpers.test.ts
@@ -112,11 +112,7 @@ describe.concurrent('combineResults', () => {
 		});
 	});
 
-	test('combining zero results returns uninitalized', () => {
-		expect(combineResults()).toEqual({
-			data: undefined,
-			error: undefined,
-			status: QueryStatus.uninitialized
-		});
+	test('combining zero results returns undefined', () => {
+		expect(combineResults()).toEqual(undefined);
 	});
 });

--- a/apps/desktop/src/lib/state/helpers.ts
+++ b/apps/desktop/src/lib/state/helpers.ts
@@ -32,13 +32,9 @@ export function isMutationDefinition(
  */
 export function combineResults<T extends [...CustomResult<any>[]]>(
 	...results: T
-): CustomResult<CustomQuery<{ [K in keyof T]: Exclude<T[K]['data'], undefined> }>> {
+): CustomResult<CustomQuery<{ [K in keyof T]: Exclude<T[K]['data'], undefined> }>> | undefined {
 	if (results.length === 0) {
-		return {
-			status: QueryStatus.uninitialized,
-			error: undefined,
-			data: undefined
-		} as CustomResult<CustomQuery<{ [K in keyof T]: Exclude<T[K]['data'], undefined> }>>;
+		return;
 	}
 
 	const data = results.every((r) => r.data !== undefined) ? results.map((r) => r.data) : undefined;


### PR DESCRIPTION
It feels more expected to pass undefined to `ReduxResult` than a fake 
result with no data.