### PR TITLE
feat: add force push protections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3252,6 +3252,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "futures",
+ "gitbutler-error",
  "gix",
  "nix 0.30.1",
  "rand 0.9.2",

--- a/apps/desktop/cypress/e2e/support/mock/projects.ts
+++ b/apps/desktop/cypress/e2e/support/mock/projects.ts
@@ -10,6 +10,7 @@ export const MOCK_PROJECT_A: Project = {
 	api: undefined,
 	preferred_key: 'systemExecutable',
 	ok_with_force_push: true,
+	force_push_protection: false,
 	omit_certificate_check: false,
 	use_diff_context: true,
 	snapshot_lines_threshold: 5,

--- a/apps/desktop/src/components/GitForm.svelte
+++ b/apps/desktop/src/components/GitForm.svelte
@@ -16,6 +16,10 @@
 	async function onForcePushClick(project: Project, value: boolean) {
 		await projectsService.updateProject({ ...project, ok_with_force_push: value });
 	}
+
+	async function onForcePushProtectionClick(project: Project, value: boolean) {
+		await projectsService.updateProject({ ...project, force_push_protection: value });
+	}
 </script>
 
 <Section>
@@ -28,22 +32,40 @@
 	<Spacer />
 	<ReduxResult {projectId} result={projectResult.current}>
 		{#snippet children(project)}
-			<SectionCard orientation="row" labelFor="allowForcePush">
-				{#snippet title()}
-					Allow force pushing
-				{/snippet}
-				{#snippet caption()}
-					Force pushing allows GitButler to override branches even if they were pushed to remote.
-					GitButler will never force push to the target branch.
-				{/snippet}
-				{#snippet actions()}
-					<Toggle
-						id="allowForcePush"
-						checked={project.ok_with_force_push}
-						onchange={(checked) => onForcePushClick(project, checked)}
-					/>
-				{/snippet}
-			</SectionCard>
+			<div class="stack-v">
+				<SectionCard orientation="row" labelFor="allowForcePush" roundedBottom={false}>
+					{#snippet title()}
+						Allow force pushing
+					{/snippet}
+					{#snippet caption()}
+						Force pushing allows GitButler to override branches even if they were pushed to remote.
+						GitButler will never force push to the target branch.
+					{/snippet}
+					{#snippet actions()}
+						<Toggle
+							id="allowForcePush"
+							checked={project.ok_with_force_push}
+							onchange={(checked) => onForcePushClick(project, checked)}
+						/>
+					{/snippet}
+				</SectionCard>
+				<SectionCard orientation="row" labelFor="forcePushProtection" roundedTop={false}>
+					{#snippet title()}
+						Force push protection
+					{/snippet}
+					{#snippet caption()}
+						Protect remote commits during force pushes. This will use Git's safer force push flags
+						to avoid overwriting remote commit history.
+					{/snippet}
+					{#snippet actions()}
+						<Toggle
+							id="forcePushProtection"
+							checked={project.force_push_protection}
+							onchange={(checked) => onForcePushProtectionClick(project, checked)}
+						/>
+					{/snippet}
+				</SectionCard>
+			</div>
 		{/snippet}
 	</ReduxResult>
 </Section>

--- a/apps/desktop/src/components/KeysForm.svelte
+++ b/apps/desktop/src/components/KeysForm.svelte
@@ -92,7 +92,6 @@
 					Configure the authentication flow for GitButler when authenticating with your Git remote
 					provider.
 				{/snippet}
-				ProjectSetupGitAuth
 				<form
 					class="git-radio"
 					class:disabled

--- a/apps/desktop/src/components/ReviewCreation.svelte
+++ b/apps/desktop/src/components/ReviewCreation.svelte
@@ -90,7 +90,6 @@
 
 	let titleInput = $state<HTMLTextAreaElement | undefined>(undefined);
 	let messageEditor = $state<MessageEditor>();
-	let _currentProject = $state<any>(undefined);
 
 	// AI things
 	const aiGenEnabled = projectAiGenEnabled(projectId);
@@ -159,7 +158,7 @@
 				projectId,
 				stackId,
 				withForce: branchDetails?.pushStatus === 'unpushedCommitsRequiringForce',
-				forcePushProtection: _currentProject?.force_push_protection,
+				skipForcePushProtection: false, // override available for regular push
 				branch: branchName
 			});
 

--- a/apps/desktop/src/components/ReviewCreation.svelte
+++ b/apps/desktop/src/components/ReviewCreation.svelte
@@ -90,6 +90,7 @@
 
 	let titleInput = $state<HTMLTextAreaElement | undefined>(undefined);
 	let messageEditor = $state<MessageEditor>();
+	let _currentProject = $state<any>(undefined);
 
 	// AI things
 	const aiGenEnabled = projectAiGenEnabled(projectId);
@@ -158,6 +159,7 @@
 				projectId,
 				stackId,
 				withForce: branchDetails?.pushStatus === 'unpushedCommitsRequiringForce',
+				forcePushProtection: _currentProject?.force_push_protection,
 				branch: branchName
 			});
 

--- a/apps/desktop/src/lib/project/project.ts
+++ b/apps/desktop/src/lib/project/project.ts
@@ -19,6 +19,7 @@ export type Project = {
 	};
 	preferred_key: AuthKey;
 	ok_with_force_push: boolean;
+	force_push_protection: boolean;
 	omit_certificate_check: boolean | undefined;
 	use_diff_context: boolean | undefined;
 	snapshot_lines_threshold: number | undefined;

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -1053,7 +1053,7 @@ function injectEndpoints(api: ClientState['backendApi'], uiState: UiState) {
 					projectId: string;
 					stackId: string;
 					withForce: boolean;
-					forcePushProtection: boolean;
+					skipForcePushProtection: boolean;
 					branch: string;
 				}
 			>({

--- a/crates/but-api/src/commands/stack.rs
+++ b/crates/but-api/src/commands/stack.rs
@@ -266,6 +266,7 @@ pub struct PushStackParams {
     pub project_id: ProjectId,
     pub stack_id: StackId,
     pub with_force: bool,
+    pub force_push_protection: bool,
     pub branch: String,
 }
 
@@ -276,6 +277,7 @@ pub fn push_stack(app: &App, params: PushStackParams) -> Result<PushResult, Erro
         &ctx,
         params.stack_id,
         params.with_force,
+        params.force_push_protection,
         params.branch,
     )
     .map_err(|e| e.into())

--- a/crates/but-api/src/commands/stack.rs
+++ b/crates/but-api/src/commands/stack.rs
@@ -266,7 +266,7 @@ pub struct PushStackParams {
     pub project_id: ProjectId,
     pub stack_id: StackId,
     pub with_force: bool,
-    pub force_push_protection: bool,
+    pub skip_force_push_protection: bool,
     pub branch: String,
 }
 
@@ -277,7 +277,7 @@ pub fn push_stack(app: &App, params: PushStackParams) -> Result<PushResult, Erro
         &ctx,
         params.stack_id,
         params.with_force,
-        params.force_push_protection,
+        params.skip_force_push_protection,
         params.branch,
     )
     .map_err(|e| e.into())

--- a/crates/but-api/src/commands/virtual_branches.rs
+++ b/crates/but-api/src/commands/virtual_branches.rs
@@ -204,11 +204,7 @@ pub struct PushBaseBranchParams {
 pub fn push_base_branch(app: &App, params: PushBaseBranchParams) -> Result<(), Error> {
     let project = gitbutler_project::get(params.project_id)?;
     let ctx = CommandContext::open(&project, app.app_settings.get()?.clone())?;
-    gitbutler_branch_actions::push_base_branch(
-        &ctx,
-        params.with_force,
-        ctx.app_settings().force_if_includes,
-    )?;
+    gitbutler_branch_actions::push_base_branch(&ctx, params.with_force)?;
     Ok(())
 }
 

--- a/crates/but-settings/assets/defaults.jsonc
+++ b/crates/but-settings/assets/defaults.jsonc
@@ -40,7 +40,5 @@
 	"fetch": {
 	  // The frequency at which the app will automatically fetch. A negative value (e.g. -1) disables auto fetching.
 		"autoFetchIntervalMinutes": 15
-	},
-	// If true, force push operations will be performed with a --force-if-includes flag which increases safety of force pushes.
-	"forceIfIncludes": false
+	}
 }

--- a/crates/but-settings/src/lib.rs
+++ b/crates/but-settings/src/lib.rs
@@ -18,8 +18,6 @@ pub struct AppSettings {
     pub extra_csp: app_settings::ExtraCsp,
     /// Settings related to fetching.
     pub fetch: app_settings::Fetch,
-    /// If true, force push operations will be performed with a --force-if-includes flag which increases safety of force pushes.
-    pub force_if_includes: bool,
 }
 
 impl Default for AppSettings {

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -146,12 +146,8 @@ pub fn set_target_push_remote(ctx: &CommandContext, push_remote: &str) -> Result
     base::set_target_push_remote(ctx, push_remote)
 }
 
-pub fn push_base_branch(
-    ctx: &CommandContext,
-    with_force: bool,
-    force_if_includes: bool,
-) -> Result<()> {
-    base::push(ctx, with_force, force_if_includes)
+pub fn push_base_branch(ctx: &CommandContext, with_force: bool) -> Result<()> {
+    base::push(ctx, with_force)
 }
 
 pub fn integrate_upstream_commits(

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -373,13 +373,13 @@ fn default_target(base_path: &Path) -> Result<Target> {
     VirtualBranchesHandle::new(base_path).get_default_target()
 }
 
-pub(crate) fn push(ctx: &CommandContext, with_force: bool, force_if_includes: bool) -> Result<()> {
+pub(crate) fn push(ctx: &CommandContext, with_force: bool) -> Result<()> {
     let target = default_target(&ctx.project().gb_dir())?;
     let _ = ctx.push(
         target.sha,
         &target.branch,
         with_force,
-        force_if_includes,
+        ctx.project().force_push_protection,
         None,
         None,
     );

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -158,6 +158,7 @@ pub fn push_stack(
     ctx: &CommandContext,
     stack_id: StackId,
     with_force: bool,
+    force_push_protection: bool,
     branch_limit: String,
 ) -> Result<PushResult> {
     ctx.verify(ctx.project().exclusive_worktree_access().write_permission())?;
@@ -204,7 +205,7 @@ pub fn push_stack(
             push_details.head,
             &push_details.remote_refname,
             with_force,
-            ctx.app_settings().force_if_includes,
+            force_push_protection,
             None,
             Some(Some(stack.id)),
         )?;

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -158,7 +158,7 @@ pub fn push_stack(
     ctx: &CommandContext,
     stack_id: StackId,
     with_force: bool,
-    force_push_protection: bool,
+    skip_force_push_protection: bool,
     branch_limit: String,
 ) -> Result<PushResult> {
     ctx.verify(ctx.project().exclusive_worktree_access().write_permission())?;
@@ -187,6 +187,9 @@ pub fn push_stack(
         remote: default_target.push_remote_name(),
         branch_to_remote: vec![],
     };
+
+    let force_push_protection = !skip_force_push_protection && ctx.project().force_push_protection;
+
     for branch in stack_branches {
         if branch.archived {
             // Nothing to push for this one

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/amend.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/amend.rs
@@ -59,6 +59,7 @@ fn forcepush_allowed() -> anyhow::Result<()> {
         ctx,
         stack_entry.id,
         false,
+        ctx.project().force_push_protection,
         stack_entry.name().map(|s| s.to_string()).unwrap(),
     )
     .unwrap();

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/amend.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/amend.rs
@@ -59,7 +59,7 @@ fn forcepush_allowed() -> anyhow::Result<()> {
         ctx,
         stack_entry.id,
         false,
-        ctx.project().force_push_protection,
+        false,
         stack_entry.name().map(|s| s.to_string()).unwrap(),
     )
     .unwrap();

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
@@ -33,6 +33,7 @@ fn integration() {
             ctx,
             stack_entry.id,
             false,
+            ctx.project().force_push_protection,
             stack_entry.name().map(|n| n.to_string()).unwrap(),
         )
         .unwrap();
@@ -78,6 +79,7 @@ fn integration() {
             ctx,
             branch_id,
             false,
+            ctx.project().force_push_protection,
             branch_name.simple_name(),
         )
         .unwrap();

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
@@ -33,7 +33,7 @@ fn integration() {
             ctx,
             stack_entry.id,
             false,
-            ctx.project().force_push_protection,
+            false,
             stack_entry.name().map(|n| n.to_string()).unwrap(),
         )
         .unwrap();
@@ -79,7 +79,7 @@ fn integration() {
             ctx,
             branch_id,
             false,
-            ctx.project().force_push_protection,
+            false,
             branch_name.simple_name(),
         )
         .unwrap();

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/update_commit_message.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/update_commit_message.rs
@@ -177,6 +177,7 @@ fn forcepush_allowed() {
         ctx,
         stack_entry.id,
         false,
+        ctx.project().force_push_protection,
         stack_entry.name().map(|n| n.to_string()).unwrap(),
     )
     .unwrap();

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/update_commit_message.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/update_commit_message.rs
@@ -177,7 +177,7 @@ fn forcepush_allowed() {
         ctx,
         stack_entry.id,
         false,
-        ctx.project().force_push_protection,
+        false,
         stack_entry.name().map(|n| n.to_string()).unwrap(),
     )
     .unwrap();

--- a/crates/gitbutler-error/src/error.rs
+++ b/crates/gitbutler-error/src/error.rs
@@ -137,6 +137,7 @@ pub enum Code {
     BranchNotFound,
     SecretKeychainNotFound,
     MissingLoginKeychain,
+    GitForcePushProtection,
 }
 
 impl std::fmt::Display for Code {
@@ -153,6 +154,7 @@ impl std::fmt::Display for Code {
             Code::BranchNotFound => "errors.branch.notfound",
             Code::SecretKeychainNotFound => "errors.secret.keychain_notfound",
             Code::MissingLoginKeychain => "errors.secret.missing_login_keychain",
+            Code::GitForcePushProtection => "errors.git.force_push_protection",
         };
         f.write_str(code)
     }

--- a/crates/gitbutler-git/Cargo.toml
+++ b/crates/gitbutler-git/Cargo.toml
@@ -44,6 +44,7 @@ rand.workspace = true
 futures.workspace = true
 sysinfo = "0.36.0"
 gix.workspace = true
+gitbutler-error.workspace = true
 
 [target."cfg(unix)".dependencies]
 nix = { version = "0.30.0", features = ["process", "socket", "user"] }

--- a/crates/gitbutler-git/src/error.rs
+++ b/crates/gitbutler-git/src/error.rs
@@ -27,4 +27,7 @@ pub enum Error<BE: std::error::Error + core::fmt::Debug + Send + Sync + 'static>
     /// the remote already existed.
     #[error("remote already exists: {0}")]
     RemoteExists(String, #[source] BE),
+    /// A force push was rejected due to force push protection.
+    #[error("the force push was blocked because the remote branch contains commits that would be overwritten")]
+    ForcePushProtection(BE),
 }

--- a/crates/gitbutler-project/src/project.rs
+++ b/crates/gitbutler-project/src/project.rs
@@ -87,6 +87,9 @@ pub struct Project {
     /// for example, when updating base branch
     #[serde(default)]
     pub ok_with_force_push: DefaultTrue,
+    /// Force push protection uses safer force push flags instead of doing straight force pushes
+    #[serde(default)]
+    pub force_push_protection: bool,
     pub api: Option<ApiProject>,
     #[serde(default)]
     pub gitbutler_data_last_fetch: Option<FetchResult>,

--- a/crates/gitbutler-project/src/storage.rs
+++ b/crates/gitbutler-project/src/storage.rs
@@ -24,6 +24,7 @@ pub struct UpdateRequest {
     pub gitbutler_data_last_fetched: Option<FetchResult>,
     pub preferred_key: Option<AuthKey>,
     pub ok_with_force_push: Option<bool>,
+    pub force_push_protection: Option<bool>,
     pub gitbutler_code_push_state: Option<CodePushState>,
     pub project_data_last_fetched: Option<FetchResult>,
     pub omit_certificate_check: Option<bool>,
@@ -134,6 +135,10 @@ impl Storage {
 
         if let Some(ok_with_force_push) = update_request.ok_with_force_push {
             *project.ok_with_force_push = ok_with_force_push;
+        }
+
+        if let Some(force_push_protection) = update_request.force_push_protection {
+            project.force_push_protection = force_push_protection;
         }
 
         if let Some(omit_certificate_check) = update_request.omit_certificate_check {

--- a/crates/gitbutler-repo-actions/src/repository.rs
+++ b/crates/gitbutler-repo-actions/src/repository.rs
@@ -66,27 +66,13 @@ impl RepoActionsExt for CommandContext {
         let refname =
             RemoteRefname::from_str(&format!("refs/remotes/{remote_name}/{branch_name}",))?;
 
-        match self.push(
-            commit_id,
-            &refname,
-            false,
-            self.project().force_push_protection,
-            None,
-            askpass,
-        ) {
+        match self.push(commit_id, &refname, false, false, None, askpass) {
             Ok(()) => Ok(()),
             Err(e) => Err(anyhow::anyhow!(e.to_string())),
         }?;
 
         let empty_refspec = Some(format!(":refs/heads/{}", branch_name));
-        match self.push(
-            commit_id,
-            &refname,
-            false,
-            self.project().force_push_protection,
-            empty_refspec,
-            askpass,
-        ) {
+        match self.push(commit_id, &refname, false, false, empty_refspec, askpass) {
             Ok(()) => Ok(()),
             Err(e) => Err(anyhow::anyhow!(e.to_string())),
         }?;

--- a/crates/gitbutler-stack/tests/mod.rs
+++ b/crates/gitbutler-stack/tests/mod.rs
@@ -486,7 +486,7 @@ fn update_name_after_push() -> Result<()> {
         push_details.head,
         &push_details.remote_refname,
         false,
-        false,
+        ctx.project().force_push_protection,
         None,
         Some(Some(test_ctx.stack.id)),
     );

--- a/crates/gitbutler-stack/tests/mod.rs
+++ b/crates/gitbutler-stack/tests/mod.rs
@@ -486,7 +486,7 @@ fn update_name_after_push() -> Result<()> {
         push_details.head,
         &push_details.remote_refname,
         false,
-        ctx.project().force_push_protection,
+        false,
         None,
         Some(Some(test_ctx.stack.id)),
     );

--- a/crates/gitbutler-tauri/src/stack.rs
+++ b/crates/gitbutler-tauri/src/stack.rs
@@ -128,7 +128,7 @@ pub fn push_stack(
     project_id: ProjectId,
     stack_id: StackId,
     with_force: bool,
-    force_push_protection: bool,
+    skip_force_push_protection: bool,
     branch: String,
 ) -> Result<PushResult, Error> {
     stack::push_stack(
@@ -137,7 +137,7 @@ pub fn push_stack(
             project_id,
             stack_id,
             with_force,
-            force_push_protection,
+            skip_force_push_protection,
             branch,
         },
     )

--- a/crates/gitbutler-tauri/src/stack.rs
+++ b/crates/gitbutler-tauri/src/stack.rs
@@ -128,6 +128,7 @@ pub fn push_stack(
     project_id: ProjectId,
     stack_id: StackId,
     with_force: bool,
+    force_push_protection: bool,
     branch: String,
 ) -> Result<PushResult, Error> {
     stack::push_stack(
@@ -136,6 +137,7 @@ pub fn push_stack(
             project_id,
             stack_id,
             with_force,
+            force_push_protection,
             branch,
         },
     )

--- a/packages/ui/src/styles/utility/layout.min.css
+++ b/packages/ui/src/styles/utility/layout.min.css
@@ -81,3 +81,6 @@
 .text-right {
 	text-align: right;
 }
+.text-nowrap {
+	white-space: nowrap;
+}


### PR DESCRIPTION
## ToDo & Limitations

- **Limitation:** Currently when a force push is prevented through the git flags, the `Integrate Upstream` (yellow) button will not work anymore. As @Byron is refactoring that part, this should not be an issue for too long I hope 😀 ~~(or maybe it is an easy fix??)~~.
- ~~**ToDo: https://github.com/gitbutlerapp/gitbutler/pull/9710#issuecomment-3160360029**~~

## 🧢 Changes

- feat(core): add the ability to use more secure flags when force pushing. Every force push when the `Force push protection` setting is enabled will now happen with `--force-with-lease` and `--force-if-includes` instead of with `--force` to help make sure new remote commits are not lost.
- feat(ui): if there is new (not locally integrated) remote commits and `Force push protection` is enabled, a modal will be shown with all the commits that would be overwritten by the force push and allow the user to choose `Force push anyway` which will overwrite the remote commits (sometimes we want that) or to integrate the commits manually.
- feat(ui): add a `Force push protection` setting to the `Git stuff` Project settings page to enable the more secure way of force pushing.
- fix: at the moment when force pushing, the `--force` flag is always used, so the effect of any other `--force...` flag with protection never takes effect
- chore: removed `force_if_includes` settings flag as it is no longer needed

## ☕️ Reasoning

- At the moment there is a big issue with GitButler that a lot of things require force pushing https://github.com/gitbutlerapp/gitbutler/issues/8031, which hopefully will be eliminated in a future version. To make force pushes more secure when they are absolutely needed like after rebasing, there are flags that can be used instead of `--force` to make it less likely to lose any remote commits.
- How the 2 flags work can be read here as the git documentation is quite sparse: https://stackoverflow.com/a/78298145
- At the moment force pushing seems to be done via `--force-with-lease` and not `--force` when looking at the implementation here https://github.com/gitbutlerapp/gitbutler/blob/a86174ccb67d5eeeb59d8ead5876959d1e12e9e4/crates/gitbutler-git/src/repository.rs#L363-L365 Unfortunately this is not working and this flag is never used for 2 reasons:
  - 1: Every time GitButler pushes it first does a fetch, which basically removes all effect of `--force-with-lease` as `force-with-lease` compares the local and remote ref at push time but if we fetch the local branch before pushing in the background, we will be on the same head as the remote which will mean any newly added commits on the remote will be overwritten as this flag now allows us to force push, as it does not see any difference (which means we could loose remote commits).
  - 2: This flag even though it could take effect if we removed the automatic fetch before (and do not manually fetch and integrate the changes before ofc) would still not take effect as we always force push with `--force`. Yes `--force` is always added to the git push command which removes any effect of the flag `--force-with-lease` or even `--force-with-lease` and `--force-if-includes` at the same time. This was one of the hardest things to find as we do not add `--force` explicitly but rather it is added here via a `+` https://github.com/gitbutlerapp/gitbutler/blob/a86174ccb67d5eeeb59d8ead5876959d1e12e9e4/crates/gitbutler-repo-actions/src/repository.rs#L166-L167 A `+` in git is basically the same as adding `--force` to the git push command and as soon as `--force` is added to the git push command none of the other flags that replace `--force` will take effect.
  - As you can see the more secure way of force pushing (that is currently implemented) is never used and at the moment we basically always do a straight `--force` push. 
  - Some time ago I proposed adding a second flag `--force-if-includes` in addition to `--force-with-lease` to protect against the first issue of fetching before pushing but as the `--force-if-includes` flag was never used at all, I decided to introduced a new setting on the `Git stuff` Project settings page to enable `Force pushing protection` which uses both new flags at the same time.

## Issues

- fix https://github.com/gitbutlerapp/gitbutler/issues/2847. Merging this PR should fix this issue completely as overwriting remote commits will now be nearly impossible, so this issue could be closed as soon as this PR is merged.


## Preview

**Git stuff Project settings page:**

<img width="598" height="231" alt="image" src="https://github.com/user-attachments/assets/5ff7ff44-ef4d-495a-85b2-1c7bacdbe242" />

**Warning modal:**

<img width="504" height="303" alt="image" src="https://github.com/user-attachments/assets/24570f0e-8f5d-49b0-b80f-3531d408b898" />
