### PR TITLE
Refactor Checks polling: initialize prevIsDone with false

### DIFF
--- a/apps/desktop/src/components/ChecksPolling.svelte
+++ b/apps/desktop/src/components/ChecksPolling.svelte
@@ -107,8 +107,7 @@
 
 	// Track previous state to detect transitions.
 	// This should **not** be a derived, since we want to track the previous state, not the current one.
-	// svelte-ignore state_referenced_locally
-	let prevIsDone = $state(isDone);
+	let prevIsDone = $state(false);
 	let prevChecksStartedAt = $state<string>();
 
 	// Checks have reached a terminal state or there are no checks to monitor


### PR DESCRIPTION
Set prevIsDone to false instead of $state(isDone) to correctly track
previous state transitions. This prevents warning about initializing state with a reactive value