### PR TITLE
Refactor e2e tests for test ids, CI config, and file naming

### DIFF
--- a/.github/workflows/test-e2e-webdriver.yml
+++ b/.github/workflows/test-e2e-webdriver.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-latest
     env:
       CARGO_TERM_COLOR: always
+      CI_E2E: true
     steps:
       - uses: actions/checkout@v4
         if: ${{ github.event_name != 'workflow_dispatch' }}
@@ -28,16 +29,6 @@ jobs:
         uses: Swatinem/rust-cache@v2.8.0
         with:
           shared-key: e2e-testing-cache
-      # - name: Install OS dependencies
-      #   run: |
-      #     sudo apt update && sudo apt install -y \
-      #       libsoup-3.0-0 \
-      #       libgtk-3-dev \
-      #       libayatana-appindicator3-dev \
-      #       libwebkit2gtk-4.1-dev \
-      #       webkit2gtk-driver \
-      #       ffmpeg \
-      #       xvfb
       - name: Setup rust-toolchain stable
         id: rust-toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -15,6 +15,7 @@
 	},
 	"dependencies": {
 		"get-port": "^7.1.0",
-		"tmp-promise": "^3.0.3"
+		"tmp-promise": "^3.0.3",
+		"@gitbutler/ui": "workspace:*"
 	}
 }

--- a/e2e/test/specs/startTheApp.e2e.ts
+++ b/e2e/test/specs/startTheApp.e2e.ts
@@ -1,4 +1,4 @@
-import { GitButler, startGitButler } from './utils';
+import { getByTestId, GitButler, startGitButler } from './utils.js';
 import { expect, $ } from '@wdio/globals';
 import * as path from 'node:path';
 
@@ -12,10 +12,12 @@ describe('Application starts', () => {
 	it('should start the application', async () => {
 		await gitbutler.runScript('setup-empty-project.sh');
 		await gitbutler.visit('/');
-		// Yay! Analytics prompt :D
-		await expect($('.title')).toHaveText(expect.stringContaining('Before we begin'));
+		const onboardingPage = getByTestId('onboarding-page');
+		await onboardingPage.waitForDisplayed();
 
-		await $('button.*=Continue').click();
+		const continueButton = getByTestId('analytics-continue');
+		await continueButton.waitForDisplayed();
+		await continueButton.click();
 		browser.setCookies({
 			name: 'test-projectPath',
 			value: path.resolve(gitbutler.workDir, 'local-clone')

--- a/e2e/test/specs/utils.ts
+++ b/e2e/test/specs/utils.ts
@@ -1,3 +1,4 @@
+import { TestId } from '@gitbutler/ui/utils/testIds';
 import getPort from 'get-port';
 import { dir } from 'tmp-promise';
 import { ChildProcess, spawn } from 'node:child_process';
@@ -213,13 +214,19 @@ export async function startGitButler(browser: WebdriverIO.Browser): Promise<GitB
 function cleanup() {
 	for (const child of processes) {
 		if (!child.killed) {
-			child.kill();
+			child.kill(1);
 		}
 	}
 }
 
 export async function sleep(time: number): Promise<void> {
 	return await new Promise((resolve) => setTimeout(resolve, time));
+}
+
+type TestIdValues = `${TestId}`;
+
+export function getByTestId(testId: TestIdValues) {
+	return $(`[data-testid="${testId}"]`);
 }
 
 // Handle process termination

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
-		"moduleResolution": "node",
-		"module": "ESNext",
+		"moduleResolution": "nodenext",
+		"module": "nodenext",
 		"target": "es2022",
 		"lib": ["es2022", "dom"],
 		"types": ["node", "@wdio/mocha-framework", "@wdio/globals/types"],

--- a/e2e/wdio.web.conf.ts
+++ b/e2e/wdio.web.conf.ts
@@ -1,19 +1,19 @@
 import { existsSync, mkdirSync } from 'node:fs';
 
-const debug = !!process.env.DEBUG;
+const ci = !!process.env.CI_E2E;
 
 export const config: WebdriverIO.Config = {
 	runner: 'local',
 	tsConfigPath: './tsconfig.json',
 	specs: ['./test/specs/**/*.ts'],
 	exclude: [],
-	maxInstances: debug ? 1 : 10,
+	maxInstances: ci ? 10 : 1,
 	outputDir: './test-results',
 	capabilities: [
 		{
 			browserName: 'chrome',
 			'goog:chromeOptions': {
-				args: debug ? ['no-sandbox'] : ['headless', 'no-sandbox']
+				args: ci ? ['headless', 'no-sandbox'] : ['no-sandbox']
 			}
 		}
 	],
@@ -39,7 +39,7 @@ export const config: WebdriverIO.Config = {
 		ui: 'bdd',
 		// This is _very_ long because we are compiling the app inside the first-run test case.
 		timeout: 600000,
-		retries: debug ? 0 : 2
+		retries: ci ? 3 : 0
 	},
 
 	onPrepare: function () {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -429,6 +429,9 @@ importers:
 
   e2e:
     dependencies:
+      '@gitbutler/ui':
+        specifier: workspace:*
+        version: link:../packages/ui
       get-port:
         specifier: ^7.1.0
         version: 7.1.0


### PR DESCRIPTION
This commit includes several improvements to the e2e tests:
- Switches element selection to use test ids for better reliability.
- Adds a CI_E2E environment flag in the CI configuration for consistent behavior in CI pipelines.
- Renames the E2E test file to startTheApp.e2e.ts to follow camelCase naming.
- Updates dependencies and configuration for these changes.
- Misc. cleanup and preparation to make tests more robust and maintainable.