### PR TITLE
fix: project settings menu

### DIFF
--- a/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
+++ b/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
@@ -2,11 +2,7 @@
 	import { goto } from '$app/navigation';
 	import { vscodePath } from '$lib/project/project';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
-	import {
-		isNewProjectSettingsPath,
-		newProjectSettingsPath,
-		workspacePath
-	} from '$lib/routes/routes.svelte';
+	import { newProjectSettingsPath } from '$lib/routes/routes.svelte';
 	import { historyPath } from '$lib/routes/routes.svelte';
 	import { SETTINGS } from '$lib/settings/userSettings';
 	import { SHORTCUT_SERVICE } from '$lib/shortcuts/shortcutService';
@@ -24,11 +20,7 @@
 	$effect(() =>
 		mergeUnlisten(
 			shortcutService.on('project-settings', () => {
-				if (isNewProjectSettingsPath()) {
-					goto(workspacePath(projectId));
-				} else {
-					goto(newProjectSettingsPath(projectId));
-				}
+				goto(newProjectSettingsPath(projectId));
 			}),
 			shortcutService.on('history', () => {
 				goto(historyPath(projectId));

--- a/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
+++ b/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
@@ -2,7 +2,7 @@
 	import { goto } from '$app/navigation';
 	import { vscodePath } from '$lib/project/project';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
-	import { projectSettingsPath } from '$lib/routes/routes.svelte';
+	import { isNewProjectSettingsPath, newProjectSettingsPath, workspacePath } from '$lib/routes/routes.svelte';
 	import { historyPath } from '$lib/routes/routes.svelte';
 	import { SETTINGS } from '$lib/settings/userSettings';
 	import { SHORTCUT_SERVICE } from '$lib/shortcuts/shortcutService';
@@ -20,7 +20,11 @@
 	$effect(() =>
 		mergeUnlisten(
 			shortcutService.on('project-settings', () => {
-				goto(projectSettingsPath(projectId));
+				if (isNewProjectSettingsPath()) {
+					goto(workspacePath(projectId));
+				} else {
+					goto(newProjectSettingsPath(projectId));
+				}
 			}),
 			shortcutService.on('history', () => {
 				goto(historyPath(projectId));

--- a/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
+++ b/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
@@ -2,7 +2,11 @@
 	import { goto } from '$app/navigation';
 	import { vscodePath } from '$lib/project/project';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
-	import { isNewProjectSettingsPath, newProjectSettingsPath, workspacePath } from '$lib/routes/routes.svelte';
+	import {
+		isNewProjectSettingsPath,
+		newProjectSettingsPath,
+		workspacePath
+	} from '$lib/routes/routes.svelte';
 	import { historyPath } from '$lib/routes/routes.svelte';
 	import { SETTINGS } from '$lib/settings/userSettings';
 	import { SHORTCUT_SERVICE } from '$lib/shortcuts/shortcutService';


### PR DESCRIPTION
## 🧢 Changes

- fix: Project Settings menu (in the menu bar) currently points to a different Settings page (with horizontal tabs) instead of the v3 one.