### PR TITLE
fix-action-response-handling

### DIFF
--- a/apps/desktop/src/components/FeedItem.svelte
+++ b/apps/desktop/src/components/FeedItem.svelte
@@ -104,7 +104,7 @@
 				<span class="text-grey">Prompt:</span>{' ' +
 					(action.externalPrompt ?? action.externalSummary)}
 			</p>
-			{#if !isStringActionSource(action.source) && action.response !== undefined}
+			{#if !isStringActionSource(action.source) && !!action.response}
 				{@const newCommits = allCommitsUpdated(action.response)}
 				<FeedActionDiff {projectId} {newCommits} />
 			{/if}

--- a/apps/desktop/src/lib/actions/types.ts
+++ b/apps/desktop/src/lib/actions/types.ts
@@ -77,9 +77,9 @@ export class ButlerAction {
 	/** A GitBulter Oplog snapshot ID after the action was performed. */
 	snapshotAfter!: string;
 	/** The outcome of the action, if it was successful. */
-	response?: Outcome;
+	response!: Outcome | null;
 	/** An error message if the action failed. */
-	error?: string;
+	error!: string | null;
 	/** The source of the action, if known. */
 	source!: ActionSource;
 }


### PR DESCRIPTION
- Updated FeedItem.svelte to check for a truthy action response instead of undefined, ensuring correct rendering of FeedActionDiff.
- Made `response` and `error` fields in ActionResponse type mandatory but nullable, improving type safety and clarity in handling action outcomes.