### PR TITLE
feat: add Default terminal setting & Open in terminal menu

### DIFF
--- a/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
+++ b/apps/desktop/src/components/ProjectSettingsMenuAction.svelte
@@ -6,7 +6,7 @@
 	import { historyPath } from '$lib/routes/routes.svelte';
 	import { SETTINGS } from '$lib/settings/userSettings';
 	import { SHORTCUT_SERVICE } from '$lib/shortcuts/shortcutService';
-	import { getEditorUri, openExternalUrl, showFileInFolder } from '$lib/utils/url';
+	import { getEditorUri, openExternalUrl, showFileInFolder, openInTerminal } from '$lib/utils/url';
 	import { inject } from '@gitbutler/shared/context';
 	import { mergeUnlisten } from '@gitbutler/ui/utils/mergeUnlisten';
 
@@ -37,6 +37,13 @@
 						searchParams: { windowId: '_blank' }
 					})
 				);
+			}),
+			shortcutService.on('open-in-terminal', async () => {
+				const project = await projectsService.fetchProject(projectId);
+				if (!project) {
+					throw new Error(`Project not found: ${projectId}`);
+				}
+				await openInTerminal($userSettings.defaultTerminal.appName, vscodePath(project.path));
 			}),
 			shortcutService.on('show-in-finder', async () => {
 				const project = await projectsService.fetchProject(projectId);

--- a/apps/desktop/src/components/profileSettings/GeneralSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/GeneralSettings.svelte
@@ -191,56 +191,58 @@
 {/if}
 <Spacer />
 
-<SectionCard orientation="row" centerAlign>
-	{#snippet title()}
-		Default code editor
-	{/snippet}
-	{#snippet actions()}
-		<Select
-			value={$userSettings.defaultCodeEditor.schemeIdentifer}
-			options={editorOptionsForSelect}
-			onselect={(value) => {
-				const selected = editorOptions.find((option) => option.schemeIdentifer === value);
-				if (selected) {
-					userSettings.update((s) => ({ ...s, defaultCodeEditor: selected }));
-				}
-			}}
-		>
-			{#snippet itemSnippet({ item, highlighted })}
-				<SelectItem
-					selected={item.value === $userSettings.defaultCodeEditor.schemeIdentifer}
-					{highlighted}
-				>
-					{item.label}
-				</SelectItem>
-			{/snippet}
-		</Select>
-	{/snippet}
-</SectionCard>
+<div class="stack-v">
+	<SectionCard orientation="row" centerAlign roundedBottom={false}>
+		{#snippet title()}
+			Default code editor
+		{/snippet}
+		{#snippet actions()}
+			<Select
+				value={$userSettings.defaultCodeEditor.schemeIdentifer}
+				options={editorOptionsForSelect}
+				onselect={(value) => {
+					const selected = editorOptions.find((option) => option.schemeIdentifer === value);
+					if (selected) {
+						userSettings.update((s) => ({ ...s, defaultCodeEditor: selected }));
+					}
+				}}
+			>
+				{#snippet itemSnippet({ item, highlighted })}
+					<SelectItem
+						selected={item.value === $userSettings.defaultCodeEditor.schemeIdentifer}
+						{highlighted}
+					>
+						{item.label}
+					</SelectItem>
+				{/snippet}
+			</Select>
+		{/snippet}
+	</SectionCard>
 
-<SectionCard orientation="row" centerAlign>
-	{#snippet title()}
-		Default terminal
-	{/snippet}
-	{#snippet actions()}
-		<Select
-			value={$userSettings.defaultTerminal.appName}
-			options={terminalOptionsForSelect}
-			onselect={(value) => {
-				const selected = terminalOptions.find((option) => option.appName === value);
-				if (selected) {
-					userSettings.update((s) => ({ ...s, defaultTerminal: selected }));
-				}
-			}}
-		>
-			{#snippet itemSnippet({ item, highlighted })}
-				<SelectItem selected={item.value === $userSettings.defaultTerminal.appName} {highlighted}>
-					{item.label}
-				</SelectItem>
-			{/snippet}
-		</Select>
-	{/snippet}
-</SectionCard>
+	<SectionCard orientation="row" centerAlign roundedTop={false}>
+		{#snippet title()}
+			Default terminal
+		{/snippet}
+		{#snippet actions()}
+			<Select
+				value={$userSettings.defaultTerminal.appName}
+				options={terminalOptionsForSelect}
+				onselect={(value) => {
+					const selected = terminalOptions.find((option) => option.appName === value);
+					if (selected) {
+						userSettings.update((s) => ({ ...s, defaultTerminal: selected }));
+					}
+				}}
+			>
+				{#snippet itemSnippet({ item, highlighted })}
+					<SelectItem selected={item.value === $userSettings.defaultTerminal.appName} {highlighted}>
+						{item.label}
+					</SelectItem>
+				{/snippet}
+			</Select>
+		{/snippet}
+	</SectionCard>
+</div>
 
 <SectionCard labelFor="disable-auto-checks" orientation="row">
 	{#snippet title()}

--- a/apps/desktop/src/components/profileSettings/GeneralSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/GeneralSettings.svelte
@@ -7,7 +7,11 @@
 	import { SETTINGS_SERVICE } from '$lib/config/appSettingsV2';
 	import { showError } from '$lib/notifications/toasts';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
-	import { SETTINGS, type CodeEditorSettings } from '$lib/settings/userSettings';
+	import {
+		SETTINGS,
+		type CodeEditorSettings,
+		type TerminalSettings
+	} from '$lib/settings/userSettings';
 	import { UPDATER_SERVICE } from '$lib/updater/updater';
 	import { USER_SERVICE } from '$lib/user/userService';
 
@@ -57,6 +61,19 @@
 	const editorOptionsForSelect = editorOptions.map((option) => ({
 		label: option.displayName,
 		value: option.schemeIdentifer
+	}));
+	const terminalOptions: TerminalSettings[] = [
+		{ appName: 'Terminal.app', displayName: 'Terminal' },
+		{ appName: 'Ghostty.app', displayName: 'Ghostty' },
+		{ appName: 'Warp.app', displayName: 'Warp' },
+		{ appName: 'iTerm.app', displayName: 'iTerm 2' },
+		{ appName: 'Alacritty.app', displayName: 'Alacritty' },
+		{ appName: 'WezTerm.app', displayName: 'WezTerm' },
+		{ appName: 'Hyper.app', displayName: 'Hyper' }
+	];
+	const terminalOptionsForSelect = terminalOptions.map((option) => ({
+		label: option.displayName,
+		value: option.appName
 	}));
 
 	$effect(() => {
@@ -194,6 +211,30 @@
 					selected={item.value === $userSettings.defaultCodeEditor.schemeIdentifer}
 					{highlighted}
 				>
+					{item.label}
+				</SelectItem>
+			{/snippet}
+		</Select>
+	{/snippet}
+</SectionCard>
+
+<SectionCard orientation="row" centerAlign>
+	{#snippet title()}
+		Default terminal
+	{/snippet}
+	{#snippet actions()}
+		<Select
+			value={$userSettings.defaultTerminal.appName}
+			options={terminalOptionsForSelect}
+			onselect={(value) => {
+				const selected = terminalOptions.find((option) => option.appName === value);
+				if (selected) {
+					userSettings.update((s) => ({ ...s, defaultTerminal: selected }));
+				}
+			}}
+		>
+			{#snippet itemSnippet({ item, highlighted })}
+				<SelectItem selected={item.value === $userSettings.defaultTerminal.appName} {highlighted}>
 					{item.label}
 				</SelectItem>
 			{/snippet}

--- a/apps/desktop/src/lib/settings/userSettings.ts
+++ b/apps/desktop/src/lib/settings/userSettings.ts
@@ -9,6 +9,10 @@ export type CodeEditorSettings = {
 	schemeIdentifer: string;
 	displayName: string;
 };
+export type TerminalSettings = {
+	appName: string;
+	displayName: string;
+};
 
 export interface Settings {
 	aiSummariesEnabled?: boolean;
@@ -30,6 +34,7 @@ export interface Settings {
 	inlineUnifiedDiffs: boolean;
 	diffContrast: 'light' | 'medium' | 'strong';
 	defaultCodeEditor: CodeEditorSettings;
+	defaultTerminal: TerminalSettings;
 }
 
 const defaults: Settings = {
@@ -50,7 +55,8 @@ const defaults: Settings = {
 	diffLigatures: false,
 	inlineUnifiedDiffs: false,
 	diffContrast: 'light',
-	defaultCodeEditor: { schemeIdentifer: 'vscode', displayName: 'VSCode' }
+	defaultCodeEditor: { schemeIdentifer: 'vscode', displayName: 'VSCode' },
+	defaultTerminal: { appName: 'Terminal.app', displayName: 'Terminal' }
 };
 
 export function loadUserSettings(): Writable<Settings> {

--- a/apps/desktop/src/lib/utils/url.ts
+++ b/apps/desktop/src/lib/utils/url.ts
@@ -51,3 +51,7 @@ export function getEditorUri(params: EditorUriParams): string {
 
 	return `${params.schemeId}://file${pathString}${positionSuffix}${searchSuffix}`;
 }
+
+export async function openInTerminal(appName: string, path: string) {
+	await invoke<void>('open_in_terminal', { appName, path });
+}

--- a/crates/but-api/src/commands/open.rs
+++ b/crates/but-api/src/commands/open.rs
@@ -150,3 +150,24 @@ pub fn show_in_finder(_app: &App, params: ShowInFinderParams) -> Result<(), Erro
 
     Ok(())
 }
+
+#[derive(Deserialize)]
+pub struct OpenInTerminalParams {
+    pub app_name: String,
+    pub path: String,
+}
+
+pub fn open_in_terminal(_app: &App, params: OpenInTerminalParams) -> Result<(), Error> {
+    #[cfg(target_os = "macos")]
+    {
+        use std::process::Command;
+        Command::new("open")
+            .arg("-a")
+            .arg(&params.app_name)
+            .arg(&params.path)
+            .status()
+            .with_context(|| format!("Failed to show '{}' in Finder", params.path))?;
+    }
+
+    Ok(())
+}

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -271,6 +271,7 @@ fn main() {
                     modes::edit_changes_from_initial,
                     open::open_url,
                     open::show_in_finder,
+                    open::open_in_terminal,
                     forge::pr_templates,
                     forge::pr_template,
                     settings::get_app_settings,

--- a/crates/gitbutler-tauri/src/menu.rs
+++ b/crates/gitbutler-tauri/src/menu.rs
@@ -158,7 +158,8 @@ pub fn build<R: Runtime>(
                 .build(handle)?,
         )
         .separator()
-        .text("project/open-in-vscode", "Open in Editor");
+        .text("project/open-in-vscode", "Open in Editor")
+        .text("project/open-in-terminal", "Open in Terminal");
 
     #[cfg(target_os = "macos")]
     {
@@ -319,6 +320,11 @@ pub fn handle_event<R: Runtime>(
 
     if event.id() == "project/open-in-vscode" {
         emit(webview, SHORTCUT_EVENT, "open-in-vscode");
+        return;
+    }
+
+    if event.id() == "project/open-in-terminal" {
+        emit(webview, SHORTCUT_EVENT, "open-in-terminal");
         return;
     }
 

--- a/crates/gitbutler-tauri/src/open.rs
+++ b/crates/gitbutler-tauri/src/open.rs
@@ -15,3 +15,9 @@ pub fn open_url(app: State<'_, App>, url: String) -> Result<(), Error> {
 pub fn show_in_finder(app: State<'_, App>, path: String) -> Result<(), Error> {
     open::show_in_finder(&app, open::ShowInFinderParams { path })
 }
+
+#[tauri::command(async)]
+#[instrument(skip(app), err(Debug))]
+pub fn open_in_terminal(app: State<'_, App>, app_name: String, path: String) -> Result<(), Error> {
+    open::open_in_terminal(&app, open::OpenInTerminalParams { app_name, path })
+}


### PR DESCRIPTION
## ToDo & Limitations

- **Limitation: Currently, this change only works for macOS because the app names are specific to macOS.** I am not 100% sure how we would make this change cross platform as app names could be different on windows.
- ToDo: Instead of using links to open all the code editors (like now), we could refactor that part of the code to open via app names as well using one clean function. This would be helpful because once every default terminal and code editor is opened via the app name, we could allow custom apps we do not have in the list as well. To add a custom app the users could select an app from the app folder, which would be very useful because we would not have to add every editor and the user can just select one. Good idea??

## 🧢 Changes

- feat(ui): add default terminal settings to the `General` settings page
- feat(core): add `Open in Terminal` to project menu which opens the current project in the default terminal

## Preview

**Settings**

<img width="625" height="454" alt="image" src="https://github.com/user-attachments/assets/535819bb-d6b0-483f-bccd-4516aa33c2ec" />

**Menu**

<img width="197" height="173" alt="image" src="https://github.com/user-attachments/assets/036d6ec3-e81c-44ae-a285-a088f9ce319b" />

