### PR TITLE
Invalidate stacks and worktree changes on rule update

### DIFF
--- a/apps/desktop/src/lib/rules/rulesService.svelte.ts
+++ b/apps/desktop/src/lib/rules/rulesService.svelte.ts
@@ -54,7 +54,11 @@ function injectEndpoints(api: BackendApi) {
 			>({
 				extraOptions: { command: 'create_workspace_rule' },
 				query: (args) => args,
-				invalidatesTags: () => [invalidatesList(ReduxTag.WorkspaceRules)]
+				invalidatesTags: () => [
+					invalidatesList(ReduxTag.WorkspaceRules),
+					invalidatesList(ReduxTag.WorktreeChanges),
+					invalidatesList(ReduxTag.Stacks)
+				]
 			}),
 			deleteWorkspaceRule: build.mutation<void, { projectId: string; id: WorkspaceRuleId }>({
 				extraOptions: { command: 'delete_workspace_rule' },
@@ -71,7 +75,9 @@ function injectEndpoints(api: BackendApi) {
 					result
 						? [
 								invalidatesItem(ReduxTag.WorkspaceRules, result.id),
-								invalidatesList(ReduxTag.WorkspaceRules)
+								invalidatesList(ReduxTag.WorkspaceRules),
+								invalidatesList(ReduxTag.WorktreeChanges),
+								invalidatesList(ReduxTag.Stacks)
 							]
 						: []
 			}),


### PR DESCRIPTION
Updates the rulesService to also invalidate the Stacks and WorktreeChanges tags when creating or updating a rule. This ensures that changes to rules trigger updates in both stacks and worktree changes, and updates are correctly reflected in the UI after applying a rule.