### PR TITLE
Refactor Toolset to trait and update usage

### DIFF
--- a/crates/but-action/src/openai.rs
+++ b/crates/but-action/src/openai.rs
@@ -412,7 +412,7 @@ pub fn tool_calling_loop(
     provider: &OpenAiProvider,
     system_message: &str,
     chat_messages: Vec<ChatMessage>,
-    tool_set: &mut Toolset,
+    tool_set: &mut impl Toolset,
     model: Option<String>,
 ) -> anyhow::Result<async_openai::types::CreateChatCompletionResponse> {
     let mut messages: Vec<ChatCompletionRequestMessage> =
@@ -502,7 +502,7 @@ pub fn tool_calling_loop_stream(
     provider: &OpenAiProvider,
     system_message: &str,
     chat_messages: Vec<ChatMessage>,
-    tool_set: &mut Toolset,
+    tool_set: &mut impl Toolset,
     model: Option<String>,
     on_token: Arc<dyn Fn(&str) + Send + Sync + 'static>,
 ) -> anyhow::Result<Option<String>> {

--- a/crates/but-tools/src/workspace.rs
+++ b/crates/but-tools/src/workspace.rs
@@ -19,15 +19,15 @@ use gitbutler_stack::{PatchReferenceUpdate, VirtualBranchesHandle};
 use schemars::{JsonSchema, schema_for};
 
 use crate::emit::{Emittable, Emitter, StackUpdate};
-use crate::tool::{Tool, ToolResult, Toolset, error_to_json, result_to_json};
+use crate::tool::{Tool, ToolResult, Toolset, WorkspaceToolset, error_to_json, result_to_json};
 
 /// Creates a toolset for any kind of workspace operations.
 pub fn workspace_toolset(
     ctx: &mut CommandContext,
     emitter: std::sync::Arc<crate::emit::Emitter>,
     message_id: String,
-) -> anyhow::Result<Toolset<'_>> {
-    let mut toolset = Toolset::new(ctx, emitter, Some(message_id));
+) -> anyhow::Result<WorkspaceToolset<'_>> {
+    let mut toolset = WorkspaceToolset::new(ctx, emitter, Some(message_id));
 
     toolset.register_tool(Commit);
     toolset.register_tool(CreateBranch);
@@ -47,8 +47,8 @@ pub fn workspace_toolset(
 pub fn commit_toolset(
     ctx: &mut CommandContext,
     emitter: std::sync::Arc<crate::emit::Emitter>,
-) -> anyhow::Result<Toolset<'_>> {
-    let mut toolset = Toolset::new(ctx, emitter, None);
+) -> anyhow::Result<WorkspaceToolset<'_>> {
+    let mut toolset = WorkspaceToolset::new(ctx, emitter, None);
 
     toolset.register_tool(Commit);
     toolset.register_tool(CreateBranch);
@@ -60,8 +60,8 @@ pub fn commit_toolset(
 pub fn amend_toolset(
     ctx: &mut CommandContext,
     emitter: std::sync::Arc<crate::emit::Emitter>,
-) -> anyhow::Result<Toolset<'_>> {
-    let mut toolset = Toolset::new(ctx, emitter, None);
+) -> anyhow::Result<WorkspaceToolset<'_>> {
+    let mut toolset = WorkspaceToolset::new(ctx, emitter, None);
 
     toolset.register_tool(Amend);
     toolset.register_tool(GetProjectStatus);


### PR DESCRIPTION
- Refactored the Toolset struct to a Toolset trait with WorkspaceToolset implementation in but-tools.
- Updated all locations using Toolset to use the trait or WorkspaceToolset as appropriate in but-tools and but-action.
- Adjusted openai.rs to accept &mut impl Toolset for tool functions.
- Updated workspace.rs to return and use WorkspaceToolset, updating helper and utility functions.
- Updated trait impl and method wiring for registering and handling tools in the toolset layer.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #9732 
- <kbd>&nbsp;1&nbsp;</kbd> #9731 👈 
<!-- GitButler Footer Boundary Bottom -->

