### PR TITLE
refactor: remove anyhow::Result from toolset constructors

### DIFF
--- a/crates/but-action/src/absorb.rs
+++ b/crates/but-action/src/absorb.rs
@@ -62,7 +62,7 @@ pub fn absorb(
     let serialized_status = serde_json::to_string_pretty(&project_status)
         .context("Failed to serialize project status")?;
 
-    let mut toolset = amend_toolset(ctx, emitter)?;
+    let mut toolset = amend_toolset(ctx, emitter);
 
     let system_message ="
        You are an expert in finding where to put file changes in a project.

--- a/crates/but-action/src/auto_commit.rs
+++ b/crates/but-action/src/auto_commit.rs
@@ -20,7 +20,7 @@ pub fn auto_commit(
     let serialized_status = serde_json::to_string_pretty(&project_status)
         .context("Failed to serialize project status")?;
 
-    let mut toolset = commit_toolset(ctx, emitter.clone())?;
+    let mut toolset = commit_toolset(ctx, emitter.clone());
 
     let system_message ="
         You are an expert in grouping and committing file changes into logical units for version control.

--- a/crates/but-action/src/branch_changes.rs
+++ b/crates/but-action/src/branch_changes.rs
@@ -20,7 +20,7 @@ pub fn branch_changes(
     let serialized_status = serde_json::to_string_pretty(&project_status)
         .context("Failed to serialize project status")?;
 
-    let mut toolset = commit_toolset(ctx, emitter.clone())?;
+    let mut toolset = commit_toolset(ctx, emitter.clone());
 
     let system_message ="
         You are an expert in grouping and committing file changes into logical units for version control.

--- a/crates/but-action/src/lib.rs
+++ b/crates/but-action/src/lib.rs
@@ -55,7 +55,7 @@ pub fn freestyle(
         .map_err(|e| anyhow::anyhow!("Failed to serialize project status: {}", e))?;
 
     let mut toolset =
-        but_tools::workspace::workspace_toolset(ctx, emitter.clone(), message_id.clone())?;
+        but_tools::workspace::workspace_toolset(ctx, emitter.clone(), message_id.clone());
 
     let system_message ="
     You are a GitButler agent that can perform various actions on a Git project.

--- a/crates/but-bot/src/agent.rs
+++ b/crates/but-bot/src/agent.rs
@@ -152,7 +152,7 @@ impl Agent for ButBot<'_> {
             self.ctx,
             self.emitter.clone(),
             self.message_id.clone(),
-        )?;
+        );
 
         let mut internal_chat_messages = chat_messages;
 

--- a/crates/but-tools/src/workspace.rs
+++ b/crates/but-tools/src/workspace.rs
@@ -26,7 +26,7 @@ pub fn workspace_toolset(
     ctx: &mut CommandContext,
     emitter: std::sync::Arc<crate::emit::Emitter>,
     message_id: String,
-) -> anyhow::Result<WorkspaceToolset<'_>> {
+) -> WorkspaceToolset<'_> {
     let mut toolset = WorkspaceToolset::new(ctx, emitter, Some(message_id));
 
     toolset.register_tool(Commit);
@@ -40,33 +40,33 @@ pub fn workspace_toolset(
     toolset.register_tool(SplitBranch);
     toolset.register_tool(SplitCommit);
 
-    Ok(toolset)
+    toolset
 }
 
 /// Creates a toolset for workspace-related operations.
 pub fn commit_toolset(
     ctx: &mut CommandContext,
     emitter: std::sync::Arc<crate::emit::Emitter>,
-) -> anyhow::Result<WorkspaceToolset<'_>> {
+) -> WorkspaceToolset<'_> {
     let mut toolset = WorkspaceToolset::new(ctx, emitter, None);
 
     toolset.register_tool(Commit);
     toolset.register_tool(CreateBranch);
 
-    Ok(toolset)
+    toolset
 }
 
 /// Creates a toolset for amend operations.
 pub fn amend_toolset(
     ctx: &mut CommandContext,
     emitter: std::sync::Arc<crate::emit::Emitter>,
-) -> anyhow::Result<WorkspaceToolset<'_>> {
+) -> WorkspaceToolset<'_> {
     let mut toolset = WorkspaceToolset::new(ctx, emitter, None);
 
     toolset.register_tool(Amend);
     toolset.register_tool(GetProjectStatus);
 
-    Ok(toolset)
+    toolset
 }
 
 pub struct Commit;


### PR DESCRIPTION
Change workspace_toolset, commit_toolset, and amend_toolset to return
WorkspaceToolset directly instead of anyhow::Result. This simplifies the
API by removing unnecessary error wrapping, as these functions do not
produce errors. Update call sites accordingly to match the new return
types.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #9732 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #9731 
<!-- GitButler Footer Boundary Bottom -->

