### PR TITLE
Improve handling of stacked remote commits

### DIFF
--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -265,7 +265,17 @@ impl Graph {
         let configured_remote_tracking_branches =
             remotes::configured_remote_tracking_branches(repo)?;
         let refs_by_id = repo.collect_ref_mapping_by_prefix(
-            std::iter::once("refs/heads/").chain(if collect_tags {
+            [
+                "refs/heads/",
+                // Remote refs are special as we collect them into commits to know about them,
+                // just to later remove them unless they are on an actual remote commit.
+                // In that case, we also split the segment there if the previous segment then wouldn't be empty.
+                // Naturally we only pick them up and segment them if they are added by the local tracking branch
+                // that was seen in the walk before.
+                "refs/remotes/",
+            ]
+            .into_iter()
+            .chain(if collect_tags {
                 Some("refs/tags/")
             } else {
                 None

--- a/crates/but-graph/src/init/walk.rs
+++ b/crates/but-graph/src/init/walk.rs
@@ -764,7 +764,8 @@ pub fn possibly_split_occupied_segment(
     };
     let dst_sidx = *existing_sidx.get();
     let (top_sidx, mut bottom_sidx) =
-        // If a normal branch walks into a workspace branch, put the workspace branch on top.
+        // If a normal branch walks into a workspace branch, put the workspace branch on top
+        // so it doesn't own the existing commit.
         if graph[dst_sidx].workspace_metadata().is_some() &&
             graph[src_sidx].ref_name.as_ref()
                 .and_then(|rn| rn.category()).is_some_and(|c| matches!(c, Category::LocalBranch)) {

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -797,6 +797,54 @@ EOF
     cp .git/refs/remotes/origin/main .git/refs/remotes/origin/A
   )
 
+  git init "two-dependent-branches-rebased-with-remotes-merge-one-local"
+  (cd "two-dependent-branches-rebased-with-remotes-merge-one-local"
+    echo init>file && git add file && git commit -m "init"
+    git checkout -b A && echo A >>file && git commit -am "A"
+    git checkout -b B && echo B >>file && git commit -am "B"
+    create_workspace_commit_once B
+    git checkout -b soon-origin-A main
+      tick
+      git cherry-pick A
+      git checkout -b soon-origin-B
+      git cherry-pick B
+    git checkout -b soon-origin-main main
+      git merge --no-ff A
+    git checkout gitbutler/workspace
+
+    setup_remote_tracking soon-origin-A A "move"
+    setup_remote_tracking soon-origin-B B "move"
+    setup_remote_tracking soon-origin-main main "move"
+
+    add_main_remote_setup
+  )
+
+  git init "two-dependent-branches-rebased-with-remotes-squash-merge-one-remote"
+  (cd "two-dependent-branches-rebased-with-remotes-squash-merge-one-remote"
+    echo init>file && git add file && git commit -m "init"
+    git checkout -b A && echo A >>file && git commit -am "A"
+    git checkout -b B && echo B >>file && git commit -am "B"
+
+    git checkout main
+      tick
+      # easy squash-merge simulation of only A
+      git cherry-pick A
+      setup_target_to_match_main
+    git checkout -b rebased-B
+      # rebase B on top
+      git cherry-pick B
+
+      # setup free-standing remotes that were previously pushed.
+      # replace local branches as they don't matter there.
+      setup_remote_tracking A A "move"
+      setup_remote_tracking B B "move"
+
+      # get our rebased B back.
+      git branch -m B
+
+    create_workspace_commit_once B
+  )
+
   git init special-branches
   (cd special-branches
     commit init

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -3190,10 +3190,10 @@ fn two_dependent_branches_rebased_with_remotes_squash_merge_remote() -> anyhow::
     * 281456a init
     ");
 
-    // The branch A is not in the workspace anymore, and we signal it by removing metadata
-    add_stack_with_segments(&mut meta, 0, "B", StackState::InWorkspace, &[]);
+    // The branch A is not in the workspace anymore, and we *could* signal it by removing metadata.
+    // But even with metadata, it still works fine.
+    add_stack_with_segments(&mut meta, 0, "B", StackState::InWorkspace, &["A"]);
 
-    // TODO: fix it - should know remote branch origin/A
     let graph = Graph::from_head(&repo, &*meta, standard_options())?.validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 👉📕►►►:0[0]:gitbutler/workspace
@@ -3207,17 +3207,18 @@ fn two_dependent_branches_rebased_with_remotes_squash_merge_remote() -> anyhow::
     ├── ►:1[0]:origin/main →:2:
     │   └── →:2: (main →:1:)
     └── ►:4[0]:origin/B →:3:
-        ├── 🟣da597e8
-        └── 🟣1818c17
-            └── →:5:
+        └── 🟣da597e8
+            └── ►:6[1]:origin/A
+                └── 🟣1818c17
+                    └── →:5:
     ");
 
+    // We segment
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     📕🏘️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on 0b6b861
-    └── ≡📙:3:B <> origin/B →:4:⇡1⇣2 on 0b6b861
-        └── 📙:3:B <> origin/B →:4:⇡1⇣2
+    └── ≡📙:3:B <> origin/B →:4:⇡1⇣1 on 0b6b861
+        └── 📙:3:B <> origin/B →:4:⇡1⇣1
             ├── 🟣da597e8
-            ├── 🟣1818c17
             └── ·e0bd0a7 (🏘️)
     ");
     Ok(())


### PR DESCRIPTION
Fixes #9733.

### Tasks

* [x] manual reproduction and exploration of fix
* [x] test
* [x] fix
    - find a way to pick create segments for remote branches only when seen from another remote branch
    - maybe this can be done as a post-process, so all we need is remote branches to be seen on the commits in question.
