### PR TITLE
feat: add 'rules' feature flag to AnalyticsMonitor.svelte

### DIFF
--- a/apps/desktop/src/components/AnalyticsMonitor.svelte
+++ b/apps/desktop/src/components/AnalyticsMonitor.svelte
@@ -64,7 +64,8 @@ attached to posthog events.
 		eventContext.update({
 			v3: true,
 			butlerActions: $settingsService?.featureFlags.actions,
-			ws3: $settingsService?.featureFlags.ws3
+			ws3: $settingsService?.featureFlags.ws3,
+			rules: $settingsService?.featureFlags.rules
 		});
 	});
 </script>


### PR DESCRIPTION
This commit updates the AnalyticsMonitor.svelte component to include the 'rules' feature flag in the eventContext.update call alongside existing flags.