### PR TITLE
feat: add separator render node for Markdown <hr>

### DIFF
--- a/packages/ui/src/lib/components/markdown/MarkdownContent.svelte
+++ b/packages/ui/src/lib/components/markdown/MarkdownContent.svelte
@@ -12,6 +12,7 @@
 	import List from '$components/markdown/markdownRenderers/List.svelte';
 	import ListItem from '$components/markdown/markdownRenderers/ListItem.svelte';
 	import Paragraph from '$components/markdown/markdownRenderers/Paragraph.svelte';
+	import Separator from '$components/markdown/markdownRenderers/Separator.svelte';
 	import Strong from '$components/markdown/markdownRenderers/Strong.svelte';
 	import Text from '$components/markdown/markdownRenderers/Text.svelte';
 	import type { Token } from 'marked';
@@ -34,7 +35,8 @@
 		init: null,
 		br: Br,
 		strong: Strong,
-		em: Em
+		em: Em,
+		hr: Separator
 	};
 
 	const { type, ...rest }: Props = $props();

--- a/packages/ui/src/lib/components/markdown/markdownRenderers/Separator.svelte
+++ b/packages/ui/src/lib/components/markdown/markdownRenderers/Separator.svelte
@@ -1,0 +1,4 @@
+<script lang="ts">
+</script>
+
+<hr />


### PR DESCRIPTION
- Add new Separator.svelte which simply renders an <hr />
- Update MarkdownContent.svelte to import and use Separator for 'hr' nodes from the markdown AST.
- Connect this node to the renderer map so that horizontal rules in Markdown are displayed correctly.
