### PR TITLE
fix: singular and plural wording

### DIFF
--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -86,7 +86,7 @@
 					onclick={openModal}
 					disabled={!projectId || actionsDisabled}
 				>
-					{upstreamCommits} upstream commits
+					{upstreamCommits} upstream {upstreamCommits === 1 ? 'commit' : 'commits'}
 				</Button>
 			{:else}
 				<div class="chrome-you-are-up-to-date">

--- a/apps/desktop/src/components/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/IntegrateUpstreamModal.svelte
@@ -307,7 +307,9 @@
 		{#if base}
 			<div class="section">
 				<h3 class="text-14 text-semibold section-title">
-					<span>Incoming changes</span><Badge>{base.upstreamCommits.length}</Badge>
+					<span>Incoming {base.upstreamCommits.length === 1 ? 'change' : 'changes'}</span><Badge
+						>{base.upstreamCommits.length}</Badge
+					>
 				</h3>
 				<div class="scroll-wrap">
 					<ScrollableContainer maxHeight="16.5rem">


### PR DESCRIPTION
## 🧢 Changes

- fix: singular and plural wording. When there is 1 commit or 1 change, it should use the singular word: `commit` and `change` and not `commits` or `changes`.