### PR TITLE
fix(layout): update setActiveProjectOrRedirect signature

### DIFF
--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -180,7 +180,7 @@
 		clearFetchInterval();
 	});
 
-	async function setActiveProjectOrRedirect() {
+	async function setActiveProjectOrRedirect(projectId: string) {
 		const dontShowAgainKey = `git-filters--dont-show-again--${projectId}`;
 		// Optimistically assume the project is viewable
 		try {
@@ -217,7 +217,7 @@
 	}
 
 	$effect(() => {
-		setActiveProjectOrRedirect();
+		setActiveProjectOrRedirect(projectId);
 	});
 
 	// Clear the backend API when the project id changes.


### PR DESCRIPTION
This commit updates the +layout.svelte file for the project route:
- Changes setActiveProjectOrRedirect to take the projectId arg
- Ensures projectId is passed to setActiveProjectOrRedirect in effect

No other files or logic are changed in this commit.