### PR TITLE
Fix blue background for focused files

### DIFF
--- a/apps/desktop/src/lib/focus/focusManager.svelte.ts
+++ b/apps/desktop/src/lib/focus/focusManager.svelte.ts
@@ -87,7 +87,7 @@ export class FocusManager implements Reactive<Focusable | undefined> {
 			// We listen for events on the document in the bubble phase, giving
 			// other event handlers an opportunity to stop propagation.
 			return mergeUnlisten(
-				on(document, 'click', this.handleMouse),
+				on(document, 'click', this.handleMouse, { capture: true }),
 				on(document, 'keypress', this.handleKeys)
 			);
 		});


### PR DESCRIPTION
Change the click event listener of the focus manager to use the capture 
phase instead of the bubble phase. This ensures the handler runs 
earlier, preventing cancellation by other click handlers.