### PR TITLE
Add new GPT model options

### DIFF
--- a/apps/desktop/src/components/profileSettings/AiSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/AiSettings.svelte
@@ -94,6 +94,14 @@
 
 	const openAIModelOptions = [
 		{
+			label: 'GPT 5',
+			value: OpenAIModelName.GPT5
+		},
+		{
+			label: 'GPT 5 Mini',
+			value: OpenAIModelName.GPT5Mini
+		},
+		{
 			label: 'o3 Mini',
 			value: OpenAIModelName.O3mini
 		},
@@ -102,8 +110,16 @@
 			value: OpenAIModelName.O1mini
 		},
 		{
-			label: 'GPT 4o mini (recommended)',
+			label: 'GPT 4o mini',
 			value: OpenAIModelName.GPT4oMini
+		},
+		{
+			label: 'GPT 4.1',
+			value: OpenAIModelName.GPT4_1
+		},
+		{
+			label: 'GPT 4.1 mini (recommended)',
+			value: OpenAIModelName.GPT4_1Mini
 		}
 	];
 

--- a/apps/desktop/src/lib/ai/types.ts
+++ b/apps/desktop/src/lib/ai/types.ts
@@ -12,6 +12,10 @@ export enum ModelKind {
 export enum OpenAIModelName {
 	O3mini = 'o3-mini',
 	O1mini = 'o1-mini',
+	GPT5 = 'gpt-5',
+	GPT5Mini = 'gpt-5-mini',
+	GPT4_1 = 'gpt-4.1',
+	GPT4_1Mini = 'gpt-4.1-mini',
 	GPT4oMini = 'gpt-4o-mini'
 }
 


### PR DESCRIPTION
- Added new GPT model options including GPT 5, GPT 5 Mini, GPT 4.1, and GPT 4.1 Mini to AiSettings.svelte for selection in the UI.
- Updated OpenAIModelName enum in ai/types.ts to include these new model identifiers.