### PR TITLE
Add `create_reference()` to API to allow putting refs anywhere.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,6 +880,7 @@ dependencies = [
  "gitbutler-sync",
  "gitbutler-user",
  "gix",
+ "insta",
  "open",
  "reqwest 0.12.22",
  "serde",
@@ -5702,6 +5703,7 @@ checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
 dependencies = [
  "console",
  "once_cell",
+ "serde",
  "similar",
 ]
 

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -54,3 +54,7 @@ open = "5.3"
 url = "2.5"
 gitbutler-id.workspace = true
 uuid.workspace = true
+
+[dev-dependencies]
+insta = { version = "1.43.1", features = ["json"]}
+

--- a/crates/but-api/tests/api/commands/mod.rs
+++ b/crates/but-api/tests/api/commands/mod.rs
@@ -1,0 +1,1 @@
+mod stack;

--- a/crates/but-api/tests/api/commands/stack.rs
+++ b/crates/but-api/tests/api/commands/stack.rs
@@ -1,0 +1,83 @@
+mod create_reference {
+    use but_api::commands::stack::create_reference;
+    use but_api::commands::stack::create_reference::{Params, Request};
+    use but_api::hex_hash::HexHash;
+    use but_workspace::branch::ReferencePosition;
+    use gitbutler_project::ProjectId;
+    use std::str::FromStr;
+
+    #[test]
+    fn params_to_json() {
+        let params_no_new_stack = Params {
+            project_id: ProjectId::from_number_for_testing(1),
+            request: Request {
+                new_name: "new-branch".to_string(),
+                anchor: None,
+            },
+        };
+        insta::assert_json_snapshot!(params_no_new_stack, @r#"
+        {
+          "projectId": "00000000-0000-0000-0000-000000000001",
+          "request": {
+            "newName": "new-branch",
+            "anchor": null
+          }
+        }
+        "#);
+
+        let params_dependent_branch_at_commit = Params {
+            project_id: ProjectId::from_number_for_testing(1),
+            request: Request {
+                new_name: "new-branch".to_string(),
+                anchor: Some(create_reference::Anchor::AtCommit {
+                    commit_id: HexHash(
+                        gix::ObjectId::from_str("5c69907b1244089142905dba380371728e2e8160")
+                            .unwrap(),
+                    ),
+                    position: ReferencePosition::Above,
+                }),
+            },
+        };
+        insta::assert_json_snapshot!(params_dependent_branch_at_commit, @r#"
+        {
+          "projectId": "00000000-0000-0000-0000-000000000001",
+          "request": {
+            "newName": "new-branch",
+            "anchor": {
+              "type": "atCommit",
+              "subject": {
+                "commit_id": "5c69907b1244089142905dba380371728e2e8160",
+                "position": "Above"
+              }
+            }
+          }
+        }
+        "#);
+
+        let params_dependent_branch_at_commit = Params {
+            project_id: ProjectId::from_number_for_testing(1),
+            request: Request {
+                new_name: "new-branch".to_string(),
+                anchor: Some(create_reference::Anchor::AtReference {
+                    short_name: "anchor-ref".into(),
+                    position: ReferencePosition::Above,
+                }),
+            },
+        };
+        insta::assert_json_snapshot!(params_dependent_branch_at_commit, @r#"
+        {
+          "projectId": "00000000-0000-0000-0000-000000000001",
+          "request": {
+            "newName": "new-branch",
+            "anchor": {
+              "type": "atReference",
+              "subject": {
+                "short_name": "anchor-ref",
+                "position": "Above"
+              }
+            }
+          }
+        }
+        "#);
+    }
+}

--- a/crates/but-api/tests/api/main.rs
+++ b/crates/but-api/tests/api/main.rs
@@ -1,0 +1,1 @@
+mod commands;

--- a/crates/but-workspace/src/branch/create_reference.rs
+++ b/crates/but-workspace/src/branch/create_reference.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use std::borrow::Cow;
 
 /// For use in [`ReferenceAnchor`].
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub enum ReferencePosition {
     /// The new dependent branch will appear above its anchor.
     Above,

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -243,6 +243,7 @@ fn main() {
                     virtual_branches::integrate_upstream,
                     virtual_branches::resolve_upstream_integration,
                     virtual_branches::find_commit,
+                    stack::create_reference,
                     stack::create_branch,
                     stack::remove_branch,
                     stack::update_branch_name,

--- a/crates/gitbutler-tauri/src/stack.rs
+++ b/crates/gitbutler-tauri/src/stack.rs
@@ -11,6 +11,22 @@ use but_api::error::Error;
 
 #[tauri::command(async)]
 #[instrument(skip(app), err(Debug))]
+pub fn create_reference(
+    app: State<App>,
+    project_id: ProjectId,
+    request: stack::create_reference::Request,
+) -> Result<(), Error> {
+    stack::create_reference(
+        &app,
+        stack::create_reference::Params {
+            project_id,
+            request,
+        },
+    )
+}
+
+#[tauri::command(async)]
+#[instrument(skip(app), err(Debug))]
 pub fn create_branch(
     app: State<App>,
     project_id: ProjectId,


### PR DESCRIPTION
### Tasks

* [x] endpoint in backend
* [x] simplify/flatten types
* [x] ~~types in the frontend at least (or some lifesign that it can work?)~~ I don't think I can do this 😅, definitely worth to stop here and align on the types first.

### Notes for the Reviewer

* Are the nested enums easy enough to handle? The benefit is that only valid operations are representable, but a flat simple structure could also do the trick and the backend can just error if something isn't representable.
    - I decided to flatten the structure to keep typing in the FE simple.
