### PR TITLE
MainViewport: remove AsyncRender wrapper

### DIFF
--- a/apps/desktop/src/components/MainViewport.svelte
+++ b/apps/desktop/src/components/MainViewport.svelte
@@ -211,9 +211,7 @@ the window, then enlarge it and retain the original widths of the layout.
 			parentId: DefinedFocusable.MainViewport
 		}}
 	>
-		<AsyncRender>
-			{@render middle()}
-		</AsyncRender>
+		{@render middle()}
 	</div>
 
 	{#if right}


### PR DESCRIPTION
Remove  the AsyncRender wrapper around the middle slot rendering. 

This *seem* to fix a condition in which the stacks would sometimes not render correctly