### PR TITLE
Handle IME composition correctly in commit title editor

### DIFF
--- a/apps/desktop/src/components/CommitMessageEditor.svelte
+++ b/apps/desktop/src/components/CommitMessageEditor.svelte
@@ -68,6 +68,7 @@
 
 	let composer = $state<ReturnType<typeof MessageEditor>>();
 	let titleInput = $state<HTMLTextAreaElement>();
+	let isComposing = $state(false);
 
 	const suggestionsHandler = new CommitSuggestions(aiService, uiState);
 	const diffInputArgs = $derived<DiffInputContextArgs>(
@@ -165,14 +166,27 @@
 		onchange={(value) => {
 			onChange?.({ title: value });
 		}}
+		oninput={(e: Event) => {
+			if (e instanceof InputEvent) {
+				isComposing = e.isComposing;
+			}
+		}}
 		onkeydown={async (e: KeyboardEvent) => {
+			if (
+				['Enter', 'Escape', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'].includes(e.key) &&
+				isComposing
+			) {
+				e.preventDefault();
+				isComposing = false;
+				return;
+			}
 			if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
 				e.preventDefault();
 				if (title.trim()) {
 					emitAction();
 				}
 			}
-			if (e.key === 'Enter' || (e.key === 'Tab' && !e.shiftKey)) {
+			if ((e.key === 'Enter' || (e.key === 'Tab' && !e.shiftKey)) && !isComposing) {
 				e.preventDefault();
 				composer?.focus();
 			}

--- a/apps/desktop/src/components/CommitMessageEditor.svelte
+++ b/apps/desktop/src/components/CommitMessageEditor.svelte
@@ -17,7 +17,7 @@
 	import { WORKTREE_SERVICE } from '$lib/worktree/worktreeService.svelte';
 	import { inject } from '@gitbutler/core/context';
 	import { Button, TestId } from '@gitbutler/ui';
-	import { IMECompositionHandler } from '@gitbutler/ui/utils/imeHandling';
+	import { IME_COMPOSITION_HANDLER } from '@gitbutler/ui/utils/imeHandling';
 
 	import { tick } from 'svelte';
 
@@ -69,7 +69,7 @@
 
 	let composer = $state<ReturnType<typeof MessageEditor>>();
 	let titleInput = $state<HTMLTextAreaElement>();
-	const imeHandler = new IMECompositionHandler();
+	const imeHandler = inject(IME_COMPOSITION_HANDLER);
 
 	const suggestionsHandler = new CommitSuggestions(aiService, uiState);
 	const diffInputArgs = $derived<DiffInputContextArgs>(

--- a/apps/desktop/src/components/ReviewCreation.svelte
+++ b/apps/desktop/src/components/ReviewCreation.svelte
@@ -36,7 +36,7 @@
 	import { inject } from '@gitbutler/core/context';
 	import { persisted } from '@gitbutler/shared/persisted';
 	import { chipToasts, TestId } from '@gitbutler/ui';
-	import { IMECompositionHandler } from '@gitbutler/ui/utils/imeHandling';
+	import { IME_COMPOSITION_HANDLER } from '@gitbutler/ui/utils/imeHandling';
 	import { isDefined } from '@gitbutler/ui/utils/typeguards';
 	import { tick } from 'svelte';
 
@@ -92,7 +92,7 @@
 
 	let titleInput = $state<HTMLTextAreaElement | undefined>(undefined);
 	let messageEditor = $state<MessageEditor>();
-	const imeHandler = new IMECompositionHandler();
+	const imeHandler = inject(IME_COMPOSITION_HANDLER);
 
 	// AI things
 	const aiGenEnabled = projectAiGenEnabled(projectId);

--- a/apps/desktop/src/components/ReviewCreation.svelte
+++ b/apps/desktop/src/components/ReviewCreation.svelte
@@ -91,6 +91,7 @@
 
 	let titleInput = $state<HTMLTextAreaElement | undefined>(undefined);
 	let messageEditor = $state<MessageEditor>();
+	let isComposing = $state(false);
 
 	// AI things
 	const aiGenEnabled = projectAiGenEnabled(projectId);
@@ -387,7 +388,15 @@
 				prTitle.set(value);
 			}}
 			onkeydown={(e: KeyboardEvent) => {
-				if (e.key === 'Enter' || (e.key === 'Tab' && !e.shiftKey)) {
+				if (
+					['Enter', 'Escape', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'].includes(e.key) &&
+					isComposing
+				) {
+					e.preventDefault();
+					isComposing = false;
+					return;
+				}
+				if ((e.key === 'Enter' || (e.key === 'Tab' && !e.shiftKey)) && !isComposing) {
 					e.preventDefault();
 					messageEditor?.focus();
 				}
@@ -398,7 +407,7 @@
 					return true;
 				}
 
-				if (e.key === 'Escape') {
+				if (e.key === 'Escape' && !isComposing) {
 					e.preventDefault();
 					onClose();
 				}
@@ -408,6 +417,9 @@
 			oninput={(e: Event) => {
 				const target = e.target as HTMLInputElement;
 				prTitle.set(target.value);
+				if (e instanceof InputEvent) {
+					isComposing = e.isComposing;
+				}
 			}}
 		/>
 		<MessageEditor

--- a/apps/desktop/src/lib/bootstrap/deps.ts
+++ b/apps/desktop/src/lib/bootstrap/deps.ts
@@ -82,6 +82,7 @@ import {
 	EXTERNAL_LINK_SERVICE,
 	type ExternalLinkService
 } from '@gitbutler/ui/utils/externalLinkService';
+import { IMECompositionHandler, IME_COMPOSITION_HANDLER } from '@gitbutler/ui/utils/imeHandling';
 import { PUBLIC_API_BASE_URL } from '$env/static/public';
 
 export function initDependencies(args: {
@@ -260,6 +261,7 @@ export function initDependencies(args: {
 	// ============================================================================
 
 	const focusManager = new FocusManager();
+	const imeHandler = new IMECompositionHandler();
 	const reorderDropzoneFactory = new ReorderDropzoneFactory(stackService);
 	const shortcutService = new ShortcutService(backend);
 	const dragStateService = new DragStateService();
@@ -326,6 +328,7 @@ export function initDependencies(args: {
 		[HOOKS_SERVICE, hooksService],
 		[HTTP_CLIENT, httpClient],
 		[ID_SELECTION, idSelection],
+		[IME_COMPOSITION_HANDLER, imeHandler],
 		[IRC_CLIENT, ircClient],
 		[IRC_SERVICE, ircService],
 		[MODE_SERVICE, modeService],

--- a/packages/ui/src/lib/utils/imeHandling.ts
+++ b/packages/ui/src/lib/utils/imeHandling.ts
@@ -1,3 +1,8 @@
+import { InjectionToken } from '@gitbutler/core/context';
+
+export const IME_COMPOSITION_HANDLER: InjectionToken<IMECompositionHandler> =
+	new InjectionToken<IMECompositionHandler>('IMECompositionHandler');
+
 /**
  * IME (Input Method Editor) handling utilities for text input components.
  * This class provides a unified handler to manage IME composition state

--- a/packages/ui/src/lib/utils/imeHandling.ts
+++ b/packages/ui/src/lib/utils/imeHandling.ts
@@ -1,0 +1,82 @@
+/**
+ * IME (Input Method Editor) handling utilities for text input components.
+ * This class provides a unified handler to manage IME composition state
+ * and prevent unintended keyboard shortcuts during text composition in
+ * Japanese, Chinese, Korean, and other languages that require input method editors.
+ */
+export class IMECompositionHandler {
+	private _isComposing = false;
+
+	get isComposing(): boolean {
+		return this._isComposing;
+	}
+
+	setComposing(composing: boolean): void {
+		this._isComposing = composing;
+	}
+
+	reset(): void {
+		this._isComposing = false;
+	}
+
+	/**
+	 * Creates an input event handler that tracks IME composition state
+	 *
+	 * @param originalHandler - Optional original input handler to call
+	 * @returns Input event handler function
+	 */
+	handleInput(originalHandler?: (e: Event) => void) {
+		return (event: Event) => {
+			if (event instanceof InputEvent) {
+				this.setComposing(event.isComposing);
+			}
+
+			originalHandler?.(event);
+		};
+	}
+
+	/**
+	 * Creates a keydown event handler that blocks actions during IME composition
+	 *
+	 * @param originalHandler - Optional original keydown handler to call
+	 * @param additionalBlockingKeys - Additional keys to block during composition
+	 * @returns Keydown event handler function
+	 */
+	handleKeydown(
+		originalHandler?: (event: KeyboardEvent) => void,
+		additionalBlockingKeys: string[] = []
+	) {
+		return (event: KeyboardEvent) => {
+			if (
+				[...IME_BLOCKING_KEYS, ...additionalBlockingKeys].includes(event.key) &&
+				this.isComposing
+			) {
+				event.preventDefault();
+				event.stopPropagation();
+				this.reset();
+				return;
+			}
+
+			originalHandler?.(event);
+		};
+	}
+}
+
+/**
+ * Keys that should be blocked during IME composition to prevent unintended actions
+ */
+const IME_BLOCKING_KEYS = [
+	'Enter',
+	'Escape',
+	'Tab',
+	'0',
+	'1',
+	'2',
+	'3',
+	'4',
+	'5',
+	'6',
+	'7',
+	'8',
+	'9'
+] as const;


### PR DESCRIPTION
## 🧢 Changes

- Fixed IME (Input Method Editor) composition handling in commit title editor for CJK language input
- Added composition state tracking using `InputEvent.isComposing` property
- Implemented workaround for specific key events during IME composition to prevent premature focus shifts

## ☕️ Reasoning

### Background

When typing in Japanese, Chinese, or Korean, users need to press the Enter key to confirm character conversion during IME composition. However, GitButler's commit editor was incorrectly interpreting this Enter key press as a signal to move focus to the next input field, disrupting the text input process.

### Previous Attempt

PR #9615 attempted to fix this by checking the `isComposing` property of keyboard events. However, this solution didn't work properly because WebKit browsers (Safari) incorrectly set `e.isComposing` to `false` when Enter is pressed during IME composition, as discovered in [this comment](https://github.com/gitbutlerapp/gitbutler/issues/9611#issuecomment-3166276083). This led to the revert in #9752.

### Current Solution

This fix tracks the IME composition state using `InputEvent.isComposing` from the `oninput` event and prevents focus changes when:
- Enter key is pressed during active IME composition
- Tab key is pressed during active IME composition

Additionally, it includes a workaround for certain keys (Enter, Escape, number keys) that may terminate IME composition, ensuring the composition state is properly reset.

### Technical Details

- Uses `oninput` event to track `isComposing` state from `InputEvent`
- Checks composition state before processing Enter/Tab navigation keys
- Manually resets composition flag for keys that typically terminate IME input

### Impact

This fix resolves a critical usability issue that has been preventing CJK (Chinese, Japanese, Korean) users from effectively using GitButler. The inability to properly input text in their native languages when writing commit messages was likely a dealbreaker that caused many potential users from these regions to abandon GitButler. With this fix, GitButler becomes truly accessible to millions of developers across East Asia, opening up a significant user base that was previously unable to adopt the tool.

## 🎫 Affected issues

Fixes: #9611