### PR TITLE
butbot Agent - planning and routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,7 +901,9 @@ dependencies = [
  "but-tools",
  "gitbutler-command-context",
  "gitbutler-project",
+ "gix",
  "schemars 0.9.0",
+ "serde",
  "serde_json",
  "uuid",
 ]

--- a/apps/desktop/src/components/FeedItem.svelte
+++ b/apps/desktop/src/components/FeedItem.svelte
@@ -208,9 +208,13 @@
 						</Tooltip>
 					</div>
 				</div>
-				{#each action.toolCalls as toolCall}
-					<FeedItemKind type="tool-call" {projectId} {toolCall} />
-				{/each}
+				{#if action.toolCalls.length > 0}
+					<div class="action-item__content-tool-calls">
+						{#each action.toolCalls as toolCall}
+							<FeedItemKind type="tool-call" {projectId} {toolCall} />
+						{/each}
+					</div>
+				{/if}
 			{/if}
 			<span class="text-14">
 				<Markdown content={action.content} />
@@ -232,9 +236,7 @@
 					</Tooltip>
 				</div>
 			</div>
-			<span class="text-14">
-				<FeedStreamMessage {projectId} message={action} />
-			</span>
+			<FeedStreamMessage {projectId} message={action} />
 		</div>
 	{/if}
 </div>
@@ -300,6 +302,16 @@
 		width: 100%;
 		min-width: 0;
 		gap: 8px;
+	}
+
+	.action-item__content-tool-calls {
+		display: flex;
+		flex-direction: column;
+		padding: 10px;
+		gap: 4px;
+		border: 1px solid var(--clr-border-2);
+
+		border-radius: var(--radius-ml);
 	}
 
 	.action-item__editor-logo {

--- a/apps/desktop/src/components/FeedStreamMessage.svelte
+++ b/apps/desktop/src/components/FeedStreamMessage.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import FeedItemKind from '$components/FeedItemKind.svelte';
-	import { FEED_FACTORY, type InProgressAssistantMessage } from '$lib/feed/feed';
+	import { FEED_FACTORY, type InProgressAssistantMessage, type TodoState } from '$lib/feed/feed';
 	import { inject } from '@gitbutler/shared/context';
-	import { Markdown } from '@gitbutler/ui';
+	import { Icon, Markdown } from '@gitbutler/ui';
 
 	import type { ToolCall } from '$lib/ai/tool';
 
@@ -15,8 +15,10 @@
 
 	const feedFactory = inject(FEED_FACTORY);
 	const feed = $derived(feedFactory.getFeed(projectId));
+
 	let toolCalls = $state<ToolCall[]>(message.toolCalls);
 	let messageContent = $state(message.content);
+	let todos = $state<TodoState[]>(message.todos);
 	const paragraphs = $derived(messageContent.split('\n\n'));
 
 	let bottom = $state<HTMLDivElement>();
@@ -35,6 +37,10 @@
 		}
 	}
 
+	function handleTodoUpdate(list: TodoState[]) {
+		todos = list;
+	}
+
 	$effect(() => {
 		const unsubscribe = feed.subscribeToMessage(message.id, (updatedMessage) => {
 			switch (updatedMessage.type) {
@@ -42,6 +48,8 @@
 					return handleToken(updatedMessage.token);
 				case 'tool-call':
 					return handleToolCall(updatedMessage.toolCall);
+				case 'todo-update':
+					return handleTodoUpdate(updatedMessage.list);
 			}
 		});
 
@@ -51,16 +59,46 @@
 	});
 </script>
 
-<div>
+{#snippet todoItem(todo: TodoState)}
+	<div class="stream-message__todo-item">
+		{#if todo.status === 'in-progress'}
+			<Icon name="spinner" opacity={0.6} />
+		{:else if todo.status === 'success'}
+			<Icon name="success" color="success" opacity={0.6} />
+		{:else if todo.status === 'failed'}
+			<Icon name="error" color="error" opacity={0.6} />
+		{:else if todo.status === 'waiting'}
+			<Icon name="info" opacity={0.6} />
+		{/if}
+		<span class="text-12" class:suceeded={todo.status === 'success'}>{todo.title}</span>
+	</div>
+{/snippet}
+
+{#snippet todoList()}
+	<div class="stream-message__todo-list">
+		{#each todos as todo (todo.id)}
+			{@render todoItem(todo)}
+		{/each}
+	</div>
+{/snippet}
+
+<div class="stream-message text-14">
+	{#if todos.length > 0}
+		{@render todoList()}
+	{/if}
+
 	{#if messageContent === '' && toolCalls.length === 0}
 		<p class="thinking">Thinking...</p>
 	{:else}
 		{#if toolCalls.length > 0}
 			<p class="vibing">Vibing</p>
-			{#each toolCalls as toolCall, index (index)}
-				<FeedItemKind type="tool-call" {projectId} {toolCall} />
-			{/each}
+			<div class="stream-message__tool-calls">
+				{#each toolCalls as toolCall, index (index)}
+					<FeedItemKind type="tool-call" {projectId} {toolCall} />
+				{/each}
+			</div>
 		{/if}
+
 		<div class="text-content">
 			{#each paragraphs as paragraph, index (index)}
 				<Markdown content={paragraph} />
@@ -70,7 +108,39 @@
 	<div bind:this={bottom} style="margin-top: 8px; height: 1px; width: 100%;"></div>
 </div>
 
-<style>
+<style lang="postcss">
+	.stream-message {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.stream-message__todo-list {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.stream-message__todo-item {
+		display: flex;
+		gap: 9px;
+
+		& > span.suceeded {
+			color: var(--clr-text-2);
+			text-decoration: line-through;
+		}
+	}
+
+	.stream-message__tool-calls {
+		display: flex;
+		flex-direction: column;
+		padding: 10px;
+		gap: 8px;
+		border: 1px solid var(--clr-border-2);
+
+		border-radius: var(--radius-ml);
+	}
+
 	.thinking,
 	.vibing {
 		margin: 4px 0;

--- a/crates/but-action/src/grouping.rs
+++ b/crates/but-action/src/grouping.rs
@@ -1,11 +1,10 @@
 use std::{fmt::Debug, str};
 
-use async_openai::types::{ChatCompletionRequestSystemMessage, ChatCompletionRequestUserMessage};
 use but_tools::workspace::ProjectStatus;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{OpenAiProvider, openai};
+use crate::{ChatMessage, OpenAiProvider, openai};
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub enum BranchSuggestion {
@@ -97,13 +96,11 @@ pub fn group(openai: &OpenAiProvider, project_status: &ProjectStatus) -> anyhow:
         serialized_project_status
     );
 
-    let messages = vec![
-        ChatCompletionRequestSystemMessage::from(system_message).into(),
-        ChatCompletionRequestUserMessage::from(user_message).into(),
-    ];
+    let messages = vec![ChatMessage::User(user_message)];
 
-    let grouping = openai::structured_output_blocking::<Grouping>(openai, messages)?
-        .ok_or_else(|| anyhow::anyhow!("Failed to get grouping from OpenAI"))?;
+    let grouping =
+        openai::structured_output_blocking::<Grouping>(openai, system_message, messages)?
+            .ok_or_else(|| anyhow::anyhow!("Failed to get grouping from OpenAI"))?;
 
     Ok(grouping)
 }

--- a/crates/but-action/src/lib.rs
+++ b/crates/but-action/src/lib.rs
@@ -34,7 +34,8 @@ pub use action::Source;
 pub use action::list_actions;
 use but_graph::VirtualBranchesTomlMetadata;
 pub use openai::{
-    ChatMessage, ToolCallContent, ToolResponseContent, tool_calling_loop, tool_calling_loop_stream,
+    ChatMessage, ToolCallContent, ToolResponseContent, structured_output_blocking,
+    tool_calling_loop, tool_calling_loop_stream,
 };
 use strum::EnumString;
 use uuid::Uuid;

--- a/crates/but-action/src/lib.rs
+++ b/crates/but-action/src/lib.rs
@@ -33,7 +33,9 @@ pub use action::ActionListing;
 pub use action::Source;
 pub use action::list_actions;
 use but_graph::VirtualBranchesTomlMetadata;
-pub use openai::{ChatMessage, ToolCallContent, ToolResponseContent, tool_calling_loop_stream};
+pub use openai::{
+    ChatMessage, ToolCallContent, ToolResponseContent, tool_calling_loop, tool_calling_loop_stream,
+};
 use strum::EnumString;
 use uuid::Uuid;
 pub use workflow::WorkflowList;
@@ -128,7 +130,7 @@ pub fn freestyle(
             (emitter)(&name, payload);
         }
     });
-    let response = crate::openai::tool_calling_loop_stream(
+    let (response, _) = crate::openai::tool_calling_loop_stream(
         openai,
         system_message,
         internal_chat_messages,
@@ -137,7 +139,7 @@ pub fn freestyle(
         on_token_cb,
     )?;
 
-    Ok(response.unwrap_or_default())
+    Ok(response)
 }
 
 pub fn absorb(

--- a/crates/but-bot/Cargo.toml
+++ b/crates/but-bot/Cargo.toml
@@ -11,9 +11,11 @@ test = false
 
 [dependencies]
 schemars = "0.9.0"
+serde = { workspace = true, features = ["std"] }
 serde_json = "1.0.142"
 anyhow = "1.0.98"
 uuid.workspace = true
+gix.workspace = true
 but-tools.workspace = true
 but-action.workspace = true
 gitbutler-command-context.workspace = true

--- a/crates/but-bot/src/agent.rs
+++ b/crates/but-bot/src/agent.rs
@@ -1,398 +1,44 @@
-use but_action::OpenAiProvider;
-use but_tools::emit::Emittable;
-use gitbutler_command_context::CommandContext;
-use gitbutler_project::ProjectId;
+pub enum AgentGraphNode {
+    CreateTodos,
+    ExecuteTodo,
+    Done(String),
+}
 
-use crate::state::{AgentState, Todo};
+pub struct AgentGraph {
+    current_node: AgentGraphNode,
+}
+
+impl Default for AgentGraph {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AgentGraph {
+    pub fn new() -> Self {
+        Self {
+            current_node: AgentGraphNode::CreateTodos,
+        }
+    }
+
+    pub fn start(&mut self, agent: &mut dyn Agent) -> anyhow::Result<String> {
+        loop {
+            match self.current_node {
+                AgentGraphNode::CreateTodos => {
+                    self.current_node = agent.create_todos()?;
+                }
+                AgentGraphNode::ExecuteTodo => {
+                    self.current_node = agent.execute_todo()?;
+                }
+                AgentGraphNode::Done(ref response) => {
+                    return Ok(response.clone());
+                }
+            }
+        }
+    }
+}
 
 pub trait Agent {
-    fn evaluate(&mut self, chat_messages: Vec<but_action::ChatMessage>) -> anyhow::Result<String>;
-}
-
-const MODEL: &str = "gpt-4.1";
-
-const SYS_PROMPT: &str = "
-You are a GitButler agent that can perform various actions on a Git project.
-Your name is ButBot. Your main goal is to help the user with handling file changes in the project.
-Use the tools provided to you to perform the actions and respond with a summary of the action you've taken.
-Don't be too verbose, but be thorough and outline everything you did.
-
-### Core concepts
-- **Project**: A Git repository that has been initialized with GitButler.
-- **Stack**: A collection of dependent branches that are used to manage changes in the project. With GitButler (as opposed to normal Git), multiple stacks can be applied at the same time.
-- **Branch**: A pointer to a specific commit in the project. Branches can contain multiple commits. Commits are always listed newest to oldest.
-- **Commit**: A snapshot of the project at a specific point in time.
-- **File changes**: A set of changes made to the files in the project. This can include additions, deletions, and modifications of files. The user can assign these changes to stacks to keep things ordering.
-- **Lock**: A lock or dependency on a file change. This refers to the fact that certain uncommitted file changes can only be committed to a specific stack.
-    This is because the uncommitted changes were done on top of previously committed file changes that are part of the stack.
-
-### Main task
-Please, take a look at the provided prompt and the project status below, and perform the actions you think are necessary.
-In order to do that, please follow these steps:
-    1. Take a look at the prompt and reflect on what the intention of the user is.
-    2. Take a look at the project status and see what changes are present in the project. It's important to understand what stacks and branche are present, and what the file changes are.
-    3. Try to correlate the prompt with the project status and determine what actions you can take to help the user.
-    4. Use the tools provided to you to perform the actions.
-
-### Capabilities
-You can generally perform the normal Git operations, such as creating branches and committing to them.
-You can also perform more advanced operations, such as:
-- `absorb`: Take a set of file changes and amend them into the existing commits in the project.
-    This requires you to figure out where the changes should go based on the locks, assingments and any other user provided information.
-- `split a commit`: Take an existing commit and split it into multiple commits based on the the user directive.
-    This can be achieved by using the `split_commit` tool.
-- `split a branch`: Take an existing branch and split it into two branches. This basically takes a set of committed file changes and moves them to a new branch, removing them from the original branch.
-    This is useful when you want to separate the changes into a new branch for further work.
-    In order to do this, you will need to get the branch changes for the intended source branch (call the `get_branch_changes` tool), and then call the split branch tool with the changes you want to split off.
-
-### Important notes
-- Only perform the action on the file changes specified in the prompt.
-- If the prompt is not clear, ask the user for clarification.
-- When told to commit to the existing branch, commit to the applied stack-branch. Don't create a new branch unless explicitly asked to do so.
-";
-
-pub struct ButBot<'a> {
-    state: AgentState,
-    ctx: &'a mut CommandContext,
-    emitter: std::sync::Arc<but_tools::emit::Emitter>,
-    message_id: String,
-    project_id: ProjectId,
-    openai: &'a OpenAiProvider,
-}
-
-impl<'a> ButBot<'a> {
-    pub fn new(
-        ctx: &'a mut CommandContext,
-        emitter: std::sync::Arc<but_tools::emit::Emitter>,
-        message_id: String,
-        project_id: ProjectId,
-        openai: &'a OpenAiProvider,
-    ) -> Self {
-        Self {
-            state: AgentState::new(project_id, message_id.clone(), emitter.clone()),
-            ctx,
-            emitter,
-            message_id,
-            project_id,
-            openai,
-        }
-    }
-
-    /// Update the agent's state and the provided todos.
-    ///
-    /// Based on the provided chat messages and the project status, this function will
-    /// update the agent's internal todo list.
-    pub fn update_state(
-        &mut self,
-        chat_messages: Vec<but_action::ChatMessage>,
-    ) -> anyhow::Result<()> {
-        let repo = self.ctx.gix_repo()?;
-        let project_status = but_tools::workspace::get_project_status(self.ctx, &repo, None)?;
-        let serialized_status = serde_json::to_string_pretty(&project_status)
-            .map_err(|e| anyhow::anyhow!("Failed to serialize project status: {}", e))?;
-
-        let conversation = chat_messages
-            .iter()
-            .map(|msg| msg.to_string())
-            .collect::<Vec<_>>()
-            .join("\n\n");
-
-        let request = format!(
-            "
-Alright, let's create the plan for what the user wants to do.
-The plan should be based on the user request found in the conversation below.
-Add items to the todo list based on the plan.
-Reference relevant resources from the project status (e.g. branches, commits, file changes) when creating the todo items.
-
-<CONVERSATION>
-{}
-</CONVERSATION>
-",
-            conversation
-        );
-
-        let internal_chat_messages: Vec<but_action::ChatMessage> = vec![
-            but_action::ChatMessage::ToolCall(but_action::ToolCallContent {
-                id: "project_status".to_string(),
-                name: "get_project_status".to_string(),
-                arguments: "{\"filterChanges\": null}".to_string(),
-            }),
-            but_action::ChatMessage::ToolResponse(but_action::ToolResponseContent {
-                id: "project_status".to_string(),
-                result: serialized_status,
-            }),
-            but_action::ChatMessage::User(request),
-        ];
-
-        but_action::tool_calling_loop(
-            self.openai,
-            &self.state.sys_prompt.clone(),
-            internal_chat_messages,
-            &mut self.state,
-            Some(MODEL.to_string()),
-        )?;
-
-        Ok(())
-    }
-
-    /// Update the status of a todo item based on the conversation and project status.
-    ///
-    /// Will take a look a the conversation and the project status, and update the status of the todo item.
-    /// This also updates the todo list, adding new todos if necessary.
-    pub fn update_todo_status(
-        &mut self,
-        chat_messages: Vec<but_action::ChatMessage>,
-        todo: Todo,
-    ) -> anyhow::Result<()> {
-        let repo = self.ctx.gix_repo()?;
-        let project_status = but_tools::workspace::get_project_status(self.ctx, &repo, None)?;
-        let serialized_status = serde_json::to_string_pretty(&project_status)
-            .map_err(|e| anyhow::anyhow!("Failed to serialize project status: {}", e))?;
-
-        let conversation = chat_messages
-            .iter()
-            .map(|msg| msg.to_string())
-            .collect::<Vec<_>>()
-            .join("\n\n");
-
-        let request = format!(
-            "
-Based on the conversation below and the project status, please update the status of the todo item.
-
-<TODO_ITEM_TO_UPDATE>
-{}
-</TODO_ITEM_TO_UPDATE>
-
-
-<CONVERSATION>
-{}
-</CONVERSATION>
-",
-            todo, conversation
-        );
-
-        let internal_chat_messages: Vec<but_action::ChatMessage> = vec![
-            but_action::ChatMessage::ToolCall(but_action::ToolCallContent {
-                id: "project_status".to_string(),
-                name: "get_project_status".to_string(),
-                arguments: "{\"filterChanges\": null}".to_string(),
-            }),
-            but_action::ChatMessage::ToolResponse(but_action::ToolResponseContent {
-                id: "project_status".to_string(),
-                result: serialized_status,
-            }),
-            but_action::ChatMessage::User(request),
-        ];
-
-        but_action::tool_calling_loop(
-            self.openai,
-            &self.state.sys_prompt.clone(),
-            internal_chat_messages,
-            &mut self.state,
-            Some(MODEL.to_string()),
-        )?;
-
-        Ok(())
-    }
-
-    /// This is the workspace loop. This handles the main workspace actions.
-    fn workspace_loop(
-        &mut self,
-        chat_messages: Vec<but_action::ChatMessage>,
-    ) -> anyhow::Result<String> {
-        let repo = self.ctx.gix_repo()?;
-        let project_status = but_tools::workspace::get_project_status(self.ctx, &repo, None)?;
-        let serialized_status = serde_json::to_string_pretty(&project_status)
-            .map_err(|e| anyhow::anyhow!("Failed to serialize project status: {}", e))?;
-
-        let mut toolset = but_tools::workspace::workspace_toolset(
-            self.ctx,
-            self.emitter.clone(),
-            self.message_id.clone(),
-        );
-
-        let mut internal_chat_messages = chat_messages;
-
-        // Add the project status to the chat messages.
-        internal_chat_messages.push(but_action::ChatMessage::ToolCall(
-            but_action::ToolCallContent {
-                id: "project_status".to_string(),
-                name: "get_project_status".to_string(),
-                arguments: "{\"filterChanges\": null}".to_string(),
-            },
-        ));
-
-        internal_chat_messages.push(but_action::ChatMessage::ToolResponse(
-            but_action::ToolResponseContent {
-                id: "project_status".to_string(),
-                result: serialized_status,
-            },
-        ));
-
-        // Now we trigger the tool calling loop.
-        let message_id_cloned = self.message_id.clone();
-        let project_id_cloned = self.project_id;
-        let on_token_cb: std::sync::Arc<dyn Fn(&str) + Send + Sync + 'static> =
-            std::sync::Arc::new({
-                let emitter = self.emitter.clone();
-                let message_id = message_id_cloned;
-                let project_id = project_id_cloned;
-                move |token: &str| {
-                    let token_update = but_tools::emit::TokenUpdate {
-                        token: token.to_string(),
-                        project_id,
-                        message_id: message_id.clone(),
-                    };
-                    let (name, payload) = token_update.emittable();
-                    (emitter)(&name, payload);
-                }
-            });
-
-        let (response, _) = but_action::tool_calling_loop_stream(
-            self.openai,
-            SYS_PROMPT,
-            internal_chat_messages,
-            &mut toolset,
-            Some(MODEL.to_string()),
-            on_token_cb,
-        )?;
-
-        Ok(response)
-    }
-
-    /// Given a todo, execute the action.
-    ///
-    /// This function will take the todo item, the chat messages, and the project status,
-    /// and execute the action specified in the todo item.
-    fn execute_todo(
-        &mut self,
-        chat_messages: Vec<but_action::ChatMessage>,
-        todo: Todo,
-    ) -> anyhow::Result<(String, Vec<but_action::ChatMessage>)> {
-        let repo = self.ctx.gix_repo()?;
-        let project_status = but_tools::workspace::get_project_status(self.ctx, &repo, None)?;
-        let serialized_status = serde_json::to_string_pretty(&project_status)
-            .map_err(|e| anyhow::anyhow!("Failed to serialize project status: {}", e))?;
-
-        let mut toolset = but_tools::workspace::workspace_toolset(
-            self.ctx,
-            self.emitter.clone(),
-            self.message_id.clone(),
-        );
-
-        let mut internal_chat_messages = chat_messages;
-
-        let todos = self.state.list_todos();
-
-        let request = format!(
-            "
-<TODO_DIRECTIVE>
-{}
-
-Keep your response short please.
-Also, keep in mind all the todos done and upcoming:
-<ALL_CURRENT_TODOS>
-{}
-</ALL_CURRENT_TODOS>
-</TODO_DIRECTIVE>
-",
-            todo.as_prompt(),
-            todos
-        );
-
-        internal_chat_messages.push(but_action::ChatMessage::User(request));
-
-        // Add the project status to the chat messages.
-        internal_chat_messages.push(but_action::ChatMessage::ToolCall(
-            but_action::ToolCallContent {
-                id: "project_status".to_string(),
-                name: "get_project_status".to_string(),
-                arguments: "{\"filterChanges\": null}".to_string(),
-            },
-        ));
-
-        internal_chat_messages.push(but_action::ChatMessage::ToolResponse(
-            but_action::ToolResponseContent {
-                id: "project_status".to_string(),
-                result: serialized_status,
-            },
-        ));
-
-        // Now we trigger the tool calling loop.
-        let message_id_cloned = self.message_id.clone();
-        let project_id_cloned = self.project_id;
-        let on_token_cb: std::sync::Arc<dyn Fn(&str) + Send + Sync + 'static> =
-            std::sync::Arc::new({
-                let emitter = self.emitter.clone();
-                let message_id = message_id_cloned;
-                let project_id = project_id_cloned;
-                move |token: &str| {
-                    let token_update = but_tools::emit::TokenUpdate {
-                        token: token.to_string(),
-                        project_id,
-                        message_id: message_id.clone(),
-                    };
-                    let (name, payload) = token_update.emittable();
-                    (emitter)(&name, payload);
-                }
-            });
-
-        let (response, messages) = but_action::tool_calling_loop_stream(
-            self.openai,
-            SYS_PROMPT,
-            internal_chat_messages,
-            &mut toolset,
-            Some(MODEL.to_string()),
-            on_token_cb,
-        )?;
-
-        // Remove the injected project status tool calls and responses from the messages.
-        internal_chat_messages = messages
-            .into_iter()
-            .filter(|msg| match msg {
-                but_action::ChatMessage::ToolCall(tool_call) => tool_call.id != "project_status",
-                but_action::ChatMessage::ToolResponse(tool_response) => {
-                    tool_response.id != "project_status"
-                }
-                _ => true,
-            })
-            .collect();
-
-        // Emit a new like
-        let end_token_update = but_tools::emit::TokenEnd {
-            project_id: self.project_id,
-            message_id: self.message_id.clone(),
-        };
-        let (end_name, end_payload) = end_token_update.emittable();
-        (self.emitter)(&end_name, end_payload);
-
-        Ok((response, internal_chat_messages))
-    }
-}
-
-impl Agent for ButBot<'_> {
-    fn evaluate(&mut self, chat_messages: Vec<but_action::ChatMessage>) -> anyhow::Result<String> {
-        self.update_state(chat_messages.clone())?;
-        if self.state.nothig_to_do() {
-            return self.workspace_loop(chat_messages.clone());
-        }
-
-        let mut internal_chat_messages = chat_messages.clone();
-        let mut text_response_buffer = vec![];
-
-        while let Some(todo) = self.state.next_todo() {
-            let (text_response, messages) =
-                self.execute_todo(internal_chat_messages.clone(), todo.clone())?;
-
-            internal_chat_messages = messages;
-
-            text_response_buffer.push(text_response);
-
-            self.update_todo_status(internal_chat_messages.clone(), todo)?;
-        }
-
-        let final_response = text_response_buffer.join("\n\n---\n\n");
-
-        Ok(final_response)
-    }
+    fn create_todos(&mut self) -> anyhow::Result<AgentGraphNode>;
+    fn execute_todo(&mut self) -> anyhow::Result<AgentGraphNode>;
 }

--- a/crates/but-bot/src/agent.rs
+++ b/crates/but-bot/src/agent.rs
@@ -1,4 +1,5 @@
 pub enum AgentGraphNode {
+    Route,
     CreateTodos,
     ExecuteTodo,
     Done(String),
@@ -17,13 +18,16 @@ impl Default for AgentGraph {
 impl AgentGraph {
     pub fn new() -> Self {
         Self {
-            current_node: AgentGraphNode::CreateTodos,
+            current_node: AgentGraphNode::Route,
         }
     }
 
     pub fn start(&mut self, agent: &mut dyn Agent) -> anyhow::Result<String> {
         loop {
             match self.current_node {
+                AgentGraphNode::Route => {
+                    self.current_node = agent.route()?;
+                }
                 AgentGraphNode::CreateTodos => {
                     self.current_node = agent.create_todos()?;
                 }
@@ -39,6 +43,7 @@ impl AgentGraph {
 }
 
 pub trait Agent {
+    fn route(&mut self) -> anyhow::Result<AgentGraphNode>;
     fn create_todos(&mut self) -> anyhow::Result<AgentGraphNode>;
     fn execute_todo(&mut self) -> anyhow::Result<AgentGraphNode>;
 }

--- a/crates/but-bot/src/agent.rs
+++ b/crates/but-bot/src/agent.rs
@@ -69,7 +69,7 @@ impl<'a> ButBot<'a> {
         openai: &'a OpenAiProvider,
     ) -> Self {
         Self {
-            state: AgentState::default(),
+            state: AgentState::new(project_id, message_id.clone(), emitter.clone()),
             ctx,
             emitter,
             message_id,

--- a/crates/but-bot/src/butbot.rs
+++ b/crates/but-bot/src/butbot.rs
@@ -1,0 +1,399 @@
+use but_action::OpenAiProvider;
+use but_tools::emit::Emittable;
+use gitbutler_command_context::CommandContext;
+use gitbutler_project::ProjectId;
+
+use crate::{
+    agent::{Agent, AgentGraphNode},
+    state::{AgentState, Todo},
+};
+
+const MODEL: &str = "gpt-4.1";
+
+const SYS_PROMPT: &str = "
+You are a GitButler agent that can perform various actions on a Git project.
+Your name is ButBot. Your main goal is to help the user with handling file changes in the project.
+Use the tools provided to you to perform the actions and respond with a summary of the action you've taken.
+Don't be too verbose, but be thorough and outline everything you did.
+
+### Core concepts
+- **Project**: A Git repository that has been initialized with GitButler.
+- **Stack**: A collection of dependent branches that are used to manage changes in the project. With GitButler (as opposed to normal Git), multiple stacks can be applied at the same time.
+- **Branch**: A pointer to a specific commit in the project. Branches can contain multiple commits. Commits are always listed newest to oldest.
+- **Commit**: A snapshot of the project at a specific point in time.
+- **File changes**: A set of changes made to the files in the project. This can include additions, deletions, and modifications of files. The user can assign these changes to stacks to keep things ordering.
+- **Lock**: A lock or dependency on a file change. This refers to the fact that certain uncommitted file changes can only be committed to a specific stack.
+    This is because the uncommitted changes were done on top of previously committed file changes that are part of the stack.
+
+### Main task
+Please, take a look at the provided prompt and the project status below, and perform the actions you think are necessary.
+In order to do that, please follow these steps:
+    1. Take a look at the prompt and reflect on what the intention of the user is.
+    2. Take a look at the project status and see what changes are present in the project. It's important to understand what stacks and branche are present, and what the file changes are.
+    3. Try to correlate the prompt with the project status and determine what actions you can take to help the user.
+    4. Use the tools provided to you to perform the actions.
+
+### Capabilities
+You can generally perform the normal Git operations, such as creating branches and committing to them.
+You can also perform more advanced operations, such as:
+- `absorb`: Take a set of file changes and amend them into the existing commits in the project.
+    This requires you to figure out where the changes should go based on the locks, assingments and any other user provided information.
+- `split a commit`: Take an existing commit and split it into multiple commits based on the the user directive.
+    This can be achieved by using the `split_commit` tool.
+- `split a branch`: Take an existing branch and split it into two branches. This basically takes a set of committed file changes and moves them to a new branch, removing them from the original branch.
+    This is useful when you want to separate the changes into a new branch for further work.
+    In order to do this, you will need to get the branch changes for the intended source branch (call the `get_branch_changes` tool), and then call the split branch tool with the changes you want to split off.
+
+### Good practices
+- Small commits are better than large commits. Try to keep commits focused (4-5 file changes at most unless otherwise specified).
+- Assume that all commits should be made to the same branch, unless the user specifies otherwise.
+- If the user asks you to commit to a specific branch, make sure to commit to that branch only.
+
+### Important notes
+- Only perform the action on the file changes specified in the prompt.
+- If the prompt is not clear, ask the user for clarification.
+- When told to commit to the existing branch, commit to the applied stack-branch. Don't create a new branch unless explicitly asked to do so.
+";
+
+pub struct ButBot<'a> {
+    state: AgentState,
+    ctx: &'a mut CommandContext,
+    emitter: std::sync::Arc<but_tools::emit::Emitter>,
+    message_id: String,
+    project_id: ProjectId,
+    openai: &'a OpenAiProvider,
+    chat_messages: Vec<but_action::ChatMessage>,
+    text_response_buffer: Vec<String>,
+}
+
+impl<'a> ButBot<'a> {
+    pub fn new(
+        ctx: &'a mut CommandContext,
+        emitter: std::sync::Arc<but_tools::emit::Emitter>,
+        message_id: String,
+        project_id: ProjectId,
+        openai: &'a OpenAiProvider,
+        chat_messages: Vec<but_action::ChatMessage>,
+    ) -> Self {
+        Self {
+            state: AgentState::new(project_id, message_id.clone(), emitter.clone()),
+            ctx,
+            emitter,
+            message_id,
+            project_id,
+            openai,
+            chat_messages,
+            text_response_buffer: vec![],
+        }
+    }
+
+    /// Update the agent's state and the provided todos.
+    ///
+    /// Based on the provided chat messages and the project status, this function will
+    /// update the agent's internal todo list.
+    pub fn update_state(&mut self) -> anyhow::Result<()> {
+        let repo = self.ctx.gix_repo()?;
+        let project_status = but_tools::workspace::get_project_status(self.ctx, &repo, None)?;
+        let serialized_status = serde_json::to_string_pretty(&project_status)
+            .map_err(|e| anyhow::anyhow!("Failed to serialize project status: {}", e))?;
+
+        let conversation = self
+            .chat_messages
+            .iter()
+            .map(|msg| msg.to_string())
+            .collect::<Vec<_>>()
+            .join("\n\n");
+
+        let request = format!(
+            "
+Alright, let's create the plan for what the user wants to do.
+The plan should be based on the user request found in the conversation below.
+Add items to the todo list based on the plan.
+Reference relevant resources from the project status (e.g. branches, commits, file changes) when creating the todo items.
+
+<CONVERSATION>
+{}
+</CONVERSATION>
+",
+            conversation
+        );
+
+        let internal_chat_messages: Vec<but_action::ChatMessage> = vec![
+            but_action::ChatMessage::ToolCall(but_action::ToolCallContent {
+                id: "project_status".to_string(),
+                name: "get_project_status".to_string(),
+                arguments: "{\"filterChanges\": null}".to_string(),
+            }),
+            but_action::ChatMessage::ToolResponse(but_action::ToolResponseContent {
+                id: "project_status".to_string(),
+                result: serialized_status,
+            }),
+            but_action::ChatMessage::User(request),
+        ];
+
+        but_action::tool_calling_loop(
+            self.openai,
+            &self.state.sys_prompt.clone(),
+            internal_chat_messages,
+            &mut self.state,
+            Some(MODEL.to_string()),
+        )?;
+
+        Ok(())
+    }
+
+    /// Update the status of a todo item based on the conversation and project status.
+    ///
+    /// Will take a look a the conversation and the project status, and update the status of the todo item.
+    /// This also updates the todo list, adding new todos if necessary.
+    pub fn update_todo_status(&mut self, todo: &Todo) -> anyhow::Result<()> {
+        let repo = self.ctx.gix_repo()?;
+        let project_status = but_tools::workspace::get_project_status(self.ctx, &repo, None)?;
+        let serialized_status = serde_json::to_string_pretty(&project_status)
+            .map_err(|e| anyhow::anyhow!("Failed to serialize project status: {}", e))?;
+
+        let conversation = self
+            .chat_messages
+            .iter()
+            .map(|msg| msg.to_string())
+            .collect::<Vec<_>>()
+            .join("\n\n");
+
+        let request = format!(
+            "
+Based on the conversation below and the project status, please update the status of the todo item.
+
+<TODO_ITEM_TO_UPDATE>
+{}
+</TODO_ITEM_TO_UPDATE>
+
+
+<CONVERSATION>
+{}
+</CONVERSATION>
+",
+            todo, conversation
+        );
+
+        let internal_chat_messages: Vec<but_action::ChatMessage> = vec![
+            but_action::ChatMessage::ToolCall(but_action::ToolCallContent {
+                id: "project_status".to_string(),
+                name: "get_project_status".to_string(),
+                arguments: "{\"filterChanges\": null}".to_string(),
+            }),
+            but_action::ChatMessage::ToolResponse(but_action::ToolResponseContent {
+                id: "project_status".to_string(),
+                result: serialized_status,
+            }),
+            but_action::ChatMessage::User(request),
+        ];
+
+        but_action::tool_calling_loop(
+            self.openai,
+            &self.state.sys_prompt.clone(),
+            internal_chat_messages,
+            &mut self.state,
+            Some(MODEL.to_string()),
+        )?;
+
+        Ok(())
+    }
+
+    /// This is the workspace loop. This handles the main workspace actions.
+    fn workspace_loop(&mut self) -> anyhow::Result<String> {
+        let repo = self.ctx.gix_repo()?;
+        let project_status = but_tools::workspace::get_project_status(self.ctx, &repo, None)?;
+        let serialized_status = serde_json::to_string_pretty(&project_status)
+            .map_err(|e| anyhow::anyhow!("Failed to serialize project status: {}", e))?;
+
+        let mut toolset = but_tools::workspace::workspace_toolset(
+            self.ctx,
+            self.emitter.clone(),
+            self.message_id.clone(),
+        );
+
+        let mut internal_chat_messages = self.chat_messages.clone();
+
+        // Add the project status to the chat messages.
+        internal_chat_messages.push(but_action::ChatMessage::ToolCall(
+            but_action::ToolCallContent {
+                id: "project_status".to_string(),
+                name: "get_project_status".to_string(),
+                arguments: "{\"filterChanges\": null}".to_string(),
+            },
+        ));
+
+        internal_chat_messages.push(but_action::ChatMessage::ToolResponse(
+            but_action::ToolResponseContent {
+                id: "project_status".to_string(),
+                result: serialized_status,
+            },
+        ));
+
+        // Now we trigger the tool calling loop.
+        let message_id_cloned = self.message_id.clone();
+        let project_id_cloned = self.project_id;
+        let on_token_cb: std::sync::Arc<dyn Fn(&str) + Send + Sync + 'static> =
+            std::sync::Arc::new({
+                let emitter = self.emitter.clone();
+                let message_id = message_id_cloned;
+                let project_id = project_id_cloned;
+                move |token: &str| {
+                    let token_update = but_tools::emit::TokenUpdate {
+                        token: token.to_string(),
+                        project_id,
+                        message_id: message_id.clone(),
+                    };
+                    let (name, payload) = token_update.emittable();
+                    (emitter)(&name, payload);
+                }
+            });
+
+        let (response, _) = but_action::tool_calling_loop_stream(
+            self.openai,
+            SYS_PROMPT,
+            internal_chat_messages,
+            &mut toolset,
+            Some(MODEL.to_string()),
+            on_token_cb,
+        )?;
+
+        Ok(response)
+    }
+
+    /// Given a todo, execute the action.
+    ///
+    /// This function will take the todo item, the chat messages, and the project status,
+    /// and execute the action specified in the todo item.
+    fn execute_todo(
+        &mut self,
+        todo: &Todo,
+    ) -> anyhow::Result<(String, Vec<but_action::ChatMessage>)> {
+        let repo = self.ctx.gix_repo()?;
+        let project_status = but_tools::workspace::get_project_status(self.ctx, &repo, None)?;
+        let serialized_status = serde_json::to_string_pretty(&project_status)
+            .map_err(|e| anyhow::anyhow!("Failed to serialize project status: {}", e))?;
+
+        let mut toolset = but_tools::workspace::workspace_toolset(
+            self.ctx,
+            self.emitter.clone(),
+            self.message_id.clone(),
+        );
+
+        let mut internal_chat_messages = self.chat_messages.clone();
+
+        let request = format!(
+            "
+<TODO_DIRECTIVE>
+<TODO>
+{}
+</TODO>
+
+<IMPORTANT_NOTES>
+Keep your response short please.
+Follow best practices.
+ONLY perform the actions that are necessary to complete the todo item above.
+If you need to perform investigations, do so, and be detailed in your findings. Don't perform actions.
+If you need to perform actions, do so, and be concise in the description of the actions.
+</IMPORTANT_NOTES>
+</TODO_DIRECTIVE>
+",
+            todo.as_prompt()
+        );
+
+        internal_chat_messages.push(but_action::ChatMessage::User(request));
+
+        // Add the project status to the chat messages.
+        internal_chat_messages.push(but_action::ChatMessage::ToolCall(
+            but_action::ToolCallContent {
+                id: "project_status".to_string(),
+                name: "get_project_status".to_string(),
+                arguments: "{\"filterChanges\": null}".to_string(),
+            },
+        ));
+
+        internal_chat_messages.push(but_action::ChatMessage::ToolResponse(
+            but_action::ToolResponseContent {
+                id: "project_status".to_string(),
+                result: serialized_status,
+            },
+        ));
+
+        // Now we trigger the tool calling loop.
+        let message_id_cloned = self.message_id.clone();
+        let project_id_cloned = self.project_id;
+        let on_token_cb: std::sync::Arc<dyn Fn(&str) + Send + Sync + 'static> =
+            std::sync::Arc::new({
+                let emitter = self.emitter.clone();
+                let message_id = message_id_cloned;
+                let project_id = project_id_cloned;
+                move |token: &str| {
+                    let token_update = but_tools::emit::TokenUpdate {
+                        token: token.to_string(),
+                        project_id,
+                        message_id: message_id.clone(),
+                    };
+                    let (name, payload) = token_update.emittable();
+                    (emitter)(&name, payload);
+                }
+            });
+
+        let (response, messages) = but_action::tool_calling_loop_stream(
+            self.openai,
+            SYS_PROMPT,
+            internal_chat_messages,
+            &mut toolset,
+            Some(MODEL.to_string()),
+            on_token_cb,
+        )?;
+
+        // Remove the injected project status tool calls and responses from the messages.
+        internal_chat_messages = messages
+            .into_iter()
+            .filter(|msg| match msg {
+                but_action::ChatMessage::ToolCall(tool_call) => tool_call.id != "project_status",
+                but_action::ChatMessage::ToolResponse(tool_response) => {
+                    tool_response.id != "project_status"
+                }
+                _ => true,
+            })
+            .collect();
+
+        // Emit a new like
+        let end_token_update = but_tools::emit::TokenEnd {
+            project_id: self.project_id,
+            message_id: self.message_id.clone(),
+        };
+        let (end_name, end_payload) = end_token_update.emittable();
+        (self.emitter)(&end_name, end_payload);
+
+        Ok((response, internal_chat_messages))
+    }
+}
+
+impl Agent for ButBot<'_> {
+    fn create_todos(&mut self) -> anyhow::Result<AgentGraphNode> {
+        self.update_state()?;
+
+        if self.state.nothig_to_do() {
+            let response = self.workspace_loop()?;
+            Ok(AgentGraphNode::Done(response))
+        } else {
+            Ok(AgentGraphNode::ExecuteTodo)
+        }
+    }
+
+    fn execute_todo(&mut self) -> anyhow::Result<AgentGraphNode> {
+        if let Some(todo) = self.state.next_todo() {
+            println!("Executing todo: {}", todo.clone().as_prompt());
+            let (text_response, messages) = self.execute_todo(&todo)?;
+            self.chat_messages = messages;
+            self.text_response_buffer.push(text_response);
+            self.update_todo_status(&todo)?;
+            Ok(AgentGraphNode::ExecuteTodo)
+        } else {
+            let final_response = self.text_response_buffer.join("\n\n---\n\n");
+            Ok(AgentGraphNode::Done(final_response))
+        }
+    }
+}

--- a/crates/but-bot/src/lib.rs
+++ b/crates/but-bot/src/lib.rs
@@ -3,9 +3,11 @@ use but_tools::emit::Emitter;
 use gitbutler_command_context::CommandContext;
 use gitbutler_project::ProjectId;
 
+mod butbot;
 mod state;
 
-use crate::agent::{Agent, ButBot};
+use crate::agent::AgentGraph;
+use crate::butbot::ButBot;
 
 pub mod agent;
 
@@ -17,6 +19,7 @@ pub fn bot(
     openai: &OpenAiProvider,
     chat_messages: Vec<but_action::ChatMessage>,
 ) -> anyhow::Result<String> {
-    let mut but_bot = ButBot::new(ctx, emitter, message_id, project_id, openai);
-    but_bot.evaluate(chat_messages)
+    let mut but_bot = ButBot::new(ctx, emitter, message_id, project_id, openai, chat_messages);
+    let mut graph = AgentGraph::default();
+    graph.start(&mut but_bot)
 }

--- a/crates/but-bot/src/lib.rs
+++ b/crates/but-bot/src/lib.rs
@@ -3,6 +3,8 @@ use but_tools::emit::Emitter;
 use gitbutler_command_context::CommandContext;
 use gitbutler_project::ProjectId;
 
+mod state;
+
 use crate::agent::{Agent, ButBot};
 
 pub mod agent;

--- a/crates/but-bot/src/state.rs
+++ b/crates/but-bot/src/state.rs
@@ -1,0 +1,353 @@
+use std::{collections::BTreeMap, fmt::Display};
+
+use but_tools::tool::{Tool, Toolset};
+use gitbutler_command_context::CommandContext;
+use gix::ObjectId;
+use schemars::{JsonSchema, schema_for};
+use serde_json::json;
+
+const SYS_PROMPT: &str = "
+You are a GitButler agent that can perform various actions on a Git project.
+Your name is ButBot. Your main goal is to determine the set of steps needed to complete the user's request.
+ONLY UPDATE THE STATE IF THERE ARE USER REQUESTS PENDING OR IF THERE ARE TODOS TO BE UPDATED.
+
+### Core concepts
+- **Project**: A Git repository that has been initialized with GitButler.
+- **Stack**: A collection of dependent branches that are used to manage changes in the project. With GitButler (as opposed to normal Git), multiple stacks can be applied at the same time.
+- **Branch**: A pointer to a specific commit in the project. Branches can contain multiple commits. Commits are always listed newest to oldest.
+- **Commit**: A snapshot of the project at a specific point in time.
+- **File changes**: A set of changes made to the files in the project. This can include additions, deletions, and modifications of files. The user can assign these changes to stacks to keep things ordering.
+- **Lock**: A lock or dependency on a file change. This refers to the fact that certain uncommitted file changes can only be committed to a specific stack.
+    This is because the uncommitted changes were done on top of previously committed file changes that are part of the stack.
+
+### Main task
+Based on the provided conversation, the project status and any existinf todos, update the list of todos.
+Take a look at your capabilities in order to populate the todo list.
+Ideally, before todos that perform actions, you should add todos with clear planning steps, leveraging the tools like ('get_branch_changes', and 'get_commit_details') to gather the necessary information.
+
+### Capabilities
+You can generally perform the normal Git operations, such as creating branches and committing to them.
+You can also perform more advanced operations, such as:
+- `absorb`: Take a set of file changes and amend them into the existing commits in the project.
+    This requires you to figure out where the changes should go based on the locks, assingments and any other user provided information.
+- `split a commit`: Take an existing commit and split it into multiple commits based on the the user directive.
+    This can be achieved by using the `split_commit` tool.
+- `split a branch`: Take an existing branch and split it into two branches. This basically takes a set of committed file changes and moves them to a new branch, removing them from the original branch.
+    This is useful when you want to separate the changes into a new branch for further work.
+    In order to do this, you will need to get the branch changes for the intended source branch (call the `get_branch_changes` tool), and then call the split branch tool with the changes you want to split off.
+
+### Good practices
+- Small commits are better than large commits. Try to keep commits focused (4-5 file changes at most unless otherwise specified).
+- Assume that all commits should be made to the same branch, unless the user specifies otherwise.
+- If the user asks you to commit to a specific branch, make sure to commit to that branch only.
+
+### Important notes
+- Only add items to the list if there's a clear user request to perform an action.
+- Only add items to the todo list that are relevant to the user's request.
+- Update the todo list depending on the project status.
+- If there are todos that seem outdated based onf the project status, or user messages, update them accordingly.
+- Only respond with 'done'.
+";
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum TodoStatus {
+    Waiting,
+    InProgress,
+    Success { message: String },
+    Failed { message: String },
+}
+
+impl Display for TodoStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TodoStatus::Waiting => write!(f, "Waiting"),
+            TodoStatus::InProgress => write!(f, "InProgress"),
+            TodoStatus::Success { message } => write!(f, "Success({})", message),
+            TodoStatus::Failed { message } => write!(f, "Failed({})", message),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Todo {
+    pub id: uuid::Uuid,
+    pub title: String,
+    pub description: String,
+    pub status: TodoStatus,
+}
+
+impl Display for Todo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Todo(\nid: {},\ntitle: {},\ndescription: {:?},\nstatus: {}\n)",
+            self.id, self.title, self.description, self.status
+        )
+    }
+}
+
+impl Todo {
+    pub fn new(title: String, description: String) -> Self {
+        Self {
+            id: uuid::Uuid::new_v4(),
+            title,
+            description,
+            status: TodoStatus::Waiting,
+        }
+    }
+
+    pub fn set_status(&mut self, status: TodoStatus) {
+        self.status = status;
+    }
+
+    pub fn as_prompt(&self) -> String {
+        format!(
+            "Please complete the following todo: {}\nDescription: {}\nStatus: {}",
+            self.title, self.description, self.status
+        )
+    }
+}
+
+pub struct AgentState {
+    pub todos: Vec<Todo>,
+    pub sys_prompt: String,
+    tools: BTreeMap<String, std::sync::Arc<dyn Tool>>,
+}
+
+impl Default for AgentState {
+    fn default() -> Self {
+        let mut state = AgentState {
+            todos: Vec::new(),
+            sys_prompt: SYS_PROMPT.to_string(),
+            tools: BTreeMap::new(),
+        };
+
+        state.register_tool(AddTodos);
+        state.register_tool(UpdateTodoStatus);
+
+        state
+    }
+}
+
+impl AgentState {
+    pub fn nothig_to_do(&self) -> bool {
+        self.todos.is_empty()
+    }
+
+    pub fn add_todo(&mut self, title: String, description: String) -> &Todo {
+        let todo = Todo::new(title, description);
+        self.todos.push(todo);
+        self.todos.last().unwrap()
+    }
+
+    pub fn update_todo_status(&mut self, id: uuid::Uuid, status: TodoStatus) -> Result<(), String> {
+        match self.todos.iter_mut().find(|todo| todo.id == id) {
+            Some(todo) => {
+                todo.set_status(status);
+                Ok(())
+            }
+            None => Err("Todo not found".to_string()),
+        }
+    }
+
+    pub fn next_todo(&mut self) -> Option<Todo> {
+        let next_todo = self
+            .todos
+            .iter_mut()
+            .find(|todo| matches!(todo.status, TodoStatus::Waiting | TodoStatus::InProgress));
+
+        next_todo.map(|todo| {
+            todo.set_status(TodoStatus::InProgress);
+            todo.to_owned()
+        })
+    }
+
+    fn call_tool_inner(
+        &mut self,
+        name: &str,
+        parameters: &str,
+    ) -> anyhow::Result<serde_json::Value> {
+        let params: serde_json::Value = serde_json::from_str(parameters)
+            .map_err(|e| anyhow::anyhow!("Failed to parse parameters: {}", e))?;
+        let state_tool = AgentStateTool::try_from((name, params))?;
+
+        match state_tool {
+            AgentStateTool::AddTodos(params) => {
+                for todo in params.todos {
+                    self.add_todo(todo.title, todo.description);
+                }
+
+                Ok(json!({"status": "success", "message": "Todos added successfully"}))
+            }
+            AgentStateTool::UpdateTodoStatus(params) => {
+                let uuid = uuid::Uuid::parse_str(&params.id)
+                    .map_err(|e| anyhow::anyhow!("Failed to parse UUID: {}", e))?;
+                self.update_todo_status(uuid, params.status)
+                    .map_err(|e| anyhow::anyhow!("Failed to update todo status: {}", e))?;
+
+                Ok(json!({"status": "success", "message": "Todo status updated successfully"}))
+            }
+        }
+    }
+}
+
+impl Toolset for AgentState {
+    fn register_tool<T: Tool>(&mut self, tool: T) {
+        self.tools.insert(tool.name(), std::sync::Arc::new(tool));
+    }
+
+    fn get(&self, name: &str) -> Option<std::sync::Arc<dyn Tool>> {
+        self.tools.get(name).cloned()
+    }
+
+    fn list(&self) -> Vec<std::sync::Arc<dyn Tool>> {
+        self.tools.values().cloned().collect()
+    }
+
+    fn call_tool(&mut self, name: &str, parameters: &str) -> serde_json::Value {
+        self.call_tool_inner(name, parameters).unwrap_or_else(|e| {
+            serde_json::json!({
+                "error": format!("Failed to call tool '{}': {}", name, e.to_string())
+            })
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+enum AgentStateTool {
+    AddTodos(AddTodosParamters),
+    UpdateTodoStatus(UpdateTodoStatusParameters),
+}
+
+impl TryFrom<(&str, serde_json::Value)> for AgentStateTool {
+    type Error = anyhow::Error;
+
+    fn try_from(value: (&str, serde_json::Value)) -> Result<Self, Self::Error> {
+        match value.0 {
+            "add_todos" => {
+                let params: AddTodosParamters = serde_json::from_value(value.1)
+                    .map_err(|e| anyhow::anyhow!("Failed to parse parameters: {}", e))?;
+                Ok(AgentStateTool::AddTodos(params))
+            }
+            "update_todo_status" => {
+                let params: UpdateTodoStatusParameters = serde_json::from_value(value.1)
+                    .map_err(|e| anyhow::anyhow!("Failed to parse parameters: {}", e))?;
+                Ok(AgentStateTool::UpdateTodoStatus(params))
+            }
+            _ => Err(anyhow::anyhow!("Unknown tool: {}", value.0)),
+        }
+    }
+}
+
+pub struct AddTodos;
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TodoDescription {
+    /// The title of the todo item.
+    #[schemars(description = "
+    <description>Title of the todo item</description>
+
+    <important_notes>
+        This is a brief title that summarizes the todo item.
+        It should be concise and descriptive.
+    </important_notes>
+    ")]
+    title: String,
+    /// A detailed description of the todo item.
+    #[schemars(description = "
+    <description>The description of the todo</description>
+
+    <important_notes>
+        This should provide more context about the todo item.
+        Mention any specific requirements and relevant resources (branch names, commit ids, files etc.).
+        It should have a clear defintion of done.
+        Keep the description to under 1000 characters.
+    </important_notes>
+    ")]
+    description: String,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AddTodosParamters {
+    /// The list of todos to add.
+    #[schemars(description = "
+    <description>List of todos to add</description>
+
+    <important_notes>
+        Each todo should have a title and a description.
+        The description should be clear and concise.
+        Prefer using multiple todos for different tasks, with clear objectives.
+    </important_notes>
+    ")]
+    pub todos: Vec<TodoDescription>,
+}
+
+impl Tool for AddTodos {
+    fn name(&self) -> String {
+        "add_todos".to_string()
+    }
+
+    fn description(&self) -> String {
+        "Adds todos to the agent's state".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        schema_for!(AddTodosParamters).into()
+    }
+
+    fn call(
+        self: std::sync::Arc<Self>,
+        _: serde_json::Value,
+        _: &mut CommandContext,
+        _: std::sync::Arc<but_tools::emit::Emitter>,
+        _: &mut std::collections::HashMap<ObjectId, ObjectId>,
+    ) -> anyhow::Result<serde_json::Value> {
+        Err(anyhow::anyhow!(
+            "The tool AddTodos doesn't support contextual calls."
+        ))
+    }
+}
+
+pub struct UpdateTodoStatus;
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateTodoStatusParameters {
+    /// The id of the todo item to update.
+    #[schemars(description = "The UUID of the todo item to update.")]
+    pub id: String,
+    /// The new status for the todo item.
+    #[schemars(
+        description = "The new status for the todo item. One of: Waiting, InProgress, Success, Failed. If Success or Failed, provide a message."
+    )]
+    pub status: TodoStatus,
+}
+
+impl Tool for UpdateTodoStatus {
+    fn name(&self) -> String {
+        "update_todo_status".to_string()
+    }
+
+    fn description(&self) -> String {
+        "Updates the status of a todo item in the agent's state".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        schema_for!(UpdateTodoStatusParameters).into()
+    }
+
+    fn call(
+        self: std::sync::Arc<Self>,
+        _: serde_json::Value,
+        _: &mut CommandContext,
+        _: std::sync::Arc<but_tools::emit::Emitter>,
+        _: &mut std::collections::HashMap<ObjectId, ObjectId>,
+    ) -> anyhow::Result<serde_json::Value> {
+        Err(anyhow::anyhow!(
+            "The tool UpdateTodoStatus doesn't support contextual calls."
+        ))
+    }
+}

--- a/crates/but-tools/src/emit.rs
+++ b/crates/but-tools/src/emit.rs
@@ -72,3 +72,32 @@ impl Emittable for TokenEnd {
         (name, payload)
     }
 }
+
+pub struct TodoState {
+    pub id: String,
+    pub title: String,
+    pub status: String,
+}
+
+pub struct TodoUpdate {
+    pub project_id: ProjectId,
+    pub message_id: String,
+    pub list: Vec<TodoState>,
+}
+
+impl Emittable for TodoUpdate {
+    fn emittable(&self) -> (String, serde_json::Value) {
+        let name = format!("project://{}/todo-updates", self.project_id);
+        let payload = serde_json::json!({
+            "messageId": self.message_id,
+            "list": self.list.iter().map(|todo| {
+                serde_json::json!({
+                    "id": todo.id,
+                    "title": todo.title,
+                    "status": todo.status,
+                })
+            }).collect::<Vec<_>>(),
+        });
+        (name, payload)
+    }
+}

--- a/crates/but-tools/src/emit.rs
+++ b/crates/but-tools/src/emit.rs
@@ -56,3 +56,19 @@ impl Emittable for TokenUpdate {
         (name, payload)
     }
 }
+
+pub struct TokenEnd {
+    pub project_id: ProjectId,
+    pub message_id: String,
+}
+
+impl Emittable for TokenEnd {
+    fn emittable(&self) -> (String, serde_json::Value) {
+        let name = format!("project://{}/token-updates", self.project_id);
+        let payload = serde_json::json!({
+            "messageId": self.message_id,
+            "token": "\n\n---\n\n"
+        });
+        (name, payload)
+    }
+}


### PR DESCRIPTION
Summary
- Introduce planning-first agent workflow and routing support so the agent plans todos before executing actions.
- Emit agent state (todo list) to frontend and stream/display todos in the feed.
- Add Agent graph routing node to choose between Simple and Planning workflows.
- Refactor but-action/openai modules to support planning lifecycle, conversation/message buffering, and system/user separation.
- Add state management (todos), event emission, and orchestration for state-driven execution.

What changed
- Agent: new plan-then-execute structure, AgentState todos, emit() to stream todo updates, and updated event emission.
- Routing: AgentGraph and AgentGraphNode::Route, Agent.route() + ButBot route selection (ButBotRoute/RouteResponse).
- Frontend: feed stream handling for todo-update events and UI to show streamed todo list.
- but-action / openai: enhanced helpers, conversation transformation, buffered assistant messages, structured_output_blocking signature change (system + messages), and revised tool_calling_loop logic.
- Refactors: agent graph usage for staged flows and preparation for state-driven todo/plan execution architecture.
