### PR TITLE
Update AccountLink navigation to use newSettingsPath

### DIFF
--- a/apps/desktop/src/components/AccountLink.svelte
+++ b/apps/desktop/src/components/AccountLink.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { newSettingsPath } from '$lib/routes/routes.svelte';
 	import { USER } from '$lib/user/user';
 	import { inject } from '@gitbutler/shared/context';
 	import { Icon } from '@gitbutler/ui';
@@ -18,7 +19,7 @@
 	type="button"
 	class="btn"
 	class:pop
-	onclick={async () => await goto('/settings/')}
+	onclick={async () => goto(newSettingsPath())}
 	class:collapsed={isNavCollapsed}
 >
 	{#if !isNavCollapsed}


### PR DESCRIPTION
Don’t use the outdated settings path anymore

Changed the AccountLink.svelte component to import newSettingsPath from $lib/routes/routes.svelte and updated the navigation click handler to use this newSettingsPath function instead of the static '/settings/' path.

fixes https://github.com/gitbutlerapp/gitbutler/issues/9760