### PR TITLE
Update chat model to gpt-5-mini

### DIFF
--- a/crates/but-action/src/generate.rs
+++ b/crates/but-action/src/generate.rs
@@ -62,7 +62,7 @@ pub async fn commit_message(
     };
 
     let request = CreateChatCompletionRequestArgs::default()
-        .model("gpt-4o")
+        .model("gpt-5-mini")
         .messages([
             ChatCompletionRequestSystemMessage::from(system_message).into(),
             ChatCompletionRequestUserMessage::from(user_message).into(),
@@ -143,7 +143,7 @@ pub async fn branch_name(
     };
 
     let request = CreateChatCompletionRequestArgs::default()
-        .model("gpt-4o")
+        .model("gpt-5-mini")
         .messages([
             ChatCompletionRequestSystemMessage::from(system_message).into(),
             ChatCompletionRequestUserMessage::from(user_message).into(),


### PR DESCRIPTION
Changed the AI model used for the generation of commit messages and branch names requests in crates/but-action/src/generate.rs from "gpt-4o" to "gpt-5-mini".