### PR TITLE
Rename 'reference' to 'dependent branch' everywhere in context menus

### DIFF
--- a/apps/desktop/cypress/e2e/branchActions.cy.ts
+++ b/apps/desktop/cypress/e2e/branchActions.cy.ts
@@ -104,32 +104,6 @@ describe('Branch Actions', () => {
 		// The branch should be removed from the list header
 		cy.getByTestId('branch-header', mockBackend.localOnlyBranchStackId).should('not.exist');
 	});
-
-	it('should be able to add a dependent branch from the context menu', () => {
-		const dependentBranchName = 'dependent-branch-name';
-		// Click on the branch.
-		// And then open the context menu.
-		cy.getByTestId('branch-header', mockBackend.localOnlyBranchStackId)
-			.should('be.visible')
-			.click()
-			.rightclick();
-
-		// The context menu should be visible
-		cy.getByTestId('branch-header-context-menu').should('be.visible');
-		cy.getByTestId('branch-header-context-menu-add-dependent-branch').should('be.visible').click();
-
-		// The add dependent branch dialog should be visible
-		cy.getByTestId('branch-header-add-dependent-branch-modal')
-			.should('be.visible')
-			.within(() => {
-				// Add the dependent branch
-				cy.get('input[type="text"]').should('be.visible').type(dependentBranchName);
-			});
-
-		cy.getByTestId('branch-header-add-dependent-branch-modal-action-button')
-			.should('be.visible')
-			.click();
-	});
 });
 
 describe('Branch Actions - single branch with uncommitted changes', () => {

--- a/apps/desktop/src/components/BranchHeaderContextMenu.svelte
+++ b/apps/desktop/src/components/BranchHeaderContextMenu.svelte
@@ -170,25 +170,6 @@
 	>
 		{@const { branch, prNumber, first, stackLength } = contextData}
 		{@const branchName = branch.name}
-		{#if first && stackId}
-			<ContextMenuSection>
-				<ContextMenuItem
-					label="Add dependent branch"
-					testId={TestId.BranchHeaderContextMenu_AddDependentBranch}
-					onclick={async () => {
-						addDependentBranchModalContext = {
-							projectId,
-							stackId
-						};
-
-						await tick();
-
-						addDependentBranchModal?.show();
-						close();
-					}}
-				/>
-			</ContextMenuSection>
-		{/if}
 		<ContextMenuSection>
 			{#if branch.remoteTrackingBranch}
 				<ContextMenuItem
@@ -213,15 +194,16 @@
 		{#if stackId}
 			<ContextMenuSection>
 				<ContextMenuItem
-					label="Create reference above"
+					label="Create dependent branch above"
 					disabled={refCreation.current.isLoading}
+					testId={TestId.BranchHeaderContextMenu_AddDependentBranch}
 					onclick={async () => {
 						await handleCreateNewRef(stackId, 'Above');
 						close();
 					}}
 				/>
 				<ContextMenuItem
-					label="Create reference below"
+					label="Create dependent branch below"
 					disabled={refCreation.current.isLoading}
 					onclick={async () => {
 						await handleCreateNewRef(stackId, 'Below');

--- a/apps/desktop/src/components/CommitContextMenu.svelte
+++ b/apps/desktop/src/components/CommitContextMenu.svelte
@@ -213,7 +213,7 @@
 				</ContextMenuSection>
 				<ContextMenuSection>
 					<ContextMenuItem
-						label="Create reference above"
+						label="Create dependent branch above"
 						disabled={refCreation.current.isLoading}
 						onclick={async () => {
 							await handleCreateNewRef(stackId, commitId, 'Above');
@@ -221,7 +221,7 @@
 						}}
 					/>
 					<ContextMenuItem
-						label="Create reference below"
+						label="Create dependent branch below"
 						disabled={refCreation.current.isLoading}
 						onclick={async () => {
 							await handleCreateNewRef(stackId, commitId, 'Below');


### PR DESCRIPTION
Rename all UI labels and menu items that used the term 'reference' to now use 'dependent branch', for consistency with updated terminology. This affects both CommitContextMenu.svelte and BranchHeaderContextMenu.svelte.

- In CommitContextMenu.svelte: replaced 'Create reference above/below' with 'Create dependent branch above/below'.
- In BranchHeaderContextMenu.svelte: made the same label changes and removed the obsolete 'Add dependent branch' menu item.