### PR TITLE
rules-realtime-notify-filters

### DIFF
--- a/apps/desktop/src/components/RuleFiltersEditor.svelte
+++ b/apps/desktop/src/components/RuleFiltersEditor.svelte
@@ -57,13 +57,25 @@
 		return orderValue === maxOrderValue;
 	}
 
+	function isFilterTypeReady(type: RuleFilterType): boolean {
+		switch (type) {
+			case 'pathMatchesRegex':
+				return pathRegex !== undefined && pathRegex.trim() !== '';
+			case 'contentMatchesRegex':
+				return contentRegex !== undefined && contentRegex.trim() !== '';
+			case 'fileChangeType':
+				return treeChangeType !== undefined;
+			case 'semanticType':
+				// For now, user defined is not considered ready
+				return semanticType !== undefined && semanticType !== 'userDefined';
+			case 'claudeCodeSessionId':
+				return claudeCodeSessionId !== undefined && claudeCodeSessionId.trim() !== '';
+		}
+	}
+
 	function areDraftRuleFiltersReady(types: RuleFilterType[]): boolean {
 		for (const type of types) {
-			if (type === 'pathMatchesRegex' && !pathRegex) return false;
-			if (type === 'contentMatchesRegex' && !contentRegex) return false;
-			if (type === 'fileChangeType' && !treeChangeType) return false;
-			if (type === 'semanticType' && !semanticType) return false;
-			if (type === 'claudeCodeSessionId' && !claudeCodeSessionId) return false;
+			if (!isFilterTypeReady(type)) return false;
 		}
 		return true;
 	}
@@ -190,7 +202,11 @@
 
 <!-- Claude Code Session ID -->
 {#snippet claudeCodeSessionIdFilter()}
-	{claudeCodeSessionId}
+	<div class="rule__pill">
+		<span class="text-13 truncate">
+			{claudeCodeSessionId}
+		</span>
+	</div>
 {/snippet}
 
 <!-- This is the parent component,
@@ -209,29 +225,31 @@
 			{@render claudeCodeSessionIdFilter()}
 		{/if}
 
-		<div class="rule-filter-row__actions">
-			<Button
-				icon="bin"
-				size="cta"
-				class="rule-filter-row__button"
-				kind="ghost"
-				width="auto"
-				onclick={() => {
-					deleteFilter(type);
-				}}
-			/>
-			{#if isLastFilterType(type) && canAddMore}
+		{#if type !== 'claudeCodeSessionId'}
+			<div class="rule-filter-row__actions">
 				<Button
-					bind:el={addFilterButton}
-					class="rule-filter-row__button"
-					width="auto"
-					icon="plus"
+					icon="bin"
 					size="cta"
+					class="rule-filter-row__button"
 					kind="ghost"
-					onclick={handleAddFilter}
+					width="auto"
+					onclick={() => {
+						deleteFilter(type);
+					}}
 				/>
-			{/if}
-		</div>
+				{#if isLastFilterType(type) && canAddMore}
+					<Button
+						bind:el={addFilterButton}
+						class="rule-filter-row__button"
+						width="auto"
+						icon="plus"
+						size="cta"
+						kind="ghost"
+						onclick={handleAddFilter}
+					/>
+				{/if}
+			</div>
+		{/if}
 	</div>
 {/snippet}
 
@@ -278,6 +296,15 @@
 	.rule-filter-row__actions {
 		display: flex;
 		align-items: center;
+	}
+	.rule__pill {
+		display: flex;
+		align-items: center;
+		height: var(--size-tag);
+		padding: 0 6px;
+		gap: 6px;
+		border: 1px solid var(--clr-border-2);
+		border-radius: 100px;
 	}
 
 	:global(.rule-filter-row .rule-filter-row__button) {

--- a/apps/desktop/src/components/RulesList.svelte
+++ b/apps/desktop/src/components/RulesList.svelte
@@ -11,7 +11,8 @@
 		type StackTarget,
 		encodeStackTarget,
 		decodeStackTarget,
-		compareStackTarget
+		compareStackTarget,
+		type RuleFilter
 	} from '$lib/rules/rule';
 	import { RULES_SERVICE } from '$lib/rules/rulesService.svelte';
 	import { getStackName } from '$lib/stacks/stack';
@@ -97,6 +98,26 @@
 		resetEditor();
 	}
 
+	function updateInitialValues(filter: RuleFilter, initialValues: Partial<RuleFilterMap>): true {
+		switch (filter.type) {
+			case 'pathMatchesRegex':
+				initialValues.pathMatchesRegex = filter.subject;
+				return true;
+			case 'contentMatchesRegex':
+				initialValues.contentMatchesRegex = filter.subject;
+				return true;
+			case 'fileChangeType':
+				initialValues.fileChangeType = filter.subject;
+				return true;
+			case 'semanticType':
+				initialValues.semanticType = filter.subject;
+				return true;
+			case 'claudeCodeSessionId':
+				initialValues.claudeCodeSessionId = filter.subject;
+				return true;
+		}
+	}
+
 	async function editExistingRule(rule: WorkspaceRule) {
 		if (rule.action.type === 'implicit') {
 			chipToasts.error('Cannot edit implicit rules');
@@ -114,23 +135,7 @@
 		const initialValues: Partial<RuleFilterMap> = {};
 
 		for (const filter of rule.filters) {
-			switch (filter.type) {
-				case 'pathMatchesRegex':
-					initialValues.pathMatchesRegex = filter.subject;
-					break;
-				case 'contentMatchesRegex':
-					initialValues.contentMatchesRegex = filter.subject;
-					break;
-				case 'fileChangeType':
-					initialValues.fileChangeType = filter.subject;
-					break;
-				case 'semanticType':
-					initialValues.semanticType = filter.subject;
-					break;
-				case 'claudeCodeSessionId':
-					initialValues.claudeCodeSessionId = filter.subject;
-					break;
-			}
+			updateInitialValues(filter, initialValues);
 		}
 
 		draftRuleFilterInitialValues = initialValues;
@@ -219,7 +224,7 @@
 </div>
 
 {#snippet ruleListContent()}
-	{@const rules = rulesService.listWorkspaceRules(projectId)}
+	{@const rules = rulesService.workspaceRules(projectId)}
 	<ReduxResult {projectId} result={rules.current}>
 		{#snippet children(rules)}
 			{#if rules.length > 0}

--- a/crates/gitbutler-tauri/src/window.rs
+++ b/crates/gitbutler-tauri/src/window.rs
@@ -95,6 +95,13 @@ pub(crate) mod state {
                         }),
                         project_id,
                     },
+                    ItemKind::Rules => ChangeForFrontend {
+                        name: format!("project://{}/rule-updates", project_id),
+                        payload: serde_json::json!({
+                            "kind": "rules"
+                        }),
+                        project_id,
+                    },
                     _ => {
                         tracing::warn!("Unhandled ItemKind in ChangeForFrontend: {:?}", item);
                         ChangeForFrontend {


### PR DESCRIPTION
- Backend DB watcher and Tauri integration now emit rule-updates events for Rules item kind
- Frontend listens to rule-updates events and invalidates cache on rules DB changes
- More robust handling of rule filter types, including special pill/action behavior for session UUID (claudeCodeSessionId)
- Improved UI/UX for rule filter entry, display, and operations