### PR TITLE
Fix WS3 auto-toggle logic and set performed flag

### DIFF
--- a/apps/desktop/src/lib/config/appSettingsV2.ts
+++ b/apps/desktop/src/lib/config/appSettingsV2.ts
@@ -62,8 +62,11 @@ export class SettingsService {
 		try {
 			const response = await this.tauri.invoke<AppSettings>('get_app_settings');
 			const performedAutoToggle = getStorageItem(WS3_AUTO_TOGGLE) ?? false;
-			if (response.featureFlags.ws3 || performedAutoToggle) {
-				// If the WS3 feature flag is already enabled, or if we have already performed the auto toggle,
+			// If the auto toggle has already been performed, we do not need to do it again.
+			if (performedAutoToggle) return;
+			if (response.featureFlags.ws3) {
+				// If the WS3 feature flag is already enabled, set the flag and do not toggle it again.
+				setStorageItem(WS3_AUTO_TOGGLE, true);
 				return;
 			}
 


### PR DESCRIPTION
Updated appSettingsV2.ts to change WS3 auto-toggle behavior:

- Early return if the auto toggle has already been performed (checks performedAutoToggle and returns).
- If WS3 feature flag is already enabled, set WS3_AUTO_TOGGLE storage flag to true and return, preventing unnecessary toggles.
- Adjusted surrounding comments for clarity.
