### PR TITLE
Emit hunk assignment updates as distinct event

### DIFF
--- a/apps/desktop/src/lib/feed/feed.ts
+++ b/apps/desktop/src/lib/feed/feed.ts
@@ -43,7 +43,7 @@ export default class FeedFactory {
 }
 
 type DBEvent = {
-	kind: 'actions' | 'workflows' | 'hunk-assignments' | 'unknown';
+	kind: 'actions' | 'workflows' | 'unknown';
 	item?: string;
 };
 
@@ -238,7 +238,6 @@ class Feed {
 				this.updateCombinedFeed();
 				return;
 			}
-			case 'hunk-assignments':
 			case 'unknown': {
 				// Do nothing for now, as we are not handling these events.
 				return;

--- a/crates/gitbutler-tauri/src/window.rs
+++ b/crates/gitbutler-tauri/src/window.rs
@@ -89,7 +89,7 @@ pub(crate) mod state {
                         project_id,
                     },
                     ItemKind::Assignments => ChangeForFrontend {
-                        name: format!("project://{}/db-updates", project_id),
+                        name: format!("project://{}/hunk-assignment-update", project_id),
                         payload: serde_json::json!({
                             "kind": "hunk-assignments"
                         }),


### PR DESCRIPTION
Make the hunk assignment database updates emit their own event. Update the backend to emit 'hunk-assignment-update' instead of bundling with other DB updates, and update the frontend to listen for and handle these events so stacks can update correctly.
