### PR TITLE
popped-lane-preview

### DIFF
--- a/apps/desktop/src/components/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/WorktreeChanges.svelte
@@ -182,7 +182,7 @@
 		display: flex;
 		align-items: center;
 		width: 100%;
-		height: 42px;
+		min-height: 42px;
 		padding: 0 10px 0 14px;
 		gap: 6px;
 		border-bottom: 1px solid var(--clr-border-2);

--- a/packages/ui/src/lib/components/scroll/ScrollableContainer.svelte
+++ b/packages/ui/src/lib/components/scroll/ScrollableContainer.svelte
@@ -116,7 +116,7 @@
 	>
 		<div
 			class="hide-native-scrollbar"
-			style:height={childrenWrapHeight}
+			style:min-height={childrenWrapHeight}
 			style:display={childrenWrapDisplay}
 		>
 			{@render children()}


### PR DESCRIPTION
What changed
- Rendered details view as an absolutely positioned element to create an unfolded lane layout and keep the scrollbar on the right side of the whole lane.
- Adjusted div structure and right margin to prevent the scrollbar from appearing between sections.
- Simplified the details view resizer: removed complex resizing logic since only the changes list remains resizable and other sections use remaining space or fit content.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #9806 
- <kbd>&nbsp;1&nbsp;</kbd> #9805 👈 
<!-- GitButler Footer Boundary Bottom -->

