### PR TITLE
Assure VirtualBranches based metadata can't be used in a racy fashion.

### DIFF
--- a/crates/but-api/src/commands/diff.rs
+++ b/crates/but-api/src/commands/diff.rs
@@ -100,7 +100,8 @@ fn changes_in_branch_inner(
     remote: Option<String>,
     branch_name: String,
 ) -> anyhow::Result<TreeChanges> {
-    let (repo, _meta, graph) = ctx.graph_and_meta(ctx.gix_repo()?)?;
+    let guard = ctx.project().shared_worktree_access();
+    let (repo, _meta, graph) = ctx.graph_and_meta(ctx.gix_repo()?, guard.read_permission())?;
     let name = if let Some(remote) = remote {
         Category::RemoteBranch.to_full_name(format!("{remote}/{branch_name}").as_str())
     } else {


### PR DESCRIPTION
Currently it's easy to create an instance the is used for writing before obtaining a workspace lock, which leads to race-condition if the metadata is changed after all.

The new implementation makes this impossible by enforcing a permission to be provided.
