### PR TITLE
docs(dev): add Troubleshooting to DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -295,11 +295,12 @@ $ npm install -g pnpm
 
 #### Node version conflicts
 
-Ensure you're using Node 20+. If using a version manager like nvm:
+Use the Node version pinned by `.nvmrc` (currently LTS “jod” / Node 22):
 
 ```bash
-$ nvm use 20
-$ nvm alias default 20
+nvm install
+nvm use
+node -v
 ```
 
 ### Rust Issues

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -227,7 +227,7 @@ We are also collecting tokio's runtime tracing information that could be viewed 
 
 Common issues and solutions when developing GitButler.
 
-### Turbo/Build Issues
+### Turbo/build issues
 
 #### Case-sensitive volume problems
 
@@ -241,59 +241,27 @@ If builds are hanging or behaving unexpectedly:
 
 ```bash
 # Stop the turbo daemon
-$ pnpm exec turbo daemon stop
+pnpm exec turbo daemon stop
 
 # Clear turbo cache
-$ pnpm exec turbo daemon clean
+pnpm exec turbo daemon clean
 
 # Restart development
-$ pnpm dev:desktop
+pnpm dev:desktop
 ```
 
-### Cache Issues
+### Cache issues
 
 If you're seeing stale builds or unexpected behavior:
 
 ```bash
-# Clear all caches
-$ pnpm clean
-$ cargo clean
-$ rm -rf node_modules
-$ pnpm install
+rm -rf .turbo node_modules
+pnpm install
+# Optional (Rust artifacts):
+cargo clean
 ```
 
-### Platform-specific Issues
-
-For Windows-specific build issues, refer to the [Building on Windows](#building-on-windows) section. Common issues include:
-
-- Missing Perl interpreter for OpenSSL compilation
-- Incorrect npm prefix configuration
-- File permission issues with pnpm
-
-#### macOS
-
-- Ensure Xcode Command Line Tools are installed: `xcode-select --install`
-- If using Homebrew, ensure cmake is installed: `brew install cmake`
-
-#### Linux
-
-- Double-check all system dependencies are installed (see Prerequisites)
-- On some distributions, you may need additional development packages
-
-### Node.js and pnpm Issues
-
-#### pnpm installation failures
-
-```bash
-# Disable and re-enable corepack
-$ corepack disable
-$ corepack enable
-
-# Or install pnpm globally
-$ npm install -g pnpm
-```
-
-#### Node version conflicts
+### Node.js & pnpm
 
 Use the Node version pinned by `.nvmrc` (currently LTS “jod” / Node 22):
 
@@ -303,31 +271,21 @@ nvm use
 node -v
 ```
 
-### Rust Issues
-
-#### Cargo build failures
+Use pnpm via Corepack (avoid global installs):
 
 ```bash
-# Update Rust toolchain
-$ rustup update
-
-# Clean and rebuild
-$ cargo clean
-$ cargo build
+corepack enable
+corepack pnpm -v
+# optionally pin a major:
+corepack prepare pnpm@10 --activate
 ```
 
-#### Missing system dependencies
-
-On Linux, if you're getting linking errors, ensure all required system libraries are installed. Revisit the Prerequisites section for your distribution.
-
-### Additional Resources
+### Additional resources
 
 For issues specific to our toolchain components:
 
-- [Turborepo Issues](https://github.com/vercel/turborepo/issues)
-- [Tauri Issues](https://github.com/tauri-apps/tauri/issues)
-- [Svelte Issues](https://github.com/sveltejs/svelte/issues)
-- [Rust Issues](https://github.com/rust-lang/rust/issues)
+- [Turborepo issues](https://github.com/vercel/turborepo/issues)
+- [Tauri issues](https://github.com/tauri-apps/tauri/issues)
 
 If none of these solutions work, please check our [GitHub Issues](https://github.com/gitbutlerapp/gitbutler/issues) or create a new issue with detailed information about your system and the error you're encountering.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -16,6 +16,7 @@ you right. Let's get started.
 - [Debugging](#debugging)
   - [Logs](#logs)
   - [Tokio](#tokio)
+- [Troubleshooting](#troubleshooting)
 - [Building](#building)
   - [Building on Windows](#building-on-windows)
     - [File permissions](#file-permissions)
@@ -219,6 +220,115 @@ We are also collecting tokio's runtime tracing information that could be viewed 
   ```bash
   $ tokio-console http://127.0.0.1:6667
   ```
+
+---
+
+## Troubleshooting
+
+Common issues and solutions when developing GitButler.
+
+### Turbo/Build Issues
+
+### Case-sensitive volume problems
+
+If you're experiencing issues with the `dev:desktop` target failing to start, especially on macOS with case-sensitive filesystems, this may be related to Turborepo's handling of case-sensitive volumes.
+
+**Solution:** See the related issue at [vercel/turborepo#8491](https://github.com/vercel/turborepo/issues/8491) for current workarounds.
+
+#### Turbo daemon issues
+
+If builds are hanging or behaving unexpectedly:
+
+```bash
+# Stop the turbo daemon
+$ pnpm exec turbo daemon stop
+
+# Clear turbo cache
+$ pnpm exec turbo daemon clean
+
+# Restart development
+$ pnpm dev:desktop
+```
+
+### Cache Issues
+
+If you're seeing stale builds or unexpected behavior:
+
+```bash
+# Clear all caches
+$ pnpm clean
+$ cargo clean
+$ rm -rf node_modules
+$ pnpm install
+```
+
+### Platform-specific Issues
+
+For Windows-specific build issues, refer to the [Building on Windows](#building-on-windows) section. Common issues include:
+
+- Missing Perl interpreter for OpenSSL compilation
+- Incorrect npm prefix configuration
+- File permission issues with pnpm
+
+#### macOS
+
+- Ensure Xcode Command Line Tools are installed: `xcode-select --install`
+- If using Homebrew, ensure cmake is installed: `brew install cmake`
+
+#### Linux
+
+- Double-check all system dependencies are installed (see Prerequisites)
+- On some distributions, you may need additional development packages
+
+### Node.js and pnpm Issues
+
+#### pnpm installation failures
+
+```bash
+# Disable and re-enable corepack
+$ corepack disable
+$ corepack enable
+
+# Or install pnpm globally
+$ npm install -g pnpm
+```
+
+#### Node version conflicts
+
+Ensure you're using Node 20+. If using a version manager like nvm:
+
+```bash
+$ nvm use 20
+$ nvm alias default 20
+```
+
+### Rust Issues
+
+#### Cargo build failures
+
+```bash
+# Update Rust toolchain
+$ rustup update
+
+# Clean and rebuild
+$ cargo clean
+$ cargo build
+```
+
+#### Missing system dependencies
+
+On Linux, if you're getting linking errors, ensure all required system libraries are installed. Revisit the Prerequisites section for your distribution.
+
+### Additional Resources
+
+For issues specific to our toolchain components:
+
+- [Turborepo Issues](https://github.com/vercel/turborepo/issues)
+- [Tauri Issues](https://github.com/tauri-apps/tauri/issues)
+- [Svelte Issues](https://github.com/sveltejs/svelte/issues)
+- [Rust Issues](https://github.com/rust-lang/rust/issues)
+
+If none of these solutions work, please check our [GitHub Issues](https://github.com/gitbutlerapp/gitbutler/issues) or create a new issue with detailed information about your system and the error you're encountering.
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -229,7 +229,7 @@ Common issues and solutions when developing GitButler.
 
 ### Turbo/Build Issues
 
-### Case-sensitive volume problems
+#### Case-sensitive volume problems
 
 If you're experiencing issues with the `dev:desktop` target failing to start, especially on macOS with case-sensitive filesystems, this may be related to Turborepo's handling of case-sensitive volumes.
 


### PR DESCRIPTION
# Add comprehensive troubleshooting section to DEVELOPMENT.md

## Description

Addresses issue #5025 by adding a dedicated Troubleshooting section to the developer documentation. This section provides solutions for common development environment issues that can cause significant developer friction.

## Changes Made

- Added new "Troubleshooting" section to DEVELOPMENT.md positioned between "Debugging" and "Building"
- Updated Table of Contents to include the new section
- Included solutions for:
  - Case-sensitive volume issues with Turborepo (specifically addresses the vercel/turborepo#8491 issue mentioned in #5025)
  - Turbo daemon problems and cache clearing procedures
  - Node.js/pnpm installation and version conflicts
  - Links to toolchain-specific GitHub issues for further troubleshooting

## Problem Solved

Developers encountering common setup issues (like the case-sensitive filesystem problem with Turbo) previously had to hunt through various toolchain documentation and GitHub issues. This change provides centralized, easily discoverable solutions that should reduce developer onboarding friction and debugging time.

## Testing

- [x] Verified all markdown links are functional
- [x] Confirmed formatting matches existing documentation style
- [x] Verified Table of Contents anchor links work correctly

## Related Issues

Closes #5025

## Checklist

- [x] My changes follow the project's coding standards
- [x] I have tested the documentation changes
- [x] All links and references have been verified