### PR TITLE
Display Claude session rules with human-readable names

### DIFF
--- a/apps/desktop/src/components/Rule.svelte
+++ b/apps/desktop/src/components/Rule.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import ReduxResult from '$components/ReduxResult.svelte';
+	import { CLAUDE_CODE_SERVICE } from '$lib/codegen/claude';
+	import { sessionMessage } from '$lib/codegen/types';
 	import {
 		semanticTypeToString,
 		treeStatusToShortString,
@@ -23,6 +25,7 @@
 
 	const stackService = inject(STACK_SERVICE);
 	const rulesService = inject(RULES_SERVICE);
+	const claudeCodeService = inject(CLAUDE_CODE_SERVICE);
 
 	const [deleteRule, deletingRule] = rulesService.deleteWorkspaceRule;
 
@@ -86,9 +89,22 @@
 			<Icon name="tag" opacity={0.6} />
 			<span class="text-12 truncate">{semanticTypeToString(filter.subject.type)}</span>
 		{:else if filter.type === 'claudeCodeSessionId'}
-			<Icon name="tag" opacity={0.6} />
-			<!-- TODO: Make an API call to get a rich name for the session, instead of rendering a UUID -->
-			<span class="text-12 truncate">{filter.subject}</span>
+			{@const sessionDetails = claudeCodeService.sessionDetails(projectId, filter.subject)}
+			<ReduxResult {projectId} result={sessionDetails.current}>
+				{#snippet loading()}
+					<Icon name="tag" opacity={0.6} />
+					<span class="text-12 truncate">{filter.subject}</span>
+				{/snippet}
+				{#snippet error()}
+					<Icon name="tag" opacity={0.6} />
+					<span class="text-12 truncate">{filter.subject}</span>
+				{/snippet}
+				{#snippet children(sessionDetails)}
+					{@const title = sessionMessage(sessionDetails) ?? filter.subject}
+					<Icon name="tag" opacity={0.6} />
+					<span class="text-12 truncate" {title}>{title}</span>
+				{/snippet}
+			</ReduxResult>
 		{/if}
 	</div>
 {/snippet}

--- a/apps/desktop/src/lib/codegen/types.ts
+++ b/apps/desktop/src/lib/codegen/types.ts
@@ -103,3 +103,16 @@ export type ClaudeMessageContent =
 			type: 'userInput';
 			subject: { message: string };
 	  };
+
+/**
+ * Details about a Claude session, extracted from the Claude transcript.
+ * This data is derived just in time, i.e. not persisted by GitButler.
+ */
+export type ClaudeSessionDetails = {
+	summary: string | null;
+	lastPrompt: string | null;
+};
+
+export function sessionMessage(sessionDetails: ClaudeSessionDetails): string | undefined {
+	return sessionDetails.summary ?? sessionDetails.lastPrompt ?? undefined;
+}

--- a/apps/desktop/src/lib/state/tags.ts
+++ b/apps/desktop/src/lib/state/tags.ts
@@ -1,7 +1,5 @@
 // TODO: Refactor this enum into an object conataining invalidation rules.
 export enum ReduxTag {
-	InitalEditListing = 'InitialEditListing',
-	EditChangesSinceInitial = 'EditChangesSinceInitial',
 	HeadMetadata = 'HeadMetadata',
 	Diff = 'Diff',
 	Stacks = 'Stacks',
@@ -25,7 +23,10 @@ export enum ReduxTag {
 	SnapshotDiff = 'SnapshotDiff',
 	WorkspaceRules = 'WorkspaceRules',
 	Project = 'Project',
-	ClaudeCodeTranscript = 'ClaudeCodeTranscript'
+	ClaudeCodeTranscript = 'ClaudeCodeTranscript',
+	ClaudeSessionDetails = 'ClaudeSessionDetails',
+	InitalEditListing = 'InitialEditListing',
+	EditChangesSinceInitial = 'EditChangesSinceInitial'
 }
 
 type Tag<T extends string | number> = {


### PR DESCRIPTION
- If a rule is of type claude session, fetch session details to present a more readable label than a raw UUID.
- Added sessionDetails endpoint to claude codegen and a helper for extracting human readable messages.
- Updated ReduxTag for session details caching.