### PR TITLE
Add telemetry for query errors and emit from custom hook

### DIFF
--- a/apps/desktop/src/lib/error/error.ts
+++ b/apps/desktop/src/lib/error/error.ts
@@ -1,3 +1,6 @@
+import { isStr } from '@gitbutler/ui/utils/string';
+import posthog from 'posthog-js';
+
 /**
  * Error type that has both a message and a status. These errors are primarily
  * thrown by AI services and the Octokit GitHub client.
@@ -32,4 +35,72 @@ export class SilentError extends Error {
 		e.stack = error.stack;
 		return e;
 	}
+}
+
+const QUERY_ERROR_EVENT_NAME = 'query:error';
+const DEFAULT_ERROR_NAME = 'QUERY:UnknownError';
+const DEFAULT_ERROR_MESSAGE = 'QUERY:An unknown error occurred';
+
+interface QueryError {
+	name: string;
+	message: string;
+	code: string | undefined;
+}
+
+function isUnknownObject(error: unknown): error is Record<string, unknown> {
+	return typeof error === 'object' && error !== null;
+}
+
+function getBestName(error: unknown): string {
+	if (isStr(error)) return error;
+
+	if (isUnknownObject(error) && 'name' in error && typeof error.name === 'string') {
+		return error.name;
+	}
+	if (error instanceof Error) {
+		return error.name;
+	}
+
+	return DEFAULT_ERROR_NAME;
+}
+
+function getBestMessage(error: unknown): string {
+	if (isUnknownObject(error) && 'message' in error && typeof error.message === 'string') {
+		return error.message;
+	}
+
+	if (error instanceof Error) {
+		return error.message;
+	}
+
+	return DEFAULT_ERROR_MESSAGE;
+}
+
+function getBestCode(error: unknown): string | undefined {
+	if (isUnknownObject(error) && 'code' in error && typeof error.code === 'string') {
+		return error.code;
+	}
+
+	return undefined;
+}
+
+function parseQueryError(error: unknown): QueryError {
+	const name = getBestName(error);
+	const message = getBestMessage(error);
+	const code = getBestCode(error);
+
+	return {
+		name,
+		message,
+		code
+	};
+}
+
+export function emitQueryError(error: unknown) {
+	const { name, message, code } = parseQueryError(error);
+	posthog.capture(QUERY_ERROR_EVENT_NAME, {
+		erro_title: name,
+		error_message: message,
+		error_code: code
+	});
 }

--- a/apps/desktop/src/lib/state/customHooks.svelte.ts
+++ b/apps/desktop/src/lib/state/customHooks.svelte.ts
@@ -1,4 +1,4 @@
-import { SilentError } from '$lib/error/error';
+import { emitQueryError, SilentError } from '$lib/error/error';
 import { isReduxError, type ReduxError } from '$lib/state/reduxError';
 import { reactive } from '@gitbutler/shared/reactiveUtils.svelte';
 import { type Reactive } from '@gitbutler/shared/storeUtils';
@@ -94,6 +94,14 @@ export function buildQueryHooks<Definitions extends ExtensionDefinitions>({
 
 		const selector = $derived(select(queryArg));
 		const result = $derived(selector(state()));
+
+		$effect(() => {
+			if (result.error) {
+				const error = result.error;
+				emitQueryError(error);
+			}
+		});
+
 		const output = $derived.by(() => {
 			let data = result.data;
 			if (options?.transform && data) {


### PR DESCRIPTION
apps/desktop/src/lib/state/customHooks.svelte.ts: Instrumented existing custom hook to call emitQueryError when the derived result contains an error. Updated imports to include emitQueryError and added an effect to watch result.error and emit telemetry when present.
