### PR TITLE
Namespace rule analytics props and add helper

### DIFF
--- a/apps/desktop/src/lib/soup/commitAnalytics.ts
+++ b/apps/desktop/src/lib/soup/commitAnalytics.ts
@@ -160,7 +160,7 @@ export class CommitAnalytics {
 		const filterCountByType = getFilterCountMap(rules);
 		const assignmentTargetTypes = getStackTargetTypeCountMap(rules);
 
-		return {
+		const ruleMetrics = {
 			// Total number of rules in the workspace
 			totalWorkspaceRules: rules.length,
 			// Average number of filters per rule
@@ -170,7 +170,17 @@ export class CommitAnalytics {
 			/// Count the stack target types used
 			...assignmentTargetTypes
 		};
+
+		return namespaceProps(ruleMetrics, 'rule');
 	}
+}
+
+function namespaceProps(props: EventProperties, namespace: string): EventProperties {
+	const namespacedProps: EventProperties = {};
+	for (const [key, value] of Object.entries(props)) {
+		namespacedProps[`${namespace}:${key}`] = value;
+	}
+	return namespacedProps;
 }
 
 function average(arr: number[]): number {


### PR DESCRIPTION
- Renamed returned metrics object to ruleMetrics instead of returning directly.
- Added namespaceProps helper function that takes EventProperties and a namespace string and returns a new object with keys prefixed by `${namespace}:`.
- Updated function to return namespaceProps(ruleMetrics, 'rule') so all rule-related analytics properties are namespaced (e.g., 'rule:totalWorkspaceRules').