### PR TITLE
backend-refactor-system-theme

### DIFF
--- a/apps/desktop/src/components/SwitchThemeMenuAction.svelte
+++ b/apps/desktop/src/components/SwitchThemeMenuAction.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { BACKEND } from '$lib/backend';
 	import { SETTINGS } from '$lib/settings/userSettings';
 	import { SHORTCUT_SERVICE } from '$lib/shortcuts/shortcutService';
 	import { initTheme } from '$lib/utils/theme';
@@ -6,8 +7,9 @@
 
 	const userSettings = inject(SETTINGS);
 	const shortcutService = inject(SHORTCUT_SERVICE);
+	const backend = inject(BACKEND);
 
-	initTheme(userSettings);
+	initTheme(userSettings, backend);
 
 	function updateTheme() {
 		userSettings.update((s) => ({

--- a/apps/desktop/src/lib/backend/backend.ts
+++ b/apps/desktop/src/lib/backend/backend.ts
@@ -1,0 +1,49 @@
+import type { Readable } from 'svelte/store';
+type Event<T> = {
+	/** Event name */
+	event: string;
+	/** Event identifier used to unlisten */
+	id: number;
+	/** Event payload */
+	payload: T;
+};
+
+export type DownloadEvent =
+	| {
+			event: 'Started';
+			data: {
+				contentLength?: number;
+			};
+	  }
+	| {
+			event: 'Progress';
+			data: {
+				chunkLength: number;
+			};
+	  }
+	| {
+			event: 'Finished';
+	  };
+
+export type DownloadEventName = DownloadEvent['event'];
+
+export type DownloadUpdate = (onEvent?: (progress: DownloadEvent) => void) => Promise<void>;
+export type InstallUpdate = () => Promise<void>;
+
+export type Update = {
+	version: string;
+	currentVersion: string;
+	body?: string;
+	download: DownloadUpdate;
+	install: InstallUpdate;
+};
+
+export interface IBackend {
+	systemTheme: Readable<string | null>;
+	invoke: <T>(command: string, ...args: any[]) => Promise<T>;
+	listen: <T>(event: string, callback: (event: Event<T>) => void) => () => Promise<void>;
+	checkUpdate: () => Promise<Update | null>;
+	currentVersion: () => Promise<string>;
+	readFile: (path: string) => Promise<Uint8Array>;
+	openExternalUrl: (href: string) => Promise<void>;
+}

--- a/apps/desktop/src/lib/backend/web.ts
+++ b/apps/desktop/src/lib/backend/web.ts
@@ -1,6 +1,17 @@
 import { isReduxError } from '$lib/state/reduxError';
-
 import { getCookie } from '$lib/utils/cookies';
+import { readable } from 'svelte/store';
+import type { IBackend } from '$lib/backend/backend';
+
+export default class Web implements IBackend {
+	systemTheme = readable<string | null>(null);
+	invoke = webInvoke;
+	listen = webListen;
+	checkUpdate = webCheckUpdate;
+	currentVersion = webCurrentVersion;
+	readFile = webReadFile;
+	openExternalUrl = webOpenExternalUrl;
+}
 
 /**
  * Invokes a backend web command via HTTP POST and returns the result.
@@ -11,10 +22,7 @@ import { getCookie } from '$lib/utils/cookies';
  * @returns A promise that resolves with the subject of the response if successful.
  * @throws Throws an error if the backend responds with an error or if the request fails.
  */
-export async function webInvoke<T>(
-	command: string,
-	params: Record<string, unknown> = {}
-): Promise<T> {
+async function webInvoke<T>(command: string, params: Record<string, unknown> = {}): Promise<T> {
 	try {
 		const response = await fetch(`http://${getWebUrl()}`, {
 			method: 'POST',
@@ -48,27 +56,27 @@ export async function webInvoke<T>(
  * @param handle - The callback function to handle the event when it is triggered.
  * @returns A function or object that can be used to remove or manage the event listener, as provided by `WebListener.listen`.
  */
-export function webListen<T>(event: EventName, handle: EventCallback<T>) {
+function webListen<T>(event: EventName, handle: EventCallback<T>) {
 	const webListener = WebListener.getInstance();
 	return webListener.listen({ name: event, handle });
 }
 
-export async function webCheckUpdate(): Promise<null> {
+async function webCheckUpdate(): Promise<null> {
 	// TODO: Implement this for the web version if needed
 	return null;
 }
 
-export async function webCurrentVersion(): Promise<string> {
+async function webCurrentVersion(): Promise<string> {
 	// TODO: Implement this for the web version if needed
 	return '0.0.0';
 }
 
-export async function webReadFile(_path: string): Promise<Uint8Array> {
+async function webReadFile(_path: string): Promise<Uint8Array> {
 	// TODO: Implement this for the web version if needed
 	throw new Error('webReadFile is not implemented for the web version');
 }
 
-export async function webOpenExternalUrl(href: string): Promise<void> {
+async function webOpenExternalUrl(href: string): Promise<void> {
 	window.open(href, '_blank');
 	return await Promise.resolve();
 }

--- a/apps/desktop/src/lib/utils/theme.ts
+++ b/apps/desktop/src/lib/utils/theme.ts
@@ -1,25 +1,13 @@
-import { getCurrentWindow, Window, type Theme } from '@tauri-apps/api/window';
 import { type Writable } from 'svelte/store';
+import type { IBackend } from '$lib/backend';
 import type { Settings } from '$lib/settings/userSettings';
-
-let appWindow: Window | undefined;
-if (import.meta.env.VITE_BUILD_TARGET === 'web') {
-	// TODO: Implement electron alternative
-} else {
-	appWindow = getCurrentWindow();
-}
 
 let systemTheme: string | null;
 let selectedTheme: string | undefined;
 
-export function initTheme(userSettings: Writable<Settings>) {
-	if (!appWindow) return;
-	appWindow.theme().then((value: Theme | null) => {
-		systemTheme = value;
-		updateDom();
-	});
-	appWindow.onThemeChanged((e) => {
-		systemTheme = e.payload;
+export function initTheme(userSettings: Writable<Settings>, backend: IBackend) {
+	backend.systemTheme.subscribe((theme) => {
+		systemTheme = theme;
 		updateDom();
 	});
 	userSettings.subscribe((s) => {

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -19,6 +19,7 @@
 	import { AI_SERVICE, AIService } from '$lib/ai/service';
 	import { EVENT_CONTEXT } from '$lib/analytics/eventContext';
 	import { POSTHOG_WRAPPER } from '$lib/analytics/posthog';
+	import { BACKEND } from '$lib/backend';
 	import BaseBranchService, { BASE_BRANCH_SERVICE } from '$lib/baseBranch/baseBranchService.svelte';
 	import { BranchService, BRANCH_SERVICE } from '$lib/branches/branchService.svelte';
 	import CLIManager, { CLI_MANAGER } from '$lib/cli/cli';
@@ -283,6 +284,8 @@
 	provide(RESIZE_SYNC, new ResizeSync());
 	provide(GIT_SERVICE, new GitService(data.backend));
 	provide(URL_SERVICE, urlService);
+
+	provide(BACKEND, data.backend);
 
 	const settingsService = data.settingsService;
 	const settingsStore = settingsService.appSettings;


### PR DESCRIPTION
Summary
- Provide backend via context and use it in theme flow
- Ref backend implementations and expose systemTheme as a readable store

Changes
- Add BACKEND token to context providers and consumers
- Provide backend via context in layout
- Consume BACKEND in SwitchThemeMenuAction and forward to initTheme
- Update initTheme signature to accept backend from context where appropriate
- Refactor backend into class-based structure for Tauri and Web
- Move backend types into backend.ts
- Expose systemTheme as a readable store on IBackend
- Update Tauri & Web implementations to supply systemTheme
- Refactor theme utilities to leverage backend.systemTheme

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #9833 
- <kbd>&nbsp;1&nbsp;</kbd> #9832 👈 
<!-- GitButler Footer Boundary Bottom -->

