### PR TITLE
feat(updater): delegate relaunch to backend implementations

### DIFF
--- a/apps/desktop/src/components/CloneForm.svelte
+++ b/apps/desktop/src/components/CloneForm.svelte
@@ -3,6 +3,7 @@
 	import InfoMessage, { type MessageStyle } from '$components/InfoMessage.svelte';
 	import Section from '$components/Section.svelte';
 	import { POSTHOG_WRAPPER } from '$lib/analytics/posthog';
+	import { BACKEND } from '$lib/backend';
 	import { GIT_SERVICE } from '$lib/git/gitService';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
 	import { projectPath } from '$lib/routes/routes.svelte';
@@ -12,14 +13,12 @@
 	import { Button, Spacer, Textbox } from '@gitbutler/ui';
 
 	import * as Sentry from '@sentry/sveltekit';
-	import { documentDir } from '@tauri-apps/api/path';
-	import { join } from '@tauri-apps/api/path';
-	import { open } from '@tauri-apps/plugin-dialog';
 	import { onMount } from 'svelte';
 
 	const projectsService = inject(PROJECTS_SERVICE);
 	const gitService = inject(GIT_SERVICE);
 	const posthog = inject(POSTHOG_WRAPPER);
+	const backend = inject(BACKEND);
 
 	let loading = $state(false);
 	let errors = $state<{ label: string }[]>([]);
@@ -32,12 +31,12 @@
 		if ($savedTargetDirPath) {
 			targetDirPath = $savedTargetDirPath;
 		} else {
-			targetDirPath = await documentDir();
+			targetDirPath = await backend.documentDir();
 		}
 	});
 
 	async function handleCloneTargetSelect() {
-		const selectedPath = await open({
+		const selectedPath = await backend.filePicker({
 			directory: true,
 			recursive: true,
 			title: 'Target Clone Directory'
@@ -83,7 +82,7 @@
 				return;
 			}
 
-			const targetDir = await join(targetDirPath, remoteUrl.name);
+			const targetDir = await backend.joinPath(targetDirPath, remoteUrl.name);
 
 			await gitService.cloneRepo(repositoryUrl, targetDir);
 

--- a/apps/desktop/src/components/FileContextMenu.svelte
+++ b/apps/desktop/src/components/FileContextMenu.svelte
@@ -3,6 +3,7 @@
 	import ReduxResult from '$components/ReduxResult.svelte';
 	import { ACTION_SERVICE } from '$lib/actions/actionService.svelte';
 	import { AI_SERVICE } from '$lib/ai/service';
+	import { BACKEND } from '$lib/backend';
 	import { writeClipboard } from '$lib/backend/clipboard';
 	import { changesToDiffSpec } from '$lib/commits/utils';
 	import { projectAiExperimentalFeaturesEnabled, projectAiGenEnabled } from '$lib/config/config';
@@ -30,7 +31,6 @@
 		Textbox,
 		chipToasts
 	} from '@gitbutler/ui';
-	import { join } from '@tauri-apps/api/path';
 	import type { DiffSpec } from '$lib/hunks/hunk';
 	import type { SelectionId } from '$lib/selection/key';
 
@@ -64,6 +64,7 @@
 	const actionService = inject(ACTION_SERVICE);
 	const fileService = inject(FILE_SERVICE);
 	const urlService = inject(URL_SERVICE);
+	const backend = inject(BACKEND);
 	const [autoCommit, autoCommitting] = actionService.autoCommit;
 	const [branchChanges, branchingChanges] = actionService.branchChanges;
 	const [absorbChanges, absorbingChanges] = actionService.absorb;
@@ -397,7 +398,7 @@
 							const project = await projectService.fetchProject(projectId);
 							const projectPath = project?.path;
 							if (projectPath) {
-								const absPath = await join(projectPath, item.changes[0]!.path);
+								const absPath = await backend.joinPath(projectPath, item.changes[0]!.path);
 								await writeClipboard(absPath, {
 									errorMessage: 'Failed to copy absolute path'
 								});
@@ -448,7 +449,7 @@
 							const project = await projectService.fetchProject(projectId);
 							const projectPath = project?.path;
 							if (projectPath) {
-								const absPath = await join(projectPath, item.changes[0]!.path);
+								const absPath = await backend.joinPath(projectPath, item.changes[0]!.path);
 								await fileService.showFileInFolder(absPath);
 							}
 							contextMenu.close();

--- a/apps/desktop/src/lib/backend/backend.ts
+++ b/apps/desktop/src/lib/backend/backend.ts
@@ -38,6 +38,54 @@ export type Update = {
 	install: InstallUpdate;
 };
 
+type DialogFilter = {
+	/** Filter name. */
+	name: string;
+	/**
+	 * Extensions to filter, without a `.` prefix.
+	 * @example
+	 * ```typescript
+	 * extensions: ['svg', 'png']
+	 * ```
+	 */
+	extensions: string[];
+};
+
+export type OpenDialogOptions = {
+	/** The title of the dialog window (desktop only). */
+	title?: string;
+	/** The filters of the dialog. */
+	filters?: DialogFilter[];
+	/**
+	 * Initial directory or file path.
+	 * If it's a directory path, the dialog interface will change to that folder.
+	 * If it's not an existing directory, the file name will be set to the dialog's file name input and the dialog will be set to the parent folder.
+	 *
+	 * On mobile the file name is always used on the dialog's file name input.
+	 * If not provided, Android uses `(invalid).txt` as default file name.
+	 */
+	defaultPath?: string;
+	/** Whether the dialog allows multiple selection or not. */
+	multiple?: boolean;
+	/** Whether the dialog is a directory selection or not. */
+	directory?: boolean;
+	/**
+	 * If `directory` is true, indicates that it will be read recursively later.
+	 * Defines whether subdirectories will be allowed on the scope or not.
+	 */
+	recursive?: boolean;
+	/** Whether to allow creating directories in the dialog. Enabled by default. **macOS Only** */
+	canCreateDirectories?: boolean;
+};
+
+export type OpenDialogReturn<T extends OpenDialogOptions> = T['directory'] extends true
+	? T['multiple'] extends true
+		? string[] | null
+		: string | null
+	: T['multiple'] extends true
+		? string[] | null
+		: string | null;
+
 export interface IBackend {
 	systemTheme: Readable<string | null>;
 	invoke: <T>(command: string, ...args: any[]) => Promise<T>;
@@ -47,4 +95,7 @@ export interface IBackend {
 	readFile: (path: string) => Promise<Uint8Array>;
 	openExternalUrl: (href: string) => Promise<void>;
 	relaunch: () => Promise<void>;
+	documentDir: () => Promise<string>;
+	joinPath: (path: string, ...paths: string[]) => Promise<string>;
+	filePicker<T extends OpenDialogOptions>(options?: T): Promise<OpenDialogReturn<T>>;
 }

--- a/apps/desktop/src/lib/backend/backend.ts
+++ b/apps/desktop/src/lib/backend/backend.ts
@@ -46,4 +46,5 @@ export interface IBackend {
 	currentVersion: () => Promise<string>;
 	readFile: (path: string) => Promise<Uint8Array>;
 	openExternalUrl: (href: string) => Promise<void>;
+	relaunch: () => Promise<void>;
 }

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -29,6 +29,7 @@ export default class Tauri implements IBackend {
 	currentVersion = tauriGetVersion;
 	readFile = tauriReadFile;
 	openExternalUrl = tauriOpenExternalUrl;
+	relaunch = relaunchTauri;
 }
 
 async function tauriInvoke<T>(command: string, params: Record<string, unknown> = {}): Promise<T> {

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -2,8 +2,12 @@ import { isReduxError } from '$lib/state/reduxError';
 import { getVersion as tauriGetVersion } from '@tauri-apps/api/app';
 import { invoke as invokeTauri } from '@tauri-apps/api/core';
 import { listen as listenTauri } from '@tauri-apps/api/event';
+import { documentDir as documentDirTauri } from '@tauri-apps/api/path';
+import { join as joinPathTauri } from '@tauri-apps/api/path';
 import { getCurrentWindow, Window } from '@tauri-apps/api/window';
+import { open as filePickerTauri, type OpenDialogOptions } from '@tauri-apps/plugin-dialog';
 import { readFile as tauriReadFile } from '@tauri-apps/plugin-fs';
+import { relaunch as relaunchTauri } from '@tauri-apps/plugin-process';
 import { check as tauriCheck } from '@tauri-apps/plugin-updater';
 import { readable } from 'svelte/store';
 import type { IBackend } from '$lib/backend/backend';
@@ -30,6 +34,11 @@ export default class Tauri implements IBackend {
 	readFile = tauriReadFile;
 	openExternalUrl = tauriOpenExternalUrl;
 	relaunch = relaunchTauri;
+	documentDir = documentDirTauri;
+	joinPath = joinPathTauri;
+	async filePicker<T extends OpenDialogOptions>() {
+		return await filePickerTauri<T>();
+	}
 }
 
 async function tauriInvoke<T>(command: string, params: Record<string, unknown> = {}): Promise<T> {

--- a/apps/desktop/src/lib/backend/web.ts
+++ b/apps/desktop/src/lib/backend/web.ts
@@ -11,6 +11,12 @@ export default class Web implements IBackend {
 	currentVersion = webCurrentVersion;
 	readFile = webReadFile;
 	openExternalUrl = webOpenExternalUrl;
+	relaunch = webRelaunch;
+}
+
+function webRelaunch(): Promise<void> {
+	// The web version does not support relaunching
+	throw new Error('Relaunch is not implemented in the web version');
 }
 
 /**

--- a/apps/desktop/src/lib/backend/web.ts
+++ b/apps/desktop/src/lib/backend/web.ts
@@ -1,7 +1,8 @@
 import { isReduxError } from '$lib/state/reduxError';
 import { getCookie } from '$lib/utils/cookies';
 import { readable } from 'svelte/store';
-import type { IBackend } from '$lib/backend/backend';
+import path from 'path';
+import type { IBackend, OpenDialogOptions, OpenDialogReturn } from '$lib/backend/backend';
 
 export default class Web implements IBackend {
 	systemTheme = readable<string | null>(null);
@@ -12,9 +13,64 @@ export default class Web implements IBackend {
 	readFile = webReadFile;
 	openExternalUrl = webOpenExternalUrl;
 	relaunch = webRelaunch;
+	documentDir = webDocumentDir;
+	joinPath = webJoinPath;
+	async filePicker<T extends OpenDialogOptions>(options?: T): Promise<OpenDialogReturn<T>> {
+		return await webFilePicker<T>(options);
+	}
 }
 
-function webRelaunch(): Promise<void> {
+async function webJoinPath(pathSegment: string, ...paths: string[]): Promise<string> {
+	// TODO: We might want to expose some endpoint in the backedn to handle path joining in the right way.
+	// This will break on windows
+	return await Promise.resolve(path.join(pathSegment, ...paths));
+}
+
+async function webDocumentDir(): Promise<string> {
+	// This needs to be implemented for the web version
+	return await Promise.resolve('');
+}
+
+async function webFilePicker<T extends OpenDialogOptions>(
+	options?: T
+): Promise<OpenDialogReturn<T>> {
+	const fileInput = document.createElement('input');
+	fileInput.type = 'file';
+
+	if (options?.multiple) {
+		fileInput.multiple = true;
+	}
+
+	const promise = new Promise<OpenDialogReturn<T>>((resolve) => {
+		fileInput.onchange = () => {
+			const files = fileInput.files;
+			if (!files) {
+				resolve(null);
+				return;
+			}
+			const paths: string[] = [];
+			for (const file of files) {
+				paths.push(file.name);
+			}
+			if (paths.length === 0) {
+				resolve(null);
+				return;
+			}
+			if (options?.multiple) {
+				resolve(paths as OpenDialogReturn<T>);
+				return;
+			}
+
+			const path = paths[0];
+			resolve(path as OpenDialogReturn<T>);
+		};
+	});
+
+	fileInput.click();
+	return await promise;
+}
+
+async function webRelaunch(): Promise<void> {
 	// The web version does not support relaunching
 	throw new Error('Relaunch is not implemented in the web version');
 }

--- a/apps/desktop/src/lib/project/projectsService.ts
+++ b/apps/desktop/src/lib/project/projectsService.ts
@@ -5,10 +5,9 @@ import { getCookie } from '$lib/utils/cookies';
 import { InjectionToken } from '@gitbutler/shared/context';
 import { persisted } from '@gitbutler/shared/persisted';
 import { chipToasts } from '@gitbutler/ui';
-import { open } from '@tauri-apps/plugin-dialog';
 import { get } from 'svelte/store';
+import type { IBackend } from '$lib/backend';
 import type { ClientState } from '$lib/state/clientState.svelte';
-import type { HttpClient } from '@gitbutler/shared/network/httpClient';
 
 export type ProjectInfo = {
 	is_exclusive: boolean;
@@ -25,7 +24,7 @@ export class ProjectsService {
 	constructor(
 		state: ClientState,
 		private homeDir: string | undefined,
-		private httpClient: HttpClient
+		private backend: IBackend
 	) {
 		this.api = injectEndpoints(state.backendApi);
 	}
@@ -59,15 +58,11 @@ export class ProjectsService {
 		if (cookiePath) {
 			return cookiePath;
 		}
-
-		let selectedPath: string | undefined | null;
-		if (import.meta.env.VITE_BUILD_TARGET === 'web') {
-			// TODO: Consider: this is electron specific, could we use a web API
-			// and also work on the real web?
-			selectedPath = await window.electronAPI?.openDirectory();
-		} else {
-			selectedPath = await open({ directory: true, recursive: true, defaultPath: this.homeDir });
-		}
+		const selectedPath = await this.backend.filePicker({
+			directory: true,
+			recursive: true,
+			defaultPath: this.homeDir
+		});
 		if (selectedPath) {
 			return selectedPath;
 		}

--- a/apps/desktop/src/lib/updater/updater.ts
+++ b/apps/desktop/src/lib/updater/updater.ts
@@ -1,6 +1,5 @@
 import { showToast } from '$lib/notifications/toasts';
 import { InjectionToken } from '@gitbutler/shared/context';
-import { relaunch } from '@tauri-apps/plugin-process';
 import { get, writable } from 'svelte/store';
 import type { PostHogWrapper } from '$lib/analytics/posthog';
 import type {
@@ -180,7 +179,7 @@ export class UpdaterService {
 
 	async relaunchApp() {
 		try {
-			await relaunch();
+			await this.backend.relaunch();
 		} catch (err: unknown) {
 			handleError(err, true);
 		}

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -200,7 +200,7 @@
 
 	const urlService = new URLService(data.backend);
 
-	const projectsService = new ProjectsService(clientState, data.homeDir, data.httpClient);
+	const projectsService = new ProjectsService(clientState, data.homeDir, data.backend);
 	provide(PROJECTS_SERVICE, projectsService);
 
 	const shortcutService = new ShortcutService(data.backend);


### PR DESCRIPTION
Move relaunch logic out of the updater and into the platform backend
abstraction so the updater calls this.backend.relaunch() instead of
directly importing Tauri's relaunch API. This adds a relaunch method to
the backend interface and implements it for the Tauri backend
(tauriRelaunch). For the web backend, provide a stub that throws an
explicit "not implemented" error to make unsupported behavior explicit.

Introduce IBackend-backed methods for documentDir, joinPath and filePicker
and wire them into CloneForm to replace direct tauri/api calls. This moves
platform-specific file and path logic behind the BACKEND injector so the
desktop UI can run in both Tauri and web environments.

Inject BACKEND into CloneForm and use backend.documentDir,
backend.filePicker and backend.joinPath instead of direct tauri/api
imports (documentDir, join, open). This ensures platform-appropriate
implementations are used and simplifies testing.
Extend Web backend implementation with stubbed documentDir, joinPath
and a DOM-based filePicker implementation. The joinPath uses Node
path.join (note: currently not Windows-safe in web) and filePicker
uses a hidden file input to emulate dialog behavior in browsers.
Extend Tauri backend implementation to expose documentDir, joinPath
and filePicker via the corresponding Tauri APIs and plugin wrappers.
Update imports and type declarations to support the new backend API.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #9834 
- <kbd>&nbsp;1&nbsp;</kbd> #9833 👈 
<!-- GitButler Footer Boundary Bottom -->

