### PR TITLE
Refactor backend, add homeDirectory to interface

### DIFF
--- a/apps/desktop/src/lib/backend/backend.ts
+++ b/apps/desktop/src/lib/backend/backend.ts
@@ -98,4 +98,5 @@ export interface IBackend {
 	documentDir: () => Promise<string>;
 	joinPath: (path: string, ...paths: string[]) => Promise<string>;
 	filePicker<T extends OpenDialogOptions>(options?: T): Promise<OpenDialogReturn<T>>;
+	homeDirectory(): Promise<string>;
 }

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -39,6 +39,11 @@ export default class Tauri implements IBackend {
 	async filePicker<T extends OpenDialogOptions>() {
 		return await filePickerTauri<T>();
 	}
+	async homeDirectory(): Promise<string> {
+		// TODO: Find a workaround to avoid this dynamic import
+		// https://github.com/sveltejs/kit/issues/905
+		return await (await import('@tauri-apps/api/path')).homeDir();
+	}
 }
 
 async function tauriInvoke<T>(command: string, params: Record<string, unknown> = {}): Promise<T> {

--- a/apps/desktop/src/lib/backend/web.ts
+++ b/apps/desktop/src/lib/backend/web.ts
@@ -15,9 +15,15 @@ export default class Web implements IBackend {
 	relaunch = webRelaunch;
 	documentDir = webDocumentDir;
 	joinPath = webJoinPath;
+	homeDirectory = webHomeDirectory;
 	async filePicker<T extends OpenDialogOptions>(options?: T): Promise<OpenDialogReturn<T>> {
 		return await webFilePicker<T>(options);
 	}
+}
+
+async function webHomeDirectory(): Promise<string> {
+	// This needs to be implemented for the web version
+	return await Promise.resolve('/tmp/gitbutler');
 }
 
 async function webJoinPath(pathSegment: string, ...paths: string[]): Promise<string> {

--- a/apps/desktop/src/routes/+layout.ts
+++ b/apps/desktop/src/routes/+layout.ts
@@ -27,15 +27,6 @@ export const csr = true;
 
 // eslint-disable-next-line
 export const load: LayoutLoad = async () => {
-	// TODO: Find a workaround to avoid this dynamic import
-	// https://github.com/sveltejs/kit/issues/905
-	let homeDir: string;
-	if (import.meta.env.VITE_BUILD_TARGET === 'web') {
-		homeDir = '/tmp/gitbutler';
-	} else {
-		homeDir = await (await import('@tauri-apps/api/path')).homeDir();
-	}
-
 	const tokenMemoryService = new TokenMemoryService();
 	const httpClient = new HttpClient(window.fetch, PUBLIC_API_BASE_URL, tokenMemoryService.token);
 	const uploadsService = new UploadsService(httpClient);
@@ -57,6 +48,8 @@ export const load: LayoutLoad = async () => {
 	const fileService = new FileService(backend);
 	const hooksService = new HooksService(backend);
 	const userService = new UserService(backend, httpClient, tokenMemoryService, posthog);
+
+	const homeDir = await backend.homeDirectory();
 
 	// Await settings to prevent immediate reloads on initial render.
 	await settingsService.refresh();


### PR DESCRIPTION
This commit refactors backend initialization to provide a standard method homeDirectory on the backend abstraction across Tauri and web implementations. Removed old logic from +layout.ts and routed directory retrieval through the backend interface. Tauri and web implementations provide their own version of homeDirectory. This centralizes directory logic and streamlines the code using the backend context.