### PR TITLE
Provide app name/version via generic backend (getAppInfo)

### DIFF
--- a/apps/desktop/src/components/AppUpdater.test.ts
+++ b/apps/desktop/src/components/AppUpdater.test.ts
@@ -16,7 +16,7 @@ describe('AppUpdater', () => {
 	const MockSettingsService = getSettingsdServiceMock();
 	const settingsService = new MockSettingsService();
 	const eventContext = new EventContext();
-	const posthog = new PostHogWrapper(settingsService, eventContext);
+	const posthog = new PostHogWrapper(settingsService, backend, eventContext);
 
 	beforeEach(() => {
 		vi.useFakeTimers();

--- a/apps/desktop/src/components/ShareIssueModal.svelte
+++ b/apps/desktop/src/components/ShareIssueModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
+	import { BACKEND } from '$lib/backend';
 	import { FILE_SERVICE } from '$lib/files/fileService';
 	import { GIT_SERVICE } from '$lib/git/gitService';
 	import { SHORTCUT_SERVICE } from '$lib/shortcuts/shortcutService';
@@ -9,7 +10,6 @@
 	import { HTTP_CLIENT } from '@gitbutler/shared/network/httpClient';
 
 	import { Button, Checkbox, Modal, Textarea, Textbox, chipToasts } from '@gitbutler/ui';
-	import { getVersion } from '@tauri-apps/api/app';
 
 	type Feedback = {
 		id: number;
@@ -26,6 +26,7 @@
 	const dataSharingService = inject(DATA_SHARING_SERVICE);
 	const gitService = inject(GIT_SERVICE);
 	const user = inject(USER);
+	const backend = inject(BACKEND);
 
 	export function show() {
 		modal?.show();
@@ -65,7 +66,8 @@
 
 		// put together context information to send with the feedback
 		let context = '';
-		const appVersion = await getVersion();
+		const appInfo = await backend.getAppInfo();
+		const appVersion = appInfo.version;
 		const indexLength = await gitIndexLength();
 		context += 'GitButler Version: ' + appVersion + '\n';
 		context += 'Browser: ' + navigator.userAgent + '\n';

--- a/apps/desktop/src/lib/analytics/analytics.ts
+++ b/apps/desktop/src/lib/analytics/analytics.ts
@@ -1,7 +1,6 @@
 import { PostHogWrapper } from '$lib/analytics/posthog';
 import { initSentry } from '$lib/analytics/sentry';
 import { AppSettings } from '$lib/config/appSettings';
-import { getName, getVersion } from '@tauri-apps/api/app';
 import posthog from 'posthog-js';
 
 export function initAnalyticsIfEnabled(appSettings: AppSettings, postHog: PostHogWrapper) {
@@ -14,12 +13,7 @@ export function initAnalyticsIfEnabled(appSettings: AppSettings, postHog: PostHo
 			});
 			appSettings.appMetricsEnabled.onDisk().then(async (enabled) => {
 				if (enabled) {
-					if (import.meta.env.VITE_BUILD_TARGET === 'web') {
-						postHog.init('gitbutler-web', '0.0.0');
-					} else {
-						const [appName, appVersion] = await Promise.all([getName(), getVersion()]);
-						postHog.init(appName, appVersion);
-					}
+					await postHog.init();
 				}
 			});
 			appSettings.appNonAnonMetricsEnabled.onDisk().then((enabled) => {

--- a/apps/desktop/src/lib/analytics/posthog.ts
+++ b/apps/desktop/src/lib/analytics/posthog.ts
@@ -1,6 +1,7 @@
 import { InjectionToken } from '@gitbutler/shared/context';
 import { PostHog, posthog, type Properties } from 'posthog-js';
 import type { EventContext } from '$lib/analytics/eventContext';
+import type { IBackend } from '$lib/backend';
 import type { SettingsService } from '$lib/config/appSettingsV2';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import { PUBLIC_POSTHOG_API_KEY } from '$env/static/public';
@@ -12,6 +13,7 @@ export class PostHogWrapper {
 
 	constructor(
 		private settingsService: SettingsService,
+		private backend: IBackend,
 		private eventContext: EventContext
 	) {}
 
@@ -21,7 +23,8 @@ export class PostHogWrapper {
 		this._instance?.capture(eventName, newProperties);
 	}
 
-	async init(appName: string, appVersion: string) {
+	async init() {
+		const appInfo = await this.backend.getAppInfo();
 		this._instance = posthog.init(PUBLIC_POSTHOG_API_KEY, {
 			api_host: 'https://eu.posthog.com',
 			autocapture: false,
@@ -34,8 +37,8 @@ export class PostHogWrapper {
 			}
 		});
 		posthog.register({
-			appName,
-			appVersion
+			appName: appInfo.name,
+			appVersion: appInfo.version
 		});
 	}
 

--- a/apps/desktop/src/lib/backend/backend.ts
+++ b/apps/desktop/src/lib/backend/backend.ts
@@ -86,6 +86,10 @@ export type OpenDialogReturn<T extends OpenDialogOptions> = T['directory'] exten
 		? string[] | null
 		: string | null;
 
+export type AppInfo = {
+	name: string;
+	version: string;
+};
 export interface IBackend {
 	systemTheme: Readable<string | null>;
 	invoke: <T>(command: string, ...args: any[]) => Promise<T>;
@@ -99,4 +103,5 @@ export interface IBackend {
 	joinPath: (path: string, ...paths: string[]) => Promise<string>;
 	filePicker<T extends OpenDialogOptions>(options?: T): Promise<OpenDialogReturn<T>>;
 	homeDirectory(): Promise<string>;
+	getAppInfo: () => Promise<AppInfo>;
 }

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -1,5 +1,5 @@
 import { isReduxError } from '$lib/state/reduxError';
-import { getVersion as tauriGetVersion } from '@tauri-apps/api/app';
+import { getName, getVersion, getVersion as tauriGetVersion } from '@tauri-apps/api/app';
 import { invoke as invokeTauri } from '@tauri-apps/api/core';
 import { listen as listenTauri } from '@tauri-apps/api/event';
 import { documentDir as documentDirTauri } from '@tauri-apps/api/path';
@@ -10,7 +10,7 @@ import { readFile as tauriReadFile } from '@tauri-apps/plugin-fs';
 import { relaunch as relaunchTauri } from '@tauri-apps/plugin-process';
 import { check as tauriCheck } from '@tauri-apps/plugin-updater';
 import { readable } from 'svelte/store';
-import type { IBackend } from '$lib/backend/backend';
+import type { AppInfo, IBackend } from '$lib/backend/backend';
 import type { EventCallback, EventName } from '@tauri-apps/api/event';
 
 export default class Tauri implements IBackend {
@@ -36,6 +36,7 @@ export default class Tauri implements IBackend {
 	relaunch = relaunchTauri;
 	documentDir = documentDirTauri;
 	joinPath = joinPathTauri;
+	getAppInfo = tauriGetAppInfo;
 	async filePicker<T extends OpenDialogOptions>() {
 		return await filePickerTauri<T>();
 	}
@@ -44,6 +45,11 @@ export default class Tauri implements IBackend {
 		// https://github.com/sveltejs/kit/issues/905
 		return await (await import('@tauri-apps/api/path')).homeDir();
 	}
+}
+
+async function tauriGetAppInfo(): Promise<AppInfo> {
+	const [appName, appVersion] = await Promise.all([getName(), getVersion()]);
+	return { name: appName, version: appVersion };
 }
 
 async function tauriInvoke<T>(command: string, params: Record<string, unknown> = {}): Promise<T> {

--- a/apps/desktop/src/lib/backend/web.ts
+++ b/apps/desktop/src/lib/backend/web.ts
@@ -2,7 +2,7 @@ import { isReduxError } from '$lib/state/reduxError';
 import { getCookie } from '$lib/utils/cookies';
 import { readable } from 'svelte/store';
 import path from 'path';
-import type { IBackend, OpenDialogOptions, OpenDialogReturn } from '$lib/backend/backend';
+import type { AppInfo, IBackend, OpenDialogOptions, OpenDialogReturn } from '$lib/backend/backend';
 
 export default class Web implements IBackend {
 	systemTheme = readable<string | null>(null);
@@ -16,9 +16,17 @@ export default class Web implements IBackend {
 	documentDir = webDocumentDir;
 	joinPath = webJoinPath;
 	homeDirectory = webHomeDirectory;
+	getAppInfo = webGetAppInfo;
 	async filePicker<T extends OpenDialogOptions>(options?: T): Promise<OpenDialogReturn<T>> {
 		return await webFilePicker<T>(options);
 	}
+}
+
+async function webGetAppInfo(): Promise<AppInfo> {
+	return await Promise.resolve({
+		name: 'gitbutler-web',
+		version: '0.0.0'
+	});
 }
 
 async function webHomeDirectory(): Promise<string> {

--- a/apps/desktop/src/lib/forge/forgeFactory.test.ts
+++ b/apps/desktop/src/lib/forge/forgeFactory.test.ts
@@ -1,5 +1,6 @@
 import { EventContext } from '$lib/analytics/eventContext';
 import { PostHogWrapper } from '$lib/analytics/posthog';
+import createBackend from '$lib/backend';
 import { DefaultForgeFactory } from '$lib/forge/forgeFactory.svelte';
 import { GitHub } from '$lib/forge/github/github';
 import { GitLab } from '$lib/forge/gitlab/gitlab';
@@ -12,9 +13,10 @@ import type { ThunkDispatch, UnknownAction } from '@reduxjs/toolkit';
 
 describe.concurrent('DefaultforgeFactory', () => {
 	const MockSettingsService = getSettingsdServiceMock();
+	const backend = createBackend();
 	const settingsService = new MockSettingsService();
 	const eventContext = new EventContext();
-	const posthog = new PostHogWrapper(settingsService, eventContext);
+	const posthog = new PostHogWrapper(settingsService, backend, eventContext);
 	const gitHubApi: GitHubApi = {
 		endpoints: {},
 		reducerPath: 'github',

--- a/apps/desktop/src/lib/updater/updater.test.ts
+++ b/apps/desktop/src/lib/updater/updater.test.ts
@@ -18,7 +18,7 @@ describe('Updater', () => {
 	const shortcuts = new ShortcutService(backend);
 	const settingsService = new MockSettingsService();
 	const eventContext = new EventContext();
-	const posthog = new PostHogWrapper(settingsService, eventContext);
+	const posthog = new PostHogWrapper(settingsService, backend, eventContext);
 
 	beforeEach(() => {
 		vi.useFakeTimers();

--- a/apps/desktop/src/routes/+layout.ts
+++ b/apps/desktop/src/routes/+layout.ts
@@ -38,7 +38,7 @@ export const load: LayoutLoad = async () => {
 	const eventContext = new EventContext();
 	// Awaited and will block initial render, but it is necessary in order to respect the user
 	// settings on telemetry.
-	const posthog = new PostHogWrapper(settingsService, eventContext);
+	const posthog = new PostHogWrapper(settingsService, backend, eventContext);
 	const appSettings = await loadAppSettings();
 	initAnalyticsIfEnabled(appSettings, posthog);
 


### PR DESCRIPTION
- Introduced a generic getAppInfo() method in the backend interface.
- Implemented getAppInfo for both Tauri and Web platform backends.
- Updated analytics, PostHog, and feedback modal to use backend.getAppInfo() for obtaining app name and version, instead of Tauri API or environment code directly.
- Updated tests and dependency injection for new backend usage where necessary.
- Ensured backend is now passed to PostHogWrapper and consumed accordingly.