### PR TITLE
fix: validate stackId before operations

### DIFF
--- a/apps/desktop/src/components/BranchCommitList.svelte
+++ b/apps/desktop/src/components/BranchCommitList.svelte
@@ -31,6 +31,7 @@
 	import { STACK_SERVICE, type SeriesIntegrationStrategy } from '$lib/stacks/stackService.svelte';
 	import { combineResults } from '$lib/state/helpers';
 	import { UI_STATE } from '$lib/state/uiState.svelte';
+	import { ensureValue } from '$lib/utils/validation';
 	import { inject } from '@gitbutler/shared/context';
 	import { Button, Modal, TestId } from '@gitbutler/ui';
 	import { getTimeAgo } from '@gitbutler/ui/utils/timeAgo';
@@ -130,10 +131,9 @@
 	let confirmResetModal = $state<ReturnType<typeof Modal>>();
 
 	async function integrate(strategy?: SeriesIntegrationStrategy): Promise<void> {
-		if (!stackId) return;
 		await integrateUpstreamCommits({
 			projectId,
-			stackId,
+			stackId: ensureValue(stackId),
 			seriesName: branchName,
 			strategy
 		});

--- a/apps/desktop/src/components/BranchList.svelte
+++ b/apps/desktop/src/components/BranchList.svelte
@@ -19,6 +19,7 @@
 	import { combineResults } from '$lib/state/helpers';
 	import { UI_STATE } from '$lib/state/uiState.svelte';
 	import { URL_SERVICE } from '$lib/utils/url';
+	import { ensureValue } from '$lib/utils/validation';
 	import { copyToClipboard } from '@gitbutler/shared/clipboard';
 	import { inject } from '@gitbutler/shared/context';
 
@@ -66,8 +67,12 @@
 		$state<ReturnType<typeof ConflictResolutionConfirmModal>>();
 
 	async function handleUncommit(commitId: string, branchName: string) {
-		if (!stackId) return;
-		await stackService.uncommit({ projectId, stackId, branchName, commitId: commitId });
+		await stackService.uncommit({
+			projectId,
+			stackId: ensureValue(stackId),
+			branchName,
+			commitId: commitId
+		});
 	}
 
 	function startEditingCommitMessage(branchName: string, commitId: string) {
@@ -86,7 +91,6 @@
 		hasConflicts: boolean;
 		isAncestorMostConflicted: boolean;
 	}) {
-		if (!stackId) return;
 		if (args.type === 'LocalAndRemote' && args.hasConflicts && !args.isAncestorMostConflicted) {
 			conflictResolutionConfirmationModal?.show();
 			return;
@@ -94,7 +98,7 @@
 		await editPatch({
 			modeService,
 			commitId: args.commitId,
-			stackId,
+			stackId: ensureValue(stackId),
 			projectId
 		});
 	}
@@ -198,10 +202,9 @@
 							kind="outline"
 							tooltip="Create empty commit"
 							onclick={async () => {
-								if (!stackId) return;
 								await insertBlankCommitInBranch({
 									projectId,
-									stackId,
+									stackId: ensureValue(stackId),
 									commitId: undefined,
 									offset: -1
 								});
@@ -224,10 +227,9 @@
 								kind="outline"
 								tooltip="Create new branch"
 								onclick={async () => {
-									if (!stackId) return;
 									addDependentBranchModalContext = {
 										projectId,
-										stackId
+										stackId: ensureValue(stackId)
 									};
 
 									await tick();

--- a/apps/desktop/src/components/CommitContextMenu.svelte
+++ b/apps/desktop/src/components/CommitContextMenu.svelte
@@ -46,6 +46,7 @@
 	import { rewrapCommitMessage } from '$lib/config/uiFeatureFlags';
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
 	import { URL_SERVICE } from '$lib/utils/url';
+	import { ensureValue } from '$lib/utils/validation';
 	import { inject } from '@gitbutler/shared/context';
 	import {
 		ContextMenu,
@@ -199,8 +200,7 @@
 						label="Add empty commit above"
 						disabled={commitInsertion.current.isLoading}
 						onclick={() => {
-							if (!stackId) return;
-							insertBlankCommit(stackId, commitId, 'above');
+							insertBlankCommit(ensureValue(stackId), commitId, 'above');
 							close();
 						}}
 					/>
@@ -208,8 +208,7 @@
 						label="Add empty commit below"
 						disabled={commitInsertion.current.isLoading}
 						onclick={() => {
-							if (!stackId) return;
-							insertBlankCommit(stackId, commitId, 'below');
+							insertBlankCommit(ensureValue(stackId), commitId, 'below');
 							close();
 						}}
 					/>
@@ -219,8 +218,7 @@
 						label="Create dependent branch above"
 						disabled={refCreation.current.isLoading}
 						onclick={async () => {
-							if (!stackId) return;
-							await handleCreateNewRef(stackId, commitId, 'Above');
+							await handleCreateNewRef(ensureValue(stackId), commitId, 'Above');
 							close();
 						}}
 					/>
@@ -228,8 +226,7 @@
 						label="Create dependent branch below"
 						disabled={refCreation.current.isLoading}
 						onclick={async () => {
-							if (!stackId) return;
-							await handleCreateNewRef(stackId, commitId, 'Below');
+							await handleCreateNewRef(ensureValue(stackId), commitId, 'Below');
 							close();
 						}}
 					/>

--- a/apps/desktop/src/components/CommitView.svelte
+++ b/apps/desktop/src/components/CommitView.svelte
@@ -17,6 +17,7 @@
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
 	import { UI_STATE } from '$lib/state/uiState.svelte';
 	import { splitMessage } from '$lib/utils/commitMessage';
+	import { ensureValue } from '$lib/utils/validation';
 	import { inject, injectOptional } from '@gitbutler/shared/context';
 	import { AsyncButton, Button, TestId } from '@gitbutler/ui';
 
@@ -106,7 +107,6 @@
 	}
 
 	async function saveCommitMessage(title: string, description: string) {
-		if (!stackId) return;
 		const commitMessage = combineParts(title, description);
 		if (!branchName) {
 			throw new Error('No branch selected!');
@@ -118,19 +118,23 @@
 
 		const newCommitId = await updateCommitMessage({
 			projectId,
-			stackId,
+			stackId: ensureValue(stackId),
 			commitId: commitKey.commitId,
 			message: commitMessage
 		});
 
-		uiState.lane(stackId).selection.set({ branchName, commitId: newCommitId });
+		uiState.lane(ensureValue(stackId)).selection.set({ branchName, commitId: newCommitId });
 		setMode('view');
 	}
 
 	async function handleUncommit() {
-		if (!stackId) return;
 		if (!branchName) return;
-		await stackService.uncommit({ projectId, stackId, branchName, commitId: commitKey.commitId });
+		await stackService.uncommit({
+			projectId,
+			stackId: ensureValue(stackId),
+			branchName,
+			commitId: commitKey.commitId
+		});
 	}
 
 	function canEdit() {
@@ -138,11 +142,10 @@
 	}
 
 	async function handleEditPatch() {
-		if (!stackId) return;
 		await editPatch({
 			modeService,
 			commitId: commitKey.commitId,
-			stackId,
+			stackId: ensureValue(stackId),
 			projectId
 		});
 	}

--- a/apps/desktop/src/components/NewBranchModal.svelte
+++ b/apps/desktop/src/components/NewBranchModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
 	import { URL_SERVICE } from '$lib/utils/url';
+	import { ensureValue } from '$lib/utils/validation';
 	import { inject } from '@gitbutler/shared/context';
 
 	import { Button, LinkButton, Modal, Textbox, chipToasts } from '@gitbutler/ui';
@@ -32,7 +33,6 @@
 	const generatedNameDiverges = $derived(!!createRefName && slugifiedRefName !== createRefName);
 
 	async function addSeries() {
-		if (!stackId) return;
 		if (!slugifiedRefName) {
 			chipToasts.error('No branch name provided');
 			createRefModal?.close();
@@ -41,7 +41,7 @@
 
 		await createNewBranch({
 			projectId,
-			stackId,
+			stackId: ensureValue(stackId),
 			request: { targetPatch: undefined, name: slugifiedRefName }
 		});
 

--- a/apps/desktop/src/components/PushButton.svelte
+++ b/apps/desktop/src/components/PushButton.svelte
@@ -67,7 +67,6 @@
 	}
 
 	async function push(args: { withForce: boolean; skipForcePushProtection: boolean }) {
-		if (!stackId) return;
 		const { withForce, skipForcePushProtection } = args;
 		try {
 			const pushResult = await pushStack({

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -241,8 +241,7 @@
 		selectionId={createWorktreeSelection({ stackId })}
 		onclose={() => {
 			idSelection.clear(createWorktreeSelection({ stackId: stackId }));
-			if (!stackId) return;
-			intelligentScrollingService.show(projectId, stackId, 'stack');
+			intelligentScrollingService.show(projectId, laneId, 'stack');
 		}}
 		draggableFiles
 	/>

--- a/apps/desktop/src/lib/stacks/dropHandler.ts
+++ b/apps/desktop/src/lib/stacks/dropHandler.ts
@@ -1,6 +1,7 @@
 import { changesToDiffSpec } from '$lib/commits/utils';
 import { ChangeDropData } from '$lib/dragging/draggables';
 import StackMacros from '$lib/stacks/macros';
+import { ensureValue } from '$lib/utils/validation';
 import { chipToasts } from '@gitbutler/ui';
 import type { DropzoneHandler } from '$lib/dragging/handler';
 import type { DiffService } from '$lib/hunks/diffService.svelte';
@@ -70,9 +71,6 @@ export class OutsideLaneDzHandler implements DropzoneHandler {
 			case 'commit': {
 				const { stack, outcome, branchName } = await this.macros.createNewStackAndCommit();
 
-				if (!stack.id) {
-					throw new Error('New stack has no stack id');
-				}
 				if (!outcome.newCommit) {
 					throw new Error('Failed to create a new commit');
 				}
@@ -82,7 +80,7 @@ export class OutsideLaneDzHandler implements DropzoneHandler {
 				if (sourceStackId) {
 					const diffSpec = changesToDiffSpec(await data.treeChanges());
 					await this.macros.moveChangesToNewCommit(
-						stack.id,
+						ensureValue(stack.id),
 						outcome.newCommit,
 						sourceStackId,
 						sourceCommitId,
@@ -100,17 +98,13 @@ export class OutsideLaneDzHandler implements DropzoneHandler {
 					projectId: this.projectId,
 					branch: { name: undefined }
 				});
-				const stackId = stack.id;
-				if (!stackId) {
-					throw new Error('New stack has no stack id');
-				}
 
 				const changes = await data.treeChanges();
 				const assignments = changes
 					.flatMap((c) =>
 						this.uncommittedService.getAssignmentsByPath(data.stackId ?? null, c.path)
 					)
-					.map((h) => ({ ...h, stackId }));
+					.map((h) => ({ ...h, stackId: ensureValue(stack.id) }));
 				await this.diffService.assignHunk({
 					projectId: this.projectId,
 					assignments

--- a/apps/desktop/src/lib/stacks/macros.ts
+++ b/apps/desktop/src/lib/stacks/macros.ts
@@ -1,4 +1,5 @@
 import { getStackName } from '$lib/stacks/stack';
+import { ensureValue } from '$lib/utils/validation';
 import type { DiffSpec } from '$lib/hunks/hunk';
 import type {
 	CreateCommitRequestWorktreeChanges,
@@ -58,13 +59,10 @@ export default class StackMacros {
 			projectId: this.projectId,
 			branch: { name }
 		});
-		if (!stack.id) {
-			throw new Error('New stack has no stack id');
-		}
 		const branchName = getStackName(stack);
 		const outcome = await this.stackService.createCommitMutation({
 			projectId: this.projectId,
-			stackId: stack.id,
+			stackId: ensureValue(stack.id),
 			stackBranchName: branchName,
 			parentId: undefined,
 			message: message ?? STUB_COMMIT_MESSAGE,

--- a/apps/desktop/src/lib/utils/validation.ts
+++ b/apps/desktop/src/lib/utils/validation.ts
@@ -1,0 +1,12 @@
+/**
+ * Ensures that a value is not null or undefined, throwing an error if it is.
+ */
+export function ensureValue<T>(value: T | null | undefined): T {
+	if (value === null || value === undefined) {
+		const message = `Expected value but got ${value === null ? 'null' : 'undefined'}`;
+		const error = new Error(message);
+		Error.captureStackTrace(error, ensureValue);
+		throw error;
+	}
+	return value;
+}


### PR DESCRIPTION
Ensure stackId is validated before calling functions that require it.
Replace explicit null-checks and early returns with ensureValue(stackId)
so callers always pass a non-null stackId to stackService and related
helpers.

Key changes:
- Import ensureValue in multiple components (CommitContextMenu,
  BranchList, BranchCommitList).
- Use ensureValue(stackId) when calling insertBlankCommit,
  handleCreateNewRef, stackService.uncommit, editPatch, 
  insertBlankCommitInBranch, addDependentBranch modal setup, and 
  integrateUpstreamCommits.
- Fix selection close handler in StackView to call  
  itelligentScrollingService with laneId instead of stackId (uses the 
  intended lane identifier).

Reason:
Avoid scattered null-checks and early returns that silently fail action
handlers. Using ensureValue centralizes validation and surfaces errors
earlier, leading to more predictable behavior and fewer no-op UI actions.