### PR TITLE
Clean up createCommit method in stackService

### DIFF
--- a/apps/desktop/src/components/NewCommitView.svelte
+++ b/apps/desktop/src/components/NewCommitView.svelte
@@ -28,7 +28,7 @@
 	// Using a dummy stackId kind of sucks... but it's fine for now
 	const laneState = $derived(uiState.lane(stackId || 'new-commit-view--new-stack'));
 
-	const [createCommitInStack, commitCreation] = stackService.createCommit({});
+	const [createCommitInStack, commitCreation] = stackService.createCommit();
 
 	let isCooking = $state(false);
 

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -34,7 +34,6 @@ import type { DefaultForgeFactory } from '$lib/forge/forgeFactory.svelte';
 import type { TreeChange, TreeChanges, TreeStats } from '$lib/hunks/change';
 import type { DiffSpec } from '$lib/hunks/hunk';
 import type { BranchDetails, Stack, StackDetails, CreateRefRequest } from '$lib/stacks/stack';
-import type { PropertiesFn } from '$lib/state/customHooks.svelte';
 import type { ReduxError } from '$lib/state/reduxError';
 
 type BranchParams = {
@@ -457,9 +456,8 @@ export class StackService {
 		});
 	}
 
-	createCommit(args: { propertiesFn?: PropertiesFn }) {
-		const propertiesFn = args.propertiesFn;
-		return this.api.endpoints.createCommit.useMutation({ propertiesFn });
+	createCommit() {
+		return this.api.endpoints.createCommit.useMutation();
 	}
 
 	get createCommitMutation() {


### PR DESCRIPTION
Refactored createCommit method in stackService.svelte.ts to remove the unused argument and updated the API usage. This change simplifies the method interface and improves code maintainability.