### PR TITLE
Fix filePicker method typing and parameter handling

### DIFF
--- a/apps/desktop/src/lib/backend/backend.ts
+++ b/apps/desktop/src/lib/backend/backend.ts
@@ -102,7 +102,7 @@ export interface IBackend {
 	relaunch: () => Promise<void>;
 	documentDir: () => Promise<string>;
 	joinPath: (path: string, ...paths: string[]) => Promise<string>;
-	filePicker<T extends OpenDialogOptions>(options?: T): Promise<OpenDialogReturn<T>>;
+	filePicker<T extends OpenDialogOptions>(options: T): Promise<OpenDialogReturn<T>>;
 	homeDirectory(): Promise<string>;
 	getAppInfo: () => Promise<AppInfo>;
 	writeTextToClipboard: (text: string) => Promise<void>;

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -45,8 +45,8 @@ export default class Tauri implements IBackend {
 	getAppInfo = tauriGetAppInfo;
 	readTextFromClipboard = tauriReadText;
 	writeTextToClipboard = tauriWriteText;
-	async filePicker<T extends OpenDialogOptions>() {
-		return await filePickerTauri<T>();
+	async filePicker<T extends OpenDialogOptions>(options?: T) {
+		return await filePickerTauri<T>(options);
 	}
 	async homeDirectory(): Promise<string> {
 		// TODO: Find a workaround to avoid this dynamic import


### PR DESCRIPTION
Fixes the parameter typing for the filePicker method by making the options argument required in backend.ts, and ensures the tauri implementation properly accepts and passes the options parameter. This resolves interface mismatches and potential issues when calling filePicker from other modules.