### PR TITLE
Add error boundary to Chrome for project fetch errors

### DIFF
--- a/apps/desktop/src/components/Chrome.svelte
+++ b/apps/desktop/src/components/Chrome.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
+	import ChromeErrorBoundary from '$components/ChromeErrorBoundary.svelte';
 	import ChromeHeader from '$components/ChromeHeader.svelte';
 	import ChromeSidebar from '$components/ChromeSidebar.svelte';
-	import ProjectNotFound from '$components/ProjectNotFound.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
-	import { Code } from '$lib/error/knownErrors';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
-	import { isReduxError } from '$lib/state/reduxError';
 	import { inject } from '@gitbutler/shared/context';
 	import type { Snippet } from 'svelte';
 
@@ -36,11 +34,7 @@
 		</div>
 	{/snippet}
 	{#snippet error(e)}
-		{#if isReduxError(e)}
-			{#if e.code === Code.ProjectMissing}
-				<ProjectNotFound {projectId} />
-			{/if}
-		{/if}
+		<ChromeErrorBoundary {projectId} error={e} />
 	{/snippet}
 </ReduxResult>
 

--- a/apps/desktop/src/components/ChromeErrorBoundary.svelte
+++ b/apps/desktop/src/components/ChromeErrorBoundary.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import DecorativeSplitView from '$components/DecorativeSplitView.svelte';
+	import InfoMessage from '$components/InfoMessage.svelte';
+	import ProjectNotFound from '$components/ProjectNotFound.svelte';
+	import loadErrorSvg from '$lib/assets/illustrations/load-error.svg?raw';
+	import { parseQueryError } from '$lib/error/error';
+	import { Code } from '$lib/error/knownErrors';
+	import { Button } from '@gitbutler/ui';
+
+	type Props = {
+		projectId: string;
+		error: unknown;
+	};
+
+	const { projectId, error }: Props = $props();
+
+	const parsedError = $derived(parseQueryError(error));
+
+	function isMonday() {
+		const today = new Date();
+		return today.getDay() === 1;
+	}
+
+	function apologiy(): string {
+		if (isMonday()) {
+			return 'Sorry about that. Mondays can be tough!';
+		}
+		return 'We apologize for the inconvenience.';
+	}
+</script>
+
+{#if parsedError.code === Code.ProjectMissing}
+	<ProjectNotFound {projectId} />
+{:else}
+	<DecorativeSplitView img={loadErrorSvg}>
+		<div class="container">
+			<div class="text-content">
+				<h2 class="title-text text-18 text-body text-bold">Something went wrong</h2>
+
+				<p class="description-text text-13 text-body">
+					{apologiy()}
+				</p>
+			</div>
+
+			<InfoMessage error={parsedError.message} style="error">
+				{#snippet title()}
+					{parsedError.name}
+				{/snippet}
+				{#snippet content()}
+					An asynchronous operation failed.
+				{/snippet}
+			</InfoMessage>
+
+			<div class="button-container">
+				<Button type="button" style="pop" onclick={async () => await goto('/')}>Go back</Button>
+			</div>
+		</div>
+	</DecorativeSplitView>
+{/if}
+
+<style lang="postcss">
+	.container {
+		display: flex;
+		flex-direction: column;
+		gap: 20px;
+	}
+
+	.text-content {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+
+	.title-text {
+		color: var(--clr-scale-ntrl-30);
+	}
+
+	.button-container {
+		display: flex;
+		justify-content: end;
+		gap: 8px;
+	}
+
+	.description-text {
+		color: var(--clr-text-2);
+		line-height: 1.6;
+	}
+</style>

--- a/apps/desktop/src/components/ProblemLoadingRepo.svelte
+++ b/apps/desktop/src/components/ProblemLoadingRepo.svelte
@@ -49,7 +49,7 @@
 	});
 </script>
 
-{#snippet page()}
+<Chrome {projectId} sidebarDisabled>
 	<DecorativeSplitView img={loadErrorSvg}>
 		<div class="problem">
 			<div class="project-name">
@@ -85,10 +85,6 @@
 			</div>
 		</div>
 	</DecorativeSplitView>
-{/snippet}
-
-<Chrome {projectId} sidebarDisabled>
-	{@render page()}
 </Chrome>
 
 <style lang="postcss">

--- a/apps/desktop/src/components/ProjectSetup.svelte
+++ b/apps/desktop/src/components/ProjectSetup.svelte
@@ -43,6 +43,13 @@
 			posthog.capture('Project Setup Complete');
 		}
 	}
+
+	$effect(() => {
+		if (projectResult.current.isError) {
+			console.error('Failed to load project, redirecting:', projectResult.current.error);
+			goto('/');
+		}
+	});
 </script>
 
 <DecorativeSplitView img={newProjectSvg} testId={TestId.ProjectSetupPage}>

--- a/apps/desktop/src/components/ProjectSetupTarget.svelte
+++ b/apps/desktop/src/components/ProjectSetupTarget.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
 	import GithubIntegration from '$components/GithubIntegration.svelte';
 	import Login from '$components/Login.svelte';
 	import ProjectNameLabel from '$components/ProjectNameLabel.svelte';
@@ -58,12 +57,6 @@
 	const projectsService = inject(PROJECTS_SERVICE);
 	async function deleteProjectAndGoBack() {
 		await projectsService.deleteProject(projectId);
-
-		if (history.length > 0) {
-			history.back();
-		} else {
-			goto('/');
-		}
 	}
 </script>
 
@@ -240,7 +233,7 @@
 		</SetupFeature>
 	</div>
 	<div class="action-buttons">
-		<Button kind="outline" onmousedown={deleteProjectAndGoBack}>Cancel</Button>
+		<Button kind="outline" onclick={deleteProjectAndGoBack}>Cancel</Button>
 		<Button
 			style="pop"
 			{loading}

--- a/apps/desktop/src/lib/error/error.ts
+++ b/apps/desktop/src/lib/error/error.ts
@@ -84,7 +84,7 @@ function getBestCode(error: unknown): string | undefined {
 	return undefined;
 }
 
-function parseQueryError(error: unknown): QueryError {
+export function parseQueryError(error: unknown): QueryError {
 	const name = getBestName(error);
 	const message = getBestMessage(error);
 	const code = getBestCode(error);

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -106,7 +106,9 @@
 	});
 
 	const debouncedBaseBranchRefresh = debounce(async () => {
-		await baseBranchService.refreshBaseBranch(projectId);
+		await baseBranchService.refreshBaseBranch(projectId).catch((error) => {
+			console.error('Failed to refresh base branch:', error);
+		});
 	}, 500);
 
 	const debouncedRemoteBranchRefresh = debounce(async () => {


### PR DESCRIPTION
Introduces ChromeErrorBoundary and integrates it into Chrome.svelte to catch and render a better error message or fallback UI if an error occurs when fetching the project. Also updates ProblemLoadingRepo to mount inside Chrome and exports parseQueryError for use in boundaries.

Fixes https://github.com/gitbutlerapp/gitbutler/issues/9851