### PR TITLE
partial-stack-force-push

### DIFF
--- a/apps/desktop/src/components/PushButton.svelte
+++ b/apps/desktop/src/components/PushButton.svelte
@@ -2,11 +2,10 @@
 	import ReduxResult from '$components/ReduxResult.svelte';
 	import { CLIPBOARD_SERVICE } from '$lib/backend/clipboard';
 	import { DEFAULT_FORGE_FACTORY } from '$lib/forge/forgeFactory.svelte';
-	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
 	import {
 		branchHasConflicts,
 		branchHasUnpushedCommits,
-		branchRequiresForcePush
+		partialStackRequestsForcePush
 	} from '$lib/stacks/stack';
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
 	import { combineResults } from '$lib/state/helpers';
@@ -45,14 +44,13 @@
 	}: Props = $props();
 
 	const stackService = inject(STACK_SERVICE);
-	const projectsService = inject(PROJECTS_SERVICE);
 	const uiState = inject(UI_STATE);
 	const forge = inject(DEFAULT_FORGE_FACTORY);
 	const urlService = inject(URL_SERVICE);
 	const clipboardService = inject(CLIPBOARD_SERVICE);
 
 	const branchDetails = $derived(stackService.branchDetails(projectId, stackId, branchName));
-	const projectResult = $derived(projectsService.getProject(projectId));
+	const branchesResult = $derived(stackService.branches(projectId, stackId));
 	const [pushStack, pushResult] = stackService.pushStack;
 	const upstreamCommitsResult = $derived(
 		stackService.upstreamCommits(projectId, stackId, branchName)
@@ -114,9 +112,9 @@
 	let forcePushProtectionModal = $state<ReturnType<typeof Modal>>();
 </script>
 
-<ReduxResult {projectId} result={combineResults(branchDetails.current, projectResult.current)}>
-	{#snippet children([branchDetails])}
-		{@const withForce = branchRequiresForcePush(branchDetails)}
+<ReduxResult {projectId} result={combineResults(branchDetails.current, branchesResult.current)}>
+	{#snippet children([branchDetails, branches])}
+		{@const withForce = partialStackRequestsForcePush(branchName, branches)}
 		{@const hasThingsToPush = branchHasUnpushedCommits(branchDetails)}
 		{@const hasConflicts = branchHasConflicts(branchDetails)}
 

--- a/apps/desktop/src/components/ReviewCreation.svelte
+++ b/apps/desktop/src/components/ReviewCreation.svelte
@@ -25,7 +25,7 @@
 	import { updatePrDescriptionTables as updatePrStackInfo } from '$lib/forge/shared/prFooter';
 	import { showError, showToast } from '$lib/notifications/toasts';
 	import { REMOTES_SERVICE } from '$lib/remotes/remotesService';
-	import { requiresPush } from '$lib/stacks/stack';
+	import { partialStackRequestsForcePush, requiresPush } from '$lib/stacks/stack';
 	import { STACK_SERVICE, type BranchPushResult } from '$lib/stacks/stackService.svelte';
 	import { UI_STATE } from '$lib/state/uiState.svelte';
 	import { parseRemoteUrl } from '$lib/url/gitUrl';
@@ -154,10 +154,11 @@
 	): Promise<[string | undefined, BranchPushResult | undefined]> {
 		if (pushBeforeCreate) {
 			const firstPush = branchDetails?.pushStatus === 'completelyUnpushed';
+			const withForce = partialStackRequestsForcePush(branchName, branches);
 			const pushResult = await pushStack({
 				projectId,
 				stackId,
-				withForce: branchDetails?.pushStatus === 'unpushedCommitsRequiringForce',
+				withForce,
 				skipForcePushProtection: false, // override available for regular push
 				branch: branchName
 			});

--- a/apps/desktop/src/lib/stacks/stack.ts
+++ b/apps/desktop/src/lib/stacks/stack.ts
@@ -213,6 +213,29 @@ export function branchRequiresForcePush(branch: BranchDetails): boolean {
 	return branch.pushStatus === 'unpushedCommitsRequiringForce';
 }
 
+/**
+ * Does the branch or other branch this depends on require a force push?
+ *
+ * @param branchName The name of the branch to check
+ * @param allBranches Complete list of branches in the stack. The order is expected to be child-to-parent
+ */
+export function partialStackRequestsForcePush(
+	branchName: string,
+	allBranches: BranchDetails[]
+): boolean {
+	let foundBranch = false;
+
+	for (const branch of allBranches) {
+		if (branch.name === branchName && !foundBranch) {
+			foundBranch = true;
+		}
+		if (!foundBranch) continue;
+		if (branchRequiresForcePush(branch)) return true;
+	}
+
+	return false;
+}
+
 export function stackHasConflicts(stack: StackDetails): boolean {
 	return stack.isConflicted;
 }


### PR DESCRIPTION
If any of the parent branches needs to be force pushed, force push the whole stack

Summary
- Add partialStackRequestsForcePush helper to stacks/stack.ts.
- Replace ad-hoc force-push checks in PushButton.svelte and ReviewCreation.svelte with the new helper.

Fixes https://github.com/gitbutlerapp/gitbutler/issues/9734
