### PR TITLE
Move disk store creation logic into backend module

### DIFF
--- a/apps/desktop/src/lib/backend/backend.ts
+++ b/apps/desktop/src/lib/backend/backend.ts
@@ -1,4 +1,84 @@
 import type { Readable } from 'svelte/store';
+
+export interface IBackend {
+	/**
+	 * The name of the platform, e.g. 'macos', 'windows', 'linux', or 'web'
+	 */
+	platformName: string;
+	/**
+	 * The theme of the system, e.g. 'light', 'dark'
+	 */
+	systemTheme: Readable<string | null>;
+	/**
+	 * Executes a command in the backend.
+	 */
+	invoke: <T>(command: string, ...args: any[]) => Promise<T>;
+	/**
+	 * Subscribes to an event in the backend.
+	 */
+	listen: <T>(event: string, callback: (event: Event<T>) => void) => () => Promise<void>;
+	/**
+	 * Checks for updates in the backend.
+	 */
+	checkUpdate: () => Promise<Update | null>;
+	/**
+	 * Returns the current version of the application.
+	 */
+	currentVersion: () => Promise<string>;
+	/**
+	 * Reads a file from the disk.
+	 */
+	readFile: (path: string) => Promise<Uint8Array>;
+	/**
+	 * Opens an external URL in the system's default browser.
+	 */
+	openExternalUrl: (href: string) => Promise<void>;
+	/**
+	 * Relaunches the application.
+	 */
+	relaunch: () => Promise<void>;
+	/**
+	 * Returns the absolute path to the user's document directory.
+	 */
+	documentDir: () => Promise<string>;
+	/**
+	 * Joins path segments into a single path, taking care of platform-specific path separators.
+	 */
+	joinPath: (path: string, ...paths: string[]) => Promise<string>;
+	/**
+	 * Opens a file picker dialog to select files or directories.
+	 */
+	filePicker<T extends OpenDialogOptions>(options: T): Promise<OpenDialogReturn<T>>;
+	/**
+	 * Returns the absolute path to the user's home directory.
+	 */
+	homeDirectory(): Promise<string>;
+	/**
+	 * Gets the application name and version.
+	 */
+	getAppInfo: () => Promise<AppInfo>;
+	/**
+	 * Writes text to the system clipboard.
+	 */
+	writeTextToClipboard: (text: string) => Promise<void>;
+	/**
+	 * Reads text from the system clipboard.
+	 */
+	readTextFromClipboard: () => Promise<string>;
+	/**
+	 * Loads a disk store from a file.
+	 */
+	loadDiskStore: (fileName: string) => Promise<DiskStore>;
+}
+
+export interface DiskStore {
+	set: (key: string, value: unknown) => Promise<void>;
+
+	get<T>(key: string, defaultValue: undefined): Promise<T | undefined>;
+	get<T>(key: string, defaultValue: T): Promise<T>;
+	get<T>(key: string, defaultValue?: T): Promise<T | undefined>;
+}
+
 type Event<T> = {
 	/** Event name */
 	event: string;
@@ -90,21 +170,3 @@ export type AppInfo = {
 	name: string;
 	version: string;
 };
-export interface IBackend {
-	platformName: string;
-	systemTheme: Readable<string | null>;
-	invoke: <T>(command: string, ...args: any[]) => Promise<T>;
-	listen: <T>(event: string, callback: (event: Event<T>) => void) => () => Promise<void>;
-	checkUpdate: () => Promise<Update | null>;
-	currentVersion: () => Promise<string>;
-	readFile: (path: string) => Promise<Uint8Array>;
-	openExternalUrl: (href: string) => Promise<void>;
-	relaunch: () => Promise<void>;
-	documentDir: () => Promise<string>;
-	joinPath: (path: string, ...paths: string[]) => Promise<string>;
-	filePicker<T extends OpenDialogOptions>(options: T): Promise<OpenDialogReturn<T>>;
-	homeDirectory(): Promise<string>;
-	getAppInfo: () => Promise<AppInfo>;
-	writeTextToClipboard: (text: string) => Promise<void>;
-	readTextFromClipboard: () => Promise<string>;
-}

--- a/apps/desktop/src/lib/backend/web.ts
+++ b/apps/desktop/src/lib/backend/web.ts
@@ -2,7 +2,13 @@ import { isReduxError } from '$lib/state/reduxError';
 import { getCookie } from '$lib/utils/cookies';
 import { readable } from 'svelte/store';
 import path from 'path';
-import type { AppInfo, IBackend, OpenDialogOptions, OpenDialogReturn } from '$lib/backend/backend';
+import type {
+	AppInfo,
+	DiskStore,
+	IBackend,
+	OpenDialogOptions,
+	OpenDialogReturn
+} from '$lib/backend/backend';
 
 export default class Web implements IBackend {
 	platformName = 'web';
@@ -22,6 +28,27 @@ export default class Web implements IBackend {
 	writeTextToClipboard = webWriteTextToClipboard;
 	async filePicker<T extends OpenDialogOptions>(options?: T): Promise<OpenDialogReturn<T>> {
 		return await webFilePicker<T>(options);
+	}
+	async loadDiskStore(_filename: string): Promise<DiskStore> {
+		// For the web version, we don't have a disk store, so we return a no-op implementation
+		return new WebDiskStore();
+	}
+}
+
+class WebDiskStore implements DiskStore {
+	constructor() {}
+
+	async set(_key: string, _value: unknown): Promise<void> {
+		// TODO: Implement this for the web version
+		// This is a no-op for the web version
+	}
+
+	async get<T>(key: string, defaultValue: undefined): Promise<T | undefined>;
+	async get<T>(key: string, defaultValue: T): Promise<T>;
+	async get<T>(_: string, defaultValue?: T): Promise<T | undefined> {
+		// TODO: Implement this for the web version
+		// This is a no-op for the web version
+		return defaultValue;
 	}
 }
 
@@ -45,7 +72,6 @@ async function webGetAppInfo(): Promise<AppInfo> {
 }
 
 async function webHomeDirectory(): Promise<string> {
-	// This needs to be implemented for the web version
 	return await Promise.resolve('/tmp/gitbutler');
 }
 

--- a/apps/desktop/src/lib/config/appSettings.ts
+++ b/apps/desktop/src/lib/config/appSettings.ts
@@ -7,18 +7,13 @@
 
 import { InjectionToken } from '@gitbutler/shared/context';
 import { persisted } from '@gitbutler/shared/persisted';
-import { Store } from '@tauri-apps/plugin-store';
 import { get, writable, type Writable } from 'svelte/store';
+import type { DiskStore, IBackend } from '$lib/backend';
 
 type DiskWritable<T> = Writable<T> & { onDisk: () => Promise<T> };
 
-export async function loadAppSettings() {
-	let diskStore: Store | undefined;
-	if (import.meta.env.VITE_BUILD_TARGET === 'web') {
-		// TODO: Implement electron alternative
-	} else {
-		diskStore = await Store.load('settings.json', { autoSave: true });
-	}
+export async function loadAppSettings(backend: IBackend) {
+	const diskStore = await backend.loadDiskStore('settings.json');
 	return new AppSettings(diskStore);
 }
 
@@ -51,7 +46,7 @@ export class AppSettings {
 	 */
 	readonly appNonAnonMetricsEnabled: DiskWritable<boolean>;
 
-	constructor(private diskStore: Store | undefined) {
+	constructor(private diskStore: DiskStore) {
 		this.appAnalyticsConfirmed = this.persisted(false, 'appAnalyticsConfirmed');
 		this.appMetricsEnabled = this.persisted(true, 'appMetricsEnabled');
 		this.appErrorReportingEnabled = this.persisted(true, 'appErrorReportingEnabled');
@@ -77,7 +72,7 @@ export class AppSettings {
 		const subscribe = keySpecificStore.subscribe;
 
 		async function setAndPersist(value: T, set: (value: T) => void) {
-			diskStore?.set(key, value);
+			diskStore.set(key, value);
 			set(value);
 		}
 
@@ -102,7 +97,7 @@ export class AppSettings {
 	}
 
 	async storeValueWithDefault<T>(initial: T, key: string): Promise<T> {
-		const stored = (await this.diskStore?.get(key)) as T;
+		const stored = await this.diskStore.get<T>(key);
 		return stored === null || stored === undefined ? initial : stored;
 	}
 }

--- a/apps/desktop/src/routes/+layout.ts
+++ b/apps/desktop/src/routes/+layout.ts
@@ -39,7 +39,7 @@ export const load: LayoutLoad = async () => {
 	// Awaited and will block initial render, but it is necessary in order to respect the user
 	// settings on telemetry.
 	const posthog = new PostHogWrapper(settingsService, backend, eventContext);
-	const appSettings = await loadAppSettings();
+	const appSettings = await loadAppSettings(backend);
 	initAnalyticsIfEnabled(appSettings, posthog);
 
 	const gitConfig = new GitConfigService(backend);


### PR DESCRIPTION
- Move the logic for creating a disk store from the app settings config to the backend modules.
- Update the IBackend interface to include a loadDiskStore method, and implement platform-specific DiskStore classes for Tauri and Web.
- Adjust appSettings, layout, and platform backends to use the new backend-provided disk store factory.
- Ensures storage logic is centralized in the backend, improving clarity and portability.