### PR TITLE
fix: resolve branch name parsing causing git reference errors

### DIFF
--- a/apps/desktop/src/components/BranchesView.svelte
+++ b/apps/desktop/src/components/BranchesView.svelte
@@ -30,6 +30,7 @@
 	} from '$lib/selection/key';
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
 	import { UI_STATE } from '$lib/state/uiState.svelte';
+	import { parseBranchName } from '$lib/utils/branch';
 	import { inject } from '@gitbutler/shared/context';
 	import { persisted } from '@gitbutler/shared/persisted';
 	import { AsyncButton, Button, Modal, TestId } from '@gitbutler/ui';
@@ -70,7 +71,8 @@
 			const branchName = current.remote
 				? current.remote + '/' + current.branchName
 				: current.branchName;
-			return createBranchSelection({ stackId: current.stackId, branchName });
+			const { branchName: parsedBranchName } = parseBranchName(branchName);
+			return createBranchSelection({ stackId: current.stackId, branchName: parsedBranchName });
 		}
 	});
 

--- a/apps/desktop/src/lib/utils/branch.test.ts
+++ b/apps/desktop/src/lib/utils/branch.test.ts
@@ -56,3 +56,108 @@ describe.concurrent('getBranchRemoteFromRef', () => {
 		expect(BranchUtils.getBranchRemoteFromRef(ref)).toBe('origin');
 	});
 });
+
+describe.concurrent('parseBranchName', () => {
+	test('When provided a local branch name without remote, it returns just the branch name', () => {
+		const result = BranchUtils.parseBranchName('feature/awesome-stuff');
+
+		expect(result).toEqual({
+			remote: undefined,
+			branchName: 'feature/awesome-stuff'
+		});
+	});
+
+	test('When provided a branch with origin remote prefix, it extracts remote and branch name', () => {
+		const result = BranchUtils.parseBranchName('origin/feature/awesome-stuff');
+
+		expect(result).toEqual({
+			remote: 'origin',
+			branchName: 'feature/awesome-stuff'
+		});
+	});
+
+	test('When provided a branch with upstream remote prefix, it extracts remote and branch name', () => {
+		const result = BranchUtils.parseBranchName('upstream/main');
+
+		expect(result).toEqual({
+			remote: 'upstream',
+			branchName: 'main'
+		});
+	});
+
+	test('When provided a branch with fork remote prefix, it extracts remote and branch name', () => {
+		const result = BranchUtils.parseBranchName('fork/bugfix/issue-123');
+
+		expect(result).toEqual({
+			remote: 'fork',
+			branchName: 'bugfix/issue-123'
+		});
+	});
+
+	test('When provided a branch with an explicit remote parameter, it uses the provided remote', () => {
+		const result = BranchUtils.parseBranchName('origin/feature/test', 'upstream');
+
+		expect(result).toEqual({
+			remote: 'upstream',
+			branchName: 'feature/test'
+		});
+	});
+
+	test('When provided a branch name that matches the provided remote, it strips the remote prefix', () => {
+		const result = BranchUtils.parseBranchName('origin/feature/test', 'origin');
+
+		expect(result).toEqual({
+			remote: 'origin',
+			branchName: 'feature/test'
+		});
+	});
+
+	test('When provided a branch name with non-standard remote name, it treats it as part of branch name', () => {
+		const result = BranchUtils.parseBranchName('my-company/special-feature');
+
+		expect(result).toEqual({
+			remote: undefined,
+			branchName: 'my-company/special-feature'
+		});
+	});
+
+	test('When provided a single-part branch name, it returns unchanged', () => {
+		const result = BranchUtils.parseBranchName('main');
+
+		expect(result).toEqual({
+			remote: undefined,
+			branchName: 'main'
+		});
+	});
+
+	test('When provided an empty string, it throws an error', () => {
+		expect(() => BranchUtils.parseBranchName('')).toThrow();
+	});
+
+	test('When provided a branch with multiple slashes but unknown remote, it keeps the full path', () => {
+		const result = BranchUtils.parseBranchName('some/deep/feature/branch');
+
+		expect(result).toEqual({
+			remote: undefined,
+			branchName: 'some/deep/feature/branch'
+		});
+	});
+
+	test('When provided a branch with remote remote prefix, it extracts remote and branch name', () => {
+		const result = BranchUtils.parseBranchName('remote/hotfix/critical-bug');
+
+		expect(result).toEqual({
+			remote: 'remote',
+			branchName: 'hotfix/critical-bug'
+		});
+	});
+
+	test('When provided a complex nested branch with known remote, it handles correctly', () => {
+		const result = BranchUtils.parseBranchName('origin/release/v2.1.0/hotfix/security');
+
+		expect(result).toEqual({
+			remote: 'origin',
+			branchName: 'release/v2.1.0/hotfix/security'
+		});
+	});
+});


### PR DESCRIPTION
## 🧢 Changes

  - **Add new `parseBranchName` utility function** to properly extract remote prefixes
  from branch names
  - **Fix BranchesView.svelte** to use `parseBranchName` when creating selection IDs,
  preventing unparsed branch names from reaching the backend
  - **Optimize StackView.svelte** to parse branch name and remote in a single reactive
  derivation instead of two separate calls
  - **Add comprehensive test suite** covering all parsing scenarios including edge cases
  and error conditions
  - **Clean up code quality** by removing redundant comments and eliminating duplicate
  parsing logic

  ## ☕️ Reasoning

  Users were encountering git reference errors like `"The reference
  'refs/heads/origin/feat/APL-2641-target-path-redirect-after-auth' did not exist"` when
  interacting with remote branches in the UI.

  **Root Cause**: Branch names containing remote prefixes (e.g.,
  `"origin/feat/branch-name"`) were being passed directly to the backend without parsing.
  The backend would then construct invalid git references by prepending `refs/heads/` to
  the unparsed name, resulting in malformed refs like `refs/heads/origin/feat/branch-name`
   instead of the correct `refs/remotes/origin/feat/branch-name`.

  **Solution**: The new `parseBranchName` function intelligently separates remote prefixes
   from branch names, ensuring the backend receives clean branch names and proper remote
  information. This allows the backend to construct valid git references and eliminates
  the reference errors.

  **Impact**: Fixes branch selection and viewing for all remote branches, improving the
  user experience when working with branches from multiple remotes.

<img width="2866" height="442" alt="Screenshot 2025-08-16 at 1 22 32 PM" src="https://github.com/user-attachments/assets/2c3b55e8-0747-42d9-8c11-174156ffcbab" />
