### PR TITLE
create-branch-for-commits

### DIFF
--- a/apps/desktop/src/components/BranchHeaderContextMenu.svelte
+++ b/apps/desktop/src/components/BranchHeaderContextMenu.svelte
@@ -194,7 +194,7 @@
 		{#if stackId}
 			<ContextMenuSection>
 				<ContextMenuItem
-					label="Create dependent branch above"
+					label="Create branch above"
 					disabled={refCreation.current.isLoading}
 					testId={TestId.BranchHeaderContextMenu_AddDependentBranch}
 					onclick={async () => {
@@ -203,7 +203,7 @@
 					}}
 				/>
 				<ContextMenuItem
-					label="Create dependent branch below"
+					label="Create branch below"
 					disabled={refCreation.current.isLoading}
 					onclick={async () => {
 						await handleCreateNewRef(stackId, 'Below');

--- a/apps/desktop/src/components/CommitContextMenu.svelte
+++ b/apps/desktop/src/components/CommitContextMenu.svelte
@@ -55,6 +55,7 @@
 		KebabButton,
 		TestId
 	} from '@gitbutler/ui';
+	import type { AnchorPosition } from '$lib/stacks/stack';
 
 	type Props = {
 		flat?: boolean;
@@ -70,6 +71,7 @@
 	const stackService = inject(STACK_SERVICE);
 	const clipboardService = inject(CLIPBOARD_SERVICE);
 	const [insertBlankCommitInBranch, commitInsertion] = stackService.insertBlankCommit;
+	const [createRef, refCreation] = stackService.createReference;
 
 	let contextMenu = $state<ReturnType<typeof ContextMenu>>();
 	let kebabButtonElement = $state<HTMLElement>();
@@ -84,6 +86,24 @@
 			stackId,
 			commitId: commitId,
 			offset: location === 'above' ? -1 : 1
+		});
+	}
+
+	async function handleCreateNewRef(stackId: string, commitId: string, position: AnchorPosition) {
+		const newName = await stackService.fetchNewBranchName(projectId);
+		await createRef({
+			projectId,
+			stackId,
+			request: {
+				newName,
+				anchor: {
+					type: 'atCommit',
+					subject: {
+						commit_id: commitId,
+						position
+					}
+				}
+			}
 		});
 	}
 
@@ -190,6 +210,24 @@
 						disabled={commitInsertion.current.isLoading}
 						onclick={() => {
 							insertBlankCommit(ensureValue(stackId), commitId, 'below');
+							close();
+						}}
+					/>
+				</ContextMenuSection>
+				<ContextMenuSection>
+					<ContextMenuItem
+						label="Branch from this commit"
+						disabled={refCreation.current.isLoading}
+						onclick={async () => {
+							await handleCreateNewRef(ensureValue(stackId), commitId, 'Above');
+							close();
+						}}
+					/>
+					<ContextMenuItem
+						label="Branch after this commit"
+						disabled={refCreation.current.isLoading}
+						onclick={async () => {
+							await handleCreateNewRef(ensureValue(stackId), commitId, 'Below');
 							close();
 						}}
 					/>


### PR DESCRIPTION
- Simplify context menu labels for creating branches (above/below) in the UI
- Restore "branch from/after commit" actions to the commit menu

<img width="550" height="944" alt="image" src="https://github.com/user-attachments/assets/9a252a95-9913-4231-baec-1eef3445ce24" />
