### PR TITLE
Implement claude permissions mechanism over MCP

### DIFF
--- a/crates/but-claude/src/db.rs
+++ b/crates/but-claude/src/db.rs
@@ -183,3 +183,31 @@ impl TryFrom<crate::ClaudeMessage> for but_db::ClaudeMessage {
         })
     }
 }
+
+impl TryFrom<but_db::ClaudePermissionRequest> for crate::ClaudePermissionRequest {
+    type Error = anyhow::Error;
+    fn try_from(value: but_db::ClaudePermissionRequest) -> Result<Self, Self::Error> {
+        Ok(crate::ClaudePermissionRequest {
+            id: value.id.to_string(),
+            created_at: value.created_at,
+            updated_at: value.updated_at,
+            tool_name: value.tool_name,
+            input: serde_json::from_str(&value.input)?,
+            approved: value.approved,
+        })
+    }
+}
+
+impl TryFrom<crate::ClaudePermissionRequest> for but_db::ClaudePermissionRequest {
+    type Error = anyhow::Error;
+    fn try_from(value: crate::ClaudePermissionRequest) -> Result<Self, Self::Error> {
+        Ok(but_db::ClaudePermissionRequest {
+            id: value.id,
+            created_at: value.created_at,
+            updated_at: value.updated_at,
+            tool_name: value.tool_name,
+            input: serde_json::to_string(&value.input)?,
+            approved: value.approved,
+        })
+    }
+}

--- a/crates/but-claude/src/lib.rs
+++ b/crates/but-claude/src/lib.rs
@@ -64,3 +64,20 @@ pub struct ClaudeSessionDetails {
     pub summary: Option<String>,
     pub last_prompt: Option<String>,
 }
+
+/// Represents a request for permission to use a tool in the Claude MCP.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ClaudePermissionRequest {
+    /// Maps to the tool_use_id from the MCP request
+    pub id: String,
+    /// When the requst was made.
+    pub created_at: chrono::NaiveDateTime,
+    /// When the request was updated.
+    pub updated_at: chrono::NaiveDateTime,
+    /// The tool for which permission is requested
+    pub tool_name: String,
+    /// The input for the tool
+    pub input: serde_json::Value,
+    /// The status of the request or None if not yet handled
+    pub approved: Option<bool>,
+}

--- a/crates/but-db/migrations/2025-08-17-195624_claude_approval_requests/down.sql
+++ b/crates/but-db/migrations/2025-08-17-195624_claude_approval_requests/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE IF EXISTS `claude_permission_requests`;

--- a/crates/but-db/migrations/2025-08-17-195624_claude_approval_requests/up.sql
+++ b/crates/but-db/migrations/2025-08-17-195624_claude_approval_requests/up.sql
@@ -1,0 +1,9 @@
+-- Your SQL goes here
+CREATE TABLE `claude_permission_requests`(
+	`id` TEXT NOT NULL PRIMARY KEY,
+	`created_at` TIMESTAMP NOT NULL,
+	`updated_at` TIMESTAMP NOT NULL,
+	`tool_name` TEXT NOT NULL,
+	`input` TEXT NOT NULL,
+	`approved` BOOL
+);

--- a/crates/but-db/src/lib.rs
+++ b/crates/but-db/src/lib.rs
@@ -14,7 +14,7 @@ mod schema;
 mod workflows;
 pub use workflows::Workflow;
 mod claude;
-pub use claude::{ClaudeMessage, ClaudeSession};
+pub use claude::{ClaudeMessage, ClaudePermissionRequest, ClaudeSession};
 mod file_write_locks;
 pub use file_write_locks::FileWriteLock;
 mod workspace_rules;

--- a/crates/but-db/src/schema.rs
+++ b/crates/but-db/src/schema.rs
@@ -73,3 +73,14 @@ diesel::table! {
         content -> Text,
     }
 }
+
+diesel::table! {
+    claude_permission_requests (id) {
+        id -> Text,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+        tool_name -> Text,
+        input -> Text,
+        approved -> Nullable<Bool>,
+    }
+}

--- a/crates/but/src/main.rs
+++ b/crates/but/src/main.rs
@@ -75,7 +75,9 @@ async fn main() -> Result<()> {
                 metrics_if_configured(app_settings, CommandName::ClaudeStop, p).ok();
                 Ok(())
             }
-            claude::Subcommands::PermissionPromptMcp => but_claude::mcp::start().await,
+            claude::Subcommands::PermissionPromptMcp => {
+                but_claude::mcp::start(&args.current_dir).await
+            }
         },
         Subcommands::Log => {
             let result = log::commit_graph(&args.current_dir, args.json);


### PR DESCRIPTION
I have been testing like so:
```bash
 claude -d -p "Add Foo to the Readme"  --permission-prompt-tool mcp__but-security__approval_prompt --mcp-config /Users/kiril/but-security.json --output-format json
 ```
**Note:** depending on where this is invoked from, it may be necessary to pass `--current-dir <PATH>` as well

The contents of but-security.json
```json
{
  "mcpServers": {
    "but-security": {
      "type": "stdio",
      "command": "/Users/kiril/src/gitbutler/target/debug/but",
      "args": ["claude", "pp"],
      "env": {}
    }
  }
}
```

In the process of doing this I learned that `--permission-prompt-tool` has no effect if claude is in interactive mode.
