### PR TITLE
V3 apply/unapply

### DIFF
--- a/crates/but-core/src/diff/mod.rs
+++ b/crates/but-core/src/diff/mod.rs
@@ -61,15 +61,6 @@ impl TreeChange {
     }
 }
 
-impl std::fmt::Debug for TreeChange {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("TreeChange")
-            .field("path", &self.path)
-            .field("status", &self.status)
-            .finish()
-    }
-}
-
 impl std::fmt::Debug for IgnoredWorktreeChange {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IgnoredWorktreeChange")

--- a/crates/but-core/src/diff/tree_changes.rs
+++ b/crates/but-core/src/diff/tree_changes.rs
@@ -81,7 +81,6 @@ impl From<gix::object::tree::diff::ChangeDetached> for TreeChange {
                     },
                     is_untracked: false,
                 },
-                status_item: None,
             },
             Change::Deletion {
                 location,
@@ -96,7 +95,6 @@ impl From<gix::object::tree::diff::ChangeDetached> for TreeChange {
                         kind: entry_mode.kind(),
                     },
                 },
-                status_item: None,
             },
             Change::Modification {
                 location,
@@ -120,7 +118,6 @@ impl From<gix::object::tree::diff::ChangeDetached> for TreeChange {
                         state,
                         flags: ModeFlags::calculate(&previous_state, &state),
                     },
-                    status_item: None,
                 }
             }
             Change::Rewrite {
@@ -150,7 +147,6 @@ impl From<gix::object::tree::diff::ChangeDetached> for TreeChange {
                         state,
                         flags: ModeFlags::calculate(&previous_state, &state),
                     },
-                    status_item: None,
                 }
             }
         }

--- a/crates/but-core/src/diff/worktree.rs
+++ b/crates/but-core/src/diff/worktree.rs
@@ -479,6 +479,7 @@ fn worktree_changes_inner(
     let mut path_check = gix::status::plumbing::SymlinkCheck::new(
         repo.workdir().map(ToOwned::to_owned).context("non-bare")?,
     );
+    let original_changes = tmp.iter().map(|(_, change)| change.clone()).collect();
     for (_origin, change) in tmp {
         // At this point we know that the current `change` is the tree/index variant
         // of a prior change between index/worktree.
@@ -538,6 +539,7 @@ fn worktree_changes_inner(
     Ok(WorktreeChanges {
         changes,
         ignored_changes,
+        original_changes,
     })
 }
 
@@ -933,5 +935,14 @@ impl TreeChange {
                 diff_filter,
             ),
         }
+    }
+}
+
+impl std::fmt::Debug for WorktreeChanges {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WorktreeChanges")
+            .field("changes", &self.changes)
+            .field("ignored_changes", &self.ignored_changes)
+            .finish()
     }
 }

--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -346,12 +346,16 @@ pub struct IgnoredWorktreeChange {
 }
 
 /// The type returned by [`worktree_changes()`](diff::worktree_changes).
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct WorktreeChanges {
     /// Changes that could be committed.
     pub changes: Vec<TreeChange>,
     /// Changes that were in the index that we can't handle. The user can see them and interact with them to clear them out before a commit can be made.
     pub ignored_changes: Vec<IgnoredWorktreeChange>,
+    /// The unprocessed (but sorted, by path) changes which were used to produce `changes` and `ignored_changes`.
+    /// This doesn't include index conflicts!
+    /// TODO: can this be specific index changes? After all that's the only thing we need.
+    pub original_changes: Vec<TreeChange>,
 }
 
 /// Computed using the file kinds/modes of two [`ChangeState`] instances to represent

--- a/crates/but-core/src/ui.rs
+++ b/crates/but-core/src/ui.rs
@@ -29,6 +29,7 @@ impl From<crate::WorktreeChanges> for WorktreeChanges {
         crate::WorktreeChanges {
             changes,
             ignored_changes,
+            original_changes: _,
         }: crate::WorktreeChanges,
     ) -> Self {
         WorktreeChanges {

--- a/crates/but-core/src/ui.rs
+++ b/crates/but-core/src/ui.rs
@@ -29,7 +29,8 @@ impl From<crate::WorktreeChanges> for WorktreeChanges {
         crate::WorktreeChanges {
             changes,
             ignored_changes,
-            original_changes: _,
+            index_changes: _,
+            index_conflicts: _,
         }: crate::WorktreeChanges,
     ) -> Self {
         WorktreeChanges {
@@ -270,20 +271,12 @@ impl From<TreeChange> for crate::TreeChange {
         crate::TreeChange {
             path: path_bytes,
             status: status.into(),
-            // Lossy conversion, but this is fine.
-            status_item: None,
         }
     }
 }
 
 impl From<crate::TreeChange> for TreeChange {
-    fn from(
-        crate::TreeChange {
-            path,
-            status,
-            status_item: _,
-        }: crate::TreeChange,
-    ) -> Self {
+    fn from(crate::TreeChange { path, status }: crate::TreeChange) -> Self {
         TreeChange {
             path: path.clone().into(),
             path_bytes: path,

--- a/crates/but-workspace/tests/fixtures/generated-archives/.gitignore
+++ b/crates/but-workspace/tests/fixtures/generated-archives/.gitignore
@@ -29,3 +29,4 @@
 /with-conflict.tar
 /journey*.tar
 /single-branch*.tar
+/index*.tar

--- a/crates/but-workspace/tests/fixtures/scenario/index-modified-added-deleted.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/index-modified-added-deleted.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+### Description
+# A commit with an executable, a normal file, and an untracked fifo,
+# which subsequently get modified and deleted in the index, with the symlink being added to it.
+set -eu -o pipefail
+
+git init
+echo content > modified-content
+echo change-exe-bit > modified-exe
+echo "soon deleted in index but left on disk" > deleted-exe && chmod +x deleted-exe
+mkfifo fifo-should-be-ignored
+
+git add . && git commit -m "init"
+
+echo index-content >modified-content && \
+  git add modified-content && \
+  echo content >modified-content
+
+ln -s only-in-index link && \
+  git add link && \
+  rm link
+
+git rm --cached deleted-exe
+
+chmod +x modified-exe && \
+  git add modified-exe && \
+  chmod -x modified-exe
+

--- a/crates/but-workspace/tests/workspace/snapshot/index_create_and_resolve.rs
+++ b/crates/but-workspace/tests/workspace/snapshot/index_create_and_resolve.rs
@@ -7,9 +7,9 @@ use gix::prelude::ObjectIdExt;
 #[test]
 fn unborn_added_to_index() -> anyhow::Result<()> {
     let repo = read_only_in_memory_scenario("unborn-all-file-types-added-to-index")?;
-    let (head_tree_id, state, no_workspace_and_meta) = args_for_worktree_changes(&repo)?;
+    let (head_tree_id, mut state, no_workspace_and_meta) = args_for_worktree_changes(&repo)?;
 
-    let out = snapshot::create_tree(head_tree_id, state, no_workspace_and_meta)?;
+    let out = snapshot::create_tree(head_tree_id, state.clone(), no_workspace_and_meta)?;
     insta::assert_snapshot!(visualize_tree(out.snapshot_tree.attach(&repo)), @r#"
     085f2bf
     ├── HEAD:4b825dc 
@@ -62,15 +62,20 @@ fn unborn_added_to_index() -> anyhow::Result<()> {
         res_out.workspace_references.is_none(),
         "didn't ask to store this"
     );
+
+    state.selection.clear();
+    let out = snapshot::create_tree(head_tree_id, state, no_workspace_and_meta)?;
+    // An empty selection always means there is no effective change.
+    insta::assert_snapshot!(visualize_tree(out.snapshot_tree.attach(&repo)), @"4b825dc");
     Ok(())
 }
 
 #[test]
 fn with_conflicts() -> anyhow::Result<()> {
     let repo = read_only_in_memory_scenario("merge-with-two-branches-conflict")?;
-    let (head_tree_id, state, no_workspace_and_meta) = args_for_worktree_changes(&repo)?;
+    let (head_tree_id, mut state, no_workspace_and_meta) = args_for_worktree_changes(&repo)?;
 
-    let out = snapshot::create_tree(head_tree_id, state, no_workspace_and_meta)?;
+    let out = snapshot::create_tree(head_tree_id, state.clone(), no_workspace_and_meta)?;
     insta::assert_snapshot!(visualize_tree(out.snapshot_tree.attach(&repo)), @r#"
     60bd065
     ├── HEAD:429a9b9 
@@ -123,6 +128,11 @@ fn with_conflicts() -> anyhow::Result<()> {
         res_out.workspace_references.is_none(),
         "didn't ask to store this"
     );
+
+    state.selection.clear();
+    let out = snapshot::create_tree(head_tree_id, state, no_workspace_and_meta)?;
+    // An empty selection always means there is no effective change.
+    insta::assert_snapshot!(visualize_tree(out.snapshot_tree.attach(&repo)), @"4b825dc");
     Ok(())
 }
 

--- a/crates/but-workspace/tests/workspace/snapshot/worktree_create_and_resolve.rs
+++ b/crates/but-workspace/tests/workspace/snapshot/worktree_create_and_resolve.rs
@@ -49,9 +49,9 @@ fn unborn_empty() -> anyhow::Result<()> {
 #[test]
 fn unborn_untracked() -> anyhow::Result<()> {
     let repo = read_only_in_memory_scenario("unborn-untracked-all-file-types")?;
-    let (head_tree_id, state, no_workspace_and_meta) = args_for_worktree_changes(&repo)?;
+    let (head_tree_id, mut state, no_workspace_and_meta) = args_for_worktree_changes(&repo)?;
 
-    let out = snapshot::create_tree(head_tree_id, state, no_workspace_and_meta)?;
+    let out = snapshot::create_tree(head_tree_id, state.clone(), no_workspace_and_meta)?;
     assert!(!out.is_empty(), "it picks up the untracked files");
     insta::assert_snapshot!(visualize_tree(out.snapshot_tree.attach(&repo)), @r#"
     a863d4e
@@ -96,15 +96,20 @@ fn unborn_untracked() -> anyhow::Result<()> {
         res_out.workspace_references.is_none(),
         "didn't ask to store this"
     );
+
+    state.selection.clear();
+    let out = snapshot::create_tree(head_tree_id, state, no_workspace_and_meta)?;
+    // An empty selection always means there is no effective change.
+    insta::assert_snapshot!(visualize_tree(out.snapshot_tree.attach(&repo)), @"4b825dc");
     Ok(())
 }
 
 #[test]
 fn worktree_all_filetypes() -> anyhow::Result<()> {
     let repo = read_only_in_memory_scenario("all-file-types-renamed-and-modified")?;
-    let (head_tree_id, state, no_workspace_and_meta) = args_for_worktree_changes(&repo)?;
+    let (head_tree_id, mut state, no_workspace_and_meta) = args_for_worktree_changes(&repo)?;
 
-    let out = snapshot::create_tree(head_tree_id, state, no_workspace_and_meta)?;
+    let out = snapshot::create_tree(head_tree_id, state.clone(), no_workspace_and_meta)?;
     insta::assert_snapshot!(visualize_tree(out.snapshot_tree.attach(&repo)), @r#"
     9d274f3
     ├── HEAD:3fd29f0 
@@ -152,5 +157,10 @@ fn worktree_all_filetypes() -> anyhow::Result<()> {
         res_out.workspace_references.is_none(),
         "didn't ask to store this"
     );
+
+    state.selection.clear();
+    let out = snapshot::create_tree(head_tree_id, state, no_workspace_and_meta)?;
+    // An empty selection always means there is no effective change.
+    insta::assert_snapshot!(visualize_tree(out.snapshot_tree.attach(&repo)), @"4b825dc");
     Ok(())
 }


### PR DESCRIPTION
With [stashing](https://github.com/gitbutlerapp/gitbutler/pull/9725) available, a single-branch aware version of branch apply and unapply is possible.

### Tasks

* [x] add missing snapshot tests/fix snapshotting
* [ ] formulate rules
* [ ] impl TBD


### Rules

* **The workspace is a conflict-free zone**
    - nothing that operates on the conflict must write conflicts into the index.
      This is as conflicts are currently hidden from view.
* **Symmetry**
   - If `apply` is doing something, then `unapply` undoes exactly that, or in other words `State + apply + unapply == State`

Thus:

* snapshots of worktree changes will be made to apply by forcing merge-conflicts to be... auto-resolved.
  This is a problem, but **we can't have conflicts** as the UI doesn't show them right now, nor does it allow interacting with them.


### Research

#### Unapply: Assignments - with stashing

- uncommitted but assigned changes should create a snapshot commit
- when applying the same branch this snapshot is applied

However, the user should be able to interact with these.

#### Unapply: Assignments - with WIP commit

- uncommitted but assigned changes should create a WIP commit
     - or just unassign these assignments and they are back in the unassigned changes of the workspace
- MVP apply: do nothing with the WIP commit
- final version: apply restores the assignments from the WIP commit (which then is tracked with metadata)

#### Unapply with worktree changes

* **worktree changes that don't re-apply cleanly**

### Possible Follow-Ups

* Find a way to display and handle conflicts in the UI (Gitizen).
    - this would allow us to write conflicts as well and deal with them.
* Conflict handling TBD