### PR TITLE
Move logErrorToFile to backend module

### DIFF
--- a/apps/desktop/src/hooks.client.ts
+++ b/apps/desktop/src/hooks.client.ts
@@ -1,7 +1,7 @@
+import { logErrorToFile } from '$lib/backend';
 import { SilentError } from '$lib/error/error';
 import { showError } from '$lib/notifications/toasts';
 import { captureException } from '@sentry/sveltekit';
-import { error as logErrorToFile } from '@tauri-apps/plugin-log';
 import type { HandleClientError } from '@sveltejs/kit';
 
 // SvelteKit error handler.
@@ -61,13 +61,10 @@ function logError(error: unknown) {
 			showError('Unhandled exception', error);
 		}
 
+		const logMessage = loggableError(error);
+		logErrorToFile(logMessage);
+
 		console.error(error);
-		if (import.meta.env.VITE_BUILD_TARGET === 'web') {
-			// TODO: Replace with electron log file
-		} else {
-			const errorMessage = loggableError(error);
-			logErrorToFile(errorMessage);
-		}
 	} catch (err: unknown) {
 		console.error('Error while trying to log error.', err);
 	}

--- a/apps/desktop/src/lib/backend/index.ts
+++ b/apps/desktop/src/lib/backend/index.ts
@@ -1,5 +1,5 @@
-import Tauri, { tauriPathSeparator } from '$lib/backend/tauri';
-import Web, { webPathSeparator } from '$lib/backend/web';
+import Tauri, { tauriLogErrorToFile, tauriPathSeparator } from '$lib/backend/tauri';
+import Web, { webLogErrorToFile, webPathSeparator } from '$lib/backend/web';
 import { InjectionToken } from '@gitbutler/shared/context';
 import type { IBackend } from '$lib/backend/backend';
 
@@ -25,6 +25,15 @@ export function platformPathSeparator(): string {
 		return webPathSeparator();
 	}
 	return tauriPathSeparator();
+}
+
+export function logErrorToFile(error: string) {
+	if (import.meta.env.VITE_BUILD_TARGET === 'web') {
+		webLogErrorToFile(error);
+		return;
+	}
+
+	tauriLogErrorToFile(error);
 }
 
 export * from '$lib/backend/backend';

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -11,6 +11,7 @@ import {
 } from '@tauri-apps/plugin-clipboard-manager';
 import { open as filePickerTauri, type OpenDialogOptions } from '@tauri-apps/plugin-dialog';
 import { readFile as tauriReadFile } from '@tauri-apps/plugin-fs';
+import { error as logErrorToFile } from '@tauri-apps/plugin-log';
 import { platform } from '@tauri-apps/plugin-os';
 import { relaunch as relaunchTauri } from '@tauri-apps/plugin-process';
 import { Store } from '@tauri-apps/plugin-store';
@@ -73,6 +74,10 @@ class TauriDiskStore implements DiskStore {
 		const value = await this.store.get<T>(key);
 		return value !== undefined ? value : defaultValue;
 	}
+}
+
+export async function tauriLogErrorToFile(error: string) {
+	await logErrorToFile(error);
 }
 
 export function tauriPathSeparator(): string {

--- a/apps/desktop/src/lib/backend/web.ts
+++ b/apps/desktop/src/lib/backend/web.ts
@@ -52,6 +52,11 @@ class WebDiskStore implements DiskStore {
 	}
 }
 
+export function webLogErrorToFile(error: string) {
+	// TODO: Implement this for the web version if needed
+	console.error('Logging to file is not supported in web builds.');
+	console.error(error);
+}
 export function webPathSeparator(): string {
 	return '/'; // Web uses forward slashes for path
 }


### PR DESCRIPTION
Refactor error logging to move platform-specific log-to-file implementations into backend module.

- Introduce `logErrorToFile` in `backend/index.ts` to route logging to either Tauri or Web based methods.
- Move Tauri logging to its own exported async function and Web to its stub implementation.
- Update all usage in hooks/client to use the new interface.