### PR TITLE
V3 apply/unapply

### DIFF
--- a/crates/but-graph/src/init/overlay.rs
+++ b/crates/but-graph/src/init/overlay.rs
@@ -1,5 +1,5 @@
-use crate::init::Overlay;
 use crate::init::walk::RefsById;
+use crate::init::{Entrypoint, Overlay};
 use crate::is_workspace_ref_name;
 use but_core::{RefMetadata, ref_metadata};
 use gix::prelude::ReferenceExt;
@@ -14,6 +14,17 @@ impl Overlay {
         refs: impl IntoIterator<Item = gix::refs::Reference>,
     ) -> Self {
         self.nonoverriding_references = refs.into_iter().collect();
+        self
+    }
+
+    /// Override the starting position of the traversal by setting it to `id`,
+    /// and optionally, by providing the `ref_name` that points to `id`.
+    pub fn with_entrypoint(
+        mut self,
+        id: gix::ObjectId,
+        ref_name: Option<gix::refs::FullName>,
+    ) -> Self {
+        self.entrypoint = Some((id, ref_name));
         self
     }
 
@@ -43,7 +54,7 @@ impl Overlay {
         self,
         repo: &'repo gix::Repository,
         meta: &'meta T,
-    ) -> (OverlayRepo<'repo>, OverlayMetadata<'meta, T>)
+    ) -> (OverlayRepo<'repo>, OverlayMetadata<'meta, T>, Entrypoint)
     where
         T: RefMetadata,
     {
@@ -51,6 +62,7 @@ impl Overlay {
             nonoverriding_references,
             meta_branches,
             workspace,
+            entrypoint,
         } = self;
         (
             OverlayRepo {
@@ -62,6 +74,7 @@ impl Overlay {
                 meta_branches,
                 workspace,
             },
+            entrypoint,
         )
     }
 }

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -298,6 +298,14 @@ mkdir ws
      create_workspace_commit_once main
   )
 
+  git init just-init-with-two-branches
+  (cd just-init-with-two-branches
+    commit init
+    git branch A
+    git branch B
+    git checkout -b gitbutler/workspace
+  )
+
   git init just-init-with-branches
   (cd just-init-with-branches
     commit init && setup_target_to_match_main

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -699,7 +699,7 @@ fn stack_configuration_is_respected_if_one_of_them_is_an_entrypoint() -> anyhow:
     └── 👉📕►►►:0[0]:gitbutler/workspace
         ├── 📙►:2[1]:A
         │   └── ►:1[2]:anon:
-        │       └── ·fafd9d0 (⌂|🏘️|1) ►main
+        │       └── ·fafd9d0 (⌂|🏘|1) ►main
         └── 📙►:3[1]:B
             └── →:1:
     ");
@@ -720,7 +720,7 @@ fn stack_configuration_is_respected_if_one_of_them_is_an_entrypoint() -> anyhow:
     └── 📕►►►:1[0]:gitbutler/workspace
         └── 👉📙►:0[1]:B
             └── 📙►:2[2]:A
-                └── ·fafd9d0 (⌂|🏘️|1) ►main
+                └── ·fafd9d0 (⌂|🏘|1) ►main
     ");
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     📕🏘️⚠️:1:gitbutler/workspace <> ✓!

--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -1,0 +1,218 @@
+use std::borrow::Cow;
+
+/// Returned by [function::apply()].
+pub struct Outcome<'graph> {
+    /// The newly created graph, if owned, useful to project a workspace and see how the workspace looks like with the branch applied.
+    /// If borrowed, the graph already contains the desired branch and nothing had to be applied.
+    pub graph: Cow<'graph, but_graph::Graph>,
+    /// `true` if we created the given workspace ref as it didn't exist yet.
+    pub workspace_ref_created: bool,
+}
+
+impl Outcome<'_> {
+    /// Return `true` if a new graph traversal was performed, which always is a sign for an operation which changed the workspace.
+    /// This is `false` if the to be applied branch was already contained in the current workspace.
+    pub fn workspace_changed(&self) -> bool {
+        matches!(self.graph, Cow::Owned(_))
+    }
+}
+
+impl std::fmt::Debug for Outcome<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Outcome")
+            .field("workspace_changed", &self.workspace_changed())
+            .field("workspace_ref_created", &self.workspace_ref_created)
+            .finish()
+    }
+}
+
+/// How the newly applied branch should be integrated into the workspace.
+#[derive(Default, Debug, Copy, Clone)]
+pub enum IntegrationMode {
+    /// Do nothing but to merge it into the workspace commit, *even* if it's not needed as the workspace reference
+    /// can connect directly with the *one* workspace base.
+    #[default]
+    AlwaysMerge,
+    /// Only create a merge commit if a new commit is effectively merged in. This avoids *unnecessary* merge commits,
+    /// but also requires support for this when creating commits (which may then have to create a merge-commit themselves).
+    // TODO: make this the default
+    MergeIfNeeded,
+}
+
+/// What to do if the applied branch conflicts?
+#[derive(Default, Debug, Copy, Clone)]
+pub enum OnWorkspaceConflict {
+    /// Provide additional information about the stack that conflicted and the files involved in it,
+    /// and don't perform the operation.
+    #[default]
+    AbortAndReportConflictingStack,
+}
+
+/// Decide how a newly created workspace reference should be named.
+#[derive(Default, Debug, Clone)]
+pub enum WorkspaceReferenceNaming {
+    /// Create a default workspace branch
+    #[default]
+    Default,
+    /// Create a workspace with the given name instead.
+    Given(gix::refs::FullName),
+}
+
+/// Options for [function::apply()].
+#[derive(Default, Debug, Clone)]
+pub struct Options {
+    /// how the branch should be brought into the workspace.
+    pub integration_mode: IntegrationMode,
+    /// Decide how to deal with conflicts.
+    pub on_workspace_conflict: OnWorkspaceConflict,
+    /// How the workspace reference should be named should it be created.
+    /// The creation is always needed if there are more than one branch applied.
+    pub workspace_reference_naming: WorkspaceReferenceNaming,
+}
+
+pub(crate) mod function {
+    use super::{Options, Outcome, WorkspaceReferenceNaming};
+    use crate::ref_info::WorkspaceExt;
+    use anyhow::bail;
+    use but_core::RefMetadata;
+    use but_graph::projection::WorkspaceKind;
+    use std::borrow::Cow;
+
+    /// Apply `branch` to the given `workspace`, and possibly create the workspace reference in `repo`
+    /// along with its `meta`-data if it doesn't exist yet.
+    /// Otherwise, add it to the existing `workspace`, and update its metadata accordingly.
+    /// **This means that the contents of `branch` is observable from the new state of `repo`**.
+    ///
+    /// Note that `workspace` is expected to match the state in `repo` as it's used instead of querying `repo` directly
+    /// where possible.
+    ///
+    /// Also note that we will create a managed workspace reference as needed if necessary, and a workspace commit if there is more than
+    /// one reference in the workspace afterward.
+    ///
+    /// On `error`, neither `repo` nor `meta` will have been changed, but `repo` may contain in-memory objects.
+    /// Otherwise, objects will have been persisted, and references and metadata will have been updated.
+    pub fn apply<'graph, T: RefMetadata>(
+        branch: &gix::refs::FullNameRef,
+        workspace: &but_graph::projection::Workspace<'graph>,
+        repo: &mut gix::Repository,
+        _meta: &mut T,
+        Options {
+            integration_mode: _,
+            on_workspace_conflict: _,
+            workspace_reference_naming,
+        }: Options,
+    ) -> anyhow::Result<Outcome<'graph>> {
+        if workspace.is_reachable_from_entrypoint(branch) {
+            if workspace.is_entrypoint()
+                || workspace
+                    .stacks
+                    .iter()
+                    .flat_map(|s| s.segments.iter().filter_map(|s| s.ref_name.as_ref()))
+                    .any(|rn| rn.as_ref() == branch)
+            {
+                return Ok(Outcome {
+                    graph: Cow::Borrowed(workspace.graph),
+                    workspace_ref_created: false,
+                });
+            }
+        } else if workspace.refname_is_segment(branch) {
+            todo!("checkout workspace so the to-be-applied branch becomes visible")
+        }
+
+        if let Some(ws_ref_name) = workspace.ref_name()
+            && repo.try_find_reference(ws_ref_name)?.is_none()
+        {
+            // The workspace is the probably ad-hoc, and doesn't exist, *assume* unborn.
+            bail!(
+                "Cannot create reference on unborn branch '{}'",
+                ws_ref_name.shorten()
+            );
+        }
+
+        if workspace.has_workspace_commit_in_ancestry(repo) {
+            bail!("Refusing to work on workspace whose workspace commit isn't at the top");
+        }
+
+        // In general, we only have to deal with one branch to apply. But when we are on an adhoc workspace,
+        // we need to assure both branches go into the existing or the new workspace.
+        let (_workspace_ref_name_to_update, _branches_to_apply) = match &workspace.kind {
+            WorkspaceKind::Managed { ref_name }
+            | WorkspaceKind::ManagedMissingWorkspaceCommit { ref_name } => {
+                (ref_name.clone(), vec![branch])
+            }
+            WorkspaceKind::AdHoc => {
+                // We need to switch over to a possibly existing workspace.
+                // We know that the current branch is *not* reachable from the workspace or isn't naturally included,
+                // so it needs to be added as well.
+                let next_ws_ref_name = match workspace_reference_naming {
+                    WorkspaceReferenceNaming::Default => {
+                        gix::refs::FullName::try_from("refs/heads/gitbutler/workspace")
+                            .expect("known statically")
+                    }
+                    WorkspaceReferenceNaming::Given(name) => name,
+                };
+                (
+                    next_ws_ref_name,
+                    workspace
+                        .ref_name()
+                        .into_iter()
+                        .chain(Some(branch))
+                        .collect(),
+                )
+                // let ws_ref_id = match repo.try_find_reference(next_ws_ref_name.as_ref())? {
+                //     None => {
+                //         // Create a workspace reference later at the current AdHoc workspace id
+                //         let ws_id = workspace
+                //             .stacks
+                //             .first()
+                //             .and_then(|s| s.segments.first())
+                //             .and_then(|s| s.commits.first().map(|c| c.id))
+                //             .context("BUG: how can an empty ad-hoc workspace exist? Should have at least one stack-segment with commit")?;
+                //         ws_id
+                //     }
+                //     Some(mut existing_workspace_reference) => {
+                //         let id = existing_workspace_reference.peel_to_id_in_place()?;
+                //         id.detach()
+                //     }
+                // };
+
+                // let mut ws_md = meta.workspace(next_ws_ref_name.as_ref())?;
+                // {
+                //     let ws_mut: &mut ref_metadata::Workspace = &mut *ws_md;
+                //     ws_mut.stacks.push(WorkspaceStack {
+                //         id: StackId::generate(),
+                //         branches: vec![WorkspaceStackBranch {
+                //             ref_name: branch.to_owned(),
+                //             archived: false,
+                //         }],
+                //     })
+                // }
+                // let ws_md_override = Some((next_ws_ref_name.clone(), (*ws_md).clone()));
+
+                // let graph = workspace.graph.redo_traversal_with_overlay(
+                //     repo,
+                //     meta,
+                //     Overlay::default()
+                //         .with_entrypoint(ws_ref_id, Some(next_ws_ref_name))
+                //         .with_branch_metadata_override(branch_md_override)
+                //         .with_workspace_metadata_override(ws_md_override),
+                // )?;
+            }
+        };
+
+        // Everything worked? Assure the ref exists now that (nearly nothing) can go wrong anymore.
+        let _workspace_ref_created = false; // TODO: use rval of reference update to know if it existed.
+
+        // if let Some(branch_md) = branch_to_apply_metadata {
+        //     meta.set_branch(branch_md)?;
+        // }
+
+        todo!(
+            "prepare outcome once all values were written out and the graph was regenerated - the simulation is now reality"
+        );
+        // Ok(Outcome {
+        //     graph: Cow::Borrowed(workspace.graph),
+        //     workspace_ref_created,
+        // })
+    }
+}

--- a/crates/but-workspace/src/branch/create_reference.rs
+++ b/crates/but-workspace/src/branch/create_reference.rs
@@ -225,9 +225,14 @@ pub(super) mod function {
                                 ref_name.shorten()
                             );
                         };
-                        position.resolve_commit(segment.commits.first().context(
-                            "BUG: empty segments aren't possible without workspace metadata",
-                        )?.into(), ws_base)?
+                        position.resolve_commit(
+                            segment
+                                .commits
+                                .first()
+                                .context("Cannot create reference on unborn branch")?
+                                .into(),
+                            ws_base,
+                        )?
                     };
                     (
                         validate_id,

--- a/crates/but-workspace/src/branch/mod.rs
+++ b/crates/but-workspace/src/branch/mod.rs
@@ -460,6 +460,6 @@ impl Stack {
 pub mod remove_reference;
 pub use remove_reference::function::remove_reference;
 
-mod create_reference;
+/// related types for creating a workspace reference.
+pub mod create_reference;
 pub use create_reference::function::create_reference;
-pub use create_reference::*;

--- a/crates/but-workspace/src/branch/mod.rs
+++ b/crates/but-workspace/src/branch/mod.rs
@@ -456,6 +456,10 @@ impl Stack {
     }
 }
 
+/// Functions and types related to applying a workspace branch.
+pub mod apply;
+pub use apply::function::apply;
+
 /// related types for removing a workspace reference.
 pub mod remove_reference;
 pub use remove_reference::function::remove_reference;

--- a/crates/but-workspace/tests/fixtures/scenario/detached-with-multiple-branches.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/detached-with-multiple-branches.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### Description
+# The HEAD is detached, and there are multiple branches.
+
+git init
+commit M1
+git branch B
+git branch C
+git checkout -b A
+  commit A1
+git checkout B
+  commit B1
+git checkout C
+  commit C1
+git checkout --detach HEAD

--- a/crates/but-workspace/tests/fixtures/scenario/unborn-empty-detached-remote.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/unborn-empty-detached-remote.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### Description
+# A newly initialized git repository, but with a known remote that has an object.
+
+git init remote
+(cd remote
+  commit "M1"
+)
+
+git init unborn
+(cd unborn
+  git remote add orphan ../remote
+  git fetch orphan
+)

--- a/crates/but-workspace/tests/fixtures/scenario/with-remotes-and-workspace.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/with-remotes-and-workspace.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-### General Description
-
-# Various directories with different scenarios for testing stack information *with* a workspace commit,
-# and of course with a remote and a branch to integrate with.
 set -eu -o pipefail
 
 source "${BASH_SOURCE[0]%/*}/shared.sh"
 
+### General Description
+
+# Various directories with different scenarios for testing stack information *with* a workspace commit,
+# and of course with a remote and a branch to integrate with.
 
 git init remote
 (cd remote

--- a/crates/but-workspace/tests/fixtures/scenario/ws-ref-no-ws-commit-one-stack-one-branch.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/ws-ref-no-ws-commit-one-stack-one-branch.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A ws-ref points to a commit, which is also owned by a stack. There is another branch outside of the workspace pointing to the same commit.
+git init
+commit A
+git branch A
+git branch B
+git checkout -b gitbutler/workspace

--- a/crates/but-workspace/tests/fixtures/scenario/ws-ref-ws-commit-one-stack-ws-advanced.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/ws-ref-ws-commit-one-stack-ws-advanced.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A ws-ref points to a ws-commit, with an empty stack inside, but the workspace ref is advanced by an outside commit.
+git init
+commit M1
+
+git branch B
+git checkout -b A
+
+create_workspace_commit_once A
+commit O1

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply_commit_uncommit.rs
@@ -1,0 +1,354 @@
+use crate::ref_info::with_workspace_commit::utils::{
+    StackState, add_stack_with_segments, named_read_only_in_memory_scenario,
+    named_writable_scenario_with_description_and_graph,
+};
+use crate::utils::r;
+use but_graph::init::Options;
+use but_testsupport::{graph_workspace, id_at, visualize_commit_graph_all};
+use but_workspace::branch::apply::{
+    IntegrationMode, OnWorkspaceConflict, WorkspaceReferenceNaming,
+};
+
+#[test]
+#[ignore = "TBD: idempotent"]
+fn unapply_branch_not_in_workspace() -> anyhow::Result<()> {
+    Ok(())
+}
+
+#[test]
+fn operation_denied_on_improper_workspace() -> anyhow::Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-one-stack-ws-advanced",
+            |_meta| {},
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 0d01196 (HEAD -> gitbutler/workspace) O1
+    * 4979833 GitButler Workspace Commit
+    * 3183e43 (main, B, A) M1
+    ");
+    let ws = graph.to_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on 3183e43
+    └── ≡:2:anon: on 3183e43
+        └── :2:anon:
+            ├── ·0d01196 (🏘️)
+            └── ·4979833 (🏘️)
+    ");
+
+    let err = but_workspace::branch::apply(
+        r("refs/heads/B"),
+        &ws,
+        &mut repo,
+        &mut meta,
+        default_options(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Refusing to work on workspace whose workspace commit isn't at the top",
+        "cannot apply on a workspace that isn't proper"
+    );
+
+    // TODO: unapply, commit, uncommit
+    Ok(())
+}
+
+#[test]
+#[ignore = "WIP"]
+fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-no-ws-commit-one-stack-one-branch",
+            |_meta| {},
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
+    let ws = graph.to_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @"📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542");
+
+    // Put "A" into the workspace, yielding a single branch.
+    let out = but_workspace::branch::apply(
+        r("refs/heads/A"),
+        &ws,
+        &mut repo,
+        &mut meta,
+        default_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, @r"
+    Outcome {
+        workspace_changed: false,
+        workspace_ref_created: false,
+    }
+    ");
+    insta::assert_snapshot!(graph_workspace(&out.graph.to_workspace()?), @"📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542");
+    // A ws commit was created as it's needed for the current commit implementation.
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
+
+    let out = but_workspace::branch::apply(
+        r("refs/heads/B"),
+        &ws,
+        &mut repo,
+        &mut meta,
+        default_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, @r"
+    Outcome {
+        workspace_changed: false,
+        workspace_ref_created: false,
+    }
+    ");
+    insta::assert_snapshot!(graph_workspace(&out.graph.to_workspace()?), @"📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542");
+
+    // TODO: commit/uncommit
+    // TODO: unapply
+
+    Ok(())
+}
+
+#[test]
+#[ignore = "WIP"]
+fn new_workspace_exists_elsewhere_and_to_be_applied_branch_exists_there() -> anyhow::Result<()> {
+    let (_tmp, ws_graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-no-ws-commit-one-stack-one-branch",
+            |_meta| {},
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
+    // The default workspace, it's empty as target is set to `main`.
+    insta::assert_snapshot!(graph_workspace(&ws_graph.to_workspace()?), @"📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542");
+
+    // Pretend "B" is checked out (it's at the right state independently of that)
+    let (b_id, b_ref) = id_at(&repo, "B");
+    let graph = but_graph::Graph::from_commit_traversal(b_id, b_ref, &meta, Default::default())?;
+    let ws = graph.to_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    ⌂:0:B <> ✓!
+    └── ≡:0:B
+        └── :0:B
+            └── ·e5d0542 ►A, ►main
+    ");
+
+    // Put "A" into the workspace, hence we want "A" and "B" in it.
+    let out = but_workspace::branch::apply(
+        r("refs/heads/A"),
+        &ws,
+        &mut repo,
+        &mut meta,
+        default_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, @r"
+    Outcome {
+        workspace_changed: false,
+        workspace_ref_created: false,
+    }
+    ");
+
+    // HEAD must now point to the workspace (that already existed)
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
+
+    Ok(())
+}
+
+#[test]
+#[ignore = "WIP"]
+fn detached_head_journey() -> anyhow::Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "detached-with-multiple-branches",
+            |_meta| {},
+        )?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 49d4b34 (A) A1
+    | * f57c528 (B) B1
+    |/  
+    | * aaa195b (HEAD, C) C1
+    |/  
+    * 3183e43 (main) M1
+    ");
+    let ws = graph.to_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    ⌂:0:DETACHED <> ✓!
+    └── ≡:0:anon:
+        ├── :0:anon:
+        │   └── ·aaa195b ►C
+        └── :1:main
+            └── ·3183e43 (✓)
+    ");
+
+    let out = but_workspace::branch::apply(
+        r("refs/heads/A"),
+        &ws,
+        &mut repo,
+        &mut meta,
+        default_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, @r"
+    Outcome {
+        workspace_changed: false,
+        workspace_ref_created: false,
+    }
+    ");
+    Ok(())
+}
+
+#[test]
+fn auto_checkout_of_enclosing_workspace() -> anyhow::Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-no-ws-commit-one-stack-one-branch",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "B", StackState::InWorkspace, &[]);
+            },
+        )?;
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
+
+    let ws = graph.to_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓! on e5d0542
+    ├── ≡📙:3:B on e5d0542
+    │   └── 📙:3:B
+    └── ≡📙:2:A on e5d0542
+        └── 📙:2:A
+    ");
+
+    let (b_id, b_ref) = id_at(&repo, "B");
+    let graph =
+        but_graph::Graph::from_commit_traversal(b_id, b_ref.clone(), &meta, Default::default())?;
+    let ws = graph.to_workspace()?;
+    // TODO: fix this - the entrypoint shouldn't alter the stack setup.
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    📕🏘️⚠️:1:gitbutler/workspace <> ✓!
+    └── ≡👉📙:0:B
+        ├── 👉📙:0:B
+        └── 📙:2:A
+            └── ·e5d0542 (🏘️) ►main
+    ");
+
+    // Already applied (the HEAD points to it, it literally IS the workspace).
+    let out =
+        but_workspace::branch::apply(b_ref.as_ref(), &ws, &mut repo, &mut meta, default_options())?;
+    insta::assert_debug_snapshot!(out, @r"
+    Outcome {
+        workspace_changed: false,
+        workspace_ref_created: false,
+    }
+    ");
+
+    // To apply, we just checkout the surrounding workspace.
+    // TODO: doesn't work because A isn't a separate stack like it should.
+    let out = but_workspace::branch::apply(
+        r("refs/heads/A"),
+        &ws,
+        &mut repo,
+        &mut meta,
+        default_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, @r"
+    Outcome {
+        workspace_changed: false,
+        workspace_ref_created: false,
+    }
+    ");
+    Ok(())
+}
+
+#[test]
+#[ignore = "WIP"]
+fn apply_nonexisting_branch_failure() -> anyhow::Result<()> {
+    let (mut repo, mut meta) =
+        named_read_only_in_memory_scenario("ws-ref-no-ws-commit-one-stack-one-branch", "")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
+
+    let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
+    let ws = graph.to_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    📕🏘️⚠️:0:gitbutler/workspace <> ✓!
+    └── ≡:1:anon:
+        └── :1:anon:
+            └── ·e5d0542 (🏘️) ►A, ►B, ►main
+    ");
+
+    let err = but_workspace::branch::apply(
+        r("refs/heads/does-not-exist"),
+        &ws,
+        &mut repo,
+        &mut *meta,
+        default_options(),
+    )
+    .unwrap_err();
+    assert_eq!(err.to_string(), "TBD");
+
+    // Nothing should be changed
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* e5d0542 (HEAD -> gitbutler/workspace, main, B, A) A");
+    Ok(())
+}
+
+#[test]
+#[ignore = "TBD"]
+fn unapply_nonexisting_branch_failure() -> anyhow::Result<()> {
+    Ok(())
+}
+
+#[test]
+fn unborn_apply_needs_base() -> anyhow::Result<()> {
+    let (mut repo, mut meta) =
+        named_read_only_in_memory_scenario("unborn-empty-detached-remote", "unborn")?;
+    // Depending on the Git version it produces`* 3183e43 (orphan/main, orphan/HEAD) M1` on CI,
+    // so a comment is used as reference.
+    // insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 3183e43 (orphan/main) M1");
+
+    let graph = but_graph::Graph::from_head(&repo, &*meta, Options::limited())?;
+    let ws = graph.to_workspace()?;
+    insta::assert_snapshot!(graph_workspace(&ws), @r"
+    ⌂:0:main <> ✓!
+    └── ≡:0:main
+        └── :0:main
+    ");
+
+    // Idempotency in ad-hoc workspace
+    let out = but_workspace::branch::apply(
+        r("refs/heads/main"),
+        &ws,
+        &mut repo,
+        &mut *meta,
+        default_options(),
+    )?;
+    insta::assert_debug_snapshot!(out, @r"
+    Outcome {
+        workspace_changed: false,
+        workspace_ref_created: false,
+    }
+    ");
+
+    // Cannot apply branch without a base.
+    let err = but_workspace::branch::apply(
+        r("refs/remotes/orphan/main"),
+        &ws,
+        &mut repo,
+        &mut *meta,
+        default_options(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Cannot create reference on unborn branch 'main'"
+    );
+    Ok(())
+}
+
+fn default_options() -> but_workspace::branch::apply::Options {
+    but_workspace::branch::apply::Options {
+        integration_mode: IntegrationMode::MergeIfNeeded,
+        on_workspace_conflict: OnWorkspaceConflict::AbortAndReportConflictingStack,
+        workspace_reference_naming: WorkspaceReferenceNaming::Default,
+    }
+}
+
+#[test]
+#[ignore = "TBD"]
+fn apply_branch_resting_on_base() -> anyhow::Result<()> {
+    // THis can't work, but should fail gracefully.
+    Ok(())
+}

--- a/crates/but-workspace/tests/workspace/branch/create_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/create_reference.rs
@@ -2,12 +2,11 @@ use crate::ref_info::with_workspace_commit::utils::{
     named_read_only_in_memory_scenario, named_writable_scenario,
 };
 use crate::utils::{r, rc};
-use ReferencePosition::*;
 use but_core::RefMetadata;
 use but_core::ref_metadata::ValueInfo;
 use but_graph::init::Options;
 use but_testsupport::{graph_workspace, id_at, id_by_rev, visualize_commit_graph_all};
-use but_workspace::branch::{ReferenceAnchor, ReferencePosition};
+use but_workspace::branch::create_reference::{Anchor, Position::*};
 
 mod with_workspace {
     use crate::ref_info::with_workspace_commit::utils::{
@@ -20,8 +19,7 @@ mod with_workspace {
     use but_graph::VirtualBranchesTomlMetadata;
     use but_graph::init::Options;
     use but_testsupport::{graph_workspace, id_at, id_by_rev, visualize_commit_graph_all};
-    use but_workspace::branch::ReferenceAnchor;
-    use but_workspace::branch::ReferencePosition::*;
+    use but_workspace::branch::create_reference::{Anchor, Position::*};
     use std::borrow::Cow;
 
     #[test]
@@ -134,7 +132,7 @@ mod with_workspace {
         let above_a = rc("refs/heads/above-A");
         let graph = but_workspace::branch::create_reference(
             above_a,
-            ReferenceAnchor::AtSegment {
+            Anchor::AtSegment {
                 ref_name: Cow::Borrowed(a_ref),
                 position: Above,
             },
@@ -155,7 +153,7 @@ mod with_workspace {
         let below_b = rc("refs/heads/below-B");
         let graph = but_workspace::branch::create_reference(
             below_b,
-            ReferenceAnchor::AtSegment {
+            Anchor::AtSegment {
                 ref_name: Cow::Borrowed(b_ref),
                 position: Below,
             },
@@ -221,7 +219,7 @@ mod with_workspace {
         let bottom_id = id_by_rev(&repo, ":/A1");
         let graph = but_workspace::branch::create_reference(
             above_bottom_ref,
-            ReferenceAnchor::AtCommit {
+            Anchor::AtCommit {
                 commit_id: bottom_id.detach(),
                 position: Above,
             },
@@ -244,7 +242,7 @@ mod with_workspace {
         let bottom_ref = rc("refs/heads/bottom");
         let graph = but_workspace::branch::create_reference(
             bottom_ref,
-            ReferenceAnchor::AtSegment {
+            Anchor::AtSegment {
                 ref_name: Cow::Borrowed(above_bottom_ref),
                 position: Below,
             },
@@ -268,7 +266,7 @@ mod with_workspace {
         let a_id = id_by_rev(&repo, ":/A");
         let graph = but_workspace::branch::create_reference(
             above_a_commit_ref,
-            ReferenceAnchor::AtCommit {
+            Anchor::AtCommit {
                 commit_id: a_id.detach(),
                 position: Above,
             },
@@ -295,7 +293,7 @@ mod with_workspace {
         let a_ref = rc("refs/heads/A");
         let graph = but_workspace::branch::create_reference(
             a_ref,
-            ReferenceAnchor::AtCommit {
+            Anchor::AtCommit {
                 commit_id: a_id.detach(),
                 position: Above,
             },
@@ -321,7 +319,7 @@ mod with_workspace {
         let a_ref = rc("refs/heads/A");
         let graph = but_workspace::branch::create_reference(
             above_a_ref,
-            ReferenceAnchor::AtSegment {
+            Anchor::AtSegment {
                 ref_name: a_ref,
                 position: Above,
             },
@@ -347,7 +345,7 @@ mod with_workspace {
         let below_a_commit_ref = rc("refs/heads/below-A-commit");
         let graph = but_workspace::branch::create_reference(
             below_a_commit_ref,
-            ReferenceAnchor::AtCommit {
+            Anchor::AtCommit {
                 commit_id: a_id.detach(),
                 position: Below,
             },
@@ -373,7 +371,7 @@ mod with_workspace {
         let below_a_ref = rc("refs/heads/below-A");
         let graph = but_workspace::branch::create_reference(
             below_a_ref,
-            ReferenceAnchor::AtSegment {
+            Anchor::AtSegment {
                 ref_name: Cow::Borrowed(above_a_commit_ref),
                 position: Below,
             },
@@ -420,7 +418,7 @@ mod with_workspace {
         let above_b_ref = rc("refs/heads/above-B");
         let graph = but_workspace::branch::create_reference(
             above_b_ref,
-            ReferenceAnchor::AtSegment {
+            Anchor::AtSegment {
                 ref_name: Cow::Borrowed(b_ref),
                 position: Above,
             },
@@ -452,7 +450,7 @@ mod with_workspace {
         let below_b_ref = rc("refs/heads/below-B");
         let graph = but_workspace::branch::create_reference(
             below_b_ref,
-            ReferenceAnchor::AtSegment {
+            Anchor::AtSegment {
                 ref_name: Cow::Borrowed(b_ref),
                 position: Below,
             },
@@ -540,7 +538,7 @@ mod with_workspace {
         let bottom_id = id_by_rev(&repo, ":/A1");
         let graph = but_workspace::branch::create_reference(
             above_bottom_ref,
-            ReferenceAnchor::AtCommit {
+            Anchor::AtCommit {
                 commit_id: bottom_id.detach(),
                 position: Above,
             },
@@ -561,7 +559,7 @@ mod with_workspace {
         let bottom_ref = rc("refs/heads/bottom");
         let graph = but_workspace::branch::create_reference(
             bottom_ref,
-            ReferenceAnchor::AtSegment {
+            Anchor::AtSegment {
                 ref_name: Cow::Borrowed(above_bottom_ref),
                 position: Below,
             },
@@ -587,7 +585,7 @@ mod with_workspace {
         let a_id = id_by_rev(&repo, ":/A");
         let graph = but_workspace::branch::create_reference(
             above_a_commit_ref,
-            ReferenceAnchor::AtCommit {
+            Anchor::AtCommit {
                 commit_id: a_id.detach(),
                 position: Above,
             },
@@ -613,7 +611,7 @@ mod with_workspace {
         let a_ref = rc("refs/heads/A");
         let graph = but_workspace::branch::create_reference(
             above_a_ref,
-            ReferenceAnchor::AtSegment {
+            Anchor::AtSegment {
                 ref_name: a_ref,
                 position: Above,
             },
@@ -641,7 +639,7 @@ mod with_workspace {
         let a_ref = rc("refs/heads/A");
         let graph = but_workspace::branch::create_reference(
             above_a_ref,
-            ReferenceAnchor::AtSegment {
+            Anchor::AtSegment {
                 ref_name: a_ref,
                 position: Above,
             },
@@ -666,7 +664,7 @@ mod with_workspace {
         let below_a_commit_ref = rc("refs/heads/below-A-commit");
         let graph = but_workspace::branch::create_reference(
             below_a_commit_ref,
-            ReferenceAnchor::AtCommit {
+            Anchor::AtCommit {
                 commit_id: a_id.detach(),
                 position: Below,
             },
@@ -692,7 +690,7 @@ mod with_workspace {
         let below_a_ref = rc("refs/heads/below-A");
         let graph = but_workspace::branch::create_reference(
             below_a_ref,
-            ReferenceAnchor::AtSegment {
+            Anchor::AtSegment {
                 ref_name: Cow::Borrowed(above_a_commit_ref),
                 position: Below,
             },
@@ -739,7 +737,7 @@ mod with_workspace {
         let above_b_ref = rc("refs/heads/above-B");
         let graph = but_workspace::branch::create_reference(
             above_b_ref,
-            ReferenceAnchor::AtSegment {
+            Anchor::AtSegment {
                 ref_name: Cow::Borrowed(b_ref),
                 position: Above,
             },
@@ -771,7 +769,7 @@ mod with_workspace {
         let below_b_ref = rc("refs/heads/below-B");
         let graph = but_workspace::branch::create_reference(
             below_b_ref,
-            ReferenceAnchor::AtSegment {
+            Anchor::AtSegment {
                 ref_name: Cow::Borrowed(b_ref),
                 position: Below,
             },
@@ -857,7 +855,7 @@ mod with_workspace {
         let bottom_id = id_by_rev(&repo, ":/A1");
         let graph = but_workspace::branch::create_reference(
             bottom_ref,
-            ReferenceAnchor::AtCommit {
+            Anchor::AtCommit {
                 commit_id: bottom_id.detach(),
                 position: Below,
             },
@@ -910,7 +908,7 @@ mod with_workspace {
         let bottom_a_id = id_by_rev(&repo, ":/A1");
         let graph = but_workspace::branch::create_reference(
             bottom_ref_a,
-            ReferenceAnchor::AtCommit {
+            Anchor::AtCommit {
                 commit_id: bottom_a_id.detach(),
                 position: Below,
             },
@@ -934,7 +932,7 @@ mod with_workspace {
         let bottom_b_id = id_by_rev(&repo, ":/B1");
         let graph = but_workspace::branch::create_reference(
             bottom_ref_b,
-            ReferenceAnchor::AtCommit {
+            Anchor::AtCommit {
                 commit_id: bottom_b_id.detach(),
                 position: Below,
             },
@@ -977,8 +975,8 @@ mod with_workspace {
         let (ws_id, ws_ref_name) = id_at(&repo, "gitbutler/workspace");
         let main_remote_id = id_by_rev(&repo, "@~1");
         for anchor in [
-            (ReferenceAnchor::at_id(main_remote_id, Above)),
-            (ReferenceAnchor::at_segment(r("refs/remotes/origin/main"), Above)),
+            (Anchor::at_id(main_remote_id, Above)),
+            (Anchor::at_segment(r("refs/remotes/origin/main"), Above)),
         ] {
             let err = but_workspace::branch::create_reference(
                 ws_ref_name.as_ref(),
@@ -989,7 +987,7 @@ mod with_workspace {
             )
             .unwrap_err();
 
-            let expected_err = if matches!(anchor, ReferenceAnchor::AtCommit { .. }) {
+            let expected_err = if matches!(anchor, Anchor::AtCommit { .. }) {
                 "Commit 3183e43ff482a2c4c8ff531d595453b64f58d90b isn't part of the workspace"
             } else {
                 "Couldn't find any stack that contained the branch named 'origin/main'"
@@ -1042,8 +1040,8 @@ mod with_workspace {
         // Try to set gitbutler/workspace to a position in the workspace, but one below its current position
         let (a_id, a_ref_name) = id_at(&repo, "A");
         for anchor in [
-            (ReferenceAnchor::at_id(a_id, Below)),
-            (ReferenceAnchor::at_segment(a_ref_name.as_ref(), Below)),
+            (Anchor::at_id(a_id, Below)),
+            (Anchor::at_segment(a_ref_name.as_ref(), Below)),
         ] {
             let err = but_workspace::branch::create_reference(
                 ws_ref_name.as_ref(),
@@ -1073,8 +1071,8 @@ mod with_workspace {
         // Try to set gitbutler/workspace to the same position, which technically is in the workspace
         // and is where it's currently pointing to so it seems like nothing changes.
         for anchor in [
-            (ReferenceAnchor::at_id(a_id, Above)),
-            (ReferenceAnchor::at_segment(a_ref_name.as_ref(), Above)),
+            (Anchor::at_id(a_id, Above)),
+            (Anchor::at_segment(a_ref_name.as_ref(), Above)),
         ] {
             let err = but_workspace::branch::create_reference(
                 ws_ref_name.as_ref(),
@@ -1129,7 +1127,7 @@ mod with_workspace {
         let new_name = rc("refs/heads/new");
         let err = but_workspace::branch::create_reference(
             new_name,
-            ReferenceAnchor::AtSegment {
+            Anchor::AtSegment {
                 ref_name: rc("refs/heads/bogus"),
                 position: Below,
             },
@@ -1171,8 +1169,8 @@ fn errors() -> anyhow::Result<()> {
     let (id, ref_name) = id_at(&repo, "main");
     let new_name = r("refs/heads/does-not-matter");
     for anchor in [
-        ReferenceAnchor::at_id(id, Below),
-        ReferenceAnchor::at_segment(ref_name.as_ref(), Below),
+        Anchor::at_id(id, Below),
+        Anchor::at_segment(ref_name.as_ref(), Below),
     ] {
         // Below first in history
         let err = but_workspace::branch::create_reference(new_name, anchor, &repo, &ws, &mut *meta)
@@ -1194,8 +1192,8 @@ fn errors() -> anyhow::Result<()> {
 
     // Ambiguity (multiple refs in one spot).
     for anchor in [
-        ReferenceAnchor::at_id(id, Above),
-        ReferenceAnchor::at_segment(ref_name.as_ref(), Above),
+        Anchor::at_id(id, Above),
+        Anchor::at_segment(ref_name.as_ref(), Above),
     ] {
         assert!(repo.try_find_reference(new_name)?.is_none());
         let err = but_workspace::branch::create_reference(new_name, anchor, &repo, &ws, &mut *meta)
@@ -1217,10 +1215,7 @@ fn errors() -> anyhow::Result<()> {
 
     // Misaligned workspace - commit not included.
     let (id, ref_name) = id_at(&repo, "A");
-    for anchor in [
-        ReferenceAnchor::at_id(id, Below),
-        ReferenceAnchor::at_id(id, Above),
-    ] {
+    for anchor in [Anchor::at_id(id, Below), Anchor::at_id(id, Above)] {
         let err = but_workspace::branch::create_reference(new_name, anchor, &repo, &ws, &mut *meta)
             .unwrap_err();
         assert_eq!(
@@ -1242,8 +1237,8 @@ fn errors() -> anyhow::Result<()> {
     // Misaligned workspace - segment not included.
     let (a_id, a_ref) = id_at(&repo, "A");
     for anchor in [
-        (ReferenceAnchor::at_segment(a_ref.as_ref(), Below)),
-        (ReferenceAnchor::at_segment(a_ref.as_ref(), Above)),
+        (Anchor::at_segment(a_ref.as_ref(), Below)),
+        (Anchor::at_segment(a_ref.as_ref(), Above)),
     ] {
         let err = but_workspace::branch::create_reference(new_name, anchor, &repo, &ws, &mut *meta)
             .unwrap_err();
@@ -1278,8 +1273,8 @@ fn errors() -> anyhow::Result<()> {
     let a_ref = r("refs/heads/A");
     let (main_id, main_ref) = id_at(&repo, "main");
     for anchor in [
-        (ReferenceAnchor::at_segment(main_ref.as_ref(), Above)),
-        (ReferenceAnchor::at_id(main_id, Above)),
+        (Anchor::at_segment(main_ref.as_ref(), Above)),
+        (Anchor::at_id(main_id, Above)),
     ] {
         let err = but_workspace::branch::create_reference(a_ref, anchor, &repo, &ws, &mut *meta)
             .unwrap_err();
@@ -1317,8 +1312,8 @@ fn errors() -> anyhow::Result<()> {
 
     let (a_id, _a_ref_owned) = id_at(&repo, "A");
     for anchor in [
-        (ReferenceAnchor::at_segment(a_ref, Below)),
-        (ReferenceAnchor::at_id(a_id, Below)),
+        (Anchor::at_segment(a_ref, Below)),
+        (Anchor::at_id(a_id, Below)),
     ] {
         let err = but_workspace::branch::create_reference(new_name, anchor, &repo, &ws, &mut *meta)
             .unwrap_err();
@@ -1363,7 +1358,7 @@ fn journey() -> anyhow::Result<()> {
     let new_name = r("refs/heads/below-main");
     let graph = but_workspace::branch::create_reference(
         new_name,
-        ReferenceAnchor::at_segment(main_ref.as_ref(), Below),
+        Anchor::at_segment(main_ref.as_ref(), Below),
         &repo,
         &ws,
         &mut meta,
@@ -1396,7 +1391,7 @@ fn journey() -> anyhow::Result<()> {
     // Creating the same reference again is idempotent.
     let graph = but_workspace::branch::create_reference(
         new_name,
-        ReferenceAnchor::at_id(main_id, Below),
+        Anchor::at_id(main_id, Below),
         &repo,
         &ws,
         &mut meta,
@@ -1415,7 +1410,7 @@ fn journey() -> anyhow::Result<()> {
     // the last possible branch without a workspace.
     let graph = but_workspace::branch::create_reference(
         rc("refs/heads/two-below-main"),
-        ReferenceAnchor::at_segment(r("refs/heads/below-main"), Below),
+        Anchor::at_segment(r("refs/heads/below-main"), Below),
         &repo,
         &ws,
         &mut meta,
@@ -1436,7 +1431,7 @@ fn journey() -> anyhow::Result<()> {
     // the last possible branch without a workspace.
     let err = but_workspace::branch::create_reference(
         rc("refs/heads/another-below-main"),
-        ReferenceAnchor::at_segment(main_ref.as_ref(), Below),
+        Anchor::at_segment(main_ref.as_ref(), Below),
         &repo,
         &ws,
         &mut meta,
@@ -1470,7 +1465,7 @@ fn journey() -> anyhow::Result<()> {
     // However, creating a dependent branch creates metadata as well.
     let graph = but_workspace::branch::create_reference(
         main_ref,
-        ReferenceAnchor::AtCommit {
+        Anchor::AtCommit {
             commit_id: main_id.detach(),
             position: Above,
         },
@@ -1523,7 +1518,7 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
     let first_id = id_by_rev(&repo, "@~2");
     let graph = but_workspace::branch::create_reference(
         first_ref,
-        ReferenceAnchor::AtCommit {
+        Anchor::AtCommit {
             commit_id: first_id.detach(),
             position: Above,
         },
@@ -1555,7 +1550,7 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
     let second_id = id_by_rev(&repo, "@~1");
     let graph = but_workspace::branch::create_reference(
         second_ref,
-        ReferenceAnchor::AtCommit {
+        Anchor::AtCommit {
             commit_id: second_id.detach(),
             position: Above,
         },

--- a/crates/but-workspace/tests/workspace/branch/mod.rs
+++ b/crates/but-workspace/tests/workspace/branch/mod.rs
@@ -1,2 +1,4 @@
+/// Various journeys with apply, unapply and commit operations.
+mod apply_unapply_commit_uncommit;
 mod create_reference;
 mod remove_reference;


### PR DESCRIPTION
With [stashing](https://github.com/gitbutlerapp/gitbutler/pull/9725) available, a single-branch aware version of branch apply and unapply is possible.

Follow-up of #9874.

### Tasks


- Permutations: starting point
    - [ ] test unborn
    - [ ] starting point without WS ref
    - [ ] starting point with WS ref but not WS-commit or metadata
    - [ ] starting point with WS ref and WS commit
- Permutations: base position
    - [ ] base below
    - [ ] base above
- `but_workspace::checkout()`
   - [ ] apply conflict
   - [ ] apply worktree snapshot conflict
   - [ ] unapply worktree snapshot conflict
- [ ] Validate StackID handling in VB.toml adapter (assure it can keep unapplied branches correctly)
    - We need *all* the tests so at a later point we can possibly localise the stack-id and keep it with each branch instead.
- [ ] without single-branch mode, it's possible to have a workspace with just one stack, or even no stacks at all.
- [ ] don't apply the target branch!
- [ ] try to fix `but-graph` issue 

### Shortcomings

* Worktree change in a detached HEAD can't be stashed as there is no reference to associated the stash with.

### Notes

#### General Rules

* **The workspace is a conflict-free zone**
    - nothing that operates on the conflict must write conflicts into the index.
      This is as conflicts are currently hidden from view.
* **Symmetry**
   - If `apply` is doing something, then `unapply` undoes exactly that, or in other words `State + apply + unapply == State`
* **There is no single-branch workspace** when starting in single-branch mode
    - A workspace consists of at least two branches and a workspace commit
    - The workspace commit is optional if there is only one commit involved, i.e. when it's just a bunch of branches on top of a single commit
* **Workspace Commit ALWAYS for even for a single branch**
    - The workspace backend can deal with anything, but `commit()` currently can't.
    - Have to add commit() and `uncommit()`  as well to all apply-unapply tests so these can later be re-tested with different behaviour.
    - Implied by the previous rule

### Follow-Ups

- commit with auto-workspace-commit creation
    - At the same time, it needs uncommit() that is symmetric 

Thus:

* snapshots of worktree changes will be made to apply by forcing merge-conflicts to be... auto-resolved.
  This is a problem, but **we can't have conflicts** as the UI doesn't show them right now, nor does it allow interacting with them.

#### Unapply

* **Conflicting paths** are passed added as extra commit at first, without additional special handling in `apply` just to be able to handle them.
    - This means assignments aren't taken care of in all cases (but we will see how all this interacts with stack-ids)


### Research

#### Unapply: Assignments - with stashing

- uncommitted but assigned changes should create a snapshot commit
- when applying the same branch this snapshot is applied

However, the user should be able to interact with these.

#### Unapply: Assignments - with WIP commit

- uncommitted but assigned changes should create a WIP commit
     - or just unassign these assignments and they are back in the unassigned changes of the workspace
- MVP apply: do nothing with the WIP commit
- final version: apply restores the assignments from the WIP commit (which then is tracked with metadata)

#### Unapply with worktree changes

* **worktree changes that don't re-apply cleanly**

### Possible Follow-Ups

* Find a way to display and handle conflicts in the UI (Gitizen).
    - this would allow us to write conflicts as well and deal with them.

