### PR TITLE
vscode auto-format tsconfig.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,6 +31,9 @@
 	"[json]": {
 		"editor.defaultFormatter": "esbenp.prettier-vscode"
 	},
+	"[jsonc]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
 	"[mdx]": {
 		"editor.defaultFormatter": "esbenp.prettier-vscode"
 	},


### PR DESCRIPTION
Turns out it's detected as `jsonc`