### PR TITLE
Move `initAnalyticsIfEnabled` back into +layout.svelte

### DIFF
--- a/apps/desktop/src/lib/bootstrap/deps.ts
+++ b/apps/desktop/src/lib/bootstrap/deps.ts
@@ -4,7 +4,6 @@ import {
 	PROMPT_SERVICE as AI_PROMPT_SERVICE
 } from '$lib/ai/promptService';
 import { AIService, AI_SERVICE } from '$lib/ai/service';
-import { initAnalyticsIfEnabled } from '$lib/analytics/analytics';
 import { EVENT_CONTEXT, EventContext } from '$lib/analytics/eventContext';
 import { POSTHOG_WRAPPER, PostHogWrapper } from '$lib/analytics/posthog';
 import { type IBackend } from '$lib/backend';
@@ -107,7 +106,6 @@ export function initDependencies(args: {
 
 	const eventContext = new EventContext();
 	const posthog = new PostHogWrapper(settingsService, backend, eventContext);
-	initAnalyticsIfEnabled(appSettings, posthog);
 
 	// ============================================================================
 	// AUTHENTICATION & SECURITY

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -13,8 +13,10 @@
 	import SwitchThemeMenuAction from '$components/SwitchThemeMenuAction.svelte';
 	import ToastController from '$components/ToastController.svelte';
 	import ZoomInOutMenuAction from '$components/ZoomInOutMenuAction.svelte';
+	import { initAnalyticsIfEnabled } from '$lib/analytics/analytics';
 	import { POSTHOG_WRAPPER } from '$lib/analytics/posthog';
 	import { initDependencies } from '$lib/bootstrap/deps';
+	import { APP_SETTINGS } from '$lib/config/appSettings';
 	import { SETTINGS_SERVICE } from '$lib/config/appSettingsV2';
 	import { ircEnabled, ircServer } from '$lib/config/uiFeatureFlags';
 	import { GITHUB_CLIENT } from '$lib/forge/github/githubClient';
@@ -45,7 +47,11 @@
 	initDependencies(data);
 
 	const clientState = inject(CLIENT_STATE);
+	const appSettings = inject(APP_SETTINGS);
+	const posthog = inject(POSTHOG_WRAPPER);
+
 	clientState.initPersist();
+	initAnalyticsIfEnabled(appSettings, posthog);
 
 	// =============================================================================
 	// CORE REACTIVE STATE & EFFECTS
@@ -79,8 +85,6 @@
 	// ANALYTICS & NAVIGATION
 	// =============================================================================
 
-	// Analytics for single page app navigation
-	const posthog = inject(POSTHOG_WRAPPER);
 	if (browser) {
 		beforeNavigate(() => posthog.capture('$pageleave'));
 		afterNavigate(() => posthog.capture('$pageview'));


### PR DESCRIPTION
We want `initDependencies` to be free of side-effects, and only 
bootstrap deps.