### PR TITLE
Changes: Use full RefName

### DIFF
--- a/apps/desktop/cypress/e2e/selection.cy.ts
+++ b/apps/desktop/cypress/e2e/selection.cy.ts
@@ -51,7 +51,8 @@ describe('Selection', () => {
 				.scrollIntoView()
 				.should('be.visible')
 				.within(() => {
-					const changedFileNames = mockBackend.getBranchChangesFileNames(stackId, stackName);
+					const branch = `refs/heads/${stackName}`;
+					const changedFileNames = mockBackend.getBranchChangesFileNames(stackId, branch);
 					for (const fileName of changedFileNames) {
 						cy.getByTestId('file-list-item', fileName).should('be.visible');
 					}

--- a/apps/desktop/cypress/e2e/support/mock/backend.ts
+++ b/apps/desktop/cypress/e2e/support/mock/backend.ts
@@ -442,10 +442,10 @@ export default class MockBackend {
 
 	public getBranchChanges(args: InvokeArgs | undefined): TreeChanges {
 		if (!args || !isGetBranchChangesParams(args)) {
-			throw new Error('Invalid arguments for getBranchChanges');
+			throw new Error('Invalid arguments for getBranchChanges: ' + JSON.stringify(args));
 		}
 
-		const { stackId, branchName } = args;
+		const { stackId, branch } = args;
 
 		if (!stackId) {
 			return {
@@ -463,9 +463,9 @@ export default class MockBackend {
 			throw new Error(`No changes found for stack with ID ${stackId}`);
 		}
 
-		const branchChanges = stackBranchChanges.get(branchName);
+		const branchChanges = stackBranchChanges.get(branch);
 		if (!branchChanges) {
-			throw new Error(`No changes found for branch with name ${branchName}`);
+			throw new Error(`No changes found for branch with name ${branch}`);
 		}
 
 		return {
@@ -480,10 +480,10 @@ export default class MockBackend {
 
 	public getBranchChangesFileNames(
 		stackId: string,
-		branchName: string,
+		branch: string,
 		projectId: string = PROJECT_ID
 	): string[] {
-		const changes = this.getBranchChanges({ projectId, stackId, branchName });
+		const changes = this.getBranchChanges({ projectId, stackId, branch });
 		return changes.changes.map((change) => change.path).map((path) => path.split('/').pop()!);
 	}
 

--- a/apps/desktop/cypress/e2e/support/mock/changes.ts
+++ b/apps/desktop/cypress/e2e/support/mock/changes.ts
@@ -148,8 +148,7 @@ export function isGetCommitChangesParams(args: unknown): args is GetCommitChange
 export type GetBranchChangesParams = {
 	projectId: string;
 	stackId?: string;
-	branchName: string;
-	remote?: string;
+	branch: string;
 };
 
 export function isGetBranchChangesParams(args: unknown): args is GetBranchChangesParams {
@@ -159,9 +158,8 @@ export function isGetBranchChangesParams(args: unknown): args is GetBranchChange
 		'projectId' in args &&
 		typeof args['projectId'] === 'string' &&
 		(typeof (args as any).stackId === 'string' || (args as any).stackId === undefined) &&
-		'branchName' in args &&
-		typeof args['branchName'] === 'string' &&
-		(typeof (args as any).remote === 'string' || (args as any).remote === undefined)
+		'branch' in args &&
+		typeof args['branch'] === 'string'
 	);
 }
 

--- a/apps/desktop/cypress/e2e/support/scenarios/branchesWithChanges.ts
+++ b/apps/desktop/cypress/e2e/support/scenarios/branchesWithChanges.ts
@@ -635,13 +635,16 @@ export default class BranchesWithChanges extends MockBackend {
 		this.stackDetails.set(MOCK_STACK_C_ID, MOCK_STACK_DETAILS_C);
 
 		const stackAChanges = new Map<string, TreeChange[]>();
-		stackAChanges.set(MOCK_STACK_A_ID, MOCK_BRANCH_A_CHANGES);
+		const branchARef = `refs/heads/${MOCK_STACK_A_ID}`;
+		stackAChanges.set(branchARef, MOCK_BRANCH_A_CHANGES);
 
 		const stackBChanges = new Map<string, TreeChange[]>();
-		stackBChanges.set(MOCK_STACK_B_ID, MOCK_BRANCH_B_CHANGES);
+		const branchBRef = `refs/heads/${MOCK_STACK_B_ID}`;
+		stackBChanges.set(branchBRef, MOCK_BRANCH_B_CHANGES);
 
 		const stackCChanges = new Map<string, TreeChange[]>();
-		stackCChanges.set(MOCK_STACK_C_ID, MOCK_BRANCH_C_CHANGES);
+		const branchCRef = `refs/heads/${MOCK_STACK_C_ID}`;
+		stackCChanges.set(branchCRef, MOCK_BRANCH_C_CHANGES);
 
 		this.branchChanges.set(MOCK_STACK_A_ID, stackAChanges);
 		this.branchChanges.set(MOCK_STACK_B_ID, stackBChanges);

--- a/apps/desktop/src/components/BranchesView.svelte
+++ b/apps/desktop/src/components/BranchesView.svelte
@@ -67,10 +67,11 @@
 			return createCommitSelection({ commitId: current.commitId, stackId: current.stackId });
 		}
 		if (current.branchName) {
-			const branchName = current.remote
-				? current.remote + '/' + current.branchName
-				: current.branchName;
-			return createBranchSelection({ stackId: current.stackId, branchName });
+			return createBranchSelection({
+				stackId: current.stackId,
+				branchName: current.branchName,
+				remote: current.remote
+			});
 		}
 	});
 

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -30,6 +30,7 @@
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
 	import { UI_STATE } from '$lib/state/uiState.svelte';
 
+	import { createBranchRef } from '$lib/utils/branch';
 	import { computeChangeStatus } from '$lib/utils/fileStatus';
 	import { inject } from '@gitbutler/shared/context';
 	import { persistWithExpiration } from '@gitbutler/shared/persisted';
@@ -111,7 +112,7 @@
 		if (commitId) {
 			return createCommitSelection({ commitId, stackId: stackId });
 		} else if (branchName) {
-			return createBranchSelection({ stackId: stackId, branchName });
+			return createBranchSelection({ stackId: stackId, branchName, remote: undefined });
 		}
 	});
 
@@ -229,7 +230,7 @@
 	This file is growing complex, and should be simplified where possible.  It
 	is also intentionally intriciate, as it allows us to render the components
 	in two different configurations.
-	
+
 	While tedious to maintain, it is also a good forcing function for making
 	components that compose better. Be careful when changing, especially since
 	integration tests only covers the default layout.
@@ -344,7 +345,7 @@
 	{@const changesResult = stackService.branchChanges({
 		projectId,
 		stackId: stackId,
-		branchName
+		branch: createBranchRef(branchName, undefined)
 	})}
 	<ReduxResult {projectId} {stackId} result={changesResult.current}>
 		{#snippet children(changes, { projectId, stackId })}
@@ -354,7 +355,7 @@
 				{stackId}
 				draggableFiles
 				autoselect
-				selectionId={createBranchSelection({ stackId: stackId, branchName })}
+				selectionId={createBranchSelection({ stackId: stackId, branchName, remote: undefined })}
 				noshrink={!!previewKey}
 				ontoggle={() => {
 					changedFilesCollapsed = !changedFilesCollapsed;

--- a/apps/desktop/src/components/UnappliedBranchView.svelte
+++ b/apps/desktop/src/components/UnappliedBranchView.svelte
@@ -7,6 +7,7 @@
 	import ReduxResult from '$components/ReduxResult.svelte';
 	import { createBranchSelection, type SelectionId } from '$lib/selection/key';
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
+	import { createBranchRef } from '$lib/utils/branch';
 	import { inject } from '@gitbutler/shared/context';
 	import { Icon, TestId, Tooltip } from '@gitbutler/ui';
 
@@ -29,12 +30,12 @@
 			? stackService.branchDetails(projectId, stackId, branchName)
 			: stackService.unstackedBranchDetails(projectId, branchName, remote)
 	);
-	const changesResult = $derived(stackService.branchChanges({ projectId, branchName, remote }));
 
 	const selectionId: SelectionId = $derived.by(() => {
-		const bname = remote ? remote + '/' + branchName : branchName;
-		return createBranchSelection({ stackId, branchName: bname });
+		return createBranchSelection({ stackId, branchName, remote });
 	});
+
+	const branchRef = $derived(createBranchRef(branchName, remote));
 </script>
 
 <ReduxResult {projectId} result={branchResult.current} {onerror}>
@@ -94,6 +95,7 @@
 			</div>
 		</Drawer>
 
+		{@const changesResult = stackService.branchChanges({ projectId, branch: branchRef })}
 		<ReduxResult {projectId} result={changesResult.current}>
 			{#snippet children(changes, env)}
 				<ChangedFiles

--- a/apps/desktop/src/lib/selection/idSelection.svelte.ts
+++ b/apps/desktop/src/lib/selection/idSelection.svelte.ts
@@ -7,6 +7,7 @@ import {
 	type SelectionId,
 	type SelectedFile
 } from '$lib/selection/key';
+import { createBranchRef } from '$lib/utils/branch';
 import { InjectionToken } from '@gitbutler/shared/context';
 import { reactive } from '@gitbutler/shared/reactiveUtils.svelte';
 import { SvelteSet } from 'svelte/reactivity';
@@ -148,13 +149,16 @@ export class IdSelection {
 				return this.uncommittedService
 					.getChangesByStackId(params.stackId || null)
 					.filter((c) => paths.includes(c.path));
-			case 'branch':
+			case 'branch': {
+				const { remote, branchName } = params;
+				const branch = createBranchRef(branchName, remote);
 				return await this.stackService.branchChangesByPaths({
 					projectId,
 					stackId: params.stackId,
-					branchName: params.branchName,
+					branch,
 					paths: paths
 				});
+			}
 			case 'commit':
 				return await this.stackService.commitChangesByPaths(projectId, params.commitId, paths);
 			case 'snapshot':
@@ -236,13 +240,16 @@ export class IdSelection {
 		switch (selectedFile.type) {
 			case 'commit':
 				return this.stackService.commitChange(projectId, selectedFile.commitId, selectedFile.path);
-			case 'branch':
+			case 'branch': {
+				const { remote, branchName } = selectedFile;
+				const branch = createBranchRef(branchName, remote);
 				return this.stackService.branchChange({
 					projectId,
 					stackId: selectedFile.stackId,
-					branchName: selectedFile.branchName,
+					branch,
 					path: selectedFile.path
 				});
+			}
 			case 'worktree':
 				this.uncommittedService.assignmentsByPath(selectedFile.stackId || null, selectedFile.path);
 				return this.worktreeService.treeChangeByPath(projectId, selectedFile.path);

--- a/apps/desktop/src/lib/utils/branch.ts
+++ b/apps/desktop/src/lib/utils/branch.ts
@@ -1,6 +1,18 @@
+import type { BrandedId } from '@gitbutler/shared/utils/branding';
+
 const PREFERRED_REMOTE = 'origin';
 const BRANCH_SEPARATOR = '/';
 const REF_REMOTES_PREFIX = 'refs/remotes/';
+const REF_HEADS_PREFIX = 'refs/heads/';
+
+export type BranchRef = BrandedId<'BranchRef'>;
+
+export function createBranchRef(branchName: string, remote: string | undefined): BranchRef {
+	if (remote) {
+		return `${REF_REMOTES_PREFIX}${remote}${BRANCH_SEPARATOR}${branchName}` as BranchRef;
+	}
+	return `${REF_HEADS_PREFIX}${branchName}` as BranchRef;
+}
 
 /**
  * Get the branch name from a refname.

--- a/crates/gitbutler-tauri/src/diff.rs
+++ b/crates/gitbutler-tauri/src/diff.rs
@@ -8,6 +8,7 @@ use but_core::ui::{TreeChange, TreeChanges};
 use but_hunk_assignment::{AssignmentRejection, HunkAssignmentRequest, WorktreeChanges};
 use but_workspace::StackId;
 use gitbutler_project::ProjectId;
+use gitbutler_reference::Refname;
 use tauri::State;
 use tracing::instrument;
 
@@ -52,16 +53,14 @@ pub fn changes_in_branch(
     project_id: ProjectId,
     // TODO: remove this, go by name. Ideally, the UI would pass us two commits.
     _stack_id: Option<StackId>,
-    branch_name: String,
-    remote: Option<String>,
+    branch: Refname,
 ) -> anyhow::Result<TreeChanges, Error> {
     diff::changes_in_branch(
         &app,
         ChangesInBranchParams {
             project_id,
             _stack_id,
-            branch_name,
-            remote,
+            branch,
         },
     )
 }


### PR DESCRIPTION
## Fix 'getting branch changes'

Getting branch changes for remote branches was broken because we didn't properly pass the information about the branch we wanted changes for to the BE. Now we do.

## STABILITYYYYYYYYY
This API was yielding a bunch of errors according to the metrics, so this should bring some peace to some 30ish users
<img width="547" height="508" alt="Screenshot 2025-08-18 at 16 26 53" src="https://github.com/user-attachments/assets/9b0f9f7d-d2d3-405e-99bd-ca73cf6815b1" />



Summary
- Backend Rust API refactor: branch changes endpoints now accept full branch refname (Refname) instead of separate branch name + remote.
- Frontend selection & services updated to track remotes and use refnames when selecting or requesting branch changes.
- stackService methods (branchChanges, branchChange, branchChangesByPaths) now accept & forward refnames.
- Added createBranchRef utility to consistently build branch refnames (local heads or remotes).
- UI components (BranchesView, StackView, UnappliedBranchView) updated to use remote + branchName tracking and pass refnames to the API.

What changed
- API contract: branch change requests use a single refname field.
- Selection keys and parsing/generation updated to include remote and construct refnames.
- Tauri integration adjusted to match the new backend interface.
- Centralized refname construction via createBranchRef to ensure consistency across FE/BE.
