### PR TITLE
cypress: add handler for update_feature_flags in support mocks

### DIFF
--- a/apps/desktop/cypress/e2e/support/index.ts
+++ b/apps/desktop/cypress/e2e/support/index.ts
@@ -159,6 +159,8 @@ Cypress.on('window:before:load', (win) => {
 				return MOCK_USER;
 			case 'plugin:window|theme':
 				return 'light';
+			case 'update_feature_flags':
+				return await Promise.resolve();
 			case 'get_app_settings':
 				return MOCK_APP_SETTINGS;
 			case 'plugin:event|unlisten':


### PR DESCRIPTION
Add an async handler for 'update_feature_flags' to the Cypress e2e support index mocks. This prevents unhandled calls during tests by returning a resolved promise. The change inserts a new case in the ipcRenderer.invoke mock switch alongside existing get_app_settings and others. Only test support code modified.