### PR TITLE
Add missing space in placeholder commit message

### DIFF
--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -92,7 +92,7 @@ pub fn update_workspace_commit(
     if !virtual_branches.is_empty() {
         message.push_str("This is a merge commit the virtual branches in your workspace.\n\n");
     } else {
-        message.push_str("This is placeholder commit and will be replaced by a merge of your");
+        message.push_str("This is placeholder commit and will be replaced by a merge of your ");
         message.push_str("virtual branches.\n\n");
     }
     message.push_str(


### PR DESCRIPTION
## 🧢 Changes

Before, there was no space between "your" and "virtual branches" in the placeholder commit that GitButler generates:
```
commit d2bb4b515b5935676ee1c009bebf829c4ca832de (HEAD -> gitbutler/workspace)
Author: GitButler <gitbutler@gitbutler.com>
Date:   Mon Aug 18 11:00:24 2025 -0700

    GitButler Workspace Commit

    This is placeholder commit and will be replaced by a merge of yourvirtual branches.
```

Now there will be!

## ☕️ Reasoning

I noticed a typo while trying GitButler and inspecting the `git log` of the `gitbutler/workspace` branch - and figured it would be easy to open a PR to fix it.

## 🎫 Affected issues

I didn't open one, but I can if that's needed.