### PR TITLE
Show concise rub summary in overview mode

### DIFF
--- a/crates/but/src/args.rs
+++ b/crates/but/src/args.rs
@@ -22,8 +22,11 @@ pub enum Subcommands {
     Status,
 
     /// Combines two entities together to perform an operation.
-    #[clap(about = "Combines two entities together to perform an operation.
-Non-exhaustive list of operations
+    #[clap(
+        about = "Combines two entities together to perform an operation",
+        long_about = "Combines two entities together to perform an operation.
+
+Non-exhaustive list of operations:
       │Source     │Target
 ──────┼───────────┼──────
 Amend │File,Branch│Commit
@@ -31,7 +34,8 @@ Squash│Commit     │Commit
 Assign│File,Branch│Branch
 Move  │Commit     │Branch
 
-For examples `but rub --help`.")]
+For examples see `but rub --help`."
+    )]
     Rub {
         /// The source entity to combine
         source: String,


### PR DESCRIPTION
When listing top-level commands (overview mode), the rub subcommand displayed its full long_about documentation — including a multi-line table of operations — which cluttered the overview. Users expect a single-line summary in the command list and the full detailed docs only when explicitly requesting help for the subcommand (e.g. `but rub --help`).

This change shortens the rub clap attribute to provide a concise about string for overview mode and moves the detailed table into long_about so the full documentation appears only when the subcommand is invoked with help.