### PR TITLE
Fix: some hunk locks not visible in ui

### DIFF
--- a/apps/desktop/src/lib/hunks/hunk.test.ts
+++ b/apps/desktop/src/lib/hunks/hunk.test.ts
@@ -278,6 +278,27 @@ describe('hunkContainsHunk', () => {
 		const outer = { ...baseHunk, oldStart: 5, oldLines: 20, newStart: 15, newLines: 20, diff: '' };
 		expect(hunkContainsHunk(baseHunk, outer)).toBe(false);
 	});
+	test('returns true when hunk b ends at the exact same line as hunk a', () => {
+		// Hunk a: oldStart=10, oldLines=10 -> covers old lines 10-19
+		// Hunk b: oldStart=15, oldLines=5 -> covers old lines 15-19 (ends at same line)
+		const inner = { oldStart: 15, oldLines: 5, newStart: 25, newLines: 5, diff: '' };
+		expect(hunkContainsHunk(baseHunk, inner)).toBe(true);
+	});
+	test('returns false when hunk b extends beyond hunk a by one line', () => {
+		// Hunk a: oldStart=10, oldLines=10 -> covers old lines 10-19
+		// Hunk b: oldStart=15, oldLines=6 -> covers old lines 15-20 (extends beyond by 1)
+		const extending = {
+			oldStart: 15,
+			oldLines: 6,
+			newStart: 25,
+			newLines: 6,
+			diff: ''
+		};
+		expect(hunkContainsHunk(baseHunk, extending)).toBe(false);
+	});
+	test('returns true when ranges are identical', () => {
+		expect(hunkContainsHunk(baseHunk, baseHunk)).toBe(true);
+	});
 });
 
 describe('hunkContainsLine', () => {

--- a/apps/desktop/src/lib/hunks/hunk.ts
+++ b/apps/desktop/src/lib/hunks/hunk.ts
@@ -315,9 +315,9 @@ export function canBePartiallySelected(patch: Patch): boolean {
 export function hunkContainsHunk(a: DiffHunk, b: DiffHunk): boolean {
 	return (
 		a.oldStart <= b.oldStart &&
-		a.oldStart + a.oldLines - 1 >= b.oldStart + b.oldLines &&
+		a.oldStart + a.oldLines - 1 >= b.oldStart + b.oldLines - 1 &&
 		a.newStart <= b.newStart &&
-		a.newStart + a.newLines - 1 >= b.newStart + b.newLines
+		a.newStart + a.newLines - 1 >= b.newStart + b.newLines - 1
 	);
 }
 


### PR DESCRIPTION
Correct the off-by-one errors in hunkContainsHunk so that end-line 
comparisons treat the last line inclusive. The previous comparisons 
incorrectly compared inclusive starts with exclusive ends, causing some 
hunks or locks not to be recognized as contained.

Add tests covering hunk range edge cases and add debug logging to help 
track down a hunk range comparison bug. The new tests verify behavior 
when hunks end at the same line, when a hunk extends beyond another by 
one line, and when ranges are identical.