### PR TITLE
Handle project creation cancellation gracefully

### DIFF
--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -136,7 +136,9 @@
 						try {
 							const project = await projectsService.addProject();
 							if (!project) {
-								throw new Error('Failed to add project.');
+								// User cancelled the project creation
+								newProjectLoading = false;
+								return;
 							}
 							goto(projectPath(project.id));
 						} finally {

--- a/apps/desktop/src/components/FileMenuAction.svelte
+++ b/apps/desktop/src/components/FileMenuAction.svelte
@@ -14,7 +14,8 @@
 			shortcutService.on('add-local-repo', async () => {
 				const project = await projectsService.addProject();
 				if (!project) {
-					throw new Error('Failed to add project.');
+					// User cancelled the project creation
+					return;
 				}
 				goto(projectPath(project.id));
 			}),

--- a/apps/desktop/src/components/ProjectSwitcher.svelte
+++ b/apps/desktop/src/components/ProjectSwitcher.svelte
@@ -49,7 +49,9 @@
 					try {
 						const project = await projectsService.addProject();
 						if (!project) {
-							throw new Error('Failed to add project.');
+							// User cancelled the project creation
+							newProjectLoading = false;
+							return;
 						}
 						goto(projectPath(project.id));
 					} finally {


### PR DESCRIPTION
Updated the logic where users can cancel project creation across ChromeHeader, FileMenuAction, and ProjectSwitcher components:
- Introduced a check for user cancellation without throwing errors.
- Ensured relevant loading state resets and early returns to avoid erroneous flows.
