### PR TITLE
Clear branch selection if selected PR does not exist

### DIFF
--- a/apps/desktop/src/lib/forge/github/githubListingService.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubListingService.svelte.ts
@@ -2,7 +2,6 @@ import { ghQuery } from '$lib/forge/github/ghQuery';
 import { ghResponseToInstance } from '$lib/forge/github/types';
 import { createSelectByIds } from '$lib/state/customSelectors';
 import { providesList, ReduxTag } from '$lib/state/tags';
-import { reactive } from '@gitbutler/shared/reactiveUtils.svelte';
 import { isDefined } from '@gitbutler/ui/utils/typeguards';
 import { createEntityAdapter, type EntityState } from '@reduxjs/toolkit';
 import type { ForgeListingService } from '$lib/forge/interface/forgeListingService';
@@ -17,13 +16,10 @@ export class GitHubListingService implements ForgeListingService {
 	}
 
 	list(projectId: string, pollingInterval?: number) {
-		const result = $derived(
-			this.api.endpoints.listPrs.useQuery(projectId, {
-				transform: (result) => prSelectors.selectAll(result),
-				subscriptionOptions: { pollingInterval }
-			})
-		);
-		return reactive(() => result.current);
+		return this.api.endpoints.listPrs.useQuery(projectId, {
+			transform: (result) => prSelectors.selectAll(result),
+			subscriptionOptions: { pollingInterval }
+		});
 	}
 
 	getByBranch(projectId: string, branchName: string) {

--- a/apps/desktop/src/lib/forge/gitlab/gitlabListingService.svelte.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlabListingService.svelte.ts
@@ -3,7 +3,6 @@ import { mrToInstance } from '$lib/forge/gitlab/types';
 import { createSelectByIds } from '$lib/state/customSelectors';
 import { providesList, ReduxTag } from '$lib/state/tags';
 import { toSerializable } from '@gitbutler/shared/network/types';
-import { reactive } from '@gitbutler/shared/reactiveUtils.svelte';
 import { isDefined } from '@gitbutler/ui/utils/typeguards';
 import { createEntityAdapter, type EntityState } from '@reduxjs/toolkit';
 import type { ForgeListingService } from '$lib/forge/interface/forgeListingService';
@@ -18,13 +17,10 @@ export class GitLabListingService implements ForgeListingService {
 	}
 
 	list(projectId: string, pollingInterval?: number) {
-		const result = $derived(
-			this.api.endpoints.listPrs.useQuery(projectId, {
-				transform: (result) => prSelectors.selectAll(result),
-				subscriptionOptions: { pollingInterval }
-			})
-		);
-		return reactive(() => result.current);
+		return this.api.endpoints.listPrs.useQuery(projectId, {
+			transform: (result) => prSelectors.selectAll(result),
+			subscriptionOptions: { pollingInterval }
+		});
 	}
 
 	getByBranch(projectId: string, branchName: string) {

--- a/apps/desktop/src/lib/forge/prPolling.svelte.ts
+++ b/apps/desktop/src/lib/forge/prPolling.svelte.ts
@@ -1,0 +1,31 @@
+import { updateStalePrSelection, type UiState } from '$lib/state/uiState.svelte';
+import { reactive } from '@gitbutler/shared/reactiveUtils.svelte';
+import type { DefaultForgeFactory } from '$lib/forge/forgeFactory.svelte';
+import type { PullRequest } from '$lib/forge/interface/types';
+import type { Reactive } from '@gitbutler/shared/storeUtils';
+
+const POLLING_INTERVAL = 15 * 60 * 1000; // 15 minutes.
+
+/**
+ * Return a reactive list of pull requests for the given project ID.
+ *
+ * This will poll the PRs in the defined interval, and update the everytime the project ID changes.
+ * This will also update the branch selection. If a PR is selected, it will check if the PR still exists.
+ */
+export default function prList(
+	projectId: Reactive<string>,
+	forge: DefaultForgeFactory,
+	uiState: UiState
+): Reactive<PullRequest[]> {
+	const prListResult = $derived(
+		forge.current.listService?.list(projectId.current, POLLING_INTERVAL)
+	);
+
+	const prList = $derived(prListResult?.current.data ?? []);
+
+	$effect(() => {
+		updateStalePrSelection(uiState, projectId.current, prList);
+	});
+
+	return reactive(() => prList);
+}

--- a/apps/desktop/src/lib/state/uiState.svelte.ts
+++ b/apps/desktop/src/lib/state/uiState.svelte.ts
@@ -10,6 +10,7 @@ import {
 	type ThunkDispatch,
 	type UnknownAction
 } from '@reduxjs/toolkit';
+import type { PullRequest } from '$lib/forge/interface/types';
 import type { StackDetails } from '$lib/stacks/stack';
 import type { RejectionReason } from '$lib/stacks/stackService.svelte';
 
@@ -466,5 +467,17 @@ export function updateStaleStackState(
 		case 'create-pr':
 			// Do nothing, alles gut
 			break;
+	}
+}
+
+export function updateStalePrSelection(uiState: UiState, projectId: string, prs: PullRequest[]) {
+	const projectState = uiState.project(projectId);
+	if (projectState.branchesSelection.current.prNumber === undefined) {
+		return;
+	}
+
+	const prNumber = projectState.branchesSelection.current.prNumber;
+	if (!prs.some((pr) => pr.number === prNumber)) {
+		projectState.branchesSelection.set({});
 	}
 }


### PR DESCRIPTION
- Adds a mechanism to clear the branch selection if the user selects a pull request that does not exist.
- Modifies affected components and centralizes stale PR detection logic.