### PR TITLE
Use the deduced push-remote if there is no deduced fetch remote.

### DIFF
--- a/crates/but-core/src/ref_metadata.rs
+++ b/crates/but-core/src/ref_metadata.rs
@@ -29,6 +29,10 @@ pub struct Workspace {
     /// If there is no target name, this is a local workspace (and if no global target is set).
     /// Note that even though this is per workspace, the implementation can fill in global information at will.
     pub target_ref: Option<gix::refs::FullName>,
+    /// The symbolic name of the remote to push branches to.
+    ///
+    /// This is useful when there are no push permissions for the remote behind `target_ref`.
+    pub push_remote: Option<String>,
 }
 
 impl Workspace {

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -319,6 +319,8 @@ mkdir ws
       commit A2
     create_workspace_commit_once A
     setup_remote_tracking soon-remote A "move"
+    mkdir .git/refs/remotes/push-remote
+    cp .git/refs/remotes/origin/A .git/refs/remotes/push-remote/A
 
 cat <<EOF >>.git/config
 [remote "origin"]

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -1031,7 +1031,7 @@ fn deduced_remote_ahead() -> anyhow::Result<()> {
     * 8b39ce4 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
     * 9d34471 (A) A2
     * 5b89c71 A1
-    | * 3ea1a8f (origin/A) only-remote-02
+    | * 3ea1a8f (push-remote/A, origin/A) only-remote-02
     | * 9c50f71 only-remote-01
     | * 2cfbb79 merge
     |/| 
@@ -1117,6 +1117,49 @@ fn deduced_remote_ahead() -> anyhow::Result<()> {
         │   ├── ·5b89c71 (🏘️)
         │   └── ❄️998eae6 (🏘️)
         └── 👉:0:main
+            └── ❄fafd9d0 (🏘️)
+    ");
+
+    // When the push-remote is configured, it overrides the remote we use for listing, even if a fetch remote is available.
+    meta.data_mut()
+        .default_target
+        .as_mut()
+        .expect("set by default")
+        .push_remote_name = Some("push-remote".into());
+    let graph = Graph::from_head(&repo, &*meta, standard_options())?;
+    insta::assert_snapshot!(graph_tree(&graph), @r"
+    ├── 👉📕►►►:0[0]:gitbutler/workspace
+    │   └── ·8b39ce4 (⌂|🏘️|1)
+    │       └── ►:1[1]:A <> push-remote/A →:2:
+    │           ├── ·9d34471 (⌂|🏘️|11)
+    │           └── ·5b89c71 (⌂|🏘️|11)
+    │               └── ►:5[3]:anon:
+    │                   └── ·998eae6 (⌂|🏘️|11)
+    │                       └── ►:3[4]:main
+    │                           └── ·fafd9d0 (⌂|🏘️|11)
+    └── ►:2[0]:push-remote/A →:1:
+        ├── 🟣3ea1a8f
+        └── 🟣9c50f71
+            └── ►:4[1]:anon:
+                └── 🟣2cfbb79
+                    ├── →:5:
+                    └── ►:6[2]:anon:
+                        └── 🟣e898cd0
+                            └── →:5:
+    ");
+
+    insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
+    📕🏘️:0:gitbutler/workspace <> ✓!
+    └── ≡:1:A <> push-remote/A →:2:⇡2⇣4
+        ├── :1:A <> push-remote/A →:2:⇡2⇣4
+        │   ├── 🟣3ea1a8f
+        │   ├── 🟣9c50f71
+        │   ├── 🟣2cfbb79
+        │   ├── 🟣e898cd0
+        │   ├── ·9d34471 (🏘️)
+        │   ├── ·5b89c71 (🏘️)
+        │   └── ❄️998eae6 (🏘️)
+        └── :3:main
             └── ❄fafd9d0 (🏘️)
     ");
     Ok(())

--- a/crates/but-graph/tests/graph/vis.rs
+++ b/crates/but-graph/tests/graph/vis.rs
@@ -23,6 +23,7 @@ fn post_graph_traversal() -> anyhow::Result<()> {
             ref_info: Default::default(),
             stacks: vec![],
             target_ref: None,
+            push_remote: None,
         })),
         ..Default::default()
     };

--- a/crates/but-workspace/tests/workspace/branch_details.rs
+++ b/crates/but-workspace/tests/workspace/branch_details.rs
@@ -27,7 +27,7 @@ mod with_workspace {
         |/  
         * ff045ef (main) init
         ");
-        let store = WorkspaceStore::default()
+        let store = WorkspaceRefMetadataStore::default()
             .with_target("B")
             .with_named_branch("A");
         insta::assert_debug_snapshot!(
@@ -77,7 +77,7 @@ mod with_workspace {
         * d79bba9 new file in A
         * c166d42 (origin/main, origin/HEAD, main) init-integration
         ");
-        let store = WorkspaceStore::default()
+        let store = WorkspaceRefMetadataStore::default()
             .with_target("main")
             .with_named_branch("A");
         insta::assert_debug_snapshot!(but_workspace::branch_details_v3(&repo, refname("A").as_ref(), &store).unwrap(), @r#"
@@ -129,7 +129,7 @@ mod with_workspace {
         * c166d42 (origin/main, origin/HEAD, main) init-integration
         ");
 
-        let store = WorkspaceStore::default()
+        let store = WorkspaceRefMetadataStore::default()
             .with_target("main")
             .with_named_branch("A");
         insta::assert_debug_snapshot!(but_workspace::branch_details_v3(&repo, refname("A").as_ref(), &store).unwrap(), @r#"
@@ -208,7 +208,7 @@ mod with_workspace {
         * c166d42 (origin/main, origin/HEAD, main) init-integration
         ");
 
-        let store = WorkspaceStore::default()
+        let store = WorkspaceRefMetadataStore::default()
             .with_target("main")
             .with_named_branch("A");
         insta::assert_debug_snapshot!(but_workspace::branch_details_v3(&repo, refname("A").as_ref(), &store).unwrap(), @r#"
@@ -252,17 +252,18 @@ mod with_workspace {
     }
 
     #[derive(Default)]
-    struct WorkspaceStore {
+    struct WorkspaceRefMetadataStore {
         workspace: Workspace,
         branches: Vec<(FullName, but_core::ref_metadata::Branch)>,
     }
 
-    impl WorkspaceStore {
+    impl WorkspaceRefMetadataStore {
         pub fn with_target(mut self, short_name: &str) -> Self {
             self.workspace = but_core::ref_metadata::Workspace {
                 ref_info: Default::default(),
                 stacks: vec![],
                 target_ref: Some(refname(short_name)),
+                push_remote: None,
             };
             self
         }
@@ -320,7 +321,7 @@ mod with_workspace {
         }
     }
 
-    impl RefMetadata for WorkspaceStore {
+    impl RefMetadata for WorkspaceRefMetadataStore {
         type Handle<T> = NullHandle<T>;
 
         fn iter(&self) -> impl Iterator<Item = anyhow::Result<(FullName, Box<dyn Any>)>> + '_ {


### PR DESCRIPTION
That way, the typical fork workflow would work naturally as one will push branches to the push remote and they will be shown.

Setting up the push remote like this…

<img width="626" height="381" alt="Screenshot 2025-08-19 at 12 00 34" src="https://github.com/user-attachments/assets/ed2b287b-bc74-4cf6-952b-21e0b6fdd8c1" />

…and pushing to it…

<img width="366" height="311" alt="Screenshot 2025-08-19 at 12 02 08" src="https://github.com/user-attachments/assets/639ccff9-2ca8-4fce-965f-674fee922715" />

…still shows up as if there is no remote as it's not picked up automatically. It must be deduced.


### Tasks

* [x] improve virtual branches adapter for access to push remotes
* [x] reproduce in test (with fetch remote also available, and without)
* [x] adjust deduction to prefer the push remote for display
* [ ] see if UI tooltip can show the remote name