### PR TITLE
Improve commit dialog file selection: check selected or all

### DIFF
--- a/apps/desktop/src/components/UnassignedView.svelte
+++ b/apps/desktop/src/components/UnassignedView.svelte
@@ -57,6 +57,18 @@
 	function foldUnnassignedView() {
 		unassignedSidebaFolded.set(true);
 	}
+
+	function checkFilesForCommit() {
+		const selectionId = createWorktreeSelection({});
+		const selectedPaths = idSelection.values(selectionId).map((entry) => entry.path);
+
+		// If there are selected paths in the unassigned selection, we check those.
+		if (selectedPaths.length > 0) {
+			uncommittedService.checkFiles(null, selectedPaths);
+		} else {
+			uncommittedService.checkAll(null);
+		}
+	}
 </script>
 
 {#snippet foldButton()}
@@ -118,7 +130,7 @@
 							stackId: undefined,
 							branchName: undefined
 						});
-						uncommittedService.checkAll(null);
+						checkFilesForCommit();
 					}}
 					icon={isCommitting ? undefined : 'plus-small'}
 					testId={TestId.CommitToNewBranchButton}

--- a/apps/desktop/src/lib/selection/uncommitted.ts
+++ b/apps/desktop/src/lib/selection/uncommitted.ts
@@ -216,6 +216,30 @@ export const uncommittedSlice = createSlice({
 				});
 			}
 		},
+		checkFiles(state, action: PayloadAction<{ stackId: string | null; paths: string[] }>) {
+			const { stackId, paths } = action.payload;
+			const hunkSelections: HunkSelection[] = [];
+			for (const path of paths) {
+				const prefix = partialKey(stackId, path);
+				const assignments = uncommittedSelectors.hunkAssignments.selectByPrefix(
+					state.hunkAssignments,
+					prefix
+				);
+
+				for (const assignment of assignments) {
+					const key = hunkAssignmentAdapter.selectId(assignment);
+					hunkSelections.push({
+						stableId: assignment.id,
+						stackId: stackId,
+						path: assignment.path,
+						assignmentId: key,
+						lines: []
+					});
+				}
+			}
+
+			state.hunkSelection = hunkSelectionAdapter.upsertMany(state.hunkSelection, hunkSelections);
+		},
 		uncheckFile(state, action: PayloadAction<{ stackId: string | null; path: string }>) {
 			const { stackId, path } = action.payload;
 			const prefix = partialKey(stackId, path);

--- a/apps/desktop/src/lib/selection/uncommittedService.svelte.ts
+++ b/apps/desktop/src/lib/selection/uncommittedService.svelte.ts
@@ -417,6 +417,10 @@ export class UncommittedService {
 		this.dispatch(uncommittedActions.checkFile({ stackId, path }));
 	}
 
+	checkFiles(stackId: string | null, paths: string[]) {
+		this.dispatch(uncommittedActions.checkFiles({ stackId, paths }));
+	}
+
 	uncheckFile(stackId: string | null, path: string) {
 		this.dispatch(uncommittedActions.uncheckFile({ stackId, path }));
 	}


### PR DESCRIPTION
- Updated StackView.svelte to refine file selection logic when starting a commit: if there are selected files (assigned or unassigned), only those are checked by default; otherwise, all files are checked.
- Added checkFiles method to uncommittedService for batch file selection.
- Added checkFiles action and reducer logic to uncommitted.ts to support multi-file selection state update.