### PR TITLE
feat(ui): normalize commit view paddings and limit height to 40vh

### DIFF
--- a/apps/desktop/src/components/CommitDetails.svelte
+++ b/apps/desktop/src/components/CommitDetails.svelte
@@ -115,6 +115,7 @@
 	.commit {
 		display: flex;
 		flex-direction: column;
+		padding: 14px;
 		gap: 12px;
 	}
 

--- a/apps/desktop/src/components/CommitView.svelte
+++ b/apps/desktop/src/components/CommitView.svelte
@@ -256,13 +256,15 @@
 <style>
 	.commit-view {
 		position: relative;
-		padding: 14px;
+		/* Limit the commit view to at most 40vh to ensure other sections remain visible */
+		max-height: 40vh;
 		background-color: var(--clr-bg-1);
 	}
 
 	.edit-commit-view {
 		display: flex;
 		flex-direction: column;
+		padding: 14px;
 
 		&.no-paddings {
 			margin: -14px;


### PR DESCRIPTION
- Padding fix. Previous implementation didn’t work with scrolling.
- Limit commit view maximum height to 40vh to improve layout and prevent overflow