### PR TITLE
Enable Dependabot updates for Rust toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,8 @@ updates:
     groups:
       rust-updates:
         update-types: [minor, patch]
+
+  - package-ecosystem: 'rust-toolchain'
+    directory: '/'
+    schedule:
+      interval: 'monthly'


### PR DESCRIPTION
## 🧢 Changes

Enables Dependabot updates for Rust toolchain

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

The project currently targets `nightly-2025-02-14`, which is quite out-of-date. Dependabot now supports updating `rust-toolchain.toml`: https://github.blog/changelog/2025-08-19-dependabot-now-supports-rust-toolchain-updates/

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
