### PR TITLE
Fix branch name UI to reset after rename failure

### DIFF
--- a/apps/desktop/src/components/BranchCard.svelte
+++ b/apps/desktop/src/components/BranchCard.svelte
@@ -165,6 +165,7 @@
 				iconName={args.iconName}
 				{updateBranchName}
 				isUpdatingName={nameUpdate.current.isLoading}
+				failedMisserablyToUpdateBranchName={nameUpdate.current.isError}
 				{active}
 				{readonly}
 				{isPushed}
@@ -239,6 +240,7 @@
 			iconName={args.iconName}
 			{updateBranchName}
 			isUpdatingName={nameUpdate.current.isLoading}
+			failedMisserablyToUpdateBranchName={nameUpdate.current.isError}
 			{active}
 			readonly
 			{isPushed}
@@ -266,6 +268,7 @@
 			iconName="branch-remote"
 			{updateBranchName}
 			isUpdatingName={nameUpdate.current.isLoading}
+			failedMisserablyToUpdateBranchName={nameUpdate.current.isError}
 			{active}
 			readonly
 			isPushed
@@ -288,6 +291,7 @@
 			iconName="branch-local"
 			{updateBranchName}
 			isUpdatingName={nameUpdate.current.isLoading}
+			failedMisserablyToUpdateBranchName={nameUpdate.current.isError}
 			{active}
 			readonly={false}
 			isPushed={false}

--- a/apps/desktop/src/components/BranchHeader.svelte
+++ b/apps/desktop/src/components/BranchHeader.svelte
@@ -22,6 +22,7 @@
 		onclick?: () => void;
 		updateBranchName: (name: string) => void;
 		isUpdatingName: boolean;
+		failedMisserablyToUpdateBranchName: boolean;
 		emptyState?: Snippet;
 		content?: Snippet;
 		menu?: Snippet<[{ rightClickTrigger: HTMLElement }]>;
@@ -36,6 +37,7 @@
 		active,
 		isCommitting,
 		isUpdatingName,
+		failedMisserablyToUpdateBranchName,
 		readonly,
 		isPushed,
 		lineColor,
@@ -83,6 +85,7 @@
 					name={branchName}
 					fontSize="15"
 					disabled={isUpdatingName}
+					error={failedMisserablyToUpdateBranchName}
 					readonly={readonly || isPushed}
 					onChange={(name) => updateBranchName(name)}
 				/>

--- a/apps/desktop/src/components/BranchLabel.svelte
+++ b/apps/desktop/src/components/BranchLabel.svelte
@@ -8,6 +8,7 @@
 		name: string;
 		disabled?: boolean;
 		readonly?: boolean;
+		error?: boolean;
 		fontSize?: '14' | '15';
 		allowClear?: boolean;
 		onChange?: (value: string) => void;
@@ -20,6 +21,7 @@
 		fontSize = '14',
 		readonly = false,
 		allowClear,
+		error,
 		onChange,
 		onDblClick
 	}: Props = $props();
@@ -88,6 +90,12 @@
 		const target = e.currentTarget as HTMLInputElement;
 		currentValue = target.value;
 	}
+
+	$effect(() => {
+		if (error) {
+			currentValue = name;
+		}
+	});
 </script>
 
 <!-- Hidden element for measuring text width -->


### PR DESCRIPTION
This commit updates the branch name editing flow. Now, if updating a branch name fails, the displayed name immediately reverts to the original (pre-edit) branch name, instead of leaving an incorrect or unsaved value. The involved components now properly convey and react to rename errors.

- BranchCard: pass through error state on update failure.
- BranchHeader: propagate rename failure state for UI handling.
- BranchLabel: reset value on error so the user sees the correct (original) branch name.
