### PR TITLE
Fix error on SSH key selection with unset preferred key

### DIFF
--- a/apps/desktop/src/components/CredentialCheck.svelte
+++ b/apps/desktop/src/components/CredentialCheck.svelte
@@ -8,11 +8,12 @@
 
 	interface Props {
 		projectId: string;
+		disabled: boolean;
 		remoteName: string | null | undefined;
 		branchName: string | null | undefined;
 	}
 
-	const { projectId, remoteName, branchName }: Props = $props();
+	const { projectId, remoteName, branchName, disabled }: Props = $props();
 
 	const gitConfig = inject(GIT_CONFIG_SERVICE);
 
@@ -106,7 +107,7 @@
 			</InfoMessage>
 		</div>
 	{/if}
-	<Button style="pop" wide icon="item-tick" disabled={loading} onclick={checkCredentials}>
+	<Button style="pop" wide icon="item-tick" {loading} {disabled} onclick={checkCredentials}>
 		{#if loading || checks?.length === 0}
 			Test credentials
 		{:else}

--- a/apps/desktop/src/lib/utils/debounce.ts
+++ b/apps/desktop/src/lib/utils/debounce.ts
@@ -1,4 +1,4 @@
-export function debounce<Args extends unknown[], Return, Fn extends (...args: Args) => Return>(
+export function debounce<Args extends any[], Return, Fn extends (...args: Args) => Return>(
 	fn: Fn,
 	delay: number
 ): (...args: Args) => void {


### PR DESCRIPTION
These changes fix a UI logic error that occurred when the SSH key authentication option for Git was selected without specifying a preferred key. Now, the update call for the preferred key is only sent if the key is actually set, preventing unnecessary errors. Additionally, disables the credential check button when SSH key is selected but no key is provided. Also refines debounce utility type for consistency.

fixes https://github.com/gitbutlerapp/gitbutler/issues/9903
