### PR TITLE
Add testId prop to MainViewport and workspace TestId

### DIFF
--- a/apps/desktop/src/components/MainViewport.svelte
+++ b/apps/desktop/src/components/MainViewport.svelte
@@ -3,8 +3,8 @@
 A three way split view that manages resizing of the panels.
 
 The left panel is set in rem units, the left-sideview has fixed width constraints,
-and the mainSection panel grows as the window resizes. If the window shrinks to where 
-it is smaller than the sum of the preferred widths, then the derived widths adjust 
+and the mainSection panel grows as the window resizes. If the window shrinks to where
+it is smaller than the sum of the preferred widths, then the derived widths adjust
 down, with the left hand side shrinking before the left-sideview panel.
 
 Persisted widths are only stored when resizing manually, meaning you can shrink
@@ -34,6 +34,7 @@ the window, then enlarge it and retain the original widths of the layout.
 	import type { Snippet } from 'svelte';
 
 	type Props = {
+		testId?: string;
 		name: string;
 		left: Snippet;
 		leftWidth: {
@@ -53,7 +54,7 @@ the window, then enlarge it and retain the original widths of the layout.
 		};
 	};
 
-	const { name, left, leftWidth, preview, previewWidth, middle, right, rightWidth }: Props =
+	const { testId, name, left, leftWidth, preview, previewWidth, middle, right, rightWidth }: Props =
 		$props();
 
 	const userSettings = inject(SETTINGS);
@@ -132,6 +133,7 @@ the window, then enlarge it and retain the original widths of the layout.
 	class="main-viewport"
 	use:focusable={{ id: DefinedFocusable.MainViewport }}
 	bind:clientWidth={containerBindWidth}
+	data-testid={testId}
 	class:left-sideview-open={!!preview}
 >
 	{#if !unassignedSidebaFolded.current}

--- a/apps/desktop/src/components/WorkspaceView.svelte
+++ b/apps/desktop/src/components/WorkspaceView.svelte
@@ -20,6 +20,7 @@
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
 	import { UI_STATE, type ExclusiveAction } from '$lib/state/uiState.svelte';
 	import { inject } from '@gitbutler/shared/context';
+	import { TestId } from '@gitbutler/ui';
 	import { isDefined } from '@gitbutler/ui/utils/typeguards';
 	import { setContext } from 'svelte';
 	import { writable } from 'svelte/store';
@@ -157,6 +158,7 @@
 {/snippet}
 
 <MainViewport
+	testId={TestId.WorkspaceView}
 	name="workspace"
 	leftWidth={{ default: 280, min: 220 }}
 	preview={previewOpen ? leftPreview : undefined}

--- a/packages/ui/src/lib/utils/testIds.ts
+++ b/packages/ui/src/lib/utils/testIds.ts
@@ -1,4 +1,5 @@
 export enum TestId {
+	WorkspaceView = 'workspace-view',
 	NavigationWorkspaceButton = 'navigation-workspace-button',
 	NavigationBranchesButton = 'navigation-branches-button',
 	BranchNameLabel = 'branch-name-label',


### PR DESCRIPTION
- apps/desktop/src/components/MainViewport.svelte:
  - Added optional testId?: string prop to Props type.
  - Destructured testId from $props and bound it to the root element as data-testid attribute.
  - Adjusted imports/whitespace in the file header.

- apps/desktop/src/components/WorkspaceView.svelte:
  - Imported TestId from @gitbutler/ui.
  - Passed TestId.WorkspaceView to <MainViewport> via testId prop.

- packages/ui/src/lib/utils/testIds.ts:
  - Added WorkspaceView = 'workspace-view' enum entry to TestId so consumer can reference the value.