### PR TITLE
Enable Playwright test parallelism with multiple workers

### DIFF
--- a/e2e/playwright/src/setup.ts
+++ b/e2e/playwright/src/setup.ts
@@ -4,6 +4,23 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { Socket } from 'node:net';
 import path from 'node:path';
 
+const DESKTOP_PORT = process.env.DESKTOP_PORT || '3000';
+const BUTLER_PORT = process.env.BUTLER_PORT || '6978';
+
+export function getBaseURL() {
+	const parallelId = process.env.TEST_PARALLEL_INDEX ?? '0';
+	const id = parseInt(parallelId, 10);
+	const port = parseInt(DESKTOP_PORT, 10);
+
+	return `http://localhost:${port + id}`;
+}
+
+export function getButlerPort(): string {
+	const parallelId = process.env.TEST_PARALLEL_INDEX ?? '0';
+	const id = parseInt(parallelId, 10);
+	return `${parseInt(BUTLER_PORT, 10) + id}`;
+}
+
 export interface GitButler {
 	pathInWorkdir: (filePath: string) => string;
 	runScript(scriptName: string): Promise<void>;
@@ -33,7 +50,7 @@ class GitButlerManager implements GitButler {
 
 		this.butServerProcess = spawnProcess('cargo', ['run', '-p', 'but-server'], this.rootDir, {
 			E2E_TEST_APP_DATA_DIR: this.configDir || path.join(this.workdir, 'config'),
-			BUTLER_PORT: process.env.BUTLER_PORT || '6978'
+			BUTLER_PORT: getButlerPort()
 		});
 
 		this.butServerProcess.on('message', (message) => {

--- a/e2e/playwright/src/util.ts
+++ b/e2e/playwright/src/util.ts
@@ -1,5 +1,5 @@
 import { TestId } from '@gitbutler/ui/utils/testIds';
-import { type Page } from '@playwright/test';
+import { type Locator, type Page } from '@playwright/test';
 
 type TestIdValues = `${TestId}`;
 
@@ -10,4 +10,14 @@ type TestIdValues = `${TestId}`;
  */
 export function getByTestId(page: Page, testId: TestIdValues) {
 	return page.getByTestId(testId);
+}
+
+/**
+ * Click an element by test ID.
+ */
+export async function clickByTestId(page: Page, testId: TestIdValues): Promise<Locator> {
+	const element = getByTestId(page, testId);
+	await element.waitFor();
+	await element.click();
+	return element;
 }

--- a/e2e/playwright/tests/startTheApp.spec.ts
+++ b/e2e/playwright/tests/startTheApp.spec.ts
@@ -1,8 +1,12 @@
-import { type GitButler, startGitButler } from '../src/setup.ts';
-import { getByTestId } from '../src/util.ts';
+import { getBaseURL, type GitButler, startGitButler } from '../src/setup.ts';
+import { clickByTestId, getByTestId } from '../src/util.ts';
 import { test } from '@playwright/test';
 
 let gitbutler: GitButler;
+
+test.use({
+	baseURL: getBaseURL()
+});
 
 test.afterEach(async () => {
 	gitbutler?.destroy();
@@ -19,15 +23,11 @@ test('should start the application', async ({ page, context }, testInfo) => {
 	const onboardingPage = getByTestId(page, 'onboarding-page');
 	await onboardingPage.waitFor();
 
-	const continueButton = getByTestId(page, 'analytics-continue');
-	await continueButton.waitFor();
-	await continueButton.click();
+	clickByTestId(page, 'analytics-continue');
 
 	// Add a local project
 	const fileChooserPromise = page.waitForEvent('filechooser');
-	const addLocalProjectButton = getByTestId(page, 'add-local-project');
-	await addLocalProjectButton.waitFor();
-	await addLocalProjectButton.click();
+	clickByTestId(page, 'add-local-project');
 
 	const fileChooser = await fileChooserPromise;
 	const projectPath = gitbutler.pathInWorkdir('local-clone/');
@@ -37,16 +37,12 @@ test('should start the application', async ({ page, context }, testInfo) => {
 	const projectSetupPage = getByTestId(page, 'project-setup-page');
 	await projectSetupPage.waitFor();
 
-	const targetBranchSelect = getByTestId(page, 'set-base-branch');
-	await targetBranchSelect.waitFor();
-	await targetBranchSelect.click();
+	clickByTestId(page, 'set-base-branch');
 
 	// Should see the keys form page
 	const gitAuthPage = getByTestId(page, 'project-setup-git-auth-page');
 	await gitAuthPage.waitFor();
-	const acceptGitAuthButton = getByTestId(page, 'accept-git-auth');
-	await acceptGitAuthButton.waitFor();
-	await acceptGitAuthButton.click();
+	clickByTestId(page, 'accept-git-auth');
 
 	// Should load the workspace
 	const workspaceView = getByTestId(page, 'workspace-view');


### PR DESCRIPTION
- Update playwright.config.ts to enable parallel test execution using multiple workers, with environment variable-driven dynamic port assignment.
- Introduce helper functions getBaseURL and getButlerPort to support parallel runs with unique ports in src/setup.ts.
- Add clickByTestId helper to simplify test actions in src/util.ts.
- Refactor startTheApp.spec.ts to use new parallel-enabled utilities and streamline test steps.

These changes allow Playwright tests to run in true parallel, using multiple servers and dynamic URLs.