### PR TITLE
Remove data-testid from NewCommitView wrapper

### DIFF
--- a/apps/desktop/src/components/StackDraft.svelte
+++ b/apps/desktop/src/components/StackDraft.svelte
@@ -42,7 +42,7 @@
 	>
 		<ConfigurableScrollableContainer>
 			<div class="draft-stack__scroll-wrap">
-				<div class="new-commit-view" data-testid={TestId.NewCommitView}>
+				<div class="new-commit-view">
 					<NewCommitView {projectId} />
 				</div>
 				<ReduxResult {projectId} result={newNameResult.current}>


### PR DESCRIPTION
Removed the data-testid attribute from the wrapping div around NewCommitView in StackDraft.svelte. This is a small UI/markup cleanup: <div class="new-commit-view" data-testid={TestId.NewCommitView}> -> <div class="new-commit-view">. 