### PR TITLE
E2E test: verify file commit & file-watcher

### DIFF
--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -40,46 +40,29 @@ export default defineConfig({
 	},
 
 	/* Configure projects for major browsers */
-	projects: [
-		{
-			name: 'chromium',
-			use: { ...devices['Desktop Chrome'] }
-		}
-
-		// {
-		// 	name: 'firefox',
-		// 	use: { ...devices['Desktop Firefox'] }
-		// },
-
-		// {
-		// 	name: 'webkit',
-		// 	use: { ...devices['Desktop Safari'] }
-		// }
-
-		/* Test against mobile viewports. */
-		// {
-		//   name: 'Mobile Chrome',
-		//   use: { ...devices['Pixel 5'] },
-		// },
-		// {
-		//   name: 'Mobile Safari',
-		//   use: { ...devices['iPhone 12'] },
-		// },
-
-		/* Test against branded browsers. */
-		// {
-		//   name: 'Microsoft Edge',
-		//   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-		// },
-		// {
-		//   name: 'Google Chrome',
-		//   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-		// },
-	],
+	projects: projects(),
 
 	/* Run your local dev server before starting the tests */
 	webServer: webServers()
 });
+
+function projects() {
+	const projects = [];
+	if (process.env.CI) {
+		projects.push({
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] }
+		});
+		return projects;
+	}
+
+	projects.push({
+		name: 'Chrome',
+		use: { ...devices['Desktop Chrome'], channel: 'chrome', headless: false }
+	});
+
+	return projects;
+}
 
 /**
  * Command to start the frontend server.

--- a/e2e/playwright/src/file.ts
+++ b/e2e/playwright/src/file.ts
@@ -1,0 +1,19 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Write text to a file.
+ *
+ * The file and directory will be created if they do not exist.
+ */
+export function writeToFile(filePath: string, content: string): void {
+	ensuereDirectoryExists(filePath);
+	fs.writeFileSync(filePath, content, { flag: 'w+', encoding: 'utf-8' });
+}
+
+function ensuereDirectoryExists(filePath: string): void {
+	const dir = path.dirname(filePath);
+	if (!fs.existsSync(dir)) {
+		fs.mkdirSync(dir, { recursive: true });
+	}
+}

--- a/e2e/playwright/src/setup.ts
+++ b/e2e/playwright/src/setup.ts
@@ -23,7 +23,7 @@ export function getButlerPort(): string {
 
 export interface GitButler {
 	pathInWorkdir: (filePath: string) => string;
-	runScript(scriptName: string): Promise<void>;
+	runScript(scriptName: string, args?: string[]): Promise<void>;
 	destroy(): void;
 }
 
@@ -84,10 +84,11 @@ class GitButlerManager implements GitButler {
 		return path.join(this.workdir, filePath);
 	}
 
-	async runScript(scriptName: string): Promise<void> {
+	async runScript(scriptName: string, args?: string[]): Promise<void> {
 		const scriptPath = path.resolve(this.scriptsDir, scriptName);
 		if (!existsSync(scriptPath)) log(`Script not found: ${scriptPath}`, colors.red);
-		await runCommand('bash', [scriptPath], this.workdir);
+		const scriptArgs = args ?? [];
+		await runCommand('bash', [scriptPath, ...scriptArgs], this.workdir);
 	}
 }
 

--- a/e2e/playwright/src/util.ts
+++ b/e2e/playwright/src/util.ts
@@ -12,12 +12,46 @@ export function getByTestId(page: Page, testId: TestIdValues) {
 	return page.getByTestId(testId);
 }
 
+export async function waitForTestId(page: Page, testId: TestIdValues): Promise<Locator> {
+	const element = getByTestId(page, testId);
+	await element.waitFor();
+	return element;
+}
+
 /**
  * Click an element by test ID.
  */
 export async function clickByTestId(page: Page, testId: TestIdValues): Promise<Locator> {
-	const element = getByTestId(page, testId);
-	await element.waitFor();
+	const element = await waitForTestId(page, testId);
 	await element.click();
 	return element;
+}
+
+export async function fillByTestId(
+	page: Page,
+	testId: TestIdValues,
+	value: string
+): Promise<Locator> {
+	const element = await waitForTestId(page, testId);
+	await element.fill(value);
+	return element;
+}
+
+/**
+ * Type into the rich text editor by test ID.
+ *
+ * Only use this for the rich text editor, as this is a workaround for the fact that
+ * the rich text editor does not support the `fill` method.
+ *
+ * If you need to pass text into a norma input element, @see fillByTestId instead
+ */
+export async function textEditorFillByTestId(page: Page, testId: TestIdValues, value: string) {
+	const element = await waitForTestId(page, testId);
+	await element.click();
+	await element.pressSequentially(value);
+	return element;
+}
+
+export async function sleep(ms: number): Promise<void> {
+	return await new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
Extend the Playwright E2E test suite:
- Add helper for writing files from tests (src/file.ts).
- Update test to create a file, verify its appearance in the UI, and ensure the commit flow works through the app (tests/startTheApp.spec.ts).
- Improve Playwright configuration to allow clearer project selection and launching locally/headless (playwright.config.ts).
- Add several utility helpers for interactivity with the test UI (src/util.ts).
- Minor adjustments to test setup and script running to take arguments (src/setup.ts).
This verifies that the file-watcher detects changes and that committing files via the UI works as intended.