### PR TITLE
Fix uiState reactivity

### DIFF
--- a/apps/desktop/src/lib/bootstrap/deps.ts
+++ b/apps/desktop/src/lib/bootstrap/deps.ts
@@ -136,9 +136,8 @@ export function initDependencies(args: {
 	const clientState = new ClientState(backend, gitHubClient, gitLabClient, ircClient, posthog);
 	const githubUserService = new GitHubUserService(backend, clientState['githubApi']);
 
-	const uiStateSlice = clientState.uiState;
 	const uiState = new UiState(
-		reactive(() => uiStateSlice),
+		reactive(() => clientState.uiState),
 		clientState.dispatch
 	);
 	const ircService = new IrcService(clientState, clientState.dispatch, ircClient);


### PR DESCRIPTION
This regressed in fe2a062c due to a missing derived, but it doesn't need
it as long as we pass the variable it along without redeclaring it. Svelte magic.