### PR TITLE
feat(cli): add project command to but-testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,6 +1195,7 @@ dependencies = [
  "gitbutler-filemonitor",
  "gitbutler-operating-modes",
  "gitbutler-project",
+ "gitbutler-reference",
  "gitbutler-stack",
  "gix",
  "itertools",

--- a/crates/but-testing/Cargo.toml
+++ b/crates/but-testing/Cargo.toml
@@ -29,6 +29,7 @@ but-hunk-assignment.workspace = true
 gitbutler-branch-actions.workspace = true
 gitbutler-branch.workspace = true
 gitbutler-operating-modes.workspace = true
+gitbutler-reference.workspace = true
 
 gitbutler-commit = { workspace = true, optional = true, features = ["testing"] }
 

--- a/crates/but-testing/src/args.rs
+++ b/crates/but-testing/src/args.rs
@@ -1,3 +1,4 @@
+use gitbutler_reference::RemoteRefname;
 use gitbutler_stack::StackId;
 use std::path::PathBuf;
 
@@ -35,6 +36,16 @@ pub struct Args {
 
 #[derive(Debug, clap::Subcommand)]
 pub enum Subcommands {
+    /// Add the given Git repository as project for use with GitButler.
+    AddProject {
+        /// The long name of the remote reference to track, like `refs/remotes/origin/main`,
+        /// when switching to the workspace branch.
+        #[clap(short = 's', long)]
+        switch_to_workspace: Option<RemoteRefname>,
+        /// The path at which the repository worktree is located.
+        #[clap(default_value = ".", value_name = "REPOSITORY")]
+        path: PathBuf,
+    },
     /// Commit or amend all worktree changes to a new commit.
     Commit {
         /// The repo-relative path to the changed file to commit.

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -111,6 +111,7 @@ pub use commit::commit;
 use gitbutler_command_context::CommandContext;
 
 pub mod diff;
+pub mod project;
 
 pub mod assignment {
     use crate::command::{debug_print, project_from_path};

--- a/crates/but-testing/src/command/project.rs
+++ b/crates/but-testing/src/command/project.rs
@@ -1,0 +1,27 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use but_settings::AppSettings;
+use gitbutler_command_context::CommandContext;
+use gitbutler_reference::RemoteRefname;
+
+use crate::command::debug_print;
+
+pub fn add(data_dir: PathBuf, path: PathBuf, refname: Option<RemoteRefname>) -> Result<()> {
+    let path = gix::discover(path)?
+        .workdir()
+        .context("Only non-bare repositories can be added")?
+        .to_owned()
+        .canonicalize()?;
+    let project = gitbutler_project::add_with_path(data_dir, path, None, None)?;
+    let ctx = CommandContext::open(&project, AppSettings::default())?;
+    if let Some(refname) = refname {
+        gitbutler_branch_actions::set_base_branch(
+            &ctx,
+            &refname,
+            false,
+            ctx.project().exclusive_worktree_access().write_permission(),
+        )?;
+    };
+    debug_print(project)
+}


### PR DESCRIPTION
This commit introduces a new CLI command (`add-project`) in `but-testing` to add a project for GitButler, providing an option to specify a remote reference to track and a repo path. It also:
- Updates dependencies in `Cargo.toml` and `Cargo.lock`.
- Refactors and expands CLI argument parsing for the new command.
- Implements the command logic in a new file, handling data dir setup and error reporting.
- Wires the new command into the CLI's main logic flow.