### PR TITLE
e2e: Extract env vars and update setup to use them

### DIFF
--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -1,3 +1,4 @@
+import { BUT_SERVER_PORT, DESKTOP_PORT } from './src/env.ts';
 import { defineConfig, devices } from '@playwright/test';
 import path from 'node:path';
 
@@ -8,9 +9,6 @@ import path from 'node:path';
 // import dotenv from 'dotenv';
 // import path from 'path';
 // dotenv.config({ path: path.resolve(__dirname, '.env') });
-
-const BUT_SERVER_PORT = process.env.BUTLER_PORT || '6978';
-const DESKTOP_PORT = process.env.DESKTOP_PORT || '3000';
 
 const AMOUNT_OF_WORKERS = 2;
 

--- a/e2e/playwright/src/env.ts
+++ b/e2e/playwright/src/env.ts
@@ -1,0 +1,8 @@
+import path from 'node:path';
+
+const ROOT = path.resolve(import.meta.dirname, '../../..');
+
+export const BUT_SERVER_PORT = process.env.BUTLER_PORT || '6978';
+export const DESKTOP_PORT = process.env.DESKTOP_PORT || '3000';
+export const BUT_TESTING =
+	process.env.BUT_TESTING || path.join(ROOT, 'target', 'debug', 'but-testing');


### PR DESCRIPTION
- dded new module e2e/playwright/src/env.ts exporting BUT_SERVER_PORT, 
  ;DESKTOP_PORT, and BUT_TESTING derived from process.env and project root.
- Updated e2e/playwright/playwright.config.ts to import BUT_SERVER_PORT and DESKTOP_PORT from ./src/env.ts and removed inline port defaults.
- Updated e2e/playwright/src/setup.ts to import env constants, use getButlerPort() based on BUT_SERVER_PORT, pass Butler data dir to spawned commands, and include BUT_TESTING in environment when launching Electron. Refactored runCommand to accept env overrides and updated spawnProcess calls accordingly; added helper getButlerDataDir.
- Ensures server readiness error messages use computed port variable.