### PR TITLE
test(e2e): add remote-branch test and setup script

### DIFF
--- a/.github/workflows/test-e2e-playwright.yml
+++ b/.github/workflows/test-e2e-playwright.yml
@@ -17,12 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
-      GIT_CONFIG_GLOBAL: ${{ github.workspace }}/e2e/playwright/fixtures/.gitconfig
       DESKTOP_PORT: 3000
       BUTLER_PORT: 6978
       VITE_BUTLER_PORT: 6978
       VITE_BUTLER_HOST: 'localhost'
       VITE_BUILD_TARGET: 'web'
+      BUT_TESTING: ${{ github.workspace}}/target/debug/but-testing
+      GIT_CONFIG_GLOBAL: ${{ github.workspace }}/e2e/playwright/fixtures/.gitconfig
     steps:
       - uses: actions/checkout@v5
         if: ${{ github.event_name != 'workflow_dispatch' }}
@@ -74,6 +75,8 @@ jobs:
         run: cd e2e && pnpm exec playwright install --with-deps
       - name: Build but-server
         run: cargo build -p but-server
+      - name: Build but-testing
+        run: cargo build -p but-testing
       - name: Build SvelteKit
         run: pnpm build:desktop
       - name: Run Playwright tests

--- a/e2e/playwright/scripts/project-with-remote-branches.sh
+++ b/e2e/playwright/scripts/project-with-remote-branches.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $GITBUTLER_CLI_DATA_DIR"
+echo "BUT_TESTING $BUT_TESTING"
+
+# Setup a remote project.
+# GitButler currently requires projects to have a remote
+mkdir remote-project
+pushd remote-project
+git init -b master --object-format=sha1
+echo "foo\nbar\nbaz" > a_file
+git add a_file
+git commit -am "Hey, look! A commit."
+
+# Create branch 1
+git checkout -b branch1
+echo "branch1 commit 1" >> a_file
+git commit -am "branch1: first commit"
+echo "branch1 commit 2" >> a_file
+git commit -am "branch1: second commit"
+
+git checkout master
+
+# Create branch 2
+git checkout -b branch2
+echo "branch2 commit 1" >> a_file
+git commit -am "branch2: first commit"
+echo "branch2 commit 2" >> a_file
+git commit -am "branch2: second commit"
+git checkout master
+popd
+
+# Clone the remote into a folder and add the project to the application.
+git clone remote-project local-clone
+pushd local-clone
+  git checkout master
+  $BUT_TESTING add-project --switch-to-workspace "$(git rev-parse --symbolic-full-name @{u})"
+popd

--- a/e2e/playwright/tests/branches.spec.ts
+++ b/e2e/playwright/tests/branches.spec.ts
@@ -1,0 +1,59 @@
+import { getBaseURL, type GitButler, startGitButler } from '../src/setup.ts';
+import { clickByTestId, getByTestId, waitForTestId } from '../src/util.ts';
+import { expect, test } from '@playwright/test';
+
+let gitbutler: GitButler;
+
+test.use({
+	baseURL: getBaseURL()
+});
+
+test.afterEach(async () => {
+	gitbutler?.destroy();
+});
+
+test('should be able to apply a remote branch', async ({ page, context }, testInfo) => {
+	const workdir = testInfo.outputPath('workdir');
+	const configdir = testInfo.outputPath('config');
+	gitbutler = await startGitButler(workdir, configdir, context);
+
+	// const projectPath = gitbutler.pathInWorkdir('local-clone/');
+
+	await gitbutler.runScript('project-with-remote-branches.sh');
+
+	await page.goto('/');
+
+	// Should load the workspace
+	await waitForTestId(page, 'workspace-view');
+
+	// Should navigate to the branches page when clicking the branches button
+	await clickByTestId(page, 'navigation-branches-button');
+	const header = await waitForTestId(page, 'target-commit-list-header');
+
+	await expect(header).toContainText('origin/master');
+
+	const branchListCards = getByTestId(page, 'branch-list-card');
+	await expect(branchListCards).toHaveCount(2);
+
+	const firstBranchCard = branchListCards.filter({ hasText: 'branch1' });
+	await expect(firstBranchCard).toBeVisible();
+	await firstBranchCard.click();
+
+	// The delete branch should be visible
+	await waitForTestId(page, 'branches-view-delete-local-branch-button');
+
+	// Apply the branch
+	await clickByTestId(page, 'branches-view-apply-branch-button');
+	// Should be redirected to the workspace
+	await waitForTestId(page, 'workspace-view');
+
+	// There should be only one stack
+	const stacks = getByTestId(page, 'stack');
+	await expect(stacks).toHaveCount(1);
+	const stack = stacks.first();
+	await expect(stack).toContainText('branch1');
+
+	// The stack should have two commits
+	const commits = getByTestId(page, 'commit-row');
+	await expect(commits).toHaveCount(2);
+});


### PR DESCRIPTION
Add a Playwright end-to-end test that verifies the app can load a
workspace with remote branches. Start and tear down a GitButler test
server per test, run a project setup script, and wait for the
workspace view to appear.

Add a Bash script that creates a remote Git repository with master and
two feature branches, clones it into a local project, and registers the
project with the test runner. The script sets author/committer env
vars and uses the test CLI to add the project so tests can exercise
remote-branch behavior.