### PR TITLE
feat(ui): add Vue file type icon mapping

### DIFF
--- a/packages/ui/src/lib/components/file/typeMap.ts
+++ b/packages/ui/src/lib/components/file/typeMap.ts
@@ -307,6 +307,7 @@ export const symbolFileExtensionsToIcons: { [key: string]: string } = {
 	vob: 'video',
 	vsix: 'puzzle',
 	vsixmanifest: 'puzzle',
+	vue: 'vue',
 	wav: 'audio',
 	webm: 'video',
 	webp: 'image',


### PR DESCRIPTION
## 🧢 Changes

The file list view was missing the icon for `.vue` files.
I noticed the corresponding SVG icon already existed, but the extension-to-icon mapping hadn't been added.
This PR adds it.

Before:
<img width="295" height="175" src="https://github.com/user-attachments/assets/5f2a36ac-ee6d-46e4-a2cb-c78d67a693ce" />

After:
<img width="294" height="181" src="https://github.com/user-attachments/assets/321c2ecc-0396-447f-99e9-7760c2bfce23" />

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
