### PR TITLE
move-commit-illegal-actions

### DIFF
--- a/apps/desktop/src/lib/commits/commit.ts
+++ b/apps/desktop/src/lib/commits/commit.ts
@@ -159,3 +159,31 @@ export function commitStatusLabel(status: CommitStatusType): string {
 			return status;
 	}
 }
+
+export type MoveCommitIllegalAction =
+	| {
+			type: 'dependsOnCommits';
+			subject: string[];
+	  }
+	| {
+			type: 'hasDependentChanges';
+			subject: string[];
+	  }
+	| {
+			type: 'hasDependentUncommittedChanges';
+	  };
+
+function formatCommitIds(ids: string[]): string {
+	return ids.map((id) => id.slice(0, 7)).join('\n');
+}
+
+export function getMoveCommitIllegalActionMessage(action: MoveCommitIllegalAction): string {
+	switch (action.type) {
+		case 'dependsOnCommits':
+			return `Cannot move commit because it depends on the following commits: ${formatCommitIds(action.subject)}`;
+		case 'hasDependentChanges':
+			return `Cannot move commit because it has dependent changes: ${formatCommitIds(action.subject)}`;
+		case 'hasDependentUncommittedChanges':
+			return `Cannot move commit because it has dependent uncommitted changes`;
+	}
+}

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -29,7 +29,7 @@ import {
 } from '@reduxjs/toolkit';
 import type { StackOrder } from '$lib/branches/branch';
 import type { Commit, CommitDetails, UpstreamCommit } from '$lib/branches/v3';
-import type { CommitKey } from '$lib/commits/commit';
+import type { CommitKey, MoveCommitIllegalAction } from '$lib/commits/commit';
 import type { DefaultForgeFactory } from '$lib/forge/forgeFactory.svelte';
 import type { TreeChange, TreeChanges, TreeStats } from '$lib/hunks/change';
 import type { DiffSpec } from '$lib/hunks/hunk';
@@ -1392,7 +1392,7 @@ function injectEndpoints(api: ClientState['backendApi'], uiState: UiState) {
 				]
 			}),
 			moveCommit: build.mutation<
-				void,
+				MoveCommitIllegalAction | null,
 				{ projectId: string; sourceStackId: string; commitId: string; targetStackId: string }
 			>({
 				extraOptions: {

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -1,7 +1,7 @@
 use super::r#virtual as vbranch;
 use crate::branch_upstream_integration;
 use crate::branch_upstream_integration::IntegrationStrategy;
-use crate::move_commits;
+use crate::move_commits::{self, MoveCommitIllegalAction};
 use crate::reorder::{self, StackOrder};
 use crate::upstream_integration::{
     self, BaseBranchResolution, BaseBranchResolutionApproach, IntegrationOutcome, Resolution,
@@ -409,7 +409,7 @@ pub fn move_commit(
     target_stack_id: StackId,
     commit_oid: git2::Oid,
     source_stack_id: StackId,
-) -> Result<()> {
+) -> Result<Option<MoveCommitIllegalAction>> {
     let mut guard = ctx.project().exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
     ensure_open_workspace_mode(ctx).context("Moving a commit requires open workspace mode")?;

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -74,5 +74,7 @@ pub use branch::{
 
 pub use integration::GITBUTLER_WORKSPACE_COMMIT_TITLE;
 
+pub use move_commits::MoveCommitIllegalAction;
+
 pub mod hooks;
 pub mod stack;

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -8,8 +8,8 @@ use gitbutler_branch_actions::upstream_integration::{
     StackStatuses,
 };
 use gitbutler_branch_actions::{
-    BaseBranch, BranchListing, BranchListingDetails, BranchListingFilter, RemoteBranchData,
-    RemoteBranchFile, RemoteCommit, StackOrder,
+    BaseBranch, BranchListing, BranchListingDetails, BranchListingFilter, MoveCommitIllegalAction,
+    RemoteBranchData, RemoteBranchFile, RemoteCommit, StackOrder,
 };
 use gitbutler_project::ProjectId;
 use gitbutler_reference::{Refname, RemoteRefname};
@@ -364,7 +364,7 @@ pub fn move_commit(
     commit_id: String,
     target_stack_id: StackId,
     source_stack_id: StackId,
-) -> Result<(), Error> {
+) -> Result<Option<MoveCommitIllegalAction>, Error> {
     virtual_branches::move_commit(
         &app,
         virtual_branches::MoveCommitParams {


### PR DESCRIPTION
Summary
- Consolidate MoveCommitIllegalAction logic, propagation, type definitions, and error handling across the Rust workspace and API.
- Add MoveCommitIllegalAction type and formatting utilities.
- UpdateService moveCommit mutation to return MoveCommitIllegalAction | null and adjust types.
- Surface commit move legality outputs to frontend/API consumers and tighten boundary interfaces.
- Handle illegal move attempts in frontend dropHandler and display toast notifications.