### PR TITLE
user-setup-popup

### DIFF
--- a/.github/workflows/test-e2e-playwright.yml
+++ b/.github/workflows/test-e2e-playwright.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
+      GIT_CONFIG_GLOBAL: ${{ github.workspace }}/e2e/playwright/fixtures/.gitconfig
       DESKTOP_PORT: 3000
       BUTLER_PORT: 6978
       VITE_BUTLER_PORT: 6978

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,7 @@ dependencies = [
  "but-graph",
  "but-hunk-assignment",
  "but-hunk-dependency",
+ "but-rebase",
  "but-rules",
  "but-settings",
  "but-workspace",

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -26,6 +26,7 @@ but-workspace.workspace = true
 but-core.workspace = true
 but-hunk-assignment.workspace = true
 but-action.workspace = true
+but-rebase.workspace = true
 gitbutler-branch.workspace = true
 gitbutler-branch-actions.workspace = true
 gitbutler-command-context.workspace = true

--- a/crates/but-api/src/commands/config.rs
+++ b/crates/but-api/src/commands/config.rs
@@ -29,3 +29,29 @@ pub fn set_gb_config(_app: &App, params: SetGbConfigParams) -> Result<(), Error>
         .set_git_settings(&params.config.into())
         .map_err(Into::into)
 }
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StoreAuthorGloballyParams {
+    pub project_id: ProjectId,
+    pub name: String,
+    pub email: String,
+}
+
+pub fn store_author_globally_if_unset(
+    _app: &App,
+    StoreAuthorGloballyParams {
+        project_id,
+        name,
+        email,
+    }: StoreAuthorGloballyParams,
+) -> Result<(), Error> {
+    let repo = but_core::open_repo(gitbutler_project::get(project_id)?.path)?;
+    but_rebase::commit::save_author_if_unset_in_repo(
+        &repo,
+        gix::config::Source::User,
+        name.as_str(),
+        email.as_str(),
+    )?;
+    Ok(())
+}

--- a/crates/but-api/src/commands/projects.rs
+++ b/crates/but-api/src/commands/projects.rs
@@ -20,10 +20,7 @@ pub struct AddProjectParams {
 }
 
 pub fn add_project(_app: &App, params: AddProjectParams) -> Result<projects::Project, Error> {
-    let user = gitbutler_user::get_user()?;
-    let name = user.as_ref().and_then(|u| u.name.clone());
-    let email = user.as_ref().and_then(|u| u.email.clone());
-    Ok(gitbutler_project::add(&params.path, name, email)?)
+    Ok(gitbutler_project::add(&params.path)?)
 }
 
 #[derive(Deserialize)]

--- a/crates/but-rebase/src/commit.rs
+++ b/crates/but-rebase/src/commit.rs
@@ -9,6 +9,26 @@ use std::io::Write;
 use std::path::Path;
 use std::process::Stdio;
 
+/// Represents the author information from the git configuration.
+pub struct AuthorInfo {
+    /// The name of the author.
+    pub name: Option<BString>,
+    /// The email of the author.
+    pub email: Option<BString>,
+}
+
+/// Get the author information from the repository's git configuration.
+pub fn get_author_info(repo: &gix::Repository) -> anyhow::Result<AuthorInfo> {
+    let config = repo.config_snapshot();
+    let name = config
+        .string(&gix::config::tree::User::NAME)
+        .map(|s| s.into_owned());
+    let email = config
+        .string(&gix::config::tree::User::EMAIL)
+        .map(|s| s.into_owned());
+    Ok(AuthorInfo { name, email })
+}
+
 /// What to do with the committer (actor) and the commit time when [creating a new commit](create()).
 #[derive(Debug, Copy, Clone)]
 pub enum DateMode {

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -357,6 +357,10 @@ async fn handle_command(
         // Config management commands
         "get_gb_config" => run_cmd(&app, request.params, config::get_gb_config),
         "set_gb_config" => run_cmd(&app, request.params, config::set_gb_config),
+        "store_author_globally_if_unset" => {
+            run_cmd(&app, request.params, config::store_author_globally_if_unset)
+        }
+        "get_author_info" => run_cmd(&app, request.params, config::get_author_info),
         // Remotes management commands
         "list_remotes" => run_cmd(&app, request.params, remotes::list_remotes),
         "add_remote" => run_cmd(&app, request.params, remotes::add_remote),

--- a/crates/but-testing/src/command/project.rs
+++ b/crates/but-testing/src/command/project.rs
@@ -13,7 +13,7 @@ pub fn add(data_dir: PathBuf, path: PathBuf, refname: Option<RemoteRefname>) -> 
         .context("Only non-bare repositories can be added")?
         .to_owned()
         .canonicalize()?;
-    let project = gitbutler_project::add_with_path(data_dir, path, None, None)?;
+    let project = gitbutler_project::add_with_path(data_dir, path)?;
     let ctx = CommandContext::open(&project, AppSettings::default())?;
     if let Some(refname) = refname {
         gitbutler_branch_actions::set_base_branch(

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/init.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/init.rs
@@ -9,9 +9,8 @@ fn twice() {
     let test_project = TestProject::default();
 
     {
-        let project =
-            gitbutler_project::add_with_path(data_dir.path(), test_project.path(), None, None)
-                .expect("failed to add project");
+        let project = gitbutler_project::add_with_path(data_dir.path(), test_project.path())
+            .expect("failed to add project");
         let ctx = CommandContext::open(&project, AppSettings::default()).unwrap();
 
         gitbutler_branch_actions::set_base_branch(
@@ -28,8 +27,7 @@ fn twice() {
 
     {
         let project =
-            gitbutler_project::add_with_path(data_dir.path(), test_project.path(), None, None)
-                .unwrap();
+            gitbutler_project::add_with_path(data_dir.path(), test_project.path()).unwrap();
         let ctx = CommandContext::open(&project, AppSettings::default()).unwrap();
         gitbutler_branch_actions::set_base_branch(
             &ctx,

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/mod.rs
@@ -31,9 +31,8 @@ impl Default for Test {
         let data_dir = paths::data_dir();
 
         let test_project = TestProject::default();
-        let project =
-            gitbutler_project::add_with_path(data_dir.as_ref(), test_project.path(), None, None)
-                .expect("failed to add project");
+        let project = gitbutler_project::add_with_path(data_dir.as_ref(), test_project.path())
+            .expect("failed to add project");
         let ctx = CommandContext::open(&project, AppSettings::default()).unwrap();
 
         Self {

--- a/crates/gitbutler-cli/src/command/project.rs
+++ b/crates/gitbutler-cli/src/command/project.rs
@@ -26,7 +26,7 @@ pub fn add(data_dir: PathBuf, path: PathBuf, refname: Option<RemoteRefname>) -> 
         .context("Only non-bare repositories can be added")?
         .to_owned()
         .canonicalize()?;
-    let project = gitbutler_project::add_with_path(data_dir, path, None, None)?;
+    let project = gitbutler_project::add_with_path(data_dir, path)?;
     let ctx = CommandContext::open(&project, AppSettings::default())?;
     if let Some(refname) = refname {
         gitbutler_branch_actions::set_base_branch(

--- a/crates/gitbutler-project/src/controller.rs
+++ b/crates/gitbutler-project/src/controller.rs
@@ -60,12 +60,7 @@ impl Controller {
         }
     }
 
-    pub(crate) fn add<P: AsRef<Path>>(
-        &self,
-        path: P,
-        name: Option<String>,
-        email: Option<String>,
-    ) -> Result<Project> {
+    pub(crate) fn add<P: AsRef<Path>>(&self, path: P) -> Result<Project> {
         let path = path.as_ref();
         let all_projects = self
             .projects_storage
@@ -128,22 +123,6 @@ impl Controller {
         // Create a .git/gitbutler directory for app data
         if let Err(error) = std::fs::create_dir_all(project.gb_dir()) {
             tracing::error!(project_id = %project.id, ?error, "failed to create {:?} on project add", project.gb_dir());
-        }
-
-        let repo = gix::open(&project.path)?;
-        if repo.author().transpose()?.is_none() {
-            let git2_repo = git2::Repository::open(repo.path())?;
-            let config = git2_repo.config()?;
-
-            let mut local = config.open_level(git2::ConfigLevel::Local)?;
-            local.set_str(
-                "user.name",
-                &name.unwrap_or("Firstname Lastname".to_string()),
-            )?;
-            local.set_str(
-                "user.email",
-                &email.unwrap_or("name@example.com".to_string()),
-            )?;
         }
 
         Ok(project)

--- a/crates/gitbutler-project/src/lib.rs
+++ b/crates/gitbutler-project/src/lib.rs
@@ -60,24 +60,15 @@ pub fn update_with_path<P: AsRef<Path>>(
     controller.update(project)
 }
 
-pub fn add<P: AsRef<Path>>(
-    path: P,
-    name: Option<String>,
-    email: Option<String>,
-) -> anyhow::Result<Project> {
+pub fn add<P: AsRef<Path>>(path: P) -> anyhow::Result<Project> {
     let controller = Controller::from_path(but_path::app_data_dir()?);
-    controller.add(path, name, email)
+    controller.add(path)
 }
 
 /// Testing purpose only.
-pub fn add_with_path<P: AsRef<Path>>(
-    data_dir: P,
-    path: P,
-    name: Option<String>,
-    email: Option<String>,
-) -> anyhow::Result<Project> {
+pub fn add_with_path<P: AsRef<Path>>(data_dir: P, path: P) -> anyhow::Result<Project> {
     let controller = Controller::from_path(data_dir.as_ref());
-    controller.add(path, name, email)
+    controller.add(path)
 }
 
 pub fn list() -> anyhow::Result<Vec<Project>> {

--- a/crates/gitbutler-project/tests/projects/main.rs
+++ b/crates/gitbutler-project/tests/projects/main.rs
@@ -13,7 +13,7 @@ mod add {
         let tmp = paths::data_dir();
         let repository = gitbutler_testsupport::TestProject::default();
         let path = repository.path();
-        let project = gitbutler_project::add_with_path(tmp.path(), path, None, None).unwrap();
+        let project = gitbutler_project::add_with_path(tmp.path(), path).unwrap();
         assert_eq!(project.path, path);
         assert_eq!(
             project.title,
@@ -29,8 +29,7 @@ mod add {
         fn non_bare_without_worktree() {
             let tmp = paths::data_dir();
             let root = repo_path_at("non-bare-without-worktree");
-            let err = gitbutler_project::add_with_path(tmp.path(), root.as_path(), None, None)
-                .unwrap_err();
+            let err = gitbutler_project::add_with_path(tmp.path(), root.as_path()).unwrap_err();
             assert_eq!(
                 err.to_string(),
                 "Cannot add non-bare repositories without a workdir"
@@ -41,8 +40,7 @@ mod add {
         fn submodule() {
             let tmp = paths::data_dir();
             let root = repo_path_at("with-submodule").join("submodule");
-            let err = gitbutler_project::add_with_path(tmp.path(), root.as_path(), None, None)
-                .unwrap_err();
+            let err = gitbutler_project::add_with_path(tmp.path(), root.as_path()).unwrap_err();
             assert_eq!(
                 err.to_string(),
                 "A git-repository without a `.git` directory cannot currently be added"
@@ -54,14 +52,9 @@ mod add {
             let data_dir = paths::data_dir();
             let tmp = tempfile::tempdir().unwrap();
             assert_eq!(
-                gitbutler_project::add_with_path(
-                    data_dir.path(),
-                    &tmp.path().join("missing"),
-                    None,
-                    None
-                )
-                .unwrap_err()
-                .to_string(),
+                gitbutler_project::add_with_path(data_dir.path(), &tmp.path().join("missing"),)
+                    .unwrap_err()
+                    .to_string(),
                 "path not found"
             );
         }
@@ -73,7 +66,7 @@ mod add {
             let path = tmp.path();
             std::fs::write(path.join("file.txt"), "hello world").unwrap();
             assert_eq!(
-                gitbutler_project::add_with_path(data_dir.path(), path, None, None)
+                gitbutler_project::add_with_path(data_dir.path(), path)
                     .unwrap_err()
                     .to_string(),
                 "must be a Git repository"
@@ -84,8 +77,7 @@ mod add {
         fn empty() {
             let data_dir = paths::data_dir();
             let tmp = tempfile::tempdir().unwrap();
-            let err = gitbutler_project::add_with_path(data_dir.path(), tmp.path(), None, None)
-                .unwrap_err();
+            let err = gitbutler_project::add_with_path(data_dir.path(), tmp.path()).unwrap_err();
             assert_eq!(err.to_string(), "must be a Git repository");
         }
 
@@ -94,9 +86,9 @@ mod add {
             let data_dir = paths::data_dir();
             let repository = gitbutler_testsupport::TestProject::default();
             let path = repository.path();
-            gitbutler_project::add_with_path(data_dir.path(), path, None, None).unwrap();
+            gitbutler_project::add_with_path(data_dir.path(), path).unwrap();
             assert_eq!(
-                gitbutler_project::add_with_path(data_dir.path(), path, None, None)
+                gitbutler_project::add_with_path(data_dir.path(), path)
                     .unwrap_err()
                     .to_string(),
                 "project already exists"
@@ -113,8 +105,7 @@ mod add {
             create_initial_commit(&repo);
 
             let err =
-                gitbutler_project::add_with_path(data_dir.path(), repo_dir.as_path(), None, None)
-                    .unwrap_err();
+                gitbutler_project::add_with_path(data_dir.path(), repo_dir.as_path()).unwrap_err();
             assert_eq!(err.to_string(), "bare repositories are unsupported");
         }
 
@@ -130,8 +121,7 @@ mod add {
 
             let worktree = repo.worktree("feature", &worktree_dir, None).unwrap();
             let err =
-                gitbutler_project::add_with_path(data_dir.path(), worktree.path(), None, None)
-                    .unwrap_err();
+                gitbutler_project::add_with_path(data_dir.path(), worktree.path()).unwrap_err();
             assert_eq!(err.to_string(), "can only work in main worktrees");
         }
 
@@ -169,7 +159,7 @@ mod delete {
         let data_dir = paths::data_dir();
         let repository = gitbutler_testsupport::TestProject::default();
         let path = repository.path();
-        let project = gitbutler_project::add_with_path(data_dir.path(), path, None, None).unwrap();
+        let project = gitbutler_project::add_with_path(data_dir.path(), path).unwrap();
         assert!(gitbutler_project::delete_with_path(data_dir.path(), project.id).is_ok());
         assert!(gitbutler_project::delete_with_path(data_dir.path(), project.id).is_ok()); // idempotent
         assert!(gitbutler_project::get_with_path(data_dir.path(), project.id).is_err());

--- a/crates/gitbutler-tauri/src/config.rs
+++ b/crates/gitbutler-tauri/src/config.rs
@@ -39,3 +39,12 @@ pub fn store_author_globally_if_unset(
         },
     )
 }
+
+#[tauri::command(async)]
+#[instrument(skip(app), err(Debug))]
+pub fn get_author_info(
+    app: State<App>,
+    project_id: ProjectId,
+) -> Result<config::AuthorInfo, Error> {
+    config::get_author_info(&app, project_id)
+}

--- a/crates/gitbutler-tauri/src/config.rs
+++ b/crates/gitbutler-tauri/src/config.rs
@@ -1,10 +1,10 @@
+use but_api::commands::config::StoreAuthorGloballyParams;
+use but_api::error::Error;
 use but_api::{commands::config, App};
 use but_core::settings::git::ui::GitConfigSettings;
 use gitbutler_project::ProjectId;
 use tauri::State;
 use tracing::instrument;
-
-use but_api::error::Error;
 
 #[tauri::command(async)]
 #[instrument(skip(app), err(Debug))]
@@ -20,4 +20,22 @@ pub fn set_gb_config(
     config: GitConfigSettings,
 ) -> Result<(), Error> {
     config::set_gb_config(&app, config::SetGbConfigParams { project_id, config })
+}
+
+#[tauri::command(async)]
+#[instrument(skip(app), err(Debug))]
+pub fn store_author_globally_if_unset(
+    app: State<App>,
+    project_id: ProjectId,
+    name: String,
+    email: String,
+) -> Result<(), Error> {
+    config::store_author_globally_if_unset(
+        &app,
+        StoreAuthorGloballyParams {
+            project_id,
+            name,
+            email,
+        },
+    )
 }

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -276,6 +276,7 @@ fn main() {
                     undo::snapshot_diff,
                     config::get_gb_config,
                     config::set_gb_config,
+                    config::store_author_globally_if_unset,
                     menu::menu_item_set_enabled,
                     github::init_device_oauth,
                     github::check_auth_status,

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -277,6 +277,7 @@ fn main() {
                     config::get_gb_config,
                     config::set_gb_config,
                     config::store_author_globally_if_unset,
+                    config::get_author_info,
                     menu::menu_item_set_enabled,
                     github::init_device_oauth,
                     github::check_auth_status,

--- a/crates/gitbutler-testsupport/src/lib.rs
+++ b/crates/gitbutler-testsupport/src/lib.rs
@@ -238,12 +238,7 @@ pub mod read_only {
         // Assure the project is valid the first time.
         let project = if was_inserted {
             let tmp = tempfile::TempDir::new()?;
-            gitbutler_project::add_with_path(
-                tmp.path(),
-                project_worktree_dir.as_path(),
-                None,
-                None,
-            )?
+            gitbutler_project::add_with_path(tmp.path(), project_worktree_dir.as_path())?
         } else {
             Project {
                 id: ProjectId::generate(),

--- a/crates/gitbutler-testsupport/src/suite.rs
+++ b/crates/gitbutler-testsupport/src/suite.rs
@@ -68,8 +68,6 @@ impl Suite {
             gitbutler_project::add_with_path(
                 self.local_app_data(),
                 repository.path().parent().unwrap(),
-                None,
-                None,
             )
             .expect("failed to add project"),
             tmp,

--- a/e2e/playwright/fixtures/.gitconfig
+++ b/e2e/playwright/fixtures/.gitconfig
@@ -1,0 +1,13 @@
+[user]
+	name = Branchy McBranchface
+	email = me@branchy.com
+[core]
+	editor = vim
+[gitbutler]
+	aiModelProvider = openai
+	aiOllamaModelName = ""
+	aiOpenAIKeyOption = butlerAPI
+	aiOpenAIModelName = gpt-5-mini
+	aiAnthropicKeyOption = bringYourOwn
+[init]
+	defaultBranch = main

--- a/e2e/playwright/scripts/setup-empty-project.sh
+++ b/e2e/playwright/scripts/setup-empty-project.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
-export GIT_AUTHOR_NAME="Scott Chacon"
-export GIT_AUTHOR_EMAIL="git_overloard@example.com"
-export GIT_COMMITTER_NAME="Scott Chacon"
-export GIT_COMMITTER_EMAIL="git_overloard@example.com"
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $GITBUTLER_CLI_DATA_DIR"
+echo "BUT_TESTING $BUT_TESTING"
 
 # Setup a remote project.
 # GitButler currently requires projects to have a remote

--- a/e2e/playwright/src/env.ts
+++ b/e2e/playwright/src/env.ts
@@ -1,8 +1,11 @@
 import path from 'node:path';
 
 const ROOT = path.resolve(import.meta.dirname, '../../..');
+const E2E_DIR = path.resolve(ROOT, 'e2e/playwright');
 
 export const BUT_SERVER_PORT = process.env.BUTLER_PORT || '6978';
 export const DESKTOP_PORT = process.env.DESKTOP_PORT || '3000';
 export const BUT_TESTING =
 	process.env.BUT_TESTING || path.join(ROOT, 'target', 'debug', 'but-testing');
+export const GIT_CONFIG_GLOBAL =
+	process.env.GIT_CONFIG_GLOBAL || path.join(E2E_DIR, 'fixtures', '.gitconfig');


### PR DESCRIPTION
Summary
- Replace automatic user setup with a popup flow that defers user creation and allows later failure handling.
- Expose missing author condition via an attached error code for discoverability.
- Add a new endpoint to store a global user when none is set.
- Ensure deterministic git config in e2e tests by providing a .gitconfig fixture and propagating GIT_GLOBAL_CONFIG to test and server processes.

What changed
- Removed automatic user setup; operations that require an author may now fail and surface a prompt-based setup later.
- Introduced an error code to make "no author" situations detectable programmatically.
- Implemented an API endpoint to persist a global user configuration.
- Standardized git identity/config for Playwright e2e tests and updated env/test/server scripts to use a shared GIT_GLOBAL_CONFIG.
