### PR TITLE
refactor(api): accept params struct in get_author_info

### DIFF
--- a/crates/but-api/src/commands/config.rs
+++ b/crates/but-api/src/commands/config.rs
@@ -74,8 +74,14 @@ impl From<but_rebase::commit::AuthorInfo> for AuthorInfo {
     }
 }
 
-pub fn get_author_info(_app: &App, project_id: ProjectId) -> Result<AuthorInfo, Error> {
-    let repo = but_core::open_repo(gitbutler_project::get(project_id)?.path)?;
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetAuthorInfoParams {
+    pub project_id: ProjectId,
+}
+
+pub fn get_author_info(_app: &App, params: GetAuthorInfoParams) -> Result<AuthorInfo, Error> {
+    let repo = but_core::open_repo(gitbutler_project::get(params.project_id)?.path)?;
     let author = but_rebase::commit::get_author_info(&repo)?;
     Ok(author.into())
 }

--- a/crates/gitbutler-tauri/src/config.rs
+++ b/crates/gitbutler-tauri/src/config.rs
@@ -1,4 +1,4 @@
-use but_api::commands::config::StoreAuthorGloballyParams;
+use but_api::commands::config::{GetAuthorInfoParams, StoreAuthorGloballyParams};
 use but_api::error::Error;
 use but_api::{commands::config, App};
 use but_core::settings::git::ui::GitConfigSettings;
@@ -46,5 +46,5 @@ pub fn get_author_info(
     app: State<App>,
     project_id: ProjectId,
 ) -> Result<config::AuthorInfo, Error> {
-    config::get_author_info(&app, project_id)
+    config::get_author_info(&app, GetAuthorInfoParams { project_id })
 }


### PR DESCRIPTION
Change get_author_info signature to accept a GetAuthorInfoParams struct (serde camelCase) instead of raw project_id. This wraps the ProjectId in a params object for API consistency with other commands. Update repo lookup to use params.project_id. Added GetAuthorInfoParams struct with Deserialize and serde rename_all = "camelCase".