### PR TITLE
cleanup but-rebase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,6 +880,7 @@ dependencies = [
  "gitbutler-repo",
  "gitbutler-repo-actions",
  "gitbutler-secret",
+ "gitbutler-serde",
  "gitbutler-stack",
  "gitbutler-sync",
  "gitbutler-user",

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -27,6 +27,7 @@ but-core.workspace = true
 but-hunk-assignment.workspace = true
 but-action.workspace = true
 but-rebase.workspace = true
+gitbutler-serde.workspace = true
 gitbutler-branch.workspace = true
 gitbutler-branch-actions.workspace = true
 gitbutler-command-context.workspace = true

--- a/crates/but-rebase/src/commit.rs
+++ b/crates/but-rebase/src/commit.rs
@@ -9,26 +9,6 @@ use std::io::Write;
 use std::path::Path;
 use std::process::Stdio;
 
-/// Represents the author information from the git configuration.
-pub struct AuthorInfo {
-    /// The name of the author.
-    pub name: Option<BString>,
-    /// The email of the author.
-    pub email: Option<BString>,
-}
-
-/// Get the author information from the repository's git configuration.
-pub fn get_author_info(repo: &gix::Repository) -> anyhow::Result<AuthorInfo> {
-    let config = repo.config_snapshot();
-    let name = config
-        .string(&gix::config::tree::User::NAME)
-        .map(|s| s.into_owned());
-    let email = config
-        .string(&gix::config::tree::User::EMAIL)
-        .map(|s| s.into_owned());
-    Ok(AuthorInfo { name, email })
-}
-
 /// What to do with the committer (actor) and the commit time when [creating a new commit](create()).
 #[derive(Debug, Copy, Clone)]
 pub enum DateMode {


### PR DESCRIPTION
Follow up on #9938 and the PR that creates the new endpoint in the first place.

It's probably fine to use `but-api` and move it 'down' only when other plumbing crates also need the new functionality.
