### PR TITLE
Add file icon mapping for .graphqls extension

### DIFF
--- a/packages/ui/src/lib/components/file/typeMap.ts
+++ b/packages/ui/src/lib/components/file/typeMap.ts
@@ -94,6 +94,7 @@ export const symbolFileExtensionsToIcons: { [key: string]: string } = {
 	gql: 'graphql',
 	gradle: 'gradle',
 	graphql: 'graphql',
+	graphqls: 'graphql',
 	h: 'h',
 	haml: 'haml',
 	heex: 'elixir',


### PR DESCRIPTION
## 🧢 Changes
Before:
<img width="280" height="33" alt="graphqls-icon-before" src="https://github.com/user-attachments/assets/26379c64-0929-4742-ad97-ce064ca6c538" />


After:
<img width="280" height="33" alt="graphqls-icon-after" src="https://github.com/user-attachments/assets/d233a3a3-af46-462e-a692-3ce24be705ff" />

## ☕️ Reasoning
It's a less common extension for GraphQL schema files, but some projects just choose to use this one 🤷🏻‍♂️  It's not a complete niche because it's recognized across most of the GraphQL tooling. VSCode built-in icon theme also has this association.

References:
- https://github.com/graphql/graphiql/tree/b3c42a65160ba4878b5ea87d9e72385889856464/packages/vscode-graphql-syntax#graphql-syntax-support
- https://github.com/ardatan/graphql-tools/blob/0a7cc399c89ca6e94cd20502e961200395958173/packages/load-files/src/index.ts#L95
- https://github.com/microsoft/vscode/blob/a86edb56835c46cd6d233455a375ffb92b93a011/extensions/theme-seti/icons/vs-seti-icon-theme.json#L1621

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
