### PR TITLE
feat(commitline): add slim prop and CSS variant

### DIFF
--- a/apps/desktop/src/components/CommitLine.svelte
+++ b/apps/desktop/src/components/CommitLine.svelte
@@ -10,16 +10,17 @@
 		tooltip?: string;
 		lastCommit?: boolean;
 		lastBranch?: boolean;
+		slim?: boolean;
 	}
 
-	const { commitStatus, diverged, tooltip, lastCommit, lastBranch }: Props = $props();
+	const { commitStatus, diverged, tooltip, lastCommit, lastBranch, slim }: Props = $props();
 
 	const color = $derived(getColorFromCommitState(commitStatus, diverged));
 
 	const rhombus = $derived(commitStatus === 'LocalAndRemote');
 </script>
 
-<div class="commit-lines" style:--commit-color={color}>
+<div class="commit-lines" style:--commit-color={color} class:slim>
 	<div class="top"></div>
 	{#if diverged}
 		<div class="local-shadow-commit-dot">
@@ -56,6 +57,10 @@
 		align-items: center;
 		width: 42px;
 		gap: 3px;
+
+		&.slim {
+			width: 24px;
+		}
 	}
 
 	.top,


### PR DESCRIPTION
Add optional 'slim' boolean prop to CommitLine Svelte component and apply class binding to adjust layout.

Changes:
- Add 'slim?: boolean' to Props type and include in destructured props.
- Add .slim CSS modifier to reduce width from 42px to 24px.
