### PR TITLE
prevent failure during graph post-processing

### DIFF
--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -121,7 +121,7 @@ impl Graph {
                             if is_splittable {
                                 let info = (node.id, cidx, rn.clone());
                                 // This means we are more interested in the split than in representing every reference for now.
-                                if split_info.contains(&info) {
+                                if split_info.iter().any(|(a_sidx, a_cidx, _)| *a_sidx == node.id && *a_cidx == cidx) {
                                     tracing::debug!(?node.id, ?commit_with_refs.id, ?rn, "Ignoring remote reference which *should* have no effect");
                                 } else {
                                     split_info.push(info);

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -852,6 +852,35 @@ EOF
     create_workspace_commit_once D
   )
 
+  git init "two-dependent-branches-rebased-with-remotes-squash-merge-one-remote-ambiguous"
+  (cd "two-dependent-branches-rebased-with-remotes-squash-merge-one-remote-ambiguous"
+    echo init>file && git add file && git commit -m "init"
+    git checkout -b A && echo A >>file && git commit -am "A"
+    git branch B
+    git branch C
+    git checkout -b D && echo D >>file && git commit -am "D"
+
+    git checkout main
+      tick
+      # easy squash-merge simulation of only A
+      git cherry-pick A
+      setup_target_to_match_main
+    git checkout -b rebased-D
+      git cherry-pick D
+
+      # setup free-standing remotes that were previously pushed.
+      # replace local branches as they don't matter there.
+      setup_remote_tracking A A "move"
+      setup_remote_tracking B B "move"
+      setup_remote_tracking C C "move"
+      setup_remote_tracking D D "move"
+
+      # get our rebased tip back
+      git branch -m D
+
+    create_workspace_commit_once D
+  )
+
   git init special-branches
   (cd special-branches
     commit init


### PR DESCRIPTION
Previously, it was possible to attempt to split the same remote segment at the same spot, which would have to fail after the first split.

Now it will not double-split anymore, and in fact avoid splitting when there is ambiguity as to which remote gets the commit.
