### PR TITLE
ui-fixes-127

### DIFF
--- a/apps/desktop/src/components/CloudForm.svelte
+++ b/apps/desktop/src/components/CloudForm.svelte
@@ -59,12 +59,8 @@
 					Enable experimental AI features
 				{/snippet}
 				{#snippet caption()}
-					If enabled, you will be able to access the AI features currently in development.
-
-					<b
-						>This also requires you to use OpenAI through GitButler in order for the features to
-						work.</b
-					>
+					If enabled, you will be able to access the AI features currently in development. This also
+					requires you to use OpenAI through GitButler in order for the features to work.
 				{/snippet}
 				{#snippet actions()}
 					<Toggle

--- a/packages/ui/src/lib/components/select/Select.svelte
+++ b/packages/ui/src/lib/components/select/Select.svelte
@@ -267,7 +267,7 @@
 		}
 
 		if (optionsGroupBoundingRect && inputBoundingRect && popupAlign === 'center') {
-			return `${window.innerWidth / 2 - optionsGroupBoundingRect.width / 2}px`;
+			return `${inputBoundingRect.left + inputBoundingRect.width / 2 - optionsGroupBoundingRect.width / 2}px`;
 		}
 
 		if (inputBoundingRect?.left && optionsGroupBoundingRect && popupAlign === 'right') {

--- a/packages/ui/src/lib/utils/timeAgo.test.ts
+++ b/packages/ui/src/lib/utils/timeAgo.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect } from 'vitest';
 describe.concurrent('timeAgo without suffix', () => {
 	it('should format 30s ago correctly', () => {
 		const date = dayjs().subtract(30, 'second').toDate();
-		expect(getTimeAgo(date, false)).toBe('< 1 min');
+		expect(getTimeAgo(date, false)).toBe('a few sec');
 	});
 
 	it('should format 3 hours ago correctly', () => {
@@ -27,7 +27,7 @@ describe.concurrent('timeAgo', () => {
 
 	it('should format 30s ago correctly', () => {
 		const date = dayjs().subtract(30, 'second').toDate();
-		expect(getTimeAgo(date)).toBe('< 1 min ago');
+		expect(getTimeAgo(date)).toBe('a few sec ago');
 	});
 
 	it('should format 3 mins ago correctly', () => {

--- a/packages/ui/src/lib/utils/timeAgo.ts
+++ b/packages/ui/src/lib/utils/timeAgo.ts
@@ -33,8 +33,6 @@ export function getTimeAgo(input: Date | number, addSuffix: boolean = true): str
 	const seconds = Math.round(Math.abs((new Date().getTime() - date.getTime()) / 1000.0));
 	if (seconds < 10) {
 		return 'just now';
-	} else if (seconds < 60) {
-		return `< 1 min${addSuffix ? ' ago' : ''}`;
 	} else {
 		return customFormatDistance(date, addSuffix);
 	}


### PR DESCRIPTION
- Fix wrong text styling: usage of `<b>` tag (we don’t use `<b>` tag)
- Remove unused condition related to seconds handling (now shown as “A few sec ago”)
- Fix select popup positioning: make popup positioned relative to input instead of viewport