### PR TITLE
Settings: add staging behavior feature flag and UI

### DIFF
--- a/apps/desktop/src/components/UnassignedView.svelte
+++ b/apps/desktop/src/components/UnassignedView.svelte
@@ -5,6 +5,7 @@
 	import WorktreeTipsFooter from '$components/WorktreeTipsFooter.svelte';
 	import noChanges from '$lib/assets/illustrations/no-changes.svg?raw';
 	import { SETTINGS_SERVICE } from '$lib/config/appSettingsV2';
+	import { stagingBehaviorFeature } from '$lib/config/uiFeatureFlags';
 	import { DefinedFocusable } from '$lib/focus/focusManager.svelte';
 	import { INTELLIGENT_SCROLLING_SERVICE } from '$lib/intelligentScrolling/service';
 	import { ID_SELECTION } from '$lib/selection/idSelection.svelte';
@@ -58,7 +59,7 @@
 		unassignedSidebaFolded.set(true);
 	}
 
-	function checkFilesForCommit() {
+	function checkSelectedFilesForCommit() {
 		const selectionId = createWorktreeSelection({});
 		const selectedPaths = idSelection.values(selectionId).map((entry) => entry.path);
 
@@ -67,6 +68,29 @@
 			uncommittedService.checkFiles(null, selectedPaths);
 		} else {
 			uncommittedService.checkAll(null);
+		}
+	}
+
+	function uncheckAll() {
+		uncommittedService.uncheckAll(null);
+	}
+
+	function checkAllFiles() {
+		uncommittedService.checkAll(null);
+	}
+
+	function checkFilesForCommit(): true {
+		switch ($stagingBehaviorFeature) {
+			case 'all':
+				checkAllFiles();
+				return true;
+			case 'selection':
+				// We only check the selected files.
+				checkSelectedFilesForCommit();
+				return true;
+			case 'none':
+				uncheckAll();
+				return true;
 		}
 	}
 </script>

--- a/apps/desktop/src/components/projectSettings/AppearanceSettings.svelte
+++ b/apps/desktop/src/components/projectSettings/AppearanceSettings.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import ThemeSelector from '$components/ThemeSelector.svelte';
-	import { autoSelectBranchNameFeature } from '$lib/config/uiFeatureFlags';
+	import {
+		autoSelectBranchNameFeature,
+		stagingBehaviorFeature,
+		type StagingBehavior
+	} from '$lib/config/uiFeatureFlags';
 	import { SETTINGS, type ScrollbarVisilitySettings } from '$lib/settings/userSettings';
 	import { inject } from '@gitbutler/shared/context';
 	import {
@@ -36,6 +40,13 @@
 			...s,
 			scrollbarVisibilityState: selectedScrollbarVisibility
 		}));
+	}
+
+	function onStagingBehaviorFormChange(form: HTMLFormElement) {
+		const formData = new FormData(form);
+		const selectedStagingBehavior = formData.get('stagingBehaviorType') as StagingBehavior | null;
+		if (!selectedStagingBehavior) return;
+		stagingBehaviorFeature.set(selectedStagingBehavior);
 	}
 </script>
 
@@ -283,3 +294,67 @@
 		/>
 	{/snippet}
 </SectionCard>
+
+<form class="stack-v" onchange={(e) => onStagingBehaviorFormChange(e.currentTarget)}>
+	<SectionCard roundedBottom={false} orientation="row" labelFor="stage-all">
+		{#snippet title()}
+			Stage all files
+		{/snippet}
+		{#snippet caption()}
+			Stage all files assigned to the stack on commit. If no files are staged, all unassinged files
+			will be staged.
+		{/snippet}
+		{#snippet actions()}
+			<RadioButton
+				name="stagingBehaviorType"
+				value="all"
+				id="stage-all"
+				checked={$stagingBehaviorFeature === 'all'}
+			/>
+		{/snippet}
+	</SectionCard>
+
+	<SectionCard
+		roundedTop={false}
+		roundedBottom={false}
+		orientation="row"
+		labelFor="stage-selection"
+	>
+		{#snippet title()}
+			Stage selected files
+		{/snippet}
+		{#snippet caption()}
+			Stage the selected assigned files to the stack on commit. If no files are selected, stage all
+			files. If there are no assigned files, stage all selected unassigned files.
+			<br />
+			Aaand if no files are selected, stage all unassigned files.
+		{/snippet}
+		{#snippet actions()}
+			<RadioButton
+				name="stagingBehaviorType"
+				value="selection"
+				id="stage-selection"
+				checked={$stagingBehaviorFeature === 'selection'}
+			/>
+		{/snippet}
+	</SectionCard>
+
+	<SectionCard roundedTop={false} orientation="row" labelFor="stage-none">
+		{#snippet title()}
+			Don't stage files automatically
+		{/snippet}
+		{#snippet caption()}
+			Do not stage any files automatically.
+			<br />
+			You're more of a DIY developer in that way.
+		{/snippet}
+		{#snippet actions()}
+			<RadioButton
+				name="stagingBehaviorType"
+				value="none"
+				id="stage-none"
+				checked={$stagingBehaviorFeature === 'none'}
+			/>
+		{/snippet}
+	</SectionCard>
+</form>

--- a/apps/desktop/src/lib/config/uiFeatureFlags.ts
+++ b/apps/desktop/src/lib/config/uiFeatureFlags.ts
@@ -11,3 +11,5 @@ export const ircEnabled = persistWithExpiration(false, 'feature-irc', 1440 * 30)
 export const ircServer = persistWithExpiration('', 'feature-irc-server', 1440 * 30);
 export const rewrapCommitMessage = persistWithExpiration(true, 'rewrap-commit-msg', 1440 * 30);
 export const codegenEnabled = persistWithExpiration(false, 'feature-codegen', 1440 * 30);
+export type StagingBehavior = 'all' | 'selection' | 'none';
+export const stagingBehaviorFeature = persisted<StagingBehavior>('all', 'feature-staging-behavior');

--- a/apps/desktop/src/lib/soup/commitAnalytics.ts
+++ b/apps/desktop/src/lib/soup/commitAnalytics.ts
@@ -1,8 +1,10 @@
+import { autoSelectBranchNameFeature, stagingBehaviorFeature } from '$lib/config/uiFeatureFlags';
 import { getFilterCountMap, getStackTargetTypeCountMap, type WorkspaceRule } from '$lib/rules/rule';
 import { StackService } from '$lib/stacks/stackService.svelte';
 import { UiState } from '$lib/state/uiState.svelte';
 import { WorktreeService } from '$lib/worktree/worktreeService.svelte';
 import { InjectionToken } from '@gitbutler/shared/context';
+import { get } from 'svelte/store';
 import type { Commit } from '$lib/branches/v3';
 import type { HunkAssignment } from '$lib/hunks/hunk';
 import type RulesService from '$lib/rules/rulesService.svelte';
@@ -85,7 +87,9 @@ export class CommitAnalytics {
 				// Total number of files that have not been assigned
 				totalUnassignedFiles: this.getUnassignedFiles(assignments).length,
 				// Rule metrics
-				...this.getRuleMetrics(rules)
+				...this.getRuleMetrics(rules),
+				// Behavior metrics
+				...this.getBehaviorMetrics()
 			};
 		} catch (error) {
 			console.error('Failed to fetch commit analytics:', error);
@@ -172,6 +176,18 @@ export class CommitAnalytics {
 		};
 
 		return namespaceProps(ruleMetrics, 'workspaceRules');
+	}
+
+	private getBehaviorMetrics(): EventProperties {
+		// Placeholder for future behavior metrics
+		const stagingBehavior = get(stagingBehaviorFeature);
+		const autoSelectBranchName = get(autoSelectBranchNameFeature);
+		const behaviorMetrics = {
+			stagingBehavior,
+			autoSelectBranchName
+		};
+
+		return namespaceProps(behaviorMetrics, 'behavior');
 	}
 }
 


### PR DESCRIPTION
- Introduce StagingBehavior type and stagingBehaviorFeature persisted flag in uiFeatureFlags.ts.
- Wire stagingBehaviorFeature into AppearanceSettings.svelte: import the flag, expose radio options for 'all', 'selection', and 'none', and handle form onchange to update the feature flag.
- Update StackView.svelte and UnassignedView.svelte to reference stagingBehaviorFeature and implement staging behavior logic:
  - Rename checkFilesForCommit to checkSelectedFilesForCommit and add helper functions checkAllFiles, uncheckAll, and checkAllFiles handling assigned/unassigned logic.
  - Implement checkFilesForCommit() that chooses behavior based on $stagingBehaviorFeature ('all' | 'selection' | 'none').

Also, add metrics

![Screenshot 2025-08-27 at 15.34.57.png](https://app.gitbutler.com/uploads/065674e6-1ceb-464d-934e-d5dfd82d2896)

