### PR TITLE
Open in Editor hotkey Short cut 

### DIFF
--- a/crates/gitbutler-tauri/src/menu.rs
+++ b/crates/gitbutler-tauri/src/menu.rs
@@ -158,7 +158,11 @@ pub fn build<R: Runtime>(
                 .build(handle)?,
         )
         .separator()
-        .text("project/open-in-vscode", "Open in Editor");
+        .item(
+            &MenuItemBuilder::with_id("project/open-in-vscode", "Open in Editor")
+                .accelerator("CmdOrCtrl+Shift+A")
+                .build(handle)?,
+        );
 
     #[cfg(target_os = "macos")]
     {


### PR DESCRIPTION
## 🧢 Changes

Add a hotkey shortcut "Open in Editor" item with accelerator to the project menu CmdOrCtrl+Shift+A, just like GitHub Desktop

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

Make the app more relevant and familiar to those who came from GitHub Desktop background

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
