### PR TITLE
fix: remove semicolons from text editor line wrapping

### DIFF
--- a/packages/ui/src/lib/richText/linewrap.ts
+++ b/packages/ui/src/lib/richText/linewrap.ts
@@ -85,7 +85,7 @@ export function parseBullet(text: string): Bullet | undefined {
 	const prefix = match[0];
 	const numberStr = match.groups?.['number'];
 	const number = numberStr ? parseInt(numberStr) : undefined;
-	const indent = number ? ' '.repeat(number.toString().length + 2) : spaces + '  ;';
+	const indent = number ? ' '.repeat(number.toString().length + 2) : spaces + '  ';
 	return { prefix, indent, number };
 }
 


### PR DESCRIPTION
## 🧢 Changes

When writing commit or PR messages in the floating text editor, I noticed that backspacing in first wrapped line of a multiline… line… within a bullet (e.g. `- `) inserts a semicolon at the beginning of that wrapped line. It also removes the first character of the whole line. I made a one-line change to strip the semicolon from the `parseBullet` function, which seems like a typo to me. If I'm missing some context here or there's a good reason for this, feel free to close without comment. 😊