### PR TITLE
Fix scrollbar css

### DIFF
--- a/packages/ui/src/lib/components/scroll/ScrollableContainer.svelte
+++ b/packages/ui/src/lib/components/scroll/ScrollableContainer.svelte
@@ -121,19 +121,19 @@
 		>
 			{@render children()}
 		</div>
-		<Scrollbar
-			{whenToShow}
-			{viewport}
-			{initiallyVisible}
-			{padding}
-			{shift}
-			{thickness}
-			{zIndex}
-			{horz}
-			{onscrollexists}
-			{onthumbdrag}
-		/>
 	</div>
+	<Scrollbar
+		{whenToShow}
+		{viewport}
+		{initiallyVisible}
+		{padding}
+		{shift}
+		{thickness}
+		{zIndex}
+		{horz}
+		{onscrollexists}
+		{onthumbdrag}
+	/>
 </div>
 
 <style lang="postcss">


### PR DESCRIPTION
We need `position: relative` on the viewport in order to draw a focus 
cursor inside it using absolute positioning, but that messes with the 
scrollbar. So we move the scrollbar outside the viewport.