### PR TITLE
Fix keyboard navigation interference

### DIFF
--- a/apps/desktop/src/components/FocusCursor.svelte
+++ b/apps/desktop/src/components/FocusCursor.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { FOCUS_MANAGER } from '$lib/focus/focusManager';
 	import { inject } from '@gitbutler/shared/context';
-	import { on } from 'svelte/events';
 
 	const { cursor: target, outline } = inject(FOCUS_MANAGER);
 
@@ -55,15 +54,6 @@
 				element.remove();
 				observer.disconnect();
 			};
-		}
-	});
-	$effect(() => {
-		if ($target) {
-			return on(document, 'keypress', (e) => {
-				if (e.key === '?') {
-					outline.set(!$outline);
-				}
-			});
 		}
 	});
 </script>

--- a/apps/desktop/src/lib/focus/focusManager.ts
+++ b/apps/desktop/src/lib/focus/focusManager.ts
@@ -433,7 +433,15 @@ export class FocusManager {
 	}
 
 	handleKeydown(event: KeyboardEvent) {
-		if (!this._currentElement) return;
+		// Ignore keyboard navigation if user is focused on an
+		// input element, or no current element.
+		if (
+			event.target instanceof HTMLInputElement ||
+			event.target instanceof HTMLTextAreaElement ||
+			!this._currentElement
+		) {
+			return;
+		}
 
 		const metadata = this.getCurrentMetadata();
 		if (!metadata) return;


### PR DESCRIPTION
- ignore keydown when event target is an input element
- remove the `?` keybinding for displaying outline