### PR TITLE
ui-fixes-128

### DIFF
--- a/apps/desktop/src/components/ChromeSidebar.svelte
+++ b/apps/desktop/src/components/ChromeSidebar.svelte
@@ -476,7 +476,6 @@
 		transform: translateX(-50%) translateY(50%);
 		border-radius: var(--radius-m);
 		background-color: var(--clr-theme-pop-element);
-		content: '';
 	}
 
 	/* OVERRIDE BUTTON STYLES */

--- a/apps/desktop/src/components/CommitRow.svelte
+++ b/apps/desktop/src/components/CommitRow.svelte
@@ -116,6 +116,12 @@
 		></div>
 	{/if}
 
+	{#if !selected && !args.disableCommitActions}
+		<div class="commit-row__drag-handle">
+			<Icon name="draggable-narrow" />
+		</div>
+	{/if}
+
 	<CommitLine
 		commitStatus={args.type}
 		diverged={args.type === 'LocalAndRemote' ? (args.diverged ?? false) : false}
@@ -163,6 +169,11 @@
 		&:hover,
 		&.menu-shown {
 			background-color: var(--clr-bg-1-muted);
+		}
+
+		&:hover .commit-row__drag-handle {
+			opacity: 1;
+			pointer-events: auto;
 		}
 
 		&:not(.last) {
@@ -218,5 +229,15 @@
 		display: flex;
 		margin-right: 4px;
 		color: var(--clr-theme-err-element);
+	}
+
+	.commit-row__drag-handle {
+		position: absolute;
+		top: 50%;
+		left: 0;
+		transform: translateY(-50%);
+		color: var(--clr-text-3);
+		opacity: 0;
+		pointer-events: none;
 	}
 </style>

--- a/apps/desktop/src/components/FileContextMenu.svelte
+++ b/apps/desktop/src/components/FileContextMenu.svelte
@@ -631,9 +631,6 @@
 		border-radius: var(--radius-m);
 		background-color: var(--clr-bg-1);
 	}
-	.radio-aditional-info {
-		color: var(--clr-text-2);
-	}
 	/* MODAL WINDOW */
 	.content-wrap {
 		display: flex;

--- a/apps/desktop/src/components/RuleFiltersEditor.svelte
+++ b/apps/desktop/src/components/RuleFiltersEditor.svelte
@@ -208,24 +208,22 @@
 
 <!-- Claude Code Session ID -->
 {#snippet claudeCodeSessionIdFilter(sessionId: string)}
-	<div class="rule__pill expand">
-		<ClaudeSessionDescriptor {projectId} {sessionId}>
-			{#snippet fallback()}
-				<Textbox value={sessionId} readonly>
-					{#snippet customIconLeft()}
-						<Icon name="ai" />
-					{/snippet}
-				</Textbox>
-			{/snippet}
-			{#snippet children(descriptor)}
-				<Textbox value={descriptor} readonly>
-					{#snippet customIconLeft()}
-						<Icon name="ai" />
-					{/snippet}
-				</Textbox>
-			{/snippet}
-		</ClaudeSessionDescriptor>
-	</div>
+	<ClaudeSessionDescriptor {projectId} {sessionId}>
+		{#snippet fallback()}
+			<Textbox value={sessionId} readonly wide>
+				{#snippet customIconLeft()}
+					<Icon name="ai" />
+				{/snippet}
+			</Textbox>
+		{/snippet}
+		{#snippet children(descriptor)}
+			<Textbox value={descriptor} readonly wide>
+				{#snippet customIconLeft()}
+					<Icon name="ai" />
+				{/snippet}
+			</Textbox>
+		{/snippet}
+	</ClaudeSessionDescriptor>
 {/snippet}
 
 <!-- This is the parent component,

--- a/apps/desktop/src/components/SyncButton.svelte
+++ b/apps/desktop/src/components/SyncButton.svelte
@@ -31,6 +31,7 @@
 	{loading}
 	{disabled}
 	icon="update"
+	reversedDirection
 	onmousedown={async (e: MouseEvent) => {
 		e.preventDefault();
 		e.stopPropagation();
@@ -47,17 +48,17 @@
 		}
 	}}
 >
-	{#snippet custom()}
-		<span class="text-12 text-semibold capitalize fetch-status">
-			{#if loading}
-				Fetching...
-			{:else if lastFetched}
-				<TimeAgo date={lastFetched} addSuffix={true} />
-			{:else}
-				Refetch
-			{/if}
-		</span>
+	<span class="capitalize">
+		{#if loading}
+			Fetching...
+		{:else if lastFetched}
+			<TimeAgo date={lastFetched} addSuffix={true} />
+		{:else}
+			Refetch
+		{/if}
+	</span>
 
+	{#snippet custom()}
 		{#if baseBranch.current.data}
 			<div class="target-branch">
 				<Icon name="remote-target-branch" color="var(--clr-text-2)" />
@@ -70,10 +71,6 @@
 </Button>
 
 <style lang="postcss">
-	.fetch-status {
-		padding: 0 2px;
-	}
-
 	.target-branch {
 		display: inline-flex;
 		align-items: center;
@@ -81,7 +78,7 @@
 		gap: 4px;
 		color: var(--clr-text-2);
 
-		&:before {
+		&:after {
 			display: inline-block;
 			width: 1px;
 			height: 12px;


### PR DESCRIPTION
- add drag handle for commit rows and reveal it on hover
- reverse and simplify label/snippet layout in sync UI
- remove extra wrapper and make session boxes full width
- remove redundant content from sidebar pseudo-element
- remove unused .radio-ad-info CSS rule and simplify styles to avoid dead code