### PR TITLE
update `gix` to adapt to breaking changes in `gix@main`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,7 +1612,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3767,7 +3767,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.73.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "gix-actor 0.35.4",
  "gix-attributes 0.27.0",
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.35.4"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "gix-date 0.10.5",
@@ -3869,7 +3869,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.27.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "gix-glob 0.21.0",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.14"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "thiserror 2.0.12",
 ]
@@ -3912,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "thiserror 2.0.12",
 ]
@@ -3920,7 +3920,7 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.6.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "gix-path 0.10.20",
@@ -3945,7 +3945,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "gix-chunk 0.4.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.46.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -3978,7 +3978,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.15.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -3990,7 +3990,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4021,7 +4021,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.10.5"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "itoa",
@@ -4034,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.53.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "gix-attributes 0.27.0",
@@ -4057,7 +4057,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "gix-discover 0.41.0",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.41.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "dunce",
@@ -4121,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.43.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4175,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.16.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4200,7 +4200,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -4224,7 +4224,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "faster-hex",
  "gix-features 0.43.1",
@@ -4247,7 +4247,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.9.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "gix-hash 0.19.0",
  "hashbrown 0.15.4",
@@ -4270,7 +4270,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "gix-glob 0.21.0",
@@ -4311,7 +4311,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.41.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -4350,7 +4350,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "18.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "gix-tempfile 18.0.0",
  "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.27.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "gix-actor 0.35.4",
@@ -4372,7 +4372,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4396,7 +4396,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bitflags 2.9.1",
  "gix-commitgraph 0.29.0",
@@ -4432,7 +4432,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.50.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "gix-actor 0.35.4",
@@ -4453,7 +4453,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.70.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "arc-swap",
  "gix-date 0.10.5",
@@ -4474,7 +4474,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.60.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "clru",
  "gix-chunk 0.4.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4495,7 +4495,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4506,7 +4506,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4531,7 +4531,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.20"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "gix-trace 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4544,7 +4544,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -4558,7 +4558,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.11.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4570,7 +4570,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.51.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -4607,7 +4607,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4638,7 +4638,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.53.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "gix-actor 0.35.4",
  "gix-features 0.43.1",
@@ -4659,7 +4659,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "gix-hash 0.19.0",
@@ -4672,7 +4672,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -4705,7 +4705,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "gix-commitgraph 0.29.0",
  "gix-date 0.10.5",
@@ -4731,7 +4731,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bitflags 2.9.1",
  "gix-path 0.10.20",
@@ -4743,7 +4743,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.5.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "gix-hash 0.19.0",
@@ -4755,7 +4755,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "filetime",
@@ -4777,7 +4777,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "gix-config",
@@ -4806,7 +4806,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "18.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "dashmap",
  "gix-fs 0.16.1",
@@ -4849,7 +4849,7 @@ checksum = "e2ccaf54b0b1743a695b482ca0ab9d7603744d8d10b2e5d1a332fef337bee658"
 [[package]]
 name = "gix-trace"
 version = "0.1.13"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "tracing-core",
 ]
@@ -4857,7 +4857,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.48.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -4893,7 +4893,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.47.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bitflags 2.9.1",
  "gix-commitgraph 0.29.0",
@@ -4909,7 +4909,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "gix-features 0.43.1",
@@ -4933,7 +4933,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4953,7 +4953,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "thiserror 2.0.12",
@@ -4981,7 +4981,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.42.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "gix-attributes 0.27.0",
@@ -5000,7 +5000,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f3be6e380450d6b1e178d2fda0446674429bdfe6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
 dependencies = [
  "bstr",
  "gix-features 0.43.1",
@@ -11001,7 +11001,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
The impl was added to suport `gitui`, and to cleanup an overly high-level ConsumeHunk interface.

Without this PR, the next unsuspecting `gix` update would be breaking.
