### PR TITLE
Windows environment fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3767,7 +3767,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.73.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "gix-actor 0.35.4",
  "gix-attributes 0.27.0",
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.35.4"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "gix-date 0.10.5",
@@ -3869,7 +3869,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.27.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "gix-glob 0.21.0",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.14"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "thiserror 2.0.12",
 ]
@@ -3912,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "thiserror 2.0.12",
 ]
@@ -3920,7 +3920,7 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.6.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "gix-path 0.10.20",
@@ -3945,7 +3945,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "gix-chunk 0.4.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.46.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -3967,6 +3967,7 @@ dependencies = [
  "gix-path 0.10.20",
  "gix-ref 0.53.1",
  "gix-sec 0.12.0",
+ "home",
  "memchr",
  "once_cell",
  "smallvec",
@@ -3978,7 +3979,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.15.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -3990,7 +3991,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4021,7 +4022,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.10.5"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "itoa",
@@ -4034,7 +4035,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.53.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "gix-attributes 0.27.0",
@@ -4057,7 +4058,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "gix-discover 0.41.0",
@@ -4092,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.41.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "dunce",
@@ -4121,7 +4122,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.43.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -4141,7 +4142,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4175,7 +4176,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.16.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4200,7 +4201,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -4224,7 +4225,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "faster-hex",
  "gix-features 0.43.1",
@@ -4247,7 +4248,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.9.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "gix-hash 0.19.0",
  "hashbrown 0.15.4",
@@ -4270,7 +4271,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "gix-glob 0.21.0",
@@ -4311,7 +4312,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.41.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -4350,7 +4351,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "18.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "gix-tempfile 18.0.0",
  "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4360,7 +4361,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.27.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "gix-actor 0.35.4",
@@ -4372,7 +4373,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4396,7 +4397,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bitflags 2.9.1",
  "gix-commitgraph 0.29.0",
@@ -4432,7 +4433,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.50.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "gix-actor 0.35.4",
@@ -4453,7 +4454,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.70.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "arc-swap",
  "gix-date 0.10.5",
@@ -4474,7 +4475,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.60.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "clru",
  "gix-chunk 0.4.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4495,7 +4496,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4506,7 +4507,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4531,7 +4532,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.20"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "gix-trace 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4544,7 +4545,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -4558,7 +4559,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.11.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4570,7 +4571,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.51.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -4607,7 +4608,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4638,7 +4639,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.53.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "gix-actor 0.35.4",
  "gix-features 0.43.1",
@@ -4659,7 +4660,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "gix-hash 0.19.0",
@@ -4672,7 +4673,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bitflags 2.9.1",
  "bstr",
@@ -4705,7 +4706,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "gix-commitgraph 0.29.0",
  "gix-date 0.10.5",
@@ -4731,7 +4732,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bitflags 2.9.1",
  "gix-path 0.10.20",
@@ -4743,7 +4744,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.5.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "gix-hash 0.19.0",
@@ -4755,7 +4756,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "filetime",
@@ -4777,7 +4778,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "gix-config",
@@ -4806,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "18.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "dashmap",
  "gix-fs 0.16.1",
@@ -4849,7 +4850,7 @@ checksum = "e2ccaf54b0b1743a695b482ca0ab9d7603744d8d10b2e5d1a332fef337bee658"
 [[package]]
 name = "gix-trace"
 version = "0.1.13"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "tracing-core",
 ]
@@ -4857,7 +4858,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.48.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -4893,7 +4894,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.47.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bitflags 2.9.1",
  "gix-commitgraph 0.29.0",
@@ -4909,7 +4910,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "gix-features 0.43.1",
@@ -4933,7 +4934,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4953,7 +4954,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "thiserror 2.0.12",
@@ -4981,7 +4982,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.42.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "gix-attributes 0.27.0",
@@ -5000,7 +5001,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#f7f087cb7b2d239688203f58d166fde42d4bde8c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#10a20d6b3027179791c04a95731e1697001fb5f8"
 dependencies = [
  "bstr",
  "gix-features 0.43.1",

--- a/crates/but-core/src/cmd.rs
+++ b/crates/but-core/src/cmd.rs
@@ -25,11 +25,8 @@ pub fn prepare_with_shell_on_windows(program: impl Into<OsString>) -> gix::comma
 /// or if it couldn't be launched, or if the environment extraction failed.
 #[instrument()]
 pub fn extract_interactive_login_shell_environment() -> Option<Vec<(OsString, OsString)>> {
-    let shell_path: PathBuf = if cfg!(windows) {
-        gix::path::env::shell().into()
-    } else {
-        std::env::var_os("SHELL")?.into()
-    };
+    // NOTE that `SHELL` isn't usually set on Windows, so this will not usually run there.
+    let shell_path: PathBuf = std::env::var_os("SHELL")?.into();
     let stdout = std::process::Command::from(
         // This automatically prevents a Window from popping up on Windows.
         gix::command::prepare(shell_path)

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -92,7 +92,11 @@ fn main() {
                         "system git executable for fetch/push: {git:?}",
                         git = gix::path::env::exe_invocation(),
                     );
-                    tracing::info!("system git bash: {git:?}", git = gix::path::env::shell(),);
+                    if cfg!(windows) {
+                        tracing::info!("system git bash: {bash:?}", bash = gix::path::env::shell());
+                    } else {
+                        tracing::info!("SHELL env: {var:?}", var = std::env::var_os("SHELL"));
+                    }
 
                     // On MacOS, in dev mode with debug assertions, we encounter popups each time
                     // the binary is rebuilt. To counter that, use a git-credential based implementation.
@@ -395,14 +399,18 @@ fn inherit_interactive_login_shell_environment_if_not_launched_from_terminal() {
         );
         return;
     }
-    if let Some(terminal_vars) = but_core::cmd::extract_interactive_login_shell_environment() {
-        tracing::info!("Inheriting static interactive shell environment, valid for the entire runtime of the application");
-        for (key, value) in terminal_vars {
-            std::env::set_var(key, value);
+
+    // This can be slow on Windows, background it.
+    std::thread::spawn(|| {
+        if let Some(terminal_vars) = but_core::cmd::extract_interactive_login_shell_environment() {
+            tracing::info!("Inheriting static interactive shell environment, valid for the entire runtime of the application");
+            for (key, value) in terminal_vars {
+                std::env::set_var(key, value);
+            }
+        } else {
+            tracing::info!(
+                "SHELL variable isn't set - launching with default GUI application environment "
+            );
         }
-    } else {
-        tracing::info!(
-            "SHELL variable isn't set - launching with default GUI application environment "
-        );
-    }
+    });
 }

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -92,6 +92,7 @@ fn main() {
                         "system git executable for fetch/push: {git:?}",
                         git = gix::path::env::exe_invocation(),
                     );
+                    tracing::info!("system git bash: {git:?}", git = gix::path::env::shell(),);
 
                     // On MacOS, in dev mode with debug assertions, we encounter popups each time
                     // the binary is rebuilt. To counter that, use a git-credential based implementation.


### PR DESCRIPTION
It looks like #10008 is having trouble to find the correct environment variables
from the terminal, which affects our ability to write Git configuration files for the user
on Windows.

~~See if we can use the Git bash specifically to achieve that, and fixes #10008 in the process,
and related issues.~~

We cannot and should not use Git bash as shell on Windows due to the special unix paths in its environment, something that works very differently in Windows where these paths are relative to the drive of the current working directory.

Now we only make that clear and use a fixed version of `gix` which can detect the homedir on Windows even if no `HOME` variable is set.

### Tasks

* [x] sort out environment hassle
* [x] revert attempt to use `git bash` - doesn't work as paths are Unix style
* [x] validate `gix` fix works
* [x] update `gix` to latest version from main

### The Trap

One path, two ways of interpreting it, which was very confusing in the context of this issue.

<img width="435" height="104" alt="Screenshot 2025-08-29 at 18 31 04" src="https://github.com/user-attachments/assets/befd8d55-9a5f-462d-be50-41a0f66a5f9f" />
<img width="548" height="120" alt="Screenshot 2025-08-29 at 18 30 19" src="https://github.com/user-attachments/assets/fddc7dcf-0e8e-4ad3-a40f-6fec0cd92302" />

