### PR TITLE
fix: correct redirect path for customize prompts button

### DIFF
--- a/apps/desktop/src/components/CloudForm.svelte
+++ b/apps/desktop/src/components/CloudForm.svelte
@@ -5,6 +5,7 @@
 	import WelcomeSigninAction from '$components/WelcomeSigninAction.svelte';
 	import { projectAiExperimentalFeaturesEnabled, projectAiGenEnabled } from '$lib/config/config';
 	import { focusable } from '$lib/focus/focusable';
+	import { newSettingsPath } from '$lib/routes/routes.svelte';
 	import { USER_SERVICE } from '$lib/user/userService';
 	import { inject } from '@gitbutler/shared/context';
 	import { Button, SectionCard, Spacer, Toggle } from '@gitbutler/ui';
@@ -90,7 +91,7 @@
 			You can apply your own custom prompts to the project. By default, the project uses GitButler
 			prompts, but you can create your own prompts in the general settings.
 		</p>
-		<Button kind="outline" icon="edit" onclick={async () => await goto('/settings/ai')}
+		<Button kind="outline" icon="edit" onclick={() => goto(newSettingsPath('ai'))}
 			>Customize prompts</Button
 		>
 	</SectionCard>


### PR DESCRIPTION
## 🧢 Changes

The button (Customize prompts) under Project Settings -> AI options was using `/settings/ai` as its redirect path, while other pages use `/new-settings` through a shared helper, it seems that `/settings` has already been deprecated.

This PR fixes the inconsistency by using the same method as other pages.

Reference code:

<img width="635" height="404" src="https://github.com/user-attachments/assets/95a92e2e-b7c7-4384-9bc3-53e1edb1bca0" />

https://github.com/gitbutlerapp/gitbutler/blob/fea03750de890153acb7c23ba42e857908678a16/apps/desktop/src/lib/routes/routes.svelte.ts#L92-L101

https://github.com/gitbutlerapp/gitbutler/blob/fea03750de890153acb7c23ba42e857908678a16/apps/desktop/src/components/Feed.svelte#L134-L136

Before & After screenshot video:
https://github.com/user-attachments/assets/000c598c-ea4d-40d2-8a38-17728f0975e7

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
