### PR TITLE
Fix SVG printing by 'removing' some invalid character in the multi-house emoji

### DIFF
--- a/crates/but-graph/src/segment.rs
+++ b/crates/but-graph/src/segment.rs
@@ -70,7 +70,7 @@ impl CommitFlags {
             let mut out = out[..out.len() - 1]
                 .to_string()
                 .replace("NotInRemote", "⌂")
-                .replace("InWorkspace", "🏘️")
+                .replace("InWorkspace", "🏘")
                 .replace("Integrated", "✓")
                 .replace(" ", "");
             if extra != 0 {


### PR DESCRIPTION
Yes, this is real. Without this patch, `dot` will fail with

```
❯ dot -Tsvg -o out.svg < in.dot

(process:7627): Pango-WARNING **: 09:46:13.696: couldn't load font "emoji Not-Rotated With-Color 14", modified variant/weight/stretch as fallback, expect ugly output.

(process:7627): Pango-ERROR **: 09:46:13.698: Could not load fallback font, bailing out.
[1]    7627 trace trap  dot -Tsvg -o out.svg < in.dot
```

It's unclear to me which update is now causing this, but even downgrading `dot` didn't help.
