### PR TITLE
Make focusables work better with UI components

### DIFF
--- a/apps/desktop/src/components/AuthorizationBanner.svelte
+++ b/apps/desktop/src/components/AuthorizationBanner.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import Login from '$components/Login.svelte';
 	import { Icon, SectionCard } from '@gitbutler/ui';
-	import { focusable } from '@gitbutler/ui/focus/focusable';
 
 	interface Props {
 		title?: string;
@@ -14,7 +13,7 @@
 	}: Props = $props();
 </script>
 
-<SectionCard orientation="row" {focusable}>
+<SectionCard orientation="row">
 	{#snippet iconSide()}
 		<Icon name="warning" color="warning" />
 	{/snippet}

--- a/apps/desktop/src/components/Chrome.svelte
+++ b/apps/desktop/src/components/Chrome.svelte
@@ -6,7 +6,6 @@
 	import ReduxResult from '$components/ReduxResult.svelte';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
 	import { inject } from '@gitbutler/core/context';
-	import { focusable } from '@gitbutler/ui/focus/focusable';
 	import type { Snippet } from 'svelte';
 
 	const {
@@ -21,7 +20,7 @@
 
 <ReduxResult {projectId} result={projectResult.current}>
 	{#snippet children(project, { projectId })}
-		<div class="chrome" use:focusable={{ default: true }}>
+		<div class="chrome">
 			<ChromeHeader {projectId} projectTitle={project.title} actionsDisabled={sidebarDisabled} />
 			<div class="chrome-body">
 				<EnsureAuthorInfo {projectId} />

--- a/apps/desktop/src/components/CloudForm.svelte
+++ b/apps/desktop/src/components/CloudForm.svelte
@@ -8,7 +8,6 @@
 	import { USER_SERVICE } from '$lib/user/userService';
 	import { inject } from '@gitbutler/core/context';
 	import { Button, SectionCard, Spacer, Toggle } from '@gitbutler/ui';
-	import { focusable } from '@gitbutler/ui/focus/focusable';
 
 	const { projectId }: { projectId: string } = $props();
 
@@ -34,7 +33,7 @@
 	{/if}
 
 	<div class="options">
-		<SectionCard labelFor="aiGenEnabled" orientation="row" {focusable}>
+		<SectionCard labelFor="aiGenEnabled" orientation="row">
 			{#snippet title()}
 				Enable branch and commit message generation
 			{/snippet}
@@ -56,7 +55,7 @@
 
 	{#if $aiGenEnabled}
 		<div class="options">
-			<SectionCard labelFor="aiExperimental" orientation="row" {focusable}>
+			<SectionCard labelFor="aiExperimental" orientation="row">
 				{#snippet title()}
 					Enable experimental AI features
 				{/snippet}
@@ -77,7 +76,7 @@
 		</div>
 	{/if}
 
-	<SectionCard {focusable}>
+	<SectionCard>
 		{#snippet title()}
 			Custom prompts
 		{/snippet}

--- a/apps/desktop/src/components/DetailsForm.svelte
+++ b/apps/desktop/src/components/DetailsForm.svelte
@@ -4,7 +4,6 @@
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
 	import { inject } from '@gitbutler/core/context';
 	import { SectionCard, Spacer, Textarea, Textbox, Toggle } from '@gitbutler/ui';
-	import { focusable } from '@gitbutler/ui/focus/focusable';
 
 	const { projectId }: { projectId: string } = $props();
 
@@ -14,7 +13,7 @@
 	const runCommitHooks = $derived(projectRunCommitHooks(projectId));
 </script>
 
-<SectionCard {focusable}>
+<SectionCard>
 	<ReduxResult {projectId} result={projectResult.current}>
 		{#snippet children(project)}
 			<form>
@@ -51,7 +50,7 @@
 
 <Spacer />
 
-<SectionCard labelFor="runHooks" orientation="row" {focusable}>
+<SectionCard labelFor="runHooks" orientation="row">
 	{#snippet title()}
 		Run commit hooks
 	{/snippet}

--- a/apps/desktop/src/components/FileListItemWrapper.svelte
+++ b/apps/desktop/src/components/FileListItemWrapper.svelte
@@ -15,7 +15,6 @@
 	import { inject } from '@gitbutler/core/context';
 	import { FileListItem, FileViewHeader, TestId } from '@gitbutler/ui';
 	import { type FocusableOptions } from '@gitbutler/ui/focus/focusManager';
-	import { focusable } from '@gitbutler/ui/focus/focusable';
 	import { sticky as stickyAction } from '@gitbutler/ui/utils/sticky';
 	import type { ConflictEntriesObj } from '$lib/files/conflicts';
 	import type { Rename } from '$lib/hunks/change';
@@ -35,7 +34,7 @@
 		linesRemoved?: number;
 		depth?: number;
 		executable?: boolean;
-		focusableOpts?: FocusableOptions<any>;
+		focusableOpts?: FocusableOptions;
 		showCheckbox?: boolean;
 		draggable?: boolean;
 		transparent?: boolean;
@@ -211,7 +210,6 @@
 			{onclick}
 			oncheck={(e) => onCheck(e.currentTarget.checked)}
 			oncontextmenu={onContextMenu}
-			action={focusable}
 			actionOpts={focusableOpts}
 		/>
 	{/if}

--- a/apps/desktop/src/components/FocusCursor.svelte
+++ b/apps/desktop/src/components/FocusCursor.svelte
@@ -7,7 +7,10 @@
 	function findNearestRelativeDiv(element: HTMLElement): HTMLElement | undefined {
 		let current = element.parentElement;
 
-		while (current && current !== document.body) {
+		while (current) {
+			if (current === document.body) {
+				return current;
+			}
 			if (isRelativePos(current)) {
 				return current;
 			}
@@ -32,8 +35,8 @@
 	function copyPosition(from: HTMLElement, to: HTMLElement) {
 		const left = from.offsetLeft;
 		const top = from.offsetTop;
-		const width = from.clientWidth;
-		const height = from.clientHeight;
+		const width = from.offsetWidth;
+		const height = from.offsetHeight;
 
 		to.style.left = left ? left + 'px' : '0';
 		to.style.top = top ? top + 'px' : '0';
@@ -60,7 +63,7 @@
 
 <style lang="postcss">
 	:global(.focus-cursor) {
-		z-index: var(--z-lifted);
+		z-index: var(--z-blocker);
 		position: absolute;
 
 		/* Focus outline frame */

--- a/apps/desktop/src/components/GitForm.svelte
+++ b/apps/desktop/src/components/GitForm.svelte
@@ -7,7 +7,6 @@
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
 	import { inject } from '@gitbutler/core/context';
 	import { SectionCard, Spacer, Toggle } from '@gitbutler/ui';
-	import { focusable } from '@gitbutler/ui/focus/focusable';
 	import type { Project } from '$lib/project/project';
 
 	const { projectId }: { projectId: string } = $props();
@@ -35,7 +34,7 @@
 	<ReduxResult {projectId} result={projectResult.current}>
 		{#snippet children(project)}
 			<div class="stack-v">
-				<SectionCard orientation="row" labelFor="allowForcePush" roundedBottom={false} {focusable}>
+				<SectionCard orientation="row" labelFor="allowForcePush" roundedBottom={false}>
 					{#snippet title()}
 						Allow force pushing
 					{/snippet}
@@ -51,12 +50,7 @@
 						/>
 					{/snippet}
 				</SectionCard>
-				<SectionCard
-					orientation="row"
-					labelFor="forcePushProtection"
-					roundedTop={false}
-					{focusable}
-				>
+				<SectionCard orientation="row" labelFor="forcePushProtection" roundedTop={false}>
 					{#snippet title()}
 						Force push protection
 					{/snippet}

--- a/apps/desktop/src/components/GithubIntegration.svelte
+++ b/apps/desktop/src/components/GithubIntegration.svelte
@@ -6,7 +6,6 @@
 	import { inject } from '@gitbutler/core/context';
 
 	import { Button, Icon, Modal, SectionCard, chipToasts as toasts } from '@gitbutler/ui';
-	import { focusable } from '@gitbutler/ui/focus/focusable';
 	import { fade } from 'svelte/transition';
 
 	interface Props {
@@ -78,7 +77,7 @@
 {#if minimal}
 	<Button style="pop" {disabled} onclick={gitHubStartOauth}>Authorize</Button>
 {:else}
-	<SectionCard orientation="row" {focusable}>
+	<SectionCard orientation="row">
 		{#snippet iconSide()}
 			<div class="icon-wrapper">
 				{#if $user?.github_access_token}

--- a/apps/desktop/src/components/KeysForm.svelte
+++ b/apps/desktop/src/components/KeysForm.svelte
@@ -10,7 +10,6 @@
 	import { debounce } from '$lib/utils/debounce';
 	import { inject } from '@gitbutler/core/context';
 	import { Link, RadioButton, SectionCard, TestId, Textbox } from '@gitbutler/ui';
-	import { focusable } from '@gitbutler/ui/focus/focusable';
 
 	import { onMount } from 'svelte';
 
@@ -116,12 +115,7 @@
 						onFormChange(selectedType);
 					}}
 				>
-					<SectionCard
-						roundedBottom={false}
-						orientation="row"
-						labelFor="git-executable"
-						{focusable}
-					>
+					<SectionCard roundedBottom={false} orientation="row" labelFor="git-executable">
 						{#snippet title()}
 							Use a Git executable <span style="color: var(--clr-text-2)">(default)</span>
 						{/snippet}
@@ -143,7 +137,6 @@
 						bottomBorder={selectedType !== 'local'}
 						orientation="row"
 						labelFor="credential-local"
-						{focusable}
 					>
 						{#snippet title()}
 							Use existing SSH key
@@ -161,13 +154,7 @@
 					</SectionCard>
 
 					{#if selectedType === 'local'}
-						<SectionCard
-							topDivider
-							roundedTop={false}
-							roundedBottom={false}
-							orientation="row"
-							{focusable}
-						>
+						<SectionCard topDivider roundedTop={false} roundedBottom={false} orientation="row">
 							<div class="inputs-group">
 								<Textbox
 									label="Path to private key"
@@ -186,7 +173,6 @@
 						roundedBottom={false}
 						orientation="row"
 						labelFor="credential-helper"
-						{focusable}
 					>
 						{#snippet title()}
 							Use a Git credentials helper
@@ -214,7 +200,7 @@
 						{/snippet}
 					</SectionCard>
 
-					<SectionCard roundedTop={false} orientation="row" {focusable}>
+					<SectionCard roundedTop={false} orientation="row">
 						<CredentialCheck
 							bind:this={credentialCheck}
 							disabled={selectedType === 'local' && privateKeyPath.trim() === ''}

--- a/apps/desktop/src/components/PreferencesForm.svelte
+++ b/apps/desktop/src/components/PreferencesForm.svelte
@@ -4,7 +4,6 @@
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
 	import { inject } from '@gitbutler/core/context';
 	import { SectionCard, Textbox, Toggle } from '@gitbutler/ui';
-	import { focusable } from '@gitbutler/ui/focus/focusable';
 
 	const { projectId }: { projectId: string } = $props();
 	const projectsService = inject(PROJECTS_SERVICE);
@@ -14,7 +13,7 @@
 <ReduxResult {projectId} result={projectResult.current}>
 	{#snippet children(project)}
 		<Section gap={8}>
-			<SectionCard orientation="row" labelFor="omitCertificateCheck" {focusable}>
+			<SectionCard orientation="row" labelFor="omitCertificateCheck">
 				{#snippet title()}
 					Ignore host certificate checks
 				{/snippet}
@@ -35,7 +34,7 @@
 				{/snippet}
 			</SectionCard>
 
-			<SectionCard orientation="row" centerAlign {focusable}>
+			<SectionCard orientation="row" centerAlign>
 				{#snippet title()}
 					Snapshot lines threshold
 				{/snippet}

--- a/apps/desktop/src/components/profileSettings/AiSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/AiSettings.svelte
@@ -20,7 +20,6 @@
 		Spacer,
 		Textbox
 	} from '@gitbutler/ui';
-	import { focusable } from '@gitbutler/ui/focus/focusable';
 
 	import { onMount, tick } from 'svelte';
 	import { run } from 'svelte/legacy';
@@ -216,7 +215,6 @@
 		orientation="row"
 		labelFor="open-ai"
 		bottomBorder={modelKind !== ModelKind.OpenAI}
-		{focusable}
 	>
 		{#snippet title()}
 			Open AI
@@ -226,7 +224,7 @@
 		{/snippet}
 	</SectionCard>
 	{#if modelKind === ModelKind.OpenAI}
-		<SectionCard roundedTop={false} roundedBottom={false} topDivider {focusable}>
+		<SectionCard roundedTop={false} roundedBottom={false} topDivider>
 			<Select
 				value={openAIKeyOption}
 				options={keyOptions}
@@ -285,7 +283,6 @@
 		orientation="row"
 		labelFor="anthropic"
 		bottomBorder={modelKind !== ModelKind.Anthropic}
-		{focusable}
 	>
 		{#snippet title()}
 			Anthropic
@@ -295,7 +292,7 @@
 		{/snippet}
 	</SectionCard>
 	{#if modelKind === ModelKind.Anthropic}
-		<SectionCard roundedTop={false} roundedBottom={false} topDivider {focusable}>
+		<SectionCard roundedTop={false} roundedBottom={false} topDivider>
 			<Select
 				value={anthropicKeyOption}
 				options={keyOptions}
@@ -352,7 +349,6 @@
 		orientation="row"
 		labelFor="ollama"
 		bottomBorder={modelKind !== ModelKind.Ollama}
-		{focusable}
 	>
 		{#snippet title()}
 			Ollama 🦙
@@ -362,7 +358,7 @@
 		{/snippet}
 	</SectionCard>
 	{#if modelKind === ModelKind.Ollama}
-		<SectionCard roundedTop={false} roundedBottom={false} topDivider {focusable}>
+		<SectionCard roundedTop={false} roundedBottom={false} topDivider>
 			<Textbox label="Endpoint" bind:value={ollamaEndpoint} placeholder="http://127.0.0.1:11434" />
 			<Textbox label="Model" bind:value={ollamaModel} placeholder="llama3" />
 			<InfoMessage filled outlined={false}>
@@ -386,7 +382,6 @@
 		orientation="row"
 		labelFor="lmstudio"
 		bottomBorder={modelKind !== ModelKind.LMStudio}
-		{focusable}
 	>
 		{#snippet title()}
 			LM Studio
@@ -396,7 +391,7 @@
 		{/snippet}
 	</SectionCard>
 	{#if modelKind === ModelKind.LMStudio}
-		<SectionCard roundedTop={false} roundedBottom={false} topDivider {focusable}>
+		<SectionCard roundedTop={false} roundedBottom={false} topDivider>
 			<Textbox label="Endpoint" bind:value={lmStudioEndpoint} placeholder="http://127.0.0.1:1234" />
 			<Textbox label="Model" bind:value={lmStudioModel} placeholder="default" />
 			<InfoMessage filled outlined={false}>
@@ -428,14 +423,14 @@
 	{/if}
 
 	<!-- AI credential check -->
-	<SectionCard roundedTop={false} {focusable}>
+	<SectionCard roundedTop={false}>
 		<AiCredentialCheck />
 	</SectionCard>
 </form>
 
 <Spacer />
 
-<SectionCard orientation="row" {focusable}>
+<SectionCard orientation="row">
 	{#snippet title()}
 		Amount of provided context
 	{/snippet}

--- a/apps/desktop/src/components/profileSettings/GeneralSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/GeneralSettings.svelte
@@ -10,9 +10,7 @@
 	import { SETTINGS, type CodeEditorSettings } from '$lib/settings/userSettings';
 	import { UPDATER_SERVICE } from '$lib/updater/updater';
 	import { USER_SERVICE } from '$lib/user/userService';
-
 	import { inject } from '@gitbutler/core/context';
-
 	import {
 		Button,
 		Modal,
@@ -24,7 +22,6 @@
 		Toggle,
 		chipToasts
 	} from '@gitbutler/ui';
-	import { focusable } from '@gitbutler/ui/focus/focusable';
 	import type { User } from '$lib/user/user';
 
 	const userService = inject(USER_SERVICE);
@@ -144,7 +141,7 @@
 </script>
 
 {#if $user}
-	<SectionCard {focusable}>
+	<SectionCard>
 		<form onsubmit={onSubmit} class="profile-form">
 			<label id="profile-picture" class="profile-pic-wrapper focus-state" for="picture">
 				<input
@@ -178,7 +175,7 @@
 {/if}
 <Spacer />
 
-<SectionCard orientation="row" centerAlign {focusable}>
+<SectionCard orientation="row" centerAlign>
 	{#snippet title()}
 		Default code editor
 	{/snippet}
@@ -205,7 +202,7 @@
 	{/snippet}
 </SectionCard>
 
-<SectionCard labelFor="disable-auto-checks" orientation="row" {focusable}>
+<SectionCard labelFor="disable-auto-checks" orientation="row">
 	{#snippet title()}
 		Automatically check for updates
 	{/snippet}
@@ -223,7 +220,7 @@
 	{/snippet}
 </SectionCard>
 
-<SectionCard orientation="column" {focusable}>
+<SectionCard orientation="column">
 	{#snippet title()}
 		Install the GitButler CLI (but)
 	{/snippet}
@@ -260,7 +257,7 @@
 <Spacer />
 
 {#if $user}
-	<SectionCard orientation="row" {focusable}>
+	<SectionCard orientation="row">
 		{#snippet title()}
 			Signing out
 		{/snippet}
@@ -272,7 +269,7 @@
 	</SectionCard>
 {/if}
 
-<SectionCard orientation="row" {focusable}>
+<SectionCard orientation="row">
 	{#snippet title()}
 		Remove all projects
 	{/snippet}

--- a/apps/desktop/src/components/profileSettings/GitSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/GitSettings.svelte
@@ -2,8 +2,6 @@
 	import { GIT_CONFIG_SERVICE } from '$lib/config/gitConfigService';
 	import { inject } from '@gitbutler/core/context';
 	import { Link, SectionCard, Toggle } from '@gitbutler/ui';
-	import { focusable } from '@gitbutler/ui/focus/focusable';
-
 	import { onMount } from 'svelte';
 
 	const gitConfig = inject(GIT_CONFIG_SERVICE);
@@ -20,7 +18,7 @@
 	});
 </script>
 
-<SectionCard labelFor="committerSigning" orientation="row" {focusable}>
+<SectionCard labelFor="committerSigning" orientation="row">
 	{#snippet title()}
 		Credit GitButler as the committer
 	{/snippet}

--- a/apps/desktop/src/components/projectSettings/AppearanceSettings.svelte
+++ b/apps/desktop/src/components/projectSettings/AppearanceSettings.svelte
@@ -16,7 +16,6 @@
 		Textbox,
 		Toggle
 	} from '@gitbutler/ui';
-	import { focusable } from '@gitbutler/ui/focus/focusable';
 
 	const userSettings = inject(SETTINGS);
 	const diff = `@@ -56,10 +56,9 @@
@@ -51,14 +50,14 @@
 	}
 </script>
 
-<SectionCard {focusable}>
+<SectionCard>
 	{#snippet title()}
 		Theme
 	{/snippet}
 	<ThemeSelector {userSettings} />
 </SectionCard>
 <div class="stack-v">
-	<SectionCard centerAlign roundedBottom={false} {focusable}>
+	<SectionCard centerAlign roundedBottom={false}>
 		{#snippet title()}
 			Diff preview
 		{/snippet}
@@ -75,7 +74,7 @@
 		/>
 	</SectionCard>
 
-	<SectionCard orientation="column" roundedTop={false} roundedBottom={false} {focusable}>
+	<SectionCard orientation="column" roundedTop={false} roundedBottom={false}>
 		{#snippet title()}
 			Font family
 		{/snippet}
@@ -102,7 +101,6 @@
 		orientation="row"
 		roundedTop={false}
 		roundedBottom={false}
-		{focusable}
 	>
 		{#snippet title()}
 			Allow font ligatures
@@ -121,7 +119,7 @@
 		{/snippet}
 	</SectionCard>
 
-	<SectionCard orientation="row" centerAlign roundedTop={false} roundedBottom={false} {focusable}>
+	<SectionCard orientation="row" centerAlign roundedTop={false} roundedBottom={false}>
 		{#snippet title()}
 			Tab size
 		{/snippet}
@@ -149,13 +147,7 @@
 		{/snippet}
 	</SectionCard>
 
-	<SectionCard
-		labelFor="wrapText"
-		orientation="row"
-		roundedTop={false}
-		roundedBottom={false}
-		{focusable}
-	>
+	<SectionCard labelFor="wrapText" orientation="row" roundedTop={false} roundedBottom={false}>
 		{#snippet title()}
 			Soft wrap
 		{/snippet}
@@ -177,7 +169,7 @@
 		{/snippet}
 	</SectionCard>
 
-	<SectionCard orientation="row" roundedTop={false} roundedBottom={false} {focusable}>
+	<SectionCard orientation="row" roundedTop={false} roundedBottom={false}>
 		{#snippet title()}
 			Lines contrast
 		{/snippet}
@@ -209,7 +201,7 @@
 		{/snippet}
 	</SectionCard>
 
-	<SectionCard labelFor="inlineUnifiedDiffs" orientation="row" roundedTop={false} {focusable}>
+	<SectionCard labelFor="inlineUnifiedDiffs" orientation="row" roundedTop={false}>
 		{#snippet title()}
 			Display word diffs inline
 		{/snippet}
@@ -233,7 +225,7 @@
 </div>
 
 <form class="stack-v" onchange={(e) => onScrollbarFormChange(e.currentTarget)}>
-	<SectionCard roundedBottom={false} orientation="row" labelFor="scrollbar-on-scroll" {focusable}>
+	<SectionCard roundedBottom={false} orientation="row" labelFor="scrollbar-on-scroll">
 		{#snippet title()}
 			Scrollbar-On-Scroll
 		{/snippet}
@@ -255,7 +247,6 @@
 		roundedBottom={false}
 		orientation="row"
 		labelFor="scrollbar-on-hover"
-		{focusable}
 	>
 		{#snippet title()}
 			Scrollbar-On-Hover
@@ -273,7 +264,7 @@
 		{/snippet}
 	</SectionCard>
 
-	<SectionCard roundedTop={false} orientation="row" labelFor="scrollbar-always" {focusable}>
+	<SectionCard roundedTop={false} orientation="row" labelFor="scrollbar-always">
 		{#snippet title()}
 			Always show scrollbar
 		{/snippet}
@@ -288,7 +279,7 @@
 	</SectionCard>
 </form>
 
-<SectionCard labelFor="branchLaneContents" orientation="row" {focusable}>
+<SectionCard labelFor="branchLaneContents" orientation="row">
 	{#snippet title()}
 		Auto-select text on branch/lane rename
 	{/snippet}
@@ -305,7 +296,7 @@
 </SectionCard>
 
 <form class="stack-v" onchange={(e) => onStagingBehaviorFormChange(e.currentTarget)}>
-	<SectionCard roundedBottom={false} orientation="row" labelFor="stage-all" {focusable}>
+	<SectionCard roundedBottom={false} orientation="row" labelFor="stage-all">
 		{#snippet title()}
 			Stage all files
 		{/snippet}
@@ -328,7 +319,6 @@
 		roundedBottom={false}
 		orientation="row"
 		labelFor="stage-selection"
-		{focusable}
 	>
 		{#snippet title()}
 			Stage selected files
@@ -348,7 +338,7 @@
 		{/snippet}
 	</SectionCard>
 
-	<SectionCard roundedTop={false} orientation="row" labelFor="stage-none" {focusable}>
+	<SectionCard roundedTop={false} orientation="row" labelFor="stage-none">
 		{#snippet title()}
 			Don't stage files automatically
 		{/snippet}

--- a/apps/desktop/src/lib/floating/FloatingModal.svelte
+++ b/apps/desktop/src/lib/floating/FloatingModal.svelte
@@ -192,7 +192,7 @@
 <div
 	bind:this={modalEl}
 	use:portal={'body'}
-	use:focusable
+	use:focusable={{ trap: true, activate: true }}
 	class="floating-modal"
 	class:snapping
 	class:resizing={dragResizeHandler.isResizing}

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -34,6 +34,7 @@
 	import { inject } from '@gitbutler/core/context';
 	import { ChipToastContainer } from '@gitbutler/ui';
 	import { FOCUS_MANAGER } from '@gitbutler/ui/focus/focusManager';
+	import { focusable } from '@gitbutler/ui/focus/focusable';
 	import { setExternalLinkService } from '@gitbutler/ui/utils/externalLinkService';
 	import { type Snippet } from 'svelte';
 	import type { LayoutData } from './$types';
@@ -157,6 +158,7 @@
 	ondragover={(e) => e.preventDefault()}
 	onkeydown={handleKeyDown}
 />
+<svelte:body use:focusable={{ activate: true }} />
 
 <div class="app-root" role="application" oncontextmenu={(e) => !dev && e.preventDefault()}>
 	{@render children()}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -16,8 +16,7 @@
 		"verbatimModuleSyntax": true,
 		"isolatedModules": true,
 		"outDir": "dist",
-		"rootDir": "src",
-		"mapRoot": "../../dist"
+		"rootDir": "src"
 	},
 	"include": ["src/**/*"],
 	"exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.spec.ts"]

--- a/packages/ui/src/lib/components/Button.svelte
+++ b/packages/ui/src/lib/components/Button.svelte
@@ -545,4 +545,8 @@
 			text-overflow: ellipsis;
 		}
 	}
+	/* See `tabbable.ts` for more on this class. */
+	:global(.focus-visible) {
+		outline: 2px solid var(--clr-theme-pop-element-hover);
+	}
 </style>

--- a/packages/ui/src/lib/components/ContextMenuItemSubmenu.svelte
+++ b/packages/ui/src/lib/components/ContextMenuItemSubmenu.svelte
@@ -145,55 +145,48 @@
 	}
 </script>
 
-{#snippet submenuButton()}
-	<div
-		bind:this={menuItemElement}
-		class="submenu-wrapper"
-		class:active={isSubmenuOpen}
-		onmouseenter={handleMouseEnter}
-		onmouseleave={handleMouseLeave}
-		onkeydown={handleKeyDown}
-		role="menuitem"
-		aria-haspopup="menu"
-		aria-expanded={isSubmenuOpen}
-		tabindex="-1"
+<div
+	bind:this={menuItemElement}
+	class="submenu-wrapper"
+	class:active={isSubmenuOpen}
+	onmouseenter={handleMouseEnter}
+	onmouseleave={handleMouseLeave}
+	onkeydown={handleKeyDown}
+	role="menuitem"
+	aria-haspopup="menu"
+	aria-expanded={isSubmenuOpen}
+	tabindex="-1"
+>
+	<ContextMenuItem
+		{icon}
+		{label}
+		{disabled}
+		{keyboardShortcut}
+		{testId}
+		{tooltip}
+		onclick={handleClick}
 	>
-		<ContextMenuItem
-			{icon}
-			{label}
-			{disabled}
-			{keyboardShortcut}
-			{testId}
-			{tooltip}
-			onclick={handleClick}
-		>
-			{#snippet control()}
-				<div class="submenu-chevron">
-					<Icon name="chevron-right-small" />
-				</div>
-			{/snippet}
-		</ContextMenuItem>
-	</div>
-{/snippet}
+		{#snippet control()}
+			<div class="submenu-chevron">
+				<Icon name="chevron-right-small" />
+			</div>
+		{/snippet}
+	</ContextMenuItem>
+</div>
 
-{#snippet menuContent()}
-	{@render submenuButton()}
-
-	<ContextMenu
-		bind:this={contextMenu}
-		leftClickTrigger={menuItemElement}
-		parentMenuId={submenuCoordination.getMenuId()}
-		side={submenuSide}
-		align={submenuVerticalAlign === 'top' ? 'start' : 'end'}
-		onclose={() => {
-			isSubmenuOpen = false;
-		}}
-	>
-		{@render submenu({ close: closeSubmenu })}
-	</ContextMenu>
-{/snippet}
-
-{@render menuContent()}
+<ContextMenu
+	bind:this={contextMenu}
+	leftClickTrigger={menuItemElement}
+	parentMenuId={submenuCoordination.getMenuId()}
+	side={submenuSide}
+	align={submenuVerticalAlign === 'top' ? 'start' : 'end'}
+	onclose={() => {
+		isSubmenuOpen = false;
+		menuItemElement?.focus();
+	}}
+>
+	{@render submenu({ close: closeSubmenu })}
+</ContextMenu>
 
 <style lang="postcss">
 	.submenu-wrapper {

--- a/packages/ui/src/lib/components/Modal.svelte
+++ b/packages/ui/src/lib/components/Modal.svelte
@@ -34,7 +34,7 @@
 <script lang="ts" generics="T extends undefined | any = any">
 	import ModalFooter from '$components/ModalFooter.svelte';
 	import ModalHeader from '$components/ModalHeader.svelte';
-	import { focusTrap } from '$lib/utils/focusTrap';
+	import { focusable } from '$lib/focus/focusable';
 	import { portal } from '$lib/utils/portal';
 	import { pxToRem } from '$lib/utils/pxToRem';
 	import { onDestroy } from 'svelte';
@@ -126,13 +126,13 @@
 		onkeydown={onKeyDown}
 	>
 		<form
-			use:focusTrap
 			class="modal-form"
 			class:medium={width === 'medium'}
 			class:large={width === 'large'}
 			class:small={width === 'small'}
 			class:xsmall={width === 'xsmall'}
 			style:width={typeof width === 'number' ? `${pxToRem(width)}rem` : undefined}
+			use:focusable={{ trap: true, activate: true }}
 			onsubmit={(e) => {
 				e.preventDefault();
 				onSubmit?.(close, item);

--- a/packages/ui/src/lib/components/SectionCard.svelte
+++ b/packages/ui/src/lib/components/SectionCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
+	import { focusable } from '$lib/focus/focusable';
 	import type { Snippet } from 'svelte';
-	import type { Action } from 'svelte/action';
 
 	interface Props {
 		orientation?: 'row' | 'column';
@@ -21,7 +21,6 @@
 		children?: Snippet;
 		actions?: Snippet;
 		onclick?: (e: MouseEvent) => void;
-		focusable?: Action<HTMLElement, object>;
 	}
 
 	let {
@@ -42,10 +41,8 @@
 		caption,
 		children,
 		actions,
-		focusable,
 		onclick
 	}: Props = $props();
-	const focusableWithFallback = focusable || (() => {});
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -66,7 +63,7 @@
 	class:error={background === 'error'}
 	class:clickable={labelFor !== '' || clickable}
 	class:disabled
-	use:focusableWithFallback={{}}
+	use:focusable
 	{onclick}
 >
 	{#if iconSide}

--- a/packages/ui/src/lib/components/file/FileListItem.svelte
+++ b/packages/ui/src/lib/components/file/FileListItem.svelte
@@ -8,8 +8,9 @@
 	import FileIndent from '$components/file/FileIndent.svelte';
 	import FileName from '$components/file/FileName.svelte';
 	import FileStatusBadge from '$components/file/FileStatusBadge.svelte';
+	import { focusable } from '$lib/focus/focusable';
 	import type { FileStatus } from '$components/file/types';
-	import type { Action } from 'svelte/action';
+	import type { FocusableOptions } from '$lib/focus/focusManager';
 
 	interface Props {
 		ref?: HTMLDivElement;
@@ -34,6 +35,7 @@
 		active?: boolean;
 		hideBorder?: boolean;
 		executable?: boolean;
+		actionOpts?: FocusableOptions;
 		oncheckclick?: (e: MouseEvent) => void;
 		oncheck?: (
 			e: Event & {
@@ -45,8 +47,6 @@
 		onresolveclick?: (e: MouseEvent) => void;
 		onkeydown?: (e: KeyboardEvent) => void;
 		oncontextmenu?: (e: MouseEvent) => void;
-		action?: Action<HTMLDivElement, any>;
-		actionOpts?: unknown;
 	}
 
 	let {
@@ -72,7 +72,6 @@
 		listMode = 'list',
 		depth,
 		executable,
-		action,
 		actionOpts,
 		oncheck,
 		oncheckclick,
@@ -84,7 +83,6 @@
 	}: Props = $props();
 
 	const showIndent = $derived(depth && depth > 0);
-	const action2 = action || (() => ({}));
 </script>
 
 <div
@@ -105,7 +103,7 @@
 	{onclick}
 	{ondblclick}
 	{onkeydown}
-	use:action2={actionOpts}
+	use:focusable={actionOpts}
 	oncontextmenu={(e) => {
 		if (oncontextmenu) {
 			e.preventDefault();

--- a/packages/ui/src/lib/focus/focusable.ts
+++ b/packages/ui/src/lib/focus/focusable.ts
@@ -1,5 +1,5 @@
 import { FOCUS_MANAGER, type FocusableOptions, type Payload } from '$lib/focus/focusManager';
-import { inject } from '@gitbutler/core/context';
+import { injectOptional } from '@gitbutler/core/context';
 import type { Action } from 'svelte/action';
 
 /**
@@ -18,22 +18,23 @@ export function focusable(
 	element: HTMLElement,
 	options: FocusableOptions = {}
 ): ReturnType<Action<HTMLElement, FocusableOptions>> {
-	const focus = inject(FOCUS_MANAGER);
+	const focusManager = injectOptional(FOCUS_MANAGER, undefined);
+	if (!focusManager) return;
 
 	let currentOptions = options;
 	let isRegistered = false;
 
 	function register() {
-		if (isRegistered) return;
+		if (isRegistered || !focusManager) return;
 
-		focus.register(currentOptions, element);
+		focusManager.register(currentOptions, element);
 		isRegistered = true;
 	}
 
 	function unregister() {
-		if (!isRegistered) return;
+		if (!isRegistered || !focusManager) return;
 
-		focus.unregister(currentOptions.id, element);
+		focusManager.unregister(currentOptions.id, element);
 		isRegistered = false;
 	}
 
@@ -64,7 +65,7 @@ export function focusable(
 				currentOptions = newOptions;
 
 				// Update the existing registration
-				focus.updateElementOptions(element, newOptions);
+				focusManager.updateElementOptions(element, newOptions);
 			}
 		}
 	};

--- a/packages/ui/src/lib/focus/tabbable.ts
+++ b/packages/ui/src/lib/focus/tabbable.ts
@@ -1,14 +1,12 @@
 export type FocusOptions = {
 	container: HTMLElement;
-	wrap?: boolean;
-	customSelector?: string;
 	forward?: boolean;
+	wrap?: boolean;
 };
 
 export function focusNextTabIndex(options: FocusOptions): boolean {
-	const { container, forward, wrap = true, customSelector = '' } = options;
+	const { container, forward, wrap = true } = options;
 
-	// Build selector array
 	const focusableSelectors: string[] = [
 		'a[href]',
 		'button:not([disabled])',
@@ -18,10 +16,6 @@ export function focusNextTabIndex(options: FocusOptions): boolean {
 		'[tabindex]:not([tabindex="-1"])',
 		'[contenteditable="true"]'
 	];
-
-	if (customSelector) {
-		focusableSelectors.push(customSelector);
-	}
 
 	const focusableElements: NodeListOf<Element> = container.querySelectorAll(
 		focusableSelectors.join(',')
@@ -71,8 +65,21 @@ export function focusNextTabIndex(options: FocusOptions): boolean {
 	}
 
 	const nextElement: Element | undefined = focusableArray[nextIndex];
+
 	if (nextElement instanceof HTMLElement) {
 		nextElement.focus();
+		// We don't want an outline when clicking elements with a mouse, and the
+		// built-in `:focus-visible` isn't triggered when programatically focusing
+		// elements. We therefore need this explicit class in order to show the
+		// outline when tabbing through elements.
+		nextElement.classList.add('focus-visible');
+		nextElement.addEventListener(
+			'focusout',
+			() => {
+				nextElement.classList.remove('focus-visible');
+			},
+			{ once: true }
+		);
 		return true;
 	}
 


### PR DESCRIPTION
Changes the focusable to be compatible with an optionally provided 
focusManager, leaving it a noop if unavailable.

Updates old workaround where `focusable` was passed to `SectionCard`, 
cleaning up the settings code.

Also introduces an `ignoreKeys` hack in the focusManager to make it work
better with context menus. A good solution for the interop between 
focusables and the existing `focusTrap` is left for a later time.