### PR TITLE
hide archived stacks from the workspace listing

### DIFF
--- a/crates/but-core/src/ref_metadata.rs
+++ b/crates/but-core/src/ref_metadata.rs
@@ -200,8 +200,9 @@ pub struct WorkspaceStackBranch {
     /// If `true`, the branch is now underneath the lower-base of the workspace after a workspace update.
     /// This means it's not interesting anymore, by all means, but we'd still have to keep it available and list
     /// these segments as being part of the workspace when creating PRs. Their descriptions contain references
-    /// to archived segments, which simply shouldn't disappear just yet.
-    /// However, they may disappear once the whole stack has been integrated and the workspace has moved past it.
+    /// to archived segments, which simply shouldn't disappear from PRs just yet.
+    /// However, they must disappear once the whole stack has been integrated and the workspace has moved past it.
+    /// Note that this flag must be stored with the workspace as it must survive the deletion of a reference.
     pub archived: bool,
 }
 

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -239,6 +239,23 @@ mkdir ws
      create_workspace_commit_once B
   )
 
+  git init single-merge-into-main
+  (cd single-merge-into-main
+     commit init
+       git branch B
+     git checkout -b A
+       commit A
+     git checkout B
+       commit B
+     git checkout -b merge
+       git merge --no-ff A
+       cp .git/refs/heads/merge .git/refs/heads/main
+       setup_target_to_match_main
+     git checkout -b C
+       commit C
+     create_workspace_commit_once C
+  )
+
   git init dual-merge
   (cd dual-merge
      commit init


### PR DESCRIPTION
### Tasks

* [x]  simplest-possible reproduction
* [x] impl
* [x] test to assure archived only applies to branches on the base
* [x] real-world validation

The idea is to only have a single, most simple test and assume the implementation will scale to what we typically have in the real world.
This is tested by hand, and only if it doesn't work will there be another test with the specific case.

Fixes #10033
