### PR TITLE
Common error titles

### DIFF
--- a/apps/desktop/src/lib/error/parser.ts
+++ b/apps/desktop/src/lib/error/parser.ts
@@ -78,3 +78,21 @@ export function parseError(error: unknown): ParsedError {
 
 	return { message: JSON.stringify(error, null, 2) };
 }
+
+const CommonErrorMessageStart: Record<string, string> = {
+	'Although you appear to have the correct authorization credentials,':
+		'GitHub Organizations OAuth Error'
+};
+/**
+ * Returns an unified title for common error messages.
+ *
+ * This is used mainly to group errors unders a readable title and be able to graph them into the same group.
+ */
+export function getTitleFromCommonErrorMessage(errorMessage: string): string | undefined {
+	for (const [start, title] of Object.entries(CommonErrorMessageStart)) {
+		if (errorMessage.startsWith(start)) {
+			return title;
+		}
+	}
+	return undefined;
+}

--- a/apps/desktop/src/lib/notifications/toasts.ts
+++ b/apps/desktop/src/lib/notifications/toasts.ts
@@ -1,4 +1,4 @@
-import { isBundlingError, parseError } from '$lib/error/parser';
+import { getTitleFromCommonErrorMessage, isBundlingError, parseError } from '$lib/error/parser';
 import posthog from 'posthog-js';
 import { writable, type Writable } from 'svelte/store';
 import type { MessageStyle } from '$components/InfoMessage.svelte';
@@ -47,8 +47,9 @@ export function showError(title: string, error: unknown, extraAction?: ExtraActi
 		return;
 	}
 	if (!ignored) {
+		const commonErrorTitle = getTitleFromCommonErrorMessage(message);
 		showToast({
-			title: name || title,
+			title: name || commonErrorTitle || title,
 			message: description,
 			error: message,
 			style: 'error',


### PR DESCRIPTION
Add a new way of retrieving groupable error titles, so that common error message types (e.g. the GitHub org oAuth errors) can be bundled together in the metrics