### PR TITLE
Make focusable code easier to understand

### DIFF
--- a/packages/ui/src/lib/focus/utils.ts
+++ b/packages/ui/src/lib/focus/utils.ts
@@ -55,6 +55,45 @@ export async function scrollIntoViewIfNeeded(
 }
 
 export function isContentEditable(element: HTMLElement): boolean {
+	if (!(element instanceof HTMLElement)) {
+		return false;
+	}
 	const contentEditableValue = element.contentEditable.toLowerCase();
 	return contentEditableValue === 'true' || contentEditableValue === 'plaintext-only';
+}
+
+/**
+ * Safely removes an element from an array and returns whether it was found
+ */
+export function safeRemoveFromArray<T>(array: T[], item: T): boolean {
+	const index = array.indexOf(item);
+	if (index !== -1) {
+		array.splice(index, 1);
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Adds an element to an array and sorts by DOM order
+ */
+export function addAndSortByDomOrder<T extends Element>(array: T[], item: T): void {
+	addToArray(array, item);
+	sortByDomOrder(array);
+}
+
+/**
+ * Moves an element from one array to another and sorts the destination array
+ */
+export function moveElementBetweenArrays<T extends Element>(
+	sourceArray: T[],
+	destinationArray: T[],
+	item: T
+): boolean {
+	if (safeRemoveFromArray(sourceArray, item)) {
+		destinationArray.push(item);
+		sortByDomOrder(destinationArray);
+		return true;
+	}
+	return false;
 }


### PR DESCRIPTION
- Return a no-op action when the focus manager is missing instead
  returning undefined. This prevents runtime errors when the decorator
  is used outside of a registered manager.
- Wrap register/unregister calls in try/catch and log warnings to avoid
  uncaught exceptions from breaking component behavior.
- Handle id and disabled transitions more precisely:
  - Re-register when id changes.
  - Unregister when disabled becomes true, and re-register when it
    becomes false.
  - Only call updateElementOptions when the element is still registered.
- Adjust update signature to use the same FocusableOptions generic and
  preserve currentOptions updates safely.

- In focusManager:
  - Replace several utility helpers with addAndSortByDomOrder and
    moveElementBetweenArrays for clearer semantics.
  - Remove Payload/generic plumbing from FocusManager types and handlers
    to simplify the API: eliminate Payload, FocusContext, and generic
    KeyboardHandler; make onKeydown/onFocus use simpler signatures.
  - Add MAX_HISTORY_SIZE constant.
  - Clean up imports and remove unused type exports.