### PR TITLE
feat(focus): unify and extend focusable regions across UI

### DIFF
--- a/apps/desktop/src/components/BranchCard.svelte
+++ b/apps/desktop/src/components/BranchCard.svelte
@@ -15,7 +15,6 @@
 	import { UI_STATE } from '$lib/state/uiState.svelte';
 	import { inject } from '@gitbutler/core/context';
 	import { ReviewBadge, Icon, Tooltip, TestId } from '@gitbutler/ui';
-	import { focusable } from '@gitbutler/ui/focus/focusable';
 	import { getTimeAgo } from '@gitbutler/ui/utils/timeAgo';
 	import type { DropzoneHandler } from '$lib/dragging/handler';
 	import type { PushStatus } from '$lib/stacks/stack';
@@ -104,8 +103,6 @@
 	const selected = $derived(selection?.branchName === branchName);
 	const isPushed = $derived(!!(args.type === 'draft-branch' ? undefined : args.trackingBranch));
 
-	let active = $state(false);
-
 	async function updateBranchName(title: string) {
 		if (args.type === 'draft-branch') {
 			uiState.global.draftBranchName.set(title);
@@ -136,19 +133,6 @@
 	class:draft={args.type === 'draft-branch'}
 	data-series-name={branchName}
 	data-testid={TestId.BranchCard}
-	use:focusable={{
-		list: true,
-		onKeydown: (e) => {
-			if (e.key === 'Enter' || (!e.metaKey && e.key === 'ArrowRight')) {
-				if (args.type === 'normal-branch' || args.type === 'stack-branch') {
-					e.stopPropagation();
-					args.onclick();
-				}
-			}
-		},
-		onFocus: () => (active = true),
-		onBlur: () => (active = false)
-	}}
 >
 	{#if args.type === 'stack-branch'}
 		{@const moveHandler = args.stackId
@@ -181,7 +165,6 @@
 				{updateBranchName}
 				isUpdatingName={nameUpdate.current.isLoading}
 				failedMisserablyToUpdateBranchName={nameUpdate.current.isError}
-				{active}
 				{readonly}
 				{isPushed}
 				onclick={args.onclick}
@@ -256,7 +239,6 @@
 			{updateBranchName}
 			isUpdatingName={nameUpdate.current.isLoading}
 			failedMisserablyToUpdateBranchName={nameUpdate.current.isError}
-			{active}
 			readonly
 			{isPushed}
 			onclick={args.onclick}
@@ -284,7 +266,6 @@
 			{updateBranchName}
 			isUpdatingName={nameUpdate.current.isLoading}
 			failedMisserablyToUpdateBranchName={nameUpdate.current.isError}
-			{active}
 			readonly
 			isPushed
 		>
@@ -307,7 +288,6 @@
 			{updateBranchName}
 			isUpdatingName={nameUpdate.current.isLoading}
 			failedMisserablyToUpdateBranchName={nameUpdate.current.isError}
-			{active}
 			readonly={false}
 			isPushed={false}
 		>

--- a/apps/desktop/src/components/BranchList.svelte
+++ b/apps/desktop/src/components/BranchList.svelte
@@ -22,7 +22,6 @@
 	import { copyToClipboard } from '@gitbutler/shared/clipboard';
 
 	import { Button, Modal, TestId } from '@gitbutler/ui';
-	import { focusable } from '@gitbutler/ui/focus/focusable';
 	import { getForgeLogo } from '@gitbutler/ui/utils/getForgeLogo';
 	import { QueryStatus } from '@reduxjs/toolkit/query';
 	import { tick } from 'svelte';
@@ -123,7 +122,7 @@
 	const canPublishPR = $derived(forge.current.authenticated);
 </script>
 
-<div class="branches-wrapper" use:focusable={{ list: true, disabled: branches.length <= 1 }}>
+<div class="branches-wrapper">
 	{#each branches as branch, i}
 		{@const branchName = branch.name}
 		{@const localAndRemoteCommits = stackService.commits(projectId, stackId, branchName)}

--- a/apps/desktop/src/components/CommitRow.svelte
+++ b/apps/desktop/src/components/CommitRow.svelte
@@ -102,7 +102,12 @@
 	{onclick}
 	use:focusable={{
 		id: DefinedFocusable.Commit,
-		linkToIds: [DefinedFocusable.FileItem, DefinedFocusable.Commit],
+		linkToIds: [
+			DefinedFocusable.FileItem,
+			DefinedFocusable.Commit,
+			DefinedFocusable.Branch,
+			DefinedFocusable.Assignments
+		],
 		onKeydown: (e) => {
 			if (disabled) return false;
 
@@ -112,8 +117,7 @@
 				return true;
 			}
 		},
-		onFocus: () => (active = true),
-		onBlur: () => (active = false)
+		onActive: (value) => (active = value)
 	}}
 >
 	{#if selected}

--- a/apps/desktop/src/components/FileList.svelte
+++ b/apps/desktop/src/components/FileList.svelte
@@ -192,7 +192,12 @@
 		showCheckbox={showCheckboxes}
 		focusableOpts={{
 			id: DefinedFocusable.FileItem,
-			linkToIds: [DefinedFocusable.Commit, DefinedFocusable.FileItem],
+			linkToIds: [
+				DefinedFocusable.FileItem,
+				DefinedFocusable.Commit,
+				DefinedFocusable.Branch,
+				DefinedFocusable.Assignments
+			],
 			onKeydown: (e) => {
 				if (e.key === 'Enter' || e.key === 'l') {
 					e.stopPropagation();

--- a/apps/desktop/src/components/FileListItemWrapper.svelte
+++ b/apps/desktop/src/components/FileListItemWrapper.svelte
@@ -197,8 +197,7 @@
 			oncontextmenu={onContextMenu}
 			actionOpts={{
 				...focusableOpts,
-				onFocus: () => (active = true),
-				onBlur: () => (active = false)
+				onActive: (value) => (active = value)
 			}}
 		/>
 	{/if}

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -31,6 +31,7 @@
 	import { persistWithExpiration } from '@gitbutler/shared/persisted';
 
 	import { Button, FileViewHeader, Icon, TestId } from '@gitbutler/ui';
+	import { DefinedFocusable } from '@gitbutler/ui/focus/focusManager';
 	import { focusable } from '@gitbutler/ui/focus/focusable';
 	import { intersectionObserver } from '@gitbutler/ui/utils/intersectionObserver';
 	import { fly } from 'svelte/transition';
@@ -446,7 +447,15 @@
 						<div
 							class="assignments-wrap"
 							class:assignments__empty={changes.current.length === 0 && !isCommitting}
-							use:focusable
+							use:focusable={{
+								id: DefinedFocusable.Assignments,
+								linkToIds: [
+									DefinedFocusable.FileItem,
+									DefinedFocusable.Commit,
+									DefinedFocusable.Branch,
+									DefinedFocusable.Assignments
+								]
+							}}
 						>
 							<div
 								class="worktree-wrap"

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -162,9 +162,13 @@
 	ondragover={(e) => e.preventDefault()}
 	onkeydown={handleKeyDown}
 />
-<svelte:body use:focusable={{ activate: true }} />
 
-<div class="app-root" role="application" oncontextmenu={(e) => !dev && e.preventDefault()}>
+<div
+	use:focusable={{ activate: true }}
+	class="app-root"
+	role="application"
+	oncontextmenu={(e) => !dev && e.preventDefault()}
+>
 	{@render children()}
 </div>
 <ShareIssueModal />


### PR DESCRIPTION
Expand focus navigation and centralize focus handling for key list
areas (commit row, file list, branch header, stack assignments) to
support consistent keyboard traversal and active state management.

- Add DefinedFocusable imports and link To IDs to include Branch and
  Assignments so FileItem, Commit, Branch and Assignments are navigable
  as a group.
- Replace separate onFocus/onBlur handlers with a single onActive
  callback in CommitRow to simplify active state updates.
- Wire focusable options on the assignments container in StackView so
  it participates in focus linking.
- Rework BranchHeader structure to wrap interactive area with
  focusable config: introduce a focused wrapper, handle Enter/ArrowRight
  keys, expose list behavior, and update active state via onActive.
- Minor cleanup: move data-testid and role markup inside the new
  focusable wrapper to preserve semantics.

These changes improve keyboard accessibility and make focus behavior
consistent across list and header components.