### PR TITLE
Remove unnecessary focusable regions

### DIFF
--- a/apps/desktop/src/components/BranchesView.svelte
+++ b/apps/desktop/src/components/BranchesView.svelte
@@ -190,7 +190,7 @@
 			current.stackId || (current.branchName && !isTargetBranch)}
 		{@const isNonLocalPr = !isStackOrNormalBranchPreview && current.prNumber !== undefined}
 
-		<div class="branches-view" use:focusable>
+		<div class="branches-view">
 			<div class="relative overflow-hidden radius-ml">
 				<div
 					bind:this={branchViewLeftEl}

--- a/apps/desktop/src/components/MainViewport.svelte
+++ b/apps/desktop/src/components/MainViewport.svelte
@@ -130,7 +130,6 @@ the window, then enlarge it and retain the original widths of the layout.
 
 <div
 	class="main-viewport"
-	use:focusable
 	bind:clientWidth={containerBindWidth}
 	data-testid={testId}
 	class:left-sideview-open={!!preview}

--- a/apps/desktop/src/components/codegen/CodegenPage.svelte
+++ b/apps/desktop/src/components/codegen/CodegenPage.svelte
@@ -52,7 +52,6 @@
 		EmptyStatePlaceholder,
 		Modal
 	} from '@gitbutler/ui';
-	import { focusable } from '@gitbutler/ui/focus/focusable';
 	import type { ClaudeMessage, ThinkingLevel, ModelType } from '$lib/codegen/types';
 
 	type Props = {
@@ -336,7 +335,7 @@
 	});
 </script>
 
-<div class="page" use:focusable>
+<div class="page">
 	<ReduxResult result={claudeAvailable.current} {projectId}>
 		{#snippet children(claudeAvailable, { projectId })}
 			{#if claudeAvailable}


### PR DESCRIPTION
The "main viewport" focusable sections are a bit useless, removing them.