### PR TITLE
Simplify but-api functions with a procmacro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,6 +853,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "but-action",
+ "but-api-macros",
  "but-broadcaster",
  "but-claude",
  "but-core",
@@ -895,6 +896,16 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "but-api-macros"
+version = "0.0.0"
+dependencies = [
+ "convert_case 0.8.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1711,6 +1722,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2068,7 +2088,7 @@ version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ but-bot = { path = "crates/but-bot" }
 but-status = { path = "crates/but-status" }
 but-tools = { path = "crates/but-tools" }
 but-api = { path = "crates/but-api" }
+but-api-macros = { path = "crates/but-api-macros" }
 but-claude = { path = "crates/but-claude" }
 but-broadcaster = { path = "crates/but-broadcaster" }
 git2-hooks = { version = "0.5.0" }

--- a/crates/but-api-macros/Cargo.toml
+++ b/crates/but-api-macros/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "but-api-macros"
+version = "0.0.0"
+edition = "2024"
+authors = ["GitButler <gitbutler@gitbutler.com>"]
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "2"
+quote = "1"
+proc-macro2 = "1"
+convert_case = "0.8"

--- a/crates/but-api-macros/src/lib.rs
+++ b/crates/but-api-macros/src/lib.rs
@@ -1,0 +1,72 @@
+use convert_case::{Case, Casing};
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{FnArg, ItemFn, Pat, parse_macro_input};
+
+/// To be used on functions, so a function `func` will be turned into:
+/// * `func` - the original item, unchanged
+/// * `func_params(FuncParams)` taking a struct with all parameters
+/// * `func_cmd` for calls from the frontend, taking `serde_json::Value` and returning `Result<serde_json::Value, Error>`
+#[proc_macro_attribute]
+pub fn api_cmd(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input_fn = parse_macro_input!(item as ItemFn);
+
+    let vis = &input_fn.vis;
+    let sig = &input_fn.sig;
+    let fn_name = &sig.ident;
+    let output = &sig.output;
+
+    // Collect parameter names and types
+    let mut fields = Vec::new();
+    let mut param_names = Vec::new();
+    for arg in &sig.inputs {
+        if let FnArg::Typed(pat_type) = arg {
+            let ty = &pat_type.ty;
+            let pat = &pat_type.pat;
+            if let Pat::Ident(ident) = &**pat {
+                let name = &ident.ident;
+                fields.push(quote! { pub #name: #ty });
+                param_names.push(name);
+            }
+        }
+    }
+
+    // Struct name: <FunctionName>Params (PascalCase)
+    let struct_name = format_ident!("{}Params", fn_name.to_string().to_case(Case::Pascal));
+
+    // Wrapper function name: <function_name>_params
+    let wrapper_name = format_ident!("{}_params", fn_name);
+
+    // Cmd function name: <function_name>_cmd
+    let cmd_name = format_ident!("{}_cmd", fn_name);
+
+    let expanded = quote! {
+        // Original function stays
+        #input_fn
+
+        // Generated struct
+        #[derive(::serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        pub struct #struct_name {
+            #(#fields,)*
+        }
+
+        // Wrapper function
+        #vis fn #wrapper_name(params: #struct_name) #output {
+            #fn_name(#(params.#param_names),*)
+        }
+
+        // Cmd function
+        #vis fn #cmd_name(
+            params: ::serde_json::Value,
+        ) -> Result<::serde_json::Value, crate::error::Error> {
+            use crate::error::ToError;
+            let params: #struct_name = ::serde_json::from_value(params).to_error()?;
+            let result = #fn_name(#(params.#param_names),*)?;
+            ::serde_json::to_value(result).to_error()
+        }
+
+    };
+
+    expanded.into()
+}

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -26,6 +26,7 @@ but-workspace.workspace = true
 but-core.workspace = true
 but-hunk-assignment.workspace = true
 but-action.workspace = true
+but-api-macros.workspace = true
 but-rebase.workspace = true
 gitbutler-serde.workspace = true
 gitbutler-branch.workspace = true

--- a/crates/but-api/src/commands/virtual_branches.rs
+++ b/crates/but-api/src/commands/virtual_branches.rs
@@ -21,7 +21,7 @@ use gitbutler_stack::{StackId, VirtualBranchesHandle};
 use gix::reference::Category;
 use serde::Deserialize;
 
-use crate::commands::workspace::{CannedBranchNameParams, canned_branch_name};
+use crate::commands::workspace::canned_branch_name;
 use crate::error::Error;
 // Parameter structs for all functions
 
@@ -50,11 +50,7 @@ pub fn create_virtual_branch(params: CreateVirtualBranchParams) -> Result<StackE
                     .branch
                     .name
                     .map(Ok)
-                    .unwrap_or_else(|| {
-                        canned_branch_name(CannedBranchNameParams {
-                            project_id: params.project_id,
-                        })
-                    })?
+                    .unwrap_or_else(|| canned_branch_name(params.project_id))?
                     .as_str(),
             )
             .map_err(anyhow::Error::from)?;

--- a/crates/but-api/src/commands/workspace.rs
+++ b/crates/but-api/src/commands/workspace.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use crate::error::Error;
 use crate::hex_hash::HexHash;
 use anyhow::Context;
+use but_api_macros::api_cmd;
 use but_graph::VirtualBranchesTomlMetadata;
 use but_hunk_assignment::HunkAssignmentRequest;
 use but_settings::AppSettings;
@@ -16,47 +17,34 @@ use gitbutler_oplog::{OplogExt, SnapshotExt};
 use gitbutler_project::{Project, ProjectId};
 use gitbutler_reference::{LocalRefname, Refname};
 use gitbutler_stack::{StackId, VirtualBranchesHandle};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 fn ref_metadata_toml(project: &Project) -> anyhow::Result<VirtualBranchesTomlMetadata> {
     VirtualBranchesTomlMetadata::from_path(project.gb_dir().join("virtual_branches.toml"))
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StacksParams {
-    pub project_id: ProjectId,
-    pub filter: Option<but_workspace::StacksFilter>,
-}
-
-pub fn stacks(params: StacksParams) -> Result<Vec<StackEntry>, Error> {
-    let project = gitbutler_project::get(params.project_id)?;
+#[api_cmd]
+pub fn stacks(
+    project_id: ProjectId,
+    filter: Option<but_workspace::StacksFilter>,
+) -> Result<Vec<StackEntry>, Error> {
+    let project = gitbutler_project::get(project_id)?;
     let ctx = CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
     let repo = ctx.gix_repo_for_merging_non_persisting()?;
     if ctx.app_settings().feature_flags.ws3 {
         let meta = ref_metadata_toml(ctx.project())?;
-        but_workspace::stacks_v3(&repo, &meta, params.filter.unwrap_or_default(), None)
+        but_workspace::stacks_v3(&repo, &meta, filter.unwrap_or_default(), None)
     } else {
-        but_workspace::stacks(
-            &ctx,
-            &project.gb_dir(),
-            &repo,
-            params.filter.unwrap_or_default(),
-        )
+        but_workspace::stacks(&ctx, &project.gb_dir(), &repo, filter.unwrap_or_default())
     }
     .map_err(Into::into)
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ShowGraphSvgParams {
-    pub project_id: ProjectId,
-}
-
 #[cfg(unix)]
-pub fn show_graph_svg(params: ShowGraphSvgParams) -> Result<(), Error> {
+#[api_cmd]
+pub fn show_graph_svg(project_id: ProjectId) -> Result<(), Error> {
     use but_settings::AppSettings;
 
-    let project = gitbutler_project::get(params.project_id)?;
+    let project = gitbutler_project::get(project_id)?;
     let ctx = CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
     let repo = ctx.gix_repo_local_only()?;
     let meta = ref_metadata_toml(&project)?;
@@ -94,77 +82,53 @@ pub fn show_graph_svg(params: ShowGraphSvgParams) -> Result<(), Error> {
     Ok(())
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StackDetailsParams {
-    pub project_id: ProjectId,
-    pub stack_id: Option<StackId>,
-}
-
-pub fn stack_details(params: StackDetailsParams) -> Result<but_workspace::ui::StackDetails, Error> {
-    let project = gitbutler_project::get(params.project_id)?;
+#[api_cmd]
+pub fn stack_details(
+    project_id: ProjectId,
+    stack_id: Option<StackId>,
+) -> Result<but_workspace::ui::StackDetails, Error> {
+    let project = gitbutler_project::get(project_id)?;
     let ctx = CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
     if ctx.app_settings().feature_flags.ws3 {
         let repo = ctx.gix_repo_for_merging_non_persisting()?;
         let meta = ref_metadata_toml(ctx.project())?;
-        but_workspace::stack_details_v3(params.stack_id, &repo, &meta)
+        but_workspace::stack_details_v3(stack_id, &repo, &meta)
     } else {
         but_workspace::stack_details(
             &project.gb_dir(),
-            params.stack_id.context("BUG(opt-stack-id)")?,
+            stack_id.context("BUG(opt-stack-id)")?,
             &ctx,
         )
     }
     .map_err(Into::into)
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct BranchDetailsParams {
-    pub project_id: ProjectId,
-    pub branch_name: String,
-    pub remote: Option<String>,
-}
-
+#[api_cmd]
 pub fn branch_details(
-    params: BranchDetailsParams,
+    project_id: ProjectId,
+    branch_name: String,
+    remote: Option<String>,
 ) -> Result<but_workspace::ui::BranchDetails, Error> {
-    let project = gitbutler_project::get(params.project_id)?;
+    let project = gitbutler_project::get(project_id)?;
     let ctx = CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
     if ctx.app_settings().feature_flags.ws3 {
         let repo = ctx.gix_repo_for_merging_non_persisting()?;
         let meta = ref_metadata_toml(ctx.project())?;
-        let ref_name: gix::refs::FullName = match params.remote.as_deref() {
+        let ref_name: gix::refs::FullName = match remote.as_deref() {
             None => {
-                format!("refs/heads/{}", params.branch_name)
+                format!("refs/heads/{branch_name}")
             }
             Some(remote) => {
-                format!("refs/remotes/{remote}/{}", params.branch_name)
+                format!("refs/remotes/{remote}/{branch_name}")
             }
         }
         .try_into()
         .map_err(anyhow::Error::from)?;
         but_workspace::branch_details_v3(&repo, ref_name.as_ref(), &meta)
     } else {
-        but_workspace::branch_details(
-            &project.gb_dir(),
-            &params.branch_name,
-            params.remote.as_deref(),
-            &ctx,
-        )
+        but_workspace::branch_details(&project.gb_dir(), &branch_name, remote.as_deref(), &ctx)
     }
     .map_err(Into::into)
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CreateCommitFromWorktreeChangesParams {
-    pub project_id: ProjectId,
-    pub stack_id: StackId,
-    pub parent_id: Option<HexHash>,
-    pub worktree_changes: Vec<but_workspace::DiffSpec>,
-    pub message: String,
-    pub stack_branch_name: String,
 }
 
 /// Create a new commit with `message` on top of `parent_id` that contains all `changes`.
@@ -175,21 +139,27 @@ pub struct CreateCommitFromWorktreeChangesParams {
 /// hunks would fail.
 /// `stack_branch_name` is the short name of the reference that the UI knows is present in a given segment.
 /// It is necessary to insert the new commit into the right bucket.
+#[api_cmd]
 pub fn create_commit_from_worktree_changes(
-    params: CreateCommitFromWorktreeChangesParams,
+    project_id: ProjectId,
+    stack_id: StackId,
+    parent_id: Option<HexHash>,
+    worktree_changes: Vec<but_workspace::DiffSpec>,
+    message: String,
+    stack_branch_name: String,
 ) -> Result<commit_engine::ui::CreateCommitOutcome, Error> {
-    let project = gitbutler_project::get(params.project_id)?;
+    let project = gitbutler_project::get(project_id)?;
     let ctx = CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
     let mut guard = project.exclusive_worktree_access();
     let snapshot_tree = ctx.prepare_snapshot(guard.read_permission());
 
     let outcome = commit_engine::create_commit_simple(
         &ctx,
-        params.stack_id,
-        params.parent_id.map(|id| id.into()),
-        params.worktree_changes,
-        params.message.clone(),
-        params.stack_branch_name,
+        stack_id,
+        parent_id.map(|id| id.into()),
+        worktree_changes,
+        message.clone(),
+        stack_branch_name,
         guard.write_permission(),
     );
 
@@ -197,7 +167,7 @@ pub fn create_commit_from_worktree_changes(
         ctx.snapshot_commit_creation(
             snapshot_tree,
             outcome.as_ref().err(),
-            params.message.to_owned(),
+            message.to_owned(),
             None,
             guard.write_permission(),
         )
@@ -207,38 +177,33 @@ pub fn create_commit_from_worktree_changes(
     Ok(outcome.into())
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AmendCommitFromWorktreeChangesParams {
-    pub project_id: ProjectId,
-    pub stack_id: StackId,
-    pub commit_id: HexHash,
-    pub worktree_changes: Vec<but_workspace::DiffSpec>,
-}
-
 /// Amend all `changes` to `commit_id`, keeping its commit message exactly as is.
 /// `stack_id` is the stack that contains the `commit_id`, and it's fatal if that's not the case.
 /// All `changes` are meant to be relative to the worktree.
 /// Note that submodules *must* be provided as diffspec without hunks, as attempting to generate
 /// hunks would fail.
+#[api_cmd]
 pub fn amend_commit_from_worktree_changes(
-    params: AmendCommitFromWorktreeChangesParams,
+    project_id: ProjectId,
+    stack_id: StackId,
+    commit_id: HexHash,
+    worktree_changes: Vec<but_workspace::DiffSpec>,
 ) -> Result<commit_engine::ui::CreateCommitOutcome, Error> {
-    let project = gitbutler_project::get(params.project_id)?;
+    let project = gitbutler_project::get(project_id)?;
     let mut guard = project.exclusive_worktree_access();
     let repo = but_core::open_repo_for_merging(project.worktree_path())?;
     let app_settings = AppSettings::load_from_default_path_creating()?;
     let outcome = commit_engine::create_commit_and_update_refs_with_project(
         &repo,
         &project,
-        Some(params.stack_id),
+        Some(stack_id),
         commit_engine::Destination::AmendCommit {
-            commit_id: params.commit_id.into(),
+            commit_id: commit_id.into(),
             // TODO: Expose this in the UI for 'edit message' functionality.
             new_message: None,
         },
         None,
-        params.worktree_changes,
+        worktree_changes,
         app_settings.context_lines,
         guard.write_permission(),
     )?;
@@ -248,22 +213,17 @@ pub fn amend_commit_from_worktree_changes(
     Ok(outcome.into())
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DiscardWorktreeChangesParams {
-    pub project_id: ProjectId,
-    pub worktree_changes: Vec<but_workspace::DiffSpec>,
-}
-
 /// Discard all worktree changes that match the specs in `worktree_changes`.
 ///
 /// If whole files should be discarded, be sure to not pass any [hunks](but_workspace::discard::ui::DiscardSpec::hunk_headers)
 ///
 /// Returns the `worktree_changes` that couldn't be applied,
+#[api_cmd]
 pub fn discard_worktree_changes(
-    params: DiscardWorktreeChangesParams,
+    project_id: ProjectId,
+    worktree_changes: Vec<but_workspace::DiffSpec>,
 ) -> Result<Vec<but_workspace::DiffSpec>, Error> {
-    let project = gitbutler_project::get(params.project_id)?;
+    let project = gitbutler_project::get(project_id)?;
     let repo = but_core::open_repo(project.worktree_path())?;
     let ctx = CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
     let mut guard = project.exclusive_worktree_access();
@@ -274,7 +234,7 @@ pub fn discard_worktree_changes(
     );
     let refused = but_workspace::discard_workspace_changes(
         &repo,
-        params.worktree_changes,
+        worktree_changes,
         ctx.app_settings().context_lines,
     )?;
     if !refused.is_empty() {
@@ -301,21 +261,16 @@ impl From<MoveChangesResult> for UIMoveChangesResult {
     }
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct MoveChangesBetweenCommitsParams {
-    pub project_id: ProjectId,
-    pub source_stack_id: StackId,
-    pub source_commit_id: HexHash,
-    pub destination_stack_id: StackId,
-    pub destination_commit_id: HexHash,
-    pub changes: Vec<but_workspace::DiffSpec>,
-}
-
+#[api_cmd]
 pub fn move_changes_between_commits(
-    params: MoveChangesBetweenCommitsParams,
+    project_id: ProjectId,
+    source_stack_id: StackId,
+    source_commit_id: HexHash,
+    destination_stack_id: StackId,
+    destination_commit_id: HexHash,
+    changes: Vec<but_workspace::DiffSpec>,
 ) -> Result<UIMoveChangesResult, Error> {
-    let project = gitbutler_project::get(params.project_id)?;
+    let project = gitbutler_project::get(project_id)?;
     let ctx = CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
     let mut guard = project.exclusive_worktree_access();
 
@@ -325,11 +280,11 @@ pub fn move_changes_between_commits(
     );
     let result = but_workspace::move_changes_between_commits(
         &ctx,
-        params.source_stack_id,
-        params.source_commit_id.into(),
-        params.destination_stack_id,
-        params.destination_commit_id.into(),
-        params.changes,
+        source_stack_id,
+        source_commit_id.into(),
+        destination_stack_id,
+        destination_commit_id.into(),
+        changes,
         ctx.app_settings().context_lines,
     )?;
 
@@ -339,18 +294,15 @@ pub fn move_changes_between_commits(
     Ok(result.into())
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SplitBranchParams {
-    pub project_id: ProjectId,
-    pub source_stack_id: StackId,
-    pub source_branch_name: String,
-    pub new_branch_name: String,
-    pub file_changes_to_split_off: Vec<String>,
-}
-
-pub fn split_branch(params: SplitBranchParams) -> Result<UIMoveChangesResult, Error> {
-    let project = gitbutler_project::get(params.project_id)?;
+#[api_cmd]
+pub fn split_branch(
+    project_id: ProjectId,
+    source_stack_id: StackId,
+    source_branch_name: String,
+    new_branch_name: String,
+    file_changes_to_split_off: Vec<String>,
+) -> Result<UIMoveChangesResult, Error> {
+    let project = gitbutler_project::get(project_id)?;
     let ctx = CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
     let mut guard = project.exclusive_worktree_access();
 
@@ -361,17 +313,17 @@ pub fn split_branch(params: SplitBranchParams) -> Result<UIMoveChangesResult, Er
 
     let (_, move_changes_result) = but_workspace::split_branch(
         &ctx,
-        params.source_stack_id,
-        params.source_branch_name,
-        params.new_branch_name.clone(),
-        &params.file_changes_to_split_off,
+        source_stack_id,
+        source_branch_name,
+        new_branch_name.clone(),
+        &file_changes_to_split_off,
         ctx.app_settings().context_lines,
     )?;
 
     let vb_state = VirtualBranchesHandle::new(ctx.project().gb_dir());
     update_workspace_commit(&vb_state, &ctx)?;
 
-    let refname = Refname::Local(LocalRefname::new(&params.new_branch_name, None));
+    let refname = Refname::Local(LocalRefname::new(&new_branch_name, None));
     let branch_manager = ctx.branch_manager();
     branch_manager.create_virtual_branch_from_branch(
         &refname,
@@ -383,20 +335,15 @@ pub fn split_branch(params: SplitBranchParams) -> Result<UIMoveChangesResult, Er
     Ok(move_changes_result.into())
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SplitBranchIntoDependentBranchParams {
-    pub project_id: ProjectId,
-    pub source_stack_id: StackId,
-    pub source_branch_name: String,
-    pub new_branch_name: String,
-    pub file_changes_to_split_off: Vec<String>,
-}
-
+#[api_cmd]
 pub fn split_branch_into_dependent_branch(
-    params: SplitBranchIntoDependentBranchParams,
+    project_id: ProjectId,
+    source_stack_id: StackId,
+    source_branch_name: String,
+    new_branch_name: String,
+    file_changes_to_split_off: Vec<String>,
 ) -> Result<UIMoveChangesResult, Error> {
-    let project = gitbutler_project::get(params.project_id)?;
+    let project = gitbutler_project::get(project_id)?;
     let ctx = CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
     let mut guard = project.exclusive_worktree_access();
 
@@ -407,10 +354,10 @@ pub fn split_branch_into_dependent_branch(
 
     let move_changes_result = but_workspace::split_into_dependent_branch(
         &ctx,
-        params.source_stack_id,
-        params.source_branch_name,
-        params.new_branch_name.clone(),
-        &params.file_changes_to_split_off,
+        source_stack_id,
+        source_branch_name,
+        new_branch_name.clone(),
+        &file_changes_to_split_off,
         ctx.app_settings().context_lines,
     )?;
 
@@ -420,23 +367,20 @@ pub fn split_branch_into_dependent_branch(
     Ok(move_changes_result.into())
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct UncommitChangesParams {
-    pub project_id: ProjectId,
-    pub stack_id: StackId,
-    pub commit_id: HexHash,
-    pub changes: Vec<but_workspace::DiffSpec>,
-    pub assign_to: Option<StackId>,
-}
-
 /// Uncommits the changes specified in the `diffspec`.
 ///
 /// If `assign_to` is provided, the changes will be assigned to the stack
 /// specified.
 /// If `assign_to` is not provided, the changes will be unassigned.
-pub fn uncommit_changes(params: UncommitChangesParams) -> Result<UIMoveChangesResult, Error> {
-    let project = gitbutler_project::get(params.project_id)?;
+#[api_cmd]
+pub fn uncommit_changes(
+    project_id: ProjectId,
+    stack_id: StackId,
+    commit_id: HexHash,
+    changes: Vec<but_workspace::DiffSpec>,
+    assign_to: Option<StackId>,
+) -> Result<UIMoveChangesResult, Error> {
+    let project = gitbutler_project::get(project_id)?;
     let mut ctx = CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
     let mut guard = project.exclusive_worktree_access();
 
@@ -453,7 +397,7 @@ pub fn uncommit_changes(params: UncommitChangesParams) -> Result<UIMoveChangesRe
     // As such, we take all the old assignments, and all the new assignments from after the
     // uncommit, and find the ones that are not present in the old assignments.
     // We then convert those into assignment requests for the given stack.
-    let before_assignments = if params.assign_to.is_some() {
+    let before_assignments = if assign_to.is_some() {
         let changes = but_hunk_assignment::assignments_with_fallback(
             &mut ctx,
             false,
@@ -467,16 +411,16 @@ pub fn uncommit_changes(params: UncommitChangesParams) -> Result<UIMoveChangesRe
 
     let result = but_workspace::remove_changes_from_commit_in_stack(
         &ctx,
-        params.stack_id,
-        params.commit_id.into(),
-        params.changes,
+        stack_id,
+        commit_id.into(),
+        changes,
         ctx.app_settings().context_lines,
     )?;
 
     let vb_state = VirtualBranchesHandle::new(ctx.project().gb_dir());
     update_workspace_commit(&vb_state, &ctx)?;
 
-    if let (Some(before_assignments), Some(stack_id)) = (before_assignments, params.assign_to) {
+    if let (Some(before_assignments), Some(stack_id)) = (before_assignments, assign_to) {
         let (after_assignments, _) = but_hunk_assignment::assignments_with_fallback(
             &mut ctx,
             false,
@@ -505,34 +449,29 @@ pub fn uncommit_changes(params: UncommitChangesParams) -> Result<UIMoveChangesRe
     Ok(result.into())
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StashIntoBranchParams {
-    pub project_id: ProjectId,
-    pub branch_name: String,
-    pub worktree_changes: Vec<but_workspace::DiffSpec>,
-}
-
 /// This API allows the user to quickly "stash" a bunch of uncommitted changes - getting them out of the worktree.
 /// Unlike the regular stash, the user specifies a new branch where those changes will be 'saved'/committed.
 /// Immediatelly after the changes are committed, the branch is unapplied from the workspace, and the "stash" branch can be re-applied at a later time
 /// In theory it should be possible to specify an existing "dumping" branch for this, but currently this endpoint expects a new branch.
+#[api_cmd]
 pub fn stash_into_branch(
-    params: StashIntoBranchParams,
+    project_id: ProjectId,
+    branch_name: String,
+    worktree_changes: Vec<but_workspace::DiffSpec>,
 ) -> Result<commit_engine::ui::CreateCommitOutcome, Error> {
-    let project = gitbutler_project::get(params.project_id)?;
+    let project = gitbutler_project::get(project_id)?;
     let ctx = CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
     let repo = ctx.gix_repo_for_merging()?;
 
     let mut guard = project.exclusive_worktree_access();
     let perm = guard.write_permission();
 
-    let _ = ctx.snapshot_stash_into_branch(params.branch_name.clone(), perm);
+    let _ = ctx.snapshot_stash_into_branch(branch_name.clone(), perm);
 
     let branch_manager = ctx.branch_manager();
     let stack = branch_manager.create_virtual_branch(
         &gitbutler_branch::BranchCreateRequest {
-            name: Some(params.branch_name.clone()),
+            name: Some(branch_name.clone()),
             ..Default::default()
         },
         perm,
@@ -556,7 +495,7 @@ pub fn stash_into_branch(
             }),
         },
         None,
-        params.worktree_changes,
+        worktree_changes,
         ctx.app_settings().context_lines,
         perm,
     );
@@ -571,16 +510,11 @@ pub fn stash_into_branch(
     Ok(outcome.into())
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CannedBranchNameParams {
-    pub project_id: ProjectId,
-}
-
 /// Returns a new available branch name based on a simple template - user_initials-branch-count
 /// The main point of this is to be able to provide branch names that are not already taken.
-pub fn canned_branch_name(params: CannedBranchNameParams) -> Result<String, Error> {
-    let project = gitbutler_project::get(params.project_id)?;
+#[api_cmd]
+pub fn canned_branch_name(project_id: ProjectId) -> Result<String, Error> {
+    let project = gitbutler_project::get(project_id)?;
     let ctx = CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
     let template = gitbutler_stack::canned_branch_name(ctx.repo())?;
     let state = VirtualBranchesHandle::new(ctx.project().gb_dir());
@@ -588,23 +522,18 @@ pub fn canned_branch_name(params: CannedBranchNameParams) -> Result<String, Erro
         .map_err(Into::into)
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TargetCommitsParams {
-    pub project_id: ProjectId,
-    pub last_commit_id: Option<HexHash>,
-    pub page_size: Option<usize>,
-}
-
+#[api_cmd]
 pub fn target_commits(
-    params: TargetCommitsParams,
+    project_id: ProjectId,
+    last_commit_id: Option<HexHash>,
+    page_size: Option<usize>,
 ) -> Result<Vec<but_workspace::ui::Commit>, Error> {
-    let project = gitbutler_project::get(params.project_id)?;
+    let project = gitbutler_project::get(project_id)?;
     let ctx = CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
     but_workspace::log_target_first_parent(
         &ctx,
-        params.last_commit_id.map(|id| id.into()),
-        params.page_size.unwrap_or(30),
+        last_commit_id.map(|id| id.into()),
+        page_size.unwrap_or(30),
     )
     .map_err(Into::into)
 }

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -184,32 +184,29 @@ async fn handle_command(
         "changes_in_worktree" => run_cmd(request.params, diff::changes_in_worktree),
         "assign_hunk" => run_cmd(request.params, diff::assign_hunk),
         // Workspace commands
-        "stacks" => run_cmd(request.params, workspace::stacks),
+        "stacks" => workspace::stacks_cmd(request.params),
         #[cfg(unix)]
         "show_graph_svg" => run_cmd(request.params, workspace::show_graph_svg),
-        "stack_details" => run_cmd(request.params, workspace::stack_details),
-        "branch_details" => run_cmd(request.params, workspace::branch_details),
-        "create_commit_from_worktree_changes" => run_cmd(
-            request.params,
-            workspace::create_commit_from_worktree_changes,
-        ),
-        "amend_commit_from_worktree_changes" => run_cmd(
-            request.params,
-            workspace::amend_commit_from_worktree_changes,
-        ),
-        "discard_worktree_changes" => run_cmd(request.params, workspace::discard_worktree_changes),
-        "move_changes_between_commits" => {
-            run_cmd(request.params, workspace::move_changes_between_commits)
+        "stack_details" => workspace::stack_details_cmd(request.params),
+        "branch_details" => workspace::branch_details_cmd(request.params),
+        "create_commit_from_worktree_changes" => {
+            workspace::create_commit_from_worktree_changes_cmd(request.params)
         }
-        "split_branch" => run_cmd(request.params, workspace::split_branch),
-        "split_branch_into_dependent_branch" => run_cmd(
-            request.params,
-            workspace::split_branch_into_dependent_branch,
-        ),
-        "uncommit_changes" => run_cmd(request.params, workspace::uncommit_changes),
-        "stash_into_branch" => run_cmd(request.params, workspace::stash_into_branch),
-        "canned_branch_name" => run_cmd(request.params, workspace::canned_branch_name),
-        "target_commits" => run_cmd(request.params, workspace::target_commits),
+        "amend_commit_from_worktree_changes" => {
+            workspace::amend_commit_from_worktree_changes_cmd(request.params)
+        }
+        "discard_worktree_changes" => workspace::discard_worktree_changes_cmd(request.params),
+        "move_changes_between_commits" => {
+            workspace::move_changes_between_commits_cmd(request.params)
+        }
+        "split_branch" => workspace::split_branch_cmd(request.params),
+        "split_branch_into_dependent_branch" => {
+            workspace::split_branch_into_dependent_branch_cmd(request.params)
+        }
+        "uncommit_changes" => workspace::uncommit_changes_cmd(request.params),
+        "stash_into_branch" => workspace::stash_into_branch_cmd(request.params),
+        "canned_branch_name" => workspace::canned_branch_name_cmd(request.params),
+        "target_commits" => workspace::target_commits_cmd(request.params),
         // App settings
         "get_app_settings" => run_cmd(request.params, settings::get_app_settings),
         "update_onboarding_complete" => {

--- a/crates/gitbutler-tauri/src/workspace.rs
+++ b/crates/gitbutler-tauri/src/workspace.rs
@@ -1,10 +1,4 @@
-use but_api::commands::workspace::{
-    self, AmendCommitFromWorktreeChangesParams, BranchDetailsParams, CannedBranchNameParams,
-    CreateCommitFromWorktreeChangesParams, DiscardWorktreeChangesParams,
-    MoveChangesBetweenCommitsParams, ShowGraphSvgParams, SplitBranchIntoDependentBranchParams,
-    SplitBranchParams, StackDetailsParams, StacksParams, StashIntoBranchParams,
-    TargetCommitsParams, UIMoveChangesResult, UncommitChangesParams,
-};
+use but_api::commands::workspace::{self, UIMoveChangesResult};
 use but_api::error::Error;
 use but_api::hex_hash::HexHash;
 use but_workspace::StacksFilter;
@@ -19,14 +13,14 @@ pub fn stacks(
     project_id: ProjectId,
     filter: Option<StacksFilter>,
 ) -> Result<Vec<StackEntry>, Error> {
-    workspace::stacks(StacksParams { project_id, filter })
+    workspace::stacks(project_id, filter)
 }
 
 #[cfg(unix)]
 #[tauri::command(async)]
 #[instrument(err(Debug))]
 pub fn show_graph_svg(project_id: ProjectId) -> Result<(), Error> {
-    workspace::show_graph_svg(ShowGraphSvgParams { project_id })
+    workspace::show_graph_svg(project_id)
 }
 
 #[tauri::command(async)]
@@ -35,10 +29,7 @@ pub fn stack_details(
     project_id: ProjectId,
     stack_id: Option<StackId>,
 ) -> Result<but_workspace::ui::StackDetails, Error> {
-    workspace::stack_details(StackDetailsParams {
-        project_id,
-        stack_id,
-    })
+    workspace::stack_details(project_id, stack_id)
 }
 
 #[tauri::command(async)]
@@ -48,11 +39,7 @@ pub fn branch_details(
     branch_name: String,
     remote: Option<String>,
 ) -> Result<but_workspace::ui::BranchDetails, Error> {
-    workspace::branch_details(BranchDetailsParams {
-        project_id,
-        branch_name,
-        remote,
-    })
+    workspace::branch_details(project_id, branch_name, remote)
 }
 
 #[tauri::command(async)]
@@ -65,14 +52,14 @@ pub fn create_commit_from_worktree_changes(
     message: String,
     stack_branch_name: String,
 ) -> Result<commit_engine::ui::CreateCommitOutcome, Error> {
-    workspace::create_commit_from_worktree_changes(CreateCommitFromWorktreeChangesParams {
+    workspace::create_commit_from_worktree_changes(
         project_id,
         stack_id,
         parent_id,
         worktree_changes,
         message,
         stack_branch_name,
-    })
+    )
 }
 
 #[tauri::command(async)]
@@ -83,12 +70,7 @@ pub fn amend_commit_from_worktree_changes(
     commit_id: HexHash,
     worktree_changes: Vec<but_workspace::DiffSpec>,
 ) -> Result<commit_engine::ui::CreateCommitOutcome, Error> {
-    workspace::amend_commit_from_worktree_changes(AmendCommitFromWorktreeChangesParams {
-        project_id,
-        stack_id,
-        commit_id,
-        worktree_changes,
-    })
+    workspace::amend_commit_from_worktree_changes(project_id, stack_id, commit_id, worktree_changes)
 }
 
 #[tauri::command(async)]
@@ -97,10 +79,7 @@ pub fn discard_worktree_changes(
     project_id: ProjectId,
     worktree_changes: Vec<but_workspace::DiffSpec>,
 ) -> Result<Vec<but_workspace::DiffSpec>, Error> {
-    workspace::discard_worktree_changes(DiscardWorktreeChangesParams {
-        project_id,
-        worktree_changes,
-    })
+    workspace::discard_worktree_changes(project_id, worktree_changes)
 }
 
 #[tauri::command(async)]
@@ -113,14 +92,14 @@ pub fn move_changes_between_commits(
     destination_commit_id: HexHash,
     changes: Vec<but_workspace::DiffSpec>,
 ) -> Result<UIMoveChangesResult, Error> {
-    workspace::move_changes_between_commits(MoveChangesBetweenCommitsParams {
+    workspace::move_changes_between_commits(
         project_id,
         source_stack_id,
         source_commit_id,
         destination_stack_id,
         destination_commit_id,
         changes,
-    })
+    )
 }
 
 #[tauri::command(async)]
@@ -132,13 +111,13 @@ pub fn split_branch(
     new_branch_name: String,
     file_changes_to_split_off: Vec<String>,
 ) -> Result<UIMoveChangesResult, Error> {
-    workspace::split_branch(SplitBranchParams {
+    workspace::split_branch(
         project_id,
         source_stack_id,
         source_branch_name,
         new_branch_name,
         file_changes_to_split_off,
-    })
+    )
 }
 
 #[tauri::command(async)]
@@ -150,13 +129,13 @@ pub fn split_branch_into_dependent_branch(
     new_branch_name: String,
     file_changes_to_split_off: Vec<String>,
 ) -> Result<UIMoveChangesResult, Error> {
-    workspace::split_branch_into_dependent_branch(SplitBranchIntoDependentBranchParams {
+    workspace::split_branch_into_dependent_branch(
         project_id,
         source_stack_id,
         source_branch_name,
         new_branch_name,
         file_changes_to_split_off,
-    })
+    )
 }
 
 #[tauri::command(async)]
@@ -168,13 +147,7 @@ pub fn uncommit_changes(
     changes: Vec<but_workspace::DiffSpec>,
     assign_to: Option<StackId>,
 ) -> Result<UIMoveChangesResult, Error> {
-    workspace::uncommit_changes(UncommitChangesParams {
-        project_id,
-        stack_id,
-        commit_id,
-        changes,
-        assign_to,
-    })
+    workspace::uncommit_changes(project_id, stack_id, commit_id, changes, assign_to)
 }
 
 #[tauri::command(async)]
@@ -184,17 +157,13 @@ pub fn stash_into_branch(
     branch_name: String,
     worktree_changes: Vec<but_workspace::DiffSpec>,
 ) -> Result<commit_engine::ui::CreateCommitOutcome, Error> {
-    workspace::stash_into_branch(StashIntoBranchParams {
-        project_id,
-        branch_name,
-        worktree_changes,
-    })
+    workspace::stash_into_branch(project_id, branch_name, worktree_changes)
 }
 
 #[tauri::command(async)]
 #[instrument(err(Debug))]
 pub fn canned_branch_name(project_id: ProjectId) -> Result<String, Error> {
-    workspace::canned_branch_name(CannedBranchNameParams { project_id })
+    workspace::canned_branch_name(project_id)
 }
 
 #[tauri::command(async)]
@@ -204,9 +173,5 @@ pub fn target_commits(
     last_commit_id: Option<HexHash>,
     page_size: Option<usize>,
 ) -> Result<Vec<but_workspace::ui::Commit>, Error> {
-    workspace::target_commits(TargetCommitsParams {
-        project_id,
-        last_commit_id,
-        page_size,
-    })
+    workspace::target_commits(project_id, last_commit_id, page_size)
 }


### PR DESCRIPTION
This is a continuation from https://github.com/gitbutlerapp/gitbutler/pull/10093 where it removed an unnecessary `app` dependency that was being passed in all commands for no reason. 

The aim here is to further simplify the functions that we create in `but-api` such that they can be conveniently used from various high level sources:
- tauri commands
- but-server endpoints (electron)
- but (CLI)
- AI/Agent tools
- Tests 

The `but-api` functions already give us a high level functions/ surface area, so the aim here is to make that conveniently usable without having to create "params" structs for all functions.

This uses the `workspace` module as the starting point, with the intention of converting all funcs in a follow up PR