### PR TITLE
Fix dropzone activation for assignments

### DIFF
--- a/apps/desktop/src/components/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/WorktreeChanges.svelte
@@ -75,13 +75,7 @@
 	let scrollTopIsVisible = $state(true);
 
 	const assignmentDZHandler = $derived(
-		new AssignmentDropHandler(
-			projectId,
-			diffService,
-			uncommittedService,
-			stackId || null,
-			idSelection
-		)
+		new AssignmentDropHandler(projectId, diffService, uncommittedService, stackId, idSelection)
 	);
 
 	function getDropzoneLabel(handler: DropzoneHandler | undefined): string {

--- a/apps/desktop/src/lib/hunks/dropHandler.ts
+++ b/apps/desktop/src/lib/hunks/dropHandler.ts
@@ -9,7 +9,7 @@ export class AssignmentDropHandler implements DropzoneHandler {
 		private readonly projectId: string,
 		private readonly diffService: DiffService,
 		private readonly uncommittedService: UncommittedService,
-		private readonly stackId: string | null,
+		private readonly stackId: string | undefined,
 		private readonly idSelection: IdSelection
 	) {}
 
@@ -29,12 +29,13 @@ export class AssignmentDropHandler implements DropzoneHandler {
 	}
 
 	async ondrop(data: ChangeDropData | HunkDropDataV3) {
+		if (data.stackId === this.stackId) return;
 		if (data instanceof ChangeDropData) {
 			// A whole file.
 			const changes = await data.treeChanges();
 			const assignments = changes
 				.flatMap((c) => this.uncommittedService.getAssignmentsByPath(data.stackId || null, c.path))
-				.map((h) => ({ ...h, stackId: this.stackId }));
+				.map((h) => ({ ...h, stackId: this.stackId || null }));
 			await this.diffService.assignHunk({
 				projectId: this.projectId,
 				assignments
@@ -54,7 +55,7 @@ export class AssignmentDropHandler implements DropzoneHandler {
 			);
 			await this.diffService.assignHunk({
 				projectId: this.projectId,
-				assignments: [{ ...assignment, stackId: this.stackId }]
+				assignments: [{ ...assignment, stackId: this.stackId || null }]
 			});
 
 			// If we just moved the last assignment, remove the file from the selection.


### PR DESCRIPTION
Fixes bug where a file would deselect if dropped into its own zone, and 
the fix is to never activate that zone in the first place. This was 
caused by a null to undefined comparison.