### PR TITLE
Remove `rust_2018_idioms` declarations

### DIFF
--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs, rust_2018_idioms)]
+#![deny(missing_docs)]
 //! The basic primitives that GitButler is built around.
 //!
 //! It also is a catch-all for code until it's worth putting it into its own crate.

--- a/crates/but-hunk-dependency/src/lib.rs
+++ b/crates/but-hunk-dependency/src/lib.rs
@@ -1,5 +1,5 @@
 #![feature(unsigned_signed_diff)]
-#![deny(missing_docs, rust_2018_idioms)]
+#![deny(missing_docs)]
 
 //! ## Module Guidelines
 //!

--- a/crates/but-testing/src/main.rs
+++ b/crates/but-testing/src/main.rs
@@ -1,5 +1,4 @@
 //! A debug-CLI for making `but`-crates functionality available in real-world repositories.
-#![deny(rust_2018_idioms)]
 use std::{path::PathBuf, str::FromStr};
 
 use anyhow::{Context, Result, bail};

--- a/crates/gitbutler-filemonitor/src/lib.rs
+++ b/crates/gitbutler-filemonitor/src/lib.rs
@@ -1,5 +1,5 @@
 //! Implement the file-monitoring agent that informs about changes in interesting locations.
-#![deny(unsafe_code, rust_2018_idioms)]
+#![deny(unsafe_code)]
 #![allow(clippy::doc_markdown, clippy::missing_errors_doc)]
 
 mod events;

--- a/crates/gitbutler-repo/src/commit_message.rs
+++ b/crates/gitbutler-repo/src/commit_message.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use bstr::{BString, ByteSlice as _, ByteVec as _};
 
 pub struct CommitMessage {

--- a/crates/gitbutler-sync/src/stack_upload.rs
+++ b/crates/gitbutler-sync/src/stack_upload.rs
@@ -1,5 +1,3 @@
-#![forbid(rust_2018_idioms)]
-
 use anyhow::{bail, Result};
 // A happy little module for uploading stacks.
 

--- a/crates/gitbutler-testsupport/src/lib.rs
+++ b/crates/gitbutler-testsupport/src/lib.rs
@@ -1,4 +1,3 @@
-#![forbid(rust_2018_idioms)]
 pub const VAR_NO_CLEANUP: &str = "GITBUTLER_TESTS_NO_CLEANUP";
 
 use but_graph::VirtualBranchesTomlMetadata;

--- a/crates/gitbutler-watcher/src/lib.rs
+++ b/crates/gitbutler-watcher/src/lib.rs
@@ -1,5 +1,5 @@
 //! Implement the file-monitoring agent that informs about changes in interesting locations.
-#![deny(unsafe_code, rust_2018_idioms)]
+#![deny(unsafe_code)]
 #![allow(clippy::doc_markdown, clippy::missing_errors_doc)]
 
 use std::path::Path;


### PR DESCRIPTION
They are superseded by a much better `clippy` which forces you to add annotations only when they are meaningful, leading to less noisy code overall without any disadvantages.
