### PR TITLE
Persist 'dont delete' branch preferences in IntegrateUpstreamModal

### DIFF
--- a/packages/shared/src/lib/persisted.ts
+++ b/packages/shared/src/lib/persisted.ts
@@ -19,8 +19,24 @@ export function getStorageItem(key: string): unknown {
 	}
 }
 
+export function getBooleanStorageItem(key: string): boolean | undefined {
+	const item = getStorageItem(key);
+	if (typeof item === 'boolean') {
+		return item;
+	}
+	return undefined;
+}
+
 export function setStorageItem(key: string, value: unknown): void {
 	window.localStorage.setItem(key, JSON.stringify(value));
+}
+
+export function setBooleanStorageItem(key: string, value: boolean): void {
+	setStorageItem(key, value);
+}
+
+export function removeStorageItem(key: string): void {
+	window.localStorage.removeItem(key);
 }
 
 export function persisted<T>(initial: T, key: string): Persisted<T> {


### PR DESCRIPTION
Persist whether a branch should be deleted by default on integration

Changes in IntegrateUpstreamModal.svelte:
- Import getBooleanStorageItem, setBooleanStorageItem, and removeStorageItem from @gitbutler/shared/persisted.
- Add helper getDontDeleteBranchStorageKey(projectId, branchName) to derive storage keys for branch preferences.
- Add someBranchesShouldNotBeDeleted(branchNames) to check stored preferences for a list of branches and return true if any should not be deleted.
- Update results construction to set deleteIntegratedBranches based on stored preferences (deleteIntegratedBranches: !dontDelete).
- Refactor updateBranchShouldBeDeletedMap to accept branchNames: string[] and set/remove persistent flags per branch; still updates in-memory results map.
- Update call site of updateBranchShouldBeDeletedMap to pass branchNames and preserve previous behavior.

Changes in packages/shared/src/lib/persisted.ts:
- Add getBooleanStorageItem(key) which returns a boolean or undefined if not set or not a boolean.
- Add setBooleanStorageItem(key, value) which delegates to setStorageItem.
- Add removeStorageItem(key) to remove keys from localStorage.
- Ensure setStorageItem and getStorageItem usages remain consistent.

These changes group related UI behavior updates and persistence helpers together: UI reads/writes persistent "dont delete" preferences and shared utilities provide the storage API.