### PR TITLE
Graceful handling of project add (+ e2e tests)

### DIFF
--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -8,6 +8,7 @@
 	import { ircEnabled } from '$lib/config/uiFeatureFlags';
 	import { IRC_SERVICE } from '$lib/irc/ircService.svelte';
 	import { MODE_SERVICE } from '$lib/mode/modeService';
+	import { handleAddProjectOutcome } from '$lib/project/project';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
 	import { ircPath, projectPath, isWorkspacePath } from '$lib/routes/routes.svelte';
 	import { UI_STATE } from '$lib/state/uiState.svelte';
@@ -183,13 +184,14 @@
 						onClick={async () => {
 							newProjectLoading = true;
 							try {
-								const project = await projectsService.addProject();
-								if (!project) {
+								const outcome = await projectsService.addProject();
+								if (!outcome) {
 									// User cancelled the project creation
 									newProjectLoading = false;
 									return;
 								}
-								goto(projectPath(project.id));
+
+								handleAddProjectOutcome(outcome, (project) => goto(projectPath(project.id)));
 							} finally {
 								newProjectLoading = false;
 							}
@@ -223,7 +225,7 @@
 		</div>
 
 		{#if isNotInWorkspace}
-			<Tooltip text="Switch back to gitButler/workspace">
+			<Tooltip text="Switch back to gitbutler/workspace">
 				<Button
 					kind="outline"
 					icon="undo"

--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -156,6 +156,7 @@
 			>
 				{#snippet customSelectButton()}
 					<Button
+						testId={TestId.ChromeHeaderProjectSelector}
 						reversedDirection
 						width="auto"
 						kind="outline"
@@ -180,6 +181,7 @@
 				<OptionsGroup>
 					<SelectItem
 						icon="plus"
+						testId={TestId.ChromeHeaderProjectSelectorAddLocalProject}
 						loading={newProjectLoading}
 						onClick={async () => {
 							newProjectLoading = true;

--- a/apps/desktop/src/components/CloneForm.svelte
+++ b/apps/desktop/src/components/CloneForm.svelte
@@ -5,6 +5,7 @@
 	import { POSTHOG_WRAPPER } from '$lib/analytics/posthog';
 	import { BACKEND } from '$lib/backend';
 	import { GIT_SERVICE } from '$lib/git/gitService';
+	import { handleAddProjectOutcome } from '$lib/project/project';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
 	import { projectPath } from '$lib/routes/routes.svelte';
 	import { parseRemoteUrl } from '$lib/url/gitUrl';
@@ -87,11 +88,12 @@
 			await gitService.cloneRepo(repositoryUrl, targetDir);
 
 			posthog.capture('Repository Cloned', { protocol: remoteUrl.protocol });
-			const project = await projectsService.addProject(targetDir);
-			if (!project) {
+			const outcome = await projectsService.addProject(targetDir);
+			if (!outcome) {
 				throw new Error('Failed to add project after cloning.');
 			}
-			goto(projectPath(project.id));
+
+			handleAddProjectOutcome(outcome, (project) => goto(projectPath(project.id)));
 		} catch (e) {
 			Sentry.captureException(e);
 			const errorMessage = getErrorMessage(e);

--- a/apps/desktop/src/components/FileMenuAction.svelte
+++ b/apps/desktop/src/components/FileMenuAction.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { handleAddProjectOutcome } from '$lib/project/project';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
 	import { clonePath, projectPath } from '$lib/routes/routes.svelte';
 	import { SHORTCUT_SERVICE } from '$lib/shortcuts/shortcutService';
@@ -12,12 +13,12 @@
 	$effect(() =>
 		mergeUnlisten(
 			shortcutService.on('add-local-repo', async () => {
-				const project = await projectsService.addProject();
-				if (!project) {
+				const outcome = await projectsService.addProject();
+				if (!outcome) {
 					// User cancelled the project creation
 					return;
 				}
-				goto(projectPath(project.id));
+				handleAddProjectOutcome(outcome, (project) => goto(projectPath(project.id)));
 			}),
 			shortcutService.on('clone-repo', async () => {
 				goto(clonePath());

--- a/apps/desktop/src/components/InfoMessage.svelte
+++ b/apps/desktop/src/components/InfoMessage.svelte
@@ -20,11 +20,14 @@
 		filled?: boolean;
 		primaryLabel?: string | undefined;
 		primaryIcon?: IconName | undefined;
+		primaryTestId?: string | undefined;
 		primaryAction?: () => void;
 		secondaryLabel?: string | undefined;
 		secondaryIcon?: IconName | undefined;
+		secondaryTestId?: string | undefined;
 		secondaryAction?: () => void;
 		tertiaryLabel?: string | undefined;
+		tertiaryTestId?: string | undefined;
 		tertiaryIcon?: IconName | undefined;
 		tertiaryAction?: () => void;
 		shadow?: boolean;
@@ -41,12 +44,15 @@
 		filled = false,
 		primaryLabel = '',
 		primaryIcon,
+		primaryTestId,
 		primaryAction,
 		secondaryLabel = '',
 		secondaryIcon,
+		secondaryTestId,
 		secondaryAction,
 		tertiaryLabel = '',
 		tertiaryIcon,
+		tertiaryTestId,
 		tertiaryAction,
 		shadow = false,
 		error,
@@ -121,12 +127,22 @@
 					</Button>
 				{/if}
 				{#if tertiaryLabel}
-					<Button kind="outline" onclick={() => tertiaryAction?.()} icon={tertiaryIcon}>
+					<Button
+						kind="outline"
+						testId={tertiaryTestId}
+						onclick={() => tertiaryAction?.()}
+						icon={tertiaryIcon}
+					>
 						{tertiaryLabel}
 					</Button>
 				{/if}
 				{#if secondaryLabel}
-					<Button kind="outline" onclick={() => secondaryAction?.()} icon={secondaryIcon}>
+					<Button
+						kind="outline"
+						testId={secondaryTestId}
+						onclick={() => secondaryAction?.()}
+						icon={secondaryIcon}
+					>
 						{secondaryLabel}
 					</Button>
 				{/if}
@@ -135,6 +151,7 @@
 						style={primaryButtonMap[style]}
 						onclick={() => primaryAction?.()}
 						icon={primaryIcon}
+						testId={primaryTestId}
 					>
 						{primaryLabel}
 					</Button>

--- a/apps/desktop/src/components/ProjectSwitcher.svelte
+++ b/apps/desktop/src/components/ProjectSwitcher.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { handleAddProjectOutcome } from '$lib/project/project';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
 	import { projectPath } from '$lib/routes/routes.svelte';
 	import { inject } from '@gitbutler/core/context';
@@ -47,13 +48,13 @@
 				onClick={async () => {
 					newProjectLoading = true;
 					try {
-						const project = await projectsService.addProject();
-						if (!project) {
+						const outcome = await projectsService.addProject();
+						if (!outcome) {
 							// User cancelled the project creation
 							newProjectLoading = false;
 							return;
 						}
-						goto(projectPath(project.id));
+						handleAddProjectOutcome(outcome, (project) => goto(projectPath(project.id)));
 					} finally {
 						newProjectLoading = false;
 					}

--- a/apps/desktop/src/components/ToastController.svelte
+++ b/apps/desktop/src/components/ToastController.svelte
@@ -11,10 +11,11 @@
 		{@const dismiss = () => dismissToast(toast.id)}
 		<div transition:slide={{ duration: 170 }}>
 			<InfoMessage
-				testId={TestId.ToastInfoMessage}
+				testId={toast.testId ?? TestId.ToastInfoMessage}
 				style={toast.style ?? 'neutral'}
 				error={toast.error}
 				secondaryLabel={toast.extraAction ? toast.extraAction.label : 'Dismiss'}
+				secondaryTestId={toast.extraAction ? toast.extraAction.testId : undefined}
 				secondaryAction={toast.extraAction ? () => toast.extraAction?.onClick(dismiss) : dismiss}
 				tertiaryLabel={toast.extraAction ? 'Dismiss' : undefined}
 				tertiaryAction={toast.extraAction ? dismiss : undefined}

--- a/apps/desktop/src/components/Welcome.svelte
+++ b/apps/desktop/src/components/Welcome.svelte
@@ -5,6 +5,7 @@
 	import WelcomeSigninAction from '$components/WelcomeSigninAction.svelte';
 	import cloneRepoSvg from '$lib/assets/welcome/clone-repo.svg?raw';
 	import newProjectSvg from '$lib/assets/welcome/new-local-project.svg?raw';
+	import { handleAddProjectOutcome } from '$lib/project/project';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
 	import { inject } from '@gitbutler/core/context';
 	import { TestId } from '@gitbutler/ui';
@@ -18,7 +19,11 @@
 		newProjectLoading = true;
 		try {
 			const testDirectoryPath = directoryInputElement?.value;
-			await projectsService.addProject(testDirectoryPath ?? '');
+			const outcome = await projectsService.addProject(testDirectoryPath ?? '');
+
+			if (outcome) {
+				handleAddProjectOutcome(outcome);
+			}
 		} finally {
 			newProjectLoading = false;
 		}

--- a/apps/desktop/src/lib/notifications/toasts.ts
+++ b/apps/desktop/src/lib/notifications/toasts.ts
@@ -5,11 +5,13 @@ import type { MessageStyle } from '$components/InfoMessage.svelte';
 
 type ExtraAction = {
 	label: string;
+	testId?: string;
 	onClick: (dismiss: () => void) => void;
 };
 
 export interface Toast {
 	id?: string;
+	testId?: string;
 	message?: string;
 	error?: any;
 	title?: string;

--- a/apps/desktop/src/lib/notifications/toasts.ts
+++ b/apps/desktop/src/lib/notifications/toasts.ts
@@ -25,12 +25,21 @@ let idCounter = 0;
 
 export function showToast(toast: Toast) {
 	if (toast.error) {
-		// TODO: Make toast a service, so we can inject posthog.
 		posthog.capture('toast:show_error', {
+			error_test_id: toast.testId,
 			error_title: toast.title,
 			error_message: String(toast.error)
 		});
 	}
+
+	if (toast.style === 'warning') {
+		posthog.capture('toast:show_warning', {
+			warning_test_id: toast.testId,
+			warning_title: toast.title,
+			warning_message: toast.message
+		});
+	}
+
 	toast.message = toast.message?.replace(/^ */gm, '');
 	toastStore.update((items) => [
 		...items.filter((t) => toast.id === undefined || t.id !== toast.id),

--- a/apps/desktop/src/lib/project/project.ts
+++ b/apps/desktop/src/lib/project/project.ts
@@ -1,3 +1,7 @@
+import { goto } from '$app/navigation';
+import { showToast } from '$lib/notifications/toasts';
+import { projectPath } from '$lib/routes/routes.svelte';
+import { TestId } from '@gitbutler/ui';
 import type { ForgeName } from '$lib/forge/interface/forge';
 
 export type KeyType = 'gitCredentialsHelper' | 'local' | 'systemExecutable';
@@ -48,3 +52,121 @@ export type CloudProject = {
 	created_at: string;
 	updated_at: string;
 };
+
+export type AddProjectOutcome =
+	| {
+			type: 'added';
+			subject: Project;
+	  }
+	| {
+			type: 'alreadyExists';
+			subject: Project;
+	  }
+	| {
+			type: 'pathNotFound';
+	  }
+	| {
+			type: 'notADirectory';
+	  }
+	| {
+			type: 'bareRepository';
+	  }
+	| {
+			type: 'nonMainWorktree';
+	  }
+	| {
+			type: 'noWorkdir';
+	  }
+	| {
+			type: 'noDotGitDirectory';
+	  }
+	| {
+			type: 'notAGitRepository';
+			/**
+			 * The error message received
+			 */
+			subject: string;
+	  };
+
+/**
+ * Correctly handle the outcome of an addProject operation by passing the project to the callback or
+ * showing toasts as necessary.
+ */
+export function handleAddProjectOutcome(
+	outcome: AddProjectOutcome,
+	onAdded?: (project: Project) => void
+): true {
+	switch (outcome.type) {
+		case 'added':
+			onAdded?.(outcome.subject);
+			return true;
+		case 'alreadyExists':
+			showToast({
+				testId: TestId.AddProjectAlreadyExistsModal,
+				style: 'warning',
+				title: `Project '${outcome.subject.title}' already exists`,
+				message: `The project at "${outcome.subject.path}" is already added`,
+				extraAction: {
+					label: 'Open project',
+					testId: TestId.AddProjectAlreadyExistsModalOpenProjectButton,
+					onClick: (dismiss) => {
+						goto(projectPath(outcome.subject.id));
+						dismiss();
+					}
+				}
+			});
+			return true;
+		case 'pathNotFound':
+			showToast({
+				style: 'warning',
+				title: 'Path not found',
+				message: 'The specified path does not exist on the filesystem.'
+			});
+			return true;
+		case 'notADirectory':
+			showToast({
+				style: 'warning',
+				title: 'Not a directory',
+				message: 'The specified path is not a directory.'
+			});
+			return true;
+		case 'bareRepository':
+			showToast({
+				testId: TestId.AddProjectBareRepoModal,
+				style: 'error',
+				title: 'Bare repository',
+				message: 'The specified path appears to be a bare Git repository and cannot be added.'
+			});
+			return true;
+		case 'nonMainWorktree':
+			showToast({
+				style: 'warning',
+				title: 'Non-main worktree',
+				message: 'The specified path is not the main worktree of the repository.'
+			});
+			return true;
+		case 'noWorkdir':
+			showToast({
+				style: 'warning',
+				title: 'No workdir',
+				message: 'The specified repository does not have a working directory.'
+			});
+			return true;
+		case 'noDotGitDirectory':
+			showToast({
+				testId: TestId.AddProjectNoDotGitDirectoryModal,
+				style: 'warning',
+				title: 'No .git directory',
+				message: 'The specified path does not contain a .git directory.'
+			});
+			return true;
+		case 'notAGitRepository':
+			showToast({
+				testId: TestId.AddProjectNotAGitRepoModal,
+				style: 'warning',
+				title: 'Not a Git repository',
+				message: `Unable to add project: ${outcome.subject}`
+			});
+			return true;
+	}
+}

--- a/apps/desktop/src/lib/project/projectsService.ts
+++ b/apps/desktop/src/lib/project/projectsService.ts
@@ -1,5 +1,5 @@
 import { showError } from '$lib/notifications/toasts';
-import { type Project } from '$lib/project/project';
+import { type AddProjectOutcome, type Project } from '$lib/project/project';
 import { invalidatesList, providesItem, providesList, ReduxTag } from '$lib/state/tags';
 import { getCookie } from '$lib/utils/cookies';
 import { InjectionToken } from '@gitbutler/core/context';
@@ -152,7 +152,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				query: (args) => args,
 				providesTags: (_result, _error, args) => providesItem(ReduxTag.Project, args.projectId)
 			}),
-			addProject: build.mutation<Project, { path: string }>({
+			addProject: build.mutation<AddProjectOutcome, { path: string }>({
 				extraOptions: { command: 'add_project' },
 				query: (args) => args,
 				invalidatesTags: () => [invalidatesList(ReduxTag.Project)]

--- a/crates/but-api/src/commands/projects.rs
+++ b/crates/but-api/src/commands/projects.rs
@@ -9,7 +9,7 @@ pub fn update_project(project: projects::UpdateRequest) -> Result<projects::Proj
 }
 
 #[api_cmd]
-pub fn add_project(path: PathBuf) -> Result<projects::Project, Error> {
+pub fn add_project(path: PathBuf) -> Result<projects::AddProjectOutcome, Error> {
     Ok(gitbutler_project::add(&path)?)
 }
 

--- a/crates/but-testing/src/command/project.rs
+++ b/crates/but-testing/src/command/project.rs
@@ -13,7 +13,9 @@ pub fn add(data_dir: PathBuf, path: PathBuf, refname: Option<RemoteRefname>) -> 
         .context("Only non-bare repositories can be added")?
         .to_owned()
         .canonicalize()?;
-    let project = gitbutler_project::add_with_path(data_dir, path)?;
+    let outcome = gitbutler_project::add_with_path(data_dir, path)?;
+    let project = outcome.try_project()?;
+
     let ctx = CommandContext::open(&project, AppSettings::default())?;
     if let Some(refname) = refname {
         gitbutler_branch_actions::set_base_branch(

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/init.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/init.rs
@@ -10,7 +10,8 @@ fn twice() {
 
     {
         let project = gitbutler_project::add_with_path(data_dir.path(), test_project.path())
-            .expect("failed to add project");
+            .expect("failed to add project")
+            .unwrap_project();
         let ctx = CommandContext::open(&project, AppSettings::default()).unwrap();
 
         gitbutler_branch_actions::set_base_branch(
@@ -26,8 +27,9 @@ fn twice() {
     }
 
     {
-        let project =
-            gitbutler_project::add_with_path(data_dir.path(), test_project.path()).unwrap();
+        let project = gitbutler_project::add_with_path(data_dir.path(), test_project.path())
+            .unwrap()
+            .unwrap_project();
         let ctx = CommandContext::open(&project, AppSettings::default()).unwrap();
         gitbutler_branch_actions::set_base_branch(
             &ctx,

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/mod.rs
@@ -31,8 +31,9 @@ impl Default for Test {
         let data_dir = paths::data_dir();
 
         let test_project = TestProject::default();
-        let project = gitbutler_project::add_with_path(data_dir.as_ref(), test_project.path())
+        let outcome = gitbutler_project::add_with_path(data_dir.as_ref(), test_project.path())
             .expect("failed to add project");
+        let project = outcome.unwrap_project();
         let ctx = CommandContext::open(&project, AppSettings::default()).unwrap();
 
         Self {

--- a/crates/gitbutler-cli/src/command/project.rs
+++ b/crates/gitbutler-cli/src/command/project.rs
@@ -26,7 +26,8 @@ pub fn add(data_dir: PathBuf, path: PathBuf, refname: Option<RemoteRefname>) -> 
         .context("Only non-bare repositories can be added")?
         .to_owned()
         .canonicalize()?;
-    let project = gitbutler_project::add_with_path(data_dir, path)?;
+    let outcome = gitbutler_project::add_with_path(data_dir, path)?;
+    let project = outcome.try_project()?;
     let ctx = CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
     if let Some(refname) = refname {
         gitbutler_branch_actions::set_base_branch(

--- a/crates/gitbutler-project/src/lib.rs
+++ b/crates/gitbutler-project/src/lib.rs
@@ -7,7 +7,9 @@ mod storage;
 use std::path::Path;
 
 use controller::Controller;
-pub use project::{ApiProject, AuthKey, CodePushState, FetchResult, Project, ProjectId};
+pub use project::{
+    AddProjectOutcome, ApiProject, AuthKey, CodePushState, FetchResult, Project, ProjectId,
+};
 pub use storage::UpdateRequest;
 
 /// A utility to be used from applications to optimize `git2` configuration.
@@ -60,13 +62,13 @@ pub fn update_with_path<P: AsRef<Path>>(
     controller.update(project)
 }
 
-pub fn add<P: AsRef<Path>>(path: P) -> anyhow::Result<Project> {
+pub fn add<P: AsRef<Path>>(path: P) -> anyhow::Result<AddProjectOutcome> {
     let controller = Controller::from_path(but_path::app_data_dir()?);
     controller.add(path)
 }
 
 /// Testing purpose only.
-pub fn add_with_path<P: AsRef<Path>>(data_dir: P, path: P) -> anyhow::Result<Project> {
+pub fn add_with_path<P: AsRef<Path>>(data_dir: P, path: P) -> anyhow::Result<AddProjectOutcome> {
     let controller = Controller::from_path(data_dir.as_ref());
     controller.add(path)
 }

--- a/crates/gitbutler-tauri/src/projects.rs
+++ b/crates/gitbutler-tauri/src/projects.rs
@@ -24,7 +24,7 @@ pub fn update_project(
 
 #[tauri::command(async)]
 #[instrument(err(Debug))]
-pub fn add_project(path: &path::Path) -> Result<gitbutler_project::Project, Error> {
+pub fn add_project(path: &path::Path) -> Result<gitbutler_project::AddProjectOutcome, Error> {
     projects::add_project(path.to_path_buf())
 }
 

--- a/crates/gitbutler-testsupport/src/lib.rs
+++ b/crates/gitbutler-testsupport/src/lib.rs
@@ -237,7 +237,9 @@ pub mod read_only {
         // Assure the project is valid the first time.
         let project = if was_inserted {
             let tmp = tempfile::TempDir::new()?;
-            gitbutler_project::add_with_path(tmp.path(), project_worktree_dir.as_path())?
+            let outcome =
+                gitbutler_project::add_with_path(tmp.path(), project_worktree_dir.as_path())?;
+            outcome.try_project()?
         } else {
             Project {
                 id: ProjectId::generate(),

--- a/crates/gitbutler-testsupport/src/suite.rs
+++ b/crates/gitbutler-testsupport/src/suite.rs
@@ -64,14 +64,14 @@ impl Suite {
         }
         commit_all(&repository);
 
-        (
-            gitbutler_project::add_with_path(
-                self.local_app_data(),
-                repository.path().parent().unwrap(),
-            )
-            .expect("failed to add project"),
-            tmp,
-        )
+        let outcome = gitbutler_project::add_with_path(
+            self.local_app_data(),
+            repository.path().parent().unwrap(),
+        );
+
+        let project = outcome.expect("failed to add project").unwrap_project();
+
+        (project, tmp)
     }
 
     pub fn new_case_with_files(&self, fs: HashMap<PathBuf, &str>) -> Case {

--- a/e2e/playwright/scripts/setup-empty-project-bare.sh
+++ b/e2e/playwright/scripts/setup-empty-project-bare.sh
@@ -16,11 +16,4 @@ popd
 
 # Clone the remote into a folder.
 # This is what we are going to add in the client
-git clone remote-project local-clone
-
-mkdir not-a-git-repo
-pushd not-a-git-repo
-  echo "I am not a git repository" > another_file
-popd
-
-mkdir empty-dir
+git clone --bare remote-project local-clone

--- a/e2e/playwright/scripts/two-projects-with-remote-branches.sh
+++ b/e2e/playwright/scripts/two-projects-with-remote-branches.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $GITBUTLER_CLI_DATA_DIR"
+echo "BUT_TESTING $BUT_TESTING"
+
+# Setup a remote project.
+# GitButler currently requires projects to have a remote
+mkdir remote-project
+pushd remote-project
+git init -b master --object-format=sha1
+echo "foo\nbar\nbaz" > a_file
+git add a_file
+git commit -am "Hey, look! A commit."
+
+# Create branch 1
+git checkout -b branch1
+echo "branch1 commit 1" >> a_file
+git commit -am "branch1: first commit"
+echo "branch1 commit 2" >> a_file
+git commit -am "branch1: second commit"
+
+git checkout master
+
+# Create branch 2
+git checkout -b branch2
+echo "branch2 commit 1" >> a_file
+git commit -am "branch2: first commit"
+echo "branch2 commit 2" >> a_file
+git commit -am "branch2: second commit"
+git checkout master
+popd
+
+# Clone the remote into a folder and add the project to the application.
+git clone remote-project local-clone
+pushd local-clone
+  git checkout master
+  $BUT_TESTING add-project --switch-to-workspace "$(git rev-parse --symbolic-full-name @{u})"
+popd
+
+# Clone the remote into another folder and add the project as well.
+git clone remote-project local-clone-2
+pushd local-clone-2
+  git checkout master
+  $BUT_TESTING add-project --switch-to-workspace "$(git rev-parse --symbolic-full-name @{u})"
+popd

--- a/e2e/playwright/src/setup.ts
+++ b/e2e/playwright/src/setup.ts
@@ -20,7 +20,7 @@ export function getButlerPort(): string {
 }
 
 export interface GitButler {
-	pathInWorkdir: (filePath: string) => string;
+	pathInWorkdir: (...filePathSegments: string[]) => string;
 	runScript(scriptName: string, args?: string[], env?: Record<string, string>): Promise<void>;
 	destroy(): void;
 }
@@ -85,8 +85,8 @@ class GitButlerManager implements GitButler {
 		this.butServerProcess.kill('SIGTERM');
 	}
 
-	pathInWorkdir(filePath: string): string {
-		return path.join(this.workdir, filePath);
+	pathInWorkdir(...filePathSegments: string[]): string {
+		return path.join(this.workdir, ...filePathSegments);
 	}
 
 	async runScript(

--- a/e2e/playwright/src/util.ts
+++ b/e2e/playwright/src/util.ts
@@ -21,9 +21,15 @@ export async function waitForTestId(page: Page, testId: TestIdValues): Promise<L
 /**
  * Click an element by test ID.
  */
-export async function clickByTestId(page: Page, testId: TestIdValues): Promise<Locator> {
+export async function clickByTestId(
+	page: Page,
+	testId: TestIdValues,
+	force?: boolean
+): Promise<Locator> {
 	const element = await waitForTestId(page, testId);
-	await element.click();
+	await element.click({
+		force
+	});
 	return element;
 }
 

--- a/e2e/playwright/tests/addingAProject.spec.ts
+++ b/e2e/playwright/tests/addingAProject.spec.ts
@@ -1,0 +1,99 @@
+import { getBaseURL, startGitButler, type GitButler } from '../src/setup.ts';
+import { clickByTestId, getByTestId, waitForTestId } from '../src/util.ts';
+import { expect, test } from '@playwright/test';
+
+let gitbutler: GitButler;
+
+test.use({
+	baseURL: getBaseURL()
+});
+
+test.afterEach(async () => {
+	gitbutler?.destroy();
+});
+
+test('should handle gracefully adding an existing project', async ({ page, context }, testInfo) => {
+	const workdir = testInfo.outputPath('workdir');
+	const configdir = testInfo.outputPath('config');
+	gitbutler = await startGitButler(workdir, configdir, context);
+
+	const projectPath = gitbutler.pathInWorkdir('local-clone-2/');
+
+	await gitbutler.runScript('two-projects-with-remote-branches.sh');
+
+	await page.goto('/');
+
+	// Should load the workspace
+	await waitForTestId(page, 'workspace-view');
+
+	// Open the project selector
+	await clickByTestId(page, 'chrome-header-project-selector');
+	// Click the add local project button
+	const fileChooserPromise = page.waitForEvent('filechooser');
+	await clickByTestId(page, 'chrome-header-project-selector-add-local-project');
+
+	const fileChooser = await fileChooserPromise;
+	await fileChooser.setFiles(projectPath);
+
+	// Should display the "project already exists" modal
+	await waitForTestId(page, 'add-project-already-exists-modal');
+	// Click it in order to close the select dropdown behind
+	await clickByTestId(page, 'add-project-already-exists-modal', true);
+
+	// Click to open the existing project
+	await clickByTestId(page, 'add-project-already-exists-modal-open-project-button');
+
+	// Should navigate to the existing project
+	const projectSelector = getByTestId(page, 'chrome-header-project-selector');
+	await expect(projectSelector).toContainText('local-clone-2');
+});
+
+test('should handle gracefully adding bare repo', async ({ page, context }, testInfo) => {
+	const workdir = testInfo.outputPath('workdir');
+	const configdir = testInfo.outputPath('config');
+	gitbutler = await startGitButler(workdir, configdir, context);
+
+	const projectPath = gitbutler.pathInWorkdir('local-clone/');
+
+	await gitbutler.runScript('setup-empty-project-bare.sh');
+
+	await page.goto('/');
+	const onboardingPage = getByTestId(page, 'onboarding-page');
+	await onboardingPage.waitFor();
+
+	clickByTestId(page, 'analytics-continue');
+
+	// Add a local project
+	const fileChooserPromise = page.waitForEvent('filechooser');
+	clickByTestId(page, 'add-local-project');
+
+	const fileChooser = await fileChooserPromise;
+	await fileChooser.setFiles(projectPath);
+
+	await waitForTestId(page, 'add-project-bare-repo-modal');
+});
+
+test('should handle gracefully adding a non-git directory', async ({ page, context }, testInfo) => {
+	const workdir = testInfo.outputPath('workdir');
+	const configdir = testInfo.outputPath('config');
+	gitbutler = await startGitButler(workdir, configdir, context);
+
+	const projectPath = gitbutler.pathInWorkdir('not-a-git-repo/');
+
+	await gitbutler.runScript('setup-empty-project.sh');
+
+	await page.goto('/');
+	const onboardingPage = getByTestId(page, 'onboarding-page');
+	await onboardingPage.waitFor();
+
+	clickByTestId(page, 'analytics-continue');
+
+	// Add a local project
+	const fileChooserPromise = page.waitForEvent('filechooser');
+	clickByTestId(page, 'add-local-project');
+
+	const fileChooser = await fileChooserPromise;
+	await fileChooser.setFiles(projectPath);
+
+	await waitForTestId(page, 'add-project-not-a-git-repo-modal');
+});

--- a/packages/ui/src/lib/components/select/SelectItem.svelte
+++ b/packages/ui/src/lib/components/select/SelectItem.svelte
@@ -11,6 +11,7 @@
 		loading?: boolean;
 		highlighted?: boolean;
 		value?: string | undefined;
+		testId?: string;
 		children?: Snippet;
 		onClick?: (value: string | undefined) => void;
 	}
@@ -23,12 +24,14 @@
 		loading = false,
 		highlighted = false,
 		value = undefined,
+		testId,
 		onClick,
 		children
 	}: Props = $props();
 </script>
 
 <button
+	data-testid={testId}
 	type="button"
 	{disabled}
 	class="select-button"

--- a/packages/ui/src/lib/utils/testIds.ts
+++ b/packages/ui/src/lib/utils/testIds.ts
@@ -125,7 +125,14 @@ export enum TestId {
 	ProjectSetupPageTargetBranchSelect = 'project-setup-page-target-branch-select',
 	ProjectSetupPageTargetContinueButton = 'set-base-branch',
 	ProjectSetupGitAuthPage = 'project-setup-git-auth-page',
-	ProjectSetupGitAuthPageButton = 'accept-git-auth'
+	ProjectSetupGitAuthPageButton = 'accept-git-auth',
+	AddProjectAlreadyExistsModal = 'add-project-already-exists-modal',
+	AddProjectAlreadyExistsModalOpenProjectButton = 'add-project-already-exists-modal-open-project-button',
+	AddProjectBareRepoModal = 'add-project-bare-repo-modal',
+	AddProjectNoDotGitDirectoryModal = 'add-project-no-dot-git-directory-modal',
+	AddProjectNotAGitRepoModal = 'add-project-not-a-git-repo-modal',
+	ChromeHeaderProjectSelector = 'chrome-header-project-selector',
+	ChromeHeaderProjectSelectorAddLocalProject = 'chrome-header-project-selector-add-local-project'
 }
 
 export enum ElementId {


### PR DESCRIPTION
This adds friendlier handling for the project addition errors.


**Summary**
- Add AddProjectOutcome enum and core support to represent all possible results when adding a project.
- Refactor core APIs and callers to use AddProjectOutcome instead of ad-hoc checks.
- Centralize handling of add-project outcomes via handleAddOutcome helper to avoid logic and ensure consistent navigation/notifications.
- Update UI components (CloneForm, ProjectSwitcher, FileMenuAction) to use the new handler.
- Update tests and add e2e suite covering add-project behavior; adapt test utilities and test IDs (toasts, select items, chrome header) to support the new flows.
- Add metrics to the warning toasts

**Files / areas changed**
- project.rs: AddProjectOutcome enum, unwrap_project/try_project helpers
- Core/public APIs: signature changes to return AddProjectOutcome
- Desktop app: handleAddProjectOutcome helper and imports; updated callers in CloneForm, ProjectSwitcher, FileMenuAction
- Tests: updated unit tests, added e2e add-project tests
- Test utils / IDs: force click utility; test IDs for toasts, toast buttons, select items, chrome header

**Notes**
- Behavior now consistently shows warnings for non-added outcomes and only navigates when a project was actually added.
- No unrelated functional changes included.