### PR TITLE
Treat null as valid data and remove unused import

### DIFF
--- a/apps/desktop/src/components/ReduxResult.svelte
+++ b/apps/desktop/src/components/ReduxResult.svelte
@@ -8,7 +8,6 @@
 	import { isParsedError } from '$lib/error/parser';
 
 	import { Icon } from '@gitbutler/ui';
-	import { isDefined } from '@gitbutler/ui/utils/typeguards';
 	import { QueryStatus } from '@reduxjs/toolkit/query';
 	import type { Snippet } from 'svelte';
 
@@ -47,7 +46,8 @@
 			return { result: props.result, env };
 		}
 
-		if (isDefined(props.result?.data)) {
+		// This needs to test for 'undefined' specifically, enabling 'null' as a valid data value.
+		if (props.result?.data !== undefined) {
 			cache = { result: props.result, env };
 			return cache;
 		}


### PR DESCRIPTION
- Removed unused import: isDefined from '@gitbutler/ui/utils/typeguards'.
- Changed runtime check for result.data to explicitly test for undefined (props.result?.data !== undefined), allowing null to be treated as valid data value.
- Added a comment explaining the rationale for checking undefined specifically.
