### PR TITLE
Show files in pop color based on active list rather than focused item

### DIFF
--- a/apps/desktop/src/components/FileList.svelte
+++ b/apps/desktop/src/components/FileList.svelte
@@ -87,6 +87,7 @@
 	const fileChunks: TreeChange[][] = $derived(chunk(changes, 100));
 	const visibleFiles: TreeChange[] = $derived(fileChunks.slice(0, currentDisplayIndex + 1).flat());
 	let aiConfigurationValid = $state(false);
+	let active = $state(false);
 
 	const aiGenEnabled = $derived(projectAiGenEnabled(projectId));
 
@@ -226,6 +227,7 @@
 		{selected}
 		{listMode}
 		{depth}
+		{active}
 		hideBorder={hideLastFileBorder && idx === visibleFiles.length - 1}
 		draggable={draggableFiles}
 		executable={!!isExecutable}
@@ -246,13 +248,18 @@
 
 <div
 	class="file-list"
-	use:focusable={{ id: DefinedFocusable.FileList, list: true, disabled: visibleFiles.length <= 1 }}
+	use:focusable={{
+		id: DefinedFocusable.FileList,
+		list: true,
+		onActive: (value) => (active = value)
+	}}
 >
 	<!-- Conflicted changes -->
 	{#each Object.entries(unrepresentedConflictedEntries) as [path, kind]}
 		<FileListItem
 			draggable={draggableFiles}
 			filePath={path}
+			{active}
 			conflicted
 			conflictHint={conflictEntryHint(kind)}
 			listMode="list"

--- a/apps/desktop/src/components/FileListItemWrapper.svelte
+++ b/apps/desktop/src/components/FileListItemWrapper.svelte
@@ -38,6 +38,7 @@
 		draggable?: boolean;
 		transparent?: boolean;
 		sticky?: boolean;
+		active?: boolean;
 		onclick?: (e: MouseEvent) => void;
 		onkeydown?: (e: KeyboardEvent) => void;
 		onCloseClick?: () => void;
@@ -62,6 +63,7 @@
 		draggable,
 		transparent,
 		focusableOpts,
+		active,
 		onclick,
 		onkeydown,
 		onCloseClick,
@@ -117,8 +119,6 @@
 
 	const conflict = $derived(conflictEntries ? conflictEntries.entries[change.path] : undefined);
 	const draggableDisabled = $derived(!draggable || showCheckbox);
-
-	let active = $state(false);
 </script>
 
 <div
@@ -195,10 +195,7 @@
 			{onclick}
 			oncheck={(e) => onCheck(e.currentTarget.checked)}
 			oncontextmenu={onContextMenu}
-			actionOpts={{
-				...focusableOpts,
-				onActive: (value) => (active = value)
-			}}
+			actionOpts={focusableOpts}
 		/>
 	{/if}
 </div>


### PR DESCRIPTION
Selecting multiple files will now show all of them in pop color, as long
as the list or any of its children have focus.