### PR TITLE
Increase non-Windows file monitor tick to 100ms

### DIFF
--- a/crates/gitbutler-filemonitor/src/file_monitor.rs
+++ b/crates/gitbutler-filemonitor/src/file_monitor.rs
@@ -20,7 +20,7 @@ const DEBOUNCE_TIMEOUT: Duration = Duration::from_secs(60);
 const TICK_RATE: Duration = if cfg!(windows) {
     Duration::from_millis(250)
 } else {
-    Duration::from_millis(50)
+    Duration::from_millis(100)
 };
 
 // The number of TICK_RATE intervals required of "dead air" (i.e. no new events


### PR DESCRIPTION
Based on offline conversation with Kiril, we want to be just a bit 
careful and not set it too low.