### PR TITLE
Clarify rebase description text

### DIFF
--- a/apps/desktop/src/components/BranchCommitList.svelte
+++ b/apps/desktop/src/components/BranchCommitList.svelte
@@ -185,7 +185,7 @@
 				<div class="integration-radio-content">
 					<h4 class="text-12 text-semibold">Rebase upstream changes</h4>
 					<p class="text-11 text-body clr-text-2">
-						Move your commits on top of upstream changes. Creates clean, linear history.
+						Place the upstream changes on top of your commits. Creates clean, linear history.
 					</p>
 				</div>
 				<RadioButton


### PR DESCRIPTION
Update copy in BranchCommitList.svelte: changed description text from 'Move your commits on top of upstream changes. Creates clean, linear history.' to 'Place the upstream changes on top of your commits. Creates clean, linear history.' This is a wording clarification and affects only UI copy.