### PR TITLE
feat(ui): creating vs executing states for review controls

### DIFF
--- a/apps/desktop/src/components/BranchReview.svelte
+++ b/apps/desktop/src/components/BranchReview.svelte
@@ -78,7 +78,8 @@
 
 		{#snippet controls(close)}
 			<ReviewCreationControls
-				isSubmitting={!!reviewCreation?.imports.isLoading}
+				isCreatingPR={!!reviewCreation?.imports.isLoading}
+				isFormBusy={!!reviewCreation?.imports.isExecuting}
 				{canPublishPR}
 				{reviewUnit}
 				onCancel={close}

--- a/apps/desktop/src/components/CreateReviewBox.svelte
+++ b/apps/desktop/src/components/CreateReviewBox.svelte
@@ -45,7 +45,8 @@
 	<div class="create-review-box" data-testid={TestId.CreateReviewBox}>
 		<ReviewCreation bind:this={reviewCreation} {projectId} {stackId} {branchName} onClose={close} />
 		<ReviewCreationControls
-			isSubmitting={!!reviewCreation?.imports.isLoading}
+			isCreatingPR={!!reviewCreation?.imports.isLoading}
+			isFormBusy={!!reviewCreation?.imports.isExecuting}
 			{canPublishPR}
 			{reviewUnit}
 			onCancel={() => {

--- a/apps/desktop/src/components/ReviewCreation.svelte
+++ b/apps/desktop/src/components/ReviewCreation.svelte
@@ -106,6 +106,7 @@
 
 	let isCreatingReview = $state<boolean>(false);
 	const isExecuting = $derived(stackPush.current.isLoading || aiIsLoading || isCreatingReview);
+	const isSubmittingReview = $derived(stackPush.current.isLoading || isCreatingReview);
 
 	async function getDefaultTitle(commits: Commit[]): Promise<string> {
 		if (commits.length === 1) {
@@ -358,6 +359,9 @@
 
 	export const imports = {
 		get isLoading() {
+			return isSubmittingReview;
+		},
+		get isExecuting() {
 			return isExecuting;
 		}
 	};

--- a/apps/desktop/src/components/ReviewCreationControls.svelte
+++ b/apps/desktop/src/components/ReviewCreationControls.svelte
@@ -10,16 +10,24 @@
 	} from '@gitbutler/ui';
 
 	interface Props {
-		isSubmitting: boolean;
+		isCreatingPR: boolean;
 		canPublishPR: boolean;
 		submitDisabled?: boolean;
+		isFormBusy?: boolean;
 		reviewUnit: string | undefined;
 		onCancel: () => void;
 		onSubmit: () => void;
 	}
 
-	let { canPublishPR, submitDisabled, isSubmitting, onCancel, onSubmit, reviewUnit }: Props =
-		$props();
+	let {
+		canPublishPR,
+		submitDisabled,
+		isCreatingPR,
+		isFormBusy,
+		onCancel,
+		onSubmit,
+		reviewUnit
+	}: Props = $props();
 
 	const unit = $derived(reviewUnit ?? 'PR');
 	let commitButton = $state<DropdownButton>();
@@ -31,7 +39,7 @@
 	<Button
 		testId={TestId.ReviewCancelButton}
 		kind="outline"
-		disabled={isSubmitting}
+		disabled={isFormBusy || isCreatingPR}
 		width={120}
 		onclick={onCancel}>Cancel</Button
 	>
@@ -40,13 +48,13 @@
 		testId={TestId.ReviewCreateButton}
 		bind:this={commitButton}
 		onclick={() => {
-			if (isSubmitting) return;
+			if (isFormBusy || isCreatingPR) return;
 			onSubmit();
 		}}
 		wide
 		style="pop"
-		loading={isSubmitting}
-		disabled={submitDisabled}
+		loading={isCreatingPR}
+		disabled={submitDisabled || isFormBusy}
 		hotkey="⌘↵"
 	>
 		{$createDraft ? `Create ${unit} draft` : `Create ${unit}`}


### PR DESCRIPTION
Don't show the spinner icon on both buttons when generating a message.

Before:

https://github.com/user-attachments/assets/66c3bb34-a413-43aa-b858-2075e6a2ffe7

After: 

https://github.com/user-attachments/assets/db8831a2-c546-4c35-8d7a-0e709ddd1dbe


