### PR TITLE
ui-fixes-131

### DIFF
--- a/apps/desktop/src/components/BranchCommitList.svelte
+++ b/apps/desktop/src/components/BranchCommitList.svelte
@@ -183,7 +183,7 @@
 		<div class="uppstream-integration-actions__radio-container">
 			<label class="integration-radio-option" class:selected={$integrationMode === 'rebase'}>
 				<div class="integration-radio-content">
-					<h4 class="text-12 text-semibold">Rebase upstream changes</h4>
+					<h4 class="text-13 text-semibold">Rebase upstream changes</h4>
 					<p class="text-11 text-body clr-text-2">
 						Place the upstream changes on top of your commits. Creates clean, linear history.
 					</p>
@@ -198,7 +198,7 @@
 			</label>
 			<label class="integration-radio-option" class:selected={$integrationMode === 'interactive'}>
 				<div class="integration-radio-content">
-					<h4 class="text-12 text-semibold">Interactive integration</h4>
+					<h4 class="text-13 text-semibold">Interactive integration</h4>
 					<p class="text-11 text-body clr-text-2">
 						Review and resolve any conflicts before completing the integration.
 					</p>

--- a/apps/desktop/src/components/BranchesView.svelte
+++ b/apps/desktop/src/components/BranchesView.svelte
@@ -338,31 +338,39 @@
 							</div>
 						{/if}
 
-						<div
-							class="commits"
-							class:target-branch={isTargetBranch}
-							use:focusable={{ list: true }}
-						>
-							{#if isTargetBranch}
+						{#if isTargetBranch}
+							<div class="commits" use:focusable={{ list: true }}>
 								<TargetCommitList {projectId} />
-							{:else if current.stackId}
-								<BranchesViewStack {projectId} stackId={current.stackId} {onerror} />
-							{:else if current.branchName}
-								<BranchesViewBranch
-									{projectId}
-									branchName={current.branchName}
-									remote={current.remote}
-									{onerror}
-								/>
-							{:else if current.prNumber}
+							</div>
+						{/if}
+
+						{#if !isTargetBranch && someBranchSelected && !isNonLocalPr}
+							<ConfigurableScrollableContainer>
+								<div class="commits with-padding" use:focusable={{ list: true }}>
+									{#if current.stackId}
+										<BranchesViewStack {projectId} stackId={current.stackId} {onerror} />
+									{:else if current.branchName}
+										<BranchesViewBranch
+											{projectId}
+											branchName={current.branchName}
+											remote={current.remote}
+											{onerror}
+										/>
+									{/if}
+								</div>
+							</ConfigurableScrollableContainer>
+						{/if}
+
+						{#if isNonLocalPr && current.prNumber}
+							<div class="commits" use:focusable={{ list: true }}>
 								<BranchesViewPr
 									bind:this={prBranch}
 									{projectId}
 									prNumber={current.prNumber}
 									{onerror}
 								/>
-							{/if}
-						</div>
+							</div>
+						{/if}
 
 						<Resizer
 							viewport={branchColumn}
@@ -513,11 +521,10 @@
 		position: relative;
 		flex: 1;
 		flex-direction: column;
-		padding: 12px;
 		overflow: hidden;
 
-		&.target-branch {
-			padding: 0;
+		&.with-padding {
+			padding: 12px;
 		}
 	}
 

--- a/apps/desktop/src/components/BranchesViewBranch.svelte
+++ b/apps/desktop/src/components/BranchesViewBranch.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import BranchCard from '$components/BranchCard.svelte';
 	import CommitRow from '$components/CommitRow.svelte';
-	import ConfigurableScrollableContainer from '$components/ConfigurableScrollableContainer.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
 	import { pushStatusToColor, pushStatusToIcon, type BranchDetails } from '$lib/stacks/stack';
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
@@ -37,9 +36,7 @@
 		{#if stackId}
 			{@render branchCard(branch, env)}
 		{:else}
-			<ConfigurableScrollableContainer>
-				{@render branchCard(branch, env)}
-			</ConfigurableScrollableContainer>
+			{@render branchCard(branch, env)}
 		{/if}
 	{/snippet}
 </ReduxResult>

--- a/apps/desktop/src/components/BranchesViewStack.svelte
+++ b/apps/desktop/src/components/BranchesViewStack.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import BranchesViewBranch from '$components/BranchesViewBranch.svelte';
-	import ConfigurableScrollableContainer from '$components/ConfigurableScrollableContainer.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
 	import { getStackBranchNames } from '$lib/stacks/stack';
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
@@ -21,10 +20,8 @@
 
 <ReduxResult result={stackResult.current} {projectId} {stackId} {onerror}>
 	{#snippet children(stack, { stackId, projectId })}
-		<ConfigurableScrollableContainer>
-			{#each getStackBranchNames(stack) as branchName, idx}
-				<BranchesViewBranch {projectId} {stackId} {branchName} isTopBranch={idx === 0} {onerror} />
-			{/each}
-		</ConfigurableScrollableContainer>
+		{#each getStackBranchNames(stack) as branchName, idx}
+			<BranchesViewBranch {projectId} {stackId} {branchName} isTopBranch={idx === 0} {onerror} />
+		{/each}
 	{/snippet}
 </ReduxResult>

--- a/apps/desktop/src/components/ChromeSidebar.svelte
+++ b/apps/desktop/src/components/ChromeSidebar.svelte
@@ -208,6 +208,7 @@
 					width={34}
 					class={['btn-square', isCodegenPath() && 'btn-active']}
 					tooltip="Codegen"
+					tooltipAlign="start"
 					{disabled}
 				>
 					{#snippet custom()}

--- a/apps/desktop/src/components/FileContextMenu.svelte
+++ b/apps/desktop/src/components/FileContextMenu.svelte
@@ -591,8 +591,7 @@
 
 		<div class="explanation">
 			<p class="primary-text">
-				Your selected changes will be moved to a new branch called
-				<strong>{stashBranchName || '[branch name]'}</strong> and removed from your current workspace.
+				Your selected changes will be moved to a new branch and removed from your current workspace.
 				To get these changes back later, switch to the new branch and uncommit the stash.
 			</p>
 		</div>

--- a/packages/ui/src/lib/components/hunkDiff/HunkDiff.svelte
+++ b/packages/ui/src/lib/components/hunkDiff/HunkDiff.svelte
@@ -102,7 +102,7 @@
 
 <div
 	bind:this={tableWrapperElem}
-	class="table__wrapper hide-native-scrollbar contrast-{diffContrast}"
+	class="table__wrapper contrast-{diffContrast}"
 	style="--tab-size: {tabSize}; --diff-font: {diffFont};"
 	style:font-variant-ligatures={diffLigatures ? 'common-ligatures' : 'none'}
 >
@@ -112,6 +112,7 @@
 		</div>
 	{/if}
 	<ScrollableContainer horz whenToShow="always" padding={{ left: numberHeaderWidth }}>
+		<!-- <div style="overflow: auto; max-height: 600px;"> -->
 		<table class="table__section">
 			<thead class="table__title" class:draggable={!draggingDisabled}>
 				<tr>
@@ -179,6 +180,7 @@
 				/>
 			{/if}
 		</table>
+		<!-- </div> -->
 	</ScrollableContainer>
 </div>
 

--- a/packages/ui/src/lib/components/hunkDiff/HunkDiff.svelte
+++ b/packages/ui/src/lib/components/hunkDiff/HunkDiff.svelte
@@ -106,6 +106,11 @@
 	style="--tab-size: {tabSize}; --diff-font: {diffFont};"
 	style:font-variant-ligatures={diffLigatures ? 'common-ligatures' : 'none'}
 >
+	{#if !draggingDisabled}
+		<div class="table__drag-handle">
+			<Icon name="draggable" />
+		</div>
+	{/if}
 	<ScrollableContainer horz whenToShow="always" padding={{ left: numberHeaderWidth }}>
 		<table class="table__section">
 			<thead class="table__title" class:draggable={!draggingDisabled}>
@@ -137,12 +142,6 @@
 						<span>
 							{hunkSummary}
 						</span>
-
-						{#if !draggingDisabled}
-							<div class="table__drag-handle">
-								<Icon name="draggable" />
-							</div>
-						{/if}
 					</th>
 				</tr>
 			</thead>

--- a/packages/ui/src/lib/components/scroll/ScrollableContainer.svelte
+++ b/packages/ui/src/lib/components/scroll/ScrollableContainer.svelte
@@ -119,7 +119,11 @@
 		bind:offsetHeight={viewportHeight}
 		onscroll={handleScroll}
 		class="viewport hide-native-scrollbar"
-		style="padding-top: {top}px; padding-bottom: {bottom}px;"
+		style="padding-top: {top}px; padding-bottom: {bottom}px; --overflow-x: {horz
+			? 'auto'
+			: 'hidden'}; --overflow-y: {horz ? 'hidden' : 'auto'}; --flex-direction: {horz
+			? 'row'
+			: 'column'};"
 	>
 		<div style:min-height={childrenWrapHeight} style:display={childrenWrapDisplay}>
 			{@render children()}
@@ -153,7 +157,7 @@
 		flex-direction: column;
 		width: 100%;
 		height: 100%;
-		overflow-x: hidden;
-		overflow-y: auto;
+		overflow-x: var(--overflow-x, hidden);
+		overflow-y: var(--overflow-y, auto);
 	}
 </style>

--- a/packages/ui/src/lib/components/scroll/ScrollableContainer.svelte
+++ b/packages/ui/src/lib/components/scroll/ScrollableContainer.svelte
@@ -121,11 +121,7 @@
 		class="viewport hide-native-scrollbar"
 		style="padding-top: {top}px; padding-bottom: {bottom}px;"
 	>
-		<div
-			class="hide-native-scrollbar"
-			style:min-height={childrenWrapHeight}
-			style:display={childrenWrapDisplay}
-		>
+		<div style:min-height={childrenWrapHeight} style:display={childrenWrapDisplay}>
 			{@render children()}
 		</div>
 	</div>

--- a/packages/ui/src/stories/components/HunkDiff.stories.svelte
+++ b/packages/ui/src/stories/components/HunkDiff.stories.svelte
@@ -24,15 +24,13 @@
 	});
 </script>
 
-<Story name="default">
+<Story name="Playground">
 	{#snippet template(args)}
 		<div class="wrap">
 			<HunkDiff {...args} />
 		</div>
 	{/snippet}
 </Story>
-
-<Story name="Playground" />
 
 <style>
 	.wrap {


### PR DESCRIPTION
- Simplified stash dialog branch name text to avoid using a placeholder
- Aligned Code tooltip to start for consistent positioning in the sidebar
- Fixed hunk drag handle positioning (it was absolutely positioned relative to header which scrolls)
- Removed extra `hide-native-scrollbar` class
- Fixed horizontal scrolling for scrollable components
- Renamed HunkDiff story "default" to "Playground" for clarity
- Throttled scroll events, added requestAnimationFrame cleanup, and exposed scroll APIs
- Fixed scroll padding on branches page