### PR TITLE
Workspace improvements

### DIFF
--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -253,8 +253,6 @@ impl Graph {
         } = options;
 
         let max_limit = Limit::new(limit);
-        // TODO: also traverse (outside)-branches that ought to be in the workspace. That way we have the desired ones
-        //       automatically and just have to find a way to prune the undesired ones.
         let ref_name = ref_name.into();
         if ref_name
             .as_ref()
@@ -454,7 +452,6 @@ impl Graph {
                 // have to adjust the existing queue item.
                 existing_segment
             } else {
-                // TODO: test in graph
                 let extra_target_sidx = graph.insert_root(branch_segment_from_name_and_meta(
                     None,
                     meta,

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -1777,39 +1777,32 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     │                   └── ·777b552 (⌂|🏘|✓|1)
     │                       └── ►:6[3]:anon:
     │                           └── ·ce4a760 (⌂|🏘|✓|1)
-    │                               ├── ►:7[5]:anon:
-    │                               │   └── ·01d0e1e (⌂|🏘|✓|1)
-    │                               │       └── ►:5[6]:main
-    │                               │           ├── ·4b3e5a8 (⌂|🏘|✓|1)
-    │                               │           ├── ·34d0715 (⌂|🏘|✓|1)
-    │                               │           └── ·eb5f731 (⌂|🏘|✓|1)
+    │                               ├── ►:7[4]:anon:
+    │                               │   └── ✂·01d0e1e (⌂|🏘|✓|1)
     │                               └── ►:8[4]:A-feat
-    │                                   ├── ·fea59b5 (⌂|🏘|✓|1)
-    │                                   └── ·4deea74 (⌂|🏘|✓|1)
-    │                                       └── →:7:
+    │                                   └── ✂·fea59b5 (⌂|🏘|✓|1)
     └── ►:2[0]:origin/main
         ├── 🟣d0df794 (✓)
         └── 🟣09c6e08 (✓)
             └── ►:4[1]:anon:
                 └── 🟣7b9f260 (✓)
-                    ├── →:5: (main)
+                    ├── ►:5[2]:main
+                    │   ├── 🟣4b3e5a8 (✓)
+                    │   ├── 🟣34d0715 (✓)
+                    │   └── 🟣eb5f731 (✓)
                     └── →:0: (A)
     ");
     // Because the branch is integrated, the surrounding workspace isn't shown.
     insta::assert_snapshot!(graph_workspace(&graph.to_workspace()?), @r"
     ⌂:0:A <> ✓!
     └── ≡:0:A
-        ├── :0:A
-        │   ├── ·79bbb29 (🏘️|✓)
-        │   ├── ·fc98174 (🏘️|✓)
-        │   ├── ·a381df5 (🏘️|✓)
-        │   ├── ·777b552 (🏘️|✓)
-        │   ├── ·ce4a760 (🏘️|✓)
-        │   └── ·01d0e1e (🏘️|✓)
-        └── :5:main
-            ├── ·4b3e5a8 (🏘️|✓)
-            ├── ·34d0715 (🏘️|✓)
-            └── ·eb5f731 (🏘️|✓)
+        └── :0:A
+            ├── ·79bbb29 (🏘️|✓)
+            ├── ·fc98174 (🏘️|✓)
+            ├── ·a381df5 (🏘️|✓)
+            ├── ·777b552 (🏘️|✓)
+            ├── ·ce4a760 (🏘️|✓)
+            └── ✂️·01d0e1e (🏘️|✓)
     ");
 
     // See what happens with an out-of-workspace HEAD and an arbitrary extra target.
@@ -2169,8 +2162,7 @@ fn workspace_obeys_limit_when_target_branch_is_missing() -> anyhow::Result<()> {
     │           └── ·03ad472 (⌂|🏘|1)
     │               └── ►:4[2]:A
     │                   ├── ·79bbb29 (⌂|🏘|✓|1)
-    │                   ├── ·fc98174 (⌂|🏘|✓|1)
-    │                   └── ✂·a381df5 (⌂|🏘|✓|1)
+    │                   └── ✂·fc98174 (⌂|🏘|✓|1)
     └── ►:1[0]:origin/main
         ├── 🟣d0df794 (✓)
         └── 🟣09c6e08 (✓)
@@ -2403,12 +2395,13 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     ");
 
     add_workspace(&mut meta);
-    let (id, ref_name) = id_at(&repo, "main");
+    let (main_id, main_ref_name) = id_at(&repo, "main");
     // Validate that we will perform long searches to connect connectable segments, without interfering
     // with other searches that may take even longer.
     // Also, without limit, we should be able to see all of 'main' without cut-off
-    let graph = Graph::from_commit_traversal(id, ref_name.clone(), &*meta, standard_options())?
-        .validated()?;
+    let graph =
+        Graph::from_commit_traversal(main_id, main_ref_name.clone(), &*meta, standard_options())?
+            .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 📕►►►:1[0]:gitbutler/workspace
     │   └── ·41ed0e4 (⌂|🏘)
@@ -2473,9 +2466,13 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     // When setting a limit when traversing 'main', it is respected.
     // We still want it to be found and connected though, and it's notable that the limit kicks in
     // once everything reconciled.
-    let graph =
-        Graph::from_commit_traversal(id, ref_name, &*meta, standard_options().with_limit_hint(1))?
-            .validated()?;
+    let graph = Graph::from_commit_traversal(
+        main_id,
+        main_ref_name,
+        &*meta,
+        standard_options().with_limit_hint(1),
+    )?
+    .validated()?;
     insta::assert_snapshot!(graph_tree(&graph), @r"
     ├── 📕►►►:1[0]:gitbutler/workspace
     │   └── ·41ed0e4 (⌂|🏘)
@@ -2488,12 +2485,7 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     │               │           ├── ·f49c977 (⌂|🏘|✓|1)
     │               │           ├── ·7b7ebb2 (⌂|🏘|✓|1)
     │               │           ├── ·dca4960 (⌂|🏘|✓|1)
-    │               │           ├── ·11c29b8 (⌂|🏘|✓|1)
-    │               │           ├── ·c32dd03 (⌂|🏘|✓|1)
-    │               │           ├── ·b625665 (⌂|🏘|✓|1)
-    │               │           ├── ·a821094 (⌂|🏘|✓|1)
-    │               │           ├── ·bce0c5e (⌂|🏘|✓|1)
-    │               │           └── ·3183e43 (⌂|🏘|✓|1)
+    │               │           └── ✂·11c29b8 (⌂|🏘|✓|1)
     │               └── ►:7[3]:long-main-to-workspace
     │                   ├── ·77f31a0 (⌂|🏘|✓)
     │                   ├── ·eb17e31 (⌂|🏘|✓)
@@ -2529,12 +2521,7 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
             ├── ·f49c977 (🏘️|✓)
             ├── ·7b7ebb2 (🏘️|✓)
             ├── ·dca4960 (🏘️|✓)
-            ├── ·11c29b8 (🏘️|✓)
-            ├── ·c32dd03 (🏘️|✓)
-            ├── ·b625665 (🏘️|✓)
-            ├── ·a821094 (🏘️|✓)
-            ├── ·bce0c5e (🏘️|✓)
-            └── ·3183e43 (🏘️|✓)
+            └── ✂️·11c29b8 (🏘️|✓)
     ");
 
     // From the workspace, even without limit, we don't traverse all of 'main' as it's uninteresting.

--- a/crates/but-workspace/src/changeset.rs
+++ b/crates/but-workspace/src/changeset.rs
@@ -124,7 +124,7 @@ impl RefInfo {
                             // This happens when the identity match with the remote didn't work.
                             LocalCommitRelation::LocalOnly |
                             // This would be expected to be a remote-match by identity (we don't check for this),
-                            // something that is determined during graph traversal time. But we want ot see
+                            // something that is determined during graph traversal time. But we want to see
                             // if any of these is also integrated.
                             LocalCommitRelation::LocalAndRemote(_)
                         )


### PR DESCRIPTION
This PR aims to improve a real-life scenario encountered by Matthias that exposed various shortcomings:

### Tasks

* [x] The 'dot' shortcut shows a strange graph
    - The issue was that the rather large graph was pruned, but that only shows up in debug
      messages and it was implemented in such a way that important information was lost.
      Now it's better, albeit far from perfect.
* [x] The integration status of one commit wasn't shown (even though the old workspace impl did)
    - The commit should match by change-id (probably something about ambiguity that fails it?)
- [x] The `master` branch searches for its connection to the workspace partition
      forever.
    - Only a problem if extra-commit is set!
    - the issue is that the workspce partition stops early, so both partitions never meet.
      This blows up the runtime and commit-graph and definitely shouldn't happen.
    - **Issue is the following**: the remote tracking branch is looking for its local one, but hits the extra-commit first. With that the goal gets lost, even though it should be transferred to the tips in that direction.
* [x] fix performance issue and validate the few failing tests



### Research

Similarity is correctly not detected as these commits, despite having the same change-id, are dissimilar.

```
❯ gix cat cacac72
tree 62a7daea3b7c882140032635090a575fa6f76851
parent 4804de62d2af2cd6439f60599e7d19b20571052c
author Mattias Granlund <mtsgrd@gmail.com> 1756939171 +0200
committer Mattias Granlund <mtsgrd@gmail.com> 1756939663 +0300
gitbutler-headers-version 2
gitbutler-change-id 248cea13-a9f6-47b2-bdee-323311d0f126

Show the active teal color oly if an item is selected _and_ focused%                                                                                                                                     
gitbutler-strange-state ( gitbutler/workspace) [$?] via 
❯ tig

gitbutler-strange-state ( gitbutler/workspace) [$?] via  took 5s
❯ gix cat 52c3201
tree daed77e327ae002ab8a0ecc87b2754f6c19336f3
parent 4804de62d2af2cd6439f60599e7d19b20571052c
author Mattias Granlund <mtsgrd@gmail.com> 1756939653 +0200
committer Mattias Granlund <mtsgrd@gmail.com> 1756939653 +0200
gitbutler-headers-version 2
gitbutler-change-id 248cea13-a9f6-47b2-bdee-323311d0f126

Show the active teal color oly if an item is selected _and_ focused%                                                                                                                                     
gitbutler-strange-state ( gitbutler/workspace) [$?] via 
❯ git show 52c3201 --stat
commit 52c32011eb310d4da24204f611bb136ada22af45 (teal-for-focused)
Author: Mattias Granlund <mtsgrd@gmail.com>
Date:   Thu Sep 4 00:47:33 2025 +0200

    Show the active teal color oly if an item is selected _and_ focused

 apps/desktop/src/components/BranchCard.svelte          | 14 ++++++++------
 apps/desktop/src/components/BranchCommitList.svelte    |  4 ----
 apps/desktop/src/components/BranchList.svelte          |  5 +----
 apps/desktop/src/components/BranchesViewBranch.svelte  |  1 -
 apps/desktop/src/components/CommitRow.svelte           |  5 +++--
 apps/desktop/src/components/FileList.svelte            |  1 -
 apps/desktop/src/components/FileListItemWrapper.svelte | 22 +++++-----------------
 apps/desktop/src/components/MultiStackView.svelte      | 10 +++++-----
 apps/desktop/src/components/StackView.svelte           | 16 +---------------
 packages/ui/src/lib/focus/focusManager.ts              | 14 ++++++--------
 10 files changed, 29 insertions(+), 63 deletions(-)

gitbutler-strange-state ( gitbutler/workspace) [$?] via 
❯ git show cacac72 --stat
commit cacac72ac47717a503a6c87d11572027c61024ef
Author: Mattias Granlund <mtsgrd@gmail.com>
Date:   Thu Sep 4 00:39:31 2025 +0200

    Show the active teal color oly if an item is selected _and_ focused

 apps/desktop/src/components/BranchCard.svelte          | 15 +++++++++------
 apps/desktop/src/components/BranchCommitList.svelte    |  4 ----
 apps/desktop/src/components/BranchList.svelte          |  5 +----
 apps/desktop/src/components/BranchesViewBranch.svelte  |  1 -
 apps/desktop/src/components/CommitRow.svelte           |  6 ++++--
 apps/desktop/src/components/FileList.svelte            |  1 -
 apps/desktop/src/components/FileListItemWrapper.svelte | 23 ++++++-----------------
 apps/desktop/src/components/MultiStackView.svelte      | 10 +++++-----
 apps/desktop/src/components/StackView.svelte           | 16 +---------------
 9 files changed, 26 insertions(+), 55 deletions(-)
```

