### PR TITLE
Rename and simplify focus manager methods

### DIFF
--- a/packages/ui/src/lib/components/file/FileViewHeader.svelte
+++ b/packages/ui/src/lib/components/file/FileViewHeader.svelte
@@ -6,7 +6,6 @@
 	import ExecutableLabel from '$components/file/ExecutableLabel.svelte';
 	import FileName from '$components/file/FileName.svelte';
 	import FileStatusBadge from '$components/file/FileStatusBadge.svelte';
-	import { focusable } from '$lib/focus/focusable';
 	import type { FileStatus } from '$components/file/types';
 
 	interface Props {
@@ -56,7 +55,6 @@
 			oncontextmenu(e);
 		}
 	}}
-	use:focusable
 >
 	{#if draggable}
 		<div class="file-header__drag-handle">


### PR DESCRIPTION
- rename getRightValidPreviousElement to getValidPreviousElement and use
  a clearer variable name (previousElement) where it's used to restore
  focus simplifies history manipulation and improves readability.
- rename fireOnActiveForHierarchy to triggerOnActiveCallbacks for a more
  descriptive name.
- extract findFocusableChild to centralize logic that prefers a cached or
  preferred child when activating a container; try preferred child first,
  then other children, returning the first successfully activated child.
- change setActive to return the activated element (or undefined) and
  simplify early returns; centralize behavior:
  - validate element and metadata early, log a warning if metadata is
    missing
  - attempt to find/focus a child via findFocusableChild before acting on
    the element itself
  - consistently trigger onActive(false) for previous element, add it to
    history, set _currentElement, cache active index, trigger onActive(true)
  - update cursor only once with the resolved target
- rename findNext to findNextByType to clarify purpose and update the
  recursive call accordingly.
- rename getPreferredChildFromContainer to getPreferredChild and adjust
  signature to align with usage.

These changes improve naming clarity, reduce duplicated logic, and make
focus activation flow easier to follow and more reliable when containers
should forward focus to children.