### PR TITLE
Rename IdSelection to FileSelection

### DIFF
--- a/apps/desktop/src/components/ChangedFiles.svelte
+++ b/apps/desktop/src/components/ChangedFiles.svelte
@@ -4,7 +4,7 @@
 	import FileListMode from '$components/FileListMode.svelte';
 	import Resizer from '$components/Resizer.svelte';
 	import emptyFolderSvg from '$lib/assets/empty-state/empty-folder.svg?raw';
-	import { ID_SELECTION } from '$lib/selection/idSelection.svelte';
+	import { FILE_SELECTION_MANAGER } from '$lib/selection/fileSelectionManager.svelte';
 	import { inject } from '@gitbutler/core/context';
 	import { Badge, EmptyStatePlaceholder, LineStats } from '@gitbutler/ui';
 
@@ -49,7 +49,7 @@
 		ontoggle
 	}: Props = $props();
 
-	const idSelection = inject(ID_SELECTION);
+	const idSelection = inject(FILE_SELECTION_MANAGER);
 
 	let listMode: 'list' | 'tree' = $state('tree');
 

--- a/apps/desktop/src/components/FileContextMenu.svelte
+++ b/apps/desktop/src/components/FileContextMenu.svelte
@@ -11,7 +11,7 @@
 	import { isTreeChange, type TreeChange } from '$lib/hunks/change';
 	import { vscodePath } from '$lib/project/project';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
-	import { ID_SELECTION } from '$lib/selection/idSelection.svelte';
+	import { FILE_SELECTION_MANAGER } from '$lib/selection/fileSelectionManager.svelte';
 	import { SETTINGS } from '$lib/settings/userSettings';
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
 	import { UI_STATE } from '$lib/state/uiState.svelte';
@@ -60,7 +60,7 @@
 	const { trigger, selectionId, stackId, projectId, editMode = false }: Props = $props();
 	const stackService = inject(STACK_SERVICE);
 	const uiState = inject(UI_STATE);
-	const idSelection = inject(ID_SELECTION);
+	const idSelection = inject(FILE_SELECTION_MANAGER);
 	const aiService = inject(AI_SERVICE);
 	const actionService = inject(ACTION_SERVICE);
 	const fileService = inject(FILE_SERVICE);

--- a/apps/desktop/src/components/FileList.svelte
+++ b/apps/desktop/src/components/FileList.svelte
@@ -13,8 +13,8 @@
 	import { type TreeChange, type Modification } from '$lib/hunks/change';
 	import { MODE_SERVICE } from '$lib/mode/modeService';
 	import { showToast } from '$lib/notifications/toasts';
-	import { ID_SELECTION } from '$lib/selection/idSelection.svelte';
-	import { selectFilesInList, updateSelection } from '$lib/selection/idSelectionUtils';
+	import { FILE_SELECTION_MANAGER } from '$lib/selection/fileSelectionManager.svelte';
+	import { selectFilesInList, updateSelection } from '$lib/selection/fileSelectionUtils';
 	import { type SelectionId } from '$lib/selection/key';
 	import { chunk } from '$lib/utils/array';
 	import { inject, injectOptional } from '@gitbutler/core/context';
@@ -52,8 +52,8 @@
 		onselect
 	}: Props = $props();
 
-	const idSelection = inject(ID_SELECTION);
 	const focusManager = inject(FOCUS_MANAGER);
+	const idSelection = inject(FILE_SELECTION_MANAGER);
 	const aiService = inject(AI_SERVICE);
 	const actionService = inject(ACTION_SERVICE);
 	const modeService = injectOptional(MODE_SERVICE, undefined);
@@ -212,6 +212,7 @@
 			});
 			return true;
 		}
+		return false;
 	}
 	const lastAdded = $derived(idSelection.getById(selectionId).lastAdded);
 	$effect(() => {

--- a/apps/desktop/src/components/FileListItemWrapper.svelte
+++ b/apps/desktop/src/components/FileListItemWrapper.svelte
@@ -8,7 +8,7 @@
 	import { DROPZONE_REGISTRY } from '$lib/dragging/registry';
 	import { getFilename } from '$lib/files/utils';
 	import { type TreeChange } from '$lib/hunks/change';
-	import { ID_SELECTION } from '$lib/selection/idSelection.svelte';
+	import { FILE_SELECTION_MANAGER } from '$lib/selection/fileSelectionManager.svelte';
 	import { key, type SelectionId } from '$lib/selection/key';
 	import { UNCOMMITTED_SERVICE } from '$lib/selection/uncommittedService.svelte';
 	import { computeChangeStatus } from '$lib/utils/fileStatus';
@@ -71,7 +71,7 @@
 		scrollContainer
 	}: Props = $props();
 
-	const idSelection = inject(ID_SELECTION);
+	const idSelection = inject(FILE_SELECTION_MANAGER);
 	const uncommittedService = inject(UNCOMMITTED_SERVICE);
 	const dropzoneRegistry = inject(DROPZONE_REGISTRY);
 	const dragStateService = inject(DRAG_STATE_SERVICE);

--- a/apps/desktop/src/components/NewCommitView.svelte
+++ b/apps/desktop/src/components/NewCommitView.svelte
@@ -3,7 +3,7 @@
 	import { projectRunCommitHooks } from '$lib/config/config';
 	import { HOOKS_SERVICE } from '$lib/hooks/hooksService';
 	import { showError, showToast } from '$lib/notifications/toasts';
-	import { ID_SELECTION } from '$lib/selection/idSelection.svelte';
+	import { FILE_SELECTION_MANAGER } from '$lib/selection/fileSelectionManager.svelte';
 	import { createWorktreeSelection } from '$lib/selection/key';
 	import { UNCOMMITTED_SERVICE } from '$lib/selection/uncommittedService.svelte';
 	import { COMMIT_ANALYTICS } from '$lib/soup/commitAnalytics';
@@ -25,7 +25,7 @@
 	const hooksService = inject(HOOKS_SERVICE);
 	const uncommittedService = inject(UNCOMMITTED_SERVICE);
 	const commitAnalytics = inject(COMMIT_ANALYTICS);
-	const idSelection = inject(ID_SELECTION);
+	const idSelection = inject(FILE_SELECTION_MANAGER);
 
 	const projectState = $derived(uiState.project(projectId));
 	// Using a dummy stackId kind of sucks... but it's fine for now

--- a/apps/desktop/src/components/SelectionView.svelte
+++ b/apps/desktop/src/components/SelectionView.svelte
@@ -4,7 +4,7 @@
 	import ReduxResult from '$components/ReduxResult.svelte';
 	import UnifiedDiffView from '$components/UnifiedDiffView.svelte';
 	import { DIFF_SERVICE } from '$lib/hunks/diffService.svelte';
-	import { ID_SELECTION } from '$lib/selection/idSelection.svelte';
+	import { FILE_SELECTION_MANAGER } from '$lib/selection/fileSelectionManager.svelte';
 	import { readKey, type SelectionId } from '$lib/selection/key';
 	import { inject } from '@gitbutler/core/context';
 
@@ -30,7 +30,7 @@
 		bottomBorder
 	}: Props = $props();
 
-	const idSelection = inject(ID_SELECTION);
+	const idSelection = inject(FILE_SELECTION_MANAGER);
 	const diffService = inject(DIFF_SERVICE);
 
 	const selection = $derived(selectionId ? idSelection.valuesReactive(selectionId) : undefined);

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -13,7 +13,7 @@
 	import { stagingBehaviorFeature } from '$lib/config/uiFeatureFlags';
 	import { isParsedError } from '$lib/error/parser';
 	import { DIFF_SERVICE } from '$lib/hunks/diffService.svelte';
-	import { ID_SELECTION } from '$lib/selection/idSelection.svelte';
+	import { FILE_SELECTION_MANAGER } from '$lib/selection/fileSelectionManager.svelte';
 	import {
 		createBranchSelection,
 		createCommitSelection,
@@ -62,7 +62,7 @@
 	const diffService = inject(DIFF_SERVICE);
 	const uncommittedService = inject(UNCOMMITTED_SERVICE);
 	const uiState = inject(UI_STATE);
-	const idSelection = inject(ID_SELECTION);
+	const idSelection = inject(FILE_SELECTION_MANAGER);
 
 	// Component is read-only when stackId is undefined
 	const isReadOnly = $derived(!stackId);

--- a/apps/desktop/src/components/UnassignedView.svelte
+++ b/apps/desktop/src/components/UnassignedView.svelte
@@ -6,7 +6,7 @@
 	import noChanges from '$lib/assets/illustrations/no-changes.svg?raw';
 	import { SETTINGS_SERVICE } from '$lib/config/appSettingsV2';
 	import { stagingBehaviorFeature } from '$lib/config/uiFeatureFlags';
-	import { ID_SELECTION } from '$lib/selection/idSelection.svelte';
+	import { FILE_SELECTION_MANAGER } from '$lib/selection/fileSelectionManager.svelte';
 	import { createWorktreeSelection } from '$lib/selection/key';
 	import { UNCOMMITTED_SERVICE } from '$lib/selection/uncommittedService.svelte';
 	import { UI_STATE } from '$lib/state/uiState.svelte';
@@ -24,7 +24,7 @@
 
 	const uiState = inject(UI_STATE);
 	const uncommittedService = inject(UNCOMMITTED_SERVICE);
-	const idSelection = inject(ID_SELECTION);
+	const idSelection = inject(FILE_SELECTION_MANAGER);
 	const settingsService = inject(SETTINGS_SERVICE);
 	const settingsStore = $derived(settingsService.appSettings);
 	const projectState = $derived(uiState.project(projectId));

--- a/apps/desktop/src/components/WorkspaceView.svelte
+++ b/apps/desktop/src/components/WorkspaceView.svelte
@@ -8,7 +8,7 @@
 	import UnassignedView from '$components/UnassignedView.svelte';
 	import { BASE_BRANCH_SERVICE } from '$lib/baseBranch/baseBranchService.svelte';
 	import { SETTINGS_SERVICE } from '$lib/config/appSettingsV2';
-	import { ID_SELECTION } from '$lib/selection/idSelection.svelte';
+	import { FILE_SELECTION_MANAGER } from '$lib/selection/fileSelectionManager.svelte';
 	import { createWorktreeSelection } from '$lib/selection/key';
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
 	import { UI_STATE, type ExclusiveAction } from '$lib/state/uiState.svelte';
@@ -25,7 +25,7 @@
 
 	const stackService = inject(STACK_SERVICE);
 	const uiState = inject(UI_STATE);
-	const idSelection = inject(ID_SELECTION);
+	const idSelection = inject(FILE_SELECTION_MANAGER);
 	const settingsService = inject(SETTINGS_SERVICE);
 	const baseBranchService = inject(BASE_BRANCH_SERVICE);
 

--- a/apps/desktop/src/components/WorktreeChanges.svelte
+++ b/apps/desktop/src/components/WorktreeChanges.svelte
@@ -8,7 +8,7 @@
 	import { UncommitDzHandler } from '$lib/commits/dropHandler';
 	import { DIFF_SERVICE } from '$lib/hunks/diffService.svelte';
 	import { AssignmentDropHandler } from '$lib/hunks/dropHandler';
-	import { ID_SELECTION } from '$lib/selection/idSelection.svelte';
+	import { FILE_SELECTION_MANAGER } from '$lib/selection/fileSelectionManager.svelte';
 	import { createWorktreeSelection } from '$lib/selection/key';
 	import { UNCOMMITTED_SERVICE } from '$lib/selection/uncommittedService.svelte';
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
@@ -53,7 +53,7 @@
 	const diffService = inject(DIFF_SERVICE);
 	const uncommittedService = inject(UNCOMMITTED_SERVICE);
 	const uiState = inject(UI_STATE);
-	const idSelection = inject(ID_SELECTION);
+	const idSelection = inject(FILE_SELECTION_MANAGER);
 
 	// Create selectionId for this worktree lane
 	const selectionId = $derived(createWorktreeSelection({ stackId }));

--- a/apps/desktop/src/lib/bootstrap/deps.ts
+++ b/apps/desktop/src/lib/bootstrap/deps.ts
@@ -42,7 +42,10 @@ import { PROMPT_SERVICE, PromptService } from '$lib/prompt/promptService';
 import { REMOTES_SERVICE, RemotesService } from '$lib/remotes/remotesService';
 import RulesService, { RULES_SERVICE } from '$lib/rules/rulesService.svelte';
 import { RustSecretService, SECRET_SERVICE } from '$lib/secrets/secretsService';
-import { IdSelection, ID_SELECTION } from '$lib/selection/idSelection.svelte';
+import {
+	FileSelectionManager,
+	FILE_SELECTION_MANAGER
+} from '$lib/selection/fileSelectionManager.svelte';
 import { UncommittedService, UNCOMMITTED_SERVICE } from '$lib/selection/uncommittedService.svelte';
 import { loadUserSettings, SETTINGS } from '$lib/settings/userSettings';
 import { ShortcutService, SHORTCUT_SERVICE } from '$lib/shortcuts/shortcutService';
@@ -216,7 +219,7 @@ export function initDependencies(args: {
 	// ============================================================================
 
 	const uncommittedService = new UncommittedService(clientState, worktreeService, diffService);
-	const idSelection = new IdSelection(
+	const fileSelectionManager = new FileSelectionManager(
 		stackService,
 		uncommittedService,
 		worktreeService,
@@ -327,7 +330,7 @@ export function initDependencies(args: {
 		[HISTORY_SERVICE, historyService],
 		[HOOKS_SERVICE, hooksService],
 		[HTTP_CLIENT, httpClient],
-		[ID_SELECTION, idSelection],
+		[FILE_SELECTION_MANAGER, fileSelectionManager],
 		[IME_COMPOSITION_HANDLER, imeHandler],
 		[IRC_CLIENT, ircClient],
 		[IRC_SERVICE, ircService],

--- a/apps/desktop/src/lib/dragging/draggables.ts
+++ b/apps/desktop/src/lib/dragging/draggables.ts
@@ -3,7 +3,7 @@ import type { CodegenRuleDropData } from '$lib/codegen/dropzone';
 import type { CommitDropData } from '$lib/commits/dropHandler';
 import type { TreeChange } from '$lib/hunks/change';
 import type { HunkAssignment, HunkHeader } from '$lib/hunks/hunk';
-import type { IdSelection } from '$lib/selection/idSelection.svelte';
+import type { FileSelectionManager } from '$lib/selection/fileSelectionManager.svelte';
 
 export class HunkDropDataV3 {
 	constructor(
@@ -27,7 +27,7 @@ export class ChangeDropData {
 		 * want to ignore what is selected and only drag the actual file being
 		 * dragged.
 		 */
-		private selection: IdSelection,
+		private selection: FileSelectionManager,
 		readonly selectionId: SelectionId,
 		readonly stackId?: string
 	) {}

--- a/apps/desktop/src/lib/hunks/dropHandler.ts
+++ b/apps/desktop/src/lib/hunks/dropHandler.ts
@@ -1,7 +1,7 @@
 import { ChangeDropData, HunkDropDataV3 } from '$lib/dragging/draggables';
 import { type DiffService } from '$lib/hunks/diffService.svelte';
 import type { DropzoneHandler } from '$lib/dragging/handler';
-import type { IdSelection } from '$lib/selection/idSelection.svelte';
+import type { FileSelectionManager } from '$lib/selection/fileSelectionManager.svelte';
 import type { UncommittedService } from '$lib/selection/uncommittedService.svelte';
 
 export class AssignmentDropHandler implements DropzoneHandler {
@@ -10,7 +10,7 @@ export class AssignmentDropHandler implements DropzoneHandler {
 		private readonly diffService: DiffService,
 		private readonly uncommittedService: UncommittedService,
 		private readonly stackId: string | undefined,
-		private readonly idSelection: IdSelection
+		private readonly idSelection: FileSelectionManager
 	) {}
 
 	accepts(data: unknown) {

--- a/apps/desktop/src/lib/selection/fileSelectionManager.svelte.ts
+++ b/apps/desktop/src/lib/selection/fileSelectionManager.svelte.ts
@@ -20,12 +20,14 @@ import type { UncommittedService } from '$lib/selection/uncommittedService.svelt
 import type { StackService } from '$lib/stacks/stackService.svelte';
 import type { WorktreeService } from '$lib/worktree/worktreeService.svelte';
 
-export const ID_SELECTION = new InjectionToken<IdSelection>('IdSelection');
+export const FILE_SELECTION_MANAGER = new InjectionToken<FileSelectionManager>(
+	'FileSelectionManager'
+);
 
 /**
  * File selection mechanism based on strings id's.
  */
-export class IdSelection {
+export class FileSelectionManager {
 	private selections: Map<
 		/** Return value of `selectionKey`. */
 		string,

--- a/apps/desktop/src/lib/selection/fileSelectionUtils.ts
+++ b/apps/desktop/src/lib/selection/fileSelectionUtils.ts
@@ -9,7 +9,7 @@ import { getSelectionDirection } from '$lib/utils/getSelectionDirection';
 import { KeyName } from '@gitbutler/ui/utils/hotkeys';
 import { get } from 'svelte/store';
 import type { TreeChange } from '$lib/hunks/change';
-import type { IdSelection } from '$lib/selection/idSelection.svelte';
+import type { FileSelectionManager } from '$lib/selection/fileSelectionManager.svelte';
 
 function getFile(files: TreeChange[], id: string): TreeChange | undefined {
 	return files.find((f) => f.path === id);
@@ -60,7 +60,7 @@ interface UpdateSelectionParams {
 	targetElement: HTMLElement;
 	files: TreeChange[];
 	selectedFileIds: SelectedFile[];
-	fileIdSelection: IdSelection;
+	fileIdSelection: FileSelectionManager;
 	selectionId: SelectionId;
 	preventDefault: () => void;
 }
@@ -76,7 +76,7 @@ export function updateSelection({
 	fileIdSelection,
 	selectionId,
 	preventDefault
-}: UpdateSelectionParams) {
+}: UpdateSelectionParams): boolean | undefined {
 	if (!selectedFileIds[0] || selectedFileIds.length === 0) return;
 
 	const firstFileId = selectedFileIds[0].path;
@@ -186,7 +186,7 @@ export function selectFilesInList(
 	e: MouseEvent | KeyboardEvent,
 	change: TreeChange,
 	sortedFiles: TreeChange[],
-	idSelection: IdSelection,
+	idSelection: FileSelectionManager,
 	selectedFileIds: SelectedFile[],
 	allowMultiple: boolean,
 	index: number,

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -22,7 +22,7 @@
 	import { IRC_CLIENT } from '$lib/irc/ircClient.svelte';
 	import { IRC_SERVICE } from '$lib/irc/ircService.svelte';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
-	import { ID_SELECTION } from '$lib/selection/idSelection.svelte';
+	import { FILE_SELECTION_MANAGER } from '$lib/selection/fileSelectionManager.svelte';
 	import { SHORTCUT_SERVICE } from '$lib/shortcuts/shortcutService';
 	import { CLIENT_STATE } from '$lib/state/clientState.svelte';
 	import { UI_STATE } from '$lib/state/uiState.svelte';
@@ -108,7 +108,7 @@
 	const settingsService = inject(SETTINGS_SERVICE);
 	const settingsStore = settingsService.appSettings;
 	const uiState = inject(UI_STATE);
-	const idSelection = inject(ID_SELECTION);
+	const idSelection = inject(FILE_SELECTION_MANAGER);
 
 	// Debug keyboard shortcuts
 	const handleKeyDown = createKeybind({

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -24,7 +24,7 @@
 	import { showError, showInfo, showWarning } from '$lib/notifications/toasts';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
 	import { SECRET_SERVICE } from '$lib/secrets/secretsService';
-	import { ID_SELECTION } from '$lib/selection/idSelection.svelte';
+	import { FILE_SELECTION_MANAGER } from '$lib/selection/fileSelectionManager.svelte';
 	import { UNCOMMITTED_SERVICE } from '$lib/selection/uncommittedService.svelte';
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
 	import { CLIENT_STATE } from '$lib/state/clientState.svelte';
@@ -134,7 +134,7 @@
 	// ================================================ReorderDropzoneFactory
 
 	const uncommittedService = inject(UNCOMMITTED_SERVICE);
-	const idSelection = inject(ID_SELECTION);
+	const idSelection = inject(FILE_SELECTION_MANAGER);
 
 	const worktreeDataResult = $derived(worktreeService.worktreeData(projectId));
 	const worktreeData = $derived(worktreeDataResult.current.data);

--- a/apps/desktop/src/routes/[projectId]/history/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/history/+page.svelte
@@ -10,7 +10,7 @@
 	import SnapshotCard from '$components/SnapshotCard.svelte';
 	import emptyFolderSvg from '$lib/assets/empty-state/empty-folder.svg?raw';
 	import { HISTORY_SERVICE, createdOnDay } from '$lib/history/history';
-	import { ID_SELECTION } from '$lib/selection/idSelection.svelte';
+	import { FILE_SELECTION_MANAGER } from '$lib/selection/fileSelectionManager.svelte';
 	import { createSnapshotSelection, type SelectionId } from '$lib/selection/key';
 	import { inject } from '@gitbutler/core/context';
 	import { EmptyStatePlaceholder, Icon } from '@gitbutler/ui';
@@ -22,7 +22,7 @@
 
 	const MIN_SNAPSHOTS_TO_LOAD = 30;
 
-	const idSelection = inject(ID_SELECTION);
+	const idSelection = inject(FILE_SELECTION_MANAGER);
 
 	let sidebarEl = $state<HTMLElement>();
 


### PR DESCRIPTION
Rename the selection service and types from Id/ID_SELECTION to
FileSelectionManager/FILE_SELECTION_MANAGER across the desktop app.
Update imports, dependency injection keys, bootstrap registration, and 
all type annotations and usage sites (FileList, FileListItemWrapper,
idSelectionUtils, drop handler and deps).

This clarifies the purpose of the selection component (managing file
selection) and brings naming consistency between the service and its
injection token.