### PR TITLE
Await PostHog initialization before funnel event

### DIFF
--- a/apps/desktop/src/components/AnalyticsConfirmation.svelte
+++ b/apps/desktop/src/components/AnalyticsConfirmation.svelte
@@ -22,8 +22,10 @@
 			icon="chevron-right-small"
 			onclick={() => {
 				$analyticsConfirmed = true;
-				initAnalyticsIfEnabled(appSettings, posthog);
-				posthog.captureOnboarding(OnboardingEvent.ConfirmedAnalytics);
+				initAnalyticsIfEnabled(appSettings, posthog, true).then(() => {
+					// Await the initialization before logging the event to ensure PostHog is ready
+					posthog.captureOnboarding(OnboardingEvent.ConfirmedAnalytics);
+				});
 			}}
 		>
 			Continue


### PR DESCRIPTION
- Make initAnalyticsIfEnabled an async function.
- Pass confirmedOverride parameter to allow awaiting confirmation for analytics.
- In AnalyticsConfirmation.svelte, await analytics initialization before firing onboarding event to ensure PostHog is ready.
