### PR TITLE
Make PostHog init method idempotent

### DIFF
--- a/apps/desktop/src/lib/analytics/posthog.ts
+++ b/apps/desktop/src/lib/analytics/posthog.ts
@@ -37,6 +37,7 @@ export class PostHogWrapper {
 	}
 
 	async init() {
+		if (this._instance) return;
 		const appInfo = await this.backend.getAppInfo();
 		this._instance = posthog.init(PUBLIC_POSTHOG_API_KEY, {
 			api_host: 'https://eu.posthog.com',


### PR DESCRIPTION
Adds a check in the PostHog analytics class's init method to return early if the instance has already been initialized. Ensures that calling init() multiple times does not reinitialize and prevents possible side effects from multiple initializations.