### PR TITLE
Disable analytics metrics init on CI

### DIFF
--- a/apps/desktop/src/lib/analytics/analytics.ts
+++ b/apps/desktop/src/lib/analytics/analytics.ts
@@ -8,7 +8,7 @@ export async function initAnalyticsIfEnabled(
 	postHog: PostHogWrapper,
 	confirmedOverride?: boolean
 ) {
-	if (import.meta.env.MODE === 'development') return;
+	if (import.meta.env.MODE === 'development' || import.meta.env.CI) return;
 
 	const confirmed = confirmedOverride ?? (await appSettings.appAnalyticsConfirmed.onDisk());
 


### PR DESCRIPTION
This change modifies the analytics initialization check so that if the application is running in a CI environment it doesn’t emit metrics