### PR TITLE
A bit of redux housekeeping

### DIFF
--- a/apps/desktop/src/lib/state/context.ts
+++ b/apps/desktop/src/lib/state/context.ts
@@ -1,6 +1,6 @@
 import type { PostHogWrapper } from '$lib/analytics/posthog';
-import type { EntityState, ThunkDispatch, UnknownAction } from '@reduxjs/toolkit';
-import type { CombinedState } from '@reduxjs/toolkit/query';
+import type { ThunkDispatch, UnknownAction } from '@reduxjs/toolkit';
+import type { RootState } from '@reduxjs/toolkit/query';
 
 /**
  *	The api is necessary to create the store, so we need to provide
@@ -11,7 +11,7 @@ import type { CombinedState } from '@reduxjs/toolkit/query';
  */
 export type HookContext = {
 	/** Without the nested function we get looping reactivity.  */
-	getState: () => () => { [k: string]: CombinedState<any, any, any> | EntityState<any, any> };
+	getState: () => RootState<any, any, any>;
 	getDispatch: () => ThunkDispatch<any, any, UnknownAction>;
 	posthog?: PostHogWrapper;
 };

--- a/apps/desktop/src/lib/state/customHooks.svelte.ts
+++ b/apps/desktop/src/lib/state/customHooks.svelte.ts
@@ -14,7 +14,6 @@ import {
 	type QueryActionCreatorResult,
 	type QueryArgFrom,
 	type ResultTypeFrom,
-	type RootState,
 	type StartQueryActionCreatorOptions
 } from '@reduxjs/toolkit/query';
 import { createSubscriber } from 'svelte/reactivity';
@@ -49,7 +48,6 @@ export function buildQueryHooks<Definitions extends ExtensionDefinitions>({
 	ctx: HookContext;
 }) {
 	const endpoint = api.endpoints[endpointName]!;
-	const state = getState() as any as () => RootState<any, any, any>;
 
 	const { initiate, select } = endpoint as ApiEndpointQuery<CustomQuery<any>, Definitions>;
 
@@ -128,7 +126,7 @@ export function buildQueryHooks<Definitions extends ExtensionDefinitions>({
 		}
 
 		const selector = $derived(select(queryArg));
-		const result = $derived(selector(state()));
+		const result = $derived(selector(getState()));
 
 		const output = $derived.by(() => {
 			let data = result.data;
@@ -181,7 +179,7 @@ export function buildQueryHooks<Definitions extends ExtensionDefinitions>({
 
 		const results = queryArgs.map((queryArg) => {
 			const selector = $derived(select(queryArg));
-			const result = $derived(selector(state()));
+			const result = $derived(selector(getState()));
 			const output = $derived.by(() => {
 				let data = result.data;
 				if (options?.transform && data) {
@@ -202,7 +200,7 @@ export function buildQueryHooks<Definitions extends ExtensionDefinitions>({
 
 	function useQueryState<T extends TranformerFn>(queryArg: unknown, options?: { transform?: T }) {
 		const selector = $derived(select(queryArg));
-		const result = $derived(selector(state()));
+		const result = $derived(selector(getState()));
 		const output = $derived.by(() => {
 			let data = result.data;
 			if (options?.transform && data) {
@@ -219,7 +217,7 @@ export function buildQueryHooks<Definitions extends ExtensionDefinitions>({
 
 	function useQueryTimeStamp(queryArg: unknown) {
 		const selector = $derived(select(queryArg));
-		const result = $derived(selector(state()));
+		const result = $derived(selector(getState()));
 		return reactive(() => result.startedTimeStamp);
 	}
 
@@ -344,7 +342,6 @@ export function buildMutationHook<
 	ctx: HookContext;
 }): MutationHook<D> {
 	const endpoint = api.endpoints[endpointName]!;
-	const state = getState() as any as () => RootState<any, any, any>;
 
 	const { initiate, select } = endpoint as unknown as ApiEndpointMutation<D, Definitions>;
 
@@ -454,7 +451,7 @@ export function buildMutationHook<
 		}
 
 		const selector = $derived(select({ requestId: promise?.requestId, fixedCacheKey }));
-		const result = $derived(selector(state()));
+		const result = $derived(selector(getState()));
 
 		const subscribe = createSubscriber(() => {
 			return () => {

--- a/apps/desktop/src/lib/testing/mockGitHubApi.svelte.ts
+++ b/apps/desktop/src/lib/testing/mockGitHubApi.svelte.ts
@@ -31,7 +31,7 @@ export function setupMockGitHubApi() {
 	const gitHubClient = new GitHubClient({ client: octokit });
 	gitHubClient.setRepo({ owner: 'test-owner', repo: 'test-repo' });
 	const gitHubApi = createGitHubApi(
-		butlerModule({ getDispatch: () => dispatch!, getState: () => () => state })
+		butlerModule({ getDispatch: () => dispatch!, getState: () => state })
 	);
 
 	const store = configureStore({


### PR DESCRIPTION
We've had this weird function signature in the core of the redux state 
management. In this commit we remove that extra function, while 
preserving reactivity as is.

Also cleans up a few typos, and reduces a bit of code duplication.