### PR TITLE
Try to make "Back to workspace" button disapper when there is no operating mode

### DIFF
--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -228,7 +228,7 @@
 			{/if}
 		</div>
 
-		{#if currentMode !== null && isNotInWorkspace}
+		{#if currentMode && isNotInWorkspace}
 			<Tooltip text="Switch back to gitbutler/workspace">
 				<Button
 					kind="outline"


### PR DESCRIPTION
Follow-up to 
https://github.com/gitbutlerapp/gitbutler/pull/10170
which should have worked. But there the `null` check worked for some reason.
