### PR TITLE
Worktree changes: Dependecy errors toast and fallback

### DIFF
--- a/apps/desktop/src/lib/dependencies/dependencies.ts
+++ b/apps/desktop/src/lib/dependencies/dependencies.ts
@@ -1,5 +1,9 @@
 import type { DiffHunk } from '$lib/hunks/hunk';
 
+export type DependencyError = {
+	description: string;
+};
+
 export type CalculationError = {
 	/**
 	 * The error message.

--- a/apps/desktop/src/lib/hunks/change.ts
+++ b/apps/desktop/src/lib/hunks/change.ts
@@ -1,6 +1,5 @@
-import type { HunkDependencies } from '$lib/dependencies/dependencies';
-import type { HunkAssignment } from '$lib/hunks/hunk';
-import type { ReduxError } from '$lib/state/reduxError';
+import type { DependencyError, HunkDependencies } from '$lib/dependencies/dependencies';
+import type { HunkAssignment, HunkAssignmentError } from '$lib/hunks/hunk';
 
 /** Contains the changes that are in the worktree */
 export type WorktreeChanges = {
@@ -12,9 +11,9 @@ export type WorktreeChanges = {
 	 */
 	readonly ignoredChanges: IgnoredChange[];
 	readonly assignments: HunkAssignment[];
-	readonly assignmentsError: ReduxError | null;
+	readonly assignmentsError: HunkAssignmentError | null;
 	readonly dependencies: HunkDependencies | null;
-	readonly dependenciesError: ReduxError | null;
+	readonly dependenciesError: DependencyError | null;
 };
 
 /**

--- a/apps/desktop/src/lib/hunks/hunk.ts
+++ b/apps/desktop/src/lib/hunks/hunk.ts
@@ -35,6 +35,10 @@ export type HunkHeader = {
 	readonly newLines: number;
 };
 
+export type HunkAssignmentError = {
+	description: string;
+};
+
 /**
  * Represents a loose association between a hunk and a stack.
  * A hunk being assigned to a stack means that upon unapplying the stack,

--- a/apps/desktop/src/lib/notifications/toasts.ts
+++ b/apps/desktop/src/lib/notifications/toasts.ts
@@ -47,7 +47,7 @@ export function showToast(toast: Toast) {
 	]);
 }
 
-export function showError(title: string, error: unknown, extraAction?: ExtraAction) {
+export function showError(title: string, error: unknown, extraAction?: ExtraAction, id?: string) {
 	const { name, message, description, ignored } = parseError(error);
 	if (isBundlingError(message)) {
 		console.warn(
@@ -60,6 +60,7 @@ export function showError(title: string, error: unknown, extraAction?: ExtraActi
 	if (!ignored) {
 		const commonErrorTitle = getTitleFromCommonErrorMessage(message);
 		showToast({
+			id,
 			title: name || commonErrorTitle || title,
 			message: description,
 			error: message,

--- a/crates/but-hunk-dependency/src/ui.rs
+++ b/crates/but-hunk-dependency/src/ui.rs
@@ -44,7 +44,7 @@ pub fn hunk_dependencies_for_workspace_changes_by_worktree_dir(
 ///
 /// Note that the [`errors`](Self::errors) field may contain information about specific failures, while other paths
 /// may have succeeded computing.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Default)]
 pub struct HunkDependencies {
     /// A map from hunk diffs to stack and commit dependencies.
     pub diffs: Vec<(String, DiffHunk, Vec<HunkLock>)>,


### PR DESCRIPTION
- If the calculation of dependencies and assignments fails, fallback to assuming there are no dependencies
- Surface any errors regarding the calculation of dependencies or hunk assignments when fetching the worktree changes

Has to do (but doesn't fully take care of): https://github.com/gitbutlerapp/gitbutler/issues/10198