### PR TITLE
Enable commitActions test and add Tauri event plugin mocks

### DIFF
--- a/apps/desktop/cypress/e2e/commitActions.cy.ts
+++ b/apps/desktop/cypress/e2e/commitActions.cy.ts
@@ -727,7 +727,7 @@ describe('Commit Actions with lots of uncommitted changes', () => {
 		clearCommandMocks();
 	});
 
-	it.skip('should be able to commit a bunch of times in a row and edit their message', () => {
+	it('should be able to commit a bunch of times in a row and edit their message', () => {
 		const TIMES = 3;
 		for (let i = 0; i < TIMES; i++) {
 			// Click commit button

--- a/apps/desktop/cypress/e2e/support/index.ts
+++ b/apps/desktop/cypress/e2e/support/index.ts
@@ -17,6 +17,7 @@ import type { ProjectInfo } from '$lib/project/projectsService';
 function mockInternals(window: any) {
 	window.__TAURI_INTERNALS__ = window.__TAURI_INTERNALS__ ?? {};
 	window.__TAURI_OS_PLUGIN_INTERNALS__ = window.__TAURI_OS_PLUGIN_INTERNALS__ ?? {};
+	window.__TAURI_EVENT_PLUGIN_INTERNALS__ = window.__TAURI_EVENT_PLUGIN_INTERNALS__ ?? {};
 }
 
 type MockCallback = (args?: InvokeArgs) => unknown;
@@ -53,6 +54,8 @@ export function mockIPC(window: any, cb: MockCommandCallback): void {
 	): Promise<unknown> {
 		return cb(cmd, args);
 	} as typeof invoke;
+
+	window.__TAURI_EVENT_PLUGIN_INTERNALS__.unregisterListener = async () => await Promise.resolve();
 }
 
 export function mockWindows(window: any, current: string, ..._additionalWindows: string[]): void {


### PR DESCRIPTION
- Re-enabled a skipped Cypress test in commitActions.cy.ts by removing it.skip, so the test runs: should be able to commit a bunch of times in a row and edit their message.
- Add initialization for __TAURI_EVENT_PLUGIN_INTERNALS__ mock in cypress support index to mirror other Tauri internals and prevent undefined access.
- Add a noop unregisterListener implementation on window.__TAURI_EVENT_PLUGIN_INTERNALS__ to satisfy calls during tests.
