### PR TITLE
optional unidiff

### DIFF
--- a/apps/desktop/src/components/FileListItemWrapper.svelte
+++ b/apps/desktop/src/components/FileListItemWrapper.svelte
@@ -24,7 +24,7 @@
 		projectId: string;
 		stackId?: string;
 		change: TreeChange;
-		diff?: UnifiedDiff;
+		diff?: UnifiedDiff | null;
 		selectionId: SelectionId;
 		selected?: boolean;
 		isHeader?: boolean;

--- a/apps/desktop/src/components/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/UnifiedDiffView.svelte
@@ -36,7 +36,7 @@
 		projectId: string;
 		selectable: boolean;
 		change: TreeChange;
-		diff: UnifiedDiff;
+		diff: UnifiedDiff | null;
 		selectionId: SelectionId;
 		stackId?: string;
 		commitId?: string;
@@ -174,7 +174,15 @@
 		class:top-padding={topPadding}
 		bind:this={viewport}
 	>
-		{#if diff.type === 'Patch'}
+		{#if diff === null}
+			<div class="hunk-placehoder">
+				<EmptyStatePlaceholder image={binarySvg} gap={12} topBottomPadding={34}>
+					{#snippet caption()}
+						Was not able to load the diff
+					{/snippet}
+				</EmptyStatePlaceholder>
+			</div>
+		{:else if diff.type === 'Patch'}
 			{@const linesModified = diff.subject.linesAdded + diff.subject.linesRemoved}
 			{#if linesModified > LARGE_DIFF_THRESHOLD && !showAnyways}
 				<LargeDiffMessage

--- a/apps/desktop/src/components/editor/commitSuggestions.svelte.ts
+++ b/apps/desktop/src/components/editor/commitSuggestions.svelte.ts
@@ -31,7 +31,7 @@ export default class CommitSuggestions {
 	setStagedChanges(changes: ChangeDiff[]) {
 		this.stagedChanges = changes
 			.map((change) => {
-				if (change.diff.type !== 'Patch') return;
+				if (change.diff?.type !== 'Patch') return;
 				return {
 					path: change.path,
 					diffs: change.diff.subject.hunks.map((hunk) => hunk.diff)

--- a/apps/desktop/src/lib/ai/diffInputContext.svelte.ts
+++ b/apps/desktop/src/lib/ai/diffInputContext.svelte.ts
@@ -129,7 +129,7 @@ export default class DiffInputContext {
 			const filePath = diff.path;
 			const diffStringBuffer: string[] = [];
 
-			if (diff.diff.type !== 'Patch') continue;
+			if (diff.diff?.type !== 'Patch') continue;
 
 			for (const hunk of diff.diff.subject.hunks) {
 				diffStringBuffer.push(hunk.diff);

--- a/apps/desktop/src/lib/hunks/diffService.svelte.ts
+++ b/apps/desktop/src/lib/hunks/diffService.svelte.ts
@@ -8,7 +8,7 @@ import type { ClientState } from '$lib/state/clientState.svelte';
 
 export type ChangeDiff = {
 	path: string;
-	diff: UnifiedDiff;
+	diff: UnifiedDiff | null;
 };
 
 export const DIFF_SERVICE = new InjectionToken<DiffService>('DiffService');
@@ -59,7 +59,7 @@ export class DiffService {
 function injectEndpoints(api: ClientState['backendApi']) {
 	return api.injectEndpoints({
 		endpoints: (build) => ({
-			getDiff: build.query<UnifiedDiff, { projectId: string; change: TreeChange }>({
+			getDiff: build.query<UnifiedDiff | null, { projectId: string; change: TreeChange }>({
 				extraOptions: { command: 'tree_change_diffs' },
 				query: (args) => args,
 				providesTags: [providesList(ReduxTag.Diff)]

--- a/apps/desktop/src/lib/selection/uncommittedService.svelte.ts
+++ b/apps/desktop/src/lib/selection/uncommittedService.svelte.ts
@@ -81,7 +81,7 @@ export class UncommittedService {
 		}
 		const file = changeDiff;
 
-		if (file.type !== 'Patch') return undefined;
+		if (file?.type !== 'Patch') return undefined;
 
 		const hunkDiff = file.subject.hunks.find(
 			(hunkDiff) =>
@@ -224,7 +224,7 @@ export class UncommittedService {
 				if (hunksAtPath.length === 0) return undefined;
 
 				// If the diff is not a patch, we can't/don't need to filter it.
-				if (diff.diff.type !== 'Patch') return diff;
+				if (diff.diff?.type !== 'Patch') return diff;
 
 				// Select the diff hunks that are also in the list of relevant hunks.
 				const filteredDiff = diff.diff.subject.hunks.filter((h) => {


### PR DESCRIPTION
This way the UI can indicate that diff-computation isn't possible here as first step.
As second step, it can predict this for common cases (TypeChange, but not change from blob to symlink) itself
and show something meaningful instead.

Fixes #10198 .

### Tasks

* [x] backend
* [x] frontend