### PR TITLE
Check for active input element before enabling kb nav

### DIFF
--- a/packages/ui/src/lib/focus/focusManager.ts
+++ b/packages/ui/src/lib/focus/focusManager.ts
@@ -769,6 +769,14 @@ export class FocusManager {
 
 		const navigationContext = this.buildNavigationContext(event, metadata);
 
+		if (this.shouldIgnoreNavigationForInput(navigationContext)) {
+			return false;
+		}
+
+		if (navigationContext.hasSelection) {
+			return false;
+		}
+
 		if (this.shouldShowOutlineOnly(navigationContext)) {
 			this.outline.set(true);
 			event.stopPropagation();
@@ -841,14 +849,6 @@ export class FocusManager {
 		navigationContext: NavigationContext
 	): boolean {
 		if (!navigationContext.action) return false;
-
-		if (this.shouldIgnoreNavigationForInput(navigationContext)) {
-			return false;
-		}
-
-		if (navigationContext.hasSelection) {
-			return false;
-		}
 
 		event.preventDefault();
 		event.stopPropagation();


### PR DESCRIPTION
This is part of a larger feature, but for it is needed for the next release so landing it early.