### PR TITLE
Worktree changes: add error filtering helpers and use them

### DIFF
--- a/apps/desktop/src/lib/dependencies/dependencies.ts
+++ b/apps/desktop/src/lib/dependencies/dependencies.ts
@@ -4,6 +4,14 @@ export type DependencyError = {
 	description: string;
 };
 
+export function shouldRaiseDependencyError(
+	error: DependencyError | null
+): error is DependencyError {
+	if (!error) return false;
+	if (error.description === 'errors.projects.default_target.not_found') return false;
+	return true;
+}
+
 export type CalculationError = {
 	/**
 	 * The error message.

--- a/apps/desktop/src/lib/hunks/hunk.ts
+++ b/apps/desktop/src/lib/hunks/hunk.ts
@@ -39,6 +39,14 @@ export type HunkAssignmentError = {
 	description: string;
 };
 
+export function shouldRaiseHunkAssignmentError(
+	error: HunkAssignmentError | null
+): error is HunkAssignmentError {
+	if (!error) return false;
+	if (error.description === 'errors.projects.default_target.not_found') return false;
+	return true;
+}
+
 /**
  * Represents a loose association between a hunk and a stack.
  * A hunk being assigned to a stack means that upon unapplying the stack,

--- a/apps/desktop/src/lib/worktree/worktreeService.svelte.ts
+++ b/apps/desktop/src/lib/worktree/worktreeService.svelte.ts
@@ -1,12 +1,16 @@
+import {
+	shouldRaiseDependencyError,
+	type DependencyError,
+	type HunkDependencies
+} from '$lib/dependencies/dependencies';
+import { shouldRaiseHunkAssignmentError, type HunkAssignment } from '$lib/hunks/hunk';
 import { showError } from '$lib/notifications/toasts';
 import { hasBackendExtra } from '$lib/state/backendQuery';
 import { createSelectByIds } from '$lib/state/customSelectors';
 import { invalidatesList, providesList, ReduxTag } from '$lib/state/tags';
 import { InjectionToken } from '@gitbutler/core/context';
 import { createEntityAdapter, type EntityState } from '@reduxjs/toolkit';
-import type { DependencyError, HunkDependencies } from '$lib/dependencies/dependencies';
 import type { IgnoredChange, TreeChange, WorktreeChanges } from '$lib/hunks/change';
-import type { HunkAssignment } from '$lib/hunks/hunk';
 import type { ClientState } from '$lib/state/clientState.svelte';
 
 export const WORKTREE_SERVICE = new InjectionToken<WorktreeService>('WorktreeService');
@@ -136,7 +140,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 				 * that we can use selectors like `selectById`.
 				 */
 				transformResponse(response: WorktreeChanges) {
-					if (response.dependenciesError) {
+					if (shouldRaiseDependencyError(response.dependenciesError)) {
 						showError(
 							'Failed to compute dependencies',
 							response.dependenciesError.description,
@@ -145,7 +149,7 @@ function injectEndpoints(api: ClientState['backendApi']) {
 						);
 					}
 
-					if (response.assignmentsError) {
+					if (shouldRaiseHunkAssignmentError(response.assignmentsError)) {
 						showError(
 							'Failed to compute hunk assignments',
 							response.assignmentsError.description,


### PR DESCRIPTION
Introduce shouldRaiseHunkAssignmentError and shouldRaiseDependencyError
helpers to centralize logic that ignores non-actionable errors coming from
the backend (specifically 'errors.projects.default_target.not_found').

Replace direct null checks in the worktree service transformResponse with
these helpers so to avoid showing redundant error toasts for that known
benign condition. Keep existing behavior for other errors by returning
true when the error should be raised.