### PR TITLE
Fix stable file autoselect and selection id logic

### DIFF
--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -23,6 +23,7 @@
 	} from '$lib/selection/key';
 	import { UNCOMMITTED_SERVICE } from '$lib/selection/uncommittedService.svelte';
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
+	import { mapResult } from '$lib/state/helpers';
 	import { UI_STATE } from '$lib/state/uiState.svelte';
 
 	import { createBranchRef } from '$lib/utils/branch';
@@ -338,8 +339,12 @@
 
 {#snippet commitChangedFiles(commitId: string)}
 	{@const changesResult = stackService.commitChanges(projectId, commitId)}
-	<ReduxResult {projectId} {stackId} result={changesResult.current}>
-		{#snippet children(changes, { projectId, stackId })}
+	<ReduxResult
+		{projectId}
+		{stackId}
+		result={mapResult(changesResult.current, (changes) => ({ changes, commitId }))}
+	>
+		{#snippet children({ changes, commitId }, { projectId, stackId })}
 			{@const commitsResult = branchName
 				? stackService.commits(projectId, stackId, branchName)
 				: undefined}

--- a/apps/desktop/src/lib/state/helpers.ts
+++ b/apps/desktop/src/lib/state/helpers.ts
@@ -57,3 +57,17 @@ export function combineResults<T extends [...CustomResult<any>[]]>(
 		data
 	} as CustomResult<CustomQuery<{ [K in keyof T]: Exclude<T[K]['data'], undefined> }>>;
 }
+
+/**
+ * Map the data of a CustomResult, preserving other status fields as they are.
+ */
+export function mapResult<T, A>(
+	result: CustomResult<CustomQuery<T>>,
+	fn: (data: T) => A
+): CustomResult<CustomQuery<A>> {
+	if (result.data === undefined) {
+		return result as CustomResult<CustomQuery<A>>;
+	}
+
+	return { ...result, data: fn(result.data) } as CustomResult<CustomQuery<A>>;
+}


### PR DESCRIPTION
Fix inconsistent file autoselection due to unstable selection id generation and premature population from outdated changes list. Now, stable selection keys are used and the first changed file path is derived and used only after change list is loaded, fixing the timing bug in fileSelectionManager usage.

Also adds mapResult helper for result mapping and refactors selection key handling to new types and utilities.