### PR TITLE
Migrate GitConfigService API calls to RTK Query

### DIFF
--- a/apps/desktop/src/lib/ai/service.test.ts
+++ b/apps/desktop/src/lib/ai/service.test.ts
@@ -44,7 +44,13 @@ const defaultSecretsConfig = Object.freeze({
 class DummyGitConfigService extends GitConfigService {
 	constructor(private config: { [index: string]: string | undefined }) {
 		const backend = mockCreateBackend();
-		super(backend);
+		const MockClientState = vi.fn();
+		MockClientState.prototype.dispatch = vi.fn();
+		MockClientState.prototype.backendApi = {
+			injectEndpoints: vi.fn()
+		};
+		const mockClientState = new MockClientState();
+		super(mockClientState, backend);
 	}
 	async getGbConfig(_projectId: string): Promise<GbConfig> {
 		throw new Error('Method not implemented.');

--- a/apps/desktop/src/lib/bootstrap/deps.ts
+++ b/apps/desktop/src/lib/bootstrap/deps.ts
@@ -151,7 +151,7 @@ export function initDependencies(args: {
 	// ============================================================================
 
 	const projectsService = new ProjectsService(clientState, homeDir, backend);
-	const gitConfig = new GitConfigService(backend);
+	const gitConfig = new GitConfigService(clientState, backend);
 
 	// ============================================================================
 	// AI SERVICES

--- a/apps/desktop/src/lib/state/tags.ts
+++ b/apps/desktop/src/lib/state/tags.ts
@@ -31,7 +31,8 @@ export enum ReduxTag {
 	InitalEditListing = 'InitialEditListing',
 	EditChangesSinceInitial = 'EditChangesSinceInitial',
 	AuthorInfo = 'AuthorInfo',
-	IntegrationSteps = 'IntegrationSteps'
+	IntegrationSteps = 'IntegrationSteps',
+	GitConfigProperty = 'GitConfigProperty'
 }
 
 type Tag<T extends string | number> = {

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -17,6 +17,7 @@
 	import { POSTHOG_WRAPPER } from '$lib/analytics/posthog';
 	import { initDependencies } from '$lib/bootstrap/deps';
 	import { SETTINGS_SERVICE } from '$lib/config/appSettingsV2';
+	import { GIT_CONFIG_SERVICE } from '$lib/config/gitConfigService';
 	import { ircEnabled, ircServer, codegenEnabled } from '$lib/config/uiFeatureFlags';
 	import { GITHUB_CLIENT } from '$lib/forge/github/githubClient';
 	import { IRC_CLIENT } from '$lib/irc/ircClient.svelte';
@@ -77,9 +78,16 @@
 	// ANALYTICS & NAVIGATION
 	// =============================================================================
 
+	const gitConfig = inject(GIT_CONFIG_SERVICE);
+
 	if (browser) {
 		beforeNavigate(() => posthog.capture('$pageleave'));
-		afterNavigate(() => posthog.capture('$pageview'));
+		afterNavigate(() => {
+			// Invalidate the git config on every navigation to ensure we have the latest
+			// (in case the user changed something outside of GitButler)
+			gitConfig.invalidateGitConfig();
+			posthog.capture('$pageview');
+		});
 	}
 
 	// =============================================================================


### PR DESCRIPTION
This migrates the git config service to use RTK Query for all get/set/remove global config methods, leveraging Redux and query cache/invalidations for improved data consistency and less manual fetching. Includes new tags, endpoint injection, and integration into the app's layout for cache invalidation on navigation.