### PR TITLE
V3 apply/unapply: workspace checkout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,7 +1626,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3777,7 +3777,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.73.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "gix-actor 0.35.4",
  "gix-attributes 0.27.0",
@@ -3848,7 +3848,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.35.4"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "gix-date 0.10.5",
@@ -3879,7 +3879,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.27.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "gix-glob 0.21.0",
@@ -3905,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.14"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "thiserror 2.0.16",
 ]
@@ -3922,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "thiserror 2.0.16",
 ]
@@ -3930,7 +3930,7 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.6.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "gix-path 0.10.20",
@@ -3955,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "gix-chunk 0.4.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3968,7 +3968,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.46.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -3988,7 +3988,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.15.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bitflags 2.9.3",
  "bstr",
@@ -4000,7 +4000,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4031,7 +4031,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.10.5"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "itoa",
@@ -4044,7 +4044,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.53.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "gix-attributes 0.27.0",
@@ -4067,7 +4067,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "gix-discover 0.41.0",
@@ -4102,7 +4102,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.41.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "dunce",
@@ -4131,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.43.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -4151,7 +4151,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4185,7 +4185,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.16.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4210,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bitflags 2.9.3",
  "bstr",
@@ -4234,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "faster-hex",
  "gix-features 0.43.1",
@@ -4257,7 +4257,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.9.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "gix-hash 0.19.0",
  "hashbrown 0.16.0",
@@ -4280,7 +4280,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "gix-glob 0.21.0",
@@ -4321,7 +4321,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.41.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bitflags 2.9.3",
  "bstr",
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "18.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "gix-tempfile 18.0.0",
  "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4370,7 +4370,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.27.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "gix-actor 0.35.4",
@@ -4382,7 +4382,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4406,7 +4406,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bitflags 2.9.3",
  "gix-commitgraph 0.29.0",
@@ -4442,7 +4442,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.50.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "gix-actor 0.35.4",
@@ -4463,7 +4463,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.70.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "arc-swap",
  "gix-date 0.10.5",
@@ -4484,7 +4484,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.60.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "clru",
  "gix-chunk 0.4.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4505,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4516,7 +4516,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4541,7 +4541,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.20"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "gix-trace 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4554,7 +4554,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bitflags 2.9.3",
  "bstr",
@@ -4568,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.11.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4580,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.51.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -4617,7 +4617,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4648,7 +4648,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.53.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "gix-actor 0.35.4",
  "gix-features 0.43.1",
@@ -4669,7 +4669,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "gix-hash 0.19.0",
@@ -4682,7 +4682,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bitflags 2.9.3",
  "bstr",
@@ -4715,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "gix-commitgraph 0.29.0",
  "gix-date 0.10.5",
@@ -4741,7 +4741,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bitflags 2.9.3",
  "gix-path 0.10.20",
@@ -4753,7 +4753,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.5.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "gix-hash 0.19.0",
@@ -4765,7 +4765,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "filetime",
@@ -4787,7 +4787,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "gix-config",
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "18.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "dashmap",
  "gix-fs 0.16.1",
@@ -4859,7 +4859,7 @@ checksum = "e2ccaf54b0b1743a695b482ca0ab9d7603744d8d10b2e5d1a332fef337bee658"
 [[package]]
 name = "gix-trace"
 version = "0.1.13"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "tracing-core",
 ]
@@ -4867,7 +4867,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.48.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -4903,7 +4903,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.47.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bitflags 2.9.3",
  "gix-commitgraph 0.29.0",
@@ -4919,7 +4919,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "gix-features 0.43.1",
@@ -4943,7 +4943,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4963,7 +4963,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "thiserror 2.0.16",
@@ -4991,7 +4991,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.42.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "gix-attributes 0.27.0",
@@ -5010,7 +5010,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#81c0c1612ddc280edd6e3ceb7f0d7e239516d963"
 dependencies = [
  "bstr",
  "gix-features 0.43.1",
@@ -11068,7 +11068,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,7 +1293,6 @@ dependencies = [
  "insta",
  "itertools",
  "md5",
- "pretty_assertions",
  "serde",
  "tracing",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ gitbutler-git = { path = "crates/gitbutler-git" }
 gitbutler-watcher = { path = "crates/gitbutler-watcher" }
 gitbutler-filemonitor = { path = "crates/gitbutler-filemonitor" }
 gitbutler-testsupport = { path = "crates/gitbutler-testsupport" }
-gitbutler-cli = { path = "crates/gitbutler-cli" }
 gitbutler-branch-actions = { path = "crates/gitbutler-branch-actions" }
 gitbutler-sync = { path = "crates/gitbutler-sync" }
 gitbutler-oplog = { path = "crates/gitbutler-oplog" }
@@ -71,7 +70,6 @@ gitbutler-hunk-dependency = { path = "crates/gitbutler-hunk-dependency" }
 but-settings = { path = "crates/but-settings" }
 gitbutler-workspace = { path = "crates/gitbutler-workspace" }
 but = { path = "crates/but" }
-but-server = { path = "crates/but-server" }
 but-testsupport = { path = "crates/but-testsupport" }
 but-rebase = { path = "crates/but-rebase" }
 but-core = { path = "crates/but-core" }
@@ -112,3 +110,18 @@ incremental = false
 
 [profile.test]
 incremental = false
+
+# Assure that `gix` is always fast so debug builds aren't unnecessarily slow.
+[profile.dev.package]
+gix-object = { opt-level = 3 }
+gix-ref = { opt-level = 3 }
+gix-pack = { opt-level = 3 }
+gix-hash = { opt-level = 3 }
+gix-actor = { opt-level = 3 }
+gix-config = { opt-level = 3 }
+sha1-checked = { opt-level = 3 }
+zlib-rs = { opt-level = 3 }
+# This one is special as we can run into debug assertions otherwise.
+# They have a time, but let's chose the time instead of always being hit by it.
+gix-merge = { opt-level = 3, debug-assertions = false }
+

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -158,7 +158,7 @@ impl Graph {
             }
             gix::head::Kind::Symbolic(existing_reference) => {
                 let mut existing_reference = existing_reference.attach(repo);
-                let tip = existing_reference.peel_to_id_in_place()?;
+                let tip = existing_reference.peel_to_id()?;
                 (tip, Some(existing_reference.inner.name))
             }
         };
@@ -487,7 +487,7 @@ impl Graph {
             {
                 let Some(segment_tip) = repo
                     .try_find_reference(segment.ref_name.as_ref())?
-                    .map(|mut r| r.peel_to_id_in_place())
+                    .map(|mut r| r.peel_to_id())
                     .transpose()?
                 else {
                     continue;

--- a/crates/but-graph/src/init/walk.rs
+++ b/crates/but-graph/src/init/walk.rs
@@ -667,7 +667,7 @@ pub fn try_refname_to_id(
 ) -> anyhow::Result<Option<gix::ObjectId>> {
     Ok(repo
         .try_find_reference(refname)?
-        .map(|mut r| r.peel_to_id_in_place())
+        .map(|mut r| r.peel_to_id())
         .transpose()?
         .map(|id| id.detach()))
 }

--- a/crates/but-graph/src/ref_metadata_legacy.rs
+++ b/crates/but-graph/src/ref_metadata_legacy.rs
@@ -78,7 +78,7 @@ impl Snapshot {
                         let Ok(mut r) = repo.find_reference(&segment.name) else {
                             continue;
                         };
-                        if let Ok(id) = r.peel_to_id_in_place() {
+                        if let Ok(id) = r.peel_to_id() {
                             segment.head = CommitOrChangeId::CommitId(id.to_string());
                         }
                     }

--- a/crates/but-rebase/src/lib.rs
+++ b/crates/but-rebase/src/lib.rs
@@ -1,7 +1,7 @@
 //! An API for an interactive rebases, suitable for interactive, UI driven, and programmatic use.
 //!
 //! It will only affect the commit-graph, and never the alter the worktree in any way.
-#![deny(rust_2018_idioms, missing_docs)]
+#![deny(missing_docs)]
 
 use crate::commit::DateMode;
 use anyhow::{Context, Ok, Result, anyhow, bail};

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -510,7 +510,7 @@ pub fn graph(
         None => but_graph::Graph::from_head(&repo, &*meta, opts),
         Some(ref_name) => {
             let mut reference = repo.find_reference(ref_name)?;
-            let id = reference.peel_to_id_in_place()?;
+            let id = reference.peel_to_id()?;
             but_graph::Graph::from_commit_traversal(id, reference.name().to_owned(), &*meta, opts)
         }
     }?;

--- a/crates/but-testsupport/src/lib.rs
+++ b/crates/but-testsupport/src/lib.rs
@@ -1,5 +1,5 @@
 //! Utilities for testing.
-#![deny(rust_2018_idioms, missing_docs)]
+#![deny(missing_docs)]
 
 use gix::Repository;
 use gix::bstr::{BStr, ByteSlice};

--- a/crates/but-testsupport/src/lib.rs
+++ b/crates/but-testsupport/src/lib.rs
@@ -252,7 +252,7 @@ pub fn id_at<'repo>(repo: &'repo Repository, name: &str) -> (gix::Id<'repo>, gix
     let mut rn = repo
         .find_reference(name)
         .expect("statically known reference exists");
-    let id = rn.peel_to_id_in_place().expect("must be valid reference");
+    let id = rn.peel_to_id().expect("must be valid reference");
     (id, rn.inner.name)
 }
 

--- a/crates/but-workspace/Cargo.toml
+++ b/crates/but-workspace/Cargo.toml
@@ -35,7 +35,6 @@ flume = "0.11.1"
 
 [dev-dependencies]
 but-testsupport.workspace = true
-pretty_assertions = "1.4.1"
 insta = "1.43.1"
 but-core = { workspace = true, features = ["testing"] }
 # for stable hashes in `gitbuter-` crates while we use them.

--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -171,7 +171,7 @@ pub(crate) mod function {
                 //         ws_id
                 //     }
                 //     Some(mut existing_workspace_reference) => {
-                //         let id = existing_workspace_reference.peel_to_id_in_place()?;
+                //         let id = existing_workspace_reference.peel_to_id()?;
                 //         id.detach()
                 //     }
                 // };

--- a/crates/but-workspace/src/branch/checkout.rs
+++ b/crates/but-workspace/src/branch/checkout.rs
@@ -1,0 +1,336 @@
+/// What to do when uncommitted changes are in the way of files that will be affected by the checkout, and that
+/// don't re-apply cleanly on top of the new worktree commit.
+#[derive(Default, Debug, Copy, Clone)]
+pub enum UncommitedWorktreeChanges {
+    /// Do not alter anything if local worktree changes conflict with the incoming one, but abort the operation instead.
+    #[default]
+    KeepAndAbortOnConflict,
+    /// Place the files that would be altered, AND at least one conflicts when brought back, into a snapshot based
+    /// on the current `HEAD`, and overwrite them.
+    /// Note that uncommitted changes that aren't affected will just be left as is.
+    KeepConflictingInSnapshotAndOverwrite,
+}
+
+/// Options for use in [super::safe_checkout()].
+#[derive(Default, Debug, Copy, Clone)]
+pub struct Options {
+    /// How to deal with uncommitted changes.
+    pub uncommitted_changes: UncommitedWorktreeChanges,
+}
+
+/// The successful outcome of [super::safe_checkout()] operation.
+#[derive(Clone)]
+pub struct Outcome {
+    /// The tree of the snapshot which stores the worktree changes that have been overwritten as part of the checkout,
+    /// based on the `current_head_tree_id` from which it was created.
+    pub snapshot_tree: Option<gix::ObjectId>,
+    /// If `new_head_id` was a commit, these are the ref-edits returned after performing the transaction.
+    pub head_update: Option<Vec<gix::refs::transaction::RefEdit>>,
+    /// The number of files that were deleted turn the current worktree into the desired one.
+    /// Note that this only counts files, not directories.
+    pub num_deleted_files: usize,
+    /// The number of files that were added or modified turn the current worktree into the desired one.
+    /// Note that this only counts files, not directories.
+    pub num_added_or_updated_files: usize,
+}
+
+pub(crate) mod function {
+    use super::{Options, Outcome, UncommitedWorktreeChanges};
+    use crate::snapshot;
+    use crate::snapshot::create_tree::no_workspace_and_meta;
+    use anyhow::bail;
+    use bstr::{BStr, BString, ByteSlice, ByteVec};
+    use but_core::TreeStatus;
+    use gitbutler_oxidize::ObjectIdExt;
+    use gix::diff::rewrites::tracker::{Change as _, ChangeKind};
+    use gix::diff::tree::visit;
+    use gix::index::entry::Stage;
+    use gix::object::tree::EntryKind;
+    use gix::objs::TreeRefIter;
+    use gix::prelude::ObjectIdExt as _;
+    use gix::refs::Target;
+    use gix::refs::transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog};
+    use std::collections::{BTreeSet, VecDeque};
+
+    impl std::fmt::Debug for Outcome {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let Outcome {
+                snapshot_tree,
+                head_update,
+                num_deleted_files,
+                num_added_or_updated_files,
+            } = self;
+            f.debug_struct("Outcome")
+                .field("snapshot_tree", snapshot_tree)
+                .field("num_deleted_files", num_deleted_files)
+                .field("num_added_or_updated_files", num_added_or_updated_files)
+                .field(
+                    "head_update",
+                    &match head_update {
+                        None => "None".to_string(),
+                        Some(edits) => edits
+                            .last()
+                            .map(|edit| {
+                                format!(
+                                    "Update {} to {:?}",
+                                    edit.name.as_bstr(),
+                                    edit.change.new_value()
+                                )
+                            })
+                            .unwrap_or_default(),
+                    },
+                )
+                .finish()
+        }
+    }
+
+    /// Given the `current_head_id^{tree}` for the tree that matches what `HEAD` points to, perform all file operations necessary
+    /// to turn the *worktree* of `repo` into `new_head_id^{tree}`. Note that the current *worktree* is assumed to be at the state of
+    /// `current_head_tree_id` along with arbitrary uncommitted user changes.
+    ///
+    /// Note that we don't care if the worktree actually matches the `new_head_id^{tree}`, we only care about the operations from
+    /// `current_head_id^{tree}` to be performed, and if there are none, we will do nothing.
+    ///
+    /// If `new_head_id` is a commit, we will also set `HEAD` (or the ref it points to if symbolic) to the `new_head_id`.
+    /// We will also update the `.git/index` to match the `new_head_id^{tree}`.
+    /// Note that the value for [`UncommitedWorktreeChanges`] is critical to determine what happens if a change would be overwritten.
+    ///
+    /// We will always handle changes in the worktree safely to avoid loss of uncommited information. This also means that deletions
+    /// never cause us to conflict. Conflicted files that would be checked out will cause an error.
+    ///
+    /// #### Note: No rename tracking
+    ///
+    /// To keep it simpler, we don't do rename tracking, so deletions and additions are always treated separately.
+    /// If this changes, then the source sid of a rename could also cause conflicts, maybe? It's a bit unclear what it would mean
+    /// in practice, but I guess that we bring deleted files back instead of conflicting.
+    pub fn safe_checkout(
+        current_head_id: gix::ObjectId,
+        new_head_id: gix::ObjectId,
+        repo: &gix::Repository,
+        Options {
+            uncommitted_changes,
+        }: Options,
+    ) -> anyhow::Result<Outcome> {
+        let source_tree = current_head_id.attach(repo).object()?.peel_to_tree()?;
+        let new_object = new_head_id.attach(repo).object()?;
+        let destination_tree = new_object.clone().peel_to_tree()?;
+
+        let mut delegate = Delegate::default();
+        gix::diff::tree(
+            TreeRefIter::from_bytes(&source_tree.data),
+            TreeRefIter::from_bytes(&destination_tree.data),
+            &mut gix::diff::tree::State::default(),
+            repo,
+            &mut delegate,
+        )?;
+
+        let mut opts = git2::build::CheckoutBuilder::new();
+        let snapshot_tree = if !delegate.changed_files.is_empty() {
+            let changes = but_core::diff::worktree_changes_no_renames(repo)?;
+            if !changes.changes.is_empty() {
+                let actual_head_tree_id = repo.head_tree_id_or_empty()?;
+                if actual_head_tree_id != source_tree.id {
+                    bail!(
+                        "Specified HEAD {source} didn't match actual HEAD^{{tree}} {actual_head_tree_id}",
+                        source = source_tree.id
+                    )
+                }
+                // Figure out which added or modified files are actually touched. Deletions we ignore, and allow
+                // these files to be recreated during checkout even if they were part in a rename
+                // (we don't do rename tracking here)
+                let mut change_lut = repo.empty_tree().edit()?;
+                for change in &changes.changes {
+                    match change.status {
+                        TreeStatus::Deletion { .. } => {
+                            // additive snapshots only so checkout can write onto deleted files
+                            // (and has to, to restore more)
+                            opts.path(change.path.as_bytes());
+                        }
+                        TreeStatus::Addition { .. } | TreeStatus::Modification { .. } => {
+                            // It's not about the actual values, just to have a lookup for overlapping paths.
+                            change_lut.upsert(
+                                &change.path,
+                                EntryKind::Blob,
+                                repo.object_hash().empty_blob(),
+                            )?;
+                        }
+                        TreeStatus::Rename { .. } => {
+                            unreachable!("rename tracking was disabled")
+                        }
+                    }
+                }
+
+                let selection_of_changes_checkout_would_affect = BTreeSet::new();
+                // TODO: find uncommitted that would be overwritten.
+                for _file_to_be_modified in &delegate.changed_files {
+                    // selection.extend(change_lut.extend_leafs(&file_to_be_modified))
+                }
+
+                if !selection_of_changes_checkout_would_affect.is_empty() {
+                    let repo_in_memory = repo.clone().with_object_memory();
+                    let _out = crate::snapshot::create_tree(
+                        source_tree.id.attach(&repo_in_memory),
+                        snapshot::create_tree::State {
+                            changes,
+                            selection: selection_of_changes_checkout_would_affect,
+                            head: false,
+                        },
+                        no_workspace_and_meta(),
+                    )?;
+
+                    match uncommitted_changes {
+                        UncommitedWorktreeChanges::KeepAndAbortOnConflict => {}
+                        UncommitedWorktreeChanges::KeepConflictingInSnapshotAndOverwrite => {}
+                    }
+                    todo!("deal with snapshot")
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        // Finally, perform the actual checkout
+        // TODO(gix): use unconditional `gix` checkout implementation as pre-cursor to the real deal (not needed here).
+        //            All it has to do is to be able to apply the target changes to any working tree, while using filters,
+        //            and while doing it symlink-safe.
+        if !delegate.changed_files.is_empty() {
+            let git2_repo = git2::Repository::open(repo.git_dir())?;
+            let destination_tree = git2_repo
+                .find_tree(destination_tree.id.to_git2())?
+                .into_object();
+            let index = repo.index()?;
+            let mut conflicting = Vec::new();
+            for (_kind, path_to_alter) in &delegate.changed_files {
+                if index
+                    .entry_by_path(path_to_alter.as_bstr())
+                    .is_some_and(|e| e.stage() != Stage::Unconflicted)
+                {
+                    conflicting.push(path_to_alter.as_bstr());
+                }
+                opts.path(path_to_alter.as_bytes());
+            }
+
+            if !conflicting.is_empty() {
+                bail!(
+                    "Refusing to overwrite conflicting paths: {}",
+                    conflicting
+                        .into_iter()
+                        .map(|rela_path| format!("'{rela_path}'"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+            }
+
+            git2_repo.checkout_tree(
+                &destination_tree,
+                Some(opts.force().disable_pathspec_match(true)),
+            )?;
+        }
+
+        let head_update = if new_object.kind.is_commit() {
+            let needs_update = repo
+                .head()?
+                .id()
+                .is_none_or(|actual_head_id| actual_head_id != new_head_id);
+            if needs_update {
+                let edits = repo.edit_reference(RefEdit {
+                    change: Change::Update {
+                        log: LogChange {
+                            mode: RefLog::AndReference,
+                            force_create_reflog: false,
+                            message: gix::reference::log::message(
+                                "safe checkout",
+                                "GitButler".into(),
+                                new_object.into_commit().parent_ids().count(),
+                            ),
+                        },
+                        // We play it loose here, as we assume a repository lock so we won't interfere with ourselves.
+                        // Git itself enforces no lock either, so we rely on basic locking ref-locking here. Good enough.
+                        expected: PreviousValue::Any,
+                        new: Target::Object(new_head_id),
+                    },
+                    name: "HEAD".try_into().expect("root refs are always valid"),
+                    deref: true,
+                })?;
+                Some(edits)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let num_deleted_files = delegate
+            .changed_files
+            .iter()
+            .filter(|(kind, _)| matches!(kind, ChangeKind::Deletion))
+            .count();
+        Ok(Outcome {
+            snapshot_tree,
+            head_update,
+            num_deleted_files,
+            num_added_or_updated_files: delegate.changed_files.len() - num_deleted_files,
+        })
+    }
+
+    #[derive(Default)]
+    struct Delegate {
+        path_deque: VecDeque<BString>,
+        path: BString,
+        // Repo-relative slash separated paths that need to be altered during checkout.
+        changed_files: Vec<(ChangeKind, BString)>,
+    }
+
+    impl Delegate {
+        fn pop_element(&mut self) {
+            if let Some(pos) = self.path.rfind_byte(b'/') {
+                self.path.resize(pos, 0);
+            } else {
+                self.path.clear();
+            }
+        }
+
+        fn push_element(&mut self, name: &BStr) {
+            if name.is_empty() {
+                return;
+            }
+            if !self.path.is_empty() {
+                self.path.push(b'/');
+            }
+            self.path.push_str(name);
+        }
+    }
+
+    impl gix::diff::tree::Visit for Delegate {
+        fn pop_front_tracked_path_and_set_current(&mut self) {
+            self.path = self
+                .path_deque
+                .pop_front()
+                .expect("every parent is set only once");
+        }
+
+        fn push_back_tracked_path_component(&mut self, component: &BStr) {
+            self.push_element(component);
+            self.path_deque.push_back(self.path.clone());
+        }
+
+        fn push_path_component(&mut self, component: &BStr) {
+            self.push_element(component);
+        }
+
+        fn pop_path_component(&mut self) {
+            self.pop_element();
+        }
+
+        fn visit(&mut self, change: visit::Change) -> visit::Action {
+            if change.entry_mode().is_no_tree() {
+                self.changed_files.push((change.kind(), self.path.clone()));
+            }
+            visit::Action::Continue
+        }
+    }
+}

--- a/crates/but-workspace/src/branch/mod.rs
+++ b/crates/but-workspace/src/branch/mod.rs
@@ -456,6 +456,10 @@ impl Stack {
     }
 }
 
+/// Functions related to workspace checkouts.
+pub mod checkout;
+pub use checkout::function::safe_checkout;
+
 /// Functions and types related to applying a workspace branch.
 pub mod apply;
 pub use apply::function::apply;

--- a/crates/but-workspace/src/branch_details.rs
+++ b/crates/but-workspace/src/branch_details.rs
@@ -137,10 +137,10 @@ pub fn branch_details_v3(
     let mut integration_branch = repo
         .find_reference(&integration_branch_name)
         .context("The branch to integrate with must be present")?;
-    let integration_branch_id = integration_branch.peel_to_id_in_place()?;
+    let integration_branch_id = integration_branch.peel_to_id()?;
 
     let mut branch = repo.find_reference(name)?;
-    let branch_id = branch.peel_to_id_in_place()?;
+    let branch_id = branch.peel_to_id()?;
 
     let mut remote_tracking_branch = repo
         .branch_remote_tracking_ref_name(name, Direction::Fetch)
@@ -148,7 +148,7 @@ pub fn branch_details_v3(
         .and_then(|remote_tracking_ref| repo.find_reference(remote_tracking_ref.as_ref()).ok());
     let remote_tracking_branch_id = remote_tracking_branch
         .as_mut()
-        .map(|r| r.peel_to_id_in_place())
+        .map(|r| r.peel_to_id())
         .transpose()?;
 
     let meta = meta.branch(name)?;
@@ -181,7 +181,7 @@ pub fn branch_details_v3(
 
         let upstream_commits = if let Some(remote_tracking_branch) = remote_tracking_branch.as_mut()
         {
-            let remote_id = remote_tracking_branch.peel_to_id_in_place()?;
+            let remote_id = remote_tracking_branch.peel_to_id()?;
             upstream_commits_gix(
                 remote_id,
                 integration_branch_id.detach(),

--- a/crates/but-workspace/src/commit_engine/mod.rs
+++ b/crates/but-workspace/src/commit_engine/mod.rs
@@ -360,7 +360,7 @@ pub fn create_commit_and_update_refs(
         let mut all_refs_by_id = gix::hashtable::HashMap::<_, Vec<_>>::default();
         let mut checked_out_ref_name = None;
         let checked_out_ref = repo.head_ref()?.and_then(|mut r| {
-            let id = r.peel_to_id_in_place().ok()?.detach();
+            let id = r.peel_to_id().ok()?.detach();
             checked_out_ref_name = Some(r.inner.name.clone());
             Some((id, r.inner.name))
         });

--- a/crates/but-workspace/src/head.rs
+++ b/crates/but-workspace/src/head.rs
@@ -33,7 +33,7 @@ pub fn merge_worktree_with_workspace<'a>(
 
     let conflict_kind = TreatAsUnresolved::git();
     let outcome = gix_repo.merge_trees(
-        head.peel_to_commit_in_place()?.tree_id()?,
+        head.peel_to_commit()?.tree_id()?,
         workdir_tree,
         workspace_tree,
         gix_repo.default_merge_labels(),

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -173,7 +173,7 @@ pub struct RefInfo {
     pub workspace_ref_name: Option<gix::refs::FullName>,
     /// The stacks visible in the current workspace.
     ///
-    /// This is an empty array if the `HEAD` is detached.
+    /// This is an empty array if the `HEAD` is unborn.
     /// Otherwise, there is one or more stacks.
     pub stacks: Vec<branch::Stack>,
     /// The target to integrate workspace stacks into.

--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -380,7 +380,7 @@ pub(crate) mod function {
         meta: &impl but_core::RefMetadata,
         opts: super::Options,
     ) -> anyhow::Result<RefInfo> {
-        let id = existing_ref.peel_to_id_in_place()?;
+        let id = existing_ref.peel_to_id()?;
         let repo = id.repo;
         let graph = Graph::from_commit_traversal(
             id,

--- a/crates/but-workspace/src/snapshot/create_tree.rs
+++ b/crates/but-workspace/src/snapshot/create_tree.rs
@@ -9,7 +9,8 @@ pub struct State {
     ///
     /// It contains detailed information about the complete set of possible changes to become part of the worktree.
     pub changes: but_core::WorktreeChanges,
-    /// Repository-relative and slash-separated paths that match any change in the  [`changes`](State::changes) field.
+    /// Repository-relative and slash-separated paths that match any change in the  [`changes`](State::changes) field
+    /// to define which entry in `changes` is actually stored in the snapshot.
     /// It is *not* error if there is no match, as there can be snapshots without working tree changes, but with other changes.
     /// It's up to the caller to check for that via [`Outcome::is_empty()`].
     pub selection: BTreeSet<BString>,
@@ -108,7 +109,7 @@ pub(super) mod function {
         State {
             changes,
             selection,
-            head: _,
+            head: _to_be_implemented,
         }: State,
         _workspace_and_meta: Option<(&but_graph::projection::Workspace, &impl RefMetadata)>,
     ) -> anyhow::Result<Outcome> {

--- a/crates/but-workspace/tests/fixtures/scenario/ws-ref-ws-commit-two-stacks.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/ws-ref-ws-commit-two-stacks.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A ws-ref points to a workspace commit, with two stacks inside, each with their own commit.
+git init
+commit M
+setup_target_to_match_main
+
+git branch B
+git checkout -b A
+  commit A
+git checkout B
+  commit B
+create_workspace_commit_once A B

--- a/crates/but-workspace/tests/workspace/branch/checkout.rs
+++ b/crates/but-workspace/tests/workspace/branch/checkout.rs
@@ -1,0 +1,447 @@
+use crate::branch::checkout::utils::build_commit;
+use crate::utils::{
+    read_only_in_memory_scenario, visualize_index, writable_scenario, writable_scenario_slow,
+};
+use but_testsupport::{git_status, visualize_commit_graph_all};
+use but_workspace::branch::safe_checkout;
+use gix::object::tree::EntryKind;
+
+#[test]
+fn update_unborn_head() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario("unborn-empty");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"");
+    insta::assert_snapshot!(git_status(&repo)?, @r"");
+
+    let empty_tree = repo.empty_tree().id;
+    let head_commit = repo.new_commit("init", empty_tree, None::<gix::ObjectId>)?;
+
+    let out = safe_checkout(empty_tree, head_commit.id, &repo, Default::default())?;
+    insta::assert_debug_snapshot!(out, @r#"
+    Outcome {
+        snapshot_tree: None,
+        num_deleted_files: 0,
+        num_added_or_updated_files: 0,
+        head_update: "Update refs/heads/main to Some(Object(Sha1(6f695b43b0a2fc309a7444d3e918226f1561c66c)))",
+    }
+    "#);
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 6f695b4 (HEAD -> main) init");
+    insta::assert_snapshot!(git_status(&repo)?, @r"");
+    Ok(())
+}
+
+#[test]
+fn no_op_trees_never_touch_worktree() -> anyhow::Result<()> {
+    let repo = read_only_in_memory_scenario("all-file-types-renamed-and-modified")?;
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 4e26689 (HEAD -> main) init");
+    insta::assert_snapshot!(visualize_index(&*repo.index()?), @r"
+    100755:01e79c3 executable
+    100644:3aac70f file
+    120000:c4c364c link
+    ");
+    insta::assert_snapshot!(git_status(&repo)?, @r"
+     D executable
+     D file
+     D link
+    ?? executable-renamed
+    ?? file-renamed
+    ?? link-renamed
+    ");
+
+    let a_commit = repo.head_commit()?;
+    let a_tree = a_commit.tree_id()?.detach();
+
+    let out = safe_checkout(a_tree, a_commit.id, &repo, Default::default())?;
+    insta::assert_debug_snapshot!(out, @r#"
+    Outcome {
+        snapshot_tree: None,
+        num_deleted_files: 0,
+        num_added_or_updated_files: 0,
+        head_update: "None",
+    }
+    "#);
+
+    // Nothing changed
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 4e26689 (HEAD -> main) init");
+    insta::assert_snapshot!(visualize_index(&*repo.index()?), @r"
+    100755:01e79c3 executable
+    100644:3aac70f file
+    120000:c4c364c link
+    ");
+    insta::assert_snapshot!(git_status(&repo)?, @r"
+     D executable
+     D file
+     D link
+    ?? executable-renamed
+    ?? file-renamed
+    ?? link-renamed
+    ");
+    Ok(())
+}
+
+#[test]
+fn worktree_and_index_deletions_are_ignored_in_snapshots() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario("deletion-addition-untracked");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 226d5ea (HEAD -> main) init");
+    insta::assert_snapshot!(visualize_index(&*repo.index()?), @r"
+    100644:3e75765 added-to-index
+    100644:d95f3ad to-be-deleted
+    ");
+    insta::assert_snapshot!(git_status(&repo)?, @r"
+    A  added-to-index
+     D to-be-deleted
+    D  to-be-deleted-in-index
+    ?? untracked
+    ");
+
+    // Turn deleted files into directory - these won't conflict no matter what they were in the index.
+    let (head_commit, new_commit) = build_commit(
+        &repo,
+        |tree| {
+            let empty_blob = repo.empty_blob();
+            tree.upsert("to-be-deleted/a", EntryKind::Blob, empty_blob.id)?;
+            // TODO(gix): needs `gix` impl of checkout as `git2` fails, trying to access a null object
+            //            The issue is that it should checkout a file inside of a directory, which was previously
+            //            a file that is deleted from the index and the worktree.
+            // tree.upsert("to-be-deleted-in-index/a", EntryKind::Blob, empty_blob.id)?;
+            Ok(())
+        },
+        "turn changed file into a directory",
+    )?;
+
+    let out = safe_checkout(head_commit.id, new_commit.id, &repo, Default::default())?;
+    insta::assert_debug_snapshot!(out, @r#"
+    Outcome {
+        snapshot_tree: None,
+        num_deleted_files: 1,
+        num_added_or_updated_files: 1,
+        head_update: "Update refs/heads/main to Some(Object(Sha1(24f802a1250d2f84e1f49094e3b8bb1e5c0d29ad)))",
+    }
+    "#);
+
+    // Nothing changed as the checkout was aborted.
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 24f802a (HEAD -> main) turn changed file into a directory
+    * 226d5ea init
+    ");
+    insta::assert_snapshot!(visualize_index(&*repo.index()?), @r"
+    100644:3e75765 added-to-index
+    100644:637f034 to-be-deleted-in-index
+    100644:e69de29 to-be-deleted/a
+    ");
+    insta::assert_snapshot!(git_status(&repo)?, @r"
+    A  added-to-index
+    ?? untracked
+    ");
+
+    Ok(())
+}
+
+#[test]
+#[ignore = "TBD: needs gix support for learning about affected paths, Editor::get_all()"]
+fn snapshot_fails_by_default_if_changed_file_turns_into_directory() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario("mixed-hunk-modifications");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 647cc94 (HEAD -> main) init");
+    insta::assert_snapshot!(visualize_index(&*repo.index()?), @r"
+    100755:3d3b36f file
+    100755:cb89473 file-in-index
+    100644:3d3b36f file-renamed-in-index
+    100644:3d3b36f file-to-be-renamed
+    ");
+    insta::assert_snapshot!(git_status(&repo)?, @r"
+     M file
+    M  file-in-index
+    RM file-to-be-renamed-in-index -> file-renamed-in-index
+     D file-to-be-renamed
+    ?? file-renamed
+    ");
+
+    // Turn changed file into directory - conflict as snapshot won't apply cleanly.
+    let (head_commit, new_commit) = build_commit(
+        &repo,
+        |tree| {
+            tree.upsert("file/a", EntryKind::Blob, repo.empty_blob().id)?;
+            tree.upsert("file-in-index/a", EntryKind::Blob, repo.empty_blob().id)?;
+            Ok(())
+        },
+        "turn changed file into a directory",
+    )?;
+
+    let err = safe_checkout(head_commit.id, new_commit.id, &repo, Default::default()).unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "TBD",
+        "conflicting worktree changes prevent a commit"
+    );
+
+    // Nothing changed as the checkout was aborted.
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 94cc54f (HEAD -> merge) turn a directory back into a file
+    * df178e3 turn file into a directory
+    *   2a6d103 Merge branch 'A' into merge
+    |\
+    | * 7f389ed (A) add 10 to the beginning
+    * | 91ef6f6 (B) add 10 to the end
+    |/
+    * ff045ef (main) init
+    ");
+    insta::assert_snapshot!(visualize_index(&*repo.index()?), @"100644:e69de29 file");
+    insta::assert_snapshot!(git_status(&repo)?, @"");
+
+    Ok(())
+}
+
+#[test]
+fn checkout_handles_directory_and_file_replacements() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario("merge-with-two-branches-line-offset");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    *   2a6d103 (HEAD -> merge) Merge branch 'A' into merge
+    |\  
+    | * 7f389ed (A) add 10 to the beginning
+    * | 91ef6f6 (B) add 10 to the end
+    |/  
+    * ff045ef (main) init
+    ");
+    insta::assert_snapshot!(visualize_index(&*repo.index()?), @"100644:e8823e1 file");
+    insta::assert_snapshot!(git_status(&repo)?, @"");
+
+    // Turn file into directory
+    let (head_commit, new_commit) = build_commit(
+        &repo,
+        |tree| {
+            let empty_blob = repo.empty_blob();
+            tree.upsert("file/sub/a", EntryKind::Blob, empty_blob.id)?;
+            tree.upsert("file/sub2/b", EntryKind::Blob, empty_blob.id)?;
+            tree.upsert("file/c", EntryKind::Blob, empty_blob.id)?;
+            Ok(())
+        },
+        "turn file into a directory",
+    )?;
+    let out = safe_checkout(head_commit.id, new_commit.id, &repo, Default::default())?;
+    insta::assert_debug_snapshot!(out, @r#"
+    Outcome {
+        snapshot_tree: None,
+        num_deleted_files: 1,
+        num_added_or_updated_files: 3,
+        head_update: "Update refs/heads/merge to Some(Object(Sha1(df178e3012ac0862407185ae7dd8d634a6cde677)))",
+    }
+    "#);
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * df178e3 (HEAD -> merge) turn file into a directory
+    *   2a6d103 Merge branch 'A' into merge
+    |\  
+    | * 7f389ed (A) add 10 to the beginning
+    * | 91ef6f6 (B) add 10 to the end
+    |/  
+    * ff045ef (main) init
+    ");
+    insta::assert_snapshot!(visualize_index(&*repo.index()?), @r"
+    100644:e69de29 file/c
+    100644:e69de29 file/sub/a
+    100644:e69de29 file/sub2/b
+    ");
+    insta::assert_snapshot!(git_status(&repo)?, @"");
+
+    let (head_commit, new_commit) = build_commit(
+        &repo,
+        |tree| {
+            let empty_blob = repo.empty_blob();
+            tree.upsert("file", EntryKind::Blob, empty_blob.id)?;
+            Ok(())
+        },
+        "turn a directory back into a file",
+    )?;
+    let out = safe_checkout(head_commit.id, new_commit.id, &repo, Default::default())?;
+    insta::assert_debug_snapshot!(out, @r#"
+    Outcome {
+        snapshot_tree: None,
+        num_deleted_files: 3,
+        num_added_or_updated_files: 1,
+        head_update: "Update refs/heads/merge to Some(Object(Sha1(94cc54fa25411ad51e319a9895d031d8da97b7ab)))",
+    }
+    "#);
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 94cc54f (HEAD -> merge) turn a directory back into a file
+    * df178e3 turn file into a directory
+    *   2a6d103 Merge branch 'A' into merge
+    |\  
+    | * 7f389ed (A) add 10 to the beginning
+    * | 91ef6f6 (B) add 10 to the end
+    |/  
+    * ff045ef (main) init
+    ");
+    insta::assert_snapshot!(visualize_index(&*repo.index()?), @"100644:e69de29 file");
+    insta::assert_snapshot!(git_status(&repo)?, @"");
+
+    Ok(())
+}
+
+#[test]
+fn unrelated_additions_are_fine_even_with_conflicts_in_index() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario_slow("merge-with-two-branches-conflict");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 88d7acc (A) 10 to 20
+    | * 47334c6 (HEAD -> merge, B) 20 to 30
+    |/  
+    * 15bcd1b (main) init
+    ");
+    insta::assert_snapshot!(visualize_index(&*repo.index()?), @r"
+    100644:e69de29 file:1
+    100644:e6c4914 file:2
+    100644:e33f5e9 file:3
+    ");
+    insta::assert_snapshot!(git_status(&repo)?, @"UU file");
+
+    let (head_commit, new_commit) = build_commit(
+        &repo,
+        |tree| {
+            tree.upsert("unrelated", EntryKind::Blob, repo.empty_blob().id)?;
+            Ok(())
+        },
+        "add unrelated file",
+    )?;
+    let out = safe_checkout(head_commit.id, new_commit.id, &repo, Default::default())?;
+    insta::assert_debug_snapshot!(out, @r#"
+    Outcome {
+        snapshot_tree: None,
+        num_deleted_files: 0,
+        num_added_or_updated_files: 1,
+        head_update: "Update refs/heads/merge to Some(Object(Sha1(a7f60850de59562526c0f31331d47903a78d1d43)))",
+    }
+    "#);
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 88d7acc (A) 10 to 20
+    | * a7f6085 (HEAD -> merge) add unrelated file
+    | * 47334c6 (B) 20 to 30
+    |/  
+    * 15bcd1b (main) init
+    ");
+    // Only the unrelated file was added, only visible in the index.
+    insta::assert_snapshot!(visualize_index(&*repo.index()?), @r"
+    100644:e69de29 file:1
+    100644:e6c4914 file:2
+    100644:e33f5e9 file:3
+    100644:e69de29 unrelated
+    ");
+    insta::assert_snapshot!(git_status(&repo)?, @"UU file");
+
+    // Edit the file that is conflicting
+    let (head_commit, new_commit) = build_commit(
+        &repo,
+        |tree| {
+            tree.upsert("file", EntryKind::Blob, repo.empty_blob().id)?;
+            Ok(())
+        },
+        "overwrite conflicting file",
+    )?;
+
+    let err = safe_checkout(head_commit.id, new_commit.id, &repo, Default::default()).unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Refusing to overwrite conflicting paths: 'file'",
+        "We don't allow to checkout conflicting files with default settings as there is no snapshot"
+    );
+
+    // Nothing was changed
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 88d7acc (A) 10 to 20
+    | * a7f6085 (HEAD -> merge) add unrelated file
+    | * 47334c6 (B) 20 to 30
+    |/  
+    * 15bcd1b (main) init
+    ");
+    // The worktree is unaltered.
+    insta::assert_snapshot!(visualize_index(&*repo.index()?), @r"
+    100644:e69de29 file:1
+    100644:e6c4914 file:2
+    100644:e33f5e9 file:3
+    100644:e69de29 unrelated
+    ");
+    insta::assert_snapshot!(git_status(&repo)?, @"UU file");
+    Ok(())
+}
+
+#[test]
+fn unrelated_additions_do_not_affect_worktree_changes() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario_slow("all-file-types-renamed-and-modified");
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @"* 4e26689 (HEAD -> main) init");
+    insta::assert_snapshot!(visualize_index(&*repo.index()?), @r"
+    100755:01e79c3 executable
+    100644:3aac70f file
+    120000:c4c364c link
+    ");
+    insta::assert_snapshot!(git_status(&repo)?, @r"
+     D executable
+     D file
+     D link
+    ?? executable-renamed
+    ?? file-renamed
+    ?? link-renamed
+    ");
+
+    let (head_commit, new_commit) = build_commit(
+        &repo,
+        |tree| {
+            tree.upsert("unrelated", EntryKind::Blob, repo.empty_blob().id)?;
+            Ok(())
+        },
+        "add unrelated file",
+    )?;
+    let out = safe_checkout(head_commit.id, new_commit.id, &repo, Default::default())?;
+    insta::assert_debug_snapshot!(out, @r#"
+    Outcome {
+        snapshot_tree: None,
+        num_deleted_files: 0,
+        num_added_or_updated_files: 1,
+        head_update: "Update refs/heads/main to Some(Object(Sha1(7add6cadcf636e5b3a6c15c75e82abbec97d6eef)))",
+    }
+    "#);
+
+    insta::assert_snapshot!(visualize_commit_graph_all(&repo)?, @r"
+    * 7add6ca (HEAD -> main) add unrelated file
+    * 4e26689 init
+    ");
+    // Only the unrelated file was added, only visible in the index.
+    insta::assert_snapshot!(visualize_index(&*repo.index()?), @r"
+    100755:01e79c3 executable
+    100644:3aac70f file
+    120000:c4c364c link
+    100644:e69de29 unrelated
+    ");
+
+    // It also restored the deleted files, after all they are part of the tree.
+    insta::assert_snapshot!(git_status(&repo)?, @r"
+    ?? executable-renamed
+    ?? file-renamed
+    ?? link-renamed
+    ");
+    Ok(())
+}
+
+mod utils {
+    /// Using the `repo` `HEAD` commit, build a new commit based on its tree with `edit` and `message`, and return the `(current_commit, new_commit)`.
+    pub fn build_commit<'repo>(
+        repo: &'repo gix::Repository,
+        mut edit: impl FnMut(&mut gix::object::tree::Editor) -> anyhow::Result<()>,
+        message: &str,
+    ) -> anyhow::Result<(gix::Commit<'repo>, gix::Commit<'repo>)> {
+        let head_commit = repo.head_commit()?;
+
+        repo.write_blob([])?;
+        let mut editor = head_commit.tree()?.edit()?;
+        edit(&mut editor)?;
+
+        let new_commit_id = repo
+            .write_object(gix::objs::Commit {
+                tree: editor.write()?.detach(),
+                parents: [head_commit.id].into(),
+                message: message.into(),
+                ..head_commit.decode()?.to_owned()
+            })?
+            .detach();
+        Ok((head_commit, repo.find_commit(new_commit_id)?))
+    }
+}

--- a/crates/but-workspace/tests/workspace/branch/mod.rs
+++ b/crates/but-workspace/tests/workspace/branch/mod.rs
@@ -1,4 +1,5 @@
 /// Various journeys with apply, unapply and commit operations.
 mod apply_unapply_commit_uncommit;
+mod checkout;
 mod create_reference;
 mod remove_reference;

--- a/crates/but-workspace/tests/workspace/commit_engine/amend_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/amend_commit.rs
@@ -110,7 +110,7 @@ fn all_aspects_of_amended_commit_are_copied() -> anyhow::Result<()> {
     parent 91ef6f6fc0a8b97fb456886c1cc3b2a3536ea2eb
     parent 7f389eda1b366f3d56ecc1300b3835727c3309b6
     author author <author@example.com> 946684800 +0000
-    committer Committer (Memory Override) <committer@example.com> 946771200 +0000
+    committer committer (From Env) <committer@example.com> 946771200 +0000
 
     Merge branch 'A' into merge
     ");

--- a/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
+++ b/crates/but-workspace/tests/workspace/commit_engine/refs_update.rs
@@ -137,7 +137,7 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
     assure_no_worktree_changes(&repo)?;
     // The top commit has a different hash now thanks to amending.
     insta::assert_snapshot!(graph_commit_outcome(&repo, &outcome)?, @r"
-    * 09c046d (HEAD -> main) third commit
+    * 6073a81 (HEAD -> main) third commit
     * 64c4463 (tag: tag-that-should-not-move, another-tip) second commit
     * 3dd3955 initial commit
     ");
@@ -193,7 +193,7 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
     CreateCommitOutcome {
         rejected_specs: [],
         new_commit: Some(
-            Sha1(63721329122c6ab8b11b1a90040e07549e91b936),
+            Sha1(28868dd070be350f335ad8869c728343fa2929f8),
         ),
         changed_tree_pre_cherry_pick: Some(
             Sha1(273aeca7ca98af0f7972af6e7859a3ae7fde497a),
@@ -205,22 +205,22 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
                         "refs/heads/main",
                     ),
                 ),
-                old_commit_id: Sha1(09c046de220b8d33c13699620b69c7b37901f2ee),
-                new_commit_id: Sha1(63721329122c6ab8b11b1a90040e07549e91b936),
+                old_commit_id: Sha1(6073a81d14db7169b56ac39bcf59f906df532302),
+                new_commit_id: Sha1(28868dd070be350f335ad8869c728343fa2929f8),
             },
             UpdatedReference {
                 reference: Virtual(
                     "s1-b/second",
                 ),
-                old_commit_id: Sha1(09c046de220b8d33c13699620b69c7b37901f2ee),
-                new_commit_id: Sha1(63721329122c6ab8b11b1a90040e07549e91b936),
+                old_commit_id: Sha1(6073a81d14db7169b56ac39bcf59f906df532302),
+                new_commit_id: Sha1(28868dd070be350f335ad8869c728343fa2929f8),
             },
             UpdatedReference {
                 reference: Virtual(
                     "s2-b/second",
                 ),
-                old_commit_id: Sha1(09c046de220b8d33c13699620b69c7b37901f2ee),
-                new_commit_id: Sha1(63721329122c6ab8b11b1a90040e07549e91b936),
+                old_commit_id: Sha1(6073a81d14db7169b56ac39bcf59f906df532302),
+                new_commit_id: Sha1(28868dd070be350f335ad8869c728343fa2929f8),
             },
         ],
         rebase_output: None,
@@ -230,8 +230,8 @@ fn new_commits_to_tip_from_unborn_head() -> anyhow::Result<()> {
     write_vrbranches_to_refs(&vb, &repo)?;
     // It updates stack heads and stack branch heads.
     insta::assert_snapshot!(graph_commit_outcome(&repo, &outcome)?, @r"
-    * 6372132 (HEAD -> main, s2-b/second, s1-b/second) fourth commit
-    * 09c046d third commit
+    * 28868dd (HEAD -> main, s2-b/second, s1-b/second) fourth commit
+    * 6073a81 third commit
     * 64c4463 (tag: tag-that-should-not-move, s2-b/first, s1-b/first, another-tip) second commit
     * 3dd3955 (s2-b/init, s1-b/init) initial commit
     ");
@@ -305,7 +305,7 @@ fn new_stack_receives_commit_and_adds_it_to_workspace_commit() -> anyhow::Result
     write_vrbranches_to_refs(&vb, &repo)?;
     // head was updated to point to the new workspace commit.
     insta::assert_snapshot!(visualize_commit_graph(&repo, repo.head_id()?)?, @r"
-    *   942c5c7 (HEAD -> main) GitButler Workspace Commit
+    *   3a78d15 (HEAD -> main) GitButler Workspace Commit
     |\  
     | * 2ed9fca (s2/top) new file with 15 lines
     * | b451685 (s1/top, feat1) insert 5 lines to the top
@@ -606,7 +606,7 @@ fn insert_commit_into_single_stack_with_signatures() -> anyhow::Result<()> {
     write_vrbranches_to_refs(&vb, &repo)?;
     let rewritten_head_id = repo.head_id()?.detach();
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
-    * 02a7317 (HEAD -> main) insert 10 lines to the top
+    * a8fbed8 (HEAD -> main) insert 10 lines to the top
     * 170d5fe (s1-b/init) between initial and former first
     * ecd6722 (tag: first-commit, first-commit) init
     ");
@@ -642,7 +642,7 @@ fn insert_commit_into_single_stack_with_signatures() -> anyhow::Result<()> {
                     ),
                 ),
                 old_commit_id: Sha1(8b9db8455554fe317ea3ab86b9a042805326b493),
-                new_commit_id: Sha1(02a731715b329bd3263dd3d7af9c237dc0ac565e),
+                new_commit_id: Sha1(a8fbed8ea304d850e168033468be9d9f128e17c3),
             },
             UpdatedReference {
                 reference: Virtual(
@@ -654,7 +654,7 @@ fn insert_commit_into_single_stack_with_signatures() -> anyhow::Result<()> {
         ],
         rebase_output: Some(
             RebaseOutput {
-                top_commit: Sha1(02a731715b329bd3263dd3d7af9c237dc0ac565e),
+                top_commit: Sha1(a8fbed8ea304d850e168033468be9d9f128e17c3),
                 references: [],
                 commit_mapping: [
                     (
@@ -662,7 +662,7 @@ fn insert_commit_into_single_stack_with_signatures() -> anyhow::Result<()> {
                             Sha1(170d5fe258ee28dd6de85bfd6d566231c446d8ec),
                         ),
                         Sha1(8b9db8455554fe317ea3ab86b9a042805326b493),
-                        Sha1(02a731715b329bd3263dd3d7af9c237dc0ac565e),
+                        Sha1(a8fbed8ea304d850e168033468be9d9f128e17c3),
                     ),
                 ],
             },
@@ -699,8 +699,8 @@ fn insert_commit_into_single_stack_with_signatures() -> anyhow::Result<()> {
     )?;
     let rewritten_head_id = repo.head_id()?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
-    * 4de3053 (HEAD -> main) insert 10 lines to the top
-    * c9726ec (s1-b/init) between initial and former first
+    * 07a0229 (HEAD -> main) insert 10 lines to the top
+    * d9d87b9 (s1-b/init) between initial and former first
     * ecd6722 (tag: first-commit, first-commit) init
     ");
     insta::assert_snapshot!(but_testsupport::visualize_tree(rewritten_head_id), @r#"
@@ -760,7 +760,7 @@ fn branch_tip_below_non_merge_workspace_commit() -> anyhow::Result<()> {
 
     write_vrbranches_to_refs(&vb, &repo)?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, repo.head_id()?)?, @r"
-    * 047fed2 (HEAD -> main) insert 20 lines to the top
+    * 5f32f5c (HEAD -> main) insert 20 lines to the top
     * e798e62 (s1-b/init) extend lines to 110
     * 4342edf (tag: first-commit) init
     ");
@@ -866,7 +866,7 @@ fn insert_commits_into_workspace() -> anyhow::Result<()> {
 
     let rewritten_head_id = repo.head_id()?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
-    *   a09f86b (HEAD -> merge) Merge branch 'A' into merge
+    *   7f680d5 (HEAD -> merge) Merge branch 'A' into merge
     |\  
     | * 3538622 (A) add 10 to the beginning
     * | 9762353 (s1-b/init) add 10 more lines at end
@@ -1141,7 +1141,7 @@ fn merge_commit_remains_unsigned_in_remerge() -> anyhow::Result<()> {
 
     let rewritten_head_id = repo.head_id()?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
-    *   688ae93 (HEAD -> merge) Merge branch 'A' into merge
+    *   7044c9b (HEAD -> merge) Merge branch 'A' into merge
     |\  
     | * 12d8f47 (s1-b/top) remove 5 lines from beginning
     | * eede47d (A) add 10 to the beginning
@@ -1362,7 +1362,7 @@ fn commit_on_top_of_branch_in_workspace() -> anyhow::Result<()> {
 
     let rewritten_head_id = repo.head_id()?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
-    *   1e5d541 (HEAD -> merge) Merge branch 'A' into merge
+    *   f00525a (HEAD -> merge) Merge branch 'A' into merge
     |\  
     | * 608f07b (s1-b/top) remove 5 lines from beginning
     | * 7f389ed (s1-b/below-top, A) add 10 to the beginning
@@ -1450,7 +1450,7 @@ fn commit_on_top_of_branch_in_workspace() -> anyhow::Result<()> {
     let rewritten_head_id = repo.head_id()?;
     // The B-segment refs moved
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
-    *   dbdacbb (HEAD -> merge) Merge branch 'A' into merge
+    *   376bcdb (HEAD -> merge) Merge branch 'A' into merge
     |\  
     | * 608f07b (s1-b/top) remove 5 lines from beginning
     | * 7f389ed (s1-b/below-top, A) add 10 to the beginning
@@ -1520,7 +1520,7 @@ fn commit_on_top_of_branch_in_workspace() -> anyhow::Result<()> {
     let rewritten_head_id = repo.head_id()?;
     // The empty commit was inserted.
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
-    *   55a8e52 (HEAD -> merge) Merge branch 'A' into merge
+    *   4e7e322 (HEAD -> merge) Merge branch 'A' into merge
     |\  
     | * 608f07b (s1-b/top) remove 5 lines from beginning
     | * 7f389ed (s1-b/below-top, A) add 10 to the beginning
@@ -1578,9 +1578,9 @@ fn amend_on_top_of_branch_in_workspace() -> anyhow::Result<()> {
 
     let rewritten_head_id = repo.head_id()?;
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
-    *   dc63885 (HEAD -> merge) Merge branch 'A' into merge
+    *   0bb4efb (HEAD -> merge) Merge branch 'A' into merge
     |\  
-    | * c73ae7d (s1-b/top, A) add 10 to the beginning
+    | * 3edfe68 (s1-b/top, A) add 10 to the beginning
     * | 91ef6f6 (B) add 10 to the end
     |/  
     * ff045ef (main) init
@@ -1655,9 +1655,9 @@ fn amend_edit_message_only() -> anyhow::Result<()> {
     let rewritten_head_id = repo.head_id()?;
     // TODO: make some change observable.
     insta::assert_snapshot!(visualize_commit_graph(&repo, rewritten_head_id)?, @r"
-    *   c7b0b84 (HEAD -> merge) Merge branch 'A' into merge
+    *   42690f2 (HEAD -> merge) Merge branch 'A' into merge
     |\  
-    | * 2ab2b22 (s1-b/top, A) add 10 to the beginning (amended)
+    | * bc22104 (s1-b/top, A) add 10 to the beginning (amended)
     * | 91ef6f6 (B) add 10 to the end
     |/  
     * ff045ef (main) init

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -3332,7 +3332,7 @@ pub(crate) mod utils {
             remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
             sha: repo
                 .try_find_reference("main")?
-                .map(|mut r| r.peel_to_id_in_place())
+                .map(|mut r| r.peel_to_id())
                 .transpose()?
                 .map(|id| id.detach())
                 .unwrap_or_else(|| gix::hash::Kind::Sha1.null()),
@@ -3384,7 +3384,7 @@ pub(crate) mod utils {
             remote_url: "should not be needed and when it is extract it from `repo`".to_string(),
             sha: repo
                 .try_find_reference("main")?
-                .map(|mut r| r.peel_to_id_in_place())
+                .map(|mut r| r.peel_to_id())
                 .transpose()?
                 .map(|id| id.detach())
                 .unwrap_or_else(|| gix::hash::Kind::Sha1.null()),

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -376,7 +376,7 @@ pub fn upstream_integration_statuses(
 
     let merge_outcome = gix_repo.merge_trees(
         merge_base_tree,
-        gix_repo.head()?.peel_to_commit_in_place()?.tree_id()?,
+        gix_repo.head()?.peel_to_commit()?.tree_id()?,
         target_tree,
         gix_repo.default_merge_labels(),
         merge_options_fail_fast.clone(),


### PR DESCRIPTION
With [stashing](https://github.com/gitbutlerapp/gitbutler/pull/9725) available, a single-branch aware version of branch apply and unapply is possible.

Follow-up of #9878.

### Tasks

* [x] tests to trigger a first checkout without much ado
* [x] update gix for fixes
* [ ] find changed files that overlap with those to checkout and handle them
* [ ] implement and test workspace checkouts, also dealing with snapshots
    - [x] assure there is a test for renames (which shouldn't matter as we don't have to consider them)
    - [x] how does it all respond if the index is conflicted (and we ask git2 to update it?)
    - [x] deleted files have to be checked out as well (even if not in the natural changeset)
* [ ] see if the back-to-workspace button could just be a (safe) checkout


### Future Tasks

- Permutations: starting point
    - [ ] test unborn
    - [ ] starting point without WS ref
    - [ ] starting point with WS ref but not WS-commit or metadata
    - [ ] starting point with WS ref and WS commit
- Permutations: base position
    - [ ] base below
    - [ ] base above
- `but_workspace::checkout()`
   - [ ] apply conflict
   - [ ] apply worktree snapshot conflict
   - [ ] unapply worktree snapshot conflict
- [ ] Validate StackID handling in VB.toml adapter (assure it can keep unapplied branches correctly)
    - We need *all* the tests so at a later point we can possibly localise the stack-id and keep it with each branch instead.
- [ ] without single-branch mode, it's possible to have a workspace with just one stack, or even no stacks at all.
- [ ] don't apply the target branch!
- [ ] try to fix `but-graph` issue 

### Shortcomings

* Worktree change in a detached HEAD can't be stashed as there is no reference to associated the stash with.

### Notes

#### General Rules

* **The workspace is a conflict-free zone**
    - nothing that operates on the conflict must write conflicts into the index.
      This is as conflicts are currently hidden from view.
* **Symmetry**
   - If `apply` is doing something, then `unapply` undoes exactly that, or in other words `State + apply + unapply == State`
* **There is no single-branch workspace** when starting in single-branch mode
    - A workspace consists of at least two branches and a workspace commit
    - The workspace commit is optional if there is only one commit involved, i.e. when it's just a bunch of branches on top of a single commit
* **Workspace Commit ALWAYS for even for a single branch**
    - The workspace backend can deal with anything, but `commit()` currently can't.
    - Have to add commit() and `uncommit()`  as well to all apply-unapply tests so these can later be re-tested with different behaviour.
    - Implied by the previous rule

### Follow-Ups

- commit with auto-workspace-commit creation
    - At the same time, it needs uncommit() that is symmetric 

Thus:

* snapshots of worktree changes will be made to apply by forcing merge-conflicts to be... auto-resolved.
  This is a problem, but **we can't have conflicts** as the UI doesn't show them right now, nor does it allow interacting with them.

#### Unapply

* **Conflicting paths** are passed added as extra commit at first, without additional special handling in `apply` just to be able to handle them.
    - This means assignments aren't taken care of in all cases (but we will see how all this interacts with stack-ids)


### Research

#### Unapply: Assignments - with stashing

- uncommitted but assigned changes should create a snapshot commit
- when applying the same branch this snapshot is applied

However, the user should be able to interact with these.

#### Unapply: Assignments - with WIP commit

- uncommitted but assigned changes should create a WIP commit
     - or just unassign these assignments and they are back in the unassigned changes of the workspace
- MVP apply: do nothing with the WIP commit
- final version: apply restores the assignments from the WIP commit (which then is tracked with metadata)

#### Unapply with worktree changes

* **worktree changes that don't re-apply cleanly**

### Possible Follow-Ups

* Find a way to display and handle conflicts in the UI (Gitizen).
    - this would allow us to write conflicts as well and deal with them.

