### PR TITLE
'Unapplied stacks' stack & branch application tests

### DIFF
--- a/apps/desktop/cypress/e2e/support/mock/backend.ts
+++ b/apps/desktop/cypress/e2e/support/mock/backend.ts
@@ -48,7 +48,12 @@ import type { UnifiedDiff } from '$lib/hunks/diff';
 import type { HunkAssignment } from '$lib/hunks/hunk';
 import type { GitRemote } from '$lib/remotes/remotesService';
 import type { WorkspaceRule } from '$lib/rules/rule';
-import type { BranchDetails, Stack, StackDetails } from '$lib/stacks/stack';
+import type {
+	BranchDetails,
+	CreateBranchFromBranchOutcome,
+	Stack,
+	StackDetails
+} from '$lib/stacks/stack';
 import type { BranchPushResult } from '$lib/stacks/stackService.svelte';
 import type { BranchStatusesResponse, IntegrationOutcome } from '$lib/upstream/types';
 import type { InvokeArgs } from '@tauri-apps/api/core';
@@ -609,12 +614,18 @@ export default class MockBackend {
 		this.stackDetails.set(stackId, editableDetails);
 	}
 
-	public createVirtualBranchFromBranch(args: InvokeArgs | undefined) {
+	public createVirtualBranchFromBranch(
+		args: InvokeArgs | undefined
+	): CreateBranchFromBranchOutcome {
 		if (!args || !isCreateVirtualBranchFromBranchParams(args)) {
 			throw new Error('Invalid arguments for createVirtualBranchFromBranch');
 		}
 
 		// Do nothing for now
+		return {
+			stackId: 'something',
+			unappliedStacks: []
+		};
 	}
 
 	public deleteLocalBranch(args: InvokeArgs | undefined) {

--- a/apps/desktop/src/components/BranchesView.svelte
+++ b/apps/desktop/src/components/BranchesView.svelte
@@ -28,6 +28,7 @@
 		createCommitSelection,
 		type SelectionId
 	} from '$lib/selection/key';
+	import { handleCreateBranchFromBranchOutcome } from '$lib/stacks/stack';
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
 	import { UI_STATE } from '$lib/state/uiState.svelte';
 	import { inject } from '@gitbutler/core/context';
@@ -84,12 +85,13 @@
 		const remoteRef = remote ? `refs/remotes/${remote}/${branchName}` : undefined;
 		const branchRef = hasLocal ? `refs/heads/${branchName}` : remoteRef;
 		if (branchRef) {
-			await stackService.createVirtualBranchFromBranch({
+			const outcome = await stackService.createVirtualBranchFromBranch({
 				projectId,
 				branch: branchRef,
 				remote: remoteRef,
 				prNumber
 			});
+			handleCreateBranchFromBranchOutcome(outcome);
 			await baseBranchService.refreshBaseBranch(projectId);
 		}
 		goto(workspacePath(projectId));

--- a/apps/desktop/src/components/BranchesViewPR.svelte
+++ b/apps/desktop/src/components/BranchesViewPR.svelte
@@ -7,6 +7,7 @@
 	import { showError } from '$lib/notifications/toasts';
 	import { REMOTES_SERVICE } from '$lib/remotes/remotesService';
 	import { workspacePath } from '$lib/routes/routes.svelte';
+	import { handleCreateBranchFromBranchOutcome } from '$lib/stacks/stack';
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
 
 	import { UI_STATE } from '$lib/state/uiState.svelte';
@@ -72,13 +73,14 @@
 			const remoteRef = 'refs/remotes/' + inputRemoteName + '/' + pr.sourceBranch;
 			await remotesService.addRemote(projectId, inputRemoteName, remoteUrl);
 			await baseBranchService.fetchFromRemotes(projectId);
-			await stackService.createVirtualBranchFromBranch({
+			const outcome = await stackService.createVirtualBranchFromBranch({
 				projectId,
 				branch: remoteRef,
 				remote: remoteRef,
 				prNumber
 			});
 
+			handleCreateBranchFromBranchOutcome(outcome);
 			goto(workspacePath(projectId));
 		} catch (err: unknown) {
 			showError('Failed to apply forked branch', err);

--- a/apps/desktop/src/lib/stacks/stack.ts
+++ b/apps/desktop/src/lib/stacks/stack.ts
@@ -1,6 +1,24 @@
+import { showToast } from '$lib/notifications/toasts';
+import { TestId } from '@gitbutler/ui';
 import type { Author, Commit, UpstreamCommit } from '$lib/branches/v3';
 import type { CellType } from '@gitbutler/ui/components/commitLines/types';
 import type iconsJson from '@gitbutler/ui/data/icons.json';
+
+export type CreateBranchFromBranchOutcome = {
+	stackId: string;
+	unappliedStacks: string[];
+};
+
+export function handleCreateBranchFromBranchOutcome(outcome: CreateBranchFromBranchOutcome) {
+	if (outcome.unappliedStacks.length > 0) {
+		showToast({
+			testId: TestId.StacksUnappliedToast,
+			title: 'Heads up: We had to unapply some stacks to apply this one',
+			message: `It seems that the branch created couldn't be applied cleanly alongside your other ${outcome.unappliedStacks.length} ${outcome.unappliedStacks.length === 1 ? 'stack' : 'stacks'}.
+You can always re-apply them later from the branches page.`
+		});
+	}
+}
 
 export type StackHeadInfo = {
 	/**

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -38,7 +38,8 @@ import type {
 	Stack,
 	StackDetails,
 	CreateRefRequest,
-	InteractiveIntegrationStep
+	InteractiveIntegrationStep,
+	CreateBranchFromBranchOutcome
 } from '$lib/stacks/stack';
 import type { ReduxError } from '$lib/state/reduxError';
 
@@ -1480,7 +1481,7 @@ function injectEndpoints(api: ClientState['backendApi'], uiState: UiState) {
 				]
 			}),
 			createVirtualBranchFromBranch: build.mutation<
-				void,
+				CreateBranchFromBranchOutcome,
 				{ projectId: string; branch: string; remote?: string; prNumber?: number }
 			>({
 				extraOptions: {

--- a/crates/but-api/src/commands/virtual_branches.rs
+++ b/crates/but-api/src/commands/virtual_branches.rs
@@ -118,13 +118,13 @@ pub fn create_virtual_branch_from_branch(
     branch: Refname,
     remote: Option<RemoteRefname>,
     pr_number: Option<usize>,
-) -> Result<StackId, Error> {
+) -> Result<gitbutler_branch_actions::CreateBranchFromBranchOutcome, Error> {
     let project = gitbutler_project::get(project_id)?;
     let ctx = CommandContext::open(&project, AppSettings::load_from_default_path_creating()?)?;
-    let branch_id = gitbutler_branch_actions::create_virtual_branch_from_branch(
+    let outcome = gitbutler_branch_actions::create_virtual_branch_from_branch(
         &ctx, &branch, remote, pr_number,
     )?;
-    Ok(branch_id)
+    Ok(outcome.into())
 }
 
 #[api_cmd]

--- a/crates/but-tools/src/workspace.rs
+++ b/crates/but-tools/src/workspace.rs
@@ -1296,7 +1296,7 @@ pub struct SplitBranchParameters {
     ")]
     pub source_branch_name: String,
 
-    /// The name of the new branch to create with the split-off files.
+    /// The name of the new branch to create with the split off files.
     #[schemars(description = "
     <description>
         The name of the new branch to create with the split-off files.
@@ -1405,7 +1405,7 @@ pub fn split_branch(
     let refname = Refname::Local(LocalRefname::new(&params.new_branch_name, None));
     let branch_manager = ctx.branch_manager();
 
-    let stack_id = branch_manager.create_virtual_branch_from_branch(
+    let (stack_id, _) = branch_manager.create_virtual_branch_from_branch(
         &refname,
         None,
         None,
@@ -1991,7 +1991,7 @@ pub struct AbsorbSpec {
     <description>
         The title of the commit to use in the amended commit.
     </description>
-    
+
     <important_notes>
         The title should be concise and descriptive.
         Don't use more than 50 characters.

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -469,7 +469,7 @@ pub fn create_virtual_branch_from_branch(
     branch: &Refname,
     remote: Option<RemoteRefname>,
     pr_number: Option<usize>,
-) -> Result<StackId> {
+) -> Result<(StackId, Vec<StackId>)> {
     let mut guard = ctx.project().exclusive_worktree_access();
     ctx.verify(guard.write_permission())?;
     ensure_open_workspace_mode(ctx)

--- a/crates/gitbutler-branch-actions/src/branch_manager/mod.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/mod.rs
@@ -1,3 +1,4 @@
+pub use branch_creation::CreateBranchFromBranchOutcome;
 use gitbutler_command_context::CommandContext;
 
 mod branch_creation;

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -24,7 +24,7 @@ pub mod internal {
 }
 
 mod branch_manager;
-pub use branch_manager::{BranchManager, BranchManagerExt};
+pub use branch_manager::{BranchManager, BranchManagerExt, CreateBranchFromBranchOutcome};
 
 pub mod base;
 pub use base::BaseBranch;

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/apply_virtual_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/apply_virtual_branch.rs
@@ -88,13 +88,15 @@ fn rebase_commit() {
 
     {
         // apply first vbranch again
-        stack_1_id = gitbutler_branch_actions::create_virtual_branch_from_branch(
+        let outcome = gitbutler_branch_actions::create_virtual_branch_from_branch(
             ctx,
             &unapplied_branch,
             None,
             None,
         )
         .unwrap();
+
+        stack_1_id = outcome.0;
 
         // it should be rebased
         let stacks = stack_details(ctx);

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
@@ -56,6 +56,7 @@ fn integration() {
         None,
         Some(123),
     )
+    .map(|o| o.0)
     .unwrap();
 
     {
@@ -154,6 +155,7 @@ fn no_conflicts() {
         None,
         None,
     )
+    .map(|o| o.0)
     .unwrap();
 
     let stacks = stack_details(ctx);
@@ -207,6 +209,7 @@ fn conflicts_with_uncommited() {
         None,
         None,
     )
+    .map(|o| o.0)
     .unwrap();
     let (_, b) = stack_details(ctx)
         .into_iter()
@@ -261,6 +264,7 @@ fn conflicts_with_commited() {
         None,
         None,
     )
+    .map(|o| o.0)
     .unwrap();
     let (_, b) = stack_details(ctx)
         .into_iter()

--- a/e2e/playwright/scripts/project-with-remote-branches__add-commit-to-base.sh
+++ b/e2e/playwright/scripts/project-with-remote-branches__add-commit-to-base.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $GITBUTLER_CLI_DATA_DIR"
+echo "BUT_TESTING $BUT_TESTING"
+
+pushd remote-project
+# Checkout branch 1
+git checkout master
+echo "create file b" >> b_file
+git add b_file
+git commit -am "commit in base"
+
+git checkout branch1
+git rebase master
+echo "update file b" >> b_file
+git add b_file
+git commit -am "branch1: update after base change"
+
+git checkout master
+popd
+

--- a/e2e/playwright/tests/branches.spec.ts
+++ b/e2e/playwright/tests/branches.spec.ts
@@ -325,3 +325,58 @@ test('should be able gracefully handle adding a branch that is ahead of our targ
 
 	expect(existsSync(fileBPath)).toBe(true);
 });
+
+test('should handle gracefully applying two conflicting branches', async ({
+	page,
+	context
+}, testInfo) => {
+	const workdir = testInfo.outputPath('workdir');
+	const configdir = testInfo.outputPath('config');
+	gitbutler = await startGitButler(workdir, configdir, context);
+
+	await gitbutler.runScript('project-with-remote-branches.sh');
+
+	await page.goto('/');
+
+	// Should load the workspace
+	await waitForTestId(page, 'workspace-view');
+
+	// Should navigate to the branches page when clicking the branches button
+	await clickByTestId(page, 'navigation-branches-button');
+	const header = await waitForTestId(page, 'target-commit-list-header');
+
+	await expect(header).toContainText('origin/master');
+
+	const branchListCards = getByTestId(page, 'branch-list-card');
+	await expect(branchListCards).toHaveCount(2);
+
+	const firstBranchCard = branchListCards.filter({ hasText: 'branch1' });
+	await expect(firstBranchCard).toBeVisible();
+	await firstBranchCard.click();
+
+	// The delete branch should be visible
+	await waitForTestId(page, 'branches-view-delete-local-branch-button');
+
+	// Apply the branch
+	await clickByTestId(page, 'branches-view-apply-branch-button');
+	// Should be redirected to the workspace
+	await waitForTestId(page, 'workspace-view');
+
+	const commits = getByTestId(page, 'commit-row');
+	await expect(commits).toHaveCount(2);
+
+	// Should navigate to the branches page when clicking the branches button
+	await clickByTestId(page, 'navigation-branches-button');
+
+	const branchCard2 = getByTestId(page, 'branch-list-card').filter({ hasText: 'branch2' });
+	await expect(branchCard2).toBeVisible();
+	await branchCard2.click();
+
+	// Apply the second branch
+	await clickByTestId(page, 'branches-view-apply-branch-button');
+	// Should be redirected to the workspace
+	await waitForTestId(page, 'workspace-view');
+
+	// The modal explaining this should be visible
+	await waitForTestId(page, 'stacks-unapplied-toast');
+});

--- a/packages/ui/src/lib/utils/testIds.ts
+++ b/packages/ui/src/lib/utils/testIds.ts
@@ -138,7 +138,8 @@ export enum TestId {
 	ChromeHeaderProjectSelectorAddLocalProject = 'chrome-header-project-selector-add-local-project',
 	SyncButton = 'sync-button',
 	EditMode = 'edit-mode',
-	EditModeSaveAndExitButton = 'edit-mode-save-and-exit-button'
+	EditModeSaveAndExitButton = 'edit-mode-save-and-exit-button',
+	StacksUnappliedToast = 'stacks-unapplied-toast'
 }
 
 export enum ElementId {


### PR DESCRIPTION
- If applying a branch unapplies others, display a toast explaining what happened
- Test the application of branches ahead of the current target
- Test the application of a branch that conflicts with applied stacks

Summary
- Show a toast notifying users about unapplied stacks when applying a branch that results in unapplied stacks.
-agate CreateBranchFromOutcome (including unapplied stacks) through Rust backend and frontend flow.
- Call outcome handler after createVirtualBranchFromBranch in Branches and PR views so users are notified.
- Add TestId for StacksUnappliedToast and new Playwright e2e tests covering unapplied-stacks notification and applying branches with base ahead of target.
- Update types, imports, stackService API usage, serialization, docs, and tests to expect and handle the new outcome structure.