### PR TITLE
feat(ui): make codegen input scrollable with and actions overlay

### DIFF
--- a/apps/desktop/src/components/codegen/CodegenInput.svelte
+++ b/apps/desktop/src/components/codegen/CodegenInput.svelte
@@ -58,9 +58,10 @@
 		autofocus
 		placeholder="What would you like to make..."
 		borderless
-		maxRows={8}
+		maxRows={10}
+		minRows={2}
 		padding={{
-			bottom: 96
+			bottom: 64
 		}}
 	/>
 
@@ -142,7 +143,7 @@
 		padding: 0;
 		overflow: hidden;
 		border: 1px solid var(--clr-border-2);
-		border-radius: var(--radius-ml);
+		border-radius: var(--radius-m);
 		background-color: var(--clr-bg-1);
 	}
 
@@ -204,11 +205,11 @@
 		right: 0;
 		bottom: 0;
 		left: 0;
-		height: 96px;
+		height: 70px;
 		background: linear-gradient(
 			to bottom,
 			rgba(0, 0, 0, 0) 0%,
-			var(--clr-bg-1) 55%,
+			var(--clr-bg-1) 32%,
 			var(--clr-bg-1) 100%
 		);
 		pointer-events: none;

--- a/apps/desktop/src/components/codegen/CodegenInput.svelte
+++ b/apps/desktop/src/components/codegen/CodegenInput.svelte
@@ -52,16 +52,19 @@
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="text-input dialog-input" onkeypress={handleKeypress}>
+<div class="dialog-input" onkeypress={handleKeypress}>
 	<Textarea
 		bind:value
 		autofocus
 		placeholder="What would you like to make..."
 		borderless
+		maxRows={8}
 		padding={{
-			bottom: 60
+			bottom: 96
 		}}
 	/>
+
+	<div class="dialog-input__fade"></div>
 
 	<div class="dialog-input__actions">
 		<div class="dialog-input__actions-item">
@@ -137,10 +140,15 @@
 		position: relative;
 		flex-direction: column;
 		padding: 0;
+		overflow: hidden;
+		border: 1px solid var(--clr-border-2);
+		border-radius: var(--radius-ml);
+		background-color: var(--clr-bg-1);
 	}
 
 	.dialog-input__actions {
 		display: flex;
+		z-index: 2;
 		position: absolute;
 		bottom: 0;
 		align-items: center;
@@ -188,6 +196,22 @@
 			cursor: not-allowed;
 			opacity: 0.5;
 		}
+	}
+
+	.dialog-input__fade {
+		z-index: 1;
+		position: absolute;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		height: 96px;
+		background: linear-gradient(
+			to bottom,
+			rgba(0, 0, 0, 0) 0%,
+			var(--clr-bg-1) 55%,
+			var(--clr-bg-1) 100%
+		);
+		pointer-events: none;
 	}
 
 	.circle-icon {


### PR DESCRIPTION
Move to a borderless textarea wrapper and add maxRows so the input can grow up to 8 lines before scrolling. Constrain the input container with overflow hidden and a fixed bottom padding to make space for action buttons. Add a semi-opaque fade overlay at the bottom to visually mask the scroll boundary, and place the action toolbar above the fade using z-index so buttons remain accessible. Also add a subtle border, radius, and background to match other dialogs.