### PR TITLE
Add e2e test for remote branch with conflicts

### DIFF
--- a/e2e/playwright/scripts/project-with-remote-branches__add-commit-to-base-and-branch.sh
+++ b/e2e/playwright/scripts/project-with-remote-branches__add-commit-to-base-and-branch.sh
@@ -7,9 +7,16 @@ echo "BUT_TESTING $BUT_TESTING"
 pushd remote-project
 # Checkout branch 1
 git checkout master
-echo "Update to main branch" >> a_file
+echo "create file b" >> b_file
 git add b_file
 git commit -am "commit in base"
 
+git checkout branch1
+git rebase master
+echo "update file b" >> b_file
+git add b_file
+git commit -am "branch1: update after base change"
+
+git checkout master
 popd
 


### PR DESCRIPTION
Adds another e2e test that checks whether it is possible to add a branch that’s behind the workspace to the workspace gracefully and resolve any conflicts that may arise. This includes:
- New script: project-with-remote-branches__add-commit-to-base-and-branch.sh.
- Tweaks to the base and branch adding test script.
- An additional playwright test covering the scenario where a branch is behind the workspace, including conflict resolution steps and validation of results.