### PR TITLE
Work around broken settings env object

### DIFF
--- a/apps/desktop/src/components/codegen/ClaudeCodeSettingsModal.svelte
+++ b/apps/desktop/src/components/codegen/ClaudeCodeSettingsModal.svelte
@@ -153,12 +153,24 @@
 						/>
 					{/snippet}
 				</SectionCard>
+
+				<SectionCard orientation="row">
+					{#snippet title()}
+						Use configured model
+					{/snippet}
+					{#snippet caption()}
+						Use the model configured in .claude/settings.json. Useful for 3rd party API providers.
+					{/snippet}
+					{#snippet actions()}
+						<Toggle checked={useConfiguredModel} onchange={updateUseConfiguredModel} />
+					{/snippet}
+				</SectionCard>
 			</div>
 		</ScrollableContainer>
 	{/snippet}
 </Modal>
 
-<style>
+<style lang="postcss">
 	.settings-content {
 		display: flex;
 		flex-direction: column;

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -174,6 +174,7 @@
 <SwitchThemeMenuAction />
 <GlobalModal />
 <FocusCursor />
+<NotificationPrompt />
 
 {#if import.meta.env.MODE === 'development'}
 	<ReloadWarning />

--- a/crates/but-claude/src/bridge.rs
+++ b/crates/but-claude/src/bridge.rs
@@ -25,7 +25,7 @@ use crate::{
     db,
     rules::{create_claude_assignment_rule, list_claude_assignment_rules},
 };
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use but_broadcaster::{Broadcaster, FrontendEvent};
 use but_workspace::StackId;
 use gitbutler_command_context::CommandContext;
@@ -33,7 +33,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{
     collections::HashMap,
+    fs,
     io::{BufRead, BufReader, PipeReader, Read as _},
+    path::PathBuf,
     process::ExitStatus,
     sync::Arc,
 };
@@ -513,4 +515,52 @@ pub async fn check_claude_available(claude_executable: &str) -> ClaudeCheckResul
         },
         _ => ClaudeCheckResult::NotAvailable,
     }
+}
+
+#[cfg(target_os = "macos")]
+const ENTERPRISE_PATH: &str = "/Library/Application Support/ClaudeCode/managed-settings.json";
+#[cfg(target_os = "linux")]
+const ENTERPRISE_PATH: &str = "/etc/claude-code/managed-settings.json";
+#[cfg(target_os = "windows")]
+const ENTERPRISE_PATH: &str = "C:\\ProgramData\\ClaudeCode\\managed-settings.json";
+
+/// Collect any configured environment variables in the `settings.json`s. This
+/// is in order to work around https://github.com/anthropics/claude-code/issues/7452.
+async fn collect_configured_env(project_path: &std::path::Path) -> HashMap<String, String> {
+    collect_configured_env_inner(project_path)
+        .await
+        .unwrap_or(HashMap::new())
+}
+
+async fn collect_configured_env_inner(
+    project_path: &std::path::Path,
+) -> Result<HashMap<String, String>> {
+    let home = dirs::home_dir().context("Can't find home")?;
+    // Paths in order of precidence
+    let paths = [
+        home.join(".claude/settings.json"),
+        project_path.join(".claude/settings.local.json"),
+        project_path.join(".claude/settings.json"),
+        PathBuf::from(ENTERPRISE_PATH),
+    ];
+
+    let mut out = HashMap::new();
+
+    for path in paths {
+        if !fs::exists(&path)? {
+            continue;
+        }
+
+        let string = fs::read_to_string(&path)?;
+        let settings: serde_json::Value = serde_json::from_str(&string)?;
+        if let Some(env) = settings["env"].as_object() {
+            for (key, value) in env {
+                if let Some(value) = value.as_str() {
+                    out.insert(key.clone(), value.to_owned());
+                }
+            }
+        }
+    }
+
+    Ok(out)
 }


### PR DESCRIPTION
This commit implements a workaround for this issue: https://github.com/anthropics/claude-code/issues/7452

In 1.0.111 and 1.0.112, the `env` property doesn’t work when invoking `claude` with `-p`.

This collects all of these and passes them as env-vars which for some reason does work!