### PR TITLE
fix UTF-8 errors when diffing content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,7 +1626,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3777,7 +3777,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.73.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "gix-actor 0.35.4",
  "gix-attributes 0.27.0",
@@ -3848,7 +3848,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.35.4"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "gix-date 0.10.5",
@@ -3879,7 +3879,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.27.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "gix-glob 0.21.0",
@@ -3905,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.14"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "thiserror 2.0.16",
 ]
@@ -3922,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.11"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "thiserror 2.0.16",
 ]
@@ -3930,7 +3930,7 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.6.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "gix-path 0.10.20",
@@ -3955,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "gix-chunk 0.4.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -3968,7 +3968,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.46.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -3988,7 +3988,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.15.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bitflags 2.9.3",
  "bstr",
@@ -4000,7 +4000,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.30.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4031,7 +4031,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.10.5"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "itoa",
@@ -4044,7 +4044,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.53.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "gix-attributes 0.27.0",
@@ -4067,7 +4067,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.15.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "gix-discover 0.41.0",
@@ -4102,7 +4102,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.41.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "dunce",
@@ -4131,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.43.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -4151,7 +4151,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4185,7 +4185,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.16.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4210,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bitflags 2.9.3",
  "bstr",
@@ -4234,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "faster-hex",
  "gix-features 0.43.1",
@@ -4257,7 +4257,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.9.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "gix-hash 0.19.0",
  "hashbrown 0.16.0",
@@ -4280,7 +4280,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "gix-glob 0.21.0",
@@ -4321,7 +4321,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.41.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bitflags 2.9.3",
  "bstr",
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "18.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "gix-tempfile 18.0.0",
  "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4370,7 +4370,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.27.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "gix-actor 0.35.4",
@@ -4382,7 +4382,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4406,7 +4406,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bitflags 2.9.3",
  "gix-commitgraph 0.29.0",
@@ -4442,7 +4442,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.50.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "gix-actor 0.35.4",
@@ -4463,7 +4463,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.70.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "arc-swap",
  "gix-date 0.10.5",
@@ -4484,7 +4484,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.60.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "clru",
  "gix-chunk 0.4.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4505,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4516,7 +4516,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4541,7 +4541,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.10.20"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "gix-trace 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4554,7 +4554,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bitflags 2.9.3",
  "bstr",
@@ -4568,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.11.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4580,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.51.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -4617,7 +4617,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.6.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
@@ -4648,7 +4648,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.53.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "gix-actor 0.35.4",
  "gix-features 0.43.1",
@@ -4669,7 +4669,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.31.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "gix-hash 0.19.0",
@@ -4682,7 +4682,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bitflags 2.9.3",
  "bstr",
@@ -4715,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.21.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "gix-commitgraph 0.29.0",
  "gix-date 0.10.5",
@@ -4741,7 +4741,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.12.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bitflags 2.9.3",
  "gix-path 0.10.20",
@@ -4753,7 +4753,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.5.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "gix-hash 0.19.0",
@@ -4765,7 +4765,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "filetime",
@@ -4787,7 +4787,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "gix-config",
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "18.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "dashmap",
  "gix-fs 0.16.1",
@@ -4859,7 +4859,7 @@ checksum = "e2ccaf54b0b1743a695b482ca0ab9d7603744d8d10b2e5d1a332fef337bee658"
 [[package]]
 name = "gix-trace"
 version = "0.1.13"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "tracing-core",
 ]
@@ -4867,7 +4867,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.48.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -4903,7 +4903,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.47.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bitflags 2.9.3",
  "gix-commitgraph 0.29.0",
@@ -4919,7 +4919,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.32.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "gix-features 0.43.1",
@@ -4943,7 +4943,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4963,7 +4963,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "thiserror 2.0.16",
@@ -4991,7 +4991,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.42.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "gix-attributes 0.27.0",
@@ -5010,7 +5010,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#a78bf84c03c52a674e3c0a45e504901e64e9bc36"
+source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#382dc5dc02c3e0631489d7eed1431f5da1cb611c"
 dependencies = [
  "bstr",
  "gix-features 0.43.1",
@@ -11068,7 +11068,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Turns out this is easy to reproduce, and that the source of the issue is in `gitoxide`!

### Tasks

* [x] upgrade to the fixed version of `gitoxide`. https://github.com/gitbutlerapp/gitbutler/pull/10255 for content-diff fix
* ~~see if non-utf8 branch names work (on Linux, won't really work no MacOS)~~ - ignore, as it's unlikely to have ever worked, and will work after the rewrite.
