### PR TITLE
Fix formatting of LFS warning

### DIFF
--- a/crates/gitbutler-tauri/src/projects.rs
+++ b/crates/gitbutler-tauri/src/projects.rs
@@ -197,7 +197,7 @@ Ensure these aren't touched by GitButler or avoid using it in this repository.",
         msg.push_str(
             r#"
 
-`git lfs pull --include="*" to restore git-lfs files.` can be used to restore git-lfs files after GitButler touched them."#,
+`git lfs pull --include="*"` can be used to restore git-lfs files after GitButler touched them."#,
         );
     }
     let max_files = 10;


### PR DESCRIPTION
Fixes typo

## 🧢 Changes

<img width="516" height="211" alt="Screenshot 2025-09-12 at 2 28 20 PM" src="https://github.com/user-attachments/assets/fca4f3b2-7397-4be3-8ca8-d4ec10d6c84c" />

Remove extraneous text in the command:

Before:

```
git lfs pull --include="*" to restore git-lfs files.
```

After
```
git lfs pull --include="*"
```

## ☕️ Reasoning

Helps people use the correct command to heal their Git LFS setup.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
