### PR TITLE
Make clear that Claude could also not be executable in the UI

### DIFF
--- a/apps/desktop/src/components/v3/ClaudeCheck.svelte
+++ b/apps/desktop/src/components/v3/ClaudeCheck.svelte
@@ -49,7 +49,8 @@
 
 		{#if recheckedAvailability === 'recheck-failed'}
 			<div class="claude-status claude-status--unavailable">
-				✗ Claude Code not found at the specified path.
+				✗ Either Claude Code not found at the specified path or it could not be executed (`node`
+				missing?).
 			</div>
 		{:else if recheckedAvailability === 'recheck-succeeded'}
 			<div class="claude-status claude-status--available">✓ Claude Code is available</div>


### PR DESCRIPTION
The code documents it, but it's not in the enum variant and the UI also didn't say it, which can be confusing for users who clearly see that Claude is at the given path.

Related to https://discord.com/channels/1060193121130000425/1206670506271707156/1416457031799406695.

The message is now longer, but includes the other most common way `claude` fails.

<img width="994" height="419" alt="Screenshot 2025-09-13 at 19 28 13" src="https://github.com/user-attachments/assets/e5d32cfb-91d9-4c58-82d0-620269fff3d6" />

We should probably link to our docs to help people solve it - the only way I could solve it is to open GitButler from the terminal. Alternatives would be to assure `node` really is in the path which isn't the case if `nvm` is used (it seems).