### PR TITLE
Ensure correct project state updates on stack/branch/commit changes

### DIFF
--- a/apps/desktop/src/routes/[projectId]/workspace/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/workspace/+page.svelte
@@ -23,6 +23,11 @@
 	const firstStackResult = $derived(stackService.stackAt(projectId, 0));
 	const firstStack = $derived(firstStackResult.current.data);
 
+	// Read all local commits in the workspace for the given project
+	$effect(() => {
+		stackService.allLocalCommits(projectId);
+	});
+
 	$effect(() => {
 		if (urlStackId) {
 			projectState.stackId.set(urlStackId);


### PR DESCRIPTION
- Refactored updateStaleProjectState to take stack IDs, branches, and commit IDs, and clear selections/actions that reference stale entities.
- stackService.svelte.ts: Added allLocalCommits method to collect all stack/branch/commit info for a project and update state accordingly; removed old per-stack logic.
- uiState.svelte.ts: Refactored state-updating logic for completeness, using a helper for exclusive action clearing.
- +page.svelte: Invokes allLocalCommits at workspace scope to ensure consistent state.
