### PR TITLE
Filter F-mode shortcuts to elements inside trapped node

### DIFF
--- a/packages/ui/src/lib/focus/fModeManager.ts
+++ b/packages/ui/src/lib/focus/fModeManager.ts
@@ -28,13 +28,17 @@ export class FModeManager {
 		}
 	}
 
-	handleKeypress(event: KeyboardEvent, elements?: Map<HTMLElement, FocusableNode>): boolean {
+	handleKeypress(
+		event: KeyboardEvent,
+		elements?: Map<HTMLElement, FocusableNode>,
+		currentNode?: FocusableNode
+	): boolean {
 		if (!this.featureEnabled) return false;
 
 		const key = event.key;
 
 		if (key === 'f' && !this._active) {
-			this.activate(elements);
+			this.activate(elements, currentNode);
 			event.preventDefault();
 			event.stopPropagation();
 			return true;
@@ -99,7 +103,7 @@ export class FModeManager {
 		return false;
 	}
 
-	activate(elements?: Map<HTMLElement, FocusableNode>): void {
+	activate(elements?: Map<HTMLElement, FocusableNode>, currentNode?: FocusableNode): void {
 		if (this._active) return;
 
 		this._active = true;
@@ -107,8 +111,18 @@ export class FModeManager {
 		this.shortcuts.clear();
 
 		if (elements) {
+			// Check if current element has trap: true
+			const trapElement = currentNode?.options.trap ? currentNode.element : undefined;
+
 			for (const [element, node] of elements) {
-				this.addElement(element, node);
+				// If we have a trap element, only add elements contained within it
+				if (trapElement) {
+					if (trapElement.contains(element)) {
+						this.addElement(element, node);
+					}
+				} else {
+					this.addElement(element, node);
+				}
 			}
 		}
 	}

--- a/packages/ui/src/lib/focus/focusManager.ts
+++ b/packages/ui/src/lib/focus/focusManager.ts
@@ -308,7 +308,7 @@ export class FocusManager {
 
 		// Handle F mode toggle and input (global, doesn't need current element)
 		if (event.key === 'f' || event.key === 'F' || this.fModeManager.active) {
-			if (this.fModeManager.handleKeypress(event, this.nodeMap)) {
+			if (this.fModeManager.handleKeypress(event, this.nodeMap, this.currentNode)) {
 				this.outline.set(false);
 				return;
 			}


### PR DESCRIPTION
When a current focus node has trap: true, F-mode should only include
shortcut targets that are contained within that node. Without this,
shortcuts could activate elements outside the intended trapped area.

- Add optional currentNode parameter to fModeManager.handleKeypress and
  activate so the manager can inspect the current node's options.
- If currentNode.options.trap is true, only add elements that are
  contained within the trap element; otherwise add all elements as before.