### PR TITLE
feat: add error ignore feature for GitHub OAuth

### DIFF
--- a/apps/desktop/src/lib/config/config.ts
+++ b/apps/desktop/src/lib/config/config.ts
@@ -1,4 +1,9 @@
-import { persisted, type Persisted } from '@gitbutler/shared/persisted';
+import {
+	getBooleanStorageItem,
+	persisted,
+	setStorageItem,
+	type Persisted
+} from '@gitbutler/shared/persisted';
 
 export function projectCommitGenerationExtraConcise(projectId: string): Persisted<boolean> {
 	const key = 'projectCommitGenerationExtraConcise_';
@@ -37,4 +42,13 @@ export function persistedChatModelName<T extends string>(
 ): Persisted<T> {
 	const key = 'projectChatModelName_';
 	return persisted(defaultValue, key + projectId);
+}
+
+const GITHUB_ORG_AUTH_ERROR_HANDLING_KEY = 'swallowGitHubOrgAuthErrors';
+export function persistSwallowGitHubOrgAuthErrors(swallow: boolean) {
+	setStorageItem(GITHUB_ORG_AUTH_ERROR_HANDLING_KEY, swallow);
+}
+
+export function getSwallowGitHubOrgAuthErrors(): boolean {
+	return getBooleanStorageItem(GITHUB_ORG_AUTH_ERROR_HANDLING_KEY) ?? false;
 }

--- a/apps/desktop/src/lib/error/parser.ts
+++ b/apps/desktop/src/lib/error/parser.ts
@@ -1,3 +1,4 @@
+import { getSwallowGitHubOrgAuthErrors } from '$lib/config/config';
 import { KNOWN_ERRORS } from '$lib/error/knownErrors';
 import {
 	isHttpError,
@@ -79,9 +80,25 @@ export function parseError(error: unknown): ParsedError {
 	return { message: JSON.stringify(error, null, 2) };
 }
 
+const GH_ORG_AUTH_ERROR = 'GitHub Organizations OAuth Error';
+
+export function isGitHubOrgAuthError(title: string): boolean {
+	return title === GH_ORG_AUTH_ERROR;
+}
+
+export function shouldOfferToIgnoreError(title: string): boolean {
+	return isGitHubOrgAuthError(title);
+}
+
+export function shouldIgnoreThistError(title: string): boolean {
+	if (isGitHubOrgAuthError(title)) {
+		return getSwallowGitHubOrgAuthErrors();
+	}
+	return false;
+}
+
 const CommonErrorMessageStart: Record<string, string> = {
-	'Although you appear to have the correct authorization credentials,':
-		'GitHub Organizations OAuth Error'
+	'Although you appear to have the correct authorization credentials,': GH_ORG_AUTH_ERROR
 };
 /**
  * Returns an unified title for common error messages.


### PR DESCRIPTION
Adds functionality for users to ignore specific error types, starting with the GitHub Organizations OAuth error.
- Adds persistence helpers for toggling the ignore flag in config.
- Exposes utilities to identify error types and decide whether to offer opt-out or auto-dismiss.
- Integrates this flow into toast notification logic, letting users choose to "Don't show this again" for GitHub Org OAuth errors.