### PR TITLE
Changes in branch show only the changes in the branch

### DIFF
--- a/crates/but-workspace/src/ui/diff.rs
+++ b/crates/but-workspace/src/ui/diff.rs
@@ -9,26 +9,25 @@ pub fn changes_in_branch(
     workspace: &but_graph::projection::Workspace<'_>,
     branch: &gix::refs::FullNameRef,
 ) -> anyhow::Result<ui::TreeChanges> {
-    let commits =
-        if let Some((stack, segment)) = workspace.find_segment_and_stack_by_refname(branch) {
-            let base = stack.base();
-            segment.tip().zip(base)
-        } else {
-            // TODO: this should be (kept) in sync with branch-listing!
-            let tip = repo.find_reference(branch)?.peel_to_commit()?.id;
-            workspace.target.as_ref().and_then(|target| {
-                // NOTE: Can't do merge-base computation in graph as `branch` might not be contained in it.
-                let base = workspace
-                    .graph
-                    .tip_skip_empty(target.segment_index)
-                    .map(|c| c.id)?;
-                // This works because the lower-bound itself is the merge-base
-                // between all applicable targets and the workspace branches.
-                repo.merge_base(tip, base)
-                    .ok()
-                    .map(|base| (tip, base.detach()))
-            })
-        };
+    let commits = if let Some((_, segment)) = workspace.find_segment_and_stack_by_refname(branch) {
+        let base = segment.base;
+        segment.tip().zip(base)
+    } else {
+        // TODO: this should be (kept) in sync with branch-listing!
+        let tip = repo.find_reference(branch)?.peel_to_commit()?.id;
+        workspace.target.as_ref().and_then(|target| {
+            // NOTE: Can't do merge-base computation in graph as `branch` might not be contained in it.
+            let base = workspace
+                .graph
+                .tip_skip_empty(target.segment_index)
+                .map(|c| c.id)?;
+            // This works because the lower-bound itself is the merge-base
+            // between all applicable targets and the workspace branches.
+            repo.merge_base(tip, base)
+                .ok()
+                .map(|base| (tip, base.detach()))
+        })
+    };
 
     let Some((tip, base)) = commits else {
         return Ok(ui::TreeChanges::default());


### PR DESCRIPTION
In the application, showing the changes for a stacked branch would display the changes inside that and all other branches below it in the stack.
This is kind of unexpected as we want to see the changes in that branch and not all changes up to the tip of the commit.

This makes it so that only the changes that will end up in that branch are shown