### PR TITLE
Improve focus/keyboard behavior and f-key toggle

### DIFF
--- a/apps/desktop/src/components/BranchList.svelte
+++ b/apps/desktop/src/components/BranchList.svelte
@@ -224,6 +224,7 @@
 											branchName
 										});
 									}}
+									hotkey={active && i === 0 ? '⌘P' : undefined}
 									testId={TestId.CreateReviewButton}
 									disabled={!!projectState.exclusiveAction.current}
 									icon={getForgeLogo(forge.current.name, true)}

--- a/apps/desktop/src/components/ChromeSidebar.svelte
+++ b/apps/desktop/src/components/ChromeSidebar.svelte
@@ -2,7 +2,7 @@
 	import { goto } from '$app/navigation';
 	import KeyboardShortcutsModal from '$components/KeyboardShortcutsModal.svelte';
 	import ShareIssueModal from '$components/ShareIssueModal.svelte';
-	import { ircEnabled, codegenEnabled } from '$lib/config/uiFeatureFlags';
+	import { ircEnabled, codegenEnabled, fModeEnabled } from '$lib/config/uiFeatureFlags';
 	import {
 		branchesPath,
 		ircPath,
@@ -342,15 +342,12 @@
 				icon="keyboard"
 				kind="ghost"
 				style="neutral"
-				tooltip="Keyboard Shortcuts (Coming soon...)"
+				tooltip={$fModeEnabled ? 'Disable F key navigation' : 'Enable F key navigation'}
 				tooltipPosition="top"
 				tooltipAlign="start"
 				width={34}
-				class="faded-btn"
-				onclick={() => {
-					keyboardShortcutsModal?.show();
-				}}
-				disabled={true}
+				class={$fModeEnabled ? undefined : 'faded-btn'}
+				onclick={() => fModeEnabled.set(!$fModeEnabled)}
 			/>
 			<Button
 				icon="mail"

--- a/apps/desktop/src/components/PushButton.svelte
+++ b/apps/desktop/src/components/PushButton.svelte
@@ -153,7 +153,7 @@
 			style="neutral"
 			{loading}
 			disabled={buttonDisabled}
-			hotkey={active ? '⌘P' : undefined}
+			hotkey={active && isFirstBranchInStack ? '⇧⌘P' : undefined}
 			tooltip={getButtonTooltip(
 				hasThingsToPush,
 				hasConflicts,

--- a/apps/desktop/src/lib/floating/FloatingModal.svelte
+++ b/apps/desktop/src/lib/floating/FloatingModal.svelte
@@ -205,6 +205,7 @@
 		dim: true,
 		onEsc: () => {
 			onCancel?.();
+			return true;
 		}
 	}}
 	class="floating-modal"

--- a/packages/ui/src/lib/components/Button.svelte
+++ b/packages/ui/src/lib/components/Button.svelte
@@ -48,7 +48,7 @@
 	import Icon from '$components/Icon.svelte';
 	import Tooltip, { type TooltipAlign, type TooltipPosition } from '$components/Tooltip.svelte';
 	import { focusable } from '$lib/focus/focusable';
-	import { extractHotkeyLetter, formatHotkeyForPlatform } from '$lib/utils/hotkeySymbols';
+	import { formatHotkeyForPlatform } from '$lib/utils/hotkeySymbols';
 	import { pxToRem } from '$lib/utils/pxToRem';
 	import type iconsJson from '$lib/data/icons.json';
 	import type { ComponentColorType, ComponentKindType } from '$lib/utils/colorTypes';
@@ -101,7 +101,6 @@
 		}
 	}
 
-	const hotkeyLetter = $derived(hotkey ? extractHotkeyLetter(hotkey) : undefined);
 	const displayHotkey = $derived(hotkey ? formatHotkeyForPlatform(hotkey) : undefined);
 </script>
 
@@ -117,7 +116,7 @@
 		bind:this={el}
 		use:focusable={{
 			button: true,
-			hotkey: hotkeyLetter,
+			hotkey: hotkey,
 			onAction: () => {
 				el?.click();
 			}

--- a/packages/ui/src/lib/components/ContextMenu.svelte
+++ b/packages/ui/src/lib/components/ContextMenu.svelte
@@ -364,7 +364,7 @@
 			data-testid={testId}
 			bind:this={menuContainer}
 			tabindex="-1"
-			use:focusable={{ activate: true, isolate: true, dim: true }}
+			use:focusable={{ activate: true, isolate: true, focusable: true, dim: true, trap: true }}
 			autofocus
 			{onclick}
 			{onkeypress}

--- a/packages/ui/src/lib/components/Modal.svelte
+++ b/packages/ui/src/lib/components/Modal.svelte
@@ -132,7 +132,16 @@
 			class:small={width === 'small'}
 			class:xsmall={width === 'xsmall'}
 			style:width={typeof width === 'number' ? `${pxToRem(width)}rem` : undefined}
-			use:focusable={{ trap: true, activate: true, dim: true }}
+			use:focusable={{
+				trap: true,
+				activate: true,
+				focusable: true,
+				dim: true,
+				onEsc: () => {
+					close();
+					return true;
+				}
+			}}
 			onsubmit={(e) => {
 				e.preventDefault();
 				onSubmit?.(close, item);

--- a/packages/ui/src/lib/focus/focusTypes.ts
+++ b/packages/ui/src/lib/focus/focusTypes.ts
@@ -32,7 +32,7 @@ export interface FocusableOptions {
 	autoAction?: boolean;
 	// Register as a button (excluded from keyboard navigation but accessible via F mode)
 	button?: boolean;
-	// Cmd+letter (A-Z) or Cmd+number (1-9) hotkey for instant activation (no visual hints)
+	// Hotkey combination for instant activation (e.g., "⌘K", "⇧⌘P", "⌃⌥A")
 	hotkey?: string;
 	// Whether this element can receive focus (default: true)
 	focusable?: boolean;
@@ -44,7 +44,7 @@ export interface FocusableOptions {
 	// Called when Space or Enter is pressed on this focused element, or when autoAction is true and element becomes active
 	onAction?: () => boolean | void;
 	// Called when Escape is pressed on this focused element
-	onEsc?: () => boolean | void;
+	onEsc?: () => boolean;
 }
 
 export interface FocusableNode {

--- a/packages/ui/src/lib/utils/hotkeySymbols.ts
+++ b/packages/ui/src/lib/utils/hotkeySymbols.ts
@@ -162,10 +162,11 @@ export function parseHotkey(hotkey: string): ParsedHotkey | undefined {
  * Check if a keyboard event matches a parsed hotkey
  */
 export function matchesHotkey(event: KeyboardEvent, parsed: ParsedHotkey): boolean {
-	if (parsed.modifiers.meta && !event.metaKey) return false;
-	if (parsed.modifiers.ctrl && !event.ctrlKey) return false;
-	if (parsed.modifiers.alt && !event.altKey) return false;
-	if (parsed.modifiers.shift && !event.shiftKey) return false;
+	// Check for exact modifier match - both required and not required
+	if (parsed.modifiers.meta !== event.metaKey) return false;
+	if (parsed.modifiers.ctrl !== event.ctrlKey) return false;
+	if (parsed.modifiers.alt !== event.altKey) return false;
+	if (parsed.modifiers.shift !== event.shiftKey) return false;
 
 	// Check if the key matches (case-insensitive for letters)
 	const eventKey = event.key.length === 1 ? event.key.toUpperCase() : event.key;
@@ -235,27 +236,4 @@ export function formatHotkeyForPlatform(hotkey: string): string {
 	display += keySymbol;
 
 	return display;
-}
-
-/**
- * Extract just the letter from a Cmd+letter style hotkey
- * This is for compatibility with the existing focusManager hotkey handling
- */
-export function extractHotkeyLetter(hotkey: string): string | undefined {
-	const parsed = parseHotkey(hotkey);
-	if (!parsed) return undefined;
-
-	// Only return if it's a simple Cmd+letter pattern
-	if (
-		parsed.modifiers.meta &&
-		!parsed.modifiers.ctrl &&
-		!parsed.modifiers.alt &&
-		!parsed.modifiers.shift
-	) {
-		if (parsed.key.length === 1 && /[A-Za-z0-9]/.test(parsed.key)) {
-			return parsed.key.toUpperCase();
-		}
-	}
-
-	return undefined;
 }


### PR DESCRIPTION
- fixed modal focus issue
- create pr with cmd + p, push branch with shift + cmd + p
- toggle f-mode with keyboard icon in bottom left
- only target top branch to avoid ambiguity
- added context menu trap