### PR TITLE
Support picking upstream commit in branch integration

### DIFF
--- a/apps/desktop/src/components/BranchIntegrationModal.svelte
+++ b/apps/desktop/src/components/BranchIntegrationModal.svelte
@@ -339,7 +339,7 @@
 					<Button
 						kind="outline"
 						size="tag"
-						icon="download"
+						icon="target"
 						tooltip="Pick the upstream commit instead"
 						onclick={() => pickUpstreamFromStep(stepId, commitId, upstreamSha)}
 					>
@@ -352,7 +352,7 @@
 				<Button
 					kind="outline"
 					size="tag"
-					icon="commit"
+					icon="target"
 					tooltip="Pick the local commit instead"
 					onclick={() => pickLocalFromStep(stepId, commitId)}
 				>

--- a/apps/desktop/src/components/BranchIntegrationModal.svelte
+++ b/apps/desktop/src/components/BranchIntegrationModal.svelte
@@ -365,18 +365,6 @@
 	</div>
 {/snippet}
 
-{#snippet commitItemSkeleton()}
-	<CommitLine alignDot="start" commitStatus="Remote" diverged={false} />
-	<div class="branch-integration__commit-content">
-		<SimpleCommitRow title=" " sha="" date={new Date()} onlyContent />
-		<div class="branch-integration__commit-actions">
-			<Button kind="outline" size="tag" icon="download" tooltip="Pick the upstream commit instead">
-				Pick upstream
-			</Button>
-		</div>
-	</div>
-{/snippet}
-
 {#snippet genericStep(step: InteractiveIntegrationStep)}
 	{@const isSquashStep = step.type === 'squash'}
 	{@const isIndividualStep = step.type === 'pick' || step.type === 'skip'}
@@ -423,11 +411,24 @@
 		</ReduxResult>
 	{:else if step.type === 'pickUpstream'}
 		{@const commitDetails = stackService.commitDetails(projectId, step.subject.upstreamCommitId)}
+		{@const localCommitDetails = stackService.commitById(projectId, stackId, step.subject.commitId)}
 		<ReduxResult {projectId} result={commitDetails.current}>
 			{#snippet loading()}
-				<div class="branch-integration__commit">
-					{@render commitItemSkeleton()}
-				</div>
+				<!-- Show local commit data while loading upstream commit to prevent flickering -->
+				<ReduxResult {projectId} result={localCommitDetails.current}>
+					{#snippet children(localCommit)}
+						<div class="branch-integration__commit">
+							{@render commitItemTemplate(
+								localCommit,
+								step.subject.id,
+								step.subject.commitId,
+								step.type,
+								false,
+								false
+							)}
+						</div>
+					{/snippet}
+				</ReduxResult>
 			{/snippet}
 			{#snippet children(commit)}
 				<div class="branch-integration__commit">

--- a/apps/desktop/src/lib/branches/v3.ts
+++ b/apps/desktop/src/lib/branches/v3.ts
@@ -62,6 +62,15 @@ export function isCommit(something: Commit | UpstreamCommit): something is Commi
 	return 'state' in something;
 }
 
+export function extractUpstreamCommitId(commit: Commit | UpstreamCommit): string | undefined {
+	if (isCommit(commit)) {
+		if (commit.state.type === 'LocalAndRemote') {
+			return commit.state.subject;
+		}
+	}
+	return undefined;
+}
+
 /** Represents the author of a commit. */
 export type Author = {
 	/** The name from the git commit signature */

--- a/apps/desktop/src/lib/stacks/stack.ts
+++ b/apps/desktop/src/lib/stacks/stack.ts
@@ -319,6 +319,14 @@ export type InteractiveIntegrationStep =
 			};
 	  }
 	| {
+			type: 'pickUpstream';
+			subject: {
+				id: string;
+				commitId: string;
+				upstreamCommitId: string;
+			};
+	  }
+	| {
 			type: 'squash';
 			subject: {
 				id: string;

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -1162,6 +1162,7 @@ function injectEndpoints(api: ClientState['backendApi'], uiState: UiState) {
 				},
 				{ projectId: string; commitId: string }
 			>({
+				keepUnusedDataFor: 60, // Keep for 1 minute after last use
 				extraOptions: { command: 'commit_details' },
 				query: (args) => args,
 				providesTags: (_result, _error, { commitId }) => [

--- a/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/branch_upstream_integration.rs
@@ -24,6 +24,13 @@ pub enum InteractiveIntegrationStep {
         #[serde(with = "gitbutler_serde::object_id", rename = "commitId")]
         commit_id: ObjectId,
     },
+    PickUpstream {
+        id: Uuid,
+        #[serde(with = "gitbutler_serde::object_id", rename = "commitId")]
+        commit_id: ObjectId,
+        #[serde(with = "gitbutler_serde::object_id", rename = "upstreamCommitId")]
+        upstream_commit_id: ObjectId,
+    },
     Squash {
         id: Uuid,
         #[serde(with = "gitbutler_serde::object_id_vec", rename = "commits")]
@@ -184,6 +191,15 @@ fn integration_steps_to_rebase_steps(
             InteractiveIntegrationStep::Pick { commit_id, .. } => {
                 rebase_steps.push(RebaseStep::Pick {
                     commit_id: commit_id.to_owned(),
+                    new_message: None,
+                });
+            }
+            InteractiveIntegrationStep::PickUpstream {
+                upstream_commit_id: upstream_commit,
+                ..
+            } => {
+                rebase_steps.push(RebaseStep::Pick {
+                    commit_id: upstream_commit.to_owned(),
                     new_message: None,
                 });
             }

--- a/packages/ui/src/lib/components/SimpleCommitRow.svelte
+++ b/packages/ui/src/lib/components/SimpleCommitRow.svelte
@@ -3,11 +3,13 @@
 	export interface Props {
 		title: string;
 		sha: string;
+		upstreamSha?: string;
 		date: Date;
 		author?: string;
 		url?: string;
 		onlyContent?: boolean;
 		onCopy?: () => void;
+		onCopyUpstream?: () => void;
 		onOpen?: (url: string) => void;
 	}
 </script>
@@ -16,7 +18,18 @@
 	import Icon from '$components/Icon.svelte';
 	import { getTimeAndAuthor } from '$lib/utils/getTimeAndAuthor';
 
-	const { title, sha, author, date, url, onlyContent, onCopy, onOpen }: Props = $props();
+	const {
+		title,
+		sha,
+		author,
+		date,
+		url,
+		onlyContent,
+		upstreamSha,
+		onCopy,
+		onCopyUpstream,
+		onOpen
+	}: Props = $props();
 </script>
 
 <div class="simple-commit-item no-select" class:content-only={onlyContent}>
@@ -32,6 +45,14 @@
 				<span>{sha.substring(0, 7)}</span>
 				<Icon name="copy-small" />
 			</button>
+
+			{#if upstreamSha}
+				<span class="details-divider">•</span>
+				<button type="button" class="details-btn copy-btn" onclick={onCopyUpstream}>
+					<span> upstream {upstreamSha.substring(0, 7)}</span>
+					<Icon name="copy-small" />
+				</button>
+			{/if}
 
 			{#if url && onOpen}
 				<span class="details-divider">•</span>


### PR DESCRIPTION
- Add support for 'pick upstream' in the BranchIntegrationModal UI and internal logic.
- Update types in stack.ts to handle new step.
- Add extractUpstreamCommitId util function in branches/v3.ts.
- Update stackService for commit details cache duration.
- Add PickUpstream logic to Rust backend for branch actions.
- Update SimpleCommitRow.svelte to support and copy upstream SHAs in the UI.

## images
<img width="563" height="469" alt="Screenshot 2025-09-16 at 13 18 39" src="https://github.com/user-attachments/assets/f6913001-bbed-469b-a14b-fba59c01fa07" />
<img width="563" height="469" alt="Screenshot 2025-09-16 at 13 19 57" src="https://github.com/user-attachments/assets/5af107ab-cf39-4642-8b2c-98c788a855e2" />
