### PR TITLE
Pass force flag to click helper in e2e test

### DIFF
--- a/e2e/playwright/tests/startTheApp.spec.ts
+++ b/e2e/playwright/tests/startTheApp.spec.ts
@@ -135,7 +135,7 @@ test('no author setup - should start the application and be able to commit', asy
 	await waitForTestId(page, 'global-modal-author-missing');
 	await fillByTestId(page, 'global-modal-author-missing-name-input', 'Test User');
 	await fillByTestId(page, 'global-modal-author-missing-email-input', 'test@example.com');
-	await clickByTestId(page, 'global-modal-author-missing-action-button');
+	await clickByTestId(page, 'global-modal-author-missing-action-button', true);
 
 	// Let's write some files
 	const filePath = gitbutler.pathInWorkdir('local-clone/test-file.txt');


### PR DESCRIPTION
- Update e2e/playwright/tests/startTheApp.spec.ts: change call to clickByTestId for 'global-modal-author-missing-action-button' to pass third argument 'true', enabling force click behavior in Playwright helper.
- This change is isolated to the Playwright test file and ensures the test clicks the button even if Playwright reports it as not hittable.