### PR TITLE
Add sampling for high-volume analytics events and rate-limit flag

### DIFF
--- a/apps/desktop/src/lib/state/customHooks.svelte.ts
+++ b/apps/desktop/src/lib/state/customHooks.svelte.ts
@@ -65,16 +65,6 @@ export function buildQueryHooks<Definitions extends ExtensionDefinitions>({
 			error_message: parsedError?.message,
 			error_code: parsedError?.code
 		});
-
-		/** TODO: How long do we need to send these duplicates? */
-		const legacyName = args.failure ? `${actionName} Failed` : `${actionName} Successful`;
-		posthog?.capture(legacyName, {
-			actionName,
-			command,
-			durationMs,
-			failure: args.failure,
-			error: args.error
-		});
 	}
 
 	async function fetch<T extends TranformerFn>(


### PR DESCRIPTION
- Add shouldIgnoreEvent to probabilistically drop high/mid volume events (tauri_command with specific commands) to reduce noise.
- Add HIGH_VOLUME_EVENTS and MID_VOLUME_EVENTS lists and associated EventDescription type.
- Early return in capture if shouldIgnoreEvent returns true.
- Add skip_client_rate_limiting flag for tauri_command events when properties.command is set to avoid client-side rate limiting.