### PR TITLE
Include project name in window title

### DIFF
--- a/apps/desktop/cypress/e2e/support/index.ts
+++ b/apps/desktop/cypress/e2e/support/index.ts
@@ -162,6 +162,8 @@ Cypress.on('window:before:load', (win) => {
 				return MOCK_USER;
 			case 'plugin:window|theme':
 				return 'light';
+			case 'plugin:window|set_title':
+				return await Promise.resolve();
 			case 'update_feature_flags':
 				return await Promise.resolve();
 			case 'get_app_settings':

--- a/apps/desktop/src/lib/backend/backend.ts
+++ b/apps/desktop/src/lib/backend/backend.ts
@@ -69,6 +69,10 @@ export interface IBackend {
 	 * Loads a disk store from a file.
 	 */
 	loadDiskStore: (fileName: string) => Promise<DiskStore>;
+	/**
+	 * Sets the window title.
+	 */
+	setWindowTitle: (title: string) => void;
 }
 
 export interface DiskStore {

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -59,6 +59,12 @@ export default class Tauri implements IBackend {
 		const store = await Store.load(fileName, { autoSave: true });
 		return new TauriDiskStore(store);
 	}
+	setWindowTitle(title: string): void {
+		if (!this.appWindow) {
+			this.appWindow = getCurrentWindow();
+		}
+		this.appWindow.setTitle(title);
+	}
 }
 
 class TauriDiskStore implements DiskStore {

--- a/apps/desktop/src/lib/backend/web.ts
+++ b/apps/desktop/src/lib/backend/web.ts
@@ -32,6 +32,9 @@ export default class Web implements IBackend {
 		// For the web version, we don't have a disk store, so we return a no-op implementation
 		return new WebDiskStore();
 	}
+	setWindowTitle(title: string): void {
+		document.title = title;
+	}
 }
 
 class WebDiskStore implements DiskStore {

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -15,7 +15,6 @@
 	import ToastController from '$components/ToastController.svelte';
 	import ZoomInOutMenuAction from '$components/ZoomInOutMenuAction.svelte';
 	import { POSTHOG_WRAPPER } from '$lib/analytics/posthog';
-	import { BACKEND } from '$lib/backend';
 	import { initDependencies } from '$lib/bootstrap/deps';
 	import { SETTINGS_SERVICE } from '$lib/config/appSettingsV2';
 	import { GIT_CONFIG_SERVICE } from '$lib/config/gitConfigService';

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -15,6 +15,7 @@
 	import ToastController from '$components/ToastController.svelte';
 	import ZoomInOutMenuAction from '$components/ZoomInOutMenuAction.svelte';
 	import { POSTHOG_WRAPPER } from '$lib/analytics/posthog';
+	import { BACKEND } from '$lib/backend';
 	import { initDependencies } from '$lib/bootstrap/deps';
 	import { SETTINGS_SERVICE } from '$lib/config/appSettingsV2';
 	import { GIT_CONFIG_SERVICE } from '$lib/config/gitConfigService';

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -74,6 +74,13 @@
 	const shortcutService = inject(SHORTCUT_SERVICE);
 	$effect(() => shortcutService.listen());
 
+	// Reset window title when not in a project
+	$effect(() => {
+		if (!projectId) {
+			backend.setWindowTitle('GitButler');
+		}
+	});
+
 	// =============================================================================
 	// ANALYTICS & NAVIGATION
 	// =============================================================================

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -11,6 +11,7 @@
 	import ProjectSettingsMenuAction from '$components/ProjectSettingsMenuAction.svelte';
 	import ReduxResult from '$components/ReduxResult.svelte';
 	import { OnboardingEvent, POSTHOG_WRAPPER } from '$lib/analytics/posthog';
+	import { BACKEND } from '$lib/backend';
 	import { BASE_BRANCH_SERVICE } from '$lib/baseBranch/baseBranchService.svelte';
 	import { BRANCH_SERVICE } from '$lib/branches/branchService.svelte';
 	import { SETTINGS_SERVICE } from '$lib/config/appSettingsV2';
@@ -59,6 +60,7 @@
 	// Project data
 	const projectsResult = $derived(projectsService.projects());
 	const projects = $derived(projectsResult.current.data);
+	const currentProject = $derived(projects?.find((p) => p.id === projectId));
 
 	// =============================================================================
 	// REPOSITORY & BRANCH MANAGEMENT
@@ -170,6 +172,19 @@
 		return () => {
 			posthog.setPostHogRepo(undefined);
 		};
+	});
+
+	// =============================================================================
+	// WINDOW TITLE
+	// =============================================================================
+
+	const backend = inject(BACKEND);
+	$effect(() => {
+		if (currentProject?.title) {
+			backend.setWindowTitle(`${currentProject.title} — GitButler`);
+		} else {
+			backend.setWindowTitle('GitButler');
+		}
 	});
 
 	// =============================================================================

--- a/crates/gitbutler-tauri/capabilities/main.json
+++ b/crates/gitbutler-tauri/capabilities/main.json
@@ -7,6 +7,7 @@
 	"permissions": [
 		"core:default",
 		"core:window:allow-start-dragging",
+		"core:window:allow-set-title",
 		"core:window:default",
 		"dialog:allow-open",
 		"fs:allow-read-file",


### PR DESCRIPTION
## 🧢 Changes

- include the project in the window title (previously it was simply 'GitButler' on all screens)
- update tauri permissions so that can be done from the frontend

## ☕️ Reasoning

makes it easier to differentiate between different gitbutler windows in 
certain tab managers (like [alt-tab](https://alt-tab-macos.netlify.app/))

![Screenshot 2025-09-16 at 21.14.22@2x.png](https://app.gitbutler.com/uploads/39eceea6-2b84-4508-b2d8-63bc4f3b3190)
