### PR TITLE
V3 apply/unapply: spread safe checkout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3398,6 +3398,7 @@ dependencies = [
  "anyhow",
  "but-core",
  "but-graph",
+ "but-workspace",
  "git2",
  "gitbutler-branch",
  "gitbutler-command-context",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,13 +1159,16 @@ dependencies = [
  "but-settings",
  "futures-util",
  "gitbutler-project",
- "gitbutler-user",
+ "gitbutler-secret",
  "gitbutler-watcher",
  "serde",
  "serde_json",
  "tokio",
  "tower 0.5.2",
  "tower-http",
+ "tracing",
+ "tracing-forest",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3766,6 +3766,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "but-rebase",
+ "but-workspace",
  "git2",
  "gitbutler-cherry-pick",
  "gitbutler-command-context",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ incremental = false
 
 # Assure that `gix` is always fast so debug builds aren't unnecessarily slow.
 [profile.dev.package]
+gix = { opt-level = 3 }
 gix-object = { opt-level = 3 }
 gix-ref = { opt-level = 3 }
 gix-pack = { opt-level = 3 }

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -37,7 +37,6 @@ This builds the **web** target, points it to the but-server on `http://localhost
 
 Open Chrome (let's not kid ourselves) and got to `http://localhost:1420` and enjoy
 
-
 ### Development
 
 #### Auto-build the server on Rust changes

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -36,3 +36,12 @@ This builds the **web** target, points it to the but-server on `http://localhost
 #### 3. Go to the browser
 
 Open Chrome (let's not kid ourselves) and got to `http://localhost:1420` and enjoy
+
+
+### Development
+
+#### Auto-build the server on Rust changes
+
+```bash
+watchexec -w crates -r -- cargo run -p but-server
+```

--- a/crates/but-api/src/commands/workspace.rs
+++ b/crates/but-api/src/commands/workspace.rs
@@ -487,7 +487,7 @@ pub fn uncommit_changes(
 
 /// This API allows the user to quickly "stash" a bunch of uncommitted changes - getting them out of the worktree.
 /// Unlike the regular stash, the user specifies a new branch where those changes will be 'saved'/committed.
-/// Immediatelly after the changes are committed, the branch is unapplied from the workspace, and the "stash" branch can be re-applied at a later time
+/// Immediately after the changes are committed, the branch is unapplied from the workspace, and the "stash" branch can be re-applied at a later time
 /// In theory it should be possible to specify an existing "dumping" branch for this, but currently this endpoint expects a new branch.
 #[api_cmd]
 #[tauri::command(async)]
@@ -542,7 +542,13 @@ pub fn stash_into_branch(
     gitbutler_branch_actions::update_workspace_commit(&vb_state, &ctx)
         .context("failed to update gitbutler workspace")?;
 
-    branch_manager.unapply(stack.id, perm, false, Vec::new())?;
+    branch_manager.unapply(
+        stack.id,
+        perm,
+        false,
+        Vec::new(),
+        ctx.app_settings().feature_flags.cv3,
+    )?;
 
     let outcome = outcome?;
     Ok(outcome.into())

--- a/crates/but-server/Cargo.toml
+++ b/crates/but-server/Cargo.toml
@@ -35,6 +35,9 @@ but-broadcaster.workspace = true
 but-path.workspace = true
 but-settings.workspace = true
 but-feedback.workspace = true
-gitbutler-user.workspace = true
 gitbutler-project.workspace = true
 gitbutler-watcher.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+tracing-forest = { version = "0.2.0" }
+gitbutler-secret.workspace = true

--- a/crates/but-server/src/main.rs
+++ b/crates/but-server/src/main.rs
@@ -1,4 +1,32 @@
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
+    trace::init()?;
+    // On macOS, in dev mode with debug assertions, we encounter popups each time
+    // the binary is rebuilt. To counter that, use a git-credential based implementation.
+    // This isn't an issue for actual release build (i.e. nightly, production),
+    // hence the specific condition.
+    if cfg!(debug_assertions) && cfg!(target_os = "macos") {
+        gitbutler_secret::secret::git_credentials::setup().ok();
+    }
     but_server::run().await;
+    Ok(())
+}
+
+mod trace {
+    use tracing::metadata::LevelFilter;
+    use tracing_subscriber::Layer;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+
+    pub fn init() -> anyhow::Result<()> {
+        tracing_subscriber::registry()
+            .with(
+                tracing_forest::ForestLayer::from(
+                    tracing_forest::printer::PrettyPrinter::new().writer(std::io::stderr),
+                )
+                .with_filter(LevelFilter::DEBUG),
+            )
+            .init();
+        Ok(())
+    }
 }

--- a/crates/but-workspace/src/branch/checkout/function.rs
+++ b/crates/but-workspace/src/branch/checkout/function.rs
@@ -11,9 +11,22 @@ use gix::refs::transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog};
 use std::collections::BTreeSet;
 use tracing::instrument;
 
+/// Like [`safe_checkout()`], but the current tree will always be fetched from
+pub fn safe_checkout_from_head(
+    new_head_id: gix::ObjectId,
+    repo: &gix::Repository,
+    opts: Options,
+) -> anyhow::Result<Outcome> {
+    safe_checkout(
+        repo.head_tree_id_or_empty()?.detach(),
+        new_head_id,
+        repo,
+        opts,
+    )
+}
 /// Given the `current_head_id^{tree}` for the tree that matches what `HEAD` points to, perform all file operations necessary
 /// to turn the *worktree* of `repo` into `new_head_id^{tree}`. Note that the current *worktree* is assumed to be at the state of
-/// `current_head_tree_id` along with arbitrary uncommitted user changes.
+/// `current_head_id` along with arbitrary uncommitted user changes.
 ///
 /// Note that we don't care if the worktree actually matches the `new_head_id^{tree}`, we only care about the operations from
 /// `current_head_id^{tree}` to be performed, and if there are none, we will do nothing.

--- a/crates/but-workspace/src/branch/mod.rs
+++ b/crates/but-workspace/src/branch/mod.rs
@@ -458,7 +458,7 @@ impl Stack {
 
 /// Functions related to workspace checkouts.
 pub mod checkout;
-pub use checkout::function::safe_checkout;
+pub use checkout::function::{safe_checkout, safe_checkout_from_head};
 
 /// Functions and types related to applying a workspace branch.
 pub mod apply;

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -49,7 +49,7 @@ pub use tree_manipulation::{
     split_commit::{CommitFiles, CommmitSplitOutcome, split_commit},
 };
 pub mod head;
-pub use head::{head, merge_worktree_with_workspace};
+pub use head::{merge_worktree_with_workspace, remerged_head_commit};
 
 /// 🚧utilities for applying and unapplying branches 🚧.
 /// Ignore the name of this module; it's just a place to put code by now.

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -49,7 +49,9 @@ pub use tree_manipulation::{
     split_commit::{CommitFiles, CommmitSplitOutcome, split_commit},
 };
 pub mod head;
-pub use head::{merge_worktree_with_workspace, remerged_head_commit};
+pub use head::{
+    merge_worktree_with_workspace, remerged_workspace_commit_v2, remerged_workspace_tree_v2,
+};
 
 /// 🚧utilities for applying and unapplying branches 🚧.
 /// Ignore the name of this module; it's just a place to put code by now.

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -265,8 +265,13 @@ pub fn unapply_stack(
         .context("Deleting a branch order requires open workspace mode")?;
     let branch_manager = ctx.branch_manager();
     // NB: unapply_without_saving is also called from save_and_unapply
-    let branch_name =
-        branch_manager.unapply(stack_id, guard.write_permission(), false, assigned_diffspec)?;
+    let branch_name = branch_manager.unapply(
+        stack_id,
+        guard.write_permission(),
+        false,
+        assigned_diffspec,
+        ctx.app_settings().feature_flags.cv3,
+    )?;
     Ok(branch_name)
 }
 

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -58,7 +58,7 @@ pub fn get_base_branch_data(ctx: &CommandContext) -> Result<BaseBranch> {
 fn go_back_to_integration(ctx: &CommandContext, default_target: &Target) -> Result<BaseBranch> {
     let gix_repo = ctx.gix_repo_for_merging()?;
     if ctx.app_settings().feature_flags.cv3 {
-        let workspace_commit_to_checkout = but_workspace::head(ctx)?;
+        let workspace_commit_to_checkout = but_workspace::remerged_head_commit(ctx)?;
         let tree_to_checkout_to_avoid_ref_update = gix_repo
             .find_commit(workspace_commit_to_checkout.to_gix())?
             .tree_id()?;

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -58,7 +58,7 @@ pub fn get_base_branch_data(ctx: &CommandContext) -> Result<BaseBranch> {
 fn go_back_to_integration(ctx: &CommandContext, default_target: &Target) -> Result<BaseBranch> {
     let gix_repo = ctx.gix_repo_for_merging()?;
     if ctx.app_settings().feature_flags.cv3 {
-        let workspace_commit_to_checkout = but_workspace::remerged_head_commit(ctx)?;
+        let workspace_commit_to_checkout = but_workspace::remerged_workspace_commit_v2(ctx)?;
         let tree_to_checkout_to_avoid_ref_update = gix_repo
             .find_commit(workspace_commit_to_checkout.to_gix())?
             .tree_id()?;

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -1,4 +1,4 @@
-use super::{checkout_remerged_head, BranchManager};
+use super::BranchManager;
 use crate::r#virtual as vbranch;
 use crate::{hunk::VirtualBranchHunk, integration::update_workspace_commit, VirtualBranchesExt};
 use anyhow::{anyhow, bail, Context, Result};
@@ -139,7 +139,9 @@ impl BranchManager<'_> {
         pr_number: Option<usize>,
         perm: &mut WorktreeWritePermission,
     ) -> Result<(StackId, Vec<StackId>)> {
-        let old_cwd = self.ctx.repo().create_wd_tree(0)?.id();
+        let old_cwd = (!self.ctx.app_settings().feature_flags.cv3)
+            .then(|| self.ctx.repo().create_wd_tree(0).map(|tree| tree.id()))
+            .transpose()?;
         let old_workspace = WorkspaceState::create(self.ctx, perm.read_permission())?;
         // only set upstream if it's not the default target
         let upstream_branch = match upstream_branch {
@@ -270,13 +272,7 @@ impl BranchManager<'_> {
         )?;
         self.ctx.add_branch_reference(&branch)?;
 
-        match self.apply_branch(
-            branch.id,
-            perm,
-            old_workspace,
-            old_cwd,
-            self.ctx.app_settings().feature_flags.cv3,
-        ) {
+        match self.apply_branch(branch.id, perm, old_workspace, old_cwd) {
             Ok((_, unapplied_stacks)) => Ok((branch.id, unapplied_stacks)),
             Err(err)
                 if err
@@ -299,8 +295,7 @@ impl BranchManager<'_> {
         stack_id: StackId,
         perm: &mut WorktreeWritePermission,
         workspace_state: WorkspaceState,
-        old_cwd: git2::Oid,
-        safe_checkout: bool,
+        old_cwd: Option<git2::Oid>,
     ) -> Result<(String, Vec<StackId>)> {
         let repo = self.ctx.repo();
 
@@ -351,6 +346,7 @@ impl BranchManager<'_> {
                     .filter(|branch| branch.id != stack_id)
                 {
                     unapplied_stacks.push(stack_to_unapply.id);
+                    let safe_checkout = old_cwd.is_none();
                     let res =
                         self.unapply(stack_to_unapply.id, perm, false, Vec::new(), safe_checkout);
                     if res.is_err() {
@@ -437,23 +433,19 @@ impl BranchManager<'_> {
 
         // Permissions here might be wonky, just go with it though.
         let new_workspace = WorkspaceState::create(self.ctx, perm.read_permission())?;
-        if safe_checkout {
-            let res = checkout_remerged_head(self.ctx, &gix_repo);
-            if res.is_err() {
-                stack.in_workspace = false;
-                vb_state.set_stack(stack.clone())?;
-            }
-            res?;
-        } else {
-            update_uncommited_changes_with_tree(
-                self.ctx,
-                workspace_state,
-                new_workspace,
-                old_cwd,
-                Some(true),
-                perm,
-            )?;
+        let res = update_uncommited_changes_with_tree(
+            self.ctx,
+            workspace_state,
+            new_workspace,
+            old_cwd,
+            Some(true),
+            perm,
+        );
+        if res.is_err() {
+            stack.in_workspace = false;
+            vb_state.set_stack(stack.clone())?;
         }
+        res?;
 
         update_workspace_commit(&vb_state, self.ctx)?;
 

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_creation.rs
@@ -270,7 +270,13 @@ impl BranchManager<'_> {
         )?;
         self.ctx.add_branch_reference(&branch)?;
 
-        match self.apply_branch(branch.id, perm, old_workspace, old_cwd) {
+        match self.apply_branch(
+            branch.id,
+            perm,
+            old_workspace,
+            old_cwd,
+            self.ctx.app_settings().feature_flags.cv3,
+        ) {
             Ok((_, unapplied_stacks)) => Ok((branch.id, unapplied_stacks)),
             Err(err)
                 if err
@@ -294,6 +300,7 @@ impl BranchManager<'_> {
         perm: &mut WorktreeWritePermission,
         workspace_state: WorkspaceState,
         old_cwd: git2::Oid,
+        safe_checkout: bool,
     ) -> Result<(String, Vec<StackId>)> {
         let repo = self.ctx.repo();
 
@@ -344,7 +351,7 @@ impl BranchManager<'_> {
                     .filter(|branch| branch.id != stack_id)
                 {
                     unapplied_stacks.push(stack.id);
-                    self.unapply(stack.id, perm, false, Vec::new())?;
+                    self.unapply(stack.id, perm, false, Vec::new(), safe_checkout)?;
                 }
             }
         }

--- a/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/branch_removal.rs
@@ -22,6 +22,7 @@ impl BranchManager<'_> {
         perm: &mut WorktreeWritePermission,
         delete_vb_state: bool,
         assigned_diffspec: Vec<but_workspace::DiffSpec>,
+        safe_checkout: bool,
     ) -> Result<String> {
         let vb_state = self.ctx.project().virtual_branches();
         let mut stack = vb_state.get_stack(stack_id)?;
@@ -59,48 +60,68 @@ impl BranchManager<'_> {
         stack.in_workspace = false;
         vb_state.set_stack(stack.clone())?;
 
-        // On v3 we want to take the `current_wd_tree` and try to extract
-        // whatever branch we want to unapply. There are a handful of ways
-        // to achieve this, including calculating the inverse diff and
-        // applying that.
-        //
-        // We can however do more or less what `git revert` does, and
-        // perform a three way merge where the `ours` side is the cwdt, the
-        // `theirs` side is the workspace root, and the `base` is the head
-        // of the branch we want to unapply.
-        //
-        // In order to handle locked files, I'm going to choose to
-        // resolve conflicts in the favor of `ours` (the cwdt) which will
-        // keep any locked changes in the cwdt.
+        let gix_repo = self.ctx.gix_repo_for_merging()?;
+        if safe_checkout {
+            // This reads the just stored data and re-merges it all stacks, excluding the unapplied one.
+            let res = (|| -> Result<()> {
+                let workspace_without_stack = but_workspace::remerged_head_commit(self.ctx)?;
+                but_workspace::branch::safe_checkout_from_head(
+                    workspace_without_stack.to_gix(),
+                    &gix_repo,
+                    but_workspace::branch::checkout::Options::default(),
+                )?;
+                Ok(())
+            })();
 
-        let gix_repo = self.ctx.gix_repo()?;
-        // dump current assignments into a WIP commit
-        let merge_options = gix_repo
-            .tree_merge_options()?
-            .with_file_favor(Some(gix::merge::tree::FileFavor::Ours))
-            .with_tree_favor(Some(gix::merge::tree::TreeFavor::Ours));
+            // Undo the removal, stack is still there officially now.
+            if res.is_err() {
+                stack.in_workspace = true;
+                vb_state.set_stack(stack.clone())?;
+            }
+            res?
+        } else {
+            // On v3 we want to take the `current_wd_tree` and try to extract
+            // whatever branch we want to unapply. There are a handful of ways
+            // to achieve this, including calculating the inverse diff and
+            // applying that.
+            //
+            // We can however do more or less what `git revert` does, and
+            // perform a three-way merge where the `ours` side is the cwdt, the
+            // `theirs` side is the workspace root, and the `base` is the head
+            // of the branch we want to unapply.
+            //
+            // In order to handle locked files, I'm going to choose to
+            // resolve conflicts in the favor of `ours` (the cwdt) which will
+            // keep any locked changes in the cwdt.
 
-        let cwdt = repo.create_wd_tree(0)?.id().to_gix();
-        let workspace_base = gix_repo
-            .find_commit(workspace_base(self.ctx, perm.read_permission())?)?
-            .tree_id()?;
-        let stack_head =
-            gix_repo.find_real_tree(&stack.head_oid(&gix_repo)?, Default::default())?;
+            // dump current assignments into a WIP commit
+            let merge_options = gix_repo
+                .tree_merge_options()?
+                .with_file_favor(Some(gix::merge::tree::FileFavor::Ours))
+                .with_tree_favor(Some(gix::merge::tree::TreeFavor::Ours));
 
-        let mut merge = gix_repo.merge_trees(
-            stack_head,
-            cwdt,
-            workspace_base,
-            gix_repo.default_merge_labels(),
-            merge_options,
-        )?;
-        let tree = merge.tree.write()?;
-        let tree = repo.find_tree(tree.to_git2())?;
+            let cwdt = repo.create_wd_tree(0)?.id().to_gix();
+            let workspace_base = gix_repo
+                .find_commit(workspace_base(self.ctx, perm.read_permission())?)?
+                .tree_id()?;
+            let stack_head =
+                gix_repo.find_real_tree(&stack.head_oid(&gix_repo)?, Default::default())?;
 
-        repo.checkout_tree_builder(&tree)
-            .force()
-            .checkout()
-            .context("failed to checkout tree")?;
+            let mut merge = gix_repo.merge_trees(
+                stack_head,
+                cwdt,
+                workspace_base,
+                gix_repo.default_merge_labels(),
+                merge_options,
+            )?;
+            let new_workspace_tree_with_worktree_changes =
+                repo.find_tree(merge.tree.write()?.to_git2())?;
+
+            repo.checkout_tree_builder(&new_workspace_tree_with_worktree_changes)
+                .force()
+                .checkout()
+                .context("failed to checkout tree")?;
+        }
 
         if delete_vb_state {
             self.ctx.delete_branch_reference(&stack)?;

--- a/crates/gitbutler-branch-actions/src/branch_manager/mod.rs
+++ b/crates/gitbutler-branch-actions/src/branch_manager/mod.rs
@@ -1,8 +1,23 @@
 pub use branch_creation::CreateBranchFromBranchOutcome;
 use gitbutler_command_context::CommandContext;
+use gitbutler_oxidize::OidExt;
 
 mod branch_creation;
 mod branch_removal;
+
+/// Note that this checks out the commit and sets the HEAD ref to point to it.
+pub(crate) fn checkout_remerged_head(
+    ctx: &CommandContext,
+    repo: &gix::Repository,
+) -> anyhow::Result<()> {
+    let (workspace_tree_id, _, _) = but_workspace::remerged_workspace_tree_v2(ctx, repo)?;
+    but_workspace::branch::safe_checkout_from_head(
+        workspace_tree_id.to_gix(),
+        repo,
+        but_workspace::branch::checkout::Options::default(),
+    )?;
+    Ok(())
+}
 
 pub struct BranchManager<'l> {
     ctx: &'l CommandContext,

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -84,7 +84,7 @@ pub fn update_workspace_commit(
         .list_stacks_in_workspace()
         .context("failed to list virtual branches")?;
 
-    let workspace_head = repo.find_commit(but_workspace::head(ctx)?)?;
+    let workspace_head = repo.find_commit(but_workspace::remerged_head_commit(ctx)?)?;
 
     // message that says how to get back to where they were
     let mut message = GITBUTLER_WORKSPACE_COMMIT_TITLE.to_string();

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -84,7 +84,7 @@ pub fn update_workspace_commit(
         .list_stacks_in_workspace()
         .context("failed to list virtual branches")?;
 
-    let workspace_head = repo.find_commit(but_workspace::remerged_head_commit(ctx)?)?;
+    let workspace_head = repo.find_commit(but_workspace::remerged_workspace_commit_v2(ctx)?)?;
 
     // message that says how to get back to where they were
     let mut message = GITBUTLER_WORKSPACE_COMMIT_TITLE.to_string();

--- a/crates/gitbutler-branch-actions/src/status.rs
+++ b/crates/gitbutler-branch-actions/src/status.rs
@@ -33,7 +33,7 @@ pub fn get_applied_status(
     ctx: &CommandContext,
     perm: Option<&mut WorktreeWritePermission>,
 ) -> Result<VirtualBranchesStatus> {
-    let diffs = gitbutler_diff::workdir(ctx.repo(), but_workspace::head(ctx)?)?;
+    let diffs = gitbutler_diff::workdir(ctx.repo(), but_workspace::remerged_head_commit(ctx)?)?;
     get_applied_status_cached(ctx, perm, &diffs)
 }
 

--- a/crates/gitbutler-branch-actions/src/status.rs
+++ b/crates/gitbutler-branch-actions/src/status.rs
@@ -33,7 +33,10 @@ pub fn get_applied_status(
     ctx: &CommandContext,
     perm: Option<&mut WorktreeWritePermission>,
 ) -> Result<VirtualBranchesStatus> {
-    let diffs = gitbutler_diff::workdir(ctx.repo(), but_workspace::remerged_head_commit(ctx)?)?;
+    let diffs = gitbutler_diff::workdir(
+        ctx.repo(),
+        but_workspace::remerged_workspace_commit_v2(ctx)?,
+    )?;
     get_applied_status_cached(ctx, perm, &diffs)
 }
 

--- a/crates/gitbutler-branch-actions/src/upstream_integration.rs
+++ b/crates/gitbutler-branch-actions/src/upstream_integration.rs
@@ -513,8 +513,13 @@ pub(crate) fn integrate_upstream(
                 continue;
             };
 
-            ctx.branch_manager()
-                .unapply(*stack_id, permission, false, Vec::new())?;
+            ctx.branch_manager().unapply(
+                *stack_id,
+                permission,
+                false,
+                Vec::new(),
+                ctx.app_settings().feature_flags.cv3,
+            )?;
         }
 
         let mut stacks = virtual_branches_state.list_stacks_in_workspace()?;

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -226,7 +226,7 @@ pub fn commit(
     ownership: Option<&BranchOwnershipClaims>,
 ) -> Result<git2::Oid> {
     // get the files to commit
-    let diffs = gitbutler_diff::workdir(ctx.repo(), but_workspace::head(ctx)?)?;
+    let diffs = gitbutler_diff::workdir(ctx.repo(), but_workspace::remerged_head_commit(ctx)?)?;
     let statuses = get_applied_status_cached(ctx, None, &diffs)
         .context("failed to get status by branch")?
         .branches;

--- a/crates/gitbutler-branch-actions/src/virtual.rs
+++ b/crates/gitbutler-branch-actions/src/virtual.rs
@@ -226,7 +226,10 @@ pub fn commit(
     ownership: Option<&BranchOwnershipClaims>,
 ) -> Result<git2::Oid> {
     // get the files to commit
-    let diffs = gitbutler_diff::workdir(ctx.repo(), but_workspace::remerged_head_commit(ctx)?)?;
+    let diffs = gitbutler_diff::workdir(
+        ctx.repo(),
+        but_workspace::remerged_workspace_commit_v2(ctx)?,
+    )?;
     let statuses = get_applied_status_cached(ctx, None, &diffs)
         .context("failed to get status by branch")?
         .branches;

--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -289,7 +289,7 @@ pub(crate) fn save_and_return_to_workspace(
         ctx,
         old_workspace,
         new_workspace,
-        uncommtied_changes,
+        Some(uncommtied_changes),
         Some(true),
         perm,
     )?;

--- a/crates/gitbutler-oplog/Cargo.toml
+++ b/crates/gitbutler-oplog/Cargo.toml
@@ -26,6 +26,7 @@ gitbutler-fs.workspace = true
 gitbutler-reference.workspace = true
 gitbutler-stack.workspace = true
 but-core.workspace = true
+but-workspace.workspace = true
 
 [[test]]
 name = "oplog"

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -619,11 +619,19 @@ fn restore_snapshot(
     repo.ignore_large_files_in_diffs(AUTO_TRACK_LIMIT_BYTES)?;
 
     // Define the checkout builder
-    let mut checkout_builder = git2::build::CheckoutBuilder::new();
-    checkout_builder.remove_untracked(true);
-    checkout_builder.force();
-    // Checkout the tree
-    repo.checkout_tree(workdir_tree.as_object(), Some(&mut checkout_builder))?;
+    if ctx.app_settings().feature_flags.cv3 {
+        but_workspace::branch::safe_checkout_from_head(
+            workdir_tree.id().to_gix(),
+            &gix_repo,
+            but_workspace::branch::checkout::Options::default(),
+        )?;
+    } else {
+        let mut checkout_builder = git2::build::CheckoutBuilder::new();
+        checkout_builder.remove_untracked(true);
+        checkout_builder.force();
+        // Checkout the tree
+        repo.checkout_tree(workdir_tree.as_object(), Some(&mut checkout_builder))?;
+    }
 
     // Update virtual_branches.toml with the state from the snapshot
     fs::write(

--- a/crates/gitbutler-workspace/Cargo.toml
+++ b/crates/gitbutler-workspace/Cargo.toml
@@ -18,4 +18,5 @@ gitbutler-commit.workspace = true
 gitbutler-oxidize.workspace = true
 gitbutler-command-context.workspace = true
 gitbutler-cherry-pick.workspace = true
+but-workspace.workspace = true
 but-rebase.workspace = true

--- a/crates/gitbutler-workspace/src/branch_trees.rs
+++ b/crates/gitbutler-workspace/src/branch_trees.rs
@@ -53,42 +53,52 @@ pub fn update_uncommited_changes(
     perm: &mut WorktreeWritePermission,
 ) -> Result<()> {
     let repo = ctx.repo();
-    let uncommited_changes = repo.create_wd_tree(0)?;
+    let uncommited_changes = (!ctx.app_settings().feature_flags.cv3)
+        .then(|| repo.create_wd_tree(0).map(|tree| tree.id()))
+        .transpose()?;
 
-    update_uncommited_changes_with_tree(ctx, old, new, uncommited_changes.id(), None, perm)
+    update_uncommited_changes_with_tree(ctx, old, new, uncommited_changes, None, perm)
 }
 
+/// `old_uncommitted_changes` is `None` if the `safe_checkout` feature is toggled on in `ctx`
 pub fn update_uncommited_changes_with_tree(
     ctx: &CommandContext,
     old: WorkspaceState,
     new: WorkspaceState,
-    old_uncommited_changes: git2::Oid,
+    old_uncommited_changes: Option<git2::Oid>,
     always_checkout: Option<bool>,
     _perm: &mut WorktreeWritePermission,
 ) -> Result<()> {
     let repo = ctx.repo();
+    if let Some(worktree_id) = old_uncommited_changes {
+        let mut new_uncommited_changes = move_tree_between_workspaces(repo, worktree_id, old, new)?;
 
-    let mut new_uncommited_changes =
-        move_tree_between_workspaces(repo, old_uncommited_changes, old, new)?;
-
-    // If the new tree and old tree are the same, then we don't need to do anything
-    if !new_uncommited_changes.has_conflicts() && !always_checkout.unwrap_or(false) {
-        let tree = new_uncommited_changes.write_tree_to(repo)?;
-        if tree == old_uncommited_changes {
-            return Ok(());
+        // If the new tree and old tree are the same, then we don't need to do anything
+        if !new_uncommited_changes.has_conflicts() && !always_checkout.unwrap_or(false) {
+            let tree = new_uncommited_changes.write_tree_to(repo)?;
+            if tree == worktree_id {
+                return Ok(());
+            }
         }
+
+        repo.checkout_index(
+            Some(&mut new_uncommited_changes),
+            Some(
+                git2::build::CheckoutBuilder::new()
+                    .force()
+                    .remove_untracked(true)
+                    .conflict_style_diff3(true),
+            ),
+        )?;
+    } else {
+        let new_tree_id = merge_workspace(repo, new)?.to_gix();
+        let gix_repo = ctx.gix_repo_for_merging()?;
+        but_workspace::branch::safe_checkout_from_head(
+            new_tree_id,
+            &gix_repo,
+            but_workspace::branch::checkout::Options::default(),
+        )?;
     }
-
-    repo.checkout_index(
-        Some(&mut new_uncommited_changes),
-        Some(
-            git2::build::CheckoutBuilder::new()
-                .force()
-                .remove_untracked(true)
-                .conflict_style_diff3(true),
-        ),
-    )?;
-
     Ok(())
 }
 

--- a/crates/gitbutler-workspace/src/branch_trees.rs
+++ b/crates/gitbutler-workspace/src/branch_trees.rs
@@ -65,12 +65,12 @@ pub fn update_uncommited_changes_with_tree(
     ctx: &CommandContext,
     old: WorkspaceState,
     new: WorkspaceState,
-    old_uncommited_changes: Option<git2::Oid>,
+    old_uncommitted_changes: Option<git2::Oid>,
     always_checkout: Option<bool>,
     _perm: &mut WorktreeWritePermission,
 ) -> Result<()> {
     let repo = ctx.repo();
-    if let Some(worktree_id) = old_uncommited_changes {
+    if let Some(worktree_id) = old_uncommitted_changes {
         let mut new_uncommited_changes = move_tree_between_workspaces(repo, worktree_id, old, new)?;
 
         // If the new tree and old tree are the same, then we don't need to do anything
@@ -91,9 +91,11 @@ pub fn update_uncommited_changes_with_tree(
             ),
         )?;
     } else {
+        let old_tree_id = merge_workspace(repo, old)?.to_gix();
         let new_tree_id = merge_workspace(repo, new)?.to_gix();
         let gix_repo = ctx.gix_repo_for_merging()?;
-        but_workspace::branch::safe_checkout_from_head(
+        but_workspace::branch::safe_checkout(
+            old_tree_id,
             new_tree_id,
             &gix_repo,
             but_workspace::branch::checkout::Options::default(),


### PR DESCRIPTION
With [stashing](https://github.com/gitbutlerapp/gitbutler/pull/9725) available, a single-branch aware version of branch apply and unapply is possible.

Follow-up of #10282.

### Tasks

* [x] unapply
* [x] apply
* [x] check usage of `update_uncommited_changes_with_tree`.
* [x] ~~edit-mode~~ - after some fiddling I realised that there are some specifics that aren't super-well covered yet (worktree-changes are expected when saving/cancelling, so safe-checkout would be in the way)
    - Edit-Mode can get a rewrite once conflicts can be handled differently.

### Next PR?

* [ ] apply branch that is already in the stack, but hidden due to ambiguity (so no ref commit change is needed)
* [ ] cherry-pick index as well (but only conflicts) - consider skipping but make sure it doesn't get lost


### Future Tasks

- Permutations: starting point
    - [ ] test unborn
    - [ ] starting point without WS ref
    - [ ] starting point with WS ref but not WS-commit or metadata
    - [ ] starting point with WS ref and WS commit
- Permutations: base position
    - [ ] base below
    - [ ] base above
- [ ] Validate StackID handling in VB.toml adapter (assure it can keep unapplied branches correctly)
    - We need *all* the tests so at a later point we can possibly localise the stack-id and keep it with each branch instead.
- [ ] without single-branch mode, it's possible to have a workspace with just one stack, or even no stacks at all.
- [ ] unapply: must take care of assignments (see research)
- [ ] don't apply the target branch!
- [ ] try to fix `but-graph` issue 

### Shortcomings

* Worktree change in a detached HEAD can't be stashed as there is no reference to associated the stash with.

### Notes

#### General Rules

* **The workspace is a conflict-free zone**
    - nothing that operates on the conflict must write conflicts into the index.
      This is as conflicts are currently hidden from view.
* **Symmetry**
   - If `apply` is doing something, then `unapply` undoes exactly that, or in other words `State + apply + unapply == State`
* **There is no single-branch workspace** when starting in single-branch mode
    - A workspace consists of at least two branches and a workspace commit
    - The workspace commit is optional if there is only one commit involved, i.e. when it's just a bunch of branches on top of a single commit
* **Workspace Commit ALWAYS for even for a single branch**
    - The workspace backend can deal with anything, but `commit()` currently can't.
    - Have to add commit() and `uncommit()`  as well to all apply-unapply tests so these can later be re-tested with different behaviour.
    - Implied by the previous rule

### Follow-Ups

- commit with auto-workspace-commit creation
    - At the same time, it needs uncommit() that is symmetric 

Thus:

* snapshots of worktree changes will be made to apply by forcing merge-conflicts to be... auto-resolved.
  This is a problem, but **we can't have conflicts** as the UI doesn't show them right now, nor does it allow interacting with them.

#### Unapply

* **Conflicting paths** are passed added as extra commit at first, without additional special handling in `apply` just to be able to handle them.
    - This means assignments aren't taken care of in all cases (but we will see how all this interacts with stack-ids)


### Research

#### Unapply: Assignments - with stashing

- uncommitted but assigned changes should create a snapshot commit
- when applying the same branch this snapshot is applied

However, the user should be able to interact with these.

#### Unapply: Assignments - with WIP commit

- uncommitted but assigned changes should create a WIP commit
     - or just unassign these assignments and they are back in the unassigned changes of the workspace
- MVP apply: do nothing with the WIP commit
- final version: apply restores the assignments from the WIP commit (which then is tracked with metadata)

#### Unapply with worktree changes

* **worktree changes that don't re-apply cleanly**

### Possible Follow-Ups

* Find a way to display and handle conflicts in the UI (Gitizen).
    - this would allow us to write conflicts as well and deal with them.


