### PR TITLE
Testing CLI: Create stack from remote branch

### DIFF
--- a/crates/but-testing/src/args.rs
+++ b/crates/but-testing/src/args.rs
@@ -215,6 +215,9 @@ pub enum Subcommands {
         /// This is the place where some metadata about the branch can be stored.
         #[clap(long, short = 'd')]
         description: Option<String>,
+        /// Whether the branch is a remote branch
+        #[clap(long, short = 'u', default_value_t = false)]
+        remote: bool,
     },
     /// Create a reference at the given position (dependent and independent)
     CreateReference {

--- a/crates/but-testing/src/command/mod.rs
+++ b/crates/but-testing/src/command/mod.rs
@@ -162,10 +162,12 @@ pub mod stacks {
     use but_settings::AppSettings;
     use but_workspace::{StacksFilter, stack_branches, ui};
     use gitbutler_command_context::CommandContext;
+    use gitbutler_reference::{Refname, RemoteRefname};
     use gitbutler_stack::StackId;
     use gix::bstr::ByteSlice;
     use gix::refs::Category;
     use std::path::Path;
+    use std::str::FromStr;
 
     pub fn list(
         current_dir: &Path,
@@ -255,9 +257,40 @@ pub mod stacks {
     /// Create a new stack containing only a branch with the given name.
     fn create_stack_with_branch(
         ctx: &CommandContext,
+        project: gitbutler_project::Project,
         name: &str,
+        remote: bool,
         description: Option<&str>,
-    ) -> anyhow::Result<ui::StackEntryNoOpt> {
+    ) -> anyhow::Result<ui::StackEntry> {
+        let repo = ctx.gix_repo()?;
+        let remotes = repo.remote_names();
+        if remote {
+            let remote_name = remotes
+                .first()
+                .map(|r| r.to_str().unwrap())
+                .context("No remote found in repository")?;
+
+            let ref_name = Refname::from_str(&format!("refs/remotes/{remote_name}/{name}"))?;
+            let remote_ref_name = RemoteRefname::new(remote_name, name);
+
+            let (stack_id, _) = gitbutler_branch_actions::create_virtual_branch_from_branch(
+                ctx,
+                &ref_name,
+                Some(remote_ref_name),
+                None,
+            )?;
+
+            let stack_entries =
+                but_workspace::stacks(ctx, &project.gb_dir(), &repo, Default::default())?;
+            let stack_entry = stack_entries
+                .into_iter()
+                .find(|entry| entry.id == Some(stack_id))
+                .ok_or_else(|| {
+                    anyhow::anyhow!("Failed to find newly created stack with ID: {stack_id}")
+                })?;
+            return Ok(stack_entry);
+        };
+
         let creation_request = gitbutler_branch::BranchCreateRequest {
             name: Some(name.to_string()),
             ..Default::default()
@@ -277,7 +310,7 @@ pub mod stacks {
             )?;
         }
 
-        Ok(stack_entry)
+        Ok(stack_entry.into())
     }
 
     /// Add a branch to an existing stack.
@@ -326,6 +359,7 @@ pub mod stacks {
         name: &str,
         description: Option<&str>,
         current_dir: &Path,
+        remote: bool,
         use_json: bool,
         ws3: bool,
     ) -> anyhow::Result<()> {
@@ -348,7 +382,7 @@ pub mod stacks {
 
         let stack_entry = match id {
             Some(id) => add_branch_to_stack(&ctx, id, name, description, project.clone(), &repo)?,
-            None => create_stack_with_branch(&ctx, name, description)?.into(),
+            None => create_stack_with_branch(&ctx, project.clone(), name, remote, description)?,
         };
 
         if use_json {

--- a/crates/but-testing/src/main.rs
+++ b/crates/but-testing/src/main.rs
@@ -184,12 +184,14 @@ async fn main() -> Result<()> {
             id,
             branch_name,
             description,
+            remote,
         } => match (branch_name, id) {
             (Some(branch_name), maybe_id) => command::stacks::create_branch(
                 *maybe_id,
                 branch_name,
                 description.as_deref(),
                 &args.current_dir,
+                *remote,
                 args.json,
                 args.v3,
             ),


### PR DESCRIPTION
Implement the ability to specify a remote branch when creating or stacking branches through the but-testing CLI tool. 

- Add `remote` option to CLI args
- Support logic changes for remote branch operations in main command logic and handler

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #10342 
- <kbd>&nbsp;1&nbsp;</kbd> #10341 👈 
<!-- GitButler Footer Boundary Bottom -->

