### PR TITLE
E2E: Apply the branches from the script

### DIFF
--- a/e2e/playwright/scripts/project-with-remote-branches__apply-branch-1.sh
+++ b/e2e/playwright/scripts/project-with-remote-branches__apply-branch-1.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $GITBUTLER_CLI_DATA_DIR"
+echo "BUT_TESTING $BUT_TESTING"
+
+# Apply branch 1 to the workspace.
+pushd local-clone
+  $BUT_TESTING stack-branches -u -b branch1
+popd

--- a/e2e/playwright/tests/branches.spec.ts
+++ b/e2e/playwright/tests/branches.spec.ts
@@ -137,31 +137,11 @@ test('should be able to apply a remote branch and integrate the remote changes -
 	const fileCPath = gitbutler.pathInWorkdir('local-clone/c_file');
 
 	await gitbutler.runScript('project-with-remote-branches.sh');
+	await gitbutler.runScript('project-with-remote-branches__apply-branch-1.sh');
 
 	await page.goto('/');
 
 	// Should load the workspace
-	await waitForTestId(page, 'workspace-view');
-
-	// Should navigate to the branches page when clicking the branches button
-	await clickByTestId(page, 'navigation-branches-button');
-	const header = await waitForTestId(page, 'target-commit-list-header');
-
-	await expect(header).toContainText('origin/master');
-
-	const branchListCards = getByTestId(page, 'branch-list-card');
-	await expect(branchListCards).toHaveCount(2);
-
-	const firstBranchCard = branchListCards.filter({ hasText: 'branch1' });
-	await expect(firstBranchCard).toBeVisible();
-	await firstBranchCard.click();
-
-	// The delete branch should be visible
-	await waitForTestId(page, 'branches-view-delete-local-branch-button');
-
-	// Apply the branch
-	await clickByTestId(page, 'branches-view-apply-branch-button');
-	// Should be redirected to the workspace
 	await waitForTestId(page, 'workspace-view');
 
 	// There should be only one stack
@@ -217,33 +197,12 @@ test('should be able to apply a remote branch and integrate the remote changes -
 	const filePath = gitbutler.pathInWorkdir('local-clone/a_file');
 
 	await gitbutler.runScript('project-with-remote-branches.sh');
+	await gitbutler.runScript('project-with-remote-branches__apply-branch-1.sh');
 
 	await page.goto('/');
 
 	// Should load the workspace
 	await waitForTestId(page, 'workspace-view');
-
-	// Should navigate to the branches page when clicking the branches button
-	await clickByTestId(page, 'navigation-branches-button');
-	const header = await waitForTestId(page, 'target-commit-list-header');
-
-	await expect(header).toContainText('origin/master');
-
-	const branchListCards = getByTestId(page, 'branch-list-card');
-	await expect(branchListCards).toHaveCount(2);
-
-	const firstBranchCard = branchListCards.filter({ hasText: 'branch1' });
-	await expect(firstBranchCard).toBeVisible();
-	await firstBranchCard.click();
-
-	// The delete branch should be visible
-	await waitForTestId(page, 'branches-view-delete-local-branch-button');
-
-	// Apply the branch
-	await clickByTestId(page, 'branches-view-apply-branch-button');
-	// Should be redirected to the workspace
-	await waitForTestId(page, 'workspace-view');
-
 	// There should be only one stack
 	const stacks = getByTestId(page, 'stack');
 	await expect(stacks).toHaveCount(1);
@@ -584,31 +543,11 @@ test('should handle gracefully applying two conflicting branches', async ({
 	gitbutler = await startGitButler(workdir, configdir, context);
 
 	await gitbutler.runScript('project-with-remote-branches.sh');
+	await gitbutler.runScript('project-with-remote-branches__apply-branch-1.sh');
 
 	await page.goto('/');
 
 	// Should load the workspace
-	await waitForTestId(page, 'workspace-view');
-
-	// Should navigate to the branches page when clicking the branches button
-	await clickByTestId(page, 'navigation-branches-button');
-	const header = await waitForTestId(page, 'target-commit-list-header');
-
-	await expect(header).toContainText('origin/master');
-
-	const branchListCards = getByTestId(page, 'branch-list-card');
-	await expect(branchListCards).toHaveCount(2);
-
-	const firstBranchCard = branchListCards.filter({ hasText: 'branch1' });
-	await expect(firstBranchCard).toBeVisible();
-	await firstBranchCard.click();
-
-	// The delete branch should be visible
-	await waitForTestId(page, 'branches-view-delete-local-branch-button');
-
-	// Apply the branch
-	await clickByTestId(page, 'branches-view-apply-branch-button');
-	// Should be redirected to the workspace
 	await waitForTestId(page, 'workspace-view');
 
 	const commits = getByTestId(page, 'commit-row');


### PR DESCRIPTION
Save time and lines of code by applying the branches to the workspace from the script

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #10342 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #10341 
<!-- GitButler Footer Boundary Bottom -->

