### PR TITLE
Rename ReactiveResult to ReactiveQuery and usages

### DIFF
--- a/apps/desktop/src/components/AnalyticsMonitor.svelte
+++ b/apps/desktop/src/components/AnalyticsMonitor.svelte
@@ -19,7 +19,7 @@ attached to posthog events.
 	const projectsService = inject(PROJECTS_SERVICE);
 	const settingsService = inject(SETTINGS_SERVICE);
 
-	const projectResult = $derived(projectsService.getProject(projectId));
+	const projectQuery = $derived(projectsService.getProject(projectId));
 	const globalState = uiState.global;
 	const projectState = $derived(uiState.project(projectId));
 
@@ -51,7 +51,7 @@ attached to posthog events.
 	});
 
 	$effect(() => {
-		const project = projectResult.current.data;
+		const project = projectQuery.response;
 		if (project) {
 			eventContext.update({
 				forcePushAllowed: project.ok_with_force_push,

--- a/apps/desktop/src/components/BaseBranchSwitch.svelte
+++ b/apps/desktop/src/components/BaseBranchSwitch.svelte
@@ -9,16 +9,16 @@
 
 	const stackService = inject(STACK_SERVICE);
 	const baseBranchService = inject(BASE_BRANCH_SERVICE);
-	const baseBranchResponse = $derived(baseBranchService.baseBranch(projectId));
-	const baseBranch = $derived(baseBranchResponse.current.data);
-	const remoteBranchesResponse = $derived(baseBranchService.remoteBranches(projectId));
+	const baseBranchQuery = $derived(baseBranchService.baseBranch(projectId));
+	const baseBranch = $derived(baseBranchQuery.response);
+	const remoteBranchesQuery = $derived(baseBranchService.remoteBranches(projectId));
 	const [setBaseBranchTarget, targetBranchSwitch] = baseBranchService.setTarget;
 
 	let selectedBranch = $derived(baseBranch?.branchName);
 	let selectedRemote = $derived(baseBranch?.actualPushRemoteName());
 
-	const stacksResult = $derived(stackService.stacks(projectId));
-	const stackCount = $derived(stacksResult.current.data?.length);
+	const stacksQuery = $derived(stackService.stacks(projectId));
+	const stackCount = $derived(stacksQuery.response?.length);
 	const targetChangeDisabled = $derived(!!(stackCount && stackCount > 0));
 
 	function uniqueRemotes(remoteBranches: { name: string }[]) {
@@ -42,15 +42,15 @@
 	}
 </script>
 
-{#if remoteBranchesResponse.current.isLoading}
+{#if remoteBranchesQuery.result.isLoading}
 	<InfoMessage filled outlined={false} icon="info">
 		{#snippet content()}
 			Loading remote branches...
 		{/snippet}
 	</InfoMessage>
-{:else if remoteBranchesResponse.current.isSuccess}
-	{@const remoteBranches = remoteBranchesResponse.current.data}
-	{#if remoteBranches.length > 0}
+{:else if remoteBranchesQuery.result.isSuccess}
+	{@const remoteBranches = remoteBranchesQuery.response}
+	{#if remoteBranches && remoteBranches.length > 0}
 		<SectionCard>
 			{#snippet title()}
 				Remote configuration
@@ -120,7 +120,7 @@
 			{/if}
 		</SectionCard>
 	{/if}
-{:else if remoteBranchesResponse.current.isError}
+{:else if remoteBranchesQuery.result.isError}
 	<InfoMessage filled outlined={true} style="error" icon="error">
 		{#snippet title()}
 			We got an error trying to list your remote branches

--- a/apps/desktop/src/components/BranchCard.svelte
+++ b/apps/desktop/src/components/BranchCard.svelte
@@ -164,12 +164,7 @@
 			? rulesService.aiRuleForStack({ projectId, stackId: args.stackId })
 			: undefined}
 		{@const codegenRuleHandler = args.stackId
-			? new CodegenRuleDropHandler(
-					projectId,
-					args.stackId,
-					rulesService,
-					!!rule?.current.data?.rule
-				)
+			? new CodegenRuleDropHandler(projectId, args.stackId, rulesService, !!rule?.response?.rule)
 			: undefined}
 
 		<Dropzone
@@ -242,8 +237,8 @@
 						<span class="branch-header__divider">•</span>
 						<div class="branch-header__review-badges">
 							{#if args.prNumber}
-								{@const prResult = prService?.get(args.prNumber, { forceRefetch: true })}
-								{@const pr = prResult?.current.data}
+								{@const prQuery = prService?.get(args.prNumber, { forceRefetch: true })}
+								{@const pr = prQuery?.response}
 								<ReviewBadge type={prUnit?.abbr} number={args.prNumber} status="unknown" />
 								{#if pr && !pr.closedAt && forge.current.checks && pr.state === 'open'}
 									<ChecksPolling
@@ -352,13 +347,13 @@
 		? rulesService.aiRuleForStack({ projectId, stackId: args.stackId })
 		: undefined}
 	{#if rule}
-		<ReduxResult result={rule?.current} {projectId} stackId={args.stackId}>
+		<ReduxResult result={rule?.result} {projectId} stackId={args.stackId}>
 			{#snippet children({ rule }, { projectId, stackId })}
 				{#if rule}
 					{@const sessionId = (rule.filters[0]! as RuleFilter & { type: 'claudeCodeSessionId' })
 						.subject}
 					{@const sessionDetails = claudeCodeService.sessionDetails(projectId, sessionId)}
-					<ReduxResult result={sessionDetails.current} {projectId} {stackId}>
+					<ReduxResult result={sessionDetails.result} {projectId} {stackId}>
 						{#snippet children(sessionDetails, { projectId, stackId: _stackId })}
 							<ClaudeSessionDescriptor {projectId} {sessionId}>
 								{#snippet loading()}

--- a/apps/desktop/src/components/BranchCommitList.svelte
+++ b/apps/desktop/src/components/BranchCommitList.svelte
@@ -108,8 +108,8 @@
 		stackService.upstreamCommits(projectId, stackId, branchName)
 	);
 
-	const baseBranchResponse = $derived(baseBranchService.baseBranch(projectId));
-	const base = $derived(baseBranchResponse.current.data);
+	const baseBranchQuery = $derived(baseBranchService.baseBranch(projectId));
+	const base = $derived(baseBranchQuery.response);
 	const baseSha = $derived(base?.baseSha);
 
 	let integrationModal = $state<Modal>();
@@ -237,7 +237,7 @@
 <ReduxResult
 	{stackId}
 	{projectId}
-	result={combineResults(upstreamOnlyCommits.current, localAndRemoteCommits.current)}
+	result={combineResults(upstreamOnlyCommits.result, localAndRemoteCommits.result)}
 >
 	{#snippet children([upstreamOnlyCommits, localAndRemoteCommits], { stackId })}
 		{@const hasRemoteCommits = upstreamOnlyCommits.length > 0}

--- a/apps/desktop/src/components/BranchExplorer.svelte
+++ b/apps/desktop/src/components/BranchExplorer.svelte
@@ -73,9 +73,9 @@
 		uiState
 	);
 
-	const branchesResult = $derived(branchService.list(projectId));
+	const branchesQuery = $derived(branchService.list(projectId));
 	const combined = $derived(
-		combineBranchesAndPrs(prs.current, branchesResult.current.data || [], selectedOption)
+		combineBranchesAndPrs(prs.current, branchesQuery.response || [], selectedOption)
 	);
 
 	const groupedBranches = $derived(groupBranches(combined, forgeUser));

--- a/apps/desktop/src/components/BranchHeaderContextMenu.svelte
+++ b/apps/desktop/src/components/BranchHeaderContextMenu.svelte
@@ -87,7 +87,7 @@
 		return stackService.fetchUnstackedCommits(projectId, contextData.branch.name);
 	}
 
-	const commits = $derived(allCommits?.current.data);
+	const commits = $derived(allCommits?.response);
 	const branchType = $derived(commits?.at(0)?.state.type || 'LocalOnly');
 	const isConflicted = $derived(commits?.some((commit) => commit.hasConflicts) ?? false);
 
@@ -273,7 +273,7 @@
 			<ContextMenuSection>
 				{#if stackId && first && $codegenEnabled}
 					{@const rule = rulesService.aiRuleForStack({ projectId, stackId })}
-					{#if !rule.current.data?.rule}
+					{#if !rule.response?.rule}
 						<ContextMenuItem
 							label="Start agent session"
 							icon="agents-tab"
@@ -339,8 +339,8 @@
 			</ContextMenuSection>
 		{/if}
 		{#if prNumber}
-			{@const prResult = forge.current.prService?.get(prNumber)}
-			<ReduxResult {projectId} {stackId} result={prResult?.current}>
+			{@const prQuery = forge.current.prService?.get(prNumber)}
+			<ReduxResult {projectId} {stackId} result={prQuery?.result}>
 				{#snippet children(pr)}
 					<ContextMenuSection>
 						<ContextMenuItemSubmenu label="Pull Request" icon="pr">

--- a/apps/desktop/src/components/BranchIntegrationModal.svelte
+++ b/apps/desktop/src/components/BranchIntegrationModal.svelte
@@ -37,7 +37,7 @@
 		branchName
 	);
 
-	let editableSteps = $derived(initialIntegrationSteps.current?.data ?? []);
+	let editableSteps = $derived(initialIntegrationSteps.response ?? []);
 
 	// Constants
 	const FLIP_ANIMATION_DURATION = 150;
@@ -369,8 +369,8 @@
 	{@const isSquashStep = step.type === 'squash'}
 	{@const isIndividualStep = step.type === 'pick' || step.type === 'skip'}
 	{#if isSquashStep}
-		{@const commitsResult = stackService.commitsByIds(projectId, stackId, step.subject.commits)}
-		<ReduxResult {projectId} result={commitsResult.current}>
+		{@const commitsQuery = stackService.commitsByIds(projectId, stackId, step.subject.commits)}
+		<ReduxResult {projectId} result={commitsQuery.result}>
 			{#snippet children(commits)}
 				{#each commits as commit, commitIndex (commit.id)}
 					{@const isLastCommit = commitIndex === commits.length - 1}
@@ -394,7 +394,7 @@
 		</ReduxResult>
 	{:else if isIndividualStep}
 		{@const commitDetails = stackService.commitById(projectId, stackId, step.subject.commitId)}
-		<ReduxResult {projectId} result={commitDetails.current}>
+		<ReduxResult {projectId} result={commitDetails.result}>
 			{#snippet children(commit)}
 				{@const isSkipStep = step.type === 'skip'}
 				<div class="branch-integration__commit" class:skipped={isSkipStep}>
@@ -412,10 +412,10 @@
 	{:else if step.type === 'pickUpstream'}
 		{@const commitDetails = stackService.commitDetails(projectId, step.subject.upstreamCommitId)}
 		{@const localCommitDetails = stackService.commitById(projectId, stackId, step.subject.commitId)}
-		<ReduxResult {projectId} result={commitDetails.current}>
+		<ReduxResult {projectId} result={commitDetails.result}>
 			{#snippet loading()}
 				<!-- Show local commit data while loading upstream commit to prevent flickering -->
-				<ReduxResult {projectId} result={localCommitDetails.current}>
+				<ReduxResult {projectId} result={localCommitDetails.result}>
 					{#snippet children(localCommit)}
 						<div class="branch-integration__commit">
 							{@render commitItemTemplate(

--- a/apps/desktop/src/components/BranchList.svelte
+++ b/apps/desktop/src/components/BranchList.svelte
@@ -104,7 +104,7 @@
 	);
 
 	$effect(() => {
-		if (selectedCommit && selectedCommit.current.status === QueryStatus.rejected) {
+		if (selectedCommit && selectedCommit.result.status === QueryStatus.rejected) {
 			const branchName = selection.current?.branchName;
 			if (branchName) {
 				selection.set({ branchName, commitId: undefined });
@@ -129,9 +129,9 @@
 		{@const branchName = branch.name}
 		{@const localAndRemoteCommits = stackService.commits(projectId, stackId, branchName)}
 		{@const upstreamOnlyCommits = stackService.upstreamCommits(projectId, stackId, branchName)}
-		{@const branchDetailsResult = stackService.branchDetails(projectId, stackId, branchName)}
-		{@const commitResult = stackService.commitAt(projectId, stackId, branchName, 0)}
-		{@const prResult = branch.prNumber ? forge.current.prService?.get(branch.prNumber) : undefined}
+		{@const branchDetailsQuery = stackService.branchDetails(projectId, stackId, branchName)}
+		{@const commitQuery = stackService.commitAt(projectId, stackId, branchName, 0)}
+		{@const prQuery = branch.prNumber ? forge.current.prService?.get(branch.prNumber) : undefined}
 
 		{@const first = i === 0}
 
@@ -139,10 +139,10 @@
 			{projectId}
 			{stackId}
 			result={combineResults(
-				localAndRemoteCommits.current,
-				upstreamOnlyCommits.current,
-				branchDetailsResult.current,
-				commitResult.current
+				localAndRemoteCommits.result,
+				upstreamOnlyCommits.result,
+				branchDetailsQuery.result,
+				commitQuery.result
 			)}
 		>
 			{#snippet children([localAndRemoteCommits, upstreamOnlyCommits, branchDetails, commit])}
@@ -231,7 +231,7 @@
 									{`Create ${forge.current.name === 'gitlab' ? 'MR' : 'PR'}`}
 								</Button>
 							{:else}
-								{@const prUrl = prResult?.current.data?.htmlUrl}
+								{@const prUrl = prQuery?.response?.htmlUrl}
 								<Button
 									size="tag"
 									kind="outline"

--- a/apps/desktop/src/components/BranchRenameModal.svelte
+++ b/apps/desktop/src/components/BranchRenameModal.svelte
@@ -16,7 +16,7 @@
 	const { projectId, stackId, laneId, branchName, isPushed }: BranchRenameModalProps = $props();
 	const stackService = inject(STACK_SERVICE);
 
-	const [renameBranch, renameResult] = stackService.updateBranchName;
+	const [renameBranch, renameQuery] = stackService.updateBranchName;
 
 	let newName: string | undefined = $state();
 	let modal: Modal | undefined = $state();
@@ -61,7 +61,7 @@
 			style="pop"
 			type="submit"
 			disabled={!newName}
-			loading={renameResult.current.isLoading}>Rename</Button
+			loading={renameQuery.current.isLoading}>Rename</Button
 		>
 	{/snippet}
 </Modal>

--- a/apps/desktop/src/components/BranchView.svelte
+++ b/apps/desktop/src/components/BranchView.svelte
@@ -44,9 +44,9 @@
 
 	const stackService = inject(STACK_SERVICE);
 
-	const branchResult = $derived(stackService.branchDetails(projectId, stackId, branchName));
-	const branchesResult = $derived(stackService.branches(projectId, stackId));
-	const topCommitResult = $derived(stackService.commitAt(projectId, stackId, branchName, 0));
+	const branchQuery = $derived(stackService.branchDetails(projectId, stackId, branchName));
+	const branchesQuery = $derived(stackService.branches(projectId, stackId));
+	const topCommitQuery = $derived(stackService.commitAt(projectId, stackId, branchName, 0));
 
 	let renameBranchModal = $state<BranchRenameModal>();
 	let deleteBranchModal = $state<DeleteBranchModal>();
@@ -56,7 +56,7 @@
 	{stackId}
 	{projectId}
 	{onerror}
-	result={combineResults(branchesResult.current, branchResult.current, topCommitResult.current)}
+	result={combineResults(branchesQuery.result, branchQuery.result, topCommitQuery.result)}
 >
 	{#snippet children([branches, branch, topCommit], { stackId, projectId })}
 		{@const hasCommits = !!topCommit || branch.upstreamCommits.length > 0}

--- a/apps/desktop/src/components/BranchesView.svelte
+++ b/apps/desktop/src/components/BranchesView.svelte
@@ -54,7 +54,7 @@
 	const projectState = $derived(uiState.project(projectId));
 	const branchesState = $derived(projectState.branchesSelection);
 
-	const baseBranchResult = $derived(baseBranchService.baseBranch(projectId));
+	const baseBranchQuery = $derived(baseBranchService.baseBranch(projectId));
 
 	const selectedOption = persisted<BranchFilterOption>(
 		'all',
@@ -179,7 +179,7 @@
 	{/snippet}
 </Modal>
 
-<ReduxResult {projectId} result={baseBranchResult.current}>
+<ReduxResult {projectId} result={baseBranchQuery.result}>
 	{#snippet children(baseBranch)}
 		{@const lastCommit = baseBranch.recentCommits.at(0)}
 		{@const current = branchesState.current}
@@ -222,7 +222,7 @@
 					<BranchExplorer
 						{projectId}
 						bind:selectedOption={$selectedOption}
-						forgeUser={forgeUserQuery.current.data}
+						forgeUser={forgeUserQuery.response}
 					>
 						{#snippet sidebarEntry(sidebarEntrySubject: SidebarEntrySubject)}
 							{#if sidebarEntrySubject.type === 'branchListing'}

--- a/apps/desktop/src/components/BranchesViewBranch.svelte
+++ b/apps/desktop/src/components/BranchesViewBranch.svelte
@@ -20,7 +20,7 @@
 	const { projectId, stackId, branchName, remote, isTopBranch = true, onerror }: Props = $props();
 
 	const stackService = inject(STACK_SERVICE);
-	const branchResult = $derived(
+	const branchQuery = $derived(
 		stackId
 			? stackService.branchDetails(projectId, stackId, branchName)
 			: stackService.unstackedBranchDetails(projectId, branchName, remote)
@@ -31,7 +31,7 @@
 	const branchesState = $derived(projectState.branchesSelection);
 </script>
 
-<ReduxResult result={branchResult.current} {projectId} {stackId} {onerror}>
+<ReduxResult result={branchQuery.result} {projectId} {stackId} {onerror}>
 	{#snippet children(branch, env)}
 		{#if stackId}
 			{@render branchCard(branch, env)}

--- a/apps/desktop/src/components/BranchesViewPR.svelte
+++ b/apps/desktop/src/components/BranchesViewPR.svelte
@@ -25,7 +25,7 @@
 
 	const forge = inject(DEFAULT_FORGE_FACTORY);
 	const prService = $derived(forge.current.prService);
-	const prResult = $derived(prService?.get(prNumber, { forceRefetch: true }));
+	const prQuery = $derived(prService?.get(prNumber, { forceRefetch: true }));
 	const prUnit = $derived(prService?.unit);
 
 	const uiState = inject(UI_STATE);
@@ -35,8 +35,8 @@
 	const selected = $derived(branchesState.current.prNumber === prNumber);
 
 	const baseBranchService = inject(BASE_BRANCH_SERVICE);
-	const baseRepoResponse = $derived(baseBranchService.repo(projectId));
-	const baseRepo = $derived(baseRepoResponse.current.data);
+	const baseRepoQuery = $derived(baseBranchService.repo(projectId));
+	const baseRepo = $derived(baseRepoQuery.response);
 
 	const remotesService = inject(REMOTES_SERVICE);
 	const stackService = inject(STACK_SERVICE);
@@ -94,7 +94,7 @@
 	}
 </script>
 
-<ReduxResult result={prResult?.current} {projectId} {onerror}>
+<ReduxResult result={prQuery?.result} {projectId} {onerror}>
 	{#snippet children(pr)}
 		<div class="pr-card">
 			<PRListCard

--- a/apps/desktop/src/components/BranchesViewStack.svelte
+++ b/apps/desktop/src/components/BranchesViewStack.svelte
@@ -15,10 +15,10 @@
 
 	const stackService = inject(STACK_SERVICE);
 
-	const stackResult = $derived(stackService.allStackById(projectId, stackId));
+	const stackQuery = $derived(stackService.allStackById(projectId, stackId));
 </script>
 
-<ReduxResult result={stackResult.current} {projectId} {stackId} {onerror}>
+<ReduxResult result={stackQuery.result} {projectId} {stackId} {onerror}>
 	{#snippet children(stack, { stackId, projectId })}
 		{#each getStackBranchNames(stack) as branchName, idx}
 			<BranchesViewBranch {projectId} {stackId} {branchName} isTopBranch={idx === 0} {onerror} />

--- a/apps/desktop/src/components/CanPublishReviewPlugin.svelte
+++ b/apps/desktop/src/components/CanPublishReviewPlugin.svelte
@@ -19,10 +19,10 @@
 	const commits = $derived(
 		stackId && branchName ? stackService.commits(projectId, stackId, branchName) : undefined
 	);
-	const branchEmpty = $derived(commits?.current.data ? commits.current.data.length === 0 : false);
+	const branchEmpty = $derived(commits?.response ? commits.response.length === 0 : false);
 	const prService = $derived(forge.current.prService);
-	const prResult = $derived(prNumber ? prService?.get(prNumber) : undefined);
-	const pr = $derived(prResult?.current.data);
+	const prQuery = $derived(prNumber ? prService?.get(prNumber) : undefined);
+	const pr = $derived(prQuery?.response);
 
 	const canPublishPR = $derived(forge.current.authenticated && !pr);
 
@@ -36,7 +36,7 @@
 			return branchEmpty;
 		},
 		get branchIsConflicted() {
-			return commits?.current.data?.some((commit) => commit.hasConflicts) || false;
+			return commits?.response?.some((commit) => commit.hasConflicts) || false;
 		},
 		get prNumber() {
 			return prNumber;

--- a/apps/desktop/src/components/ChecksPolling.svelte
+++ b/apps/desktop/src/components/ChecksPolling.svelte
@@ -46,16 +46,16 @@
 
 	const pollingInterval = $derived(getPollingInterval(elapsedMs, isDone));
 
-	const checksResult = $derived(
+	const checksQuery = $derived(
 		enabled
 			? checksService?.get(branchName, { subscriptionOptions: { pollingInterval } })
 			: undefined
 	);
 
-	const loading = $derived(checksResult?.current.isLoading);
+	const loading = $derived(checksQuery?.result.isLoading);
 
 	const checksTagInfo: StatusInfo = $derived.by(() => {
-		const checks = checksResult?.current.data;
+		const checks = checksQuery?.response;
 		if (!checksService && isFork) {
 			return {
 				style: 'neutral',
@@ -66,7 +66,7 @@
 			};
 		}
 
-		if (checksResult?.current.error) {
+		if (checksQuery?.result.error) {
 			return {
 				style: 'error',
 				icon: 'warning-small',
@@ -110,9 +110,7 @@
 	let prevChecksStartedAt = $state<string>();
 
 	// Checks have reached a terminal state or there are no checks to monitor
-	const shouldStop = $derived(
-		checksResult?.current.data?.completed || checksResult?.current.data === null
-	);
+	const shouldStop = $derived(checksQuery?.response?.completed || checksQuery?.response === null);
 
 	$effect(() => {
 		// If polling was previously done but now should restart (e.g., after a force push)
@@ -120,7 +118,7 @@
 			loadedOnce = false;
 		}
 
-		const result = checksResult?.current;
+		const result = checksQuery?.result;
 		const checks = result?.data;
 
 		// Mark as loaded once we start loading again

--- a/apps/desktop/src/components/Chrome.svelte
+++ b/apps/desktop/src/components/Chrome.svelte
@@ -16,10 +16,10 @@
 	}: { projectId: string; children: Snippet; sidebarDisabled?: boolean } = $props();
 
 	const projectService = inject(PROJECTS_SERVICE);
-	const projectResult = $derived(projectService.getProject(projectId));
+	const projectQuery = $derived(projectService.getProject(projectId));
 </script>
 
-<ReduxResult {projectId} result={projectResult.current}>
+<ReduxResult {projectId} result={projectQuery.result}>
 	{#snippet children(project, { projectId })}
 		<div class="chrome" use:focusable={{ vertical: true, activate: true }}>
 			<ChromeHeader {projectId} projectTitle={project.title} actionsDisabled={sidebarDisabled} />

--- a/apps/desktop/src/components/ChromeHeader.svelte
+++ b/apps/desktop/src/components/ChromeHeader.svelte
@@ -40,7 +40,7 @@
 	const uiState = inject(UI_STATE);
 	const modeService = inject(MODE_SERVICE);
 	const baseReponse = $derived(projectId ? baseBranchService.baseBranch(projectId) : undefined);
-	const base = $derived(baseReponse?.current.data);
+	const base = $derived(baseReponse?.response);
 	const settingsStore = $derived(settingsService.appSettings);
 	const isWorkspace = $derived(isWorkspacePath());
 	const canUseActions = $derived($settingsStore?.featureFlags.actions ?? false);
@@ -48,7 +48,7 @@
 	const backend = inject(BACKEND);
 
 	const mode = $derived(modeService.mode({ projectId }));
-	const currentMode = $derived(mode.current.data);
+	const currentMode = $derived(mode.response);
 	const currentBranchName = $derived.by(() => {
 		if (currentMode?.type === 'OpenWorkspace') {
 			return 'gitbutler/workspace';
@@ -82,7 +82,7 @@
 	const projects = $derived(projectsService.projects());
 
 	const mappedProjects = $derived(
-		projects.current.data?.map((project) => ({
+		projects.response?.map((project) => ({
 			value: project.id,
 			label: project.title
 		})) || []

--- a/apps/desktop/src/components/ClaudeSessionDescriptor.svelte
+++ b/apps/desktop/src/components/ClaudeSessionDescriptor.svelte
@@ -42,7 +42,7 @@
 
 <ReduxResult
 	{projectId}
-	result={sessionDetails.current}
+	result={sessionDetails.result}
 	loading={loadingSnippet}
 	error={errorSnippet}
 	children={resultChildren}

--- a/apps/desktop/src/components/CommitFailedFileEntry.svelte
+++ b/apps/desktop/src/components/CommitFailedFileEntry.svelte
@@ -41,8 +41,8 @@
 			<div class="commit-failed__file-entry__header__unfold-action">
 				<span class="text-12 text-semibold"
 					>{isFolded ? 'Show' : 'Hide'}
-					hunks ({#if fileDependencies.current.data}
-						{fileDependencies.current.data.dependencies.length}
+					hunks ({#if fileDependencies.response}
+						{fileDependencies.response.dependencies.length}
 					{:else}
 						0
 					{/if})</span
@@ -54,7 +54,7 @@
 
 		{#if !isFolded}
 			<div class="commit-failed__file-entry-dependencies">
-				<ReduxResult {projectId} result={fileDependencies.current}>
+				<ReduxResult {projectId} result={fileDependencies.result}>
 					{#snippet children(fileDependencies)}
 						{#each fileDependencies.dependencies as dependency, i}
 							<HunkDiff
@@ -77,8 +77,8 @@
 								</div>
 								<div class="commit-failed__file-entry__dependency-locks__content">
 									{#each dependency.locks as lock}
-										{@const brnachesResult = stackService.branches(projectId, lock.stackId)}
-										{@const branch = brnachesResult.current.data}
+										{@const brnachesQuery = stackService.branches(projectId, lock.stackId)}
+										{@const branch = brnachesQuery.response}
 										{@const commitBranch = branch?.find((b) =>
 											b.commits.some((c) => c.id === lock.commitId)
 										)}

--- a/apps/desktop/src/components/CommitView.svelte
+++ b/apps/desktop/src/components/CommitView.svelte
@@ -64,11 +64,11 @@
 	const selected = $derived(laneState.selection);
 	const branchName = $derived(selected.current?.branchName);
 
-	const commitResult = $derived(
+	const commitQuery = $derived(
 		stackService.commitById(projectId, commitKey.stackId, commitKey.commitId)
 	);
 
-	const [updateCommitMessage, messageUpdateResult] = stackService.updateCommitMessage;
+	const [updateCommitMessage, messageUpdateQuery] = stackService.updateCommitMessage;
 
 	type Mode = 'view' | 'edit';
 
@@ -89,7 +89,7 @@
 	}
 
 	const parsedMessage = $derived(
-		commitResult.current.data ? splitMessage(commitResult.current.data.message) : undefined
+		commitQuery.response ? splitMessage(commitQuery.response.message) : undefined
 	);
 
 	function combineParts(title?: string, description?: string): string {
@@ -152,7 +152,7 @@
 	}
 </script>
 
-<ReduxResult {stackId} {projectId} result={commitResult.current} {onerror}>
+<ReduxResult {stackId} {projectId} result={commitQuery.result} {onerror}>
 	{#snippet children(commit, env)}
 		{@const isConflicted = isCommit(commit) && commit.hasConflicts}
 
@@ -237,7 +237,7 @@
 							actionLabel="Save changes"
 							onCancel={cancelEdit}
 							floatingBoxHeader="Edit commit message"
-							loading={messageUpdateResult.current.isLoading}
+							loading={messageUpdateQuery.current.isLoading}
 							existingCommitId={commit.id}
 							title={parsedMessage?.title || ''}
 							description={parsedMessage?.description || ''}

--- a/apps/desktop/src/components/CreateBranchModal.svelte
+++ b/apps/desktop/src/components/CreateBranchModal.svelte
@@ -41,8 +41,8 @@
 	const generatedNameDiverges = $derived(!!createRefName && slugifiedRefName !== createRefName);
 
 	// Get all stacks in the workspace
-	const allStacksResult = $derived(stackService.stacks(projectId));
-	const allStacks = $derived(allStacksResult?.current?.data ?? []);
+	const allStacksQuery = $derived(stackService.stacks(projectId));
+	const allStacks = $derived(allStacksQuery?.response ?? []);
 
 	// Create options for the selector (stack represented by first branch name)
 	const stackOptions = $derived(

--- a/apps/desktop/src/components/CreateReviewBox.svelte
+++ b/apps/desktop/src/components/CreateReviewBox.svelte
@@ -32,11 +32,11 @@
 
 	const branch = $derived(stackService.branchByName(projectId, stackId, branchName));
 
-	const prNumber = $derived(branch.current.data?.prNumber ?? undefined);
+	const prNumber = $derived(branch.response?.prNumber ?? undefined);
 	const prService = $derived(forge.current.prService);
 	const reviewUnit = $derived(prService?.unit.abbr ?? 'PR');
-	const prResult = $derived(prNumber ? prService?.get(prNumber) : undefined);
-	const pr = $derived(prResult?.current.data);
+	const prQuery = $derived(prNumber ? prService?.get(prNumber) : undefined);
+	const pr = $derived(prQuery?.response);
 
 	const canPublishPR = $derived(!!(forge.current.authenticated && !pr));
 </script>

--- a/apps/desktop/src/components/DetailsForm.svelte
+++ b/apps/desktop/src/components/DetailsForm.svelte
@@ -8,13 +8,13 @@
 	const { projectId }: { projectId: string } = $props();
 
 	const projectsService = inject(PROJECTS_SERVICE);
-	const projectResult = $derived(projectsService.getProject(projectId));
+	const projectQuery = $derived(projectsService.getProject(projectId));
 
 	const runCommitHooks = $derived(projectRunCommitHooks(projectId));
 </script>
 
 <SectionCard>
-	<ReduxResult {projectId} result={projectResult.current}>
+	<ReduxResult {projectId} result={projectQuery.result}>
 		{#snippet children(project)}
 			<form>
 				<fieldset class="fields-wrapper">

--- a/apps/desktop/src/components/EnsureAuthorInfo.svelte
+++ b/apps/desktop/src/components/EnsureAuthorInfo.svelte
@@ -15,8 +15,8 @@
 	const authorInfo = $derived(gitService.getAuthorInfo(projectId));
 
 	$effect(() => {
-		if (authorInfo.current.data) {
-			const { name, email } = authorInfo.current.data;
+		if (authorInfo.response) {
+			const { name, email } = authorInfo.response;
 			if (name === null || email === null) {
 				uiState.global.modal.set({
 					type: 'author-missing',

--- a/apps/desktop/src/components/FeedItem.svelte
+++ b/apps/desktop/src/components/FeedItem.svelte
@@ -153,7 +153,7 @@
 					<Markdown content={action.details?.body} />
 				{/if}
 				{#if snapshotDiff}
-					<ReduxResult result={snapshotDiff.current} {projectId}>
+					<ReduxResult result={snapshotDiff.result} {projectId}>
 						{#snippet children(files)}
 							{#each files as file}
 								<span class="text-greyer">{file.path}</span>

--- a/apps/desktop/src/components/FileContextMenu.svelte
+++ b/apps/desktop/src/components/FileContextMenu.svelte
@@ -372,7 +372,7 @@
 							stackId,
 							selectionBranchName
 						)}
-						<ReduxResult {projectId} result={branchIsConflicted?.current}>
+						<ReduxResult {projectId} result={branchIsConflicted?.result}>
 							{#snippet children(isConflicted)}
 								{#if isConflicted === false}
 									<ContextMenuItem

--- a/apps/desktop/src/components/ForgeForm.svelte
+++ b/apps/desktop/src/components/ForgeForm.svelte
@@ -19,8 +19,8 @@
 	const instanceUrl = gitLabState?.instanceUrl ?? writable<string | undefined>('');
 
 	const projectsService = inject(PROJECTS_SERVICE);
-	const projectResult = $derived(projectsService.getProject(projectId));
-	const project = $derived(projectResult.current.data);
+	const projectQuery = $derived(projectsService.getProject(projectId));
+	const project = $derived(projectQuery.response);
 
 	const forgeOptions: { label: string; value: ForgeName }[] = [
 		{

--- a/apps/desktop/src/components/GitForm.svelte
+++ b/apps/desktop/src/components/GitForm.svelte
@@ -11,7 +11,7 @@
 
 	const { projectId }: { projectId: string } = $props();
 	const projectsService = inject(PROJECTS_SERVICE);
-	const projectResult = $derived(projectsService.getProject(projectId));
+	const projectQuery = $derived(projectsService.getProject(projectId));
 	const backend = inject(BACKEND);
 
 	async function onForcePushClick(project: Project, value: boolean) {
@@ -31,7 +31,7 @@
 	{/if}
 
 	<Spacer />
-	<ReduxResult {projectId} result={projectResult.current}>
+	<ReduxResult {projectId} result={projectQuery.result}>
 		{#snippet children(project)}
 			<div class="stack-v">
 				<SectionCard orientation="row" labelFor="allowForcePush" roundedBottom={false}>

--- a/apps/desktop/src/components/IntegrateUpstreamModal.svelte
+++ b/apps/desktop/src/components/IntegrateUpstreamModal.svelte
@@ -53,8 +53,8 @@
 	const forge = inject(DEFAULT_FORGE_FACTORY);
 	// const forgeListingService = $derived(forge.current.listService);
 	const baseBranchService = inject(BASE_BRANCH_SERVICE);
-	const baseBranchResponse = $derived(baseBranchService.baseBranch(projectId));
-	const base = $derived(baseBranchResponse.current.data);
+	const baseBranchQuery = $derived(baseBranchService.baseBranch(projectId));
+	const base = $derived(baseBranchQuery.response);
 	const urlService = inject(URL_SERVICE);
 	const clipboardService = inject(CLIPBOARD_SERVICE);
 

--- a/apps/desktop/src/components/KeysForm.svelte
+++ b/apps/desktop/src/components/KeysForm.svelte
@@ -31,11 +31,11 @@
 	}: Props = $props();
 
 	const baseBranchService = inject(BASE_BRANCH_SERVICE);
-	const baseBranchResponse = $derived(baseBranchService.baseBranch(projectId));
-	const baseBranch = $derived(baseBranchResponse.current.data);
+	const baseBranchQuery = $derived(baseBranchService.baseBranch(projectId));
+	const baseBranch = $derived(baseBranchQuery.response);
 	const projectsService = inject(PROJECTS_SERVICE);
-	const projectResult = $derived(projectsService.getProject(projectId));
-	const project = $derived(projectResult.current.data);
+	const projectQuery = $derived(projectsService.getProject(projectId));
+	const project = $derived(projectQuery.response);
 
 	let credentialCheck = $state<CredentialCheck>();
 
@@ -92,7 +92,7 @@
 </script>
 
 <div data-testid={TestId.ProjectSetupGitAuthPage}>
-	<ReduxResult {projectId} result={projectResult.current}>
+	<ReduxResult {projectId} result={projectQuery.result}>
 		{#snippet children(project)}
 			<Section>
 				{#snippet top()}

--- a/apps/desktop/src/components/LineLocksWarning.svelte
+++ b/apps/desktop/src/components/LineLocksWarning.svelte
@@ -16,10 +16,10 @@
 	const stackService = inject(STACK_SERVICE);
 
 	const lockedToStackIds = $derived(locks.map((lock) => lock.stackId));
-	const stacksResult = $derived(stackService.stacks(projectId));
+	const stacksQuery = $derived(stackService.stacks(projectId));
 </script>
 
-<ReduxResult result={stacksResult.current} {projectId}>
+<ReduxResult result={stacksQuery.result} {projectId}>
 	{#snippet children(stacks)}
 		{@const lockedToStacks = stacks.filter(
 			(stack) => stack.id && lockedToStackIds.includes(stack.id)

--- a/apps/desktop/src/components/NewCommitView.svelte
+++ b/apps/desktop/src/components/NewCommitView.svelte
@@ -39,8 +39,8 @@
 	const commitAction = $derived(exclusiveAction?.type === 'commit' ? exclusiveAction : undefined);
 
 	const selectedLines = $derived(uncommittedService.selectedLines(stackId));
-	const topBranchResult = $derived(stackId ? stackService.branches(projectId, stackId) : undefined);
-	const topBranchName = $derived(topBranchResult?.current.data?.at(0)?.name);
+	const topBranchQuery = $derived(stackId ? stackService.branches(projectId, stackId) : undefined);
+	const topBranchName = $derived(topBranchQuery?.response?.at(0)?.name);
 
 	const draftBranchName = $derived(uiState.global.draftBranchName.current);
 	const canCommit = $derived(selectedLines.current.length > 0);
@@ -156,7 +156,7 @@
 		}
 	}
 
-	const [createNewStack, newStackResult] = stackService.newStack;
+	const [createNewStack, newStackQuery] = stackService.newStack;
 
 	async function handleCommitCreation(title: string, description: string) {
 		laneState.newCommitMessage.set({ title, description });
@@ -216,7 +216,7 @@
 		onChange={({ title, description }) => handleMessageUpdate(title, description)}
 		onCancel={cancel}
 		disabledAction={!canCommit}
-		loading={commitCreation.current.isLoading || newStackResult.current.isLoading || isCooking}
+		loading={commitCreation.current.isLoading || newStackQuery.current.isLoading || isCooking}
 		title={laneState.newCommitMessage.current.title}
 		description={laneState.newCommitMessage.current.description}
 	/>

--- a/apps/desktop/src/components/NoBaseBranch.svelte
+++ b/apps/desktop/src/components/NoBaseBranch.svelte
@@ -7,15 +7,15 @@
 
 	const { projectId }: { projectId: string } = $props();
 	const baseBranchService = inject(BASE_BRANCH_SERVICE);
-	const remoteBranchesResponse = $derived(baseBranchService.remoteBranches(projectId));
+	const remoteBranchesQuery = $derived(baseBranchService.remoteBranches(projectId));
 </script>
 
-{#if remoteBranchesResponse.current.isLoading}
+{#if remoteBranchesQuery.result.isLoading}
 	<!--TODO: Add project id -->
 	<FullviewLoading />
-{:else if remoteBranchesResponse.current.isSuccess}
-	{@const remoteBranches = remoteBranchesResponse.current.data}
-	{#if remoteBranches.length === 0}
+{:else if remoteBranchesQuery.result.isSuccess}
+	{@const remoteBranches = remoteBranchesQuery.response}
+	{#if !remoteBranches || remoteBranches.length === 0}
 		<ProblemLoadingRepo
 			{projectId}
 			error="Currently, GitButler requires a remote branch to base its virtual branch work on. To
@@ -24,7 +24,7 @@
 	{:else}
 		<ProjectSetup {projectId} {remoteBranches} />
 	{/if}
-{:else if remoteBranchesResponse.current.isError}
+{:else if remoteBranchesQuery.result.isError}
 	<ProblemLoadingRepo
 		{projectId}
 		error="Currently, GitButler requires a remote branch to base its virtual branch work on. To

--- a/apps/desktop/src/components/NotOnGitButlerBranch.svelte
+++ b/apps/desktop/src/components/NotOnGitButlerBranch.svelte
@@ -40,8 +40,7 @@
 	}
 
 	const conflicts = $derived(
-		mode.current.data?.type === 'OutsideWorkspace' &&
-			mode.current.data.subject.worktreeConflicts.length > 0
+		mode.response?.type === 'OutsideWorkspace' && mode.response.subject.worktreeConflicts.length > 0
 	);
 
 	let selectedHandlingOfUncommitted: OptionsType = $state('stash');
@@ -61,7 +60,7 @@
 	]);
 
 	async function initSwithToWorkspace() {
-		if (changes.current.data?.length === 0) {
+		if (changes.response?.length === 0) {
 			switchTarget(baseBranch.branchName);
 		} else {
 			switchTarget(baseBranch.branchName, undefined, doStash);
@@ -75,7 +74,7 @@
 		{@render children()}
 	{:else}
 		<DecorativeSplitView img={directionDoubtSvg} hideDetails>
-			{@const uncommittedChanges = changes.current.data || []}
+			{@const uncommittedChanges = changes.response || []}
 
 			<div class="switchrepo__content">
 				<p class="switchrepo__title text-18 text-body text-bold">
@@ -110,7 +109,7 @@
 									Some files can’t be applied due to conflicts:
 								</p>
 								<div class="switchrepo__file-list">
-									<ReduxResult result={mode.current} {projectId}>
+									<ReduxResult result={mode.result} {projectId}>
 										{#snippet children(mode, _env)}
 											{#if mode.type === 'OutsideWorkspace'}
 												{#each mode.subject.worktreeConflicts || [] as path}

--- a/apps/desktop/src/components/PRBranchView.svelte
+++ b/apps/desktop/src/components/PRBranchView.svelte
@@ -15,11 +15,11 @@
 
 	const forge = inject(DEFAULT_FORGE_FACTORY);
 	const prService = $derived(forge.current.prService);
-	const prResult = $derived(prService?.get(prNumber, { forceRefetch: true }));
+	const prQuery = $derived(prService?.get(prNumber, { forceRefetch: true }));
 	const unitSymbol = $derived(prService?.unit.symbol ?? '');
 </script>
 
-<ReduxResult result={prResult?.current} {projectId} {onerror}>
+<ReduxResult result={prQuery?.result} {projectId} {onerror}>
 	{#snippet children(pr)}
 		<Drawer testId={TestId.PRBranchDrawer}>
 			{#snippet header()}

--- a/apps/desktop/src/components/PrNumberUpdater.svelte
+++ b/apps/desktop/src/components/PrNumberUpdater.svelte
@@ -17,9 +17,9 @@
 	// make it more concise somehow.
 	const forgeListing = $derived(forge.current.listService);
 	const forgeName = $derived(forge.current.name);
-	const listedPrResult = $derived(forgeListing?.getByBranch(projectId, branchName));
+	const listedPrQuery = $derived(forgeListing?.getByBranch(projectId, branchName));
 
-	const listedPrNumber = $derived(listedPrResult?.current.data?.number);
+	const listedPrNumber = $derived(listedPrQuery?.response?.number);
 
 	let hasRun = false;
 	$effect(() => {

--- a/apps/desktop/src/components/PrTemplateSection.svelte
+++ b/apps/desktop/src/components/PrTemplateSection.svelte
@@ -24,7 +24,7 @@
 	const enabled = $derived(template.enabled);
 
 	// Available pull request templates.
-	const templatesResult = $derived(stackService.templates(projectId, forgeName));
+	const templatesQuery = $derived(stackService.templates(projectId, forgeName));
 
 	async function selectTemplate(newPath: string) {
 		const template = await stackService.template(projectId, forgeName, newPath);
@@ -35,10 +35,10 @@
 	}
 
 	async function setEnabled(value: boolean) {
-		const ts = templatesResult;
+		const ts = templatesQuery;
 		enabled.set(value);
 		if (value) {
-			const path = $path ? $path : ts.current?.data?.at(0);
+			const path = $path ? $path : ts.response?.at(0);
 			if (path) {
 				selectTemplate(path);
 			}
@@ -46,7 +46,7 @@
 	}
 </script>
 
-<ReduxResult {projectId} result={templatesResult.current}>
+<ReduxResult {projectId} result={templatesQuery.result}>
 	{#snippet children(templates)}
 		{#if templates && templates.length > 0}
 			<div class="pr-template__wrap">

--- a/apps/desktop/src/components/PreferencesForm.svelte
+++ b/apps/desktop/src/components/PreferencesForm.svelte
@@ -7,10 +7,10 @@
 
 	const { projectId }: { projectId: string } = $props();
 	const projectsService = inject(PROJECTS_SERVICE);
-	const projectResult = $derived(projectsService.getProject(projectId));
+	const projectQuery = $derived(projectsService.getProject(projectId));
 </script>
 
-<ReduxResult {projectId} result={projectResult.current}>
+<ReduxResult {projectId} result={projectQuery.result}>
 	{#snippet children(project)}
 		<Section gap={8}>
 			<SectionCard orientation="row" labelFor="omitCertificateCheck">

--- a/apps/desktop/src/components/ProjectNotFound.svelte
+++ b/apps/desktop/src/components/ProjectNotFound.svelte
@@ -16,7 +16,7 @@
 	const { projectId }: Props = $props();
 
 	const projectsService = inject(PROJECTS_SERVICE);
-	const projectResult = $derived(projectsService.getProject(projectId, true));
+	const projectQuery = $derived(projectsService.getProject(projectId, true));
 
 	let deleteSucceeded: boolean | undefined = $state(undefined);
 	let isDeleting = $state(false);
@@ -54,7 +54,7 @@
 
 <DecorativeSplitView testId={TestId.ProjectNotFoundPage} img={notFoundSvg}>
 	<div class="container">
-		<ReduxResult {projectId} result={projectResult.current}>
+		<ReduxResult {projectId} result={projectQuery.result}>
 			{#snippet children(project)}
 				{#if deleteSucceeded === undefined}
 					<div class="text-content">

--- a/apps/desktop/src/components/ProjectSetup.svelte
+++ b/apps/desktop/src/components/ProjectSetup.svelte
@@ -24,7 +24,7 @@
 	const baseService = inject(BASE_BRANCH_SERVICE);
 	const posthog = inject(POSTHOG_WRAPPER);
 	const backend = inject(BACKEND);
-	const projectResult = $derived(projectsService.getProject(projectId));
+	const projectQuery = $derived(projectsService.getProject(projectId));
 	const [setBaseBranchTarget, settingBranch] = baseService.setTarget;
 
 	let selectedBranch = $state(['', '']);
@@ -46,8 +46,8 @@
 	}
 
 	$effect(() => {
-		if (projectResult.current.isError) {
-			console.error('Failed to load project, redirecting:', projectResult.current.error);
+		if (projectQuery.result.isError) {
+			console.error('Failed to load project, redirecting:', projectQuery.result.error);
 			goto('/');
 		}
 	});
@@ -73,7 +73,7 @@
 			>
 		</div>
 	{:else}
-		<ReduxResult {projectId} result={projectResult.current}>
+		<ReduxResult {projectId} result={projectQuery.result}>
 			{#snippet children(project)}
 				<ProjectSetupTarget
 					{projectId}

--- a/apps/desktop/src/components/ProjectSwitcher.svelte
+++ b/apps/desktop/src/components/ProjectSwitcher.svelte
@@ -9,12 +9,12 @@
 	const { projectId }: { projectId?: string } = $props();
 
 	const projectsService = inject(PROJECTS_SERVICE);
-	const projectsResult = $derived(projectsService.projects());
+	const projectsQuery = $derived(projectsService.projects());
 
 	let selectedId = $state<string | undefined>(projectId);
 
 	const mappedProjects = $derived(
-		projectsResult.current?.data?.map((project) => ({
+		projectsQuery.response?.map((project) => ({
 			value: project.id,
 			label: project.title
 		})) || []

--- a/apps/desktop/src/components/PullRequestCard.svelte
+++ b/apps/desktop/src/components/PullRequestCard.svelte
@@ -60,8 +60,8 @@
 	const urlService = inject(URL_SERVICE);
 	const clipboardService = inject(CLIPBOARD_SERVICE);
 
-	const prResult = $derived(prService?.get(prNumber, { forceRefetch: true }));
-	const pr = $derived(prResult?.current.data);
+	const prQuery = $derived(prService?.get(prNumber, { forceRefetch: true }));
+	const pr = $derived(prQuery?.response);
 
 	const { name, abbr, symbol } = $derived(prService!.unit);
 
@@ -108,7 +108,7 @@
 	});
 </script>
 
-<ReduxResult result={prResult?.current} projectId="dummy">
+<ReduxResult result={prQuery?.result} projectId="dummy">
 	{#snippet children(pr)}
 		{#if poll}
 			<PullRequestPolling number={pr.number} />

--- a/apps/desktop/src/components/PullRequestPolling.svelte
+++ b/apps/desktop/src/components/PullRequestPolling.svelte
@@ -16,10 +16,10 @@
 
 	let pollingInterval = $derived(getPollingInterval(elapsedMs, isClosed));
 
-	const prResult = $derived(prService?.get(number, { subscriptionOptions: { pollingInterval } }));
+	const prQuery = $derived(prService?.get(number, { subscriptionOptions: { pollingInterval } }));
 
 	$effect(() => {
-		const result = prResult?.current;
+		const result = prQuery?.result;
 		const pr = result?.data;
 
 		if (pr) {

--- a/apps/desktop/src/components/PushButton.svelte
+++ b/apps/desktop/src/components/PushButton.svelte
@@ -54,12 +54,12 @@
 	const isReadOnly = $derived(!stackId);
 
 	const branchDetails = $derived(stackService.branchDetails(projectId, stackId, branchName));
-	const branchesResult = $derived(stackService.branches(projectId, stackId));
-	const [pushStack, pushResult] = stackService.pushStack;
-	const upstreamCommitsResult = $derived(
+	const branchesQuery = $derived(stackService.branches(projectId, stackId));
+	const [pushStack, pushQuery] = stackService.pushStack;
+	const upstreamCommitsQuery = $derived(
 		stackService.upstreamCommits(projectId, stackId, branchName)
 	);
-	const upstreamCommits = $derived(upstreamCommitsResult.current.data);
+	const upstreamCommits = $derived(upstreamCommitsQuery.response);
 	const runHooks = $derived(projectRunCommitHooks(projectId));
 
 	function handleClick(args: { withForce: boolean; skipForcePushProtection: boolean }) {
@@ -97,7 +97,7 @@
 		}
 	}
 
-	const loading = $derived(pushResult.current.isLoading);
+	const loading = $derived(pushQuery.current.isLoading);
 
 	function getButtonTooltip(
 		hasThingsToPush: boolean,
@@ -137,7 +137,7 @@
 	let forcePushProtectionModal = $state<ReturnType<typeof Modal>>();
 </script>
 
-<ReduxResult {projectId} result={combineResults(branchDetails.current, branchesResult.current)}>
+<ReduxResult {projectId} result={combineResults(branchDetails.result, branchesQuery.result)}>
 	{#snippet children([branchDetails, branches])}
 		{@const withForce = partialStackRequestsForcePush(branchName, branches)}
 		{@const hasThingsToPush = branchHasUnpushedCommits(branchDetails)}

--- a/apps/desktop/src/components/RemoveProjectForm.svelte
+++ b/apps/desktop/src/components/RemoveProjectForm.svelte
@@ -12,7 +12,7 @@
 	const { projectId }: { projectId: string } = $props();
 
 	const projectsService = inject(PROJECTS_SERVICE);
-	const projectResult = $derived(projectsService.getProject(projectId));
+	const projectQuery = $derived(projectsService.getProject(projectId));
 	const { closeSettings } = useSettingsModal();
 
 	let isDeleting = $state(false);
@@ -33,7 +33,7 @@
 	}
 </script>
 
-<ReduxResult {projectId} result={projectResult.current}>
+<ReduxResult {projectId} result={projectQuery.result}>
 	{#snippet children(project)}
 		<SectionCard>
 			{#snippet title()}

--- a/apps/desktop/src/components/Rule.svelte
+++ b/apps/desktop/src/components/Rule.svelte
@@ -91,7 +91,7 @@
 	{#if target.type === 'stackId'}
 		{@const stackId = target.subject}
 		{@const stack = stackService.stackById(projectId, stackId)}
-		<ReduxResult {projectId} result={stack.current}>
+		<ReduxResult {projectId} result={stack.result}>
 			{#snippet children(stack)}
 				{#if stack !== null}
 					{@const stackName = getStackName(stack)}

--- a/apps/desktop/src/components/RulesList.svelte
+++ b/apps/desktop/src/components/RulesList.svelte
@@ -230,7 +230,7 @@
 
 {#snippet ruleListContent()}
 	{@const rules = rulesService.workspaceRules(projectId)}
-	<ReduxResult {projectId} result={rules.current}>
+	<ReduxResult {projectId} result={rules.result}>
 		{#snippet children(rules)}
 			{@const filteredRules = rules.filter((r) => !isAiRule(r))}
 			{#if filteredRules.length > 0}
@@ -274,7 +274,7 @@
 
 		<div class="rules-list__action">
 			<h3 class="text-13 text-semibold">Assign to branch</h3>
-			<ReduxResult {projectId} result={stackEntries.current}>
+			<ReduxResult {projectId} result={stackEntries.result}>
 				{#snippet children(stacks)}
 					{@const stackOptions = [
 						...stacks
@@ -347,7 +347,7 @@
 				kind="solid"
 				style="neutral"
 				disabled={!canSaveRule}
-				loading={stackEntries.current.isLoading ||
+				loading={stackEntries.result.isLoading ||
 					creatingRule.current.isLoading ||
 					updatingRule.current.isLoading}>Save rule</Button
 			>

--- a/apps/desktop/src/components/SelectionView.svelte
+++ b/apps/desktop/src/components/SelectionView.svelte
@@ -53,12 +53,12 @@
 
 <div class="selection-view" data-testid={testId}>
 	{#if selectedFile}
-		{@const changeResult = idSelection.changeByKey(projectId, selectedFile)}
-		<ReduxResult {projectId} result={changeResult.current}>
+		{@const changeQuery = idSelection.changeByKey(projectId, selectedFile)}
+		<ReduxResult {projectId} result={changeQuery.result}>
 			{#snippet children(change)}
-				{@const diffResult = diffService.getDiff(projectId, change)}
+				{@const diffQuery = diffService.getDiff(projectId, change)}
 				{@const isExecutable = isExecutableStatus(change.status)}
-				<ReduxResult {projectId} result={diffResult.current}>
+				<ReduxResult {projectId} result={diffQuery.result}>
 					{#snippet children(diff, env)}
 						<div
 							class="selected-change-item"

--- a/apps/desktop/src/components/SnapshotCard.svelte
+++ b/apps/desktop/src/components/SnapshotCard.svelte
@@ -189,7 +189,7 @@
 				onclick={() => {
 					onRestoreClick();
 				}}
-				disabled={mode.current.data?.type !== 'OpenWorkspace'}>Revert</Button
+				disabled={mode.response?.type !== 'OpenWorkspace'}>Revert</Button
 			>
 		</div>
 		<span class="snapshot-time text-11">
@@ -220,7 +220,7 @@
 			{/if}
 		</div>
 
-		<ReduxResult result={snapshotDiff.current} {projectId}>
+		<ReduxResult result={snapshotDiff.result} {projectId}>
 			{#snippet children(files)}
 				{#if files.length > 0 && !isRestoreSnapshot}
 					<SnapshotAttachment foldable={files.length > 2} foldedAmount={files.length}>

--- a/apps/desktop/src/components/StackDraft.svelte
+++ b/apps/desktop/src/components/StackDraft.svelte
@@ -24,7 +24,7 @@
 
 	let draftPanelEl: HTMLDivElement | undefined = $state();
 
-	const newNameResult = $derived(stackService.newBranchName(projectId));
+	const newNameQuery = $derived(stackService.newBranchName(projectId));
 
 	onMount(() => {
 		if (draftPanelEl) {
@@ -45,7 +45,7 @@
 				<div class="new-commit-view">
 					<NewCommitView {projectId} />
 				</div>
-				<ReduxResult {projectId} result={newNameResult.current}>
+				<ReduxResult {projectId} result={newNameQuery.result}>
 					{#snippet children(newName)}
 						{@const branchName = draftBranchName.current || newName}
 						<BranchCard

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -84,7 +84,7 @@
 		1440
 	);
 
-	const branchesResult = $derived(stackService.branches(projectId, stackId));
+	const branchesQuery = $derived(stackService.branches(projectId, stackId));
 
 	let dropzoneActivated = $state(false);
 
@@ -122,7 +122,7 @@
 	const selectedFile = $derived($activeLastAdded?.key ? readKey($activeLastAdded.key) : undefined);
 
 	const previewKey = $derived(assignedKey || selectedFile);
-	const previewChangeResult = $derived(
+	const previewChangeQuery = $derived(
 		previewKey ? idSelection.changeByKey(projectId, previewKey) : undefined
 	);
 
@@ -134,8 +134,8 @@
 	let changedFilesCollapsed = $state<boolean>();
 	let active = $state(false);
 
-	const defaultBranchResult = $derived(stackService.defaultBranch(projectId, stackId));
-	const defaultBranch = $derived(defaultBranchResult?.current.data);
+	const defaultBranchQuery = $derived(stackService.defaultBranch(projectId, stackId));
+	const defaultBranch = $derived(defaultBranchQuery?.response);
 
 	// Resizer configuration for stack panels and details view
 	const RESIZER_CONFIG = {
@@ -338,17 +338,17 @@
 {/snippet}
 
 {#snippet commitChangedFiles(commitId: string)}
-	{@const changesResult = stackService.commitChanges(projectId, commitId)}
+	{@const changesQuery = stackService.commitChanges(projectId, commitId)}
 	<ReduxResult
 		{projectId}
 		{stackId}
-		result={mapResult(changesResult.current, (changes) => ({ changes, commitId }))}
+		result={mapResult(changesQuery.result, (changes) => ({ changes, commitId }))}
 	>
 		{#snippet children({ changes, commitId }, { projectId, stackId })}
-			{@const commitsResult = branchName
+			{@const commitsQuery = branchName
 				? stackService.commits(projectId, stackId, branchName)
 				: undefined}
-			{@const commits = commitsResult?.current.data || []}
+			{@const commits = commitsQuery?.response || []}
 			{@const ancestorMostConflictedCommitId = getAncestorMostConflicted(commits)?.id}
 
 			<ChangedFiles
@@ -381,12 +381,12 @@
 {/snippet}
 
 {#snippet branchChangedFiles(branchName: string)}
-	{@const changesResult = stackService.branchChanges({
+	{@const changesQuery = stackService.branchChanges({
 		projectId,
 		stackId: stackId,
 		branch: createBranchRef(branchName, undefined)
 	})}
-	<ReduxResult {projectId} {stackId} result={changesResult.current}>
+	<ReduxResult {projectId} {stackId} result={changesQuery.result}>
 		{#snippet children(changes, { projectId, stackId })}
 			<ChangedFiles
 				title="Combined Changes"
@@ -458,7 +458,7 @@
 			use:focusable={{ vertical: true, onActive: (value) => (active = value) }}
 			bind:this={stackViewEl}
 		>
-			<ReduxResult {projectId} result={branchesResult.current}>
+			<ReduxResult {projectId} result={branchesQuery.result}>
 				{#snippet children(branches)}
 					<div class="stack-v">
 						<!-- If we are currently committing, we should keep this open so users can actually stop committing again :wink: -->
@@ -584,10 +584,10 @@
 
 				<!-- BOTTOM SECTION: File Preview (no resizer) -->
 				{#if assignedStackId || selectedFile}
-					<ReduxResult {projectId} result={previewChangeResult?.current}>
+					<ReduxResult {projectId} result={previewChangeQuery?.result}>
 						{#snippet children(previewChange)}
-							{@const diffResult = diffService.getDiff(projectId, previewChange)}
-							{@const diffData = diffResult.current.data}
+							{@const diffQuery = diffService.getDiff(projectId, previewChange)}
+							{@const diffData = diffQuery.response}
 
 							<div class="file-preview-section">
 								{#if assignedStackId}

--- a/apps/desktop/src/components/StackedPullRequestCard.svelte
+++ b/apps/desktop/src/components/StackedPullRequestCard.svelte
@@ -27,31 +27,31 @@
 	const repoService = $derived(forge.current.repoService);
 	const prService = $derived(forge.current.prService);
 
-	const branchResult = $derived(stackService.branchByName(projectId, stackId, branchName));
-	const branch = $derived(branchResult.current.data);
-	const branchDetailsResult = $derived(stackService.branchDetails(projectId, stackId, branchName));
-	const branchDetails = $derived(branchDetailsResult.current.data);
+	const branchQuery = $derived(stackService.branchByName(projectId, stackId, branchName));
+	const branch = $derived(branchQuery.response);
+	const branchDetailsQuery = $derived(stackService.branchDetails(projectId, stackId, branchName));
+	const branchDetails = $derived(branchDetailsQuery.response);
 	const isPushed = $derived(branchDetails?.pushStatus !== 'completelyUnpushed');
-	const prResult = $derived(branch?.prNumber ? prService?.get(branch?.prNumber) : undefined);
-	const pr = $derived(prResult?.current.data);
+	const prQuery = $derived(branch?.prNumber ? prService?.get(branch?.prNumber) : undefined);
+	const pr = $derived(prQuery?.response);
 
-	const parentResult = $derived(stackService.branchParentByName(projectId, stackId, branchName));
-	const parent = $derived(parentResult.current.data);
+	const parentQuery = $derived(stackService.branchParentByName(projectId, stackId, branchName));
+	const parent = $derived(parentQuery.response);
 	const hasParent = $derived(!!parent);
-	const parentBranchDetailsResult = $derived(
+	const parentBranchDetailsQuery = $derived(
 		parent ? stackService.branchDetails(projectId, stackId, parent.name) : undefined
 	);
-	const parentBranchDetails = $derived(parentBranchDetailsResult?.current.data);
+	const parentBranchDetails = $derived(parentBranchDetailsQuery?.response);
 	const parentIsPushed = $derived(parentBranchDetails?.pushStatus !== 'completelyUnpushed');
-	const childResult = $derived(stackService.branchChildByName(projectId, stackId, branchName));
-	const child = $derived(childResult.current.data);
+	const childQuery = $derived(stackService.branchChildByName(projectId, stackId, branchName));
+	const child = $derived(childQuery.response);
 
-	const baseBranchResponse = $derived(baseBranchService.baseBranch(projectId));
-	const baseBranch = $derived(baseBranchResponse.current.data);
-	const baseBranchRepoResponse = $derived(baseBranchService.repo(projectId));
-	const baseBranchRepo = $derived(baseBranchRepoResponse.current.data);
-	const repoResult = $derived(repoService?.getInfo());
-	const repoInfo = $derived(repoResult?.current.data);
+	const baseBranchQuery = $derived(baseBranchService.baseBranch(projectId));
+	const baseBranch = $derived(baseBranchQuery.response);
+	const baseBranchRepoQuery = $derived(baseBranchService.repo(projectId));
+	const baseBranchRepo = $derived(baseBranchRepoQuery.response);
+	const repoQuery = $derived(repoService?.getInfo());
+	const repoInfo = $derived(repoQuery?.response);
 
 	let shouldUpdateTargetBaseBranch = $derived(
 		repoInfo?.deleteBranchAfterMerge === false && !!child?.prNumber

--- a/apps/desktop/src/components/SyncButton.svelte
+++ b/apps/desktop/src/components/SyncButton.svelte
@@ -19,7 +19,7 @@
 	const forge = inject(DEFAULT_FORGE_FACTORY);
 	const listingService = $derived(forge.current.listService);
 
-	const lastFetched = $derived(baseBranch.current.data?.lastFetched);
+	const lastFetched = $derived(baseBranch.result.data?.lastFetched);
 
 	let loading = $state(false);
 </script>
@@ -41,7 +41,7 @@
 			await baseBranchService.fetchFromRemotes(projectId, 'modal');
 			await Promise.all([
 				listingService?.refresh(projectId),
-				baseBranch.current.refetch(),
+				baseBranch.result?.refetch(),
 				branchService.refresh()
 			]);
 		} finally {
@@ -60,11 +60,11 @@
 	</span>
 
 	{#snippet custom()}
-		{#if baseBranch.current.data}
+		{#if baseBranch.response}
 			<div class="target-branch">
 				<Icon name="remote-target-branch" color="var(--clr-text-2)" />
 				<span class="text-12 text-semibold">
-					{baseBranch.current.data.remoteName}/{baseBranch.current.data.shortName}
+					{baseBranch.response.remoteName}/{baseBranch.response.shortName}
 				</span>
 			</div>
 		{/if}

--- a/apps/desktop/src/components/TargetCommitList.svelte
+++ b/apps/desktop/src/components/TargetCommitList.svelte
@@ -25,8 +25,8 @@
 
 	const projectState = $derived(uiState.project(projectId));
 	const branchesState = $derived(projectState.branchesSelection);
-	const baseBranchResult = $derived(baseBranchService.baseBranch(projectId));
-	const baseSha = $derived(baseBranchResult.current.data?.baseSha);
+	const baseBranchQuery = $derived(baseBranchService.baseBranch(projectId));
+	const baseSha = $derived(baseBranchQuery.response?.baseSha);
 
 	let loadedIds = $state<string[]>([]);
 	let commits = $state<Commit[]>([]);
@@ -69,7 +69,7 @@
 	});
 </script>
 
-<ReduxResult {projectId} result={baseBranchResult.current}>
+<ReduxResult {projectId} result={baseBranchQuery.result}>
 	{#snippet children(baseBranch)}
 		{@const lastUpdate = baseBranch.recentCommits.at(0)?.createdAt.getTime() || 0}
 

--- a/apps/desktop/src/components/UnappliedBranchView.svelte
+++ b/apps/desktop/src/components/UnappliedBranchView.svelte
@@ -25,7 +25,7 @@
 
 	const stackService = inject(STACK_SERVICE);
 
-	const branchResult = $derived(
+	const branchQuery = $derived(
 		stackId
 			? stackService.branchDetails(projectId, stackId, branchName)
 			: stackService.unstackedBranchDetails(projectId, branchName, remote)
@@ -38,7 +38,7 @@
 	const branchRef = $derived(createBranchRef(branchName, remote));
 </script>
 
-<ReduxResult {projectId} result={branchResult.current} {onerror}>
+<ReduxResult {projectId} result={branchQuery.result} {onerror}>
 	{#snippet children(branch, { stackId, projectId })}
 		{@const hasCommits = branch.commits.length > 0}
 		{@const remoteTrackingBranch = branch.remoteTrackingBranch}
@@ -95,8 +95,8 @@
 			</div>
 		</Drawer>
 
-		{@const changesResult = stackService.branchChanges({ projectId, branch: branchRef })}
-		<ReduxResult {projectId} result={changesResult.current}>
+		{@const changesQuery = stackService.branchChanges({ projectId, branch: branchRef })}
+		<ReduxResult {projectId} result={changesQuery.result}>
 			{#snippet children(changes, env)}
 				<ChangedFiles
 					title="All changed files"

--- a/apps/desktop/src/components/UnappliedCommitView.svelte
+++ b/apps/desktop/src/components/UnappliedCommitView.svelte
@@ -18,11 +18,11 @@
 	const { projectId, commitId, onclose }: Props = $props();
 
 	const stackService = inject(STACK_SERVICE);
-	const changesResult = $derived(stackService.commitChanges(projectId, commitId));
-	const commitResult = $derived(stackService.commitDetails(projectId, commitId));
+	const changesQuery = $derived(stackService.commitChanges(projectId, commitId));
+	const commitQuery = $derived(stackService.commitDetails(projectId, commitId));
 </script>
 
-<ReduxResult {projectId} result={commitResult.current}>
+<ReduxResult {projectId} result={commitQuery.result}>
 	{#snippet children(commit)}
 		<Drawer {onclose} bottomBorder>
 			{#snippet header()}
@@ -37,7 +37,7 @@
 				<CommitDetails {commit} rewrap={$rewrapCommitMessage} />
 			</div>
 		</Drawer>
-		<ReduxResult {projectId} result={changesResult.current}>
+		<ReduxResult {projectId} result={changesQuery.result}>
 			{#snippet children(changes)}
 				<ChangedFiles
 					title="Changed files"

--- a/apps/desktop/src/components/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/UnifiedDiffView.svelte
@@ -76,7 +76,7 @@
 	const uncommittedService = inject(UNCOMMITTED_SERVICE);
 	const dependencyService = inject(DEPENDENCY_SERVICE);
 
-	const fileDependenciesResult = $derived(
+	const fileDependenciesQuery = $derived(
 		selectionId.type === 'worktree'
 			? dependencyService.fileDependencies(projectId, change.path)
 			: undefined
@@ -161,8 +161,8 @@
 	}
 </script>
 
-{#if fileDependenciesResult}
-	<ReduxResult {projectId} result={fileDependenciesResult.current} children={unifiedDiff} />
+{#if fileDependenciesQuery}
+	<ReduxResult {projectId} result={fileDependenciesQuery.result} children={unifiedDiff} />
 {:else}
 	{@render unifiedDiff(undefined)}
 {/if}

--- a/apps/desktop/src/components/WorkspaceView.svelte
+++ b/apps/desktop/src/components/WorkspaceView.svelte
@@ -31,14 +31,14 @@
 
 	const selectionId = createWorktreeSelection({ stackId: undefined });
 	const worktreeSelection = $derived(idSelection.getById(selectionId));
-	const stacksResult = $derived(stackService.stacks(projectId));
+	const stacksQuery = $derived(stackService.stacks(projectId));
 	const projectState = $derived(uiState.project(projectId));
 	const settingsStore = $derived(settingsService.appSettings);
 	const canUseActions = $derived($settingsStore?.featureFlags.actions ?? false);
 	const showingActions = $derived(projectState.showActions.current && canUseActions);
 	const exclusiveAction = $derived(projectState.exclusiveAction.current);
-	const baseBranchResult = $derived(baseBranchService.baseBranch(projectId));
-	const baseSha = $derived(baseBranchResult.current.data?.baseSha);
+	const baseBranchQuery = $derived(baseBranchService.baseBranch(projectId));
+	const baseSha = $derived(baseBranchQuery.response?.baseSha);
 
 	const lastAdded = $derived(worktreeSelection.lastAdded);
 	const previewOpen = $derived(!!$lastAdded?.key);
@@ -60,7 +60,7 @@
 		const branch = stackService.branchDetails(projectId, action.stackId, action.branchName);
 
 		$effect(() => {
-			const stackFound = stacks.current?.data?.find((s) => s.id === action.stackId);
+			const stackFound = stacks.response?.find((s) => s.id === action.stackId);
 			if (!stackFound) {
 				uiState.project(projectId).exclusiveAction.set(undefined);
 			}
@@ -69,7 +69,7 @@
 				return;
 			}
 
-			if (!branch?.current?.data) {
+			if (!branch?.response) {
 				uiState.project(projectId).exclusiveAction.set(undefined);
 				return;
 			}
@@ -81,7 +81,7 @@
 
 			// When we're committing to the bottom of the stack we set the
 			// commit id to equal the workspace base.
-			const hasCommit = branch.current.data.commits.some((c) => c.id === action.parentCommitId);
+			const hasCommit = branch.response.commits.some((c) => c.id === action.parentCommitId);
 			if (!hasCommit && action.parentCommitId !== baseSha) {
 				uiState.project(projectId).exclusiveAction.set(undefined);
 			}
@@ -126,7 +126,7 @@
 		<UnassignedView {projectId} />
 	{/snippet}
 	{#snippet middle()}
-		<ReduxResult {projectId} result={stacksResult?.current}>
+		<ReduxResult {projectId} result={stacksQuery?.result}>
 			{#snippet loading()}
 				<div class="stacks-view-skeleton"></div>
 			{/snippet}

--- a/apps/desktop/src/components/branchesPage/BranchListCard.svelte
+++ b/apps/desktop/src/components/branchesPage/BranchListCard.svelte
@@ -34,10 +34,10 @@
 	// TODO: Use information from all PRs in a stack?
 	const pr = $derived(prs.at(0));
 
-	const branchDetailsResult = $derived(branchService.get(projectId, branchListing.name));
+	const branchDetailsQuery = $derived(branchService.get(projectId, branchListing.name));
 
 	let lastCommitDetails = $state<{ authorName: string; lastCommitAt?: Date }>();
-	let branchListingDetails = $derived(branchDetailsResult?.current.data);
+	let branchListingDetails = $derived(branchDetailsQuery?.response);
 
 	// If there are zero commits we should not show the author
 	const ownedByUser = $derived(branchListingDetails?.numberOfCommits === 0);

--- a/apps/desktop/src/components/profileSettings/CliSymLink.svelte
+++ b/apps/desktop/src/components/profileSettings/CliSymLink.svelte
@@ -20,8 +20,8 @@
 </script>
 
 <div class="symlink-copy-box {classes}">
-	{#if cliPath.current?.data}
-		{@const command = cliCommand(cliPath.current.data)}
+	{#if cliPath.response}
+		{@const command = cliCommand(cliPath.response)}
 		<p>{command}</p>
 		<button type="button" class="symlink-copy-icon" onclick={() => copyToClipboard(command)}>
 			<Icon name="copy" />

--- a/apps/desktop/src/lib/ai/diffInputContext.svelte.ts
+++ b/apps/desktop/src/lib/ai/diffInputContext.svelte.ts
@@ -66,11 +66,11 @@ export default class DiffInputContext {
 	private async changes(): Promise<TreeChange[] | null> {
 		switch (this.args.type) {
 			case 'commit': {
-				const commitChangesResult = await this.stackService.fetchCommitChanges(
+				const commitChangesQuery = await this.stackService.fetchCommitChanges(
 					this.args.projectId,
 					this.args.commitId
 				);
-				return commitChangesResult.changes ?? null;
+				return commitChangesQuery.changes ?? null;
 			}
 
 			case 'change-selection': {

--- a/apps/desktop/src/lib/ai/tool.ts
+++ b/apps/desktop/src/lib/ai/tool.ts
@@ -328,7 +328,7 @@ function safeParseJson(jsonString: string): unknown {
 	}
 }
 
-function isErrorResult(something: unknown): boolean {
+function isErrorQuery(something: unknown): boolean {
 	return (
 		typeof something === 'object' &&
 		something !== null &&
@@ -344,7 +344,7 @@ type CommitToolResult = {
 	};
 };
 
-function isCommitToolResult(result: unknown): result is CommitToolResult {
+function isCommitToolQuery(result: unknown): result is CommitToolResult {
 	return (
 		typeof result === 'object' &&
 		result !== null &&
@@ -396,12 +396,12 @@ export function getToolCallIcon(name: ToolName, isError: boolean): IconName {
 export function parseToolCall(toolCall: ToolCall): ParsedToolCall {
 	const rawParams = safeParseJson(toolCall.parameters);
 	const rawResult = safeParseJson(toolCall.result);
-	const isError = isErrorResult(rawResult);
+	const isError = isErrorQuery(rawResult);
 
 	switch (toolCall.name) {
 		case 'commit': {
 			const parameters = isCommitToolParams(rawParams) ? rawParams : undefined;
-			const parsedResult = isCommitToolResult(rawResult) ? rawResult : undefined;
+			const parsedResult = isCommitToolQuery(rawResult) ? rawResult : undefined;
 			return {
 				name: toolCall.name,
 				parameters,
@@ -425,7 +425,7 @@ export function parseToolCall(toolCall: ToolCall): ParsedToolCall {
 		}
 		case 'amend': {
 			const parameters = isAmendToolParams(rawParams) ? rawParams : undefined;
-			const parsedResult = isCommitToolResult(rawResult) ? rawResult : undefined;
+			const parsedResult = isCommitToolQuery(rawResult) ? rawResult : undefined;
 			return {
 				name: toolCall.name,
 				parameters,

--- a/apps/desktop/src/lib/codegen/messages.ts
+++ b/apps/desktop/src/lib/codegen/messages.ts
@@ -140,7 +140,7 @@ export function formatMessages(
 			}
 
 			if (subject.type === 'claudeExit' && subject.subject.code !== 0) {
-				if (previousEventLoginFailureResult(events, event)) {
+				if (previousEventLoginFailureQuery(events, event)) {
 					const message: Message = {
 						type: 'claude',
 						message: `Claude Code is currently not logged in.\n\n Please run \`claude\` in your terminal and complete the login flow in order to use the GitButler Claude Code integration.`,
@@ -204,7 +204,7 @@ export function formatMessages(
 	return out;
 }
 
-function previousEventLoginFailureResult(events: ClaudeMessage[], event: ClaudeMessage): boolean {
+function previousEventLoginFailureQuery(events: ClaudeMessage[], event: ClaudeMessage): boolean {
 	const idx = events.findIndex((e) => e === event);
 	if (idx <= 0) return false;
 	const previous = events[idx - 1]!;

--- a/apps/desktop/src/lib/forge/azure/azure.ts
+++ b/apps/desktop/src/lib/forge/azure/azure.ts
@@ -2,7 +2,7 @@ import { AzureBranch } from '$lib/forge/azure/azureBranch';
 import type { Forge, ForgeName } from '$lib/forge/interface/forge';
 import type { ForgeRepoService } from '$lib/forge/interface/forgeRepoService';
 import type { ForgeArguments, ForgeUser } from '$lib/forge/interface/types';
-import type { ReactiveResult } from '$lib/state/butlerModule';
+import type { ReactiveQuery } from '$lib/state/butlerModule';
 import type { ReduxTag } from '$lib/state/tags';
 import type { RepoInfo } from '$lib/url/gitUrl';
 import type { TagDescription } from '@reduxjs/toolkit/query';
@@ -52,8 +52,8 @@ export class AzureDevOps implements Forge {
 
 	get user() {
 		return {
-			current: { status: 'uninitialized' as const, data: undefined }
-		} as ReactiveResult<ForgeUser>;
+			result: { status: 'uninitialized' as const, data: undefined }
+		} as ReactiveQuery<ForgeUser>;
 	}
 
 	get listService() {

--- a/apps/desktop/src/lib/forge/bitbucket/bitbucket.ts
+++ b/apps/desktop/src/lib/forge/bitbucket/bitbucket.ts
@@ -1,7 +1,7 @@
 import { BitBucketBranch } from '$lib/forge/bitbucket/bitbucketBranch';
 import type { Forge, ForgeName } from '$lib/forge/interface/forge';
 import type { ForgeArguments, ForgeUser } from '$lib/forge/interface/types';
-import type { ReactiveResult } from '$lib/state/butlerModule';
+import type { ReactiveQuery } from '$lib/state/butlerModule';
 import type { ReduxTag } from '$lib/state/tags';
 import type { TagDescription } from '@reduxjs/toolkit/query';
 
@@ -48,8 +48,8 @@ export class BitBucket implements Forge {
 
 	get user() {
 		return {
-			current: { status: 'uninitialized' as const, data: undefined }
-		} as ReactiveResult<ForgeUser>;
+			result: { status: 'uninitialized' as const, data: undefined }
+		} as ReactiveQuery<ForgeUser>;
 	}
 
 	get listService() {

--- a/apps/desktop/src/lib/forge/default/default.ts
+++ b/apps/desktop/src/lib/forge/default/default.ts
@@ -6,7 +6,7 @@ import type { ForgeListingService } from '$lib/forge/interface/forgeListingServi
 import type { ForgePrService } from '$lib/forge/interface/forgePrService';
 import type { ForgeRepoService } from '$lib/forge/interface/forgeRepoService';
 import type { ForgeUser } from '$lib/forge/interface/types';
-import type { ReactiveResult } from '$lib/state/butlerModule';
+import type { ReactiveQuery } from '$lib/state/butlerModule';
 import type { ReduxTag } from '$lib/state/tags';
 import type { TagDescription } from '@reduxjs/toolkit/query';
 
@@ -41,8 +41,8 @@ export class DefaultForge implements Forge {
 	}
 	get user() {
 		return {
-			current: { status: 'uninitialized' as const, data: undefined }
-		} as ReactiveResult<ForgeUser>;
+			result: { status: 'uninitialized' as const, data: undefined }
+		} as ReactiveQuery<ForgeUser>;
 	}
 	invalidate(_tags: TagDescription<ReduxTag>[]) {
 		return undefined;

--- a/apps/desktop/src/lib/forge/github/githubRepoService.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubRepoService.svelte.ts
@@ -2,7 +2,7 @@ import { ghQuery } from '$lib/forge/github/ghQuery';
 import { providesList, ReduxTag } from '$lib/state/tags';
 import type { RepoResult } from '$lib/forge/github/types';
 import type { ForgeRepoService, RepoDetailedInfo } from '$lib/forge/interface/forgeRepoService';
-import type { ReactiveResult } from '$lib/state/butlerModule';
+import type { ReactiveQuery } from '$lib/state/butlerModule';
 import type { GitHubApi } from '$lib/state/clientState.svelte';
 
 export class GitHubRepoService implements ForgeRepoService {
@@ -12,7 +12,7 @@ export class GitHubRepoService implements ForgeRepoService {
 		this.api = injectEndpoints(gitHubApi);
 	}
 
-	getInfo(): ReactiveResult<RepoDetailedInfo> {
+	getInfo(): ReactiveQuery<RepoDetailedInfo> {
 		return this.api.endpoints.getRepos.useQuery(undefined, {
 			transform: (result) => ({
 				deleteBranchAfterMerge: result.delete_branch_on_merge

--- a/apps/desktop/src/lib/forge/interface/forge.ts
+++ b/apps/desktop/src/lib/forge/interface/forge.ts
@@ -5,7 +5,7 @@ import type { ForgeListingService } from '$lib/forge/interface/forgeListingServi
 import type { ForgePrService } from '$lib/forge/interface/forgePrService';
 import type { ForgeRepoService } from '$lib/forge/interface/forgeRepoService';
 import type { ForgeUser } from '$lib/forge/interface/types';
-import type { ReactiveResult } from '$lib/state/butlerModule';
+import type { ReactiveQuery } from '$lib/state/butlerModule';
 import type { ReduxTag } from '$lib/state/tags';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type { TagDescription } from '@reduxjs/toolkit/query';
@@ -29,7 +29,7 @@ export interface Forge {
 	// Results from CI check-runs.
 	get checks(): ChecksService | undefined;
 
-	get user(): ReactiveResult<ForgeUser>;
+	get user(): ReactiveQuery<ForgeUser>;
 
 	// Host specific branch information.
 	branch(name: string): ForgeBranch | undefined;

--- a/apps/desktop/src/lib/forge/interface/forgeChecksMonitor.ts
+++ b/apps/desktop/src/lib/forge/interface/forgeChecksMonitor.ts
@@ -1,7 +1,7 @@
 import type { ChecksStatus } from '$lib/forge/interface/types';
-import type { QueryOptions, ReactiveResult } from '$lib/state/butlerModule';
+import type { QueryOptions, ReactiveQuery } from '$lib/state/butlerModule';
 
 export interface ChecksService {
-	get(branch: string, options?: QueryOptions): ReactiveResult<ChecksStatus | null>;
+	get(branch: string, options?: QueryOptions): ReactiveQuery<ChecksStatus | null>;
 	fetch(branch: string, options?: QueryOptions): Promise<ChecksStatus | null>;
 }

--- a/apps/desktop/src/lib/forge/interface/forgeListingService.ts
+++ b/apps/desktop/src/lib/forge/interface/forgeListingService.ts
@@ -1,10 +1,13 @@
 import type { PullRequest } from '$lib/forge/interface/types';
-import type { ReactiveResult } from '$lib/state/butlerModule';
+import type { QueryExtensions, ReactiveQuery } from '$lib/state/butlerModule';
 
 export interface ForgeListingService {
-	list(projectId: string, pollingInterval?: number): ReactiveResult<PullRequest[]>;
-	getByBranch(projectId: string, branchName: string): ReactiveResult<PullRequest>;
-	filterByBranch(projectId: string, branchName: string[]): ReactiveResult<PullRequest[]>;
+	list(projectId: string, pollingInterval?: number): ReactiveQuery<PullRequest[], QueryExtensions>;
+	getByBranch(projectId: string, branchName: string): ReactiveQuery<PullRequest | undefined>;
+	filterByBranch(
+		projectId: string,
+		branchName: string[]
+	): ReactiveQuery<PullRequest[], QueryExtensions>;
 	fetchByBranch(projectId: string, branchName: string[]): Promise<PullRequest[]>;
 	refresh(projectId: string): Promise<void>;
 }

--- a/apps/desktop/src/lib/forge/interface/forgePrService.ts
+++ b/apps/desktop/src/lib/forge/interface/forgePrService.ts
@@ -4,7 +4,7 @@ import type {
 	MergeMethod,
 	PullRequest
 } from '$lib/forge/interface/types';
-import type { ReactiveResult } from '$lib/state/butlerModule';
+import type { ReactiveQuery } from '$lib/state/butlerModule';
 import type { StartQueryActionCreatorOptions } from '@reduxjs/toolkit/query';
 import type { Writable } from 'svelte/store';
 
@@ -20,7 +20,7 @@ export interface ForgePrService {
 	get(
 		prNumber: number,
 		options?: StartQueryActionCreatorOptions
-	): ReactiveResult<DetailedPullRequest>;
+	): ReactiveQuery<DetailedPullRequest>;
 	fetch(
 		prNumber: number,
 		options?: StartQueryActionCreatorOptions

--- a/apps/desktop/src/lib/forge/interface/forgeRepoService.ts
+++ b/apps/desktop/src/lib/forge/interface/forgeRepoService.ts
@@ -1,4 +1,4 @@
-import type { ReactiveResult } from '$lib/state/butlerModule';
+import type { ReactiveQuery } from '$lib/state/butlerModule';
 
 export interface RepoDetailedInfo {
 	/**
@@ -10,5 +10,5 @@ export interface RepoDetailedInfo {
 }
 
 export type ForgeRepoService = {
-	getInfo(): ReactiveResult<RepoDetailedInfo>;
+	getInfo(): ReactiveQuery<RepoDetailedInfo>;
 };

--- a/apps/desktop/src/lib/forge/prPolling.svelte.ts
+++ b/apps/desktop/src/lib/forge/prPolling.svelte.ts
@@ -17,11 +17,11 @@ export default function prList(
 	forge: DefaultForgeFactory,
 	uiState: UiState
 ): Reactive<PullRequest[]> {
-	const prListResult = $derived(
+	const prListQuery = $derived(
 		forge.current.listService?.list(projectId.current, POLLING_INTERVAL)
 	);
 
-	const prList = $derived(prListResult?.current.data ?? []);
+	const prList = $derived(prListQuery?.response ?? []);
 
 	$effect(() => {
 		updateStalePrSelection(uiState, projectId.current, prList);

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -380,7 +380,7 @@ export class StackService {
 	allLocalCommits(projectId: string) {
 		const stacks = $derived(this.stacks(projectId));
 		const stackIds = $derived(
-			mapResult(stacks.current, (stacks) => stacks.map((s) => s.id).filter(isDefined))
+			mapResult(stacks.result, (stacks) => stacks.map((s) => s.id).filter(isDefined))
 		);
 		const stackIdsData = $derived(stackIds.data ?? []);
 		const args = $derived(stackIdsData.map((stackId) => ({ projectId, stackId })));

--- a/apps/desktop/src/routes/+page.svelte
+++ b/apps/desktop/src/routes/+page.svelte
@@ -6,7 +6,7 @@
 
 	const projectsService = inject(PROJECTS_SERVICE);
 
-	const projectsResult = projectsService.projects();
+	const projectsQuery = projectsService.projects();
 
 	type Redirect =
 		| {
@@ -19,7 +19,7 @@
 
 	const persistedId = projectsService.getLastOpenedProject();
 	const redirect: Redirect = $derived.by(() => {
-		const projects = projectsResult.current.data;
+		const projects = projectsQuery.response;
 		if (projects === undefined) return { type: 'loading' };
 		const projectId = projects.find((p) => p.id === persistedId)?.id;
 		if (projectId) {

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -58,8 +58,8 @@
 	const accessToken = $derived($user?.github_access_token);
 
 	// Project data
-	const projectsResult = $derived(projectsService.projects());
-	const projects = $derived(projectsResult.current.data);
+	const projectsQuery = $derived(projectsService.projects());
+	const projects = $derived(projectsQuery.result.data);
 	const currentProject = $derived(projects?.find((p) => p.id === projectId));
 
 	// =============================================================================
@@ -70,13 +70,13 @@
 	const branchService = inject(BRANCH_SERVICE);
 	const gitService = inject(GIT_SERVICE);
 
-	const repoInfoResponse = $derived(baseBranchService.repo(projectId));
-	const repoInfo = $derived(repoInfoResponse.current.data);
-	const baseBranchResponse = $derived(baseBranchService.baseBranch(projectId));
-	const baseBranch = $derived(baseBranchResponse.current.data);
+	const repoInfoQuery = $derived(baseBranchService.repo(projectId));
+	const repoInfo = $derived(repoInfoQuery.result.data);
+	const baseBranchQuery = $derived(baseBranchService.baseBranch(projectId));
+	const baseBranch = $derived(baseBranchQuery.result.data);
 	const baseBranchName = $derived(baseBranch?.shortName);
-	const pushRepoResponse = $derived(baseBranchService.pushRepo(projectId));
-	const forkInfo = $derived(pushRepoResponse.current.data);
+	const pushRepoQuery = $derived(baseBranchService.pushRepo(projectId));
+	const forkInfo = $derived(pushRepoQuery.result.data);
 
 	// =============================================================================
 	// WORKSPACE & MODE MANAGEMENT
@@ -87,8 +87,8 @@
 	const worktreeService = inject(WORKTREE_SERVICE);
 
 	const mode = $derived(modeService.mode({ projectId }));
-	const headResult = $derived(modeService.head({ projectId }));
-	const head = $derived(headResult.current.data);
+	const headQuery = $derived(modeService.head({ projectId }));
+	const head = $derived(headQuery.result.data);
 
 	// Invalidate stacks when switching branches outside workspace
 	$effect(() => {
@@ -138,8 +138,8 @@
 	const uncommittedService = inject(UNCOMMITTED_SERVICE);
 	const idSelection = inject(FILE_SELECTION_MANAGER);
 
-	const worktreeDataResult = $derived(worktreeService.worktreeData(projectId));
-	const worktreeData = $derived(worktreeDataResult.current.data);
+	const worktreeDataQuery = $derived(worktreeService.worktreeData(projectId));
+	const worktreeData = $derived(worktreeDataQuery.response);
 
 	// Bridge between RTKQ and custom slice
 	$effect(() => {
@@ -231,7 +231,7 @@
 
 	// Refresh when branch data changes
 	$effect(() => {
-		if (baseBranch || headResult.current.data) debouncedRemoteBranchRefresh();
+		if (baseBranch || headQuery.result.data) debouncedRemoteBranchRefresh();
 	});
 
 	// Auto-fetch setup
@@ -326,7 +326,7 @@
 <ProjectSettingsMenuAction {projectId} />
 <FileMenuAction />
 
-<ReduxResult {projectId} result={combineResults(baseBranchResponse.current, mode.current)}>
+<ReduxResult {projectId} result={combineResults(baseBranchQuery.result, mode.result)}>
 	{#snippet children([baseBranch, mode], { projectId })}
 		{#if !baseBranch}
 			<NoBaseBranch {projectId} />

--- a/apps/desktop/src/routes/[projectId]/edit/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/edit/+page.svelte
@@ -14,10 +14,10 @@
 	let editModeMetadata = $state<EditModeMetadata>();
 
 	$effect(() => {
-		if (!isDefined(mode.current.data)) return;
+		if (!isDefined(mode.response)) return;
 
-		if (mode.current.data.type === 'Edit') {
-			editModeMetadata = mode.current.data.subject;
+		if (mode.response.type === 'Edit') {
+			editModeMetadata = mode.response.subject;
 		} else {
 			goto(`/${projectId}`);
 		}

--- a/apps/desktop/src/routes/[projectId]/workspace/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/workspace/+page.svelte
@@ -20,8 +20,8 @@
 	const urlStackId = $derived(page.url.searchParams.get('stackId'));
 	let scrollToStackId = $state<string | undefined>(undefined);
 
-	const firstStackResult = $derived(stackService.stackAt(projectId, 0));
-	const firstStack = $derived(firstStackResult.current.data);
+	const firstStackQuery = $derived(stackService.stackAt(projectId, 0));
+	const firstStack = $derived(firstStackQuery.response);
 
 	// Read all local commits in the workspace for the given project
 	$effect(() => {
@@ -42,7 +42,7 @@
 	}
 
 	$effect(() => {
-		if (mode.current.data?.type === 'Edit') {
+		if (mode.response?.type === 'Edit') {
 			// That was causing an incorrect linting error when project.id was accessed inside the reactive block
 			gotoEdit();
 		}

--- a/apps/desktop/src/routes/onboarding/+page.svelte
+++ b/apps/desktop/src/routes/onboarding/+page.svelte
@@ -15,14 +15,14 @@
 	const analyticsConfirmed = appSettings.appAnalyticsConfirmed;
 
 	const projectsService = inject(PROJECTS_SERVICE);
-	const projectsResult = $derived(projectsService.projects());
+	const projectsQuery = $derived(projectsService.projects());
 
 	// We don't want to have this guard in the layout, because we want to have
 	// `/onboarding/clone` accessable.
 	$effect(() => {
 		// Users should not be able to get here now that we load projects
 		// sensibly, but hey, let's be sure.
-		if (projectsResult.current.data && projectsResult.current.data.length > 0) {
+		if (projectsQuery.response && projectsQuery.response.length > 0) {
 			sleep(50).then(() => {
 				goto('/');
 			});


### PR DESCRIPTION
Change ReactiveResult types and variables to ReactiveQuery across the
desktop app to reflect the new abstraction for query-like reactive
responses. Update API and state accessors and corresponding variable
names (e.g. projectResult -> projectQuery, commitResult -> commitQuery,
messageUpdateResult -> messageUpdateQuery, topBranchResult ->
topBranchQuery) and adjust property accessors from .current/.data to
.result/.response where appropriate.

This clarifies intent between Redux-style results and query-style
responses, reduces ambiguity in the codebase, and aligns variable names
with the updated butlerModule types and conventions.