### PR TITLE
codegen-fixes

### DIFF
--- a/apps/desktop/src/components/codegen/CodegenInput.svelte
+++ b/apps/desktop/src/components/codegen/CodegenInput.svelte
@@ -87,6 +87,13 @@
 			borderless
 			maxRows={10}
 			minRows={2}
+			onkeydown={(e) => {
+				// Global gotakey on the button doesn't work inside textarea, so we handle it here
+				if (e.key === 'c' && e.ctrlKey && onAbort) {
+					e.preventDefault();
+					onAbort();
+				}
+			}}
 		/>
 
 		<div class="dialog-input__actions">
@@ -102,6 +109,7 @@
 							style="error"
 							action={onAbort}
 							icon="stop"
+							hotkey="⌃C"
 							reversedDirection
 						>
 							Stop

--- a/apps/desktop/src/components/codegen/CodegenPage.svelte
+++ b/apps/desktop/src/components/codegen/CodegenPage.svelte
@@ -1085,7 +1085,7 @@
 		gap: 8px;
 
 		/* SHARABLE */
-		--message-max-width: 520px;
+		--message-max-width: 620px;
 	}
 
 	.chat-view {

--- a/apps/desktop/src/components/codegen/CodegenUserMessage.svelte
+++ b/apps/desktop/src/components/codegen/CodegenUserMessage.svelte
@@ -44,6 +44,11 @@
 		background-color: var(--clr-bg-2);
 		text-wrap: wrap;
 		word-break: break-word;
+
+		/* make code blocks visible */
+		:global(.markdown pre) {
+			background-color: var(--clr-bg-1);
+		}
 	}
 
 	.user-icon {

--- a/packages/ui/src/lib/components/Textarea.svelte
+++ b/packages/ui/src/lib/components/Textarea.svelte
@@ -195,6 +195,8 @@
 		width: 100%;
 		padding: var(--padding-top) var(--padding-right) var(--padding-bottom) var(--padding-left);
 		line-height: var(--lineheight-ratio);
+		scroll-padding: var(--padding-top) var(--padding-right) var(--padding-bottom)
+			var(--padding-left);
 		word-wrap: break-word;
 		white-space: pre-wrap;
 	}

--- a/packages/ui/src/styles/sharable/markdown.css
+++ b/packages/ui/src/styles/sharable/markdown.css
@@ -76,6 +76,7 @@
 		margin: 1em 0;
 		padding: 1em;
 		overflow: auto;
+		border: 1px solid var(--clr-border-3);
 		border-radius: var(--radius-m);
 		background-color: var(--clr-bg-2);
 		font-size: 92%;


### PR DESCRIPTION
- Increase chat message max width to px (was previously specified in px)
- Add border to markdown blocks and adjust background visibility
- Abort CC generation when user presses Ctrl+C
- Fix textarea behavior so it respects padding when switching to a new line

<img width="934" height="523" alt="Screenshot 2025-09-17 at 16 17 56" src="https://github.com/user-attachments/assets/d633df64-a987-4b0d-919a-1d6087ad84aa" />

https://github.com/user-attachments/assets/873c15fc-2c73-4a98-8194-b9c2f9f24556

https://github.com/user-attachments/assets/194fbc14-76d8-4769-adb2-4bf2ae74bde3


