### PR TITLE
Dismiss Button tooltips onmousedown

### DIFF
--- a/packages/ui/src/lib/components/Button.svelte
+++ b/packages/ui/src/lib/components/Button.svelte
@@ -86,7 +86,7 @@
 		tooltipDelay,
 		tooltipMaxWidth,
 		onclick,
-		onmousedown,
+		onmousedown: onmousedownExternal,
 		oncontextmenu,
 		onkeydown,
 		children,
@@ -104,9 +104,16 @@
 	}
 
 	const displayHotkey = $derived(hotkey ? formatHotkeyForPlatform(hotkey) : undefined);
+	let tooltipInstance = $state<Tooltip>();
+
+	function onmousedown(e: MouseEvent) {
+		tooltipInstance?.dismiss();
+		onmousedownExternal?.(e);
+	}
 </script>
 
 <Tooltip
+	bind:this={tooltipInstance}
 	text={tooltip}
 	align={tooltipAlign}
 	position={tooltipPosition}

--- a/packages/ui/src/lib/components/Tooltip.svelte
+++ b/packages/ui/src/lib/components/Tooltip.svelte
@@ -85,6 +85,10 @@
 			handleMouseLeave();
 		}
 	}
+
+	export function dismiss() {
+		show = false;
+	}
 </script>
 
 {#if isTextEmpty}


### PR DESCRIPTION
Wire the Tooltip instance into Button and call dismiss on mousedown
before invoking the external onmousedown handler. This prevents the
tooltip from sticking or obstructing UI when the button is pressed.