### PR TITLE
Improve defaults after settings.json was deleted + recreated

### DIFF
--- a/crates/but-settings/assets/defaults.jsonc
+++ b/crates/but-settings/assets/defaults.jsonc
@@ -19,11 +19,11 @@
 	},
 	"featureFlags": {
 		// Deprecated, was used for the new version of the UI.
-		"v3": false,
+		"v3": true,
 		// Enables the v3 safe checkout.
 		"cv3": false,
 		/// Enable the usage of V3 workspace APIs.
-		"ws3": false,
+		"ws3": true,
 		/// Enable undo/redo support.
 		"undo": false,
 		/// Enable the usage of GitButler Acitions.

--- a/crates/gitbutler-branch-actions/tests/reorder.rs
+++ b/crates/gitbutler-branch-actions/tests/reorder.rs
@@ -469,7 +469,9 @@ fn file(ctx: &CommandContext, commit_id: gix::ObjectId) -> String {
 }
 
 fn command_ctx(name: &str) -> Result<(CommandContext, TempDir)> {
-    gitbutler_testsupport::writable::fixture("reorder.sh", name)
+    gitbutler_testsupport::writable::fixture_with_settings("reorder.sh", name, |settings| {
+        settings.feature_flags.ws3 = false
+    })
 }
 
 fn test_ctx(ctx: &CommandContext) -> Result<TestContext> {

--- a/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/virtual_branches/create_virtual_branch_from_branch.rs
@@ -7,7 +7,8 @@ use super::*;
 
 #[test]
 fn integration() {
-    let Test { repo, ctx, .. } = &Test::default();
+    let Test { repo, ctx, .. } =
+        &Test::new_with_settings(|settings| settings.feature_flags.ws3 = false);
 
     gitbutler_branch_actions::set_base_branch(
         ctx,

--- a/crates/gitbutler-testsupport/src/lib.rs
+++ b/crates/gitbutler-testsupport/src/lib.rs
@@ -81,8 +81,17 @@ pub mod writable {
         script_name: &str,
         project_directory: &str,
     ) -> anyhow::Result<(CommandContext, TempDir)> {
+        fixture_with_settings(script_name, project_directory, |_| {})
+    }
+    pub fn fixture_with_settings(
+        script_name: &str,
+        project_directory: &str,
+        change_settings: fn(&mut AppSettings),
+    ) -> anyhow::Result<(CommandContext, TempDir)> {
         let (project, tempdir) = fixture_project(script_name, project_directory)?;
-        let open = CommandContext::open(&project, AppSettings::default());
+        let mut settings = AppSettings::default();
+        change_settings(&mut settings);
+        let open = CommandContext::open(&project, settings);
         let ctx = open?;
         Ok((ctx, tempdir))
     }


### PR DESCRIPTION
Fixes #10356.

When `settings.json` gets deleted, the user doesn't get the onboarding step
again to initialise the most important values.

This leads to defaults not being respected, while enabling telemetry by default.
