### PR TITLE
Use a normal tempfile instead of a `gix` lock to avoid name clashes with tracked files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,6 +1323,7 @@ dependencies = [
  "itertools",
  "md5",
  "serde",
+ "tempfile",
  "tracing",
  "url",
 ]

--- a/crates/but-workspace/Cargo.toml
+++ b/crates/but-workspace/Cargo.toml
@@ -32,6 +32,7 @@ md5 = "0.8.0"
 tracing.workspace = true
 # For SPMC channel
 flume = "0.11.1"
+tempfile.workspace = true
 
 [dev-dependencies]
 but-testsupport.workspace = true


### PR DESCRIPTION
Supersedes #10350.
