### PR TITLE
Provide correctly the GitLab state

### DIFF
--- a/apps/desktop/src/components/ForgeForm.svelte
+++ b/apps/desktop/src/components/ForgeForm.svelte
@@ -2,9 +2,8 @@
 	import { DEFAULT_FORGE_FACTORY } from '$lib/forge/forgeFactory.svelte';
 	import { GITLAB_STATE } from '$lib/forge/gitlab/gitlabState.svelte';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
-	import { inject, injectOptional } from '@gitbutler/core/context';
+	import { inject } from '@gitbutler/core/context';
 	import { Link, SectionCard, Select, SelectItem, Spacer, Textbox } from '@gitbutler/ui';
-	import { writable } from 'svelte/store';
 
 	import type { ForgeName } from '$lib/forge/interface/forge';
 	import type { Project } from '$lib/project/project';
@@ -12,11 +11,11 @@
 	const { projectId }: { projectId: string } = $props();
 
 	const forge = inject(DEFAULT_FORGE_FACTORY);
-	const gitLabState = injectOptional(GITLAB_STATE, null);
-	const token = gitLabState?.token ?? writable<string | undefined>('');
-	const forkProjectId = gitLabState?.forkProjectId ?? writable<string | undefined>('');
-	const upstreamProjectId = gitLabState?.upstreamProjectId ?? writable<string | undefined>('');
-	const instanceUrl = gitLabState?.instanceUrl ?? writable<string | undefined>('');
+	const gitLabState = inject(GITLAB_STATE);
+	const token = gitLabState.token;
+	const forkProjectId = gitLabState.forkProjectId;
+	const upstreamProjectId = gitLabState.upstreamProjectId;
+	const instanceUrl = gitLabState.instanceUrl;
 
 	const projectsService = inject(PROJECTS_SERVICE);
 	const projectResult = $derived(projectsService.getProject(projectId));

--- a/apps/desktop/src/lib/bootstrap/deps.ts
+++ b/apps/desktop/src/lib/bootstrap/deps.ts
@@ -28,6 +28,7 @@ import { DefaultForgeFactory, DEFAULT_FORGE_FACTORY } from '$lib/forge/forgeFact
 import { GITHUB_CLIENT, GitHubClient } from '$lib/forge/github/githubClient';
 import { GitHubUserService, GITHUB_USER_SERVICE } from '$lib/forge/github/githubUserService.svelte';
 import { GITLAB_CLIENT, GitLabClient } from '$lib/forge/gitlab/gitlabClient.svelte';
+import { GITLAB_STATE, GitLabState } from '$lib/forge/gitlab/gitlabState.svelte';
 import { GitService, GIT_SERVICE } from '$lib/git/gitService';
 import { HISTORY_SERVICE, HistoryService } from '$lib/history/history';
 import { OplogService, OPLOG_SERVICE } from '$lib/history/oplogService.svelte';
@@ -124,6 +125,8 @@ export function initDependencies(args: {
 
 	const gitHubClient = new GitHubClient();
 	const gitLabClient = new GitLabClient();
+	const gitLabState = new GitLabState(secretsService);
+	gitLabClient.set(gitLabState);
 
 	// ============================================================================
 	// EXPERIMENTAL STUFF
@@ -325,6 +328,7 @@ export function initDependencies(args: {
 		[GITHUB_CLIENT, gitHubClient],
 		[GITHUB_USER_SERVICE, githubUserService],
 		[GITLAB_CLIENT, gitLabClient],
+		[GITLAB_STATE, gitLabState],
 		[GIT_CONFIG_SERVICE, gitConfig],
 		[GIT_SERVICE, gitService],
 		[HISTORY_SERVICE, historyService],

--- a/apps/desktop/src/lib/forge/gitlab/gitlabState.svelte.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlabState.svelte.ts
@@ -1,6 +1,6 @@
 import { InjectionToken } from '@gitbutler/core/context';
 import { persisted } from '@gitbutler/shared/persisted';
-import { derived, get, writable, type Readable, type Writable } from 'svelte/store';
+import { derived, get, readable, writable, type Readable, type Writable } from 'svelte/store';
 import type { SecretsService } from '$lib/secrets/secretsService';
 import type { RepoInfo } from '$lib/url/gitUrl';
 
@@ -8,22 +8,49 @@ export const GITLAB_STATE = new InjectionToken<GitLabState>('GitLabState');
 
 export class GitLabState {
 	readonly token: Writable<string | undefined>;
-	readonly forkProjectId: Writable<string | undefined>;
-	readonly upstreamProjectId: Writable<string | undefined>;
-	readonly instanceUrl: Writable<string | undefined>;
-	readonly configured: Readable<boolean>;
+	private _forkProjectId: Writable<string | undefined> | undefined;
+	private _upstreamProjectId: Writable<string | undefined> | undefined;
+	private _instanceUrl: Writable<string | undefined> | undefined;
+	private _configured: Readable<boolean> | undefined;
 
-	constructor(
-		private readonly secretService: SecretsService,
-		repoInfo: RepoInfo | undefined,
-		projectId: string
-	) {
+	constructor(private readonly secretService: SecretsService) {
+		this.token = writable<string | undefined>();
+	}
+
+	get forkProjectId() {
+		if (!this._forkProjectId) {
+			return writable<string | undefined>(undefined);
+		}
+		return this._forkProjectId;
+	}
+
+	get upstreamProjectId() {
+		if (!this._upstreamProjectId) {
+			return writable<string | undefined>(undefined);
+		}
+		return this._upstreamProjectId;
+	}
+
+	get instanceUrl() {
+		if (!this._instanceUrl) {
+			return writable<string | undefined>(undefined);
+		}
+		return this._instanceUrl;
+	}
+
+	get configured() {
+		if (!this._configured) {
+			return readable(false);
+		}
+		return this._configured;
+	}
+
+	init(projectId: string, repoInfo: RepoInfo | undefined) {
 		// For whatever reason, the token _sometimes_ is incorrectly fetched as null.
 		// I have no idea why, but this seems to work. There were also some
 		// weird reactivity issues. Don't touch it as you might make it angry.
 		const tokenLoading = writable(true);
 		let tokenLoadedAsNull = false;
-		this.token = writable<string | undefined>();
 		this.secretService.get(`git-lab-token:${projectId}`).then((fetchedToken) => {
 			if (fetchedToken) {
 				this.token.set(fetchedToken ?? '');
@@ -50,32 +77,30 @@ export class GitLabState {
 			return unsubscribe;
 		});
 
-		const forkProjectId = persisted<string | undefined>(
+		this._forkProjectId = persisted<string | undefined>(
 			undefined,
 			`gitlab-project-id:${projectId}`
 		);
-		if (!get(forkProjectId) && repoInfo) {
-			forkProjectId.set(`${repoInfo.owner}/${repoInfo.name}`);
-		}
-		this.forkProjectId = forkProjectId;
 
-		const upstreamProjectId = persisted<string | undefined>(
+		this._upstreamProjectId = persisted<string | undefined>(
 			undefined,
 			`gitlab-upstream-project-id:${projectId}`
 		);
-		if (!get(upstreamProjectId)) {
-			upstreamProjectId.set(get(forkProjectId));
+		if (!get(this._upstreamProjectId)) {
+			this._upstreamProjectId.set(get(this._forkProjectId));
 		}
-		this.upstreamProjectId = upstreamProjectId;
 
-		const instanceUrl = persisted<string>('https://gitlab.com', `gitlab-instance-url:${projectId}`);
-		this.instanceUrl = instanceUrl;
+		this._instanceUrl = persisted<string>('https://gitlab.com', `gitlab-instance-url:${projectId}`);
 
-		this.configured = derived(
+		this._configured = derived(
 			[this.token, this.upstreamProjectId, this.forkProjectId, this.instanceUrl],
 			([token, upstreamProjectId, forkProjectId, instanceUrl]) => {
 				return !!token && !!upstreamProjectId && !!forkProjectId && !!instanceUrl;
 			}
 		);
+
+		if (!get(this.forkProjectId) && repoInfo) {
+			this.forkProjectId.set(`${repoInfo.owner}/${repoInfo.name}`);
+		}
 	}
 }

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -18,13 +18,11 @@
 	import { FEED_FACTORY } from '$lib/feed/feed';
 	import { DEFAULT_FORGE_FACTORY } from '$lib/forge/forgeFactory.svelte';
 	import { GITHUB_CLIENT } from '$lib/forge/github/githubClient';
-	import { GITLAB_CLIENT } from '$lib/forge/gitlab/gitlabClient.svelte';
-	import { GitLabState, GITLAB_STATE } from '$lib/forge/gitlab/gitlabState.svelte';
+	import { GITLAB_STATE } from '$lib/forge/gitlab/gitlabState.svelte';
 	import { GIT_SERVICE } from '$lib/git/gitService';
 	import { MODE_SERVICE } from '$lib/mode/modeService';
 	import { showError, showInfo, showWarning } from '$lib/notifications/toasts';
 	import { PROJECTS_SERVICE } from '$lib/project/projectsService';
-	import { SECRET_SERVICE } from '$lib/secrets/secretsService';
 	import { FILE_SELECTION_MANAGER } from '$lib/selection/fileSelectionManager.svelte';
 	import { UNCOMMITTED_SERVICE } from '$lib/selection/uncommittedService.svelte';
 	import { STACK_SERVICE } from '$lib/stacks/stackService.svelte';
@@ -33,7 +31,7 @@
 	import { USER_SERVICE } from '$lib/user/userService';
 	import { debounce } from '$lib/utils/debounce';
 	import { WORKTREE_SERVICE } from '$lib/worktree/worktreeService.svelte';
-	import { inject, provide } from '@gitbutler/core/context';
+	import { inject } from '@gitbutler/core/context';
 	import { onDestroy, untrack, type Snippet } from 'svelte';
 	import type { LayoutData } from './$types';
 
@@ -102,8 +100,7 @@
 	// =============================================================================
 
 	const gitHubClient = inject(GITHUB_CLIENT);
-	const gitLabClient = inject(GITLAB_CLIENT);
-	const secretService = inject(SECRET_SERVICE);
+	const gitLabState = inject(GITLAB_STATE);
 	const forgeFactory = inject(DEFAULT_FORGE_FACTORY);
 
 	// GitHub setup
@@ -111,13 +108,8 @@
 	$effect.pre(() => gitHubClient.setRepo({ owner: repoInfo?.owner, repo: repoInfo?.name }));
 
 	// GitLab setup
-	const gitLabState = $derived(new GitLabState(secretService, repoInfo, projectId));
 	const gitlabConfigured = $derived(gitLabState.configured);
-
-	$effect.pre(() => {
-		provide(GITLAB_STATE, gitLabState);
-		gitLabClient.set(gitLabState);
-	});
+	$effect.pre(() => gitLabState.init(projectId, repoInfo));
 
 	// Forge factory configuration
 	$effect(() => {


### PR DESCRIPTION
Since now the GitLab state needs to be available everywhere, provide it from the root.

Change it so that setting the project specific information doesn’t involve recreating it, but rather updating it’s information

fixes https://github.com/gitbutlerapp/gitbutler/issues/10256