### PR TITLE
Finishing touch to ReactiveQuery refactor

### DIFF
--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -57,7 +57,7 @@
 
 	// Project data
 	const projectsQuery = $derived(projectsService.projects());
-	const projects = $derived(projectsQuery.result.data);
+	const projects = $derived(projectsQuery.response);
 	const currentProject = $derived(projects?.find((p) => p.id === projectId));
 
 	// =============================================================================
@@ -69,12 +69,14 @@
 	const gitService = inject(GIT_SERVICE);
 
 	const repoInfoQuery = $derived(baseBranchService.repo(projectId));
-	const repoInfo = $derived(repoInfoQuery.result.data);
-	const baseBranchQuery = $derived(baseBranchService.baseBranch(projectId));
-	const baseBranch = $derived(baseBranchQuery.result.data);
-	const baseBranchName = $derived(baseBranch?.shortName);
 	const pushRepoQuery = $derived(baseBranchService.pushRepo(projectId));
-	const forkInfo = $derived(pushRepoQuery.result.data);
+
+	const repoInfo = $derived(repoInfoQuery.response);
+	const forkInfo = $derived(pushRepoQuery.response);
+
+	const baseBranchQuery = $derived(baseBranchService.baseBranch(projectId));
+	const baseBranch = $derived(baseBranchQuery.response);
+	const baseBranchName = $derived(baseBranch?.shortName);
 
 	// =============================================================================
 	// WORKSPACE & MODE MANAGEMENT
@@ -86,7 +88,7 @@
 
 	const mode = $derived(modeService.mode({ projectId }));
 	const headQuery = $derived(modeService.head({ projectId }));
-	const head = $derived(headQuery.result.data);
+	const head = $derived(headQuery.response);
 
 	// Invalidate stacks when switching branches outside workspace
 	$effect(() => {
@@ -223,7 +225,7 @@
 
 	// Refresh when branch data changes
 	$effect(() => {
-		if (baseBranch || headQuery.result.data) debouncedRemoteBranchRefresh();
+		if (baseBranch || headQuery.response) debouncedRemoteBranchRefresh();
 	});
 
 	// Auto-fetch setup


### PR DESCRIPTION
Missed some opportunities to use `query.response` rather than
`query.result.data`.