### PR TITLE
profile: use undefined for missing name/email

### DIFF
--- a/apps/desktop/src/components/profileSettings/GeneralSettings.svelte
+++ b/apps/desktop/src/components/profileSettings/GeneralSettings.svelte
@@ -66,8 +66,8 @@
 			userService.getUser().then((cloudUser) => {
 				const userData: User = {
 					...cloudUser,
-					name: cloudUser.name || 'unknown',
-					email: cloudUser.email || 'unknown@example.com',
+					name: cloudUser.name || undefined,
+					email: cloudUser.email || undefined,
 					login: cloudUser.login || undefined,
 					picture: cloudUser.picture || '#',
 					locale: cloudUser.locale || 'en',


### PR DESCRIPTION
Modify GeneralSettings.svelte to set name and email to undefined when absent in cloud user data instead of using placeholder strings. This changes two lines:
- name: cloudUser.name || 'unknown' -> name: cloudUser.name || undefined
- email: cloudUser.email || 'unknown@example.com' -> email: cloudUser.email || undefined
