### PR TITLE
Dropzones don't let the drop event propagate

### DIFF
--- a/apps/desktop/src/lib/dragging/dropzone.ts
+++ b/apps/desktop/src/lib/dragging/dropzone.ts
@@ -105,6 +105,7 @@ export class Dropzone {
 
 	private async onDrop(e: DragEvent) {
 		e.preventDefault();
+		e.stopPropagation();
 		if (!this.activated) return;
 		this.acceptedHandler?.ondrop(this.data);
 	}


### PR DESCRIPTION
Dropping a commit or file won’t propagate outside of the dropzones