### PR TITLE
Reword the "git hooks" settings description

### DIFF
--- a/apps/desktop/src/components/DetailsForm.svelte
+++ b/apps/desktop/src/components/DetailsForm.svelte
@@ -52,10 +52,11 @@
 
 <SectionCard labelFor="runHooks" orientation="row">
 	{#snippet title()}
-		Run commit hooks
+		Run git hooks
 	{/snippet}
 	{#snippet caption()}
-		Enabling this will run any git pre and post commit hooks you have configured in your repository.
+		Enabling this will run git pre-push, pre and post commit, and commit-msg hooks you have
+		configured in your repository.
 	{/snippet}
 	{#snippet actions()}
 		<Toggle id="runHooks" bind:checked={$runCommitHooks} />

--- a/apps/desktop/src/components/DetailsForm.svelte
+++ b/apps/desktop/src/components/DetailsForm.svelte
@@ -52,7 +52,7 @@
 
 <SectionCard labelFor="runHooks" orientation="row">
 	{#snippet title()}
-		Run git hooks
+		Run Git hooks
 	{/snippet}
 	{#snippet caption()}
 		Enabling this will run git pre-push, pre and post commit, and commit-msg hooks you have


### PR DESCRIPTION
It was saying only commit hooks run, while we have commit-msg and 
pre-push as well.