### PR TITLE
Do not persist credentials during checkout to prevent exfiltration or accidental logging

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: 'gitbutlerapp/gitbutler'
       - uses: actions/labeler@v6
         with:

--- a/.github/workflows/push-e2e-img.yml
+++ b/.github/workflows/push-e2e-img.yml
@@ -12,6 +12,8 @@ jobs:
     permissions: write-all
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -212,3 +212,32 @@ jobs:
           shared-key: windows-rust-testing
       - name: 'cargo check'
         run: cargo check --workspace --all-targets --features windows
+
+  # Check that all `actions/checkout` in CI jobs have `persist-credentials: false`.
+  check-no-persist-credentials:
+    runs-on: ubuntu-latest
+
+    env:
+      GLOB: .github/workflows/*.@(yaml|yml)
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          sparse-checkout: '.github/workflows'
+      - name: Generate workflows list to scan
+        run: |
+          shopt -s extglob
+          printf '%s\n' ${{ env.GLOB }} | grep -v .github/workflows/publish.yaml >workflows.list
+          cat workflows.list
+          echo "Note that publish.yaml is excluded until it's ensured to not need this feature"
+      - name: Scan workflows
+        run: |
+          shopt -s extglob
+          yq '.jobs.*.steps[]
+            | select(.uses == "actions/checkout@*" and .with.["persist-credentials"]? != false)
+            | {"file": filename, "line": line, "name": (.name // .uses)}
+            | .file + ":" + (.line | tostring) + ": " + .name
+          ' -- $(cat workflows.list) >query-output.txt
+          cat query-output.txt
+          test -z "$(<query-output.txt)"  # Report failure if we found anything.

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -20,6 +20,8 @@ jobs:
       rust: ${{ steps.filter.outputs.rust }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -49,6 +51,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/init-env-node
       - run: pnpm prettier
 
@@ -58,6 +62,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/init-env-node
       - run: pnpm lint
 
@@ -67,6 +73,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/init-env-node
       - run: pnpm check
 
@@ -76,6 +84,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/init-env-node
       - run: pnpm test
 
@@ -89,6 +99,8 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - run: cargo fmt --check --all
       - run: cargo check --workspace --all-targets
 
@@ -102,6 +114,8 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       # TODO(qix-): we have to exclude the app here for now because for some
       # TODO(qix-): reason it doesn't build with the docs feature enabled.
       - run: cargo doc --no-deps --all-features --document-private-items -p gitbutler-git
@@ -114,6 +128,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: EmbarkStudios/cargo-deny-action@f2ba7abc2abebaf185c833c3961145a3c275caad # v2.0.13
         with:
           command: check bans licenses sources
@@ -129,6 +145,8 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.8.0
         with:
@@ -186,6 +204,8 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.8.0
         with:

--- a/.github/workflows/test-client-fe-integration.yml
+++ b/.github/workflows/test-client-fe-integration.yml
@@ -15,10 +15,13 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
         if: ${{ github.event_name != 'workflow_dispatch' }}
       - uses: actions/checkout@v5
         if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.inputs.sha }}
       - name: Setup node environment
         uses: ./.github/actions/init-env-node

--- a/.github/workflows/test-e2e-blackbox.yml
+++ b/.github/workflows/test-e2e-blackbox.yml
@@ -19,10 +19,13 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
         if: ${{ github.event_name != 'workflow_dispatch' }}
       - uses: actions/checkout@v5
         if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.inputs.sha }}
       - name: Install Tauri OS dependencies
         run: |

--- a/.github/workflows/test-e2e-playwright.yml
+++ b/.github/workflows/test-e2e-playwright.yml
@@ -27,10 +27,13 @@ jobs:
       GIT_CONFIG_GLOBAL: ${{ github.workspace }}/e2e/playwright/fixtures/.gitconfig
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
         if: ${{ github.event_name != 'workflow_dispatch' }}
       - uses: actions/checkout@v5
         if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.inputs.sha }}
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.8.0


### PR DESCRIPTION
Based on this commit in Gitoxide:

https://github.com/GitoxideLabs/gitoxide/pull/2187/commits/a235ac803598df05cefb2f3eff46598e42a16b96

### Tasks

* [x] add directive to all non-publish workflows
* [x] prevent future checkouts with persisted credentials in everything but publish.yml


Note that the exception of `publish.yml` is merely done out of fear of testing this, as it's possible that
this workflow relies on persisted credentials.
