### PR TITLE
feat(cursor): add Cursor action source and render Cursor hook in UI

### DIFF
--- a/apps/desktop/src/components/FeedItem.svelte
+++ b/apps/desktop/src/components/FeedItem.svelte
@@ -8,6 +8,7 @@
 		ButlerAction,
 		getDisplayNameForWorkflowKind,
 		isClaudeCodeActionSource,
+		isCursorActionSource,
 		isDefinedMCPActionSource,
 		isStringActionSource,
 		isUndefinedMCPActionSource,
@@ -84,6 +85,13 @@
 					{@html butbotSvg}
 				</div>
 			</div>
+		{:else if isCursorActionSource(action.source)}
+			<div class="action-item__editor-logo">
+				<EditorLogo name="cursor" />
+				<div class="action-item__editor-source">
+					{@html butbotSvg}
+				</div>
+			</div>
 		{/if}
 		<div class="action-item__content">
 			<div class="action-item__content__header">
@@ -101,6 +109,8 @@
 						<span class="text-13 text-greyer" title={new Date(action.createdAt).toLocaleString()}>
 							{#if isClaudeCodeActionSource(action.source)}
 								Claude Hook
+							{:else if isCursorActionSource(action.source)}
+								Cursor Hook
 							{:else}
 								MCP call
 							{/if}

--- a/apps/desktop/src/lib/actions/types.ts
+++ b/apps/desktop/src/lib/actions/types.ts
@@ -30,12 +30,17 @@ type ClaudeCodeActionSource = {
 	ClaudeCode: string;
 };
 
+type CursorActionSource = {
+	ClaudeCode: string;
+};
+
 export type ActionSource =
 	| 'ButCli'
 	| 'GitButler'
 	| 'Unknown'
 	| MCPActionSource
-	| ClaudeCodeActionSource;
+	| ClaudeCodeActionSource
+	| CursorActionSource;
 
 export function isStringActionSource(
 	source: ActionSource
@@ -57,6 +62,10 @@ export function isDefinedMCPActionSource(source: ActionSource): source is Define
 
 export function isClaudeCodeActionSource(source: ActionSource): source is ClaudeCodeActionSource {
 	return typeof source === 'object' && source !== null && 'ClaudeCode' in source;
+}
+
+export function isCursorActionSource(source: ActionSource): source is CursorActionSource {
+	return typeof source === 'object' && source !== null && 'Cursor' in source;
 }
 
 /** Represents a snapshot of an automatic action taken by a GitButler automation.  */

--- a/crates/but-action/src/action.rs
+++ b/crates/but-action/src/action.rs
@@ -27,6 +27,7 @@ pub enum Source {
     GitButler,
     Mcp(Option<McpClientInfo>),
     ClaudeCode(String),
+    Cursor(String),
     #[default]
     Unknown,
 }

--- a/crates/but-cursor/src/lib.rs
+++ b/crates/but-cursor/src/lib.rs
@@ -216,7 +216,7 @@ pub async fn handle_stop(nightly: bool) -> anyhow::Result<CursorHookOutput> {
         &summary,
         Some(prompt.clone()),
         ActionHandler::HandleChangesSimple,
-        Source::ClaudeCode(input.conversation_id),
+        Source::Cursor(input.conversation_id),
         Some(stack_id),
     )?;
 


### PR DESCRIPTION
Render the right editor icon for the hook event

<img width="1428" height="975" alt="Screenshot 2025-09-22 at 20 40 32" src="https://github.com/user-attachments/assets/432f746b-54f4-40c9-8195-f64941e9760b" />
