### PR TITLE
Close preview without clearing selection. Toggle preview on click.

### DIFF
--- a/apps/desktop/src/components/BranchCard.svelte
+++ b/apps/desktop/src/components/BranchCard.svelte
@@ -154,7 +154,7 @@
 >
 	{#if args.type === 'stack-branch'}
 		{@const moveHandler = args.stackId
-			? new MoveCommitDzHandler(stackService, args.stackId, projectId)
+			? new MoveCommitDzHandler(stackService, args.stackId, projectId, uiState)
 			: undefined}
 		{#if !args.prNumber && args.stackId}
 			<PrNumberUpdater {projectId} stackId={args.stackId} {branchName} />

--- a/apps/desktop/src/components/BranchCommitList.svelte
+++ b/apps/desktop/src/components/BranchCommitList.svelte
@@ -106,7 +106,11 @@
 	let integrationModal = $state<Modal>();
 
 	async function handleCommitClick(commitId: string, upstream: boolean) {
-		if (selectedCommitId !== commitId) {
+		const currentSelection = laneState.selection.current;
+		// Toggle: if this exact commit is already selected, clear the selection
+		if (currentSelection?.commitId === commitId && currentSelection?.branchName === branchName) {
+			laneState.selection.set(undefined);
+		} else {
 			laneState.selection.set({ branchName, commitId, upstream });
 		}
 		projectState.stackId.set(stackId);

--- a/apps/desktop/src/components/BranchList.svelte
+++ b/apps/desktop/src/components/BranchList.svelte
@@ -186,7 +186,13 @@
 					trackingBranch={branch.remoteTrackingBranch ?? undefined}
 					readonly={!!branch.remoteTrackingBranch}
 					onclick={() => {
-						uiState.lane(laneId).selection.set({ branchName });
+						const currentSelection = uiState.lane(laneId).selection.current;
+						// Toggle: if this branch is already selected, clear the selection
+						if (currentSelection?.branchName === branchName && !currentSelection?.commitId) {
+							uiState.lane(laneId).selection.set(undefined);
+						} else {
+							uiState.lane(laneId).selection.set({ branchName });
+						}
 						onselect?.();
 					}}
 				>

--- a/apps/desktop/src/components/ChangedFiles.svelte
+++ b/apps/desktop/src/components/ChangedFiles.svelte
@@ -29,6 +29,7 @@
 		autoselect?: boolean;
 		ancestorMostConflictedCommitId?: string;
 		ontoggle?: (collapsed: boolean) => void;
+		allowUnselect?: boolean;
 	};
 
 	const {
@@ -46,7 +47,8 @@
 		resizer,
 		autoselect,
 		ancestorMostConflictedCommitId,
-		ontoggle
+		ontoggle,
+		allowUnselect = true
 	}: Props = $props();
 
 	const idSelection = inject(FILE_SELECTION_MANAGER);
@@ -91,6 +93,7 @@
 				{conflictEntries}
 				{draggableFiles}
 				{ancestorMostConflictedCommitId}
+				{allowUnselect}
 				hideLastFileBorder={false}
 			/>
 		{:else}

--- a/apps/desktop/src/components/FileList.svelte
+++ b/apps/desktop/src/components/FileList.svelte
@@ -37,6 +37,7 @@
 		ancestorMostConflictedCommitId?: string;
 		hideLastFileBorder?: boolean;
 		onselect?: (change: TreeChange) => void;
+		allowUnselect?: boolean;
 	};
 
 	const {
@@ -50,7 +51,8 @@
 		draggableFiles,
 		ancestorMostConflictedCommitId,
 		hideLastFileBorder = true,
-		onselect
+		onselect,
+		allowUnselect = true
 	}: Props = $props();
 
 	const focusManager = inject(FOCUS_MANAGER);
@@ -190,7 +192,7 @@
 				true,
 				idx,
 				selectionId,
-				true
+				allowUnselect
 			);
 			onselect?.(change);
 			return true;
@@ -269,7 +271,7 @@
 				true,
 				idx,
 				selectionId,
-				true
+				allowUnselect
 			);
 			onselect?.(change);
 		}}

--- a/apps/desktop/src/components/FileList.svelte
+++ b/apps/desktop/src/components/FileList.svelte
@@ -181,7 +181,17 @@
 	function handleKeyDown(change: TreeChange, idx: number, e: KeyboardEvent) {
 		if (e.key === 'Enter' || e.key === ' ' || e.key === 'l') {
 			e.stopPropagation();
-			selectFilesInList(e, change, changes, idSelection, selectedFileIds, true, idx, selectionId);
+			selectFilesInList(
+				e,
+				change,
+				changes,
+				idSelection,
+				selectedFileIds,
+				true,
+				idx,
+				selectionId,
+				true
+			);
 			onselect?.(change);
 			return true;
 		}
@@ -250,7 +260,17 @@
 		}}
 		onclick={(e) => {
 			e.stopPropagation();
-			selectFilesInList(e, change, changes, idSelection, selectedFileIds, true, idx, selectionId);
+			selectFilesInList(
+				e,
+				change,
+				changes,
+				idSelection,
+				selectedFileIds,
+				true,
+				idx,
+				selectionId,
+				true
+			);
 			onselect?.(change);
 		}}
 		{conflictEntries}

--- a/apps/desktop/src/components/SnapshotCard.svelte
+++ b/apps/desktop/src/components/SnapshotCard.svelte
@@ -225,6 +225,7 @@
 								listMode="list"
 								hideLastFileBorder={false}
 								onselect={(change) => onDiffClick(change.path)}
+								allowUnselect={false}
 							/>
 						</ScrollableContainer>
 					</SnapshotAttachment>

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -402,6 +402,7 @@
 					defaultValue: 16
 				}}
 				autoselect
+				allowUnselect={false}
 			/>
 		{/snippet}
 	</ReduxResult>
@@ -435,6 +436,7 @@
 					maxHeight: 32,
 					defaultValue: 16
 				}}
+				allowUnselect={false}
 			/>
 		{/snippet}
 	</ReduxResult>

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -59,6 +59,8 @@
 
 	let lanesSrollableEl = $state<HTMLDivElement>();
 
+	let isDetailsViewForcesClosed = $state(false);
+
 	const stackService = inject(STACK_SERVICE);
 	const diffService = inject(DIFF_SERVICE);
 	const uncommittedService = inject(UNCOMMITTED_SERVICE);
@@ -229,6 +231,11 @@
 		selection.set(undefined);
 	}
 
+	function onclosePreviewOnly() {
+		// Close the details view but keep the selection intact
+		isDetailsViewForcesClosed = true;
+	}
+
 	const startCommitVisible = $derived(uncommittedService.startCommitVisible(stackId));
 
 	function onerror(err: unknown) {
@@ -250,7 +257,27 @@
 		return undefined;
 	}
 
-	let isDetailsViewOpen = $derived(!!(branchName || commitId || assignedKey || selectedFile));
+	let isDetailsViewOpen = $derived(
+		!!(branchName || commitId || assignedKey || selectedFile) && !isDetailsViewForcesClosed
+	);
+
+	// Track the current selection to detect when it changes
+	let previousSelection = $state<{ branchName?: string; commitId?: string }>({});
+
+	// Reset the forced closed state when selection changes to a different branch/commit
+	$effect(() => {
+		const currentSelection = { branchName, commitId };
+
+		// Check if selection actually changed
+		if (
+			currentSelection.branchName !== previousSelection.branchName ||
+			currentSelection.commitId !== previousSelection.commitId
+		) {
+			// Selection changed, allow details view to open again
+			isDetailsViewForcesClosed = false;
+			previousSelection = { ...currentSelection };
+		}
+	});
 	const DETAILS_RIGHT_PADDING_REM = 1.125;
 
 	// Function to update CSS custom property for details view width
@@ -317,7 +344,7 @@
 {/snippet}
 
 {#snippet branchView(branchName: string)}
-	<BranchView {stackId} {laneId} {projectId} {branchName} {onerror} {onclose} />
+	<BranchView {stackId} {laneId} {projectId} {branchName} {onerror} onclose={onclosePreviewOnly} />
 {/snippet}
 
 {#snippet commitView(branchName: string, commitId: string)}
@@ -333,7 +360,7 @@
 		}}
 		draggableFiles
 		{onerror}
-		{onclose}
+		onclose={onclosePreviewOnly}
 	/>
 {/snippet}
 
@@ -436,7 +463,7 @@
 	use:focusable={{
 		onKeydown: (event) => {
 			if (event.key === 'Escape' && isDetailsViewOpen) {
-				selection.set(undefined);
+				onclosePreviewOnly();
 				event.preventDefault();
 				event.stopPropagation();
 				return true;

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -299,7 +299,7 @@
 		scrollContainer={selectionPreviewScrollContainer}
 		selectionId={createWorktreeSelection({ stackId })}
 		onclose={() => {
-			idSelection.clear(createWorktreeSelection({ stackId: stackId }));
+			idSelection.clearPreview(createWorktreeSelection({ stackId: stackId }));
 		}}
 		draggableFiles
 	/>

--- a/apps/desktop/src/components/StackView.svelte
+++ b/apps/desktop/src/components/StackView.svelte
@@ -276,6 +276,12 @@
 			// Selection changed, allow details view to open again
 			isDetailsViewForcesClosed = false;
 			previousSelection = { ...currentSelection };
+
+			// Clear file selections from the previous context to allow auto-selection
+			// to work properly for the new context
+			if (activeSelectionId) {
+				idSelection.clear(activeSelectionId);
+			}
 		}
 	});
 	const DETAILS_RIGHT_PADDING_REM = 1.125;

--- a/apps/desktop/src/components/UnappliedBranchView.svelte
+++ b/apps/desktop/src/components/UnappliedBranchView.svelte
@@ -107,6 +107,7 @@
 					{selectionId}
 					changes={changes.changes}
 					stats={changes.stats}
+					allowUnselect={false}
 				/>
 			{/snippet}
 		</ReduxResult>

--- a/apps/desktop/src/components/UnappliedCommitView.svelte
+++ b/apps/desktop/src/components/UnappliedCommitView.svelte
@@ -46,6 +46,7 @@
 					{projectId}
 					selectionId={createCommitSelection({ commitId })}
 					changes={changes.changes}
+					allowUnselect={false}
 				/>
 			{/snippet}
 		</ReduxResult>

--- a/apps/desktop/src/components/WorkspaceView.svelte
+++ b/apps/desktop/src/components/WorkspaceView.svelte
@@ -107,7 +107,7 @@
 			draggableFiles
 			scrollContainer={selectionPreviewScrollContainer}
 			onclose={() => {
-				idSelection.clear(selectionId);
+				idSelection.clearPreview(selectionId);
 			}}
 		/>
 	</ConfigurableScrollableContainer>

--- a/apps/desktop/src/components/codegen/CodegenPage.svelte
+++ b/apps/desktop/src/components/codegen/CodegenPage.svelte
@@ -756,6 +756,7 @@
 									showCheckboxes={false}
 									draggableFiles={false}
 									hideLastFileBorder={true}
+									allowUnselect={false}
 								/>
 							{:else}
 								<div class="right-sidebar__changes-placeholder">

--- a/apps/desktop/src/lib/commits/dropHandler.ts
+++ b/apps/desktop/src/lib/commits/dropHandler.ts
@@ -34,7 +34,8 @@ export class MoveCommitDzHandler implements DropzoneHandler {
 	constructor(
 		private stackService: StackService,
 		private stackId: string,
-		private projectId: string
+		private projectId: string,
+		private uiState?: UiState
 	) {}
 
 	accepts(data: unknown): boolean {
@@ -55,6 +56,14 @@ export class MoveCommitDzHandler implements DropzoneHandler {
 	}
 
 	ondrop(data: CommitDropData): void {
+		// Clear the selection from the source lane if this commit was selected
+		if (this.uiState) {
+			const sourceSelection = untrack(() => this.uiState!.lane(data.stackId).selection.current);
+			if (sourceSelection?.commitId === data.commit.id) {
+				this.uiState.lane(data.stackId).selection.set(undefined);
+			}
+		}
+
 		this.stackService
 			.moveCommit({
 				projectId: this.projectId,

--- a/apps/desktop/src/lib/selection/fileSelectionManager.svelte.ts
+++ b/apps/desktop/src/lib/selection/fileSelectionManager.svelte.ts
@@ -120,6 +120,11 @@ export class FileSelectionManager {
 		selection.lastAdded.set(undefined);
 	}
 
+	clearPreview(selectionId: SelectionId) {
+		const selection = this.getById(selectionId);
+		selection.lastAdded.set(undefined);
+	}
+
 	keys(selectionId: SelectionId) {
 		const selection = this.getById(selectionId);
 		return Array.from(selection.entries);

--- a/apps/desktop/src/lib/selection/fileSelectionUtils.ts
+++ b/apps/desktop/src/lib/selection/fileSelectionUtils.ts
@@ -176,7 +176,7 @@ export function updateSelection({
 			break;
 		case KeyName.Escape:
 			preventDefault();
-			fileIdSelection.clear(selectionId);
+			fileIdSelection.clearPreview(selectionId);
 			targetElement.blur();
 			break;
 	}


### PR DESCRIPTION
This pull request introduces improvements to selection and details view handling in the desktop app, focusing on making selection toggling more intuitive and refining how the details view is opened and closed. The changes also include updates to file selection logic and some minor UI tweaks.

Demo:

https://github.com/user-attachments/assets/dbf7a903-d560-488c-b0d2-9617c44f9dcc


**Selection and Details View Behavior**

* Added logic to toggle selection for commits and branches: clicking an already selected commit or branch now clears the selection instead of re-selecting. (`BranchCommitList.svelte` [[1]](diffhunk://#diff-149974f0265cdf94b6eee58ae93dd3014bed081d9fa151bb16d9db73669ca820L129-R133) `BranchList.svelte` [[2]](diffhunk://#diff-1ad580da2436dcbcce1c2ae53082aaa7b0e9d9efef5a964beed3ee454d75aa3cR189-R195)
* Introduced a mechanism to force close the details view without clearing the selection, and ensured the details view reopens when the selection changes. (`StackView.svelte` [[1]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54R62-R63) [[2]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54R234-R238) [[3]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54L253-R280) [[4]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54L320-R347) [[5]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54L336-R363) [[6]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54L439-R466)

**File Selection Logic**

* Updated file selection handling to pass an additional argument for better control over selection behavior, and added a dedicated method `clearPreview` to clear only preview selections. (`FileList.svelte` [[1]](diffhunk://#diff-cf7b57202a20d50cd471cf460f089d25f9f425314729c9cc96b00325ccfee240L184-R194) [[2]](diffhunk://#diff-cf7b57202a20d50cd471cf460f089d25f9f425314729c9cc96b00325ccfee240L253-R273); `fileSelectionManager.svelte.ts` [[3]](diffhunk://#diff-5fdb7972806fd90c8160ef2a1d70c97cfb24e6cebae3fcef0523b319f35f8322R123-R127); `fileSelectionUtils.ts` [[4]](diffhunk://#diff-9d0fc45bdde02fb30010e169e68d6a960bd60bab528a71f411f515de3353c1f2L179-R179)
* Replaced calls to `idSelection.clear` with `idSelection.clearPreview` in details view close handlers for consistency. (`StackView.svelte` [[1]](diffhunk://#diff-b9c0b50dd6991cb42a5b6a2516c054af101054caee603f9359e8b370758eaa54L302-R329) `WorkspaceView.svelte` [[2]](diffhunk://#diff-838ecef8772b2ba446e8aa4a220d46bec36627f3c820bf37aae1dde4ed664735L110-R110)

**UI Improvements**

* Removed the bottom border from the last directory entry in the added directories list for a cleaner look. (`AddedDirectoriesList.svelte` [apps/desktop/src/components/codegen/AddedDirectoriesList.svelteR77-R80](diffhunk://#diff-c8a6628866c161e418a59e9d93f7e9b8ec3d5636af48adaf868a18db3a0b6736R77-R80))


