### PR TITLE
Use focus manager for navigation context menus

### DIFF
--- a/packages/ui/src/lib/components/ContextMenu.svelte
+++ b/packages/ui/src/lib/components/ContextMenu.svelte
@@ -329,13 +329,6 @@
 		return isVisible;
 	}
 
-	function handleKeyNavigation(e: KeyboardEvent) {
-		if (e.key === 'Escape') {
-			e.preventDefault();
-			close();
-		}
-	}
-
 	$effect(() => {
 		if (!menuContainer) return;
 		const config = { attributes: false, childList: true, subtree: true };
@@ -358,17 +351,26 @@
 </script>
 
 {#if isVisible}
-	<div class="portal-wrap" use:portal={'body'}>
-		<!-- svelte-ignore a11y_autofocus -->
+	<!-- `use:focusable` must come before `use:portal`-->
+	<div
+		class="portal-wrap"
+		use:focusable={{
+			activate: true,
+			trap: true,
+			vertical: true,
+			onEsc: () => {
+				close();
+				return true;
+			}
+		}}
+		use:portal={'body'}
+	>
 		<div
 			data-testid={testId}
 			bind:this={menuContainer}
 			tabindex="-1"
-			use:focusable={{ activate: true, isolate: true, focusable: true, dim: true, trap: true }}
-			autofocus
 			{onclick}
 			{onkeypress}
-			onkeydown={handleKeyNavigation}
 			class="context-menu hide-native-scrollbar"
 			class:top-oriented={side === 'top'}
 			class:bottom-oriented={side === 'bottom'}

--- a/packages/ui/src/lib/components/ContextMenuItem.svelte
+++ b/packages/ui/src/lib/components/ContextMenuItem.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Icon from '$components/Icon.svelte';
 	import Tooltip from '$components/Tooltip.svelte';
+	import { focusable } from '$lib/focus/focusable';
 	import { keysStringToArr } from '$lib/utils/hotkeys';
 	import { getContext } from 'svelte';
 	import type iconsJson from '@gitbutler/ui/data/icons.json';
@@ -62,12 +63,13 @@
 	<button
 		data-testid={testId}
 		type="button"
-		class="menu-item focus-state no-select"
+		class="menu-item no-select"
 		style:--item-height={caption ? 'auto' : '1.625rem'}
 		class:disabled
 		{disabled}
 		onclick={handleClick}
 		onmouseenter={handleMouseEnter}
+		use:focusable={{ focusable: true, button: true }}
 	>
 		<div class="menu-item__content">
 			{#if icon}
@@ -119,6 +121,7 @@
 		padding: 6px 8px;
 		gap: 4px;
 		border-radius: var(--radius-s);
+		outline: none;
 		color: var(--clr-text-1);
 		text-align: left;
 		cursor: pointer;

--- a/packages/ui/src/lib/components/ContextMenuItemSubmenu.svelte
+++ b/packages/ui/src/lib/components/ContextMenuItemSubmenu.svelte
@@ -110,39 +110,6 @@
 		isSubmenuOpen = false;
 		contextMenu?.close();
 	}
-
-	// Handle arrow key navigation
-	function handleKeyDown(e: KeyboardEvent) {
-		if (disabled) return;
-
-		switch (e.key) {
-			case 'ArrowRight':
-				if (submenuSide === 'right') {
-					e.preventDefault();
-					e.stopPropagation();
-					isSubmenuOpen = true;
-					contextMenu?.open();
-				}
-				break;
-			case 'ArrowLeft':
-				if (submenuSide === 'left') {
-					e.preventDefault();
-					e.stopPropagation();
-					isSubmenuOpen = true;
-					contextMenu?.open();
-				}
-				break;
-			case 'Enter':
-			case ' ':
-				e.preventDefault();
-				e.stopPropagation();
-				if (disabled) return;
-
-				isSubmenuOpen = !isSubmenuOpen;
-				contextMenu?.toggle();
-				break;
-		}
-	}
 </script>
 
 <div
@@ -151,11 +118,7 @@
 	class:active={isSubmenuOpen}
 	onmouseenter={handleMouseEnter}
 	onmouseleave={handleMouseLeave}
-	onkeydown={handleKeyDown}
-	role="menuitem"
-	aria-haspopup="menu"
-	aria-expanded={isSubmenuOpen}
-	tabindex="-1"
+	role="group"
 >
 	<ContextMenuItem
 		{icon}
@@ -182,7 +145,6 @@
 	align={submenuVerticalAlign === 'top' ? 'start' : 'end'}
 	onclose={() => {
 		isSubmenuOpen = false;
-		menuItemElement?.focus();
 	}}
 >
 	{@render submenu({ close: closeSubmenu })}

--- a/packages/ui/src/lib/components/KebabButton.svelte
+++ b/packages/ui/src/lib/components/KebabButton.svelte
@@ -68,6 +68,17 @@
 		onclick?.(e.currentTarget as HTMLElement);
 	}
 
+	function onKeyDown(e: KeyboardEvent) {
+		if (e.key !== 'Enter') {
+			return;
+		}
+		e.stopPropagation();
+		e.preventDefault();
+		isContextMenuOpen = !isContextMenuOpen;
+		openedViaClick = isContextMenuOpen; // Track if opened via click
+		onclick?.(e.currentTarget as HTMLElement);
+	}
+
 	$effect(() => {
 		if (contextElement) {
 			contextElement.addEventListener('contextmenu', onContextMenu);
@@ -110,6 +121,7 @@
 		class:visible={visible || isContextMenuOpen}
 		class:activated={activated || (isContextMenuOpen && openedViaClick)}
 		onclick={onClick}
+		onkeypress={onKeyDown}
 		data-testid={testId}
 	>
 		<Icon name="kebab" />
@@ -123,6 +135,7 @@
 		kind="ghost"
 		activated={activated || (isContextMenuOpen && openedViaClick)}
 		onclick={onClick}
+		onkeydown={onKeyDown}
 	/>
 {/if}
 

--- a/packages/ui/src/lib/focus/focusTypes.ts
+++ b/packages/ui/src/lib/focus/focusTypes.ts
@@ -23,12 +23,10 @@ export interface FocusableOptions {
 	disabled?: boolean;
 	// Treat children as vertically oriented (changes arrow key behavior, automatically skips during navigation)
 	vertical?: boolean;
-	// Prevent keyboard navigation from leaving this element
-	trap?: boolean;
 	// Automatically focus this element when registered
 	activate?: boolean;
-	// Don't establish parent-child relationships with other focusables
-	isolate?: boolean;
+	// Prevent keyboard navigation from leaving this element
+	trap?: boolean;
 	// Never highlight the element
 	dim?: boolean;
 	// Automatically trigger onAction when this element becomes active


### PR DESCRIPTION
Removes custom keyboard navigation for context menus, and replaces it 
with the new focus manager functionality. Note that ContextMenuItem 
contains two focusables, one for navigation and one to support f-keys.